### PR TITLE
add napari based zarr proofreader, add obj voxelization

### DIFF
--- a/segmentation/dataset_creation/voxelize_objs.py
+++ b/segmentation/dataset_creation/voxelize_objs.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+from glob import glob
+import numpy as np
+import open3d as o3d
+import os
+import tifffile
+from PIL import Image
+from concurrent.futures import ProcessPoolExecutor
+import multiprocessing
+from numba import jit, prange, set_num_threads
+import sys
+import argparse
+from tqdm import tqdm  # Progress bar
+
+# Determine default number of workers: half of CPU count (at least 1)
+default_workers = max(1, multiprocessing.cpu_count() // 2)
+
+# We no longer need normals for expansion, but we still need to find
+# intersections of triangles with the z-plane.
+MAX_INTERSECTIONS = 3  # Maximum number of intersections per triangle
+
+@jit(nopython=True)
+def get_intersection_point_2d(start, end, z_plane):
+    """
+    Given two 3D vertices start/end, returns the 2D intersection (x,y)
+    on the plane z = z_plane, if it exists. Otherwise returns None.
+    """
+    z_s = start[2]
+    z_e = end[2]
+
+    # Check if one of the vertices is exactly on the plane
+    if abs(z_s - z_plane) < 1e-8:
+        return start[:2]
+    if abs(z_e - z_plane) < 1e-8:
+        return end[:2]
+
+    # If neither vertex is on the plane, check if we can intersect
+    denom = (z_e - z_s)
+    if abs(denom) < 1e-15:
+        return None  # Parallel or effectively so
+
+    t = (z_plane - z_s) / denom
+    # Only treat intersection if t is in [0,1], with slight relax
+    if not (0.0 - 1e-3 <= t <= 1.0 + 1e-3):
+        return None
+
+    # Compute intersection in xy
+    x = start[0] + t * (end[0] - start[0])
+    y = start[1] + t * (end[1] - start[1])
+    return np.array([x, y], dtype=np.float32)
+
+@jit(nopython=True)
+def rasterize_line_label(x0, y0, x1, y1, w, h, label_img, mesh_label):
+    """
+    Simple line rasterization in label_img with the integer mesh label.
+    Uses a basic DDA approach.
+    """
+    dx = x1 - x0
+    dy = y1 - y0
+
+    steps = int(max(abs(dx), abs(dy)))  # Use the larger magnitude as steps
+    if steps == 0:
+        # Single point (start == end)
+        ix = int(round(x0))
+        iy = int(round(y0))
+        if 0 <= ix < w and 0 <= iy < h:
+            label_img[iy, ix] = mesh_label
+        return
+
+    x_inc = dx / steps
+    y_inc = dy / steps
+    x_f = x0
+    y_f = y0
+
+    for i in range(steps + 1):
+        ix = int(round(x_f))
+        iy = int(round(y_f))
+        if 0 <= ix < w and 0 <= iy < h:
+            label_img[iy, ix] = mesh_label
+        x_f += x_inc
+        y_f += y_inc
+
+@jit(nopython=True)
+def process_slice_points_label(vertices, triangles, mesh_labels, zslice, w, h):
+    """
+    For the plane z=zslice, find the intersection lines of each triangle
+    and draw them into a 2D array (label_img) using the triangle's mesh label.
+    """
+    label_img = np.zeros((h, w), dtype=np.uint16)
+
+    for i in range(len(triangles)):
+        tri = triangles[i]
+        label = mesh_labels[i]
+        v0 = vertices[tri[0]]
+        v1 = vertices[tri[1]]
+        v2 = vertices[tri[2]]
+
+        # Quick check if the z-range of the triangle might intersect zslice
+        z_min = min(v0[2], v1[2], v2[2])
+        z_max = max(v0[2], v1[2], v2[2])
+        if not (z_min <= zslice <= z_max):
+            continue
+
+        # Find up to three intersection points
+        pts_2d = []
+        # Each edge
+        for (a, b) in [(v0, v1), (v1, v2), (v2, v0)]:
+            p = get_intersection_point_2d(a, b, zslice)
+            if p is not None:
+                # Check for duplicates in pts_2d
+                is_dup = False
+                for pp in pts_2d:
+                    dist2 = (p[0] - pp[0]) ** 2 + (p[1] - pp[1]) ** 2
+                    if dist2 < 1e-12:
+                        is_dup = True
+                        break
+                if not is_dup:
+                    pts_2d.append(p)
+
+        # If we have at least two unique intersection points, draw lines
+        n_inter = len(pts_2d)
+        if n_inter >= 2:
+            # Typically you expect 2 intersection points, but we’ll connect all pairs
+            for ii in range(n_inter):
+                for jj in range(ii + 1, n_inter):
+                    x0, y0 = pts_2d[ii]
+                    x1, y1 = pts_2d[jj]
+                    rasterize_line_label(x0, y0, x1, y1, w, h, label_img, label)
+
+    return label_img
+
+def process_mesh(mesh_path, mesh_index):
+    """
+    Load a mesh from disk, return (vertices, triangles, labels_for_those_triangles).
+    We assign mesh_index+1 as the label.
+    """
+    print(f"Processing mesh: {mesh_path}")
+    mesh = o3d.io.read_triangle_mesh(mesh_path)
+    # Normals are not computed since they're not needed.
+    # mesh.compute_vertex_normals()
+
+    vertices = np.asarray(mesh.vertices, dtype=np.float32)
+    triangles = np.asarray(mesh.triangles, dtype=np.int32)
+
+    # Every triangle in this mesh gets the same label: mesh_index+1
+    labels = np.full(len(triangles), mesh_index + 1, dtype=np.uint16)
+
+    return vertices, triangles, labels
+
+def process_slice(args):
+    """
+    Process a single z-slice, writing out a label TIF if non-empty.
+    """
+    (zslice, vertices, triangles, labels, w, h, out_path) = args
+    # (No per-slice print; progress is tracked with tqdm.)
+    img_label = process_slice_points_label(vertices, triangles, labels, zslice, w, h)
+
+    # Save if there's at least one nonzero pixel
+    if np.any(img_label):
+        out_file = os.path.join(out_path, f"{zslice}.tif")
+        tifffile.imwrite(out_file, img_label, compression='zlib')
+
+    return zslice
+
+def main():
+    # Parse command-line arguments.
+    parser = argparse.ArgumentParser(
+        description="Process OBJ meshes and slice them along z to produce label images."
+    )
+    parser.add_argument("folder", help="Path to folder containing OBJ meshes")
+    parser.add_argument("--scroll", required=True, choices=["scroll1", "scroll2", "scroll3", "scroll4", "scroll5"],
+                        help="Scroll shape to use (determines image dimensions)")
+    parser.add_argument("--output_path", default="mesh_labels_slices",
+                        help="Output folder for label images (default: mesh_labels_slices)")
+    parser.add_argument("--num_workers", type=int, default=default_workers,
+                        help="Number of worker processes to use (default: half of CPU count)")
+    args = parser.parse_args()
+
+    # Use the provided number of worker processes.
+    N_PROCESSES = args.num_workers
+    print(f"Using {N_PROCESSES} worker processes")
+    set_num_threads(N_PROCESSES)
+
+    # Folder where OBJ meshes are located.
+    folder_path = args.folder
+    print(f"Using mesh folder: {folder_path}")
+
+    # Set the image dimensions based on the specified scroll.
+    scroll_shapes = {
+        "scroll1": (7888, 8096),   # (h, w) for scroll1
+        "scroll2": (10112, 11984), # (h, w) for scroll2
+        "scroll3": (3550, 3400),   # (h, w) for scroll3
+        "scroll4": (3440, 3340),   # (h, w) for scroll4
+        "scroll5": (6700, 9100)    # (h, w) for scroll5
+    }
+    if args.scroll not in scroll_shapes:
+        print("Invalid scroll shape specified.")
+        sys.exit(1)
+
+    # Here, the shape is defined as (height, width)
+    h, w = scroll_shapes[args.scroll]
+    print(f"Using scroll '{args.scroll}' with dimensions: height={h}, width={w}")
+
+    # Folder where label images will be saved.
+    out_path = args.output_path
+    os.makedirs(out_path, exist_ok=True)
+    print(f"Output folder for label images: {out_path}")
+
+    mesh_paths = glob(os.path.join(folder_path, '*.obj'))
+    print(f"Found {len(mesh_paths)} meshes to process")
+
+    # Read all meshes in parallel.
+    with ProcessPoolExecutor(max_workers=N_PROCESSES) as executor:
+        mesh_results = list(executor.map(process_mesh, mesh_paths, range(len(mesh_paths))))
+
+    # Merge all into a single set of (vertices, triangles, labels).
+    all_vertices = []
+    all_triangles = []
+    all_labels = []
+    vertex_offset = 0
+
+    for (vertices_i, triangles_i, labels_i) in mesh_results:
+        all_vertices.append(vertices_i)
+        # Shift triangles by current offset.
+        all_triangles.append(triangles_i + vertex_offset)
+        all_labels.append(labels_i)
+        vertex_offset += len(vertices_i)
+
+    # Create the big arrays.
+    vertices = np.vstack(all_vertices)
+    triangles = np.vstack(all_triangles)
+    mesh_labels = np.concatenate(all_labels)
+
+    # Determine slice range from the vertices.
+    z_min = int(np.floor(vertices[:, 2].min()))
+    z_max = int(np.ceil(vertices[:, 2].max()))
+    z_slices = np.arange(z_min, z_max + 1)
+    print(f"Processing slices from {z_min} to {z_max} (inclusive).")
+    print(f"Total number of slices: {len(z_slices)}")
+
+    # Prepare parallel arguments for slices.
+    slice_args = [(z, vertices, triangles, mesh_labels, w, h, out_path) for z in z_slices]
+
+    # Run slice processing in parallel with a tqdm progress bar.
+    with ProcessPoolExecutor(max_workers=N_PROCESSES) as executor:
+        for _ in tqdm(executor.map(process_slice, slice_args), total=len(slice_args), desc="Slices processed"):
+            pass
+
+if __name__ == "__main__":
+    main()

--- a/segmentation/vc_proofreader/config.py
+++ b/segmentation/vc_proofreader/config.py
@@ -1,0 +1,18 @@
+# config.py
+
+config = {
+    # Zarr paths can be local file system paths or HTTP URLs.
+    "image_zarr": "https://dl.ash2txt.org/community-uploads/james/Scroll1/Scroll1_8um.zarr/",  # Replace with your image zarr path
+    "label_zarr": "/mnt/raid_hdd/labels/surfaces/s1_surface_label.zarr",    # Replace with your label zarr path
+
+    # Output directory where subfolders "imagesTr" and "labelsTr" will be created.
+    "dataset_out_path": "/mnt/raid_nvme/testds",
+
+    # Patch extraction settings (patch_size is specified in display resolution units).
+    "patch_size": 128,
+    "sampling": "sequence",  # Options: "sequence" or "random"
+
+    # Progress saving options.
+    "save_progress": True,                                    # Set to True to enable saving progress.
+    "progress_file": "/mnt/raid_nvme/testds/progress.txt",                # Path to the file where progress is saved.
+}

--- a/segmentation/vc_proofreader/main.py
+++ b/segmentation/vc_proofreader/main.py
@@ -1,0 +1,334 @@
+import os
+import numpy as np
+import napari
+import zarr
+import fsspec
+import tifffile
+from magicgui import magicgui
+
+# Try to import config defaults; if not found, use empty defaults.
+try:
+    from config import config
+except ImportError:
+    config = {}
+
+# Global state – for production code you might encapsulate this in a class.
+state = {
+    # Volumes for display (lower res) and saving (high res)
+    'display_image_volume': None,
+    'display_label_volume': None,
+    'highres_image_volume': None,
+    'highres_label_volume': None,
+    'patch_size': None,  # (in display resolution units)
+    'patch_coords': None,  # Coordinates (tuples) in display resolution
+    'current_index': 0,  # Index into patch_coords; the currently displayed patch is at current_index - 1
+    'dataset_out_path': None,
+    'images_out_dir': None,
+    'labels_out_dir': None,
+    'current_patch': None,  # Info about current patch (from display volume)
+    'scale_factor': None,  # Downsampling factor: highres = display * scale_factor
+    'save_progress': False,  # Whether to save progress to a file
+    'progress_file': "",  # Path to the progress file
+}
+
+
+def generate_patch_coords(vol_shape, patch_size, sampling):
+    """
+    Generate a list of top-left (or front-top-left) coordinates for patches.
+    Works for 2D (shape (H, W)) or 3D (shape (D, H, W)) volumes.
+    """
+    coords = []
+    if len(vol_shape) == 2:
+        H, W = vol_shape
+        for i in range(0, H - patch_size + 1, patch_size):
+            for j in range(0, W - patch_size + 1, patch_size):
+                coords.append((i, j))
+    elif len(vol_shape) >= 3:
+        # Assume first three dimensions are spatial.
+        D, H, W = vol_shape[:3]
+        for z in range(0, D - patch_size + 1, patch_size):
+            for y in range(0, H - patch_size + 1, patch_size):
+                for x in range(0, W - patch_size + 1, patch_size):
+                    coords.append((z, y, x))
+    else:
+        raise ValueError("Volume must be at least 2D")
+    if sampling == 'random':
+        np.random.shuffle(coords)
+    return coords
+
+
+def extract_patch(volume, coord, patch_size):
+    """
+    Extract a patch from a volume starting at the given coordinate.
+    For spatial dimensions, a slice is created from coord to coord+patch_size.
+    Any extra dimensions (e.g. channels) are included in full.
+    """
+    slices = tuple(slice(c, c + patch_size) for c in coord)
+    if volume.ndim > len(coord):
+        slices = slices + (slice(None),) * (volume.ndim - len(coord))
+    return volume[slices]
+
+
+def load_next_patch():
+    """
+    Load the next valid patch (one whose label patch is not all zeros)
+    from the display volumes and show it in napari.
+    """
+    global state, viewer
+    if state.get('patch_coords') is None:
+        print("Volume not initialized.")
+        return
+
+    patch_size = state['patch_size']
+    display_image_volume = state['display_image_volume']
+    display_label_volume = state['display_label_volume']
+    coords = state['patch_coords']
+
+    while state['current_index'] < len(coords):
+        coord = coords[state['current_index']]
+        # Extract patch from the display volumes.
+        image_patch = extract_patch(display_image_volume, coord, patch_size)
+        label_patch = extract_patch(display_label_volume, coord, patch_size)
+
+        state['current_patch'] = {
+            'coords': coord,  # in display resolution
+            'image': image_patch,
+            'label': label_patch,
+            'index': state['current_index']
+        }
+        state['current_index'] += 1
+
+        # Skip patch if the label patch is completely zero.
+        if np.any(label_patch != 0):
+            # Update or add napari layers.
+            if "patch_image" in viewer.layers:
+                viewer.layers["patch_image"].data = image_patch
+            else:
+                viewer.add_image(image_patch, name="patch_image", colormap='gray')
+            if "patch_label" in viewer.layers:
+                viewer.layers["patch_label"].data = label_patch
+            else:
+                viewer.add_labels(label_patch, name="patch_label")
+            print(f"Loaded patch at display coordinate {coord}.")
+            return
+        else:
+            print(f"Skipping patch at {coord} (label patch is all zeros).")
+    print("No more patches available.")
+
+
+def save_current_patch():
+    """
+    Save the current patch extracted from the high resolution volumes.
+    The display patch coordinates are scaled up to map to the high resolution.
+    File names are constructed using the high-res zyx (or yx) coordinates:
+      - Image file gets a '_0000' suffix (e.g. img_z{z}_y{y}_x{x}_0000.tif).
+      - Label file does not (e.g. lbl_z{z}_y{y}_x{x}.tif).
+    """
+    global state
+    if state.get('current_patch') is None:
+        print("No patch available to save.")
+        return
+
+    patch = state['current_patch']
+    display_coord = patch['coords']
+    patch_size = state['patch_size']
+    scale_factor = state['scale_factor']
+
+    # Map display coordinate to high resolution coordinate.
+    hr_coord = tuple(c * scale_factor for c in display_coord)
+    hr_patch_size = patch_size * scale_factor
+
+    # Extract high-resolution patches.
+    highres_image_patch = extract_patch(state['highres_image_volume'], hr_coord, hr_patch_size)
+    highres_label_patch = extract_patch(state['highres_label_volume'], hr_coord, hr_patch_size)
+
+    # Construct coordinate string.
+    # For 3D, assume hr_coord is (z, y, x); for 2D, assume (y, x).
+    if len(hr_coord) == 3:
+        coord_str = f"z{hr_coord[0]}_y{hr_coord[1]}_x{hr_coord[2]}"
+    elif len(hr_coord) == 2:
+        coord_str = f"y{hr_coord[0]}_x{hr_coord[1]}"
+    else:
+        coord_str = "_".join(str(c) for c in hr_coord)
+
+    # Build filenames using the coordinate string.
+    image_filename = f"img_{coord_str}_0000.tif"
+    label_filename = f"lbl_{coord_str}.tif"
+    image_path = os.path.join(state['images_out_dir'], image_filename)
+    label_path = os.path.join(state['labels_out_dir'], label_filename)
+
+    tifffile.imwrite(image_path, highres_image_patch)
+    tifffile.imwrite(label_path, highres_label_patch)
+    print(f"Saved high-res image patch to {image_path} and label patch to {label_path}")
+
+
+def update_progress():
+    """
+    If the save_progress option is enabled, write the current patch index to the progress file.
+    """
+    if state.get('save_progress') and state.get('progress_file'):
+        try:
+            with open(state['progress_file'], "w") as f:
+                f.write(str(state['current_index']))
+            print(f"Progress saved to {state['progress_file']}.")
+        except Exception as e:
+            print("Error saving progress:", e)
+
+
+def load_progress():
+    """
+    If a progress file exists and save_progress is enabled, load the patch index.
+    """
+    if state.get('save_progress') and state.get('progress_file'):
+        if os.path.exists(state['progress_file']):
+            try:
+                with open(state['progress_file'], "r") as f:
+                    idx = int(f.read().strip())
+                state['current_index'] = idx
+                print(f"Resuming from patch index {idx} as per progress file.")
+            except Exception as e:
+                print("Error loading progress:", e)
+
+
+@magicgui(
+    sampling={"choices": ["random", "sequence"]}
+)
+def init_volume(
+        image_zarr: str = config.get("image_zarr", ""),
+        label_zarr: str = config.get("label_zarr", ""),
+        dataset_out_path: str = config.get("dataset_out_path", ""),
+        patch_size: int = config.get("patch_size", 64),
+        sampling: str = config.get("sampling", "sequence"),
+        save_progress: bool = config.get("save_progress", False),
+        progress_file: str = config.get("progress_file", ""),
+):
+    """
+    Load image and label volumes from Zarr (local or HTTP).
+    For multiresolution Zarrs, load resolution '1' for display and resolution '0' for saving.
+    Also creates output directories and computes patch coordinates (based on display volume).
+    Optionally loads a progress file to resume patch iteration.
+    """
+    global state, viewer
+
+    # --- Load image volume ---
+    try:
+        image_mapper = fsspec.get_mapper(image_zarr)
+        image_group = zarr.open_group(image_mapper, mode='r')
+        if "1" in image_group:
+            display_image_volume = image_group["1"]
+            print("Using resolution '1' for display of image volume.")
+        else:
+            display_image_volume = image_group
+            print("No resolution '1' found for image volume; using provided array for display.")
+        if "0" in image_group:
+            highres_image_volume = image_group["0"]
+            print("Using resolution '0' for saving patches of image volume.")
+        else:
+            highres_image_volume = image_group
+            print("No resolution '0' found for image volume; using provided array for saving patches.")
+    except Exception as e:
+        print(f"Error loading image zarr: {e}")
+        return
+
+    # --- Load label volume ---
+    try:
+        label_mapper = fsspec.get_mapper(label_zarr)
+        label_group = zarr.open_group(label_mapper, mode='r')
+        if "1" in label_group:
+            display_label_volume = label_group["1"]
+            print("Using resolution '1' for display of label volume.")
+        else:
+            display_label_volume = label_group
+            print("No resolution '1' found for label volume; using provided array for display.")
+        if "0" in label_group:
+            highres_label_volume = label_group["0"]
+            print("Using resolution '0' for saving patches of label volume.")
+        else:
+            highres_label_volume = label_group
+            print("No resolution '0' found for label volume; using provided array for saving patches.")
+    except Exception as e:
+        print(f"Error loading label zarr: {e}")
+        return
+
+    # Save the loaded volumes.
+    state['display_image_volume'] = display_image_volume
+    state['highres_image_volume'] = highres_image_volume
+    state['display_label_volume'] = display_label_volume
+    state['highres_label_volume'] = highres_label_volume
+    state['patch_size'] = patch_size  # in display resolution units
+    state['dataset_out_path'] = dataset_out_path
+
+    # Save progress options.
+    state['save_progress'] = save_progress
+    state['progress_file'] = progress_file
+
+    # Create output directories.
+    images_dir = os.path.join(dataset_out_path, 'imagesTr')
+    labels_dir = os.path.join(dataset_out_path, 'labelsTr')
+    os.makedirs(images_dir, exist_ok=True)
+    os.makedirs(labels_dir, exist_ok=True)
+    state['images_out_dir'] = images_dir
+    state['labels_out_dir'] = labels_dir
+
+    # Compute the scale factor between high-res and display volumes.
+    # We assume the spatial dimensions are the first 2 (for 2D) or 3 (for 3D).
+    num_spatial = 2 if len(display_image_volume.shape) == 2 else 3
+    display_shape = display_image_volume.shape[:num_spatial]
+    highres_shape = highres_image_volume.shape[:num_spatial]
+    scale_factors = [high / disp for disp, high in zip(display_shape, highres_shape)]
+    if not all(np.isclose(sf, scale_factors[0]) for sf in scale_factors):
+        print("Warning: Non-isotropic scale factors detected. Using first dimension's scale factor.")
+    scale_factor = int(round(scale_factors[0]))
+    state['scale_factor'] = scale_factor
+    print(f"Computed scale factor: {scale_factor}")
+
+    # Compute patch coordinates on the display volume.
+    vol_shape = display_shape
+    state['patch_coords'] = generate_patch_coords(vol_shape, patch_size, sampling)
+
+    # If progress saving is enabled and a progress file exists, load the saved progress.
+    load_progress()
+
+    print(f"Loaded display volumes with shape {vol_shape}.")
+    print(f"Found {len(state['patch_coords'])} patch positions using '{sampling}' sampling.")
+    load_next_patch()
+
+
+@magicgui(call_button="next pair")
+def iter_pair(approved: bool):
+    """
+    When "next pair" is pressed, if "approved" is checked, save the current patch
+    from the high-resolution volumes, then load the next patch (skipping all-zero labels).
+    After iterating, update the progress file if enabled.
+    Also, the "approved" checkbox is reset to False.
+    """
+    if approved:
+        save_current_patch()
+    load_next_patch()
+    update_progress()
+    # Reset the approved checkbox:
+    iter_pair.approved.value = False
+
+
+@magicgui(call_button="previous pair")
+def prev_pair():
+    """
+    When "previous pair" is pressed, go back one patch.
+    This is done by decrementing the current index by 2 (so that the previously
+    displayed patch becomes the next one to load) and then loading that patch.
+    """
+    global state
+    if state['current_index'] > 1:
+        state['current_index'] -= 2
+        load_next_patch()
+        update_progress()
+    else:
+        print("No previous patch available.")
+
+
+if __name__ == '__main__':
+    viewer = napari.Viewer()
+    viewer.window.add_dock_widget(init_volume, name="Initialize Volumes", area="right")
+    viewer.window.add_dock_widget(iter_pair, name="Iterate Patches", area="right")
+    viewer.window.add_dock_widget(prev_pair, name="Previous Patch", area="right")
+    napari.run()


### PR DESCRIPTION
napari zarr proofreader loads im/lbl pairs and if approved is checked, writes the pair as multipage tif and stores in nnunet dataset format

obj voxelizer is just a numba accelerated obj voxelation script that takes in a folder of objs and outputs slices of the obj in the scroll volume shape but voxelized