### PR TITLE
Incrementing recursion limit for Welzl recursive algorithm

### DIFF
--- a/foundation/scrollcase/src/scrollcase/smallest_circle.py
+++ b/foundation/scrollcase/src/scrollcase/smallest_circle.py
@@ -1,7 +1,8 @@
 import numpy as np
 import random
 from typing import Tuple
-
+import sys
+sys.setrecursionlimit(1000000)
 
 def _is_in_circle(pt: np.ndarray, center: np.ndarray, radius: float) -> bool:
     """Check if point `pt` is inside or on the circle defined by (center, radius).


### PR DESCRIPTION
I am incrementing the default recursion limit for Welzl recursive algorithm because with the default value the step fails when processing some scrolls.