### PR TITLE
Update discord link, add year to prizes sidebar

### DIFF
--- a/scrollprize.org/docs/01_get_started.md
+++ b/scrollprize.org/docs/01_get_started.md
@@ -42,7 +42,7 @@ import Admonition from '@theme/Admonition';
 
 ### 1. Join the community
 
-Join our [Discord server](https://discord.gg/V4fJhvtaQn), subscribe to our [mailing list](https://scrollprize.substack.com), follow [@scrollprize](https://x.com/scrollprize) on X, and complete our [community survey](https://forms.gle/mtA3B4uQusVFTEDu9).
+Join our [Discord server](https://discord.com/invite/uTfNwwecCQ), subscribe to our [mailing list](https://scrollprize.substack.com), follow [@scrollprize](https://x.com/scrollprize) on X, and complete our [community survey](https://forms.gle/mtA3B4uQusVFTEDu9).
 
 ### 2. See a scroll
 
@@ -84,7 +84,7 @@ There are many great tools and resources that you can use and contribute to:
 
 For prototyping new ideas, we particularly recommend the [Python](https://github.com/ScrollPrize/villa/tree/main/vesuvius) and [C](https://github.com/ScrollPrize/villa/tree/main/vesuvius-c) libraries for easily working with scroll data.
 
-Reach out to our [Discord community](https://discord.gg/V4fJhvtaQn) and [team](mailto:team@scrollprize.org) with your questions!
+Reach out to our [Discord community](https://discord.com/invite/uTfNwwecCQ) and [team](mailto:team@scrollprize.org) with your questions!
 
 <!-- cloud image https://github.com/ScrollPrize/cloud-image -->
 <!-- cloud credits (link to form to apply for them) -->

--- a/scrollprize.org/docs/09_faq.md
+++ b/scrollprize.org/docs/09_faq.md
@@ -153,7 +153,7 @@ Here are some other excellent books we recommend:
 
 ### What if I would like to contribute, but don’t have time to compete for the Grand Prize?
 
-* Join our [Discord](https://discord.gg/V4fJhvtaQn) to learn about current efforts and how you can pitch in.
+* Join our [Discord](https://discord.com/invite/uTfNwwecCQ) to learn about current efforts and how you can pitch in.
 * You can make smaller open source contributions, which would benefit the whole community. Everyone in the community will be grateful for your work, and you might even be able to win a prize - see those [already awarded](winners)!
 
 ### Can I share my progress on social media?

--- a/scrollprize.org/docs/11_livestream.md
+++ b/scrollprize.org/docs/11_livestream.md
@@ -36,7 +36,7 @@ hide_table_of_contents: true
   />
 </head>
 
-Be sure to check [Discord](https://discord.gg/V4fJhvtaQn), [Substack](https://scrollprize.substack.com/), and [X](https://x.com/scrollprize) for livestream announcements!
+Be sure to check [Discord](https://discord.com/invite/uTfNwwecCQ), [Substack](https://scrollprize.substack.com/), and [X](https://x.com/scrollprize) for livestream announcements!
 
 ### July 31, 2024 - Office Hours
 

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -49,7 +49,7 @@ Some highlighted contributions are added to this repository as submodules.
 
 We keep this repository updated as much as we can, but research moves _fast_! 🏃💨
 
-For state-of-the-art updates join our [Discord server](https://discord.com/invite/V4fJhvtaQn) 💬⏰
+For state-of-the-art updates join our [Discord server](https://discord.com/invite/uTfNwwecCQ) 💬⏰
 
 ## 📊 Data access/visualization
 

--- a/scrollprize.org/docs/25_submissions_closed.md
+++ b/scrollprize.org/docs/25_submissions_closed.md
@@ -50,7 +50,7 @@ We have accelerated progress on this amazing research problem, and we will read 
 
 Vesuvius Challenge is not over.
 Along with Grand Prize results, we will soon announce the next stages.
-For now, please stay engaged in our [community on Discord](https://discord.gg/V4fJhvtaQn), where discussion and exploration are ongoing.
+For now, please stay engaged in our [community on Discord](https://discord.com/invite/uTfNwwecCQ), where discussion and exploration are ongoing.
 The [datasets](data) will also remain available on our data server.
 
 Happy New Year to all, and let's make 2024 as incredible as 2023!

--- a/scrollprize.org/docs/26_grandprize.md
+++ b/scrollprize.org/docs/26_grandprize.md
@@ -151,7 +151,7 @@ Of the remaining submissions, the scores from our team of papyrologists identify
   <figcaption className="mt-[-6px]">Louis Schlessinger and Arefeh Sherafati. <a href="https://github.com/lschlessinger1/vesuvius-grand-prize-submission">GitHub</a></figcaption>
 </div>
 
-These teams each brought to the table new approaches to the subtleties of ink labeling and sampling. Be sure to check out their methods at the links above. Other teams may also now choose to share their approaches, so be sure to follow our [Discord community](https://discord.gg/UtCXDCe4) for updates. Joining our community also provides access to the CT data and more images under our data agreement, as well as a front-row seat to daily discovery and collaboration!
+These teams each brought to the table new approaches to the subtleties of ink labeling and sampling. Be sure to check out their methods at the links above. Other teams may also now choose to share their approaches, so be sure to follow our [Discord community](https://discord.com/invite/uTfNwwecCQ) for updates. Joining our community also provides access to the CT data and more images under our data agreement, as well as a front-row seat to daily discovery and collaboration!
 
 ## What does the scroll say?
 

--- a/scrollprize.org/docs/28_2024_prizes.md
+++ b/scrollprize.org/docs/28_2024_prizes.md
@@ -51,7 +51,7 @@ This year, the community goal is to read 90% of our scanned scrolls. There are a
 * 4 x \$60,000 - **[First Letters and First Title Prizes](#3-first-letters-prizes--first-title-prize)** - Find the title of Scroll 1, or first letters in Scrolls 2, 3, or 4
 * \$350,000 - **[Monthly Progress Prizes](#monthly-progress-prizes)** - Open ended prizes from \$1,000-20,000
 
-Details below! This is a lot of information, and we want to help - bring your questions to our [Discord community](https://discord.gg/V4fJhvtaQn) or to [our team](mailto:team@scrollprize.org).
+Details below! This is a lot of information, and we want to help - bring your questions to our [Discord community](https://discord.com/invite/uTfNwwecCQ) or to [our team](mailto:team@scrollprize.org).
 
 ## 2024 Grand Prize
 

--- a/scrollprize.org/docs/34_prizes.md
+++ b/scrollprize.org/docs/34_prizes.md
@@ -1,7 +1,7 @@
 ---
 id: prizes
 title: "New Year, New Prizes"
-sidebar_label: "Prizes"
+sidebar_label: "2025 Prizes"
 hide_table_of_contents: true
 ---
 


### PR DESCRIPTION
i created a new permalink with hope that it will resolve expired links. i did not find that link to be expired, but it would be a strange thing for a person to report if it were not true. also added 2025 before prizes to make it a bit more clear these are new prizes 