### PR TITLE
Update configuration.py

### DIFF
--- a/segmentation/models/arch/nnunet/nnunetv2/configuration.py
+++ b/segmentation/models/arch/nnunet/nnunetv2/configuration.py
@@ -4,7 +4,7 @@ from nnunetv2.utilities.default_n_proc_DA import get_allowed_n_proc_DA
 
 default_num_processes = 8 if 'nnUNet_def_n_proc' not in os.environ else int(os.environ['nnUNet_def_n_proc'])
 
-ANISO_THRESHOLD = 3  # determines when a sample is considered anisotropic (3 means that the spacing in the low
-# resolution axis must be 3x as large as the next largest spacing)
+ANISO_THRESHOLD = 5  # determines when a sample is considered anisotropic (5 means that the spacing in the low
+# resolution axis must be 5x as large as the next largest spacing), the default value was 3
 
 default_n_proc_DA = get_allowed_n_proc_DA()


### PR DESCRIPTION
Allow to process in 3D patch sizes of size `[min_dim, max_dim, max_dim]` such that` `max_dim/min_dim > ANISO_THRESHOLD`. For instance, if `ANISO_THRESHOLD = 3`,  and `patch_size = (64,256,256)`

https://github.com/ScrollPrize/villa/blob/eefa68db0a9bfc8903644f48f2da6fbeafc740ed/segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py#L486 sets the `do_dummy_2d_data_aug` to `True` and then the 3D dataloader does no longer work.