### PR TITLE
Small corrections for Segmentation page (Docker file name and Docker image name)

### DIFF
--- a/scrollprize.org/docs/35_segmentation.md
+++ b/scrollprize.org/docs/35_segmentation.md
@@ -86,7 +86,7 @@ Move into the directory you have cloned the repo into, and then install the imag
 
 ```bash
 cd volume-cartographer-dev-next
-sudo docker build -f ubuntu-22.04-jammy.Dockerfile -t vc3d3 .
+sudo docker build -f ubuntu-24.04-noble.Dockerfile -t vc3d .
 ```
 
 **Launch VC3D**


### PR DESCRIPTION
- Fix Docker file name (guide mentions Ubuntu 24.04 but uses 22.04)
- Fix incorrect Docker image name