### PR TITLE
Support locally weighting direction field losses

### DIFF
--- a/volume-cartographer/core/include/vc/tracer/Tracer.hpp
+++ b/volume-cartographer/core/include/vc/tracer/Tracer.hpp
@@ -1,12 +1,14 @@
 #pragma once
 #include "vc/core/util/Surface.hpp"
 
+struct Chunked3dFloatFromUint8;
 struct Chunked3dVec3fFromUint8;
 
 struct DirectionField
 {
     std::string direction;
     std::unique_ptr<Chunked3dVec3fFromUint8> field_ptr;
+    std::unique_ptr<Chunked3dFloatFromUint8> weight_ptr;
 };
 
 QuadSurface *grow_surf_from_surfs(SurfaceMeta *seed, const std::vector<SurfaceMeta*> &surfs_v, const nlohmann::json &params, float voxelsize = 1.0);

--- a/volume-cartographer/core/src/GrowPatch.cpp
+++ b/volume-cartographer/core/src/GrowPatch.cpp
@@ -225,15 +225,15 @@ int gen_direction_loss(ceres::Problem &problem, const cv::Vec2i &p, const int of
         if (field.direction == "horizontal") {
             if (!loc_valid(state(p_off_horz)))
                 continue;
-            problem.AddResidualBlock(FiberDirectionLoss::Create(*field.field_ptr, w), nullptr, &loc(p)[0], &loc(p_off_horz)[0]);
+            problem.AddResidualBlock(FiberDirectionLoss::Create(*field.field_ptr, field.weight_ptr.get(), w), nullptr, &loc(p)[0], &loc(p_off_horz)[0]);
         } else if (field.direction == "vertical") {
             if (!loc_valid(state(p_off_vert)))
                 continue;
-            problem.AddResidualBlock(FiberDirectionLoss::Create(*field.field_ptr, w), nullptr, &loc(p)[0], &loc(p_off_vert)[0]);
+            problem.AddResidualBlock(FiberDirectionLoss::Create(*field.field_ptr, field.weight_ptr.get(), w), nullptr, &loc(p)[0], &loc(p_off_vert)[0]);
         } else if (field.direction == "normal") {
             if (!loc_valid(state(p_off_horz)) || !loc_valid(state(p_off_vert)))
                 continue;
-            problem.AddResidualBlock(NormalDirectionLoss::Create(*field.field_ptr, w), nullptr, &loc(p)[0], &loc(p_off_horz)[0], &loc(p_off_vert)[0]);
+            problem.AddResidualBlock(NormalDirectionLoss::Create(*field.field_ptr, field.weight_ptr.get(), w), nullptr, &loc(p)[0], &loc(p_off_horz)[0], &loc(p_off_vert)[0]);
         } else {
             assert(false);
         }


### PR DESCRIPTION
- adds another entry to `direction_fields` json specifying a [0,255]-valued zarr to be used to weight the corresponding direction loss at each point