### PR TITLE
Remove the unused pen tool and segmentation tool buttons from gui

### DIFF
--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -49,48 +49,6 @@
         <number>0</number>
        </property>
        <item>
-        <layout class="QHBoxLayout" name="toolButtonLayout">
-         <item>
-          <widget class="QPushButton" name="btnSegTool">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Segmentation Tool</string>
-           </property>
-           <property name="icon">
-            <iconset theme="format-justify-fill"/>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="btnPenTool">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Pen Tool</string>
-           </property>
-           <property name="icon">
-            <iconset theme="edit-find-replace"/>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
         <layout class="QVBoxLayout" name="viewerLayout">
          <item>
           <widget class="QTabWidget" name="tabWidget">


### PR DESCRIPTION
The buttons aren't used for anything. I confirmed using grep. So the buttons widgets were removed. Also the layout and surrounding item containers were removed as well to avoid leaving empty ui elements.
<img width="722" height="498" alt="everythingworks" src="https://github.com/user-attachments/assets/e3b91ae5-0640-43a6-9cb2-e9205684bf98" />

