### PR TITLE
normalize the flattened segment image to 0 - 255 before rendering

### DIFF
--- a/volume-cartographer/apps/VC3D/CVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/CVolumeViewer.cpp
@@ -913,8 +913,6 @@ cv::Mat CVolumeViewer::render_area(const cv::Rect &roi)
             accumulator /= count;
         }
         accumulator.convertTo(img, CV_8U);
-        
-        return img;
     }
     else {
         // Standard single-slice rendering
@@ -933,8 +931,9 @@ cv::Mat CVolumeViewer::render_area(const cv::Rect &roi)
         }
 
         readInterpolated3D(img, volume->zarrDataset(_ds_sd_idx), coords*_ds_scale, cache, _useFastInterpolation);
-        return img;
     }
+    cv::normalize(img, img, 0, 255, cv::NORM_MINMAX, CV_8U);
+    return img;
 }
 
 class LifeTime


### PR DESCRIPTION
david was seeing a case where he has a volume of labels, say values 0 1 2 and 3, and they all look black in the viewer. this stretches the output image to use the entire 0 - 255 range.

I'll merge if David confirms this fixes the issue