### PR TITLE
accurate mesh area calculation and recalculate button

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.hpp
+++ b/volume-cartographer/apps/VC3D/CWindow.hpp
@@ -71,6 +71,7 @@ public slots:
     void onVoxelizePaths();
    void onFocusPOIChanged(std::string name, POI* poi);
     void onPointDoubleClicked(uint64_t pointId);
+    void onRecalculateAreaFromMaskSelected();  // Recalc area for currently selected items
 
 public:
     CWindow();
@@ -128,6 +129,8 @@ private:
 
     void setVolume(std::shared_ptr<Volume> newvol);
 
+    void recalcAreaForSegments(const std::vector<std::string>& ids);
+
 private slots:
     void Open(void);
     void Open(const QString& path);
@@ -153,6 +156,7 @@ private slots:
     void onCopyCoordinates();
     void onImportObjAsPatches();
     void onAxisAlignedSlicesToggled(bool enabled);
+    
 
 private:
     bool appInitComplete{false};
@@ -188,6 +192,7 @@ private:
     QAction* fReportingAct;
     QAction* fVoxelizePathsAct;
     QAction* fDrawBBoxAct;
+    QAction* fRecalcAreaFromMaskAct = nullptr;
     QAction* fSelectionSurfaceFromAct;
     QAction* fSelectionClearAct;
     QAction* fInpaintTeleaAct = nullptr;


### PR DESCRIPTION
- accurate mesh area calculation from triangulation of quadmesh, both in GrowPatch.cpp and GrowSurface.cpp
- introduce the Recalculate area from mask GUI button wanted by @skyward7187 , unfortunately, I noticed that it is producing inaccurate results if the UV map is not properly flattened. Can't spot the bug, but I recommend to flatten with SLIM before calculating area