### PR TITLE
add option to paint invalid regions on seg window

### DIFF
--- a/volume-cartographer/apps/VC3D/SegmentationEditManager.hpp
+++ b/volume-cartographer/apps/VC3D/SegmentationEditManager.hpp
@@ -43,6 +43,10 @@ public:
     [[nodiscard]] int holeSearchRadius() const { return _holeSearchRadius; }
     [[nodiscard]] int holeSmoothIterations() const { return _holeSmoothIterations; }
     [[nodiscard]] bool hasPendingChanges() const { return _dirty; }
+    [[nodiscard]] const cv::Mat_<cv::Vec3f>& previewPoints() const;
+    bool setPreviewPoints(const cv::Mat_<cv::Vec3f>& points,
+                          bool dirtyState);
+    bool invalidateRegion(int centerRow, int centerCol, int radius);
 
     void resetPreview();
     void applyPreview();

--- a/volume-cartographer/apps/VC3D/SegmentationModule.hpp
+++ b/volume-cartographer/apps/VC3D/SegmentationModule.hpp
@@ -205,6 +205,20 @@ private:
     void onCorrectionsCollectionSelected(uint64_t id);
     void onCorrectionsAnnotateToggled(bool enabled);
     void onCorrectionsZRangeChanged(bool enabled, int zMin, int zMax);
+    void onMaskEditingToggled(bool active);
+    void onMaskApplyRequested();
+    void setMaskSampling(int step);
+    void setMaskBrushRadius(int radius);
+    bool beginMaskEditing();
+    void cancelMaskEditing(bool silent = false);
+    void handleMaskErase(const cv::Vec3f& worldPos);
+    void updateMaskOverlay();
+    void clearMaskOverlay();
+    void updateMaskUi();
+    [[nodiscard]] std::optional<cv::Vec3f> maskWorldForCell(int row,
+                                                            int col,
+                                                            const cv::Mat_<cv::Vec3f>& preview) const;
+    [[nodiscard]] static bool maskCellInvalid(const cv::Vec3f& point);
 
     SegmentationWidget* _widget{nullptr};
     SegmentationEditManager* _editManager{nullptr};
@@ -244,4 +258,15 @@ private:
     bool _cursorValid{false};
     bool _growthInProgress{false};
     CVolumeViewer* _cursorViewer{nullptr};
+    bool _maskEditingActive{false};
+    bool _maskDirty{false};
+    bool _maskOriginalDirty{false};
+    bool _maskHasOriginal{false};
+    bool _maskStrokeActive{false};
+    cv::Mat_<cv::Vec3f> _maskOriginalPoints;
+    std::vector<cv::Vec3f> _maskOverlayPoints;
+    float _maskOverlayRadius{4.0f};
+    int _maskSamplingStep{2};
+    int _maskBrushRadius{3};
+    std::optional<std::pair<int, int>> _maskLastCell;
 };

--- a/volume-cartographer/apps/VC3D/SegmentationWidget.hpp
+++ b/volume-cartographer/apps/VC3D/SegmentationWidget.hpp
@@ -44,6 +44,8 @@ public:
     [[nodiscard]] bool handlesAlwaysVisible() const { return _handlesAlwaysVisible; }
     [[nodiscard]] float handleDisplayDistance() const { return _handleDisplayDistance; }
     [[nodiscard]] bool fillInvalidRegions() const { return _fillInvalidRegions; }
+    [[nodiscard]] int maskSampling() const { return _maskSampling; }
+    [[nodiscard]] int maskBrushRadius() const { return _maskBrushRadius; }
     [[nodiscard]] SegmentationGrowthMethod growthMethod() const { return _growthMethod; }
     [[nodiscard]] std::vector<SegmentationGrowthDirection> allowedGrowthDirections() const;
 
@@ -82,6 +84,10 @@ public slots:
     void setHandlesAlwaysVisible(bool value);
     void setHandleDisplayDistance(float value);
     void setFillInvalidRegions(bool value);
+    void setMaskEditingActive(bool active);
+    void setMaskApplyEnabled(bool enabled);
+    void setMaskSampling(int value);
+    void setMaskBrushRadius(int value);
 
 signals:
     void editingModeChanged(bool enabled);
@@ -110,6 +116,10 @@ signals:
     void correctionsCreateRequested();
     void correctionsZRangeChanged(bool enabled, int zMin, int zMax);
     void volumeSelectionChanged(const QString& volumeId);
+    void maskEditingToggled(bool active);
+    void maskApplyRequested();
+    void maskSamplingChanged(int value);
+    void maskBrushRadiusChanged(int value);
 
 private:
     void setupUI();
@@ -122,10 +132,10 @@ private:
     void updateGrowthDirectionMaskFromUi(QCheckBox* changedCheckbox);
     void applyGrowthDirectionMaskToUi();
     static int normalizeGrowthDirectionMask(int mask);
-
     QCheckBox* _chkEditing;
     QLabel* _editingStatus;
     QGroupBox* _groupGrowth;
+    QGroupBox* _groupMasking;
     QGroupBox* _groupSampling;
     QSpinBox* _spinDownsample;
     QSpinBox* _spinRadius;
@@ -155,6 +165,10 @@ private:
     QCheckBox* _chkGrowthDirDown;
     QCheckBox* _chkGrowthDirLeft;
     QCheckBox* _chkGrowthDirRight;
+    QPushButton* _btnMaskEdit;
+    QPushButton* _btnMaskApply;
+    QSpinBox* _spinMaskSampling;
+    QSpinBox* _spinMaskRadius;
     class QComboBox* _comboVolume;
     QGroupBox* _groupCorrections;
     class QComboBox* _comboCorrections;
@@ -182,6 +196,10 @@ private:
     float _highlightDistance = 15.0f;      // screen-space pixels
     bool _fillInvalidRegions = true;
     bool _hasPendingChanges = false;
+    bool _maskEditingActive = false;
+    bool _maskApplyEnabled = false;
+    int _maskSampling = 2;
+    int _maskBrushRadius = 3;
     SegmentationGrowthMethod _growthMethod{SegmentationGrowthMethod::Corrections};
     SegmentationGrowthDirection _growthDirection{SegmentationGrowthDirection::All};
     int _growthSteps{5};

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
@@ -96,6 +96,19 @@ void SegmentationOverlayController::collectPrimitives(CVolumeViewer* viewer,
         return;
     }
 
+    const bool segmentationView = viewer->surfName() == "segmentation";
+    if (_maskOverlayVisible && segmentationView && !_maskOverlayPoints.empty()) {
+        ViewerOverlayControllerBase::PathPrimitive maskPath;
+        maskPath.points = _maskOverlayPoints;
+        maskPath.renderMode = ViewerOverlayControllerBase::PathRenderMode::Points;
+        maskPath.brushShape = ViewerOverlayControllerBase::PathBrushShape::Square;
+        maskPath.pointRadius = _maskOverlayPointRadius;
+        maskPath.color = _maskOverlayColor;
+        maskPath.opacity = _maskOverlayOpacity;
+        maskPath.z = 60.0f;
+        builder.addPath(maskPath);
+    }
+
     if (!_handlesVisible) {
         return;
     }
@@ -381,5 +394,22 @@ void SegmentationOverlayController::setSliceDisplayMode(SegmentationSliceDisplay
         return;
     }
     _sliceDisplayMode = mode;
+    refreshAll();
+}
+
+void SegmentationOverlayController::setMaskOverlay(const std::vector<cv::Vec3f>& points,
+                                                   bool visible,
+                                                   float pointRadius,
+                                                   float opacity)
+{
+    _maskOverlayPointRadius = std::max(0.5f, pointRadius);
+    _maskOverlayOpacity = std::clamp(opacity, 0.0f, 1.0f);
+    if (!visible) {
+        _maskOverlayVisible = false;
+        _maskOverlayPoints.clear();
+    } else {
+        _maskOverlayVisible = !points.empty();
+        _maskOverlayPoints = points;
+    }
     refreshAll();
 }

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
@@ -32,6 +32,10 @@ public:
     void setCursorWorld(const cv::Vec3f& world, bool valid);
     void setSliceFadeDistance(float distance);
     void setSliceDisplayMode(SegmentationSliceDisplayMode mode);
+    void setMaskOverlay(const std::vector<cv::Vec3f>& points,
+                        bool visible,
+                        float pointRadius,
+                        float opacity);
 
 private slots:
     void onSurfaceChanged(std::string name, Surface* surf);
@@ -57,4 +61,9 @@ private:
     cv::Vec3f _cursorWorld{0.0f, 0.0f, 0.0f};
     float _sliceFadeDistance{10.0f};
     SegmentationSliceDisplayMode _sliceDisplayMode{SegmentationSliceDisplayMode::Fade};
+    bool _maskOverlayVisible{false};
+    std::vector<cv::Vec3f> _maskOverlayPoints;
+    float _maskOverlayPointRadius{4.0f};
+    float _maskOverlayOpacity{0.35f};
+    QColor _maskOverlayColor{QColor(255, 140, 0)};
 };


### PR DESCRIPTION
does not use mask files , edits the current editing surface and marks grids as invalid , then uses this edited surf on tracer() call