### PR TITLE
Patch inpaint

### DIFF
--- a/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
+++ b/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
@@ -157,7 +157,8 @@ int main(int argc, char *argv[])
             ("resume", po::value<std::string>(), "Path to a tifxyz surface to resume from")
             ("rewind-gen", po::value<int>(), "Generation to rewind to")
             ("correct", po::value<std::string>(), "JSON file with point-based corrections for resume mode")
-            ("skip-overlap-check", "Do not perform overlap check with other surfaces after tracing.");
+            ("skip-overlap-check", "Do not perform overlap check with other surfaces after tracing")
+            ("inpaint", "perform automatic inpainting on all detected holes.");
 
         po::variables_map vm;
         try {
@@ -209,6 +210,10 @@ int main(int argc, char *argv[])
 
         if (vm.count("rewind-gen")) {
             params["rewind_gen"] = vm["rewind-gen"].as<int>();
+        }
+
+        if (vm.count("inpaint")) {
+            params["inpaint"] = true;
         }
 
         if (vm.count("skip-overlap-check")) {

--- a/volume-cartographer/core/src/GrowPatch.cpp
+++ b/volume-cartographer/core/src/GrowPatch.cpp
@@ -205,7 +205,7 @@ struct LossSettings {
 
     LossSettings() {
         w[LossType::SNAP] = 0.1f;
-        w[LossType::NORMAL] = 1.0f;
+        w[LossType::NORMAL] = 10.0f;
         w[LossType::STRAIGHT] = 0.2f;
         w[LossType::DIST] = 1.0f;
         w[LossType::DIRECTION] = 1.0f;

--- a/volume-cartographer/core/src/GrowPatch.cpp
+++ b/volume-cartographer/core/src/GrowPatch.cpp
@@ -1487,12 +1487,11 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
                 local_optimization(radius, corr_center_i, trace_params, trace_data, loss_inpaint, false, true);
             }
 
-            if (!tgt_path.empty() && snapshot_interval > 0) {
-                QuadSurface* surf = create_surface_from_state();
-                surf->save(tgt_path.string()+"_s1", true);
-                delete surf;
-            }
-
+            // if (!tgt_path.empty() && snapshot_interval > 0) {
+            //     QuadSurface* surf = create_surface_from_state();
+            //     surf->save(tgt_path.string()+"_corr_stage1", true);
+            //     delete surf;
+            // }
 
             for (const auto& opt_params : opt_centers) {
                 LossSettings loss_inpaint = loss_settings;
@@ -1502,11 +1501,11 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
                 local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_inpaint, false, true);
             }
 
-            if (!tgt_path.empty() && snapshot_interval > 0) {
-                QuadSurface* surf = create_surface_from_state();
-                surf->save(tgt_path.string()+"_s2", true);
-                delete surf;
-            }
+            // if (!tgt_path.empty() && snapshot_interval > 0) {
+            //     QuadSurface* surf = create_surface_from_state();
+            //     surf->save(tgt_path.string()+"_corr_stage2", true);
+            //     delete surf;
+            // }
 
             for (const auto& opt_params : opt_centers) {
                 LossSettings loss_inpaint = loss_settings;
@@ -1515,36 +1514,20 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
                 local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_inpaint, false, true);
             }
 
-            if (!tgt_path.empty() && snapshot_interval > 0) {
-                QuadSurface* surf = create_surface_from_state();
-                surf->save(tgt_path.string()+"_s3", true);
-                delete surf;
-            }
+            // if (!tgt_path.empty() && snapshot_interval > 0) {
+            //     QuadSurface* surf = create_surface_from_state();
+            //     surf->save(tgt_path.string()+"_corr_stage3", true);
+            //     delete surf;
+            // }
 
             for (const auto& opt_params : opt_centers) {
                 local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_settings, false, true);
             }
 
-            if (!tgt_path.empty() && snapshot_interval > 0) {
-                QuadSurface* surf = create_surface_from_state();
-                surf->save(tgt_path.string()+"_s4", true);
-                delete surf;
-            }
-
-
-            // for (const auto& opt_params : opt_centers)
-                // local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_settings, false, true);
-
             // if (!tgt_path.empty() && snapshot_interval > 0) {
             //     QuadSurface* surf = create_surface_from_state();
-            //     surf->save(tgt_path.string()+"_s3", true);
+            //     surf->save(tgt_path.string()+"_corr_stage4", true);
             //     delete surf;
-            // }
-
-            // trace_data.point_correction = PointCorrection();
-
-            // for (const auto& opt_params : opt_centers) {
-            //     local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_settings, false, true);
             // }
 
             if (!tgt_path.empty() && snapshot_interval > 0) {

--- a/volume-cartographer/core/src/GrowPatch.cpp
+++ b/volume-cartographer/core/src/GrowPatch.cpp
@@ -856,7 +856,147 @@ static int add_missing_losses(ceres::Problem &problem, cv::Mat_<uint16_t> &loss_
 }
 
 
+template <typename T>
+void masked_blur(cv::Mat_<T>& img, const cv::Mat_<uchar>& mask) {
+    cv::Mat_<T> fw_pass = img.clone();
+    cv::Mat_<T> bw_pass = img.clone();
+
+    // Initial forward pass (top-left neighbors)
+    for (int y = 1; y < img.rows; ++y) {
+        for (int x = 1; x < img.cols - 1; ++x) {
+            if (mask(y, x) == 0) {
+                T val = (fw_pass(y - 1, x) + fw_pass(y, x - 1) + fw_pass(y - 1, x - 1) + fw_pass(y - 1, x + 1)) * 0.25;
+                fw_pass(y, x) = val;
+            }
+        }
+    }
+
+    // Initial backward pass (bottom-right neighbors)
+    for (int y = img.rows - 2; y >= 0; --y) {
+        for (int x = img.cols - 2; x >= 1; --x) {
+            if (mask(y, x) == 0) {
+                T val = (bw_pass(y + 1, x) + bw_pass(y, x + 1) + bw_pass(y + 1, x + 1) + bw_pass(y + 1, x - 1)) * 0.25;
+                bw_pass(y, x) = val;
+            }
+        }
+    }
+
+    // Average initial passes
+    for (int y = 0; y < img.rows; ++y) {
+        for (int x = 0; x < img.cols; ++x) {
+            if (mask(y, x) == 0) {
+                img(y, x) = (fw_pass(y, x) + bw_pass(y, x)) * 0.5;
+            }
+        }
+    }
+
+    // 4 additional passes
+    for (int i = 0; i < 4; ++i) {
+        // Forward pass
+        for (int y = 1; y < img.rows; ++y) {
+            for (int x = 1; x < img.cols - 1; ++x) {
+                if (mask(y, x) == 0) {
+                    T val = (img(y, x) + img(y - 1, x) + img(y, x - 1) + img(y - 1, x - 1) + img(y - 1, x + 1)) * 0.2;
+                    img(y, x) = val;
+                }
+            }
+        }
+        // Backward pass
+        for (int y = img.rows - 2; y >= 0; --y) {
+            for (int x = img.cols - 2; x >= 1; --x) {
+                if (mask(y, x) == 0) {
+                    T val = (img(y, x) + img(y + 1, x) + img(y, x + 1) + img(y + 1, x + 1) + img(y + 1, x - 1)) * 0.2;
+                    img(y, x) = val;
+                }
+            }
+        }
+    }
+}
+
+static void local_optimization(const cv::Rect &roi, const cv::Mat_<uchar> &mask, TraceParameters &params, const TraceData &trace_data, LossSettings &settings, int flags);
+
 //optimize within a radius, setting edge points to constant
+static void inpaint(const cv::Rect &roi, const cv::Mat_<uchar> &mask, TraceParameters &params, const TraceData &trace_data)
+{
+    // check that a two pixel border is 1
+    for (int y = 0; y < roi.height; ++y) {
+        for (int x = 0; x < roi.width; ++x) {
+            if (y < 2 || y >= roi.height - 2 || x < 2 || x >= roi.width - 2) {
+                if (mask(y, x) == 0) {
+                    throw std::runtime_error("Mask border is not 1");
+                }
+            }
+        }
+    }
+
+    cv::Mat_<cv::Vec3d> dpoints_roi = params.dpoints(roi);
+    masked_blur(dpoints_roi, mask);
+
+    ceres::Problem problem;
+    LossSettings settings;
+    settings[DIST] = 1.0;
+    settings[STRAIGHT] = 1.0;
+
+    for (int y = 0; y < roi.height; ++y) {
+        for (int x = 0; x < roi.width; ++x) {
+            if (!mask(y, x)) {
+                params.state(roi.y + y, roi.x + x) = STATE_LOC_VALID | STATE_COORD_VALID;
+            }
+        }
+    }
+
+    LossSettings base;
+    base[NORMAL] = 10.0;
+    LossSettings nosnap = base;
+    nosnap[SNAP] = 0;
+    local_optimization(roi, mask, params, trace_data, nosnap, LOSS_DIST | LOSS_STRAIGHT);
+    local_optimization(roi, mask, params, trace_data, nosnap, LOSS_DIST | LOSS_STRAIGHT | LOSS_NORMALSNAP);
+
+    LossSettings lowsnap = base;
+    lowsnap[SNAP] = 0.01*base[SNAP];
+    local_optimization(roi, mask, params, trace_data, lowsnap, LOSS_DIST | LOSS_STRAIGHT | LOSS_NORMALSNAP);
+    lowsnap[SNAP] = 0.1*base[SNAP];
+    local_optimization(roi, mask, params, trace_data, lowsnap, LOSS_DIST | LOSS_STRAIGHT | LOSS_NORMALSNAP);
+    lowsnap[SNAP] = base[SNAP];
+    local_optimization(roi, mask, params, trace_data, lowsnap, LOSS_DIST | LOSS_STRAIGHT | LOSS_NORMALSNAP);
+    LossSettings default_settings;
+    local_optimization(roi, mask, params, trace_data, default_settings, LOSS_DIST | LOSS_STRAIGHT | LOSS_NORMALSNAP);
+}
+
+
+//optimize within a radius, setting edge points to constant
+static void local_optimization(const cv::Rect &roi, const cv::Mat_<uchar> &mask, TraceParameters &params, const TraceData &trace_data, LossSettings &settings, int flags)
+{
+    ceres::Problem problem;
+
+    for (int y = 2; y < roi.height - 2; ++y) {
+        for (int x = 2; x < roi.width - 2; ++x) {
+            // if (!mask(y, x)) {
+                add_losses(problem, {roi.y + y, roi.x + x}, params, trace_data, settings, flags);
+            // }
+        }
+    }
+
+    for (int y = 0; y < roi.height; ++y) {
+        for (int x = 0; x < roi.width; ++x) {
+            if (mask(y, x) && problem.HasParameterBlock(&params.dpoints.at<cv::Vec3d>(roi.y + y, roi.x + x)[0])) {
+                problem.SetParameterBlockConstant(&params.dpoints.at<cv::Vec3d>(roi.y + y, roi.x + x)[0]);
+            }
+        }
+    }
+
+    ceres::Solver::Options options;
+    options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
+    options.max_num_iterations = 10000;
+    // options.minimizer_progress_to_stdout = true;
+    ceres::Solver::Summary summary;
+    ceres::Solve(options, &problem, &summary);
+
+    // std::cout << "inpaint solve " << summary.BriefReport() << std::endl;
+
+    // cv::imwrite("opt_mask.tif", mask);
+}
+
 static float local_optimization(int radius, const cv::Vec2i &p, TraceParameters &params,
     TraceData& trace_data, LossSettings &settings, bool quiet = false, bool parallel = false)
 {
@@ -1062,7 +1202,20 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
 
     int w, h;
     if (resume_surf) {
-        cv::Mat resume_generations = resume_surf->channel("generations");
+        cv::Mat_<uint16_t> resume_generations = resume_surf->channel("generations");
+        if (resume_generations.empty()) {
+            cv::Mat_<cv::Vec3f> resume_points = resume_surf->rawPoints();
+            resume_generations = cv::Mat_<uint16_t>(resume_points.size(), (uint16_t)0);
+
+            for (int j = 0; j < resume_points.rows; ++j) {
+                for (int i = 0; i < resume_points.cols; ++i) {
+                    if (resume_points(j,i)[0] != -1) {
+                        resume_generations(j,i) = 1;
+                    }
+                }
+            }
+            resume_surf->setChannel("generations", resume_generations);
+        }
         double min_val, max_val;
         cv::minMaxLoc(resume_generations, &min_val, &max_val);
         int start_gen = (rewind_gen == -1) ? static_cast<int>(max_val) : rewind_gen;
@@ -1204,6 +1357,10 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
     int loss_count = 0;
     double last_elapsed_seconds = 0.0;
     int last_succ = 0;
+    int start_gen = 0;
+
+    int resume_pad_y = 0;
+    int resume_pad_x = 0;
 
     std::cout << "lets go! " << std::endl;
 
@@ -1215,16 +1372,16 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
         }
 
         cv::Mat_<cv::Vec3f> resume_points = resume_surf->rawPoints();
-        cv::Mat resume_generations = resume_surf->channel("generations");
+        cv::Mat_<uint16_t> resume_generations = resume_surf->channel("generations");
 
-        int pad_x = (w - resume_points.cols) / 2;
-        int pad_y = (h - resume_points.rows) / 2;
+        resume_pad_x = (w - resume_points.cols) / 2;
+        resume_pad_y = (h - resume_points.rows) / 2;
 
-        used_area = cv::Rect(pad_x, pad_y, resume_points.cols, resume_points.rows);
+        used_area = cv::Rect(resume_pad_x, resume_pad_y, resume_points.cols, resume_points.rows);
  
         double min_val, max_val;
         cv::minMaxLoc(resume_generations, &min_val, &max_val);
-        int start_gen = (rewind_gen == -1) ? static_cast<int>(max_val) : rewind_gen;
+        start_gen = (rewind_gen == -1) ? static_cast<int>(max_val) : rewind_gen;
         generation = start_gen;
 
         int min_gen = std::numeric_limits<int>::max();
@@ -1232,8 +1389,8 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
         y0 = -1;
         for (int j = 0; j < resume_points.rows; ++j) {
             for (int i = 0; i < resume_points.cols; ++i) {
-                int target_y = pad_y + j;
-                int target_x = pad_x + i;
+                int target_y = resume_pad_y + j;
+                int target_x = resume_pad_x + i;
                 uint16_t gen = resume_generations.at<uint16_t>(j, i);
                 if (gen > 0 && gen <= start_gen && resume_points(j,i)[0] != -1) {
                     trace_params.dpoints(target_y, target_x) = resume_points(j, i);
@@ -1276,9 +1433,9 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
 
                 for (int j = 0; j < mask.rows; ++j) {
                     for (int i = 0; i < mask.cols; ++i) {
-                        if (mask.at<uint8_t>(j, i) == 0 && trace_params.state(pad_y + j, pad_x + i)) {
-                            int target_y = pad_y + j;
-                            int target_x = pad_x + i;
+                        if (mask.at<uint8_t>(j, i) == 0 && trace_params.state(resume_pad_y + j, resume_pad_x + i)) {
+                            int target_y = resume_pad_y + j;
+                            int target_x = resume_pad_x + i;
                             cv::Point2f p(target_x, target_y);
                             bool keep = false;
                             for (const auto& hull : all_hulls) {
@@ -1324,25 +1481,78 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
 
                 std::cout << "correction opt centered at " << avg_loc << " with radius " << radius << std::endl;
                 LossSettings loss_inpaint = loss_settings;
-                loss_inpaint[SNAP] = 0.0;
+                loss_inpaint[SNAP] *= 0.01;
                 loss_inpaint[DIST] *= 0.1;
+                loss_inpaint[STRAIGHT] *= 10.0;
                 local_optimization(radius, corr_center_i, trace_params, trace_data, loss_inpaint, false, true);
-                loss_inpaint[SNAP] = 0.01;
-                local_optimization(radius, corr_center_i, trace_params, trace_data, loss_inpaint, false, true);
-                loss_inpaint[SNAP] = 0.05;
-                local_optimization(radius, corr_center_i, trace_params, trace_data, loss_inpaint, false, true);
-                local_optimization(radius, corr_center_i, trace_params, trace_data, loss_settings, false, true);
-                local_optimization(radius, corr_center_i, trace_params, trace_data, loss_settings, false, true);
             }
 
-            trace_data.point_correction = PointCorrection();
+            if (!tgt_path.empty() && snapshot_interval > 0) {
+                QuadSurface* surf = create_surface_from_state();
+                surf->save(tgt_path.string()+"_s1", true);
+                delete surf;
+            }
+
+
+            for (const auto& opt_params : opt_centers) {
+                LossSettings loss_inpaint = loss_settings;
+                loss_inpaint[SNAP] *= 0.1;
+                loss_inpaint[DIST] *= 0.1;
+                loss_inpaint[STRAIGHT] *= 10.0;
+                local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_inpaint, false, true);
+            }
+
+            if (!tgt_path.empty() && snapshot_interval > 0) {
+                QuadSurface* surf = create_surface_from_state();
+                surf->save(tgt_path.string()+"_s2", true);
+                delete surf;
+            }
 
             for (const auto& opt_params : opt_centers) {
                 LossSettings loss_inpaint = loss_settings;
                 loss_inpaint[DIST] *= 0.1;
+                loss_inpaint[STRAIGHT] *= 10.0;
                 local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_inpaint, false, true);
             }
 
+            if (!tgt_path.empty() && snapshot_interval > 0) {
+                QuadSurface* surf = create_surface_from_state();
+                surf->save(tgt_path.string()+"_s3", true);
+                delete surf;
+            }
+
+            for (const auto& opt_params : opt_centers) {
+                local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_settings, false, true);
+            }
+
+            if (!tgt_path.empty() && snapshot_interval > 0) {
+                QuadSurface* surf = create_surface_from_state();
+                surf->save(tgt_path.string()+"_s4", true);
+                delete surf;
+            }
+
+
+            // for (const auto& opt_params : opt_centers)
+                // local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_settings, false, true);
+
+            // if (!tgt_path.empty() && snapshot_interval > 0) {
+            //     QuadSurface* surf = create_surface_from_state();
+            //     surf->save(tgt_path.string()+"_s3", true);
+            //     delete surf;
+            // }
+
+            // trace_data.point_correction = PointCorrection();
+
+            // for (const auto& opt_params : opt_centers) {
+            //     local_optimization(opt_params.radius, opt_params.center, trace_params, trace_data, loss_settings, false, true);
+            // }
+
+            if (!tgt_path.empty() && snapshot_interval > 0) {
+                QuadSurface* surf = create_surface_from_state();
+                surf->save(tgt_path, true);
+                delete surf;
+                std::cout << "saved snapshot in " << tgt_path << std::endl;
+            }
         }
 
         // Rebuild fringe from valid points
@@ -1392,6 +1602,91 @@ QuadSurface *tracer(z5::Dataset *ds, float scale, ChunkCache *cache, cv::Vec3f o
     //just continue on resume no additional global opt	
     if (!resume_surf) {
         local_optimization(8, {y0,x0}, trace_params, trace_data, loss_settings, true);
+    } else if (params.value("inpaint", true)) {
+        cv::Mat mask = resume_surf->channel("mask");
+        cv::Mat_<uchar> hole_mask(trace_params.state.size(), (uchar)0);
+        
+        cv::Mat active_area_mask(trace_params.state.size(), (uchar)0);
+        for (int y = 0; y < trace_params.state.rows; ++y) {
+            for (int x = 0; x < trace_params.state.cols; ++x) {
+                if (trace_params.state(y, x) & STATE_LOC_VALID) {
+                    active_area_mask.at<uchar>(y, x) = 255;
+                }
+            }
+        }
+
+        if (!mask.empty()) {
+            cv::Mat padded_mask = cv::Mat::zeros(trace_params.state.size(), CV_8U);
+            mask.copyTo(padded_mask(used_area));
+            cv::bitwise_and(active_area_mask, padded_mask, hole_mask);
+        } else {
+            active_area_mask.copyTo(hole_mask);
+        }
+
+        std::vector<std::vector<cv::Point>> contours;
+        std::vector<cv::Vec4i> hierarchy;
+        cv::findContours(hole_mask, contours, hierarchy, cv::RETR_CCOMP, cv::CHAIN_APPROX_SIMPLE);
+
+        std::cout << "performing inpaint on " << contours.size() << " potential holes" << std::endl;
+
+        int inpaint_count = 0;
+        int inpaint_skip = 0;
+
+        // cv::Mat_<cv::Vec3b> vis(hole_mask.size());
+
+#pragma omp parallel for schedule(dynamic)
+        for (int i = 0; i < contours.size(); i++) {
+            if (hierarchy[i][3] != -1) { // It's a hole
+                cv::Rect roi = cv::boundingRect(contours[i]);
+                
+                int margin = 4;
+                roi.x = std::max(0, roi.x - margin);
+                roi.y = std::max(0, roi.y - margin);
+                roi.width = std::min(hole_mask.cols - roi.x, roi.width + 2 * margin);
+                roi.height = std::min(hole_mask.rows - roi.y, roi.height + 2 * margin);
+
+                // std::cout << hole_mask.size() << trace_params.state.size() << resume_pad_x << "x" << resume_pad_y << std::endl;
+
+                // cv::Point testp(2492+resume_pad_x, 508+resume_pad_y);
+                // cv::Point testp(2500+resume_pad_x, 566+resume_pad_y);
+                // cv::Point testp(2340+resume_pad_x, 577+resume_pad_y);
+
+                // cv::rectangle(vis, roi, cv::Scalar(255,255,255));
+
+                // if (!roi.contains(testp)) {
+                //     // std::cout << "skip " << roi << std::endl;
+                //     continue;
+                // }
+
+                cv::Mat_<uchar> inpaint_mask(roi.size(), (uchar)1);
+                
+                std::vector<cv::Point> hole_contour_roi;
+                for(const auto& p : contours[i]) {
+                    hole_contour_roi.push_back({p.x - roi.x, p.y - roi.y});
+                }
+                std::vector<std::vector<cv::Point>> contours_to_fill = {hole_contour_roi};
+                cv::fillPoly(inpaint_mask, contours_to_fill, cv::Scalar(0));
+
+                // std::cout << "Inpainting hole at " << roi << " - " << inpaint_count << "+" << inpaint_skip << "/" << contours.size() << std::endl;
+                inpaint(roi, inpaint_mask, trace_params, trace_data);
+
+#pragma omp critical
+                if (inpaint_count % snapshot_interval == 0 && !tgt_path.empty() && snapshot_interval > 0) {
+                    QuadSurface* surf = create_surface_from_state();
+                    surf->save(tgt_path, true);
+                    delete surf;
+                    std::cout << "saved snapshot in " << tgt_path << " (" << inpaint_count << "+" << inpaint_skip << "/" << contours.size() << ")" << std::endl;
+                }
+
+#pragma omp atomic
+                inpaint_count++;
+            }
+            else
+#pragma omp atomic
+                inpaint_skip++;
+        }
+
+        // cv::imwrite("vis_inp_rect.tif", vis);
     }
 
     // Prepare a new set of Ceres options used later during local solves


### PR DESCRIPTION
- add --inpaint to vc_grow_seg_from_seed - in combination with --resume performs automatic inpainting of all detected holes
- improves corrections issues by reducing correction point roi influence
- use inpaint tuned weights also for regular growing - seem induce way fewer sheet switches