### PR TITLE
Crop & Export button

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -1072,6 +1072,11 @@ void CWindow::CreateWidgets(void)
             this, [this](const QString& segmentId) {
                 onAWSUpload(segmentId.toStdString());
             });
+    connect(_surfacePanel.get(), &SurfacePanelController::exportTifxyzChunksRequested,
+        this, [this](const QString& segmentId) {
+            onExportWidthChunks(segmentId.toStdString());
+        });
+
     connect(_surfacePanel.get(), &SurfacePanelController::growSeedsRequested,
             this, [this](const QString& segmentId, bool isExpand, bool isRandomSeed) {
                 onGrowSeeds(segmentId.toStdString(), isExpand, isRandomSeed);

--- a/volume-cartographer/apps/VC3D/CWindow.hpp
+++ b/volume-cartographer/apps/VC3D/CWindow.hpp
@@ -86,6 +86,7 @@ public slots:
     void onConvertToObj(const std::string& segmentId);
     void onSlimFlatten(const std::string& segmentId);
     void onAWSUpload(const std::string& segmentId);
+    void onExportWidthChunks(const std::string& segmentId);
     void onGrowSeeds(const std::string& segmentId, bool isExpand, bool isRandomSeed = false);
     void onGrowSegmentationSurface(SegmentationGrowthMethod method,
                                    SegmentationGrowthDirection direction,

--- a/volume-cartographer/apps/VC3D/CWindowContextMenu.cpp
+++ b/volume-cartographer/apps/VC3D/CWindowContextMenu.cpp
@@ -1050,3 +1050,163 @@ void CWindow::onAWSUpload(const std::string& segmentId)
         statusBar()->showMessage(tr("No files to upload"), 3000);
     }
 }
+
+void CWindow::onExportWidthChunks(const std::string& segmentId)
+{
+    auto surfMeta = fVpkg ? fVpkg->getSurface(segmentId) : nullptr;
+    if (currentVolume == nullptr || !surfMeta) {
+        QMessageBox::warning(this, tr("Error"),
+                             tr("Cannot export: No volume or invalid segment selected"));
+        return;
+    }
+
+    QuadSurface* surf = surfMeta->surface();
+    if (!surf) {
+        QMessageBox::warning(this, tr("Error"),
+                             tr("Cannot export: Failed to load segment surface"));
+        return;
+    }
+
+    // Settings with sensible defaults (chunk width is in REAL UV pixels)
+    QSettings settings("VC.ini", QSettings::IniFormat);
+    const int  chunkWidthReal = std::max(1, settings.value("export/chunk_width_px", 40000).toInt());
+    const bool overwrite      = settings.value("export/overwrite", true).toBool();
+
+    // Determine export root directory: <volpkg>/export (not inside paths)
+    const QString configuredRoot = settings.value("export/dir", "").toString().trimmed();
+    const QString segDir  = QString::fromStdString(surfMeta->path.string());
+    const QString segName = QString::fromStdString(segmentId);
+
+    QString volpkgRoot = fVpkg ? QString::fromStdString(fVpkg->getVolpkgDirectory()) : QString();
+    if (volpkgRoot.isEmpty()) {
+        QDir d(QFileInfo(segDir).absoluteDir());   // start at parent of the segment folder
+        while (!d.isRoot() && !d.dirName().endsWith(".volpkg")) d.cdUp();
+        volpkgRoot = d.dirName().endsWith(".volpkg") ? d.absolutePath()
+                                                    : QFileInfo(segDir).absolutePath();
+    }
+    const QString exportRoot = configuredRoot.isEmpty()
+        ? QDir(volpkgRoot).filePath("export")
+        : configuredRoot;
+
+    QDir outRoot(exportRoot);
+    if (!outRoot.exists() && !outRoot.mkpath(".")) {
+        QMessageBox::critical(this, tr("Error"),
+                              tr("Cannot create export directory:\n%1").arg(exportRoot));
+        return;
+    }
+
+    // Pull points; ROI will be taken from this matrix.
+    cv::Mat_<cv::Vec3f> points = surf->rawPoints();
+    const int W = points.cols;
+    const int H = points.rows;
+    const cv::Vec2f sc = surf->scale();
+    const double sx = (std::isfinite(sc[0]) && sc[0] > 0.0f) ? double(sc[0]) : 1.0; // guard
+
+    // Convert desired real-pixel chunk width → grid columns
+    // Example: 40k real px with scale 0.05 → 2,000 columns per chunk
+    const int chunkCols = std::max(1, int(std::llround(double(chunkWidthReal) * sx)));
+    const int nChunks   = (W + chunkCols - 1) / chunkCols; // ceil-div purely in grid space
+    if (W <= 0 || H <= 0) {
+        QMessageBox::warning(this, tr("Error"),
+                             tr("Surface has invalid dimensions (%1 x %2)").arg(W).arg(H));
+        return;
+    }
+
+    if (nChunks <= 0) {
+        QMessageBox::information(this, tr("Export"), tr("Nothing to export."));
+        return;
+    }
+
+    // Progress dialog
+    QProgressDialog prog(tr("Exporting width-chunks…"), tr("Cancel"), 0, nChunks, this);
+    prog.setWindowModality(Qt::WindowModal);
+    prog.setAutoClose(false);
+    prog.setAutoReset(true);
+    prog.setMinimumDuration(0);
+
+    // Helper to generate a unique directory name if overwrite is false and target exists
+    auto uniqueName = [&](const QString& base)->QString {
+        if (!QFileInfo(outRoot.filePath(base)).exists()) return base;
+        int k = 1;
+        while (QFileInfo(outRoot.filePath(QString("%1_%2").arg(base).arg(k))).exists()) ++k;
+        return QString("%1_%2").arg(base).arg(k);
+    };
+
+    // Zero-pad for nicer sorting
+    auto padded = [nChunks](int idx)->QString {
+        const int digits = (nChunks < 10) ? 1 : (nChunks < 100) ? 2 : (nChunks < 1000) ? 3 : 4;
+        return QString("%1").arg(idx, digits, 10, QChar('0'));
+    };
+
+    // Export loop
+    int exported = 0;
+    QStringList results;
+    QStringList failures;
+
+    for (int c = 0; c < nChunks; ++c) {
+        if (prog.wasCanceled()) break;
+        prog.setLabelText(tr("Exporting slice %1 / %2…").arg(c+1).arg(nChunks));
+        prog.setValue(c);
+        QCoreApplication::processEvents();
+
+        const int x0 = c * chunkCols;
+        const int dx = std::min(chunkCols, W - x0);
+
+        // ROI [all rows, x0:x0+dx)
+        cv::Mat_<cv::Vec3f> roi(points, cv::Range::all(), cv::Range(x0, x0 + dx));
+        cv::Mat_<cv::Vec3f> roiCopy = roi.clone();  // ensure contiguous, independent buffer
+
+        // Create a temp surface for this chunk; scale is preserved.
+        QuadSurface chunkSurf(roiCopy, surf->scale());
+
+        // Build target dir under exportRoot, name "<segName>_<indexPadded>"
+        const QString baseName = QString("%1_%2").arg(segName, padded(c));
+        QString outDirName = baseName;
+        bool forceOverwrite = false;
+        if (QFileInfo(outRoot.filePath(outDirName)).exists()) {
+            if (overwrite) {
+                forceOverwrite = true;
+            } else {
+                outDirName = uniqueName(baseName);
+            }
+        }
+        const QString outAbs = outRoot.filePath(outDirName);
+        const std::string outPath = outAbs.toStdString();
+        const std::string uuid    = outDirName.toStdString();  // uuid ~ folder name
+
+        try {
+            chunkSurf.save(outPath, uuid, forceOverwrite);
+            ++exported;
+            results << outAbs;
+        } catch (const std::exception& e) {
+            failures << QString("%1 — %2").arg(outAbs, e.what());
+        }
+
+        QCoreApplication::processEvents();
+    }
+    prog.setValue(nChunks);
+
+    // Summarize
+    if (exported > 0 && failures.isEmpty()) {
+        QMessageBox::information(this, tr("Export complete"),
+                                 tr("Exported %1 slice(s) to:\n%2")
+                                 .arg(exported)
+                                 .arg(QDir::toNativeSeparators(exportRoot)));
+        statusBar()->showMessage(tr("Exported %1 slice(s) → %2")
+                                 .arg(exported)
+                                 .arg(QDir::toNativeSeparators(exportRoot)),
+                                 5000);
+    } else if (exported > 0 && !failures.isEmpty()) {
+        QMessageBox::warning(this, tr("Partial export"),
+                             tr("Exported %1 slice(s), but failed:\n\n%2")
+                             .arg(exported)
+                             .arg(failures.join('\n')));
+        statusBar()->showMessage(tr("Export partially complete"), 5000);
+    } else if (!failures.isEmpty()) {
+        QMessageBox::critical(this, tr("Export failed"),
+                              tr("All slices failed:\n\n%1").arg(failures.join('\n')));
+        statusBar()->showMessage(tr("Export failed"), 5000);
+    } else {
+        statusBar()->showMessage(tr("Export cancelled"), 3000);
+    }
+}

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
@@ -580,6 +580,13 @@ void SurfacePanelController::showContextMenu(const QPoint& pos)
 
     contextMenu.addSeparator();
 
+    QAction* exportChunksAction = contextMenu.addAction(tr("Export width-chunks (40k px)"));
+    connect(exportChunksAction, &QAction::triggered, this, [this, segmentId]() {
+        emit exportTifxyzChunksRequested(segmentId);
+    });
+
+    contextMenu.addSeparator();
+
     QAction* inpaintTeleaAction = contextMenu.addAction(tr("Inpaint (Telea) && Rebuild Segment"));
     connect(inpaintTeleaAction, &QAction::triggered, this, [this]() {
         emit teleaInpaintRequested();

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.hpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.hpp
@@ -114,6 +114,7 @@ signals:
     void growSeedsRequested(const QString& segmentId, bool isExpand, bool isRandomSeed);
     void teleaInpaintRequested();
     void recalcAreaRequested(const QStringList& segmentIds);
+    void exportTifxyzChunksRequested(const QString& segmentId);
     void statusMessageRequested(const QString& message, int timeoutMs);
 
 private:

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -319,7 +319,7 @@ auto VolumePkg::getAvailableSegmentationDirectories() const -> std::vector<std::
     std::vector<std::string> dirs;
     
     // Check for common segmentation directories
-    const std::vector<std::string> commonDirs = {"paths", "traces"};
+    const std::vector<std::string> commonDirs = {"paths", "traces", "export"};
     for (const auto& dir : commonDirs) {
         if (std::filesystem::exists(rootDir_ / dir) && std::filesystem::is_directory(rootDir_ / dir)) {
             dirs.push_back(dir);


### PR DESCRIPTION
We create another folder, called `export`.
When selecting a `patch`, or a `trace`, and click on the `Export` button, we will crop it in consecutives pieces `40k` pixels wide in the UV frame, and save them in the `export` folder.