### PR TITLE
Fix compilation error

### DIFF
--- a/volume-cartographer/core/src/Umbilicus.cpp
+++ b/volume-cartographer/core/src/Umbilicus.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cctype>
 #include <cmath>
+#include <numbers>
 #include <fstream>
 #include <limits>
 #include <sstream>
@@ -36,7 +37,7 @@ cv::Vec2f SeamDirectionVector(vc::core::util::Umbilicus::SeamDirection direction
     throw std::logic_error("Unhandled seam direction");
 }
 
-constexpr double DegreesPerRadian = 180.0 / std::acos(-1.0);
+constexpr double DegreesPerRadian = 180.0 / std::numbers::pi_v<double>;
 
 } // namespace
 


### PR DESCRIPTION
Should fix compilation errors in local environments if we’re using clang++ + libstdc++ where std::acos is not constexpr