### PR TITLE
add segment copying along normals

### DIFF
--- a/volume-cartographer/core/src/GrowPatch.cpp
+++ b/volume-cartographer/core/src/GrowPatch.cpp
@@ -278,7 +278,32 @@ public:
         double max_value = std::numeric_limits<double>::lowest();
         bool hit_threshold = false;
         cv::Vec3d current = start;
-        for (int i = 1; i <= steps; ++i) {
+
+        const double start_value = sample(start);
+        int begin_step = 1;
+        if (std::isfinite(start_value) && start_value >= threshold_) {
+            bool exited_material = false;
+            for (; begin_step <= steps; ++begin_step) {
+                current += delta;
+                const double value = sample(current);
+                if (!std::isfinite(value)) {
+                    continue;
+                }
+                if (value < threshold_) {
+                    exited_material = true;
+                    ++begin_step;  // start checking one step beyond the exit.
+                    break;
+                }
+            }
+            if (!exited_material) {
+                residual[0] = 0.0;
+                return true;
+            }
+        } else {
+            current = start;
+        }
+
+        for (int i = begin_step; i <= steps; ++i) {
             current += delta;
             const double value = sample(current);
             if (!std::isfinite(value)) {


### PR DESCRIPTION
add mode "gen_neighbor" which creates a 'neighbor' of the src tifxyz, it works by doing the following: 

- for each vertex on the src, cast a ray along the normals
- after a min distance, and once you have 'stepped out' of the original prediction, sample pixel values along this ray
- once a nonzero 'hit' is registered, place the new vertex at this location, up to a max distance (if nothing is hit, keep store vertex as (-1,-1,-1) 
- after all hits are registered to their grid positions, do scanline interpolation along row/col to 'infill' the misses
- write new grid to new tifxyz


takes some new params in json

```json
 {
"thread_limit": 1,
"min_area_cm": 0.001,
"normal_grid_path": "/mnt/raid_nvme/volpkgs/PHerc172.volpkg/normal_grids",
"cache_root": "/mnt/raid_nvme/volpkgs/caches/172_edt_cache/",
"neighbor_dir": "in",
"neighbor_max_distance": 50,
"mode": "gen_neighbor",
"neighbor_min_clearance": 2,
"neighbor_fill": true,
"neighbor_interp_window": 5
 }
```

used command 

```bash
 build/bin/vc_grow_seg_from_seed --volume /mnt/raid_nvme/volpkgs/PHerc172.volpkg/volumes/s5_105.zarr \
 --target-dir /mnt/raid_nvme/volpkgs/PHerc172.volpkg/paths \
 --params /mnt/raid_nvme/volpkgs/PHerc172.volpkg/seed_neighbor.json \
 --resume /mnt/raid_nvme/volpkgs/PHerc172.volpkg/paths/1918-sm
 ```