### PR TITLE
remove spdlog dependency and fix clang compile errors

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindowContextMenu.cpp
+++ b/volume-cartographer/apps/VC3D/CWindowContextMenu.cpp
@@ -915,7 +915,7 @@ void CWindow::onNeighborCopyRequested(const QString& segmentId, bool copyOut)
     pass2JsonFile->write(QJsonDocument(pass2Params).toJson(QJsonDocument::Indented));
     pass2JsonFile->flush();
 
-    _neighborCopyJob.emplace();
+    _neighborCopyJob = NeighborCopyJob{};
     auto& job = *_neighborCopyJob;
     job.stage = NeighborCopyJob::Stage::FirstPass;
     job.segmentId = segmentId;

--- a/volume-cartographer/cmake/Packing.cmake
+++ b/volume-cartographer/cmake/Packing.cmake
@@ -39,6 +39,6 @@ set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)#ONE_PER_GROUP)
 set(CPACK_DEB_COMPONENT_INSTALL YES)
 
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS qt6-base-dev libceres-dev libboost-system-dev libboost-program-options-dev libopencv-dev libblosc-dev libspdlog-dev libgsl-dev libsdl2-dev)
+set(CPACK_DEBIAN_PACKAGE_DEPENDS qt6-base-dev libceres-dev libboost-system-dev libboost-program-options-dev libopencv-dev libblosc-dev libgsl-dev libsdl2-dev)
 
 include(CPack)

--- a/volume-cartographer/cmake/VCConfig.cmake.in
+++ b/volume-cartographer/cmake/VCConfig.cmake.in
@@ -39,8 +39,6 @@ find_dependency(OpenCV @OpenCV_VERSION_MAJOR@.@OpenCV_VERSION_MINOR@ QUIET REQUI
 ### TIFF ###
 find_dependency(TIFF QUIET REQUIRED)
 
-### spdlog ###
-find_dependency(spdlog CONFIG QUIET REQUIRED)
 
 ### smgl ###
 find_dependency(smgl @smgl_VERSION@ CONFIG QUIET REQUIRED)

--- a/volume-cartographer/cmake/VCFindDependencies.cmake
+++ b/volume-cartographer/cmake/VCFindDependencies.cmake
@@ -98,9 +98,6 @@ endif()
 set(XTENSOR_USE_XSIMD 1)
 find_package(xtensor REQUIRED)
 
-# ---- spdlog ------------------------------------------------------------------
-find_package(spdlog 1.4.2 CONFIG REQUIRED)
-
 # ---- nlohmann/json -----------------------------------------------------------
 if (VC_BUILD_JSON)
     FetchContent_Declare(

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -28,7 +28,6 @@ target_link_libraries(vc_core
         opencv_highgui
         opencv_calib3d
         opencv_video
-        spdlog::spdlog
         nlohmann_json::nlohmann_json
         z5
         OpenMP::OpenMP_CXX

--- a/volume-cartographer/core/include/vc/core/util/Logging.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Logging.hpp
@@ -1,11 +1,71 @@
 #pragma once
 
-#include <spdlog/spdlog.h>
-
 #include <filesystem>
+#include <memory>
+#include <string>
+#include <format>
+
+// Forward declaration
+class MinimalLogger;
 
 void AddLogFile(const std::filesystem::path& path);
 void SetLogLevel(const std::string& s);
-auto Logger() -> std::shared_ptr<spdlog::logger>;
+auto Logger() -> std::shared_ptr<MinimalLogger>;
 
+enum class LogLevel {
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+    Off = 4
+};
 
+class MinimalLogger {
+public:
+    MinimalLogger();
+    ~MinimalLogger();
+
+    // Variadic template logging methods
+    template<typename... Args>
+    void debug(std::format_string<Args...> fmt, Args&&... args) {
+        log(LogLevel::Debug, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void info(std::format_string<Args...> fmt, Args&&... args) {
+        log(LogLevel::Info, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void warn(std::format_string<Args...> fmt, Args&&... args) {
+        log(LogLevel::Warn, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void error(std::format_string<Args...> fmt, Args&&... args) {
+        log(LogLevel::Error, fmt, std::forward<Args>(args)...);
+    }
+
+    // Simple string overloads
+    void debug(const std::string& msg);
+    void info(const std::string& msg);
+    void warn(const std::string& msg);
+    void error(const std::string& msg);
+
+    void set_level(LogLevel level);
+    void add_file(const std::filesystem::path& path);
+
+private:
+    template<typename... Args>
+    void log(LogLevel level, std::format_string<Args...> fmt, Args&&... args) {
+        if (level < current_level_) return;
+        std::string msg = std::format(fmt, std::forward<Args>(args)...);
+        write_log(level, msg);
+    }
+
+    void write_log(LogLevel level, const std::string& msg);
+    const char* level_string(LogLevel level);
+
+    LogLevel current_level_;
+    std::unique_ptr<class LoggerImpl> impl_;
+};

--- a/volume-cartographer/core/src/Logging.cpp
+++ b/volume-cartographer/core/src/Logging.cpp
@@ -1,28 +1,130 @@
 #include "vc/core/util/Logging.hpp"
 
-#include <memory>
+#include <iostream>
+#include <fstream>
+#include <mutex>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <vector>
 
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/dist_sink.h>
-#include <spdlog/sinks/stdout_sinks.h>
+// Internal implementation class
+class LoggerImpl {
+public:
+    std::mutex mutex;
+    std::vector<std::shared_ptr<std::ofstream>> file_sinks;
 
+    std::string get_timestamp() {
+        auto now = std::chrono::system_clock::now();
+        auto time_t = std::chrono::system_clock::to_time_t(now);
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            now.time_since_epoch()) % 1000;
 
-auto DistSink() -> std::shared_ptr<spdlog::sinks::dist_sink_mt>;
-auto DistSink() -> std::shared_ptr<spdlog::sinks::dist_sink_mt>
+        std::tm tm;
+        #ifdef _WIN32
+        localtime_s(&tm, &time_t);
+        #else
+        localtime_r(&time_t, &tm);
+        #endif
+
+        std::ostringstream oss;
+        oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S")
+            << '.' << std::setfill('0') << std::setw(3) << ms.count();
+        return oss.str();
+    }
+};
+
+MinimalLogger::MinimalLogger()
+    : current_level_(LogLevel::Info)
+    , impl_(std::make_unique<LoggerImpl>())
 {
-    static auto loggers = std::make_shared<spdlog::sinks::dist_sink_mt>();
-    return loggers;
 }
 
-static auto Init() -> std::shared_ptr<spdlog::sinks::dist_sink_mt>
-{
-    DistSink()->add_sink(std::make_shared<spdlog::sinks::stdout_sink_mt>());
-    return DistSink();
+MinimalLogger::~MinimalLogger() = default;
+
+const char* MinimalLogger::level_string(LogLevel level) {
+    switch (level) {
+        case LogLevel::Debug: return "DEBUG";
+        case LogLevel::Info:  return "INFO ";
+        case LogLevel::Warn:  return "WARN ";
+        case LogLevel::Error: return "ERROR";
+        default:              return "?????";
+    }
 }
 
+void MinimalLogger::write_log(LogLevel level, const std::string& msg) {
+    if (level < current_level_) return;
 
-auto Logger() -> std::shared_ptr<spdlog::logger>
-{
-    static auto logger = std::make_shared<spdlog::logger>("volcart", Init());
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+
+    std::string timestamp = impl_->get_timestamp();
+    std::string formatted = std::format("[{}] [{}] {}", timestamp, level_string(level), msg);
+
+    // Always write to stdout
+    std::cout << formatted << std::endl;
+
+    // Write to file sinks
+    for (auto& file : impl_->file_sinks) {
+        if (file && file->is_open()) {
+            (*file) << formatted << std::endl;
+            file->flush();
+        }
+    }
+}
+
+void MinimalLogger::debug(const std::string& msg) {
+    write_log(LogLevel::Debug, msg);
+}
+
+void MinimalLogger::info(const std::string& msg) {
+    write_log(LogLevel::Info, msg);
+}
+
+void MinimalLogger::warn(const std::string& msg) {
+    write_log(LogLevel::Warn, msg);
+}
+
+void MinimalLogger::error(const std::string& msg) {
+    write_log(LogLevel::Error, msg);
+}
+
+void MinimalLogger::set_level(LogLevel level) {
+    current_level_ = level;
+}
+
+void MinimalLogger::add_file(const std::filesystem::path& path) {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+
+    auto file = std::make_shared<std::ofstream>(path, std::ios::app);
+    if (file->is_open()) {
+        impl_->file_sinks.push_back(file);
+    }
+}
+
+// Global functions
+auto Logger() -> std::shared_ptr<MinimalLogger> {
+    static auto logger = std::make_shared<MinimalLogger>();
     return logger;
+}
+
+void AddLogFile(const std::filesystem::path& path) {
+    Logger()->add_file(path);
+}
+
+void SetLogLevel(const std::string& s) {
+    LogLevel level = LogLevel::Info;
+
+    if (s == "debug" || s == "DEBUG") {
+        level = LogLevel::Debug;
+    } else if (s == "info" || s == "INFO") {
+        level = LogLevel::Info;
+    } else if (s == "warn" || s == "WARN" || s == "warning" || s == "WARNING") {
+        level = LogLevel::Warn;
+    } else if (s == "error" || s == "ERROR") {
+        level = LogLevel::Error;
+    } else if (s == "off" || s == "OFF") {
+        level = LogLevel::Off;
+    }
+
+    Logger()->set_level(level);
 }


### PR DESCRIPTION
clang dies when trying to compile spdlog stuff because of compile time stuff that I don't care to debug. We hardly use spdlog anyway and implementing a minimal logger in its place is small so I just did that and removed the dependency entirely.

There were a couple other small issues with clang compilation that this fixes