### PR TITLE
refactor readarea3d readinterpolated3d and readnearestneighbor to be templated on the dtype

### DIFF
--- a/volume-cartographer/core/include/vc/core/util/Slicing.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Slicing.hpp
@@ -51,12 +51,11 @@ private:
 
 //NOTE depending on request this might load a lot (the whole array) into RAM
 // void readInterpolated3D(xt::xarray<uint8_t> &out, z5::Dataset *ds, const xt::xarray<float> &coords, ChunkCache *cache = nullptr);
-void readInterpolated3D(cv::Mat_<uint8_t> &out, z5::Dataset *ds, const cv::Mat_<cv::Vec3f> &coords, ChunkCache *cache = nullptr, bool nearest_neighbor=false);
-void readInterpolated3D(cv::Mat_<uint16_t> &out, z5::Dataset *ds, const cv::Mat_<cv::Vec3f> &coords, ChunkCache *cache = nullptr, bool nearest_neighbor=false);
 template <typename T>
-void readArea3D(xt::xtensor<T,3,xt::layout_type::column_major> &out, const cv::Vec3i offset, z5::Dataset *ds, ChunkCache *cache) { throw std::runtime_error("missing implementation"); }
-void readArea3D(xt::xtensor<uint8_t,3,xt::layout_type::column_major> &out, const cv::Vec3i offset, z5::Dataset *ds, ChunkCache *cache);
-void readArea3D(xt::xtensor<uint16_t,3,xt::layout_type::column_major> &out, const cv::Vec3i offset, z5::Dataset *ds, ChunkCache *cache);
+void readInterpolated3D(cv::Mat_<T> &out, z5::Dataset *ds, const cv::Mat_<cv::Vec3f> &coords, ChunkCache *cache = nullptr, bool nearest_neighbor=false);
+
+template <typename T>
+void readArea3D(xt::xtensor<T,3,xt::layout_type::column_major> &out, const cv::Vec3i offset, z5::Dataset *ds, ChunkCache *cache);
 cv::Mat_<cv::Vec3f> smooth_vc_segmentation(const cv::Mat_<cv::Vec3f> &points);
 cv::Mat_<cv::Vec3f> vc_segmentation_calc_normals(const cv::Mat_<cv::Vec3f> &points);
 void vc_segmentation_scales(cv::Mat_<cv::Vec3f> points, double &sx, double &sy);


### PR DESCRIPTION
this is written to not need the chunk cache refactor I put up but I'd prefer for that to go in first then I'll refactor this to use it