### PR TITLE
delete dependency on opencv_highgui

### DIFF
--- a/volume-cartographer/apps/CMakeLists.txt
+++ b/volume-cartographer/apps/CMakeLists.txt
@@ -8,7 +8,7 @@ add_subdirectory(VC3D)
 #################
 
 add_executable(vc_render_video src/vc_render_video.cpp)
-target_link_libraries(vc_render_video z5 opencv_core vc_core)
+target_link_libraries(vc_render_video z5 opencv_core vc_core opencv_videoio)
 
 add_executable(vc_render_tifxyz src/vc_render_tifxyz.cpp)
 target_link_libraries(vc_render_tifxyz vc_core Boost::program_options tiff)
@@ -71,9 +71,8 @@ set(vc_diffuse_winding_sources
 add_executable(vc_diffuse_winding ${vc_diffuse_winding_sources})
 target_include_directories(vc_diffuse_winding PRIVATE diffusion)
 target_link_libraries(vc_diffuse_winding
-    PRIVATE
         z5
-        opencv_highgui
+        opencv_videoio
         opencv_ximgproc
         vc_core
         vc_ui
@@ -138,7 +137,7 @@ target_link_libraries(vc_telea_inpaint
 )
 
 add_executable(vc_thinning src/vc_thinning.cpp)
-target_link_libraries(vc_thinning vc_core opencv_highgui opencv_ximgproc)
+target_link_libraries(vc_thinning vc_core opencv_ximgproc)
 
 add_executable(vc_tifxyz src/vc_tifxyz.cpp)
 target_link_libraries(vc_tifxyz vc_core Boost::program_options opencv_core)

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -65,7 +65,6 @@
 #include <initializer_list>
 #include <omp.h>
 #include <opencv2/imgproc.hpp>
-#include <opencv2/highgui.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <QStringList>
 

--- a/volume-cartographer/apps/VC3D/DrawingWidget.cpp
+++ b/volume-cartographer/apps/VC3D/DrawingWidget.cpp
@@ -16,7 +16,7 @@
 #include <QPainterPath>
 
 #include <opencv2/imgproc.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/types/VolumePkg.hpp"

--- a/volume-cartographer/apps/diffusion/spiral_common.cpp
+++ b/volume-cartographer/apps/diffusion/spiral_common.cpp
@@ -28,7 +28,7 @@ void visualize_spiral(
 #include <sstream>
 
 #include <opencv2/imgproc.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 
 bool find_intersections(

--- a/volume-cartographer/apps/diffusion/vc_diffuse_winding.cpp
+++ b/volume-cartographer/apps/diffusion/vc_diffuse_winding.cpp
@@ -15,7 +15,7 @@
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgcodecs.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/videoio.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/ximgproc.hpp>
 #include <boost/graph/adjacency_list.hpp>

--- a/volume-cartographer/apps/src/ObjAlphaCompRefinement.cpp
+++ b/volume-cartographer/apps/src/ObjAlphaCompRefinement.cpp
@@ -10,7 +10,7 @@
 #include "z5/multiarray/xtensor_access.hxx"
 #include "z5/attributes.hxx"
 
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 

--- a/volume-cartographer/apps/src/ZarrExtract.cpp
+++ b/volume-cartographer/apps/src/ZarrExtract.cpp
@@ -10,7 +10,7 @@
 #include "z5/multiarray/xtensor_access.hxx"
 #include "z5/attributes.hxx"
 
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <opencv2/core.hpp>
 
 #include "vc/core/util/Slicing.hpp"

--- a/volume-cartographer/apps/src/vc_fill_quadmesh.cpp
+++ b/volume-cartographer/apps/src/vc_fill_quadmesh.cpp
@@ -9,7 +9,7 @@
 #include "z5/factory.hxx"
 #include <nlohmann/json.hpp>
 
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
 #include <omp.h>
 

--- a/volume-cartographer/apps/src/vc_render_video.cpp
+++ b/volume-cartographer/apps/src/vc_render_video.cpp
@@ -10,9 +10,10 @@
 #include "z5/multiarray/xtensor_access.hxx"
 #include "z5/attributes.hxx"
 
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
 
 #include "vc/core/util/Slicing.hpp"
 #include "vc/core/util/Surface.hpp"

--- a/volume-cartographer/apps/src/vc_surface_diff.cpp
+++ b/volume-cartographer/apps/src/vc_surface_diff.cpp
@@ -1,14 +1,11 @@
 #include <nlohmann/json.hpp>
 
-#include <opencv2/highgui.hpp>
 #include <opencv2/core.hpp>
-#include <opencv2/imgproc.hpp>
 
 #include "vc/core/util/Surface.hpp"
 #include "vc/core/util/QuadSurface.hpp"
 #include "vc/core/util/SurfaceArea.hpp"
 
-#include <unordered_map>
 #include <filesystem>
 #include <chrono>
 #include <iostream>

--- a/volume-cartographer/apps/src/vc_thinning.cpp
+++ b/volume-cartographer/apps/src/vc_thinning.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <chrono>
 #include <fstream>
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <opencv2/ximgproc.hpp>
 #include "vc/core/util/Thinning.hpp"
 

--- a/volume-cartographer/apps/src/vc_tiffxyz_upscale_grounding.cpp
+++ b/volume-cartographer/apps/src/vc_tiffxyz_upscale_grounding.cpp
@@ -8,7 +8,7 @@
 #include "z5/factory.hxx"
 #include <nlohmann/json.hpp>
 
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <omp.h>
 
 

--- a/volume-cartographer/apps/src/vc_tifxyz_inp_mask.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz_inp_mask.cpp
@@ -4,7 +4,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
 
 

--- a/volume-cartographer/apps/src/vc_tifxyz_winding.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz_winding.cpp
@@ -6,7 +6,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
 #include <omp.h>
 

--- a/volume-cartographer/apps/src/vc_visualize.cpp
+++ b/volume-cartographer/apps/src/vc_visualize.cpp
@@ -10,7 +10,7 @@
 
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <nlohmann/json.hpp>
 #include <boost/program_options.hpp>
 

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(vc_core
         opencv_core
         opencv_imgproc
         opencv_imgcodecs
-        opencv_highgui
         opencv_calib3d
         opencv_video
         nlohmann_json::nlohmann_json

--- a/volume-cartographer/core/src/GrowSurface.cpp
+++ b/volume-cartographer/core/src/GrowSurface.cpp
@@ -1,7 +1,7 @@
 #include <omp.h>
 #include <random>
 
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -9,7 +9,7 @@
 
 #include <opencv2/imgproc.hpp>
 #include <opencv2/calib3d.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 #include <nlohmann/json.hpp>
 #include <system_error>

--- a/volume-cartographer/core/src/normalgridtools.cpp
+++ b/volume-cartographer/core/src/normalgridtools.cpp
@@ -2,7 +2,7 @@
 #include <random>
 #include <iostream>
 #include <opencv2/imgproc.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 #include "vc/core/util/normalgridtools.hpp"
 


### PR DESCRIPTION
we don't use opencv_highgui anywhere but it was pulling in QT5 system libraries on my ubuntu 25.10 install when we link against qt6 and causing weird issues sometimes.