### PR TITLE
vc_render_tifxyz: make voxel metadata flags optional with sane fallback and emit physical OME‑Zarr scales

### DIFF
--- a/volume-cartographer/core/include/vc/core/util/Zarr.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Zarr.hpp
@@ -76,5 +76,5 @@ void writeZarrAttrs(z5::filesystem::handle::File& outFile,
                     const std::filesystem::path& volPath, int groupIdx,
                     size_t baseZ, double sliceStep, double accumStep,
                     const std::string& accumTypeStr, size_t accumSamples,
-                    const cv::Size& canvasSize, size_t CZ, size_t CH, size_t CW);
-
+                    const cv::Size& canvasSize, size_t CZ, size_t CH, size_t CW,
+                    double baseVoxelSize, const std::string& voxelUnit);

--- a/volume-cartographer/core/src/Zarr.cpp
+++ b/volume-cartographer/core/src/Zarr.cpp
@@ -234,7 +234,8 @@ void writeZarrAttrs(z5::filesystem::handle::File& outFile,
                     const std::filesystem::path& volPath, int groupIdx,
                     size_t baseZ, double sliceStep, double accumStep,
                     const std::string& accumTypeStr, size_t accumSamples,
-                    const cv::Size& canvasSize, size_t CZ, size_t CH, size_t CW)
+                    const cv::Size& canvasSize, size_t CZ, size_t CH, size_t CW,
+                    double baseVoxelSize, const std::string& voxelUnit)
 {
     json attrs;
     attrs["source_zarr"] = volPath.string();
@@ -253,17 +254,18 @@ void writeZarrAttrs(z5::filesystem::handle::File& outFile,
     json ms;
     ms["version"] = "0.4"; ms["name"] = "render";
     ms["axes"] = json::array({
-        json{{"name","z"},{"type","space"}},
-        json{{"name","y"},{"type","space"}},
-        json{{"name","x"},{"type","space"}}
+        json{{"name","z"},{"type","space"},{"unit",voxelUnit}},
+        json{{"name","y"},{"type","space"},{"unit",voxelUnit}},
+        json{{"name","x"},{"type","space"},{"unit",voxelUnit}}
     });
     ms["datasets"] = json::array();
     for (int l = 0; l <= 5; l++) {
-        double s = std::pow(2.0, l);
+        const double levelScale = std::pow(2.0, l);
+        const double physicalScale = baseVoxelSize * levelScale;
         ms["datasets"].push_back({
             {"path", std::to_string(l)},
             {"coordinateTransformations", json::array({
-                json{{"type","scale"},{"scale",json::array({s,s,s})}},
+                json{{"type","scale"},{"scale",json::array({physicalScale,physicalScale,physicalScale})}},
                 json{{"type","translation"},{"translation",json::array({0.0,0.0,0.0})}}
             })}
         });


### PR DESCRIPTION
### Motivation
- Ensure `--voxel-size` / `--voxel-unit` are truly optional and provide a sensible default when volume metadata is absent or invalid so tools like Neuroglancer get usable physical scale information.
- Avoid hard failures on missing/incorrect metadata while preserving the ability to explicitly set a validated physical voxel size.

### Description
- Clarified the `--voxel-size` help text to document the fallback order (CLI value → volume metadata voxelsize → default `1.0`).
- Added `readVolumeVoxelSize` and updated voxel-size resolution in `vc_render_tifxyz.cpp` to use `--voxel-size` if present (validated positive), else use metadata when valid, else fall back to `1.0` while emitting a warning/info message.
- Extended `writeZarrAttrs` signature and implementation to accept `baseVoxelSize` and `voxelUnit` and to emit `multiscales.axes[*].unit` and per-level `coordinateTransformations.scale` as physical voxel spacings (files changed: `volume-cartographer/apps/src/vc_render_tifxyz.cpp`, `volume-cartographer/core/include/vc/core/util/Zarr.hpp`, `volume-cartographer/core/src/Zarr.cpp`).
- Small include cleanup to enable `std::optional` usage (`#include <optional>` added).

### Testing
- Attempted a full CMake configure with `cmake -S volume-cartographer -B /tmp/vcbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, which failed due to external dependency fetch being blocked by the environment (git clone of `xtl` returned HTTP 403), so a full build/test could not be completed.
- Performed automated repository inspections and diffs (`git` commands and `nl`/`sed` checks) to verify option definitions, new `readVolumeVoxelSize` helper, fallback behavior, and that calls to `writeZarrAttrs` now pass the computed `base_voxel_size * ds_scale` and `voxel_unit`; these checks succeeded.
- No unit or integration tests were added or run in this change; recommend running a full build and validating produced `.zattrs` with a small `vc_render_tifxyz` invocation such as `vc_render_tifxyz --pre --zarr-output <out> --volume <vol> --group-idx <g> --voxel-size <value> --voxel-unit <unit>` once dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699951b3dd1c832cb549994b412bbbf6)