### PR TITLE
Mirror overlapping links in GrowSurface to handle asymmetric metadata

### DIFF
--- a/volume-cartographer/core/src/GrowSurface.cpp
+++ b/volume-cartographer/core/src/GrowSurface.cpp
@@ -1538,12 +1538,12 @@ QuadSurface *grow_surf_from_surfs(QuadSurface *seed, const std::vector<QuadSurfa
     for(auto sm : approved_sm)
         std::cout << "approved: " << sm->id << std::endl;
 
-    // Build overlapping map: for each surface, collect pointers to its overlapping surfaces.
-    // Mirror links as a safety net for one-sided overlap metadata so candidate expansion can
-    // still traverse both ways.
+    // Build overlapping map: for each non-defective surface, collect pointers to overlapping
+    // non-defective surfaces. Mirror links as a safety net for one-sided overlap metadata so
+    // candidate expansion can still traverse both ways.
     std::unordered_map<QuadSurface*, std::set<QuadSurface*>> overlapping_map;
-    for(auto &sm : surfs_v)
-        for(const auto& name : sm->overlappingIds())
+    for (const auto& [_, sm] : surfs)
+        for (const auto& name : sm->overlappingIds())
             if (surfs.contains(name)) {
                 auto* other = surfs[name];
                 overlapping_map[sm].insert(other);

--- a/volume-cartographer/core/src/GrowSurface.cpp
+++ b/volume-cartographer/core/src/GrowSurface.cpp
@@ -1538,12 +1538,17 @@ QuadSurface *grow_surf_from_surfs(QuadSurface *seed, const std::vector<QuadSurfa
     for(auto sm : approved_sm)
         std::cout << "approved: " << sm->id << std::endl;
 
-    // Build overlapping map: for each surface, collect pointers to its overlapping surfaces
+    // Build overlapping map: for each surface, collect pointers to its overlapping surfaces.
+    // Mirror links as a safety net for one-sided overlap metadata so candidate expansion can
+    // still traverse both ways.
     std::unordered_map<QuadSurface*, std::set<QuadSurface*>> overlapping_map;
     for(auto &sm : surfs_v)
         for(const auto& name : sm->overlappingIds())
-            if (surfs.contains(name))
-                overlapping_map[sm].insert(surfs[name]);
+            if (surfs.contains(name)) {
+                auto* other = surfs[name];
+                overlapping_map[sm].insert(other);
+                overlapping_map[other].insert(sm);
+            }
 
     SurfacePatchIndex patch_index;
     SurfacePatchIndex* patch_index_ptr = nullptr;


### PR DESCRIPTION
### Motivation
- The tracer sometimes missed approved/overlapping patches when overlap metadata was one-sided, preventing candidate expansion from the other side.
- Make the in-memory overlap graph robust to asymmetric `overlappingIds()` so traversal does not depend on perfectly symmetric on-disk metadata.

### Description
- Update `grow_surf_from_surfs` in `volume-cartographer/core/src/GrowSurface.cpp` to build `overlapping_map` with mirrored edges so that when `A` lists `B`, both `A->B` and `B->A` are recorded in-memory.
- Add a short explanatory comment above the overlap-map construction explaining the defensive mirroring.
- Change is local and deterministic and does not alter numeric behavior beyond making candidate traversal consider the reverse direction.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors (passed).
- Performed code inspection and local diffs (`git diff`) to verify the overlap-map mutation is limited to the `overlapping_map` construction and that downstream use sites read the same map (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999596f78d8832cbf7c5de4e1eb2435)