### PR TITLE
Set TIFF DPI from volume voxel size

### DIFF
--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -1316,6 +1316,29 @@ int main(int argc, char *argv[])
         printMat4x4(affineTransform.matrix, "Final composed affine:");
     }
 
+    // Try to read voxelsize from meta.json to set TIFF DPI.
+    // meta.json stores the level-0 voxel size; renders at --group-idx > 0
+    // come from a 2^group_idx-downsampled pyramid, so each output pixel
+    // covers (voxelsize / ds_scale) µm. Account for that so the DPI tag
+    // matches the actual pixel grid.
+    float tifDpi = 0.f;
+    {
+        auto metaPath = vol_path / "meta.json";
+        if (std::filesystem::exists(metaPath)) {
+            try {
+                auto meta = Json::parse_file(metaPath);
+                if (meta.contains("voxelsize")) {
+                    const double vs = meta["voxelsize"].get_double();
+                    const double vsLevel = ds_scale > 0
+                                               ? vs / double(ds_scale)
+                                               : vs;
+                    tifDpi = voxelSizeToDpi(vsLevel);
+                }
+            } catch (...) {
+            }
+        }
+    }
+
     // --- Open source volume ---
     std::shared_ptr<Volume> remoteVolume;
     std::unique_ptr<vc::VcDataset> ownedDs;
@@ -1609,7 +1632,7 @@ int main(int argc, char *argv[])
                 uint32_t tiffTileW = (uint32_t(outW) + 15u) & ~15u;
                 uint16_t tifComp = quickTif ? COMPRESSION_PACKBITS : COMPRESSION_LZW;
                 for (int z = 0; z < tifSlices; z++)
-                    tifWriters.emplace_back(makePartPath(z), uint32_t(outW), uint32_t(outH), cvType, tiffTileW, tiffTileH, 0.0f, tifComp);
+                    tifWriters.emplace_back(makePartPath(z), uint32_t(outW), uint32_t(outH), cvType, tiffTileW, tiffTileH, 0.0f, tifComp, tifDpi);
             }
         }
 

--- a/volume-cartographer/apps/src/vc_zarr_to_tiff.cpp
+++ b/volume-cartographer/apps/src/vc_zarr_to_tiff.cpp
@@ -60,6 +60,31 @@ int main(int argc, char** argv)
 
     const uint16_t compression = parseCompression(compressionStr);
 
+    // Try to read voxelsize from meta.json to set TIFF DPI.
+    // meta.json stores the voxel size at level 0; pyramid levels are 2x/4x/8x
+    // downsampled, so the physical pixel size at `level` is vs * 2^level and
+    // the DPI scales by 1/2^level.
+    float dpi = 0.f;
+    {
+        fs::path metaPath = fs::path(inputPath) / "meta.json";
+        if (fs::exists(metaPath)) {
+            try {
+                auto meta = Json::parse_file(metaPath);
+                if (meta.contains("voxelsize")) {
+                    double vs = meta["voxelsize"].get_double();
+                    double vsLevel = vs * (1ULL << level);
+                    dpi = voxelSizeToDpi(vsLevel);
+                    if (dpi > 0.f) {
+                        std::cout << "Voxel size: " << vs << " µm"
+                                  << " (level " << level << ": "
+                                  << vsLevel << " µm) → DPI: " << dpi << "\n";
+                    }
+                }
+            } catch (...) {
+            }
+        }
+    }
+
     // Open zarr dataset
     fs::path inRoot(inputPath);
     std::string dsName = std::to_string(level);
@@ -110,11 +135,7 @@ int main(int argc, char** argv)
         fs::path outPath = outDir / fname.str();
 
         constexpr uint32_t tileSize = 256;
-        TiffWriter writer(outPath,
-                          static_cast<uint32_t>(X),
-                          static_cast<uint32_t>(Y),
-                          cvType, tileSize, tileSize,
-                          0.0f, compression);
+        TiffWriter writer(outPath, static_cast<uint32_t>(X), static_cast<uint32_t>(Y), cvType, tileSize, tileSize, 0.0f, compression, dpi);
 
         for (uint32_t ty = 0; ty < Y; ty += tileSize) {
             for (uint32_t tx = 0; tx < X; tx += tileSize) {

--- a/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
@@ -420,6 +420,10 @@ public:
     void refreshMaskTimestamp();
     static std::optional<std::filesystem::file_time_type> readMaskTimestamp(const std::filesystem::path& dir);
 
+    // DPI for TIFF output (0 = don't set). Set via setDpi() or voxelSizeToDpi().
+    float dpi() const { return dpi_; }
+    void setDpi(float d) { dpi_ = d; }
+
 protected:
     std::unordered_map<std::string, cv::Mat> _channels;
     std::unique_ptr<cv::Mat_<cv::Vec3f>> _points;
@@ -428,6 +432,7 @@ protected:
     Rect3D _bbox = {{-1,-1,-1},{-1,-1,-1}};
     std::set<std::string> _overlappingIds;
     std::optional<std::filesystem::file_time_type> _maskTimestamp;
+    float dpi_ = 0.f;
 
 private:
     // Write surface data to directory without modifying state. skipChannel can be used to exclude a channel.

--- a/volume-cartographer/core/include/vc/core/util/Tiff.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Tiff.hpp
@@ -7,18 +7,28 @@
 #include <cstdint>
 #include <tiffio.h>
 
+// Convert voxel size in micrometers to DPI (dots per inch)
+// Returns 0 if voxelSize is <= 0
+inline float voxelSizeToDpi(double voxelSizeUm)
+{
+    return voxelSizeUm > 0 ? static_cast<float>(25400.0 / voxelSizeUm) : 0.f;
+}
+
 // Write single-channel image (8U, 16U, 32F) as tiled TIFF
 // cvType: output type (-1 = same as input). If different, values are scaled:
 //         8U↔16U: scale by 257, 8U↔32F: scale by 1/255, 16U↔32F: scale by 1/65535
 // compression: libtiff compression constant (e.g. COMPRESSION_LZW, COMPRESSION_PACKBITS)
 // padValue: value for padding partial tiles (default -1.0f, used for float; int types use 0)
-void writeTiff(const std::filesystem::path& outPath,
-               const cv::Mat& img,
-               int cvType = -1,
-               uint32_t tileW = 1024,
-               uint32_t tileH = 1024,
-               float padValue = -1.0f,
-               uint16_t compression = COMPRESSION_LZW);
+// dpi: resolution in dots per inch (0 = don't set). Use voxelSizeToDpi() to convert from µm.
+void writeTiff(
+    const std::filesystem::path& outPath,
+    const cv::Mat& img,
+    int cvType = -1,
+    uint32_t tileW = 1024,
+    uint32_t tileH = 1024,
+    float padValue = -1.0f,
+    uint16_t compression = COMPRESSION_LZW,
+    float dpi = 0.f);
 
 // Class for incremental tiled TIFF writing
 // Useful for writing tiles in parallel or from streaming data
@@ -27,13 +37,17 @@ public:
     // Open a new TIFF file for tiled writing
     // cvType: CV_8UC1, CV_16UC1, or CV_32FC1
     // padValue: value for padding partial tiles (used for float; int types use 0)
-    TiffWriter(const std::filesystem::path& path,
-               uint32_t width, uint32_t height,
-               int cvType,
-               uint32_t tileW = 1024,
-               uint32_t tileH = 1024,
-               float padValue = -1.0f,
-               uint16_t compression = COMPRESSION_LZW);
+    // dpi: resolution in dots per inch (0 = don't set). Use voxelSizeToDpi() to convert from µm.
+    TiffWriter(
+        const std::filesystem::path& path,
+        uint32_t width,
+        uint32_t height,
+        int cvType,
+        uint32_t tileW = 1024,
+        uint32_t tileH = 1024,
+        float padValue = -1.0f,
+        uint16_t compression = COMPRESSION_LZW,
+        float dpi = 0.f);
 
     ~TiffWriter();
 

--- a/volume-cartographer/core/src/GrowPatch.cpp
+++ b/volume-cartographer/core/src/GrowPatch.cpp
@@ -3156,6 +3156,7 @@ QuadSurface *tracer(vc::VcDataset *ds, float scale, vc::cache::BlockPipeline *ca
         cv::Mat_<uint16_t> generations_crop = generations(used_area_safe);
 
         auto surf = new QuadSurface(points_crop, {1/T, 1/T});
+        surf->setDpi(voxelSizeToDpi(voxelsize));
         surf->setChannel("generations", generations_crop);
 
         if (params.value("vis_losses", false)) {

--- a/volume-cartographer/core/src/GrowSurface.cpp
+++ b/volume-cartographer/core/src/GrowSurface.cpp
@@ -2372,6 +2372,7 @@ QuadSurface *grow_surf_from_surfs(QuadSurface *seed, const std::vector<QuadSurfa
                                /*inpaint=*/false, approved_weight_hr, prefer_approved_in_hr);
 
     auto surf = new QuadSurface(points_hr(used_area_hr), {1/src_step,1/src_step});
+    surf->setDpi(voxelSizeToDpi(voxelsize));
 
     auto gen_channel = surftrack_generation_channel(generations, used_area, step);
     if (!gen_channel.empty())

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -514,7 +514,7 @@ void QuadSurface::writeValidMask(const cv::Mat& img)
     cv::Mat_<uint8_t> mask = validMask();
 
     if (img.empty()) {
-        writeTiff(maskPath, mask);
+        writeTiff(maskPath, mask, -1, 1024, 1024, -1.0f, COMPRESSION_LZW, dpi_);
     } else {
         std::vector<cv::Mat> layers = {mask, img};
         cv::imwritemulti(maskPath.string(), layers);
@@ -1035,9 +1035,9 @@ void QuadSurface::writeDataToDirectory(const std::filesystem::path& dir, const s
     cv::split((*_points), xyz);
 
     // Write x/y/z as 32-bit float tiled TIFF with LZW
-    writeTiff(dir / "x.tif", xyz[0]);
-    writeTiff(dir / "y.tif", xyz[1]);
-    writeTiff(dir / "z.tif", xyz[2]);
+    writeTiff(dir / "x.tif", xyz[0], -1, 1024, 1024, -1.0f, COMPRESSION_LZW, dpi_);
+    writeTiff(dir / "y.tif", xyz[1], -1, 1024, 1024, -1.0f, COMPRESSION_LZW, dpi_);
+    writeTiff(dir / "z.tif", xyz[2], -1, 1024, 1024, -1.0f, COMPRESSION_LZW, dpi_);
 
     // OpenCV compression params for fallback
     std::vector<int> compression_params = { cv::IMWRITE_TIFF_COMPRESSION, 5 };
@@ -1052,7 +1052,7 @@ void QuadSurface::writeDataToDirectory(const std::filesystem::path& dir, const s
                 (mat.type() == CV_8UC1 || mat.type() == CV_16UC1 || mat.type() == CV_32FC1))
             {
                 try {
-                    writeTiff(dir / (name + ".tif"), mat);
+                    writeTiff(dir / (name + ".tif"), mat, -1, 1024, 1024, -1.0f, COMPRESSION_LZW, dpi_);
                     wrote = true;
                 } catch (...) {
                     wrote = false; // Fall back to OpenCV

--- a/volume-cartographer/core/src/Tiff.cpp
+++ b/volume-cartographer/core/src/Tiff.cpp
@@ -79,13 +79,7 @@ cv::Mat convertWithScaling(const cv::Mat& img, int targetType) {
 // writeTiff implementation
 // ============================================================================
 
-void writeTiff(const std::filesystem::path& outPath,
-               const cv::Mat& img,
-               int cvType,
-               uint32_t tileW,
-               uint32_t tileH,
-               float padValue,
-               uint16_t compression)
+void writeTiff(const std::filesystem::path& outPath, const cv::Mat& img, int cvType, uint32_t tileW, uint32_t tileH, float padValue, uint16_t compression, float dpi)
 {
     if (img.empty())
         throw std::runtime_error("Empty image for " + outPath.string());
@@ -117,6 +111,11 @@ void writeTiff(const std::filesystem::path& outPath,
         TIFFSetField(tf, TIFFTAG_PREDICTOR,   PREDICTOR_HORIZONTAL);
     TIFFSetField(tf, TIFFTAG_TILEWIDTH,       tileW);
     TIFFSetField(tf, TIFFTAG_TILELENGTH,      tileH);
+    if (dpi > 0.f) {
+        TIFFSetField(tf, TIFFTAG_RESOLUTIONUNIT, RESUNIT_INCH);
+        TIFFSetField(tf, TIFFTAG_XRESOLUTION, dpi);
+        TIFFSetField(tf, TIFFTAG_YRESOLUTION, dpi);
+    }
 
     const size_t tileBytes = static_cast<size_t>(tileW) * tileH * params.elemSize;
     std::vector<uint8_t> tileBuf(tileBytes);
@@ -158,15 +157,8 @@ void writeTiff(const std::filesystem::path& outPath,
 // TiffWriter implementation
 // ============================================================================
 
-TiffWriter::TiffWriter(const std::filesystem::path& path,
-                       uint32_t width, uint32_t height,
-                       int cvType,
-                       uint32_t tileW,
-                       uint32_t tileH,
-                       float padValue,
-                       uint16_t compression)
-    : _width(width), _height(height), _tileW(tileW), _tileH(tileH),
-      _cvType(cvType), _padValue(padValue), _path(path)
+TiffWriter::TiffWriter(const std::filesystem::path& path, uint32_t width, uint32_t height, int cvType, uint32_t tileW, uint32_t tileH, float padValue, uint16_t compression, float dpi)
+    : _width(width), _height(height), _tileW(tileW), _tileH(tileH), _cvType(cvType), _padValue(padValue), _path(path)
 {
     const auto params = getTiffParams(cvType);
     _elemSize = params.elemSize;
@@ -187,6 +179,11 @@ TiffWriter::TiffWriter(const std::filesystem::path& path,
         TIFFSetField(_tiff, TIFFTAG_PREDICTOR,   PREDICTOR_HORIZONTAL);
     TIFFSetField(_tiff, TIFFTAG_TILEWIDTH,       tileW);
     TIFFSetField(_tiff, TIFFTAG_TILELENGTH,      tileH);
+    if (dpi > 0.f) {
+        TIFFSetField(_tiff, TIFFTAG_RESOLUTIONUNIT, RESUNIT_INCH);
+        TIFFSetField(_tiff, TIFFTAG_XRESOLUTION, dpi);
+        TIFFSetField(_tiff, TIFFTAG_YRESOLUTION, dpi);
+    }
 
     // Allocate reusable tile buffer
     _tileBuf.resize(static_cast<size_t>(tileW) * tileH * _elemSize);
@@ -299,6 +296,10 @@ bool mergeTiffParts(const std::string& outputPath, int numParts)
         TIFFGetField(first, TIFFTAG_SAMPLESPERPIXEL, &spp);
         TIFFGetField(first, TIFFTAG_SAMPLEFORMAT, &sf);
         TIFFGetField(first, TIFFTAG_COMPRESSION, &comp);
+        uint16_t resUnit = 0;
+        float xRes = 0, yRes = 0;
+        bool hasRes = TIFFGetField(first, TIFFTAG_RESOLUTIONUNIT, &resUnit) && TIFFGetField(first, TIFFTAG_XRESOLUTION, &xRes) &&
+                      TIFFGetField(first, TIFFTAG_YRESOLUTION, &yRes);
         TIFFClose(first);
 
         TIFF* out = TIFFOpen(finalPath.c_str(), "w");
@@ -308,6 +309,11 @@ bool mergeTiffParts(const std::string& outputPath, int numParts)
         TIFFSetField(out, TIFFTAG_BITSPERSAMPLE, bps); TIFFSetField(out, TIFFTAG_SAMPLESPERPIXEL, spp);
         TIFFSetField(out, TIFFTAG_SAMPLEFORMAT, sf); TIFFSetField(out, TIFFTAG_COMPRESSION, comp);
         TIFFSetField(out, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+        if (hasRes) {
+            TIFFSetField(out, TIFFTAG_RESOLUTIONUNIT, resUnit);
+            TIFFSetField(out, TIFFTAG_XRESOLUTION, xRes);
+            TIFFSetField(out, TIFFTAG_YRESOLUTION, yRes);
+        }
 
         tmsize_t tileBytes = TIFFTileSize(out);
         std::vector<uint8_t> buf(tileBytes, 0), zero(tileBytes, 0);


### PR DESCRIPTION
## Summary
- Derives DPI from `voxelsize` metadata (`25400 / voxelSize_µm`) and embeds it in TIFF output via `TIFFTAG_XRESOLUTION`/`TIFFTAG_YRESOLUTION` tags
- Adds `voxelSizeToDpi()` helper and optional `dpi` parameter to `writeTiff()`/`TiffWriter`
- Propagates resolution tags through `mergeTiffParts`
- Sets DPI on `QuadSurface` from tracer/grower voxelsize so all saved segment TIFFs get correct resolution
- Reads voxelsize from `meta.json` in `vc_zarr_to_tiff` and `vc_render_tifxyz`

## Test plan
- [ ] Build and verify no regressions
- [ ] Run `vc_zarr_to_tiff` on a volume with known voxelsize, verify output TIFFs have correct DPI via `tiffinfo`
- [ ] Grow a segment and verify saved x/y/z.tif files have DPI set
- [ ] Render with `vc_render_tifxyz` and verify output TIFFs have DPI set

🤖 Generated with [Claude Code](https://claude.com/claude-code)