### PR TITLE
volume-registration: add optional constraint fitting mode

### DIFF
--- a/foundation/volume-registration/README.md
+++ b/foundation/volume-registration/README.md
@@ -79,7 +79,7 @@ First one roughly positions the moving source using the following commands:
 
 Next, landmark points are added to each source based on visual features.
 These refine the transform.
-After there are 4+ pairs of landmark points, the transform is automatically fit to the landmark points each time a point pair is added.
+After there are sufficient pairs of landmark points (4+ in unconstrained mode, 3+ in constrained mode), the transform is automatically fit to the landmark points each time a point pair is added.
 
 - `Alt + 1` - Add landmark point to fixed volume at cursor position
 - `Alt + 2` - Add landmark point to moving volume at cursor position
@@ -107,6 +107,13 @@ After the transform is fit from landmarks, a **landmark errors** layer appears i
 - `Alt + Shift + ]` - Navigate to the landmark with the largest error
 
 This is useful for identifying landmarks that may need adjustment, or for spotting regions where a non-affine transform might be needed.
+
+#### Constrained fit mode
+
+By default, landmark fitting uses an unconstrained 12 DOF affine (requires 4+ point pairs). For volumes that share physical constraints — roughly aligned z-axis, isotropic scaling, rotation mainly around z — a **constrained fit mode** is available that fits only 5 continuous parameters: isotropic scale, z-rotation angle, and 3D translation. It additionally tries all 8 axis flip combinations (independent ±1 on each axis) and picks the best. This requires only 3+ point pairs.
+
+- `m` - Toggle between constrained and unconstrained fit mode
+- `--constrained-fit` - Start in constrained fit mode
 
 #### Automatically refining the transform
 > **_NOTE:_**  Not particularly recommended, as the current implementation uses low-resolution levels of the Zarr input volumes, and does not result in precise transforms.

--- a/foundation/volume-registration/find_transform.py
+++ b/foundation/volume-registration/find_transform.py
@@ -1640,6 +1640,9 @@ def delete_nearest_point(action_state):
 def toggle_constrained_fit(_):
     """Toggle between constrained and unconstrained affine fitting."""
     global constrained_fit_mode
+    if not constrained_fit_mode and moving_source.source_type == "mesh":
+        print("Constrained fit mode is not supported with mesh moving sources.")
+        return
     constrained_fit_mode = not constrained_fit_mode
     mode = "CONSTRAINED (5 DOF + z-flip)" if constrained_fit_mode else "UNCONSTRAINED (12 DOF)"
     print(f"Fit mode: {mode}")
@@ -1914,6 +1917,12 @@ if __name__ == "__main__":
         args.moving_source_unit_size,
     )
     scale_factor = moving_source.unit_size_um / fixed_dimensions.voxel_size_um
+
+    if moving_source.source_type == "mesh" and constrained_fit_mode:
+        raise ValueError(
+            "Constrained fit mode is not supported with mesh moving sources "
+            "(mesh landmarks use XYZ order, but the constrained solver assumes ZYX)."
+        )
 
     if moving_source.source_type == "mesh":
         moving_mesh_geometry = read_vtk_mesh_geometry(args.moving)

--- a/foundation/volume-registration/find_transform.py
+++ b/foundation/volume-registration/find_transform.py
@@ -39,6 +39,7 @@ from transform_utils import (
     get_vtk_mesh_info,
     invert_affine_matrix,
     fit_affine_transform_from_points,
+    fit_constrained_transform_from_points,
     MeshGeometry,
     matrix_swap_output_xyz_zyx,
     matrix_swap_xyz_zyx,
@@ -137,6 +138,7 @@ mesh_slice_max_segments = 256
 numba_mesh_slice_kernels_warmed = False
 slice_overlay_update_pending = False
 last_mesh_slice_overlay_key = None
+constrained_fit_mode = False
 
 
 def infer_moving_source_type(path: str, explicit_type: str) -> str:
@@ -1380,7 +1382,12 @@ def navigate_to_next_fixed_point(action_state):
 
 
 def update_transform_if_sufficient_points(state):
-    """Update transform if there are 4+ matching point pairs."""
+    """Update transform if there are sufficient matching point pairs.
+
+    Uses constrained fitting (5 DOF + z-flip, min 3 pairs) or unconstrained
+    affine fitting (12 DOF, min 4 pairs) depending on constrained_fit_mode.
+    """
+    global constrained_fit_mode
     if (
         FIXED_POINTS_LAYER_STR in state.layers
         and MOVING_POINTS_LAYER_STR in state.layers
@@ -1388,22 +1395,29 @@ def update_transform_if_sufficient_points(state):
         fixed_annotations = state.layers[FIXED_POINTS_LAYER_STR].layer.annotations
         moving_annotations = state.layers[MOVING_POINTS_LAYER_STR].layer.annotations
 
+        min_points = 3 if constrained_fit_mode else 4
         if (
             len(fixed_annotations) == len(moving_annotations)
-            and len(fixed_annotations) >= 4
+            and len(fixed_annotations) >= min_points
         ):
-            # Extract point coordinates from annotations
             fixed_points_list = [list(ann.point) for ann in fixed_annotations]
             moving_points_list = [list(ann.point) for ann in moving_annotations]
 
-            transform = fit_affine_transform_from_points(
-                fixed_points_list, moving_points_list
-            )
+            if constrained_fit_mode:
+                mode_label = "constrained"
+                transform = fit_constrained_transform_from_points(
+                    fixed_points_list, moving_points_list
+                )
+            else:
+                mode_label = "unconstrained"
+                transform = fit_affine_transform_from_points(
+                    fixed_points_list, moving_points_list
+                )
             if transform is not None:
                 set_current_transform(state, transform)
                 update_error_layer(state)
                 print(
-                    f"Automatically updated transform from {len(fixed_annotations)} point pairs"
+                    f"Updated transform ({mode_label}) from {len(fixed_annotations)} point pairs"
                 )
                 return True
     return False
@@ -1623,6 +1637,16 @@ def delete_nearest_point(action_state):
         update_transform_if_sufficient_points(state)
 
 
+def toggle_constrained_fit(_):
+    """Toggle between constrained and unconstrained affine fitting."""
+    global constrained_fit_mode
+    constrained_fit_mode = not constrained_fit_mode
+    mode = "CONSTRAINED (5 DOF + z-flip)" if constrained_fit_mode else "UNCONSTRAINED (12 DOF)"
+    print(f"Fit mode: {mode}")
+    with viewer.txn() as state:
+        update_transform_if_sufficient_points(state)
+
+
 def write_current_transform(_):
     """Write the current transform and print the shareable URL."""
     with viewer.txn() as state:
@@ -1641,6 +1665,7 @@ def add_actions_and_keybinds(
 ) -> None:
 
     viewer.actions.add("toggle-color", toggle_color)
+    viewer.actions.add("toggle-constrained-fit", toggle_constrained_fit)
     viewer.actions.add("write-transform", write_current_transform)
     if enable_fine_align:
         viewer.actions.add("fine-align", fine_align)
@@ -1710,6 +1735,7 @@ def add_actions_and_keybinds(
 
     with viewer.config_state.txn() as s:
         s.input_event_bindings.viewer["keyc"] = "toggle-color"
+        s.input_event_bindings.viewer["keym"] = "toggle-constrained-fit"
         s.input_event_bindings.viewer["keyw"] = "write-transform"
         if enable_fine_align:
             s.input_event_bindings.viewer["keyf"] = "fine-align"
@@ -1853,6 +1879,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Invert the initial transform before applying it",
     )
+    parser.add_argument(
+        "--constrained-fit",
+        action="store_true",
+        help="Start in constrained fit mode (5 DOF + z-flip instead of 12 DOF affine). Toggle at runtime with 'm'.",
+    )
     args = parser.parse_args()
 
     if not sys.flags.interactive:
@@ -1860,6 +1891,10 @@ if __name__ == "__main__":
             f"Running in non-interactive mode. Use `python -i {Path(__file__).name}` to run in interactive mode (required for neuroglancer)."
         )
         sys.exit(1)
+
+    if args.constrained_fit:
+        constrained_fit_mode = True
+        print("Starting in CONSTRAINED fit mode (5 DOF + z-flip). Press 'm' to toggle.")
 
     if args.output_transform is not None:
         if not args.output_transform.endswith(".json"):

--- a/foundation/volume-registration/requirements.txt
+++ b/foundation/volume-registration/requirements.txt
@@ -32,6 +32,7 @@ referencing==0.36.2
 requests==2.32.4
 rpds-py==0.27.0
 rsa==4.9.1
+scipy==1.15.3
 simpleitk==2.5.2
 six==1.17.0
 tornado==6.5.1

--- a/foundation/volume-registration/transform_utils.py
+++ b/foundation/volume-registration/transform_utils.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin, urlparse
 import jsonschema
 import numpy as np
 import requests
+from scipy.optimize import least_squares
 import SimpleITK as sitk
 import zarr
 
@@ -506,6 +507,83 @@ def fit_affine_transform_from_points(fixed_points, moving_points):
     transform_4x4 = np.vstack([transform_3x4, [0, 0, 0, 1]])
 
     return transform_4x4
+
+
+def fit_constrained_transform_from_points(fixed_points, moving_points):
+    """Fit a constrained affine transform from corresponding point pairs.
+
+    Fits 5 continuous parameters + 3 discrete sign choices:
+    - Isotropic scale s
+    - Rotation around z-axis (index 0 in ZYX) by angle theta
+    - Translation tx, ty, tz
+    - Independent axis flips: fz, fy, fx each ±1 (tries all 8 combinations)
+
+    The transform applies flip, then rotation, then scale, then translation.
+    The resulting 4x4 matrix in ZYX order is:
+        [fz*s    0               0              tz]
+        [0       fy*s*cos(θ)    -fx*s*sin(θ)    ty]
+        [0       fy*s*sin(θ)     fx*s*cos(θ)    tx]
+        [0       0               0               1]
+
+    Args:
+        fixed_points: List of points in fixed space (Nx3, ZYX order)
+        moving_points: List of points in moving space (Nx3, ZYX order)
+
+    Returns:
+        4x4 affine transformation matrix or None if insufficient points
+    """
+    if len(fixed_points) != len(moving_points) or len(fixed_points) < 3:
+        return None
+
+    fixed_array = np.array(fixed_points)
+    moving_array = np.array(moving_points)
+
+    def _build_matrix(params, flips):
+        s, theta, tx, ty, tz = params
+        fz, fy, fx = flips
+        cos_t = np.cos(theta)
+        sin_t = np.sin(theta)
+        return np.array([
+            [fz * s, 0,              0,             tz],
+            [0,      fy * s * cos_t, -fx * s * sin_t, ty],
+            [0,      fy * s * sin_t,  fx * s * cos_t, tx],
+            [0,      0,              0,              1],
+        ])
+
+    def _residuals(params, flips):
+        mat = _build_matrix(params, flips)
+        moving_h = np.column_stack([moving_array, np.ones(len(moving_array))])
+        predicted = (mat @ moving_h.T).T[:, :3]
+        return (predicted - fixed_array).ravel()
+
+    # Initial scale estimate
+    fixed_spread = np.linalg.norm(fixed_array - fixed_array.mean(axis=0), axis=1).mean()
+    moving_spread = np.linalg.norm(moving_array - moving_array.mean(axis=0), axis=1).mean()
+    s0 = fixed_spread / moving_spread if moving_spread > 0 else 1.0
+
+    fixed_centroid = fixed_array.mean(axis=0)  # [z, y, x]
+    moving_centroid = moving_array.mean(axis=0)
+
+    best_result = None
+    best_cost = np.inf
+    best_flips = (1, 1, 1)
+
+    for fz in [1, -1]:
+        for fy in [1, -1]:
+            for fx in [1, -1]:
+                flips = (fz, fy, fx)
+                # Initial translation: t = fixed_centroid - diag(fz,fy,fx)*s0 * moving_centroid
+                tz0 = fixed_centroid[0] - fz * s0 * moving_centroid[0]
+                ty0 = fixed_centroid[1] - fy * s0 * moving_centroid[1]
+                tx0 = fixed_centroid[2] - fx * s0 * moving_centroid[2]
+                init = [s0, 0.0, tx0, ty0, tz0]
+                result = least_squares(_residuals, init, args=(flips,))
+                if result.cost < best_cost:
+                    best_cost = result.cost
+                    best_result = result
+                    best_flips = flips
+
+    return _build_matrix(best_result.x, best_flips)
 
 
 def check_images_with_transform(


### PR DESCRIPTION
This is valuable for finding an initial fit with less points without ending up with crazy sheared fits when some points are off and with a shallower distribution of points (e.g. across z).

The constraints are:
 - only isotropic scaling allowed + translation
 - z-axis parallel between scans
 - flips / reflections allowed

You can change the fit mode with key `m`. Usually, after finding an initial fit using the unconstrained mode will lead to better results, probably because the z-axis is slightly tilted in most cases.