### PR TITLE
[codex] Fix volume-cartographer rasterize and ignore-label semantics

### DIFF
--- a/volume-cartographer/.dockerignore
+++ b/volume-cartographer/.dockerignore
@@ -6,3 +6,7 @@
 .zenodo.json
 build
 results
+**/build/
+**/CMakeFiles/
+**/CMakeCache.txt
+**/cmake-build*/

--- a/volume-cartographer/apps/VC3D/CMakeLists.txt
+++ b/volume-cartographer/apps/VC3D/CMakeLists.txt
@@ -175,6 +175,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endif()
 endif()
 
+if(AVAHI_FOUND)
+    target_compile_definitions(VC3D PRIVATE VC_HAVE_AVAHI=1)
+else()
+    target_compile_definitions(VC3D PRIVATE VC_HAVE_AVAHI=0)
+endif()
+
 target_link_libraries(VC3D
     vc_core
     vc_ui
@@ -189,4 +195,3 @@ target_link_libraries(VC3D
     $<$<BOOL:${AVAHI_FOUND}>:PkgConfig::AVAHI>
     blosc_static
 )
-

--- a/volume-cartographer/apps/VC3D/LasagnaServiceManager.cpp
+++ b/volume-cartographer/apps/VC3D/LasagnaServiceManager.cpp
@@ -22,7 +22,7 @@
 #endif
 
 // Avahi client library for mDNS service discovery
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) && defined(VC_HAVE_AVAHI) && VC_HAVE_AVAHI
 #include <avahi-client/client.h>
 #include <avahi-client/lookup.h>
 #include <avahi-common/error.h>
@@ -613,7 +613,7 @@ QJsonArray LasagnaServiceManager::discoverServices()
     }
 
     // --- mDNS discovery via avahi-client library ---
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) && defined(VC_HAVE_AVAHI) && VC_HAVE_AVAHI
     {
         struct AvahiDiscovery {
             QJsonArray* result;
@@ -729,6 +729,9 @@ QJsonArray LasagnaServiceManager::discoverServices()
             avahi_simple_poll_free(poll);
         }
     }
+#elif defined(Q_OS_LINUX)
+    std::cerr << "[lasagna] avahi-client headers not available; skipping mDNS discovery"
+              << std::endl;
 #endif
 
     return result;

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -202,33 +202,73 @@ static bool writeJsonObject(const QString& path, const QJsonObject& obj)
     return true;
 }
 
-static bool selectRasterizeChunkSize(QWidget* parent, int* outChunkSize)
+struct RasterizeDialogResult {
+    int chunkSize{128};
+    int zMin{0};
+    int zMax{-1};
+};
+
+static bool selectRasterizeParams(QWidget* parent, RasterizeDialogResult* out)
 {
-    if (!outChunkSize) {
+    if (!out) {
         return false;
     }
+
+    QDialog dlg(parent);
+    dlg.setWindowTitle(QObject::tr("Rasterize"));
+
+    auto* main = new QVBoxLayout(&dlg);
+    auto* form = new QFormLayout();
 
     QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
     const int savedChunkSize = std::clamp(
         settings.value(QStringLiteral("tools/rasterize_chunk_size"), 128).toInt(),
         1, 4096);
+    const int savedZMin = std::max(0, settings.value(QStringLiteral("tools/rasterize_z_min"), 0).toInt());
+    const int savedZMax = settings.value(QStringLiteral("tools/rasterize_z_max"), -1).toInt();
 
-    bool ok = false;
-    const int chunkSize = QInputDialog::getInt(
-        parent,
-        QObject::tr("Rasterize"),
-        QObject::tr("Isotropic chunk size (voxels, applied to all pyramid levels):"),
-        savedChunkSize,
-        1,
-        4096,
-        1,
-        &ok);
-    if (!ok) {
+    auto* spChunkSize = new QSpinBox(&dlg);
+    spChunkSize->setRange(1, 4096);
+    spChunkSize->setValue(savedChunkSize);
+    spChunkSize->setToolTip(QObject::tr("Isotropic chunk size applied to all pyramid levels."));
+    form->addRow(QObject::tr("Chunk size:"), spChunkSize);
+
+    auto* spZMin = new QSpinBox(&dlg);
+    spZMin->setRange(0, 1000000000);
+    spZMin->setValue(savedZMin);
+    form->addRow(QObject::tr("Level-0 Z min:"), spZMin);
+
+    auto* spZMax = new QSpinBox(&dlg);
+    spZMax->setRange(-1, 1000000000);
+    spZMax->setValue(savedZMax);
+    spZMax->setToolTip(QObject::tr("-1 means the end of the level-0 volume."));
+    form->addRow(QObject::tr("Level-0 Z max (exclusive):"), spZMax);
+
+    main->addLayout(form);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dlg);
+    QObject::connect(buttons, &QDialogButtonBox::accepted, &dlg, [&]() {
+        if (spZMax->value() >= 0 && spZMin->value() >= spZMax->value()) {
+            QMessageBox::warning(&dlg,
+                                 QObject::tr("Error"),
+                                 QObject::tr("Z min must be smaller than Z max unless Z max is -1."));
+            return;
+        }
+        settings.setValue(QStringLiteral("tools/rasterize_chunk_size"), spChunkSize->value());
+        settings.setValue(QStringLiteral("tools/rasterize_z_min"), spZMin->value());
+        settings.setValue(QStringLiteral("tools/rasterize_z_max"), spZMax->value());
+        dlg.accept();
+    });
+    QObject::connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+    main->addWidget(buttons);
+
+    if (dlg.exec() != QDialog::Accepted) {
         return false;
     }
 
-    settings.setValue(QStringLiteral("tools/rasterize_chunk_size"), chunkSize);
-    *outChunkSize = chunkSize;
+    out->chunkSize = spChunkSize->value();
+    out->zMin = spZMin->value();
+    out->zMax = spZMax->value();
     return true;
 }
 
@@ -272,7 +312,7 @@ static bool isRasterizedLabelVolumePath(const QString& volumePath)
 struct IgnoreLabelDialogResult {
     QString volumePath;
     QString outputName;
-    int ignoreValue{127};
+    int ignoreValue{2};
     double chunkAlphaL0{64.0};
     int workers{0};
     int zMin{0};
@@ -393,7 +433,7 @@ bool selectIgnoreLabelParams(QWidget* parent,
 
     auto* spIgnore = new QSpinBox(&dlg);
     spIgnore->setRange(1, 254);
-    spIgnore->setValue(settings.value(QStringLiteral("tools/add_ignore_label_ignore_value"), 127).toInt());
+    spIgnore->setValue(settings.value(QStringLiteral("tools/add_ignore_label_ignore_value"), 2).toInt());
     form->addRow(QObject::tr("Ignore value:"), spIgnore);
 
     auto* lblMode = new QLabel(
@@ -2654,8 +2694,8 @@ void SegmentationCommandHandler::onRasterizeSegments(const QStringList& segmentI
         return;
     }
 
-    int chunkSize = 128;
-    if (!selectRasterizeChunkSize(_parentWidget, &chunkSize)) {
+    RasterizeDialogResult rasterizeParams;
+    if (!selectRasterizeParams(_parentWidget, &rasterizeParams)) {
         return;
     }
 
@@ -2746,10 +2786,15 @@ void SegmentationCommandHandler::onRasterizeSegments(const QStringList& segmentI
          << QStringLiteral("--reference-zarr")
          << referenceZarr
          << QStringLiteral("--chunk-size")
-         << QString::number(chunkSize)
+         << QString::number(rasterizeParams.chunkSize)
+         << QStringLiteral("--z-min")
+         << QString::number(rasterizeParams.zMin)
          << QStringLiteral("--raster-mode")
          << QStringLiteral("zyx-integer")
          << QStringLiteral("--overwrite");
+    if (rasterizeParams.zMax >= 0) {
+        args << QStringLiteral("--z-max") << QString::number(rasterizeParams.zMax);
+    }
     for (const QString& segmentId : validIds) {
         args << QStringLiteral("--source-segment") << segmentId;
     }
@@ -3435,7 +3480,7 @@ bool SegmentationCommandHandler::appendRasterizationMetadata(const QString& outp
         metaJson["slices"] = 0;
         metaJson["voxelsize"] = 0.0;
         metaJson["min"] = 0.0;
-        metaJson["max"] = 255.0;
+        metaJson["max"] = 1.0;
         metaJson["format"] = QStringLiteral("zarr");
     }
 

--- a/volume-cartographer/apps/src/vc_add_ignore_label.cpp
+++ b/volume-cartographer/apps/src/vc_add_ignore_label.cpp
@@ -53,7 +53,7 @@ constexpr double kDefaultAlpha = 0.005;
 constexpr double kDefaultShrink = 0.95;
 constexpr int kDefaultInnerSmoothing = 5;
 constexpr int kDefaultOuterSmoothing = 5;
-constexpr int kDefaultIgnoreValue = 127;
+constexpr int kDefaultIgnoreValue = 2;
 constexpr std::size_t kLockPoolSize = 4096;
 constexpr double kPi = 3.14159265358979323846264338327950288;
 constexpr double kRadPerDeg = kPi / 180.0;
@@ -697,6 +697,82 @@ static std::size_t linearIndex(const Shape3& shape,
                                std::size_t x)
 {
     return (z * shape[1] + y) * shape[2] + x;
+}
+
+static bool shouldDropIgnoreSparseChunk(const Shape3& datasetShape,
+                                        const Shape3& chunkShape,
+                                        const ChunkIndex& chunk,
+                                        const std::vector<uint8_t>& chunkBuf,
+                                        uint8_t ignoreValue)
+{
+    const Shape3 chunkOrigin = {
+        chunk.z * chunkShape[0],
+        chunk.y * chunkShape[1],
+        chunk.x * chunkShape[2],
+    };
+    const Shape3 validShape = {
+        chunkOrigin[0] < datasetShape[0] ? std::min(chunkShape[0], datasetShape[0] - chunkOrigin[0]) : 0,
+        chunkOrigin[1] < datasetShape[1] ? std::min(chunkShape[1], datasetShape[1] - chunkOrigin[1]) : 0,
+        chunkOrigin[2] < datasetShape[2] ? std::min(chunkShape[2], datasetShape[2] - chunkOrigin[2]) : 0,
+    };
+
+    const auto isUniformValid = [&](uint8_t value) {
+        if (validShape[0] == 0 || validShape[1] == 0 || validShape[2] == 0) {
+            return true;
+        }
+        for (std::size_t z = 0; z < validShape[0]; ++z) {
+            for (std::size_t y = 0; y < validShape[1]; ++y) {
+                const std::size_t rowBase = linearIndex(chunkShape, z, y, 0);
+                for (std::size_t x = 0; x < validShape[2]; ++x) {
+                    if (chunkBuf[rowBase + x] != value) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    };
+
+    return isUniformValid(uint8_t(0)) || isUniformValid(ignoreValue);
+}
+
+static bool persistIgnoreSparseChunk(vc::VcDataset& dataset,
+                                     const ChunkIndex& chunk,
+                                     const std::vector<uint8_t>& chunkBuf,
+                                     uint8_t ignoreValue,
+                                     ProfileStats* profile = nullptr,
+                                     bool pyramidWrite = false)
+{
+    const Shape3 datasetShape = toShape3(dataset.shape());
+    const Shape3 chunkShape = toShape3(dataset.defaultChunkShape());
+    auto writeStart = std::chrono::steady_clock::now();
+    const bool dropChunk =
+        shouldDropIgnoreSparseChunk(datasetShape, chunkShape, chunk, chunkBuf, ignoreValue);
+    bool changed = false;
+    if (dropChunk) {
+        changed = dataset.removeChunk(chunk.z, chunk.y, chunk.x);
+    } else {
+        dataset.writeChunk(chunk.z,
+                           chunk.y,
+                           chunk.x,
+                           chunkBuf.data(),
+                           chunkBuf.size() * sizeof(uint8_t));
+        changed = true;
+    }
+
+    if (profile) {
+        auto writeEnd = std::chrono::steady_clock::now();
+        if (pyramidWrite) {
+            profile->tPyramidWrite.add(std::chrono::duration<double>(writeEnd - writeStart).count());
+        } else {
+            profile->tChunkWriteIo.add(std::chrono::duration<double>(writeEnd - writeStart).count());
+            ++profile->chunkIoWrites;
+        }
+        if (!dropChunk) {
+            profile->bytesWritten += chunkBuf.size() * sizeof(uint8_t);
+        }
+    }
+    return changed;
 }
 
 static bool boxIntersectsZRange(const Box3& box, int zStart, int zStop)
@@ -1382,7 +1458,7 @@ static void applyMaskToOutputZRangeLegacy(
                 std::lock_guard<std::mutex> guard(lockPool.lockFor(cz, cy, cx));
                 auto ioStart = std::chrono::steady_clock::now();
                 chunkBuf.assign(chunkElems, 0);
-                output.readChunk(cz, cy, cx, chunkBuf.data());
+                output.readChunkOrFill(cz, cy, cx, chunkBuf.data());
                 if (profile) {
                     auto ioEnd = std::chrono::steady_clock::now();
                     profile->tChunkReadIo.add(
@@ -1415,16 +1491,9 @@ static void applyMaskToOutputZRangeLegacy(
                 }
 
                 if (changed) {
-                    auto ioWriteStart = std::chrono::steady_clock::now();
-                    output.writeChunk(cz, cy, cx, chunkBuf.data(), chunkBytes);
-                    if (profile) {
-                        auto ioWriteEnd = std::chrono::steady_clock::now();
-                        profile->tChunkWriteIo.add(
-                            std::chrono::duration<double>(ioWriteEnd - ioWriteStart).count());
-                        ++profile->chunkIoWrites;
-                        profile->bytesWritten += chunkBytes;
+                    if (persistIgnoreSparseChunk(output, chunk, chunkBuf, ignoreValue, profile)) {
+                        touchedLevel0.insert(chunk);
                     }
-                    touchedLevel0.insert(chunk);
                 }
             }
         }
@@ -1500,7 +1569,7 @@ static void applyMaskToOutputZRangeMapped(
                 std::lock_guard<std::mutex> guard(lockPool.lockFor(cz, cy, cx));
                 auto ioStart = std::chrono::steady_clock::now();
                 chunkBuf.assign(chunkElems, 0);
-                output.readChunk(cz, cy, cx, chunkBuf.data());
+                output.readChunkOrFill(cz, cy, cx, chunkBuf.data());
                 if (profile) {
                     auto ioEnd = std::chrono::steady_clock::now();
                     profile->tChunkReadIo.add(std::chrono::duration<double>(ioEnd - ioStart).count());
@@ -1535,16 +1604,9 @@ static void applyMaskToOutputZRangeMapped(
                 }
 
                 if (changed) {
-                    auto ioWriteStart = std::chrono::steady_clock::now();
-                    output.writeChunk(cz, cy, cx, chunkBuf.data(), chunkBytes);
-                    if (profile) {
-                        auto ioWriteEnd = std::chrono::steady_clock::now();
-                        profile->tChunkWriteIo.add(
-                            std::chrono::duration<double>(ioWriteEnd - ioWriteStart).count());
-                        ++profile->chunkIoWrites;
-                        profile->bytesWritten += chunkBytes;
+                    if (persistIgnoreSparseChunk(output, chunk, chunkBuf, ignoreValue, profile)) {
+                        touchedLevel0.insert(chunk);
                     }
-                    touchedLevel0.insert(chunk);
                 }
             }
         }
@@ -1862,6 +1924,18 @@ static void copyRootMetadata(const fs::path& inputRoot,
     }
 }
 
+static void rewriteOutputFillValue(const fs::path& outputRoot,
+                                   const std::vector<int>& levels,
+                                   uint8_t fillValue)
+{
+    for (int level : levels) {
+        const fs::path zarrayPath = outputRoot / std::to_string(level) / ".zarray";
+        nlohmann::json zarray = readJsonFile(zarrayPath);
+        zarray["fill_value"] = static_cast<int>(fillValue);
+        writeJsonFile(zarrayPath, zarray);
+    }
+}
+
 static void copyLevelFromExisting(const fs::path& inputLevelPath,
                                   const fs::path& outputLevelPath,
                                   const std::unordered_set<ChunkIndex, ChunkIndexHash>& existingChunks,
@@ -2067,9 +2141,7 @@ static bool readAlignedSourceRegionByChunk(vc::VcDataset& src,
                     for (std::size_t xc = xChunkStart; xc < xChunkStart + xChunks; ++xc) {
                         const std::size_t dstX = (xc - xChunkStart) * srcChunk[2];
                         try {
-                            if (!src.readChunk(zc, yc, xc, chunkBuf.data())) {
-                                std::fill(chunkBuf.begin(), chunkBuf.end(), uint8_t(0));
-                            }
+                            src.readChunkOrFill(zc, yc, xc, chunkBuf.data());
                         } catch (...) {
                             return false;
                         }
@@ -2087,6 +2159,146 @@ static bool readAlignedSourceRegionByChunk(vc::VcDataset& src,
     }
 
     return true;
+}
+
+static std::vector<ChunkIndex> clearLevel0OutsideZRange(
+    vc::VcDataset& output,
+    const Shape3& outShape,
+    const Shape3& outChunk,
+    const std::unordered_set<ChunkIndex, ChunkIndexHash>& existingOutputChunks,
+    std::size_t keepZ0,
+    std::size_t keepZ1,
+    uint8_t ignoreValue,
+    std::size_t workers,
+    ProfileStats* profile = nullptr)
+{
+    if (keepZ0 == 0 && keepZ1 == outShape[0]) {
+        return {};
+    }
+
+    std::vector<ChunkIndex> affected;
+    affected.reserve(existingOutputChunks.size());
+    for (const auto& chunk : existingOutputChunks) {
+        const std::size_t chunkZ0 = chunk.z * outChunk[0];
+        const std::size_t chunkZ1 = std::min(chunkZ0 + outChunk[0], outShape[0]);
+        if (chunkZ0 >= chunkZ1) {
+            continue;
+        }
+        if (chunkZ0 >= keepZ0 && chunkZ1 <= keepZ1) {
+            continue;
+        }
+        affected.push_back(chunk);
+    }
+    if (affected.empty()) {
+        return {};
+    }
+
+    std::sort(affected.begin(), affected.end(), chunkIndexLess);
+    const std::size_t chunkElems = volumeElements(outChunk);
+    const std::size_t chunkBytes = chunkElems * sizeof(uint8_t);
+
+    std::atomic<std::size_t> next{0};
+    std::atomic<bool> hadError{false};
+    std::mutex touchedMutex;
+    std::mutex profileMutex;
+    std::mutex errMutex;
+    std::string firstError;
+    std::vector<ChunkIndex> touched;
+    touched.reserve(affected.size());
+    ProfileStats profileAccum;
+    std::vector<std::thread> threads;
+    threads.reserve(workers);
+
+    for (std::size_t tid = 0; tid < workers; ++tid) {
+        threads.emplace_back([&, tid]() {
+            (void)tid;
+            vc::VcDataset outputLocal(output.path());
+            std::vector<uint8_t> chunkBuf(chunkElems, 0);
+            ProfileStats localProfile;
+            std::vector<ChunkIndex> localTouched;
+            localTouched.reserve(64);
+
+            while (!hadError.load()) {
+                const std::size_t idx = next.fetch_add(1);
+                if (idx >= affected.size()) {
+                    break;
+                }
+
+                try {
+                    const ChunkIndex chunk = affected[idx];
+                    const std::size_t chunkZ0 = chunk.z * outChunk[0];
+                    const std::size_t chunkActualZ = chunkZ0 < outShape[0]
+                        ? std::min(outChunk[0], outShape[0] - chunkZ0)
+                        : 0;
+                    if (chunkActualZ == 0) {
+                        continue;
+                    }
+
+                    auto readStart = std::chrono::steady_clock::now();
+                    outputLocal.readChunkOrFill(chunk.z, chunk.y, chunk.x, chunkBuf.data());
+                    auto readEnd = std::chrono::steady_clock::now();
+                    localProfile.tChunkReadIo.add(std::chrono::duration<double>(readEnd - readStart).count());
+                    ++localProfile.chunkIoReads;
+                    localProfile.bytesRead += chunkBytes;
+
+                    bool changed = false;
+                    const std::size_t sliceElems = outChunk[1] * outChunk[2];
+                    for (std::size_t localZ = 0; localZ < chunkActualZ; ++localZ) {
+                        const std::size_t globalZ = chunkZ0 + localZ;
+                        if (globalZ >= keepZ0 && globalZ < keepZ1) {
+                            continue;
+                        }
+
+                        uint8_t* slicePtr = chunkBuf.data() + localZ * sliceElems;
+                        if (hasAnyNonZero(slicePtr, sliceElems)) {
+                            std::fill(slicePtr, slicePtr + sliceElems, uint8_t(0));
+                            changed = true;
+                        }
+                    }
+
+                    if (!changed &&
+                        !shouldDropIgnoreSparseChunk(outShape, outChunk, chunk, chunkBuf, ignoreValue)) {
+                        continue;
+                    }
+
+                    if (persistIgnoreSparseChunk(outputLocal, chunk, chunkBuf, ignoreValue, &localProfile)) {
+                        localTouched.push_back(chunk);
+                    }
+                } catch (const std::exception& e) {
+                    hadError.store(true);
+                    std::lock_guard<std::mutex> lk(errMutex);
+                    if (firstError.empty()) {
+                        firstError = e.what();
+                    }
+                    break;
+                }
+            }
+
+            {
+                std::lock_guard<std::mutex> lk(touchedMutex);
+                touched.insert(touched.end(), localTouched.begin(), localTouched.end());
+            }
+            if (profile) {
+                std::lock_guard<std::mutex> lk(profileMutex);
+                profileAccum.accumulate(localProfile);
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+    if (hadError.load()) {
+        throw std::runtime_error("failed clearing outside z range: " + firstError);
+    }
+
+    if (profile) {
+        profile->accumulate(profileAccum);
+    }
+
+    std::sort(touched.begin(), touched.end(), chunkIndexLess);
+    touched.erase(std::unique(touched.begin(), touched.end()), touched.end());
+    return touched;
 }
 
 static std::vector<ChunkIndex> buildTouchedParents(const std::vector<ChunkIndex>& sourceTouched,
@@ -2266,7 +2478,7 @@ static std::vector<ChunkIndex> buildLabelPriorityPyramidLevelTouched(
                                                        srcActualY,
                                                        srcActualX,
                                                        srcBuf)) {
-                        srcBuf.assign(srcElems, 0);
+                        srcBuf.assign(srcElems, ignoreValue);
                         srcLocal.readRegion({srcZ0, srcY0, srcX0},
                                             {srcActualZ, srcActualY, srcActualX},
                                             srcBuf.data());
@@ -2284,15 +2496,18 @@ static std::vector<ChunkIndex> buildLabelPriorityPyramidLevelTouched(
                         vc::core::util::Shape3{dstChunk[0], dstChunk[1], dstChunk[2]},
                         ignoreValue);
 
-                    if (hasAnyNonZero(dstBuf)) {
-                        auto tWriteStart = std::chrono::steady_clock::now();
-                        dstLocal.writeChunk(cz, cy, cx, dstBuf.data(), dstBuf.size() * sizeof(uint8_t));
-                        auto tWriteEnd = std::chrono::steady_clock::now();
-                        localProfile.tPyramidWrite.add(std::chrono::duration<double>(tWriteEnd - tWriteStart).count());
+                    if (hasAnyNonZero(dstBuf) ||
+                        shouldDropIgnoreSparseChunk(dstShape, dstChunk, chunk, dstBuf, ignoreValue)) {
+                        if (persistIgnoreSparseChunk(dstLocal,
+                                                     chunk,
+                                                     dstBuf,
+                                                     ignoreValue,
+                                                     &localProfile,
+                                                     true)) {
+                            std::lock_guard<std::mutex> lk(outTouchedMutex);
+                            outputTouched.push_back(chunk);
+                        }
                         ++localProfile.pyramidWriteCalls;
-                        localProfile.bytesWritten += dstBuf.size() * sizeof(uint8_t);
-                        std::lock_guard<std::mutex> lk(outTouchedMutex);
-                        outputTouched.push_back(chunk);
                     }
                     const std::size_t progressDone = done.fetch_add(1) + 1;
                     if (structuredProgress &&
@@ -2528,7 +2743,7 @@ static void writeReplicatedCoreMaskToLevel0(
 
                 auto readStart = std::chrono::steady_clock::now();
                 chunkBuf.assign(chunkElems, 0);
-                output.readChunk(cz, cy, cx, chunkBuf.data());
+                output.readChunkOrFill(cz, cy, cx, chunkBuf.data());
                 if (profile) {
                     auto readEnd = std::chrono::steady_clock::now();
                     profile->tChunkReadIo.add(std::chrono::duration<double>(readEnd - readStart).count());
@@ -2572,15 +2787,9 @@ static void writeReplicatedCoreMaskToLevel0(
                     continue;
                 }
 
-                auto writeStart = std::chrono::steady_clock::now();
-                output.writeChunk(cz, cy, cx, chunkBuf.data(), chunkBytes);
-                if (profile) {
-                    auto writeEnd = std::chrono::steady_clock::now();
-                    profile->tChunkWriteIo.add(std::chrono::duration<double>(writeEnd - writeStart).count());
-                    ++profile->chunkIoWrites;
-                    profile->bytesWritten += chunkBytes;
+                if (persistIgnoreSparseChunk(output, chunk, chunkBuf, ignoreValue, profile)) {
+                    touchedLevel0.insert(chunk);
                 }
-                touchedLevel0.insert(chunk);
             }
         }
     }
@@ -2649,7 +2858,11 @@ static void writeOutputMetadata(const Config& cfg,
     meta["slices"] = static_cast<long long>(shape0[0]);
     meta["format"] = "zarr";
     meta["min"] = 0.0;
-    meta["max"] = 255.0;
+    double maxValue = static_cast<double>(std::max(1, cfg.ignoreValue));
+    if (meta.contains("max") && meta["max"].is_number()) {
+        maxValue = std::max(maxValue, meta["max"].get<double>());
+    }
+    meta["max"] = maxValue;
     meta["label_volume"] = "rasterized";
     meta["ignore_label_value"] = cfg.ignoreValue;
     meta["ignore_label_added_at"] = nowIsoUtc();
@@ -2847,6 +3060,19 @@ static int processChunkAlphaWrap(
     std::string firstError;
     std::unordered_set<ChunkIndex, ChunkIndexHash> touchedLevel0Global;
     ProfileStats profile;
+    const std::size_t keepZ0 = static_cast<std::size_t>(zStart) * scale;
+    const std::size_t keepZ1 = std::min(static_cast<std::size_t>(zStop) * scale, outShape[0]);
+    const auto existingOutputLevel0Chunks = scanLevelExistingChunks(cfg.outputRoot / "0");
+    const auto clearedChunks = clearLevel0OutsideZRange(out0,
+                                                        outShape,
+                                                        outChunk,
+                                                        existingOutputLevel0Chunks,
+                                                        keepZ0,
+                                                        keepZ1,
+                                                        static_cast<uint8_t>(cfg.ignoreValue),
+                                                        workers,
+                                                        &profile);
+    touchedLevel0Global.insert(clearedChunks.begin(), clearedChunks.end());
     std::vector<std::thread> threads;
     threads.reserve(workers);
 
@@ -3547,6 +3773,44 @@ static bool runSelfTest()
                 }
             }
 
+            auto dsIgnore = vc::createZarrDataset(tmpRoot,
+                                                  "1",
+                                                  {128, 128, 256},
+                                                  {128, 128, 128},
+                                                  vc::VcDtype::uint8,
+                                                  "none",
+                                                  ".",
+                                                  2);
+            dsIgnore->writeChunk(0, 0, 0, chunk.data(), chunk.size() * sizeof(uint8_t));
+            region.clear();
+            const bool ignoreOk = readAlignedSourceRegionByChunk(*dsIgnore,
+                                                                 {128, 128, 256},
+                                                                 {128, 128, 128},
+                                                                 0,
+                                                                 0,
+                                                                 0,
+                                                                 128,
+                                                                 128,
+                                                                 256,
+                                                                 region);
+            if (!ignoreOk) {
+                std::cerr << "self-test failed: aligned ignore-fill read returned false\n";
+                fs::remove_all(tmpRoot, ec);
+                return false;
+            }
+            for (std::size_t z = 0; z < 128; ++z) {
+                for (std::size_t y = 0; y < 128; ++y) {
+                    const std::size_t right = linearIndex({128, 128, 256}, z, y, 128);
+                    if (!std::all_of(region.begin() + static_cast<std::ptrdiff_t>(right),
+                                     region.begin() + static_cast<std::ptrdiff_t>(right + 128),
+                                     [](uint8_t v) { return v == 2; })) {
+                        std::cerr << "self-test failed: aligned read did not use ignore fill value\n";
+                        fs::remove_all(tmpRoot, ec);
+                        return false;
+                    }
+                }
+            }
+
             fs::remove_all(tmpRoot, ec);
             return true;
         } catch (const std::exception& e) {
@@ -3556,10 +3820,87 @@ static bool runSelfTest()
         }
     };
 
+    auto checkClearOutsideRangeSparse = [&]() {
+        const fs::path tmpRoot = fs::temp_directory_path() / "vc_add_ignore_selftest_clear_range";
+        std::error_code ec;
+        fs::remove_all(tmpRoot, ec);
+        fs::create_directories(tmpRoot, ec);
+        if (ec) {
+            std::cerr << "self-test failed: unable to create temp root for clear-range test\n";
+            return false;
+        }
+
+        try {
+            constexpr uint8_t ignoreValue = 2;
+            const Shape3 shape = {8, 2, 2};
+            const Shape3 chunk = {2, 2, 2};
+            auto ds = vc::createZarrDataset(tmpRoot,
+                                            "0",
+                                            {shape[0], shape[1], shape[2]},
+                                            {chunk[0], chunk[1], chunk[2]},
+                                            vc::VcDtype::uint8,
+                                            "none",
+                                            ".",
+                                            ignoreValue);
+            std::vector<uint8_t> fullChunk(volumeElements(chunk), 1);
+            for (std::size_t cz = 0; cz < 4; ++cz) {
+                ds->writeChunk(cz, 0, 0, fullChunk.data(), fullChunk.size() * sizeof(uint8_t));
+            }
+
+            ProfileStats profile;
+            const auto touched = clearLevel0OutsideZRange(*ds,
+                                                          shape,
+                                                          chunk,
+                                                          scanLevelExistingChunks(tmpRoot / "0"),
+                                                          1,
+                                                          5,
+                                                          ignoreValue,
+                                                          1,
+                                                          &profile);
+            if (touched.size() != 3) {
+                std::cerr << "self-test failed: expected 3 touched chunks after clear-range\n";
+                fs::remove_all(tmpRoot, ec);
+                return false;
+            }
+            if (ds->chunkExists(3, 0, 0)) {
+                std::cerr << "self-test failed: fully outside chunk was not removed\n";
+                fs::remove_all(tmpRoot, ec);
+                return false;
+            }
+
+            std::vector<uint8_t> volume(volumeElements(shape), 0);
+            ds->readRegion({0, 0, 0}, {shape[0], shape[1], shape[2]}, volume.data());
+            for (std::size_t y = 0; y < shape[1]; ++y) {
+                for (std::size_t x = 0; x < shape[2]; ++x) {
+                    if (volume[linearIndex(shape, 0, y, x)] != 0 ||
+                        volume[linearIndex(shape, 1, y, x)] != 1 ||
+                        volume[linearIndex(shape, 4, y, x)] != 1 ||
+                        volume[linearIndex(shape, 5, y, x)] != 0 ||
+                        volume[linearIndex(shape, 6, y, x)] != ignoreValue ||
+                        volume[linearIndex(shape, 7, y, x)] != ignoreValue) {
+                        std::cerr << "self-test failed: clear-range output values are incorrect\n";
+                        fs::remove_all(tmpRoot, ec);
+                        return false;
+                    }
+                }
+            }
+
+            fs::remove_all(tmpRoot, ec);
+            return true;
+        } catch (const std::exception& e) {
+            std::cerr << "self-test failed in clear-range test: " << e.what() << '\n';
+            fs::remove_all(tmpRoot, ec);
+            return false;
+        }
+    };
+
     if (!checkChunkAlphaWrapConsistency()) {
         return false;
     }
     if (!checkAlignedReadMissingChunk()) {
+        return false;
+    }
+    if (!checkClearOutsideRangeSparse()) {
         return false;
     }
 
@@ -3668,6 +4009,8 @@ static int process(const Config& cfg)
     const double copyStageSeconds =
         std::chrono::duration<double>(std::chrono::steady_clock::now() - copyStageStart).count();
 
+    rewriteOutputFillValue(cfg.outputRoot, levels, static_cast<uint8_t>(cfg.ignoreValue));
+
     vc::VcDataset computeDs(cfg.inputRoot / std::to_string(cfg.computeLevel));
     vc::VcDataset out0(cfg.outputRoot / "0");
     const Shape3 computeShape = toShape3(computeDs.shape());
@@ -3703,6 +4046,18 @@ static int process(const Config& cfg)
         std::size_t{1} << static_cast<std::size_t>(cfg.computeLevel - cfg.outputLevel);
 
     ProfileStats profile;
+    const std::size_t keepZ0 = static_cast<std::size_t>(zStart) * zScale;
+    const std::size_t keepZ1 = std::min(static_cast<std::size_t>(zStop) * zScale, outShape[0]);
+    const auto existingOutputLevel0Chunks = scanLevelExistingChunks(cfg.outputRoot / "0");
+    const auto clearedChunks = clearLevel0OutsideZRange(out0,
+                                                        outShape,
+                                                        outChunk,
+                                                        existingOutputLevel0Chunks,
+                                                        keepZ0,
+                                                        keepZ1,
+                                                        static_cast<uint8_t>(cfg.ignoreValue),
+                                                        workers,
+                                                        &profile);
 
     std::vector<uint8_t> preloadedCompute;
     if (cachePlan.mode == ComputeCacheMode::preload) {
@@ -3758,6 +4113,7 @@ static int process(const Config& cfg)
     std::mutex errMutex;
     std::string firstError;
     std::unordered_set<ChunkIndex, ChunkIndexHash> touchedLevel0Global;
+    touchedLevel0Global.insert(clearedChunks.begin(), clearedChunks.end());
     std::vector<std::thread> threads;
     threads.reserve(workers);
 
@@ -4073,7 +4429,7 @@ static int process(const Config& cfg)
                                     }
 
                                     auto readTimer = std::chrono::steady_clock::now();
-                                    localOut0.readChunk(slab, cy, cx, state.buf.data());
+                                    localOut0.readChunkOrFill(slab, cy, cx, state.buf.data());
                                     auto readEnd = std::chrono::steady_clock::now();
                                     localProfile.tChunkReadIo.add(std::chrono::duration<double>(readEnd - readTimer).count());
                                     ++localProfile.chunkIoReads;
@@ -4126,14 +4482,14 @@ static int process(const Config& cfg)
                             const std::size_t cy = static_cast<std::size_t>((packed >> 32) & 0xFFFFFFFFULL);
                             const ChunkIndex chunk = {slab, cy, cx};
 
-                            auto writeTimer = std::chrono::steady_clock::now();
-                            localOut0.writeChunk(slab, cy, cx, it->second.buf.data(), outChunkBytes);
-                            auto writeEnd = std::chrono::steady_clock::now();
-                            localProfile.tChunkWriteIo.add(std::chrono::duration<double>(writeEnd - writeTimer).count());
-                            ++localProfile.chunkIoWrites;
-                            localProfile.bytesWritten += outChunkBytes;
+                            if (persistIgnoreSparseChunk(localOut0,
+                                                         chunk,
+                                                         it->second.buf,
+                                                         static_cast<uint8_t>(cfg.ignoreValue),
+                                                         &localProfile)) {
+                                localTouchedLevel0.insert(chunk);
+                            }
                             it->second.loaded = false;
-                            localTouchedLevel0.insert(chunk);
                         }
                     } catch (const std::exception& e) {
                         hadError.store(true);
@@ -4339,7 +4695,7 @@ int main(int argc, char* argv[])
             ("mode", po::value<std::string>(&modeArg)->default_value(processingModeToString(Config{}.mode)),
              "Processing mode: chunk-alpha-wrap | legacy-slice")
             ("ignore-value", po::value<int>(&cfg.ignoreValue)->default_value(kDefaultIgnoreValue),
-             "Ignore label value [1..254] (default 127)")
+             "Ignore label value [1..254] (default 2)")
             ("alpha", po::value<double>(&cfg.alpha)->default_value(kDefaultAlpha),
              "Legacy 2D alpha, or chunk alpha alias in chunk-alpha-wrap mode")
             ("chunk-alpha", po::value<double>(&cfg.chunkAlpha)->default_value(0.0),

--- a/volume-cartographer/apps/src/vc_tifxyz2zarr_sparse.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz2zarr_sparse.cpp
@@ -24,9 +24,12 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <thread>
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 #include <optional>
 #include <cstring>
@@ -43,7 +46,7 @@ constexpr size_t kLocalSpoolFlushThreshold = 8192;
 constexpr int kQuadRowWorkBlock = 32;
 constexpr float kAxisPlaneEps = 1e-5f;
 constexpr float kSegmentEps2 = 1e-12f;
-constexpr uint8_t kSurfaceValue = 255;
+constexpr uint8_t kSurfaceValue = 1;
 const char* kChunkSuffix = "vc_tifxyz2zarr_sparse";
 
 using Shape3 = std::array<size_t, 3>;
@@ -615,6 +618,29 @@ static Shape3 parseShapeFromReference(const fs::path& ref) {
     return {s[0], s[1], s[2]};
 }
 
+static std::pair<std::size_t, std::size_t> normalizeZRange(long long requestedMin,
+                                                           long long requestedMax,
+                                                           const Shape3& shape)
+{
+    if (requestedMin < 0) {
+        throw std::runtime_error("--z-min must be >= 0");
+    }
+    if (requestedMax < -1) {
+        throw std::runtime_error("--z-max must be >= -1");
+    }
+
+    const std::size_t zMin = std::min<std::size_t>(static_cast<std::size_t>(requestedMin), shape[0]);
+    const std::size_t zMax = requestedMax < 0
+        ? shape[0]
+        : std::min<std::size_t>(static_cast<std::size_t>(requestedMax), shape[0]);
+
+    if (zMin >= zMax) {
+        throw std::runtime_error("empty z range after applying --z-min/--z-max");
+    }
+
+    return {zMin, zMax};
+}
+
 static nlohmann::json toJsonArray(const std::vector<std::string>& values) {
     nlohmann::json result = nlohmann::json::array();
     for (const auto& value : values) {
@@ -860,16 +886,26 @@ static void rasterizePointGridRows(const cv::Mat_<cv::Vec3f>& pts,
 template<typename EmitVoxel>
 static void rasterizeTifxyzMeshToSpool(const fs::path& meshPath,
                                        const Shape3& shape,
+                                       std::size_t zMin,
+                                       std::size_t zMax,
                                        RasterMode rasterMode,
                                        EmitVoxel&& emit) {
     auto surf = load_quad_from_tifxyz(meshPath.string());
     const cv::Mat_<cv::Vec3f> pts = surf->rawPoints();
     if (pts.empty()) return;
-    rasterizePointGridRows(pts, 0, pts.rows - 1, shape, rasterMode, emit);
+    rasterizePointGridRows(pts, 0, pts.rows - 1, shape, rasterMode,
+        [&](size_t z, size_t y, size_t x) {
+            if (z < zMin || z >= zMax) {
+                return;
+            }
+            emit(z, y, x);
+        });
 }
 
 static void rasterizeSingleMeshIntraParallel(const fs::path& meshPath,
                                              const Shape3& shape,
+                                             std::size_t zMin,
+                                             std::size_t zMax,
                                              RasterMode rasterMode,
                                              size_t numThreads,
                                              SpoolManager& spool) {
@@ -883,6 +919,9 @@ static void rasterizeSingleMeshIntraParallel(const fs::path& meshPath,
         ThreadSpoolBuffer buffer(spool, spool.chunkShape(), spool.volumeShape());
         rasterizePointGridRows(pts, 0, quadRows, shape, rasterMode,
             [&](size_t z, size_t y, size_t x) {
+                if (z < zMin || z >= zMax) {
+                    return;
+                }
                 buffer.emit(z, y, x);
             });
         buffer.flushAll();
@@ -906,6 +945,9 @@ static void rasterizeSingleMeshIntraParallel(const fs::path& meshPath,
                     const int rowEnd = std::min(rowBegin + kQuadRowWorkBlock, quadRows);
                     rasterizePointGridRows(pts, rowBegin, rowEnd, shape, rasterMode,
                         [&](size_t z, size_t y, size_t x) {
+                            if (z < zMin || z >= zMax) {
+                                return;
+                            }
                             buffer.emit(z, y, x);
                         });
                 }
@@ -927,6 +969,8 @@ static void rasterizeSingleMeshIntraParallel(const fs::path& meshPath,
 
 static void rasterizeSingleMeshPhase(const fs::path& meshPath,
                                      const Shape3& shape,
+                                     std::size_t zMin,
+                                     std::size_t zMax,
                                      RasterMode rasterMode,
                                      size_t numThreads,
                                      SpoolManager& spool,
@@ -937,7 +981,7 @@ static void rasterizeSingleMeshPhase(const fs::path& meshPath,
     if (hadError.load()) return;
 
     try {
-        rasterizeSingleMeshIntraParallel(meshPath, shape, rasterMode, numThreads, spool);
+        rasterizeSingleMeshIntraParallel(meshPath, shape, zMin, zMax, rasterMode, numThreads, spool);
     } catch (const std::exception& e) {
         std::lock_guard<std::mutex> lk(outMutex);
         std::cerr << "mesh rasterization failed for " << meshPath
@@ -958,6 +1002,8 @@ static void rasterizePhase(const std::vector<fs::path>& meshes,
                           size_t start,
                           size_t stride,
                           const Shape3& shape,
+                          std::size_t zMin,
+                          std::size_t zMax,
                           RasterMode rasterMode,
                           SpoolManager& spool,
                           std::atomic<bool>& hadError,
@@ -971,7 +1017,7 @@ static void rasterizePhase(const std::vector<fs::path>& meshes,
         if (hadError.load()) return;
 
         try {
-            rasterizeTifxyzMeshToSpool(meshes[i], shape, rasterMode,
+            rasterizeTifxyzMeshToSpool(meshes[i], shape, zMin, zMax, rasterMode,
                 [&](size_t z, size_t y, size_t x) {
                     buffer.emit(z, y, x);
                 });
@@ -1272,7 +1318,7 @@ static void writeVolumeMetadata(const fs::path& outDir,
     meta["slices"] = static_cast<long long>(level0Shape[0]);
     meta["voxelsize"] = voxelSize;
     meta["min"] = 0.0;
-    meta["max"] = 255.0;
+    meta["max"] = static_cast<double>(kSurfaceValue);
     meta["format"] = "zarr";
 
     if (sourceRef) {
@@ -1304,6 +1350,61 @@ static void writeVolumeMetadata(const fs::path& outDir,
     }
 }
 
+static bool runSelfTest()
+{
+    const Shape3 shape{16, 16, 16};
+    const cv::Vec3f p00{2.0f, 2.0f, 9.6f};
+    const cv::Vec3f p01{12.0f, 2.0f, 10.4f};
+    const cv::Vec3f p10{2.0f, 12.0f, 10.4f};
+    const cv::Vec3f p11{12.0f, 12.0f, 11.2f};
+
+    std::set<std::tuple<size_t, size_t, size_t>> full;
+    std::set<std::tuple<size_t, size_t, size_t>> clipped;
+    rasterizeQuadForMode(p00, p01, p10, p11, shape, RasterMode::ZYXInteger,
+        [&](size_t z, size_t y, size_t x) {
+            full.emplace(z, y, x);
+        });
+    rasterizeQuadForMode(p00, p01, p10, p11, shape, RasterMode::ZYXInteger,
+        [&](size_t z, size_t y, size_t x) {
+            if (z < 10 || z >= 11) {
+                return;
+            }
+            clipped.emplace(z, y, x);
+        });
+
+    if (full.empty() || clipped.empty()) {
+        std::cerr << "self-test failed: rasterization produced no voxels\n";
+        return false;
+    }
+    if (std::all_of(full.begin(), full.end(), [](const auto& voxel) {
+            return std::get<0>(voxel) == 10;
+        })) {
+        std::cerr << "self-test failed: z clipping did not reduce output\n";
+        return false;
+    }
+    if (!std::all_of(clipped.begin(), clipped.end(), [](const auto& voxel) {
+            return std::get<0>(voxel) == 10;
+        })) {
+        std::cerr << "self-test failed: clipped output contains voxels outside z range\n";
+        return false;
+    }
+
+    std::vector<uint8_t> buf(shape[0] * shape[1] * shape[2], 0);
+    const auto linear = [&](size_t z, size_t y, size_t x) {
+        return (z * shape[1] + y) * shape[2] + x;
+    };
+    for (const auto& [z, y, x] : clipped) {
+        buf[linear(z, y, x)] = kSurfaceValue;
+    }
+    if (std::none_of(buf.begin(), buf.end(), [](uint8_t v) { return v == 1; })) {
+        std::cerr << "self-test failed: rasterized foreground value is not 1\n";
+        return false;
+    }
+
+    std::cout << "self-test passed\n";
+    return true;
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -1317,11 +1418,13 @@ int main(int argc, char* argv[])
                   << " <input_tifxyz_dir> <output_omezarr> [options]\n"
                   << "\n"
                   << "Options:\n"
-                  << "  Surface voxels are written as 255 in uint8 output.\n"
+                  << "  Surface voxels are written as 1 in uint8 output.\n"
                   << "  --shape-z N               full output Z\n"
                   << "  --shape-y N               full output Y\n"
                   << "  --shape-x N               full output X\n"
                   << "  --reference-zarr PATH      infer shape from existing zarr (uses /0 if present)\n"
+                  << "  --z-min N                 level-0 start slice (inclusive)\n"
+                  << "  --z-max N                 level-0 end slice (exclusive, -1 = end)\n"
                   << "  --chunk-size N             isotropic chunk edge (default 128)\n"
                   << "  --source-segment SEGMENT    optional segment ID provenance (repeatable)\n"
                   << "  --source-mesh PATH         optional mesh path provenance (repeatable)\n"
@@ -1333,6 +1436,7 @@ int main(int argc, char* argv[])
                   << "  --source-group IDX          optional source group for metadata\n"
                   << "  --raster-mode MODE         zyx-integer (default) or z-half\n"
                   << "  --metrics-json PATH        write timing + unique-voxel metrics json\n"
+                  << "  --self-test                run built-in synthetic regression harness and exit\n"
                   << "\n"
                   << "Note:\n"
                   << "  --chunk-size-z/x/y are intentionally not supported; use --chunk-size.\n";
@@ -1349,6 +1453,8 @@ int main(int argc, char* argv[])
             ("shape-y", po::value<size_t>(), "Output Y size")
             ("shape-x", po::value<size_t>(), "Output X size")
             ("reference-zarr", po::value<std::string>(), "Reference OME-Zarr for shape inference")
+            ("z-min", po::value<long long>()->default_value(0), "Level-0 start slice (inclusive)")
+            ("z-max", po::value<long long>()->default_value(-1), "Level-0 end slice (exclusive, -1 = end)")
             ("chunk-size", po::value<size_t>()->default_value(128), "Isotropic chunk size")
             ("source-segment", po::value<std::vector<std::string>>()->multitoken(),
              "Segment ID used for provenance (repeatable)")
@@ -1365,6 +1471,7 @@ int main(int argc, char* argv[])
             ("raster-mode", po::value<std::string>()->default_value("zyx-integer"),
              "Raster mode: zyx-integer or z-half")
             ("metrics-json", po::value<std::string>(), "Write timing + unique-voxel metrics json")
+            ("self-test", po::bool_switch()->default_value(false), "Run built-in synthetic regression harness and exit")
             ("chunk-size-z", po::value<size_t>(), "DEPRECATED: ignored; use --chunk-size")
             ("chunk-size-y", po::value<size_t>(), "DEPRECATED: ignored; use --chunk-size")
             ("chunk-size-x", po::value<size_t>(), "DEPRECATED: ignored; use --chunk-size");
@@ -1382,8 +1489,14 @@ int main(int argc, char* argv[])
         po::notify(vm);
 
         if (vm.count("help") || !vm.count("input") || !vm.count("output")) {
+            if (vm.count("self-test") && vm["self-test"].as<bool>()) {
+                return runSelfTest() ? EXIT_SUCCESS : EXIT_FAILURE;
+            }
             std::cerr << desc << "\n";
             return EXIT_FAILURE;
+        }
+        if (vm["self-test"].as<bool>()) {
+            return runSelfTest() ? EXIT_SUCCESS : EXIT_FAILURE;
         }
 
         const bool hasChunkAxisFlags = vm.count("chunk-size-z") ||
@@ -1443,6 +1556,9 @@ int main(int argc, char* argv[])
         } else {
             throw std::runtime_error("provide either --shape-z/y/x or --reference-zarr");
         }
+        const auto [zMin, zMax] = normalizeZRange(vm["z-min"].as<long long>(),
+                                                  vm["z-max"].as<long long>(),
+                                                  shape);
 
         int threadCount = vm["threads"].as<int>();
         if (threadCount <= 0) {
@@ -1515,13 +1631,13 @@ int main(int argc, char* argv[])
 
         std::vector<std::thread> rasterThreads;
         if (rasterMode == RasterMode::ZYXInteger && meshes.size() == 1 && numThreads > 1) {
-            rasterizeSingleMeshPhase(meshes.front(), shape, rasterMode, numThreads,
+            rasterizeSingleMeshPhase(meshes.front(), shape, zMin, zMax, rasterMode, numThreads,
                                      spool, hadError, rasterizedCount, verbose, ioMutex);
         } else {
             rasterThreads.reserve(numThreads);
             for (size_t tid = 0; tid < numThreads; ++tid) {
                 rasterThreads.emplace_back([&, tid]() {
-                    rasterizePhase(meshes, tid, numThreads, shape, rasterMode,
+                    rasterizePhase(meshes, tid, numThreads, shape, zMin, zMax, rasterMode,
                                   spool, hadError, rasterizedCount,
                                   verbose, ioMutex, meshes.size());
                 });

--- a/volume-cartographer/core/include/vc/core/types/VcDataset.hpp
+++ b/volume-cartographer/core/include/vc/core/types/VcDataset.hpp
@@ -46,9 +46,16 @@ public:
     // Returns false if chunk doesn't exist.
     bool readChunk(size_t iz, size_t iy, size_t ix, void* output) const;
 
+    // Read a chunk when present, or materialize the dataset fill value when absent.
+    // Returns true if the chunk existed on disk, false if output was filled instead.
+    bool readChunkOrFill(size_t iz, size_t iy, size_t ix, void* output) const;
+
     // Write a chunk (input is raw uncompressed data).
     bool writeChunk(size_t iz, size_t iy, size_t ix,
                     const void* input, size_t nbytes);
+
+    // Remove a chunk file if it exists.
+    bool removeChunk(size_t iz, size_t iy, size_t ix);
 
     // --- Region I/O (replaces z5::multiarray::readSubarray) ---
     bool readRegion(const std::vector<size_t>& offset,

--- a/volume-cartographer/core/src/VcDataset.cpp
+++ b/volume-cartographer/core/src/VcDataset.cpp
@@ -537,6 +537,17 @@ bool VcDataset::readChunk(size_t iz, size_t iy, size_t ix, void* output) const
     return true;
 }
 
+bool VcDataset::readChunkOrFill(size_t iz, size_t iy, size_t ix, void* output) const
+{
+    if (readChunk(iz, iy, ix, output)) {
+        return true;
+    }
+
+    auto* outBytes = static_cast<uint8_t*>(output);
+    fillTypedElements(outBytes, impl_->chunkSize_, impl_->fillValueBytes_);
+    return false;
+}
+
 bool VcDataset::writeChunk(size_t iz, size_t iy, size_t ix,
                             const void* input, size_t nbytes)
 {
@@ -545,6 +556,21 @@ bool VcDataset::writeChunk(size_t iz, size_t iy, size_t ix,
         static_cast<const std::byte*>(input), nbytes);
     impl_->zarrArray_->write_chunk(indices, data);
     return true;
+}
+
+bool VcDataset::removeChunk(size_t iz, size_t iy, size_t ix)
+{
+    auto p = impl_->fsPath /
+        (std::to_string(iz) + impl_->delimiter_ +
+         std::to_string(iy) + impl_->delimiter_ +
+         std::to_string(ix));
+
+    std::error_code ec;
+    const bool removed = std::filesystem::remove(p, ec);
+    if (ec) {
+        throw std::runtime_error("failed removing chunk: " + p.string());
+    }
+    return removed;
 }
 
 bool VcDataset::readRegion(const std::vector<size_t>& offset,

--- a/volume-cartographer/core/test/test_vcdataset.cpp
+++ b/volume-cartographer/core/test/test_vcdataset.cpp
@@ -162,3 +162,38 @@ TEST(VcDataset, WriteZarrRegionU8ByChunkPreservesSubregionAndFillPadding)
         }
     }
 }
+
+TEST(VcDataset, ReadChunkOrFillUsesDatasetFillAndRemoveChunkDeletesFile)
+{
+    ScopedTempDir tempDir;
+    const std::vector<size_t> shape = {8, 8, 8};
+    const std::vector<size_t> chunks = {4, 4, 4};
+
+    auto ds = vc::createZarrDataset(
+        tempDir.path(), "0", shape, chunks, vc::VcDtype::uint8, "none", ".", 2);
+    ASSERT_TRUE(ds != nullptr);
+
+    std::vector<uint8_t> missing(chunks[0] * chunks[1] * chunks[2], 0);
+    EXPECT_FALSE(ds->readChunkOrFill(0, 0, 1, missing.data()));
+    for (uint8_t value : missing) {
+        EXPECT_EQ(value, uint8_t(2));
+    }
+
+    std::vector<uint8_t> chunk(chunks[0] * chunks[1] * chunks[2], 1);
+    EXPECT_TRUE(ds->writeChunk(0, 0, 0, chunk.data(), chunk.size() * sizeof(uint8_t)));
+    EXPECT_TRUE(ds->chunkExists(0, 0, 0));
+
+    std::vector<uint8_t> roundTrip(chunk.size(), 0);
+    EXPECT_TRUE(ds->readChunkOrFill(0, 0, 0, roundTrip.data()));
+    EXPECT_EQ(roundTrip, chunk);
+
+    EXPECT_TRUE(ds->removeChunk(0, 0, 0));
+    EXPECT_FALSE(ds->chunkExists(0, 0, 0));
+    EXPECT_FALSE(ds->removeChunk(0, 0, 0));
+
+    std::fill(roundTrip.begin(), roundTrip.end(), 0);
+    EXPECT_FALSE(ds->readChunkOrFill(0, 0, 0, roundTrip.data()));
+    for (uint8_t value : roundTrip) {
+        EXPECT_EQ(value, uint8_t(2));
+    }
+}

--- a/volume-cartographer/ubuntu-24.04-noble.Dockerfile
+++ b/volume-cartographer/ubuntu-24.04-noble.Dockerfile
@@ -94,18 +94,20 @@ RUN make SCOTCH_HOME=/usr/local/scotch
 RUN make SCOTCH_HOME=/usr/local/scotch install
     
     # --- build libigl-based target (after overlay) ---
-WORKDIR /src/libs/flatboi/build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release \
+WORKDIR /src/libs/flatboi
+RUN rm -rf build \
+ && cmake -S . -B build \
+      -DCMAKE_BUILD_TYPE=Release \
       -DLIBIGL_WITH_PASTIX=ON \
       -DBLA_VENDOR=OpenBLAS \
       -DCMAKE_PREFIX_PATH=/usr/local/pastix \
       -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
       -DCMAKE_CXX_FLAGS="-DSLIM_CACHED"
-RUN cmake --build . -j"$(nproc)"
+RUN cmake --build build -j"$(nproc)"
     
 # Install the flatboi binary into PATH before removing /src
-RUN install -m 0755 ./flatboi /usr/local/bin/flatboi
+RUN install -m 0755 /src/libs/flatboi/build/flatboi /usr/local/bin/flatboi
 
 # ------------------------- Build the main project ---------------------------
 RUN mkdir -p /src/build


### PR DESCRIPTION
## Summary
This PR fixes the `volume-cartographer` rasterize / ignore-label workflow for sparse label volumes.

It adds z-range support to rasterization, changes rasterized foreground labels to `1`, changes ignore-label default output to `2`, rewrites ignore-label output arrays to use `fill_value = ignoreValue`, and makes ignore-label writes omit chunks that collapse to ignore-sparse output semantics.

It also fixes the Docker Flatboi build stage so host-generated nested CMake build artifacts do not poison the image build.

## Root Cause
There were three separate issues in the current behavior:

1. `vc_tifxyz2zarr_sparse` still hardcoded rasterized foreground as `255` and did not expose a z-range.
2. `vc_add_ignore_label` copied the full rasterized tree and only edited slices inside the requested z-window, so labels outside the range survived.
3. Ignore-label output inherited rasterized metadata and several code paths treated missing chunks as zero instead of as the dataset fill value, which broke the intended sparse ignore semantics.

The Docker build failure came from a copied host `libs/flatboi/build/CMakeCache.txt` being reused inside `/src`, which made CMake reject the Flatboi configure step.

## What Changed
- Added `--z-min` / `--z-max` to `vc_tifxyz2zarr_sparse` and wired them through the VC3D rasterize launcher.
- Changed rasterized foreground default from `255` to `1`.
- Added synthetic self-test coverage to `vc_tifxyz2zarr_sparse`.
- Added `VcDataset::readChunkOrFill(...)` and `VcDataset::removeChunk(...)`.
- Changed `vc_add_ignore_label` default ignore label from `127` to `2`.
- Rewrote ignore-label output `.zarray` metadata to use `fill_value = ignoreValue`.
- Added an explicit level-0 clearing pass outside the requested z-range.
- Made ignore-label level-0 writes and touched pyramid rebuilds use sparse semantics:
  - mixed chunks are written normally
  - chunks that collapse to all `0` or all ignore are removed so they read back as fill / ignore
- Added regression coverage for the new dataset helper behavior and expanded `vc_add_ignore_label --self-test`.
- Updated the Dockerfile and `.dockerignore` so Flatboi always configures in a clean in-container build directory.

## Validation
Ran locally:

- `cmake -S volume-cartographer -B volume-cartographer/build -G Ninja -DVC_BUILD_TESTS=ON`
- `cmake --build volume-cartographer/build --target vc_tifxyz2zarr_sparse vc_add_ignore_label test_vcdataset test_triangle_voxel_raster`
- `volume-cartographer/build/bin/test_vcdataset`
- `volume-cartographer/build/bin/test_triangle_voxel_raster`
- `volume-cartographer/build/bin/vc_add_ignore_label --self-test`
- `volume-cartographer/build/bin/vc_tifxyz2zarr_sparse --self-test`

For the Docker fix, a smoke build progressed past the old context/cache poisoning condition after excluding nested CMake artifacts and forcing a fresh Flatboi build directory.

## Known Follow-up
This PR does **not** update the VC3D viewer sampling path to honor Zarr `fill_value` for missing chunks. The write side now produces ignore-sparse output correctly, but omitted chunks may still display as background in VC3D until the tiled/cache sampling path stops hardcoding missing chunks as zero.
