### PR TITLE
Fix ink label URL construction for .zarr segments

### DIFF
--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -663,6 +663,9 @@ class Volume:
         # Extract parent URL and segment ID
         parent_url = os.path.dirname(base_url)
         segment_id_str = os.path.basename(base_url)
+        # Remove .zarr extension if present (fixes URL construction bug)
+        if segment_id_str.endswith('.zarr'):
+            segment_id_str = segment_id_str[:-5]
         # Construct ink label path
         inklabel_filename = f"{segment_id_str}_inklabels.png"
         inklabel_url = os.path.join(parent_url, inklabel_filename)


### PR DESCRIPTION
## Summary
- Fixes ink label download failing with 404 for segments with `.zarr` URLs
- The `download_inklabel()` method was including `.zarr` in the filename

## Problem
When segment URLs end with `.zarr/`, the code was constructing:
```
https://dl.ash2txt.org/.../20230827161847.zarr_inklabels.png  → 404
```

Instead of:
```
https://dl.ash2txt.org/.../20230827161847_inklabels.png  → 200
```

## Fix
Strip the `.zarr` extension from `segment_id_str` before constructing the ink label filename (2 lines added).

## Testing
```python
from vesuvius import Volume
segment = Volume(type='segment', segment_id=20230827161847, scroll_id=1, download_only=True, verbose=True)
print(segment.inklabel.shape)  # (9216, 5120) - now loads correctly
print(segment.inklabel.sum())  # 942433518 - actual data, not zeros
```

## Impact
This fixes Tutorial 5 (Ink Detection) which was reported broken in Discord #newbie-questions.