### PR TITLE
scrollprize.org: fix vercel deployment

### DIFF
--- a/scrollprize.org/package.json
+++ b/scrollprize.org/package.json
@@ -2,6 +2,7 @@
   "name": "my-website",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "yarn@4.6.0",
   "scripts": {
     "preinstall": "[ \"${AGENTS_AGENT_MODE:-0}\" != \"1\" ] || [ \"${AGENTS_ALLOW_INSTALL:-0}\" = \"1\" ] || { echo \"Install is disabled by default in agent mode. Set AGENTS_ALLOW_INSTALL=1 to install dependencies.\"; exit 1; }",
     "docusaurus": "docusaurus",


### PR DESCRIPTION
It seems vercel started failing probably because of some transitive dependency resolution hiccups.

According to claude, vercel's yarn classic build might be not picking up our lock file which would prevent the issue and the fix is to pin a package manager version.