### PR TITLE
Speed up normal grid generation and fitting

### DIFF
--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -40,6 +40,7 @@ using json = nlohmann::json;
 struct DirectionMetrics {
     std::string direction;
     size_t numSlices = 0;
+    size_t sampledSlices = 0;
     size_t processed = 0;
     size_t skippedExisting = 0;
     size_t unsampled = 0;
@@ -51,6 +52,7 @@ struct DirectionMetrics {
     size_t totalSegments = 0;
     size_t totalBuckets = 0;
     size_t chunkSizeTarget = 0;
+    size_t sourceChunksTouched = 0;
     size_t bytesPerSlice = 0;
     size_t estimatedBatchBytes = 0;
     size_t thinningCalls = 0;
@@ -107,8 +109,14 @@ struct ThreadSliceStats {
 };
 
 struct ThreadScratch {
-    cv::Mat binarySlice;
     std::vector<std::vector<cv::Point>> traces;
+};
+
+struct AssembledSlice {
+    SliceTask task;
+    size_t localSliceIndex = 0;
+    cv::Mat binarySlice;
+    bool anyNonZero = false;
 };
 
 static const char* direction_name(SliceDirection dir) {
@@ -154,6 +162,7 @@ static void write_metrics_json(const fs::path& path, const RunMetrics& metrics) 
         json d;
         d["direction"] = dir.direction;
         d["num_slices"] = dir.numSlices;
+        d["sampled_slices"] = dir.sampledSlices;
         d["processed"] = dir.processed;
         d["skipped_existing"] = dir.skippedExisting;
         d["unsampled"] = dir.unsampled;
@@ -165,6 +174,7 @@ static void write_metrics_json(const fs::path& path, const RunMetrics& metrics) 
         d["total_segments"] = dir.totalSegments;
         d["total_buckets"] = dir.totalBuckets;
         d["chunk_size_target"] = dir.chunkSizeTarget;
+        d["source_chunks_touched"] = dir.sourceChunksTouched;
         d["bytes_per_slice"] = dir.bytesPerSlice;
         d["estimated_batch_bytes"] = dir.estimatedBatchBytes;
         d["timings"] = json::object();
@@ -533,6 +543,7 @@ void run_generate(const po::variables_map& vm) {
     for (auto& scratch : thread_scratch) {
         scratch.traces.reserve(256);
     }
+    const auto source_chunk_shape = ds->defaultChunkShape();
 
     for (SliceDirection dir : {SliceDirection::XY, SliceDirection::XZ, SliceDirection::YZ}) {
         DirectionMetrics dir_metrics;
@@ -557,10 +568,21 @@ void run_generate(const po::variables_map& vm) {
         dir_metrics.chunkSizeTarget = chunk_size_tgt;
         dir_metrics.bytesPerSlice = batch_plan.bytesPerSlice;
         dir_metrics.estimatedBatchBytes = batch_plan.estimatedBatchBytes;
+        const auto sampled_chunk_plans = vc::core::util::planNormalGridSampledChunks(
+            shape,
+            source_chunk_shape,
+            to_normal_grid_direction(dir),
+            sparse_volume);
+        size_t sampled_slices_total = 0;
+        for (const auto& chunk_plan : sampled_chunk_plans) {
+            sampled_slices_total += chunk_plan.sampledSlices.size();
+        }
+        dir_metrics.sampledSlices = sampled_slices_total;
+        dir_metrics.sourceChunksTouched = sampled_chunk_plans.size();
 
-        size_t processed = 0;
+        size_t processed = num_slices - sampled_slices_total;
         size_t skipped_existing = 0;
-        size_t unsampled = 0;
+        size_t unsampled = num_slices - sampled_slices_total;
         size_t total_size = 0;
         size_t total_segments = 0;
         size_t total_buckets = 0;
@@ -568,110 +590,190 @@ void run_generate(const po::variables_map& vm) {
         auto last_report_time = std::chrono::steady_clock::now();
         auto start_time = std::chrono::steady_clock::now();
         std::atomic<size_t> written_counter{0};
+        run_metrics.totalProcessedAllDirs += unsampled;
 
-        for (size_t chunk_start = 0; chunk_start < num_slices; chunk_start += chunk_size_tgt) {
-            const size_t chunk_end = std::min(chunk_start + chunk_size_tgt, num_slices);
-            const size_t chunk_size = chunk_end - chunk_start;
+        const cv::Size slice_size = vc::core::util::normalGridSliceSize(
+            shape,
+            to_normal_grid_direction(dir));
+        const size_t chunk_count_z = (shape[0] + source_chunk_shape[0] - 1) / source_chunk_shape[0];
+        const size_t chunk_count_y = (shape[1] + source_chunk_shape[1] - 1) / source_chunk_shape[1];
+        const size_t chunk_count_x = (shape[2] + source_chunk_shape[2] - 1) / source_chunk_shape[2];
 
-            std::vector<SliceTask> tasks(chunk_size);
-            bool any_process = false;
-            size_t chunk_existing = 0;
-            size_t chunk_unsampled = 0;
+        for (const auto& source_chunk_plan : sampled_chunk_plans) {
+            for (size_t batch_start = 0;
+                 batch_start < source_chunk_plan.sampledSlices.size();
+                 batch_start += chunk_size_tgt) {
+                const size_t batch_end = std::min(
+                    batch_start + chunk_size_tgt,
+                    source_chunk_plan.sampledSlices.size());
+                const size_t batch_size = batch_end - batch_start;
 
-            for (size_t i_chunk = 0; i_chunk < chunk_size; ++i_chunk) {
-                const size_t i = chunk_start + i_chunk;
-                auto& task = tasks[i_chunk];
-                task.sliceIndex = i;
+                std::vector<SliceTask> tasks(batch_size);
+                std::vector<AssembledSlice> assembled_slices;
+                assembled_slices.reserve(batch_size);
+                size_t batch_existing = 0;
 
-                if (i % sparse_volume != 0) {
-                    task.kind = SliceTaskKind::Unsampled;
-                    ++chunk_unsampled;
-                    continue;
-                }
+                for (size_t batch_index = 0; batch_index < batch_size; ++batch_index) {
+                    const auto& sampled =
+                        source_chunk_plan.sampledSlices[batch_start + batch_index];
+                    auto& task = tasks[batch_index];
+                    task.sliceIndex = sampled.sliceIndex;
 
-                char filename[256];
-                snprintf(filename, sizeof(filename), "%06zu.grid", i);
-                task.outPath = output_fs_path / dir_metrics.direction / filename;
-                task.tmpPath = fs::path(task.outPath.string() + ".tmp");
+                    char filename[256];
+                    snprintf(filename, sizeof(filename), "%06zu.grid", sampled.sliceIndex);
+                    task.outPath = output_fs_path / dir_metrics.direction / filename;
+                    task.tmpPath = fs::path(task.outPath.string() + ".tmp");
 
-                char preview_filename[256];
-                snprintf(preview_filename, sizeof(preview_filename), "%06zu.jpg", i);
-                task.previewPath = output_fs_path / (dir_metrics.direction + "_img") / preview_filename;
+                    char preview_filename[256];
+                    snprintf(preview_filename, sizeof(preview_filename), "%06zu.jpg", sampled.sliceIndex);
+                    task.previewPath = output_fs_path / (dir_metrics.direction + "_img") / preview_filename;
 
-                if (fs::exists(task.outPath)) {
-                    task.kind = SliceTaskKind::Exists;
-                    ++chunk_existing;
-                } else {
+                    if (fs::exists(task.outPath)) {
+                        task.kind = SliceTaskKind::Exists;
+                        ++batch_existing;
+                        continue;
+                    }
+
                     task.kind = SliceTaskKind::Process;
-                    any_process = true;
+                    auto& assembled = assembled_slices.emplace_back();
+                    assembled.task = task;
+                    assembled.localSliceIndex = sampled.localSliceIndex;
+                    assembled.binarySlice = cv::Mat::zeros(slice_size, CV_8U);
                 }
-            }
 
-            if (!any_process) {
-                processed += chunk_size;
-                skipped_existing += chunk_existing;
-                unsampled += chunk_unsampled;
-                run_metrics.totalProcessedAllDirs += chunk_size;
-                run_metrics.totalSkippedAllDirs += chunk_existing;
-            } else {
-                std::vector<size_t> chunk_shape;
-                cv::Vec3i chunk_offset;
+                if (!assembled_slices.empty()) {
+                    const auto read_start = std::chrono::steady_clock::now();
 
-                switch (dir) {
+                    switch (dir) {
                     case SliceDirection::XY:
-                        chunk_shape = {chunk_size, shape[1], shape[2]};
-                        chunk_offset = {static_cast<int>(chunk_start), 0, 0};
+                        for (size_t chunk_y = 0; chunk_y < chunk_count_y; ++chunk_y) {
+                            const int dst_row_offset = static_cast<int>(chunk_y * source_chunk_shape[1]);
+                            const size_t valid_rows = std::min(
+                                source_chunk_shape[1],
+                                shape[1] - static_cast<size_t>(dst_row_offset));
+                            for (size_t chunk_x = 0; chunk_x < chunk_count_x; ++chunk_x) {
+                                const int dst_col_offset = static_cast<int>(chunk_x * source_chunk_shape[2]);
+                                const size_t valid_cols = std::min(
+                                    source_chunk_shape[2],
+                                    shape[2] - static_cast<size_t>(dst_col_offset));
+                                auto chunk = cache->getBlocking(vc::cache::ChunkKey{
+                                    0,
+                                    static_cast<int>(source_chunk_plan.sourceChunkIndex),
+                                    static_cast<int>(chunk_y),
+                                    static_cast<int>(chunk_x),
+                                });
+                                if (!chunk) {
+                                    continue;
+                                }
+                                const auto* chunk_data = chunk->data<uint8_t>();
+                                for (auto& assembled : assembled_slices) {
+                                    vc::core::util::copyBinarySliceRegionFromChunk(
+                                        chunk_data,
+                                        chunk->shape,
+                                        to_normal_grid_direction(dir),
+                                        assembled.localSliceIndex,
+                                        valid_rows,
+                                        valid_cols,
+                                        dst_row_offset,
+                                        dst_col_offset,
+                                        assembled.binarySlice,
+                                        assembled.anyNonZero);
+                                }
+                            }
+                        }
                         break;
                     case SliceDirection::XZ:
-                        chunk_shape = {shape[0], chunk_size, shape[2]};
-                        chunk_offset = {0, static_cast<int>(chunk_start), 0};
+                        for (size_t chunk_z = 0; chunk_z < chunk_count_z; ++chunk_z) {
+                            const int dst_row_offset = static_cast<int>(chunk_z * source_chunk_shape[0]);
+                            const size_t valid_rows = std::min(
+                                source_chunk_shape[0],
+                                shape[0] - static_cast<size_t>(dst_row_offset));
+                            for (size_t chunk_x = 0; chunk_x < chunk_count_x; ++chunk_x) {
+                                const int dst_col_offset = static_cast<int>(chunk_x * source_chunk_shape[2]);
+                                const size_t valid_cols = std::min(
+                                    source_chunk_shape[2],
+                                    shape[2] - static_cast<size_t>(dst_col_offset));
+                                auto chunk = cache->getBlocking(vc::cache::ChunkKey{
+                                    0,
+                                    static_cast<int>(chunk_z),
+                                    static_cast<int>(source_chunk_plan.sourceChunkIndex),
+                                    static_cast<int>(chunk_x),
+                                });
+                                if (!chunk) {
+                                    continue;
+                                }
+                                const auto* chunk_data = chunk->data<uint8_t>();
+                                for (auto& assembled : assembled_slices) {
+                                    vc::core::util::copyBinarySliceRegionFromChunk(
+                                        chunk_data,
+                                        chunk->shape,
+                                        to_normal_grid_direction(dir),
+                                        assembled.localSliceIndex,
+                                        valid_rows,
+                                        valid_cols,
+                                        dst_row_offset,
+                                        dst_col_offset,
+                                        assembled.binarySlice,
+                                        assembled.anyNonZero);
+                                }
+                            }
+                        }
                         break;
                     case SliceDirection::YZ:
-                        chunk_shape = {shape[0], shape[1], chunk_size};
-                        chunk_offset = {0, 0, static_cast<int>(chunk_start)};
+                        for (size_t chunk_z = 0; chunk_z < chunk_count_z; ++chunk_z) {
+                            const int dst_row_offset = static_cast<int>(chunk_z * source_chunk_shape[0]);
+                            const size_t valid_rows = std::min(
+                                source_chunk_shape[0],
+                                shape[0] - static_cast<size_t>(dst_row_offset));
+                            for (size_t chunk_y = 0; chunk_y < chunk_count_y; ++chunk_y) {
+                                const int dst_col_offset = static_cast<int>(chunk_y * source_chunk_shape[1]);
+                                const size_t valid_cols = std::min(
+                                    source_chunk_shape[1],
+                                    shape[1] - static_cast<size_t>(dst_col_offset));
+                                auto chunk = cache->getBlocking(vc::cache::ChunkKey{
+                                    0,
+                                    static_cast<int>(chunk_z),
+                                    static_cast<int>(chunk_y),
+                                    static_cast<int>(source_chunk_plan.sourceChunkIndex),
+                                });
+                                if (!chunk) {
+                                    continue;
+                                }
+                                const auto* chunk_data = chunk->data<uint8_t>();
+                                for (auto& assembled : assembled_slices) {
+                                    vc::core::util::copyBinarySliceRegionFromChunk(
+                                        chunk_data,
+                                        chunk->shape,
+                                        to_normal_grid_direction(dir),
+                                        assembled.localSliceIndex,
+                                        valid_rows,
+                                        valid_cols,
+                                        dst_row_offset,
+                                        dst_col_offset,
+                                        assembled.binarySlice,
+                                        assembled.anyNonZero);
+                                }
+                            }
+                        }
                         break;
-                }
+                    }
 
-                ALifeTime chunk_timer;
-                xt::xtensor<uint8_t, 3, xt::layout_type::column_major> chunk_data =
-                    xt::xtensor<uint8_t, 3, xt::layout_type::column_major>::from_shape(chunk_shape);
-                chunk_timer.mark("xtensor_init");
-                readArea3D(chunk_data, chunk_offset, cache.get(), 0);
-                chunk_timer.mark("read_chunk");
-
-                for (const auto& mark : chunk_timer.getMarks()) {
-                    dir_metrics.timingTotals[mark.first] += mark.second;
-                    dir_metrics.timingCounts[mark.first] += 1;
+                    dir_metrics.timingTotals["read_chunk"] += std::chrono::duration<double>(
+                        std::chrono::steady_clock::now() - read_start).count();
+                    dir_metrics.timingCounts["read_chunk"] += 1;
                 }
 
                 std::vector<ThreadSliceStats> thread_stats(static_cast<size_t>(num_threads));
 
                 #pragma omp parallel for schedule(dynamic)
-                for (size_t i_chunk = 0; i_chunk < chunk_size; ++i_chunk) {
+                for (size_t batch_index = 0; batch_index < assembled_slices.size(); ++batch_index) {
                     const int tid = omp_get_thread_num();
                     ThreadSliceStats& local_stats = thread_stats[static_cast<size_t>(tid)];
                     ThreadScratch& scratch = thread_scratch[static_cast<size_t>(tid)];
-                    const SliceTask& task = tasks[i_chunk];
+                    const auto& assembled = assembled_slices[batch_index];
+                    const SliceTask& task = assembled.task;
 
-                    if (task.kind == SliceTaskKind::Unsampled) {
-                        ++local_stats.unsampled;
-                        ++local_stats.processed;
-                        continue;
-                    }
-                    if (task.kind == SliceTaskKind::Exists) {
-                        ++local_stats.skippedExisting;
-                        ++local_stats.processed;
-                        continue;
-                    }
-
-                    const auto extract_start = std::chrono::steady_clock::now();
-                    const bool any_nonzero = vc::core::util::extractBinarySliceFromChunk(
-                        chunk_data, to_normal_grid_direction(dir), i_chunk, scratch.binarySlice);
-                    local_stats.timingTotals["extract_binary"] += std::chrono::duration<double>(
-                        std::chrono::steady_clock::now() - extract_start).count();
-                    local_stats.timingCounts["extract_binary"] += 1;
-
-                    if (!any_nonzero) {
+                    if (!assembled.anyNonZero) {
                         std::ofstream ofs(task.outPath);
                         ++local_stats.emptyBinary;
                         ++local_stats.processed;
@@ -681,7 +783,7 @@ void run_generate(const po::variables_map& vm) {
                     scratch.traces.clear();
                     const auto thinning_start = std::chrono::steady_clock::now();
                     ThinningStats thinning_stats;
-                    customThinningTraceOnly(scratch.binarySlice, scratch.traces, &thinning_stats);
+                    customThinningTraceOnly(assembled.binarySlice, scratch.traces, &thinning_stats);
                     local_stats.timingTotals["thinning"] += std::chrono::duration<double>(
                         std::chrono::steady_clock::now() - thinning_start).count();
                     local_stats.timingCounts["thinning"] += 1;
@@ -696,7 +798,7 @@ void run_generate(const po::variables_map& vm) {
                     }
 
                     vc::core::util::GridStore grid_store(
-                        cv::Rect(0, 0, scratch.binarySlice.cols, scratch.binarySlice.rows),
+                        cv::Rect(0, 0, assembled.binarySlice.cols, assembled.binarySlice.rows),
                         grid_step);
 
                     const auto populate_start = std::chrono::steady_clock::now();
@@ -717,7 +819,7 @@ void run_generate(const po::variables_map& vm) {
                     const size_t written_index = written_counter.fetch_add(1, std::memory_order_relaxed) + 1;
                     if (preview_every > 0 && (written_index % static_cast<size_t>(preview_every)) == 0) {
                         const auto preview_start = std::chrono::steady_clock::now();
-                        cv::imwrite(task.previewPath.string(), scratch.binarySlice);
+                        cv::imwrite(task.previewPath.string(), assembled.binarySlice);
                         local_stats.timingTotals["preview_image"] += std::chrono::duration<double>(
                             std::chrono::steady_clock::now() - preview_start).count();
                         local_stats.timingCounts["preview_image"] += 1;
@@ -731,10 +833,13 @@ void run_generate(const po::variables_map& vm) {
                     ++local_stats.processed;
                 }
 
+                processed += batch_existing;
+                skipped_existing += batch_existing;
+                run_metrics.totalProcessedAllDirs += batch_size;
+                run_metrics.totalSkippedAllDirs += batch_existing;
+
                 for (const auto& local_stats : thread_stats) {
                     processed += local_stats.processed;
-                    skipped_existing += local_stats.skippedExisting;
-                    unsampled += local_stats.unsampled;
                     dir_metrics.emptyBinary += local_stats.emptyBinary;
                     dir_metrics.emptyTrace += local_stats.emptyTrace;
                     dir_metrics.written += local_stats.written;
@@ -750,9 +855,6 @@ void run_generate(const po::variables_map& vm) {
                     dir_metrics.thinningStats.accumulate(local_stats.thinningStats);
                     dir_metrics.thinningCalls += local_stats.thinningCalls;
                 }
-
-                run_metrics.totalProcessedAllDirs += chunk_size;
-                run_metrics.totalSkippedAllDirs += chunk_existing + skipped_existing - dir_metrics.skippedExisting;
             }
 
             auto now = std::chrono::steady_clock::now();

--- a/volume-cartographer/apps/src/vc_ngrids.cpp
+++ b/volume-cartographer/apps/src/vc_ngrids.cpp
@@ -1565,6 +1565,21 @@ static void create_normals_output_zarr(
     vc::writeZarrAttributes(out_zarr, attrs);
 }
 
+static std::vector<size_t> bounded_normals_output_chunks(
+    const std::vector<size_t>& full_shape_zyx,
+    size_t cap = 64)
+{
+    if (full_shape_zyx.size() != 3) {
+        throw std::runtime_error("bounded_normals_output_chunks expects 3D ZYX shape");
+    }
+
+    return {
+        std::min(cap, full_shape_zyx[0]),
+        std::min(cap, full_shape_zyx[1]),
+        std::min(cap, full_shape_zyx[2]),
+    };
+}
+
 static void write_normals_crop_u8(
     const fs::path& out_zarr,
     const CropIndexBox3z& crop_zyx,
@@ -1575,75 +1590,12 @@ static void write_normals_crop_u8(
     auto out_dsx = open_normals_axis_dataset(out_zarr, "x");
     auto out_dsy = open_normals_axis_dataset(out_zarr, "y");
     auto out_dsz = open_normals_axis_dataset(out_zarr, "z");
+    const std::vector<size_t> crop_off(crop_zyx.off.begin(), crop_zyx.off.end());
+    const std::vector<size_t> crop_shape(crop_zyx.shape.begin(), crop_zyx.shape.end());
 
-    auto write_region_preserving_fill = [](
-        vc::VcDataset& ds,
-        const CropIndexBox3z& crop_box,
-        const std::vector<uint8_t>& src,
-        uint8_t fill_value) {
-        const auto& chunk_shape = ds.defaultChunkShape();
-        const size_t chunk_elems = chunk_shape[0] * chunk_shape[1] * chunk_shape[2];
-        std::vector<uint8_t> chunk_buf(chunk_elems, fill_value);
-
-        const size_t z0 = crop_box.off[0];
-        const size_t y0 = crop_box.off[1];
-        const size_t x0 = crop_box.off[2];
-        const size_t z1 = z0 + crop_box.shape[0];
-        const size_t y1 = y0 + crop_box.shape[1];
-        const size_t x1 = x0 + crop_box.shape[2];
-
-        const size_t chunk_z0 = z0 / chunk_shape[0];
-        const size_t chunk_y0 = y0 / chunk_shape[1];
-        const size_t chunk_x0 = x0 / chunk_shape[2];
-        const size_t chunk_z1 = (z1 - 1) / chunk_shape[0];
-        const size_t chunk_y1 = (y1 - 1) / chunk_shape[1];
-        const size_t chunk_x1 = (x1 - 1) / chunk_shape[2];
-
-        for (size_t cz = chunk_z0; cz <= chunk_z1; ++cz) {
-            for (size_t cy = chunk_y0; cy <= chunk_y1; ++cy) {
-                for (size_t cx = chunk_x0; cx <= chunk_x1; ++cx) {
-                    ds.readChunkOrFill(cz, cy, cx, chunk_buf.data());
-
-                    const size_t chunk_base_z = cz * chunk_shape[0];
-                    const size_t chunk_base_y = cy * chunk_shape[1];
-                    const size_t chunk_base_x = cx * chunk_shape[2];
-
-                    const size_t copy_z0 = std::max(z0, chunk_base_z);
-                    const size_t copy_y0 = std::max(y0, chunk_base_y);
-                    const size_t copy_x0 = std::max(x0, chunk_base_x);
-                    const size_t copy_z1 = std::min(z1, chunk_base_z + chunk_shape[0]);
-                    const size_t copy_y1 = std::min(y1, chunk_base_y + chunk_shape[1]);
-                    const size_t copy_x1 = std::min(x1, chunk_base_x + chunk_shape[2]);
-
-                    for (size_t z = copy_z0; z < copy_z1; ++z) {
-                        const size_t src_z = z - z0;
-                        const size_t dst_z = z - chunk_base_z;
-                        for (size_t y = copy_y0; y < copy_y1; ++y) {
-                            const size_t src_y = y - y0;
-                            const size_t dst_y = y - chunk_base_y;
-                            const size_t src_offset =
-                                (src_z * crop_box.shape[1] + src_y) * crop_box.shape[2] +
-                                (copy_x0 - x0);
-                            const size_t dst_offset =
-                                (dst_z * chunk_shape[1] + dst_y) * chunk_shape[2] +
-                                (copy_x0 - chunk_base_x);
-                            const size_t copy_len = copy_x1 - copy_x0;
-                            std::memcpy(
-                                chunk_buf.data() + dst_offset,
-                                src.data() + src_offset,
-                                copy_len * sizeof(uint8_t));
-                        }
-                    }
-
-                    ds.writeChunk(cz, cy, cx, chunk_buf.data(), chunk_buf.size() * sizeof(uint8_t));
-                }
-            }
-        }
-    };
-
-    write_region_preserving_fill(*out_dsx, crop_zyx, ax, 128);
-    write_region_preserving_fill(*out_dsy, crop_zyx, ay, 128);
-    write_region_preserving_fill(*out_dsz, crop_zyx, az, 128);
+    writeZarrRegionU8ByChunk(out_dsx.get(), crop_off, crop_shape, ax.data(), 128);
+    writeZarrRegionU8ByChunk(out_dsy.get(), crop_off, crop_shape, ay.data(), 128);
+    writeZarrRegionU8ByChunk(out_dsz.get(), crop_off, crop_shape, az.data(), 128);
 }
 
 static void run_align_normals_zarr(
@@ -2019,7 +1971,13 @@ static void run_align_normals_zarr(
     metrics["align_seconds"] = std::chrono::duration<double>(
         std::chrono::steady_clock::now() - align_start).count();
     const auto write_start = std::chrono::steady_clock::now();
-    create_normals_output_zarr(out_zarr, normals.layout, crop_zyx);
+    NormalsZarrLayout output_layout = normals.layout;
+    output_layout.chunkShapeZyx = bounded_normals_output_chunks(output_layout.fullShapeZyx);
+    for (const char* axis : {"x", "y", "z"}) {
+        std::error_code ec;
+        fs::remove_all(out_zarr / axis, ec);
+    }
+    create_normals_output_zarr(out_zarr, output_layout, crop_zyx);
     write_normals_crop_u8(out_zarr, crop_zyx, ax, ay, az);
 
     nlohmann::json attrs = vc::readZarrAttributes(out_zarr);

--- a/volume-cartographer/apps/src/vc_ngrids.cpp
+++ b/volume-cartographer/apps/src/vc_ngrids.cpp
@@ -1355,6 +1355,233 @@ static bool is_valid_normal_u8(uint8_t ux, uint8_t uy, uint8_t uz) {
     return !(ux == 128 && uy == 128 && uz == 128);
 }
 
+static std::optional<size_t> memAvailableBytes()
+{
+#ifdef __linux__
+    std::ifstream in("/proc/meminfo");
+    if (!in) {
+        return std::nullopt;
+    }
+
+    std::string key;
+    size_t value = 0;
+    std::string unit;
+    while (in >> key >> value >> unit) {
+        if (key == "MemAvailable:") {
+            return value * 1024ull;
+        }
+    }
+#endif
+    return std::nullopt;
+}
+
+struct NormalsZarrLayout {
+    std::vector<size_t> fullShapeZyx;
+    std::vector<size_t> chunkShapeZyx;
+    cv::Vec3i originXyz = cv::Vec3i(0, 0, 0);
+    int sampleStep = 1;
+};
+
+struct NormalsCropU8 {
+    NormalsZarrLayout layout;
+    CropIndexBox3z cropZyx;
+    std::vector<uint8_t> x;
+    std::vector<uint8_t> y;
+    std::vector<uint8_t> z;
+};
+
+static std::unique_ptr<vc::VcDataset> open_normals_axis_dataset(
+    const fs::path& zarr_root,
+    const char* axis)
+{
+    return std::make_unique<vc::VcDataset>(zarr_root / axis / "0");
+}
+
+static void assert_normals_fill_value_128(const fs::path& zarr_root, const char* axis)
+{
+    const fs::path zarray_path = zarr_root / axis / "0" / ".zarray";
+    if (!fs::exists(zarray_path)) {
+        throw std::runtime_error(
+            std::string("Missing ") + axis + "/0/.zarray under normals zarr root: " +
+            zarr_root.string());
+    }
+
+    nlohmann::json j = nlohmann::json::parse(std::ifstream(zarray_path));
+    if (!j.contains("fill_value")) {
+        throw std::runtime_error(
+            std::string("Missing fill_value in ") + axis + "/0/.zarray under normals zarr root: " +
+            zarr_root.string());
+    }
+
+    const int fv = j["fill_value"].get<int>();
+    if (fv != 128) {
+        std::stringstream msg;
+        msg << "Normals zarr has unexpected fill_value=" << fv
+            << " for " << axis << "/0; expected 128";
+        throw std::runtime_error(msg.str());
+    }
+}
+
+static NormalsZarrLayout read_normals_zarr_layout(const fs::path& zarr_root)
+{
+    auto dsx = open_normals_axis_dataset(zarr_root, "x");
+    auto dsy = open_normals_axis_dataset(zarr_root, "y");
+    auto dsz = open_normals_axis_dataset(zarr_root, "z");
+    if (!dsx || !dsy || !dsz) {
+        throw std::runtime_error("Failed to open x/y/z datasets under zarr root: " + zarr_root.string());
+    }
+    if (dsx->shape() != dsy->shape() || dsx->shape() != dsz->shape()) {
+        throw std::runtime_error("x/y/z datasets have different shapes under: " + zarr_root.string());
+    }
+    if (dsx->shape().size() != 3) {
+        throw std::runtime_error("Expected 3D datasets (ZYX) for normals zarr under: " + zarr_root.string());
+    }
+
+    assert_normals_fill_value_128(zarr_root, "x");
+    assert_normals_fill_value_128(zarr_root, "y");
+    assert_normals_fill_value_128(zarr_root, "z");
+
+    NormalsZarrLayout layout;
+    layout.fullShapeZyx = {dsx->shape()[0], dsx->shape()[1], dsx->shape()[2]};
+    layout.chunkShapeZyx = {
+        dsx->defaultChunkShape()[0],
+        dsx->defaultChunkShape()[1],
+        dsx->defaultChunkShape()[2],
+    };
+
+    try {
+        nlohmann::json attrs = vc::readZarrAttributes(zarr_root);
+        if (attrs.contains("grid_origin_xyz") &&
+            attrs["grid_origin_xyz"].is_array() &&
+            attrs["grid_origin_xyz"].size() == 3) {
+            layout.originXyz = cv::Vec3i(
+                attrs["grid_origin_xyz"][0].get<int>(),
+                attrs["grid_origin_xyz"][1].get<int>(),
+                attrs["grid_origin_xyz"][2].get<int>());
+        }
+        if (attrs.contains("sample_step")) {
+            layout.sampleStep = std::max(1, attrs["sample_step"].get<int>());
+        }
+    } catch (...) {
+        // Attributes are optional; keep defaults.
+    }
+
+    return layout;
+}
+
+static NormalsCropU8 load_normals_crop_u8(
+    const fs::path& zarr_root,
+    const std::optional<CropBox3i>& crop_opt,
+    double* read_seconds = nullptr)
+{
+    const auto read_start = std::chrono::steady_clock::now();
+    NormalsCropU8 crop;
+    crop.layout = read_normals_zarr_layout(zarr_root);
+
+    const CropBox3i crop_xyz = crop_opt.value_or(CropBox3i{
+        cv::Vec3i(std::numeric_limits<int>::min() / 4,
+                  std::numeric_limits<int>::min() / 4,
+                  std::numeric_limits<int>::min() / 4),
+        cv::Vec3i(std::numeric_limits<int>::max() / 4,
+                  std::numeric_limits<int>::max() / 4,
+                  std::numeric_limits<int>::max() / 4),
+    });
+
+    crop.cropZyx = crop_to_zarr_zyx(
+        crop_xyz,
+        crop.layout.originXyz,
+        crop.layout.sampleStep,
+        crop.layout.fullShapeZyx);
+    const size_t CZ = crop.cropZyx.shape[0];
+    const size_t CY = crop.cropZyx.shape[1];
+    const size_t CX = crop.cropZyx.shape[2];
+    if (CZ == 0 || CY == 0 || CX == 0) {
+        throw std::runtime_error("--crop maps to empty region in normals zarr index space");
+    }
+
+    auto dsx = open_normals_axis_dataset(zarr_root, "x");
+    auto dsy = open_normals_axis_dataset(zarr_root, "y");
+    auto dsz = open_normals_axis_dataset(zarr_root, "z");
+
+    crop.x.assign(CZ * CY * CX, 0);
+    crop.y.assign(CZ * CY * CX, 0);
+    crop.z.assign(CZ * CY * CX, 0);
+
+    const std::vector<size_t> off(crop.cropZyx.off.begin(), crop.cropZyx.off.end());
+    const std::vector<size_t> region_shape(crop.cropZyx.shape.begin(), crop.cropZyx.shape.end());
+    dsx->readRegion(off, region_shape, crop.x.data());
+    dsy->readRegion(off, region_shape, crop.y.data());
+    dsz->readRegion(off, region_shape, crop.z.data());
+
+    if (read_seconds != nullptr) {
+        *read_seconds = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - read_start).count();
+    }
+    return crop;
+}
+
+static void create_normals_output_zarr(
+    const fs::path& out_zarr,
+    const NormalsZarrLayout& layout,
+    const std::optional<CropIndexBox3z>& crop_zyx = std::nullopt)
+{
+    std::filesystem::create_directories(out_zarr);
+    vc::createZarrDataset(out_zarr / "x", "0", layout.fullShapeZyx, layout.chunkShapeZyx, vc::VcDtype::uint8, "blosc", "/", 128);
+    vc::createZarrDataset(out_zarr / "y", "0", layout.fullShapeZyx, layout.chunkShapeZyx, vc::VcDtype::uint8, "blosc", "/", 128);
+    vc::createZarrDataset(out_zarr / "z", "0", layout.fullShapeZyx, layout.chunkShapeZyx, vc::VcDtype::uint8, "blosc", "/", 128);
+
+    nlohmann::json attrs;
+    attrs["source"] = "vc_ngrids";
+    attrs["description"] = "Direction-field encoded normals: x/0,y/0,z/0 uint8 with decode (u8-128)/127";
+    attrs["encoding"] = {
+        {"type", "direction-field-u8"},
+        {"decode", "(u8-128)/127"},
+        {"fill_value", 128},
+    };
+    attrs["grid_origin_xyz"] = {
+        layout.originXyz[0],
+        layout.originXyz[1],
+        layout.originXyz[2],
+    };
+    attrs["sample_step"] = layout.sampleStep;
+    attrs["grid_shape_zyx"] = {
+        layout.fullShapeZyx[0],
+        layout.fullShapeZyx[1],
+        layout.fullShapeZyx[2],
+    };
+    if (crop_zyx.has_value()) {
+        attrs["crop_off_zyx"] = {
+            crop_zyx->off[0],
+            crop_zyx->off[1],
+            crop_zyx->off[2],
+        };
+        attrs["crop_shape_zyx"] = {
+            crop_zyx->shape[0],
+            crop_zyx->shape[1],
+            crop_zyx->shape[2],
+        };
+    }
+    vc::writeZarrAttributes(out_zarr, attrs);
+}
+
+static void write_normals_crop_u8(
+    const fs::path& out_zarr,
+    const CropIndexBox3z& crop_zyx,
+    const std::vector<uint8_t>& ax,
+    const std::vector<uint8_t>& ay,
+    const std::vector<uint8_t>& az)
+{
+    auto out_dsx = open_normals_axis_dataset(out_zarr, "x");
+    auto out_dsy = open_normals_axis_dataset(out_zarr, "y");
+    auto out_dsz = open_normals_axis_dataset(out_zarr, "z");
+
+    const std::vector<size_t> crop_off(crop_zyx.off.begin(), crop_zyx.off.end());
+    const std::vector<size_t> crop_shape(crop_zyx.shape.begin(), crop_zyx.shape.end());
+    out_dsx->writeRegion(crop_off, crop_shape, ax.data());
+    out_dsy->writeRegion(crop_off, crop_shape, ay.data());
+    out_dsz->writeRegion(crop_off, crop_shape, az.data());
+}
+
 static void run_align_normals_zarr(
     const fs::path& zarr_root,
     const fs::path& out_zarr,
@@ -1373,73 +1600,19 @@ static void run_align_normals_zarr(
     metrics["radius"] = radius;
     metrics["candidate_samples_per_iter"] = candidate_samples_per_iter;
 
-    // Determine delimiter from x/0/.zarray (fallback "." to match other tools).
-    std::string delim = ".";
-    {
-        const fs::path zarray_path = zarr_root / "x" / "0" / ".zarray";
-        if (fs::exists(zarray_path)) {
-            nlohmann::json j = nlohmann::json::parse(std::ifstream(zarray_path));
-            delim = j.value<std::string>("dimension_separator", ".");
-        }
-    }
-
-    // Optional origin/step from attrs (if present) so crop can be applied in voxel coords.
-    cv::Vec3i origin_xyz(0, 0, 0);
-    int step = 1;
-    {
-        try {
-            nlohmann::json attrs = vc::readZarrAttributes(zarr_root);
-            if (attrs.contains("grid_origin_xyz") && attrs["grid_origin_xyz"].is_array() && attrs["grid_origin_xyz"].size() == 3) {
-                origin_xyz = cv::Vec3i(attrs["grid_origin_xyz"][0].get<int>(), attrs["grid_origin_xyz"][1].get<int>(), attrs["grid_origin_xyz"][2].get<int>());
-            }
-            if (attrs.contains("sample_step")) {
-                step = std::max(1, attrs["sample_step"].get<int>());
-            }
-        } catch (...) {
-            // attrs optional.
-        }
-    }
-
-    auto open_u8_zyx = [&](const char* axis) -> std::unique_ptr<vc::VcDataset> {
-        return std::make_unique<vc::VcDataset>(zarr_root / axis / "0");
-    };
-
-    auto dsx = open_u8_zyx("x");
-    auto dsy = open_u8_zyx("y");
-    auto dsz = open_u8_zyx("z");
-    if (!dsx || !dsy || !dsz) {
-        throw std::runtime_error("Failed to open x/y/z datasets under zarr root: " + zarr_root.string());
-    }
-    if (dsx->shape() != dsy->shape() || dsx->shape() != dsz->shape()) {
-        throw std::runtime_error("x/y/z datasets have different shapes under: " + zarr_root.string());
-    }
-    if (dsx->shape().size() != 3) {
-        throw std::runtime_error("Expected 3D datasets (ZYX) for normals zarr under: " + zarr_root.string());
-    }
-    const std::vector<size_t> full_shape = {dsx->shape()[0], dsx->shape()[1], dsx->shape()[2]};
-
-    // Assert fill_value is 128 (neutral "no normal"); vc_ngrids relies on this convention.
-    auto assert_fill_value_128 = [&](const char* axis) {
-        const fs::path zarray_path = zarr_root / axis / "0" / ".zarray";
-        if (!fs::exists(zarray_path)) {
-            throw std::runtime_error(std::string("Missing ") + axis + "/0/.zarray under normals zarr root: " + zarr_root.string());
-        }
-        nlohmann::json j = nlohmann::json::parse(std::ifstream(zarray_path));
-        if (!j.contains("fill_value")) {
-            throw std::runtime_error(std::string("Missing fill_value in ") + axis + "/0/.zarray under normals zarr root: " + zarr_root.string());
-        }
-        const int fv = j["fill_value"].get<int>();
-        if (fv != 128) {
-            std::stringstream msg;
-            msg << "Normals zarr has unexpected fill_value=" << fv
-                << " for " << axis << "/0; expected 128";
-            throw std::runtime_error(msg.str());
-        }
-    };
-    assert_fill_value_128("x");
-    assert_fill_value_128("y");
-    assert_fill_value_128("z");
-
+    double read_seconds = 0.0;
+    NormalsCropU8 normals = load_normals_crop_u8(zarr_root, crop_opt, &read_seconds);
+    metrics["read_seconds"] = read_seconds;
+    const auto& crop_zyx = normals.cropZyx;
+    const auto& full_shape = normals.layout.fullShapeZyx;
+    const cv::Vec3i origin_xyz = normals.layout.originXyz;
+    const int step = normals.layout.sampleStep;
+    const size_t CZ = crop_zyx.shape[0];
+    const size_t CY = crop_zyx.shape[1];
+    const size_t CX = crop_zyx.shape[2];
+    auto& ax = normals.x;
+    auto& ay = normals.y;
+    auto& az = normals.z;
     const CropBox3i crop_xyz = crop_opt.value_or(CropBox3i{
         cv::Vec3i(std::numeric_limits<int>::min() / 4,
                   std::numeric_limits<int>::min() / 4,
@@ -1448,29 +1621,6 @@ static void run_align_normals_zarr(
                   std::numeric_limits<int>::max() / 4,
                   std::numeric_limits<int>::max() / 4),
     });
-
-    const CropIndexBox3z crop_zyx = crop_to_zarr_zyx(crop_xyz, origin_xyz, step, full_shape);
-    const size_t CZ = crop_zyx.shape[0];
-    const size_t CY = crop_zyx.shape[1];
-    const size_t CX = crop_zyx.shape[2];
-    if (CZ == 0 || CY == 0 || CX == 0) {
-        throw std::runtime_error("--crop maps to empty region in normals zarr index space");
-    }
-
-    const auto read_start = std::chrono::steady_clock::now();
-    // Load the cropped normals into memory.
-    std::vector<uint8_t> ax(CZ * CY * CX, 0);
-    std::vector<uint8_t> ay(CZ * CY * CX, 0);
-    std::vector<uint8_t> az(CZ * CY * CX, 0);
-    {
-        std::vector<size_t> off(crop_zyx.off.begin(), crop_zyx.off.end());
-        std::vector<size_t> regionShape(crop_zyx.shape.begin(), crop_zyx.shape.end());
-        dsx->readRegion(off, regionShape, ax.data());
-        dsy->readRegion(off, regionShape, ay.data());
-        dsz->readRegion(off, regionShape, az.data());
-    }
-    metrics["read_seconds"] = std::chrono::duration<double>(
-        std::chrono::steady_clock::now() - read_start).count();
 
     const size_t N = CZ * CY * CX;
     auto lin_of = [&](size_t iz, size_t iy, size_t ix) -> size_t {
@@ -1802,40 +1952,19 @@ static void run_align_normals_zarr(
         az[lin_of(iz, iy, ix)] = flip_u8_dir_component(az[lin_of(iz, iy, ix)]);
     }
 
-    // Write output zarr: create full-sized datasets and only write the cropped subarray.
-    std::filesystem::create_directories(out_zarr);
-
-    const std::vector<size_t> chunks = {std::min<size_t>(64, full_shape[0]), std::min<size_t>(64, full_shape[1]), std::min<size_t>(64, full_shape[2])};
-
-    auto out_dsx = vc::createZarrDataset(out_zarr / "x", "0", full_shape, chunks, vc::VcDtype::uint8, "blosc", "/", 128);
-    auto out_dsy = vc::createZarrDataset(out_zarr / "y", "0", full_shape, chunks, vc::VcDtype::uint8, "blosc", "/", 128);
-    auto out_dsz = vc::createZarrDataset(out_zarr / "z", "0", full_shape, chunks, vc::VcDtype::uint8, "blosc", "/", 128);
-
-    const std::vector<size_t> cropOff(crop_zyx.off.begin(), crop_zyx.off.end());
-    const std::vector<size_t> cropShape(crop_zyx.shape.begin(), crop_zyx.shape.end());
     metrics["align_seconds"] = std::chrono::duration<double>(
         std::chrono::steady_clock::now() - align_start).count();
     const auto write_start = std::chrono::steady_clock::now();
-    writeZarrRegionU8ByChunk(out_dsx.get(), cropOff, cropShape, ax.data(), 128);
-    writeZarrRegionU8ByChunk(out_dsy.get(), cropOff, cropShape, ay.data(), 128);
-    writeZarrRegionU8ByChunk(out_dsz.get(), cropOff, cropShape, az.data(), 128);
+    create_normals_output_zarr(out_zarr, normals.layout, crop_zyx);
+    write_normals_crop_u8(out_zarr, crop_zyx, ax, ay, az);
 
-    // Minimal attrs on root.
-    nlohmann::json attrs;
-    attrs["source"] = "vc_ngrids";
-    attrs["note_axes_order"] = "ZYX";
-    attrs["encoding"] = "uint8_dir";
-    attrs["decode"] = "(v-128)/127";
-    attrs["grid_origin_xyz"] = {origin_xyz[0], origin_xyz[1], origin_xyz[2]};
-    attrs["sample_step"] = step;
+    nlohmann::json attrs = vc::readZarrAttributes(out_zarr);
     attrs["align_normals"] = true;
     attrs["align_seed_samples"] = seed_samples;
     attrs["align_radius_step_units"] = radius;
     attrs["align_candidate_samples_per_iter"] = candidate_samples_per_iter;
     attrs["crop_min_xyz"] = {crop_xyz.min[0], crop_xyz.min[1], crop_xyz.min[2]};
     attrs["crop_max_xyz"] = {crop_xyz.max[0], crop_xyz.max[1], crop_xyz.max[2]};
-    attrs["crop_off_zyx"] = {crop_zyx.off[0], crop_zyx.off[1], crop_zyx.off[2]};
-    attrs["crop_shape_zyx"] = {crop_zyx.shape[0], crop_zyx.shape[1], crop_zyx.shape[2]};
     vc::writeZarrAttributes(out_zarr, attrs);
 
     metrics["write_seconds"] = std::chrono::duration<double>(
@@ -1850,6 +1979,103 @@ static void run_align_normals_zarr(
     if (metrics_json_path.has_value()) {
         write_metrics_json(*metrics_json_path, metrics);
     }
+}
+
+struct FitPlaneConfig {
+    int plane_idx = 0;
+    const char* dir = "";
+    int slice_axis = 0;
+};
+
+struct FitPlaneSliceEntry {
+    int slice = 0;
+    std::shared_ptr<const vc::core::util::GridStore> grid;
+};
+
+struct FitPlaneSliceTable {
+    FitPlaneConfig cfg;
+    std::vector<FitPlaneSliceEntry> entries;
+};
+
+struct FitGridAccessPlan {
+    bool preload = false;
+    size_t estimatedBytes = 0;
+    size_t budgetBytes = 0;
+    size_t availableBytes = 0;
+    double preloadSeconds = 0.0;
+    std::array<FitPlaneSliceTable, 3> planes;
+};
+
+static fs::path normal_grid_slice_path(
+    const fs::path& input_dir,
+    const char* plane_dir,
+    int slice)
+{
+    char filename[256];
+    snprintf(filename, sizeof(filename), "%06d.grid", slice);
+    return input_dir / plane_dir / filename;
+}
+
+static FitGridAccessPlan build_fit_grid_access_plan(
+    const fs::path& input_dir,
+    vc::core::util::NormalGridVolume& ngv,
+    const CropBox3i& read_box,
+    int sparse_volume)
+{
+    const FitPlaneConfig plane_cfgs[3] = {
+        {0, "xy", 2},
+        {1, "xz", 1},
+        {2, "yz", 0},
+    };
+
+    FitGridAccessPlan plan;
+    const auto available = memAvailableBytes();
+    plan.availableBytes = available.value_or(0);
+    if (available.has_value()) {
+        plan.budgetBytes = std::min<size_t>(
+            256ull << 20,
+            std::max<size_t>(64ull << 20, *available / 16));
+    } else {
+        plan.budgetBytes = 128ull << 20;
+    }
+
+    for (size_t plane = 0; plane < std::size(plane_cfgs); ++plane) {
+        plan.planes[plane].cfg = plane_cfgs[plane];
+        const auto& cfg = plan.planes[plane].cfg;
+        const int axis = cfg.slice_axis;
+        const int s_min = read_box.min[axis];
+        const int s_max = read_box.max[axis];
+        int slice_start = align_down(s_min, sparse_volume);
+        if (slice_start < s_min) {
+            slice_start += std::max(1, sparse_volume);
+        }
+
+        for (int slice = slice_start; slice < s_max; slice += std::max(1, sparse_volume)) {
+            const fs::path grid_path = normal_grid_slice_path(input_dir, cfg.dir, slice);
+            if (!fs::exists(grid_path)) {
+                continue;
+            }
+
+            plan.planes[plane].entries.push_back(FitPlaneSliceEntry{slice, nullptr});
+            std::error_code ec;
+            plan.estimatedBytes += fs::file_size(grid_path, ec);
+        }
+    }
+
+    plan.preload = plan.estimatedBytes > 0 && plan.estimatedBytes <= plan.budgetBytes;
+    if (!plan.preload) {
+        return plan;
+    }
+
+    const auto preload_start = std::chrono::steady_clock::now();
+    for (auto& plane : plan.planes) {
+        for (auto& entry : plane.entries) {
+            entry.grid = ngv.get_grid(plane.cfg.plane_idx, entry.slice);
+        }
+    }
+    plan.preloadSeconds = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - preload_start).count();
+    return plan;
 }
 
 static void run_fit_normals(
@@ -1905,6 +2131,22 @@ static void run_fit_normals(
         std::min(vol_xyz[1], crop.max[1] + rad_i),
         std::min(vol_xyz[2], crop.max[2] + rad_i));
 
+    FitGridAccessPlan grid_access_plan = build_fit_grid_access_plan(
+        input_dir,
+        ngv,
+        read_box,
+        sparse_volume);
+    metrics["grid_access"] = {
+        {"mode", grid_access_plan.preload ? "preload" : "stream"},
+        {"estimated_bytes", static_cast<long long>(grid_access_plan.estimatedBytes)},
+        {"budget_bytes", static_cast<long long>(grid_access_plan.budgetBytes)},
+        {"available_bytes", static_cast<long long>(grid_access_plan.availableBytes)},
+        {"preload_seconds", grid_access_plan.preloadSeconds},
+        {"xy_slices", static_cast<long long>(grid_access_plan.planes[0].entries.size())},
+        {"xz_slices", static_cast<long long>(grid_access_plan.planes[1].entries.size())},
+        {"yz_slices", static_cast<long long>(grid_access_plan.planes[2].entries.size())},
+    };
+
     // Optional PLY output: per-thread temp files then merge.
     const int nthreads = std::max(1, omp_get_max_threads());
     struct ThreadOut {
@@ -1940,17 +2182,6 @@ static void run_fit_normals(
         const int g = 0;
         const int r = static_cast<int>(std::lround(t * 255.0));
         return cv::Vec3b(static_cast<uint8_t>(b), static_cast<uint8_t>(g), static_cast<uint8_t>(r));
-    };
-
-    struct PlaneCfg {
-        int plane_idx;
-        const char* dir;
-        int slice_axis;
-    };
-    const PlaneCfg planes[3] = {
-        {0, "xy", 2},
-        {1, "xz", 1},
-        {2, "yz", 0},
     };
 
     auto has_enough_plane_support = [&](const std::array<std::vector<cv::Point3f>, 3>& dirs_unit) -> bool {
@@ -2121,7 +2352,22 @@ static void run_fit_normals(
     };
 
     std::vector<FitStats> stats = stats_of();
-    std::vector<ThreadSliceGridCache> thread_grid_cache(static_cast<size_t>(std::max(1, omp_get_max_threads())));
+    const size_t thread_grid_cache_capacity = std::max<size_t>(
+        128,
+        std::min<size_t>(
+            1024,
+            std::max({
+                grid_access_plan.planes[0].entries.size(),
+                grid_access_plan.planes[1].entries.size(),
+                grid_access_plan.planes[2].entries.size(),
+            })));
+    std::vector<ThreadSliceGridCache> thread_grid_cache;
+    if (!grid_access_plan.preload) {
+        thread_grid_cache.reserve(static_cast<size_t>(std::max(1, omp_get_max_threads())));
+        for (int t = 0; t < std::max(1, omp_get_max_threads()); ++t) {
+            thread_grid_cache.emplace_back(thread_grid_cache_capacity);
+        }
+    }
 
     auto gather_samples_for_radius = [&](
         const cv::Point3f& sample,
@@ -2130,6 +2376,7 @@ static void run_fit_normals(
         std::array<std::vector<cv::Point3f>, 3>& dirs_unit,
         std::array<std::vector<double>, 3>& weights,
         std::array<std::vector<cv::Point3f>, 3>& deltas_xyz,
+        vc::core::util::GridStore::QueryScratch& grid_query_scratch,
         int& used_segments_total,
         int& used_segments_short_paths,
         double& t_ng_read_s,
@@ -2147,7 +2394,8 @@ static void run_fit_normals(
         (void)inv_two_sigma2;
         const float sample_arr[3] = {sample.x, sample.y, sample.z};
 
-        for (const auto& pc : planes) {
+        for (const auto& plane : grid_access_plan.planes) {
+            const auto& pc = plane.cfg;
             // plane axes
             const int u_axis = (pc.plane_idx == 2) ? 1 : 0;
             const int v_axis = (pc.plane_idx == 0) ? 1 : 2;
@@ -2156,10 +2404,16 @@ static void run_fit_normals(
             const int s_center = static_cast<int>(sample_arr[s_axis]);
             const int s_min = std::max(read_box.min[s_axis], static_cast<int>(std::floor(s_center - rad)));
             const int s_max = std::min(read_box.max[s_axis], static_cast<int>(std::ceil(s_center + rad)) + 1);
-            int slice_start = align_down(s_min, sparse_volume);
-            if (slice_start < s_min) slice_start += std::max(1, sparse_volume);
+            auto slice_it = std::lower_bound(
+                plane.entries.begin(),
+                plane.entries.end(),
+                s_min,
+                [](const FitPlaneSliceEntry& entry, int slice_value) {
+                    return entry.slice < slice_value;
+                });
 
-            for (int slice = slice_start; slice < s_max; slice += std::max(1, sparse_volume)) {
+            for (; slice_it != plane.entries.end() && slice_it->slice < s_max; ++slice_it) {
+                const int slice = slice_it->slice;
                 // Shrink the 2D query rect based on distance in the slice axis:
                 // at offset ds from the center, the in-slice radius is sqrt(r^2 - ds^2).
                 const float ds = std::abs(static_cast<float>(slice) - sample_arr[s_axis]);
@@ -2175,15 +2429,22 @@ static void run_fit_normals(
                 const cv::Rect query(u0, v0, u1 - u0, v1 - v0);
 
                 const auto t_read0 = std::chrono::steady_clock::now();
-                auto grid = thread_grid_cache[static_cast<size_t>(tid)].get(ngv, pc.plane_idx, slice);
+                std::shared_ptr<const vc::core::util::GridStore> grid;
+                if (grid_access_plan.preload) {
+                    grid = slice_it->grid;
+                } else {
+                    grid = thread_grid_cache[static_cast<size_t>(tid)].get(ngv, pc.plane_idx, slice);
+                }
                 if (!grid) continue;
-
-                const auto paths = grid->get(query);
+                grid->forEach(
+                    query,
+                    grid_query_scratch,
+                    [&](const std::shared_ptr<std::vector<cv::Point>>&) {});
                 const auto t_read1 = std::chrono::steady_clock::now();
                 t_ng_read_s += std::chrono::duration<double>(t_read1 - t_read0).count();
 
                 const auto t_pp0 = std::chrono::steady_clock::now();
-                for (const auto& path_ptr : paths) {
+                for (const auto& path_ptr : grid_query_scratch.results) {
                     if (!path_ptr || path_ptr->size() < 2) continue;
 
                     const int seg_count = static_cast<int>(path_ptr->size()) - 1;
@@ -2252,6 +2513,7 @@ static void run_fit_normals(
         std::array<std::vector<cv::Point3f>, 3> dirs_unit;
         std::array<std::vector<double>, 3> weights;
         std::array<std::vector<cv::Point3f>, 3> deltas_xyz;
+        vc::core::util::GridStore::QueryScratch gridQueryScratch;
     };
     std::vector<FitBuffers> fit_buffers(static_cast<size_t>(std::max(1, omp_get_max_threads())));
     for (auto& fb : fit_buffers) {
@@ -2427,6 +2689,7 @@ static void run_fit_normals(
                                               dirs_unit,
                                               weights,
                                               deltas_xyz,
+                                              fb.gridQueryScratch,
                                               used_segments_total,
                                               used_segments_short_paths,
                                               t_ng_read_s,
@@ -2634,33 +2897,28 @@ static void run_fit_normals(
     if (out_zarr_opt.has_value()) {
         const fs::path out_zarr = *out_zarr_opt;
 
-        // Create datasets with Zarr metadata using '/' as dimension_separator.
-        // NOTE: direction-field readers in vc_grow_seg_from_seed expect:
-        //   <root>/{x,y,z}/0/.zarray
-        // and will read the delimiter from that .zarray.
-        std::filesystem::create_directories(out_zarr);
-
-        auto dsx = vc::createZarrDataset(out_zarr / "x", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/", 128);
-        auto dsy = vc::createZarrDataset(out_zarr / "y", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/", 128);
-        auto dsz = vc::createZarrDataset(out_zarr / "z", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/", 128);
-        auto ds_fit_rms = vc::createZarrDataset(out_zarr / "fit_rms", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/");
-        auto ds_fit_frac = vc::createZarrDataset(out_zarr / "fit_frac_short_paths", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/");
-        auto ds_fit_rad = vc::createZarrDataset(out_zarr / "fit_used_radius", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/");
-        auto ds_fit_sc = vc::createZarrDataset(out_zarr / "fit_segment_count", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/");
+        NormalsZarrLayout output_layout;
+        output_layout.fullShapeZyx = output_shape_zyx;
+        output_layout.chunkShapeZyx = output_chunks_zyx;
+        output_layout.sampleStep = step;
+        create_normals_output_zarr(
+            out_zarr,
+            output_layout,
+            CropIndexBox3z{
+                {static_cast<size_t>(crop_off_z), static_cast<size_t>(crop_off_y), static_cast<size_t>(crop_off_x)},
+                {static_cast<size_t>(crop_nz), static_cast<size_t>(crop_ny), static_cast<size_t>(crop_nx)},
+            });
+        vc::createZarrDataset(out_zarr / "fit_rms", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/");
+        vc::createZarrDataset(out_zarr / "fit_frac_short_paths", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/");
+        vc::createZarrDataset(out_zarr / "fit_used_radius", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/");
+        vc::createZarrDataset(out_zarr / "fit_segment_count", "0", output_shape_zyx, output_chunks_zyx, vc::VcDtype::uint8, "blosc", "/");
 
         materialize_stats = materialize_fit_output_spool(out_zarr, *output_spool, static_cast<size_t>(nthreads));
 
-        // Minimal attrs on root.
-        nlohmann::json attrs;
-        attrs["source"] = "vc_ngrids";
-        attrs["note_axes_order"] = "ZYX";
-        attrs["encoding"] = "uint8_dir";
-        attrs["decode"] = "(v-128)/127";
-        attrs["sample_step"] = step;
+        nlohmann::json attrs = vc::readZarrAttributes(out_zarr);
         attrs["radius"] = radius;
         attrs["crop_min_xyz"] = {crop.min[0], crop.min[1], crop.min[2]};
         attrs["crop_max_xyz"] = {crop.max[0], crop.max[1], crop.max[2]};
-        attrs["grid_shape_zyx"] = {output_shape_zyx[0], output_shape_zyx[1], output_shape_zyx[2]};
 
         // Diagnostics.
         attrs["fit_rms_group"] = "fit_rms/0";

--- a/volume-cartographer/apps/src/vc_ngrids.cpp
+++ b/volume-cartographer/apps/src/vc_ngrids.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 #include <chrono>
 #include <cmath>
+#include <cstring>
 #include <deque>
 #include <string>
 #include <thread>
@@ -1575,11 +1576,74 @@ static void write_normals_crop_u8(
     auto out_dsy = open_normals_axis_dataset(out_zarr, "y");
     auto out_dsz = open_normals_axis_dataset(out_zarr, "z");
 
-    const std::vector<size_t> crop_off(crop_zyx.off.begin(), crop_zyx.off.end());
-    const std::vector<size_t> crop_shape(crop_zyx.shape.begin(), crop_zyx.shape.end());
-    out_dsx->writeRegion(crop_off, crop_shape, ax.data());
-    out_dsy->writeRegion(crop_off, crop_shape, ay.data());
-    out_dsz->writeRegion(crop_off, crop_shape, az.data());
+    auto write_region_preserving_fill = [](
+        vc::VcDataset& ds,
+        const CropIndexBox3z& crop_box,
+        const std::vector<uint8_t>& src,
+        uint8_t fill_value) {
+        const auto& chunk_shape = ds.defaultChunkShape();
+        const size_t chunk_elems = chunk_shape[0] * chunk_shape[1] * chunk_shape[2];
+        std::vector<uint8_t> chunk_buf(chunk_elems, fill_value);
+
+        const size_t z0 = crop_box.off[0];
+        const size_t y0 = crop_box.off[1];
+        const size_t x0 = crop_box.off[2];
+        const size_t z1 = z0 + crop_box.shape[0];
+        const size_t y1 = y0 + crop_box.shape[1];
+        const size_t x1 = x0 + crop_box.shape[2];
+
+        const size_t chunk_z0 = z0 / chunk_shape[0];
+        const size_t chunk_y0 = y0 / chunk_shape[1];
+        const size_t chunk_x0 = x0 / chunk_shape[2];
+        const size_t chunk_z1 = (z1 - 1) / chunk_shape[0];
+        const size_t chunk_y1 = (y1 - 1) / chunk_shape[1];
+        const size_t chunk_x1 = (x1 - 1) / chunk_shape[2];
+
+        for (size_t cz = chunk_z0; cz <= chunk_z1; ++cz) {
+            for (size_t cy = chunk_y0; cy <= chunk_y1; ++cy) {
+                for (size_t cx = chunk_x0; cx <= chunk_x1; ++cx) {
+                    ds.readChunkOrFill(cz, cy, cx, chunk_buf.data());
+
+                    const size_t chunk_base_z = cz * chunk_shape[0];
+                    const size_t chunk_base_y = cy * chunk_shape[1];
+                    const size_t chunk_base_x = cx * chunk_shape[2];
+
+                    const size_t copy_z0 = std::max(z0, chunk_base_z);
+                    const size_t copy_y0 = std::max(y0, chunk_base_y);
+                    const size_t copy_x0 = std::max(x0, chunk_base_x);
+                    const size_t copy_z1 = std::min(z1, chunk_base_z + chunk_shape[0]);
+                    const size_t copy_y1 = std::min(y1, chunk_base_y + chunk_shape[1]);
+                    const size_t copy_x1 = std::min(x1, chunk_base_x + chunk_shape[2]);
+
+                    for (size_t z = copy_z0; z < copy_z1; ++z) {
+                        const size_t src_z = z - z0;
+                        const size_t dst_z = z - chunk_base_z;
+                        for (size_t y = copy_y0; y < copy_y1; ++y) {
+                            const size_t src_y = y - y0;
+                            const size_t dst_y = y - chunk_base_y;
+                            const size_t src_offset =
+                                (src_z * crop_box.shape[1] + src_y) * crop_box.shape[2] +
+                                (copy_x0 - x0);
+                            const size_t dst_offset =
+                                (dst_z * chunk_shape[1] + dst_y) * chunk_shape[2] +
+                                (copy_x0 - chunk_base_x);
+                            const size_t copy_len = copy_x1 - copy_x0;
+                            std::memcpy(
+                                chunk_buf.data() + dst_offset,
+                                src.data() + src_offset,
+                                copy_len * sizeof(uint8_t));
+                        }
+                    }
+
+                    ds.writeChunk(cz, cy, cx, chunk_buf.data(), chunk_buf.size() * sizeof(uint8_t));
+                }
+            }
+        }
+    };
+
+    write_region_preserving_fill(*out_dsx, crop_zyx, ax, 128);
+    write_region_preserving_fill(*out_dsy, crop_zyx, ay, 128);
+    write_region_preserving_fill(*out_dsz, crop_zyx, az, 128);
 }
 
 static void run_align_normals_zarr(

--- a/volume-cartographer/core/include/vc/core/util/GridStore.hpp
+++ b/volume-cartographer/core/include/vc/core/util/GridStore.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <opencv2/core/types.hpp>
 #include <vector>
 #include <memory>
@@ -22,6 +23,11 @@ public:
         size_t decodedPathBytes = 0;
     };
 
+    struct QueryScratch {
+        std::vector<size_t> ids;
+        std::vector<std::shared_ptr<std::vector<cv::Point>>> results;
+    };
+
     GridStore(const cv::Rect& bounds, int cell_size);
     explicit GridStore(const std::string& path);
     ~GridStore();
@@ -29,6 +35,9 @@ public:
     void add(const std::vector<cv::Point>& points);
     std::vector<std::shared_ptr<std::vector<cv::Point>>> get(const cv::Rect& query_rect) const;
     std::vector<std::shared_ptr<std::vector<cv::Point>>> get(const cv::Point2f& center, float radius) const;
+    void forEach(const cv::Rect& query_rect,
+                 QueryScratch& scratch,
+                 const std::function<void(const std::shared_ptr<std::vector<cv::Point>>&)>& visitor) const;
     std::vector<std::shared_ptr<std::vector<cv::Point>>> get_all() const;
     cv::Size size() const;
     size_t get_memory_usage() const;

--- a/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
+++ b/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -19,6 +20,95 @@ struct NormalGridBatchPlan {
     size_t chunkSizeTarget = 1;
     size_t estimatedBatchBytes = 0;
 };
+
+struct NormalGridSampledSlice {
+    size_t sliceIndex = 0;
+    size_t localSliceIndex = 0;
+};
+
+struct NormalGridSampledChunkPlan {
+    size_t sourceChunkIndex = 0;
+    size_t sourceSliceBegin = 0;
+    size_t sourceSliceCount = 0;
+    std::vector<NormalGridSampledSlice> sampledSlices;
+};
+
+inline size_t normalGridSliceAxis(NormalGridSliceDirection direction)
+{
+    switch (direction) {
+    case NormalGridSliceDirection::XY: return 0;
+    case NormalGridSliceDirection::XZ: return 1;
+    case NormalGridSliceDirection::YZ: return 2;
+    }
+    return 0;
+}
+
+inline cv::Size normalGridSliceSize(
+    const std::vector<size_t>& shape,
+    NormalGridSliceDirection direction)
+{
+    if (shape.size() != 3) {
+        throw std::runtime_error("normalGridSliceSize expects 3D ZYX shape");
+    }
+
+    switch (direction) {
+    case NormalGridSliceDirection::XY:
+        return cv::Size(static_cast<int>(shape[2]), static_cast<int>(shape[1]));
+    case NormalGridSliceDirection::XZ:
+        return cv::Size(static_cast<int>(shape[2]), static_cast<int>(shape[0]));
+    case NormalGridSliceDirection::YZ:
+        return cv::Size(static_cast<int>(shape[1]), static_cast<int>(shape[0]));
+    }
+    return cv::Size();
+}
+
+inline std::vector<NormalGridSampledChunkPlan> planNormalGridSampledChunks(
+    const std::vector<size_t>& shape,
+    const std::vector<size_t>& sourceChunkShape,
+    NormalGridSliceDirection direction,
+    int sparseVolume)
+{
+    if (shape.size() != 3 || sourceChunkShape.size() != 3) {
+        throw std::runtime_error("planNormalGridSampledChunks expects 3D ZYX shape/chunkShape");
+    }
+
+    const size_t sliceAxis = normalGridSliceAxis(direction);
+    const size_t numSlices = shape[sliceAxis];
+    const size_t chunkDepth = sourceChunkShape[sliceAxis];
+    if (chunkDepth == 0) {
+        throw std::runtime_error("source chunk depth must be > 0");
+    }
+
+    const size_t sampleStep = static_cast<size_t>(std::max(1, sparseVolume));
+    const size_t numSourceChunks = (numSlices + chunkDepth - 1) / chunkDepth;
+
+    std::vector<NormalGridSampledChunkPlan> plans;
+    plans.reserve(numSourceChunks);
+
+    for (size_t sourceChunkIndex = 0; sourceChunkIndex < numSourceChunks; ++sourceChunkIndex) {
+        const size_t sourceSliceBegin = sourceChunkIndex * chunkDepth;
+        const size_t sourceSliceEnd = std::min(numSlices, sourceSliceBegin + chunkDepth);
+
+        NormalGridSampledChunkPlan plan;
+        plan.sourceChunkIndex = sourceChunkIndex;
+        plan.sourceSliceBegin = sourceSliceBegin;
+        plan.sourceSliceCount = sourceSliceEnd - sourceSliceBegin;
+
+        for (size_t sliceIndex = sourceSliceBegin; sliceIndex < sourceSliceEnd; ++sliceIndex) {
+            if ((sliceIndex % sampleStep) != 0) {
+                continue;
+            }
+            plan.sampledSlices.push_back(
+                NormalGridSampledSlice{sliceIndex, sliceIndex - sourceSliceBegin});
+        }
+
+        if (!plan.sampledSlices.empty()) {
+            plans.push_back(std::move(plan));
+        }
+    }
+
+    return plans;
+}
 
 inline NormalGridBatchPlan planNormalGridBatch(
     const std::vector<size_t>& shape,
@@ -64,6 +154,66 @@ inline NormalGridBatchPlan planNormalGridBatch(
         chunkSizeTarget,
         bytesPerSlice * chunkSizeTarget,
     };
+}
+
+inline void copyBinarySliceRegionFromChunk(
+    const uint8_t* chunkData,
+    const std::array<int, 3>& chunkShape,
+    NormalGridSliceDirection direction,
+    size_t localSliceIndex,
+    size_t validRows,
+    size_t validCols,
+    int dstRowOffset,
+    int dstColOffset,
+    cv::Mat& binarySlice,
+    bool& anyNonZero)
+{
+    const int strideZ = chunkShape[1] * chunkShape[2];
+    const int strideY = chunkShape[2];
+
+    switch (direction) {
+    case NormalGridSliceDirection::XY:
+        for (size_t row = 0; row < validRows; ++row) {
+            const auto* src = chunkData +
+                static_cast<size_t>(localSliceIndex) * strideZ +
+                row * strideY;
+            auto* dst = binarySlice.ptr<uint8_t>(dstRowOffset + static_cast<int>(row)) + dstColOffset;
+            for (size_t col = 0; col < validCols; ++col) {
+                const bool isSet = src[col] > 0;
+                dst[col] = isSet ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
+                anyNonZero = anyNonZero || isSet;
+            }
+        }
+        break;
+    case NormalGridSliceDirection::XZ:
+        for (size_t row = 0; row < validRows; ++row) {
+            auto* dst = binarySlice.ptr<uint8_t>(dstRowOffset + static_cast<int>(row)) + dstColOffset;
+            for (size_t col = 0; col < validCols; ++col) {
+                const size_t srcIndex =
+                    row * strideZ +
+                    static_cast<size_t>(localSliceIndex) * strideY +
+                    col;
+                const bool isSet = chunkData[srcIndex] > 0;
+                dst[col] = isSet ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
+                anyNonZero = anyNonZero || isSet;
+            }
+        }
+        break;
+    case NormalGridSliceDirection::YZ:
+        for (size_t row = 0; row < validRows; ++row) {
+            auto* dst = binarySlice.ptr<uint8_t>(dstRowOffset + static_cast<int>(row)) + dstColOffset;
+            for (size_t col = 0; col < validCols; ++col) {
+                const size_t srcIndex =
+                    row * strideZ +
+                    col * strideY +
+                    static_cast<size_t>(localSliceIndex);
+                const bool isSet = chunkData[srcIndex] > 0;
+                dst[col] = isSet ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
+                anyNonZero = anyNonZero || isSet;
+            }
+        }
+        break;
+    }
 }
 
 inline bool extractBinarySliceFromChunk(

--- a/volume-cartographer/core/src/GridStore.cpp
+++ b/volume-cartographer/core/src/GridStore.cpp
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <optional>
 #include <random>
 #include <limits>
@@ -40,6 +41,14 @@ struct MmappedData {
 
 class GridStore::GridStoreImpl {
 public:
+    struct QueryBucketRange {
+        int startX = 0;
+        int endX = -1;
+        int startY = 0;
+        int endY = -1;
+        bool empty = true;
+    };
+
     struct SegCacheEntry {
         std::shared_ptr<LineSegList> seglist;
         size_t decoded_bytes = 0;
@@ -79,44 +88,104 @@ public:
         }
     }
 
-    std::vector<std::shared_ptr<std::vector<cv::Point>>> get(const cv::Rect& query_rect) const {
-        std::vector<std::shared_ptr<std::vector<cv::Point>>> result;
+    QueryBucketRange queryBucketRange(const cv::Rect& query_rect) const {
+        QueryBucketRange range;
+        if (grid_size_.width <= 0 || grid_size_.height <= 0) {
+            return range;
+        }
+
         cv::Rect clamped_rect = query_rect & bounds_;
+        if (clamped_rect.width <= 0 || clamped_rect.height <= 0) {
+            return range;
+        }
 
         cv::Point start = (clamped_rect.tl() - bounds_.tl()) / cell_size_;
         cv::Point end = (clamped_rect.br() - bounds_.tl()) / cell_size_;
+        start.x = std::clamp(start.x, 0, grid_size_.width - 1);
+        start.y = std::clamp(start.y, 0, grid_size_.height - 1);
+        end.x = std::clamp(end.x, 0, grid_size_.width - 1);
+        end.y = std::clamp(end.y, 0, grid_size_.height - 1);
+        if (start.x > end.x || start.y > end.y) {
+            return range;
+        }
+
+        range.startX = start.x;
+        range.endX = end.x;
+        range.startY = start.y;
+        range.endY = end.y;
+        range.empty = false;
+        return range;
+    }
+
+    void collect_query_results(const cv::Rect& query_rect, GridStore::QueryScratch& scratch) const {
+        scratch.ids.clear();
+        scratch.results.clear();
+        const QueryBucketRange range = queryBucketRange(query_rect);
+        if (range.empty) {
+            return;
+        }
 
         if (read_only_) {
-            std::unordered_set<size_t> offsets;
-            for (int y = start.y; y <= end.y; ++y) {
-                for (int x = start.x; x <= end.x; ++x) {
+            for (int y = range.startY; y <= range.endY; ++y) {
+                for (int x = range.startX; x <= range.endX; ++x) {
                     int index = y * grid_size_.width + x;
                     auto bucket_ptr = get_bucket_offsets(index);
                     if (bucket_ptr && !bucket_ptr->empty()) {
-                        offsets.insert(bucket_ptr->begin(), bucket_ptr->end());
+                        scratch.ids.insert(
+                            scratch.ids.end(),
+                            bucket_ptr->begin(),
+                            bucket_ptr->end());
                     }
                 }
             }
-            result.reserve(offsets.size());
-            for (size_t offset : offsets) {
-                result.push_back(get_points_from_offset(offset));
+            std::sort(scratch.ids.begin(), scratch.ids.end());
+            scratch.ids.erase(
+                std::unique(scratch.ids.begin(), scratch.ids.end()),
+                scratch.ids.end());
+
+            scratch.results.reserve(scratch.ids.size());
+            for (size_t offset : scratch.ids) {
+                scratch.results.push_back(get_points_from_offset(offset));
             }
         } else {
-            std::unordered_set<int> handles;
-            for (int y = start.y; y <= end.y; ++y) {
-                for (int x = start.x; x <= end.x; ++x) {
+            for (int y = range.startY; y <= range.endY; ++y) {
+                for (int x = range.startX; x <= range.endX; ++x) {
                     int index = y * grid_size_.width + x;
                     if (index >= 0 && index < grid_.size()) {
-                        handles.insert(grid_[index].begin(), grid_[index].end());
+                        scratch.ids.insert(
+                            scratch.ids.end(),
+                            grid_[index].begin(),
+                            grid_[index].end());
                     }
                 }
             }
-            result.reserve(handles.size());
-            for (int handle : handles) {
-                result.push_back(storage_[handle]->get());
+            std::sort(scratch.ids.begin(), scratch.ids.end());
+            scratch.ids.erase(
+                std::unique(scratch.ids.begin(), scratch.ids.end()),
+                scratch.ids.end());
+
+            scratch.results.reserve(scratch.ids.size());
+            for (size_t handle : scratch.ids) {
+                scratch.results.push_back(storage_[static_cast<size_t>(handle)]->get());
             }
         }
-        return result;
+    }
+
+    std::vector<std::shared_ptr<std::vector<cv::Point>>> get(const cv::Rect& query_rect) const {
+        GridStore::QueryScratch scratch;
+        collect_query_results(query_rect, scratch);
+        return std::move(scratch.results);
+    }
+
+    void forEach(
+        const cv::Rect& query_rect,
+        GridStore::QueryScratch& scratch,
+        const std::function<void(const std::shared_ptr<std::vector<cv::Point>>&)>& visitor) const
+    {
+        collect_query_results(query_rect, scratch);
+        for (const auto& path : scratch.results) {
+            visitor(path);
+        }
     }
 
     std::vector<std::shared_ptr<std::vector<cv::Point>>> get_all() const {
@@ -769,6 +838,14 @@ std::vector<std::shared_ptr<std::vector<cv::Point>>> GridStore::get(const cv::Po
     int y = static_cast<int>(center.y - radius);
     int size = static_cast<int>(radius * 2);
     return get(cv::Rect(x, y, size, size));
+}
+
+void GridStore::forEach(
+    const cv::Rect& query_rect,
+    QueryScratch& scratch,
+    const std::function<void(const std::shared_ptr<std::vector<cv::Point>>&)>& visitor) const
+{
+    pimpl_->forEach(query_rect, scratch, visitor);
 }
 
 std::vector<std::shared_ptr<std::vector<cv::Point>>> GridStore::get_all() const {

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -15,6 +15,7 @@ vc_add_test(test_sparse_chunk_spool test_sparse_chunk_spool.cpp)
 vc_add_test(test_thinning_equivalence test_thinning_equivalence.cpp)
 vc_add_test(test_triangle_voxel_raster test_triangle_voxel_raster.cpp)
 vc_add_test(test_vc_gen_normalgrids_smoke test_vc_gen_normalgrids_smoke.cpp)
+vc_add_test(test_vc_ngrids_smoke test_vc_ngrids_smoke.cpp)
 vc_add_test(test_volumepkg test_volumepkg.cpp)
 vc_add_test(test_vcdataset test_vcdataset.cpp)
 vc_add_test(test_quad_surface test_quad_surface.cpp)
@@ -22,3 +23,7 @@ vc_add_test(test_quad_surface test_quad_surface.cpp)
 add_dependencies(test_vc_gen_normalgrids_smoke vc_gen_normalgrids)
 target_compile_definitions(test_vc_gen_normalgrids_smoke PRIVATE
     VC_GEN_NORMALGRIDS_BIN="$<TARGET_FILE:vc_gen_normalgrids>")
+add_dependencies(test_vc_ngrids_smoke vc_gen_normalgrids vc_ngrids)
+target_compile_definitions(test_vc_ngrids_smoke PRIVATE
+    VC_GEN_NORMALGRIDS_BIN="$<TARGET_FILE:vc_gen_normalgrids>"
+    VC_NGRIDS_BIN="$<TARGET_FILE:vc_ngrids>")

--- a/volume-cartographer/core/test/test_gen_normalgrids_helpers.cpp
+++ b/volume-cartographer/core/test/test_gen_normalgrids_helpers.cpp
@@ -30,6 +30,36 @@ TEST(GenNormalGridsHelpers, BatchPlanFallsBackToOneSliceWithZeroBudget)
     EXPECT_EQ(plan.chunkSizeTarget, static_cast<size_t>(1));
 }
 
+TEST(GenNormalGridsHelpers, SampledChunkPlanGroupsSlicesBySourceChunk)
+{
+    const std::vector<size_t> shape = {10, 6, 8};
+    const std::vector<size_t> chunk_shape = {4, 3, 5};
+    const auto plans = vc::core::util::planNormalGridSampledChunks(
+        shape,
+        chunk_shape,
+        vc::core::util::NormalGridSliceDirection::XY,
+        3);
+
+    ASSERT_EQ(plans.size(), static_cast<size_t>(3));
+    EXPECT_EQ(plans[0].sourceChunkIndex, static_cast<size_t>(0));
+    EXPECT_EQ(plans[0].sourceSliceBegin, static_cast<size_t>(0));
+    ASSERT_EQ(plans[0].sampledSlices.size(), static_cast<size_t>(2));
+    EXPECT_EQ(plans[0].sampledSlices[0].sliceIndex, static_cast<size_t>(0));
+    EXPECT_EQ(plans[0].sampledSlices[0].localSliceIndex, static_cast<size_t>(0));
+    EXPECT_EQ(plans[0].sampledSlices[1].sliceIndex, static_cast<size_t>(3));
+    EXPECT_EQ(plans[0].sampledSlices[1].localSliceIndex, static_cast<size_t>(3));
+
+    EXPECT_EQ(plans[1].sourceChunkIndex, static_cast<size_t>(1));
+    ASSERT_EQ(plans[1].sampledSlices.size(), static_cast<size_t>(1));
+    EXPECT_EQ(plans[1].sampledSlices[0].sliceIndex, static_cast<size_t>(6));
+    EXPECT_EQ(plans[1].sampledSlices[0].localSliceIndex, static_cast<size_t>(2));
+
+    EXPECT_EQ(plans[2].sourceChunkIndex, static_cast<size_t>(2));
+    ASSERT_EQ(plans[2].sampledSlices.size(), static_cast<size_t>(1));
+    EXPECT_EQ(plans[2].sampledSlices[0].sliceIndex, static_cast<size_t>(9));
+    EXPECT_EQ(plans[2].sampledSlices[0].localSliceIndex, static_cast<size_t>(1));
+}
+
 TEST(GenNormalGridsHelpers, ExtractBinarySliceMatchesExpectedXYXZYZ)
 {
     xt::xtensor<uint8_t, 3, xt::layout_type::column_major> chunk =
@@ -61,4 +91,34 @@ TEST(GenNormalGridsHelpers, ExtractBinarySliceMatchesExpectedXYXZYZ)
     EXPECT_EQ(binary.cols, 3);
     EXPECT_EQ(binary.at<uint8_t>(0, 1), 255);
     EXPECT_EQ(binary.at<uint8_t>(1, 2), 0);
+}
+
+TEST(GenNormalGridsHelpers, CopyBinarySliceRegionBlitsSubrect)
+{
+    std::array<int, 3> chunk_shape = {3, 4, 5};
+    std::vector<uint8_t> chunk_data(static_cast<size_t>(chunk_shape[0] * chunk_shape[1] * chunk_shape[2]), 0);
+    auto index_of = [&](int z, int y, int x) {
+        return static_cast<size_t>((z * chunk_shape[1] + y) * chunk_shape[2] + x);
+    };
+    chunk_data[index_of(1, 0, 0)] = 5;
+    chunk_data[index_of(1, 1, 2)] = 7;
+
+    cv::Mat binary = cv::Mat::zeros(6, 7, CV_8U);
+    bool any_nonzero = false;
+    vc::core::util::copyBinarySliceRegionFromChunk(
+        chunk_data.data(),
+        chunk_shape,
+        vc::core::util::NormalGridSliceDirection::XY,
+        1,
+        2,
+        3,
+        2,
+        4,
+        binary,
+        any_nonzero);
+
+    EXPECT_TRUE(any_nonzero);
+    EXPECT_EQ(binary.at<uint8_t>(2, 4), 255);
+    EXPECT_EQ(binary.at<uint8_t>(3, 6), 255);
+    EXPECT_EQ(binary.at<uint8_t>(0, 0), 0);
 }

--- a/volume-cartographer/core/test/test_gridstore_cache.cpp
+++ b/volume-cartographer/core/test/test_gridstore_cache.cpp
@@ -131,6 +131,47 @@ TEST(GridStoreCache, ConcurrentRepeatedROIQueriesAreStable)
     EXPECT_GT(stats.decodedPathHits, 0);
 }
 
+TEST(GridStoreCache, ScratchQueryReusesBuffersAndMatchesGet)
+{
+    ScopedTempDir tempDir;
+    const auto gridPath = tempDir.path() / "sample.grid";
+
+    vc::core::util::GridStore writer(cv::Rect(0, 0, 256, 256), 16);
+    populateWriter(writer);
+    writer.save(gridPath.string());
+
+    vc::core::util::GridStore reader(gridPath.string());
+    vc::core::util::GridStore::QueryScratch scratch;
+    const cv::Rect roi(0, 0, 128, 128);
+
+    auto collectWithScratch = [&](const cv::Rect& query) {
+        std::multiset<std::string> encoded;
+        reader.forEach(query, scratch, [&](const std::shared_ptr<std::vector<cv::Point>>& path) {
+            std::stringstream ss;
+            for (const auto& pt : *path) {
+                ss << pt.x << "," << pt.y << ";";
+            }
+            encoded.insert(ss.str());
+        });
+        std::stringstream out;
+        for (const auto& entry : encoded) {
+            out << entry << "|";
+        }
+        return out.str();
+    };
+
+    const auto expected = pathSignature(reader.get(roi));
+    const auto first = collectWithScratch(roi);
+    const auto idsCapacity = scratch.ids.capacity();
+    const auto resultsCapacity = scratch.results.capacity();
+    const auto second = collectWithScratch(roi);
+
+    EXPECT_EQ(first, expected);
+    EXPECT_EQ(second, expected);
+    EXPECT_GE(scratch.ids.capacity(), idsCapacity);
+    EXPECT_GE(scratch.results.capacity(), resultsCapacity);
+}
+
 TEST(GridStoreCache, SaveWithoutVerificationStillReloadsIdentically)
 {
     ScopedTempDir tempDir;

--- a/volume-cartographer/core/test/test_vc_ngrids_smoke.cpp
+++ b/volume-cartographer/core/test/test_vc_ngrids_smoke.cpp
@@ -1,0 +1,171 @@
+#include "test.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "vc/core/types/VcDataset.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+class ScopedTempDir {
+public:
+    ScopedTempDir()
+    {
+        static std::atomic<unsigned long long> counter{0};
+        const auto suffix = std::to_string(
+            std::chrono::steady_clock::now().time_since_epoch().count())
+            + "_" + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+        path_ = fs::temp_directory_path() / ("vc_test_vc_ngrids_" + suffix);
+        fs::create_directories(path_);
+    }
+
+    ~ScopedTempDir()
+    {
+        std::error_code ec;
+        fs::remove_all(path_, ec);
+    }
+
+    const fs::path& path() const { return path_; }
+
+private:
+    fs::path path_;
+};
+
+void writeJson(const fs::path& path, const nlohmann::json& json)
+{
+    std::ofstream out(path);
+    out << json.dump(2) << '\n';
+}
+
+void createInputVolume(const fs::path& root)
+{
+    fs::create_directories(root);
+    writeJson(root / "meta.json", {
+        {"uuid", "vol-test"},
+        {"name", "vol-test"},
+        {"type", "vol"},
+        {"format", "zarr"},
+        {"width", 64},
+        {"height", 64},
+        {"slices", 64},
+        {"voxelsize", 1.0},
+        {"min", 0.0},
+        {"max", 255.0}
+    });
+
+    auto ds = vc::createZarrDataset(root, "0", {64, 64, 64}, {16, 16, 16}, vc::VcDtype::uint8, "none", "/");
+    std::vector<uint8_t> volume(64 * 64 * 64, 0);
+    auto idx = [](int z, int y, int x) {
+        return static_cast<size_t>((z * 64 + y) * 64 + x);
+    };
+    for (int z = 16; z < 48; ++z) {
+        for (int y = 16; y < 48; ++y) {
+            for (int x = 16; x < 48; ++x) {
+                volume[idx(z, y, x)] = 255;
+            }
+        }
+    }
+    ds->writeRegion({0, 0, 0}, {64, 64, 64}, volume.data());
+}
+
+std::string quote(const fs::path& path)
+{
+    return "\"" + path.string() + "\"";
+}
+
+std::vector<uint8_t> readDataset(const fs::path& path)
+{
+    vc::VcDataset ds(path);
+    const auto& shape = ds.shape();
+    std::vector<uint8_t> data(shape[0] * shape[1] * shape[2], 0);
+    ds.readRegion({0, 0, 0}, {shape[0], shape[1], shape[2]}, data.data());
+    return data;
+}
+
+void expectDatasetsEqual(const fs::path& aRoot, const fs::path& bRoot, const std::vector<std::string>& groups)
+{
+    for (const auto& group : groups) {
+        EXPECT_EQ(readDataset(aRoot / group / "0"), readDataset(bRoot / group / "0"));
+    }
+}
+
+size_t countValidNormals(const fs::path& zarrRoot)
+{
+    const auto x = readDataset(zarrRoot / "x" / "0");
+    const auto y = readDataset(zarrRoot / "y" / "0");
+    const auto z = readDataset(zarrRoot / "z" / "0");
+
+    size_t valid = 0;
+    for (size_t i = 0; i < x.size(); ++i) {
+        if (!(x[i] == 128 && y[i] == 128 && z[i] == 128)) {
+            ++valid;
+        }
+    }
+    return valid;
+}
+
+} // namespace
+
+TEST(NGridsSmoke, FitAndAlignNormalsAreDeterministicSingleThreaded)
+{
+    ScopedTempDir tempDir;
+    const auto inputRoot = tempDir.path() / "input.zarr";
+    const auto gridsRoot = tempDir.path() / "normal_grids";
+    const auto fit1Root = tempDir.path() / "fit1.zarr";
+    const auto fit2Root = tempDir.path() / "fit2.zarr";
+    const auto align1Root = tempDir.path() / "align1.zarr";
+    const auto align2Root = tempDir.path() / "align2.zarr";
+
+    createInputVolume(inputRoot);
+
+    std::string gen_cmd = std::string("OMP_NUM_THREADS=1 ")
+        + VC_GEN_NORMALGRIDS_BIN
+        + " generate -i " + quote(inputRoot)
+        + " -o " + quote(gridsRoot)
+        + " --sparse-volume 4"
+        + " --preview-every 0"
+        + " --level 0";
+    ASSERT_EQ(std::system(gen_cmd.c_str()), 0);
+
+    std::string fit1_cmd = std::string("OMP_NUM_THREADS=1 ")
+        + VC_NGRIDS_BIN
+        + " -i " + quote(gridsRoot)
+        + " --fit-normals --output-zarr " + quote(fit1Root);
+    std::string fit2_cmd = std::string("OMP_NUM_THREADS=1 ")
+        + VC_NGRIDS_BIN
+        + " -i " + quote(gridsRoot)
+        + " --fit-normals --output-zarr " + quote(fit2Root);
+    ASSERT_EQ(std::system(fit1_cmd.c_str()), 0);
+    ASSERT_EQ(std::system(fit2_cmd.c_str()), 0);
+
+    EXPECT_TRUE(fs::is_directory(fit1Root / "x" / "0"));
+    EXPECT_GT(countValidNormals(fit1Root), 0u);
+    expectDatasetsEqual(
+        fit1Root,
+        fit2Root,
+        {"x", "y", "z", "fit_rms", "fit_frac_short_paths", "fit_used_radius", "fit_segment_count"});
+
+    std::string align1_cmd = std::string("OMP_NUM_THREADS=1 ")
+        + VC_NGRIDS_BIN
+        + " -i " + quote(fit1Root)
+        + " --align-normals --output-zarr " + quote(align1Root);
+    std::string align2_cmd = std::string("OMP_NUM_THREADS=1 ")
+        + VC_NGRIDS_BIN
+        + " -i " + quote(fit1Root)
+        + " --align-normals --output-zarr " + quote(align2Root);
+    ASSERT_EQ(std::system(align1_cmd.c_str()), 0);
+    ASSERT_EQ(std::system(align2_cmd.c_str()), 0);
+
+    EXPECT_TRUE(fs::is_directory(align1Root / "x" / "0"));
+    EXPECT_GT(countValidNormals(align1Root), 0u);
+    expectDatasetsEqual(align1Root, align2Root, {"x", "y", "z"});
+}

--- a/volume-cartographer/core/test/test_vc_ngrids_smoke.cpp
+++ b/volume-cartographer/core/test/test_vc_ngrids_smoke.cpp
@@ -1,6 +1,7 @@
 #include "test.hpp"
 
 #include <atomic>
+#include <array>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -40,6 +41,15 @@ private:
     fs::path path_;
 };
 
+struct NormalVoxel {
+    int z = 0;
+    int y = 0;
+    int x = 0;
+    uint8_t nx = 128;
+    uint8_t ny = 128;
+    uint8_t nz = 128;
+};
+
 void writeJson(const fs::path& path, const nlohmann::json& json)
 {
     std::ofstream out(path);
@@ -77,13 +87,17 @@ void createInputVolume(const fs::path& root)
     ds->writeRegion({0, 0, 0}, {64, 64, 64}, volume.data());
 }
 
-void createChunkedNormalsInput(const fs::path& root)
+void createNormalsInput(
+    const fs::path& root,
+    const std::array<size_t, 3>& shape,
+    const std::array<size_t, 3>& chunks,
+    const std::vector<NormalVoxel>& voxels)
 {
-    const std::vector<size_t> shape = {80, 80, 80};
-    const std::vector<size_t> chunks = {64, 64, 64};
-    auto dsx = vc::createZarrDataset(root / "x", "0", shape, chunks, vc::VcDtype::uint8, "blosc", "/", 128);
-    auto dsy = vc::createZarrDataset(root / "y", "0", shape, chunks, vc::VcDtype::uint8, "blosc", "/", 128);
-    auto dsz = vc::createZarrDataset(root / "z", "0", shape, chunks, vc::VcDtype::uint8, "blosc", "/", 128);
+    const std::vector<size_t> shape_vec = {shape[0], shape[1], shape[2]};
+    const std::vector<size_t> chunk_vec = {chunks[0], chunks[1], chunks[2]};
+    auto dsx = vc::createZarrDataset(root / "x", "0", shape_vec, chunk_vec, vc::VcDtype::uint8, "blosc", "/", 128);
+    auto dsy = vc::createZarrDataset(root / "y", "0", shape_vec, chunk_vec, vc::VcDtype::uint8, "blosc", "/", 128);
+    auto dsz = vc::createZarrDataset(root / "z", "0", shape_vec, chunk_vec, vc::VcDtype::uint8, "blosc", "/", 128);
 
     std::vector<uint8_t> x(shape[0] * shape[1] * shape[2], 128);
     std::vector<uint8_t> y(shape[0] * shape[1] * shape[2], 128);
@@ -92,23 +106,39 @@ void createChunkedNormalsInput(const fs::path& root)
         return static_cast<size_t>((zz * static_cast<int>(shape[1]) + yy) * static_cast<int>(shape[2]) + xx);
     };
 
-    for (int zz = 7; zz < 9; ++zz) {
-        for (int yy = 8; yy < 10; ++yy) {
-            for (int xx = 9; xx < 11; ++xx) {
-                x[idx(zz, yy, xx)] = 255;
-                y[idx(zz, yy, xx)] = 128;
-                z[idx(zz, yy, xx)] = 128;
-            }
-        }
+    for (const auto& voxel : voxels) {
+        x[idx(voxel.z, voxel.y, voxel.x)] = voxel.nx;
+        y[idx(voxel.z, voxel.y, voxel.x)] = voxel.ny;
+        z[idx(voxel.z, voxel.y, voxel.x)] = voxel.nz;
     }
 
-    dsx->writeRegion({0, 0, 0}, shape, x.data());
-    dsy->writeRegion({0, 0, 0}, shape, y.data());
-    dsz->writeRegion({0, 0, 0}, shape, z.data());
+    dsx->writeRegion({0, 0, 0}, shape_vec, x.data());
+    dsy->writeRegion({0, 0, 0}, shape_vec, y.data());
+    dsz->writeRegion({0, 0, 0}, shape_vec, z.data());
     vc::writeZarrAttributes(root, {
         {"grid_origin_xyz", {0, 0, 0}},
         {"sample_step", 1},
     });
+}
+
+void createChunkedNormalsInput(const fs::path& root)
+{
+    std::vector<NormalVoxel> voxels;
+    for (int zz = 7; zz < 9; ++zz) {
+        for (int yy = 8; yy < 10; ++yy) {
+            for (int xx = 9; xx < 11; ++xx) {
+                voxels.push_back(NormalVoxel{
+                    .z = zz,
+                    .y = yy,
+                    .x = xx,
+                    .nx = 255,
+                    .ny = 128,
+                    .nz = 128,
+                });
+            }
+        }
+    }
+    createNormalsInput(root, {80, 80, 80}, {64, 64, 64}, voxels);
 }
 
 std::string quote(const fs::path& path)
@@ -153,6 +183,11 @@ uint8_t readVoxel(const fs::path& path, size_t z, size_t y, size_t x)
     uint8_t value = 0;
     ds.readRegion({z, y, x}, {1, 1, 1}, &value);
     return value;
+}
+
+nlohmann::json readJsonFile(const fs::path& path)
+{
+    return nlohmann::json::parse(std::ifstream(path));
 }
 
 } // namespace
@@ -233,4 +268,69 @@ TEST(NGridsSmoke, AlignCropPreservesFillOutsidePartialChunks)
     EXPECT_EQ(readVoxel(outputRoot / "z" / "0", 0, 0, 0), static_cast<uint8_t>(128));
 
     EXPECT_NE(readVoxel(outputRoot / "x" / "0", 7, 8, 9), static_cast<uint8_t>(128));
+}
+
+TEST(NGridsSmoke, AlignRerunReplacesPreviousCropData)
+{
+    ScopedTempDir tempDir;
+    const auto inputRoot = tempDir.path() / "normals_input.zarr";
+    const auto outputRoot = tempDir.path() / "aligned_output.zarr";
+
+    createNormalsInput(
+        inputRoot,
+        {80, 80, 80},
+        {64, 64, 64},
+        {
+            NormalVoxel{.z = 7, .y = 8, .x = 9, .nx = 255, .ny = 128, .nz = 128},
+            NormalVoxel{.z = 7, .y = 8, .x = 20, .nx = 255, .ny = 128, .nz = 128},
+        });
+
+    std::string align_first_cmd = std::string("OMP_NUM_THREADS=1 ")
+        + VC_NGRIDS_BIN
+        + " -i " + quote(inputRoot)
+        + " --align-normals"
+        + " --crop 9 8 7 10 9 8"
+        + " --output-zarr " + quote(outputRoot);
+    std::string align_second_cmd = std::string("OMP_NUM_THREADS=1 ")
+        + VC_NGRIDS_BIN
+        + " -i " + quote(inputRoot)
+        + " --align-normals"
+        + " --crop 20 8 7 21 9 8"
+        + " --output-zarr " + quote(outputRoot);
+
+    ASSERT_EQ(std::system(align_first_cmd.c_str()), 0);
+    EXPECT_NE(readVoxel(outputRoot / "x" / "0", 7, 8, 9), static_cast<uint8_t>(128));
+
+    ASSERT_EQ(std::system(align_second_cmd.c_str()), 0);
+    EXPECT_EQ(readVoxel(outputRoot / "x" / "0", 7, 8, 9), static_cast<uint8_t>(128));
+    EXPECT_NE(readVoxel(outputRoot / "x" / "0", 7, 8, 20), static_cast<uint8_t>(128));
+}
+
+TEST(NGridsSmoke, AlignOutputChunksAreCapped)
+{
+    ScopedTempDir tempDir;
+    const auto inputRoot = tempDir.path() / "normals_input.zarr";
+    const auto outputRoot = tempDir.path() / "aligned_output.zarr";
+
+    createNormalsInput(
+        inputRoot,
+        {80, 80, 80},
+        {80, 80, 80},
+        {
+            NormalVoxel{.z = 7, .y = 8, .x = 9, .nx = 255, .ny = 128, .nz = 128},
+        });
+
+    std::string align_cmd = std::string("OMP_NUM_THREADS=1 ")
+        + VC_NGRIDS_BIN
+        + " -i " + quote(inputRoot)
+        + " --align-normals"
+        + " --crop 9 8 7 10 9 8"
+        + " --output-zarr " + quote(outputRoot);
+    ASSERT_EQ(std::system(align_cmd.c_str()), 0);
+
+    const auto zarray = readJsonFile(outputRoot / "x" / "0" / ".zarray");
+    ASSERT_TRUE(zarray.contains("chunks"));
+    ASSERT_EQ(zarray["chunks"][0].get<int>(), 64);
+    ASSERT_EQ(zarray["chunks"][1].get<int>(), 64);
+    ASSERT_EQ(zarray["chunks"][2].get<int>(), 64);
 }

--- a/volume-cartographer/core/test/test_vc_ngrids_smoke.cpp
+++ b/volume-cartographer/core/test/test_vc_ngrids_smoke.cpp
@@ -77,6 +77,40 @@ void createInputVolume(const fs::path& root)
     ds->writeRegion({0, 0, 0}, {64, 64, 64}, volume.data());
 }
 
+void createChunkedNormalsInput(const fs::path& root)
+{
+    const std::vector<size_t> shape = {80, 80, 80};
+    const std::vector<size_t> chunks = {64, 64, 64};
+    auto dsx = vc::createZarrDataset(root / "x", "0", shape, chunks, vc::VcDtype::uint8, "blosc", "/", 128);
+    auto dsy = vc::createZarrDataset(root / "y", "0", shape, chunks, vc::VcDtype::uint8, "blosc", "/", 128);
+    auto dsz = vc::createZarrDataset(root / "z", "0", shape, chunks, vc::VcDtype::uint8, "blosc", "/", 128);
+
+    std::vector<uint8_t> x(shape[0] * shape[1] * shape[2], 128);
+    std::vector<uint8_t> y(shape[0] * shape[1] * shape[2], 128);
+    std::vector<uint8_t> z(shape[0] * shape[1] * shape[2], 128);
+    auto idx = [&](int zz, int yy, int xx) {
+        return static_cast<size_t>((zz * static_cast<int>(shape[1]) + yy) * static_cast<int>(shape[2]) + xx);
+    };
+
+    for (int zz = 7; zz < 9; ++zz) {
+        for (int yy = 8; yy < 10; ++yy) {
+            for (int xx = 9; xx < 11; ++xx) {
+                x[idx(zz, yy, xx)] = 255;
+                y[idx(zz, yy, xx)] = 128;
+                z[idx(zz, yy, xx)] = 128;
+            }
+        }
+    }
+
+    dsx->writeRegion({0, 0, 0}, shape, x.data());
+    dsy->writeRegion({0, 0, 0}, shape, y.data());
+    dsz->writeRegion({0, 0, 0}, shape, z.data());
+    vc::writeZarrAttributes(root, {
+        {"grid_origin_xyz", {0, 0, 0}},
+        {"sample_step", 1},
+    });
+}
+
 std::string quote(const fs::path& path)
 {
     return "\"" + path.string() + "\"";
@@ -111,6 +145,14 @@ size_t countValidNormals(const fs::path& zarrRoot)
         }
     }
     return valid;
+}
+
+uint8_t readVoxel(const fs::path& path, size_t z, size_t y, size_t x)
+{
+    vc::VcDataset ds(path);
+    uint8_t value = 0;
+    ds.readRegion({z, y, x}, {1, 1, 1}, &value);
+    return value;
 }
 
 } // namespace
@@ -168,4 +210,27 @@ TEST(NGridsSmoke, FitAndAlignNormalsAreDeterministicSingleThreaded)
     EXPECT_TRUE(fs::is_directory(align1Root / "x" / "0"));
     EXPECT_GT(countValidNormals(align1Root), 0u);
     expectDatasetsEqual(align1Root, align2Root, {"x", "y", "z"});
+}
+
+TEST(NGridsSmoke, AlignCropPreservesFillOutsidePartialChunks)
+{
+    ScopedTempDir tempDir;
+    const auto inputRoot = tempDir.path() / "normals_input.zarr";
+    const auto outputRoot = tempDir.path() / "aligned_output.zarr";
+
+    createChunkedNormalsInput(inputRoot);
+
+    std::string align_cmd = std::string("OMP_NUM_THREADS=1 ")
+        + VC_NGRIDS_BIN
+        + " -i " + quote(inputRoot)
+        + " --align-normals"
+        + " --crop 9 8 7 11 10 9"
+        + " --output-zarr " + quote(outputRoot);
+    ASSERT_EQ(std::system(align_cmd.c_str()), 0);
+
+    EXPECT_EQ(readVoxel(outputRoot / "x" / "0", 0, 0, 0), static_cast<uint8_t>(128));
+    EXPECT_EQ(readVoxel(outputRoot / "y" / "0", 0, 0, 0), static_cast<uint8_t>(128));
+    EXPECT_EQ(readVoxel(outputRoot / "z" / "0", 0, 0, 0), static_cast<uint8_t>(128));
+
+    EXPECT_NE(readVoxel(outputRoot / "x" / "0", 7, 8, 9), static_cast<uint8_t>(128));
 }


### PR DESCRIPTION
## Summary
- refactor `vc_gen_normalgrids` to assemble sampled slices directly from source chunks instead of materializing dense slice slabs
- add a scratch-capable `GridStore` ROI traversal path and use precomputed slice tables in `vc_ngrids --fit-normals`
- factor shared normals-zarr helpers for align/write paths and add end-to-end smoke coverage for `vc_ngrids`

## Benchmarks
Using the commands from the implementation plan on this machine:

### `vc_gen_normalgrids`
`/home/giorgio/scrolls/PHerc0172.volpkg/s5_105.zarr`
- before: `real 127.99s`
- after: `real 98.30s`
- delta: about `23%` faster

Per-direction `read_chunk` totals from metrics json:
- `xy`: `40.95s -> 30.02s`
- `xz`: `34.63s -> 28.47s`
- `yz`: `38.12s -> 30.59s`

The sparse benchmark outputs under `/tmp/vc_gen_normalgrids_bench*` matched exactly file-for-file.

### `vc_ngrids --fit-normals`
`/home/giorgio/scrolls/PHerc0172.volpkg/normal_grids`
with crop `4424 3224 10372 4680 3480 10628`
- before: `real 0.73s`
- after: `real 0.44s`
- delta: about `40%` faster

Thread-summed timings from metrics json:
- `ng_read`: `16.63s -> 8.40s`
- `preproc`: `3.19s -> 2.82s`
- `solve_call`: `1.33s -> 1.19s`

Fit quality stayed stable on the benchmark crop:
- `fit_ok_count`: `4103 -> 4103`
- `fit_rms_avg`: `0.1690859768 -> 0.1690859768`
- `fit_rms_median`: `0.1635 -> 0.1635`
- `fit_rms_max`: `0.3401550951 -> 0.3401550951`

### `vc_ngrids --align-normals`
- before: `real 0.10s`
- after: `real 0.11s`
- no material slowdown

## Verification
- built only the targeted binaries/tests
- ran:
  - `ctest --test-dir volume-cartographer/build --output-on-failure -R 'test_gen_normalgrids_helpers|test_gridstore_cache|test_thinning_equivalence|test_vc_gen_normalgrids_smoke|test_vc_ngrids_smoke'`
- added `test_vc_ngrids_smoke` to cover `vc_gen_normalgrids -> vc_ngrids --fit-normals -> vc_ngrids --align-normals`
- smoke regression runs `OMP_NUM_THREADS=1` and verifies deterministic outputs across repeated fit/align runs

## Notes
- `perf` is installed here but blocked by `perf_event_paranoid=4`, so the benchmark evidence is based on the app metrics json plus `/usr/bin/time`
- the benchmark fit/align zarr roots have different `.zattrs` and chunk bytes than the previous baseline outputs, but the new single-thread smoke regression is exact and the benchmark aggregate fit metrics are unchanged