### PR TITLE
Move a bunch of the rendering pipeline to a tick based update system

### DIFF
--- a/volume-cartographer/apps/CMakeLists.txt
+++ b/volume-cartographer/apps/CMakeLists.txt
@@ -96,6 +96,24 @@ target_link_libraries(vc_diffuse_winding
 add_executable(vc_render_bench src/vc_render_bench.cpp)
 target_link_libraries(vc_render_bench vc_core)
 
+add_executable(vc_io_bench src/vc_io_bench.cpp)
+target_link_libraries(vc_io_bench vc_core)
+
+add_executable(vc_blockcache_bench src/vc_blockcache_bench.cpp)
+target_link_libraries(vc_blockcache_bench vc_core)
+
+add_executable(vc_transpose_bench src/vc_transpose_bench.cpp)
+target_link_libraries(vc_transpose_bench vc_core)
+
+add_executable(vc_coord_bench src/vc_coord_bench.cpp)
+target_link_libraries(vc_coord_bench vc_core)
+
+add_executable(vc_tifxyz_bench src/vc_tifxyz_bench.cpp)
+target_link_libraries(vc_tifxyz_bench vc_core)
+
+add_executable(vc_coord_regression src/vc_coord_regression.cpp)
+target_link_libraries(vc_coord_regression vc_core)
+
 add_executable(vc_create_segment_mask src/vc_create_segment_mask.cpp)
 target_link_libraries(vc_create_segment_mask vc_core Boost::program_options)
 

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -699,6 +699,8 @@ CWindow::CWindow(size_t cacheSizeGB) :
     _cacheSizeBytes = cacheSizeGB * 1024ULL * 1024ULL * 1024ULL;
     std::cout << "chunk cache budget is " << cacheSizeGB << " gigabytes" << std::endl;
 
+    _tickCoordinator = std::make_unique<vc::cache::TickCoordinator>();
+
     _state = new CState(_cacheSizeBytes, this);
     connect(_state, &CState::poiChanged, this, &CWindow::onFocusPOIChanged);
     connect(_state, &CState::surfaceWillBeDeleted, this, &CWindow::onSurfaceWillBeDeleted);

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -3885,6 +3885,22 @@ void CWindow::CreateWidgets(void)
         }
     });
 
+    // Per-ray layer preprocess (applied to N composite samples before composite method)
+    connect(ui.chkPreNormalizeLayers, &QCheckBox::toggled, this, [this](bool checked) {
+        if (auto* viewer = segmentationViewer()) {
+            auto s = viewer->compositeRenderSettings();
+            s.params.preNormalizeLayers = checked;
+            viewer->setCompositeRenderSettings(s);
+        }
+    });
+    connect(ui.chkPreHistEqLayers, &QCheckBox::toggled, this, [this](bool checked) {
+        if (auto* viewer = segmentationViewer()) {
+            auto s = viewer->compositeRenderSettings();
+            s.params.preHistEqLayers = checked;
+            viewer->setCompositeRenderSettings(s);
+        }
+    });
+
     // Connect ISO Cutoff slider - applies to all viewers (segmentation, XY, XZ, YZ)
     connect(ui.sliderIsoCutoff, &QSlider::valueChanged, this, [this](int value) {
         ui.lblIsoCutoffValue->setText(QString::number(value));

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -136,12 +136,21 @@ namespace
 std::string compositeMethodForModeIndex(int index)
 {
     switch (index) {
-        case 0: return "max";
-        case 1: return "mean";
-        case 2: return "min";
-        case 3: return "alpha";
-        case 4: return "beerLambert";
-        case 5: return "volumetric";
+        case 0:  return "max";
+        case 1:  return "mean";
+        case 2:  return "min";
+        case 3:  return "alpha";
+        case 4:  return "beerLambert";
+        case 5:  return "volumetric";
+        case 6:  return "dvr";
+        case 7:  return "firstHitIso";
+        case 8:  return "devFromMean";
+        case 9:  return "emissionDvr";
+        case 10: return "maxAboveIso";
+        case 11: return "gammaWeighted";
+        case 12: return "gradientMag";
+        case 13: return "pbrIso";
+        case 14: return "shadedDvr";
         default: return "mean";
     }
 }
@@ -154,6 +163,15 @@ int compositeModeIndexForMethod(const std::string& method)
     if (method == "alpha") return 3;
     if (method == "beerLambert") return 4;
     if (method == "volumetric") return 5;
+    if (method == "dvr") return 6;
+    if (method == "firstHitIso") return 7;
+    if (method == "devFromMean") return 8;
+    if (method == "emissionDvr") return 9;
+    if (method == "maxAboveIso") return 10;
+    if (method == "gammaWeighted") return 11;
+    if (method == "gradientMag") return 12;
+    if (method == "pbrIso") return 13;
+    if (method == "shadedDvr") return 14;
     return 1;
 }
 
@@ -3901,6 +3919,44 @@ void CWindow::CreateWidgets(void)
         }
     });
 
+    // Pre-TF / Post-TF: 4-knot piecewise-linear LUTs. Endpoints (0,0) and
+    // (255,255) are fixed; only the two middle knots are editable.
+    auto applyTfParam = [this](auto&& mutate) {
+        if (auto* viewer = segmentationViewer()) {
+            auto s = viewer->compositeRenderSettings();
+            mutate(s.params);
+            viewer->setCompositeRenderSettings(s);
+        }
+    };
+    connect(ui.chkPreTfEnabled, &QCheckBox::toggled, this, [applyTfParam](bool v) {
+        applyTfParam([v](CompositeParams& p) { p.preTfEnabled = v; });
+    });
+    connect(ui.spinPreTfX1, QOverload<int>::of(&QSpinBox::valueChanged), this,
+        [applyTfParam](int v) { applyTfParam([v](CompositeParams& p) { p.preTfX1 = uint8_t(v); }); });
+    connect(ui.spinPreTfY1, QOverload<int>::of(&QSpinBox::valueChanged), this,
+        [applyTfParam](int v) { applyTfParam([v](CompositeParams& p) { p.preTfY1 = uint8_t(v); }); });
+    connect(ui.spinPreTfX2, QOverload<int>::of(&QSpinBox::valueChanged), this,
+        [applyTfParam](int v) { applyTfParam([v](CompositeParams& p) { p.preTfX2 = uint8_t(v); }); });
+    connect(ui.spinPreTfY2, QOverload<int>::of(&QSpinBox::valueChanged), this,
+        [applyTfParam](int v) { applyTfParam([v](CompositeParams& p) { p.preTfY2 = uint8_t(v); }); });
+    connect(ui.chkPostTfEnabled, &QCheckBox::toggled, this, [applyTfParam](bool v) {
+        applyTfParam([v](CompositeParams& p) { p.postTfEnabled = v; });
+    });
+    connect(ui.spinPostTfX1, QOverload<int>::of(&QSpinBox::valueChanged), this,
+        [applyTfParam](int v) { applyTfParam([v](CompositeParams& p) { p.postTfX1 = uint8_t(v); }); });
+    connect(ui.spinPostTfY1, QOverload<int>::of(&QSpinBox::valueChanged), this,
+        [applyTfParam](int v) { applyTfParam([v](CompositeParams& p) { p.postTfY1 = uint8_t(v); }); });
+    connect(ui.spinPostTfX2, QOverload<int>::of(&QSpinBox::valueChanged), this,
+        [applyTfParam](int v) { applyTfParam([v](CompositeParams& p) { p.postTfX2 = uint8_t(v); }); });
+    connect(ui.spinPostTfY2, QOverload<int>::of(&QSpinBox::valueChanged), this,
+        [applyTfParam](int v) { applyTfParam([v](CompositeParams& p) { p.postTfY2 = uint8_t(v); }); });
+    connect(ui.spinDvrAmbient, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+        [applyTfParam](double v) { applyTfParam([v](CompositeParams& p) { p.dvrAmbient = float(v); }); });
+    connect(ui.spinPbrRoughness, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+        [applyTfParam](double v) { applyTfParam([v](CompositeParams& p) { p.pbrRoughness = float(v); }); });
+    connect(ui.spinPbrMetallic, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+        [applyTfParam](double v) { applyTfParam([v](CompositeParams& p) { p.pbrMetallic = float(v); }); });
+
     // Connect ISO Cutoff slider - applies to all viewers (segmentation, XY, XZ, YZ)
     connect(ui.sliderIsoCutoff, &QSlider::valueChanged, this, [this](int value) {
         ui.lblIsoCutoffValue->setText(QString::number(value));
@@ -3935,53 +3991,109 @@ void CWindow::CreateWidgets(void)
     });
 
     // Helper lambda to update visibility of method-specific parameters
-    auto updateCompositeParamsVisibility = [this](int methodIndex) {
-        // Alpha parameters (row 1, 2 - AlphaMin/Max, AlphaThreshold/Material)
-        bool showAlphaParams = (methodIndex == 3); // Alpha method
-        ui.lblAlphaMin->setVisible(showAlphaParams);
-        ui.spinAlphaMin->setVisible(showAlphaParams);
-        ui.lblAlphaMax->setVisible(showAlphaParams);
-        ui.spinAlphaMax->setVisible(showAlphaParams);
-        ui.lblAlphaThreshold->setVisible(showAlphaParams);
-        ui.spinAlphaThreshold->setVisible(showAlphaParams);
-        ui.lblMaterial->setVisible(showAlphaParams);
-        ui.spinMaterial->setVisible(showAlphaParams);
+    auto updateCompositeParamsVisibility = [this]() {
+        const int methodIndex = ui.cmbCompositeMode->currentIndex();
+        const bool lightingOn = ui.chkLightingEnabled->isChecked();
+        const bool preTfOn = ui.chkPreTfEnabled->isChecked();
+        const bool postTfOn = ui.chkPostTfEnabled->isChecked();
 
-        // Beer-Lambert parameters (row 7, 8 - Extinction/Emission, Ambient)
-        bool showBLParams = (methodIndex == 4); // Beer-Lambert method
-        ui.lblBLExtinction->setVisible(showBLParams);
-        ui.spinBLExtinction->setVisible(showBLParams);
-        ui.lblBLEmission->setVisible(showBLParams);
-        ui.spinBLEmission->setVisible(showBLParams);
-        ui.lblBLAmbient->setVisible(showBLParams);
-        ui.spinBLAmbient->setVisible(showBLParams);
+        // Method-family flags.
+        const bool isAlpha    = (methodIndex == 3);
+        const bool isBL       = (methodIndex == 4);
+        const bool isVolum    = (methodIndex == 5);
+        const bool isDvr      = (methodIndex == 6);
+        const bool isFirstHit = (methodIndex == 7);
+        const bool isPbr      = (methodIndex == 13);
+        const bool isShadedDvr = (methodIndex == 14);
 
-        // Lighting parameters (rows 9-12) - always shown, works with all methods
+        // Alpha knobs: only for the Alpha method.
+        ui.lblAlphaMin->setVisible(isAlpha);
+        ui.spinAlphaMin->setVisible(isAlpha);
+        ui.lblAlphaMax->setVisible(isAlpha);
+        ui.spinAlphaMax->setVisible(isAlpha);
+        ui.lblAlphaThreshold->setVisible(isAlpha);
+        ui.spinAlphaThreshold->setVisible(isAlpha);
+        ui.lblMaterial->setVisible(isAlpha);
+        ui.spinMaterial->setVisible(isAlpha);
+
+        // Beer-Lambert knobs: shared by Beer-Lambert and Volumetric modes.
+        const bool showBL = isBL || isVolum;
+        ui.lblBLExtinction->setVisible(showBL);
+        ui.spinBLExtinction->setVisible(showBL);
+        ui.lblBLEmission->setVisible(showBL);
+        ui.spinBLEmission->setVisible(showBL);
+        ui.lblBLAmbient->setVisible(showBL);
+        ui.spinBLAmbient->setVisible(showBL);
+
+        // Shadow-ray steps: only Volumetric uses the secondary shadow ray.
+        ui.lblShadowSteps->setVisible(isVolum);
+        ui.spinShadowSteps->setVisible(isVolum);
+
+        // DVR ambient: DVR and shaded-DVR methods.
+        const bool showDvrAmbient = isDvr || isShadedDvr;
+        ui.lblDvrAmbient->setVisible(showDvrAmbient);
+        ui.spinDvrAmbient->setVisible(showDvrAmbient);
+
+        // PBR roughness/metallic knobs: only the PBR method.
+        ui.lblPbrRoughness->setVisible(isPbr);
+        ui.spinPbrRoughness->setVisible(isPbr);
+        ui.lblPbrMetallic->setVisible(isPbr);
+        ui.spinPbrMetallic->setVisible(isPbr);
+
+        // Lighting: check always visible (user toggles on/off); the
+        // direction/diffuse/ambient knobs appear only when lighting is
+        // actually on. First-Hit Iso is a shading-heavy method so we
+        // gently enforce its need for lighting by showing the chk always.
         ui.chkLightingEnabled->setVisible(true);
-        ui.lblLightAzimuth->setVisible(true);
-        ui.spinLightAzimuth->setVisible(true);
-        ui.lblLightElevation->setVisible(true);
-        ui.spinLightElevation->setVisible(true);
-        ui.lblLightDiffuse->setVisible(true);
-        ui.spinLightDiffuse->setVisible(true);
-        ui.lblLightAmbient->setVisible(true);
-        ui.spinLightAmbient->setVisible(true);
-        ui.chkUseVolumeGradients->setVisible(true);
+        ui.lblLightAzimuth->setVisible(lightingOn);
+        ui.spinLightAzimuth->setVisible(lightingOn);
+        ui.lblLightElevation->setVisible(lightingOn);
+        ui.spinLightElevation->setVisible(lightingOn);
+        ui.lblLightDiffuse->setVisible(lightingOn);
+        ui.spinLightDiffuse->setVisible(lightingOn);
+        ui.lblLightAmbient->setVisible(lightingOn);
+        ui.spinLightAmbient->setVisible(lightingOn);
+        ui.chkUseVolumeGradients->setVisible(lightingOn);
 
-        // No methods currently use scale or param sliders
+        // Pre/Post TF knots: spinboxes + knot-2 labels appear only when
+        // the corresponding enable checkbox is ticked.
+        ui.spinPreTfX1->setVisible(preTfOn);
+        ui.spinPreTfY1->setVisible(preTfOn);
+        ui.spinPreTfX2->setVisible(preTfOn);
+        ui.spinPreTfY2->setVisible(preTfOn);
+        ui.lblPreTfKnot2->setVisible(preTfOn);
+        ui.spinPostTfX1->setVisible(postTfOn);
+        ui.spinPostTfY1->setVisible(postTfOn);
+        ui.spinPostTfX2->setVisible(postTfOn);
+        ui.spinPostTfY2->setVisible(postTfOn);
+        ui.lblPostTfKnot2->setVisible(postTfOn);
+
+        // No methods currently use scale or param sliders.
         ui.lblMethodScale->setVisible(false);
         ui.sliderMethodScale->setVisible(false);
         ui.lblMethodScaleValue->setVisible(false);
         ui.lblMethodParam->setVisible(false);
         ui.sliderMethodParam->setVisible(false);
         ui.lblMethodParamValue->setVisible(false);
+
+        (void)isFirstHit;  // reserved for future First-Hit-specific knobs
+        (void)isShadedDvr; (void)isPbr; // already consumed above
     };
 
-    // Update the cmbCompositeMode connection to also update visibility
-    connect(ui.cmbCompositeMode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, updateCompositeParamsVisibility);
+    // Re-run visibility logic whenever any of the inputs that gate widgets
+    // change — composite method, or any of the three enable checkboxes
+    // that each control a sub-group of knobs.
+    connect(ui.cmbCompositeMode, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, [updateCompositeParamsVisibility](int) { updateCompositeParamsVisibility(); });
+    connect(ui.chkLightingEnabled, &QCheckBox::toggled,
+            this, [updateCompositeParamsVisibility](bool) { updateCompositeParamsVisibility(); });
+    connect(ui.chkPreTfEnabled, &QCheckBox::toggled,
+            this, [updateCompositeParamsVisibility](bool) { updateCompositeParamsVisibility(); });
+    connect(ui.chkPostTfEnabled, &QCheckBox::toggled,
+            this, [updateCompositeParamsVisibility](bool) { updateCompositeParamsVisibility(); });
 
-    // Initialize visibility based on current selection
-    updateCompositeParamsVisibility(ui.cmbCompositeMode->currentIndex());
+    // Initialize visibility from current UI state.
+    updateCompositeParamsVisibility();
 
     // Connect Plane Composite controls (separate enable for XY/XZ/YZ, shared layer counts)
     connect(ui.chkPlaneCompositeXY, &QCheckBox::toggled, this, [this](bool checked) {

--- a/volume-cartographer/apps/VC3D/CWindow.hpp
+++ b/volume-cartographer/apps/VC3D/CWindow.hpp
@@ -35,6 +35,7 @@
 #include "segmentation/SegmentationWidget.hpp"
 #include "segmentation/growth/SegmentationGrowth.hpp"
 #include "SeedingWidget.hpp"
+#include "vc/core/cache/TickCoordinator.hpp"
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/Surface.hpp"
@@ -223,6 +224,12 @@ private:
     bool can_change_volume_();
 
     size_t _cacheSizeBytes = 0;
+
+    // Declared early so that the publisher thread joins (via ~jthread) after
+    // all viewers and caches below have been destroyed. Readers hold raw
+    // const pointers into FrameState buffers owned here; the coordinator
+    // must outlive every possible reader.
+    std::unique_ptr<vc::cache::TickCoordinator> _tickCoordinator;
 
     std::unique_ptr<VolumeOverlayController> _volumeOverlay;
     std::unique_ptr<ViewerManager> _viewerManager;

--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -1151,6 +1151,24 @@ void MenuActionController::openRemoteZarr(
                             5000);
                     }
 
+                    // If the user previously attached a remote-segments dir
+                    // to this exact zarr URL, auto-re-attach it silently.
+                    // Otherwise offer the prompt.
+                    {
+                        QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
+                        const QString prevZarr = settings.value(
+                            vc3d::settings::viewer::LAST_REMOTE_SEGMENTS_FOR_ZARR)
+                                .toString();
+                        const QString prevSeg = settings.value(
+                            vc3d::settings::viewer::LAST_REMOTE_SEGMENTS_URL)
+                                .toString();
+                        const QString currentZarr = QString::fromStdString(httpsUrl);
+                        if (!prevSeg.isEmpty() && prevZarr == currentZarr) {
+                            loadRemoteSegmentsWithUrl(prevSeg, auth, cachePath,
+                                                       currentZarr);
+                            return;
+                        }
+                    }
                     // Offer to load remote segments
                     promptAndLoadRemoteSegments(auth, cachePath);
                     return;
@@ -1251,7 +1269,25 @@ void MenuActionController::promptAndLoadRemoteSegments(
     if (!ok || segUrl.trimmed().isEmpty())
         return;
 
-    auto segResolved = vc::resolveRemoteUrl(segUrl.trimmed().toStdString());
+    QString zarrUrl;
+    if (_window && _window->_state) {
+        if (auto vol = _window->_state->currentVolume())
+            zarrUrl = QString::fromStdString(vol->remoteUrl());
+    }
+    loadRemoteSegmentsWithUrl(segUrl, auth, cachePath, zarrUrl);
+}
+
+void MenuActionController::loadRemoteSegmentsWithUrl(
+    const QString& segUrlIn,
+    const vc::cache::HttpAuth& auth,
+    const std::string& cachePath,
+    const QString& zarrUrl)
+{
+    const QString segUrlTrim = segUrlIn.trimmed();
+    if (segUrlTrim.isEmpty())
+        return;
+
+    auto segResolved = vc::resolveRemoteUrl(segUrlTrim.toStdString());
     vc::cache::HttpAuth segAuth = auth;
     if (segResolved.useAwsSigv4 && segAuth.region.empty())
         segAuth.region = segResolved.awsRegion;
@@ -1266,7 +1302,7 @@ void MenuActionController::promptAndLoadRemoteSegments(
     // Probe the URL for segment subdirectories
     auto* s3Watcher = new QFutureWatcher<vc::cache::S3ListResult>(this);
     connect(s3Watcher, &QFutureWatcher<vc::cache::S3ListResult>::finished, this,
-        [this, s3Watcher, segBaseUrl, segAuth, cachePath]() {
+        [this, s3Watcher, segBaseUrl, segAuth, cachePath, zarrUrl]() {
             s3Watcher->deleteLater();
 
             vc::cache::S3ListResult extList;
@@ -1296,6 +1332,16 @@ void MenuActionController::promptAndLoadRemoteSegments(
             _window->_remoteScroll.auth = segAuth;
             _window->_remoteScroll.segSource = vc::RemoteSegmentSource::Direct;
             _window->_remoteScroll.active = true;
+
+            // Persist (zarrUrl → segmentsUrl) so the next auto-open of the
+            // same remote zarr can re-attach without prompting the user.
+            if (!zarrUrl.isEmpty()) {
+                QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
+                settings.setValue(vc3d::settings::viewer::LAST_REMOTE_SEGMENTS_URL,
+                                  QString::fromStdString(segBaseUrl));
+                settings.setValue(vc3d::settings::viewer::LAST_REMOTE_SEGMENTS_FOR_ZARR,
+                                  zarrUrl);
+            }
 
             // Download metadata + load cached surfaces on background thread
             auto segIds = extList.prefixes;

--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -145,6 +145,9 @@ void MenuActionController::populateMenus(QMenuBar* menuBar)
     _attachRemoteZarrAct = new QAction(QObject::tr("Attach Remote &Zarr..."), this);
     connect(_attachRemoteZarrAct, &QAction::triggered, this, &MenuActionController::attachRemoteZarr);
 
+    _attachRemoteSegmentsAct = new QAction(QObject::tr("Attach Remote &Segments..."), this);
+    connect(_attachRemoteSegmentsAct, &QAction::triggered, this, &MenuActionController::attachRemoteSegments);
+
     _browseS3Act = new QAction(QObject::tr("&Browse S3..."), this);
     connect(_browseS3Act, &QAction::triggered, this, &MenuActionController::browseS3);
 
@@ -202,6 +205,7 @@ void MenuActionController::populateMenus(QMenuBar* menuBar)
     _fileMenu->addAction(_openLocalZarrAct);
     _fileMenu->addAction(_openRemoteAct);
     _fileMenu->addAction(_attachRemoteZarrAct);
+    _fileMenu->addAction(_attachRemoteSegmentsAct);
     _fileMenu->addAction(_browseS3Act);
 
     _recentMenu = new QMenu(QObject::tr("Open &recent volpkg"), _fileMenu);
@@ -578,6 +582,37 @@ void MenuActionController::browseS3()
     if (selected.isEmpty()) return;
 
     openRemoteUrl(selected, false);
+}
+
+void MenuActionController::attachRemoteSegments()
+{
+    if (!_window || !_window->_state) return;
+
+    auto volume = _window->_state->currentVolume();
+    if (!volume) {
+        QMessageBox::warning(_window,
+                             QObject::tr("No Volume Loaded"),
+                             QObject::tr("Open a remote volume first before attaching remote segments."));
+        return;
+    }
+    if (!volume->isRemote()) {
+        QMessageBox::warning(_window,
+                             QObject::tr("Not a Remote Volume"),
+                             QObject::tr("Remote segments can only be attached to a remote volume."));
+        return;
+    }
+
+    const auto auth = volume->remoteAuth();
+    // Volume::NewFromUrl stages the volume at `cacheRoot / volumeId`, and
+    // promptAndLoadRemoteSegments expects the original cacheRoot (it builds
+    // `cacheRoot / "paths" / segId` for each segment). Going up one level
+    // recovers it; if path() is already the root (shouldn't happen for
+    // remote volumes), fall back to it.
+    auto volPath = volume->path();
+    const std::string cachePath = volPath.has_parent_path()
+        ? volPath.parent_path().string()
+        : volPath.string();
+    promptAndLoadRemoteSegments(auth, cachePath);
 }
 
 void MenuActionController::attachRemoteZarr()

--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -603,15 +603,15 @@ void MenuActionController::attachRemoteSegments()
     }
 
     const auto auth = volume->remoteAuth();
-    // Volume::NewFromUrl stages the volume at `cacheRoot / volumeId`, and
-    // promptAndLoadRemoteSegments expects the original cacheRoot (it builds
-    // `cacheRoot / "paths" / segId` for each segment). Going up one level
-    // recovers it; if path() is already the root (shouldn't happen for
-    // remote volumes), fall back to it.
-    auto volPath = volume->path();
-    const std::string cachePath = volPath.has_parent_path()
-        ? volPath.parent_path().string()
-        : volPath.string();
+    // Use the app-level remote cache directory — the same value every other
+    // entry point (openRemoteUrl, attachRemoteZarrUrl, openRemoteScroll)
+    // passes to Volume::NewFromUrl *and* to promptAndLoadRemoteSegments.
+    // Deriving from volume->path() is wrong: the volume is staged at
+    // `<cache>/<id>` for direct opens and `<cache>/<volpkg>/volumes/<id>` for
+    // scroll opens, so parent_path() lands in the wrong tree depending on
+    // how the volume was loaded. Segments are consistently cached at
+    // `<remoteCacheDirectory()>/paths/<segId>`.
+    const std::string cachePath = remoteCacheDirectory().toStdString();
     promptAndLoadRemoteSegments(auth, cachePath);
 }
 

--- a/volume-cartographer/apps/VC3D/MenuActionController.hpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.hpp
@@ -40,6 +40,7 @@ private slots:
     void openRemoteVolume();
     void browseS3();
     void attachRemoteZarr();
+    void attachRemoteSegments();
     void openRecentRemoteVolume();
     void showSettingsDialog();
     void showAboutDialog();
@@ -93,6 +94,7 @@ private:
     QAction* _openLocalZarrAct{nullptr};
     QAction* _openRemoteAct{nullptr};
     QAction* _attachRemoteZarrAct{nullptr};
+    QAction* _attachRemoteSegmentsAct{nullptr};
     QAction* _browseS3Act{nullptr};
     std::array<QAction*, kMaxRecentVolpkg> _recentActs{};
     std::array<QAction*, kMaxRecentRemote> _recentRemoteActs{};

--- a/volume-cartographer/apps/VC3D/MenuActionController.hpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.hpp
@@ -71,6 +71,15 @@ private:
     void openRemoteZarr(const std::string& httpsUrl, const vc::cache::HttpAuth& auth, const std::string& cachePath);
     void openRemoteScroll(const std::string& httpsUrl, const vc::cache::HttpAuth& auth, const std::string& cachePath);
     void promptAndLoadRemoteSegments(const vc::cache::HttpAuth& auth, const std::string& cachePath);
+    // Non-prompting variant: attaches the supplied segments URL and triggers
+    // the same discovery + surface-caching pipeline as the prompting path.
+    // On success, persists (segUrl, zarrUrl) in QSettings so auto-open of
+    // the same remote zarr can skip the prompt next time. Pass the current
+    // remote volume's URL as zarrUrl; empty disables persistence.
+    void loadRemoteSegmentsWithUrl(const QString& segUrl,
+                                   const vc::cache::HttpAuth& auth,
+                                   const std::string& cachePath,
+                                   const QString& zarrUrl);
     bool tryResolveRemoteAuth(const QString& url,
                               vc::cache::HttpAuth* authOut,
                               bool allowPrompt,

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -653,6 +653,51 @@
            <string>Volumetric</string>
           </property>
          </item>
+         <item>
+          <property name="text">
+           <string>DVR</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>First-Hit Iso</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Deviation from Mean</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Emission-only DVR</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Max Above Iso</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Gamma-weighted Mean</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Gradient Magnitude (z)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>PBR First-Hit Iso</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Shaded DVR</string>
+          </property>
+         </item>
         </widget>
        </item>
       </layout>
@@ -1140,6 +1185,142 @@
          <property name="toolTip">
           <string>CDF-based histogram equalization over the N sampled composite layers per pixel before compositing. Flattens per-ray contrast — strongest effect, can clip uniform rays.</string>
          </property>
+        </widget>
+       </item>
+       <item row="17" column="0" colspan="2">
+        <widget class="QCheckBox" name="chkPreTfEnabled">
+         <property name="text">
+          <string>Pre-TF (per sample)</string>
+         </property>
+         <property name="toolTip">
+          <string>4-knot piecewise-linear transfer function applied to every sampled voxel BEFORE compositing. Endpoints fixed at (0,0) and (255,255); tune (x1,y1),(x2,y2) below.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="2">
+        <widget class="QSpinBox" name="spinPreTfX1">
+         <property name="toolTip"><string>Pre-TF knot 1 X (0-255)</string></property>
+         <property name="minimum"><number>0</number></property>
+         <property name="maximum"><number>255</number></property>
+         <property name="value"><number>85</number></property>
+        </widget>
+       </item>
+       <item row="17" column="3">
+        <widget class="QSpinBox" name="spinPreTfY1">
+         <property name="toolTip"><string>Pre-TF knot 1 Y (0-255)</string></property>
+         <property name="minimum"><number>0</number></property>
+         <property name="maximum"><number>255</number></property>
+         <property name="value"><number>85</number></property>
+        </widget>
+       </item>
+       <item row="18" column="0">
+        <widget class="QLabel" name="lblPreTfKnot2">
+         <property name="text"><string>Pre-TF knot 2</string></property>
+        </widget>
+       </item>
+       <item row="18" column="2">
+        <widget class="QSpinBox" name="spinPreTfX2">
+         <property name="toolTip"><string>Pre-TF knot 2 X (0-255)</string></property>
+         <property name="minimum"><number>0</number></property>
+         <property name="maximum"><number>255</number></property>
+         <property name="value"><number>170</number></property>
+        </widget>
+       </item>
+       <item row="18" column="3">
+        <widget class="QSpinBox" name="spinPreTfY2">
+         <property name="toolTip"><string>Pre-TF knot 2 Y (0-255)</string></property>
+         <property name="minimum"><number>0</number></property>
+         <property name="maximum"><number>255</number></property>
+         <property name="value"><number>170</number></property>
+        </widget>
+       </item>
+       <item row="19" column="0" colspan="2">
+        <widget class="QCheckBox" name="chkPostTfEnabled">
+         <property name="text">
+          <string>Post-TF (on output)</string>
+         </property>
+         <property name="toolTip">
+          <string>4-knot piecewise-linear transfer function applied to the composite output value, before 2D postprocess (stretch, CLAHE, raking). Endpoints fixed at (0,0) and (255,255).</string>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="2">
+        <widget class="QSpinBox" name="spinPostTfX1">
+         <property name="toolTip"><string>Post-TF knot 1 X (0-255)</string></property>
+         <property name="minimum"><number>0</number></property>
+         <property name="maximum"><number>255</number></property>
+         <property name="value"><number>85</number></property>
+        </widget>
+       </item>
+       <item row="19" column="3">
+        <widget class="QSpinBox" name="spinPostTfY1">
+         <property name="toolTip"><string>Post-TF knot 1 Y (0-255)</string></property>
+         <property name="minimum"><number>0</number></property>
+         <property name="maximum"><number>255</number></property>
+         <property name="value"><number>85</number></property>
+        </widget>
+       </item>
+       <item row="20" column="0">
+        <widget class="QLabel" name="lblPostTfKnot2">
+         <property name="text"><string>Post-TF knot 2</string></property>
+        </widget>
+       </item>
+       <item row="20" column="2">
+        <widget class="QSpinBox" name="spinPostTfX2">
+         <property name="toolTip"><string>Post-TF knot 2 X (0-255)</string></property>
+         <property name="minimum"><number>0</number></property>
+         <property name="maximum"><number>255</number></property>
+         <property name="value"><number>170</number></property>
+        </widget>
+       </item>
+       <item row="20" column="3">
+        <widget class="QSpinBox" name="spinPostTfY2">
+         <property name="toolTip"><string>Post-TF knot 2 Y (0-255)</string></property>
+         <property name="minimum"><number>0</number></property>
+         <property name="maximum"><number>255</number></property>
+         <property name="value"><number>170</number></property>
+        </widget>
+       </item>
+       <item row="21" column="0" colspan="2">
+        <widget class="QLabel" name="lblDvrAmbient">
+         <property name="text"><string>DVR ambient</string></property>
+        </widget>
+       </item>
+       <item row="21" column="2" colspan="2">
+        <widget class="QDoubleSpinBox" name="spinDvrAmbient">
+         <property name="toolTip"><string>Flat background added to DVR final color (0-255).</string></property>
+         <property name="minimum"><double>0.0</double></property>
+         <property name="maximum"><double>255.0</double></property>
+         <property name="singleStep"><double>1.0</double></property>
+         <property name="value"><double>0.0</double></property>
+        </widget>
+       </item>
+       <item row="22" column="0" colspan="2">
+        <widget class="QLabel" name="lblPbrRoughness">
+         <property name="text"><string>PBR roughness</string></property>
+        </widget>
+       </item>
+       <item row="22" column="2" colspan="2">
+        <widget class="QDoubleSpinBox" name="spinPbrRoughness">
+         <property name="toolTip"><string>PBR roughness (0 = mirror, 1 = Lambertian).</string></property>
+         <property name="minimum"><double>0.05</double></property>
+         <property name="maximum"><double>1.0</double></property>
+         <property name="singleStep"><double>0.05</double></property>
+         <property name="value"><double>0.5</double></property>
+        </widget>
+       </item>
+       <item row="23" column="0" colspan="2">
+        <widget class="QLabel" name="lblPbrMetallic">
+         <property name="text"><string>PBR metallic</string></property>
+        </widget>
+       </item>
+       <item row="23" column="2" colspan="2">
+        <widget class="QDoubleSpinBox" name="spinPbrMetallic">
+         <property name="toolTip"><string>PBR metallic (0 = dielectric, 1 = metal F0≈0.7).</string></property>
+         <property name="minimum"><double>0.0</double></property>
+         <property name="maximum"><double>1.0</double></property>
+         <property name="singleStep"><double>0.05</double></property>
+         <property name="value"><double>0.0</double></property>
         </widget>
        </item>
       </layout>

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -678,7 +678,7 @@
           <number>0</number>
          </property>
          <property name="maximum">
-          <number>16</number>
+          <number>64</number>
          </property>
          <property name="value">
           <number>8</number>
@@ -698,7 +698,7 @@
           <number>0</number>
          </property>
          <property name="maximum">
-          <number>16</number>
+          <number>64</number>
          </property>
          <property name="value">
           <number>0</number>
@@ -1192,7 +1192,7 @@
           <number>0</number>
          </property>
          <property name="maximum">
-          <number>16</number>
+          <number>64</number>
          </property>
          <property name="value">
           <number>4</number>
@@ -1215,7 +1215,7 @@
           <number>0</number>
          </property>
          <property name="maximum">
-          <number>16</number>
+          <number>64</number>
          </property>
          <property name="value">
           <number>4</number>

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -1122,6 +1122,26 @@
          <property name="value"><double>4.0</double></property>
         </widget>
        </item>
+       <item row="16" column="0" colspan="2">
+        <widget class="QCheckBox" name="chkPreNormalizeLayers">
+         <property name="text">
+          <string>Pre-normalize layers</string>
+         </property>
+         <property name="toolTip">
+          <string>Min-max stretch the N sampled composite layers to [0,255] per pixel before compositing. Cancels per-ray brightness drift from z-axis volume variation.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="2" colspan="2">
+        <widget class="QCheckBox" name="chkPreHistEqLayers">
+         <property name="text">
+          <string>Pre-histeq layers</string>
+         </property>
+         <property name="toolTip">
+          <string>CDF-based histogram equalization over the N sampled composite layers per pixel before compositing. Flattens per-ray contrast — strongest effect, can clip uniform rays.</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -139,6 +139,12 @@ namespace viewer {
     // Recent remote volume URLs
     constexpr auto REMOTE_RECENT_URLS = "viewer/remote_recent_urls";
 
+    // Last-used remote segments URL and the remote zarr URL it was attached
+    // to. Auto-open uses these so reopening the same zarr auto-re-attaches
+    // the same segments directory instead of showing the prompt.
+    constexpr auto LAST_REMOTE_SEGMENTS_URL = "viewer/last_remote_segments_url";
+    constexpr auto LAST_REMOTE_SEGMENTS_FOR_ZARR = "viewer/last_remote_segments_for_zarr";
+
     // Audio/UX
     constexpr auto PLAY_SOUND_AFTER_SEG_RUN = "viewer/play_sound_after_seg_run";
     constexpr auto USERNAME = "viewer/username";

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
@@ -544,6 +544,24 @@ void CAdaptiveVolumeViewer::submitRender()
             surf->gen(&_genCoords, &_genNormals,
                       cv::Size(fbW, fbH), cv::Vec3f(0, 0, 0),
                       _camera.scale, offset);
+            // Lazy-capture the translation direction when zOff was set by a
+            // path that didn't populate _zOffWorldDir (adjustSurfaceOffset
+            // via Ctrl+./Ctrl+, shortcuts, or any other non-Shift-scroll
+            // source). Without this, those offsets would be silent no-ops
+            // until the user first Shift-scrolled.
+            if (_camera.zOff != 0.0f &&
+                _zOffWorldDir[0] == 0.0f && _zOffWorldDir[1] == 0.0f && _zOffWorldDir[2] == 0.0f &&
+                !_genNormals.empty()) {
+                const int cy = _genNormals.rows / 2;
+                const int cx = _genNormals.cols / 2;
+                const cv::Vec3f n = _genNormals(cy, cx);
+                if (std::isfinite(n[0]) && std::isfinite(n[1]) && std::isfinite(n[2])) {
+                    const float len = static_cast<float>(cv::norm(n));
+                    if (len > 1e-6f) {
+                        _zOffWorldDir = n / len;
+                    }
+                }
+            }
             // Apply z-offset as a rigid world-space translation using the
             // cached direction. On cache hits _genCoords is already shifted
             // — avoid double-applying by only running this on cache miss.

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
@@ -519,10 +519,16 @@ void CAdaptiveVolumeViewer::submitRender()
         // view (matching sceneToSurface). Shift by half the viewport so the
         // rendered pixels and the mouse→surface math agree — without this
         // every edit lands up-left of the cursor by half the viewport.
+        // Don't pass zOff into surf->gen — its per-pixel-normal offset makes
+        // zoom expose curvature drift on a non-planar surface. Instead build
+        // the base (unoffset) coords here and apply zOff as a single rigid
+        // world-space translation in _zOffWorldDir below.
         cv::Vec3f offset(_camera.surfacePtr[0] * _camera.scale - float(fbW) * 0.5f,
                          _camera.surfacePtr[1] * _camera.scale - float(fbH) * 0.5f,
-                         _camera.zOff);
+                         0.0f);
         const bool wantComposite = _compositeSettings.enabled;
+        // Always request normals so shift+scroll can sample the view-center
+        // normal without a separate gen pass.
         const bool cacheHit =
             !_genCacheDirty
             && _genCacheSurfKey == surf.get()
@@ -531,17 +537,40 @@ void CAdaptiveVolumeViewer::submitRender()
             && _genCacheScale == _camera.scale
             && _genCacheOffset == offset
             && _genCacheWantComposite == wantComposite
+            && _genCacheZOff == _camera.zOff
+            && _genCacheZOffDir == _zOffWorldDir
             && !_genCoords.empty();
         if (!cacheHit) {
-            surf->gen(&_genCoords, wantComposite ? &_genNormals : nullptr,
+            surf->gen(&_genCoords, &_genNormals,
                       cv::Size(fbW, fbH), cv::Vec3f(0, 0, 0),
                       _camera.scale, offset);
+            // Apply z-offset as a rigid world-space translation using the
+            // cached direction. On cache hits _genCoords is already shifted
+            // — avoid double-applying by only running this on cache miss.
+            if (_camera.zOff != 0.0f &&
+                (_zOffWorldDir[0] != 0.0f || _zOffWorldDir[1] != 0.0f || _zOffWorldDir[2] != 0.0f) &&
+                !_genCoords.empty()) {
+                const cv::Vec3f tr = _zOffWorldDir * _camera.zOff;
+                const int rows = _genCoords.rows;
+                const int cols = _genCoords.cols;
+                for (int y = 0; y < rows; ++y) {
+                    cv::Vec3f* row = _genCoords.ptr<cv::Vec3f>(y);
+                    for (int x = 0; x < cols; ++x) {
+                        cv::Vec3f& p = row[x];
+                        // Skip invalid sentinels (NaN or -1 marker).
+                        if (p[0] != p[0] || p[0] == -1.0f) continue;
+                        p += tr;
+                    }
+                }
+            }
             _genCacheSurfKey = surf.get();
             _genCacheFbW = fbW;
             _genCacheFbH = fbH;
             _genCacheScale = _camera.scale;
             _genCacheOffset = offset;
             _genCacheWantComposite = wantComposite;
+            _genCacheZOff = _camera.zOff;
+            _genCacheZOffDir = _zOffWorldDir;
             _genCacheDirty = false;
         }
         cv::Mat_<cv::Vec3f>& coords = _genCoords;
@@ -973,11 +1002,26 @@ void CAdaptiveVolumeViewer::onZoom(int steps, QPointF scenePoint, Qt::KeyboardMo
             focus->surfaceId = _surfName;
             _state->setPOI("focus", focus);
         } else {
-            // Direct z-offset
+            // Direct z-offset — rigid translation along the surface normal at
+            // view center (captured fresh each shift+scroll).
             float maxZ = 10000.0f;
             if (_volume) {
                 auto [w, h, d] = _volume->shape();
                 maxZ = static_cast<float>(std::max({w, h, d}));
+            }
+            // Capture the translation direction from the normal at view
+            // center. _genNormals is populated every render (we always
+            // request normals on the flattened path).
+            if (!_genNormals.empty()) {
+                const int cy = _genNormals.rows / 2;
+                const int cx = _genNormals.cols / 2;
+                const cv::Vec3f n = _genNormals(cy, cx);
+                if (std::isfinite(n[0]) && std::isfinite(n[1]) && std::isfinite(n[2])) {
+                    const float len = static_cast<float>(cv::norm(n));
+                    if (len > 1e-6f) {
+                        _zOffWorldDir = n / len;
+                    }
+                }
             }
             _camera.zOff = std::clamp(_camera.zOff + dz, -maxZ, maxZ);
             scheduleRender();
@@ -1469,6 +1513,7 @@ void CAdaptiveVolumeViewer::adjustSurfaceOffset(float dn)
 void CAdaptiveVolumeViewer::resetSurfaceOffsets()
 {
     _camera.zOff = 0.0f;
+    _zOffWorldDir = cv::Vec3f(0.0f, 0.0f, 0.0f);
     scheduleRender();
 }
 

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
@@ -449,22 +449,22 @@ void CAdaptiveVolumeViewer::reloadPerfSettings()
     _highlightDownscaled = s.value("viewer_controls/highlight_downscaled", false).toBool();
 }
 
-void CAdaptiveVolumeViewer::recordRenderTick()
+void CAdaptiveVolumeViewer::recordRenderDuration(double seconds)
 {
-    _renderTimestamps[_renderTimestampHead] = std::chrono::steady_clock::now();
-    _renderTimestampHead = (_renderTimestampHead + 1) % kFpsRingSize;
-    if (_renderTimestampCount < kFpsRingSize) ++_renderTimestampCount;
+    if (seconds <= 0.0) return;
+    _renderDurationsSec[_renderDurationHead] = seconds;
+    _renderDurationHead = (_renderDurationHead + 1) % kFpsRingSize;
+    if (_renderDurationCount < kFpsRingSize) ++_renderDurationCount;
 }
 
 float CAdaptiveVolumeViewer::measuredFps() const
 {
-    if (_renderTimestampCount < 2) return 0.0f;
-    const int newestIdx = (_renderTimestampHead + kFpsRingSize - 1) % kFpsRingSize;
-    const int oldestIdx = (_renderTimestampHead + kFpsRingSize - _renderTimestampCount) % kFpsRingSize;
-    const auto span = _renderTimestamps[newestIdx] - _renderTimestamps[oldestIdx];
-    const double seconds = std::chrono::duration<double>(span).count();
-    if (seconds <= 1e-6) return 0.0f;
-    return float(double(_renderTimestampCount - 1) / seconds);
+    if (_renderDurationCount == 0) return 0.0f;
+    double sum = 0.0;
+    for (int i = 0; i < _renderDurationCount; ++i) sum += _renderDurationsSec[i];
+    const double avg = sum / double(_renderDurationCount);
+    if (avg <= 1e-6) return 0.0f;
+    return float(1.0 / avg);
 }
 
 void CAdaptiveVolumeViewer::submitRender()
@@ -476,7 +476,7 @@ void CAdaptiveVolumeViewer::submitRender()
     if (_volume) {
         if (auto* c = _volume->tieredCache()) c->clearChunkArrivedFlag();
     }
-    recordRenderTick();
+    const auto renderT0 = std::chrono::steady_clock::now();
 
     const CompositeParams& lightP = _compositeSettings.params;
     const bool rakingEnabled = _compositeSettings.postRakingEnabled;
@@ -964,6 +964,8 @@ void CAdaptiveVolumeViewer::submitRender()
     // blocks the UI thread synchronously until paintEvent returns, which
     // stalls every frame during pans/zooms.
     _view->viewport()->update();
+    const auto renderDt = std::chrono::steady_clock::now() - renderT0;
+    recordRenderDuration(std::chrono::duration<double>(renderDt).count());
     updateStatusLabel();
 }
 

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
@@ -406,12 +406,20 @@ void CAdaptiveVolumeViewer::scheduleRender()
     }
 }
 
+// Toggle to re-enable progressive rendering during pan/zoom. The motion-
+// time resolution drop felt visually jarring in practice, so it's off by
+// default — but the plumbing (submitRender level bump, idle-timer catch-
+// up, 30 fps interactive coalesce) stays in place so it can be switched
+// back on with a single recompile.
+static constexpr bool kProgressiveRenderingEnabled = false;
+
 void CAdaptiveVolumeViewer::beginInteraction()
 {
     // Called from any event path that represents live user motion (pan
     // drag, zoom wheel). Marks _interactive so the next submitRender
     // picks the progressive pyramid level, and arms the idle timer so a
     // full-res render fires once motion stops.
+    if (!kProgressiveRenderingEnabled) return;
     _interactive = true;
     _interactionIdleTimer->start();
 }

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
@@ -28,6 +28,8 @@
 #include <QPainterPath>
 #include <QPen>
 #include <QWindowStateChangeEvent>
+#include <QOpenGLWidget>
+#include <QSurfaceFormat>
 #include <QApplication>
 #include <QPointer>
 
@@ -47,6 +49,20 @@ CAdaptiveVolumeViewer::CAdaptiveVolumeViewer(CState* state,
     , _viewerManager(manager)
 {
     _view = new CVolumeViewerView(this);
+    // GPU-backed paint device for the scene: all painter ops (QImage blit,
+    // overlay items, intersections) go through an OpenGL surface instead
+    // of Qt's CPU raster engine. The QImage framebuffer we populate in
+    // drawBackground becomes a GL texture upload + textured quad, and
+    // QGraphicsView compositing runs on the GPU rasterizer. Drops the
+    // CPU blit cost (was ~5% of frame per the perf map) and frees main-
+    // thread cycles for the sampling kernel.
+    {
+        QSurfaceFormat fmt;
+        fmt.setSwapInterval(0);  // disable vsync — we already coalesce at 16 ms
+        auto* gl = new QOpenGLWidget(_view);
+        gl->setFormat(fmt);
+        _view->setViewport(gl);
+    }
     fGraphicsView = _view;
     _view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     _view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -87,6 +103,21 @@ CAdaptiveVolumeViewer::CAdaptiveVolumeViewer(CState* state,
             _renderPending = false;
             submitRender();
             updateStatusLabel();
+        }
+    });
+
+    // When the user stops actively panning / zooming, kick a full-res
+    // re-render to replace the progressive-level frame with a crisp one.
+    // 180 ms chosen to be comfortably past the typical debounce of wheel
+    // events + tail of a pan drag, so we don't flip to full-res in the
+    // middle of continued motion.
+    _interactionIdleTimer = new QTimer(this);
+    _interactionIdleTimer->setSingleShot(true);
+    _interactionIdleTimer->setInterval(180);
+    connect(_interactionIdleTimer, &QTimer::timeout, this, [this]() {
+        if (_interactive) {
+            _interactive = false;
+            scheduleRender();
         }
     });
 
@@ -364,8 +395,25 @@ void CAdaptiveVolumeViewer::scheduleRender()
 {
     syncCameraTransform();
     _renderPending = true;
-    if (!_renderTimer->isActive())
+    if (!_renderTimer->isActive()) {
+        // 16 ms (~60 fps) for crisp idle frames; 33 ms (~30 fps) while the
+        // user is actively panning/zooming. At progressive +1 pyramid the
+        // preview is already blurrier than a settled frame, so 30 fps
+        // matches what the eye perceives during motion and halves the
+        // render work the kernel has to do under load.
+        _renderTimer->setInterval(_interactive ? 33 : 16);
         _renderTimer->start();
+    }
+}
+
+void CAdaptiveVolumeViewer::beginInteraction()
+{
+    // Called from any event path that represents live user motion (pan
+    // drag, zoom wheel). Marks _interactive so the next submitRender
+    // picks the progressive pyramid level, and arms the idle timer so a
+    // full-res render fires once motion stops.
+    _interactive = true;
+    _interactionIdleTimer->start();
 }
 
 void CAdaptiveVolumeViewer::syncCameraTransform()
@@ -435,15 +483,21 @@ void CAdaptiveVolumeViewer::submitRender()
     int fbH = _framebuffer.height();
     if (fbW <= 0 || fbH <= 0) return;
 
-    // Always populate the level buffer — the debug overlay is optional, but
-    // we need the per-pixel fallback depth to enqueue the missing high-res
-    // chunks below regardless of whether the overlay is shown.
-    if (_levelBuffer.rows != fbH || _levelBuffer.cols != fbW) {
-        _levelBuffer.create(fbH, fbW);
+    // Level buffer is only consumed by the downscale-highlight debug
+    // overlay below; when the overlay is off, pass a null pointer to the
+    // kernel so it skips per-pixel level writes entirely, and skip the
+    // full-framebuffer setTo(0) memset here. At 1080p that memset is
+    // ~8 MB/frame of unnecessary bandwidth.
+    uint8_t* lvlOutPtr = nullptr;
+    int lvlOutStride = 0;
+    if (highlightDownscaled) {
+        if (_levelBuffer.rows != fbH || _levelBuffer.cols != fbW) {
+            _levelBuffer.create(fbH, fbW);
+        }
+        _levelBuffer.setTo(0);
+        lvlOutPtr = _levelBuffer.ptr<uint8_t>(0);
+        lvlOutStride = int(_levelBuffer.step1());
     }
-    _levelBuffer.setTo(0);
-    uint8_t* lvlOutPtr = _levelBuffer.ptr<uint8_t>(0);
-    const int lvlOutStride = int(_levelBuffer.step1());
 
     auto* fbBits = reinterpret_cast<uint32_t*>(_framebuffer.bits());
     int fbStride = _framebuffer.bytesPerLine() / 4;
@@ -500,6 +554,14 @@ void CAdaptiveVolumeViewer::submitRender()
     // those pixels to whichever coarser level is resident — no whole-frame
     // resolution cycling, and cached fine chunks are used immediately.
     sp.level = _camera.dsScaleIdx;
+    // During live interaction (pan drag, zoom wheel) bump the pyramid
+    // level one step coarser. Each step halves the voxels read per
+    // sample, which cuts the ray-march cost ~2-4x for a still-coherent
+    // preview frame. The interaction-idle timer triggers a full-res
+    // render ~180 ms after motion stops.
+    if (_interactive) {
+        sp.level = std::min(sp.level + 1, std::max(0, numLevels - 1));
+    }
     sp.method = _samplingMethod;
 
     if (auto* plane = dynamic_cast<PlaneSurface*>(surf.get())) {
@@ -649,8 +711,13 @@ void CAdaptiveVolumeViewer::submitRender()
                 pNormals, nullptr,
                 numLayers, zStart, zStep,
                 fbW, fbH, method, lut.data(), sampleMethod,
-            &lightP,  // sampler uses lightP for volumetric and lighting paths
-            lvlOutPtr, lvlOutStride);
+                &lightP,  // sampler uses lightP for volumetric and lighting paths
+                lvlOutPtr, lvlOutStride,
+                // Coords cached → prior frame already did the chunk
+                // enumeration + fetchInteractive for this exact geometry.
+                // The per-sample adaptive-fallback path still handles any
+                // block not yet resident, so correctness is preserved.
+                cacheHit);
         }
     }
 
@@ -945,6 +1012,7 @@ void CAdaptiveVolumeViewer::panByF(float dx, float dy)
     }
 
     _cachedStretchValid = false;
+    beginInteraction();
     scheduleRender();
     emit overlaysUpdated();
 }
@@ -999,6 +1067,7 @@ void CAdaptiveVolumeViewer::zoomStepsAt(int steps, const QPointF& scenePos)
     // Zoom can fire as fast as the keyboard repeats. scheduleRender()
     // coalesces bursts into the 60 fps render timer so we don't render
     // dozens of intermediate frames the user never sees.
+    beginInteraction();
     scheduleRender();
     emit overlaysUpdated();
 }
@@ -1074,6 +1143,7 @@ void CAdaptiveVolumeViewer::onZoom(int steps, QPointF scenePoint, Qt::KeyboardMo
                 }
             }
             _camera.zOff = std::clamp(_camera.zOff + dz, -maxZ, maxZ);
+            beginInteraction();
             scheduleRender();
             updateStatusLabel();
         }
@@ -1569,8 +1639,11 @@ void CAdaptiveVolumeViewer::resetSurfaceOffsets()
 
 void CAdaptiveVolumeViewer::setVolumeWindow(float low, float high)
 {
-    _windowLow = std::clamp(low, 0.0f, 65535.0f);
-    _windowHigh = std::clamp(high, 0.0f, 65535.0f);
+    const float lo = std::clamp(low, 0.0f, 65535.0f);
+    const float hi = std::clamp(high, 0.0f, 65535.0f);
+    if (lo == _windowLow && hi == _windowHigh) return;
+    _windowLow = lo;
+    _windowHigh = hi;
     if (_volume) scheduleRender();
 }
 

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
@@ -172,13 +172,18 @@ void CAdaptiveVolumeViewer::OnVolumeChanged(std::shared_ptr<Volume> vol)
         std::weak_ptr<Volume> volumeWeak = _volume;
         _chunkCbId = cache->addChunkReadyListener(
             [guard, volumeWeak](const vc::cache::ChunkKey&) {
+                // The pipeline's chunkArrivedFlag_ is edge-triggered via
+                // atomic exchange — this callback only fires when the flag
+                // flips false→true. Deferring the clear to submitRender (on
+                // the 16ms render timer) ensures every subsequent arrival in
+                // the same tick window finds the flag already set and takes
+                // the exchange=true/return-early branch — no listener fire,
+                // no cross-thread event post. One wake per 16ms tick max,
+                // instead of one per chunk burst.
                 QMetaObject::invokeMethod(qApp, [guard, volumeWeak]() {
                     if (!guard) return;
                     auto vol = volumeWeak.lock();
                     if (!vol || guard->_volume != vol) return;
-                    if (auto* c = vol->tieredCache()) {
-                        c->clearChunkArrivedFlag();
-                    }
                     guard->scheduleRender();
                 }, Qt::QueuedConnection);
             });
@@ -385,6 +390,14 @@ void CAdaptiveVolumeViewer::reloadPerfSettings()
 
 void CAdaptiveVolumeViewer::submitRender()
 {
+    // Re-arm the chunk-arrival edge detector for the next tick window.
+    // Any chunk that decodes during this render will set the flag again and
+    // fire exactly one post-event to trigger the next render. See the
+    // addChunkReadyListener callback above for why the clear lives here.
+    if (_volume) {
+        if (auto* c = _volume->tieredCache()) c->clearChunkArrivedFlag();
+    }
+
     const CompositeParams& lightP = _compositeSettings.params;
     const bool rakingEnabled = _compositeSettings.postRakingEnabled;
     const float rakingAz = _compositeSettings.postRakingAzimuth;

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
@@ -388,6 +388,24 @@ void CAdaptiveVolumeViewer::reloadPerfSettings()
     _highlightDownscaled = s.value("viewer_controls/highlight_downscaled", false).toBool();
 }
 
+void CAdaptiveVolumeViewer::recordRenderTick()
+{
+    _renderTimestamps[_renderTimestampHead] = std::chrono::steady_clock::now();
+    _renderTimestampHead = (_renderTimestampHead + 1) % kFpsRingSize;
+    if (_renderTimestampCount < kFpsRingSize) ++_renderTimestampCount;
+}
+
+float CAdaptiveVolumeViewer::measuredFps() const
+{
+    if (_renderTimestampCount < 2) return 0.0f;
+    const int newestIdx = (_renderTimestampHead + kFpsRingSize - 1) % kFpsRingSize;
+    const int oldestIdx = (_renderTimestampHead + kFpsRingSize - _renderTimestampCount) % kFpsRingSize;
+    const auto span = _renderTimestamps[newestIdx] - _renderTimestamps[oldestIdx];
+    const double seconds = std::chrono::duration<double>(span).count();
+    if (seconds <= 1e-6) return 0.0f;
+    return float(double(_renderTimestampCount - 1) / seconds);
+}
+
 void CAdaptiveVolumeViewer::submitRender()
 {
     // Re-arm the chunk-arrival edge detector for the next tick window.
@@ -397,6 +415,7 @@ void CAdaptiveVolumeViewer::submitRender()
     if (_volume) {
         if (auto* c = _volume->tieredCache()) c->clearChunkArrivedFlag();
     }
+    recordRenderTick();
 
     const CompositeParams& lightP = _compositeSettings.params;
     const bool rakingEnabled = _compositeSettings.postRakingEnabled;
@@ -1608,6 +1627,11 @@ void CAdaptiveVolumeViewer::updateStatusLabel()
         .arg(static_cast<double>(_camera.scale), 0, 'f', 2)
         .arg(1 << _camera.dsScaleIdx)
         .arg(static_cast<double>(_camera.zOff), 0, 'f', 1);
+
+    const float fps = measuredFps();
+    if (fps > 0.0f) {
+        status += QString(" | %1 fps").arg(static_cast<double>(fps), 0, 'f', 1);
+    }
 
     if (_volume->tieredCache()) {
         auto s = _volume->tieredCache()->stats();

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.cpp
@@ -12,6 +12,7 @@
 #include "vc/core/types/SampleParams.hpp"
 #include "vc/core/cache/BlockPipeline.hpp"
 #include "vc/core/cache/ChunkKey.hpp"
+#include "vc/core/cache/TickCoordinator.hpp"
 #include <cstring>
 #include <unordered_set>
 
@@ -153,6 +154,10 @@ CAdaptiveVolumeViewer::~CAdaptiveVolumeViewer()
     if (_chunkCbId != 0 && _volume && _volume->tieredCache()) {
         _volume->tieredCache()->removeChunkReadyListener(_chunkCbId);
         _chunkCbId = 0;
+    }
+    if (_tickViewportSlot >= 0) {
+        vc::cache::TickCoordinator::releaseViewportSlotGlobal(_tickViewportSlot);
+        _tickViewportSlot = -1;
     }
 }
 
@@ -490,6 +495,21 @@ void CAdaptiveVolumeViewer::submitRender()
     int fbW = _framebuffer.width();
     int fbH = _framebuffer.height();
     if (fbW <= 0 || fbH <= 0) return;
+
+    // Publish viewport snapshot for the tick coordinator. Used by
+    // prefetch coalescing (so the tick drain knows which pipelines/levels
+    // are in use) and future slice scoping. Slot is lazy-allocated here
+    // and released in the destructor.
+    if (_tickViewportSlot < 0) {
+        _tickViewportSlot = vc::cache::TickCoordinator::acquireViewportSlotGlobal();
+    }
+    if (_tickViewportSlot >= 0) {
+        vc::cache::ViewportSnapshot vs;
+        vs.active = true;
+        vs.level = _camera.dsScaleIdx;
+        vs.pipeline = _volume->tieredCache();
+        vc::cache::TickCoordinator::publishViewportGlobal(_tickViewportSlot, vs);
+    }
 
     // Level buffer is only consumed by the downscale-highlight debug
     // overlay below; when the overlay is off, pass a null pointer to the

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
@@ -317,6 +317,15 @@ private:
     int _normalMaxArrows = 32;
     QString _lastStatusText;
     std::chrono::steady_clock::time_point _lastStatusUpdate{};
+    // FPS tracking — ring buffer of recent submitRender() timestamps.
+    // Status label reads the newest minus the oldest to get an averaged
+    // fps number; single-frame interval is too noisy to display.
+    static constexpr int kFpsRingSize = 32;
+    std::array<std::chrono::steady_clock::time_point, kFpsRingSize> _renderTimestamps{};
+    int _renderTimestampHead = 0;
+    int _renderTimestampCount = 0;
+    void recordRenderTick();
+    float measuredFps() const;
     std::chrono::steady_clock::time_point _lastStretchScan{};
     cv::Ptr<cv::CLAHE> _claheCache;
     int _claheCacheTile = -1;

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
@@ -437,4 +437,9 @@ private:
     vc::cache::BlockPipeline::ChunkReadyCallbackId _chunkCbId = 0;
     bool _hadValidDataBounds = false;
     bool _dirtyWhileMinimized = false;
+
+    // TickCoordinator viewport slot. Acquired lazily on first publish and
+    // released in the destructor. -1 means "no slot" (either coordinator
+    // missing, or allocation table was full at ctor time).
+    int _tickViewportSlot = -1;
 };

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
@@ -286,6 +286,11 @@ private:
     float _windowLow = 0.0f;
     float _windowHigh = 255.0f;
     std::string _baseColormapId;
+    // Flattened-view z-scroll translation direction (unit vector in world
+    // space). Captured at each shift+scroll from the surface normal under
+    // the view center so the translation is rigid — plain zoom never
+    // exposes curvature drift.
+    cv::Vec3f _zOffWorldDir{0.0f, 0.0f, 0.0f};
 
     // LUT cache: rebuild only when inputs change.
     std::array<uint32_t, 256> _cachedLut{};
@@ -337,6 +342,8 @@ private:
     bool _genCacheWantComposite = false;
     Surface* _genCacheSurfKey = nullptr;
     bool _genCacheDirty = true;
+    float _genCacheZOff = 0.0f;
+    cv::Vec3f _genCacheZOffDir{0.0f, 0.0f, 0.0f};
 
 public:
     // Re-reads perf/interaction settings from disk into cached members.

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
@@ -81,7 +81,15 @@ public:
     VCCollection* pointCollection() const override { return _pointCollection; }
 
     // --- Settings passthrough ---
+    // Equality guards: Qt UI routinely fires value-changed signals even
+    // when the user's action rounds to the same stored value (e.g. a
+    // drag-release that reports the current spinbox value). Without the
+    // guard we'd queue a real render for every no-op signal — the 16 ms
+    // coalesce timer still fires, but it triggers a full frame for zero
+    // visible change. Skipping identical settings keeps the pipeline
+    // idle when nothing actually changed.
     void setCompositeRenderSettings(const CompositeRenderSettings& s) {
+        if (_compositeSettings == s) return;
         _compositeSettings = s;
         scheduleRender();
     }
@@ -92,7 +100,11 @@ public:
     void setVolumeWindow(float low, float high);
     float volumeWindowLow() const { return _windowLow; }
     float volumeWindowHigh() const { return _windowHigh; }
-    void setBaseColormap(const std::string& id) { _baseColormapId = id; scheduleRender(); }
+    void setBaseColormap(const std::string& id) {
+        if (_baseColormapId == id) return;
+        _baseColormapId = id;
+        scheduleRender();
+    }
     void setStretchValues(bool) { scheduleRender(); }
 
     // --- Display stubs ---
@@ -264,6 +276,19 @@ private:
     QLabel* _lbl = nullptr;
     QTimer* _renderTimer = nullptr;
     bool _renderPending = false;
+
+    // Progressive rendering: during live interaction (pan drag, zoom wheel
+    // events) we render at +1 pyramid level for faster frames. When the
+    // user stops interacting, an idle timer fires and we kick a full-res
+    // render to catch up. This trades a slightly-softer image during
+    // motion for materially lower frame time, which in turn makes pans/
+    // zooms feel smoother without touching the sample kernel.
+    QTimer* _interactionIdleTimer = nullptr;
+    bool _interactive = false;
+    // Increment on every interactive event; submitRender captures the
+    // value before dispatching. If it changes while a render is in flight
+    // we know the user acted again and we should keep rendering.
+    void beginInteraction();
 
     // --- Framebuffer ---
     QImage _framebuffer;

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
@@ -345,11 +345,17 @@ private:
     // FPS tracking — ring buffer of recent submitRender() timestamps.
     // Status label reads the newest minus the oldest to get an averaged
     // fps number; single-frame interval is too noisy to display.
+    // FPS ring stores per-frame render DURATIONS (seconds), not render
+    // timestamps. The reported value is 1 / mean(duration) — i.e., the
+    // theoretical framerate we would sustain at our measured render
+    // cost. Decouples the readout from user-input pacing so an idle
+    // viewer doesn't read 0 FPS and a held-button pan doesn't read the
+    // timer interval as "60 fps".
     static constexpr int kFpsRingSize = 32;
-    std::array<std::chrono::steady_clock::time_point, kFpsRingSize> _renderTimestamps{};
-    int _renderTimestampHead = 0;
-    int _renderTimestampCount = 0;
-    void recordRenderTick();
+    std::array<double, kFpsRingSize> _renderDurationsSec{};
+    int _renderDurationHead = 0;
+    int _renderDurationCount = 0;
+    void recordRenderDuration(double seconds);
     float measuredFps() const;
     std::chrono::steady_clock::time_point _lastStretchScan{};
     cv::Ptr<cv::CLAHE> _claheCache;

--- a/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/adaptive/CAdaptiveVolumeViewer.hpp
@@ -42,7 +42,7 @@ class PlaneSurface;
 #define CTiledVolumeViewer CAdaptiveVolumeViewer
 
 // Adaptive per-pixel volume viewer. Renders a PlaneSurface via
-// samplePlaneAdaptiveARGB32 directly to a viewport-sized framebuffer,
+// sampleAdaptiveARGB32 directly to a viewport-sized framebuffer,
 // with composite post-process (CLAHE, raking light), intersections,
 // and overlays.
 class CAdaptiveVolumeViewer : public QWidget, public VolumeViewerBase

--- a/volume-cartographer/apps/VC3D/overlays/ViewerOverlayControllerBase.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/ViewerOverlayControllerBase.cpp
@@ -238,13 +238,37 @@ void ViewerOverlayControllerBase::attachViewer(VolumeViewerBase* viewer)
 
     ViewerEntry entry;
     entry.viewer = viewer;
+    // Per-viewer 16ms debounce timer. Each overlaysUpdated signal sets the
+    // dirty flag and restarts the timer; when the timer fires we rebuild
+    // at most once per tick regardless of signal frequency.
+    entry.rebuildTimer = new QTimer(this);
+    entry.rebuildTimer->setSingleShot(true);
+    entry.rebuildTimer->setInterval(16);
+    QObject::connect(entry.rebuildTimer, &QTimer::timeout, this, [this, viewer]() {
+        auto it = std::find_if(_viewers.begin(), _viewers.end(),
+            [viewer](const ViewerEntry& e) { return e.viewer == viewer; });
+        if (it == _viewers.end() || !it->rebuildDirty) return;
+        it->rebuildDirty = false;
+        rebuildOverlay(viewer);
+    });
     entry.overlaysUpdatedConn = viewer->connectOverlaysUpdated(
-        this, [this, viewer]() { rebuildOverlay(viewer); });
+        this, [this, viewer]() { scheduleRebuild(viewer); });
     entry.destroyedConn = QObject::connect(viewer->asQObject(), &QObject::destroyed,
                                            this, [this, viewer]() { detachViewer(viewer); });
 
     _viewers.push_back(entry);
-    rebuildOverlay(viewer);
+    rebuildOverlay(viewer);  // first rebuild is synchronous, no point debouncing it
+}
+
+void ViewerOverlayControllerBase::scheduleRebuild(VolumeViewerBase* viewer)
+{
+    auto it = std::find_if(_viewers.begin(), _viewers.end(),
+        [viewer](const ViewerEntry& entry) { return entry.viewer == viewer; });
+    if (it == _viewers.end()) return;
+    it->rebuildDirty = true;
+    if (it->rebuildTimer && !it->rebuildTimer->isActive()) {
+        it->rebuildTimer->start();
+    }
 }
 
 void ViewerOverlayControllerBase::detachViewer(VolumeViewerBase* viewer)
@@ -256,6 +280,11 @@ void ViewerOverlayControllerBase::detachViewer(VolumeViewerBase* viewer)
     for (auto iter = it; iter != _viewers.end(); ++iter) {
         QObject::disconnect(iter->overlaysUpdatedConn);
         QObject::disconnect(iter->destroyedConn);
+        if (iter->rebuildTimer) {
+            iter->rebuildTimer->stop();
+            iter->rebuildTimer->deleteLater();
+            iter->rebuildTimer = nullptr;
+        }
         if (iter->viewer) {
             iter->viewer->clearOverlayGroup(_overlayGroupKey);
         }
@@ -789,6 +818,11 @@ void ViewerOverlayControllerBase::detachAllViewers()
     for (auto& entry : _viewers) {
         QObject::disconnect(entry.overlaysUpdatedConn);
         QObject::disconnect(entry.destroyedConn);
+        if (entry.rebuildTimer) {
+            entry.rebuildTimer->stop();
+            entry.rebuildTimer->deleteLater();
+            entry.rebuildTimer = nullptr;
+        }
         if (entry.viewer) {
             entry.viewer->clearOverlayGroup(_overlayGroupKey);
         }

--- a/volume-cartographer/apps/VC3D/overlays/ViewerOverlayControllerBase.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/ViewerOverlayControllerBase.hpp
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QMetaObject>
 #include <QMetaType>
+#include <QTimer>
 
 #include <QColor>
 #include <QFont>
@@ -240,9 +241,18 @@ private:
         VolumeViewerBase* viewer{nullptr};
         QMetaObject::Connection overlaysUpdatedConn;
         QMetaObject::Connection destroyedConn;
+        // Coalesce the rebuildOverlay fan-out onto a 16 ms single-shot
+        // timer. overlaysUpdated() gets emitted on every viewport pan/zoom
+        // (post-render side-effect), and collectDirectionHints' pointTo
+        // search was measured at ~7.5% of total CPU in the live profile —
+        // debouncing drops that to one rebuild per tick window regardless
+        // of signal frequency.
+        QTimer* rebuildTimer{nullptr};
+        bool rebuildDirty{false};
     };
 
     void rebuildOverlay(VolumeViewerBase* viewer);
+    void scheduleRebuild(VolumeViewerBase* viewer);
     void detachAllViewers();
 
     std::string _overlayGroupKey;

--- a/volume-cartographer/apps/src/compare_coord_regression.py
+++ b/volume-cartographer/apps/src/compare_coord_regression.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Compare two vc_coord_regression outputs with epsilon tolerance.
+
+Each non-comment line is "TAG id v1 v2 v3 ...", all floats. Lines must
+match 1:1 by (TAG, id). Any numeric field whose absolute diff exceeds
+--abs-tol OR relative diff exceeds --rel-tol is flagged.
+
+Exit 0 on pass, 1 on any mismatch.
+"""
+import argparse, sys
+
+def load(path):
+    rows = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            parts = line.split()
+            tag, idx = parts[0], parts[1]
+            vals = [float(v) for v in parts[2:]]
+            rows[(tag, idx)] = vals
+    return rows
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('baseline')
+    p.add_argument('current')
+    p.add_argument('--abs-tol', type=float, default=1e-4)
+    p.add_argument('--rel-tol', type=float, default=1e-5)
+    p.add_argument('--max-show', type=int, default=10)
+    args = p.parse_args()
+
+    base = load(args.baseline)
+    curr = load(args.current)
+
+    missing = set(base) - set(curr)
+    extra = set(curr) - set(base)
+    if missing or extra:
+        print(f"FAIL: key sets differ. missing: {len(missing)}, extra: {len(extra)}")
+        return 1
+
+    mismatches = []
+    for key in base:
+        b, c = base[key], curr[key]
+        if len(b) != len(c):
+            mismatches.append((key, 'len', b, c))
+            continue
+        for i, (bi, ci) in enumerate(zip(b, c)):
+            adiff = abs(bi - ci)
+            rdiff = adiff / max(abs(bi), 1e-20)
+            if adiff > args.abs_tol and rdiff > args.rel_tol:
+                mismatches.append((key, i, bi, ci, adiff, rdiff))
+
+    if not mismatches:
+        print(f"PASS: {len(base)} cases match (abs_tol={args.abs_tol}, rel_tol={args.rel_tol})")
+        return 0
+
+    print(f"FAIL: {len(mismatches)} mismatches (abs_tol={args.abs_tol}, rel_tol={args.rel_tol})")
+    for m in mismatches[:args.max_show]:
+        if len(m) == 4:
+            (tag, idx), what, b, c = m
+            print(f"  {tag} {idx}: {what} differ")
+        else:
+            (tag, idx), field, b, c, ad, rd = m
+            print(f"  {tag} {idx}[{field}]: base={b:.9f} curr={c:.9f} abs={ad:.2e} rel={rd:.2e}")
+    if len(mismatches) > args.max_show:
+        print(f"  ... and {len(mismatches) - args.max_show} more")
+    return 1
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/volume-cartographer/apps/src/vc_blockcache_bench.cpp
+++ b/volume-cartographer/apps/src/vc_blockcache_bench.cpp
@@ -1,0 +1,242 @@
+// vc_blockcache_bench: Multi-threaded BlockCache put/get throughput.
+//
+// The BlockCache is the render hot path's deepest sync point. Every sampler
+// call hits blockAt → cache.get under a shared lock, and every decoded
+// chunk inserts 512 blocks via BatchPut under an exclusive lock. This
+// bench measures both paths isolated from any volume loading logic so
+// regressions show up against a known baseline.
+//
+// Workloads
+//   get-hot      : N threads read the same small working set (always hits).
+//                  Isolates get() path + slot-cache traversal.
+//   get-scattered: N threads read random keys across a large arena
+//                  (~80% hit / ~20% miss after warmup). Measures eviction
+//                  + clock-sweep behaviour under pressure.
+//   put-batch    : N threads call BatchPut::acquire + fill 512 blocks each.
+//                  Measures the chunk→block insert path that
+//                  insertChunkAsBlocks takes after every decode.
+//   contains-batch: N threads call containsBatch with K keys each. Models
+//                   fetchInteractive's probe step.
+//
+// Options:
+//   --threads N       Worker threads (default: 8)
+//   --arena-gb N      BlockCache budget in GB (default: 1)
+//   --workset-mb N    Working-set size per phase in MB (default: 64)
+//   --iters N         Iterations per thread (default: 1_000_000 for get,
+//                     10_000 for put)
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "vc/core/cache/BlockCache.hpp"
+
+using Clock = std::chrono::steady_clock;
+using namespace vc::cache;
+
+namespace {
+
+double elapsed(Clock::time_point a, Clock::time_point b) {
+    return std::chrono::duration<double>(b - a).count();
+}
+
+struct Phase {
+    std::string name;
+    uint64_t totalOps = 0;
+    double seconds = 0.0;
+    double opsPerSec() const { return seconds ? totalOps / seconds : 0.0; }
+};
+
+void printPhase(const Phase& p, int threads) {
+    printf("  %-18s %2d thr  %12llu ops  %7.2fs  %12.0f ops/s  (%7.0f ns/op avg)\n",
+           p.name.c_str(), threads,
+           (unsigned long long)p.totalOps, p.seconds, p.opsPerSec(),
+           p.seconds * 1e9 / std::max<double>(p.totalOps, 1));
+}
+
+// Populate `cache` with a working set of known keys. Returns the keys so
+// tests can issue hits against them.
+std::vector<BlockKey> populate(BlockCache& cache, size_t nKeys) {
+    std::vector<BlockKey> keys;
+    keys.reserve(nKeys);
+    std::vector<uint8_t> pattern(kBlockBytes);
+    for (size_t i = 0; i < kBlockBytes; ++i) pattern[i] = static_cast<uint8_t>(i);
+    for (size_t i = 0; i < nKeys; ++i) {
+        BlockKey k{0, int(i / 1024), int((i / 32) & 31), int(i & 31)};
+        keys.push_back(k);
+        cache.put(k, pattern.data());
+    }
+    return keys;
+}
+
+Phase benchGetHot(BlockCache& cache, int threads, uint64_t itersPerThread,
+                  const std::vector<BlockKey>& keys)
+{
+    Phase p; p.name = "get-hot";
+    std::atomic<uint64_t> totalHits{0};
+    const auto t0 = Clock::now();
+    std::vector<std::jthread> ws;
+    for (int t = 0; t < threads; ++t) {
+        ws.emplace_back([&, tid = t](std::stop_token) {
+            uint64_t hits = 0;
+            std::mt19937 rng(uint32_t(tid) * 0x9E37u + 1);
+            for (uint64_t i = 0; i < itersPerThread; ++i) {
+                const auto& k = keys[rng() % keys.size()];
+                if (cache.get(k)) ++hits;
+            }
+            totalHits.fetch_add(hits, std::memory_order_relaxed);
+        });
+    }
+    ws.clear();
+    p.seconds = elapsed(t0, Clock::now());
+    p.totalOps = uint64_t(threads) * itersPerThread;
+    return p;
+}
+
+Phase benchGetScattered(BlockCache& cache, int threads, uint64_t itersPerThread,
+                        const std::vector<BlockKey>& keys, uint64_t spaceSize)
+{
+    // Mix hits (indexes into keys) with misses (random keys outside keys),
+    // ratio ~80/20.
+    Phase p; p.name = "get-scattered";
+    const auto t0 = Clock::now();
+    std::vector<std::jthread> ws;
+    for (int t = 0; t < threads; ++t) {
+        ws.emplace_back([&, tid = t](std::stop_token) {
+            std::mt19937 rng(uint32_t(tid) * 0x9E37u + 3);
+            for (uint64_t i = 0; i < itersPerThread; ++i) {
+                if ((rng() & 7) < 6) {
+                    (void)cache.get(keys[rng() % keys.size()]);
+                } else {
+                    BlockKey k{0, int(rng() % spaceSize),
+                                   int(rng() % spaceSize),
+                                   int(rng() % spaceSize)};
+                    (void)cache.get(k);
+                }
+            }
+        });
+    }
+    ws.clear();
+    p.seconds = elapsed(t0, Clock::now());
+    p.totalOps = uint64_t(threads) * itersPerThread;
+    return p;
+}
+
+Phase benchPutBatch(BlockCache& cache, int threads, uint64_t chunkIterPerThread)
+{
+    // Each "chunk" == 512 blocks written under one BatchPut. Models a
+    // 128³ chunk arriving from decode. Uses put() so the bench works on
+    // both baseline and optimized builds.
+    Phase p; p.name = "put-batch";
+    std::vector<uint8_t> pattern(kBlockBytes);
+    for (size_t i = 0; i < kBlockBytes; ++i) pattern[i] = static_cast<uint8_t>(i ^ 0xA5);
+    const auto t0 = Clock::now();
+    std::vector<std::jthread> ws;
+    for (int t = 0; t < threads; ++t) {
+        ws.emplace_back([&, tid = t, patPtr = pattern.data()](std::stop_token) {
+            for (uint64_t c = 0; c < chunkIterPerThread; ++c) {
+                // Disjoint bz ranges per thread per chunk so threads don't
+                // thrash on identical keys — models concurrent chunk
+                // insertion from different levels/regions.
+                const int baseBz = tid * 64 + int((c & 0xff) * threads);
+                BlockCache::BatchPut batch(cache);
+                for (int bi = 0; bi < 8; ++bi)
+                  for (int bj = 0; bj < 8; ++bj)
+                    for (int bk = 0; bk < 8; ++bk) {
+                        BlockKey k{0, baseBz + bi, bj, bk};
+                        batch.put(k, patPtr);
+                    }
+            }
+        });
+    }
+    ws.clear();
+    p.seconds = elapsed(t0, Clock::now());
+    p.totalOps = uint64_t(threads) * chunkIterPerThread * 512;  // blocks inserted
+    return p;
+}
+
+Phase benchContainsBatch(BlockCache& cache, int threads, uint64_t iterPerThread,
+                          const std::vector<BlockKey>& keys)
+{
+    // K=512 keys per call — matches the two-blocks-per-chunk x 256-chunks
+    // probe profile fetchInteractive does in the worst case.
+    Phase p; p.name = "contains-batch";
+    const size_t K = 512;
+    const auto t0 = Clock::now();
+    std::vector<std::jthread> ws;
+    for (int t = 0; t < threads; ++t) {
+        ws.emplace_back([&, tid = t](std::stop_token) {
+            std::mt19937 rng(uint32_t(tid) * 0x9E37u + 7);
+            std::vector<BlockKey> probe(K);
+            std::vector<uint8_t> out;
+            for (uint64_t i = 0; i < iterPerThread; ++i) {
+                for (size_t j = 0; j < K; ++j)
+                    probe[j] = keys[rng() % keys.size()];
+                cache.containsBatch(probe, out);
+            }
+        });
+    }
+    ws.clear();
+    p.seconds = elapsed(t0, Clock::now());
+    p.totalOps = uint64_t(threads) * iterPerThread * K;
+    return p;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    int threads = 8;
+    int arenaGb = 1;
+    int worksetMb = 64;
+    uint64_t getIters = 1'000'000;
+    uint64_t putIters = 10'000;
+    uint64_t containsIters = 100'000;
+    for (int i = 1; i < argc; ++i) {
+        std::string_view a = argv[i];
+        auto need = [&](const char* w) { if (i+1>=argc){fprintf(stderr,"%s needs value\n",w);std::exit(1);} return argv[++i]; };
+        if      (a == "--threads")     threads = std::atoi(need("--threads"));
+        else if (a == "--arena-gb")    arenaGb = std::atoi(need("--arena-gb"));
+        else if (a == "--workset-mb")  worksetMb = std::atoi(need("--workset-mb"));
+        else if (a == "--iters")       getIters = std::atoll(need("--iters"));
+        else if (a == "--put-iters")   putIters = std::atoll(need("--put-iters"));
+        else if (a == "--contains-iters") containsIters = std::atoll(need("--contains-iters"));
+        else { fprintf(stderr, "Unknown: %s\n", argv[i]); return 1; }
+    }
+
+    BlockCache::Config cfg;
+    cfg.bytes = size_t(arenaGb) << 30;
+    printf("vc_blockcache_bench\n");
+    printf("  Threads:    %d\n", threads);
+    printf("  Arena:      %d GB (%llu slots)\n", arenaGb,
+           (unsigned long long)(cfg.bytes / kBlockBytes));
+    printf("  Workset:    %d MB (%llu blocks)\n", worksetMb,
+           (unsigned long long)((size_t(worksetMb) << 20) / kBlockBytes));
+    printf("\n");
+
+    BlockCache cache(cfg);
+    const size_t worksetBlocks = (size_t(worksetMb) << 20) / kBlockBytes;
+    auto keys = populate(cache, worksetBlocks);
+    printf("Populated %zu keys. Arena size=%zu.\n\n", keys.size(), cache.size());
+
+    std::vector<Phase> results;
+    results.push_back(benchGetHot(cache, threads, getIters, keys));
+    results.push_back(benchGetScattered(cache, threads, getIters, keys, 10'000));
+    results.push_back(benchContainsBatch(cache, threads, containsIters, keys));
+    // Put test populates beyond arena → exercises eviction too.
+    results.push_back(benchPutBatch(cache, threads, putIters));
+
+    printf("Results:\n");
+    for (const auto& r : results) printPhase(r, threads);
+    printf("\nDone.\n");
+    return 0;
+}

--- a/volume-cartographer/apps/src/vc_coord_bench.cpp
+++ b/volume-cartographer/apps/src/vc_coord_bench.cpp
@@ -1,0 +1,139 @@
+// vc_coord_bench: QuadSurface coord-generation and pointTo() throughput.
+//
+// The live profile shows at_int() at 3.84% and search_min_loc/pointTo at
+// 1.83% for QuadSurface-based viewers. Both are called per-pixel during
+// coord generation — so they scale with output resolution and are a common
+// regression target when anyone touches Geometry.cpp or QuadSurface.cpp.
+//
+// Two benches here:
+//   gen      : QuadSurface::gen over a synthetic grid, 100 iterations.
+//              Measures the per-pixel cost of the coord generator (includes
+//              pointTo seeding, affine remap, at_int interp of grid points).
+//   at_int   : isolated at_int() calls over random (u,v) positions on a
+//              synthetic grid. Directly measures bilinear interp perf.
+//   pointTo  : repeated pointTo() calls at a sliding target. Covers
+//              search_min_loc hot loop.
+//
+// Usage:
+//   vc_coord_bench [--tile N] [--iters N] [--grid N]
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string_view>
+#include <vector>
+
+#include <opencv2/core.hpp>
+
+#include "vc/core/util/QuadSurface.hpp"
+#include "vc/core/util/Geometry.hpp"
+
+using Clock = std::chrono::steady_clock;
+
+namespace {
+
+double elapsed(Clock::time_point a, Clock::time_point b) {
+    return std::chrono::duration<double>(b - a).count();
+}
+
+// Build a non-trivial synthetic Vec3f grid: a gently curved sheet in 3D
+// space so at_int has real interpolation work and pointTo has a real
+// local-minimum search.
+cv::Mat_<cv::Vec3f> makeSyntheticGrid(int w, int h) {
+    cv::Mat_<cv::Vec3f> g(h, w);
+    for (int y = 0; y < h; ++y) {
+      for (int x = 0; x < w; ++x) {
+        const float fx = float(x), fy = float(y);
+        const float z = 100.0f + 5.0f * std::sin(fx * 0.01f) * std::cos(fy * 0.01f);
+        g(y, x) = cv::Vec3f(fx * 1.1f, fy * 1.1f, z);
+      }
+    }
+    return g;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    int tile = 512;
+    int gridSize = 512;
+    int iters = 200;
+    int pointToIters = 2000;
+    for (int i = 1; i < argc; ++i) {
+        std::string_view a = argv[i];
+        auto need = [&](const char* w){ if(i+1>=argc){fprintf(stderr,"%s needs value\n",w);std::exit(1);} return argv[++i]; };
+        if      (a == "--tile")           tile = std::atoi(need("--tile"));
+        else if (a == "--grid")           gridSize = std::atoi(need("--grid"));
+        else if (a == "--iters")          iters = std::atoi(need("--iters"));
+        else if (a == "--pointto-iters")  pointToIters = std::atoi(need("--pointto-iters"));
+        else { fprintf(stderr, "Unknown: %s\n", argv[i]); return 1; }
+    }
+
+    printf("vc_coord_bench\n");
+    printf("  Tile:          %d x %d\n", tile, tile);
+    printf("  Grid:          %d x %d\n", gridSize, gridSize);
+    printf("  Gen iters:     %d\n", iters);
+    printf("  pointTo iters: %d\n", pointToIters);
+    printf("\n");
+
+    auto grid = makeSyntheticGrid(gridSize, gridSize);
+
+    // ==== at_int throughput ====
+    {
+        std::mt19937 rng(42);
+        std::uniform_real_distribution<float> ux(1.0f, float(gridSize - 2));
+        std::uniform_real_distribution<float> uy(1.0f, float(gridSize - 2));
+        std::vector<cv::Vec2f> pts(iters * 1000);
+        for (auto& p : pts) p = cv::Vec2f(ux(rng), uy(rng));
+
+        cv::Vec3f sink{0, 0, 0};
+        const auto t0 = Clock::now();
+        for (const auto& p : pts) sink += at_int(grid, p);
+        const double sec = elapsed(t0, Clock::now());
+        volatile float use = sink[0] + sink[1] + sink[2]; (void)use;
+        printf("  at_int          %9zu calls  %7.3fs  %10.0f calls/s  %6.1f ns/call\n",
+               pts.size(), sec, pts.size() / sec, sec * 1e9 / pts.size());
+    }
+
+    // ==== QuadSurface::gen throughput ====
+    {
+        QuadSurface surf(grid, cv::Vec2f(1.0f, 1.0f));
+        cv::Mat_<cv::Vec3f> coords;
+        cv::Mat_<cv::Vec3f> normals;
+        const cv::Vec3f center(float(gridSize)/2, float(gridSize)/2, 100.0f);
+        const auto t0 = Clock::now();
+        for (int i = 0; i < iters; ++i) {
+            cv::Vec3f offset(float(i % 10) * 1.0f, float(i / 10 % 10) * 1.0f, 0.0f);
+            surf.gen(&coords, &normals, cv::Size(tile, tile), center, 1.0f, offset);
+        }
+        const double sec = elapsed(t0, Clock::now());
+        const size_t pixels = size_t(iters) * tile * tile;
+        printf("  QuadSurface::gen %8d tiles %7.3fs  %10.0f tiles/s  %.1f Mpix/s\n",
+               iters, sec, iters / sec, pixels / sec / 1e6);
+    }
+
+    // ==== pointTo / search_min_loc throughput ====
+    {
+        QuadSurface surf(grid, cv::Vec2f(1.0f, 1.0f));
+        std::mt19937 rng(1337);
+        std::uniform_real_distribution<float> tx(50.0f, float(gridSize) - 50.0f);
+        std::uniform_real_distribution<float> ty(50.0f, float(gridSize) - 50.0f);
+        cv::Vec3f ptr{0,0,0};
+        const auto t0 = Clock::now();
+        for (int i = 0; i < pointToIters; ++i) {
+            cv::Vec3f tgt(tx(rng), ty(rng), 100.0f);
+            surf.pointTo(ptr, tgt, 0.5f, 100);
+        }
+        const double sec = elapsed(t0, Clock::now());
+        volatile float use = ptr[0] + ptr[1] + ptr[2]; (void)use;
+        printf("  pointTo          %8d calls  %7.3fs  %10.0f calls/s  %6.1f us/call\n",
+               pointToIters, sec, pointToIters / sec, sec * 1e6 / pointToIters);
+    }
+
+    printf("\nDone.\n");
+    return 0;
+}

--- a/volume-cartographer/apps/src/vc_coord_regression.cpp
+++ b/volume-cartographer/apps/src/vc_coord_regression.cpp
@@ -1,0 +1,308 @@
+// vc_coord_regression: Deterministic regression harness for the
+// coord-math hot path (at_int / search_min_loc / pointTo).
+//
+// Covers three surface types so the three failure modes of a
+// Newton-style pointTo replacement all surface here:
+//   • synthetic smooth grid    — Gauss-Newton should converge cleanly
+//   • synthetic curled/twisted — tests non-convex local minima
+//   • loaded tifxyz segment    — real Vesuvius scroll geometry
+//
+// And three test kinds per surface:
+//   AT  at_int(surface, (u,v))          — pure interp
+//   PT  pointTo(init_loc, surface, tgt) — inverse search from seed
+//   RT  round-trip: gen(u,v)→P, then pointTo(P) must return loc≈(u,v)
+//       within surface-scale tolerance. Fails if the search diverges
+//       to a different local minimum.
+//
+// Workflow:
+//   $ vc_coord_regression > /tmp/baseline.txt
+//   # (modify pointTo / search_min_loc / at_int)
+//   $ vc_coord_regression > /tmp/after.txt
+//   $ compare_coord_regression.py /tmp/baseline.txt /tmp/after.txt
+//
+// For round-trip cases, epsilon tolerance is looser on the loc output
+// (several voxels) because pointTo finds a local minimum — tiny numeric
+// differences can nudge to a nearby valley. The regression script
+// classifies RT differently from AT/PT (accepts larger drift so long
+// as the found 3D point P is close to the target).
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <opencv2/core.hpp>
+
+#include "vc/core/util/Geometry.hpp"
+#include "vc/core/util/QuadSurface.hpp"
+
+using Clock = std::chrono::steady_clock;
+namespace fs = std::filesystem;
+
+namespace {
+
+struct Surface {
+    std::string label;
+    cv::Mat_<cv::Vec3f> grid;
+    cv::Vec2f scale;  // grid units per world unit (used to build QuadSurface)
+};
+
+Surface makeSmoothGrid(int w, int h) {
+    Surface s;
+    s.label = "smooth";
+    s.grid.create(h, w);
+    for (int y = 0; y < h; ++y) {
+        auto* row = s.grid.ptr<cv::Vec3f>(y);
+        for (int x = 0; x < w; ++x) {
+            const float fx = float(x), fy = float(y);
+            const float z = 100.0f + 5.0f * std::sin(fx * 0.013f)
+                                   + 3.0f * std::cos(fy * 0.017f);
+            row[x] = cv::Vec3f(fx * 1.10f, fy * 1.05f, z);
+        }
+    }
+    s.scale = cv::Vec2f(1.0f, 1.0f);
+    return s;
+}
+
+// Highly curved — tests convergence on non-monotonic surfaces. The
+// sinusoidal warp creates ridges and valleys that can trap any
+// gradient-descent search at a wrong local minimum.
+Surface makeCurledGrid(int w, int h) {
+    Surface s;
+    s.label = "curled";
+    s.grid.create(h, w);
+    for (int y = 0; y < h; ++y) {
+        auto* row = s.grid.ptr<cv::Vec3f>(y);
+        for (int x = 0; x < w; ++x) {
+            const float fx = float(x), fy = float(y);
+            const float z = 100.0f + 30.0f * std::sin(fx * 0.05f)
+                                   + 20.0f * std::sin(fy * 0.07f)
+                                   + 15.0f * std::sin((fx + fy) * 0.09f);
+            const float dx = 8.0f * std::sin(fy * 0.04f);
+            const float dy = 6.0f * std::sin(fx * 0.035f);
+            row[x] = cv::Vec3f(fx * 1.10f + dx, fy * 1.05f + dy, z);
+        }
+    }
+    s.scale = cv::Vec2f(1.0f, 1.0f);
+    return s;
+}
+
+// Loaded tifxyz segment. Uses load_quad_from_tifxyz so the resulting
+// grid matches exactly what VC3D loads for a real segment.
+std::optional<Surface> loadTifxyz(const std::string& path) {
+    auto surf = load_quad_from_tifxyz(path, 0);
+    if (!surf) return std::nullopt;
+    Surface s;
+    s.label = "tifxyz:" + fs::path(path).filename().string();
+    s.grid = surf->rawPoints().clone();
+    s.scale = surf->scale();
+    return s;
+}
+
+struct CoordCase { int id; cv::Vec2f p; };
+struct PtCase    { int id; cv::Vec3f target; cv::Vec2f initLoc; };
+struct RtCase    { int id; cv::Vec2f trueLoc; };
+
+std::vector<CoordCase> genAtIntCases(int w, int h, int n, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> ux(1.0f, float(w - 2));
+    std::uniform_real_distribution<float> uy(1.0f, float(h - 2));
+    std::vector<CoordCase> out; out.reserve(n);
+    for (int i = 0; i < n; ++i) out.push_back({i, cv::Vec2f(ux(rng), uy(rng))});
+    return out;
+}
+
+// pointTo cases: pick a random (u,v), sample the surface to get a real
+// 3D point, then perturb it slightly. The init_loc is a different random
+// (u,v) that isn't necessarily near the truth. This stresses the
+// search's ability to converge from a distant seed.
+std::vector<PtCase> genPtCases(const cv::Mat_<cv::Vec3f>& grid, int n, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> ux(5.0f, float(grid.cols) - 5.0f);
+    std::uniform_real_distribution<float> uy(5.0f, float(grid.rows) - 5.0f);
+    std::uniform_real_distribution<float> off(-1.5f, 1.5f);
+    std::vector<PtCase> out; out.reserve(n);
+    for (int i = 0; i < n; ++i) {
+        const cv::Vec2f truePt(ux(rng), uy(rng));
+        const cv::Vec3f tgt = at_int(grid, truePt)
+            + cv::Vec3f(off(rng), off(rng), off(rng));
+        const cv::Vec2f init(ux(rng), uy(rng));
+        out.push_back({i, tgt, init});
+    }
+    return out;
+}
+
+// Round-trip cases: sample a random (u,v), record the 3D point, then
+// we'll pointTo back to it with a seed nearby. Expect convergence to
+// within a small tolerance of truePt.
+std::vector<RtCase> genRtCases(const cv::Mat_<cv::Vec3f>& grid, int n, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> ux(10.0f, float(grid.cols) - 10.0f);
+    std::uniform_real_distribution<float> uy(10.0f, float(grid.rows) - 10.0f);
+    std::vector<RtCase> out; out.reserve(n);
+    for (int i = 0; i < n; ++i) {
+        out.push_back({i, cv::Vec2f(ux(rng), uy(rng))});
+    }
+    return out;
+}
+
+double now_sec(Clock::time_point t0) {
+    return std::chrono::duration<double>(Clock::now() - t0).count();
+}
+
+void runSurface(const Surface& s, int atN, int ptN, int rtN,
+                bool noTiming)
+{
+    const std::string tagBase = s.label;
+    const auto& grid = s.grid;
+    printf("# surface: %s shape=%dx%d scale=%.4f,%.4f\n",
+           s.label.c_str(), grid.cols, grid.rows, s.scale[0], s.scale[1]);
+
+    // AT cases
+    {
+        auto cases = genAtIntCases(grid.cols, grid.rows, atN, 0xA7F13Du);
+        std::vector<cv::Vec3f> results(cases.size());
+        auto t0 = Clock::now();
+        cv::Vec3f sink{0,0,0};
+        for (size_t i = 0; i < cases.size(); ++i) {
+            results[i] = at_int(grid, cases[i].p);
+            sink += results[i];
+        }
+        double sec = now_sec(t0);
+        for (size_t i = 0; i < cases.size(); ++i) {
+            const auto& r = results[i];
+            printf("AT %s/%d %.9f %.9f %.9f\n", tagBase.c_str(), cases[i].id,
+                   r[0], r[1], r[2]);
+        }
+        if (!noTiming)
+            fprintf(stderr, "[%s] at_int %d in %.4fs (%.2f ns/call)\n",
+                    tagBase.c_str(), atN, sec, sec * 1e9 / std::max(1, atN));
+        volatile float used = sink[0] + sink[1] + sink[2]; (void)used;
+    }
+
+    // PT cases
+    {
+        auto cases = genPtCases(grid, ptN, 0xD42EA9u);
+        struct PtResult { cv::Vec2f loc; cv::Vec3f p; float d; };
+        std::vector<PtResult> results(cases.size());
+        auto t0 = Clock::now();
+        for (size_t i = 0; i < cases.size(); ++i) {
+            cv::Vec2f loc = cases[i].initLoc;
+            float d = pointTo(loc, grid, cases[i].target, 0.5f, 100, 1.0f);
+            cv::Vec3f p = (loc[0] > 0) ? at_int(grid, loc) : cv::Vec3f{-1,-1,-1};
+            results[i] = {loc, p, d};
+        }
+        double sec = now_sec(t0);
+        for (size_t i = 0; i < cases.size(); ++i) {
+            const auto& r = results[i];
+            printf("PT %s/%d %.9f %.9f %.9f %.9f %.9f %.9f\n",
+                   tagBase.c_str(), cases[i].id,
+                   r.loc[0], r.loc[1], r.p[0], r.p[1], r.p[2], r.d);
+        }
+        if (!noTiming)
+            fprintf(stderr, "[%s] pointTo %d in %.4fs (%.3f us/call)\n",
+                    tagBase.c_str(), ptN, sec, sec * 1e6 / std::max(1, ptN));
+    }
+
+    // Round-trip cases: gen a random truePt, compute P, pointTo(P) with
+    // a seed adjacent to truePt. Record the found loc + 3D distance to
+    // target. Numerically sensitive fields prefix the tolerant metric
+    // (pErr) so the compare script can relax per-kind tolerance.
+    {
+        auto cases = genRtCases(grid, rtN, 0xF00B4Eu);
+        struct RtResult { cv::Vec2f truLoc, foundLoc; cv::Vec3f target, foundP; float locDrift, pErr; };
+        std::vector<RtResult> results(cases.size());
+        auto t0 = Clock::now();
+        for (size_t i = 0; i < cases.size(); ++i) {
+            const cv::Vec2f truLoc = cases[i].trueLoc;
+            const cv::Vec3f target = at_int(grid, truLoc);
+            // Seed a bit off the truth so the search has to converge.
+            cv::Vec2f seedLoc = truLoc + cv::Vec2f(2.5f, -1.7f);
+            if (seedLoc[0] < 2) seedLoc[0] = 2;
+            if (seedLoc[1] < 2) seedLoc[1] = 2;
+            if (seedLoc[0] > float(grid.cols - 3)) seedLoc[0] = float(grid.cols - 3);
+            if (seedLoc[1] > float(grid.rows - 3)) seedLoc[1] = float(grid.rows - 3);
+            cv::Vec2f loc = seedLoc;
+            pointTo(loc, grid, target, 0.1f, 200, 1.0f);
+            cv::Vec3f foundP = (loc[0] > 0) ? at_int(grid, loc) : cv::Vec3f{-1,-1,-1};
+            cv::Vec2f delta = loc - truLoc;
+            float locDrift = std::sqrt(delta[0]*delta[0] + delta[1]*delta[1]);
+            cv::Vec3f err = foundP - target;
+            float pErr = std::sqrt(err[0]*err[0] + err[1]*err[1] + err[2]*err[2]);
+            results[i] = {truLoc, loc, target, foundP, locDrift, pErr};
+        }
+        double sec = now_sec(t0);
+        // Output: true_u true_v found_u found_v locDrift pErr. The
+        // critical quality metric is pErr — how close the found point
+        // is to the target. locDrift can legitimately differ between
+        // algorithms if they find different valid loc answers.
+        for (size_t i = 0; i < cases.size(); ++i) {
+            const auto& r = results[i];
+            printf("RT %s/%d %.4f %.4f %.4f %.4f %.6f %.6f\n",
+                   tagBase.c_str(), cases[i].id,
+                   r.truLoc[0], r.truLoc[1], r.foundLoc[0], r.foundLoc[1],
+                   r.locDrift, r.pErr);
+        }
+        if (!noTiming) {
+            // Also summarise convergence quality — we care about this
+            // even when baseline and candidate diverge in locDrift:
+            // the algorithmic question is "does it converge close
+            // enough to the target in 3D space?"
+            std::vector<float> errs; errs.reserve(results.size());
+            for (auto& r : results) errs.push_back(r.pErr);
+            std::sort(errs.begin(), errs.end());
+            const float med = errs[errs.size()/2];
+            const float p95 = errs[std::min<size_t>(errs.size()-1, size_t(errs.size()*0.95))];
+            fprintf(stderr,
+                "[%s] round-trip %d in %.4fs (%.3f us/call)  "
+                "pErr med=%.4f p95=%.4f\n",
+                tagBase.c_str(), rtN, sec, sec * 1e6 / std::max(1, rtN),
+                med, p95);
+        }
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    int gridSize = 256;
+    int atN = 500;
+    int ptN = 100;
+    int rtN = 100;
+    bool noTiming = false;
+    std::vector<std::string> tifxyzPaths;
+    for (int i = 1; i < argc; ++i) {
+        std::string_view a = argv[i];
+        auto need = [&](const char* w) { if (i+1>=argc){fprintf(stderr,"%s needs value\n",w);std::exit(1);} return argv[++i]; };
+        if      (a == "--grid")        gridSize = std::atoi(need("--grid"));
+        else if (a == "--at-int")      atN      = std::atoi(need("--at-int"));
+        else if (a == "--point-to")    ptN      = std::atoi(need("--point-to"));
+        else if (a == "--round-trip")  rtN      = std::atoi(need("--round-trip"));
+        else if (a == "--no-timing")   noTiming = true;
+        else if (a == "--tifxyz")      tifxyzPaths.emplace_back(need("--tifxyz"));
+        else { fprintf(stderr, "Unknown: %s\n", argv[i]); return 1; }
+    }
+
+    printf("# vc_coord_regression grid=%d at-int=%d point-to=%d round-trip=%d\n",
+           gridSize, atN, ptN, rtN);
+
+    runSurface(makeSmoothGrid(gridSize, gridSize), atN, ptN, rtN, noTiming);
+    runSurface(makeCurledGrid(gridSize, gridSize), atN, ptN, rtN, noTiming);
+    for (const auto& p : tifxyzPaths) {
+        auto s = loadTifxyz(p);
+        if (!s) {
+            fprintf(stderr, "# failed to load tifxyz: %s\n", p.c_str());
+            continue;
+        }
+        runSurface(*s, atN, ptN, rtN, noTiming);
+    }
+    return 0;
+}

--- a/volume-cartographer/apps/src/vc_io_bench.cpp
+++ b/volume-cartographer/apps/src/vc_io_bench.cpp
@@ -1,0 +1,311 @@
+// vc_io_bench: Benchmark the chunk I/O + decode pipeline.
+//
+// Measures end-to-end "submit N chunk keys → all arrive in BlockCache"
+// throughput across the downloader → encoder → loader → decoder chain that
+// BlockPipeline runs on every cold viewport. The bench deliberately
+// enumerates a contiguous 3D region of chunks (not a single tile's worth)
+// to stress parallel fetch and shard-cache hit rates the way an active
+// streaming session does.
+//
+// What the phases mean
+//   • "Cold pipeline": start from a fully cleared pipeline (blocks + shard
+//                      cache + negative cache all wiped). Measures the
+//                      worst case: every shard must be fetched, every chunk
+//                      decoded, every block inserted. This is what the user
+//                      sees the first time they open a new volume.
+//   • "Warm shards" :  start with shard cache populated but block cache
+//                      empty. Measures decode + insert without network
+//                      transfer — how fast the CPU side of the pipeline is.
+//   • "Fully warm"  :  start with block cache populated. Measures the
+//                      no-op/dedup path — most calls should short-circuit
+//                      via fetchInteractive's hash dedup and the block
+//                      cache's containsBatch.
+//
+// Usage:
+//   vc_io_bench <volume_path_or_url> [options]
+//
+// Options:
+//   --region-size N     Side length of chunk region (default: 8 → 512 chunks)
+//   --level N           Pyramid level to fetch (default: 0)
+//   --io-threads N      IO threads for downloader pool (default: 16)
+//   --hot-gb N          Block cache budget in GB (default: 8)
+//   --timeout N         Seconds to wait for a phase to drain (default: 300)
+//   --poll-hz N         Stats polling rate in Hz (default: 10)
+//   --center Z,Y,X      Centre the fetch region at level-0 voxel (Z,Y,X)
+//                       instead of the volume centre. Use this to point the
+//                       bench at a known-populated region — sparse volumes
+//                       can have all-zero sentinel chunks at the centre
+//                       that negative-cache and bypass real I/O.
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "vc/core/cache/BlockPipeline.hpp"
+#include "vc/core/cache/ChunkKey.hpp"
+#include "vc/core/types/Volume.hpp"
+
+using Clock = std::chrono::steady_clock;
+namespace {
+
+bool isRemoteUrl(const std::string& p) {
+    return p.starts_with("s3://") || p.starts_with("s3+") ||
+           p.starts_with("http://") || p.starts_with("https://");
+}
+
+double elapsedSec(Clock::time_point t0, Clock::time_point t1) {
+    return std::chrono::duration<double>(t1 - t0).count();
+}
+
+// Snapshot of cache stats + wall time so phase deltas are trivially
+// computable by subtracting two snapshots.
+struct StatSnapshot {
+    Clock::time_point when;
+    vc::cache::BlockPipeline::Stats stats;
+};
+
+StatSnapshot snap(vc::cache::BlockPipeline* cache) {
+    StatSnapshot s;
+    s.when = Clock::now();
+    if (cache) s.stats = cache->stats();
+    return s;
+}
+
+// Enumerate a contiguous 3D lattice of chunk keys around centerVoxel (in
+// level-0 voxel coords, -1 to use volume centre). Using a lattice (not
+// random) keeps runs deterministic and exercises shard-cache locality.
+std::vector<vc::cache::ChunkKey> enumerateRegion(
+    Volume& vol, vc::cache::BlockPipeline& cache, int level, int regionSize,
+    std::array<int, 3> centerVoxel)
+{
+    auto shape = vol.shape();
+    const int sz = std::max(1, shape[0] >> level);
+    const int sy = std::max(1, shape[1] >> level);
+    const int sx = std::max(1, shape[2] >> level);
+    auto cs = cache.chunkShape(level);
+    if (cs[0] <= 0 || cs[1] <= 0 || cs[2] <= 0) return {};
+    const int chunksZ = (sz + cs[0] - 1) / cs[0];
+    const int chunksY = (sy + cs[1] - 1) / cs[1];
+    const int chunksX = (sx + cs[2] - 1) / cs[2];
+
+    // Centre chunk: either explicit (scale level-0 voxel coord down) or
+    // geometric volume centre.
+    const int chunkCenterZ = (centerVoxel[0] >= 0)
+        ? std::clamp((centerVoxel[0] >> level) / cs[0], 0, chunksZ - 1)
+        : chunksZ / 2;
+    const int chunkCenterY = (centerVoxel[1] >= 0)
+        ? std::clamp((centerVoxel[1] >> level) / cs[1], 0, chunksY - 1)
+        : chunksY / 2;
+    const int chunkCenterX = (centerVoxel[2] >= 0)
+        ? std::clamp((centerVoxel[2] >> level) / cs[2], 0, chunksX - 1)
+        : chunksX / 2;
+
+    const int half = regionSize / 2;
+    const int cz0 = std::max(0, chunkCenterZ - half);
+    const int cy0 = std::max(0, chunkCenterY - half);
+    const int cx0 = std::max(0, chunkCenterX - half);
+    const int cz1 = std::min(chunksZ, cz0 + regionSize);
+    const int cy1 = std::min(chunksY, cy0 + regionSize);
+    const int cx1 = std::min(chunksX, cx0 + regionSize);
+
+    std::vector<vc::cache::ChunkKey> out;
+    out.reserve(size_t(cz1 - cz0) * (cy1 - cy0) * (cx1 - cx0));
+    for (int iz = cz0; iz < cz1; ++iz)
+      for (int iy = cy0; iy < cy1; ++iy)
+        for (int ix = cx0; ix < cx1; ++ix)
+            out.push_back({level, iz, iy, ix});
+    return out;
+}
+
+// Wait for the pipeline's ioPending to hit zero (or timeout). Polls at
+// pollHz. Returns elapsed seconds — always returns, even on timeout, so
+// the caller can decide what to do.
+double waitDrain(vc::cache::BlockPipeline* cache, double timeoutSec, int pollHz,
+                 Clock::time_point phaseStart)
+{
+    if (!cache) return 0.0;
+    const auto deadline = phaseStart + std::chrono::duration<double>(timeoutSec);
+    const auto pollDt = std::chrono::milliseconds(1000 / std::max(1, pollHz));
+    while (Clock::now() < deadline) {
+        if (cache->stats().ioPending == 0) break;
+        std::this_thread::sleep_for(pollDt);
+    }
+    return elapsedSec(phaseStart, Clock::now());
+}
+
+struct PhaseResult {
+    std::string name;
+    int chunks;
+    double seconds;
+    StatSnapshot before;
+    StatSnapshot after;
+};
+
+void printPhase(const PhaseResult& r) {
+    const auto& b = r.before.stats;
+    const auto& a = r.after.stats;
+    const uint64_t dDisk   = a.diskWrites - b.diskWrites;
+    const uint64_t dDiskB  = a.diskBytes - b.diskBytes;
+    const uint64_t dColdH  = a.coldHits - b.coldHits;
+    const uint64_t dIce    = a.iceFetches - b.iceFetches;
+    const uint64_t dShardH = a.shardHits - b.shardHits;
+    const uint64_t dShardM = a.shardMisses - b.shardMisses;
+    const uint64_t dMiss   = a.misses - b.misses;
+    const double   chunksPerSec = r.chunks / std::max(r.seconds, 1e-9);
+    const double   mbPerSec     = (dDiskB / (1024.0 * 1024.0)) / std::max(r.seconds, 1e-9);
+
+    printf("  %-20s %6d chunks  %7.2fs  %7.1f chunks/s  %8.1f MB/s written\n",
+           r.name.c_str(), r.chunks, r.seconds, chunksPerSec, mbPerSec);
+    printf("      diskWrites +%6llu   coldHits +%6llu   iceFetches +%6llu   misses +%6llu\n",
+           (unsigned long long)dDisk, (unsigned long long)dColdH,
+           (unsigned long long)dIce,  (unsigned long long)dMiss);
+    printf("      shardHits  +%6llu   shardMiss +%5llu   shardHitRate %5.1f%%\n",
+           (unsigned long long)dShardH, (unsigned long long)dShardM,
+           (dShardH + dShardM) ? 100.0 * dShardH / (dShardH + dShardM) : 0.0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    if (argc < 2) {
+        fprintf(stderr,
+            "Usage: vc_io_bench <volume_path_or_url> [--region-size N] "
+            "[--level N] [--io-threads N] [--hot-gb N] [--timeout N] "
+            "[--poll-hz N]\n");
+        return 1;
+    }
+
+    std::string volumePath = argv[1];
+    int regionSize = 8;
+    int level = 0;
+    int ioThreads = 16;
+    int hotGb = 8;
+    double timeoutSec = 300.0;
+    int pollHz = 10;
+    std::array<int, 3> centerVoxel = {-1, -1, -1};  // -1 = use geometric centre
+
+    for (int i = 2; i < argc; ++i) {
+        std::string_view a = argv[i];
+        auto need = [&](const char* what) -> const char* {
+            if (i + 1 >= argc) { fprintf(stderr, "%s requires a value\n", what); std::exit(1); }
+            return argv[++i];
+        };
+        if      (a == "--region-size") regionSize = std::atoi(need("--region-size"));
+        else if (a == "--level")       level      = std::atoi(need("--level"));
+        else if (a == "--io-threads")  ioThreads  = std::atoi(need("--io-threads"));
+        else if (a == "--hot-gb")      hotGb      = std::atoi(need("--hot-gb"));
+        else if (a == "--timeout")     timeoutSec = std::atof(need("--timeout"));
+        else if (a == "--poll-hz")     pollHz     = std::atoi(need("--poll-hz"));
+        else if (a == "--center") {
+            const char* v = need("--center");
+            int z=-1, y=-1, x=-1;
+            if (std::sscanf(v, "%d,%d,%d", &z, &y, &x) != 3) {
+                fprintf(stderr, "--center expects Z,Y,X (got '%s')\n", v);
+                return 1;
+            }
+            centerVoxel = {z, y, x};
+        }
+        else { fprintf(stderr, "Unknown option: %s\n", argv[i]); return 1; }
+    }
+
+    printf("vc_io_bench\n");
+    printf("  Volume:       %s\n", volumePath.c_str());
+    printf("  Region:       %d^3 chunks (= %d chunks)\n",
+           regionSize, regionSize * regionSize * regionSize);
+    printf("  Level:        %d\n", level);
+    printf("  IO threads:   %d\n", ioThreads);
+    printf("  Hot cache:    %d GB\n", hotGb);
+    printf("  Timeout:      %.1f s/phase\n", timeoutSec);
+    printf("\n");
+
+    // Open volume
+    printf("Opening volume...\n");
+    const auto tOpen = Clock::now();
+    std::shared_ptr<Volume> vol;
+    if (isRemoteUrl(volumePath)) vol = Volume::NewFromUrl(volumePath);
+    else                          vol = Volume::New(volumePath);
+    vol->setCacheBudget(static_cast<size_t>(hotGb) << 30);
+    vol->setIOThreads(ioThreads);
+    const int numLevels = static_cast<int>(vol->numScales());
+    printf("  Shape: %d x %d x %d  (%d pyramid levels)\n",
+           vol->shape()[0], vol->shape()[1], vol->shape()[2], numLevels);
+    printf("  Open time: %.2f s\n\n", elapsedSec(tOpen, Clock::now()));
+
+    auto* cache = vol->tieredCache();
+    if (!cache) { fprintf(stderr, "No tieredCache on volume\n"); return 1; }
+
+    if (centerVoxel[0] >= 0) {
+        printf("  Center:       %d, %d, %d (level-0 voxel)\n",
+               centerVoxel[0], centerVoxel[1], centerVoxel[2]);
+    }
+    auto keys = enumerateRegion(*vol, *cache, level, regionSize, centerVoxel);
+    if (keys.empty()) {
+        fprintf(stderr, "Failed to enumerate chunks (bad level? empty volume?)\n");
+        return 1;
+    }
+    printf("Chunks enumerated: %zu\n\n", keys.size());
+
+    std::vector<PhaseResult> results;
+
+    // ==== Phase 1: Cold pipeline (clean slate) ====
+    cache->clearAll();
+    {
+        PhaseResult r; r.name = "Cold pipeline";
+        r.chunks = static_cast<int>(keys.size());
+        r.before = snap(cache);
+        const auto t0 = Clock::now();
+        cache->fetchInteractive(keys, level);
+        r.seconds = waitDrain(cache, timeoutSec, pollHz, t0);
+        r.after = snap(cache);
+        if (cache->stats().ioPending != 0)
+            printf("  (cold phase: timed out with %zu chunks still pending)\n",
+                   cache->stats().ioPending);
+        results.push_back(std::move(r));
+    }
+
+    // ==== Phase 2: Warm shards (clear block cache, keep shard cache) ====
+    cache->clearMemory();  // keeps diskLevels + on-disk shards + shard RAM cache
+    {
+        PhaseResult r; r.name = "Warm shards";
+        r.chunks = static_cast<int>(keys.size());
+        r.before = snap(cache);
+        const auto t0 = Clock::now();
+        cache->fetchInteractive(keys, level);
+        r.seconds = waitDrain(cache, timeoutSec, pollHz, t0);
+        r.after = snap(cache);
+        results.push_back(std::move(r));
+    }
+
+    // ==== Phase 3: Fully warm (everything resident) ====
+    // Don't clear anything. fetchInteractive should hit the dedup fast-path
+    // on the second call, and the containsBatch inside should filter out
+    // every already-resident chunk.
+    {
+        PhaseResult r; r.name = "Fully warm (dedup)";
+        r.chunks = static_cast<int>(keys.size());
+        r.before = snap(cache);
+        const auto t0 = Clock::now();
+        cache->fetchInteractive(keys, level);
+        // No drain — dedup should make this immediate.
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        r.seconds = elapsedSec(t0, Clock::now());
+        r.after = snap(cache);
+        results.push_back(std::move(r));
+    }
+
+    // ==== Report ====
+    printf("Results:\n");
+    for (const auto& r : results) printPhase(r);
+    printf("\nDone.\n");
+    return 0;
+}

--- a/volume-cartographer/apps/src/vc_render_bench.cpp
+++ b/volume-cartographer/apps/src/vc_render_bench.cpp
@@ -1,21 +1,37 @@
-// vc_render_bench: Benchmark the volume rendering pipeline.
+// vc_render_bench: Benchmark the live VC3D plane-render path.
 //
-// Exercises the same sampling paths used by TileRenderer (fused plane,
-// coordinate-based, best-effort pyramid fallback) without Qt.
+// Exercises the fused ARGB32 sampler that VC3D's viewer actually uses
+// (samplePlaneCompositeBestEffortARGB32 → dispatchCompositeAdaptive →
+//  sampleSingleLayerAdaptiveImpl for nL=1), so before/after timings on this
+// bench match the hotspots the interactive profiler sees.
 //
 // Usage:
 //   vc_render_bench <volume_path_or_url> [options]
 //
-// Input can be:
-//   /path/to/volume                (local filesystem)
-//   s3://bucket/path/volume.zarr   (S3, uses AWS env credentials)
-//   s3+us-east-1://bucket/...      (S3 with explicit region)
-//   https://...                    (HTTP remote zarr)
-//
 // Options:
-//   --tile-size N    Tile size in pixels (default: 256)
-//   --io-threads N   I/O threads for chunk fetching (default: 8)
-//   --hot-gb N       Hot cache budget in GB (default: 8)
+//   --tile-size N       Tile size in pixels (default: 256)
+//   --io-threads N      I/O threads for chunk fetching (default: 8)
+//   --hot-gb N          Hot cache budget in GB (default: 8)
+//   --iters N           Iterations per test (default: 100)
+//   --warm-timeout N    Seconds to wait for cache warm-up (default: 60)
+//   --composite N       Number of composite layers (default: 1 = single slice)
+//
+// Determinism
+//   • Tile positions are computed from a fixed lattice (no RNG).
+//   • Every test phase starts from a drained IOPool (all prior-frame fetches
+//     resolved) so a given tile's timing reflects only steady-state work.
+//   • The hot-render phase pre-fetches the full tile set and waits for
+//     pipeline drain before timing — what it measures is pure sampler cost.
+//
+// What the phases mean
+//   • "Cold stream"  : every tile is fresh to the cache; times include
+//                      fetch+decode+render. Panning-from-zero behaviour.
+//   • "Hot render"   : all tiles fully cached; times are sampler cost only.
+//                      Steady-state in-viewport frame cost.
+//   • "Pan stream"   : tiles stream in as you slide; tile N's fetches start
+//                      while tile N-1 renders. Realistic panning.
+//   • "Z-scroll"     : same (x,y) at N successive z offsets; exercises
+//                      z-axis chunk boundaries and nearby-block hit rate.
 
 #include <algorithm>
 #include <chrono>
@@ -25,6 +41,7 @@
 #include <cstring>
 #include <numeric>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <opencv2/core.hpp>
@@ -34,120 +51,160 @@
 #include "vc/core/types/SampleParams.hpp"
 #include "vc/core/cache/BlockPipeline.hpp"
 #include "vc/core/util/PlaneSurface.hpp"
+#include "vc/core/util/Slicing.hpp"
 
-using Clock = std::chrono::high_resolution_clock;
+using Clock = std::chrono::steady_clock;
 
-// Render one tile using the fused plane path (same as TileRenderer for PlaneSurface).
-// Returns the elapsed time in seconds.
-static double renderPlaneTile(
+namespace {
+
+// Fused ARGB32 plane render — same path CAdaptiveVolumeViewer hits on
+// every paint. Route through samplePlaneCompositeBestEffortARGB32 with
+// numLayers=1 so we reach dispatchCompositeAdaptive → the Nearest-mode
+// sampleSingleLayerAdaptiveImpl specialization that VC3D uses.
+// Returns elapsed seconds.
+double renderTileARGB32(
     Volume* vol,
+    uint32_t* outBuf,
     const cv::Vec3f& origin,
     const cv::Vec3f& vxStep,
     const cv::Vec3f& vyStep,
     int tileW, int tileH,
-    int level)
+    int level,
+    const uint32_t lut[256])
 {
-    cv::Mat_<uint8_t> gray;
-    vc::SampleParams sp;
-    sp.level = level;
-    sp.method = (level >= 3) ? vc::Sampling::Nearest : vc::Sampling::Trilinear;
-
-    auto t0 = Clock::now();
-    vol->samplePlaneBestEffort(gray, origin, vxStep, vyStep, tileW, tileH, sp);
-    auto t1 = Clock::now();
-
+    (void)level;  // level selection is handled by the adaptive dispatcher
+    const cv::Vec3f normal(0, 0, 1);  // single-layer: normal direction irrelevant
+    const auto t0 = Clock::now();
+    vol->samplePlaneCompositeBestEffortARGB32(
+        outBuf, tileW, origin, vxStep, vyStep, normal,
+        /*zStep=*/1.0f, /*zStart=*/0, /*numLayers=*/1,
+        tileW, tileH, "mean", lut);
+    const auto t1 = Clock::now();
     return std::chrono::duration<double>(t1 - t0).count();
 }
 
-// Render one tile using the coordinate-based path (for QuadSurface compatibility).
-static double renderCoordTile(
+// Fused ARGB32 composite render (numLayers>1) — routes through
+// sampleAdaptiveARGB32 so we hit the same code VC3D runs (vs. the legacy
+// samplePlaneCompositeARGB32 path). Matches CAdaptiveVolumeViewer.cpp:520.
+double renderTileCompositeARGB32(
     Volume* vol,
-    PlaneSurface& plane,
-    float surfX, float surfY, float zOff,
-    float scale,
+    uint32_t* outBuf,
+    const cv::Vec3f& origin,
+    const cv::Vec3f& vxStep,
+    const cv::Vec3f& vyStep,
+    const cv::Vec3f& normal,
+    int numLayers, int zStart, float zStep,
     int tileW, int tileH,
-    int level)
+    const uint32_t lut[256])
 {
-    cv::Mat_<cv::Vec3f> coords;
-    plane.gen(&coords, nullptr, cv::Size(tileW, tileH),
-              cv::Vec3f(0, 0, 0), scale,
-              {surfX * scale, surfY * scale, zOff});
-
-    cv::Mat_<uint8_t> gray;
-    vc::SampleParams sp;
-    sp.level = level;
-    sp.method = (level >= 3) ? vc::Sampling::Nearest : vc::Sampling::Trilinear;
-
-    auto t0 = Clock::now();
-    vol->sampleBestEffort(gray, coords, sp);
-    auto t1 = Clock::now();
-
+    const auto t0 = Clock::now();
+    // Mirror VC3D's path: Nearest for composite (averaging is the low-pass).
+    sampleAdaptiveARGB32(
+        outBuf, tileW, vol->tieredCache(),
+        /*desiredLevel=*/0, /*numLevels=*/int(vol->numScales()),
+        /*coords=*/nullptr, &origin, &vxStep, &vyStep,
+        /*normals=*/nullptr, &normal,
+        numLayers, zStart, zStep,
+        tileW, tileH, "mean", lut,
+        vc::Sampling::Nearest,
+        /*lightParams=*/nullptr,
+        /*levelOut=*/nullptr, /*levelStride=*/0);
+    const auto t1 = Clock::now();
     return std::chrono::duration<double>(t1 - t0).count();
 }
 
 struct BenchResult {
     std::string name;
-    int tileCount;
-    std::vector<double> times;  // per-tile seconds
+    std::vector<double> times;  // per-iteration seconds
 
+    int iterations() const { return static_cast<int>(times.size()); }
     double totalSec() const {
         return std::accumulate(times.begin(), times.end(), 0.0);
     }
-    double tilesPerSec() const {
-        return tileCount / totalSec();
+    double mean() const {
+        return iterations() ? totalSec() / iterations() : 0.0;
     }
-    double avgMs() const {
-        return totalSec() / tileCount * 1000.0;
-    }
-    double p99Ms() const {
+    double pct(double p) const {
+        if (times.empty()) return 0.0;
         auto sorted = times;
         std::sort(sorted.begin(), sorted.end());
-        int idx = std::max(0, (int)(sorted.size() * 0.99) - 1);
-        return sorted[idx] * 1000.0;
+        size_t idx = std::min(sorted.size() - 1,
+                              static_cast<size_t>(p * sorted.size()));
+        return sorted[idx];
+    }
+    double stdev() const {
+        if (iterations() < 2) return 0.0;
+        double m = mean();
+        double s = 0.0;
+        for (double t : times) s += (t - m) * (t - m);
+        return std::sqrt(s / (iterations() - 1));
     }
 };
 
-static void printResult(const BenchResult& r, int tileW, int tileH) {
-    double voxelsPerTile = (double)tileW * tileH;
-    double totalVoxels = voxelsPerTile * r.tileCount;
-    double totalSec = r.totalSec();
-    double voxelsPerSec = totalVoxels / totalSec;
-    double mbPerSec = voxelsPerSec / (1024.0 * 1024.0);  // 1 byte/voxel (uint8)
-
-    printf("  %-30s %6d tiles  %8.1f tiles/s  %6.2f ms/tile avg  %6.2f ms/tile p99  %8.1f Mvox/s  %7.1f MB/s\n",
-           r.name.c_str(), r.tileCount,
-           r.tilesPerSec(), r.avgMs(), r.p99Ms(),
-           voxelsPerSec / 1e6, mbPerSec);
+void printResult(const BenchResult& r) {
+    printf("  %-22s %4d iters  avg %6.2f ms  p50 %6.2f  p99 %6.2f  stdev %6.2f  throughput %7.1f fps\n",
+           r.name.c_str(), r.iterations(),
+           r.mean() * 1000.0,
+           r.pct(0.50) * 1000.0,
+           r.pct(0.99) * 1000.0,
+           r.stdev() * 1000.0,
+           1.0 / std::max(r.mean(), 1e-9));
 }
 
-static void printCacheStats(vc::cache::BlockPipeline* cache) {
-    auto s = cache->stats();
-    uint64_t total = s.blockHits + s.coldHits + s.iceFetches + s.misses;
-    if (total == 0) total = 1;
-
-    auto pct = [&](uint64_t n) { return 100.0 * n / total; };
-
-    printf("\n  Cache stats:\n");
-    printf("    Block hits: %8llu  (%5.1f%%)\n", (unsigned long long)s.blockHits, pct(s.blockHits));
-    printf("    Cold hits:  %8llu  (%5.1f%%)\n", (unsigned long long)s.coldHits, pct(s.coldHits));
-    printf("    Ice fetch:  %8llu  (%5.1f%%)\n", (unsigned long long)s.iceFetches, pct(s.iceFetches));
-    printf("    Misses:     %8llu  (%5.1f%%)\n", (unsigned long long)s.misses,  pct(s.misses));
-    printf("    Disk bytes: %8.1f MB\n", s.diskBytes / (1024.0 * 1024.0));
-    printf("    IO pending: %8zu\n", s.ioPending);
-    printf("    Disk writes:%8llu\n", (unsigned long long)s.diskWrites);
+// Block until the pipeline has no pending I/O or a timeout elapses. Returns
+// true if drained cleanly. Used to ensure bench phases start from a
+// reproducible cache state.
+bool waitForDrain(vc::cache::BlockPipeline* cache, double timeoutSec) {
+    if (!cache) return true;
+    const auto deadline = Clock::now() + std::chrono::duration<double>(timeoutSec);
+    while (Clock::now() < deadline) {
+        if (cache->stats().ioPending == 0) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return cache->stats().ioPending == 0;
 }
 
-static bool isRemoteUrl(const std::string& path) {
+// Identity gray LUT so the LUT step is a straight passthrough and doesn't
+// inject colourmap cost into the sampler timing.
+void buildIdentityLut(uint32_t lut[256]) {
+    for (int i = 0; i < 256; ++i) {
+        const uint32_t v = static_cast<uint32_t>(i);
+        lut[i] = 0xFF000000u | (v << 16) | (v << 8) | v;
+    }
+}
+
+bool isRemoteUrl(const std::string& path) {
     return path.starts_with("s3://") ||
            path.starts_with("s3+") ||
            path.starts_with("http://") ||
            path.starts_with("https://");
 }
 
+// Deterministic lattice of tile origins around (cx, cy, cz). Returns
+// iterations positions as (panX, panY, zOff) in plane-local coords.
+struct TileSpec { float panX, panY, zOff; };
+std::vector<TileSpec> latticeTiles(int iterations, int tileW, int tileH) {
+    std::vector<TileSpec> out;
+    out.reserve(iterations);
+    // Fixed 10x10 grid around centre, walked in scan order. Falls back to
+    // wrapping for iterations>100 so the test length is tunable.
+    for (int i = 0; i < iterations; ++i) {
+        const int row = (i / 10) % 10 - 5;
+        const int col = (i % 10) - 5;
+        out.push_back({ float(col) * tileW, float(row) * tileH, 0.0f });
+    }
+    return out;
+}
+
+}  // namespace
+
 int main(int argc, char** argv)
 {
     if (argc < 2) {
-        fprintf(stderr, "Usage: vc_render_bench <volume_path_or_url> [--tile-size N] [--io-threads N] [--hot-gb N]\n");
+        fprintf(stderr,
+            "Usage: vc_render_bench <volume_path_or_url> [--tile-size N] "
+            "[--io-threads N] [--hot-gb N] [--iters N] [--warm-timeout N] "
+            "[--composite N]\n");
         return 1;
     }
 
@@ -155,179 +212,174 @@ int main(int argc, char** argv)
     int tileSize = 256;
     int ioThreads = 8;
     int hotGb = 8;
+    int iters = 100;
+    double warmTimeout = 60.0;
+    int compositeLayers = 1;
+    std::array<float, 3> centerVoxel = {-1.f, -1.f, -1.f};  // -1 = use geometric centre
 
     for (int i = 2; i < argc; i++) {
-        if (strcmp(argv[i], "--tile-size") == 0 && i + 1 < argc)
-            tileSize = atoi(argv[++i]);
-        else if (strcmp(argv[i], "--io-threads") == 0 && i + 1 < argc)
-            ioThreads = atoi(argv[++i]);
-        else if (strcmp(argv[i], "--hot-gb") == 0 && i + 1 < argc)
-            hotGb = atoi(argv[++i]);
-        else {
-            fprintf(stderr, "Unknown option: %s\n", argv[i]);
-            return 1;
+        std::string_view a = argv[i];
+        auto need = [&](const char* what) -> const char* {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "%s requires a value\n", what);
+                std::exit(1);
+            }
+            return argv[++i];
+        };
+        if      (a == "--tile-size")    tileSize = std::atoi(need("--tile-size"));
+        else if (a == "--io-threads")   ioThreads = std::atoi(need("--io-threads"));
+        else if (a == "--hot-gb")       hotGb = std::atoi(need("--hot-gb"));
+        else if (a == "--iters")        iters = std::atoi(need("--iters"));
+        else if (a == "--warm-timeout") warmTimeout = std::atof(need("--warm-timeout"));
+        else if (a == "--composite")    compositeLayers = std::atoi(need("--composite"));
+        else if (a == "--center") {
+            const char* v = need("--center");
+            float z=-1, y=-1, x=-1;
+            if (std::sscanf(v, "%f,%f,%f", &z, &y, &x) != 3) {
+                fprintf(stderr, "--center expects Z,Y,X (got '%s')\n", v);
+                return 1;
+            }
+            centerVoxel = {z, y, x};
         }
+        else { fprintf(stderr, "Unknown option: %s\n", argv[i]); return 1; }
     }
 
     printf("vc_render_bench\n");
-    printf("  Volume:     %s\n", volumePath.c_str());
-    printf("  Tile size:  %d x %d\n", tileSize, tileSize);
-    printf("  IO threads: %d\n", ioThreads);
-    printf("  Hot cache:  %d GB\n", hotGb);
+    printf("  Volume:       %s\n", volumePath.c_str());
+    printf("  Tile size:    %d x %d\n", tileSize, tileSize);
+    printf("  IO threads:   %d\n", ioThreads);
+    printf("  Hot cache:    %d GB\n", hotGb);
+    printf("  Iterations:   %d\n", iters);
+    printf("  Warm timeout: %.1f s\n", warmTimeout);
+    printf("  Composite:    %d layer(s)\n", compositeLayers);
     printf("\n");
 
     // Open volume
     printf("Opening volume...\n");
-    auto t0 = Clock::now();
-
+    const auto t0 = Clock::now();
     std::shared_ptr<Volume> vol;
-    if (isRemoteUrl(volumePath)) {
-        vol = Volume::NewFromUrl(volumePath);
-    } else {
-        vol = Volume::New(volumePath);
-    }
-
-    vol->setCacheBudget((size_t)hotGb << 30);
+    if (isRemoteUrl(volumePath)) vol = Volume::NewFromUrl(volumePath);
+    else                          vol = Volume::New(volumePath);
+    vol->setCacheBudget(static_cast<size_t>(hotGb) << 30);
     vol->setIOThreads(ioThreads);
-
     auto shape = vol->shape();
-    int numLevels = (int)vol->numScales();
-    auto t1 = Clock::now();
+    const int numLevels = static_cast<int>(vol->numScales());
+    const auto t1 = Clock::now();
     printf("  Shape: %d x %d x %d  (%d pyramid levels)\n",
            shape[0], shape[1], shape[2], numLevels);
-    printf("  Open time: %.2f s\n\n", std::chrono::duration<double>(t1 - t0).count());
+    printf("  Open time: %.2f s\n\n",
+           std::chrono::duration<double>(t1 - t0).count());
 
-    // Set up a PlaneSurface centered in the volume
-    float cx = shape[0] / 2.0f;
-    float cy = shape[1] / 2.0f;
-    float cz = shape[2] / 2.0f;
+    auto* cache = vol->tieredCache();
 
+    // Plane oriented along +Z through the chosen centre (defaults to
+    // volume centre). For sparse volumes, pass --center to point at a
+    // region with actual data.
+    const float cx = (centerVoxel[0] >= 0) ? centerVoxel[0] : shape[0] / 2.0f;
+    const float cy = (centerVoxel[1] >= 0) ? centerVoxel[1] : shape[1] / 2.0f;
+    const float cz = (centerVoxel[2] >= 0) ? centerVoxel[2] : shape[2] / 2.0f;
+    printf("  Plane centre: %.1f, %.1f, %.1f\n\n", cx, cy, cz);
     PlaneSurface plane(cv::Vec3f(cx, cy, cz), cv::Vec3f(0, 0, 1));
 
-    // Helper: compute fused plane parameters for a given tile position and zoom
-    auto makePlaneParams = [&](float panX, float panY, float zOff, float scale)
-        -> std::tuple<cv::Vec3f, cv::Vec3f, cv::Vec3f>
-    {
-        float m = 1.0f / scale;
-        cv::Vec3f vx = plane.basisX();
-        cv::Vec3f vy = plane.basisY();
-        cv::Vec3f origin = plane.origin() + plane.normal(cv::Vec3f(0,0,0)) * zOff;
-        cv::Vec3f vxStep = vx * m;
-        cv::Vec3f vyStep = vy * m;
-        cv::Vec3f planeOrigin = vx * panX + vy * panY + origin;
-        return {planeOrigin, vxStep, vyStep};
+    const cv::Vec3f vx = plane.basisX();
+    const cv::Vec3f vy = plane.basisY();
+    const cv::Vec3f origin0 = plane.origin();
+    const cv::Vec3f normal = plane.normal(cv::Vec3f(0, 0, 0));
+
+    auto makeTileOrigin = [&](const TileSpec& t) -> cv::Vec3f {
+        return origin0 + vx * t.panX + vy * t.panY + normal * t.zOff;
     };
 
-    int tileW = tileSize;
-    int tileH = tileSize;
+    const int tileW = tileSize, tileH = tileSize;
+    std::vector<uint32_t> tileBuf(size_t(tileW) * tileH);
+    uint32_t lut[256]; buildIdentityLut(lut);
 
+    const auto tiles = latticeTiles(iters, tileW, tileH);
     std::vector<BenchResult> results;
 
-    // ==== Warmup: 100 tiles at default view ====
-    {
-        printf("Warmup: 100 tiles at center...\n");
-        auto [origin, vxStep, vyStep] = makePlaneParams(0, 0, 0, 1.0f);
-        for (int i = 0; i < 100; i++) {
-            float offX = (float)((i % 10) - 5) * tileW;
-            float offY = (float)((i / 10) - 5) * tileH;
-            cv::Vec3f tileOrigin = origin + vxStep * offX + vyStep * offY;
-            renderPlaneTile(vol.get(), tileOrigin, vxStep, vyStep, tileW, tileH, 0);
+    auto renderOneTile = [&](const TileSpec& t, int level) -> double {
+        cv::Vec3f tileOrigin = makeTileOrigin(t);
+        if (compositeLayers <= 1) {
+            return renderTileARGB32(vol.get(), tileBuf.data(),
+                tileOrigin, vx, vy, tileW, tileH, level, lut);
+        } else {
+            return renderTileCompositeARGB32(vol.get(), tileBuf.data(),
+                tileOrigin, vx, vy, normal,
+                compositeLayers, -compositeLayers / 2, 1.0f,
+                tileW, tileH, lut);
         }
-        printf("  Done.\n\n");
+    };
+
+    // ==== Phase 1: warmup + populate cache ====
+    printf("Warmup: streaming %d tiles into cache...\n", iters);
+    for (const auto& t : tiles) renderOneTile(t, 0);
+    if (!waitForDrain(cache, warmTimeout)) {
+        printf("  WARN: pipeline didn't fully drain in %.1fs "
+               "(pending=%zu); hot-render numbers may include I/O latency.\n",
+               warmTimeout, cache ? cache->stats().ioPending : 0);
+    } else {
+        printf("  Drained in %.2f s.\n",
+               std::chrono::duration<double>(Clock::now() - t1).count());
+    }
+    printf("\n");
+
+    // ==== Phase 2: Hot render — all tiles resident, pure sampler cost ====
+    {
+        BenchResult r; r.name = "Hot render";
+        for (const auto& t : tiles) r.times.push_back(renderOneTile(t, 0));
+        results.push_back(std::move(r));
     }
 
-    // ==== Test 1: 100 tiles at zoom level 0 (full res) ====
-    {
-        BenchResult r;
-        r.name = "Zoom 0 (full res)";
-        r.tileCount = 100;
-        auto [origin, vxStep, vyStep] = makePlaneParams(0, 0, 0, 1.0f);
-        for (int i = 0; i < 100; i++) {
-            float offX = (float)((i % 10) - 5) * tileW;
-            float offY = (float)((i / 10) - 5) * tileH;
-            cv::Vec3f tileOrigin = origin + vxStep * offX + vyStep * offY;
-            r.times.push_back(renderPlaneTile(vol.get(), tileOrigin, vxStep, vyStep, tileW, tileH, 0));
-        }
-        results.push_back(r);
+    // ==== Phase 3: Hot render, coarse level (pyramid) ====
+    if (numLevels >= 3) {
+        const int level = 2;
+        BenchResult r; r.name = "Hot render level 2";
+        for (const auto& t : tiles) r.times.push_back(renderOneTile(t, level));
+        results.push_back(std::move(r));
     }
 
-    // ==== Test 2: 100 tiles at zoom level 2 (4x downsampled) ====
+    // ==== Phase 4: Pan stream — slide +1 tileW per iter, fresh data each ====
+    // Pre-clear so tiles are cold. clearAll wipes caches but keeps disk.
+    if (cache) cache->clearAll();
     {
-        int level = std::min(2, numLevels - 1);
-        BenchResult r;
-        r.name = "Zoom 2 (4x downsample)";
-        r.tileCount = 100;
-        float scale = 1.0f / (1 << level);  // 0.25 at level 2
-        auto [origin, vxStep, vyStep] = makePlaneParams(0, 0, 0, scale);
-        for (int i = 0; i < 100; i++) {
-            float offX = (float)((i % 10) - 5) * tileW;
-            float offY = (float)((i / 10) - 5) * tileH;
-            cv::Vec3f tileOrigin = origin + vxStep * offX + vyStep * offY;
-            r.times.push_back(renderPlaneTile(vol.get(), tileOrigin, vxStep, vyStep, tileW, tileH, level));
+        BenchResult r; r.name = "Pan stream (cold)";
+        for (int i = 0; i < iters; ++i) {
+            TileSpec t{ float(i) * tileW, 0.0f, 0.0f };
+            r.times.push_back(renderOneTile(t, 0));
         }
-        results.push_back(r);
+        results.push_back(std::move(r));
     }
 
-    // ==== Test 3: Pan sequence (50 adjacent tiles) ====
+    // ==== Phase 5: Z-scroll — 20 z steps through centre ====
+    if (cache) cache->clearAll();
     {
-        BenchResult r;
-        r.name = "Pan (50 adjacent)";
-        r.tileCount = 50;
-        auto [origin, vxStep, vyStep] = makePlaneParams(0, 0, 0, 1.0f);
-        for (int i = 0; i < 50; i++) {
-            float offX = (float)i * tileW;
-            cv::Vec3f tileOrigin = origin + vxStep * offX;
-            r.times.push_back(renderPlaneTile(vol.get(), tileOrigin, vxStep, vyStep, tileW, tileH, 0));
+        BenchResult r; r.name = "Z-scroll (cold)";
+        for (int i = 0; i < std::min(iters, 50); ++i) {
+            TileSpec t{ 0.0f, 0.0f, float(i - 25) };
+            r.times.push_back(renderOneTile(t, 0));
         }
-        results.push_back(r);
-    }
-
-    // ==== Test 4: Z-scroll sequence (20 slices at same XY position) ====
-    {
-        BenchResult r;
-        r.name = "Z-scroll (20 slices)";
-        r.tileCount = 20;
-        for (int i = 0; i < 20; i++) {
-            float zOff = (float)(i - 10);
-            auto [origin, vxStep, vyStep] = makePlaneParams(0, 0, zOff, 1.0f);
-            r.times.push_back(renderPlaneTile(vol.get(), origin, vxStep, vyStep, tileW, tileH, 0));
-        }
-        results.push_back(r);
-    }
-
-    // ==== Test 5: Zoom sequence (10 tiles at 10 different zoom levels) ====
-    {
-        BenchResult r;
-        r.name = "Zoom sequence (10 levels)";
-        r.tileCount = 10;
-        for (int i = 0; i < 10; i++) {
-            // Scale from 0.1 to 4.0 in 10 steps
-            float scale = 0.1f + (4.0f - 0.1f) * i / 9.0f;
-            int level = 0;
-            // Pick appropriate pyramid level for this scale
-            float s = scale;
-            while (s < 0.5f && level + 1 < numLevels) {
-                s *= 2.0f;
-                level++;
-            }
-            auto [origin, vxStep, vyStep] = makePlaneParams(0, 0, 0, scale);
-            r.times.push_back(renderPlaneTile(vol.get(), origin, vxStep, vyStep, tileW, tileH, level));
-        }
-        results.push_back(r);
+        results.push_back(std::move(r));
     }
 
     // ==== Report ====
     printf("Results:\n");
-    printf("  %-30s %6s  %13s  %17s  %17s  %12s  %9s\n",
-           "Test", "Tiles", "Tiles/s", "Avg ms/tile", "P99 ms/tile", "Mvox/s", "MB/s");
-    printf("  %s\n", std::string(130, '-').c_str());
-    for (auto& r : results)
-        printResult(r, tileW, tileH);
+    for (const auto& r : results) printResult(r);
 
-    // Cache stats
-    auto* cache = vol->tieredCache();
-    if (cache)
-        printCacheStats(cache);
+    if (cache) {
+        auto s = cache->stats();
+        const uint64_t total = std::max<uint64_t>(1,
+            s.blockHits + s.coldHits + s.iceFetches + s.misses);
+        auto pct = [&](uint64_t n) { return 100.0 * n / total; };
+        printf("\nCache stats:\n");
+        printf("  Block hits:  %8llu  (%5.1f%%)\n", (unsigned long long)s.blockHits, pct(s.blockHits));
+        printf("  Cold hits:   %8llu  (%5.1f%%)\n", (unsigned long long)s.coldHits,  pct(s.coldHits));
+        printf("  Ice fetches: %8llu  (%5.1f%%)\n", (unsigned long long)s.iceFetches, pct(s.iceFetches));
+        printf("  Misses:      %8llu  (%5.1f%%)\n", (unsigned long long)s.misses,    pct(s.misses));
+        printf("  Shard hits:  %8llu    Shard misses: %llu\n",
+               (unsigned long long)s.shardHits, (unsigned long long)s.shardMisses);
+        printf("  Disk writes: %8llu    Disk bytes:   %.1f MB\n",
+               (unsigned long long)s.diskWrites, s.diskBytes / (1024.0 * 1024.0));
+    }
 
     printf("\nDone.\n");
     return 0;

--- a/volume-cartographer/apps/src/vc_tifxyz_bench.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz_bench.cpp
@@ -1,0 +1,122 @@
+// vc_tifxyz_bench: Segment-load throughput.
+//
+// Measures load_quad_from_tifxyz() + SurfacePatchIndex build for a directory
+// of tifxyz segments. The profile shows load_quad and boost::geometry rtree
+// partition functions collectively at ~3-4% when many segments are loaded
+// (opening a new scroll, re-indexing after a pack). This bench provides a
+// deterministic measurement for that path.
+//
+// Usage:
+//   vc_tifxyz_bench <segments_dir> [--limit N]
+//
+// The directory is expected to contain subdirs each holding x.tif/y.tif/z.tif
+// (the tifxyz segment format).
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "vc/core/util/QuadSurface.hpp"
+
+using Clock = std::chrono::steady_clock;
+namespace fs = std::filesystem;
+
+namespace {
+
+double elapsed(Clock::time_point a, Clock::time_point b) {
+    return std::chrono::duration<double>(b - a).count();
+}
+
+std::vector<fs::path> findTifxyzSegments(const fs::path& root, int limit) {
+    std::vector<fs::path> out;
+    if (!fs::exists(root) || !fs::is_directory(root)) return out;
+    for (const auto& entry : fs::directory_iterator(root)) {
+        if (!entry.is_directory()) continue;
+        const auto dir = entry.path();
+        if (fs::exists(dir / "meta.json") &&
+            fs::exists(dir / "x.tif") &&
+            fs::exists(dir / "y.tif") &&
+            fs::exists(dir / "z.tif")) {
+            out.push_back(dir);
+            if (limit > 0 && int(out.size()) >= limit) break;
+        }
+    }
+    std::sort(out.begin(), out.end());
+    return out;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "Usage: vc_tifxyz_bench <segments_dir> [--limit N]\n");
+        return 1;
+    }
+    fs::path root = argv[1];
+    int limit = 0;
+    for (int i = 2; i < argc; ++i) {
+        std::string_view a = argv[i];
+        auto need = [&](const char* w){ if(i+1>=argc){fprintf(stderr,"%s needs value\n",w);std::exit(1);} return argv[++i]; };
+        if (a == "--limit") limit = std::atoi(need("--limit"));
+        else { fprintf(stderr, "Unknown: %s\n", argv[i]); return 1; }
+    }
+
+    printf("vc_tifxyz_bench\n");
+    printf("  Root:  %s\n", root.c_str());
+    printf("  Limit: %d\n\n", limit);
+
+    auto segs = findTifxyzSegments(root, limit);
+    if (segs.empty()) {
+        fprintf(stderr, "No tifxyz segments found under %s\n", root.c_str());
+        return 1;
+    }
+    printf("Found %zu tifxyz segments\n\n", segs.size());
+
+    // Phase 1: load all (cold disk — first time may hit page cache fresh).
+    size_t loaded = 0;
+    size_t totalPoints = 0;
+    double totalSec = 0.0;
+    std::vector<double> perSegSec;
+    perSegSec.reserve(segs.size());
+
+    const auto t0 = Clock::now();
+    for (const auto& seg : segs) {
+        const auto t1 = Clock::now();
+        try {
+            auto surf = load_quad_from_tifxyz(seg.string(), 0);
+            if (surf) {
+                loaded++;
+                // Access rawPoints() if available to touch the full grid.
+                // If not, point count is approximated by the points matrix.
+                // load_quad_from_tifxyz should have pulled the grid already.
+            }
+        } catch (const std::exception& e) {
+            fprintf(stderr, "  failed %s: %s\n", seg.c_str(), e.what());
+        }
+        perSegSec.push_back(elapsed(t1, Clock::now()));
+    }
+    totalSec = elapsed(t0, Clock::now());
+
+    std::sort(perSegSec.begin(), perSegSec.end());
+    const double p50 = perSegSec.empty() ? 0 : perSegSec[perSegSec.size() / 2];
+    const double p99 = perSegSec.empty() ? 0 : perSegSec[std::min(perSegSec.size()-1,
+                                                                   size_t(perSegSec.size() * 0.99))];
+    const double mean = perSegSec.empty() ? 0 : totalSec / perSegSec.size();
+
+    printf("Results:\n");
+    printf("  Loaded:         %zu / %zu\n", loaded, segs.size());
+    printf("  Total time:     %7.2f s\n", totalSec);
+    printf("  Segments/s:     %10.1f\n", segs.size() / std::max(totalSec, 1e-9));
+    printf("  Per-segment:    avg %7.1f ms  p50 %7.1f  p99 %7.1f\n",
+           mean * 1000, p50 * 1000, p99 * 1000);
+    (void)totalPoints;
+    printf("\nDone.\n");
+    return 0;
+}

--- a/volume-cartographer/apps/src/vc_transpose_bench.cpp
+++ b/volume-cartographer/apps/src/vc_transpose_bench.cpp
@@ -1,0 +1,159 @@
+// vc_transpose_bench: Chunk→block transpose throughput.
+//
+// Measures the inner loop of BlockPipeline::insertChunkAsBlocks: given a
+// fully decoded 128³ (or other multiple-of-16) chunk in row-major layout,
+// slice it into 16³ blocks and write each into the BlockCache arena via
+// BatchPut::acquire. This path runs on every chunk the pipeline decodes,
+// so even small regressions here compound with streaming volume.
+//
+// The bench isolates the transpose from the rest of the pipeline by:
+//   1) Pre-allocating a synthetic "decoded chunk" buffer.
+//   2) Replaying the exact insert loop N times under T worker threads
+//      using disjoint (bz,by,bx) ranges so threads don't alias slots.
+//
+// What the numbers mean
+//   blocks/s   : raw per-block insert rate (16³ voxel copies).
+//   chunks/s   : 128³ chunks inserted per second = blocks/s / 512.
+//   MB/s       : bytes moved through the transpose (useful for comparing
+//                against memory bandwidth).
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "vc/core/cache/BlockCache.hpp"
+
+using Clock = std::chrono::steady_clock;
+using namespace vc::cache;
+
+namespace {
+
+double elapsed(Clock::time_point a, Clock::time_point b) {
+    return std::chrono::duration<double>(b - a).count();
+}
+
+// The transpose loop lifted verbatim from BlockPipeline::insertChunkAsBlocks
+// so the bench measures exactly that code path. Kept local so it doesn't
+// depend on internal pipeline state.
+void insertChunkAsBlocks(BlockCache& cache, int level, int baseBz, int baseBy, int baseBx,
+                         const uint8_t* src, int cz, int cy, int cx)
+{
+    const int bzN = cz / kBlockSize;
+    const int byN = cy / kBlockSize;
+    const int bxN = cx / kBlockSize;
+    const int strideY = cx;
+    const int strideZ = cx * cy;
+    // Use put() via BatchPut so this bench works on both baseline and
+    // optimized builds (the zero-copy acquire() API is only in the
+    // optimized branch). The 4 KiB tmp + memcpy-to-slot is the same
+    // pattern the baseline insertChunkAsBlocks uses, so this bench
+    // measures the baseline variant apples-to-apples.
+    uint8_t tmp[kBlockBytes];
+    BlockCache::BatchPut batch(cache);
+    for (int bi = 0; bi < bzN; ++bi) {
+      for (int bj = 0; bj < byN; ++bj) {
+        for (int bk = 0; bk < bxN; ++bk) {
+            uint8_t* dst = tmp;
+            for (int lz = 0; lz < kBlockSize; ++lz) {
+                const uint8_t* zRow = src + (bi * kBlockSize + lz) * strideZ;
+                for (int ly = 0; ly < kBlockSize; ++ly) {
+                    const uint8_t* p = zRow + (bj * kBlockSize + ly) * strideY + bk * kBlockSize;
+                    std::memcpy(dst, p, kBlockSize);
+                    dst += kBlockSize;
+                }
+            }
+            BlockKey bkKey{level, baseBz + bi, baseBy + bj, baseBx + bk};
+            batch.put(bkKey, tmp);
+        }
+      }
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    int threads = 8;
+    int arenaGb = 4;
+    int chunkDim = 128;
+    uint64_t chunksPerThread = 2000;
+    for (int i = 1; i < argc; ++i) {
+        std::string_view a = argv[i];
+        auto need = [&](const char* w) { if(i+1>=argc){fprintf(stderr,"%s needs value\n",w);std::exit(1);} return argv[++i]; };
+        if      (a == "--threads")   threads = std::atoi(need("--threads"));
+        else if (a == "--arena-gb")  arenaGb = std::atoi(need("--arena-gb"));
+        else if (a == "--chunk-dim") chunkDim = std::atoi(need("--chunk-dim"));
+        else if (a == "--chunks")    chunksPerThread = std::atoll(need("--chunks"));
+        else { fprintf(stderr, "Unknown: %s\n", argv[i]); return 1; }
+    }
+    if (chunkDim % kBlockSize != 0) {
+        fprintf(stderr, "chunk-dim must be multiple of %d\n", kBlockSize);
+        return 1;
+    }
+
+    const size_t chunkBytes = size_t(chunkDim) * chunkDim * chunkDim;
+    const int bpcPerAxis = chunkDim / kBlockSize;
+    const uint64_t blocksPerChunk = uint64_t(bpcPerAxis) * bpcPerAxis * bpcPerAxis;
+
+    BlockCache::Config cfg;
+    cfg.bytes = size_t(arenaGb) << 30;
+    printf("vc_transpose_bench\n");
+    printf("  Threads:       %d\n", threads);
+    printf("  Arena:         %d GB\n", arenaGb);
+    printf("  Chunk dim:     %d (= %llu blocks/chunk)\n", chunkDim,
+           (unsigned long long)blocksPerChunk);
+    printf("  Chunks/thread: %llu\n", (unsigned long long)chunksPerThread);
+    printf("  Chunk bytes:   %zu (%.1f MB)\n", chunkBytes, chunkBytes / (1024.0 * 1024.0));
+    printf("\n");
+
+    BlockCache cache(cfg);
+
+    // One shared source buffer per thread, filled with a non-zero pattern so
+    // we don't accidentally trigger an isEmpty shortcut in any downstream
+    // consumer (this bench doesn't, but keep it realistic).
+    std::vector<std::vector<uint8_t>> srcs(threads);
+    for (int t = 0; t < threads; ++t) {
+        srcs[t].resize(chunkBytes);
+        for (size_t i = 0; i < chunkBytes; ++i)
+            srcs[t][i] = static_cast<uint8_t>(i ^ (t * 17));
+    }
+
+    const auto t0 = Clock::now();
+    std::vector<std::jthread> ws;
+    for (int t = 0; t < threads; ++t) {
+        ws.emplace_back([&, tid = t](std::stop_token) {
+            for (uint64_t c = 0; c < chunksPerThread; ++c) {
+                // Disjoint (bz, by, bx) per thread per chunk so threads
+                // insert into distinct arena slots concurrently.
+                const int baseBz = tid * 1024 + int(c % 64) * bpcPerAxis;
+                const int baseBy = int((c / 64) % 64) * bpcPerAxis;
+                const int baseBx = int((c / 4096) % 64) * bpcPerAxis;
+                insertChunkAsBlocks(cache, 0, baseBz, baseBy, baseBx,
+                                    srcs[tid].data(),
+                                    chunkDim, chunkDim, chunkDim);
+            }
+        });
+    }
+    ws.clear();
+    const double sec = elapsed(t0, Clock::now());
+
+    const uint64_t totalChunks = uint64_t(threads) * chunksPerThread;
+    const uint64_t totalBlocks = totalChunks * blocksPerChunk;
+    const double bytesPerSec = (totalChunks * double(chunkBytes)) / sec;
+
+    printf("Results:\n");
+    printf("  Elapsed:    %7.2f s\n", sec);
+    printf("  Chunks/s:   %12.0f\n", totalChunks / sec);
+    printf("  Blocks/s:   %12.0f\n", totalBlocks / sec);
+    printf("  Throughput: %8.1f MB/s\n", bytesPerSec / (1024.0 * 1024.0));
+    printf("  Per-chunk:  %7.2f us avg\n",
+           sec * 1e6 / std::max<double>(totalChunks, 1));
+    printf("\nDone.\n");
+    return 0;
+}

--- a/volume-cartographer/cmake/LLVMToolchain.cmake
+++ b/volume-cartographer/cmake/LLVMToolchain.cmake
@@ -4,8 +4,21 @@ set(VC_DEVIRT_FLAGS "-fstrict-vtable-pointers")
 set(VC_DEVIRT_LTO_FLAGS "-fwhole-program-vtables")
 set(VC_AGGRESSIVE_MATH "-ffast-math -fno-finite-math-only -funroll-loops -ffp-contract=fast")
 
+# Additional unsafe / performance flags — all on top of devirt + fast-math.
+#   -fno-plt              : direct calls instead of PLT for exported symbols
+#   -fno-math-errno       : allow libm functions to not set errno
+#   -fomit-frame-pointer  : frees a register (redundant with -O3, made explicit)
+#   -freciprocal-math     : implied by -ffast-math, explicit for clarity
+# ARM-specific (when applicable, added below):
+#   -mcpu=native          : tune scheduling for the actual uarch
+#   -mno-outline-atomics  : inline LL/SC atomics instead of libcall wrappers
+set(VC_EXTRA_PERF_FLAGS "-fno-plt -fno-math-errno -fomit-frame-pointer")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+    set(VC_EXTRA_PERF_FLAGS "${VC_EXTRA_PERF_FLAGS} -mcpu=native -mno-outline-atomics")
+endif()
+
 # Unsafe flags: devirtualization + aggressive math (can break correctness)
-set(VC_UNSAFE_CXX_FLAGS "${VC_DEVIRT_FLAGS} ${VC_DEVIRT_LTO_FLAGS} ${VC_AGGRESSIVE_MATH}")
+set(VC_UNSAFE_CXX_FLAGS "${VC_DEVIRT_FLAGS} ${VC_DEVIRT_LTO_FLAGS} ${VC_AGGRESSIVE_MATH} ${VC_EXTRA_PERF_FLAGS}")
 if(APPLE)
     set(VC_VISIBILITY_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden")
 else()
@@ -14,9 +27,9 @@ endif()
 
 # LLVM backend passes — aggressive, passed via linker for ThinLTO (ReleaseUnsafe only)
 string(CONCAT VC_LLVM_LINKER_PASSES
-    " -Wl,-mllvm,-inline-threshold=500"
-    " -Wl,-mllvm,-inlinehint-threshold=600"
-    " -Wl,-mllvm,-hot-callsite-threshold=500"
+    " -Wl,-mllvm,-inline-threshold=1000"
+    " -Wl,-mllvm,-inlinehint-threshold=1200"
+    " -Wl,-mllvm,-hot-callsite-threshold=1000"
     " -Wl,-mllvm,-polly"
     " -Wl,-mllvm,-polly-vectorizer=stripmine"
     " -Wl,-mllvm,-polly-tiling"
@@ -27,7 +40,9 @@ string(CONCAT VC_LLVM_LINKER_PASSES
     " -Wl,-mllvm,-enable-masked-interleaved-mem-accesses"
     " -Wl,-mllvm,-hot-cold-split"
     " -Wl,-mllvm,-enable-ext-tsp-block-placement"
-    " -Wl,-mllvm,-import-instr-limit=500"
+    " -Wl,-mllvm,-import-instr-limit=1000"
+    " -Wl,-O3"
+    " -Wl,--icf=all"
 )
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")

--- a/volume-cartographer/cmake/LLVMToolchain.cmake
+++ b/volume-cartographer/cmake/LLVMToolchain.cmake
@@ -63,6 +63,15 @@ endif()
 
 include(ProcessorCount)
 ProcessorCount(NPROC)
+# ProcessorCount() reads nproc / sched_getaffinity on Linux — on some
+# containers/CI or cpuset-limited shells it returns 1 even though the
+# machine has many cores (observed here: nproc=1 vs lscpu CPU(s)=12).
+# Fall back to cmake_host_system_information which reads the kernel's
+# NUMBER_OF_LOGICAL_CORES; only accept that if it's strictly larger.
+cmake_host_system_information(RESULT NPROC_LOGICAL QUERY NUMBER_OF_LOGICAL_CORES)
+if(NPROC_LOGICAL AND NPROC_LOGICAL GREATER NPROC)
+    set(NPROC ${NPROC_LOGICAL})
+endif()
 if(NOT NPROC OR NPROC EQUAL 0)
     set(NPROC 4)
 endif()

--- a/volume-cartographer/cmake/VCCompilerFlags.cmake
+++ b/volume-cartographer/cmake/VCCompilerFlags.cmake
@@ -42,8 +42,12 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 ${VC_LTO_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${VC_LTO_FLAGS} ${VC_LINKER_FLAGS} ${VC_THINLTO_CACHE_FLAGS} ${VC_STRIP_FLAGS}")
 elseif(CMAKE_BUILD_TYPE STREQUAL "ReleaseUnsafe")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 ${VC_LTO_FLAGS} ${VC_UNSAFE_CXX_FLAGS}")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${VC_LTO_FLAGS} ${VC_LINKER_FLAGS} ${VC_UNSAFE_LINKER_FLAGS} ${VC_THINLTO_CACHE_FLAGS} ${VC_STRIP_FLAGS}")
+    # -g1 keeps function-level debug info (enough for perf symbol
+    # resolution) without the inlining/line-number tables that bloat -g.
+    # Matches MinSizeRel's perf-friendly policy but on an O3+LTO+fast-math
+    # base, so profiles here show real release-time hotspots.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g1 ${VC_LTO_FLAGS} ${VC_UNSAFE_CXX_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${VC_LTO_FLAGS} ${VC_LINKER_FLAGS} ${VC_UNSAFE_LINKER_FLAGS} ${VC_THINLTO_CACHE_FLAGS}")
 elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     if(APPLE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 ${VC_LTO_FLAGS} -g")

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(vc_core
         src/cache/VolumeSource.cpp
         src/cache/HttpMetadataFetcher.cpp
         src/cache/BlockCache.cpp
+        src/cache/ChunkData.cpp
         src/cache/IOPool.cpp
         src/cache/BlockPipeline.cpp
         src/cache/VcDecompressor.cpp

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(vc_core
         src/cache/ChunkData.cpp
         src/cache/IOPool.cpp
         src/cache/BlockPipeline.cpp
+        src/cache/TickCoordinator.cpp
         src/cache/VcDecompressor.cpp
         src/LoadJson.cpp
         src/RemoteUrl.cpp

--- a/volume-cartographer/core/include/vc/core/cache/BlockCache.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/BlockCache.hpp
@@ -128,6 +128,7 @@ public:
     // not load-bearing, so tearing across shards is fine.
     [[nodiscard]] uint64_t blockHits() const noexcept;
 
+
     // Monotonic counter bumped on every slot reclaim (clock-sweep eviction)
     // and on clear(). Callers that cache "nothing has changed since last
     // check" decisions (e.g. fetchInteractive's dedup) read this to detect
@@ -177,8 +178,63 @@ private:
     // single global statBlockHits_.fetch_add on every get() hit cost ~12% of
     // total CPU under 12-thread render — the atomic traffic ping-ponged one
     // cacheline across all cores. Per-shard counters eliminate that.
+    //
+    // FastRwLock: single 64-bit atomic (reader count in low 32, writer bit
+    // in high bit). Each read_lock/unlock is ONE LSE atomic op (LDADDAL /
+    // LDADDL) — ~30-50 cycles uncontended vs. glibc pthread_rwlock which
+    // does several atomic ops per acquire for futex-wakeup bookkeeping.
+    // Under the 12-thread render workload the uncontended cost savings
+    // dominated: pthread_rwlock was ~44% of CPU on heavy composite
+    // frames; this cuts that to just the raw atomic RMW cost.
+    struct alignas(64) FastRwLock {
+        static constexpr uint64_t kWriterBit = 1ull << 32;
+        static constexpr uint64_t kReaderMask = 0xFFFFFFFFull;
+        mutable std::atomic<uint64_t> state{0};
+
+        void lock_shared() const noexcept {
+            uint64_t prev = state.fetch_add(1, std::memory_order_acquire);
+            if (!(prev & kWriterBit)) return;  // uncontended fast path
+            // Writer holds the lock — undo our reader and wait.
+            state.fetch_sub(1, std::memory_order_relaxed);
+            for (;;) {
+                while (state.load(std::memory_order_relaxed) & kWriterBit) {
+#if defined(__aarch64__)
+                    asm volatile("yield" ::: "memory");
+#endif
+                }
+                prev = state.fetch_add(1, std::memory_order_acquire);
+                if (!(prev & kWriterBit)) return;
+                state.fetch_sub(1, std::memory_order_relaxed);
+            }
+        }
+        void unlock_shared() const noexcept {
+            state.fetch_sub(1, std::memory_order_release);
+        }
+        void lock() noexcept {
+            // Set writer bit. Another writer may race; spin until we're
+            // the sole writer. Then wait for existing readers to drain.
+            for (;;) {
+                uint64_t prev = state.fetch_or(kWriterBit, std::memory_order_acquire);
+                if (!(prev & kWriterBit)) break;
+                while (state.load(std::memory_order_relaxed) & kWriterBit) {
+#if defined(__aarch64__)
+                    asm volatile("yield" ::: "memory");
+#endif
+                }
+            }
+            while ((state.load(std::memory_order_acquire) & kReaderMask) != 0) {
+#if defined(__aarch64__)
+                asm volatile("yield" ::: "memory");
+#endif
+            }
+        }
+        void unlock() noexcept {
+            state.fetch_and(~kWriterBit, std::memory_order_release);
+        }
+    };
+
     struct alignas(64) MapShard {
-        mutable std::shared_mutex mutex;
+        mutable FastRwLock mutex;
         std::unordered_map<BlockKey, size_t, BlockKeyHash> map;
         std::atomic<uint64_t> hits{0};
     };
@@ -187,13 +243,81 @@ private:
         return BlockKeyHash{}(k) & (kShards - 1);
     }
 
-    // arenaMutex_: protects arena bookkeeping (slotKey_, occupiedBits_,
+    // arenaMutex_: protects arena bookkeeping (slotKeyPacked_, occupiedBits_,
     // clockHand_, occupiedCount_, levelOccupied_). Readers do NOT take this
-    // lock — they only touch shards_[i].mutex. Write paths take arenaMutex_
-    // exclusively, then take the relevant shard lock for map updates.
+    // lock — they only touch shards_[i].mutex (slow path) or l2_ (fast path).
+    // Write paths take arenaMutex_ exclusively, then take the relevant shard
+    // lock for map updates.
     mutable std::shared_mutex arenaMutex_;
 
-    std::vector<BlockKey> slotKey_;
+    // Pack BlockKey into 64 bits: [level:4][bz:20][by:20][bx:20]. Covers
+    // any realistic volume (2^20 blocks × 16 voxels = 16.7M voxels per axis)
+    // and all level ids we use. The all-ones pattern (UINT64_MAX) maps to
+    // kEmptyKey {-1,-1,-1,-1}, so it doubles as the "empty slot" sentinel.
+    static uint64_t packBlockKey(const BlockKey& k) noexcept {
+        return (uint64_t(uint32_t(k.level) & 0xFu)     << 60)
+             | (uint64_t(uint32_t(k.bz)    & 0xFFFFFu) << 40)
+             | (uint64_t(uint32_t(k.by)    & 0xFFFFFu) << 20)
+             |  uint64_t(uint32_t(k.bx)    & 0xFFFFFu);
+    }
+    static BlockKey unpackBlockKey(uint64_t p) noexcept {
+        auto sx20 = [](uint32_t v) -> int {
+            return int(v & 0x80000u ? (v | 0xFFF00000u) : v);
+        };
+        auto sx4 = [](uint32_t v) -> int {
+            return int(v & 0x8u ? (v | 0xFFFFFFF0u) : v);
+        };
+        BlockKey k;
+        k.level = sx4(uint32_t((p >> 60) & 0xFu));
+        k.bz    = sx20(uint32_t((p >> 40) & 0xFFFFFu));
+        k.by    = sx20(uint32_t((p >> 20) & 0xFFFFFu));
+        k.bx    = sx20(uint32_t( p        & 0xFFFFFu));
+        return k;
+    }
+    // 32-bit key tag for the L2 direct-mapped verify check. Uses a different
+    // multiplier from the L2 index hash so colliding L2 slots don't also
+    // collide tags.
+    static uint32_t keyTag32(uint64_t packed) noexcept {
+        uint64_t h = packed * 0x9E3779B97F4A7C15ULL;
+        h ^= h >> 32;
+        return uint32_t(h);
+    }
+    static size_t l2Index(uint64_t packed, size_t bits) noexcept {
+        uint64_t h = packed * 0xBF58476D1CE4E5B9ULL;
+        return size_t(h >> (64 - bits));
+    }
+
+    // Lock-free direct-mapped L2 cache sitting in front of the shard maps.
+    // Each entry packs [keyTag32:slot32] into one 64-bit atomic. On hit,
+    // readers verify via slotKeyPacked_[slot] — if the arena slot no longer
+    // holds this key (eviction race or hash collision), we fall through to
+    // the slow path. No rwlock on the hot path — get() used to spend ~24% of
+    // CPU on pthread_rwlock_rdlock/unlock atomics (LDADD4_acq + CAS4_rel on
+    // aarch64); this L2 replaces that with a single relaxed atomic load +
+    // one verify load to the same cacheline.
+    // 8-way set-associative L2: 2^17 = 128K sets × 8 entries = 1M entries
+    // × 8 bytes = 8 MB (fits in L3). Each set occupies exactly one 64-byte
+    // cacheline, so a lookup loads one line and compares 8 tags — vs. the
+    // prior direct-mapped 1M × 1-way which, on heavy composite workloads
+    // with ~500K unique blocks, had ~25% collision rate. With 8 ways,
+    // collision rate drops by ~500× (Poisson: P(set load > 8) ≈ 5e-4 at
+    // mean load 4). Slow-path rwlock traffic (was ~40% of CPU in
+    // pthread_rwlock on heavy Max-composite frames) should fall by the
+    // same factor.
+    static constexpr size_t kL2Bits = 17;
+    static constexpr size_t kL2Ways = 8;
+    static constexpr size_t kL2Sets = size_t(1) << kL2Bits;
+    static constexpr size_t kL2Size = kL2Sets * kL2Ways;
+    static constexpr uint64_t kL2Empty = 0;  // keyTag32 returns 0 only for packed==0
+    std::unique_ptr<std::atomic<uint64_t>[]> l2_;
+    // Round-robin eviction counter per set (non-atomic; races are benign
+    // — worst case we overwrite slightly less-ideal slots). 128K bytes
+    // fits in L2D.
+    std::unique_ptr<uint8_t[]> l2RrCounters_;
+
+    // Per-slot packed BlockKey, readable lock-free by the L2 verify path.
+    // Written under arenaMutex_ only. UINT64_MAX means "empty slot".
+    std::unique_ptr<std::atomic<uint64_t>[]> slotKeyPacked_;
     // Parallel bitmasks (1 bit per slot): "occupied" (has valid key) and
     // "used" (clock-sweep NRU flag). Packs 2.5M slots into 310 KB each
     // vs. ~2.5 MB for a byte-per-slot vector. occupiedBits_ is guarded by
@@ -226,9 +350,23 @@ private:
         return (usedBits_[bitWord(i)].load(std::memory_order_relaxed) >> (i & 63u)) & 1u;
     }
     void setUsed(size_t i, bool v) noexcept {
+        auto& word = usedBits_[bitWord(i)];
         const uint64_t m = bitMask(i);
-        if (v) usedBits_[bitWord(i)].fetch_or(m, std::memory_order_relaxed);
-        else   usedBits_[bitWord(i)].fetch_and(~m, std::memory_order_relaxed);
+        if (v) {
+            // Short-circuit if already set. A relaxed load is an ordinary
+            // LDR with no coherence round-trip; fetch_or is LDSET which
+            // takes ~20-50 cycles uncontended and more with N-thread
+            // contention on the same 64-slot word. Under 12-thread render,
+            // the SAME word is hit by many L2 hits per frame because
+            // adjacent slot indices share a bit-word — eliminating the
+            // redundant LDSET traffic was visible as ~30% of CPU in
+            // post-L2-hit code (the LDSET was the actual hot atomic, with
+            // sample skid making the mov/ldr that followed look worse).
+            if ((word.load(std::memory_order_relaxed) & m) == 0)
+                word.fetch_or(m, std::memory_order_relaxed);
+        } else {
+            word.fetch_and(~m, std::memory_order_relaxed);
+        }
     }
 };
 

--- a/volume-cartographer/core/include/vc/core/cache/BlockCache.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/BlockCache.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <atomic>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -104,10 +105,17 @@ public:
     class BatchPut {
     public:
         explicit BatchPut(BlockCache& cache) noexcept
-            : cache_(cache), lock_(cache.mutex_) {}
+            : cache_(cache), lock_(cache.arenaMutex_) {}
         BatchPut(const BatchPut&) = delete;
         BatchPut& operator=(const BatchPut&) = delete;
         void put(const BlockKey& key, const uint8_t* src) noexcept;
+
+        // Reserve an arena slot for `key` without copying. Caller writes
+        // exactly kBlockBytes into the returned 16-byte-aligned buffer.
+        // Skips the src→tmp→arena double copy that put() performs — use
+        // this when the producer can assemble the block directly at its
+        // final destination.
+        [[nodiscard]] uint8_t* acquire(const BlockKey& key) noexcept;
     private:
         BlockCache& cache_;
         std::unique_lock<std::shared_mutex> lock_;
@@ -116,11 +124,26 @@ public:
     [[nodiscard]] size_t capacity() const noexcept { return nSlots_; }
     [[nodiscard]] size_t size() const noexcept;
 
+    // Sum of per-shard hit counters. Relaxed read — stats are diagnostic,
+    // not load-bearing, so tearing across shards is fine.
+    [[nodiscard]] uint64_t blockHits() const noexcept;
+
+    // Monotonic counter bumped on every slot reclaim (clock-sweep eviction)
+    // and on clear(). Callers that cache "nothing has changed since last
+    // check" decisions (e.g. fetchInteractive's dedup) read this to detect
+    // evictions without needing the cache mutex.
+    [[nodiscard]] uint64_t evictionVersion() const noexcept {
+        return evictionVersion_.load(std::memory_order_relaxed);
+    }
+
     void clear();
 
 private:
-    // Body of put()/BatchPut::put — assumes unique_lock on mutex_ is held.
+    // Body of put()/BatchPut::put — assumes unique_lock on arenaMutex_ is held.
     void putLocked(const BlockKey& key, const uint8_t* src) noexcept;
+    // Reserve a slot (overwrite if key exists, else allocate/reclaim). Returns
+    // SIZE_MAX iff nSlots_==0. Updates shard map/slotKey_/occupancy.
+    [[nodiscard]] size_t acquireSlotLocked(const BlockKey& key) noexcept;
     [[nodiscard]] size_t reclaimSlotLocked();
 
     Config config_;
@@ -134,18 +157,47 @@ private:
     size_t arenaBytes_ = 0;
     std::jthread prefaultThread_;
 
-    // shared_mutex: get()/contains()/size() take a shared lock so the render
-    // thread and the 4 worker pools can read concurrently; put()/clear()
-    // take the exclusive lock. usedBits_ is atomic so mutations from get()
-    // (setUsed on hit) and the clock sweep are lock-free.
-    mutable std::shared_mutex mutex_;
-    std::unordered_map<BlockKey, size_t, BlockKeyHash> map_;
+    // Sharded reader lock: the map is split into N shards by hash, each with
+    // its own shared_mutex. get()/contains() lock only the relevant shard,
+    // so 12 concurrent render threads rarely collide on the same cache line.
+    // Previously a single shared_mutex served every reader — even with
+    // multiple readers allowed in parallel, the CAS-based reader counter on
+    // that lock's cache line saturated with atomic traffic under hot render
+    // (~54% of CPU was in pthread_rwlock_rd{lock,unlock} atomics).
+    //
+    // Writers (put/acquire/reclaim/clear) hold `arenaMutex_` exclusively for
+    // the arena bookkeeping (slotKey_, occupiedBits_, clockHand_, levelOccupied_,
+    // occupiedCount_) and take the relevant shard's unique_lock briefly to
+    // insert/erase its map entry. The nested order is always arenaMutex_
+    // before shard — readers never take arenaMutex_, so no deadlock path.
+    static constexpr size_t kShards = 32;  // power of 2
+    static_assert(std::has_single_bit(kShards), "kShards must be a power of 2");
+    // alignas(64): each shard owns one cacheline's worth of frequently-written
+    // state (mutex + hit counter) so shards don't false-share. Previously a
+    // single global statBlockHits_.fetch_add on every get() hit cost ~12% of
+    // total CPU under 12-thread render — the atomic traffic ping-ponged one
+    // cacheline across all cores. Per-shard counters eliminate that.
+    struct alignas(64) MapShard {
+        mutable std::shared_mutex mutex;
+        std::unordered_map<BlockKey, size_t, BlockKeyHash> map;
+        std::atomic<uint64_t> hits{0};
+    };
+    std::array<MapShard, kShards> shards_;
+    static size_t shardIndex(const BlockKey& k) noexcept {
+        return BlockKeyHash{}(k) & (kShards - 1);
+    }
+
+    // arenaMutex_: protects arena bookkeeping (slotKey_, occupiedBits_,
+    // clockHand_, occupiedCount_, levelOccupied_). Readers do NOT take this
+    // lock — they only touch shards_[i].mutex. Write paths take arenaMutex_
+    // exclusively, then take the relevant shard lock for map updates.
+    mutable std::shared_mutex arenaMutex_;
 
     std::vector<BlockKey> slotKey_;
     // Parallel bitmasks (1 bit per slot): "occupied" (has valid key) and
     // "used" (clock-sweep NRU flag). Packs 2.5M slots into 310 KB each
     // vs. ~2.5 MB for a byte-per-slot vector. occupiedBits_ is guarded by
-    // mutex_; usedBits_ is atomic per word so get() can set it lock-free.
+    // arenaMutex_; usedBits_ is atomic per word so get() can set it lock-free.
     std::vector<uint64_t> occupiedBits_;
     std::unique_ptr<std::atomic<uint64_t>[]> usedBits_;
     size_t usedBitsWords_ = 0;
@@ -156,6 +208,12 @@ private:
     // occupancy <= floor are protected from the clock sweep.
     std::array<size_t, kMaxLevels> levelOccupied_{};
     std::array<size_t, kMaxLevels> levelFloor_{};
+
+    // Bumped every time a slot is reclaimed (eviction) or the whole cache
+    // is cleared. Readers use this to invalidate "last-seen" caches
+    // (fetchInteractive dedup) without needing any cache lock. Relaxed atomic —
+    // we only need monotonicity, not ordering against the slot writes.
+    std::atomic<uint64_t> evictionVersion_{0};
 
     static constexpr size_t bitWord(size_t i) noexcept { return i >> 6; }
     static constexpr uint64_t bitMask(size_t i) noexcept { return uint64_t(1) << (i & 63u); }

--- a/volume-cartographer/core/include/vc/core/cache/BlockCache.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/BlockCache.hpp
@@ -233,9 +233,53 @@ private:
         }
     };
 
+    // Per-shard lock-free open-addressing hash table. Writers are still
+    // serialized by arenaMutex_ (single writer globally), so the insert /
+    // erase paths just atomic-store entries with release semantics.
+    // Readers probe lock-free with acquire-loads and verify the returned
+    // slot via slotKeyPacked_ — that verify catches the ~1/2^32 hash-tag
+    // collisions as well as racing writer modifications.
+    //
+    // Replaces the prior FastRwLock + std::unordered_map: reads take zero
+    // locks now, just a couple of atomic loads per probe step. On heavy
+    // composite workloads with ~25% L2-miss rate, every miss previously
+    // went through the shard rwlock (~40-70 cycles per pair uncontended,
+    // much worse under the 12-thread coherence storm). This path has no
+    // rwlock tax at all.
+    //
+    // Entry layout (64 bits):
+    //   [63:62] state: 00 empty, 10 occupied, 01 tombstone
+    //   [61:32] arena slot index (30 bits — supports 1B slots, we use ≤3M)
+    //   [31: 0] 32-bit hash of the BlockKey
+    // Empty is all-zero; ctor memset suffices.
+    static constexpr uint64_t kEntryEmpty = 0ull;
+    static constexpr uint64_t kEntryOccupied = 0x8000000000000000ull;
+    static constexpr uint64_t kEntryTombstone = 0x4000000000000000ull;
+    static constexpr uint64_t kEntryStateMask = 0xC000000000000000ull;
+    static constexpr uint64_t kEntrySlotMask = 0x3FFFFFFF00000000ull;
+    static constexpr int kEntrySlotShift = 32;
+    static constexpr uint64_t kEntryHashMask = 0x00000000FFFFFFFFull;
+    static uint32_t shardMapHash(const BlockKey& k) noexcept {
+        // Different mixer from BlockKeyHash + l2Index so shard-map slots
+        // don't cluster with either of those.
+        uint64_t h = packBlockKey(k) * 0xD6E8FEB86659FD93ull;
+        h ^= h >> 32;
+        uint32_t r = uint32_t(h);
+        return r == 0 ? 1u : r;  // reserve 0 for "empty-signifier"; shift anything that lands there
+    }
+    static uint64_t makeOccupiedEntry(uint32_t slot, uint32_t hash) noexcept {
+        return kEntryOccupied | (uint64_t(slot) << kEntrySlotShift) | uint64_t(hash);
+    }
+
+    // 2^18 = 256K slots per shard × 8 B = 2 MB per shard × 32 shards = 64 MB.
+    // With max arena ~2.5M slots / 32 shards ≈ 80K entries per shard, load
+    // factor peaks at ~0.3 → short probe chains, fast lookups.
+    static constexpr size_t kShardMapBits = 18;
+    static constexpr size_t kShardMapSize = size_t(1) << kShardMapBits;
+    static constexpr size_t kShardMapMask = kShardMapSize - 1;
+
     struct alignas(64) MapShard {
-        mutable FastRwLock mutex;
-        std::unordered_map<BlockKey, size_t, BlockKeyHash> map;
+        std::unique_ptr<std::atomic<uint64_t>[]> table;
         std::atomic<uint64_t> hits{0};
     };
     std::array<MapShard, kShards> shards_;

--- a/volume-cartographer/core/include/vc/core/cache/BlockPipeline.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/BlockPipeline.hpp
@@ -181,16 +181,33 @@ private:
     // least-recently-used shard is evicted. shared_ptr on the buffer so
     // concurrent loaders can serve from the same shard without the cache
     // mutex blocking them.
-    mutable std::mutex shardCacheMutex_;
+    //
+    // Sharded by hash(ShardKey) to reduce mutex contention: with N loader
+    // threads all hitting the same mutex, the LRU splice on every hit
+    // serializes the hot fetch path. kShardCacheBuckets=16 drops contention
+    // to ~1/16 for uniformly distributed shard accesses.
+    //
+    // Budget is SHARED across buckets via the atomic shardCacheGlobalBytes_
+    // counter: any bucket can hold as much as it wants so long as the total
+    // stays under shardCacheBytes. An insert that pushes the global over
+    // budget evicts LRU entries from its OWN bucket until under — preserves
+    // per-bucket LRU semantics while making capacity fluid across uneven
+    // hash distributions (avoids the per-bucket cap starving a hot bucket).
     struct ShardCacheEntry {
         ShardKey key;
         std::shared_ptr<std::vector<std::byte>> bytes;
     };
-    std::list<ShardCacheEntry> shardCacheLru_;  // front = most recent
-    std::unordered_map<ShardKey,
-                       std::list<ShardCacheEntry>::iterator,
-                       ShardKeyHash> shardCacheMap_;
-    size_t shardCacheTotalBytes_ = 0;
+    static constexpr size_t kShardCacheBuckets = 16;
+    struct ShardCacheBucket {
+        mutable std::mutex mutex;
+        std::list<ShardCacheEntry> lru;  // front = most recent
+        std::unordered_map<ShardKey,
+                           std::list<ShardCacheEntry>::iterator,
+                           ShardKeyHash> map;
+        size_t bytes = 0;
+    };
+    mutable std::array<ShardCacheBucket, kShardCacheBuckets> shardCacheBuckets_;
+    std::atomic<size_t> shardCacheGlobalBytes_{0};
     // Hits/misses so the status bar can surface them.
     std::atomic<uint64_t> statShardHits_{0};
     std::atomic<uint64_t> statShardMisses_{0};
@@ -205,8 +222,12 @@ private:
     std::shared_ptr<std::vector<std::byte>> shardBytesFor(
         const ChunkKey& key, utils::ZarrArray& dz);
 
-    // Insert into the shard cache, evicting LRU until under budget.
-    void shardCacheInsertLocked(const ShardKey& sk,
+    // Map ShardKey → bucket index in shardCacheBuckets_.
+    static size_t shardCacheBucketIndex(const ShardKey& sk) noexcept;
+    // Insert into a specific bucket, evicting per-bucket LRU until under its
+    // share of the total budget.
+    void shardCacheInsertLocked(ShardCacheBucket& b,
+                                const ShardKey& sk,
                                 std::shared_ptr<std::vector<std::byte>> bytes);
 
     BlockCache blockCache_;
@@ -240,10 +261,29 @@ private:
     std::atomic<ChunkReadyCallbackId> nextListenerId_{1};
     std::atomic<bool> chunkArrivedFlag_{false};
 
+    // fetchInteractive dedup: the renderer calls fetchInteractive every
+    // frame, but when the viewport is idle the keys + targetLevel are
+    // identical back-to-back, and identical across multiple viewers. A
+    // commutative XOR hash of (key, targetLevel) + the BlockCache eviction
+    // version is enough to detect "nothing has changed since we last did
+    // the expensive probe/classify/updateInteractive work" and skip.
+    // Guarded by fetchInteractiveDedupMutex_ so cross-viewer calls
+    // serialize their compare-and-update of the stored state — without it
+    // two identical calls could both see a stale match and each do the
+    // work, defeating the dedup.
+    mutable std::mutex fetchInteractiveDedupMutex_;
+    uint64_t lastFetchInteractiveHash_ = 0;
+    uint64_t lastFetchInteractiveEviction_ = 0;
+    int lastFetchInteractiveTargetLevel_ = -1;
+    bool haveLastFetchInteractive_ = false;
+
     mutable std::mutex dataBoundsMutex_;
     DataBoundsL0 dataBoundsL0_;
 
-    mutable std::atomic<uint64_t> statBlockHits_{0};
+    // Hits from the empty-chunk canonical zero block (cold path in blockAt).
+    // The hot-path block hit counter lives in BlockCache::shards_ — a single
+    // atomic here saturated a cacheline under 12-thread render.
+    mutable std::atomic<uint64_t> statEmptyHits_{0};
     std::atomic<uint64_t> statColdHits_{0};
     std::atomic<uint64_t> statIceFetches_{0};
     std::atomic<uint64_t> statDiskWrites_{0};

--- a/volume-cartographer/core/include/vc/core/cache/BlockPipeline.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/BlockPipeline.hpp
@@ -66,7 +66,7 @@ public:
         Config config,
         std::unique_ptr<VolumeSource> source,
         DecompressFn decompress,
-        std::vector<std::shared_ptr<utils::ZarrArray>> diskLevels = {});
+        std::vector<std::unique_ptr<utils::ZarrArray>> diskLevels = {});
 
     ~BlockPipeline();
 
@@ -147,7 +147,7 @@ public:
 
 private:
     Config config_;
-    std::vector<std::shared_ptr<utils::ZarrArray>> diskLevels_;
+    std::vector<std::unique_ptr<utils::ZarrArray>> diskLevels_;
     std::unique_ptr<VolumeSource> source_;
     DecompressFn decompress_;
     // Four fully independent pools — each specialised for one stage so no
@@ -220,7 +220,14 @@ private:
     // Pull the whole shard file for `key` through the LRU cache. First
     // hit from any thread reads the file once; subsequent hits just bump
     // the LRU head and return the shared buffer.
-    std::shared_ptr<std::vector<std::byte>> shardBytesFor(
+    //
+    // Returns a raw pointer valid until the calling thread next invokes
+    // shardBytesFor() — a per-thread shared_ptr keeps the bytes alive
+    // across the caller's brief synchronous use. Returning a raw pointer
+    // instead of shared_ptr eliminates ~2 refcount atomics per call that
+    // were cache-line ping-ponging under 12-thread decode (perf showed
+    // the shared_ptr dtor's LDADDAL at ~20% of total CPU).
+    const std::vector<std::byte>* shardBytesFor(
         const ChunkKey& key, utils::ZarrArray& dz);
 
     // Map ShardKey → bucket index in shardCacheBuckets_.

--- a/volume-cartographer/core/include/vc/core/cache/BlockPipeline.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/BlockPipeline.hpp
@@ -252,13 +252,71 @@ private:
     // 512 identical zero blocks in the arena. blockAt() returns a pointer
     // to a single static zero-block when the block's canonical chunk is
     // in this set.
-    // shared_mutex: blockAt's miss path reads emptyChunks_ under shared_lock,
-    // while insertChunkAsBlocks/clear take unique_lock. Under 12-thread render
-    // into freshly-panned regions, every miss hits this mutex; a plain
-    // std::mutex serialised 12 readers and spent ~19% of CPU in
-    // futex_wait → queued_spin_lock_slowpath.
-    mutable std::shared_mutex emptyChunksMutex_;
-    std::unordered_set<ChunkKey, ChunkKeyHash> emptyChunks_;
+    //
+    // Lock-free hash set. Readers probe with acquire-atomic-loads; writers
+    // (insertChunkAsBlocks / clear) serialize via emptyChunksWriteMutex_
+    // and publish with release-atomic-stores. Every blockAt miss used to
+    // take a shared_mutex → ~2% of CPU in pthread_rwlock at the 12-thread
+    // render path; now just one atomic load per probe step. Entries: 64
+    // bits = [state:2 | chunkHash:62]. False positives on chunkHash are
+    // OK — an "empty" hit is cheap (returns the static zero block) and
+    // correctness is unaffected because the arena still holds the
+    // authoritative data if it's there. In practice false positives are
+    // vanishingly rare (62-bit hash).
+    static constexpr size_t kEmptyChunksBits = 14;  // 16K slots × 8 B = 128 KB
+    static constexpr size_t kEmptyChunksSize = size_t(1) << kEmptyChunksBits;
+    static constexpr size_t kEmptyChunksMask = kEmptyChunksSize - 1;
+    static constexpr uint64_t kEmptyChunksStateMask = 0xC000000000000000ull;
+    static constexpr uint64_t kEmptyChunksOccupied  = 0x8000000000000000ull;
+    static constexpr uint64_t kEmptyChunksHashMask  = 0x3FFFFFFFFFFFFFFFull;
+    std::array<std::atomic<uint64_t>, kEmptyChunksSize> emptyChunksTable_{};
+    mutable std::mutex emptyChunksWriteMutex_;
+    // Lock-free probe for "is this chunk known to be all-zero?".
+    [[nodiscard]] bool isEmptyChunk(const ChunkKey& k) const noexcept {
+        const uint64_t fh = emptyChunkFullHash(k);
+        size_t idx = fh & kEmptyChunksMask;
+        for (size_t probe = 0; probe < kEmptyChunksSize; ++probe) {
+            const uint64_t e = emptyChunksTable_[(idx + probe) & kEmptyChunksMask]
+                                  .load(std::memory_order_acquire);
+            if (e == 0) return false;  // empty → end of probe
+            if ((e & kEmptyChunksStateMask) == kEmptyChunksOccupied
+                && (e & kEmptyChunksHashMask) == fh) {
+                return true;
+            }
+            // mismatched hash: keep probing
+        }
+        return false;
+    }
+    void addEmptyChunk(const ChunkKey& k) noexcept {
+        std::lock_guard lk(emptyChunksWriteMutex_);
+        const uint64_t fh = emptyChunkFullHash(k);
+        size_t idx = fh & kEmptyChunksMask;
+        const uint64_t entry = kEmptyChunksOccupied | fh;
+        for (size_t probe = 0; probe < kEmptyChunksSize; ++probe) {
+            const size_t pos = (idx + probe) & kEmptyChunksMask;
+            const uint64_t e = emptyChunksTable_[pos].load(std::memory_order_relaxed);
+            if (e == 0) {
+                emptyChunksTable_[pos].store(entry, std::memory_order_release);
+                return;
+            }
+            if ((e & kEmptyChunksHashMask) == fh) return;  // already present
+        }
+        // Table full — in practice won't happen, we have 16K slots.
+    }
+    void clearEmptyChunks() noexcept {
+        std::lock_guard lk(emptyChunksWriteMutex_);
+        for (auto& e : emptyChunksTable_) e.store(0, std::memory_order_relaxed);
+    }
+    static uint64_t emptyChunkFullHash(const ChunkKey& k) noexcept {
+        // 62-bit hash of (level, iz, iy, ix). Collision rate 1/2^62 —
+        // negligible even over the program's lifetime.
+        uint64_t h = ChunkKeyHash{}(k);
+        h = (h ^ (h >> 31)) * 0x9E3779B97F4A7C15ull;
+        h = (h ^ (h >> 27)) * 0xBF58476D1CE4E5B9ull;
+        h ^= h >> 32;
+        h &= kEmptyChunksHashMask;
+        return h == 0 ? 1 : h;  // reserve 0 for "empty slot" sentinel
+    }
 
     // Negative cache (same design as before).
     static constexpr size_t kBloomBits = 65536;

--- a/volume-cartographer/core/include/vc/core/cache/BlockPipeline.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/BlockPipeline.hpp
@@ -9,6 +9,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -244,7 +245,12 @@ private:
     // 512 identical zero blocks in the arena. blockAt() returns a pointer
     // to a single static zero-block when the block's canonical chunk is
     // in this set.
-    mutable std::mutex emptyChunksMutex_;
+    // shared_mutex: blockAt's miss path reads emptyChunks_ under shared_lock,
+    // while insertChunkAsBlocks/clear take unique_lock. Under 12-thread render
+    // into freshly-panned regions, every miss hits this mutex; a plain
+    // std::mutex serialised 12 readers and spent ~19% of CPU in
+    // futex_wait → queued_spin_lock_slowpath.
+    mutable std::shared_mutex emptyChunksMutex_;
     std::unordered_set<ChunkKey, ChunkKeyHash> emptyChunks_;
 
     // Negative cache (same design as before).

--- a/volume-cartographer/core/include/vc/core/cache/ChunkData.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/ChunkData.hpp
@@ -63,7 +63,13 @@ struct ChunkData {
     [[nodiscard]] constexpr int strideX() const noexcept { return 1; }
 };
 
-using ChunkDataPtr = std::shared_ptr<ChunkData>;
+// Single-owner semantics: a ChunkData moves through decode → staging →
+// insertion as one object, never shared across threads after decode
+// completes. Switching from shared_ptr to unique_ptr removes ~2 refcount
+// atomic RMWs per chunk (creation + destruction) from the background
+// decode pipeline; under heavy scroll decode that was visible as
+// cas4_rel / ldadd4_acq ambient traffic on the perf callgraph.
+using ChunkDataPtr = std::unique_ptr<ChunkData>;
 
 // Callback signature for decompressing raw bytes into ChunkData.
 // The cache itself is compression-agnostic; the caller provides this.

--- a/volume-cartographer/core/include/vc/core/cache/ChunkData.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/ChunkData.hpp
@@ -63,13 +63,24 @@ struct ChunkData {
     [[nodiscard]] constexpr int strideX() const noexcept { return 1; }
 };
 
-// Single-owner semantics: a ChunkData moves through decode → staging →
-// insertion as one object, never shared across threads after decode
-// completes. Switching from shared_ptr to unique_ptr removes ~2 refcount
-// atomic RMWs per chunk (creation + destruction) from the background
-// decode pipeline; under heavy scroll decode that was visible as
-// cas4_rel / ldadd4_acq ambient traffic on the perf callgraph.
-using ChunkDataPtr = std::unique_ptr<ChunkData>;
+// Custom deleter that returns released ChunkData objects to a per-thread
+// pool instead of freeing them. A decoded canonical chunk is ~2 MB, so
+// linux's malloc implementation routes the `bytes` vector through mmap —
+// every decode/discard cycle pays kernel page-zero + page-table edit +
+// memcg accounting cost (saw ~30% of CPU in kernel mm on heavy decode
+// runs). Recycling keeps the underlying std::vector capacity alive across
+// chunks on the same thread so the next decode reuses the backing pages.
+// Pool size is capped per-thread to keep memory usage bounded.
+struct ChunkDataPoolDeleter {
+    void operator()(ChunkData* p) const noexcept;
+};
+using ChunkDataPtr = std::unique_ptr<ChunkData, ChunkDataPoolDeleter>;
+
+// Factory: returns a reset-state ChunkData from the thread-local pool,
+// or heap-allocates a fresh one when the pool is empty. Producers should
+// use this instead of `std::make_unique<ChunkData>()` so the buffer
+// capacity recycles between decodes.
+[[nodiscard]] ChunkDataPtr acquireChunkData() noexcept;
 
 // Callback signature for decompressing raw bytes into ChunkData.
 // The cache itself is compression-agnostic; the caller provides this.

--- a/volume-cartographer/core/include/vc/core/cache/ChunkKey.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/ChunkKey.hpp
@@ -25,6 +25,17 @@ struct ChunkKey {
 
     constexpr bool operator!=(const ChunkKey& o) const noexcept { return !(*this == o); }
 
+    // Lexicographic ordering on (level, iz, iy, ix). Used for sorted
+    // vectors that support binary_search against a known-empty set
+    // in the tick-published FrameState.
+    constexpr auto operator<=>(const ChunkKey& o) const noexcept
+    {
+        if (auto c = level <=> o.level; c != 0) return c;
+        if (auto c = iz    <=> o.iz;    c != 0) return c;
+        if (auto c = iy    <=> o.iy;    c != 0) return c;
+        return ix <=> o.ix;
+    }
+
     // Return the equivalent key at a coarser pyramid level.
     // Each level halves spatial resolution, so chunk indices halve.
     [[nodiscard]] constexpr ChunkKey coarsen(int targetLevel) const noexcept

--- a/volume-cartographer/core/include/vc/core/cache/IOPool.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/IOPool.hpp
@@ -83,6 +83,14 @@ private:
 
     bool shutdown_ = false;
 
+    // Count of workers currently blocked on cv_.wait inside popNext. Lets
+    // enqueue/updateInteractive skip futex_wake syscalls when every worker
+    // is already running — they'll pick up new items via their own popNext
+    // loop. Without this, every panning-viewport frame wakes all workers
+    // even though they're still processing the previous batch, generating
+    // ~Nthreads useless context switches per frame.
+    int idleCount_ = 0;
+
     int numThreads_;
     std::vector<std::jthread> workers_;
 };

--- a/volume-cartographer/core/include/vc/core/cache/TickCoordinator.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/TickCoordinator.hpp
@@ -3,13 +3,51 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 #include <thread>
 #include <vector>
 
 #include "vc/core/util/MpscRing.hpp"
+#include "BlockCache.hpp"  // Block, BlockKey, BlockPtr
 #include "ChunkKey.hpp"
 
 namespace vc::cache {
+
+class BlockPipeline;  // fwd decl
+
+// Per-viewer snapshot published by main-thread render handlers and
+// consumed by the tick loop for slice scoping / prefetch coalescing.
+// POD-only so we can seqlock-copy it between threads without a mutex.
+struct ViewportSnapshot {
+    bool active = false;
+    int level = 0;
+    BlockPipeline* pipeline = nullptr;
+    // World-space (voxel coordinate) bounding box of what the viewer may
+    // sample during its next render. Coarse; callers trade precision for
+    // cheap compute. Meaningless when `active == false`.
+    float minX = 0, minY = 0, minZ = 0;
+    float maxX = 0, maxY = 0, maxZ = 0;
+};
+
+static constexpr std::size_t kMaxViewers = 16;
+
+// Carried on chunkLandedRing_: identifies which pipeline the producer
+// wrote to so the tick thread can resolve individual block pointers
+// for slice population.
+struct ChunkLandedEvent {
+    ChunkKey key;
+    BlockPipeline* pipeline;
+    std::uint64_t _pad;  // 16 + 8 + 8 = 32 bytes, cache-friendly
+};
+
+// One slice entry. `packedKey` is the BlockSampler packKey of (bz,by,bx).
+// Readers verify `pipeline` matches their BlockPipeline&; multi-volume
+// scenes intermix entries in the published vector otherwise.
+struct SliceEntry {
+    std::uint64_t        packedKey;
+    const BlockPipeline* pipeline;
+    const Block*         block;
+};
 
 // Per-frame state published atomically by the TickCoordinator.
 // Readers load a raw const pointer via `currentFrame()` at the start of
@@ -24,13 +62,26 @@ struct FrameState {
     // loop. Only grows; a chunk becomes "empty" once and stays that way.
     std::vector<ChunkKey> emptyChunkKeys;
 
+    // Snapshots of every active viewer, copied from the seqlock slots at
+    // the start of each tick. Stable during a render.
+    std::array<ViewportSnapshot, kMaxViewers> viewports{};
+
+    // Sorted-by-packedKey slice of recently-landed blocks for which the
+    // producing pipeline is used by at least one active viewport (level
+    // filter). Readers binary-search to short-circuit the atomic-heavy
+    // BlockCache::get path. Stale entries are caught by the pipeline
+    // mismatch check in the reader.
+    std::vector<SliceEntry> slice;
+
     // Drain counts from the tick that produced this frame.
     std::uint64_t chunksLandedThisTick = 0;
     std::uint64_t emptyChunksThisTick = 0;
+    std::uint64_t prefetchCallsThisTick = 0;
 
     // Cumulative counts since process start. Useful for dashboards.
     std::uint64_t totalChunksLanded = 0;
     std::uint64_t totalEmptyChunks = 0;
+    std::uint64_t totalPrefetchCalls = 0;
 };
 
 // Single-writer, multi-reader state publisher. One dedicated std::jthread
@@ -81,7 +132,7 @@ public:
     // Producer-side push. Non-blocking; drops silently on ring overflow
     // (tracked via `dropped*` counters). These are process-wide routes
     // via the global coordinator pointer set up in the constructor.
-    static void notifyChunkLanded(const ChunkKey& k) noexcept;
+    static void notifyChunkLanded(BlockPipeline* pipeline, const ChunkKey& k) noexcept;
     static void notifyEmptyChunkNoted(const ChunkKey& k) noexcept;
 
     // Convenience accessors for readers that don't have a direct handle
@@ -91,6 +142,23 @@ public:
     // can call it unconditionally.
     static const FrameState* currentFrameGlobal() noexcept;
     static void releaseFrameGlobal(const FrameState* s) noexcept;
+
+    // Viewport slot management. `acquireViewportSlot` returns an index in
+    // [0, kMaxViewers) on success, -1 if the table is full. Release marks
+    // the slot inactive. publishViewport copies into a per-slot seqlock;
+    // the tick thread reads all slots each tick.
+    static int  acquireViewportSlotGlobal() noexcept;
+    static void releaseViewportSlotGlobal(int slotIdx) noexcept;
+    static void publishViewportGlobal(int slotIdx,
+                                      const ViewportSnapshot& s) noexcept;
+
+    // Coalesced prefetch. Callers enqueue chunks to prefetch; the tick
+    // thread groups them by (pipeline, targetLevel), dedups, and issues
+    // one fetchInteractive call per group each tick. Falls back to an
+    // immediate fetchInteractive if the coordinator is not running.
+    static void enqueuePrefetchGlobal(BlockPipeline* pipeline,
+                                      const std::vector<ChunkKey>& keys,
+                                      int targetLevel) noexcept;
 
     [[nodiscard]] std::uint64_t droppedChunkLanded() const noexcept
     {
@@ -112,8 +180,8 @@ private:
     // Producer events. Single ring per type keeps the implementation
     // simple; if CAS contention becomes visible in a profile we can
     // shard by BlockCache shard index.
-    vc::util::MpscRing<ChunkKey, 16384> chunkLandedRing_;
-    vc::util::MpscRing<ChunkKey, 4096>  emptyChunkRing_;
+    vc::util::MpscRing<ChunkLandedEvent, 16384> chunkLandedRing_;
+    vc::util::MpscRing<ChunkKey, 4096>          emptyChunkRing_;
 
     // Full-ring drops. Should be zero in practice; non-zero values mean
     // the drain thread couldn't keep up or the rings are undersized.
@@ -129,6 +197,34 @@ private:
     // only on BlockPipeline::clearMemory, which we don't signal yet (so
     // the list is monotonic in practice).
     std::vector<ChunkKey> emptyChunkMaster_;
+
+    // Master slice ring-ish buffer. New entries appended; when it exceeds
+    // kSliceMax, the front is dropped in bulk (erase from begin). Final
+    // published vector is sorted + dedup'd into the FrameState.
+    static constexpr std::size_t kSliceMax = 16384;
+    std::vector<SliceEntry> sliceMaster_;
+
+    // Per-viewer seqlock slots. `seq` is even at rest, odd while writing.
+    // Cache-line aligned to avoid false sharing when several viewers
+    // publish simultaneously on the main thread.
+    struct alignas(64) ViewportSlot {
+        std::atomic<std::uint64_t> seq{0};
+        ViewportSnapshot snapshot{};
+    };
+    std::array<ViewportSlot, kMaxViewers> viewportSlots_{};
+    std::atomic<std::uint32_t> viewportSlotAllocMask_{0};
+
+    // Pending prefetch requests. Main threads append; tick thread drains
+    // and dispatches. Short-held mutex is cheaper than an MPSC ring here
+    // because producers post *vectors* of keys at once, not single items.
+    struct PendingPrefetch {
+        BlockPipeline* pipeline;
+        int targetLevel;
+        std::vector<ChunkKey> keys;
+    };
+    std::mutex prefetchMutex_;
+    std::vector<PendingPrefetch> prefetchQueue_;
+    std::uint64_t totalPrefetchCalls_ = 0;
 
     // jthread declared last so its destructor runs first on teardown,
     // stopping the loop before member storage unwinds.

--- a/volume-cartographer/core/include/vc/core/cache/TickCoordinator.hpp
+++ b/volume-cartographer/core/include/vc/core/cache/TickCoordinator.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include "vc/core/util/MpscRing.hpp"
+#include "ChunkKey.hpp"
+
+namespace vc::cache {
+
+// Per-frame state published atomically by the TickCoordinator.
+// Readers load a raw const pointer via `currentFrame()` at the start of
+// a render and hold it for the duration. All mutation happens on the
+// coordinator's thread, between ticks, on the non-current buffer.
+struct FrameState {
+    std::uint64_t generation = 0;
+
+    // Sorted, deduplicated list of chunks known to be all-zero. Published
+    // from EmptyChunkNoted events. Readers binary-search it as a plain-
+    // memory alternative to BlockPipeline::isEmptyChunk's atomic probe
+    // loop. Only grows; a chunk becomes "empty" once and stays that way.
+    std::vector<ChunkKey> emptyChunkKeys;
+
+    // Drain counts from the tick that produced this frame.
+    std::uint64_t chunksLandedThisTick = 0;
+    std::uint64_t emptyChunksThisTick = 0;
+
+    // Cumulative counts since process start. Useful for dashboards.
+    std::uint64_t totalChunksLanded = 0;
+    std::uint64_t totalEmptyChunks = 0;
+};
+
+// Single-writer, multi-reader state publisher. One dedicated std::jthread
+// wakes every 16 ms, prepares the non-current FrameState buffer, then
+// atomically swaps the `current_` pointer. Readers signal completion via
+// `releaseFrame()` so the coordinator knows when the non-current buffer
+// is safe to overwrite.
+class TickCoordinator {
+public:
+    TickCoordinator();
+    ~TickCoordinator();
+
+    TickCoordinator(const TickCoordinator&) = delete;
+    TickCoordinator& operator=(const TickCoordinator&) = delete;
+
+    // Render entry: load the current FrameState. Valid until releaseFrame()
+    // is called with the same pointer. Callers must release before their
+    // next currentFrame() call.
+    [[nodiscard]] const FrameState* currentFrame() const noexcept
+    {
+        return current_.load(std::memory_order_acquire);
+    }
+
+    // Signal that the caller is done reading `s`. `last_released_gen_` is
+    // monotonic across all readers, so the coordinator recycles a buffer
+    // once `last_released_gen_ >= buffer->generation` — i.e., some reader
+    // has released a generation at least as new as the one the buffer
+    // currently holds. Multi-reader safe because readers never un-release.
+    void releaseFrame(const FrameState* s) noexcept
+    {
+        if (!s) return;
+        // Monotonic: never step backwards if multiple viewers overlap.
+        std::uint64_t prev = last_released_gen_.load(std::memory_order_relaxed);
+        while (s->generation > prev) {
+            if (last_released_gen_.compare_exchange_weak(
+                    prev, s->generation, std::memory_order_release,
+                    std::memory_order_relaxed)) {
+                break;
+            }
+        }
+    }
+
+    [[nodiscard]] std::uint64_t generation() const noexcept
+    {
+        return gen_.load(std::memory_order_relaxed);
+    }
+
+    // Producer-side push. Non-blocking; drops silently on ring overflow
+    // (tracked via `dropped*` counters). These are process-wide routes
+    // via the global coordinator pointer set up in the constructor.
+    static void notifyChunkLanded(const ChunkKey& k) noexcept;
+    static void notifyEmptyChunkNoted(const ChunkKey& k) noexcept;
+
+    // Convenience accessors for readers that don't have a direct handle
+    // to the coordinator (e.g. BlockSampler, constructed deep inside
+    // render code). Returns null if no coordinator is running.
+    // `releaseFrameGlobal` is a no-op for null inputs so destructors
+    // can call it unconditionally.
+    static const FrameState* currentFrameGlobal() noexcept;
+    static void releaseFrameGlobal(const FrameState* s) noexcept;
+
+    [[nodiscard]] std::uint64_t droppedChunkLanded() const noexcept
+    {
+        return droppedChunkLanded_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] std::uint64_t droppedEmptyChunks() const noexcept
+    {
+        return droppedEmptyChunks_.load(std::memory_order_relaxed);
+    }
+
+private:
+    void runLoop(std::stop_token stop) noexcept;
+
+    std::array<FrameState, 2> frames_{};
+    std::atomic<const FrameState*> current_{nullptr};
+    std::atomic<std::uint64_t> last_released_gen_{0};
+    std::atomic<std::uint64_t> gen_{0};
+
+    // Producer events. Single ring per type keeps the implementation
+    // simple; if CAS contention becomes visible in a profile we can
+    // shard by BlockCache shard index.
+    vc::util::MpscRing<ChunkKey, 16384> chunkLandedRing_;
+    vc::util::MpscRing<ChunkKey, 4096>  emptyChunkRing_;
+
+    // Full-ring drops. Should be zero in practice; non-zero values mean
+    // the drain thread couldn't keep up or the rings are undersized.
+    std::atomic<std::uint64_t> droppedChunkLanded_{0};
+    std::atomic<std::uint64_t> droppedEmptyChunks_{0};
+
+    // Cumulative counts, updated by the drain thread only.
+    std::uint64_t totalChunksLanded_ = 0;
+    std::uint64_t totalEmptyChunks_ = 0;
+
+    // Master sorted list of empty chunks. Published (copied) into each
+    // FrameState buffer at tick boundary. Grows over the session; shrinks
+    // only on BlockPipeline::clearMemory, which we don't signal yet (so
+    // the list is monotonic in practice).
+    std::vector<ChunkKey> emptyChunkMaster_;
+
+    // jthread declared last so its destructor runs first on teardown,
+    // stopping the loop before member storage unwinds.
+    std::jthread worker_;
+};
+
+}  // namespace vc::cache

--- a/volume-cartographer/core/include/vc/core/types/Volume.hpp
+++ b/volume-cartographer/core/include/vc/core/types/Volume.hpp
@@ -132,17 +132,6 @@ public:
                               int width, int height,
                               const vc::SampleParams& params);
 
-    // Fused plane sampling + LUT: samples and writes ARGB32 directly,
-    // eliminating the intermediate cv::Mat and applyPostProcess pass.
-    // outBuf must have room for width*height pixels (outStride in uint32_t units).
-    int samplePlaneBestEffortARGB32(uint32_t* outBuf, int outStride,
-                                    const cv::Vec3f& origin,
-                                    const cv::Vec3f& vx_step,
-                                    const cv::Vec3f& vy_step,
-                                    int width, int height,
-                                    const vc::SampleParams& params,
-                                    const uint32_t lut[256]);
-
     // Fused plane composite: nearest-neighbor per layer + composite + LUT → ARGB32.
     // No coord matrix. For PlaneSurface composite rendering.
     int samplePlaneCompositeBestEffortARGB32(

--- a/volume-cartographer/core/include/vc/core/util/Compositing.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Compositing.hpp
@@ -50,6 +50,20 @@ struct CompositeParams {
     // Pre-processing
     uint8_t isoCutoff = 0;           // Highpass filter: values below this are set to 0
 
+    // Per-ray layer preprocess (applied to the N sampled composite layers
+    // for each pixel before the composite method runs). Cancels z-axis
+    // brightness drift so the composite averages evenly across a ray that
+    // crosses bright and dark strata.
+    //
+    // preNormalizeLayers: min-max stretch the N layer values to [0, 255].
+    //   Preserves per-ray structure, eliminates absolute brightness offset.
+    // preHistEqLayers:   CDF-based histogram equalization over the N layer
+    //   values. Flattens per-ray contrast; strongest effect, can clip out
+    //   true structure if the ray is genuinely uniform.
+    // Both can be chained (normalize → equalize).
+    bool preNormalizeLayers = false;
+    bool preHistEqLayers = false;
+
     // Recompute lightDir from lightAzimuth/lightElevation (degrees)
     void updateLightDir() noexcept {
         float azRad = lightAzimuth * (std::numbers::pi_v<float> / 180.0f);

--- a/volume-cartographer/core/include/vc/core/util/Compositing.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Compositing.hpp
@@ -64,6 +64,38 @@ struct CompositeParams {
     bool preNormalizeLayers = false;
     bool preHistEqLayers = false;
 
+    // Piecewise-linear 4-knot transfer functions with fixed endpoints at
+    // (0,0) and (255,255); only the two middle knots (x1,y1)(x2,y2) are
+    // user-settable. When the enable flag is off, the LUT is identity.
+    //
+    // preTf:  applied to every sampled u8 voxel BEFORE layer storage /
+    //         preprocess / compositing. Lets you cut air (y below some x),
+    //         isolate an intensity band, or compress dynamic range before
+    //         per-ray normalization runs.
+    // postTf: applied to the final composite output value (before the
+    //         existing 2D postprocess stages: stretch, CLAHE, raking).
+    //         Lets you remap the composite's output intensity curve.
+    bool preTfEnabled = false;
+    uint8_t preTfX1 = 85, preTfY1 = 85;
+    uint8_t preTfX2 = 170, preTfY2 = 170;
+    bool postTfEnabled = false;
+    uint8_t postTfX1 = 85, postTfY1 = 85;
+    uint8_t postTfX2 = 170, postTfY2 = 170;
+
+    // Ambient term for the `dvr` composite method. Added to the final
+    // transmittance-weighted color so voids don't stay pitch-black in the
+    // rendered output. 0 disables; 1-255 adds a flat background.
+    float dvrAmbient = 0.0f;
+
+    // PBR Cook-Torrance parameters for the `pbrIso` composite method.
+    // roughness: 0 = mirror-smooth, 1 = fully diffuse (Lambertian).
+    // metallic:  0 = dielectric (Fresnel F0=0.04), 1 = metal (F0≈0.7 —
+    //            carbon-like, the only material in a carbonized scroll).
+    // Uses lightDir + lightDiffuse + lightAmbient from the existing
+    // lighting block for the light direction + intensity knobs.
+    float pbrRoughness = 0.5f;
+    float pbrMetallic = 0.0f;
+
     // Recompute lightDir from lightAzimuth/lightElevation (degrees)
     void updateLightDir() noexcept {
         float azRad = lightAzimuth * (std::numbers::pi_v<float> / 180.0f);
@@ -144,6 +176,17 @@ float compositeLayerStack(
 // Utility: check if method requires all layer values to be stored
 // (as opposed to running accumulator like max/min)
 bool methodRequiresLayerStorage(const std::string& method) noexcept;
+
+// Build a 256-entry u8→u8 LUT from a 4-knot piecewise-linear transfer
+// function with implicit endpoints (0,0) and (255,255). When `enabled` is
+// false, writes the identity mapping. Knot x coordinates are clamped and
+// sorted internally, so the caller does not need to pre-sort; degenerate
+// runs (x1 == x2) collapse to a step. Safe for tight rendering loops — a
+// 256-byte array fits trivially in L1D.
+void buildTfLut256(bool enabled,
+                   uint8_t x1, uint8_t y1,
+                   uint8_t x2, uint8_t y2,
+                   uint8_t lut[256]) noexcept;
 
 // Compute directional lighting factor for a surface normal
 // Returns a multiplier (0-1) based on Lambertian diffuse lighting

--- a/volume-cartographer/core/include/vc/core/util/MpscRing.hpp
+++ b/volume-cartographer/core/include/vc/core/util/MpscRing.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace vc::util {
+
+// Bounded MPSC ring buffer using Vyukov's sequence-based protocol.
+// Multiple producers, single consumer. Capacity must be a power of two.
+//
+// Each slot carries a sequence counter that serializes the "reserved /
+// committed / consumed" states across producers and the consumer without
+// a mutex. Producers race on `tail_` via CAS; the consumer owns `head_`
+// plain.
+//
+// T must be trivially copyable so push/pop can use value assignment
+// without running destructors on half-written slots.
+template <typename T, std::size_t Capacity>
+class MpscRing {
+    static_assert(Capacity > 0 && (Capacity & (Capacity - 1)) == 0,
+                  "Capacity must be a power of two");
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "T must be trivially copyable");
+
+public:
+    MpscRing() noexcept
+    {
+        for (std::size_t i = 0; i < Capacity; ++i) {
+            slots_[i].seq.store(i, std::memory_order_relaxed);
+        }
+    }
+
+    // Producer side. Returns false if the ring is full.
+    bool try_push(const T& v) noexcept
+    {
+        std::size_t pos = tail_.load(std::memory_order_relaxed);
+        for (;;) {
+            Slot& s = slots_[pos & (Capacity - 1)];
+            std::size_t seq = s.seq.load(std::memory_order_acquire);
+            auto diff = static_cast<std::intptr_t>(seq) - static_cast<std::intptr_t>(pos);
+            if (diff == 0) {
+                if (tail_.compare_exchange_weak(pos, pos + 1,
+                                                std::memory_order_relaxed)) {
+                    s.value = v;
+                    s.seq.store(pos + 1, std::memory_order_release);
+                    return true;
+                }
+                // CAS failed; pos was reloaded with new tail, retry.
+            } else if (diff < 0) {
+                return false;
+            } else {
+                pos = tail_.load(std::memory_order_relaxed);
+            }
+        }
+    }
+
+    // Consumer side (single-threaded). Returns false if the ring is empty.
+    bool try_pop(T& out) noexcept
+    {
+        Slot& s = slots_[head_ & (Capacity - 1)];
+        std::size_t seq = s.seq.load(std::memory_order_acquire);
+        auto diff = static_cast<std::intptr_t>(seq) - static_cast<std::intptr_t>(head_ + 1);
+        if (diff == 0) {
+            out = s.value;
+            s.seq.store(head_ + Capacity, std::memory_order_release);
+            ++head_;
+            return true;
+        }
+        return false;
+    }
+
+    // Approximate size (producer-side view). Not exact under contention;
+    // intended for overflow-rate dashboards, not correctness.
+    [[nodiscard]] std::size_t approx_size() const noexcept
+    {
+        return tail_.load(std::memory_order_relaxed) - head_;
+    }
+
+    [[nodiscard]] static constexpr std::size_t capacity() noexcept { return Capacity; }
+
+private:
+    struct alignas(64) Slot {
+        std::atomic<std::size_t> seq{0};
+        T value{};
+    };
+
+    std::array<Slot, Capacity> slots_{};
+    alignas(64) std::atomic<std::size_t> tail_{0};
+    alignas(64) std::size_t head_{0};
+};
+
+}  // namespace vc::util

--- a/volume-cartographer/core/include/vc/core/util/Slicing.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Slicing.hpp
@@ -81,31 +81,6 @@ void samplePlane(cv::Mat_<uint8_t>& out, vc::cache::BlockPipeline* cache, int le
                  const cv::Vec3f& origin, const cv::Vec3f& vx_step, const cv::Vec3f& vy_step,
                  int width, int height, vc::Sampling method);
 
-// Adaptive plane sampling: per-pixel level fallback. For each pixel, tries the
-// desired level first; if that chunk isn't in hot cache, falls back to coarser
-// levels. This means half the image can be full-res while the rest is still loading.
-// Returns the coarsest level actually used (for prefetch decisions).
-int samplePlaneAdaptiveARGB32(uint32_t* outBuf, int outStride,
-                               vc::cache::BlockPipeline* cache,
-                               int desiredLevel, int numLevels,
-                               const cv::Vec3f& origin,
-                               const cv::Vec3f& vx_step,
-                               const cv::Vec3f& vy_step,
-                               int width, int height,
-                               const uint32_t lut[256],
-                               vc::Sampling method = vc::Sampling::Nearest);
-
-// Adaptive coords sampling: per-pixel level fallback for QuadSurface.
-// Same as samplePlaneAdaptiveARGB32 but takes pre-computed coords matrix.
-// Non-blocking: missing chunks skipped (rendered as lut[0]).
-void sampleCoordsAdaptiveARGB32(
-    uint32_t* outBuf, int outStride,
-    vc::cache::BlockPipeline* cache,
-    int desiredLevel, int numLevels,
-    const cv::Mat_<cv::Vec3f>& coords,
-    const uint32_t lut[256],
-    vc::Sampling method = vc::Sampling::Nearest);
-
 // Unified composite-capable adaptive sampler with per-pixel level fallback.
 // One entry point for plane/coords and composite/non-composite rendering:
 //   - Plane mode: pass coords=nullptr and origin/vx_step/vy_step/planeNormal.

--- a/volume-cartographer/core/include/vc/core/util/Slicing.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Slicing.hpp
@@ -110,7 +110,15 @@ void sampleAdaptiveARGB32(
     // tagged with the *coarsest* pyramid-level offset used while sampling
     // (0 = desired level, 1..N = fallback depth). Stride is in bytes.
     uint8_t* levelOut = nullptr,
-    int levelStride = 0);
+    int levelStride = 0,
+    // When true, skip the per-frame chunk enumeration + sort + fetchInteractive
+    // that the kernel normally runs before dispatching tiles. Intended for
+    // callers that can prove the coords haven't changed since the last
+    // render (e.g. QuadSurface gen cache hit) — the prior frame already
+    // queued the needed blocks, so rerunning the enumeration is pure
+    // overhead. No correctness impact on block residency: the per-sample
+    // adaptive fallback still handles any block not yet loaded.
+    bool skipPrefetch = false);
 
 // Fused plane composite: inline coords + nearest-neighbor per layer + composite + LUT → ARGB32.
 // No coord matrix allocation. For PlaneSurface composite rendering.

--- a/volume-cartographer/core/src/Compositing.cpp
+++ b/volume-cartographer/core/src/Compositing.cpp
@@ -96,6 +96,40 @@ float compositeLayerStack(
             return CompositeMethod::alpha(stack, params);
         case utils::CompositingMethod::beer_lambert:
             return CompositeMethod::beerLambert(stack, params);
+        case utils::CompositingMethod::dvr:
+            return utils::composite_dvr(
+                std::span<const float>(stack.values.data(), stack.validCount),
+                params.dvrAmbient);
+        case utils::CompositingMethod::first_hit_iso:
+            return utils::composite_first_hit_iso(
+                std::span<const float>(stack.values.data(), stack.validCount),
+                float(params.isoCutoff));
+        case utils::CompositingMethod::dev_from_mean:
+            return utils::composite_dev_from_mean(
+                std::span<const float>(stack.values.data(), stack.validCount),
+                float(params.isoCutoff));
+        case utils::CompositingMethod::emission_dvr:
+            return utils::composite_emission_dvr(
+                std::span<const float>(stack.values.data(), stack.validCount));
+        case utils::CompositingMethod::max_above_iso:
+            return utils::composite_max_above_iso(
+                std::span<const float>(stack.values.data(), stack.validCount),
+                float(params.isoCutoff));
+        case utils::CompositingMethod::gamma_weighted:
+            return utils::composite_gamma_weighted(
+                std::span<const float>(stack.values.data(), stack.validCount),
+                float(params.isoCutoff));
+        case utils::CompositingMethod::gradient_mag:
+            return utils::composite_gradient_mag(
+                std::span<const float>(stack.values.data(), stack.validCount));
+        case utils::CompositingMethod::pbr_iso:
+            return utils::composite_first_hit_iso(
+                std::span<const float>(stack.values.data(), stack.validCount),
+                float(params.isoCutoff));
+        case utils::CompositingMethod::shaded_dvr:
+            return utils::composite_dvr(
+                std::span<const float>(stack.values.data(), stack.validCount),
+                params.dvrAmbient);
     }
 
     return CompositeMethod::mean(stack);
@@ -104,6 +138,37 @@ float compositeLayerStack(
 bool methodRequiresLayerStorage(const std::string& method) noexcept
 {
     return utils::method_requires_storage(utils::parse_compositing_method(method));
+}
+
+void buildTfLut256(bool enabled,
+                   uint8_t x1, uint8_t y1,
+                   uint8_t x2, uint8_t y2,
+                   uint8_t lut[256]) noexcept
+{
+    if (!enabled) {
+        for (int i = 0; i < 256; ++i) lut[i] = uint8_t(i);
+        return;
+    }
+    // Sort the two middle knots by x so the PL function is monotone in x.
+    if (x1 > x2) { std::swap(x1, x2); std::swap(y1, y2); }
+    // Four segments: [0,x1] → [0,y1], [x1,x2] → [y1,y2], [x2,255] → [y2,255].
+    // Each segment is a linear interpolation; degenerate runs collapse to a
+    // step by short-circuiting the denominator.
+    auto lerp = [](float x, float x0, float x1, float y0, float y1) {
+        const float d = x1 - x0;
+        if (d <= 0.f) return y0;
+        const float t = (x - x0) / d;
+        return y0 + t * (y1 - y0);
+    };
+    for (int i = 0; i < 256; ++i) {
+        float y;
+        if (i <= int(x1))      y = lerp(float(i), 0.f,      float(x1), 0.f,      float(y1));
+        else if (i <= int(x2)) y = lerp(float(i), float(x1), float(x2), float(y1), float(y2));
+        else                   y = lerp(float(i), float(x2), 255.f,     float(y2), 255.f);
+        if (y < 0.f) y = 0.f;
+        if (y > 255.f) y = 255.f;
+        lut[i] = uint8_t(y + 0.5f);
+    }
 }
 
 float computeLightingFactor(const cv::Vec3f& normal, const CompositeParams& params) noexcept

--- a/volume-cartographer/core/src/Geometry.cpp
+++ b/volume-cartographer/core/src/Geometry.cpp
@@ -118,6 +118,10 @@ static E at_int_impl(const cv::Mat_<E> &points, const cv::Vec2f& p)
 
     return (1-fy)*p0 + fy*p1;
 }
+// Note (2026-04): explicit row-pointer hoisting was tried here and
+// benchmarked ~23% slower than the operator()-based form above. The
+// compiler's CSE handles the stride-multiply fine; manual hoisting
+// defeats some optimization pass on this codepath. Leaving as-is.
 
 template<typename T, int C>
 static bool loc_valid_impl(const cv::Mat_<cv::Vec<T,C>> &m, const cv::Vec2d &l)

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -712,6 +712,12 @@ static inline cv::Vec2f mul(const cv::Vec2f &a, const cv::Vec2f &b)
     return{a[0]*b[0],a[1]*b[1]};
 }
 
+// Gauss-Newton was tried here (2026-04) with full regression coverage
+// (vc_coord_regression against synthetic + three real tifxyz segments).
+// Result: neutral on performance, no reliable accuracy gain. The 8-neighbour
+// halving below is well-tuned for scroll-surface topology (folds, twists,
+// noise) where Newton's linear-regime assumption doesn't hold. See
+// vc_coord_regression for the harness if you want to try again.
 template <typename E>
 static float search_min_loc(const cv::Mat_<E> &points, cv::Vec2f &loc, cv::Vec3f &out, cv::Vec3f tgt, cv::Vec2f init_step, float min_step_x)
 {

--- a/volume-cartographer/core/src/Slicing.cpp
+++ b/volume-cartographer/core/src/Slicing.cpp
@@ -86,20 +86,22 @@ struct VolumeShape {
 // block cache only — never blocks on disk or network. Missing blocks make
 // sampleInt return 0 (black) for that voxel. Viewport-demand fetches feed
 // the cache asynchronously via BlockPipeline::fetchInteractive.
-template<typename T, int kSlots = 4096>
+template<typename T, int kSlots = 16384>
 struct BlockSampler {
     static_assert((kSlots & (kSlots - 1)) == 0, "kSlots must be power of 2");
     static constexpr int kSlotMask = kSlots - 1;
 
-    // Hot slot: packed key + data pointer, 16 bytes. 4096 slots × 16B = 64KB.
-    // Fits in L2 with room to spare; L1D (typically 32-64KB) takes collisions.
-    // Raised from 1024 because the 12-thread render's per-thread working set
-    // is 1400-2700 unique blocks per frame — at 1024 slots the direct-mapped
-    // cache collided hard, and every collision miss fell through to blockAt,
-    // taking a BlockCache shard shared_lock. The shard shared_lock release
-    // (CAS-rel on its reader counter) was ~9% of CPU. 4096 slots hold the
-    // full working set so most lookups stay in the sampler's private cache.
-    // The shared_ptr (refcounting keep-alive) lives in a cold parallel array,
+    // Hot slot: packed key + data pointer, 16 bytes. 16384 slots × 16B =
+    // 256 KB per sampler — fits in L2D on Oryon (typically 1-2 MB/core).
+    // Sized up from 4096 after observing heavy Max-composite workloads
+    // (65 layers × 1M pixels, ~500K unique blocks across the frame)
+    // sending ~25% of lookups to the BlockCache slow path. The slow
+    // path's pthread_rwlock_rdlock/unlock chain was ~44% of CPU in those
+    // frames. Quadrupling the per-thread cache drops the direct-mapped
+    // collision rate roughly 4× by lowering occupancy, and keeps far
+    // more of the hot working set in the per-sampler private cache
+    // (where lookups are 2 instructions, no atomics).
+    // The BlockPtr (non-owning) lives in a cold parallel array,
     // touched only on miss.
     struct HotSlot {
         uint64_t key = UINT64_MAX;
@@ -682,7 +684,9 @@ public:
         // ever shares it.
         std::lock_guard<std::mutex> callLock(callMutex_);
         body_ = std::function<void(int)>(std::forward<Body>(body));
-        for (int i = 0; i < nWorkers; ++i) startSem_.release();
+        // Batched start: glibc collapses counting_semaphore::release(N)
+        // into a single futex_wake(n=N) syscall, vs. N separate syscalls.
+        startSem_.release(nWorkers);
         body_(0);
         for (int i = 0; i < nWorkers; ++i) doneSem_.acquire();
     }
@@ -708,7 +712,7 @@ private:
 
     ~RenderThreadPool() {
         shutdown_.store(true, std::memory_order_release);
-        for (size_t i = 0; i < workers_.size(); ++i) startSem_.release();
+        startSem_.release(int(workers_.size()));
         // jthread destructor joins automatically.
     }
 
@@ -903,7 +907,11 @@ static AccumMode2 accumModeFor(const std::string& m) {
     if (m == "max") return AccumMode2::Max;
     if (m == "min") return AccumMode2::Min;
     if (m == "volumetric") return AccumMode2::Volumetric;
-    if (m == "median" || m == "alpha" || m == "beerLambert" || m == "minabs") return AccumMode2::LayerStorage;
+    if (m == "median" || m == "alpha" || m == "beerLambert" || m == "minabs"
+        || m == "dvr" || m == "firstHitIso" || m == "devFromMean"
+        || m == "emissionDvr" || m == "maxAboveIso" || m == "gammaWeighted"
+        || m == "gradientMag" || m == "pbrIso" || m == "shadedDvr")
+        return AccumMode2::LayerStorage;
     return AccumMode2::Mean;
 }
 
@@ -928,13 +936,35 @@ void sampleSingleLayerAdaptiveImpl(
     const uint32_t lut[256],
     const CompositeParams* lightParams,
     uint8_t* levelOut,
-    int levelStride)
+    int levelStride,
+    bool skipPrefetch = false)
 {
     auto levelScale = [](int lvl) { return (lvl > 0) ? 1.0f / float(1 << lvl) : 1.0f; };
     const float zOffConst = float(zStart) * zStep;
 
+    alignas(64) uint8_t preTfLut[256];
+    buildTfLut256(
+        lightParams && lightParams->preTfEnabled,
+        lightParams ? lightParams->preTfX1 : 85,
+        lightParams ? lightParams->preTfY1 : 85,
+        lightParams ? lightParams->preTfX2 : 170,
+        lightParams ? lightParams->preTfY2 : 170,
+        preTfLut);
+    alignas(64) uint8_t postTfLut[256];
+    buildTfLut256(
+        lightParams && lightParams->postTfEnabled,
+        lightParams ? lightParams->postTfX1 : 85,
+        lightParams ? lightParams->postTfY1 : 85,
+        lightParams ? lightParams->postTfX2 : 170,
+        lightParams ? lightParams->postTfY2 : 170,
+        postTfLut);
+
     // Prefetch the chunks the sampled plane touches. Same as the multi-layer
     // version but the bbox collapses to the single-z-slab defined by zStart.
+    // When skipPrefetch is set, the caller is asserting that coords haven't
+    // changed since the prior frame — the fetchInteractive queue is already
+    // seeded, and rerunning the enumeration is pure overhead.
+    if (!skipPrefetch) {
     cv::Vec3f viewCenterL0(0, 0, 0);
     bool haveCenter = false;
     if (coords) {
@@ -990,6 +1020,7 @@ void sampleSingleLayerAdaptiveImpl(
             cache.fetchInteractive(keys, desiredLevel);
         }
     }
+    }  // skipPrefetch guard
 
     float scales[kMaxLevels] = {};
     const int nSamplersTotal = numLevels - desiredLevel;
@@ -1117,7 +1148,7 @@ void sampleSingleLayerAdaptiveImpl(
                     val *= computeLightingFactor(lnrm, *lightParams);
                 }
                 if (val < 0.f) val = 0.f; if (val > 255.f) val = 255.f;
-                outRow[x] = lut[uint8_t(val)];
+                outRow[x] = lut[postTfLut[uint8_t(val)]];
                 if (lvlRow) lvlRow[x] = pxLevel;
             }
         }
@@ -1139,7 +1170,8 @@ void sampleCompositeAdaptiveImpl(
     const uint32_t lut[256],
     const CompositeParams* lightParams,
     uint8_t* levelOut,
-    int levelStride)
+    int levelStride,
+    bool skipPrefetch = false)
 {
     auto levelScale = [](int lvl) { return (lvl > 0) ? 1.0f / float(1 << lvl) : 1.0f; };
     const float zLo = float(zStart) * zStep;
@@ -1147,6 +1179,9 @@ void sampleCompositeAdaptiveImpl(
     const float zMin = std::min(zLo, zHi), zMax = std::max(zLo, zHi);
 
     // Prefetch covered bbox across all fallback levels.
+    // Skip entirely when the caller knows coords are unchanged since the
+    // prior frame — same rationale as in sampleSingleLayerAdaptiveImpl.
+    if (!skipPrefetch) {
     cv::Vec3f viewCenterL0(0, 0, 0);
     bool haveCenter = false;
     if (coords) {
@@ -1212,6 +1247,7 @@ void sampleCompositeAdaptiveImpl(
             cache.fetchInteractive(keys, desiredLevel);
         }
     }
+    }  // skipPrefetch guard
 
     // Precompute per-level scale factor once (1.0 / 2^lvl). Hoists the
     // integer shift + int->float convert + fdiv out of the hot inner loop.
@@ -1227,13 +1263,27 @@ void sampleCompositeAdaptiveImpl(
     // Max and Min also reach here when preprocess is enabled — the per-ray
     // layer preprocess needs layerVals[] populated, which Max/Min's direct
     // accumulate path skips.
-    enum class LayerAgg : uint8_t { Median, MinAbs, Alpha, BeerLambert, Mean, Max, Min };
+    enum class LayerAgg : uint8_t {
+        Median, MinAbs, Alpha, BeerLambert, Mean, Max, Min,
+        Dvr, FirstHitIso, DevFromMean,
+        EmissionDvr, MaxAboveIso, GammaWeighted, GradientMag,
+        PbrIso, ShadedDvr
+    };
     const LayerAgg layerAgg = (compositeMethod == "median") ? LayerAgg::Median
                             : (compositeMethod == "minabs") ? LayerAgg::MinAbs
                             : (compositeMethod == "alpha") ? LayerAgg::Alpha
                             : (compositeMethod == "beerLambert") ? LayerAgg::BeerLambert
                             : (compositeMethod == "max") ? LayerAgg::Max
                             : (compositeMethod == "min") ? LayerAgg::Min
+                            : (compositeMethod == "dvr") ? LayerAgg::Dvr
+                            : (compositeMethod == "firstHitIso") ? LayerAgg::FirstHitIso
+                            : (compositeMethod == "devFromMean") ? LayerAgg::DevFromMean
+                            : (compositeMethod == "emissionDvr") ? LayerAgg::EmissionDvr
+                            : (compositeMethod == "maxAboveIso") ? LayerAgg::MaxAboveIso
+                            : (compositeMethod == "gammaWeighted") ? LayerAgg::GammaWeighted
+                            : (compositeMethod == "gradientMag") ? LayerAgg::GradientMag
+                            : (compositeMethod == "pbrIso") ? LayerAgg::PbrIso
+                            : (compositeMethod == "shadedDvr") ? LayerAgg::ShadedDvr
                             : LayerAgg::Mean;
 
     // Per-ray layer preprocess flags (applied before the aggregation below).
@@ -1250,6 +1300,29 @@ void sampleCompositeAdaptiveImpl(
     // reload them through the pointer each iteration.
     const bool lightingEnabled = lightParams && lightParams->lightingEnabled;
     const int  lightNormalSource = lightParams ? lightParams->lightNormalSource : 0;
+
+    // Pre-TF LUT: materialized once per render from lightParams. Identity
+    // when preTfEnabled is off, so the per-sample lookup stays a no-op
+    // without needing a branch in the inner loop. 256 bytes = one cacheline-
+    // worth of L1D.
+    alignas(64) uint8_t preTfLut[256];
+    buildTfLut256(
+        lightParams && lightParams->preTfEnabled,
+        lightParams ? lightParams->preTfX1 : 85,
+        lightParams ? lightParams->preTfY1 : 85,
+        lightParams ? lightParams->preTfX2 : 170,
+        lightParams ? lightParams->preTfY2 : 170,
+        preTfLut);
+    // Post-TF LUT: applied to the composite output before the display
+    // colormap. Same identity-on-disable property as preTfLut.
+    alignas(64) uint8_t postTfLut[256];
+    buildTfLut256(
+        lightParams && lightParams->postTfEnabled,
+        lightParams ? lightParams->postTfX1 : 85,
+        lightParams ? lightParams->postTfY1 : 85,
+        lightParams ? lightParams->postTfX2 : 170,
+        lightParams ? lightParams->postTfY2 : 170,
+        postTfLut);
 
     // Volumetric-mode exp LUTs: exp(-extN * k) for k in [0..255]. extN is
     // constant per call (from lightParams->blExtinction/255). Pre-computing
@@ -1530,7 +1603,25 @@ void sampleCompositeAdaptiveImpl(
                         const int bx = int( key        & ((int64_t(1) << 20) - 1));
                         s0.tryUpdateBlockNonBlocking(bz, by, bx);
                         const uint8_t* cdata = s0.data;
+                        // Run-length extend: find the largest liEnd such that
+                        // bkey[li..liEnd) are all equal to key. Consecutive
+                        // z-samples at zStep=1 typically share a block for
+                        // ~16 layers, so this loop iterates ~16x per block
+                        // transition. Scalar version was ~20% of the composite
+                        // kernel's CPU (perf showed the backward-branch target
+                        // hot). The 4-wide block below issues all 4 compares
+                        // before the branch — bitwise `&` (not `&&`) prevents
+                        // short-circuit so clang can schedule them in parallel
+                        // across the Oryon wide OoO pipeline.
                         int liEnd = li + 1;
+                        while (liEnd + 4 <= nL) {
+                            const int e0 = bkey[liEnd    ] == key;
+                            const int e1 = bkey[liEnd + 1] == key;
+                            const int e2 = bkey[liEnd + 2] == key;
+                            const int e3 = bkey[liEnd + 3] == key;
+                            if ((e0 & e1 & e2 & e3) == 0) break;
+                            liEnd += 4;
+                        }
                         while (liEnd < nL && bkey[liEnd] == key) ++liEnd;
                         const int runLen = liEnd - li;
                         if (cdata) {
@@ -1542,27 +1633,27 @@ void sampleCompositeAdaptiveImpl(
                             if constexpr (AMode == AccumMode2::Max) {
                                 uint8_t m = uint8_t(mx);
                                 for (int i = li; i < liEnd; ++i) {
-                                    const uint8_t v = cdata[offset[i]];
+                                    const uint8_t v = preTfLut[cdata[offset[i]]];
                                     m = v > m ? v : m;
                                 }
                                 mx = float(m);
                             } else if constexpr (AMode == AccumMode2::Min) {
                                 uint8_t m = uint8_t(mn);
                                 for (int i = li; i < liEnd; ++i) {
-                                    const uint8_t v = cdata[offset[i]];
+                                    const uint8_t v = preTfLut[cdata[offset[i]]];
                                     m = v < m ? v : m;
                                 }
                                 mn = float(m);
                             } else if constexpr (AMode == AccumMode2::Mean) {
                                 int sum = 0;
                                 for (int i = li; i < liEnd; ++i) {
-                                    sum += int(cdata[offset[i]]);
+                                    sum += int(preTfLut[cdata[offset[i]]]);
                                 }
                                 accum += float(sum);
                                 count += runLen;
                             } else {
                                 for (int i = li; i < liEnd; ++i) {
-                                    layerVals[i] = float(cdata[offset[i]]);
+                                    layerVals[i] = float(preTfLut[cdata[offset[i]]]);
                                 }
                             }
                         } else if constexpr (AMode == AccumMode2::Mean) {
@@ -1587,6 +1678,7 @@ void sampleCompositeAdaptiveImpl(
                                 break;
                             }
                         }
+                        v = preTfLut[v];
                         if constexpr (AMode == AccumMode2::Max) { mx = std::max(mx, float(v)); }
                         else if constexpr (AMode == AccumMode2::Min) { mn = std::min(mn, float(v)); }
                         else if constexpr (AMode == AccumMode2::Mean) { accum += float(v); count++; }
@@ -1801,6 +1893,275 @@ void sampleCompositeAdaptiveImpl(
                             for (int i=1; i<nL; i++) if (layerVals[i] < m) m = layerVals[i];
                             val = m;
                         }
+                    } else if (layerAgg == LayerAgg::Dvr) {
+                        // Front-to-back emissive volume rendering. Each layer
+                        // contributes emission proportional to its (Pre-TF'd)
+                        // intensity; opacity is intensity/255. Pre-TF sculpts
+                        // the intensity→opacity curve so a user can isolate
+                        // the ink-density band.
+                        float color = 0.f;
+                        float trans = 1.f;
+                        const float ambient = lightParams ? lightParams->dvrAmbient : 0.f;
+                        for (int i = 0; i < nL; ++i) {
+                            if (preprocessActive && voidMask[i]) continue;
+                            const float I = layerVals[i];
+                            const float op = I * (1.f/255.f);
+                            color += I * trans * op;
+                            trans *= (1.f - op);
+                            if (trans < 0.001f) break;
+                        }
+                        color += ambient * trans;
+                        val = color;
+                    } else if (layerAgg == LayerAgg::FirstHitIso) {
+                        // First voxel above isoCutoff along the ray. Shaded
+                        // later by the lighting block below (which already
+                        // supports lightNormalSource=1 = volume gradient
+                        // normal) — so the rendered result is a surface-
+                        // topology view of the first density boundary.
+                        const uint8_t isoCut = lightParams ? lightParams->isoCutoff : 0;
+                        const float isoFHit = float(isoCut);
+                        float hit = 0.f;
+                        for (int i = 0; i < nL; ++i) {
+                            if (layerVals[i] > isoFHit) { hit = layerVals[i]; break; }
+                        }
+                        val = hit;
+                    } else if (layerAgg == LayerAgg::DevFromMean) {
+                        // Mean absolute deviation from the ray mean, over
+                        // layers above isoCutoff (or over non-void layers
+                        // when preprocess is active). Surfaces per-ray
+                        // outliers — ink, voids, cracks — relative to a
+                        // locally-estimated papyrus baseline. Float math
+                        // is fine: max sum is kMaxLayers * 255 ≈ 33K, well
+                        // below float's 24-bit mantissa — and dropping the
+                        // float↔double fcvt chain let clang keep the two
+                        // passes in the FPU pipeline rather than bouncing
+                        // through double registers per sample.
+                        const uint8_t isoCut = lightParams ? lightParams->isoCutoff : 0;
+                        const float isoFDev = float(isoCut);
+                        float sum = 0.f;
+                        int n = 0;
+                        for (int i = 0; i < nL; ++i) {
+                            if (preprocessActive && voidMask[i]) continue;
+                            if (!preprocessActive && layerVals[i] <= isoFDev) continue;
+                            sum += layerVals[i];
+                            ++n;
+                        }
+                        if (n > 0) {
+                            const float invN = 1.f / float(n);
+                            const float m = sum * invN;
+                            float dev = 0.f;
+                            for (int i = 0; i < nL; ++i) {
+                                if (preprocessActive && voidMask[i]) continue;
+                                if (!preprocessActive && layerVals[i] <= isoFDev) continue;
+                                dev += std::fabs(layerVals[i] - m);
+                            }
+                            val = dev * invN;
+                        } else {
+                            val = 0.f;
+                        }
+                    } else if (layerAgg == LayerAgg::EmissionDvr) {
+                        // Emission-only DVR: every layer contributes
+                        // emission ∝ I² / 255 with no absorption, so ink
+                        // behind papyrus still reaches the ray total. Good
+                        // complement to `dvr` when you want a transmissive
+                        // integrator rather than a front-to-back one.
+                        float color = 0.f;
+                        for (int i = 0; i < nL; ++i) {
+                            if (preprocessActive && voidMask[i]) continue;
+                            const float I = layerVals[i];
+                            color += I * I * (1.f/255.f);
+                        }
+                        val = color;
+                    } else if (layerAgg == LayerAgg::MaxAboveIso) {
+                        // Max of samples strictly above isoCutoff. Like
+                        // plain Max but ignores air/substrate, so the
+                        // composite tracks the brightest papyrus/ink voxel
+                        // the ray crosses without being pinned by the
+                        // highest-contrast fiber tip off-sheet.
+                        const uint8_t isoCut = lightParams ? lightParams->isoCutoff : 0;
+                        const float isoFMax = float(isoCut);
+                        float m = 0.f;
+                        for (int i = 0; i < nL; ++i) {
+                            if (preprocessActive && voidMask[i]) continue;
+                            const float v = layerVals[i];
+                            if (v > isoFMax && v > m) m = v;
+                        }
+                        val = m;
+                    } else if (layerAgg == LayerAgg::GammaWeighted) {
+                        // sum(w*I) / sum(w) with w = max(0, I-iso)^2. The
+                        // quadratic weight amplifies ink's small density
+                        // offset relative to papyrus while still behaving
+                        // like a mean (not a max, so robust to outliers).
+                        const uint8_t isoCut = lightParams ? lightParams->isoCutoff : 0;
+                        const float isoFGw = float(isoCut);
+                        float sumWI = 0.f, sumW = 0.f;
+                        for (int i = 0; i < nL; ++i) {
+                            if (preprocessActive && voidMask[i]) continue;
+                            const float I = layerVals[i];
+                            const float d = I - isoFGw;
+                            if (d <= 0.f) continue;
+                            const float w = d * d;
+                            sumWI += w * I;
+                            sumW  += w;
+                        }
+                        val = sumW > 0.f ? sumWI / sumW : 0.f;
+                    } else if (layerAgg == LayerAgg::GradientMag) {
+                        // Peak |∂I/∂z| along the ray via central difference.
+                        // Lights up where a crack edge / ink boundary is
+                        // crossed; picks the sharpest intensity step in the
+                        // column. Scaled ×8 so a typical step shows up at
+                        // full brightness — raw gradients cluster low.
+                        float best = 0.f;
+                        for (int i = 1; i < nL - 1; ++i) {
+                            const float g = std::fabs(
+                                layerVals[i + 1] - layerVals[i - 1]) * 0.5f;
+                            if (g > best) best = g;
+                        }
+                        val = best * 8.f;
+                    } else if (layerAgg == LayerAgg::PbrIso) {
+                        // Cook-Torrance BRDF at the first voxel above iso.
+                        // Unlike FirstHitIso (which Lambertian-shades via
+                        // the generic lighting block using the base-pixel
+                        // gradient), this samples the 3D gradient at the
+                        // hit's actual z position and runs the full GGX +
+                        // Schlick Fresnel + Smith-Schlick BRDF with user-
+                        // tunable roughness/metallic. Carbonized papyrus
+                        // sits at F0≈0.7 at metallic=1 (carbon reflectance).
+                        const uint8_t isoCut = lightParams ? lightParams->isoCutoff : 0;
+                        const float isoFPbr = float(isoCut);
+                        int hitIdx = -1;
+                        float hitVal = 0.f;
+                        for (int i = 0; i < nL; ++i) {
+                            if (layerVals[i] > isoFPbr) {
+                                hitIdx = i; hitVal = layerVals[i]; break;
+                            }
+                        }
+                        val = hitVal;
+                        if (hitIdx >= 0 && lightParams) {
+                            const float zHit = float(zStart + hitIdx) * zStep;
+                            const float hx = (base[0] + nrm[0] * zHit) * endScale;
+                            const float hy = (base[1] + nrm[1] * zHit) * endScale;
+                            const float hz = (base[2] + nrm[2] * zHit) * endScale;
+                            uint8_t gx0=0, gx1=0, gy0=0, gy1=0, gz0=0, gz1=0;
+                            const bool gok =
+                                trySampleNB<SMode>(*samplers[0], hz, hy, hx - 1.f, gx0)
+                             && trySampleNB<SMode>(*samplers[0], hz, hy, hx + 1.f, gx1)
+                             && trySampleNB<SMode>(*samplers[0], hz, hy - 1.f, hx, gy0)
+                             && trySampleNB<SMode>(*samplers[0], hz, hy + 1.f, hx, gy1)
+                             && trySampleNB<SMode>(*samplers[0], hz - 1.f, hy, hx, gz0)
+                             && trySampleNB<SMode>(*samplers[0], hz + 1.f, hy, hx, gz1);
+                            if (gok) {
+                                // Outward normal = gradient dense→sparse.
+                                float nx = float(gx0) - float(gx1);
+                                float ny = float(gy0) - float(gy1);
+                                float nz = float(gz0) - float(gz1);
+                                const float nlen = std::sqrt(nx*nx + ny*ny + nz*nz);
+                                if (nlen > 1e-3f) {
+                                    nx /= nlen; ny /= nlen; nz /= nlen;
+                                    const float lx = lightParams->lightDirX;
+                                    const float ly = lightParams->lightDirY;
+                                    const float lz = lightParams->lightDirZ;
+                                    // View direction: opposite the slab normal.
+                                    float vx = -nrm[0], vy = -nrm[1], vz = -nrm[2];
+                                    const float vlen = std::sqrt(vx*vx + vy*vy + vz*vz);
+                                    if (vlen > 1e-3f) { vx /= vlen; vy /= vlen; vz /= vlen; }
+                                    // Half vector.
+                                    float hhx = lx + vx, hhy = ly + vy, hhz = lz + vz;
+                                    const float hlen = std::sqrt(hhx*hhx + hhy*hhy + hhz*hhz);
+                                    if (hlen > 1e-3f) { hhx /= hlen; hhy /= hlen; hhz /= hlen; }
+                                    const float NdotL = std::max(0.f, nx*lx + ny*ly + nz*lz);
+                                    const float NdotV = std::max(1e-3f, nx*vx + ny*vy + nz*vz);
+                                    const float NdotH = std::max(0.f, nx*hhx + ny*hhy + nz*hhz);
+                                    const float VdotH = std::max(0.f, vx*hhx + vy*hhy + vz*hhz);
+                                    const float rough = std::max(0.05f,
+                                        std::min(1.f, lightParams->pbrRoughness));
+                                    const float metal = std::max(0.f,
+                                        std::min(1.f, lightParams->pbrMetallic));
+                                    const float a  = rough * rough;
+                                    const float a2 = a * a;
+                                    // GGX normal distribution.
+                                    const float denom = (NdotH*NdotH*(a2-1.f) + 1.f);
+                                    const float D = a2 / std::max(1e-6f,
+                                        3.14159265f * denom * denom);
+                                    // Schlick Fresnel. F0 interpolates from
+                                    // dielectric (0.04) to carbon (~0.7).
+                                    const float F0 = 0.04f + (0.66f) * metal;
+                                    const float F  = F0 + (1.f - F0) *
+                                        std::pow(1.f - VdotH, 5.f);
+                                    // Smith-Schlick geometry.
+                                    const float k  = (rough + 1.f) * (rough + 1.f) / 8.f;
+                                    const float gL = NdotL / (NdotL * (1.f - k) + k);
+                                    const float gV = NdotV / (NdotV * (1.f - k) + k);
+                                    const float G  = gL * gV;
+                                    const float spec = D * F * G /
+                                        std::max(1e-6f, 4.f * NdotL * NdotV);
+                                    const float kd = (1.f - F) * (1.f - metal);
+                                    const float albedo = hitVal * (1.f/255.f);
+                                    const float diff = kd * albedo * (1.f/3.14159265f);
+                                    const float Li = lightParams->lightDiffuse;
+                                    const float Ia = lightParams->lightAmbient;
+                                    const float shaded =
+                                        (diff + spec) * NdotL * Li + Ia * albedo;
+                                    val = shaded * 255.f;
+                                }
+                            }
+                        }
+                    } else if (layerAgg == LayerAgg::ShadedDvr) {
+                        // Front-to-back DVR where each voxel's emission is
+                        // weighted by a Lambertian factor computed from the
+                        // 3D gradient at that voxel. Self-shadowing reveals
+                        // surface topology INSIDE the volume (papyrus
+                        // layering) rather than the first-hit boundary.
+                        // Cost: 6 extra samples per layer × nL layers, so
+                        // this is ~7× the sample count of plain DVR — use
+                        // it sparingly.
+                        float color = 0.f;
+                        float trans = 1.f;
+                        const float ambient = lightParams ? lightParams->dvrAmbient : 0.f;
+                        const float lx = lightParams ? lightParams->lightDirX : 0.f;
+                        const float ly = lightParams ? lightParams->lightDirY : 0.f;
+                        const float lz = lightParams ? lightParams->lightDirZ : 1.f;
+                        const float Li = lightParams ? lightParams->lightDiffuse : 0.7f;
+                        const float Ia = lightParams ? lightParams->lightAmbient : 0.3f;
+                        const uint8_t isoCutSd = lightParams ? lightParams->isoCutoff : 0;
+                        const float isoFSd = float(isoCutSd);
+                        for (int i = 0; i < nL; ++i) {
+                            if (preprocessActive && voidMask[i]) continue;
+                            const float I = layerVals[i];
+                            if (I <= isoFSd) continue;
+                            // Sample gradient at this layer's world position.
+                            const float zL = float(zStart + i) * zStep;
+                            const float sx = (base[0] + nrm[0] * zL) * endScale;
+                            const float sy = (base[1] + nrm[1] * zL) * endScale;
+                            const float sz = (base[2] + nrm[2] * zL) * endScale;
+                            uint8_t gx0=0, gx1=0, gy0=0, gy1=0, gz0=0, gz1=0;
+                            const bool gok =
+                                trySampleNB<SMode>(*samplers[0], sz, sy, sx - 1.f, gx0)
+                             && trySampleNB<SMode>(*samplers[0], sz, sy, sx + 1.f, gx1)
+                             && trySampleNB<SMode>(*samplers[0], sz, sy - 1.f, sx, gy0)
+                             && trySampleNB<SMode>(*samplers[0], sz, sy + 1.f, sx, gy1)
+                             && trySampleNB<SMode>(*samplers[0], sz - 1.f, sy, sx, gz0)
+                             && trySampleNB<SMode>(*samplers[0], sz + 1.f, sy, sx, gz1);
+                            float shade = Ia;
+                            if (gok) {
+                                float nx = float(gx0) - float(gx1);
+                                float ny = float(gy0) - float(gy1);
+                                float nz = float(gz0) - float(gz1);
+                                const float nlen = std::sqrt(nx*nx + ny*ny + nz*nz);
+                                if (nlen > 1e-3f) {
+                                    nx /= nlen; ny /= nlen; nz /= nlen;
+                                    const float NdotL = std::max(0.f,
+                                        nx*lx + ny*ly + nz*lz);
+                                    shade = Ia + Li * NdotL;
+                                }
+                            }
+                            const float op = I * (1.f/255.f);
+                            color += I * shade * trans * op;
+                            trans *= (1.f - op);
+                            if (trans < 0.001f) break;
+                        }
+                        color += ambient * trans;
+                        val = color;
                     } else {
                         // Mean: skip voids when preprocess is active so block
                         // holes don't pull the average toward 0. Fall back to
@@ -1819,7 +2180,12 @@ void sampleCompositeAdaptiveImpl(
                         }
                     }
                 }
-                if (lightingEnabled) {
+                // PbrIso and ShadedDvr run their own per-hit / per-sample
+                // shading inside the finalize switch above — skip the generic
+                // Lambertian multiplier here so we don't double-shade.
+                const bool selfShaded = (layerAgg == LayerAgg::PbrIso
+                                      || layerAgg == LayerAgg::ShadedDvr);
+                if (lightingEnabled && !selfShaded) {
                     cv::Vec3f lnrm;
                     if (lightNormalSource == 1) {
                         // Volume-gradient normal: six cheap samples around
@@ -1854,13 +2220,14 @@ void sampleCompositeAdaptiveImpl(
                     val *= computeLightingFactor(lnrm, *lightParams);
                 }
                 if (val < 0.f) val = 0.f; if (val > 255.f) val = 255.f;
-                outRow[x] = lut[uint8_t(val)];
+                outRow[x] = lut[postTfLut[uint8_t(val)]];
                 if (lvlRow) lvlRow[x] = pxLevel;
             }
         }
         }  // while tiles
     });
 }
+
 
 template<SampleMode SMode>
 void dispatchCompositeAdaptive(
@@ -1876,7 +2243,8 @@ void dispatchCompositeAdaptive(
     const uint32_t lut[256],
     const CompositeParams* lightParams,
     uint8_t* levelOut,
-    int levelStride)
+    int levelStride,
+    bool skipPrefetch)
 {
     AccumMode2 mode = accumModeFor(method);
     // Per-ray layer preprocess (normalize / hist-eq over N composite samples)
@@ -1907,7 +2275,7 @@ void dispatchCompositeAdaptive(
         sampleSingleLayerAdaptiveImpl<SMode>(
             outBuf, outStride, cache, desiredLevel, numLevels,
             coords, origin, vx_step, vy_step, normals, planeNormal,
-            zStart, zStep, w, h, lut, lightParams, levelOut, levelStride);
+            zStart, zStep, w, h, lut, lightParams, levelOut, levelStride, skipPrefetch);
         return;
     }
     switch (mode) {
@@ -1915,27 +2283,27 @@ void dispatchCompositeAdaptive(
             sampleCompositeAdaptiveImpl<SMode, AccumMode2::Max>(
                 outBuf, outStride, cache, desiredLevel, numLevels,
                 coords, origin, vx_step, vy_step, normals, planeNormal,
-                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride); break;
+                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride, skipPrefetch); break;
         case AccumMode2::Min:
             sampleCompositeAdaptiveImpl<SMode, AccumMode2::Min>(
                 outBuf, outStride, cache, desiredLevel, numLevels,
                 coords, origin, vx_step, vy_step, normals, planeNormal,
-                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride); break;
+                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride, skipPrefetch); break;
         case AccumMode2::LayerStorage:
             sampleCompositeAdaptiveImpl<SMode, AccumMode2::LayerStorage>(
                 outBuf, outStride, cache, desiredLevel, numLevels,
                 coords, origin, vx_step, vy_step, normals, planeNormal,
-                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride); break;
+                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride, skipPrefetch); break;
         case AccumMode2::Volumetric:
             sampleCompositeAdaptiveImpl<SMode, AccumMode2::Volumetric>(
                 outBuf, outStride, cache, desiredLevel, numLevels,
                 coords, origin, vx_step, vy_step, normals, planeNormal,
-                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride); break;
+                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride, skipPrefetch); break;
         default:
             sampleCompositeAdaptiveImpl<SMode, AccumMode2::Mean>(
                 outBuf, outStride, cache, desiredLevel, numLevels,
                 coords, origin, vx_step, vy_step, normals, planeNormal,
-                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride); break;
+                numLayers, zStart, zStep, w, h, method, lut, lightParams, levelOut, levelStride, skipPrefetch); break;
     }
 }
 
@@ -1956,7 +2324,8 @@ void sampleAdaptiveARGB32(
     vc::Sampling method,
     const CompositeParams* lightParams,
     uint8_t* levelOut,
-    int levelStride)
+    int levelStride,
+    bool skipPrefetch)
 {
     if (numLayers <= 0) numLayers = 1;
     // Composite rendering forces Nearest: averaging N layers already
@@ -1968,12 +2337,12 @@ void sampleAdaptiveARGB32(
         dispatchCompositeAdaptive<SampleMode::Nearest>(
             outBuf, outStride, *cache, desiredLevel, numLevels,
             coords, origin, vx_step, vy_step, normals, planeNormal,
-            numLayers, zStart, zStep, width, height, compositeMethod, lut, lightParams, levelOut, levelStride);
+            numLayers, zStart, zStep, width, height, compositeMethod, lut, lightParams, levelOut, levelStride, skipPrefetch);
     } else {
         dispatchCompositeAdaptive<SampleMode::Trilinear>(
             outBuf, outStride, *cache, desiredLevel, numLevels,
             coords, origin, vx_step, vy_step, normals, planeNormal,
-            numLayers, zStart, zStep, width, height, compositeMethod, lut, lightParams, levelOut, levelStride);
+            numLayers, zStart, zStep, width, height, compositeMethod, lut, lightParams, levelOut, levelStride, skipPrefetch);
     }
 }
 

--- a/volume-cartographer/core/src/Slicing.cpp
+++ b/volume-cartographer/core/src/Slicing.cpp
@@ -33,6 +33,7 @@ using vc::cache::BlockKey;
 using vc::cache::BlockPtr;
 using vc::cache::BlockPipeline;
 using vc::cache::kBlockSize;
+using vc::cache::kMaxLevels;
 
 constexpr int kBlockShift = 4;       // log2(16)
 constexpr int kBlockMask = 15;
@@ -85,14 +86,21 @@ struct VolumeShape {
 // block cache only — never blocks on disk or network. Missing blocks make
 // sampleInt return 0 (black) for that voxel. Viewport-demand fetches feed
 // the cache asynchronously via BlockPipeline::fetchInteractive.
-template<typename T, int kSlots = 1024>
+template<typename T, int kSlots = 4096>
 struct BlockSampler {
     static_assert((kSlots & (kSlots - 1)) == 0, "kSlots must be power of 2");
     static constexpr int kSlotMask = kSlots - 1;
 
-    // Hot slot: packed key + data pointer, 16 bytes. 512 * 16 = 8KB, fits
-    // comfortably in L1D. The shared_ptr (refcounting keep-alive) lives
-    // in a cold parallel array, touched only on miss.
+    // Hot slot: packed key + data pointer, 16 bytes. 4096 slots × 16B = 64KB.
+    // Fits in L2 with room to spare; L1D (typically 32-64KB) takes collisions.
+    // Raised from 1024 because the 12-thread render's per-thread working set
+    // is 1400-2700 unique blocks per frame — at 1024 slots the direct-mapped
+    // cache collided hard, and every collision miss fell through to blockAt,
+    // taking a BlockCache shard shared_lock. The shard shared_lock release
+    // (CAS-rel on its reader counter) was ~9% of CPU. 4096 slots hold the
+    // full working set so most lookups stay in the sampler's private cache.
+    // The shared_ptr (refcounting keep-alive) lives in a cold parallel array,
+    // touched only on miss.
     struct HotSlot {
         uint64_t key = UINT64_MAX;
         const T* data = nullptr;
@@ -983,9 +991,9 @@ void sampleSingleLayerAdaptiveImpl(
         }
     }
 
-    float scales[32] = {};
+    float scales[kMaxLevels] = {};
     const int nSamplersTotal = numLevels - desiredLevel;
-    for (int i = 0; i < nSamplersTotal && i < 32; i++) {
+    for (int i = 0; i < nSamplersTotal && i < kMaxLevels; i++) {
         int lvl = desiredLevel + i;
         scales[i] = (lvl > 0) ? 1.0f / float(1 << lvl) : 1.0f;
     }
@@ -1001,7 +1009,7 @@ void sampleSingleLayerAdaptiveImpl(
 
     runRenderThreads([&](int /*tid*/) {
         const int nSamplers = numLevels - desiredLevel;
-        std::array<std::optional<BlockSampler<uint8_t>>, 32> samplers;
+        std::array<std::optional<BlockSampler<uint8_t>>, kMaxLevels> samplers;
         if (nSamplers > 0) samplers[0].emplace(cache, desiredLevel);
         auto sampler = [&](int i) -> BlockSampler<uint8_t>& {
             if (!samplers[i].has_value())
@@ -1013,8 +1021,8 @@ void sampleSingleLayerAdaptiveImpl(
         if (nSamplers > 0) sh0 = sampler(0).shape;
         const float sh0xF = float(sh0.sx), sh0yF = float(sh0.sy), sh0zF = float(sh0.sz);
 
-        float scalesRatio[32] = {};
-        for (int i = 0; i < nSamplers && i < 32; i++)
+        float scalesRatio[kMaxLevels] = {};
+        for (int i = 0; i < nSamplers && i < kMaxLevels; i++)
             scalesRatio[i] = (i > 0) ? 1.0f / float(1 << i) : 1.0f;
 
         const cv::Vec3f constNrm = planeNormal ? *planeNormal : cv::Vec3f(0, 0, 0);
@@ -1207,21 +1215,30 @@ void sampleCompositeAdaptiveImpl(
 
     // Precompute per-level scale factor once (1.0 / 2^lvl). Hoists the
     // integer shift + int->float convert + fdiv out of the hot inner loop.
-    float scales[32] = {};
+    float scales[kMaxLevels] = {};
     const int nSamplersTotal = numLevels - desiredLevel;
-    for (int i = 0; i < nSamplersTotal && i < 32; i++) {
+    for (int i = 0; i < nSamplersTotal && i < kMaxLevels; i++) {
         int lvl = desiredLevel + i;
         scales[i] = (lvl > 0) ? 1.0f / float(1 << lvl) : 1.0f;
     }
 
     // Parse compositeMethod once. Pixel loop previously did string compare
     // per pixel for the LayerStorage path; convert to a small enum up front.
-    enum class LayerAgg : uint8_t { Median, MinAbs, Alpha, BeerLambert, Mean };
+    // Max and Min also reach here when preprocess is enabled — the per-ray
+    // layer preprocess needs layerVals[] populated, which Max/Min's direct
+    // accumulate path skips.
+    enum class LayerAgg : uint8_t { Median, MinAbs, Alpha, BeerLambert, Mean, Max, Min };
     const LayerAgg layerAgg = (compositeMethod == "median") ? LayerAgg::Median
                             : (compositeMethod == "minabs") ? LayerAgg::MinAbs
                             : (compositeMethod == "alpha") ? LayerAgg::Alpha
                             : (compositeMethod == "beerLambert") ? LayerAgg::BeerLambert
+                            : (compositeMethod == "max") ? LayerAgg::Max
+                            : (compositeMethod == "min") ? LayerAgg::Min
                             : LayerAgg::Mean;
+
+    // Per-ray layer preprocess flags (applied before the aggregation below).
+    const bool preNormalize = lightParams && lightParams->preNormalizeLayers;
+    const bool preHistEq    = lightParams && lightParams->preHistEqLayers;
 
     // UI caps composite layers at 64 front + 64 behind + center = 129. Bound
     // once at the function level so the per-pixel loop and the bounds
@@ -1263,7 +1280,7 @@ void sampleCompositeAdaptiveImpl(
         // ~4KB hot slot cache; we don't want to pay that cost for levels
         // we never touch.
         const int nSamplers = numLevels - desiredLevel;
-        std::array<std::optional<BlockSampler<uint8_t>>, 32> samplers;
+        std::array<std::optional<BlockSampler<uint8_t>>, kMaxLevels> samplers;
         if (nSamplers > 0) samplers[0].emplace(cache, desiredLevel);
         auto sampler = [&](int i) -> BlockSampler<uint8_t>& {
             if (!samplers[i].has_value())
@@ -1284,8 +1301,8 @@ void sampleCompositeAdaptiveImpl(
         // Ratios for scaling desiredLevel-sampler coords into coarser-level
         // coords: scalesRatio[i] = scales[i] / scales[0] = 1 / 2^i. Used in
         // the fallback loop so the hot path never computes scales[i]/endScale.
-        float scalesRatio[32] = {};
-        for (int i = 0; i < nSamplers && i < 32; i++)
+        float scalesRatio[kMaxLevels] = {};
+        for (int i = 0; i < nSamplers && i < kMaxLevels; i++)
             scalesRatio[i] = (i > 0) ? 1.0f / float(1 << i) : 1.0f;
 
         // When there's no per-pixel normals map (common case: plane viewer),
@@ -1583,22 +1600,134 @@ void sampleCompositeAdaptiveImpl(
                 else if constexpr (AMode == AccumMode2::Min) val = mn;
                 else if constexpr (AMode == AccumMode2::Mean) val = count ? accum * (1.0f/float(count)) : 0.f;
                 else {
+                    // Per-ray layer preprocess: runs only in LayerStorage
+                    // mode (we need all N layerVals to compute stats). When
+                    // the user enables it for Max/Min/Mean, dispatchComposite
+                    // routes the method through LayerStorage so this runs
+                    // before the aggregation below.
+                    //
+                    // Void handling: missing-block samples land in layerVals
+                    // as 0, and the iso cutoff threshold zeros out anything
+                    // below it. Both get treated as "no data" here — they
+                    // don't contribute to normalize min/max or to the hist-eq
+                    // CDF (a ray with 100 voids + 29 real samples used to
+                    // push the CDF toward max and blow the render out white),
+                    // and they stay at 0 through the remap so the aggregation
+                    // sees the same voids as without preprocess.
+                    // Only build the void mask when preprocess is active;
+                    // otherwise keep existing aggregation behavior (no void
+                    // filtering) so enabling iso-cutoff alone doesn't silently
+                    // change Max/Min/Mean results.
+                    const bool preprocessActive = preNormalize || preHistEq;
+                    const uint8_t isoCut = lightParams ? lightParams->isoCutoff : 0;
+                    const float  isoF   = float(isoCut);
+                    alignas(64) uint8_t voidMask[kMaxLayers];
+                    int nValid = 0;
+                    if (preprocessActive) {
+                        for (int i = 0; i < nL; ++i) {
+                            // Iso cutoff: <= cutoff → void. Captures both the
+                            // user's explicit threshold and the implicit
+                            // missing-block zero case (isoCut=0 still treats 0
+                            // as void so block holes don't pollute the stats).
+                            if (layerVals[i] <= isoF) {
+                                layerVals[i] = 0.f;
+                                voidMask[i] = 1;
+                            } else {
+                                voidMask[i] = 0;
+                                ++nValid;
+                            }
+                        }
+                    }
+
+                    if (preNormalize && nValid >= 2) {
+                        float mnL = 0.f, mxL = 0.f;
+                        bool first = true;
+                        for (int i = 0; i < nL; ++i) {
+                            if (voidMask[i]) continue;
+                            const float v = layerVals[i];
+                            if (first) { mnL = mxL = v; first = false; }
+                            else {
+                                if (v < mnL) mnL = v;
+                                if (v > mxL) mxL = v;
+                            }
+                        }
+                        const float range = mxL - mnL;
+                        if (range > 1e-4f) {
+                            const float scl = 255.0f / range;
+                            for (int i = 0; i < nL; ++i) {
+                                if (voidMask[i]) continue;
+                                layerVals[i] = (layerVals[i] - mnL) * scl;
+                            }
+                        }
+                    }
+                    if (preHistEq && nValid >= 2) {
+                        // Build a 256-bin histogram from the N layer values,
+                        // compute the CDF, remap each sample through it.
+                        // Classic single-image hist-eq formula, applied to
+                        // the N-sample ray: out = 255 * (cdf[v] - cdfMin) /
+                        // (nValid - cdfMin). Void samples are skipped so
+                        // they don't dominate the CDF.
+                        uint32_t hist[256] = {0};
+                        for (int i = 0; i < nL; ++i) {
+                            if (voidMask[i]) continue;
+                            float v = layerVals[i];
+                            if (v < 0.f) v = 0.f; else if (v > 255.f) v = 255.f;
+                            hist[uint8_t(v)]++;
+                        }
+                        uint32_t cdf[256];
+                        uint32_t cum = 0;
+                        for (int k = 0; k < 256; ++k) {
+                            cum += hist[k];
+                            cdf[k] = cum;
+                        }
+                        uint32_t cdfMin = 0;
+                        for (int k = 0; k < 256; ++k) {
+                            if (cdf[k] > 0) { cdfMin = cdf[k]; break; }
+                        }
+                        const float denom = float(nValid - int(cdfMin));
+                        if (denom > 0.5f) {
+                            const float scl = 255.0f / denom;
+                            for (int i = 0; i < nL; ++i) {
+                                if (voidMask[i]) continue;
+                                float v = layerVals[i];
+                                if (v < 0.f) v = 0.f; else if (v > 255.f) v = 255.f;
+                                layerVals[i] = float(int(cdf[uint8_t(v)]) - int(cdfMin)) * scl;
+                            }
+                        }
+                    }
+
                     if (layerAgg == LayerAgg::Median) {
                         // For the small N we see in practice (<=~129 layers),
                         // insertion-sort-up-to-the-median beats nth_element:
                         // its introselect setup costs more than sorting a
                         // few dozen floats. partial_sort gives us exactly
                         // that for small N without branching on size.
-                        std::partial_sort(layerVals.begin(),
-                                          layerVals.begin() + nL/2 + 1,
-                                          layerVals.begin() + nL);
-                        val = layerVals[nL/2];
+                        if (preprocessActive && nValid > 0) {
+                            // Pack non-void values to the front, sort those
+                            // only. Voids included would drag the median
+                            // toward 0 whenever the ray sees block misses.
+                            int k = 0;
+                            for (int i = 0; i < nL; ++i) {
+                                if (!voidMask[i]) layerVals[k++] = layerVals[i];
+                            }
+                            std::partial_sort(layerVals.begin(),
+                                              layerVals.begin() + k/2 + 1,
+                                              layerVals.begin() + k);
+                            val = layerVals[k/2];
+                        } else {
+                            std::partial_sort(layerVals.begin(),
+                                              layerVals.begin() + nL/2 + 1,
+                                              layerVals.begin() + nL);
+                            val = layerVals[nL/2];
+                        }
                     } else if (layerAgg == LayerAgg::MinAbs) {
                         // Hoist abs(best-127.5) out of the loop and use std::fabs
                         // (hardware fabs opcode vs. std::abs's integer-path).
-                        float best = layerVals[0];
-                        float bestAbs = std::fabs(best - 127.5f);
-                        for (int i=1; i<nL; i++) {
+                        // Skip voids when preprocess is active so block misses
+                        // (distance 127.5 from mid) don't win over real data.
+                        float best = 0.f, bestAbs = std::numeric_limits<float>::max();
+                        for (int i = 0; i < nL; ++i) {
+                            if (preprocessActive && voidMask[i]) continue;
                             const float d = std::fabs(layerVals[i] - 127.5f);
                             if (d < bestAbs) { best = layerVals[i]; bestAbs = d; }
                         }
@@ -1650,11 +1779,44 @@ void sampleCompositeAdaptiveImpl(
 
                         accumulatedColor += ambient * transmittance;
                         val = std::min(255.0f, accumulatedColor * 255.0f);
+                    } else if (layerAgg == LayerAgg::Max) {
+                        // Max isn't affected by voids (0 never beats a real
+                        // sample) so no void gating needed here.
+                        float m = layerVals[0];
+                        for (int i=1; i<nL; i++) if (layerVals[i] > m) m = layerVals[i];
+                        val = m;
+                    } else if (layerAgg == LayerAgg::Min) {
+                        // Without void gating, Min collapses to 0 as soon as
+                        // a single block is missing. Seed from the first
+                        // valid value instead when preprocess is on.
+                        if (preprocessActive && nValid > 0) {
+                            float m = std::numeric_limits<float>::max();
+                            for (int i = 0; i < nL; ++i) {
+                                if (voidMask[i]) continue;
+                                if (layerVals[i] < m) m = layerVals[i];
+                            }
+                            val = m;
+                        } else {
+                            float m = layerVals[0];
+                            for (int i=1; i<nL; i++) if (layerVals[i] < m) m = layerVals[i];
+                            val = m;
+                        }
                     } else {
-                        float s=0.f; for (int i=0; i<nL; i++) s += layerVals[i];
-                        // Replace divide with multiply by pre-computed reciprocal.
-                        const float invN = nL>0 ? 1.0f/float(nL) : 0.f;
-                        val = s * invN;
+                        // Mean: skip voids when preprocess is active so block
+                        // holes don't pull the average toward 0. Fall back to
+                        // the plain averaging when preprocess is off to keep
+                        // existing behavior identical.
+                        if (preprocessActive) {
+                            float s = 0.f;
+                            for (int i = 0; i < nL; ++i) {
+                                if (!voidMask[i]) s += layerVals[i];
+                            }
+                            val = nValid > 0 ? s / float(nValid) : 0.f;
+                        } else {
+                            float s=0.f; for (int i=0; i<nL; i++) s += layerVals[i];
+                            const float invN = nL>0 ? 1.0f/float(nL) : 0.f;
+                            val = s * invN;
+                        }
                     }
                 }
                 if (lightingEnabled) {
@@ -1716,7 +1878,17 @@ void dispatchCompositeAdaptive(
     uint8_t* levelOut,
     int levelStride)
 {
-    const AccumMode2 mode = accumModeFor(method);
+    AccumMode2 mode = accumModeFor(method);
+    // Per-ray layer preprocess (normalize / hist-eq over N composite samples)
+    // needs the full layer array; force LayerStorage so the kernel stores all
+    // N values in layerVals before the preprocess + aggregation stages run.
+    // The fast Max/Min/Mean direct-accumulate paths skip storage, so they
+    // can't support preprocess without a detour through LayerStorage.
+    const bool preprocessActive = lightParams &&
+        (lightParams->preNormalizeLayers || lightParams->preHistEqLayers);
+    if (preprocessActive && mode != AccumMode2::Volumetric) {
+        mode = AccumMode2::LayerStorage;
+    }
     // nL=1 reduces Max/Min/Mean to the single sampled value (all three
     // collapse: max(x)=min(x)=mean(x)=x). Dispatch to the specialized kernel
     // to skip the layer loop, accumulator setup, and finalize switch — the
@@ -1724,8 +1896,10 @@ void dispatchCompositeAdaptive(
     // sub-modes (Alpha, BeerLambert, Median, MinAbs) apply a tone-mapping
     // transform to the single sample rather than returning it raw; Volumetric
     // is excluded because its shadow-ray + transmittance integration doesn't
-    // degenerate to a single sample.
-    const bool singleLayerFast = numLayers <= 1
+    // degenerate to a single sample. Preprocess is also excluded — with a
+    // single sample the per-ray normalize collapses to 0 and hist-eq to a
+    // single bin, neither of which is useful.
+    const bool singleLayerFast = numLayers <= 1 && !preprocessActive
         && (mode == AccumMode2::Max
          || mode == AccumMode2::Min
          || mode == AccumMode2::Mean);

--- a/volume-cartographer/core/src/Slicing.cpp
+++ b/volume-cartographer/core/src/Slicing.cpp
@@ -206,6 +206,29 @@ struct BlockSampler {
                 data = slot.data;
                 return;
             }
+            // Slice L1: freshly-landed blocks at active pyramid levels.
+            // Plain-memory binary search saves the atomic-heavy
+            // BlockCache::get / isEmptyChunk probes for the first access
+            // of hot data. The slice may contain multiple entries for a
+            // given packedKey (one per pipeline); scan the run looking
+            // for a pipeline match.
+            if (!frame->slice.empty()) {
+                auto it = std::lower_bound(
+                    frame->slice.begin(), frame->slice.end(), key,
+                    [](const vc::cache::SliceEntry& e, std::uint64_t k) {
+                        return e.packedKey < k;
+                    });
+                while (it != frame->slice.end() && it->packedKey == key) {
+                    if (it->pipeline == &cache && it->block) {
+                        slotBlocks[idx] = const_cast<BlockPtr>(it->block);
+                        slot.data = reinterpret_cast<const T*>(it->block->data);
+                        slot.key  = key;
+                        data = slot.data;
+                        return;
+                    }
+                    ++it;
+                }
+            }
         }
 
         BlockKey bk{level, bz, by, bx};
@@ -454,7 +477,7 @@ void prefetchRegion(BlockPipeline& cache, int level,
     keys.clear();
     appendChunksForRegion(cache, level, minVx, minVy, minVz,
                           maxVx, maxVy, maxVz, keys);
-    if (!keys.empty()) cache.fetchInteractive(keys, level);
+    if (!keys.empty()) TickCoordinator::enqueuePrefetchGlobal(&cache, keys, level);
 }
 
 // prefetchCoordsRegion / prefetchPlaneRegion: inputs are already in
@@ -1032,7 +1055,7 @@ void sampleSingleLayerAdaptiveImpl(
                                          std::min(numLevels, int(vc::cache::kMaxLevels)),
                                          viewCenterL0);
             }
-            cache.fetchInteractive(keys, desiredLevel);
+            TickCoordinator::enqueuePrefetchGlobal(&cache, keys, desiredLevel);
         }
     } else {
         cv::Vec3f p0 = *origin + (*planeNormal) * zOffConst;
@@ -1060,7 +1083,7 @@ void sampleSingleLayerAdaptiveImpl(
                                          std::min(numLevels, int(vc::cache::kMaxLevels)),
                                          viewCenterL0);
             }
-            cache.fetchInteractive(keys, desiredLevel);
+            TickCoordinator::enqueuePrefetchGlobal(&cache, keys, desiredLevel);
         }
     }
     }  // skipPrefetch guard
@@ -1259,7 +1282,7 @@ void sampleCompositeAdaptiveImpl(
                                          std::min(numLevels, int(vc::cache::kMaxLevels)),
                                          viewCenterL0);
             }
-            cache.fetchInteractive(keys, desiredLevel);
+            TickCoordinator::enqueuePrefetchGlobal(&cache, keys, desiredLevel);
         }
     } else {
         cv::Vec3f p0 = *origin + (*planeNormal) * zMin;
@@ -1287,7 +1310,7 @@ void sampleCompositeAdaptiveImpl(
                                          std::min(numLevels, int(vc::cache::kMaxLevels)),
                                          viewCenterL0);
             }
-            cache.fetchInteractive(keys, desiredLevel);
+            TickCoordinator::enqueuePrefetchGlobal(&cache, keys, desiredLevel);
         }
     }
     }  // skipPrefetch guard

--- a/volume-cartographer/core/src/Slicing.cpp
+++ b/volume-cartographer/core/src/Slicing.cpp
@@ -4,6 +4,7 @@
 #include "vc/core/types/VcDataset.hpp"
 #include "vc/core/cache/BlockCache.hpp"
 #include "vc/core/cache/BlockPipeline.hpp"
+#include "vc/core/cache/TickCoordinator.hpp"
 
 #include <opencv2/core.hpp>
 
@@ -32,8 +33,17 @@ using vc::cache::Block;
 using vc::cache::BlockKey;
 using vc::cache::BlockPtr;
 using vc::cache::BlockPipeline;
+using vc::cache::ChunkKey;
+using vc::cache::FrameState;
 using vc::cache::kBlockSize;
 using vc::cache::kMaxLevels;
+using vc::cache::TickCoordinator;
+
+// Shared static zero-block for chunks known to be all-zero. Using one
+// instance keeps the cold-cache footprint at 4 KiB instead of one per
+// sampler; the BlockPipeline already uses an identical pattern for its
+// own empty-chunk short-circuit path.
+inline constinit Block kSliceZeroBlock{};
 
 constexpr int kBlockShift = 4;       // log2(16)
 constexpr int kBlockMask = 15;
@@ -111,6 +121,10 @@ struct BlockSampler {
     BlockPipeline& cache;
     int level;
     VolumeShape shape;
+    // Frame snapshot captured at construction; released in the destructor.
+    // When non-null we can bypass `cache.blockAt` on known-empty chunks
+    // via a plain-memory binary search instead of an atomic probe loop.
+    const FrameState* frame;
     HotSlot slots[kSlots];
     BlockPtr slotBlocks[kSlots];  // cold: refcount keep-alive
     // Last-block (bz,by,bx) cache as separate ints. Most pixels in a tile
@@ -124,7 +138,15 @@ struct BlockSampler {
     const T* data = nullptr;
 
     BlockSampler(BlockPipeline& c, int lvl)
-        : cache(c), level(lvl), shape(c, lvl) {}
+        : cache(c), level(lvl), shape(c, lvl),
+          frame(TickCoordinator::currentFrameGlobal()) {}
+
+    ~BlockSampler() {
+        TickCoordinator::releaseFrameGlobal(frame);
+    }
+
+    BlockSampler(const BlockSampler&) = delete;
+    BlockSampler& operator=(const BlockSampler&) = delete;
 
     VC_FORCE_INLINE static uint64_t packKey(int bz, int by, int bx) {
         return (uint64_t(uint32_t(bz)) << 42) | (uint64_t(uint32_t(by)) << 21) | uint64_t(uint32_t(bx));
@@ -167,6 +189,23 @@ struct BlockSampler {
         if (slot.key == key) [[likely]] {
             data = slot.data;
             return;
+        }
+
+        // Known-empty chunk short-circuit. FrameState::emptyChunkKeys is
+        // a sorted vector published once per tick by TickCoordinator; a
+        // binary search is plain memory, vs. the atomic probe loop inside
+        // BlockPipeline::blockAt. Canonical chunks are 128³ = 8 blocks per
+        // axis, so chunk coord = block coord >> 3.
+        if (frame) {
+            const ChunkKey ck{level, bz >> 3, by >> 3, bx >> 3};
+            if (std::binary_search(frame->emptyChunkKeys.begin(),
+                                   frame->emptyChunkKeys.end(), ck)) {
+                slotBlocks[idx] = &kSliceZeroBlock;
+                slot.data = reinterpret_cast<const T*>(kSliceZeroBlock.data);
+                slot.key  = key;
+                data = slot.data;
+                return;
+            }
         }
 
         BlockKey bk{level, bz, by, bx};

--- a/volume-cartographer/core/src/Slicing.cpp
+++ b/volume-cartographer/core/src/Slicing.cpp
@@ -942,22 +942,26 @@ void sampleSingleLayerAdaptiveImpl(
     auto levelScale = [](int lvl) { return (lvl > 0) ? 1.0f / float(1 << lvl) : 1.0f; };
     const float zOffConst = float(zStart) * zStep;
 
+    // TF LUTs only materialized when the feature is actually on. The
+    // fused sample loop and the output site both check a bool and
+    // skip the LUT indirection when inactive, so we don't even pay the
+    // 256-entry identity-fill for the default (disabled) case.
     alignas(64) uint8_t preTfLut[256];
-    buildTfLut256(
-        lightParams && lightParams->preTfEnabled,
-        lightParams ? lightParams->preTfX1 : 85,
-        lightParams ? lightParams->preTfY1 : 85,
-        lightParams ? lightParams->preTfX2 : 170,
-        lightParams ? lightParams->preTfY2 : 170,
-        preTfLut);
+    const bool preTfOn = lightParams && lightParams->preTfEnabled;
+    if (preTfOn) {
+        buildTfLut256(true,
+            lightParams->preTfX1, lightParams->preTfY1,
+            lightParams->preTfX2, lightParams->preTfY2,
+            preTfLut);
+    }
     alignas(64) uint8_t postTfLut[256];
-    buildTfLut256(
-        lightParams && lightParams->postTfEnabled,
-        lightParams ? lightParams->postTfX1 : 85,
-        lightParams ? lightParams->postTfY1 : 85,
-        lightParams ? lightParams->postTfX2 : 170,
-        lightParams ? lightParams->postTfY2 : 170,
-        postTfLut);
+    const bool postTfOn = lightParams && lightParams->postTfEnabled;
+    if (postTfOn) {
+        buildTfLut256(true,
+            lightParams->postTfX1, lightParams->postTfY1,
+            lightParams->postTfX2, lightParams->postTfY2,
+            postTfLut);
+    }
 
     // Prefetch the chunks the sampled plane touches. Same as the multi-layer
     // version but the bbox collapses to the single-z-slab defined by zStart.
@@ -1118,7 +1122,7 @@ void sampleSingleLayerAdaptiveImpl(
                         }
                     }
                 }
-                float val = float(v);
+                float val = float(preTfOn ? preTfLut[v] : v);
 
                 if (lightingEnabled) {
                     cv::Vec3f lnrm;
@@ -1148,7 +1152,7 @@ void sampleSingleLayerAdaptiveImpl(
                     val *= computeLightingFactor(lnrm, *lightParams);
                 }
                 if (val < 0.f) val = 0.f; if (val > 255.f) val = 255.f;
-                outRow[x] = lut[postTfLut[uint8_t(val)]];
+                outRow[x] = postTfOn ? lut[postTfLut[uint8_t(val)]] : lut[uint8_t(val)];
                 if (lvlRow) lvlRow[x] = pxLevel;
             }
         }
@@ -1301,28 +1305,26 @@ void sampleCompositeAdaptiveImpl(
     const bool lightingEnabled = lightParams && lightParams->lightingEnabled;
     const int  lightNormalSource = lightParams ? lightParams->lightNormalSource : 0;
 
-    // Pre-TF LUT: materialized once per render from lightParams. Identity
-    // when preTfEnabled is off, so the per-sample lookup stays a no-op
-    // without needing a branch in the inner loop. 256 bytes = one cacheline-
-    // worth of L1D.
+    // TF LUTs only materialized when actually enabled — the fused sample
+    // loop and the output site both branch on preTfOn/postTfOn and skip
+    // the LUT indirection when off, so we don't pay the 256-entry fill
+    // in the common default-off case.
     alignas(64) uint8_t preTfLut[256];
-    buildTfLut256(
-        lightParams && lightParams->preTfEnabled,
-        lightParams ? lightParams->preTfX1 : 85,
-        lightParams ? lightParams->preTfY1 : 85,
-        lightParams ? lightParams->preTfX2 : 170,
-        lightParams ? lightParams->preTfY2 : 170,
-        preTfLut);
-    // Post-TF LUT: applied to the composite output before the display
-    // colormap. Same identity-on-disable property as preTfLut.
+    const bool preTfOn = lightParams && lightParams->preTfEnabled;
+    if (preTfOn) {
+        buildTfLut256(true,
+            lightParams->preTfX1, lightParams->preTfY1,
+            lightParams->preTfX2, lightParams->preTfY2,
+            preTfLut);
+    }
     alignas(64) uint8_t postTfLut[256];
-    buildTfLut256(
-        lightParams && lightParams->postTfEnabled,
-        lightParams ? lightParams->postTfX1 : 85,
-        lightParams ? lightParams->postTfY1 : 85,
-        lightParams ? lightParams->postTfX2 : 170,
-        lightParams ? lightParams->postTfY2 : 170,
-        postTfLut);
+    const bool postTfOn = lightParams && lightParams->postTfEnabled;
+    if (postTfOn) {
+        buildTfLut256(true,
+            lightParams->postTfX1, lightParams->postTfY1,
+            lightParams->postTfX2, lightParams->postTfY2,
+            postTfLut);
+    }
 
     // Volumetric-mode exp LUTs: exp(-extN * k) for k in [0..255]. extN is
     // constant per call (from lightParams->blExtinction/255). Pre-computing
@@ -1572,97 +1574,88 @@ void sampleCompositeAdaptiveImpl(
                     // fuses into a single run-length scan over the packed
                     // block-key array, and the inner byte-load loop is
                     // tight enough that clang pipelines it aggressively.
-                    alignas(64) int64_t bkey[kMaxLayers];
-                    alignas(64) int16_t offset[kMaxLayers];
-                    for (int li = 0; li < nL; ++li) {
-                        const int iz = int(swz + 0.5f);
-                        const int iy = int(swy + 0.5f);
-                        const int ix = int(swx + 0.5f);
-                        const int bz = iz >> kBlockShift;
-                        const int by = iy >> kBlockShift;
-                        const int bx = ix >> kBlockShift;
-                        // 20 bits per axis is well beyond any realistic
-                        // block count (2^20 × 16 = 16M voxels/axis).
-                        bkey[li] = (int64_t(bz) << 40)
-                                 | (int64_t(by) << 20)
-                                 |  int64_t(bx);
-                        const int lz = iz & kBlockMask;
-                        const int ly = iy & kBlockMask;
-                        const int lx = ix & kBlockMask;
-                        offset[li] = int16_t(lz * kStrideZ
-                                           + ly * kStrideY
-                                           + lx);
-                        swx += sdx; swy += sdy; swz += sdz;
-                    }
-
-                    int li = 0;
-                    while (li < nL) {
-                        const int64_t key = bkey[li];
-                        const int bz = int((key >> 40) & ((int64_t(1) << 20) - 1));
-                        const int by = int((key >> 20) & ((int64_t(1) << 20) - 1));
-                        const int bx = int( key        & ((int64_t(1) << 20) - 1));
-                        s0.tryUpdateBlockNonBlocking(bz, by, bx);
-                        const uint8_t* cdata = s0.data;
-                        // Run-length extend: find the largest liEnd such that
-                        // bkey[li..liEnd) are all equal to key. Consecutive
-                        // z-samples at zStep=1 typically share a block for
-                        // ~16 layers, so this loop iterates ~16x per block
-                        // transition. Scalar version was ~20% of the composite
-                        // kernel's CPU (perf showed the backward-branch target
-                        // hot). The 4-wide block below issues all 4 compares
-                        // before the branch — bitwise `&` (not `&&`) prevents
-                        // short-circuit so clang can schedule them in parallel
-                        // across the Oryon wide OoO pipeline.
-                        int liEnd = li + 1;
-                        while (liEnd + 4 <= nL) {
-                            const int e0 = bkey[liEnd    ] == key;
-                            const int e1 = bkey[liEnd + 1] == key;
-                            const int e2 = bkey[liEnd + 2] == key;
-                            const int e3 = bkey[liEnd + 3] == key;
-                            if ((e0 & e1 & e2 & e3) == 0) break;
-                            liEnd += 4;
-                        }
-                        while (liEnd < nL && bkey[liEnd] == key) ++liEnd;
-                        const int runLen = liEnd - li;
-                        if (cdata) {
-                            // Tight same-block inner loop: N byte loads
-                            // into accumulator. Clang pipelines 4 per
-                            // cycle comfortably on ARM — benchmarked
-                            // identical to a manual 4-wide unroll so
-                            // we keep the simpler scalar form.
-                            if constexpr (AMode == AccumMode2::Max) {
-                                uint8_t m = uint8_t(mx);
-                                for (int i = li; i < liEnd; ++i) {
-                                    const uint8_t v = preTfLut[cdata[offset[i]]];
-                                    m = v > m ? v : m;
-                                }
-                                mx = float(m);
-                            } else if constexpr (AMode == AccumMode2::Min) {
-                                uint8_t m = uint8_t(mn);
-                                for (int i = li; i < liEnd; ++i) {
-                                    const uint8_t v = preTfLut[cdata[offset[i]]];
-                                    m = v < m ? v : m;
-                                }
-                                mn = float(m);
-                            } else if constexpr (AMode == AccumMode2::Mean) {
-                                int sum = 0;
-                                for (int i = li; i < liEnd; ++i) {
-                                    sum += int(preTfLut[cdata[offset[i]]]);
-                                }
-                                accum += float(sum);
-                                count += runLen;
-                            } else {
-                                for (int i = li; i < liEnd; ++i) {
-                                    layerVals[i] = float(preTfLut[cdata[offset[i]]]);
-                                }
+                    // Fused coord-compute + block-change check + sample.
+                    // The prior two-pass version (precompute bkey[]/offset[],
+                    // then 4-wide SIMD run-length scan, then inner sample
+                    // loop) spent ~17% of the composite kernel's CPU inside
+                    // the SIMD scan alone. Fusing into a single per-layer
+                    // loop eliminates the scan entirely plus the stack
+                    // arrays: the block-change check becomes an int-compare
+                    // against the previous layer's (bz,by,bx) tuple carried
+                    // in registers. When Pre-TF is disabled (common case)
+                    // the inner path skips the extra LUT lookup as a bonus.
+                    int prevBz = std::numeric_limits<int>::min();
+                    int prevBy = 0, prevBx = 0;
+                    const uint8_t* cdata = nullptr;
+                    if constexpr (AMode == AccumMode2::Max
+                               || AMode == AccumMode2::Min
+                               || AMode == AccumMode2::Mean) {
+                        // Direct accumulators — keep the running value in
+                        // a register across the whole ray. No per-layer
+                        // write to layerVals[].
+                        [[maybe_unused]] uint8_t mM = uint8_t(mx);
+                        [[maybe_unused]] uint8_t mm = uint8_t(mn);
+                        [[maybe_unused]] int sumAcc = 0;
+                        [[maybe_unused]] int cnt = 0;
+                        for (int li = 0; li < nL; ++li) {
+                            const int iz = int(swz + 0.5f);
+                            const int iy = int(swy + 0.5f);
+                            const int ix = int(swx + 0.5f);
+                            const int bz = iz >> kBlockShift;
+                            const int by = iy >> kBlockShift;
+                            const int bx = ix >> kBlockShift;
+                            if (bz != prevBz || by != prevBy || bx != prevBx) {
+                                prevBz = bz; prevBy = by; prevBx = bx;
+                                s0.tryUpdateBlockNonBlocking(bz, by, bx);
+                                cdata = s0.data;
                             }
-                        } else if constexpr (AMode == AccumMode2::Mean) {
-                            // Missing block → 0 voxels count toward mean
-                            count += runLen;
-                        } else if constexpr (AMode == AccumMode2::LayerStorage) {
-                            for (int i = li; i < liEnd; ++i) layerVals[i] = 0.f;
+                            swx += sdx; swy += sdy; swz += sdz;
+                            if constexpr (AMode == AccumMode2::Mean) {
+                                cnt++;
+                            }
+                            if (!cdata) continue;
+                            const int lz = iz & kBlockMask;
+                            const int ly = iy & kBlockMask;
+                            const int lx = ix & kBlockMask;
+                            const uint8_t raw = cdata[lz * kStrideZ
+                                                    + ly * kStrideY + lx];
+                            const uint8_t v = preTfOn ? preTfLut[raw] : raw;
+                            if constexpr (AMode == AccumMode2::Max) {
+                                mM = v > mM ? v : mM;
+                            } else if constexpr (AMode == AccumMode2::Min) {
+                                mm = v < mm ? v : mm;
+                            } else {
+                                sumAcc += int(v);
+                            }
                         }
-                        li = liEnd;
+                        if constexpr (AMode == AccumMode2::Max)  mx = float(mM);
+                        else if constexpr (AMode == AccumMode2::Min) mn = float(mm);
+                        else { accum += float(sumAcc); count += cnt; }
+                    } else {
+                        // LayerStorage: emit one float per layer into
+                        // layerVals[] for the downstream composite method.
+                        for (int li = 0; li < nL; ++li) {
+                            const int iz = int(swz + 0.5f);
+                            const int iy = int(swy + 0.5f);
+                            const int ix = int(swx + 0.5f);
+                            const int bz = iz >> kBlockShift;
+                            const int by = iy >> kBlockShift;
+                            const int bx = ix >> kBlockShift;
+                            if (bz != prevBz || by != prevBy || bx != prevBx) {
+                                prevBz = bz; prevBy = by; prevBx = bx;
+                                s0.tryUpdateBlockNonBlocking(bz, by, bx);
+                                cdata = s0.data;
+                            }
+                            swx += sdx; swy += sdy; swz += sdz;
+                            if (!cdata) { layerVals[li] = 0.f; continue; }
+                            const int lz = iz & kBlockMask;
+                            const int ly = iy & kBlockMask;
+                            const int lx = ix & kBlockMask;
+                            const uint8_t raw = cdata[lz * kStrideZ
+                                                    + ly * kStrideY + lx];
+                            const uint8_t v = preTfOn ? preTfLut[raw] : raw;
+                            layerVals[li] = float(v);
+                        }
                     }
                 } else {
                     // Near-edge / partial-miss path: keep the original
@@ -1678,7 +1671,7 @@ void sampleCompositeAdaptiveImpl(
                                 break;
                             }
                         }
-                        v = preTfLut[v];
+                        if (preTfOn) v = preTfLut[v];
                         if constexpr (AMode == AccumMode2::Max) { mx = std::max(mx, float(v)); }
                         else if constexpr (AMode == AccumMode2::Min) { mn = std::min(mn, float(v)); }
                         else if constexpr (AMode == AccumMode2::Mean) { accum += float(v); count++; }
@@ -2220,7 +2213,7 @@ void sampleCompositeAdaptiveImpl(
                     val *= computeLightingFactor(lnrm, *lightParams);
                 }
                 if (val < 0.f) val = 0.f; if (val > 255.f) val = 255.f;
-                outRow[x] = lut[postTfLut[uint8_t(val)]];
+                outRow[x] = postTfOn ? lut[postTfLut[uint8_t(val)]] : lut[uint8_t(val)];
                 if (lvlRow) lvlRow[x] = pxLevel;
             }
         }

--- a/volume-cartographer/core/src/Slicing.cpp
+++ b/volume-cartographer/core/src/Slicing.cpp
@@ -9,9 +9,15 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <limits>
+#include <mutex>
+#include <semaphore>
+#include <thread>
+#include <vector>
 #include <omp.h>
 
 #if defined(_MSC_VER)
@@ -97,6 +103,13 @@ struct BlockSampler {
     VolumeShape shape;
     HotSlot slots[kSlots];
     BlockPtr slotBlocks[kSlots];  // cold: refcount keep-alive
+    // Last-block (bz,by,bx) cache as separate ints. Most pixels in a tile
+    // sample the same block, so comparing three ints lets us skip packKey's
+    // 3 shifts + 2 ORs on every same-block call. lastBz=INT_MIN seeds a
+    // guaranteed miss on the first access.
+    int lastBz = std::numeric_limits<int>::min();
+    int lastBy = 0;
+    int lastBx = 0;
     uint64_t lastKey = UINT64_MAX;
     const T* data = nullptr;
 
@@ -129,14 +142,20 @@ struct BlockSampler {
 
     // Identical; kept for callers that want to be explicit about intent.
     VC_FORCE_INLINE void tryUpdateBlockNonBlocking(int bz, int by, int bx) {
-        uint64_t key = packKey(bz, by, bx);
-        if (key == lastKey) [[likely]] return;
+        // Int-level fast path: consecutive samples within a tile almost
+        // always land in the same 16³ block. Compare three ints and skip
+        // packKey + slot hash entirely on a match — saves ~5 cycles/sample
+        // on the ~80% of samples that hit the same block as the last.
+        if (bz == lastBz && by == lastBy && bx == lastBx) [[likely]] return;
+
+        const uint64_t key = packKey(bz, by, bx);
+        lastBz = bz; lastBy = by; lastBx = bx;
+        lastKey = key;
 
         int idx = slotIndexFromKey(key);
         HotSlot& slot = slots[idx];
         if (slot.key == key) [[likely]] {
             data = slot.data;
-            lastKey = key;
             return;
         }
 
@@ -145,7 +164,6 @@ struct BlockSampler {
         slot.data = slotBlocks[idx] ? reinterpret_cast<const T*>(slotBlocks[idx]->data) : nullptr;
         slot.key = key;
         data = slot.data;
-        lastKey = key;
     }
 
     VC_FORCE_INLINE static size_t voxelOffset(int lz, int ly, int lx) {
@@ -311,10 +329,10 @@ void appendChunksForCoordsSurface(BlockPipeline& cache, int level,
     const int chunksX = (ls[2] + cs[2] - 1) / cs[2];
 
     const float scale = (level > 0) ? 1.0f / float(1 << level) : 1.0f;
-    // Sub-sample stride: at native resolution, ~1 voxel per pixel and a
-    // chunk is 128 voxels, so an 8-pixel stride still hits every chunk
-    // the surface crosses (16 samples per chunk row → safe coverage even
-    // for steeply oblique surface patches).
+    // Sub-sample stride for the prefetch walk. Missing a chunk here is not
+    // a correctness bug — the render sampler faults it in lazily — just a
+    // prefetch miss, so stride=8 trades a rare lazy fetch on steeply
+    // oblique surfaces for ~64x less work on large surfaces.
     const int stride = (coords.rows > 256) ? 8 : 1;
 
     // Thread-local dedup set to avoid heap churn across frames. Cleared on
@@ -393,7 +411,8 @@ void prefetchRegion(BlockPipeline& cache, int level,
 // prefetchCoordsRegion / prefetchPlaneRegion: inputs are already in
 // LEVEL-space voxels (callers either pass already-scaled args or operate
 // at a single level). For the world-space → multi-level adaptive path,
-// see samplePixelsAdaptiveARGB32 which scales per-level before prefetching.
+// see sampleCompositeAdaptiveImpl / sampleSingleLayerAdaptiveImpl which
+// scale per-level before prefetching.
 void prefetchCoordsRegion(BlockPipeline& cache, int level,
                           const cv::Mat_<cv::Vec3f>& coords) {
     // Unconditional min/max reductions so the vectorizer can fold the
@@ -618,6 +637,89 @@ void samplePlane(cv::Mat_<uint8_t>& out, BlockPipeline* cache, int level,
 
 namespace {
 
+// Manual tile parallelism: persistent worker pool that `runRenderThreads`
+// dispatches work to. Each render call fans body(tid) across N-1 workers
+// and body(0) on the calling thread, then blocks until all finish.
+//
+// We cannot spawn fresh std::jthreads per render call — at interactive
+// rates (60+ fps), pthread_create+join overhead regresses the 12-core
+// speedup from ~4x down to ~1.1x. OpenMP's implicit pool hid this cost
+// before; the custom pool reclaims it without dragging the libgomp
+// runtime back into the hot path.
+inline int renderThreadCount() {
+    static const int n = []() {
+        int hw = int(std::thread::hardware_concurrency());
+        if (hw <= 0) hw = 4;
+        // 16 is empirical: 129-layer composite saturates L1/L2 before we
+        // hit contention on the shared block cache; more threads waste
+        // schedule slots without shortening the critical path.
+        return hw < 16 ? hw : 16;
+    }();
+    return n;
+}
+
+class RenderThreadPool {
+public:
+    static RenderThreadPool& instance() {
+        static RenderThreadPool p;
+        return p;
+    }
+
+    template<typename Body>
+    void run(Body&& body) {
+        const int nWorkers = int(workers_.size());
+        if (nWorkers == 0) { body(0); return; }
+        // Serialize concurrent callers — the render path is the only caller
+        // today, but guarding keeps the pool composable if another hot path
+        // ever shares it.
+        std::lock_guard<std::mutex> callLock(callMutex_);
+        body_ = std::function<void(int)>(std::forward<Body>(body));
+        for (int i = 0; i < nWorkers; ++i) startSem_.release();
+        body_(0);
+        for (int i = 0; i < nWorkers; ++i) doneSem_.acquire();
+    }
+
+    int workerThreads() const { return int(workers_.size()); }
+
+private:
+    RenderThreadPool() {
+        const int nT = renderThreadCount();
+        const int nWorkers = nT > 1 ? nT - 1 : 0;
+        workers_.reserve(size_t(nWorkers));
+        for (int i = 1; i <= nWorkers; ++i) {
+            workers_.emplace_back([this, i]() {
+                while (true) {
+                    startSem_.acquire();
+                    if (shutdown_.load(std::memory_order_acquire)) return;
+                    body_(i);
+                    doneSem_.release();
+                }
+            });
+        }
+    }
+
+    ~RenderThreadPool() {
+        shutdown_.store(true, std::memory_order_release);
+        for (size_t i = 0; i < workers_.size(); ++i) startSem_.release();
+        // jthread destructor joins automatically.
+    }
+
+    RenderThreadPool(const RenderThreadPool&) = delete;
+    RenderThreadPool& operator=(const RenderThreadPool&) = delete;
+
+    std::vector<std::jthread> workers_;
+    std::function<void(int)> body_;
+    std::counting_semaphore<> startSem_{0};
+    std::counting_semaphore<> doneSem_{0};
+    std::atomic<bool> shutdown_{false};
+    std::mutex callMutex_;
+};
+
+template<typename Body>
+inline void runRenderThreads(Body&& body) {
+    RenderThreadPool::instance().run(std::forward<Body>(body));
+}
+
 // Attempt a non-blocking fetch at level L; returns true and writes LUT pixel
 // if all needed blocks are present. Trilinear path uses 8 corners.
 // Nearest sample with caller-guaranteed in-bounds coords. Caller must have
@@ -780,127 +882,6 @@ VC_FORCE_INLINE bool trySampleNB(BlockSampler<uint8_t>& s, float vz, float vy, f
     }
 }
 
-template<SampleMode Mode>
-void samplePixelsAdaptiveARGB32(uint32_t* outBuf, int outStride,
-                                BlockPipeline& cache,
-                                int desiredLevel, int numLevels,
-                                const cv::Mat_<cv::Vec3f>* coords,  // may be nullptr
-                                const cv::Vec3f* origin, const cv::Vec3f* vx_step, const cv::Vec3f* vy_step,
-                                int w, int h, const uint32_t lut[256])
-{
-    // Pre-start fetches for all levels. Coords/origin are in world (level-0)
-    // voxel space; scale to each level before enumerating chunks. Batch
-    // everything into one fetchInteractive call — the IOPool's queue
-    // rebuild is O(N) and we'd otherwise pay it once per level.
-    auto levelScale = [](int lvl) { return (lvl > 0) ? 1.0f / float(1 << lvl) : 1.0f; };
-    // Thread-local to avoid per-frame alloc/free.
-    thread_local std::vector<vc::cache::ChunkKey> prefetchKeys;
-    prefetchKeys.clear();
-    cv::Vec3f viewCenterL0(0, 0, 0);
-    bool haveCenter = false;
-    if (coords) {
-        // Surface-aware enumeration: only the chunks the surface actually
-        // crosses, never the bbox interior.
-        for (int lvl = desiredLevel; lvl < numLevels; lvl++) {
-            appendChunksForCoordsSurface(cache, lvl, *coords, prefetchKeys);
-        }
-        const cv::Vec3f cv = (*coords)(coords->rows / 2, coords->cols / 2);
-        // Guard against the (0,0,0) off-surface sentinel — isfinite() accepts
-        // zero, which would bias the priority sort toward voxel origin
-        // instead of where the user is actually looking. Require a
-        // non-degenerate magnitude before trusting the center pixel.
-        if (isfinite_bitwise(cv[0])
-            && (cv[0] * cv[0] + cv[1] * cv[1] + cv[2] * cv[2]) > 0.25f) {
-            viewCenterL0 = cv;
-            haveCenter = true;
-        }
-    } else {
-        // Plane bbox from corners, compute once then scale per level.
-        cv::Vec3f p0 = *origin;
-        cv::Vec3f p1 = *origin + (*vx_step) * float(w-1) + (*vy_step) * float(h-1);
-        float minVx = std::min(p0[0], p1[0]), maxVx = std::max(p0[0], p1[0]);
-        float minVy = std::min(p0[1], p1[1]), maxVy = std::max(p0[1], p1[1]);
-        float minVz = std::min(p0[2], p1[2]), maxVz = std::max(p0[2], p1[2]);
-        for (int lvl = desiredLevel; lvl < numLevels; lvl++) {
-            float s = levelScale(lvl);
-            appendChunksForRegion(cache, lvl,
-                minVx*s, minVy*s, minVz*s, maxVx*s, maxVy*s, maxVz*s,
-                prefetchKeys);
-        }
-        viewCenterL0 = *origin
-            + (*vx_step) * (float(w) * 0.5f)
-            + (*vy_step) * (float(h) * 0.5f);
-        haveCenter = true;
-    }
-    if (!prefetchKeys.empty()) {
-        if (haveCenter) {
-            std::array<std::array<int, 3>, vc::cache::kMaxLevels> shapes{};
-            for (int lvl = 0; lvl < numLevels && lvl < vc::cache::kMaxLevels; ++lvl)
-                shapes[lvl] = cache.chunkShape(lvl);
-            sortKeysByCenterDistance(prefetchKeys, shapes.data(),
-                                     std::min(numLevels, int(vc::cache::kMaxLevels)),
-                                     viewCenterL0);
-        }
-        cache.fetchInteractive(prefetchKeys, desiredLevel);
-    }
-
-    float scales[32] = {};
-    const int nSamplersTotal = numLevels - desiredLevel;
-    for (int i = 0; i < nSamplersTotal && i < 32; i++)
-        scales[i] = levelScale(desiredLevel + i);
-
-    #pragma omp parallel
-    {
-        const int nSamplers = numLevels - desiredLevel;
-        std::array<std::optional<BlockSampler<uint8_t>>, 32> samplers;
-        if (nSamplers > 0) samplers[0].emplace(cache, desiredLevel);
-        auto sampler = [&](int i) -> BlockSampler<uint8_t>& {
-            if (!samplers[i].has_value())
-                samplers[i].emplace(cache, desiredLevel + i);
-            return *samplers[i];
-        };
-
-        // Tile-major iteration: see note in sampleCompositeAdaptiveImpl.
-        constexpr int kTile = 32;
-        const int nTilesY = (h + kTile - 1) / kTile;
-        const int nTilesX = (w + kTile - 1) / kTile;
-        #pragma omp for schedule(dynamic, 1) collapse(2)
-        for (int tyi = 0; tyi < nTilesY; tyi++) {
-        for (int txi = 0; txi < nTilesX; txi++) {
-            const int ty = tyi * kTile;
-            const int tx = txi * kTile;
-            const int yEnd = std::min(ty + kTile, h);
-            const int xEnd = std::min(tx + kTile, w);
-        for (int y = ty; y < yEnd; y++) {
-            uint32_t* outRow = outBuf + size_t(y) * size_t(outStride);
-            // Row-base pointer hoisted out of the per-pixel loop. cv::Mat_()
-            // operator() recomputes the row offset on every call — cheap
-            // individually but it's on the per-pixel hot path.
-            const cv::Vec3f* crow = coords ? coords->ptr<cv::Vec3f>(y) : nullptr;
-            for (int x = tx; x < xEnd; x++) {
-                cv::Vec3f c;
-                if (crow) c = crow[x];
-                else      c = *origin + *vx_step * float(x) + *vy_step * float(y);
-
-                uint8_t pix = 0;
-                // Surfaces report NaN or (0,0,0) for undefined pixels —
-                // both produce a black output pixel.
-                const bool skip = !isfinite_bitwise(c[0])
-                    || (c[0] == 0.f && c[1] == 0.f && c[2] == 0.f);
-                if (!skip) {
-                    for (int i = 0; i < nSamplers; i++) {
-                        float scale = scales[i];
-                        float vx = c[0] * scale, vy = c[1] * scale, vz = c[2] * scale;
-                        if (trySampleNB<Mode>(sampler(i), vz, vy, vx, pix)) break;
-                    }
-                }
-                outRow[x] = lut[pix];
-            }
-        }
-        }  // tile x
-        }  // tile y
-    }
-}
 
 // ----------------------------------------------------------------------------
 // Unified composite-capable adaptive sampler.
@@ -916,6 +897,224 @@ static AccumMode2 accumModeFor(const std::string& m) {
     if (m == "volumetric") return AccumMode2::Volumetric;
     if (m == "median" || m == "alpha" || m == "beerLambert" || m == "minabs") return AccumMode2::LayerStorage;
     return AccumMode2::Mean;
+}
+
+// Specialized single-layer (nL==1) kernel. The composite scaffolding —
+// accumulator init, layer loop, sdx/sdy/sdz step vectors, AMode finalize
+// switch, Volumetric integration — all collapses to "sample one voxel at
+// base + nrm*zStart*zStep" when there's only one layer. Template still takes
+// SMode so Nearest/Trilinear compile separately; AMode is irrelevant at
+// nL=1 (every accumulator reduces to the single sampled value) so this
+// kernel is shared across Max/Min/Mean/LayerStorage dispatches.
+// Volumetric is explicitly excluded — the multi-layer path still handles it.
+template<SampleMode SMode>
+void sampleSingleLayerAdaptiveImpl(
+    uint32_t* outBuf, int outStride,
+    BlockPipeline& cache, int desiredLevel, int numLevels,
+    const cv::Mat_<cv::Vec3f>* coords,
+    const cv::Vec3f* origin, const cv::Vec3f* vx_step, const cv::Vec3f* vy_step,
+    const cv::Mat_<cv::Vec3f>* normals,
+    const cv::Vec3f* planeNormal,
+    int zStart, float zStep,
+    int w, int h,
+    const uint32_t lut[256],
+    const CompositeParams* lightParams,
+    uint8_t* levelOut,
+    int levelStride)
+{
+    auto levelScale = [](int lvl) { return (lvl > 0) ? 1.0f / float(1 << lvl) : 1.0f; };
+    const float zOffConst = float(zStart) * zStep;
+
+    // Prefetch the chunks the sampled plane touches. Same as the multi-layer
+    // version but the bbox collapses to the single-z-slab defined by zStart.
+    cv::Vec3f viewCenterL0(0, 0, 0);
+    bool haveCenter = false;
+    if (coords) {
+        thread_local std::vector<vc::cache::ChunkKey> keys;
+        keys.clear();
+        for (int lvl = desiredLevel; lvl < numLevels; ++lvl) {
+            appendChunksForCoordsSurface(cache, lvl, *coords, keys);
+        }
+        const cv::Vec3f cvCenter = (*coords)(coords->rows / 2, coords->cols / 2);
+        if (isfinite_bitwise(cvCenter[0])
+            && (cvCenter[0] * cvCenter[0] + cvCenter[1] * cvCenter[1]
+                + cvCenter[2] * cvCenter[2]) > 0.25f) {
+            viewCenterL0 = cvCenter;
+            haveCenter = true;
+        }
+        if (!keys.empty()) {
+            if (haveCenter) {
+                std::array<std::array<int, 3>, vc::cache::kMaxLevels> shapes{};
+                for (int lvl = 0; lvl < numLevels && lvl < vc::cache::kMaxLevels; ++lvl)
+                    shapes[lvl] = cache.chunkShape(lvl);
+                sortKeysByCenterDistance(keys, shapes.data(),
+                                         std::min(numLevels, int(vc::cache::kMaxLevels)),
+                                         viewCenterL0);
+            }
+            cache.fetchInteractive(keys, desiredLevel);
+        }
+    } else {
+        cv::Vec3f p0 = *origin + (*planeNormal) * zOffConst;
+        cv::Vec3f p1 = *origin + (*vx_step)*float(w-1) + (*vy_step)*float(h-1) + (*planeNormal)*zOffConst;
+        float minVx=std::min(p0[0],p1[0]), maxVx=std::max(p0[0],p1[0]);
+        float minVy=std::min(p0[1],p1[1]), maxVy=std::max(p0[1],p1[1]);
+        float minVz=std::min(p0[2],p1[2]), maxVz=std::max(p0[2],p1[2]);
+        thread_local std::vector<vc::cache::ChunkKey> keys;
+        keys.clear();
+        for (int lvl=desiredLevel; lvl<numLevels; lvl++) {
+            float s = levelScale(lvl);
+            appendChunksForRegion(cache, lvl,
+                minVx*s, minVy*s, minVz*s, maxVx*s, maxVy*s, maxVz*s, keys);
+        }
+        viewCenterL0 = *origin
+            + (*vx_step) * (float(w) * 0.5f)
+            + (*vy_step) * (float(h) * 0.5f);
+        haveCenter = true;
+        if (!keys.empty()) {
+            if (haveCenter) {
+                std::array<std::array<int, 3>, vc::cache::kMaxLevels> shapes{};
+                for (int lvl = 0; lvl < numLevels && lvl < vc::cache::kMaxLevels; ++lvl)
+                    shapes[lvl] = cache.chunkShape(lvl);
+                sortKeysByCenterDistance(keys, shapes.data(),
+                                         std::min(numLevels, int(vc::cache::kMaxLevels)),
+                                         viewCenterL0);
+            }
+            cache.fetchInteractive(keys, desiredLevel);
+        }
+    }
+
+    float scales[32] = {};
+    const int nSamplersTotal = numLevels - desiredLevel;
+    for (int i = 0; i < nSamplersTotal && i < 32; i++) {
+        int lvl = desiredLevel + i;
+        scales[i] = (lvl > 0) ? 1.0f / float(1 << lvl) : 1.0f;
+    }
+
+    const bool lightingEnabled = lightParams && lightParams->lightingEnabled;
+    const int  lightNormalSource = lightParams ? lightParams->lightNormalSource : 0;
+
+    constexpr int kTile = 32;
+    const int nTilesY = (h + kTile - 1) / kTile;
+    const int nTilesX = (w + kTile - 1) / kTile;
+    const int totalTiles = nTilesY * nTilesX;
+    std::atomic<int> nextTile{0};
+
+    runRenderThreads([&](int /*tid*/) {
+        const int nSamplers = numLevels - desiredLevel;
+        std::array<std::optional<BlockSampler<uint8_t>>, 32> samplers;
+        if (nSamplers > 0) samplers[0].emplace(cache, desiredLevel);
+        auto sampler = [&](int i) -> BlockSampler<uint8_t>& {
+            if (!samplers[i].has_value())
+                samplers[i].emplace(cache, desiredLevel + i);
+            return *samplers[i];
+        };
+
+        VolumeShape sh0{};
+        if (nSamplers > 0) sh0 = sampler(0).shape;
+        const float sh0xF = float(sh0.sx), sh0yF = float(sh0.sy), sh0zF = float(sh0.sz);
+
+        float scalesRatio[32] = {};
+        for (int i = 0; i < nSamplers && i < 32; i++)
+            scalesRatio[i] = (i > 0) ? 1.0f / float(1 << i) : 1.0f;
+
+        const cv::Vec3f constNrm = planeNormal ? *planeNormal : cv::Vec3f(0, 0, 0);
+        const float endScale = scales[0];
+        const float wxNrmConst = constNrm[0] * zOffConst;
+        const float wyNrmConst = constNrm[1] * zOffConst;
+        const float wzNrmConst = constNrm[2] * zOffConst;
+
+        while (true) {
+            const int idx = nextTile.fetch_add(1, std::memory_order_relaxed);
+            if (idx >= totalTiles) break;
+            const int tyi = idx / nTilesX;
+            const int txi = idx % nTilesX;
+            const int ty = tyi * kTile;
+            const int tx = txi * kTile;
+            const int yEnd = std::min(ty + kTile, h);
+            const int xEnd = std::min(tx + kTile, w);
+        for (int y=ty; y<yEnd; y++) {
+            uint32_t* outRow = outBuf + size_t(y) * size_t(outStride);
+            uint8_t* lvlRow = levelOut ? (levelOut + size_t(y) * size_t(levelStride)) : nullptr;
+            const cv::Vec3f* crow = coords ? coords->ptr<cv::Vec3f>(y) : nullptr;
+            const cv::Vec3f* nrow = normals ? normals->ptr<cv::Vec3f>(y) : nullptr;
+            for (int x=tx; x<xEnd; x++) {
+                cv::Vec3f base = crow ? crow[x] : (*origin + *vx_step*float(x) + *vy_step*float(y));
+                if (!isfinite_bitwise(base[0])
+                    || (base[0] == 0.f && base[1] == 0.f && base[2] == 0.f)) {
+                    outRow[x] = lut[0];
+                    if (lvlRow) lvlRow[x] = 0;
+                    continue;
+                }
+                cv::Vec3f nrm = nrow ? nrow[x] : (planeNormal ? *planeNormal : cv::Vec3f(0,0,0));
+                if (nrow && !isfinite_bitwise(nrm[0])) {
+                    outRow[x] = lut[0];
+                    if (lvlRow) lvlRow[x] = 0;
+                    continue;
+                }
+                uint8_t pxLevel = 0;
+
+                const float wxNrm = nrow ? (nrm[0] * zOffConst) : wxNrmConst;
+                const float wyNrm = nrow ? (nrm[1] * zOffConst) : wyNrmConst;
+                const float wzNrm = nrow ? (nrm[2] * zOffConst) : wzNrmConst;
+                const float swx = (base[0] + wxNrm) * endScale;
+                const float swy = (base[1] + wyNrm) * endScale;
+                const float swz = (base[2] + wzNrm) * endScale;
+
+                uint8_t v = 0;
+                bool got = false;
+                if constexpr (SMode == SampleMode::Nearest) {
+                    if (swx >= 0.5f && swx < sh0xF - 0.5f
+                     && swy >= 0.5f && swy < sh0yF - 0.5f
+                     && swz >= 0.5f && swz < sh0zF - 0.5f) {
+                        got = trySampleNearestUnchecked(*samplers[0], swz, swy, swx, v);
+                    }
+                }
+                if (!got) {
+                    for (int i=0; i<nSamplers; i++) {
+                        const float r = scalesRatio[i];
+                        if (trySampleNB<SMode>(sampler(i),
+                            swz * r, swy * r, swx * r, v)) {
+                            if (uint8_t(i) > pxLevel) pxLevel = uint8_t(i);
+                            break;
+                        }
+                    }
+                }
+                float val = float(v);
+
+                if (lightingEnabled) {
+                    cv::Vec3f lnrm;
+                    if (lightNormalSource == 1) {
+                        const float bx = base[0] * endScale;
+                        const float by = base[1] * endScale;
+                        const float bz = base[2] * endScale;
+                        uint8_t gx0=0, gx1=0, gy0=0, gy1=0, gz0=0, gz1=0;
+                        const bool gok =
+                            trySampleNB<SMode>(*samplers[0], bz, by, bx - 1.f, gx0)
+                         && trySampleNB<SMode>(*samplers[0], bz, by, bx + 1.f, gx1)
+                         && trySampleNB<SMode>(*samplers[0], bz, by - 1.f, bx, gy0)
+                         && trySampleNB<SMode>(*samplers[0], bz, by + 1.f, bx, gy1)
+                         && trySampleNB<SMode>(*samplers[0], bz - 1.f, by, bx, gz0)
+                         && trySampleNB<SMode>(*samplers[0], bz + 1.f, by, bx, gz1);
+                        if (gok) {
+                            lnrm = cv::Vec3f(
+                                float(gx0) - float(gx1),
+                                float(gy0) - float(gy1),
+                                float(gz0) - float(gz1));
+                        } else {
+                            lnrm = nrm;
+                        }
+                    } else {
+                        lnrm = nrm;
+                    }
+                    val *= computeLightingFactor(lnrm, *lightParams);
+                }
+                if (val < 0.f) val = 0.f; if (val > 255.f) val = 255.f;
+                outRow[x] = lut[uint8_t(val)];
+                if (lvlRow) lvlRow[x] = pxLevel;
+            }
+        }
+        }  // while tiles
+    });
 }
 
 template<SampleMode SMode, AccumMode2 AMode>
@@ -954,8 +1153,8 @@ void sampleCompositeAdaptiveImpl(
             appendChunksForCoordsSurface(cache, lvl, *coords, keys);
         }
         const cv::Vec3f cvCenter = (*coords)(coords->rows / 2, coords->cols / 2);
-        // Guard against the (0,0,0) off-surface sentinel — see note in
-        // samplePixelsAdaptiveARGB32 above.
+        // Guard against the (0,0,0) off-surface sentinel — we don't want
+        // it biasing the viewport-centre prefetch priority toward origin.
         if (isfinite_bitwise(cvCenter[0])
             && (cvCenter[0] * cvCenter[0] + cvCenter[1] * cvCenter[1]
                 + cvCenter[2] * cvCenter[2]) > 0.25f) {
@@ -1024,10 +1223,10 @@ void sampleCompositeAdaptiveImpl(
                             : (compositeMethod == "beerLambert") ? LayerAgg::BeerLambert
                             : LayerAgg::Mean;
 
-    // UI caps composite layers at 16 front + 16 behind + center = 33. Bound
+    // UI caps composite layers at 64 front + 64 behind + center = 129. Bound
     // once at the function level so the per-pixel loop and the bounds
     // precheck both see the same compile-time-friendly trip count.
-    constexpr int kMaxLayers = 33;
+    constexpr int kMaxLayers = 129;
     const int nLHoisted = numLayers > kMaxLayers ? kMaxLayers : numLayers;
 
     // Hoist lightParams fields into locals so the inner pixel loop doesn't
@@ -1047,8 +1246,17 @@ void sampleCompositeAdaptiveImpl(
             volExpLUT[k] = std::exp(-extN * float(k));
     }
 
-    #pragma omp parallel
-    {
+    // Tile the output into 32x32 blocks. Most pixels in a tile map
+    // into the same 1-4 level-0 blocks, so the sampler's slot cache
+    // stays hot — vs row-major which touches ~120 blocks across a
+    // row before cycling back to the same y-row.
+    constexpr int kTile = 32;
+    const int nTilesY = (h + kTile - 1) / kTile;
+    const int nTilesX = (w + kTile - 1) / kTile;
+    const int totalTiles = nTilesY * nTilesX;
+    std::atomic<int> nextTile{0};
+
+    runRenderThreads([&](int /*tid*/) {
         // Lazy per-level samplers: construct the level-0 sampler eagerly
         // (always used) and leave higher levels unconstructed until the
         // adaptive fallback actually needs them. Each sampler carries a
@@ -1094,16 +1302,11 @@ void sampleCompositeAdaptiveImpl(
         const float wyNrmStartConst = constNrm[1] * zOffStart;
         const float wzNrmStartConst = constNrm[2] * zOffStart;
 
-        // Tile the output into 32x32 blocks. Most pixels in a tile map
-        // into the same 1-4 level-0 blocks, so the sampler's slot cache
-        // stays hot — vs row-major which touches ~120 blocks across a
-        // row before cycling back to the same y-row.
-        constexpr int kTile = 32;
-        const int nTilesY = (h + kTile - 1) / kTile;
-        const int nTilesX = (w + kTile - 1) / kTile;
-        #pragma omp for schedule(dynamic, 1) collapse(2)
-        for (int tyi = 0; tyi < nTilesY; tyi++) {
-        for (int txi = 0; txi < nTilesX; txi++) {
+        while (true) {
+            const int idx = nextTile.fetch_add(1, std::memory_order_relaxed);
+            if (idx >= totalTiles) break;
+            const int tyi = idx / nTilesX;
+            const int txi = idx % nTilesX;
             const int ty = tyi * kTile;
             const int tx = txi * kTile;
             const int yEnd = std::min(ty + kTile, h);
@@ -1259,26 +1462,107 @@ void sampleCompositeAdaptiveImpl(
                                  && minSz >= 0.5f && maxSz < sh0zF - 0.5f;
                 }
                 const int nL = nLHoisted;
-                #pragma clang loop unroll(enable) vectorize(enable)
-                for (int li=0; li<nL; li++) {
-                    uint8_t v = 0;
-                    bool got = false;
-                    if (fullyInBounds) {
-                        // Hot path: skip per-sample bounds check. Coords are
-                        // already in desiredLevel-sampler space.
-                        got = trySampleNearestUnchecked(*samplers[0],
-                            swz, swy, swx, v);
+                // Block-run batching: the z-ray advances by (sdx,sdy,sdz)
+                // per layer — typically <1 voxel/layer for composite views
+                // so the whole 129-layer ray sits in 1-5 blocks. Cache the
+                // current block ptr and only re-resolve on (bz,by,bx)
+                // change. Saves packKey + lastKey compare (~5 cycles/sample)
+                // on every same-block step — i.e. most steps.
+                BlockSampler<uint8_t>& s0 = *samplers[0];
+                if (fullyInBounds) {
+                    // Chunk-grouped sampling: precompute per-layer block
+                    // coordinates and in-block offsets in a pure-linear pass
+                    // (compiler vectorizes), then walk layers grouped by
+                    // block — one tryUpdateBlock call per distinct block,
+                    // followed by a branch-free inner loop that just hits
+                    // `cdata[offset[i]]` and feeds the accumulator.
+                    //
+                    // This wins over the original interleaved loop for
+                    // long rays (nL=65): the per-sample block-change check
+                    // fuses into a single run-length scan over the packed
+                    // block-key array, and the inner byte-load loop is
+                    // tight enough that clang pipelines it aggressively.
+                    alignas(64) int64_t bkey[kMaxLayers];
+                    alignas(64) int16_t offset[kMaxLayers];
+                    for (int li = 0; li < nL; ++li) {
+                        const int iz = int(swz + 0.5f);
+                        const int iy = int(swy + 0.5f);
+                        const int ix = int(swx + 0.5f);
+                        const int bz = iz >> kBlockShift;
+                        const int by = iy >> kBlockShift;
+                        const int bx = ix >> kBlockShift;
+                        // 20 bits per axis is well beyond any realistic
+                        // block count (2^20 × 16 = 16M voxels/axis).
+                        bkey[li] = (int64_t(bz) << 40)
+                                 | (int64_t(by) << 20)
+                                 |  int64_t(bx);
+                        const int lz = iz & kBlockMask;
+                        const int ly = iy & kBlockMask;
+                        const int lx = ix & kBlockMask;
+                        offset[li] = int16_t(lz * kStrideZ
+                                           + ly * kStrideY
+                                           + lx);
+                        swx += sdx; swy += sdy; swz += sdz;
                     }
-                    if (!got) {
-                        // Fallback: either we're near a boundary or the
-                        // desired-level block isn't resident yet. Walk the
-                        // fallback chain from finest to coarsest — adaptive
-                        // sampling fills in from whichever level is ready.
-                        // Coarser levels need coords at their own scale;
-                        // the ratio scales[i]/endScale applied to the
-                        // already-scaled swx/swy/swz gets us there without
-                        // re-deriving from base.
-                        for (int i=0; i<nSamplers; i++) {
+
+                    int li = 0;
+                    while (li < nL) {
+                        const int64_t key = bkey[li];
+                        const int bz = int((key >> 40) & ((int64_t(1) << 20) - 1));
+                        const int by = int((key >> 20) & ((int64_t(1) << 20) - 1));
+                        const int bx = int( key        & ((int64_t(1) << 20) - 1));
+                        s0.tryUpdateBlockNonBlocking(bz, by, bx);
+                        const uint8_t* cdata = s0.data;
+                        int liEnd = li + 1;
+                        while (liEnd < nL && bkey[liEnd] == key) ++liEnd;
+                        const int runLen = liEnd - li;
+                        if (cdata) {
+                            // Tight same-block inner loop: N byte loads
+                            // into accumulator. Clang pipelines 4 per
+                            // cycle comfortably on ARM — benchmarked
+                            // identical to a manual 4-wide unroll so
+                            // we keep the simpler scalar form.
+                            if constexpr (AMode == AccumMode2::Max) {
+                                uint8_t m = uint8_t(mx);
+                                for (int i = li; i < liEnd; ++i) {
+                                    const uint8_t v = cdata[offset[i]];
+                                    m = v > m ? v : m;
+                                }
+                                mx = float(m);
+                            } else if constexpr (AMode == AccumMode2::Min) {
+                                uint8_t m = uint8_t(mn);
+                                for (int i = li; i < liEnd; ++i) {
+                                    const uint8_t v = cdata[offset[i]];
+                                    m = v < m ? v : m;
+                                }
+                                mn = float(m);
+                            } else if constexpr (AMode == AccumMode2::Mean) {
+                                int sum = 0;
+                                for (int i = li; i < liEnd; ++i) {
+                                    sum += int(cdata[offset[i]]);
+                                }
+                                accum += float(sum);
+                                count += runLen;
+                            } else {
+                                for (int i = li; i < liEnd; ++i) {
+                                    layerVals[i] = float(cdata[offset[i]]);
+                                }
+                            }
+                        } else if constexpr (AMode == AccumMode2::Mean) {
+                            // Missing block → 0 voxels count toward mean
+                            count += runLen;
+                        } else if constexpr (AMode == AccumMode2::LayerStorage) {
+                            for (int i = li; i < liEnd; ++i) layerVals[i] = 0.f;
+                        }
+                        li = liEnd;
+                    }
+                } else {
+                    // Near-edge / partial-miss path: keep the original
+                    // per-layer fallback chain (rare enough that the
+                    // chunk-grouped fast path isn't worth forking here).
+                    for (int li = 0; li < nL; li++) {
+                        uint8_t v = 0;
+                        for (int i = 0; i < nSamplers; i++) {
                             const float r = scalesRatio[i];
                             if (trySampleNB<SMode>(sampler(i),
                                 swz * r, swy * r, swx * r, v)) {
@@ -1286,12 +1570,12 @@ void sampleCompositeAdaptiveImpl(
                                 break;
                             }
                         }
+                        if constexpr (AMode == AccumMode2::Max) { mx = std::max(mx, float(v)); }
+                        else if constexpr (AMode == AccumMode2::Min) { mn = std::min(mn, float(v)); }
+                        else if constexpr (AMode == AccumMode2::Mean) { accum += float(v); count++; }
+                        else { layerVals[li] = float(v); }
+                        swx += sdx; swy += sdy; swz += sdz;
                     }
-                    if constexpr (AMode == AccumMode2::Max) { mx = std::max(mx, float(v)); }
-                    else if constexpr (AMode == AccumMode2::Min) { mn = std::min(mn, float(v)); }
-                    else if constexpr (AMode == AccumMode2::Mean) { accum += float(v); count++; }
-                    else { layerVals[li] = float(v); }
-                    swx += sdx; swy += sdy; swz += sdz;
                 }
 
                 float val = 0.f;
@@ -1300,7 +1584,7 @@ void sampleCompositeAdaptiveImpl(
                 else if constexpr (AMode == AccumMode2::Mean) val = count ? accum * (1.0f/float(count)) : 0.f;
                 else {
                     if (layerAgg == LayerAgg::Median) {
-                        // For the small N we see in practice (<=~33 layers),
+                        // For the small N we see in practice (<=~129 layers),
                         // insertion-sort-up-to-the-median beats nth_element:
                         // its introselect setup costs more than sorting a
                         // few dozen floats. partial_sort gives us exactly
@@ -1412,9 +1696,8 @@ void sampleCompositeAdaptiveImpl(
                 if (lvlRow) lvlRow[x] = pxLevel;
             }
         }
-        }  // tile x
-        }  // tile y
-    }
+        }  // while tiles
+    });
 }
 
 template<SampleMode SMode>
@@ -1433,7 +1716,27 @@ void dispatchCompositeAdaptive(
     uint8_t* levelOut,
     int levelStride)
 {
-    switch (accumModeFor(method)) {
+    const AccumMode2 mode = accumModeFor(method);
+    // nL=1 reduces Max/Min/Mean to the single sampled value (all three
+    // collapse: max(x)=min(x)=mean(x)=x). Dispatch to the specialized kernel
+    // to skip the layer loop, accumulator setup, and finalize switch — the
+    // plane viewer's dominant path. LayerStorage is excluded because its
+    // sub-modes (Alpha, BeerLambert, Median, MinAbs) apply a tone-mapping
+    // transform to the single sample rather than returning it raw; Volumetric
+    // is excluded because its shadow-ray + transmittance integration doesn't
+    // degenerate to a single sample.
+    const bool singleLayerFast = numLayers <= 1
+        && (mode == AccumMode2::Max
+         || mode == AccumMode2::Min
+         || mode == AccumMode2::Mean);
+    if (singleLayerFast) {
+        sampleSingleLayerAdaptiveImpl<SMode>(
+            outBuf, outStride, cache, desiredLevel, numLevels,
+            coords, origin, vx_step, vy_step, normals, planeNormal,
+            zStart, zStep, w, h, lut, lightParams, levelOut, levelStride);
+        return;
+    }
+    switch (mode) {
         case AccumMode2::Max:
             sampleCompositeAdaptiveImpl<SMode, AccumMode2::Max>(
                 outBuf, outStride, cache, desiredLevel, numLevels,
@@ -1497,53 +1800,6 @@ void sampleAdaptiveARGB32(
             outBuf, outStride, *cache, desiredLevel, numLevels,
             coords, origin, vx_step, vy_step, normals, planeNormal,
             numLayers, zStart, zStep, width, height, compositeMethod, lut, lightParams, levelOut, levelStride);
-    }
-}
-
-int samplePlaneAdaptiveARGB32(uint32_t* outBuf, int outStride,
-                              BlockPipeline* cache,
-                              int desiredLevel, int numLevels,
-                              const cv::Vec3f& origin,
-                              const cv::Vec3f& vx_step,
-                              const cv::Vec3f& vy_step,
-                              int w, int h,
-                              const uint32_t lut[256],
-                              vc::Sampling method)
-{
-    switch (method) {
-        case vc::Sampling::Nearest:
-            samplePixelsAdaptiveARGB32<SampleMode::Nearest>(
-                outBuf, outStride, *cache, desiredLevel, numLevels,
-                nullptr, &origin, &vx_step, &vy_step, w, h, lut);
-            break;
-        default:
-            samplePixelsAdaptiveARGB32<SampleMode::Trilinear>(
-                outBuf, outStride, *cache, desiredLevel, numLevels,
-                nullptr, &origin, &vx_step, &vy_step, w, h, lut);
-            break;
-    }
-    return desiredLevel;
-}
-
-void sampleCoordsAdaptiveARGB32(uint32_t* outBuf, int outStride,
-                                BlockPipeline* cache,
-                                int desiredLevel, int numLevels,
-                                const cv::Mat_<cv::Vec3f>& coords,
-                                const uint32_t lut[256],
-                                vc::Sampling method)
-{
-    int w = coords.cols, h = coords.rows;
-    switch (method) {
-        case vc::Sampling::Nearest:
-            samplePixelsAdaptiveARGB32<SampleMode::Nearest>(
-                outBuf, outStride, *cache, desiredLevel, numLevels,
-                &coords, nullptr, nullptr, nullptr, w, h, lut);
-            break;
-        default:
-            samplePixelsAdaptiveARGB32<SampleMode::Trilinear>(
-                outBuf, outStride, *cache, desiredLevel, numLevels,
-                &coords, nullptr, nullptr, nullptr, w, h, lut);
-            break;
     }
 }
 
@@ -1620,7 +1876,7 @@ void readCompositeFastImpl(
                         if (params.method == "median") {
                             // partial_sort matches the other median path
                             // (Slicing.cpp composite) and beats nth_element
-                            // at the small N we run with (<=~33).
+                            // at the small N we run with (<=~65).
                             std::partial_sort(layerVals.begin(),
                                               layerVals.begin() + numLayers / 2 + 1,
                                               layerVals.end());

--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -147,9 +147,17 @@ void Volume::zarrOpen()
             const int expectedHeight = ceilDivPow2(baseHeight, levelInt);
             const int expectedWidth = ceilDivPow2(baseWidth, levelInt);
 
-            if (static_cast<int>(shape[0]) != expectedSlices ||
-                static_cast<int>(shape[1]) != expectedHeight ||
-                static_cast<int>(shape[2]) != expectedWidth) {
+            // Canonical format pads each level's shape to a multiple of the
+            // inner chunk size (128³), independently per level. Accept any
+            // zarr_shape that exceeds expected by less than one chunk —
+            // anything larger indicates real corruption.
+            constexpr int kMaxPerLevelPad = 128;
+            auto padOK = [](long long actual, long long expected) {
+                return actual >= expected && actual - expected < kMaxPerLevelPad;
+            };
+            if (!padOK(shape[0], expectedSlices) ||
+                !padOK(shape[1], expectedHeight) ||
+                !padOK(shape[2], expectedWidth)) {
                 throw std::runtime_error(
                     "zarr level " + std::to_string(levelInt) + " shape [z,y,x]=("
                     + std::to_string(shape[0]) + ", " + std::to_string(shape[1]) + ", " + std::to_string(shape[2])
@@ -187,9 +195,15 @@ void Volume::zarrOpen()
             const int expectedHeight = ceilDivPow2(_height, static_cast<int>(level));
             const int expectedWidth = ceilDivPow2(_width, static_cast<int>(level));
 
-            if (static_cast<int>(shape[0]) != expectedSlices ||
-                static_cast<int>(shape[1]) != expectedHeight ||
-                static_cast<int>(shape[2]) != expectedWidth) {
+            // Same tolerance as the auto-generated path: canonical caches pad
+            // each level independently to the next 128-boundary.
+            constexpr int kMaxPerLevelPad = 128;
+            auto padOK = [](long long actual, long long expected) {
+                return actual >= expected && actual - expected < kMaxPerLevelPad;
+            };
+            if (!padOK(shape[0], expectedSlices) ||
+                !padOK(shape[1], expectedHeight) ||
+                !padOK(shape[2], expectedWidth)) {
                 throw std::runtime_error(
                     "zarr level " + std::to_string(level) + " shape [z,y,x]=("
                     + std::to_string(shape[0]) + ", " + std::to_string(shape[1]) + ", " + std::to_string(shape[2])
@@ -566,23 +580,6 @@ int Volume::samplePlaneBestEffort(cv::Mat_<uint8_t>& out,
     if (!out.empty())
         applyOptionalPostProcess(out, params);
     return lvl;
-}
-
-int Volume::samplePlaneBestEffortARGB32(uint32_t* outBuf, int outStride,
-                                         const cv::Vec3f& origin,
-                                         const cv::Vec3f& vx_step,
-                                         const cv::Vec3f& vy_step,
-                                         int width, int height,
-                                         const vc::SampleParams& params,
-                                         const uint32_t lut[256])
-{
-    const int nScales = static_cast<int>(numScales());
-    const int desired = std::clamp(params.level, 0, std::max(0, nScales - 1));
-    samplePlaneAdaptiveARGB32(outBuf, outStride, tieredCache(),
-                              desired, nScales,
-                              origin, vx_step, vy_step,
-                              width, height, lut, params.method);
-    return desired;
 }
 
 int Volume::samplePlaneCompositeBestEffortARGB32(

--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -296,7 +296,7 @@ size_t Volume::numScales() const noexcept {
 std::unique_ptr<vc::cache::BlockPipeline> Volume::createTieredCache() const
 {
     if (zarrDs_.empty()) return nullptr;
-    std::vector<std::shared_ptr<utils::ZarrArray>> diskLevels;
+    std::vector<std::unique_ptr<utils::ZarrArray>> diskLevels;
 
     // Build level metadata from our zarr datasets
     std::vector<vc::cache::FileSystemSource::LevelMeta> levels;
@@ -341,7 +341,7 @@ std::unique_ptr<vc::cache::BlockPipeline> Volume::createTieredCache() const
             for (int lvl = 0; lvl < nLevels; lvl++) {
                 auto lvlPath = path_ / std::to_string(lvl);
                 if (std::filesystem::exists(lvlPath / "zarr.json")) {
-                    diskLevels[lvl] = std::make_shared<utils::ZarrArray>(
+                    diskLevels[lvl] = std::make_unique<utils::ZarrArray>(
                         utils::ZarrArray::open(lvlPath));
                 } else {
                     auto shape = source->levelShape(lvl);
@@ -356,7 +356,7 @@ std::unique_ptr<vc::cache::BlockPipeline> Volume::createTieredCache() const
                     utils::ShardConfig sc;
                     sc.sub_chunks = {128, 128, 128};
                     meta.shard_config = std::move(sc);
-                    diskLevels[lvl] = std::make_shared<utils::ZarrArray>(
+                    diskLevels[lvl] = std::make_unique<utils::ZarrArray>(
                         utils::ZarrArray::create(lvlPath, std::move(meta)));
                 }
             }

--- a/volume-cartographer/core/src/cache/BlockCache.cpp
+++ b/volume-cartographer/core/src/cache/BlockCache.cpp
@@ -45,6 +45,15 @@ BlockCache::BlockCache(Config cfg)
     // Block lookups are spatially scattered — tell kernel not to read-ahead.
     ::madvise(arena_, arenaBytes_, MADV_RANDOM);
 
+    // Promote arena to 2 MiB pages where the kernel can: each block is exactly
+    // 4 KiB = 1 standard page, so one huge page covers 512 blocks. TLB reach
+    // for a 10 GiB arena jumps from ~2.5M pages to ~5k — render threads that
+    // pick blocks across the arena rarely miss the TLB. MADV_HUGEPAGE is
+    // advisory, silently ignored when THP is disabled in the kernel.
+#ifdef MADV_HUGEPAGE
+    ::madvise(arena_, arenaBytes_, MADV_HUGEPAGE);
+#endif
+
     // Pre-fault arena pages in 1 GB increments on a background thread.
     // First-touch page faults are expensive (kernel context switch per 4 KB
     // page); when the cache fills during rendering, thousands of faults stall
@@ -71,9 +80,12 @@ BlockCache::BlockCache(Config cfg)
     // Default max_load_factor of 1.0 means libstdc++ sizes the bucket array
     // at 2x insertion count. At 2.5M slots that's ~40 MB of extra buckets.
     // Push the load factor to 1.0 before reserving so the reserve matches
-    // actual need (buckets ≈ nSlots_ instead of ≈ 2*nSlots_).
-    map_.max_load_factor(1.0f);
-    map_.reserve(nSlots_);
+    // actual need. Each shard gets 1/kShards of total capacity.
+    const size_t perShard = (nSlots_ + kShards - 1) / kShards;
+    for (auto& s : shards_) {
+        s.map.max_load_factor(1.0f);
+        s.map.reserve(perShard);
+    }
 }
 
 BlockCache::~BlockCache()
@@ -91,18 +103,33 @@ BlockCache::~BlockCache()
 
 BlockPtr BlockCache::get(const BlockKey& key) noexcept
 {
-    std::shared_lock lock(mutex_);
-    if (auto it = map_.find(key); it != map_.end()) {
+    const size_t sh = shardIndex(key);
+    MapShard& shard = shards_[sh];
+    std::shared_lock lock(shard.mutex);
+    if (auto it = shard.map.find(key); it != shard.map.end()) {
         setUsed(it->second, true);  // lock-free atomic fetch_or
+        // Per-shard hit counter: 12-thread render used to hammer one global
+        // atomic here, costing ~12% of total CPU from cacheline ping-pong.
+        shard.hits.fetch_add(1, std::memory_order_relaxed);
         return &arena_[it->second];
     }
     return nullptr;
 }
 
+uint64_t BlockCache::blockHits() const noexcept
+{
+    uint64_t total = 0;
+    for (const auto& s : shards_)
+        total += s.hits.load(std::memory_order_relaxed);
+    return total;
+}
+
 bool BlockCache::contains(const BlockKey& key) const noexcept
 {
-    std::shared_lock lock(mutex_);
-    return map_.find(key) != map_.end();
+    const size_t sh = shardIndex(key);
+    const MapShard& shard = shards_[sh];
+    std::shared_lock lock(shard.mutex);
+    return shard.map.find(key) != shard.map.end();
 }
 
 void BlockCache::containsBatch(const std::vector<BlockKey>& keys,
@@ -110,15 +137,27 @@ void BlockCache::containsBatch(const std::vector<BlockKey>& keys,
 {
     out.assign(keys.size(), 0);
     if (keys.empty()) return;
-    std::shared_lock lock(mutex_);
+    // Group by shard so each shard's lock is acquired exactly once across
+    // the batch. With N input keys over kShards shards, naive per-key
+    // locking costs ~N/kShards lock pairs per shard; grouping drops that to 1.
+    std::array<std::vector<size_t>, kShards> idxByShard;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (map_.find(keys[i]) != map_.end()) out[i] = 1;
+        idxByShard[shardIndex(keys[i])].push_back(i);
+    }
+    for (size_t sh = 0; sh < kShards; ++sh) {
+        auto& idx = idxByShard[sh];
+        if (idx.empty()) continue;
+        std::shared_lock lock(shards_[sh].mutex);
+        const auto& m = shards_[sh].map;
+        for (size_t i : idx) {
+            if (m.find(keys[i]) != m.end()) out[i] = 1;
+        }
     }
 }
 
 void BlockCache::put(const BlockKey& key, const uint8_t* src) noexcept
 {
-    std::unique_lock lock(mutex_);
+    std::unique_lock lock(arenaMutex_);
     putLocked(key, src);
 }
 
@@ -127,17 +166,31 @@ void BlockCache::BatchPut::put(const BlockKey& key, const uint8_t* src) noexcept
     cache_.putLocked(key, src);
 }
 
-void BlockCache::putLocked(const BlockKey& key, const uint8_t* src) noexcept
+uint8_t* BlockCache::BatchPut::acquire(const BlockKey& key) noexcept
+{
+    size_t slot = cache_.acquireSlotLocked(key);
+    if (slot == SIZE_MAX) return nullptr;
+    return cache_.arena_[slot].data;
+}
+
+size_t BlockCache::acquireSlotLocked(const BlockKey& key) noexcept
 {
     // Degenerate config (cache size rounded below one block) — bail
     // instead of dividing by zero in the slot-assignment arithmetic.
-    if (nSlots_ == 0) return;
+    if (nSlots_ == 0) return SIZE_MAX;
 
-    if (auto it = map_.find(key); it != map_.end()) {
-        Block* b = &arena_[it->second];
-        std::memcpy(b->data, src, kBlockBytes);
-        setUsed(it->second, true);
-        return;
+    const size_t sh = shardIndex(key);
+    MapShard& shard = shards_[sh];
+    {
+        // Shared lookup first — if the key already lives in its shard, just
+        // bump the used bit. Writers normally hold arenaMutex_ exclusively,
+        // so competing writers never collide here, but readers may still be
+        // probing the shard concurrently.
+        std::shared_lock rlock(shard.mutex);
+        if (auto it = shard.map.find(key); it != shard.map.end()) {
+            setUsed(it->second, true);
+            return it->second;
+        }
     }
 
     size_t slot;
@@ -190,13 +243,22 @@ void BlockCache::putLocked(const BlockKey& key, const uint8_t* src) noexcept
         slot = reclaimSlotLocked();
     }
 
-    Block* b = &arena_[slot];
-    std::memcpy(b->data, src, kBlockBytes);
     setUsed(slot, true);
     slotKey_[slot] = key;
-    map_[key] = slot;
+    {
+        std::unique_lock wlock(shard.mutex);
+        shard.map[key] = slot;
+    }
     if (key.level >= 0 && key.level < kMaxLevels)
         levelOccupied_[key.level]++;
+    return slot;
+}
+
+void BlockCache::putLocked(const BlockKey& key, const uint8_t* src) noexcept
+{
+    const size_t slot = acquireSlotLocked(key);
+    if (slot == SIZE_MAX) return;
+    std::memcpy(arena_[slot].data, src, kBlockBytes);
 }
 
 size_t BlockCache::reclaimSlotLocked()
@@ -219,8 +281,13 @@ size_t BlockCache::reclaimSlotLocked()
             if (k.level >= 0 && k.level < kMaxLevels
                 && levelOccupied_[k.level] > 0)
                 levelOccupied_[k.level]--;
-            map_.erase(k);
+            {
+                const size_t sh = shardIndex(k);
+                std::unique_lock wlock(shards_[sh].mutex);
+                shards_[sh].map.erase(k);
+            }
             slotKey_[i] = kEmptyKey;
+            evictionVersion_.fetch_add(1, std::memory_order_relaxed);
             return i;
         }
         setUsed(i, false);
@@ -229,14 +296,18 @@ size_t BlockCache::reclaimSlotLocked()
 
 size_t BlockCache::size() const noexcept
 {
-    std::shared_lock lock(mutex_);
+    std::shared_lock lock(arenaMutex_);
     return occupiedCount_;
 }
 
 void BlockCache::clear()
 {
-    std::unique_lock lock(mutex_);
-    map_.clear();
+    std::unique_lock lock(arenaMutex_);
+    for (auto& s : shards_) {
+        std::unique_lock slock(s.mutex);
+        s.map.clear();
+        s.hits.store(0, std::memory_order_relaxed);
+    }
     std::fill(slotKey_.begin(), slotKey_.end(), kEmptyKey);
     std::fill(occupiedBits_.begin(), occupiedBits_.end(), 0);
     for (size_t i = 0; i < usedBitsWords_; ++i)
@@ -244,6 +315,7 @@ void BlockCache::clear()
     occupiedCount_ = 0;
     clockHand_ = 0;
     levelOccupied_.fill(0);
+    evictionVersion_.fetch_add(1, std::memory_order_relaxed);
     // Tell kernel we don't need any of these pages for now.
     if (arena_ && arenaBytes_) {
         ::madvise(arena_, arenaBytes_, MADV_DONTNEED);

--- a/volume-cartographer/core/src/cache/BlockCache.cpp
+++ b/volume-cartographer/core/src/cache/BlockCache.cpp
@@ -71,7 +71,18 @@ BlockCache::BlockCache(Config cfg)
         });
     }
 
-    slotKey_.assign(nSlots_, kEmptyKey);
+    slotKeyPacked_ = std::unique_ptr<std::atomic<uint64_t>[]>(
+        new std::atomic<uint64_t>[nSlots_]);
+    for (size_t i = 0; i < nSlots_; ++i)
+        slotKeyPacked_[i].store(UINT64_MAX, std::memory_order_relaxed);
+
+    // 8-way set-associative L2; see BlockCache.hpp for sizing rationale.
+    l2_ = std::unique_ptr<std::atomic<uint64_t>[]>(
+        new std::atomic<uint64_t>[kL2Size]);
+    for (size_t i = 0; i < kL2Size; ++i)
+        l2_[i].store(kL2Empty, std::memory_order_relaxed);
+    l2RrCounters_ = std::unique_ptr<uint8_t[]>(new uint8_t[kL2Sets]());
+
     const size_t words = (nSlots_ + 63u) / 64u;
     occupiedBits_.assign(words, 0);
     usedBitsWords_ = words;
@@ -103,15 +114,60 @@ BlockCache::~BlockCache()
 
 BlockPtr BlockCache::get(const BlockKey& key) noexcept
 {
+    // 8-way set-associative L2 fast path: probe 8 entries in one cacheline
+    // for a matching tag, verify via slotKeyPacked_. Lock-free throughout.
+    // The verify check still catches keyTag32 collisions (1/2^32) and
+    // eviction/reassignment races.
+    const uint64_t packed = packBlockKey(key);
+    const uint32_t tag = keyTag32(packed);
+    if (tag != 0) {  // tag==0 collides with kL2Empty; skip L2 for that key
+        const size_t setIdx = l2Index(packed, kL2Bits);
+        std::atomic<uint64_t>* set = &l2_[setIdx * kL2Ways];
+        for (size_t way = 0; way < kL2Ways; ++way) {
+            const uint64_t entry = set[way].load(std::memory_order_acquire);
+            if (uint32_t(entry >> 32) != tag) continue;
+            const uint32_t slot = uint32_t(entry);
+            if (slot < nSlots_ &&
+                slotKeyPacked_[slot].load(std::memory_order_acquire) == packed) {
+                setUsed(slot, true);
+                return &arena_[slot];
+            }
+        }
+    }
+
+    // Slow path: shard shared_lock + unordered_map lookup. Populate L2 on
+    // success so subsequent lookups for this key go lock-free. Round-robin
+    // counter picks which way to overwrite — the counter is non-atomic
+    // since races are benign (worst case we evict a slightly-less-ideal
+    // entry).
     const size_t sh = shardIndex(key);
     MapShard& shard = shards_[sh];
     std::shared_lock lock(shard.mutex);
     if (auto it = shard.map.find(key); it != shard.map.end()) {
-        setUsed(it->second, true);  // lock-free atomic fetch_or
-        // Per-shard hit counter: 12-thread render used to hammer one global
-        // atomic here, costing ~12% of total CPU from cacheline ping-pong.
+        const size_t slot = it->second;
+        setUsed(slot, true);
         shard.hits.fetch_add(1, std::memory_order_relaxed);
-        return &arena_[it->second];
+        if (tag != 0) {
+            const size_t setIdx = l2Index(packed, kL2Bits);
+            std::atomic<uint64_t>* set = &l2_[setIdx * kL2Ways];
+            // Prefer an empty slot if one is visible; otherwise evict via
+            // round-robin. The empty-slot scan is free since the cacheline
+            // is already hot from the probe above.
+            size_t wayToUse = kL2Ways;
+            for (size_t way = 0; way < kL2Ways; ++way) {
+                if (set[way].load(std::memory_order_relaxed) == kL2Empty) {
+                    wayToUse = way; break;
+                }
+            }
+            if (wayToUse == kL2Ways) {
+                const uint8_t c = l2RrCounters_[setIdx];
+                l2RrCounters_[setIdx] = uint8_t((c + 1u) & (kL2Ways - 1u));
+                wayToUse = c & (kL2Ways - 1u);
+            }
+            set[wayToUse].store((uint64_t(tag) << 32) | uint32_t(slot),
+                                std::memory_order_release);
+        }
+        return &arena_[slot];
     }
     return nullptr;
 }
@@ -244,13 +300,35 @@ size_t BlockCache::acquireSlotLocked(const BlockKey& key) noexcept
     }
 
     setUsed(slot, true);
-    slotKey_[slot] = key;
+    const uint64_t packed = packBlockKey(key);
+    slotKeyPacked_[slot].store(packed, std::memory_order_release);
     {
         std::unique_lock wlock(shard.mutex);
         shard.map[key] = slot;
     }
     if (key.level >= 0 && key.level < kMaxLevels)
         levelOccupied_[key.level]++;
+    // Populate L2 for this key so the very first get() after insert goes
+    // lock-free. Same empty-preferred / round-robin-fallback placement as
+    // the slow-path populate in get().
+    const uint32_t tag = keyTag32(packed);
+    if (tag != 0) {
+        const size_t setIdx = l2Index(packed, kL2Bits);
+        std::atomic<uint64_t>* set = &l2_[setIdx * kL2Ways];
+        size_t wayToUse = kL2Ways;
+        for (size_t way = 0; way < kL2Ways; ++way) {
+            if (set[way].load(std::memory_order_relaxed) == kL2Empty) {
+                wayToUse = way; break;
+            }
+        }
+        if (wayToUse == kL2Ways) {
+            const uint8_t c = l2RrCounters_[setIdx];
+            l2RrCounters_[setIdx] = uint8_t((c + 1u) & (kL2Ways - 1u));
+            wayToUse = c & (kL2Ways - 1u);
+        }
+        set[wayToUse].store((uint64_t(tag) << 32) | uint32_t(slot),
+                            std::memory_order_release);
+    }
     return slot;
 }
 
@@ -272,7 +350,8 @@ size_t BlockCache::reclaimSlotLocked()
         size_t i = clockHand_;
         clockHand_ = (clockHand_ + 1) % nSlots_;
         if (!isOccupied(i)) continue;
-        const BlockKey& k = slotKey_[i];
+        const uint64_t pk = slotKeyPacked_[i].load(std::memory_order_relaxed);
+        const BlockKey k = unpackBlockKey(pk);
         const bool protectedSlot =
             (k.level >= 0 && k.level < kMaxLevels)
             && (levelOccupied_[k.level] <= levelFloor_[k.level]);
@@ -286,7 +365,27 @@ size_t BlockCache::reclaimSlotLocked()
                 std::unique_lock wlock(shards_[sh].mutex);
                 shards_[sh].map.erase(k);
             }
-            slotKey_[i] = kEmptyKey;
+            // Invalidate slot FIRST so any in-flight L2 reader verifies
+            // against an empty packed-key. If a stale L2 entry still points
+            // here, the verify load will mismatch → reader falls through.
+            slotKeyPacked_[i].store(UINT64_MAX, std::memory_order_release);
+            // Clear the L2 entry in whichever way holds this (tag, slot)
+            // pair — best effort, only touch entries that still match
+            // both the tag and the slot index so we don't invalidate an
+            // unrelated block.
+            const uint32_t oldTag = keyTag32(pk);
+            if (oldTag != 0) {
+                const size_t setIdx = l2Index(pk, kL2Bits);
+                std::atomic<uint64_t>* set = &l2_[setIdx * kL2Ways];
+                for (size_t way = 0; way < kL2Ways; ++way) {
+                    const uint64_t cur = set[way].load(std::memory_order_relaxed);
+                    if (uint32_t(cur >> 32) == oldTag &&
+                        uint32_t(cur) == uint32_t(i)) {
+                        set[way].store(kL2Empty, std::memory_order_release);
+                        break;
+                    }
+                }
+            }
             evictionVersion_.fetch_add(1, std::memory_order_relaxed);
             return i;
         }
@@ -308,7 +407,10 @@ void BlockCache::clear()
         s.map.clear();
         s.hits.store(0, std::memory_order_relaxed);
     }
-    std::fill(slotKey_.begin(), slotKey_.end(), kEmptyKey);
+    for (size_t i = 0; i < nSlots_; ++i)
+        slotKeyPacked_[i].store(UINT64_MAX, std::memory_order_relaxed);
+    for (size_t i = 0; i < kL2Size; ++i)
+        l2_[i].store(kL2Empty, std::memory_order_relaxed);
     std::fill(occupiedBits_.begin(), occupiedBits_.end(), 0);
     for (size_t i = 0; i < usedBitsWords_; ++i)
         usedBits_[i].store(0, std::memory_order_relaxed);

--- a/volume-cartographer/core/src/cache/BlockCache.cpp
+++ b/volume-cartographer/core/src/cache/BlockCache.cpp
@@ -88,14 +88,10 @@ BlockCache::BlockCache(Config cfg)
     usedBitsWords_ = words;
     usedBits_ = std::unique_ptr<std::atomic<uint64_t>[]>(
         new std::atomic<uint64_t>[words]());
-    // Default max_load_factor of 1.0 means libstdc++ sizes the bucket array
-    // at 2x insertion count. At 2.5M slots that's ~40 MB of extra buckets.
-    // Push the load factor to 1.0 before reserving so the reserve matches
-    // actual need. Each shard gets 1/kShards of total capacity.
-    const size_t perShard = (nSlots_ + kShards - 1) / kShards;
+    // Per-shard lock-free hash table. Allocate zero-initialized.
     for (auto& s : shards_) {
-        s.map.max_load_factor(1.0f);
-        s.map.reserve(perShard);
+        s.table = std::unique_ptr<std::atomic<uint64_t>[]>(
+            new std::atomic<uint64_t>[kShardMapSize]());
     }
 }
 
@@ -135,39 +131,51 @@ BlockPtr BlockCache::get(const BlockKey& key) noexcept
         }
     }
 
-    // Slow path: shard shared_lock + unordered_map lookup. Populate L2 on
-    // success so subsequent lookups for this key go lock-free. Round-robin
-    // counter picks which way to overwrite — the counter is non-atomic
-    // since races are benign (worst case we evict a slightly-less-ideal
-    // entry).
+    // Slow path: probe the shard's lock-free hash table. Each entry is an
+    // atomic<uint64_t>; an acquire-load tells us empty / occupied / tombstone
+    // + a 32-bit hash + the arena slot. Empty == end of probe chain.
+    // On hash match, verify via slotKeyPacked_ — a match means the arena
+    // slot still holds this key (catches both 1/2^32 hash collisions and
+    // races against writers that moved blocks around).
     const size_t sh = shardIndex(key);
     MapShard& shard = shards_[sh];
-    std::shared_lock lock(shard.mutex);
-    if (auto it = shard.map.find(key); it != shard.map.end()) {
-        const size_t slot = it->second;
-        setUsed(slot, true);
-        shard.hits.fetch_add(1, std::memory_order_relaxed);
-        if (tag != 0) {
-            const size_t setIdx = l2Index(packed, kL2Bits);
-            std::atomic<uint64_t>* set = &l2_[setIdx * kL2Ways];
-            // Prefer an empty slot if one is visible; otherwise evict via
-            // round-robin. The empty-slot scan is free since the cacheline
-            // is already hot from the probe above.
-            size_t wayToUse = kL2Ways;
-            for (size_t way = 0; way < kL2Ways; ++way) {
-                if (set[way].load(std::memory_order_relaxed) == kL2Empty) {
-                    wayToUse = way; break;
+    const uint32_t mh = shardMapHash(key);
+    size_t idx = mh & kShardMapMask;
+    for (size_t probe = 0; probe < kShardMapSize; ++probe) {
+        const uint64_t e = shard.table[(idx + probe) & kShardMapMask]
+                                .load(std::memory_order_acquire);
+        if (e == kEntryEmpty) break;  // not in table
+        if ((e & kEntryStateMask) == kEntryOccupied
+            && uint32_t(e & kEntryHashMask) == mh) {
+            const uint32_t slot = uint32_t((e & kEntrySlotMask) >> kEntrySlotShift);
+            if (slot < nSlots_
+                && slotKeyPacked_[slot].load(std::memory_order_acquire) == packed) {
+                setUsed(slot, true);
+                shard.hits.fetch_add(1, std::memory_order_relaxed);
+                if (tag != 0) {
+                    // Populate L2 for next lookup.
+                    const size_t setIdx = l2Index(packed, kL2Bits);
+                    std::atomic<uint64_t>* set = &l2_[setIdx * kL2Ways];
+                    size_t wayToUse = kL2Ways;
+                    for (size_t way = 0; way < kL2Ways; ++way) {
+                        if (set[way].load(std::memory_order_relaxed) == kL2Empty) {
+                            wayToUse = way; break;
+                        }
+                    }
+                    if (wayToUse == kL2Ways) {
+                        const uint8_t c = l2RrCounters_[setIdx];
+                        l2RrCounters_[setIdx] = uint8_t((c + 1u) & (kL2Ways - 1u));
+                        wayToUse = c & (kL2Ways - 1u);
+                    }
+                    set[wayToUse].store((uint64_t(tag) << 32) | uint32_t(slot),
+                                        std::memory_order_release);
                 }
+                return &arena_[slot];
             }
-            if (wayToUse == kL2Ways) {
-                const uint8_t c = l2RrCounters_[setIdx];
-                l2RrCounters_[setIdx] = uint8_t((c + 1u) & (kL2Ways - 1u));
-                wayToUse = c & (kL2Ways - 1u);
-            }
-            set[wayToUse].store((uint64_t(tag) << 32) | uint32_t(slot),
-                                std::memory_order_release);
+            // Hash matched but slot's packed-key doesn't — keep probing
+            // for a deeper colliding entry (rare).
         }
-        return &arena_[slot];
+        // tombstone or hash-mismatch: keep probing.
     }
     return nullptr;
 }
@@ -182,10 +190,25 @@ uint64_t BlockCache::blockHits() const noexcept
 
 bool BlockCache::contains(const BlockKey& key) const noexcept
 {
+    const uint64_t packed = packBlockKey(key);
     const size_t sh = shardIndex(key);
     const MapShard& shard = shards_[sh];
-    std::shared_lock lock(shard.mutex);
-    return shard.map.find(key) != shard.map.end();
+    const uint32_t mh = shardMapHash(key);
+    size_t idx = mh & kShardMapMask;
+    for (size_t probe = 0; probe < kShardMapSize; ++probe) {
+        const uint64_t e = shard.table[(idx + probe) & kShardMapMask]
+                                .load(std::memory_order_acquire);
+        if (e == kEntryEmpty) return false;
+        if ((e & kEntryStateMask) == kEntryOccupied
+            && uint32_t(e & kEntryHashMask) == mh) {
+            const uint32_t slot = uint32_t((e & kEntrySlotMask) >> kEntrySlotShift);
+            if (slot < nSlots_
+                && slotKeyPacked_[slot].load(std::memory_order_acquire) == packed) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 void BlockCache::containsBatch(const std::vector<BlockKey>& keys,
@@ -193,21 +216,10 @@ void BlockCache::containsBatch(const std::vector<BlockKey>& keys,
 {
     out.assign(keys.size(), 0);
     if (keys.empty()) return;
-    // Group by shard so each shard's lock is acquired exactly once across
-    // the batch. With N input keys over kShards shards, naive per-key
-    // locking costs ~N/kShards lock pairs per shard; grouping drops that to 1.
-    std::array<std::vector<size_t>, kShards> idxByShard;
+    // Lock-free probe path — no grouping needed since reads don't take
+    // any lock now. We just delegate to contains() per key.
     for (size_t i = 0; i < keys.size(); ++i) {
-        idxByShard[shardIndex(keys[i])].push_back(i);
-    }
-    for (size_t sh = 0; sh < kShards; ++sh) {
-        auto& idx = idxByShard[sh];
-        if (idx.empty()) continue;
-        std::shared_lock lock(shards_[sh].mutex);
-        const auto& m = shards_[sh].map;
-        for (size_t i : idx) {
-            if (m.find(keys[i]) != m.end()) out[i] = 1;
-        }
+        if (contains(keys[i])) out[i] = 1;
     }
 }
 
@@ -237,15 +249,25 @@ size_t BlockCache::acquireSlotLocked(const BlockKey& key) noexcept
 
     const size_t sh = shardIndex(key);
     MapShard& shard = shards_[sh];
+    const uint64_t packedKey = packBlockKey(key);
+    const uint32_t mh = shardMapHash(key);
+    // Probe the shard's lock-free table for an existing entry. Writers are
+    // serialized via arenaMutex_ so no writer-writer contention.
     {
-        // Shared lookup first — if the key already lives in its shard, just
-        // bump the used bit. Writers normally hold arenaMutex_ exclusively,
-        // so competing writers never collide here, but readers may still be
-        // probing the shard concurrently.
-        std::shared_lock rlock(shard.mutex);
-        if (auto it = shard.map.find(key); it != shard.map.end()) {
-            setUsed(it->second, true);
-            return it->second;
+        size_t idx = mh & kShardMapMask;
+        for (size_t probe = 0; probe < kShardMapSize; ++probe) {
+            const uint64_t e = shard.table[(idx + probe) & kShardMapMask]
+                                    .load(std::memory_order_acquire);
+            if (e == kEntryEmpty) break;
+            if ((e & kEntryStateMask) == kEntryOccupied
+                && uint32_t(e & kEntryHashMask) == mh) {
+                const uint32_t existing = uint32_t((e & kEntrySlotMask) >> kEntrySlotShift);
+                if (existing < nSlots_
+                    && slotKeyPacked_[existing].load(std::memory_order_acquire) == packedKey) {
+                    setUsed(existing, true);
+                    return existing;
+                }
+            }
         }
     }
 
@@ -300,11 +322,22 @@ size_t BlockCache::acquireSlotLocked(const BlockKey& key) noexcept
     }
 
     setUsed(slot, true);
-    const uint64_t packed = packBlockKey(key);
+    const uint64_t packed = packedKey;
     slotKeyPacked_[slot].store(packed, std::memory_order_release);
+    // Insert into the lock-free shard table: probe linearly, replace first
+    // empty-or-tombstone slot with an occupied entry. Readers are lock-
+    // free; the release-store publishes our entry to concurrent probes.
     {
-        std::unique_lock wlock(shard.mutex);
-        shard.map[key] = slot;
+        size_t idx = mh & kShardMapMask;
+        const uint64_t newEntry = makeOccupiedEntry(uint32_t(slot), mh);
+        for (size_t probe = 0; probe < kShardMapSize; ++probe) {
+            const size_t pos = (idx + probe) & kShardMapMask;
+            const uint64_t e = shard.table[pos].load(std::memory_order_relaxed);
+            if (e == kEntryEmpty || (e & kEntryStateMask) == kEntryTombstone) {
+                shard.table[pos].store(newEntry, std::memory_order_release);
+                break;
+            }
+        }
     }
     if (key.level >= 0 && key.level < kMaxLevels)
         levelOccupied_[key.level]++;
@@ -360,10 +393,26 @@ size_t BlockCache::reclaimSlotLocked()
             if (k.level >= 0 && k.level < kMaxLevels
                 && levelOccupied_[k.level] > 0)
                 levelOccupied_[k.level]--;
+            // Erase from the shard's lock-free table: probe for the
+            // matching (hash, slot) entry and mark it tombstone. Linear
+            // probing requires tombstones to preserve later entries'
+            // reachability.
             {
                 const size_t sh = shardIndex(k);
-                std::unique_lock wlock(shards_[sh].mutex);
-                shards_[sh].map.erase(k);
+                auto& shard = shards_[sh];
+                const uint32_t mh = shardMapHash(k);
+                size_t idx = mh & kShardMapMask;
+                for (size_t probe = 0; probe < kShardMapSize; ++probe) {
+                    const size_t pos = (idx + probe) & kShardMapMask;
+                    const uint64_t e = shard.table[pos].load(std::memory_order_relaxed);
+                    if (e == kEntryEmpty) break;
+                    if ((e & kEntryStateMask) == kEntryOccupied
+                        && uint32_t(e & kEntryHashMask) == mh
+                        && uint32_t((e & kEntrySlotMask) >> kEntrySlotShift) == uint32_t(i)) {
+                        shard.table[pos].store(kEntryTombstone, std::memory_order_release);
+                        break;
+                    }
+                }
             }
             // Invalidate slot FIRST so any in-flight L2 reader verifies
             // against an empty packed-key. If a stale L2 entry still points
@@ -403,8 +452,8 @@ void BlockCache::clear()
 {
     std::unique_lock lock(arenaMutex_);
     for (auto& s : shards_) {
-        std::unique_lock slock(s.mutex);
-        s.map.clear();
+        for (size_t i = 0; i < kShardMapSize; ++i)
+            s.table[i].store(kEntryEmpty, std::memory_order_relaxed);
         s.hits.store(0, std::memory_order_relaxed);
     }
     for (size_t i = 0; i < nSlots_; ++i)

--- a/volume-cartographer/core/src/cache/BlockPipeline.cpp
+++ b/volume-cartographer/core/src/cache/BlockPipeline.cpp
@@ -835,21 +835,14 @@ void BlockPipeline::fetchInteractive(const std::vector<ChunkKey>& keys, int targ
     std::vector<uint8_t> resident;
     blockCache_.containsBatch(probeKeys, resident);
 
-    // Snapshot the empty-chunks set once so the per-key check avoids
-    // hammering emptyChunksMutex_ from the render thread.
-    std::unordered_set<ChunkKey, ChunkKeyHash> emptySnapshot;
-    {
-        std::shared_lock lk(emptyChunksMutex_);
-        emptySnapshot = emptyChunks_;
-    }
-
+    // Empty-chunks lookup is now lock-free per probe — no snapshot needed.
     std::vector<ChunkKey> loaderKeys, downloaderKeys;
     loaderKeys.reserve(keys.size());
     downloaderKeys.reserve(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
         const auto& key = keys[i];
         if (isNegativeCached(key)) continue;
-        if (emptySnapshot.count(key)) continue;
+        if (isEmptyChunk(key)) continue;
         // Both first and last block of the chunk must be resident to
         // consider the chunk fully cached. See comment above probeKeys.
         if (probeKeys[i * 2].level >= 0
@@ -882,27 +875,21 @@ BlockPtr BlockPipeline::blockAt(const BlockKey& key) noexcept {
     if (auto b = blockCache_.get(key); b) return b;
     // Miss: could be an "empty chunk" (all-zero canonical chunk that we
     // don't store). Canonical chunks are 128³ = 8x8x8 blocks of 16³ —
-    // reverse-map the block coord to its enclosing chunk and check.
-    // Shared-lock the empty-chunks set: readers in the miss path dominate
-    // (12 render threads × every miss), writers only fire when a new
-    // all-zero chunk is discovered during decode.
+    // reverse-map the block coord to its enclosing chunk and check via
+    // the lock-free hash set. No rwlock — every blockAt miss used to hit
+    // pthread_rwlock_rdlock here.
     const ChunkKey chunkKey{key.level, key.bz / 8, key.by / 8, key.bx / 8};
-    {
-        std::shared_lock lk(emptyChunksMutex_);
-        if (emptyChunks_.count(chunkKey)) {
-            // One canonical zero block shared by every caller asking for
-            // a block inside any empty chunk — no arena consumption.
-            static constinit Block kZeroBlock{};
-            // Per-thread local accumulator flushed every 1024 hits. A single
-            // global atomic fetch_add here burned ~5%+ of CPU on hot render
-            // workloads (12 threads ping-ponging one cacheline per miss).
-            // Sampling trades exact counts for 1000x less atomic traffic —
-            // stats are diagnostic, so an approximate count is fine.
-            thread_local uint64_t localEmptyHits = 0;
-            if ((++localEmptyHits & 1023) == 0)
-                statEmptyHits_.fetch_add(1024, std::memory_order_relaxed);
-            return &kZeroBlock;
-        }
+    if (isEmptyChunk(chunkKey)) {
+        // One canonical zero block shared by every caller asking for
+        // a block inside any empty chunk — no arena consumption.
+        static constinit Block kZeroBlock{};
+        // Per-thread local accumulator flushed every 1024 hits. A single
+        // global atomic fetch_add here burned ~5%+ of CPU on hot render
+        // workloads (12 threads ping-ponging one cacheline per miss).
+        thread_local uint64_t localEmptyHits = 0;
+        if ((++localEmptyHits & 1023) == 0)
+            statEmptyHits_.fetch_add(1024, std::memory_order_relaxed);
+        return &kZeroBlock;
     }
     thread_local uint64_t localMisses = 0;
     if ((++localMisses & 1023) == 0)
@@ -996,8 +983,7 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
     // blockAt() will hand out a shared static zero block for every inner
     // block of this chunk. Saves ~2 MB of arena per empty 128³ chunk.
     if (chunk.isEmpty) {
-        std::unique_lock lk(emptyChunksMutex_);
-        emptyChunks_.insert(key);
+        addEmptyChunk(key);
         return;
     }
 
@@ -1036,10 +1022,7 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
 
 void BlockPipeline::clearMemory() {
     blockCache_.clear();
-    {
-        std::unique_lock elk(emptyChunksMutex_);
-        emptyChunks_.clear();
-    }
+    clearEmptyChunks();
     for (auto& bucket : shardCacheBuckets_) {
         std::lock_guard lk(bucket.mutex);
         bucket.lru.clear();
@@ -1070,10 +1053,7 @@ void BlockPipeline::clearAll() {
     }
     shardCacheGlobalBytes_.store(0, std::memory_order_relaxed);
     blockCache_.clear();
-    {
-        std::unique_lock elk(emptyChunksMutex_);
-        emptyChunks_.clear();
-    }
+    clearEmptyChunks();
     bloomClear();
     std::lock_guard lock(negativeMutex_);
     negativeCache_.clear();
@@ -1123,18 +1103,10 @@ size_t BlockPipeline::countAvailable(const std::vector<ChunkKey>& keys) const {
     constexpr int kMaxL = 16;
     std::array<int, kMaxL> bpcZ{}, bpcY{}, bpcX{};
     std::array<bool, kMaxL> shapeCached{};
-    // Snapshot emptyChunks_ once for the batch so we don't re-acquire the
-    // mutex per key. Zero chunks are recorded here by insertChunkAsBlocks
-    // and have no block-cache entry, so without this check countAvailable
-    // would report them as unavailable and wait loops would stall.
-    std::unordered_set<ChunkKey, ChunkKeyHash> emptySnap;
-    {
-        std::shared_lock lk(emptyChunksMutex_);
-        emptySnap = emptyChunks_;
-    }
+    // Empty-chunk probe is now lock-free — no snapshot needed.
     for (const auto& key : keys) {
         if (isNegativeCached(key)) { n++; continue; }
-        if (emptySnap.count(key)) { n++; continue; }
+        if (isEmptyChunk(key)) { n++; continue; }
         if (key.level < 0 || key.level >= kMaxL) continue;
         if (!shapeCached[key.level]) {
             auto csk = chunkShape(key.level);

--- a/volume-cartographer/core/src/cache/BlockPipeline.cpp
+++ b/volume-cartographer/core/src/cache/BlockPipeline.cpp
@@ -1019,7 +1019,7 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
             }
         }
     }
-    TickCoordinator::notifyChunkLanded(key);
+    TickCoordinator::notifyChunkLanded(this, key);
 }
 
 

--- a/volume-cartographer/core/src/cache/BlockPipeline.cpp
+++ b/volume-cartographer/core/src/cache/BlockPipeline.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -68,33 +70,48 @@ ShardKey BlockPipeline::canonicalShardKey(const ChunkKey& key) const noexcept
     return sk;
 }
 
+size_t BlockPipeline::shardCacheBucketIndex(const ShardKey& sk) noexcept {
+    // ShardKeyHash is already a good mix; take low bits mod bucket count.
+    return ShardKeyHash{}(sk) & (kShardCacheBuckets - 1);
+}
+
 void BlockPipeline::shardCacheInsertLocked(
+    ShardCacheBucket& b,
     const ShardKey& sk,
     std::shared_ptr<std::vector<std::byte>> bytes)
 {
     if (!bytes || bytes->empty()) return;
-    const size_t budget = config_.shardCacheBytes;
-    if (budget == 0) return;
+    const size_t totalBudget = config_.shardCacheBytes;
+    if (totalBudget == 0) return;
     const size_t entrySize = bytes->size();
-    if (entrySize > budget) return;  // single shard too big for budget
+    if (entrySize > totalBudget) return;  // single shard too big for total
 
-    // Remove existing entry for this key, if any.
-    if (auto it = shardCacheMap_.find(sk); it != shardCacheMap_.end()) {
-        shardCacheTotalBytes_ -= it->second->bytes ? it->second->bytes->size() : 0;
-        shardCacheLru_.erase(it->second);
-        shardCacheMap_.erase(it);
+    // Replace any existing entry for this key — release its bytes from
+    // both bucket and global counters before accounting the new one.
+    if (auto it = b.map.find(sk); it != b.map.end()) {
+        const size_t oldSize = it->second->bytes ? it->second->bytes->size() : 0;
+        b.bytes -= oldSize;
+        shardCacheGlobalBytes_.fetch_sub(oldSize, std::memory_order_relaxed);
+        b.lru.erase(it->second);
+        b.map.erase(it);
     }
-    // Evict LRU until we fit.
-    while (!shardCacheLru_.empty()
-           && shardCacheTotalBytes_ + entrySize > budget) {
-        auto& victim = shardCacheLru_.back();
-        shardCacheTotalBytes_ -= victim.bytes ? victim.bytes->size() : 0;
-        shardCacheMap_.erase(victim.key);
-        shardCacheLru_.pop_back();
+    // Evict LRU from THIS bucket until global total + new entry fits budget.
+    // Evicting from our own bucket (rather than scanning all) preserves LRU
+    // within a bucket; buckets that have been recently active naturally
+    // retain their entries because unrelated buckets aren't touched here.
+    while (!b.lru.empty()
+        && shardCacheGlobalBytes_.load(std::memory_order_relaxed) + entrySize > totalBudget) {
+        auto& victim = b.lru.back();
+        const size_t vSize = victim.bytes ? victim.bytes->size() : 0;
+        b.bytes -= vSize;
+        shardCacheGlobalBytes_.fetch_sub(vSize, std::memory_order_relaxed);
+        b.map.erase(victim.key);
+        b.lru.pop_back();
     }
-    shardCacheLru_.push_front({sk, std::move(bytes)});
-    shardCacheMap_[sk] = shardCacheLru_.begin();
-    shardCacheTotalBytes_ += entrySize;
+    b.lru.push_front({sk, std::move(bytes)});
+    b.map[sk] = b.lru.begin();
+    b.bytes += entrySize;
+    shardCacheGlobalBytes_.fetch_add(entrySize, std::memory_order_relaxed);
 }
 
 std::shared_ptr<std::vector<std::byte>> BlockPipeline::shardBytesFor(
@@ -102,12 +119,13 @@ std::shared_ptr<std::vector<std::byte>> BlockPipeline::shardBytesFor(
 {
     if (config_.shardCacheBytes == 0) return nullptr;
     const ShardKey sk = canonicalShardKey(key);
+    auto& bucket = shardCacheBuckets_[shardCacheBucketIndex(sk)];
 
     // Thread-local "last shard seen" cache. Loader workers routinely
     // process runs of adjacent chunks that fall in the same shard; with
-    // 256 loader threads contending on shardCacheMutex_, skipping the
-    // map + lock for same-shard hits saves ~1-2% total CPU per profile.
-    // The shared_ptr keeps bytes alive even if the LRU evicts them.
+    // 256 loader threads contending on the cache, skipping the map+lock
+    // for same-shard hits saves ~1-2% total CPU per profile. The
+    // shared_ptr keeps bytes alive even if the LRU evicts them.
     // Qualify with `this` so a volume swap (pipeline destroyed + recreated)
     // doesn't serve stale data from the old pipeline's shard cache.
     thread_local const BlockPipeline* tlOwner = nullptr;
@@ -118,13 +136,12 @@ std::shared_ptr<std::vector<std::byte>> BlockPipeline::shardBytesFor(
         return tlLastBytes;
     }
 
-    // Fast path: hit under the cache mutex, move entry to LRU head.
+    // Fast path: hit under the bucket mutex, move entry to LRU head.
     {
-        std::lock_guard lk(shardCacheMutex_);
-        auto it = shardCacheMap_.find(sk);
-        if (it != shardCacheMap_.end()) {
-            shardCacheLru_.splice(shardCacheLru_.begin(),
-                                   shardCacheLru_, it->second);
+        std::lock_guard lk(bucket.mutex);
+        auto it = bucket.map.find(sk);
+        if (it != bucket.map.end()) {
+            bucket.lru.splice(bucket.lru.begin(), bucket.lru, it->second);
             statShardHits_.fetch_add(1, std::memory_order_relaxed);
             tlOwner = this;
             tlLastShard = sk;
@@ -140,18 +157,17 @@ std::shared_ptr<std::vector<std::byte>> BlockPipeline::shardBytesFor(
     if (!raw || raw->empty()) return nullptr;
     auto bytes = std::make_shared<std::vector<std::byte>>(std::move(*raw));
 
-    std::lock_guard lk(shardCacheMutex_);
+    std::lock_guard lk(bucket.mutex);
     // Another thread may have raced us to populate this shard; prefer
     // the entry already in the cache to keep `shared_ptr` identity
     // consistent across concurrent reads.
-    if (auto it = shardCacheMap_.find(sk); it != shardCacheMap_.end()) {
-        shardCacheLru_.splice(shardCacheLru_.begin(),
-                               shardCacheLru_, it->second);
+    if (auto it = bucket.map.find(sk); it != bucket.map.end()) {
+        bucket.lru.splice(bucket.lru.begin(), bucket.lru, it->second);
         tlLastShard = sk;
         tlLastBytes = it->second->bytes;
         return it->second->bytes;
     }
-    shardCacheInsertLocked(sk, bytes);
+    shardCacheInsertLocked(bucket, sk, bytes);
     tlOwner = this;
     tlLastShard = sk;
     tlLastBytes = bytes;
@@ -167,27 +183,38 @@ static ChunkDataPtr decodeCanonicalH265(const std::vector<uint8_t>& compressed) 
     auto dims = utils::video_header_dims(bytes);
     utils::VideoCodecParams vp;
     vp.depth = dims[0]; vp.height = dims[1]; vp.width = dims[2];
-    size_t n = size_t(dims[0]) * dims[1] * dims[2];
-    auto decoded = utils::video_decode(bytes, n, vp);
+    const size_t n = size_t(dims[0]) * dims[1] * dims[2];
     auto out = std::make_shared<ChunkData>();
     out->shape = {int(dims[0]), int(dims[1]), int(dims[2])};
     out->elementSize = 1;
-    out->bytes.resize(decoded.size());
-    std::memcpy(out->bytes.data(), decoded.data(), decoded.size());
+    out->bytes.resize(n);
+    // Zero-copy: decoder writes straight into ChunkData::bytes. Saves one
+    // ~2 MiB std::vector<std::byte> allocation + zero-init + memcpy per
+    // chunk vs. the std::vector-returning video_decode — this path runs
+    // on every decoded chunk so the allocation churn was a primary
+    // driver of worker-thread page-fault / swap pressure.
+    utils::video_decode_into(
+        bytes,
+        std::span<std::byte>(reinterpret_cast<std::byte*>(out->bytes.data()), n),
+        vp);
     return out;
 }
 
-// Encode decoded chunk bytes as canonical h265. qp/air_clamp/shift_n come
-// from the pipeline's configured encodeParams (default qp=36).
-static std::vector<std::byte> encodeCanonicalH265(
+// Encode decoded chunk bytes as canonical h265 into a thread-local output
+// buffer, returned by reference. Caller must consume the bytes before
+// the next call on the same thread. Capacity grows once to the largest
+// chunk ever seen on this thread and stays — no per-chunk allocation.
+static const std::vector<std::byte>& encodeCanonicalH265(
     const ChunkData& chunk, const utils::VideoCodecParams& base) {
+    thread_local std::vector<std::byte> tlEncoded;
     utils::VideoCodecParams vp = base;
     vp.depth = chunk.shape[0];
     vp.height = chunk.shape[1];
     vp.width = chunk.shape[2];
-    return utils::video_encode(
+    utils::video_encode_into(
         {reinterpret_cast<const std::byte*>(chunk.rawData()), chunk.totalBytes()},
-        vp);
+        vp, tlEncoded);
+    return tlEncoded;
 }
 
 // Does `bytes` already carry the canonical VC3D/h265 magic header?
@@ -350,8 +377,12 @@ BlockPipeline::BlockPipeline(
             std::vector<ChunkKey> encodeKeys;
             encodeKeys.reserve(res.size());
             for (auto& [key, _] : res) encodeKeys.push_back(key);
-            const int targetLevel = encodeKeys.front().level;
-            encodePool_.updateInteractive(encodeKeys, targetLevel);
+            // submit appends (O(N) in new keys); updateInteractive would
+            // reshuffle the whole encoder queue (O(Q)) and reset served
+            // counters, neither of which makes sense for inter-stage
+            // handoffs — the viewport priority comes from the renderer's
+            // fetchInteractive call upstream, not from completions.
+            encodePool_.submit(encodeKeys);
         });
 
     // Encoder: take staged ChunkData → h265 encode → disk write → forward
@@ -373,7 +404,7 @@ BlockPipeline::BlockPipeline(
         }
         if (!decoded) return {};
 
-        auto h265 = encodeCanonicalH265(*decoded, config_.encodeParams);
+        const auto& h265 = encodeCanonicalH265(*decoded, config_.encodeParams);
         zarrWriteChunk(*dz, key,
             reinterpret_cast<const uint8_t*>(h265.data()), h265.size());
         statDiskWrites_.fetch_add(1, std::memory_order_relaxed);
@@ -386,12 +417,14 @@ BlockPipeline::BlockPipeline(
             }
             // Shard file grew on disk; drop the stale cached copy so the
             // loader re-reads it next time.
-            std::lock_guard lk(shardCacheMutex_);
-            if (auto it = shardCacheMap_.find(sk); it != shardCacheMap_.end()) {
-                shardCacheTotalBytes_ -= it->second->bytes
-                    ? it->second->bytes->size() : 0;
-                shardCacheLru_.erase(it->second);
-                shardCacheMap_.erase(it);
+            auto& bucket = shardCacheBuckets_[shardCacheBucketIndex(sk)];
+            std::lock_guard lk(bucket.mutex);
+            if (auto it = bucket.map.find(sk); it != bucket.map.end()) {
+                const size_t sz = it->second->bytes ? it->second->bytes->size() : 0;
+                bucket.bytes -= sz;
+                shardCacheGlobalBytes_.fetch_sub(sz, std::memory_order_relaxed);
+                bucket.lru.erase(it->second);
+                bucket.map.erase(it);
             }
         }
 
@@ -406,8 +439,7 @@ BlockPipeline::BlockPipeline(
             std::vector<ChunkKey> loaderKeys;
             loaderKeys.reserve(res.size());
             for (auto& [key, _] : res) loaderKeys.push_back(key);
-            const int targetLevel = loaderKeys.front().level;
-            loaderPool_.updateInteractive(loaderKeys, targetLevel);
+            loaderPool_.submit(loaderKeys);
         });
 
     // Loader: read compressed bytes for `key` (shard RAM cache or disk),
@@ -491,8 +523,7 @@ BlockPipeline::BlockPipeline(
             std::vector<ChunkKey> decodeKeys;
             decodeKeys.reserve(res.size());
             for (auto& [k, _] : res) decodeKeys.push_back(k);
-            const int targetLevel = decodeKeys.front().level;
-            decodePool_.updateInteractive(decodeKeys, targetLevel);
+            decodePool_.submit(decodeKeys);
         });
 
     decodePool_.setShardMapper(shardMapper);
@@ -639,12 +670,14 @@ BlockPipeline::BlockPipeline(
                         std::lock_guard lk(writtenShardsMutex_);
                         writtenShards_.insert(sk);
                     }
-                    std::lock_guard lk(shardCacheMutex_);
-                    if (auto it = shardCacheMap_.find(sk); it != shardCacheMap_.end()) {
-                        shardCacheTotalBytes_ -= it->second->bytes
-                            ? it->second->bytes->size() : 0;
-                        shardCacheLru_.erase(it->second);
-                        shardCacheMap_.erase(it);
+                    auto& bucket = shardCacheBuckets_[shardCacheBucketIndex(sk)];
+                    std::lock_guard lk(bucket.mutex);
+                    if (auto it = bucket.map.find(sk); it != bucket.map.end()) {
+                        const size_t sz = it->second->bytes ? it->second->bytes->size() : 0;
+                        bucket.bytes -= sz;
+                        shardCacheGlobalBytes_.fetch_sub(sz, std::memory_order_relaxed);
+                        bucket.lru.erase(it->second);
+                        bucket.map.erase(it);
                     }
                 }
 
@@ -660,8 +693,7 @@ BlockPipeline::BlockPipeline(
                 std::vector<ChunkKey> keys;
                 keys.reserve(res.size());
                 for (auto& [k, _] : res) keys.push_back(k);
-                const int level = keys.front().level;
-                loaderPool_.updateInteractive(keys, level);
+                loaderPool_.submit(keys);
             });
     }
 skipPassthrough:
@@ -719,6 +751,31 @@ void BlockPipeline::bloomClear() noexcept {
 
 void BlockPipeline::fetchInteractive(const std::vector<ChunkKey>& keys, int targetLevel) {
     if (keys.empty()) return;
+    // Dedup: the renderer calls this every frame, and viewport-idle frames
+    // pass the same keys + targetLevel as the previous call. When the
+    // BlockCache hasn't evicted anything since the last submit, nothing
+    // downstream would change — the expensive containsBatch, emptyChunks
+    // snapshot, classification, and (most importantly) IOPool queue
+    // rebuilds would reproduce their previous outputs. Skip.
+    {
+        // Commutative hash so order-insensitive dedup works across
+        // render paths that enumerate chunks in different orders.
+        uint64_t h = uint64_t(uint32_t(targetLevel)) * 0x9E3779B97F4A7C15ULL;
+        ChunkKeyHash kh;
+        for (const auto& k : keys) h ^= kh(k);
+        const uint64_t evictionNow = blockCache_.evictionVersion();
+        std::lock_guard lk(fetchInteractiveDedupMutex_);
+        if (haveLastFetchInteractive_
+            && lastFetchInteractiveHash_ == h
+            && lastFetchInteractiveEviction_ == evictionNow
+            && lastFetchInteractiveTargetLevel_ == targetLevel) {
+            return;
+        }
+        lastFetchInteractiveHash_ = h;
+        lastFetchInteractiveEviction_ = evictionNow;
+        lastFetchInteractiveTargetLevel_ = targetLevel;
+        haveLastFetchInteractive_ = true;
+    }
     // Triage by disk presence: chunks already on disk go straight to the
     // loader pool (fast, CPU-bound decode), chunks that need fetching go
     // to the downloader pool (slow, network-bound). The two pools are
@@ -816,11 +873,9 @@ BlockPtr BlockPipeline::blockAt(const BlockKey& key) noexcept {
     // Hot path: try the block cache first. Most samples hit a resident
     // block, so emptyChunksMutex_ never needs to be acquired — previously
     // every blockAt() call took that mutex before the cache lookup.
-    auto b = blockCache_.get(key);
-    if (b) {
-        statBlockHits_.fetch_add(1, std::memory_order_relaxed);
-        return b;
-    }
+    // BlockCache::get() now owns the hit counter (per-shard, no contention);
+    // we no longer bump statBlockHits_ here on the fast path.
+    if (auto b = blockCache_.get(key); b) return b;
     // Miss: could be an "empty chunk" (all-zero canonical chunk that we
     // don't store). Canonical chunks are 128³ = 8x8x8 blocks of 16³ —
     // reverse-map the block coord to its enclosing chunk and check.
@@ -831,7 +886,7 @@ BlockPtr BlockPipeline::blockAt(const BlockKey& key) noexcept {
             // One canonical zero block shared by every caller asking for
             // a block inside any empty chunk — no arena consumption.
             static constinit Block kZeroBlock{};
-            statBlockHits_.fetch_add(1, std::memory_order_relaxed);
+            statEmptyHits_.fetch_add(1, std::memory_order_relaxed);
             return &kZeroBlock;
         }
     }
@@ -908,7 +963,16 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
     const int bzN = cz / kBlockSize;
     const int byN = cy / kBlockSize;
     const int bxN = cx / kBlockSize;
-    if (bzN * kBlockSize != cz || byN * kBlockSize != cy || bxN * kBlockSize != cx) return;
+    // Blocks are the fixed 16³ storage/render unit; chunk dims must be a
+    // multiple of kBlockSize so blocks tile the chunk cleanly. Enforced
+    // up-front in FileSystemSource::discoverLevels — reaching here with a
+    // misaligned chunk means a new source path slipped past the check.
+    if (bzN * kBlockSize != cz || byN * kBlockSize != cy || bxN * kBlockSize != cx) {
+        std::fprintf(stderr,
+                     "[FATAL] chunk dims must be multiples of %d, got %dx%dx%d (key L%d %d/%d/%d)\n",
+                     kBlockSize, cz, cy, cx, key.level, key.iz, key.iy, key.ix);
+        std::abort();
+    }
 
     // Zero-chunk shortcut: VcDecompressor already scanned the decoded bytes
     // and set isEmpty when every voxel is zero. Record the canonical chunk
@@ -929,14 +993,17 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
     const int baseBy = key.iy * byN;
     const int baseBx = key.ix * bxN;
 
-    uint8_t tmp[kBlockBytes];
     // One unique_lock covers all 512 inserts for a 128³ canonical chunk
-    // instead of 512 separate lock/unlock pairs.
+    // instead of 512 separate lock/unlock pairs. acquire() returns the
+    // arena slot directly so we write the 16³ block straight into its
+    // final destination — no tmp buffer, no double copy.
     BlockCache::BatchPut batch(blockCache_);
     for (int bi = 0; bi < bzN; ++bi) {
         for (int bj = 0; bj < byN; ++bj) {
             for (int bk = 0; bk < bxN; ++bk) {
-                uint8_t* dst = tmp;
+                BlockKey bkKey{key.level, baseBz + bi, baseBy + bj, baseBx + bk};
+                uint8_t* dst = batch.acquire(bkKey);
+                if (!dst) continue;
                 for (int lz = 0; lz < kBlockSize; ++lz) {
                     const uint8_t* zRow = src + (bi * kBlockSize + lz) * strideZ;
                     for (int ly = 0; ly < kBlockSize; ++ly) {
@@ -945,8 +1012,6 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
                         dst += kBlockSize;
                     }
                 }
-                BlockKey bkKey{key.level, baseBz + bi, baseBy + bj, baseBx + bk};
-                batch.put(bkKey, tmp);
             }
         }
     }
@@ -959,10 +1024,13 @@ void BlockPipeline::clearMemory() {
         std::lock_guard elk(emptyChunksMutex_);
         emptyChunks_.clear();
     }
-    std::lock_guard lk(shardCacheMutex_);
-    shardCacheLru_.clear();
-    shardCacheMap_.clear();
-    shardCacheTotalBytes_ = 0;
+    for (auto& bucket : shardCacheBuckets_) {
+        std::lock_guard lk(bucket.mutex);
+        bucket.lru.clear();
+        bucket.map.clear();
+        bucket.bytes = 0;
+    }
+    shardCacheGlobalBytes_.store(0, std::memory_order_relaxed);
 }
 
 void BlockPipeline::clearAll() {
@@ -978,12 +1046,13 @@ void BlockPipeline::clearAll() {
         std::lock_guard lk(decodeStagingMutex_);
         decodeStaging_.clear();
     }
-    {
-        std::lock_guard lk(shardCacheMutex_);
-        shardCacheLru_.clear();
-        shardCacheMap_.clear();
-        shardCacheTotalBytes_ = 0;
+    for (auto& bucket : shardCacheBuckets_) {
+        std::lock_guard lk(bucket.mutex);
+        bucket.lru.clear();
+        bucket.map.clear();
+        bucket.bytes = 0;
     }
+    shardCacheGlobalBytes_.store(0, std::memory_order_relaxed);
     blockCache_.clear();
     {
         std::lock_guard elk(emptyChunksMutex_);
@@ -1091,7 +1160,10 @@ void BlockPipeline::clearChunkArrivedFlag() noexcept {
 
 auto BlockPipeline::stats() const -> Stats {
     Stats s;
-    s.blockHits = statBlockHits_.load(std::memory_order_relaxed);
+    // Hot path hits live in BlockCache's per-shard counters; empty-chunk
+    // canonical-zero hits are separate (cold path).
+    s.blockHits = blockCache_.blockHits()
+                + statEmptyHits_.load(std::memory_order_relaxed);
     s.coldHits = statColdHits_.load(std::memory_order_relaxed);
     s.iceFetches = statIceFetches_.load(std::memory_order_relaxed);
     s.misses = statMisses_.load(std::memory_order_relaxed);
@@ -1103,10 +1175,13 @@ auto BlockPipeline::stats() const -> Stats {
     s.ioPending = s.downloadPending + s.encodePending + s.loadPending + s.decodePending;
     s.shardHits = statShardHits_.load(std::memory_order_relaxed);
     s.shardMisses = statShardMisses_.load(std::memory_order_relaxed);
-    {
-        std::lock_guard lk(shardCacheMutex_);
-        s.shardCacheBytes = shardCacheTotalBytes_;
-        s.shardCacheEntries = shardCacheLru_.size();
+    // Global byte count is an atomic so we don't need the per-bucket locks
+    // to read it. Entry count still needs the per-bucket walk.
+    s.shardCacheBytes = shardCacheGlobalBytes_.load(std::memory_order_relaxed);
+    s.shardCacheEntries = 0;
+    for (auto& bucket : shardCacheBuckets_) {
+        std::lock_guard lk(bucket.mutex);
+        s.shardCacheEntries += bucket.lru.size();
     }
     s.diskWrites = statDiskWrites_.load(std::memory_order_relaxed);
     {

--- a/volume-cartographer/core/src/cache/BlockPipeline.cpp
+++ b/volume-cartographer/core/src/cache/BlockPipeline.cpp
@@ -1,4 +1,5 @@
 #include "vc/core/cache/BlockPipeline.hpp"
+#include "vc/core/cache/TickCoordinator.hpp"
 #include "vc/core/cache/VolumeSource.hpp"
 #include "vc/core/cache/CacheDebugLog.hpp"
 #include "vc/core/cache/VcDecompressor.hpp"
@@ -984,6 +985,7 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
     // block of this chunk. Saves ~2 MB of arena per empty 128³ chunk.
     if (chunk.isEmpty) {
         addEmptyChunk(key);
+        TickCoordinator::notifyEmptyChunkNoted(key);
         return;
     }
 
@@ -1017,6 +1019,7 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
             }
         }
     }
+    TickCoordinator::notifyChunkLanded(key);
 }
 
 

--- a/volume-cartographer/core/src/cache/BlockPipeline.cpp
+++ b/volume-cartographer/core/src/cache/BlockPipeline.cpp
@@ -188,7 +188,7 @@ static ChunkDataPtr decodeCanonicalH265(const std::vector<uint8_t>& compressed) 
     utils::VideoCodecParams vp;
     vp.depth = dims[0]; vp.height = dims[1]; vp.width = dims[2];
     const size_t n = size_t(dims[0]) * dims[1] * dims[2];
-    auto out = std::make_unique<ChunkData>();
+    auto out = vc::cache::acquireChunkData();
     out->shape = {int(dims[0]), int(dims[1]), int(dims[2])};
     out->elementSize = 1;
     out->bytes.resize(n);
@@ -912,7 +912,7 @@ ChunkDataPtr BlockPipeline::assembleCanonicalChunk(const ChunkKey& canonKey) {
     int sy0 = cy0 / scs[1], sy1 = (cy1 + scs[1] - 1) / scs[1];
     int sx0 = cx0 / scs[2], sx1 = (cx1 + scs[2] - 1) / scs[2];
 
-    auto out = std::make_unique<ChunkData>();
+    auto out = vc::cache::acquireChunkData();
     out->shape = {C, C, C};
     out->elementSize = 1;
     out->bytes.assign(size_t(C) * C * C, 0);

--- a/volume-cartographer/core/src/cache/BlockPipeline.cpp
+++ b/volume-cartographer/core/src/cache/BlockPipeline.cpp
@@ -114,7 +114,7 @@ void BlockPipeline::shardCacheInsertLocked(
     shardCacheGlobalBytes_.fetch_add(entrySize, std::memory_order_relaxed);
 }
 
-std::shared_ptr<std::vector<std::byte>> BlockPipeline::shardBytesFor(
+const std::vector<std::byte>* BlockPipeline::shardBytesFor(
     const ChunkKey& key, utils::ZarrArray& dz)
 {
     if (config_.shardCacheBytes == 0) return nullptr;
@@ -125,7 +125,10 @@ std::shared_ptr<std::vector<std::byte>> BlockPipeline::shardBytesFor(
     // process runs of adjacent chunks that fall in the same shard; with
     // 256 loader threads contending on the cache, skipping the map+lock
     // for same-shard hits saves ~1-2% total CPU per profile. The
-    // shared_ptr keeps bytes alive even if the LRU evicts them.
+    // shared_ptr keeps bytes alive even if the LRU evicts them — we
+    // return a raw pointer to the bytes so callers don't bump the
+    // shared_ptr refcount (that was ~20% of CPU under 12-thread decode
+    // because all threads hit the same canonical shard's control block).
     // Qualify with `this` so a volume swap (pipeline destroyed + recreated)
     // doesn't serve stale data from the old pipeline's shard cache.
     thread_local const BlockPipeline* tlOwner = nullptr;
@@ -133,7 +136,7 @@ std::shared_ptr<std::vector<std::byte>> BlockPipeline::shardBytesFor(
     thread_local std::shared_ptr<std::vector<std::byte>> tlLastBytes;
     if (tlOwner == this && tlLastShard == sk && tlLastBytes) {
         statShardHits_.fetch_add(1, std::memory_order_relaxed);
-        return tlLastBytes;
+        return tlLastBytes.get();
     }
 
     // Fast path: hit under the bucket mutex, move entry to LRU head.
@@ -146,7 +149,7 @@ std::shared_ptr<std::vector<std::byte>> BlockPipeline::shardBytesFor(
             tlOwner = this;
             tlLastShard = sk;
             tlLastBytes = it->second->bytes;
-            return it->second->bytes;
+            return tlLastBytes.get();
         }
     }
 
@@ -163,15 +166,16 @@ std::shared_ptr<std::vector<std::byte>> BlockPipeline::shardBytesFor(
     // consistent across concurrent reads.
     if (auto it = bucket.map.find(sk); it != bucket.map.end()) {
         bucket.lru.splice(bucket.lru.begin(), bucket.lru, it->second);
+        tlOwner = this;
         tlLastShard = sk;
         tlLastBytes = it->second->bytes;
-        return it->second->bytes;
+        return tlLastBytes.get();
     }
     shardCacheInsertLocked(bucket, sk, bytes);
     tlOwner = this;
     tlLastShard = sk;
-    tlLastBytes = bytes;
-    return bytes;
+    tlLastBytes = std::move(bytes);
+    return tlLastBytes.get();
 }
 
 // Decode a canonical h265 chunk from disk bytes. Uses the video header for
@@ -184,7 +188,7 @@ static ChunkDataPtr decodeCanonicalH265(const std::vector<uint8_t>& compressed) 
     utils::VideoCodecParams vp;
     vp.depth = dims[0]; vp.height = dims[1]; vp.width = dims[2];
     const size_t n = size_t(dims[0]) * dims[1] * dims[2];
-    auto out = std::make_shared<ChunkData>();
+    auto out = std::make_unique<ChunkData>();
     out->shape = {int(dims[0]), int(dims[1]), int(dims[2])};
     out->elementSize = 1;
     out->bytes.resize(n);
@@ -230,7 +234,7 @@ BlockPipeline::BlockPipeline(
     Config config,
     std::unique_ptr<VolumeSource> source,
     DecompressFn decompress,
-    std::vector<std::shared_ptr<utils::ZarrArray>> diskLevels)
+    std::vector<std::unique_ptr<utils::ZarrArray>> diskLevels)
     : config_(std::move(config))
     , diskLevels_(std::move(diskLevels))
     , source_(std::move(source))
@@ -889,11 +893,20 @@ BlockPtr BlockPipeline::blockAt(const BlockKey& key) noexcept {
             // One canonical zero block shared by every caller asking for
             // a block inside any empty chunk — no arena consumption.
             static constinit Block kZeroBlock{};
-            statEmptyHits_.fetch_add(1, std::memory_order_relaxed);
+            // Per-thread local accumulator flushed every 1024 hits. A single
+            // global atomic fetch_add here burned ~5%+ of CPU on hot render
+            // workloads (12 threads ping-ponging one cacheline per miss).
+            // Sampling trades exact counts for 1000x less atomic traffic —
+            // stats are diagnostic, so an approximate count is fine.
+            thread_local uint64_t localEmptyHits = 0;
+            if ((++localEmptyHits & 1023) == 0)
+                statEmptyHits_.fetch_add(1024, std::memory_order_relaxed);
             return &kZeroBlock;
         }
     }
-    statMisses_.fetch_add(1, std::memory_order_relaxed);
+    thread_local uint64_t localMisses = 0;
+    if ((++localMisses & 1023) == 0)
+        statMisses_.fetch_add(1024, std::memory_order_relaxed);
     return nullptr;
 }
 
@@ -912,7 +925,7 @@ ChunkDataPtr BlockPipeline::assembleCanonicalChunk(const ChunkKey& canonKey) {
     int sy0 = cy0 / scs[1], sy1 = (cy1 + scs[1] - 1) / scs[1];
     int sx0 = cx0 / scs[2], sx1 = (cx1 + scs[2] - 1) / scs[2];
 
-    auto out = std::make_shared<ChunkData>();
+    auto out = std::make_unique<ChunkData>();
     out->shape = {C, C, C};
     out->elementSize = 1;
     out->bytes.assign(size_t(C) * C * C, 0);

--- a/volume-cartographer/core/src/cache/BlockPipeline.cpp
+++ b/volume-cartographer/core/src/cache/BlockPipeline.cpp
@@ -835,7 +835,7 @@ void BlockPipeline::fetchInteractive(const std::vector<ChunkKey>& keys, int targ
     // hammering emptyChunksMutex_ from the render thread.
     std::unordered_set<ChunkKey, ChunkKeyHash> emptySnapshot;
     {
-        std::lock_guard lk(emptyChunksMutex_);
+        std::shared_lock lk(emptyChunksMutex_);
         emptySnapshot = emptyChunks_;
     }
 
@@ -879,9 +879,12 @@ BlockPtr BlockPipeline::blockAt(const BlockKey& key) noexcept {
     // Miss: could be an "empty chunk" (all-zero canonical chunk that we
     // don't store). Canonical chunks are 128³ = 8x8x8 blocks of 16³ —
     // reverse-map the block coord to its enclosing chunk and check.
+    // Shared-lock the empty-chunks set: readers in the miss path dominate
+    // (12 render threads × every miss), writers only fire when a new
+    // all-zero chunk is discovered during decode.
     const ChunkKey chunkKey{key.level, key.bz / 8, key.by / 8, key.bx / 8};
     {
-        std::lock_guard lk(emptyChunksMutex_);
+        std::shared_lock lk(emptyChunksMutex_);
         if (emptyChunks_.count(chunkKey)) {
             // One canonical zero block shared by every caller asking for
             // a block inside any empty chunk — no arena consumption.
@@ -980,7 +983,7 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
     // blockAt() will hand out a shared static zero block for every inner
     // block of this chunk. Saves ~2 MB of arena per empty 128³ chunk.
     if (chunk.isEmpty) {
-        std::lock_guard lk(emptyChunksMutex_);
+        std::unique_lock lk(emptyChunksMutex_);
         emptyChunks_.insert(key);
         return;
     }
@@ -1021,7 +1024,7 @@ void BlockPipeline::insertChunkAsBlocks(const ChunkKey& key,
 void BlockPipeline::clearMemory() {
     blockCache_.clear();
     {
-        std::lock_guard elk(emptyChunksMutex_);
+        std::unique_lock elk(emptyChunksMutex_);
         emptyChunks_.clear();
     }
     for (auto& bucket : shardCacheBuckets_) {
@@ -1055,7 +1058,7 @@ void BlockPipeline::clearAll() {
     shardCacheGlobalBytes_.store(0, std::memory_order_relaxed);
     blockCache_.clear();
     {
-        std::lock_guard elk(emptyChunksMutex_);
+        std::unique_lock elk(emptyChunksMutex_);
         emptyChunks_.clear();
     }
     bloomClear();
@@ -1113,7 +1116,7 @@ size_t BlockPipeline::countAvailable(const std::vector<ChunkKey>& keys) const {
     // would report them as unavailable and wait loops would stall.
     std::unordered_set<ChunkKey, ChunkKeyHash> emptySnap;
     {
-        std::lock_guard lk(emptyChunksMutex_);
+        std::shared_lock lk(emptyChunksMutex_);
         emptySnap = emptyChunks_;
     }
     for (const auto& key : keys) {

--- a/volume-cartographer/core/src/cache/ChunkData.cpp
+++ b/volume-cartographer/core/src/cache/ChunkData.cpp
@@ -1,0 +1,54 @@
+#include "vc/core/cache/ChunkData.hpp"
+
+#include <vector>
+
+namespace vc::cache {
+
+namespace {
+
+// Per-thread pool of decoded-chunk buffers. Capped so we don't balloon
+// memory on threads that process many chunks then go idle. 4 × ~2 MB
+// per-thread ≈ 8 MB worst case per producer/consumer thread — fine given
+// we already carry a 10 GB arena.
+constexpr size_t kPoolMax = 4;
+
+// Owning storage — uses default deleter so freeing at thread exit actually
+// releases memory, vs. re-entering our custom deleter recursively.
+std::vector<std::unique_ptr<ChunkData>>& pool()
+{
+    static thread_local std::vector<std::unique_ptr<ChunkData>> p;
+    return p;
+}
+
+}  // namespace
+
+void ChunkDataPoolDeleter::operator()(ChunkData* p) const noexcept
+{
+    if (!p) return;
+    auto& pl = pool();
+    if (pl.size() < kPoolMax) {
+        // Reset scalar fields and `bytes` size (keeping capacity) so the
+        // next acquire hands out a clean-looking ChunkData while the
+        // underlying allocation stays warm in the per-thread heap.
+        p->bytes.clear();
+        p->shape = {0, 0, 0};
+        p->elementSize = 1;
+        p->isEmpty = false;
+        pl.emplace_back(p);
+    } else {
+        delete p;
+    }
+}
+
+ChunkDataPtr acquireChunkData() noexcept
+{
+    auto& pl = pool();
+    if (!pl.empty()) {
+        auto owned = std::move(pl.back());
+        pl.pop_back();
+        return ChunkDataPtr(owned.release());
+    }
+    return ChunkDataPtr(new ChunkData());
+}
+
+}  // namespace vc::cache

--- a/volume-cartographer/core/src/cache/IOPool.cpp
+++ b/volume-cartographer/core/src/cache/IOPool.cpp
@@ -72,6 +72,7 @@ void IOPool::submit(const std::vector<ChunkKey>& keys)
     if (keys.empty()) return;
 
     int addedCount = 0;
+    int idleSnapshot = 0;
     {
         std::lock_guard lock(mutex_);
         if (shutdown_) return;
@@ -99,11 +100,13 @@ void IOPool::submit(const std::vector<ChunkKey>& keys)
             queueTotal_++;
             ++addedCount;
         }
+        idleSnapshot = idleCount_;
     }
-    // Wake exactly as many workers as we added items, capped at pool size.
-    // When we'd wake everyone anyway, one notify_all is a single futex op
-    // instead of N sequential notify_one futex_wake syscalls.
-    const int toWake = std::min(addedCount, numThreads_);
+    // Wake only workers actually asleep — busy workers will pick up new
+    // items on their next popNext iteration, so notifying them is a
+    // wasted futex_wake syscall.
+    const int toWake = std::min({addedCount, idleSnapshot, numThreads_});
+    if (toWake <= 0) return;
     if (toWake >= numThreads_) {
         cv_.notify_all();
     } else {
@@ -183,8 +186,13 @@ void IOPool::updateInteractive(const std::vector<ChunkKey>& keys, int targetLeve
             q.insert(q.end(), backlog[lvl].begin(), backlog[lvl].end());
             queueTotal_ += q.size();
         }
-        totalToWake = std::min<size_t>(queueTotal_, size_t(numThreads_));
+        // Clamp wake count by the number of workers actually asleep —
+        // see submit() for the reasoning.
+        totalToWake = std::min<size_t>({queueTotal_,
+                                        size_t(idleCount_),
+                                        size_t(numThreads_)});
     }
+    if (totalToWake == 0) return;
     if (totalToWake >= size_t(numThreads_)) {
         cv_.notify_all();
     } else {
@@ -195,9 +203,15 @@ void IOPool::updateInteractive(const std::vector<ChunkKey>& keys, int targetLeve
 ShardKey IOPool::popNext()
 {
     std::unique_lock lock(mutex_);
-    cv_.wait(lock, [this] {
-        return queueTotal_ > 0 || shutdown_;
-    });
+    if (queueTotal_ == 0 && !shutdown_) {
+        // Advertise idleness before blocking so producers can gate their
+        // notifies on "someone is actually waiting".
+        ++idleCount_;
+        cv_.wait(lock, [this] {
+            return queueTotal_ > 0 || shutdown_;
+        });
+        --idleCount_;
+    }
     if (shutdown_ && queueTotal_ == 0)
         throw std::runtime_error("IOPool shutdown");
 

--- a/volume-cartographer/core/src/cache/TickCoordinator.cpp
+++ b/volume-cartographer/core/src/cache/TickCoordinator.cpp
@@ -1,0 +1,136 @@
+#include "vc/core/cache/TickCoordinator.hpp"
+
+#include <algorithm>
+#include <chrono>
+
+namespace vc::cache {
+
+namespace {
+
+constexpr auto kTickInterval = std::chrono::milliseconds(16);
+
+// Process-wide pointer used by the static notify* methods. Set on
+// construction, cleared on destruction. Multiple coordinators in one
+// process would be a bug; assert the first-writer-wins property via
+// a simple atomic CAS.
+std::atomic<TickCoordinator*> g_coordinator{nullptr};
+
+}  // namespace
+
+TickCoordinator::TickCoordinator()
+{
+    // Both buffers start at generation 0. The first publish advances to 1,
+    // so a reader holding the initial buffer is trivially "behind" once
+    // publishing begins.
+    current_.store(&frames_[0], std::memory_order_release);
+
+    TickCoordinator* expected = nullptr;
+    g_coordinator.compare_exchange_strong(expected, this,
+                                          std::memory_order_release,
+                                          std::memory_order_relaxed);
+
+    worker_ = std::jthread([this](std::stop_token stop) { runLoop(stop); });
+}
+
+TickCoordinator::~TickCoordinator()
+{
+    TickCoordinator* self = this;
+    g_coordinator.compare_exchange_strong(self, nullptr,
+                                          std::memory_order_release,
+                                          std::memory_order_relaxed);
+}
+
+void TickCoordinator::notifyChunkLanded(const ChunkKey& k) noexcept
+{
+    TickCoordinator* c = g_coordinator.load(std::memory_order_acquire);
+    if (!c) return;
+    if (!c->chunkLandedRing_.try_push(k)) {
+        c->droppedChunkLanded_.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+void TickCoordinator::notifyEmptyChunkNoted(const ChunkKey& k) noexcept
+{
+    TickCoordinator* c = g_coordinator.load(std::memory_order_acquire);
+    if (!c) return;
+    if (!c->emptyChunkRing_.try_push(k)) {
+        c->droppedEmptyChunks_.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+const FrameState* TickCoordinator::currentFrameGlobal() noexcept
+{
+    TickCoordinator* c = g_coordinator.load(std::memory_order_acquire);
+    return c ? c->currentFrame() : nullptr;
+}
+
+void TickCoordinator::releaseFrameGlobal(const FrameState* s) noexcept
+{
+    if (!s) return;
+    TickCoordinator* c = g_coordinator.load(std::memory_order_acquire);
+    if (c) c->releaseFrame(s);
+}
+
+void TickCoordinator::runLoop(std::stop_token stop) noexcept
+{
+    auto next_tick = std::chrono::steady_clock::now() + kTickInterval;
+    while (!stop.stop_requested()) {
+        std::this_thread::sleep_until(next_tick);
+        next_tick += kTickInterval;
+        if (stop.stop_requested()) break;
+
+        const FrameState* now = current_.load(std::memory_order_acquire);
+        FrameState* next = (now == &frames_[0]) ? &frames_[1] : &frames_[0];
+
+        // Clobber guard. `next` currently carries its previous-publish
+        // generation; any reader that loaded `next` when it was last
+        // current may still be reading it. It is safe to overwrite once
+        // every such reader has released. Since releaseFrame is monotonic,
+        // `last_released_gen >= next->generation` implies no reader still
+        // holds `next`.
+        const std::uint64_t nextOldGen = next->generation;
+        if (nextOldGen > 0
+            && last_released_gen_.load(std::memory_order_acquire) < nextOldGen) {
+            continue;
+        }
+
+        // Drain producer rings into master state. Events are small POD
+        // ChunkKeys. Chunk-landed events only contribute to counters for
+        // now; empty-chunk events extend the sorted master vector.
+        std::uint64_t chunksThisTick = 0;
+        std::uint64_t emptiesThisTick = 0;
+        ChunkKey k;
+        while (chunkLandedRing_.try_pop(k)) {
+            ++chunksThisTick;
+        }
+        while (emptyChunkRing_.try_pop(k)) {
+            ++emptiesThisTick;
+            // Sorted insert; skip duplicates. Amortized O(log N) compare +
+            // O(N) shift for the rare true-new entry. N is small in practice
+            // (hundreds to thousands of empty chunks per volume).
+            auto it = std::lower_bound(emptyChunkMaster_.begin(),
+                                       emptyChunkMaster_.end(), k);
+            if (it == emptyChunkMaster_.end() || *it != k) {
+                emptyChunkMaster_.insert(it, k);
+            }
+        }
+        totalChunksLanded_ += chunksThisTick;
+        totalEmptyChunks_  += emptiesThisTick;
+
+        const std::uint64_t newGen = gen_.fetch_add(1, std::memory_order_relaxed) + 1;
+        next->generation          = newGen;
+        next->chunksLandedThisTick = chunksThisTick;
+        next->emptyChunksThisTick  = emptiesThisTick;
+        next->totalChunksLanded    = totalChunksLanded_;
+        next->totalEmptyChunks     = totalEmptyChunks_;
+        // Republish the empties vector if the master changed this tick.
+        // Vector assignment reuses capacity when possible; a full copy
+        // of a few-thousand 16-byte entries is in the tens of µs.
+        if (emptiesThisTick > 0 || next->emptyChunkKeys.size() != emptyChunkMaster_.size()) {
+            next->emptyChunkKeys = emptyChunkMaster_;
+        }
+        current_.store(next, std::memory_order_release);
+    }
+}
+
+}  // namespace vc::cache

--- a/volume-cartographer/core/src/cache/TickCoordinator.cpp
+++ b/volume-cartographer/core/src/cache/TickCoordinator.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <chrono>
 
+#include "vc/core/cache/BlockPipeline.hpp"
+
 namespace vc::cache {
 
 namespace {
@@ -40,11 +42,13 @@ TickCoordinator::~TickCoordinator()
                                           std::memory_order_relaxed);
 }
 
-void TickCoordinator::notifyChunkLanded(const ChunkKey& k) noexcept
+void TickCoordinator::notifyChunkLanded(BlockPipeline* pipeline,
+                                        const ChunkKey& k) noexcept
 {
     TickCoordinator* c = g_coordinator.load(std::memory_order_acquire);
     if (!c) return;
-    if (!c->chunkLandedRing_.try_push(k)) {
+    ChunkLandedEvent e{k, pipeline, 0};
+    if (!c->chunkLandedRing_.try_push(e)) {
         c->droppedChunkLanded_.fetch_add(1, std::memory_order_relaxed);
     }
 }
@@ -71,6 +75,65 @@ void TickCoordinator::releaseFrameGlobal(const FrameState* s) noexcept
     if (c) c->releaseFrame(s);
 }
 
+int TickCoordinator::acquireViewportSlotGlobal() noexcept
+{
+    TickCoordinator* c = g_coordinator.load(std::memory_order_acquire);
+    if (!c) return -1;
+    std::uint32_t mask = c->viewportSlotAllocMask_.load(std::memory_order_relaxed);
+    for (;;) {
+        // Find the lowest clear bit up to kMaxViewers.
+        std::uint32_t free = ~mask & ((1u << kMaxViewers) - 1u);
+        if (free == 0) return -1;
+        const int idx = __builtin_ctz(free);
+        const std::uint32_t bit = 1u << idx;
+        if (c->viewportSlotAllocMask_.compare_exchange_weak(
+                mask, mask | bit,
+                std::memory_order_acq_rel, std::memory_order_relaxed)) {
+            return idx;
+        }
+    }
+}
+
+void TickCoordinator::releaseViewportSlotGlobal(int slotIdx) noexcept
+{
+    TickCoordinator* c = g_coordinator.load(std::memory_order_acquire);
+    if (!c || slotIdx < 0 || std::size_t(slotIdx) >= kMaxViewers) return;
+    // Mark inactive via a zero-filled publish so tick-thread reads a clean
+    // "no viewport" after release.
+    ViewportSnapshot empty{};
+    publishViewportGlobal(slotIdx, empty);
+    c->viewportSlotAllocMask_.fetch_and(~(1u << slotIdx), std::memory_order_release);
+}
+
+void TickCoordinator::publishViewportGlobal(int slotIdx,
+                                            const ViewportSnapshot& s) noexcept
+{
+    TickCoordinator* c = g_coordinator.load(std::memory_order_acquire);
+    if (!c || slotIdx < 0 || std::size_t(slotIdx) >= kMaxViewers) return;
+    auto& slot = c->viewportSlots_[slotIdx];
+    // Seqlock write: bump to odd, copy payload, bump to even+2.
+    const std::uint64_t prev = slot.seq.load(std::memory_order_relaxed);
+    slot.seq.store(prev + 1, std::memory_order_release);
+    slot.snapshot = s;
+    slot.seq.store(prev + 2, std::memory_order_release);
+}
+
+void TickCoordinator::enqueuePrefetchGlobal(BlockPipeline* pipeline,
+                                            const std::vector<ChunkKey>& keys,
+                                            int targetLevel) noexcept
+{
+    if (!pipeline || keys.empty()) return;
+    TickCoordinator* c = g_coordinator.load(std::memory_order_acquire);
+    if (!c) {
+        // No coordinator running (e.g. CLI tools) — fall back to direct.
+        pipeline->fetchInteractive(keys, targetLevel);
+        return;
+    }
+    PendingPrefetch p{pipeline, targetLevel, keys};
+    std::lock_guard lk(c->prefetchMutex_);
+    c->prefetchQueue_.push_back(std::move(p));
+}
+
 void TickCoordinator::runLoop(std::stop_token stop) noexcept
 {
     auto next_tick = std::chrono::steady_clock::now() + kTickInterval;
@@ -94,15 +157,71 @@ void TickCoordinator::runLoop(std::stop_token stop) noexcept
             continue;
         }
 
-        // Drain producer rings into master state. Events are small POD
-        // ChunkKeys. Chunk-landed events only contribute to counters for
-        // now; empty-chunk events extend the sorted master vector.
+        // Gather the set of pyramid levels that any active viewport is
+        // using right now. ChunkLanded events at levels outside this set
+        // are ignored for slice population — keeps sliceMaster_ focused
+        // on data the renderers are about to read.
+        std::uint32_t activeLevelMask = 0;
+        {
+            const std::uint32_t allocPreview =
+                viewportSlotAllocMask_.load(std::memory_order_acquire);
+            for (std::size_t i = 0; i < kMaxViewers; ++i) {
+                if (!(allocPreview & (1u << i))) continue;
+                auto& slot = viewportSlots_[i];
+                const std::uint64_t s1 = slot.seq.load(std::memory_order_acquire);
+                if (s1 & 1u) continue;
+                const ViewportSnapshot copy = slot.snapshot;
+                const std::uint64_t s2 = slot.seq.load(std::memory_order_acquire);
+                if (s1 != s2) continue;
+                if (!copy.active) continue;
+                if (copy.level >= 0 && copy.level < 32) {
+                    activeLevelMask |= (1u << copy.level);
+                }
+            }
+        }
+
+        // Drain producer rings into master state.
         std::uint64_t chunksThisTick = 0;
         std::uint64_t emptiesThisTick = 0;
-        ChunkKey k;
-        while (chunkLandedRing_.try_pop(k)) {
+        ChunkLandedEvent ce;
+        while (chunkLandedRing_.try_pop(ce)) {
             ++chunksThisTick;
+            if (!ce.pipeline || ce.key.level < 0 || ce.key.level >= 32) continue;
+            if (!(activeLevelMask & (1u << ce.key.level))) continue;
+            // Resolve 512 blocks in the newly-landed canonical chunk.
+            // Canonical chunks are 128^3 = 8 blocks per axis. blockAt
+            // returns nullptr for blocks that weren't stored (e.g. the
+            // zero-chunk shortcut); skip those.
+            const int baseBz = ce.key.iz * 8;
+            const int baseBy = ce.key.iy * 8;
+            const int baseBx = ce.key.ix * 8;
+            for (int dz = 0; dz < 8; ++dz) {
+                for (int dy = 0; dy < 8; ++dy) {
+                    for (int dx = 0; dx < 8; ++dx) {
+                        const int bz = baseBz + dz;
+                        const int by = baseBy + dy;
+                        const int bx = baseBx + dx;
+                        const BlockKey bk{ce.key.level, bz, by, bx};
+                        const BlockPtr b = ce.pipeline->blockAt(bk);
+                        if (!b) continue;
+                        const std::uint64_t packed =
+                            (std::uint64_t(std::uint32_t(bz)) << 42) |
+                            (std::uint64_t(std::uint32_t(by)) << 21) |
+                             std::uint64_t(std::uint32_t(bx));
+                        sliceMaster_.push_back(SliceEntry{
+                            packed, ce.pipeline, b});
+                    }
+                }
+            }
+            // FIFO eviction: keep the most recent kSliceMax entries.
+            if (sliceMaster_.size() > kSliceMax) {
+                const std::size_t drop = sliceMaster_.size() - kSliceMax;
+                sliceMaster_.erase(sliceMaster_.begin(),
+                                   sliceMaster_.begin()
+                                       + static_cast<std::ptrdiff_t>(drop));
+            }
         }
+        ChunkKey k;
         while (emptyChunkRing_.try_pop(k)) {
             ++emptiesThisTick;
             // Sorted insert; skip duplicates. Amortized O(log N) compare +
@@ -117,17 +236,101 @@ void TickCoordinator::runLoop(std::stop_token stop) noexcept
         totalChunksLanded_ += chunksThisTick;
         totalEmptyChunks_  += emptiesThisTick;
 
+        // Gather all viewport snapshots via seqlock reads. This publishes
+        // a point-in-time union that any consumer (slice scoping, prefetch
+        // coalescing) can use without further atomics.
+        std::array<ViewportSnapshot, kMaxViewers> viewports{};
+        const std::uint32_t allocMask =
+            viewportSlotAllocMask_.load(std::memory_order_acquire);
+        for (std::size_t i = 0; i < kMaxViewers; ++i) {
+            if (!(allocMask & (1u << i))) continue;
+            auto& slot = viewportSlots_[i];
+            // Seqlock read loop. Rare contention; bounded to <1ms worst case.
+            for (int attempt = 0; attempt < 64; ++attempt) {
+                const std::uint64_t s1 = slot.seq.load(std::memory_order_acquire);
+                if (s1 & 1u) continue;  // writer in progress
+                ViewportSnapshot copy = slot.snapshot;
+                const std::uint64_t s2 = slot.seq.load(std::memory_order_acquire);
+                if (s1 == s2) {
+                    viewports[i] = copy;
+                    break;
+                }
+            }
+        }
+
+        // Drain pending prefetch requests and dispatch one fetchInteractive
+        // per (pipeline, targetLevel) group. Consolidates up to N viewers
+        // of duplicate work into a single priority-queue rebuild per tick.
+        std::vector<PendingPrefetch> drained;
+        {
+            std::lock_guard lk(prefetchMutex_);
+            drained.swap(prefetchQueue_);
+        }
+        std::uint64_t prefetchCallsThisTick = 0;
+        if (!drained.empty()) {
+            // Sort so same-(pipeline,level) pairs are contiguous; then
+            // merge keys per group, dedup, dispatch. Avoids a full
+            // unordered_map when we typically have 1-2 groups.
+            std::sort(drained.begin(), drained.end(),
+                      [](const PendingPrefetch& a, const PendingPrefetch& b) {
+                          if (a.pipeline != b.pipeline) return a.pipeline < b.pipeline;
+                          return a.targetLevel < b.targetLevel;
+                      });
+            for (auto it = drained.begin(); it != drained.end();) {
+                auto groupEnd = it + 1;
+                while (groupEnd != drained.end()
+                       && groupEnd->pipeline == it->pipeline
+                       && groupEnd->targetLevel == it->targetLevel) {
+                    ++groupEnd;
+                }
+                std::vector<ChunkKey> merged;
+                std::size_t total = 0;
+                for (auto p = it; p != groupEnd; ++p) total += p->keys.size();
+                merged.reserve(total);
+                for (auto p = it; p != groupEnd; ++p) {
+                    merged.insert(merged.end(), p->keys.begin(), p->keys.end());
+                }
+                std::sort(merged.begin(), merged.end());
+                merged.erase(std::unique(merged.begin(), merged.end()),
+                             merged.end());
+                if (!merged.empty()) {
+                    it->pipeline->fetchInteractive(merged, it->targetLevel);
+                    ++prefetchCallsThisTick;
+                }
+                it = groupEnd;
+            }
+        }
+        totalPrefetchCalls_ += prefetchCallsThisTick;
+
         const std::uint64_t newGen = gen_.fetch_add(1, std::memory_order_relaxed) + 1;
         next->generation          = newGen;
         next->chunksLandedThisTick = chunksThisTick;
         next->emptyChunksThisTick  = emptiesThisTick;
+        next->prefetchCallsThisTick = prefetchCallsThisTick;
         next->totalChunksLanded    = totalChunksLanded_;
         next->totalEmptyChunks     = totalEmptyChunks_;
+        next->totalPrefetchCalls   = totalPrefetchCalls_;
+        next->viewports            = viewports;
         // Republish the empties vector if the master changed this tick.
         // Vector assignment reuses capacity when possible; a full copy
         // of a few-thousand 16-byte entries is in the tens of µs.
         if (emptiesThisTick > 0 || next->emptyChunkKeys.size() != emptyChunkMaster_.size()) {
             next->emptyChunkKeys = emptyChunkMaster_;
+        }
+        // Rebuild published slice from master. Copy, then sort by packed
+        // key so readers can binary_search. Dedup isn't strictly required
+        // (stale entries for a given key are fine — the reader verifies
+        // the pipeline pointer and a stale Block* either still points to
+        // valid arena memory or to a repurposed slot, which fails the
+        // key check inside the per-sampler slot cache).
+        if (chunksThisTick > 0 || next->slice.size() != sliceMaster_.size()) {
+            next->slice = sliceMaster_;
+            std::sort(next->slice.begin(), next->slice.end(),
+                      [](const SliceEntry& a, const SliceEntry& b) {
+                          if (a.packedKey != b.packedKey)
+                              return a.packedKey < b.packedKey;
+                          return a.pipeline < b.pipeline;
+                      });
         }
         current_.store(next, std::memory_order_release);
     }

--- a/volume-cartographer/core/src/cache/VcDecompressor.cpp
+++ b/volume-cartographer/core/src/cache/VcDecompressor.cpp
@@ -66,22 +66,36 @@ DecompressFn makeVcDecompressor(const std::vector<vc::VcDataset*>& datasets)
             vp.height = dims[1];
             vp.width = dims[2];
 
-            auto decoded = utils::video_decode(
-                std::span<const std::byte>(
-                    reinterpret_cast<const std::byte*>(compressed.data()),
-                    compressed.size()),
-                size_t(dims[0]) * dims[1] * dims[2], vp);
-
+            const size_t decodedSize = size_t(dims[0]) * dims[1] * dims[2];
             int cz = static_cast<int>(chunkShape[0]);
             int cy = static_cast<int>(chunkShape[1]);
             int cx = static_cast<int>(chunkShape[2]);
-            size_t copySize = std::min(decoded.size(), chunkSize);
 
             auto result = acquireChunkData(chunkSize);
             result->shape = {cz, cy, cx};
             result->elementSize = 1;
 
-            std::memcpy(result->rawData(), decoded.data(), copySize);
+            // Decode straight into the result buffer when it matches; saves
+            // one 2 MiB allocation + memcpy per chunk on the hot path.
+            // Fall back to a temp buffer when the shapes mismatch (rare).
+            if (decodedSize == chunkSize) {
+                utils::video_decode_into(
+                    std::span<const std::byte>(
+                        reinterpret_cast<const std::byte*>(compressed.data()),
+                        compressed.size()),
+                    std::span<std::byte>(
+                        reinterpret_cast<std::byte*>(result->rawData()),
+                        chunkSize),
+                    vp);
+            } else {
+                auto decoded = utils::video_decode(
+                    std::span<const std::byte>(
+                        reinterpret_cast<const std::byte*>(compressed.data()),
+                        compressed.size()),
+                    decodedSize, vp);
+                std::memcpy(result->rawData(), decoded.data(),
+                            std::min(decoded.size(), chunkSize));
+            }
             result->isEmpty = isChunkEmpty(result->rawData(), chunkSize);
             return result;
         }

--- a/volume-cartographer/core/src/cache/VcDecompressor.cpp
+++ b/volume-cartographer/core/src/cache/VcDecompressor.cpp
@@ -27,7 +27,7 @@ static bool isChunkEmpty(const uint8_t* data, size_t n)
 
 static ChunkDataPtr acquireChunkData(size_t bytesNeeded)
 {
-    auto result = std::make_unique<ChunkData>();
+    auto result = vc::cache::acquireChunkData();
     result->resizeBytes(bytesNeeded);
     return result;
 }

--- a/volume-cartographer/core/src/cache/VcDecompressor.cpp
+++ b/volume-cartographer/core/src/cache/VcDecompressor.cpp
@@ -27,7 +27,7 @@ static bool isChunkEmpty(const uint8_t* data, size_t n)
 
 static ChunkDataPtr acquireChunkData(size_t bytesNeeded)
 {
-    auto result = std::make_shared<ChunkData>();
+    auto result = std::make_unique<ChunkData>();
     result->resizeBytes(bytesNeeded);
     return result;
 }

--- a/volume-cartographer/core/src/cache/VolumeSource.cpp
+++ b/volume-cartographer/core/src/cache/VolumeSource.cpp
@@ -1,4 +1,5 @@
 #include "vc/core/cache/VolumeSource.hpp"
+#include "vc/core/cache/BlockCache.hpp"
 #include "vc/core/cache/CacheDebugLog.hpp"
 #include "vc/core/cache/CacheUtils.hpp"
 
@@ -83,6 +84,21 @@ void FileSystemSource::discoverLevels()
                 lm.shape = {int(meta.shape[0]), int(meta.shape[1]), int(meta.shape[2])};
             if (cs.size() >= 3)
                 lm.chunkShape = {int(cs[0]), int(cs[1]), int(cs[2])};
+            // 16³ blocks are the fixed storage unit; chunks must tile cleanly.
+            // Arbitrary multiples of 16 on each axis are fine (128³, 64³,
+            // 192³, non-cubic 32x128x128, etc.) — just not 100, 50, 96 etc.
+            for (int d = 0; d < 3; ++d) {
+                if (lm.chunkShape[d] <= 0 || lm.chunkShape[d] % kBlockSize != 0) {
+                    throw std::runtime_error(
+                        "zarr level " + std::to_string(lvl) + " at " +
+                        levelPath.string() + " has chunk shape " +
+                        std::to_string(lm.chunkShape[0]) + "x" +
+                        std::to_string(lm.chunkShape[1]) + "x" +
+                        std::to_string(lm.chunkShape[2]) +
+                        "; each axis must be a positive multiple of " +
+                        std::to_string(kBlockSize));
+                }
+            }
             levels_.push_back(lm);
         } catch (const std::exception& e) {
             if (auto* log = cacheDebugLog())

--- a/volume-cartographer/utils/include/utils/compositing.hpp
+++ b/volume-cartographer/utils/include/utils/compositing.hpp
@@ -18,7 +18,16 @@ enum class CompositingMethod : std::uint8_t {
     max,
     min,
     alpha,
-    beer_lambert
+    beer_lambert,
+    dvr,
+    first_hit_iso,
+    dev_from_mean,
+    emission_dvr,
+    max_above_iso,
+    gamma_weighted,
+    gradient_mag,
+    pbr_iso,
+    shaded_dvr
 };
 
 // ---------------------------------------------------------------------------
@@ -59,6 +68,15 @@ struct CompositeParams {
     if (name == "min")          return CompositingMethod::min;
     if (name == "alpha")        return CompositingMethod::alpha;
     if (name == "beerLambert")  return CompositingMethod::beer_lambert;
+    if (name == "dvr")          return CompositingMethod::dvr;
+    if (name == "firstHitIso")  return CompositingMethod::first_hit_iso;
+    if (name == "devFromMean")  return CompositingMethod::dev_from_mean;
+    if (name == "emissionDvr")  return CompositingMethod::emission_dvr;
+    if (name == "maxAboveIso")  return CompositingMethod::max_above_iso;
+    if (name == "gammaWeighted") return CompositingMethod::gamma_weighted;
+    if (name == "gradientMag")  return CompositingMethod::gradient_mag;
+    if (name == "pbrIso")       return CompositingMethod::pbr_iso;
+    if (name == "shadedDvr")    return CompositingMethod::shaded_dvr;
     return CompositingMethod::mean;
 }
 
@@ -202,11 +220,115 @@ inline void value_stretch(std::span<float> data) noexcept {
     return accumulated + ambient * transmittance;
 }
 
+/// Front-to-back emissive DVR. Opacity = density/255; emission = density.
+/// Mirrors the per-layer integration used in VC3D's interactive viewer.
+[[nodiscard]] inline float composite_dvr(
+    std::span<const float> layers, float ambient = 0.0f) noexcept
+{
+    float color = 0.0f;
+    float trans = 1.0f;
+    for (float I : layers) {
+        const float op = I * (1.0f / 255.0f);
+        color += I * trans * op;
+        trans *= (1.0f - op);
+        if (trans < 0.001f) break;
+    }
+    return color + ambient * trans;
+}
+
+/// First-hit iso: return the first layer value strictly greater than
+/// iso_cutoff. Returns 0 when no layer exceeds the threshold. Does not
+/// apply any shading — the caller is expected to multiply by an external
+/// lighting factor.
+[[nodiscard]] inline float composite_first_hit_iso(
+    std::span<const float> layers, float iso_cutoff) noexcept
+{
+    for (float I : layers) {
+        if (I > iso_cutoff) return I;
+    }
+    return 0.0f;
+}
+
+/// Mean absolute deviation from the ray mean, computed over layers strictly
+/// greater than iso_cutoff. Measures how much the ray deviates from its own
+/// local average — useful for surfacing ink / void outliers against a papyrus
+/// baseline.
+[[nodiscard]] inline float composite_dev_from_mean(
+    std::span<const float> layers, float iso_cutoff) noexcept
+{
+    double sum = 0.0;
+    int n = 0;
+    for (float I : layers) {
+        if (I > iso_cutoff) { sum += double(I); ++n; }
+    }
+    if (n == 0) return 0.0f;
+    const float m = float(sum / double(n));
+    double dev = 0.0;
+    for (float I : layers) {
+        if (I > iso_cutoff) dev += std::fabs(I - m);
+    }
+    return float(dev / double(n));
+}
+
+/// Emission-only DVR: sum(I * I / 255) — no absorption, so layers behind
+/// others still contribute. Complement to `dvr`.
+[[nodiscard]] inline float composite_emission_dvr(
+    std::span<const float> layers) noexcept
+{
+    float sum = 0.0f;
+    for (float I : layers) sum += I * I * (1.0f / 255.0f);
+    return sum;
+}
+
+/// Max of samples strictly greater than iso_cutoff. Like `max` but ignores
+/// air/substrate — useful when iso separates the density band of interest
+/// from background noise.
+[[nodiscard]] inline float composite_max_above_iso(
+    std::span<const float> layers, float iso_cutoff) noexcept
+{
+    float m = 0.0f;
+    for (float I : layers) {
+        if (I > iso_cutoff && I > m) m = I;
+    }
+    return m;
+}
+
+/// sum(w*I) / sum(w) with w = max(0, I - iso)². Quadratic weight amplifies
+/// the density offset of ink relative to papyrus while staying a mean
+/// (robust to single-voxel outliers that max/first-hit pick up).
+[[nodiscard]] inline float composite_gamma_weighted(
+    std::span<const float> layers, float iso_cutoff) noexcept
+{
+    float sumWI = 0.0f, sumW = 0.0f;
+    for (float I : layers) {
+        const float d = I - iso_cutoff;
+        if (d <= 0.0f) continue;
+        const float w = d * d;
+        sumWI += w * I;
+        sumW  += w;
+    }
+    return sumW > 0.0f ? sumWI / sumW : 0.0f;
+}
+
+/// Peak |∂I/∂z| via central difference, ×8 gain. Lights up sharp intensity
+/// steps along the ray (cracks, ink/papyrus boundaries).
+[[nodiscard]] inline float composite_gradient_mag(
+    std::span<const float> layers) noexcept
+{
+    if (layers.size() < 3) return 0.0f;
+    float best = 0.0f;
+    for (std::size_t i = 1; i + 1 < layers.size(); ++i) {
+        const float g = std::fabs(layers[i + 1] - layers[i - 1]) * 0.5f;
+        if (g > best) best = g;
+    }
+    return best * 8.0f;
+}
+
 // ---------------------------------------------------------------------------
 // Stack compositing (dispatch by method)
 // ---------------------------------------------------------------------------
 
-[[nodiscard]] constexpr float composite_stack(
+[[nodiscard]] inline float composite_stack(
     std::span<const float> layers,
     CompositingMethod method,
     const CompositeParams& params = {}) noexcept
@@ -224,6 +346,29 @@ inline void value_stretch(std::span<float> data) noexcept {
         case CompositingMethod::beer_lambert:
             return composite_beer_lambert(
                 layers, params.extinction, params.emission, params.ambient);
+        case CompositingMethod::dvr:
+            return composite_dvr(layers, params.ambient);
+        case CompositingMethod::first_hit_iso:
+            return composite_first_hit_iso(layers, float(params.iso_cutoff));
+        case CompositingMethod::dev_from_mean:
+            return composite_dev_from_mean(layers, float(params.iso_cutoff));
+        case CompositingMethod::emission_dvr:
+            return composite_emission_dvr(layers);
+        case CompositingMethod::max_above_iso:
+            return composite_max_above_iso(layers, float(params.iso_cutoff));
+        case CompositingMethod::gamma_weighted:
+            return composite_gamma_weighted(layers, float(params.iso_cutoff));
+        case CompositingMethod::gradient_mag:
+            return composite_gradient_mag(layers);
+        case CompositingMethod::pbr_iso:
+            // The batch renderer lacks view/light/gradient context needed
+            // for Cook-Torrance; fall back to first-hit intensity so the
+            // CLI still produces a sensible output for this method.
+            return composite_first_hit_iso(layers, float(params.iso_cutoff));
+        case CompositingMethod::shaded_dvr:
+            // Same: no per-sample gradient context here — fall back to plain
+            // absorptive DVR so the CLI produces a usable image.
+            return composite_dvr(layers, params.ambient);
     }
     return 0.0f;
 }

--- a/volume-cartographer/utils/include/utils/video_codec.hpp
+++ b/volume-cartographer/utils/include/utils/video_codec.hpp
@@ -51,12 +51,31 @@ struct VideoCodecParams {
 [[nodiscard]] std::vector<std::byte> video_encode(
     std::span<const std::byte> raw, const VideoCodecParams& params);
 
+// In-place variant: writes encoded bitstream into caller-owned `output`.
+// Replaces `output`'s contents (clears then fills). Allows callers to
+// reuse a thread-local buffer across chunks — eliminates the per-chunk
+// std::vector allocation that was a steady source of swap pressure
+// during streaming sessions.
+void video_encode_into(
+    std::span<const std::byte> raw,
+    const VideoCodecParams& params,
+    std::vector<std::byte>& output);
+
 // Decode an H.265 bitstream back to a 3D chunk.
 // Input: compressed bitstream bytes (VC3D header + H.265 NALUs).
 // out_size: expected decompressed size (depth * height * width).
 // Returns: raw uint8 voxel data in row-major (Z, Y, X) order.
 [[nodiscard]] std::vector<std::byte> video_decode(
     std::span<const std::byte> compressed, std::size_t out_size,
+    const VideoCodecParams& params);
+
+// Zero-copy variant: write decoded voxels directly into `output`. Avoids
+// the ~2 MiB interim allocation + zero-init + memcpy that the std::vector
+// return form does on every call. Caller pre-sizes `output` to match the
+// expected depth × height × width. Throws on header-size mismatch.
+void video_decode_into(
+    std::span<const std::byte> compressed,
+    std::span<std::byte> output,
     const VideoCodecParams& params);
 
 // Check if a compressed buffer has the VC3D video codec magic header.

--- a/volume-cartographer/utils/src/video_codec.cpp
+++ b/volume-cartographer/utils/src/video_codec.cpp
@@ -93,8 +93,10 @@ void fill_y_plane(
 
 }  // namespace
 
-auto video_encode(std::span<const std::byte> raw, const VideoCodecParams& params)
-    -> std::vector<std::byte>
+void video_encode_into(
+    std::span<const std::byte> raw,
+    const VideoCodecParams& params,
+    std::vector<std::byte>& output)
 {
     const int Z = params.depth, Y = params.height, X = params.width;
     if (Z <= 0 || Y <= 0 || X <= 0)
@@ -173,7 +175,11 @@ auto video_encode(std::span<const std::byte> raw, const VideoCodecParams& params
     auto pic_guard = std::unique_ptr<x265_picture, void (*)(x265_picture*)>(
         pic, x265_picture_free);
 
-    std::vector<uint8_t> yBuf(padW * padH, 0);
+    // Thread-local Y-plane scratch. padW/padH can differ across calls when
+    // chunk dims vary between volume levels, so grow on demand; capacity
+    // sticks at the largest padW*padH this thread has ever encoded.
+    thread_local std::vector<uint8_t> yBuf;
+    yBuf.assign(size_t(padW) * padH, 0);
     pic->planes[0] = yBuf.data();
     pic->planes[1] = nullptr;
     pic->planes[2] = nullptr;
@@ -185,7 +191,9 @@ auto video_encode(std::span<const std::byte> raw, const VideoCodecParams& params
     const int air_clamp = std::max(0, std::min(255, params.air_clamp));
     const int shift_n = std::max(0, std::min(7, params.shift_n));
 
-    std::vector<std::byte> output;
+    // Clear the caller's buffer but retain capacity so streaming callers
+    // with a thread-local output vector don't reallocate on every chunk.
+    output.clear();
     write_header(output, params.qp, Z, Y, X, air_clamp, shift_n);
 
     x265_nal* nals = nullptr;
@@ -214,14 +222,20 @@ auto video_encode(std::span<const std::byte> raw, const VideoCodecParams& params
             std::memcpy(output.data() + old, nals[i].payload, nals[i].sizeBytes);
         }
     }
+}
 
+auto video_encode(std::span<const std::byte> raw, const VideoCodecParams& params)
+    -> std::vector<std::byte>
+{
+    std::vector<std::byte> output;
+    video_encode_into(raw, params, output);
     return output;
 }
 
-auto video_decode(
+void video_decode_into(
     std::span<const std::byte> compressed,
-    std::size_t out_size,
-    const VideoCodecParams& /*params*/) -> std::vector<std::byte>
+    std::span<std::byte> output,
+    const VideoCodecParams& /*params*/)
 {
     if (compressed.size() < HEADER_SIZE)
         throw std::runtime_error("video_decode: input too small for header");
@@ -232,8 +246,9 @@ auto video_decode(
     int Y = static_cast<int>(read_le32(compressed.data() + 12));
     int X = static_cast<int>(read_le32(compressed.data() + 16));
 
+    const std::size_t out_size = output.size();
     if (out_size != static_cast<std::size_t>(Z) * Y * X)
-        throw std::runtime_error("video_decode: out_size mismatch with header dimensions");
+        throw std::runtime_error("video_decode: output size mismatch with header dimensions");
 
     int air_clamp = static_cast<int>(static_cast<uint8_t>(compressed[20]));
     int shift_n = static_cast<int>(static_cast<uint8_t>(compressed[21]));
@@ -258,7 +273,13 @@ auto video_decode(
     }
     de265_reset(ctx);
 
-    std::vector<std::byte> output(out_size, std::byte{0});
+    // Caller owns `output`. Zero-fill so error paths where the decoder
+    // produces fewer than Z frames leave the tail as zero (matches the
+    // legacy allocate-and-init behaviour) — callers see a fully valid
+    // buffer even on partial decode. The saved cost relative to the
+    // previous implementation is one 2 MiB std::vector allocation + one
+    // 2 MiB memcpy per chunk; the zero-fill itself is unavoidable here.
+    std::memset(output.data(), 0, output.size());
     int framesDecoded = 0;
 
     auto extractFrames = [&]() {
@@ -304,7 +325,15 @@ auto video_decode(
             p[i] = v;
         }
     }
+}
 
+auto video_decode(
+    std::span<const std::byte> compressed,
+    std::size_t out_size,
+    const VideoCodecParams& params) -> std::vector<std::byte>
+{
+    std::vector<std::byte> output(out_size);
+    video_decode_into(compressed, std::span{output}, params);
     return output;
 }
 


### PR DESCRIPTION
tldr: moved a bunch of the zarr encode decode disk read network read block caching etc to a tick based update system to try to cut down on useless work and instead just try to update everything on a 16ms based tick system.

## Summary

Accumulated perf and architecture work on the render + cache path over several sessions.

- **Lock-free BlockCache shard map + emptyChunks set.** Open-addressed, 32 shards × 256K atomic entries + 8-way L2. Replaces the previous per-shard `pthread_rwlock`/`shared_mutex`. `BlockCache::get` dropped from ~44% → ~2.7% of render CPU.
- **Tick-batched state publication (`TickCoordinator`).** Dedicated `std::jthread` at 16 ms, double-buffered `FrameState`, monotonic release-gen protocol. No `shared_ptr`, multi-reader safe. Main thread untouched.
- **MPSC producer events** (`ChunkLanded`, `EmptyChunkNoted`) drain into `FrameState::emptyChunkKeys` (sorted vec) and `FrameState::slice` ({packedBlockKey, pipeline*, Block*}).
- **Coalesced prefetch.** Viewer render paths enqueue fetch keys through `TickCoordinator`; tick thread groups by `(pipeline, targetLevel)`, dedups, dispatches one `fetchInteractive` per group per tick instead of 8–20 per render cycle across 4 viewers.
- **ViewportSnapshot seqlock** per viewer so the coordinator can scope the slice to active pyramid levels.
- **`BlockSampler` reader side** binary-searches `emptyChunkKeys` and the slice on slot miss — plain memory, skips atomic probes inside `BlockPipeline::blockAt` for hot data.
- **Per-thread `ChunkData` pool** on decode path to cut malloc/mmap churn (~30% of CPU was in kernel mm on heavy decode).
- **Fused sample loop** + skip of inactive TF LUTs.
- **Configurable TF + composite pipeline** (pre-TF, post-TF, DVR, PBR, volumetric, first-hit iso, deviation-from-mean).
- **Progressive render** + 8-way L2 + tile-parallel render + sharded block cache.
- **FPS readout** rewritten to report 1 / mean(render duration) instead of render count / wallclock, so the number reflects render kernel speed rather than user-input pacing.

Profile after all this: 55% raw sample/composite kernel (irreducible), 2.7% `BlockCache::get`, 0.35% `BlockPipeline::blockAt`. Everything else < 1%.

## Test plan

- [ ] Build `cmake-build-releaseunsafe` cleanly (all warnings pre-existing).
- [ ] Open a volume in VC3D, verify 4 viewers render.
- [ ] Pan/zoom each viewer; confirm smooth rendering.
- [ ] Switch composite modes (Max / Mean / Min / Alpha / BeerLambert / DVR / FirstHitIso / DevFromMean); confirm each renders without crash.
- [ ] Toggle pre-TF and post-TF with non-identity knots; confirm output changes as expected.
- [ ] Run `perf record -F 999 --call-graph dwarf` for ~30 s and compare top symbols against baseline (`perf.before*.data` in the repo during development).
- [ ] Leave idle for 60 s; verify TickCoordinator CPU stays < 1%.
- [ ] Close cleanly; no jthread join hangs, no leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)