### PR TITLE
Fix OME-Zarr physical scale metadata

### DIFF
--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -1163,6 +1163,10 @@ int main(int argc, char *argv[])
     std::filesystem::path seg_path = parsed["segmentation"].as<std::string>();
 
     float tgt_scale = parsed["scale"].as<float>();
+    if (!std::isfinite(tgt_scale) || tgt_scale <= 0) {
+        logPrintf(stderr, "Error: --scale must be positive\n");
+        return EXIT_FAILURE;
+    }
     int group_idx = parsed["group-idx"].as<int>();
     int num_slices = parsed["num-slices"].as<int>();
     double slice_step = parsed["slice-step"].as<float>();
@@ -1281,7 +1285,7 @@ int main(int argc, char *argv[])
                     const double vsLevel = ds_scale > 0
                                                ? vs / double(ds_scale)
                                                : vs;
-                    tifDpi = voxelSizeToDpi(vsLevel);
+                    tifDpi = voxelSizeToDpi(vsLevel / double(tgt_scale));
                 }
             } catch (...) {
             }
@@ -1363,6 +1367,13 @@ int main(int argc, char *argv[])
     } else {
         logPrintf(stdout, "Voxel size: 1.0 (no metadata found; override with --voxel-size)\n");
     }
+    const double source_group_voxel_size = ds_scale > 0
+        ? base_voxel_size / double(ds_scale)
+        : base_voxel_size;
+    const double output_yx_voxel_size = source_group_voxel_size / double(tgt_scale);
+    const double output_z_voxel_size = base_voxel_size * slice_step;
+    logPrintf(stdout, "Output voxel size: z=%g, yx=%g %s\n",
+              output_z_voxel_size, output_yx_voxel_size, voxel_unit.c_str());
 
     int rotQuadGlobal = -1;
     if (std::abs(rotate_angle) > 1e-6) {
@@ -1514,7 +1525,7 @@ int main(int argc, char *argv[])
                 if (rotQuad >= 0 && (rotQuad % 2) == 1) std::swap(attrXY.width, attrXY.height);
                 writeZarrAttrs(outFilePath, vol_path, group_idx, baseZ, slice_step, accum_step,
                                accum_type_str, accumOffsets.size(), attrXY, baseZ, CH, CW,
-                               base_voxel_size, voxel_unit);
+                               output_z_voxel_size, output_yx_voxel_size, voxel_unit);
                 return true;
             } else if (numParts > 1) {
                 if (!std::filesystem::exists(std::filesystem::path(zarrOutputArg) / "0" / ".zarray")) {
@@ -1714,7 +1725,7 @@ int main(int argc, char *argv[])
                 if (rotQuad >= 0 && (rotQuad % 2) == 1) std::swap(attrXY.width, attrXY.height);
                 writeZarrAttrs(outFilePath, vol_path, group_idx, baseZ, slice_step, accum_step,
                                accum_type_str, accumOffsets.size(), attrXY, baseZ, CH, CW,
-                               base_voxel_size, voxel_unit);
+                               output_z_voxel_size, output_yx_voxel_size, voxel_unit);
             }
         }
         return true;

--- a/volume-cartographer/core/include/vc/core/util/Zarr.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Zarr.hpp
@@ -86,7 +86,8 @@ void writeZarrAttrs(const std::filesystem::path& outFile,
                     size_t baseZ, double sliceStep, double accumStep,
                     const std::string& accumTypeStr, size_t accumSamples,
                     const cv::Size& canvasSize, size_t CZ, size_t CH, size_t CW,
-                    double baseVoxelSize = 1.0,
+                    double zVoxelSize = 1.0,
+                    double yxVoxelSize = 1.0,
                     const std::string& voxelUnit = "");
 
 // Write a dense uint8 ZYX subregion into a freshly created dataset via

--- a/volume-cartographer/core/src/Zarr.cpp
+++ b/volume-cartographer/core/src/Zarr.cpp
@@ -340,7 +340,7 @@ void writeZarrAttrs(const std::filesystem::path& outDir,
                     size_t baseZ, double sliceStep, double accumStep,
                     const std::string& accumTypeStr, size_t accumSamples,
                     const cv::Size& canvasSize, size_t CZ, size_t CH, size_t CW,
-                    double baseVoxelSize, const std::string& voxelUnit)
+                    double zVoxelSize, double yxVoxelSize, const std::string& voxelUnit)
 {
     Json attrs;
     attrs["source_zarr"] = volPath.string();
@@ -376,8 +376,8 @@ void writeZarrAttrs(const std::filesystem::path& outDir,
     ms["axes"] = std::move(axes);
     ms["datasets"] = Json::array();
     for (int l = 0; l <= 5; l++) {
-        const double sYX = baseVoxelSize * std::pow(2.0, l);
-        const double sZ = baseVoxelSize;
+        const double sYX = yxVoxelSize * std::pow(2.0, l);
+        const double sZ = zVoxelSize;
         Json scale_arr = Json::array();
         scale_arr.push_back(sZ); scale_arr.push_back(sYX); scale_arr.push_back(sYX);
         Json trans_arr = Json::array();

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -124,6 +124,10 @@ if(VC_RUN_E2E)
         ENVIRONMENT "VC_RUN_E2E=1;VC_MERGE_TIFXYZ_BIN=$<TARGET_FILE:vc_merge_tifxyz>")
 endif()
 
+add_executable(test_zarr_attrs test_zarr_attrs.cpp)
+target_link_libraries(test_zarr_attrs PRIVATE doctest::doctest vc_core)
+add_test(NAME test_zarr_attrs COMMAND test_zarr_attrs)
+
 add_executable(bench_volume_sample bench_volume_sample.cpp)
 target_link_libraries(bench_volume_sample PRIVATE doctest::doctest vc_core)
 # Bench has a generous wall-clock assertion; not part of default ctest

--- a/volume-cartographer/core/test/test_zarr_attrs.cpp
+++ b/volume-cartographer/core/test/test_zarr_attrs.cpp
@@ -1,0 +1,65 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "utils/Json.hpp"
+#include "vc/core/util/Zarr.hpp"
+
+#include <opencv2/core.hpp>
+
+#include <filesystem>
+#include <random>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct TmpDir {
+    fs::path path;
+
+    TmpDir()
+    {
+        std::random_device rd;
+        std::mt19937_64 rng(rd());
+        path = fs::temp_directory_path() / ("vc_zarr_attrs_" + std::to_string(rng()));
+        fs::create_directories(path);
+    }
+
+    ~TmpDir()
+    {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+}  // namespace
+
+TEST_CASE("writeZarrAttrs preserves anisotropic OME-Zarr physical scale")
+{
+    TmpDir dir;
+
+    writeZarrAttrs(
+        dir.path, "scan.zarr", 2,
+        5, 3.0, 0.0, "max", 0,
+        cv::Size(80, 40), 5, 16, 16,
+        23.73, 15.82, "micrometer");
+
+    const auto attrs = utils::Json::parse_file(dir.path / ".zattrs");
+    REQUIRE(attrs.contains("multiscales"));
+
+    const auto& multiscale = attrs["multiscales"][0];
+    CHECK(multiscale["axes"][0]["name"].get_string() == "z");
+    CHECK(multiscale["axes"][0]["unit"].get_string() == "micrometer");
+    CHECK(multiscale["axes"][1]["name"].get_string() == "y");
+    CHECK(multiscale["axes"][2]["name"].get_string() == "x");
+
+    const auto& level0Scale = multiscale["datasets"][0]["coordinateTransformations"][0]["scale"];
+    CHECK(level0Scale[0].get_double() == doctest::Approx(23.73));
+    CHECK(level0Scale[1].get_double() == doctest::Approx(15.82));
+    CHECK(level0Scale[2].get_double() == doctest::Approx(15.82));
+
+    const auto& level2Scale = multiscale["datasets"][2]["coordinateTransformations"][0]["scale"];
+    CHECK(level2Scale[0].get_double() == doctest::Approx(23.73));
+    CHECK(level2Scale[1].get_double() == doctest::Approx(63.28));
+    CHECK(level2Scale[2].get_double() == doctest::Approx(63.28));
+}


### PR DESCRIPTION
## Summary

Fixes OME-Zarr physical scale metadata written by `vc_render_tifxyz` so rendered output stores the actual physical spacing for the generated Z/Y/X axes.

## What changed

- `writeZarrAttrs` now accepts separate physical sizes for Z and Y/X instead of one isotropic base voxel size.
- `vc_render_tifxyz` computes output Y/X spacing from the selected source group and `--scale`.
- Rendered Z spacing uses `--slice-step` and remains unchanged across output pyramid levels.
- Pyramid metadata doubles only Y/X scale per downsampled output level.
- TIFF DPI uses the rendered Y/X pixel size.
- Added a focused doctest for anisotropic OME-Zarr scale metadata.

## Why

The previous metadata path used one base voxel size for all output axes and levels. That loses the distinction between:

- the source OME-Zarr group resolution,
- the render pixel scale,
- the rendered slice spacing along Z,
- and the Y/X-only downsampling applied to output pyramid levels.

This can make downstream OME-Zarr consumers interpret rendered volumes with the wrong physical scale.

## Validation

Rebased onto current `main` and ran in WSL2 Ubuntu 24.04:

```text
git diff --check origin/main...HEAD
cmake -S volume-cartographer -B volume-cartographer/build/wsl-vc-pr845 -GNinja -DCMAKE_BUILD_TYPE=Release -DVC_TESTING=ON -DLAPACKE_INCLUDE_DIRS=/usr/include -DLAPACKE_LIBRARIES=/usr/lib/x86_64-linux-gnu/liblapacke.so
cmake --build volume-cartographer/build/wsl-vc-pr845 --target vc_render_tifxyz test_zarr_attrs -j2
ctest --test-dir volume-cartographer/build/wsl-vc-pr845 -R '^test_zarr_attrs$' --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 1
```

The generated build directory was removed after verification.