### PR TITLE
Mirror overlap links in tracer growth

### DIFF
--- a/volume-cartographer/core/src/GrowSurface.cpp
+++ b/volume-cartographer/core/src/GrowSurface.cpp
@@ -1669,10 +1669,22 @@ static QuadSurface *grow_surf_from_surfs_impl(QuadSurface *seed,
     for(auto sm : approved_sm)
         std::cout << "approved: " << surface_name(sm) << std::endl;
 
-    for(auto &sm : surfs_v)
-        for(const auto& name : sm->overlappingIds())
-            if (surfs.contains(name))
-                overlaps[sm].insert(surfs[name]);
+    for(auto &sm : surfs_v) {
+        auto source_it = surfs.find(surface_name(sm));
+        if (source_it == surfs.end())
+            continue;
+
+        for(const auto& name : sm->overlappingIds()) {
+            auto target_it = surfs.find(name);
+            if (target_it == surfs.end())
+                continue;
+
+            QuadSurface* source = source_it->second;
+            QuadSurface* target = target_it->second;
+            overlaps[source].insert(target);
+            overlaps[target].insert(source);
+        }
+    }
 
     std::cout << "total surface count (after defective filter): " << surfs.size() << std::endl;
     std::cout << "seed " << seed << " name " << surface_name(seed) << " seed overlapping: "


### PR DESCRIPTION
## Summary

Makes tracer overlap handling more tolerant of one-sided overlap metadata.

## What changed

- When `grow_surf_from_surfs` builds its in-memory overlap map, each valid overlap is now recorded in both directions.
- The source and target surfaces are both resolved through the non-defective surface map before adding the edge.

## Why

`overlapping.json` metadata can be one-sided: surface A may list B while B does not list A. Tracer growth treats overlaps as traversal/candidate relationships, so losing the reverse edge can make approved or relevant neighboring patches unavailable when growth starts from the other side.

This keeps the on-disk metadata untouched and only hardens the runtime graph.

## Validation

Ran in WSL2 Ubuntu 24.04:

```text
cmake -S volume-cartographer -B build/wsl-issue373 -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DVC_BUILD_TESTS=OFF -DVC_WITH_CUDA_SPARSE=off
cmake --build build/wsl-issue373 --target vc_tracer -j8
cmake --build build/wsl-issue373 --target vc_grow_seg_from_segments -j8
./build/wsl-issue373/bin/vc_grow_seg_from_segments --help
```

Also ran:

```text
git diff --check
```
