### PR TITLE
Configure website Yarn node_modules linker

### DIFF
--- a/scrollprize.org/.gitignore
+++ b/scrollprize.org/.gitignore
@@ -1,6 +1,15 @@
 # Dependencies
 /node_modules
 
+# Yarn generated state
+/.yarn/*
+!/.yarn/patches
+!/.yarn/plugins
+!/.yarn/releases
+!/.yarn/sdks
+!/.yarn/versions
+/.pnp.*
+
 # Production
 /build
 

--- a/scrollprize.org/.yarnrc.yml
+++ b/scrollprize.org/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
## Summary

Configure the ScrollPrize website workspace to use Yarn's `node-modules` linker and ignore the Yarn state files generated by that install mode.

## Why

The repo pins Yarn 4.6.0 via `packageManager`, but in a clean local WSL2 install without a `.yarnrc.yml`, Yarn 4 used Plug'n'Play. In that local setup, the Docusaurus production build failed while resolving several peer/transitive imports used by the current dependency tree, including `@docusaurus/plugin-content-docs`, `katex/dist/katex.min.css`, and `vscode-languageserver-types`.

With `nodeLinker: node-modules`, the same lockfile installs and the Docusaurus production build completes. The PR also ignores generated Yarn state such as `.yarn/install-state.gz`, unplugged packages, and `.pnp.*`, while preserving the usual Yarn project directories if they are added later.

## Validation

Ran in WSL2 Ubuntu 24.04 from `scrollprize.org`:

```text
AGENTS_AGENT_MODE=1 AGENTS_ALLOW_INSTALL=1 yarn install --immutable
yarn build
```

Result:

```text
[SUCCESS] Generated static files in "build".
```

Notes:

- The install still reports the existing `@types/react` peer warning.
- Browserslist still reports stale caniuse-lite data. This PR does not change dependency versions or the lockfile.