### PR TITLE
Avoid mutating grow seed JSON params

### DIFF
--- a/volume-cartographer/apps/VC3D/CommandLineToolRunner.cpp
+++ b/volume-cartographer/apps/VC3D/CommandLineToolRunner.cpp
@@ -9,9 +9,11 @@
 #include <QTextStream>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonParseError>
 #include <QMessageBox>
 #include <QClipboard>
 #include <QApplication>
+#include <QTemporaryFile>
 
 
 
@@ -57,6 +59,15 @@ QString formatCommand(const QString& program, const QStringList& args, int ompTh
 
 } // namespace
 
+void CommandLineToolRunner::clearTemporaryJsonParams()
+{
+    if (_temporaryJsonParams.isEmpty()) {
+        return;
+    }
+    QFile::remove(_temporaryJsonParams);
+    _temporaryJsonParams.clear();
+}
+
 CommandLineToolRunner::CommandLineToolRunner(QStatusBar* statusBar, CWindow* mainWindow, QObject* parent)
     : QObject(parent)
     , _mainWindow(mainWindow)
@@ -86,6 +97,7 @@ CommandLineToolRunner::CommandLineToolRunner(QStatusBar* statusBar, CWindow* mai
 
 CommandLineToolRunner::~CommandLineToolRunner()
 {
+    clearTemporaryJsonParams();
     if (_process) {
         if (_process->state() != QProcess::NotRunning) {
             _process->terminate();
@@ -136,6 +148,7 @@ void CommandLineToolRunner::setGrowParams(QString volumePath, QString tgtDir, QS
     setVolumePath(volumePath);
     _tgtDir = tgtDir;
     _jsonParams = jsonParams;
+    clearTemporaryJsonParams();
     _seed_x = seed_x;
     _seed_y = seed_y;
     _seed_z = seed_z;
@@ -147,7 +160,11 @@ void CommandLineToolRunner::setGrowParams(QString volumePath, QString tgtDir, QS
         QByteArray jsonData = file.readAll();
         file.close();
 
-        QJsonDocument doc = QJsonDocument::fromJson(jsonData);
+        QJsonParseError parseError;
+        QJsonDocument doc = QJsonDocument::fromJson(jsonData, &parseError);
+        if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+            return;
+        }
         QJsonObject jsonObj = doc.object();
 
         if (useExpandMode) {
@@ -161,15 +178,20 @@ void CommandLineToolRunner::setGrowParams(QString volumePath, QString tgtDir, QS
         doc.setObject(jsonObj);
         jsonData = doc.toJson();
 
-        if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-            file.write(jsonData);
-            file.close();
+        QTemporaryFile tempFile(QDir::temp().filePath(QStringLiteral("vc_grow_params_XXXXXX.json")));
+        tempFile.setAutoRemove(false);
+        if (tempFile.open()) {
+            tempFile.write(jsonData);
+            tempFile.close();
+            _temporaryJsonParams = tempFile.fileName();
+            _jsonParams = _temporaryJsonParams;
         }
     }
 }
 
 void CommandLineToolRunner::setTraceParams(QString volumePath, QString srcDir, QString tgtDir, QString jsonParams, QString srcSegment)
 {
+    clearTemporaryJsonParams();
     setVolumePath(volumePath);
     _srcDir = srcDir;
     _tgtDir = tgtDir;
@@ -534,6 +556,7 @@ void CommandLineToolRunner::onProcessFinished(int exitCode, QProcess::ExitStatus
         delete _logFile;
         _logFile = nullptr;
     }
+    clearTemporaryJsonParams();
 
     _explicitVolumePath = false;
 
@@ -596,6 +619,7 @@ void CommandLineToolRunner::onProcessError(QProcess::ProcessError error)
         delete _logFile;
         _logFile = nullptr;
     }
+    clearTemporaryJsonParams();
 
     if (_progressUtil) _progressUtil->stopAnimation(tr("Process failed"));
 
@@ -781,6 +805,7 @@ void CommandLineToolRunner::setObjRefineParams(const QString& volumePath,
                                                const QString& dstSurface,
                                                const QString& jsonParams)
 {
+    clearTemporaryJsonParams();
     setVolumePath(volumePath);
     _segmentPath = srcSurface;
     _refineDst = dstSurface;
@@ -793,6 +818,7 @@ void CommandLineToolRunner::setNeighborCopyParams(const QString& volumePath,
                                                   const QString& outputDir,
                                                   const QString& resumeOpt)
 {
+    clearTemporaryJsonParams();
     setVolumePath(volumePath);
     _jsonParams = paramsJson;
     _resumeSurfacePath = resumeSurface;

--- a/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
+++ b/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
@@ -101,6 +101,7 @@ private:
     QStringList buildArguments(Tool tool);
     QString toolName(Tool tool) const;
     QString getOutputPath() const;
+    void clearTemporaryJsonParams();
 
     CWindow* _mainWindow;
     ProgressUtil* _progressUtil;
@@ -119,6 +120,7 @@ private:
     QString _tifxyzPath;
     QString _objPath;
     QString _jsonParams;
+    QString _temporaryJsonParams;
     QString _resumeSurfacePath;
     QString _resumeOpt;
     


### PR DESCRIPTION
## Summary

Stop `CommandLineToolRunner::setGrowParams` from rewriting the package `seed.json` / `expand.json` file when selecting the runtime grow mode.

## Why

The runner only needs to override `mode` for the command invocation. Previously it opened the source params file and wrote the modified object back to that same file, so running seed/expand actions from VC3D could mutate package configuration as a side effect.

This keeps the package JSON stable and passes a temporary runtime JSON file to `vc_grow_seg_from_seed` instead.

## What changed

- Parse and validate grow params as a JSON object before applying the runtime mode.
- Write the mode-adjusted params to a temporary file.
- Pass the temporary params path to the command.
- Clean up the temporary file when the process finishes, errors, the runner is destroyed, or another JSON-param command replaces it.

## Validation

- `git diff --check`
- `cmake --build build/wsl-issue373 --target VC3D -j2`