### PR TITLE
Add VC3D JSON params editor

### DIFF
--- a/volume-cartographer/apps/VC3D/CMakeLists.txt
+++ b/volume-cartographer/apps/VC3D/CMakeLists.txt
@@ -39,6 +39,8 @@ set(srcs
     elements/DropdownChecklistButton.hpp
     elements/JsonProfileEditor.cpp
     elements/JsonProfileEditor.hpp
+    elements/JsonFileEditorDialog.cpp
+    elements/JsonFileEditorDialog.hpp
     elements/LabeledControlRow.cpp
     elements/LabeledControlRow.hpp
     elements/VolumeSelector.cpp

--- a/volume-cartographer/apps/VC3D/SeedingWidget.cpp
+++ b/volume-cartographer/apps/VC3D/SeedingWidget.cpp
@@ -19,6 +19,7 @@
 #include <opencv2/imgproc.hpp>
 
 #include "vc/core/types/Segmentation.hpp"
+#include "elements/JsonFileEditorDialog.hpp"
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/Slicing.hpp"
@@ -195,6 +196,17 @@ void SeedingWidget::setupUI()
     expandSeedsButton->setEnabled(false);
     expandSeedsButton->setToolTip("Run seed expansion using expand.json");
     mainLayout->addWidget(expandSeedsButton);
+
+    auto paramsLayout = new QHBoxLayout();
+    editSeedParamsButton = new QPushButton("Edit seed.json", this);
+    editSeedParamsButton->setEnabled(false);
+    editSeedParamsButton->setToolTip("Edit seed.json in the current volume package");
+    paramsLayout->addWidget(editSeedParamsButton);
+    editExpandParamsButton = new QPushButton("Edit expand.json", this);
+    editExpandParamsButton->setEnabled(false);
+    editExpandParamsButton->setToolTip("Edit expand.json in the current volume package");
+    paramsLayout->addWidget(editExpandParamsButton);
+    mainLayout->addLayout(paramsLayout);
     
     resetPointsButton = new QPushButton("Reset Points", this);
     resetPointsButton->setEnabled(false);
@@ -332,6 +344,8 @@ void SeedingWidget::setupUI()
     connect(clearPeaksButton, &QPushButton::clicked, this, &SeedingWidget::onClearPeaksClicked);
     connect(runSegmentationButton, &QPushButton::clicked, this, &SeedingWidget::onRunSegmentationClicked);
     connect(expandSeedsButton, &QPushButton::clicked, this, &SeedingWidget::onExpandSeedsClicked);
+    connect(editSeedParamsButton, &QPushButton::clicked, this, &SeedingWidget::onEditSeedParamsClicked);
+    connect(editExpandParamsButton, &QPushButton::clicked, this, &SeedingWidget::onEditExpandParamsClicked);
     connect(resetPointsButton, &QPushButton::clicked, this, &SeedingWidget::onResetPointsClicked);
     connect(cancelButton, &QPushButton::clicked, this, &SeedingWidget::onCancelClicked);
     connect(labelWrapsButton, &QPushButton::clicked, [this]() {
@@ -1653,6 +1667,12 @@ void SeedingWidget::updateButtonStates()
     bool hasSegmentations = fVpkg && fVpkg->hasSegmentations();
     expandSeedsButton->setEnabled(currentVolume != nullptr && hasSegmentations);
 
+    const QString vpkgPath = fVpkg ? _state->vpkgPath() : QString();
+    editSeedParamsButton->setEnabled(!vpkgPath.isEmpty() &&
+                                     QFileInfo::exists(QDir(vpkgPath).filePath(QStringLiteral("seed.json"))));
+    editExpandParamsButton->setEnabled(!vpkgPath.isEmpty() &&
+                                       QFileInfo::exists(QDir(vpkgPath).filePath(QStringLiteral("expand.json"))));
+
     // Enable reset if we have any points or paths
     bool hasAnyData = hasAnyPoints || !paths.empty();
     resetPointsButton->setEnabled(hasAnyData);
@@ -1858,6 +1878,37 @@ void SeedingWidget::onExpandSeedsClicked()
     }
 
     progressUtil->stopProgress();
+}
+
+void SeedingWidget::onEditSeedParamsClicked()
+{
+    editGrowParamsFile(QStringLiteral("seed.json"));
+}
+
+void SeedingWidget::onEditExpandParamsClicked()
+{
+    editGrowParamsFile(QStringLiteral("expand.json"));
+}
+
+void SeedingWidget::editGrowParamsFile(const QString& fileName)
+{
+    if (!_state || !_state->vpkg()) {
+        QMessageBox::warning(this, tr("Error"), tr("No volume package loaded."));
+        return;
+    }
+
+    const QString filePath = QDir(_state->vpkgPath()).filePath(fileName);
+    if (!QFileInfo::exists(filePath)) {
+        QMessageBox::warning(this,
+                             tr("Error"),
+                             tr("%1 not found in the volume package.").arg(fileName));
+        return;
+    }
+
+    JsonFileEditorDialog dlg(filePath, tr("Edit %1").arg(fileName), this);
+    if (dlg.exec() == QDialog::Accepted) {
+        emit sendStatusMessageAvailable(tr("Saved %1").arg(fileName), 5000);
+    }
 }
 
 void SeedingWidget::onCancelClicked()

--- a/volume-cartographer/apps/VC3D/SeedingWidget.hpp
+++ b/volume-cartographer/apps/VC3D/SeedingWidget.hpp
@@ -59,6 +59,8 @@ private slots:
     void onClearPeaksClicked();
     void onRunSegmentationClicked();
     void onExpandSeedsClicked();
+    void onEditSeedParamsClicked();
+    void onEditExpandParamsClicked();
     void onResetPointsClicked();
     void onCancelClicked();
     void onNeuralTraceClicked();
@@ -95,6 +97,7 @@ private:
     void updatePointsDisplay();
     void updateInfoLabel();
     void updateButtonStates();
+    void editGrowParamsFile(const QString& fileName);
     
 private:
     
@@ -123,6 +126,8 @@ private:
     QPushButton* clearPeaksButton;
     QPushButton* runSegmentationButton;
     QPushButton* expandSeedsButton;
+    QPushButton* editSeedParamsButton;
+    QPushButton* editExpandParamsButton;
     QPushButton* resetPointsButton;
     QPushButton* cancelButton;
     QPushButton* labelWrapsButton;

--- a/volume-cartographer/apps/VC3D/elements/JsonFileEditorDialog.cpp
+++ b/volume-cartographer/apps/VC3D/elements/JsonFileEditorDialog.cpp
@@ -1,0 +1,95 @@
+#include "elements/JsonFileEditorDialog.hpp"
+
+#include "elements/JsonProfileEditor.hpp"
+
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSaveFile>
+#include <QVBoxLayout>
+
+JsonFileEditorDialog::JsonFileEditorDialog(const QString& filePath,
+                                           const QString& title,
+                                           QWidget* parent)
+    : QDialog(parent)
+    , _filePath(filePath)
+{
+    setWindowTitle(title);
+    resize(720, 640);
+
+    auto* layout = new QVBoxLayout(this);
+
+    _editor = new JsonProfileEditor(QFileInfo(filePath).fileName(), this);
+    _editor->setDescription(tr("Edit and save this JSON file in the current volume package."));
+    _editor->setPlaceholderText(tr("{\n  \"key\": \"value\"\n}"));
+    _editor->setTextToolTip(filePath);
+    _editor->setProfiles({}, QStringLiteral("custom"));
+
+    QFile file(filePath);
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        _editor->setCustomText(QString::fromUtf8(file.readAll()));
+    } else {
+        _editor->setCustomText(QString());
+        QMessageBox::warning(this,
+                             tr("Error"),
+                             tr("Could not read %1:\n%2")
+                                 .arg(QDir::toNativeSeparators(filePath), file.errorString()));
+    }
+
+    layout->addWidget(_editor);
+
+    _buttons = new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel, this);
+    connect(_buttons, &QDialogButtonBox::accepted, this, &JsonFileEditorDialog::accept);
+    connect(_buttons, &QDialogButtonBox::rejected, this, &JsonFileEditorDialog::reject);
+    connect(_editor, &JsonProfileEditor::textChanged, this, &JsonFileEditorDialog::updateOkButton);
+    layout->addWidget(_buttons);
+
+    updateOkButton();
+}
+
+void JsonFileEditorDialog::accept()
+{
+    QString error;
+    const auto json = _editor->jsonObject(&error);
+    if (!json) {
+        QMessageBox::warning(this, tr("Invalid JSON"), error);
+        updateOkButton();
+        return;
+    }
+
+    QSaveFile file(_filePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QMessageBox::warning(this,
+                             tr("Error"),
+                             tr("Could not write %1:\n%2")
+                                 .arg(QDir::toNativeSeparators(_filePath), file.errorString()));
+        return;
+    }
+
+    file.write(QJsonDocument(*json).toJson(QJsonDocument::Indented));
+    if (!file.commit()) {
+        QMessageBox::warning(this,
+                             tr("Error"),
+                             tr("Could not save %1:\n%2")
+                                 .arg(QDir::toNativeSeparators(_filePath), file.errorString()));
+        return;
+    }
+
+    QDialog::accept();
+}
+
+void JsonFileEditorDialog::updateOkButton()
+{
+    if (!_buttons) {
+        return;
+    }
+
+    auto* button = _buttons->button(QDialogButtonBox::Save);
+    if (button) {
+        button->setEnabled(_editor && _editor->isValid() && !_editor->currentText().trimmed().isEmpty());
+    }
+}

--- a/volume-cartographer/apps/VC3D/elements/JsonFileEditorDialog.hpp
+++ b/volume-cartographer/apps/VC3D/elements/JsonFileEditorDialog.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QDialog>
+#include <QString>
+
+class JsonProfileEditor;
+class QDialogButtonBox;
+
+class JsonFileEditorDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit JsonFileEditorDialog(const QString& filePath,
+                                  const QString& title,
+                                  QWidget* parent = nullptr);
+
+private slots:
+    void accept() override;
+
+private:
+    void updateOkButton();
+
+    QString _filePath;
+    JsonProfileEditor* _editor{nullptr};
+    QDialogButtonBox* _buttons{nullptr};
+};


### PR DESCRIPTION
## Summary

Adds an in-app VC3D editor for grow parameter files so users can edit `seed.json` and `expand.json` from the Seeding panel without leaving the interface.

Refs #478 for the `seed.json` / `expand.json` part of the request. This PR does not claim to add a new `trace_params.json` editor path; see the notes below.

## What changed

- Added a reusable `JsonFileEditorDialog` built on the existing `JsonProfileEditor`.
- The dialog loads the target JSON file, validates that the edited content is a JSON object, and saves with `QSaveFile` for atomic replacement.
- Added `Edit seed.json` and `Edit expand.json` buttons to the Seeding widget.
- Buttons are enabled only when the current volume package contains the corresponding file.

## Notes

After rebasing onto current `main`, this PR intentionally keeps the integration narrower than the original version. The newer segmentation UI already has custom/profile parameter handling for tracer params, and the old surface context-menu grow-seed runner path no longer exists on `main`; this patch avoids reintroducing that obsolete command path.

## Validation

Ran in WSL2 Ubuntu 24.04:

```text
git diff --check origin/main...HEAD
cmake -S . -B build/wsl-vc-pr850-lapacke -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVC_TESTING=OFF -DLAPACKE_PREFIX=/usr -DLAPACKE_INCLUDE_DIRS=/usr/include -DLAPACKE_LIBRARIES=/usr/lib/x86_64-linux-gnu/liblapacke.so
cmake --build build/wsl-vc-pr850-lapacke --target VC3D -j2
```

The build completed `168/168` and linked `bin/VC3D`. The generated build directory was removed after verification.