### PR TITLE
Refresh tutorial reading goal wording

### DIFF
--- a/scrollprize.org/docs/03_tutorial.md
+++ b/scrollprize.org/docs/03_tutorial.md
@@ -61,7 +61,7 @@ Here is an excellent 2 minute overview of how this was achieved:
 
 <iframe className="w-[100%] aspect-video mb-4" src="https://www.youtube.com/embed/GduCExxB0vw" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen/>
 
-For the Herculaneum papyri, many of the same steps apply, with one key change - the ink is much less readily visible. There is much room for improvement in each step of the pipeline: We can currently only read 5% of a complete scroll. We would like to read 90% in 2024. That is your goal!
+For the Herculaneum papyri, many of the same steps apply, with one key change - the ink is much less readily visible. There is still room for improvement in each step of the pipeline as the project scales from isolated readable passages toward broad, reliable scroll reading. Current milestones and prize criteria are maintained on the [Prizes](prizes) page.
 
 
 Let's go through each of the key steps one by one.


### PR DESCRIPTION
## Summary

Updates an outdated line in the introductory tutorial that still framed the goal as reading 90% of a complete scroll "in 2024".

## What changed

- Replaced the dated 2024 target wording with evergreen language about scaling from isolated readable passages toward broad, reliable scroll reading.
- Linked readers to the maintained Prizes page for current milestones and criteria.

## Why

Issue #199 tracks stale website/documentation content. This keeps the tutorial accurate without changing historical announcement or winners pages.

## Validation

Ran in WSL2 Ubuntu 24.04 from `scrollprize.org`:

```text
AGENTS_AGENT_MODE=1 AGENTS_ALLOW_INSTALL=1 YARN_NODE_LINKER=node-modules yarn install --immutable
YARN_NODE_LINKER=node-modules yarn build
```

Result:

```text
[SUCCESS] Generated static files in "build".
```

Notes:

- Install completed from the existing cache/fetch path with the existing `@types/react` peer warning.
- Build still reports stale Browserslist/caniuse-lite data, unchanged by this PR.