### PR TITLE
Accept /volpkgs as fast cache root in addition to /ephemeral

### DIFF
--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -6,18 +6,21 @@
 
 namespace vc3d {
 
-// Prefer /ephemeral/VC3D when the host has local NVMe instance storage
-// mounted there (see scripts/build_dependencies.sh); fall back to ~/.VC3D.
+// Prefer fast local storage when available — /ephemeral (NVMe instance store
+// set up by scripts/build_dependencies.sh) or /volpkgs (manually-mounted
+// scratch volume), whichever exists first. Fall back to ~/.VC3D.
 // Cached on first call because filesystem state doesn't change during a run.
 inline QString defaultCacheBase()
 {
     static const QString base = []() {
-        const QString eph = QStringLiteral("/ephemeral");
-        QFileInfo fi(eph);
-        if (fi.isDir() && fi.isWritable()) {
-            QString p = eph + "/VC3D";
-            QDir().mkpath(p);
-            return p;
+        for (const QString& root : {QStringLiteral("/ephemeral"),
+                                    QStringLiteral("/volpkgs")}) {
+            QFileInfo fi(root);
+            if (fi.isDir() && fi.isWritable()) {
+                QString p = root + "/VC3D";
+                QDir().mkpath(p);
+                return p;
+            }
         }
         return QDir::homePath() + "/.VC3D";
     }();


### PR DESCRIPTION
## Summary

`vc3d::defaultCacheBase()` previously only looked at `/ephemeral` (the NVMe instance-store mount set up by `scripts/build_dependencies.sh`) and fell back to `~/.VC3D` otherwise. Some hosts mount their scratch volume at `/volpkgs` instead. Treat both as candidate roots — walk `/ephemeral` first, then `/volpkgs`, and use whichever is a writable directory; otherwise fall back to `~/.VC3D`.

## Test plan

- [x] Builds clean
- [ ] On a host with `/volpkgs` mounted but no `/ephemeral`: cache lands under `/volpkgs/VC3D/remote_cache`
- [ ] On a host with `/ephemeral` mounted: behavior unchanged, cache still lands under `/ephemeral/VC3D/remote_cache`
- [ ] On a host with neither: falls back to `~/.VC3D/remote_cache`