### PR TITLE
EC2 build_dependencies fixes + EC2 IAM-role auth + crash-handler hardening

### DIFF
--- a/volume-cartographer/scripts/build_dependencies.sh
+++ b/volume-cartographer/scripts/build_dependencies.sh
@@ -185,14 +185,18 @@ if [[ "$MODE" == "root" ]]; then
   popd >/dev/null
 
   # ---- xpra (from xpra.org apt repo — matches distro Python) --------------
-  # We don't build from source because xpra master uses Python APIs (e.g.
-  # PyMemoryView_CheckExact) newer than noble's Python 3.12 — the lz4 .so
-  # builds with warnings and fails at runtime with "undefined symbol".
-  # xpra.org ships prebuilt packages compiled against each distro's Python.
-  log "xpra: add xpra.org apt repo and install"
+  # On noble (24.04) we pull the beta channel for newer xpra; otherwise we
+  # fall back to the stable noble repo (works on hosts with Python 3.12).
+  . /etc/os-release
+  if [[ "${VERSION_CODENAME:-}" == "noble" ]]; then
+    XPRA_REPO="https://xpra.org/beta/"
+  else
+    XPRA_REPO="https://xpra.org/"
+  fi
+  log "xpra: add xpra apt repo ($XPRA_REPO) and install"
   install -d -m 0755 /usr/share/keyrings
   wget -qO- https://xpra.org/xpra.asc | gpg --dearmor > /usr/share/keyrings/xpra.gpg
-  echo "deb [signed-by=/usr/share/keyrings/xpra.gpg] https://xpra.org/ noble main" \
+  echo "deb [signed-by=/usr/share/keyrings/xpra.gpg] $XPRA_REPO noble main" \
     > /etc/apt/sources.list.d/xpra.list
   apt-get update
   apt-get install -y -o Dpkg::Options::="--force-confnew" xpra xpra-codecs xvfb

--- a/volume-cartographer/scripts/build_dependencies.sh
+++ b/volume-cartographer/scripts/build_dependencies.sh
@@ -184,22 +184,30 @@ if [[ "$MODE" == "root" ]]; then
   make install SCOTCH_HOME=/usr/local/scotch
   popd >/dev/null
 
-  # ---- xpra (from xpra.org apt repo — matches distro Python) --------------
-  # On noble (24.04) we pull the beta channel for newer xpra; otherwise we
-  # fall back to the stable noble repo (works on hosts with Python 3.12).
-  . /etc/os-release
-  if [[ "${VERSION_CODENAME:-}" == "noble" ]]; then
-    XPRA_REPO="https://xpra.org/beta/"
-  else
-    XPRA_REPO="https://xpra.org/"
-  fi
-  log "xpra: add xpra apt repo ($XPRA_REPO) and install"
-  install -d -m 0755 /usr/share/keyrings
-  wget -qO- https://xpra.org/xpra.asc | gpg --dearmor > /usr/share/keyrings/xpra.gpg
-  echo "deb [signed-by=/usr/share/keyrings/xpra.gpg] $XPRA_REPO noble main" \
-    > /etc/apt/sources.list.d/xpra.list
-  apt-get update
-  apt-get install -y -o Dpkg::Options::="--force-confnew" xpra xpra-codecs xvfb
+  # ---- xpra (build from source — works on any distro/python) -------------
+  log "xpra: install build deps + build from source"
+  apt-get install -y --no-install-recommends \
+    python3-dev python3-pip python3-setuptools python3-wheel cython3 \
+    libcairo2-dev libgirepository-2.0-dev \
+    libgtk-3-dev gir1.2-gtk-3.0 \
+    python3-gi python3-cairo python3-gi-cairo python3-pil \
+    libxres-dev libxtst-dev libxkbfile-dev \
+    libxcb1-dev libxcb-render0-dev libxcb-randr0-dev libxcb-shape0-dev \
+    libxcb-composite0-dev libxcb-damage0-dev libxcb-keysyms1-dev \
+    libxcb-cursor-dev libxcb-image0-dev libxcb-xfixes0-dev \
+    libavcodec-dev libavformat-dev libswscale-dev libavutil-dev libavfilter-dev \
+    libvpx-dev libwebp-dev libturbojpeg0-dev libyuv-dev \
+    libpulse-dev gstreamer1.0-plugins-base python3-gst-1.0 \
+    libdbus-1-dev libdbus-glib-1-dev python3-dbus \
+    libpam0g-dev libsystemd-dev \
+    xvfb
+
+  XPRA_SRC=/tmp/xpra
+  rm -rf "$XPRA_SRC"
+  git clone --depth 1 https://github.com/Xpra-org/xpra.git "$XPRA_SRC"
+  pushd "$XPRA_SRC" >/dev/null
+  python3 -m pip install --break-system-packages .
+  popd >/dev/null
   log "xpra installed: $(command -v xpra)"
 
   log "ROOT pass complete. Next: run WITHOUT sudo to build VC3D."

--- a/volume-cartographer/scripts/build_dependencies.sh
+++ b/volume-cartographer/scripts/build_dependencies.sh
@@ -209,6 +209,11 @@ if [[ "$MODE" == "root" ]]; then
   pushd "$XPRA_SRC" >/dev/null
   python3 setup.py build_ext -j"$JOBS"
   python3 setup.py install
+  # setup.py install drops broken pkg_resources wrappers in /usr/local/bin
+  # (dist-info has no entry_points.txt). Replace with the real scripts that
+  # setup.py shipped in the .egg.
+  EGG_SCRIPTS=$(echo /usr/local/lib/python3.*/dist-packages/xpra-*.egg)/EGG-INFO/scripts
+  install -m 0755 "$EGG_SCRIPTS"/* /usr/local/bin/
   popd >/dev/null
   log "xpra installed: $(command -v xpra)"
 

--- a/volume-cartographer/scripts/build_dependencies.sh
+++ b/volume-cartographer/scripts/build_dependencies.sh
@@ -179,6 +179,7 @@ if [[ "$MODE" == "root" ]]; then
   pushd "$PASTIX_SRC/src" >/dev/null
   cp "$LIBS_DIR/config.in" config.in
   sed -i -E "s|^SCOTCH_HOME[[:space:]]*=.*$|SCOTCH_HOME = /usr/local/scotch|" config.in
+  sed -i -E 's|^(CCFOPT[[:space:]]*=[[:space:]]*-O3.*)$|\1 -std=gnu89 -fpermissive -Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types -Wno-error=int-conversion -Wno-error=implicit-int|' config.in
   make SCOTCH_HOME=/usr/local/scotch
   make install SCOTCH_HOME=/usr/local/scotch
   popd >/dev/null

--- a/volume-cartographer/scripts/build_dependencies.sh
+++ b/volume-cartographer/scripts/build_dependencies.sh
@@ -190,7 +190,8 @@ if [[ "$MODE" == "root" ]]; then
     python3-dev python3-pip python3-setuptools python3-wheel cython3 \
     libcairo2-dev libgirepository-2.0-dev \
     libgtk-3-dev gir1.2-gtk-3.0 \
-    python3-gi python3-cairo python3-gi-cairo python3-pil \
+    python3-gi python-gi-dev python3-cairo python3-cairo-dev python3-gi-cairo python3-pil \
+    libxxhash-dev libbrotli-dev liblz4-dev \
     libxres-dev libxtst-dev libxkbfile-dev \
     libxcb1-dev libxcb-render0-dev libxcb-randr0-dev libxcb-shape0-dev \
     libxcb-composite0-dev libxcb-damage0-dev libxcb-keysyms1-dev \
@@ -206,7 +207,8 @@ if [[ "$MODE" == "root" ]]; then
   rm -rf "$XPRA_SRC"
   git clone --depth 1 https://github.com/Xpra-org/xpra.git "$XPRA_SRC"
   pushd "$XPRA_SRC" >/dev/null
-  python3 -m pip install --break-system-packages .
+  python3 setup.py build_ext -j"$JOBS"
+  python3 setup.py install
   popd >/dev/null
   log "xpra installed: $(command -v xpra)"
 

--- a/volume-cartographer/scripts/build_dependencies.sh
+++ b/volume-cartographer/scripts/build_dependencies.sh
@@ -111,14 +111,6 @@ if [[ "$MODE" == "root" ]]; then
     log "Ephemeral: /ephemeral already mounted; skipping"
   fi
 
-  log "apt: pin xtl 0.7.7 + xtensor 0.25"
-  tmpd="$(mktemp -d)"; pushd "$tmpd" >/dev/null
-  wget -q http://archive.ubuntu.com/ubuntu/pool/universe/x/xtl/xtl-dev_0.7.7-1_all.deb
-  wget -q http://archive.ubuntu.com/ubuntu/pool/universe/x/xtensor/libxtensor-dev_0.25.0-2ubuntu1_all.deb
-  apt-get install -y --no-install-recommends ./xtl-dev_0.7.7-1_all.deb ./libxtensor-dev_0.25.0-2ubuntu1_all.deb
-  apt-mark hold xtl-dev libxtensor-dev
-  popd >/dev/null; rm -rf "$tmpd"
-
   # ---- CUDA path: cuDSS + Ceres-from-source --------------------------------
   if [[ "$USE_CUDA" == "1" ]]; then
     log "apt: CUDA toolkit"
@@ -172,6 +164,7 @@ if [[ "$MODE" == "root" ]]; then
   tar -xzf "$LIBS_DIR/scotch_6.0.4.tar.gz" -C "$SCOTCH_SRC" --strip-components=1
   pushd "$SCOTCH_SRC/src" >/dev/null
   cp ./Make.inc/Makefile.inc.x86-64_pc_linux2 Makefile.inc
+  sed -i -E 's|^(CFLAGS[[:space:]]*=.*)$|\1 -std=gnu89 -fpermissive|' Makefile.inc
   make -j"$JOBS" scotch
   mkdir -p /usr/local/scotch/{bin,include,lib,share/man/man1}
   make prefix=/usr/local/scotch install
@@ -229,26 +222,6 @@ fi
 
 rm -rf "$BUILD_DIR" "$INSTALL_PREFIX"
 mkdir -p "$BUILD_DIR" "$INSTALL_PREFIX"
-
-# ---- z5 --------------------------------------------------------------------
-log "z5 → $INSTALL_PREFIX"
-pushd "$BUILD_DIR" >/dev/null
-git clone https://github.com/constantinpape/z5.git z5
-pushd z5 >/dev/null
-Z5_COMMIT=ee2081bb974fe0d0d702538400c31c38b09f1629
-git fetch origin "$Z5_COMMIT" --depth 1
-git checkout --detach "$Z5_COMMIT"
-sed -i 's|xtensor/containers/xadapt.hpp|xtensor/xadapt.hpp|' \
-  include/z5/multiarray/xtensor_util.hxx || true
-popd >/dev/null
-cmake -S z5 -B z5/build -G Ninja \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
-  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-  -DWITH_BLOSC=ON -DWITH_ZLIB=ON -DBUILD_Z5PY=OFF -DBUILD_TESTS=OFF
-cmake --build z5/build -j"$JOBS"
-cmake --install z5/build
-popd >/dev/null
 
 # ---- libigl + Flatboi ------------------------------------------------------
 log "libigl clone (pinned)"

--- a/volume-cartographer/utils/src/aws_auth.cpp
+++ b/volume-cartographer/utils/src/aws_auth.cpp
@@ -4,6 +4,8 @@
 
 #include "utils/Json.hpp"
 
+#include <curl/curl.h>
+
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
@@ -181,6 +183,85 @@ AwsAuth AwsAuth::load(const std::string& profile)
     if (auth.secret_key.empty())    auth.secret_key = getEnv("AWS_SECRET_ACCESS_KEY");
     if (auth.session_token.empty()) auth.session_token = getEnv("AWS_SESSION_TOKEN");
     if (auth.region.empty())        auth.region = getEnv("AWS_DEFAULT_REGION");
+
+    // Method 4: EC2 instance metadata service (IMDSv2) — picks up an attached
+    // IAM role automatically with no other config required.
+    if (auth.access_key.empty() || auth.secret_key.empty()) {
+        auto curlReq = [](const std::string& url, const std::string& method,
+                          const std::vector<std::string>& headers, std::string& body) -> long {
+            CURL* c = curl_easy_init();
+            if (!c) return -1;
+            curl_easy_setopt(c, CURLOPT_URL, url.c_str());
+            curl_easy_setopt(c, CURLOPT_TIMEOUT, 2L);
+            curl_easy_setopt(c, CURLOPT_CONNECTTIMEOUT, 1L);
+            curl_easy_setopt(c, CURLOPT_NOSIGNAL, 1L);
+            curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,
+                +[](char* p, size_t s, size_t n, void* ud) -> size_t {
+                    static_cast<std::string*>(ud)->append(p, s * n);
+                    return s * n;
+                });
+            curl_easy_setopt(c, CURLOPT_WRITEDATA, &body);
+            if (method == "PUT") {
+                curl_easy_setopt(c, CURLOPT_CUSTOMREQUEST, "PUT");
+                curl_easy_setopt(c, CURLOPT_POSTFIELDS, "");
+                curl_easy_setopt(c, CURLOPT_POSTFIELDSIZE, 0L);
+            }
+            curl_slist* hl = nullptr;
+            for (auto& h : headers) hl = curl_slist_append(hl, h.c_str());
+            if (hl) curl_easy_setopt(c, CURLOPT_HTTPHEADER, hl);
+            CURLcode res = curl_easy_perform(c);
+            long status = 0;
+            if (res == CURLE_OK) curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &status);
+            if (hl) curl_slist_free_all(hl);
+            curl_easy_cleanup(c);
+            return res == CURLE_OK ? status : -1;
+        };
+
+        fprintf(stderr, "[AWS] trying EC2 IMDSv2\n");
+        std::string token;
+        long st = curlReq("http://169.254.169.254/latest/api/token", "PUT",
+                          {"X-aws-ec2-metadata-token-ttl-seconds: 60"}, token);
+        if (st == 200 && !token.empty()) {
+            std::string role;
+            st = curlReq("http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+                         "GET", {"X-aws-ec2-metadata-token: " + token}, role);
+            while (!role.empty() && (role.back() == '\n' || role.back() == '\r'))
+                role.pop_back();
+            if (st == 200 && !role.empty()) {
+                std::string credsJson;
+                st = curlReq("http://169.254.169.254/latest/meta-data/iam/security-credentials/" + role,
+                             "GET", {"X-aws-ec2-metadata-token: " + token}, credsJson);
+                if (st == 200 && !credsJson.empty()) {
+                    try {
+                        auto j = Json::parse(credsJson);
+                        if (j.contains("AccessKeyId") && j.contains("SecretAccessKey")) {
+                            auth.access_key  = j["AccessKeyId"].get_string();
+                            auth.secret_key  = j["SecretAccessKey"].get_string();
+                            if (j.contains("Token"))
+                                auth.session_token = j["Token"].get_string();
+                            fprintf(stderr, "[AWS] IMDS role '%s' creds loaded (key=%s...)\n",
+                                role.c_str(), auth.access_key.substr(0, 8).c_str());
+                        }
+                    } catch (...) {
+                        fprintf(stderr, "[AWS] IMDS creds JSON parse failed\n");
+                    }
+                }
+            } else {
+                fprintf(stderr, "[AWS] IMDS no role attached (status=%ld)\n", st);
+            }
+
+            if (auth.region.empty()) {
+                std::string region;
+                long rst = curlReq("http://169.254.169.254/latest/meta-data/placement/region",
+                                   "GET", {"X-aws-ec2-metadata-token: " + token}, region);
+                while (!region.empty() && (region.back() == '\n' || region.back() == '\r'))
+                    region.pop_back();
+                if (rst == 200 && !region.empty()) auth.region = region;
+            }
+        } else {
+            fprintf(stderr, "[AWS] IMDS unavailable (token status=%ld)\n", st);
+        }
+    }
 
     fprintf(stderr, "[AWS] FINAL: key=%s... secret=%s token=%s region=%s\n",
         auth.access_key.empty() ? "(empty)" : auth.access_key.substr(0, 8).c_str(),


### PR DESCRIPTION
## Summary

Three threads bundled here, all needed to bring up VC3D on a fresh EC2 box (Ubuntu 26.04 / Python 3.14 / gcc 15 / aarch64):

### `scripts/build_dependencies.sh`
- Drop the xtl / xtensor pin block and the z5 build entirely — both are no longer used (replaced by `core/include/vc/core/types/Array3D.hpp` and `VcDataset.hpp` respectively).
- Inject `-std=gnu89 -fpermissive` into Scotch 6.0.4's `Makefile.inc` so its K&R-style function-pointer declarations (`int (* archSave) ();`) keep compiling on gcc 14+.
- Inject `-std=gnu89 -fpermissive -Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types -Wno-error=int-conversion -Wno-error=implicit-int` into PaStiX 5.2.3's `CCFOPT` for the same reason.
- Replace the xpra apt-repo install with a from-source build of Xpra-org/xpra master. The xpra.org repos only ship per-codename, per-Python builds and don't satisfy resolute / Python 3.14. Build extensions in parallel via `setup.py build_ext -j$JOBS`. After `setup.py install` copy the real launcher scripts from the `.egg`'s `EGG-INFO/scripts/` over the broken `pkg_resources` easy-install stubs in `/usr/local/bin/`.
- Add the apt build-deps xpra needs (python-gi-dev, python3-cairo-dev, libxxhash-dev, libbrotli-dev, etc.).

### `utils/src/aws_auth.cpp`
- Add EC2 IMDSv2 as a final tier in `AwsAuth::load()`. Previous chain only knew about `aws configure export-credentials`, `~/.aws/credentials`, and `AWS_*` env vars — none of which discover an attached EC2 instance role. Now an instance with a role attached just works, with no AWS CLI install or credentials file required. Also pulls region from `/latest/meta-data/placement/region` when not set elsewhere.

### `core/src/CrashHandler.cpp`
- Wrap the libgcc/libbacktrace unwinder call in a `sigjmp_buf` so a re-faulting unwinder (PC corrupt → unwind-table lookup at a bogus address) doesn't take the crash handler down with it. The manual frame-pointer walk already covers that case; this just stops the secondary fault from killing the dump.

## Test plan

- [x] Root + user pass of `build_dependencies.sh` complete on a fresh `m8gd.2xlarge` aarch64 resolute EC2 with `forrest-s3-worker` IAM profile attached.
- [x] All 48 binaries build (`build/bin/VC3D` etc.).
- [x] xpra serves VC3D over SSH to a local Wayland client.
- [ ] Verify IMDS fallback: open `s3://philodemos/forrest/paris4_c3d_r50.zarr/` from the running VC3D with no AWS CLI installed and no `~/.aws/credentials` (in progress).
- [ ] Smoke-test the crash handler siglongjmp path (synthetic PC corruption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)