### PR TITLE
vc: add bring-your-own-buffer variants of chunk reading at various levels of APIs

### DIFF
--- a/volume-cartographer/core/include/vc/core/types/Volume.hpp
+++ b/volume-cartographer/core/include/vc/core/types/Volume.hpp
@@ -212,6 +212,18 @@ public:
     [[nodiscard]] std::optional<std::vector<std::byte>> readChunk(
         int level,
         const std::array<size_t, 3>& chunkZYX) const;
+    // Decompress directly into a caller-owned scratch buffer (must be
+    // sized to chunkByteSize(level)). Returns false when the chunk is
+    // missing on disk; otherwise writes exactly chunkByteSize(level)
+    // bytes into `output` and returns true. Avoids the per-call heap
+    // allocation that readChunk() performs.
+    [[nodiscard]] bool readChunkInto(
+        int level,
+        const std::array<size_t, 3>& chunkZYX,
+        std::span<std::byte> output) const;
+    // Byte size of one decompressed chunk at the given level (matches
+    // what readChunk returns and what readChunkInto requires).
+    [[nodiscard]] size_t chunkByteSize(int level) const;
     [[nodiscard]] std::vector<std::byte> readChunkOrFill(
         int level,
         const std::array<size_t, 3>& chunkZYX) const;

--- a/volume-cartographer/core/src/VcDataset.cpp
+++ b/volume-cartographer/core/src/VcDataset.cpp
@@ -174,8 +174,8 @@ void lz4DecompressInto(std::span<const std::byte> input, std::span<std::byte> ou
 
     uint32_t originalSize = 0;
     std::memcpy(&originalSize, input.data(), sizeof(originalSize));
-    if (originalSize > output.size()) {
-        throw std::runtime_error("LZ4 original size exceeds output buffer");
+    if (originalSize != output.size()) {
+        throw std::runtime_error("LZ4 original size does not match output buffer");
     }
 
     const int rc = LZ4_decompress_safe(
@@ -185,6 +185,9 @@ void lz4DecompressInto(std::span<const std::byte> input, std::span<std::byte> ou
         checkedInt(originalSize, "LZ4 output"));
     if (rc < 0) {
         throw std::runtime_error("LZ4_decompress_safe failed");
+    }
+    if (static_cast<size_t>(rc) != output.size()) {
+        throw std::runtime_error("LZ4_decompress_safe produced unexpected byte count");
     }
 }
 

--- a/volume-cartographer/core/src/VcDataset.cpp
+++ b/volume-cartographer/core/src/VcDataset.cpp
@@ -94,20 +94,24 @@ std::vector<std::byte> bloscCompress(std::span<const std::byte> input,
     return output;
 }
 
-std::vector<std::byte> bloscDecompress(std::span<const std::byte> input, size_t outputSize)
+void bloscDecompressInto(std::span<const std::byte> input, std::span<std::byte> output)
 {
     ensureBloscInitialized();
-
-    std::vector<std::byte> output(outputSize);
-    const int rc = blosc_decompress_ctx(input.data(), output.data(), outputSize,
+    const int rc = blosc_decompress_ctx(input.data(), output.data(), output.size(),
                                         /*nthreads=*/1);
     if (rc < 0) {
-        if (input.size() == outputSize) {
-            std::memcpy(output.data(), input.data(), outputSize);
-            return output;
+        if (input.size() == output.size()) {
+            std::memcpy(output.data(), input.data(), output.size());
+            return;
         }
         throw std::runtime_error("blosc_decompress_ctx failed with code " + std::to_string(rc));
     }
+}
+
+std::vector<std::byte> bloscDecompress(std::span<const std::byte> input, size_t outputSize)
+{
+    std::vector<std::byte> output(outputSize);
+    bloscDecompressInto(input, output);
     return output;
 }
 
@@ -123,16 +127,21 @@ std::vector<std::byte> zstdCompress(std::span<const std::byte> input, const Comp
     return output;
 }
 
-std::vector<std::byte> zstdDecompress(std::span<const std::byte> input, size_t outputSize)
+void zstdDecompressInto(std::span<const std::byte> input, std::span<std::byte> output)
 {
-    std::vector<std::byte> output(outputSize);
-    const size_t rc = ZSTD_decompress(output.data(), outputSize, input.data(), input.size());
+    const size_t rc = ZSTD_decompress(output.data(), output.size(), input.data(), input.size());
     if (ZSTD_isError(rc)) {
         throw std::runtime_error(std::string("ZSTD_decompress failed: ") + ZSTD_getErrorName(rc));
     }
-    if (rc != outputSize) {
+    if (rc != output.size()) {
         throw std::runtime_error("ZSTD_decompress returned unexpected byte count");
     }
+}
+
+std::vector<std::byte> zstdDecompress(std::span<const std::byte> input, size_t outputSize)
+{
+    std::vector<std::byte> output(outputSize);
+    zstdDecompressInto(input, output);
     return output;
 }
 
@@ -157,7 +166,7 @@ std::vector<std::byte> lz4Compress(std::span<const std::byte> input, const Compr
     return output;
 }
 
-std::vector<std::byte> lz4Decompress(std::span<const std::byte> input, size_t outputSize)
+void lz4DecompressInto(std::span<const std::byte> input, std::span<std::byte> output)
 {
     if (input.size() < sizeof(uint32_t)) {
         throw std::runtime_error("LZ4 compressed data too short");
@@ -165,11 +174,10 @@ std::vector<std::byte> lz4Decompress(std::span<const std::byte> input, size_t ou
 
     uint32_t originalSize = 0;
     std::memcpy(&originalSize, input.data(), sizeof(originalSize));
-    if (originalSize > outputSize) {
+    if (originalSize > output.size()) {
         throw std::runtime_error("LZ4 original size exceeds output buffer");
     }
 
-    std::vector<std::byte> output(outputSize);
     const int rc = LZ4_decompress_safe(
         reinterpret_cast<const char*>(input.data() + sizeof(uint32_t)),
         reinterpret_cast<char*>(output.data()),
@@ -178,6 +186,12 @@ std::vector<std::byte> lz4Decompress(std::span<const std::byte> input, size_t ou
     if (rc < 0) {
         throw std::runtime_error("LZ4_decompress_safe failed");
     }
+}
+
+std::vector<std::byte> lz4Decompress(std::span<const std::byte> input, size_t outputSize)
+{
+    std::vector<std::byte> output(outputSize);
+    lz4DecompressInto(input, output);
     return output;
 }
 
@@ -218,14 +232,13 @@ std::vector<std::byte> c3dCompress(std::span<const std::byte> input,
     return utils::c3d_encode(input, p);
 }
 
-std::vector<std::byte> gzipDecompress(std::span<const std::byte> input, size_t outputSize)
+void gzipDecompressInto(std::span<const std::byte> input, std::span<std::byte> output)
 {
     z_stream stream{};
     if (inflateInit2(&stream, 16 + MAX_WBITS) != Z_OK) {
         throw std::runtime_error("inflateInit2 failed");
     }
 
-    std::vector<std::byte> output(outputSize);
     stream.avail_in = checkedUInt(input.size(), "gzip input");
     stream.next_in = reinterpret_cast<Bytef*>(const_cast<std::byte*>(input.data()));
     stream.avail_out = checkedUInt(output.size(), "gzip output");
@@ -236,6 +249,12 @@ std::vector<std::byte> gzipDecompress(std::span<const std::byte> input, size_t o
     if (rc != Z_STREAM_END && rc != Z_OK) {
         throw std::runtime_error("gzip inflate failed with code " + std::to_string(rc));
     }
+}
+
+std::vector<std::byte> gzipDecompress(std::span<const std::byte> input, size_t outputSize)
+{
+    std::vector<std::byte> output(outputSize);
+    gzipDecompressInto(input, output);
     return output;
 }
 
@@ -259,6 +278,38 @@ std::vector<std::byte> decompressBytes(const CompressorConfig& cfg,
     }
 
     throw std::runtime_error("unsupported zarr compressor");
+}
+
+// Direct-into-buffer dispatcher. Returns false when the codec has no
+// scratch-friendly path (currently c3d) so callers fall back to the
+// allocating decompressBytes() variant.
+bool decompressBytesInto(const CompressorConfig& cfg,
+                         std::span<const std::byte> input,
+                         std::span<std::byte> output)
+{
+    switch (cfg.id) {
+    case CompressorId::None:
+        if (input.size() < output.size()) {
+            throw std::runtime_error("uncompressed zarr chunk shorter than expected");
+        }
+        std::memcpy(output.data(), input.data(), output.size());
+        return true;
+    case CompressorId::Blosc:
+        bloscDecompressInto(input, output);
+        return true;
+    case CompressorId::Zstd:
+        zstdDecompressInto(input, output);
+        return true;
+    case CompressorId::Lz4:
+        lz4DecompressInto(input, output);
+        return true;
+    case CompressorId::Gzip:
+        gzipDecompressInto(input, output);
+        return true;
+    case CompressorId::C3d:
+        return false;
+    }
+    return false;
 }
 
 std::vector<std::byte> compressBytes(const CompressorConfig& cfg,
@@ -368,6 +419,12 @@ static utils::ZarrArray::Codec codecFromConfig(const CompressorConfig& cfg)
     codec.decompress = [cfg](std::span<const std::byte> data, std::size_t outSize) {
         return decompressBytes(cfg, data, outSize);
     };
+    if (cfg.id != CompressorId::C3d) {
+        codec.decompress_into = [cfg](std::span<const std::byte> data,
+                                      std::span<std::byte> out) {
+            decompressBytesInto(cfg, data, out);
+        };
+    }
     return codec;
 }
 

--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -22,6 +22,7 @@
 #include "vc/core/util/LoadJson.hpp"
 #include "vc/core/util/Logging.hpp"
 #include "vc/core/util/Slicing.hpp"
+#include "vc/core/types/VcDataset.hpp"
 #include "vc/core/render/ZarrChunkFetcher.hpp"
 #include "vc/core/util/HttpFetch.hpp"
 #include "vc/core/util/RemoteUrl.hpp"
@@ -416,6 +417,15 @@ utils::ZarrArray openLocalZarrArrayForWrite(const std::filesystem::path& path)
     if (!meta.compressor_id.empty() || !meta.codecs.empty())
         throw std::runtime_error("cannot write compressed zarr without compression codec support: " + path.string());
     return array;
+}
+
+// Read-side opener: uses the same codec registry that backs the chunked
+// read cache (ZarrChunkFetcher / VcDataset), so it works in builds where
+// `compression.hpp` is unavailable and `zarrCodecRegistry()` is empty.
+utils::ZarrArray openLocalZarrArrayForRead(const std::filesystem::path& path,
+                                           int dtypeSize)
+{
+    return utils::ZarrArray::open(path, vc::buildZarrCodecRegistry(dtypeSize));
 }
 
 std::vector<size_t> toVector(const std::array<size_t, 3>& value)
@@ -1754,7 +1764,8 @@ std::optional<std::vector<std::byte>> Volume::readChunk(
     if (!hasScaleLevel(level))
         throw std::out_of_range("Volume::readChunk requested missing zarr scale level " + std::to_string(level));
 
-    auto array = openLocalZarrArrayForWrite(zarrArrayPathForLevel(path(), level));
+    auto array = openLocalZarrArrayForRead(zarrArrayPathForLevel(path(), level),
+                                           static_cast<int>(dtypeSize()));
     return array.read_chunk(chunkZYX);
 }
 
@@ -1765,7 +1776,8 @@ std::vector<std::byte> Volume::readChunkOrFill(
     if (auto chunk = readChunk(level, chunkZYX))
         return std::move(*chunk);
 
-    auto array = openLocalZarrArrayForWrite(zarrArrayPathForLevel(path(), level));
+    auto array = openLocalZarrArrayForRead(zarrArrayPathForLevel(path(), level),
+                                           static_cast<int>(dtypeSize()));
     return filledChunkBytes(array);
 }
 
@@ -1780,7 +1792,8 @@ bool Volume::chunkExists(
     if (!hasScaleLevel(level))
         throw std::out_of_range("Volume::chunkExists requested missing zarr scale level " + std::to_string(level));
 
-    auto array = openLocalZarrArrayForWrite(zarrArrayPathForLevel(path(), level));
+    auto array = openLocalZarrArrayForRead(zarrArrayPathForLevel(path(), level),
+                                           static_cast<int>(dtypeSize()));
     if (array.is_sharded())
         return array.inner_chunk_exists(chunkZYX);
     return array.chunk_exists(chunkZYX);

--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -1769,6 +1769,30 @@ std::optional<std::vector<std::byte>> Volume::readChunk(
     return array.read_chunk(chunkZYX);
 }
 
+bool Volume::readChunkInto(
+    int level,
+    const std::array<size_t, 3>& chunkZYX,
+    std::span<std::byte> output) const
+{
+    if (isRemote())
+        throw std::runtime_error("Volume::readChunkInto is only supported for local zarr volumes");
+    if (level < 0)
+        throw std::out_of_range("Volume::readChunkInto level must be non-negative");
+    if (!hasScaleLevel(level))
+        throw std::out_of_range("Volume::readChunkInto requested missing zarr scale level " + std::to_string(level));
+
+    auto array = openLocalZarrArrayForRead(zarrArrayPathForLevel(path(), level),
+                                           static_cast<int>(dtypeSize()));
+    return array.read_chunk_into(chunkZYX, output);
+}
+
+size_t Volume::chunkByteSize(int level) const
+{
+    const auto cs = chunkShape(level);
+    return static_cast<size_t>(cs[0]) * static_cast<size_t>(cs[1]) *
+           static_cast<size_t>(cs[2]) * dtypeSize();
+}
+
 std::vector<std::byte> Volume::readChunkOrFill(
     int level,
     const std::array<size_t, 3>& chunkZYX) const

--- a/volume-cartographer/utils/include/utils/zarr.hpp
+++ b/volume-cartographer/utils/include/utils/zarr.hpp
@@ -986,9 +986,13 @@ private:
 class ZarrArray final {
 public:
     /// Codec callback struct: compress and decompress functions.
+    /// `decompress_into` is optional; when provided, callers can avoid the
+    /// per-call decompressed-buffer heap allocation by passing a reusable
+    /// scratch span sized to the (sub-)chunk byte count.
     struct Codec {
         std::function<std::vector<std::byte>(std::span<const std::byte>)> compress;
         std::function<std::vector<std::byte>(std::span<const std::byte>, std::size_t)> decompress;
+        std::function<void(std::span<const std::byte>, std::span<std::byte>)> decompress_into;
     };
 
     /// Named codec registry: maps codec name to Codec.
@@ -1199,6 +1203,61 @@ public:
         }
 
         return data;
+    }
+
+    /// Read a chunk and decompress it directly into the caller-provided
+    /// `output` buffer. `output` must be at least sub_chunk_byte_size().
+    /// Returns false if the chunk is missing on disk; otherwise writes
+    /// exactly sub_chunk_byte_size() bytes into `output` and returns true.
+    ///
+    /// When the codec exposes `decompress_into`, decompression skips the
+    /// per-call heap allocation that `read_chunk` performs. v2 filters and
+    /// host-byte-order mismatches force a fallback to the allocating path
+    /// (and a final memcpy into `output`).
+    [[nodiscard]] bool
+    read_chunk_into(std::span<const std::size_t> chunk_indices,
+                    std::span<std::byte> output) const {
+        const std::size_t expected = meta_.sub_chunk_byte_size();
+        if (output.size() < expected) {
+            throw std::runtime_error("zarr: read_chunk_into output buffer too small");
+        }
+        auto out = output.subspan(0, expected);
+
+        std::optional<std::vector<std::byte>> raw_opt;
+        if (is_sharded()) {
+            raw_opt = read_inner_chunk_from_shard(chunk_indices);
+        } else {
+            raw_opt = read_chunk_raw(chunk_indices);
+        }
+        if (!raw_opt) return false;
+
+        const bool has_v2_filters =
+            (meta_.version == ZarrVersion::v2 && !meta_.filters.empty());
+        const bool needs_decode = needs_decompression();
+
+        if (needs_decode && codec_.decompress_into && !has_v2_filters && !needs_byteswap()) {
+            codec_.decompress_into(*raw_opt, out);
+            return true;
+        }
+
+        std::vector<std::byte> data;
+        if (needs_decode) {
+            if (!codec_.decompress) return false;
+            data = codec_.decompress(*raw_opt, expected);
+        } else {
+            data = std::move(*raw_opt);
+        }
+
+        if (has_v2_filters) {
+            for (auto it = meta_.filters.rbegin(); it != meta_.filters.rend(); ++it)
+                data = it->decode(data);
+        }
+        if (needs_byteswap()) {
+            detail::byteswap_inplace(data, dtype_size(meta_.dtype));
+        }
+        if (data.size() < expected) return false;
+        std::memcpy(out.data(), data.data(), expected);
+        return true;
     }
 
     void write_chunk(std::span<const std::size_t> chunk_indices,


### PR DESCRIPTION
For the usual reasons, reusing buffers can help a lot of memory/allocation churn when you go through many chunks.