### PR TITLE
vc_gen_normalgrids: optimizations and fixes

### DIFF
--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -118,6 +118,7 @@ struct ThreadSliceStats {
 
 struct ThreadScratch {
     std::vector<std::vector<cv::Point>> traces;
+    ThinningScratch thinning;
 };
 
 // Anonymous-mmap'd buffer. Linux guarantees fresh pages read as zero (the
@@ -1150,7 +1151,7 @@ void run_generate(const po::variables_map& vm) {
                     scratch.traces.clear();
                     const auto thinning_start = std::chrono::steady_clock::now();
                     ThinningStats thinning_stats;
-                    customThinningTraceOnly(assembled.binarySlice, scratch.traces, &thinning_stats);
+                    customThinningTraceOnly(assembled.binarySlice, scratch.traces, &thinning_stats, scratch.thinning);
                     const double thinning_seconds = seconds_since(thinning_start);
                     record_timing(local_stats, "thinning", thinning_seconds);
                     local_stats.thinningStats.accumulate(thinning_stats);

--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -1009,81 +1009,51 @@ void run_generate(const po::variables_map& vm) {
                 }
 
                 if (!assembled_slices.empty()) {
-                    std::array<size_t, 3> slab_shape;
-                    std::array<int, 3> slab_offset;
-                    switch (dir) {
-                    case SliceDirection::XY:
-                        slab_shape = {source_chunk_shape[0], shape[1], shape[2]};
-                        slab_offset = {
-                            static_cast<int>(source_chunk_plan.sourceChunkIndex * source_chunk_shape[0]),
-                            0,
-                            0,
-                        };
-                        break;
-                    case SliceDirection::XZ:
-                        slab_shape = {shape[0], source_chunk_shape[1], shape[2]};
-                        slab_offset = {
-                            0,
-                            static_cast<int>(source_chunk_plan.sourceChunkIndex * source_chunk_shape[1]),
-                            0,
-                        };
-                        break;
-                    case SliceDirection::YZ:
-                        slab_shape = {shape[0], shape[1], source_chunk_shape[2]};
-                        slab_offset = {
-                            0,
-                            0,
-                            static_cast<int>(source_chunk_plan.sourceChunkIndex * source_chunk_shape[2]),
-                        };
-                        break;
-                    }
-                    // Clip slab to actual volume extents so we do not read past the end.
-                    for (int axis = 0; axis < 3; ++axis) {
-                        const size_t end = static_cast<size_t>(slab_offset[axis]) + slab_shape[axis];
-                        if (end > shape[axis]) {
-                            slab_shape[axis] = shape[axis] - static_cast<size_t>(slab_offset[axis]);
-                        }
+                    std::vector<vc::core::util::BinarySliceTarget> targets;
+                    targets.reserve(assembled_slices.size());
+                    for (auto& assembled : assembled_slices) {
+                        targets.push_back(vc::core::util::BinarySliceTarget{
+                            &assembled.binarySlice,
+                            static_cast<int>(assembled.localSliceIndex),
+                            false});
                     }
 
+                    const std::array<int, 3> volume_shape_i = {
+                        static_cast<int>(shape[0]),
+                        static_cast<int>(shape[1]),
+                        static_cast<int>(shape[2]),
+                    };
+                    const std::array<int, 3> source_chunk_shape_i = {
+                        static_cast<int>(source_chunk_shape[0]),
+                        static_cast<int>(source_chunk_shape[1]),
+                        static_cast<int>(source_chunk_shape[2]),
+                    };
+
                     const auto read_start = std::chrono::steady_clock::now();
-                    Array3D<uint8_t> chunk_data(slab_shape);
-                    input_volume.readZYX(chunk_data, slab_offset, input_level);
+                    vc::core::util::fillBinarySliceBatchFromVolume(
+                        input_volume,
+                        input_level,
+                        to_normal_grid_direction(dir),
+                        static_cast<int>(source_chunk_plan.sourceChunkIndex),
+                        volume_shape_i,
+                        source_chunk_shape_i,
+                        std::span<vc::core::util::BinarySliceTarget>(targets));
                     const double read_seconds = seconds_since(read_start);
                     record_timing(dir_metrics, "read_chunk", read_seconds);
 
-                    const size_t slab_voxels = slab_shape[0] * slab_shape[1] * slab_shape[2];
-                    const size_t slab_bytes = slab_voxels * sizeof(uint8_t);
+                    for (size_t i = 0; i < targets.size(); ++i) {
+                        assembled_slices[i].anyNonZero = targets[i].anyNonZero;
+                        assembled_slices[i].extractSeconds = 0.0;
+                    }
 
                     if (debug_per_slice) {
-                        const double mib = static_cast<double>(slab_bytes) / (1024.0 * 1024.0);
-                        const double mibps = read_seconds > 0.0 ? mib / read_seconds : 0.0;
                         log_chunk_io(dir_metrics.direction, chunk_index,
                                      sampled_chunk_plans.size(),
                                      source_chunk_plan.sourceChunkIndex,
                                      assembled_slices.size(),
-                                     slab_shape[0], slab_shape[1], slab_shape[2],
-                                     mib, read_seconds, mibps,
+                                     0, 0, 0,
+                                     0.0, read_seconds, 0.0,
                                      seconds_since(start_time));
-                    }
-
-                    const auto extract_loop_start = std::chrono::steady_clock::now();
-                    for (auto& assembled : assembled_slices) {
-                        const auto extract_start = std::chrono::steady_clock::now();
-                        const bool any_nonzero = vc::core::util::extractBinarySliceFromChunk(
-                            chunk_data,
-                            to_normal_grid_direction(dir),
-                            assembled.localSliceIndex,
-                            assembled.binarySlice);
-                        assembled.extractSeconds = seconds_since(extract_start);
-                        assembled.anyNonZero = assembled.anyNonZero || any_nonzero;
-                    }
-                    const double extract_loop_seconds = seconds_since(extract_loop_start);
-
-                    if (debug_per_slice) {
-                        log_chunk_extract(dir_metrics.direction, chunk_index,
-                                          sampled_chunk_plans.size(),
-                                          extract_loop_seconds,
-                                          assembled_slices.size());
                     }
                 }
 

--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -72,6 +72,7 @@ struct RunMetrics {
     int previewEvery = 100;
     bool verifyGridSave = false;
     int ompThreads = 1;
+    int ioThreads = 0;
     int numParts = 1;
     int partId = 0;
     size_t cacheBudgetBytes = 0;
@@ -210,6 +211,7 @@ static void write_metrics_json(const fs::path& path, const RunMetrics& metrics) 
     out["preview_every"] = metrics.previewEvery;
     out["verify_grid_save"] = metrics.verifyGridSave;
     out["omp_threads"] = metrics.ompThreads;
+    out["io_threads"] = metrics.ioThreads;
     out["num_parts"] = metrics.numParts;
     out["part_id"] = metrics.partId;
     out["cache_budget_bytes"] = metrics.cacheBudgetBytes;
@@ -439,6 +441,7 @@ static void print_usage() {
               << "  --part-id           This shard's index in [0, num-parts) (default: 0)\n"
               << "  --sparse-volume     Process every N-th slice, 1 = all (default: 1)\n"
               << "  --chunk-budget-mib  Max chunk batch budget per direction (default: 512)\n"
+              << "  --io-threads        OMP team size for the chunk-read loop, 0 = OMP default (default: 0)\n"
               << "  --preview-every     Write preview image every N written slices, 0 disables (default: 100)\n"
               << "  --verify-grid-save  Verify GridStore save by reloading each file (default: false)\n"
               << "  --debug-per-slice   Emit a stdout log line for every slice (existing/empty/written) (default: false)\n"
@@ -508,6 +511,7 @@ int main(int argc, char* argv[]) {
             ("part-id", po::value<int>()->default_value(0), "Index of this shard in [0, num-parts)")
             ("sparse-volume", po::value<int>()->default_value(1), "Process every N-th slice (1 = all slices)")
             ("chunk-budget-mib", po::value<size_t>()->default_value(512), "Maximum chunk batch budget in MiB")
+            ("io-threads", po::value<int>()->default_value(0), "OMP team size for the chunk-read loop (0 = OMP default; raise above core count when IO-bound)")
             ("preview-every", po::value<int>()->default_value(100), "Write preview image every N written slices, 0 disables")
             ("verify-grid-save", po::bool_switch()->default_value(false), "Verify GridStore files by reloading after save")
             ("debug-per-slice", po::bool_switch()->default_value(false), "Emit a stdout log line for every slice processed (existing/empty_binary/empty_trace/written)")
@@ -686,6 +690,10 @@ void run_generate(const po::variables_map& vm) {
     int sparse_volume = vm["sparse-volume"].as<int>();
     if (sparse_volume < 1) sparse_volume = 1;
     const size_t chunk_budget_mib = vm["chunk-budget-mib"].as<size_t>();
+    const int io_threads = vm["io-threads"].as<int>();
+    if (io_threads < 0) {
+        throw std::runtime_error("--io-threads must be >= 0");
+    }
     const int preview_every = vm["preview-every"].as<int>();
     if (preview_every < 0) {
         throw std::runtime_error("--preview-every must be >= 0");
@@ -850,6 +858,7 @@ void run_generate(const po::variables_map& vm) {
         metadata["sparse-volume"] = sparse_volume;
         metadata["input-level"] = input_level;
         metadata["chunk-budget-mib"] = chunk_budget_mib;
+        metadata["io-threads"] = io_threads;
         metadata["preview-every"] = preview_every;
         metadata["verify-grid-save"] = verify_grid_save;
         metadata["debug-per-slice"] = debug_per_slice;
@@ -923,6 +932,7 @@ void run_generate(const po::variables_map& vm) {
     run_metrics.previewEvery = preview_every;
     run_metrics.verifyGridSave = verify_grid_save;
     run_metrics.ompThreads = num_threads;
+    run_metrics.ioThreads = io_threads;
     run_metrics.numParts = num_parts;
     run_metrics.partId = part_id;
     run_metrics.cacheBudgetBytes = cache_budget_bytes;
@@ -1106,7 +1116,8 @@ void run_generate(const po::variables_map& vm) {
                         static_cast<int>(source_chunk_plan.sourceChunkIndex),
                         volume_shape_i,
                         source_chunk_shape_i,
-                        std::span<vc::core::util::BinarySliceTarget>(targets));
+                        std::span<vc::core::util::BinarySliceTarget>(targets),
+                        io_threads);
                     const double read_seconds = seconds_since(read_start);
                     record_timing(dir_metrics, "read_chunk", read_seconds);
 

--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -803,9 +803,8 @@ void run_generate(const po::variables_map& vm) {
     for (SliceDirection dir : directions_to_run) {
         const auto batch_plan = vc::core::util::planNormalGridBatch(
             shape,
+            source_chunk_shape,
             to_normal_grid_direction(dir),
-            num_threads,
-            sparse_volume,
             chunk_budget_mib,
             dtype_size);
         max_estimated_batch_bytes = std::max(max_estimated_batch_bytes, batch_plan.estimatedBatchBytes);
@@ -887,9 +886,8 @@ void run_generate(const po::variables_map& vm) {
 
         const auto batch_plan = vc::core::util::planNormalGridBatch(
             shape,
+            source_chunk_shape,
             to_normal_grid_direction(dir),
-            num_threads,
-            sparse_volume,
             chunk_budget_mib,
             dtype_size);
         const size_t chunk_size_tgt = std::max<size_t>(1, batch_plan.chunkSizeTarget);

--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -76,6 +76,12 @@ struct RunMetrics {
     size_t totalSlicesAllDirs = 0;
     size_t totalProcessedAllDirs = 0;
     size_t totalSkippedAllDirs = 0;
+    // Unsampled (sparse-skipped) slices across the whole shard. Each direction
+    // pre-counts its unsampled into totalProcessedAllDirs at start, so they
+    // contribute to the "Total" counter at zero wall-clock cost. Tracking them
+    // separately lets the rate / ETA exclude this instant bump.
+    size_t totalUnsampledAllDirs = 0;          // precomputed across all directions
+    size_t totalUnsampledAccountedAllDirs = 0; // running: already added at dir start
     double totalSeconds = 0.0;
     std::vector<size_t> levelShape;
     std::vector<DirectionMetrics> directions;
@@ -161,6 +167,7 @@ static void write_metrics_json(const fs::path& path, const RunMetrics& metrics) 
     out["total_slices_all_dirs"] = metrics.totalSlicesAllDirs;
     out["total_processed_all_dirs"] = metrics.totalProcessedAllDirs;
     out["total_skipped_all_dirs"] = metrics.totalSkippedAllDirs;
+    out["total_unsampled_all_dirs"] = metrics.totalUnsampledAllDirs;
     out["total_seconds"] = metrics.totalSeconds;
     out["directions"] = Json::array();
 
@@ -867,14 +874,25 @@ void run_generate(const po::variables_map& vm) {
     run_metrics.cacheBudgetBytes = cache_budget_bytes;
     run_metrics.levelShape = shape;
     run_metrics.totalSlicesAllDirs = 0;
+    run_metrics.totalUnsampledAllDirs = 0;
     for (const auto& dp : direction_plans) {
         run_metrics.totalSlicesAllDirs += dp.shardSliceTotal;
+        run_metrics.totalUnsampledAllDirs += (dp.shardSliceTotal - dp.shardSampledTotal);
     }
 
     std::vector<ThreadScratch> thread_scratch(static_cast<size_t>(num_threads));
     for (auto& scratch : thread_scratch) {
         scratch.traces.reserve(256);
     }
+
+    // Run-level rate state. We report the rate over the most recent reporting
+    // interval (not cumulative since start), so the displayed rate and ETA
+    // track the steady-state speed instead of being skewed by an early burst
+    // (e.g. the first chunks finishing fast because they're empty).
+    const auto run_start_time = std::chrono::steady_clock::now();
+    auto last_sample_time = run_start_time;
+    size_t last_sample_effort_done = 0;
+    size_t last_sample_active_done = 0;
 
     for (const auto& dir_plan : direction_plans) {
         const SliceDirection dir = dir_plan.dir;
@@ -912,6 +930,7 @@ void run_generate(const po::variables_map& vm) {
         std::atomic<size_t> slice_done_counter{0};
         const size_t slice_progress_total = sampled_slices_total;
         run_metrics.totalProcessedAllDirs += unsampled;
+        run_metrics.totalUnsampledAccountedAllDirs += unsampled;
 
         const cv::Size slice_size = vc::core::util::normalGridSliceSize(
             shape,
@@ -1162,14 +1181,50 @@ void run_generate(const po::variables_map& vm) {
             auto now = std::chrono::steady_clock::now();
             if (std::chrono::duration_cast<std::chrono::seconds>(now - last_report_time).count() >= 5) {
                 last_report_time = now;
-                const auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(now - start_time).count();
                 const size_t active_processed = processed > (skipped_existing + unsampled)
                     ? (processed - skipped_existing - unsampled)
                     : 0;
-                double slices_per_second = active_processed > 0 ? active_processed / elapsed_seconds : 0.0;
-                if (slices_per_second == 0.0) slices_per_second = 1.0;
-                const double remaining_seconds =
-                    (run_metrics.totalSlicesAllDirs - run_metrics.totalProcessedAllDirs) / slices_per_second;
+
+                // Effort = slices that consumed wall-clock (skip-check + actual work).
+                // Excludes the instant unsampled pre-count so the rate isn't inflated.
+                // Active = slices we actually processed (excludes existing files too).
+                // Both are tracked at run scope so ETA spans all directions consistently.
+                const size_t total_effort_universe =
+                    run_metrics.totalSlicesAllDirs > run_metrics.totalUnsampledAllDirs
+                        ? run_metrics.totalSlicesAllDirs - run_metrics.totalUnsampledAllDirs
+                        : 0;
+                const size_t total_effort_done =
+                    run_metrics.totalProcessedAllDirs > run_metrics.totalUnsampledAccountedAllDirs
+                        ? run_metrics.totalProcessedAllDirs - run_metrics.totalUnsampledAccountedAllDirs
+                        : 0;
+                const size_t total_active_done =
+                    total_effort_done > run_metrics.totalSkippedAllDirs
+                        ? total_effort_done - run_metrics.totalSkippedAllDirs
+                        : 0;
+
+                // Rate is over the most recent reporting interval. The first sample
+                // (last_sample_time == run_start_time, last_sample_*_done == 0)
+                // collapses to cumulative-from-run-start, which is the only honest
+                // option until we have a window to diff against.
+                const auto interval_seconds =
+                    std::chrono::duration_cast<std::chrono::duration<double>>(
+                        now - last_sample_time).count();
+                double effort_rate = 0.0;
+                double active_rate = 0.0;
+                if (interval_seconds > 0.0) {
+                    effort_rate = (total_effort_done - last_sample_effort_done) / interval_seconds;
+                    active_rate = (total_active_done - last_sample_active_done) / interval_seconds;
+                }
+
+                last_sample_time = now;
+                last_sample_effort_done = total_effort_done;
+                last_sample_active_done = total_active_done;
+
+                const double eta_rate = effort_rate > 0.0 ? effort_rate : 1.0;
+                const size_t remaining_effort = total_effort_universe > total_effort_done
+                    ? total_effort_universe - total_effort_done
+                    : 0;
+                const double remaining_seconds = remaining_effort / eta_rate;
 
                 int rem_min = static_cast<int>(remaining_seconds) / 60;
                 int rem_sec = static_cast<int>(remaining_seconds) % 60;
@@ -1178,6 +1233,8 @@ void run_generate(const po::variables_map& vm) {
                           << " | Total " << run_metrics.totalProcessedAllDirs << "/" << run_metrics.totalSlicesAllDirs
                           << " (" << std::fixed << std::setprecision(1)
                           << (100.0 * run_metrics.totalProcessedAllDirs / run_metrics.totalSlicesAllDirs) << "%)"
+                          << " @ " << std::setprecision(2) << effort_rate << " sl/s"
+                          << " (active " << std::setprecision(2) << active_rate << " sl/s)"
                           << ", skipped_existing: " << skipped_existing
                           << ", unsampled: " << unsampled
                           << ", ETA: " << rem_min << "m " << rem_sec << "s";

--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <iomanip>
 #include <limits>
+#include <cstdio>
 
 #include <boost/program_options.hpp>
 #include <opencv2/opencv.hpp>
@@ -116,6 +117,7 @@ struct AssembledSlice {
     size_t localSliceIndex = 0;
     cv::Mat binarySlice;
     bool anyNonZero = false;
+    double extractSeconds = 0.0;
 };
 
 static const char* direction_name(SliceDirection dir) {
@@ -219,6 +221,156 @@ static void write_metrics_json(const fs::path& path, const RunMetrics& metrics) 
     }
 }
 
+// --- Debug/timing helpers --------------------------------------------------
+
+static inline double seconds_since(std::chrono::steady_clock::time_point t0)
+{
+    return std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - t0).count();
+}
+
+template <class M>
+static inline void record_timing(M& m, const char* name, double s)
+{
+    m.timingTotals[name] += s;
+    m.timingCounts[name] += 1;
+}
+
+struct ProgressSnap {
+    size_t done;
+    size_t total;
+    double elapsed;
+    double rate;
+    double eta;
+};
+
+static ProgressSnap take_progress(
+    std::atomic<size_t>& counter,
+    std::chrono::steady_clock::time_point start,
+    size_t total)
+{
+    const size_t done = counter.fetch_add(1, std::memory_order_relaxed) + 1;
+    const double elapsed = seconds_since(start);
+    const double rate = elapsed > 0.0 ? static_cast<double>(done) / elapsed : 0.0;
+    const double eta = (rate > 0.0 && done < total)
+        ? static_cast<double>(total - done) / rate : 0.0;
+    return {done, total, elapsed, rate, eta};
+}
+
+static void log_slice_existing(
+    const std::string& dir, size_t idx, const ProgressSnap& p)
+{
+    std::cout << "[slice] dir=" << dir
+              << " idx=" << idx
+              << " outcome=existing"
+              << " progress=" << p.done << "/" << p.total
+              << " elapsed=" << std::fixed << std::setprecision(3) << p.elapsed << "s"
+              << " rate=" << std::setprecision(2) << p.rate << "it/s"
+              << " eta=" << std::setprecision(1) << p.eta << "s"
+              << std::endl;
+}
+
+static void log_slice_empty_binary(
+    const std::string& dir, size_t idx, int tid, const ProgressSnap& p,
+    double extract_s, int slice_w, int slice_h)
+{
+    #pragma omp critical(debug_per_slice_log)
+    std::cout << "[slice] dir=" << dir
+              << " idx=" << idx
+              << " outcome=empty_binary tid=" << tid
+              << " progress=" << p.done << "/" << p.total
+              << " elapsed=" << std::fixed << std::setprecision(3) << p.elapsed << "s"
+              << " rate=" << std::setprecision(2) << p.rate << "it/s"
+              << " eta=" << std::setprecision(1) << p.eta << "s"
+              << " extract=" << std::setprecision(4) << extract_s << "s"
+              << " slice_size=" << slice_w << "x" << slice_h
+              << std::endl;
+}
+
+static void log_slice_empty_trace(
+    const std::string& dir, size_t idx, int tid, const ProgressSnap& p,
+    double extract_s, double thinning_s)
+{
+    #pragma omp critical(debug_per_slice_log)
+    std::cout << "[slice] dir=" << dir
+              << " idx=" << idx
+              << " outcome=empty_trace tid=" << tid
+              << " progress=" << p.done << "/" << p.total
+              << " elapsed=" << std::fixed << std::setprecision(3) << p.elapsed << "s"
+              << " rate=" << std::setprecision(2) << p.rate << "it/s"
+              << " eta=" << std::setprecision(1) << p.eta << "s"
+              << " extract=" << std::setprecision(4) << extract_s << "s"
+              << " thinning=" << thinning_s << "s"
+              << std::endl;
+}
+
+static void log_slice_written(
+    const std::string& dir, size_t idx, int tid, const ProgressSnap& p,
+    double extract_s, double thinning_s, double populate_s, double save_s,
+    size_t bytes, size_t segments, size_t buckets)
+{
+    #pragma omp critical(debug_per_slice_log)
+    std::cout << "[slice] dir=" << dir
+              << " idx=" << idx
+              << " outcome=written tid=" << tid
+              << " progress=" << p.done << "/" << p.total
+              << " elapsed=" << std::fixed << std::setprecision(3) << p.elapsed << "s"
+              << " rate=" << std::setprecision(2) << p.rate << "it/s"
+              << " eta=" << std::setprecision(1) << p.eta << "s"
+              << " extract=" << std::setprecision(4) << extract_s << "s"
+              << " thinning=" << thinning_s << "s"
+              << " populate=" << populate_s << "s"
+              << " save=" << save_s << "s"
+              << " bytes=" << bytes
+              << " segments=" << segments
+              << " buckets=" << buckets
+              << std::endl;
+}
+
+static void log_batch(
+    const std::string& dir, size_t chunk_i, size_t chunk_n,
+    size_t batch_size, size_t existing, size_t to_process,
+    double prep_s, double elapsed)
+{
+    std::cout << "[batch] dir=" << dir
+              << " chunk=" << chunk_i << "/" << chunk_n
+              << " batch_size=" << batch_size
+              << " existing=" << existing
+              << " to_process=" << to_process
+              << " prep=" << std::fixed << std::setprecision(3) << prep_s << "s"
+              << " elapsed=" << elapsed << "s"
+              << std::endl;
+}
+
+static void log_chunk_io(
+    const std::string& dir, size_t chunk_i, size_t chunk_n,
+    size_t source_chunk_idx, size_t batch_size,
+    size_t slab_z, size_t slab_y, size_t slab_x,
+    double slab_mib, double read_s, double mibps, double elapsed)
+{
+    std::cout << "[chunk] dir=" << dir
+              << " chunk=" << chunk_i << "/" << chunk_n
+              << " source_chunk_idx=" << source_chunk_idx
+              << " batch_size=" << batch_size
+              << " slab=" << slab_z << "x" << slab_y << "x" << slab_x
+              << " (" << std::fixed << std::setprecision(1) << slab_mib << "MiB)"
+              << " read=" << std::setprecision(3) << read_s << "s"
+              << " (" << std::setprecision(1) << mibps << "MiB/s)"
+              << " elapsed=" << std::setprecision(3) << elapsed << "s"
+              << std::endl;
+}
+
+static void log_chunk_extract(
+    const std::string& dir, size_t chunk_i, size_t chunk_n,
+    double extract_loop_s, size_t n_slices)
+{
+    std::cout << "[chunk] dir=" << dir
+              << " chunk=" << chunk_i << "/" << chunk_n
+              << " extract_loop=" << std::fixed << std::setprecision(3) << extract_loop_s << "s"
+              << " (" << n_slices << " slices)"
+              << std::endl;
+}
+
 } // namespace
 
 void run_generate(const po::variables_map& vm);
@@ -247,6 +399,7 @@ static void print_usage() {
               << "  --chunk-budget-mib  Max chunk batch budget per direction (default: 512)\n"
               << "  --preview-every     Write preview image every N written slices, 0 disables (default: 100)\n"
               << "  --verify-grid-save  Verify GridStore save by reloading each file (default: false)\n"
+              << "  --debug-per-slice   Emit a stdout log line for every slice (existing/empty/written) (default: false)\n"
               << "  --metrics-json      Write structured metrics json\n"
               << "  --print-plan        Print partition plan as JSON to stdout and exit (no work done)\n\n"
               << "Convert options:\n"
@@ -255,6 +408,9 @@ static void print_usage() {
 }
 
 int main(int argc, char* argv[]) {
+    std::setvbuf(stdout, nullptr, _IOLBF, 0);
+    std::setvbuf(stderr, nullptr, _IOLBF, 0);
+
     po::options_description global("Global options");
     global.add_options()
         ("help,h", "Print usage message")
@@ -312,6 +468,7 @@ int main(int argc, char* argv[]) {
             ("chunk-budget-mib", po::value<size_t>()->default_value(512), "Maximum chunk batch budget in MiB")
             ("preview-every", po::value<int>()->default_value(100), "Write preview image every N written slices, 0 disables")
             ("verify-grid-save", po::bool_switch()->default_value(false), "Verify GridStore files by reloading after save")
+            ("debug-per-slice", po::bool_switch()->default_value(false), "Emit a stdout log line for every slice processed (existing/empty_binary/empty_trace/written)")
             ("metrics-json", po::value<std::string>(), "Write structured metrics json")
             ("print-plan", po::bool_switch()->default_value(false), "Print partition plan as JSON to stdout and exit (no work done)");
 
@@ -492,6 +649,7 @@ void run_generate(const po::variables_map& vm) {
         throw std::runtime_error("--preview-every must be >= 0");
     }
     const bool verify_grid_save = vm["verify-grid-save"].as<bool>();
+    const bool debug_per_slice = vm["debug-per-slice"].as<bool>();
     const std::optional<fs::path> metrics_json_path = vm.count("metrics-json")
         ? std::optional<fs::path>(fs::path(vm["metrics-json"].as<std::string>()))
         : std::nullopt;
@@ -525,6 +683,10 @@ void run_generate(const po::variables_map& vm) {
         }
     }
 
+    if (!print_plan) {
+        std::cout << "Opening volume: " << input_path << std::endl;
+    }
+    const auto open_start = std::chrono::steady_clock::now();
     Volume input_volume{fs::path(input_path)};
     auto* input_chunks = input_volume.chunkedCache();
     const auto level_shape = input_chunks->shape(input_level);
@@ -540,6 +702,14 @@ void run_generate(const po::variables_map& vm) {
         static_cast<size_t>(level_chunk_shape[1]),
         static_cast<size_t>(level_chunk_shape[2]),
     };
+    if (!print_plan) {
+        const double open_seconds = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - open_start).count();
+        std::cout << "Volume opened in " << std::fixed << std::setprecision(2) << open_seconds
+                  << "s. shape_zyx=[" << shape[0] << "," << shape[1] << "," << shape[2] << "]"
+                  << " chunk_zyx=[" << source_chunk_shape[0] << "," << source_chunk_shape[1]
+                  << "," << source_chunk_shape[2] << "]" << std::endl;
+    }
 
     if (print_plan) {
         Json plan;
@@ -640,6 +810,7 @@ void run_generate(const po::variables_map& vm) {
         metadata["chunk-budget-mib"] = chunk_budget_mib;
         metadata["preview-every"] = preview_every;
         metadata["verify-grid-save"] = verify_grid_save;
+        metadata["debug-per-slice"] = debug_per_slice;
         std::ofstream o(output_fs_path / "metadata.json");
         o << metadata.dump(4) << std::endl;
     }
@@ -662,6 +833,8 @@ void run_generate(const po::variables_map& vm) {
         256ull * 1024ull * 1024ull,
         std::max<size_t>(64ull * 1024ull * 1024ull, max_estimated_batch_bytes / 2));
 
+    std::cout << "Setting cache budget: " << (cache_budget_bytes / (1024 * 1024))
+              << " MiB" << std::endl;
     input_volume.setCacheBudget(cache_budget_bytes);
 
     struct DirectionShardPlan {
@@ -691,6 +864,10 @@ void run_generate(const po::variables_map& vm) {
             dp.shardSliceTotal += cp.sourceSliceCount;
             dp.shardSampledTotal += cp.sampledSlices.size();
         }
+        std::cout << "Shard plan " << direction_name(dir) << ": "
+                  << dp.chunkPlans.size() << "/" << total_chunks << " source chunks, "
+                  << dp.shardSampledTotal << " sampled slices, "
+                  << dp.shardSliceTotal << " source slices." << std::endl;
         direction_plans.push_back(std::move(dp));
     }
 
@@ -753,6 +930,8 @@ void run_generate(const po::variables_map& vm) {
         auto last_report_time = std::chrono::steady_clock::now();
         auto start_time = std::chrono::steady_clock::now();
         std::atomic<size_t> written_counter{0};
+        std::atomic<size_t> slice_done_counter{0};
+        const size_t slice_progress_total = sampled_slices_total;
         run_metrics.totalProcessedAllDirs += unsampled;
 
         const cv::Size slice_size = vc::core::util::normalGridSliceSize(
@@ -762,7 +941,18 @@ void run_generate(const po::variables_map& vm) {
         const size_t chunk_count_y = (shape[1] + source_chunk_shape[1] - 1) / source_chunk_shape[1];
         const size_t chunk_count_x = (shape[2] + source_chunk_shape[2] - 1) / source_chunk_shape[2];
 
+        std::cout << "Direction " << dir_metrics.direction << " starting: "
+                  << sampled_chunk_plans.size() << " source chunks, "
+                  << sampled_slices_total << " sampled slices to process." << std::endl;
+
+        size_t chunk_index = 0;
         for (const auto& source_chunk_plan : sampled_chunk_plans) {
+            ++chunk_index;
+            std::cout << "  [" << dir_metrics.direction << "] source chunk "
+                      << chunk_index << "/" << sampled_chunk_plans.size()
+                      << " (sourceChunkIndex=" << source_chunk_plan.sourceChunkIndex
+                      << ", " << source_chunk_plan.sampledSlices.size() << " sampled slices)"
+                      << std::endl;
             for (size_t batch_start = 0;
                  batch_start < source_chunk_plan.sampledSlices.size();
                  batch_start += chunk_size_tgt) {
@@ -776,6 +966,7 @@ void run_generate(const po::variables_map& vm) {
                 assembled_slices.reserve(batch_size);
                 size_t batch_existing = 0;
 
+                const auto prep_start = std::chrono::steady_clock::now();
                 for (size_t batch_index = 0; batch_index < batch_size; ++batch_index) {
                     const auto& sampled =
                         source_chunk_plan.sampledSlices[batch_start + batch_index];
@@ -794,6 +985,11 @@ void run_generate(const po::variables_map& vm) {
                     if (fs::exists(task.outPath)) {
                         task.kind = SliceTaskKind::Exists;
                         ++batch_existing;
+                        if (debug_per_slice) {
+                            const auto p = take_progress(
+                                slice_done_counter, start_time, slice_progress_total);
+                            log_slice_existing(dir_metrics.direction, task.sliceIndex, p);
+                        }
                         continue;
                     }
 
@@ -802,6 +998,14 @@ void run_generate(const po::variables_map& vm) {
                     assembled.task = task;
                     assembled.localSliceIndex = sampled.localSliceIndex;
                     assembled.binarySlice = cv::Mat::zeros(slice_size, CV_8U);
+                }
+                const double prep_seconds = seconds_since(prep_start);
+
+                if (debug_per_slice) {
+                    log_batch(dir_metrics.direction, chunk_index,
+                              sampled_chunk_plans.size(), batch_size, batch_existing,
+                              assembled_slices.size(), prep_seconds,
+                              seconds_since(start_time));
                 }
 
                 if (!assembled_slices.empty()) {
@@ -844,17 +1048,42 @@ void run_generate(const po::variables_map& vm) {
                     const auto read_start = std::chrono::steady_clock::now();
                     Array3D<uint8_t> chunk_data(slab_shape);
                     input_volume.readZYX(chunk_data, slab_offset, input_level);
-                    dir_metrics.timingTotals["read_chunk"] += std::chrono::duration<double>(
-                        std::chrono::steady_clock::now() - read_start).count();
-                    dir_metrics.timingCounts["read_chunk"] += 1;
+                    const double read_seconds = seconds_since(read_start);
+                    record_timing(dir_metrics, "read_chunk", read_seconds);
 
+                    const size_t slab_voxels = slab_shape[0] * slab_shape[1] * slab_shape[2];
+                    const size_t slab_bytes = slab_voxels * sizeof(uint8_t);
+
+                    if (debug_per_slice) {
+                        const double mib = static_cast<double>(slab_bytes) / (1024.0 * 1024.0);
+                        const double mibps = read_seconds > 0.0 ? mib / read_seconds : 0.0;
+                        log_chunk_io(dir_metrics.direction, chunk_index,
+                                     sampled_chunk_plans.size(),
+                                     source_chunk_plan.sourceChunkIndex,
+                                     assembled_slices.size(),
+                                     slab_shape[0], slab_shape[1], slab_shape[2],
+                                     mib, read_seconds, mibps,
+                                     seconds_since(start_time));
+                    }
+
+                    const auto extract_loop_start = std::chrono::steady_clock::now();
                     for (auto& assembled : assembled_slices) {
+                        const auto extract_start = std::chrono::steady_clock::now();
                         const bool any_nonzero = vc::core::util::extractBinarySliceFromChunk(
                             chunk_data,
                             to_normal_grid_direction(dir),
                             assembled.localSliceIndex,
                             assembled.binarySlice);
+                        assembled.extractSeconds = seconds_since(extract_start);
                         assembled.anyNonZero = assembled.anyNonZero || any_nonzero;
+                    }
+                    const double extract_loop_seconds = seconds_since(extract_loop_start);
+
+                    if (debug_per_slice) {
+                        log_chunk_extract(dir_metrics.direction, chunk_index,
+                                          sampled_chunk_plans.size(),
+                                          extract_loop_seconds,
+                                          assembled_slices.size());
                     }
                 }
 
@@ -872,6 +1101,14 @@ void run_generate(const po::variables_map& vm) {
                         std::ofstream ofs(task.outPath);
                         ++local_stats.emptyBinary;
                         ++local_stats.processed;
+                        if (debug_per_slice) {
+                            const auto p = take_progress(
+                                slice_done_counter, start_time, slice_progress_total);
+                            log_slice_empty_binary(dir_metrics.direction,
+                                task.sliceIndex, tid, p,
+                                assembled.extractSeconds,
+                                assembled.binarySlice.cols, assembled.binarySlice.rows);
+                        }
                         continue;
                     }
 
@@ -879,9 +1116,8 @@ void run_generate(const po::variables_map& vm) {
                     const auto thinning_start = std::chrono::steady_clock::now();
                     ThinningStats thinning_stats;
                     customThinningTraceOnly(assembled.binarySlice, scratch.traces, &thinning_stats);
-                    local_stats.timingTotals["thinning"] += std::chrono::duration<double>(
-                        std::chrono::steady_clock::now() - thinning_start).count();
-                    local_stats.timingCounts["thinning"] += 1;
+                    const double thinning_seconds = seconds_since(thinning_start);
+                    record_timing(local_stats, "thinning", thinning_seconds);
                     local_stats.thinningStats.accumulate(thinning_stats);
                     ++local_stats.thinningCalls;
 
@@ -889,6 +1125,13 @@ void run_generate(const po::variables_map& vm) {
                         std::ofstream ofs(task.outPath);
                         ++local_stats.emptyTrace;
                         ++local_stats.processed;
+                        if (debug_per_slice) {
+                            const auto p = take_progress(
+                                slice_done_counter, start_time, slice_progress_total);
+                            log_slice_empty_trace(dir_metrics.direction,
+                                task.sliceIndex, tid, p,
+                                assembled.extractSeconds, thinning_seconds);
+                        }
                         continue;
                     }
 
@@ -898,34 +1141,40 @@ void run_generate(const po::variables_map& vm) {
 
                     const auto populate_start = std::chrono::steady_clock::now();
                     populate_normal_grid(scratch.traces, grid_store, spiral_step);
-                    local_stats.timingTotals["populate_grid"] += std::chrono::duration<double>(
-                        std::chrono::steady_clock::now() - populate_start).count();
-                    local_stats.timingCounts["populate_grid"] += 1;
+                    const double populate_seconds = seconds_since(populate_start);
+                    record_timing(local_stats, "populate_grid", populate_seconds);
 
                     const auto save_start = std::chrono::steady_clock::now();
                     grid_store.save(task.tmpPath.string(), vc::core::util::GridStore::SaveOptions{
                         .verify_reload = verify_grid_save,
                     });
                     fs::rename(task.tmpPath, task.outPath);
-                    local_stats.timingTotals["save_grid"] += std::chrono::duration<double>(
-                        std::chrono::steady_clock::now() - save_start).count();
-                    local_stats.timingCounts["save_grid"] += 1;
+                    const double save_seconds = seconds_since(save_start);
+                    record_timing(local_stats, "save_grid", save_seconds);
 
                     const size_t written_index = written_counter.fetch_add(1, std::memory_order_relaxed) + 1;
                     if (preview_every > 0 && (written_index % static_cast<size_t>(preview_every)) == 0) {
                         const auto preview_start = std::chrono::steady_clock::now();
                         cv::imwrite(task.previewPath.string(), assembled.binarySlice);
-                        local_stats.timingTotals["preview_image"] += std::chrono::duration<double>(
-                            std::chrono::steady_clock::now() - preview_start).count();
-                        local_stats.timingCounts["preview_image"] += 1;
+                        record_timing(local_stats, "preview_image", seconds_since(preview_start));
                         ++local_stats.previewWrites;
                     }
 
-                    local_stats.totalSize += fs::file_size(task.outPath);
+                    const size_t written_bytes = fs::file_size(task.outPath);
+                    local_stats.totalSize += written_bytes;
                     local_stats.totalSegments += grid_store.numSegments();
                     local_stats.totalBuckets += grid_store.numNonEmptyBuckets();
                     ++local_stats.written;
                     ++local_stats.processed;
+
+                    if (debug_per_slice) {
+                        const auto p = take_progress(
+                            slice_done_counter, start_time, slice_progress_total);
+                        log_slice_written(dir_metrics.direction, task.sliceIndex,
+                            tid, p, assembled.extractSeconds, thinning_seconds,
+                            populate_seconds, save_seconds, written_bytes,
+                            grid_store.numSegments(), grid_store.numNonEmptyBuckets());
+                    }
                 }
 
                 processed += batch_existing;
@@ -953,7 +1202,7 @@ void run_generate(const po::variables_map& vm) {
             }
 
             auto now = std::chrono::steady_clock::now();
-            if (std::chrono::duration_cast<std::chrono::seconds>(now - last_report_time).count() >= 1) {
+            if (std::chrono::duration_cast<std::chrono::seconds>(now - last_report_time).count() >= 5) {
                 last_report_time = now;
                 const auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(now - start_time).count();
                 const size_t active_processed = processed > (skipped_existing + unsampled)

--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -5,6 +5,7 @@
 #include <iomanip>
 #include <limits>
 #include <cstdio>
+#include <new>
 
 #include <boost/program_options.hpp>
 #include <opencv2/opencv.hpp>
@@ -15,6 +16,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <arpa/inet.h>
+#include <sys/mman.h>
 
 #include <omp.h>
 
@@ -118,10 +120,61 @@ struct ThreadScratch {
     std::vector<std::vector<cv::Point>> traces;
 };
 
+// Anonymous-mmap'd buffer. Linux guarantees fresh pages read as zero (the
+// kernel maps a single shared read-only zero page COW until first write),
+// so the buffer is zero-initialised without an eager memset/touch pass.
+// Pages only become resident on first write — for partly-populated slices
+// the unwritten regions never cost a page-fault or a physical page.
+struct AnonMmap {
+    AnonMmap() = default;
+    explicit AnonMmap(size_t bytes) : bytes_(bytes) {
+        if (bytes_ == 0) return;
+        ptr_ = ::mmap(nullptr, bytes_, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (ptr_ == MAP_FAILED) {
+            ptr_ = nullptr;
+            bytes_ = 0;
+            throw std::bad_alloc();
+        }
+    }
+    AnonMmap(const AnonMmap&) = delete;
+    AnonMmap& operator=(const AnonMmap&) = delete;
+    AnonMmap(AnonMmap&& other) noexcept
+        : ptr_(other.ptr_), bytes_(other.bytes_)
+    {
+        other.ptr_ = nullptr;
+        other.bytes_ = 0;
+    }
+    AnonMmap& operator=(AnonMmap&& other) noexcept {
+        if (this != &other) {
+            reset();
+            ptr_ = other.ptr_;
+            bytes_ = other.bytes_;
+            other.ptr_ = nullptr;
+            other.bytes_ = 0;
+        }
+        return *this;
+    }
+    ~AnonMmap() { reset(); }
+    void reset() {
+        if (ptr_) {
+            ::munmap(ptr_, bytes_);
+        }
+        ptr_ = nullptr;
+        bytes_ = 0;
+    }
+    void* data() const { return ptr_; }
+    size_t bytes() const { return bytes_; }
+private:
+    void* ptr_ = nullptr;
+    size_t bytes_ = 0;
+};
+
 struct AssembledSlice {
     SliceTask task;
     size_t localSliceIndex = 0;
-    cv::Mat binarySlice;
+    AnonMmap binaryBuffer;     // owns the mmap; lifetime ≥ binarySlice
+    cv::Mat binarySlice;       // non-owning view over binaryBuffer.data()
     bool anyNonZero = false;
 };
 
@@ -1008,7 +1061,11 @@ void run_generate(const po::variables_map& vm) {
                     auto& assembled = assembled_slices.emplace_back();
                     assembled.task = task;
                     assembled.localSliceIndex = sampled.localSliceIndex;
-                    assembled.binarySlice = cv::Mat::zeros(slice_size, CV_8U);
+                    const size_t slice_bytes = static_cast<size_t>(slice_size.width) *
+                                               static_cast<size_t>(slice_size.height);
+                    assembled.binaryBuffer = AnonMmap(slice_bytes);
+                    assembled.binarySlice = cv::Mat(slice_size, CV_8U,
+                                                    assembled.binaryBuffer.data());
                 }
                 const double prep_seconds = seconds_since(prep_start);
 

--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -117,7 +117,6 @@ struct AssembledSlice {
     size_t localSliceIndex = 0;
     cv::Mat binarySlice;
     bool anyNonZero = false;
-    double extractSeconds = 0.0;
 };
 
 static const char* direction_name(SliceDirection dir) {
@@ -272,7 +271,7 @@ static void log_slice_existing(
 
 static void log_slice_empty_binary(
     const std::string& dir, size_t idx, int tid, const ProgressSnap& p,
-    double extract_s, int slice_w, int slice_h)
+    int slice_w, int slice_h)
 {
     #pragma omp critical(debug_per_slice_log)
     std::cout << "[slice] dir=" << dir
@@ -282,14 +281,13 @@ static void log_slice_empty_binary(
               << " elapsed=" << std::fixed << std::setprecision(3) << p.elapsed << "s"
               << " rate=" << std::setprecision(2) << p.rate << "it/s"
               << " eta=" << std::setprecision(1) << p.eta << "s"
-              << " extract=" << std::setprecision(4) << extract_s << "s"
               << " slice_size=" << slice_w << "x" << slice_h
               << std::endl;
 }
 
 static void log_slice_empty_trace(
     const std::string& dir, size_t idx, int tid, const ProgressSnap& p,
-    double extract_s, double thinning_s)
+    double thinning_s)
 {
     #pragma omp critical(debug_per_slice_log)
     std::cout << "[slice] dir=" << dir
@@ -299,14 +297,13 @@ static void log_slice_empty_trace(
               << " elapsed=" << std::fixed << std::setprecision(3) << p.elapsed << "s"
               << " rate=" << std::setprecision(2) << p.rate << "it/s"
               << " eta=" << std::setprecision(1) << p.eta << "s"
-              << " extract=" << std::setprecision(4) << extract_s << "s"
               << " thinning=" << thinning_s << "s"
               << std::endl;
 }
 
 static void log_slice_written(
     const std::string& dir, size_t idx, int tid, const ProgressSnap& p,
-    double extract_s, double thinning_s, double populate_s, double save_s,
+    double thinning_s, double populate_s, double save_s,
     size_t bytes, size_t segments, size_t buckets)
 {
     #pragma omp critical(debug_per_slice_log)
@@ -317,7 +314,6 @@ static void log_slice_written(
               << " elapsed=" << std::fixed << std::setprecision(3) << p.elapsed << "s"
               << " rate=" << std::setprecision(2) << p.rate << "it/s"
               << " eta=" << std::setprecision(1) << p.eta << "s"
-              << " extract=" << std::setprecision(4) << extract_s << "s"
               << " thinning=" << thinning_s << "s"
               << " populate=" << populate_s << "s"
               << " save=" << save_s << "s"
@@ -345,29 +341,14 @@ static void log_batch(
 static void log_chunk_io(
     const std::string& dir, size_t chunk_i, size_t chunk_n,
     size_t source_chunk_idx, size_t batch_size,
-    size_t slab_z, size_t slab_y, size_t slab_x,
-    double slab_mib, double read_s, double mibps, double elapsed)
+    double read_s, double elapsed)
 {
     std::cout << "[chunk] dir=" << dir
               << " chunk=" << chunk_i << "/" << chunk_n
               << " source_chunk_idx=" << source_chunk_idx
               << " batch_size=" << batch_size
-              << " slab=" << slab_z << "x" << slab_y << "x" << slab_x
-              << " (" << std::fixed << std::setprecision(1) << slab_mib << "MiB)"
-              << " read=" << std::setprecision(3) << read_s << "s"
-              << " (" << std::setprecision(1) << mibps << "MiB/s)"
+              << " read=" << std::fixed << std::setprecision(3) << read_s << "s"
               << " elapsed=" << std::setprecision(3) << elapsed << "s"
-              << std::endl;
-}
-
-static void log_chunk_extract(
-    const std::string& dir, size_t chunk_i, size_t chunk_n,
-    double extract_loop_s, size_t n_slices)
-{
-    std::cout << "[chunk] dir=" << dir
-              << " chunk=" << chunk_i << "/" << chunk_n
-              << " extract_loop=" << std::fixed << std::setprecision(3) << extract_loop_s << "s"
-              << " (" << n_slices << " slices)"
               << std::endl;
 }
 
@@ -941,9 +922,22 @@ void run_generate(const po::variables_map& vm) {
         const size_t chunk_count_y = (shape[1] + source_chunk_shape[1] - 1) / source_chunk_shape[1];
         const size_t chunk_count_x = (shape[2] + source_chunk_shape[2] - 1) / source_chunk_shape[2];
 
+        const size_t slice_axis_chunk_depth = source_chunk_shape[
+            vc::core::util::normalGridSliceAxis(to_normal_grid_direction(dir))];
+        const double bytes_per_slice_mib =
+            static_cast<double>(batch_plan.bytesPerSlice) / (1024.0 * 1024.0);
+        const double estimated_batch_mib =
+            static_cast<double>(batch_plan.estimatedBatchBytes) / (1024.0 * 1024.0);
         std::cout << "Direction " << dir_metrics.direction << " starting: "
                   << sampled_chunk_plans.size() << " source chunks, "
-                  << sampled_slices_total << " sampled slices to process." << std::endl;
+                  << sampled_slices_total << " sampled slices to process."
+                  << " batch_size=" << chunk_size_tgt << "/" << slice_axis_chunk_depth
+                  << " (slices per slab read)"
+                  << " bytes_per_slice=" << std::fixed << std::setprecision(1)
+                  << bytes_per_slice_mib << "MiB"
+                  << " budget_used=" << estimated_batch_mib << "/"
+                  << chunk_budget_mib << "MiB"
+                  << std::endl;
 
         size_t chunk_index = 0;
         for (const auto& source_chunk_plan : sampled_chunk_plans) {
@@ -1043,7 +1037,6 @@ void run_generate(const po::variables_map& vm) {
 
                     for (size_t i = 0; i < targets.size(); ++i) {
                         assembled_slices[i].anyNonZero = targets[i].anyNonZero;
-                        assembled_slices[i].extractSeconds = 0.0;
                     }
 
                     if (debug_per_slice) {
@@ -1051,8 +1044,7 @@ void run_generate(const po::variables_map& vm) {
                                      sampled_chunk_plans.size(),
                                      source_chunk_plan.sourceChunkIndex,
                                      assembled_slices.size(),
-                                     0, 0, 0,
-                                     0.0, read_seconds, 0.0,
+                                     read_seconds,
                                      seconds_since(start_time));
                     }
                 }
@@ -1076,7 +1068,6 @@ void run_generate(const po::variables_map& vm) {
                                 slice_done_counter, start_time, slice_progress_total);
                             log_slice_empty_binary(dir_metrics.direction,
                                 task.sliceIndex, tid, p,
-                                assembled.extractSeconds,
                                 assembled.binarySlice.cols, assembled.binarySlice.rows);
                         }
                         continue;
@@ -1099,8 +1090,7 @@ void run_generate(const po::variables_map& vm) {
                             const auto p = take_progress(
                                 slice_done_counter, start_time, slice_progress_total);
                             log_slice_empty_trace(dir_metrics.direction,
-                                task.sliceIndex, tid, p,
-                                assembled.extractSeconds, thinning_seconds);
+                                task.sliceIndex, tid, p, thinning_seconds);
                         }
                         continue;
                     }
@@ -1141,7 +1131,7 @@ void run_generate(const po::variables_map& vm) {
                         const auto p = take_progress(
                             slice_done_counter, start_time, slice_progress_total);
                         log_slice_written(dir_metrics.direction, task.sliceIndex,
-                            tid, p, assembled.extractSeconds, thinning_seconds,
+                            tid, p, thinning_seconds,
                             populate_seconds, save_seconds, written_bytes,
                             grid_store.numSegments(), grid_store.numNonEmptyBuckets());
                     }

--- a/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
+++ b/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
@@ -5,11 +5,13 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <span>
 #include <stdexcept>
 #include <vector>
 
 #include <opencv2/core.hpp>
 #include <vc/core/types/Array3D.hpp>
+#include <vc/core/types/Volume.hpp>
 
 namespace vc::core::util {
 
@@ -156,117 +158,167 @@ inline NormalGridBatchPlan planNormalGridBatch(
     };
 }
 
-inline void copyBinarySliceRegionFromChunk(
-    const uint8_t* chunkData,
-    const std::array<int, 3>& chunkShape,
-    NormalGridSliceDirection direction,
-    size_t localSliceIndex,
-    size_t validRows,
-    size_t validCols,
-    int dstRowOffset,
-    int dstColOffset,
-    cv::Mat& binarySlice,
-    bool& anyNonZero)
-{
-    const int strideZ = chunkShape[1] * chunkShape[2];
-    const int strideY = chunkShape[2];
+struct BinarySliceTarget {
+    cv::Mat* binarySlice = nullptr;     // pre-allocated full-extent CV_8U slice; written by the helper
+    int localSliceIndex = 0;            // 0..sourceChunkShape[sliceAxis]-1
+    bool anyNonZero = false;            // out: set true if any voxel of this slice is non-zero
+};
 
-    switch (direction) {
-    case NormalGridSliceDirection::XY:
-        for (size_t row = 0; row < validRows; ++row) {
-            const auto* src = chunkData +
-                static_cast<size_t>(localSliceIndex) * strideZ +
-                row * strideY;
-            auto* dst = binarySlice.ptr<uint8_t>(dstRowOffset + static_cast<int>(row)) + dstColOffset;
-            for (size_t col = 0; col < validCols; ++col) {
-                const bool isSet = src[col] > 0;
-                dst[col] = isSet ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
-                anyNonZero = anyNonZero || isSet;
+namespace detail {
+
+template <NormalGridSliceDirection Dir>
+inline void distributeChunk(
+    const std::byte* chunkBytes,
+    const std::array<int, 3>& chunkShape,           // ZYX
+    int validD, int validH, int validW,
+    int rowOffset, int colOffset,
+    std::span<const int> sliceForLocal,             // size = sourceSliceAxisLen, -1 for none
+    std::span<BinarySliceTarget> targets)
+{
+    const int H = chunkShape[1];
+    const int W = chunkShape[2];
+    const auto* chunk = reinterpret_cast<const uint8_t*>(chunkBytes);
+
+    for (int lz = 0; lz < validD; ++lz) {
+        for (int ly = 0; ly < validH; ++ly) {
+            const uint8_t* row = chunk + (lz * H + ly) * W;
+            for (int lx = 0; lx < validW; ++lx) {
+                int local;
+                int dr;
+                int dc;
+                if constexpr (Dir == NormalGridSliceDirection::XY) {
+                    local = lz; dr = rowOffset + ly; dc = colOffset + lx;
+                } else if constexpr (Dir == NormalGridSliceDirection::XZ) {
+                    local = ly; dr = rowOffset + lz; dc = colOffset + lx;
+                } else { // YZ
+                    local = lx; dr = rowOffset + lz; dc = colOffset + ly;
+                }
+                const int slot = sliceForLocal[local];
+                if (slot < 0) continue;
+                const uint8_t v = row[lx];
+                targets[slot].binarySlice->ptr<uint8_t>(dr)[dc] =
+                    v ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
+                if (v) targets[slot].anyNonZero = true;
             }
         }
-        break;
-    case NormalGridSliceDirection::XZ:
-        for (size_t row = 0; row < validRows; ++row) {
-            auto* dst = binarySlice.ptr<uint8_t>(dstRowOffset + static_cast<int>(row)) + dstColOffset;
-            for (size_t col = 0; col < validCols; ++col) {
-                const size_t srcIndex =
-                    row * strideZ +
-                    static_cast<size_t>(localSliceIndex) * strideY +
-                    col;
-                const bool isSet = chunkData[srcIndex] > 0;
-                dst[col] = isSet ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
-                anyNonZero = anyNonZero || isSet;
-            }
-        }
-        break;
-    case NormalGridSliceDirection::YZ:
-        for (size_t row = 0; row < validRows; ++row) {
-            auto* dst = binarySlice.ptr<uint8_t>(dstRowOffset + static_cast<int>(row)) + dstColOffset;
-            for (size_t col = 0; col < validCols; ++col) {
-                const size_t srcIndex =
-                    row * strideZ +
-                    col * strideY +
-                    static_cast<size_t>(localSliceIndex);
-                const bool isSet = chunkData[srcIndex] > 0;
-                dst[col] = isSet ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
-                anyNonZero = anyNonZero || isSet;
-            }
-        }
-        break;
     }
 }
 
-inline bool extractBinarySliceFromChunk(
-    const Array3D<uint8_t>& chunkData,
-    NormalGridSliceDirection direction,
-    size_t iChunk,
-    cv::Mat& binarySlice)
-{
-    bool anyNonZero = false;
+}  // namespace detail
 
-    switch (direction) {
-    case NormalGridSliceDirection::XY:
-        binarySlice.create(static_cast<int>(chunkData.shape()[1]),
-                           static_cast<int>(chunkData.shape()[2]),
-                           CV_8U);
-        for (int row = 0; row < binarySlice.rows; ++row) {
-            uint8_t* dst = binarySlice.ptr<uint8_t>(row);
-            for (int col = 0; col < binarySlice.cols; ++col) {
-                const bool isSet = chunkData(iChunk, static_cast<size_t>(row), static_cast<size_t>(col)) > 0;
-                dst[col] = isSet ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
-                anyNonZero = anyNonZero || isSet;
-            }
-        }
-        break;
-    case NormalGridSliceDirection::XZ:
-        binarySlice.create(static_cast<int>(chunkData.shape()[0]),
-                           static_cast<int>(chunkData.shape()[2]),
-                           CV_8U);
-        for (int row = 0; row < binarySlice.rows; ++row) {
-            uint8_t* dst = binarySlice.ptr<uint8_t>(row);
-            for (int col = 0; col < binarySlice.cols; ++col) {
-                const bool isSet = chunkData(static_cast<size_t>(row), iChunk, static_cast<size_t>(col)) > 0;
-                dst[col] = isSet ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
-                anyNonZero = anyNonZero || isSet;
-            }
-        }
-        break;
-    case NormalGridSliceDirection::YZ:
-        binarySlice.create(static_cast<int>(chunkData.shape()[0]),
-                           static_cast<int>(chunkData.shape()[1]),
-                           CV_8U);
-        for (int row = 0; row < binarySlice.rows; ++row) {
-            uint8_t* dst = binarySlice.ptr<uint8_t>(row);
-            for (int col = 0; col < binarySlice.cols; ++col) {
-                const bool isSet = chunkData(static_cast<size_t>(row), static_cast<size_t>(col), iChunk) > 0;
-                dst[col] = isSet ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
-                anyNonZero = anyNonZero || isSet;
-            }
-        }
-        break;
+// Walk the chunk grid of one chunk-aligned slab along the slice axis,
+// decode each chunk via volume.readChunk (uncached; nullopt = missing or
+// AllFill), and distribute voxels into the caller-provided binary slice
+// batch. Each target's cv::Mat is pre-allocated zero CV_8U at the slice
+// extent given by normalGridSliceSize(volumeShape, direction); the helper
+// writes 255 where voxel != 0, 0 otherwise, and toggles anyNonZero.
+//
+// Sequential implementation; no global slab buffer.
+inline void fillBinarySliceBatchFromVolume(
+    Volume& volume,
+    int level,
+    NormalGridSliceDirection direction,
+    int sliceAxisChunkIndex,
+    const std::array<int, 3>& volumeShape,
+    const std::array<int, 3>& sourceChunkShape,
+    std::span<BinarySliceTarget> targets)
+{
+    if (targets.empty()) {
+        return;
+    }
+    if (volume.dtype() != vc::render::ChunkDtype::UInt8) {
+        throw std::runtime_error(
+            "fillBinarySliceBatchFromVolume currently supports uint8 volumes only");
     }
 
-    return anyNonZero;
+    const int sliceAxis = static_cast<int>(normalGridSliceAxis(direction));
+    const int sourceSliceAxisLen = sourceChunkShape[sliceAxis];
+    if (sourceSliceAxisLen <= 0) {
+        throw std::runtime_error("source chunk slice-axis length must be > 0");
+    }
+
+    int axisA = 0;
+    int axisB = 0;
+    switch (direction) {
+    case NormalGridSliceDirection::XY: axisA = 1; axisB = 2; break;
+    case NormalGridSliceDirection::XZ: axisA = 0; axisB = 2; break;
+    case NormalGridSliceDirection::YZ: axisA = 0; axisB = 1; break;
+    }
+    const int chunkSizeA = sourceChunkShape[axisA];
+    const int chunkSizeB = sourceChunkShape[axisB];
+    const int volA = volumeShape[axisA];
+    const int volB = volumeShape[axisB];
+    const int Ca = (volA + chunkSizeA - 1) / chunkSizeA;
+    const int Cb = (volB + chunkSizeB - 1) / chunkSizeB;
+
+    // local-slice -> target slot
+    std::vector<int> sliceForLocal(static_cast<size_t>(sourceSliceAxisLen), -1);
+    for (size_t i = 0; i < targets.size(); ++i) {
+        const int local = targets[i].localSliceIndex;
+        if (local < 0 || local >= sourceSliceAxisLen) {
+            throw std::runtime_error(
+                "fillBinarySliceBatchFromVolume: localSliceIndex out of range");
+        }
+        sliceForLocal[static_cast<size_t>(local)] = static_cast<int>(i);
+    }
+
+    const int D = sourceChunkShape[0];
+    const int H = sourceChunkShape[1];
+    const int W = sourceChunkShape[2];
+    const int volZ = volumeShape[0];
+    const int volY = volumeShape[1];
+    const int volX = volumeShape[2];
+
+    for (int ca = 0; ca < Ca; ++ca) {
+        for (int cb = 0; cb < Cb; ++cb) {
+            std::array<size_t, 3> chunkKey{};
+            chunkKey[static_cast<size_t>(sliceAxis)] = static_cast<size_t>(sliceAxisChunkIndex);
+            chunkKey[static_cast<size_t>(axisA)] = static_cast<size_t>(ca);
+            chunkKey[static_cast<size_t>(axisB)] = static_cast<size_t>(cb);
+
+            auto bytes = volume.readChunk(level, chunkKey);
+            if (!bytes) {
+                continue;  // missing or AllFill
+            }
+
+            const int rowOffset = ca * chunkSizeA;
+            const int colOffset = cb * chunkSizeB;
+
+            int validD = D;
+            int validH = H;
+            int validW = W;
+
+            switch (direction) {
+            case NormalGridSliceDirection::XY:
+                validD = std::min(D, std::max(0, volZ - sliceAxisChunkIndex * D));
+                validH = std::min(H, std::max(0, volY - rowOffset));
+                validW = std::min(W, std::max(0, volX - colOffset));
+                detail::distributeChunk<NormalGridSliceDirection::XY>(
+                    bytes->data(), sourceChunkShape, validD, validH, validW,
+                    rowOffset, colOffset,
+                    std::span<const int>(sliceForLocal), targets);
+                break;
+            case NormalGridSliceDirection::XZ:
+                validD = std::min(D, std::max(0, volZ - rowOffset));
+                validH = std::min(H, std::max(0, volY - sliceAxisChunkIndex * H));
+                validW = std::min(W, std::max(0, volX - colOffset));
+                detail::distributeChunk<NormalGridSliceDirection::XZ>(
+                    bytes->data(), sourceChunkShape, validD, validH, validW,
+                    rowOffset, colOffset,
+                    std::span<const int>(sliceForLocal), targets);
+                break;
+            case NormalGridSliceDirection::YZ:
+                validD = std::min(D, std::max(0, volZ - rowOffset));
+                validH = std::min(H, std::max(0, volY - colOffset));
+                validW = std::min(W, std::max(0, volX - sliceAxisChunkIndex * W));
+                detail::distributeChunk<NormalGridSliceDirection::YZ>(
+                    bytes->data(), sourceChunkShape, validD, validH, validW,
+                    rowOffset, colOffset,
+                    std::span<const int>(sliceForLocal), targets);
+                break;
+            }
+        }
+    }
 }
 
-} // namespace vc::core::util
+}  // namespace vc::core::util

--- a/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
+++ b/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include <omp.h>
 #include <opencv2/core.hpp>
 #include <vc/core/types/Array3D.hpp>
 #include <vc/core/types/Volume.hpp>
@@ -221,6 +222,12 @@ inline void distributeChunk(
 // extent given by normalGridSliceSize(volumeShape, direction); the helper
 // writes 255 where voxel != 0, 0 otherwise, and toggles anyNonZero.
 //
+// `ioThreads` overrides the OMP team size for the chunk-read loop. Pass 0
+// to keep the OMP default (omp_get_max_threads()). Useful as an IO-bound
+// lever — read syscalls block, so oversubscribing cores lets the kernel
+// keep more concurrent reads in flight without starving compute on the
+// critical path.
+//
 // Sequential implementation; no global slab buffer.
 inline void fillBinarySliceBatchFromVolume(
     Volume& volume,
@@ -229,7 +236,8 @@ inline void fillBinarySliceBatchFromVolume(
     int sliceAxisChunkIndex,
     const std::array<int, 3>& volumeShape,
     const std::array<int, 3>& sourceChunkShape,
-    std::span<BinarySliceTarget> targets)
+    std::span<BinarySliceTarget> targets,
+    int ioThreads = 0)
 {
     if (targets.empty()) {
         return;
@@ -291,7 +299,8 @@ inline void fillBinarySliceBatchFromVolume(
     // buffer for the lifetime of the parallel region, so blosc decompress
     // writes into a hot, already-resident allocation instead of mmap/munmap-ing
     // a fresh page-aligned vector for every chunk.
-    #pragma omp parallel
+    const int teamSize = ioThreads > 0 ? ioThreads : omp_get_max_threads();
+    #pragma omp parallel num_threads(teamSize)
     {
         std::vector<std::byte> scratch(chunkBytes);
 

--- a/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
+++ b/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
@@ -114,22 +114,21 @@ inline std::vector<NormalGridSampledChunkPlan> planNormalGridSampledChunks(
 
 inline NormalGridBatchPlan planNormalGridBatch(
     const std::vector<size_t>& shape,
+    const std::vector<size_t>& sourceChunkShape,
     NormalGridSliceDirection direction,
-    int numThreads,
-    int sparseVolume,
     size_t chunkBudgetMiB,
     size_t bytesPerVoxel = 1)
 {
-    if (shape.size() != 3) {
-        throw std::runtime_error("planNormalGridBatch expects 3D ZYX shape");
+    if (shape.size() != 3 || sourceChunkShape.size() != 3) {
+        throw std::runtime_error("planNormalGridBatch expects 3D ZYX shape/chunkShape");
     }
     if (bytesPerVoxel == 0) {
         throw std::runtime_error("bytesPerVoxel must be > 0");
     }
 
     const size_t budgetBytes = chunkBudgetMiB * 1024ull * 1024ull;
-    const size_t threadSlices = static_cast<size_t>(std::max(1, numThreads)) *
-                                static_cast<size_t>(std::max(1, sparseVolume));
+    const size_t sliceAxis = normalGridSliceAxis(direction);
+    const size_t sourceChunkSliceAxisLen = sourceChunkShape[sliceAxis];
 
     size_t bytesPerSlice = 0;
     switch (direction) {
@@ -144,11 +143,16 @@ inline NormalGridBatchPlan planNormalGridBatch(
         break;
     }
 
-    size_t chunkSizeTarget = threadSlices;
+    // N = clamp(1, sourceChunkSliceAxisLen, floor(budget / bytesPerSlice)).
+    // Capping at sourceChunkSliceAxisLen means at most one chunk-walk per
+    // source chunk; raising budget above (sourceChunkSliceAxisLen *
+    // bytesPerSlice) buys nothing beyond that.
+    size_t chunkSizeTarget = 1;
     if (bytesPerSlice > 0 && budgetBytes > 0) {
-        chunkSizeTarget = std::max<size_t>(1, std::min(threadSlices, budgetBytes / bytesPerSlice));
-    } else if (budgetBytes == 0) {
-        chunkSizeTarget = 1;
+        chunkSizeTarget = std::max<size_t>(1, budgetBytes / bytesPerSlice);
+    }
+    if (sourceChunkSliceAxisLen > 0) {
+        chunkSizeTarget = std::min(chunkSizeTarget, sourceChunkSliceAxisLen);
     }
 
     return NormalGridBatchPlan{

--- a/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
+++ b/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -177,7 +178,8 @@ inline void distributeChunk(
     int validD, int validH, int validW,
     int rowOffset, int colOffset,
     std::span<const int> sliceForLocal,             // size = sourceSliceAxisLen, -1 for none
-    std::span<BinarySliceTarget> targets)
+    std::span<BinarySliceTarget> targets,
+    std::span<std::atomic<uint8_t>> anyFlags)
 {
     const int H = chunkShape[1];
     const int W = chunkShape[2];
@@ -202,7 +204,9 @@ inline void distributeChunk(
                 const uint8_t v = row[lx];
                 targets[slot].binarySlice->ptr<uint8_t>(dr)[dc] =
                     v ? static_cast<uint8_t>(255) : static_cast<uint8_t>(0);
-                if (v) targets[slot].anyNonZero = true;
+                if (v) {
+                    anyFlags[slot].store(1, std::memory_order_relaxed);
+                }
             }
         }
     }
@@ -273,6 +277,15 @@ inline void fillBinarySliceBatchFromVolume(
     const int volY = volumeShape[1];
     const int volX = volumeShape[2];
 
+    // Concurrent any-non-zero accumulators. Each (ca, cb) chunk maps to a
+    // disjoint slice region, so voxel writes don't race; the flag is the
+    // only cross-thread write.
+    std::vector<std::atomic<uint8_t>> anyFlags(targets.size());
+    for (auto& f : anyFlags) {
+        f.store(0, std::memory_order_relaxed);
+    }
+
+    #pragma omp parallel for collapse(2) schedule(dynamic)
     for (int ca = 0; ca < Ca; ++ca) {
         for (int cb = 0; cb < Cb; ++cb) {
             std::array<size_t, 3> chunkKey{};
@@ -300,7 +313,8 @@ inline void fillBinarySliceBatchFromVolume(
                 detail::distributeChunk<NormalGridSliceDirection::XY>(
                     bytes->data(), sourceChunkShape, validD, validH, validW,
                     rowOffset, colOffset,
-                    std::span<const int>(sliceForLocal), targets);
+                    std::span<const int>(sliceForLocal), targets,
+                    std::span<std::atomic<uint8_t>>(anyFlags));
                 break;
             case NormalGridSliceDirection::XZ:
                 validD = std::min(D, std::max(0, volZ - rowOffset));
@@ -309,7 +323,8 @@ inline void fillBinarySliceBatchFromVolume(
                 detail::distributeChunk<NormalGridSliceDirection::XZ>(
                     bytes->data(), sourceChunkShape, validD, validH, validW,
                     rowOffset, colOffset,
-                    std::span<const int>(sliceForLocal), targets);
+                    std::span<const int>(sliceForLocal), targets,
+                    std::span<std::atomic<uint8_t>>(anyFlags));
                 break;
             case NormalGridSliceDirection::YZ:
                 validD = std::min(D, std::max(0, volZ - rowOffset));
@@ -318,9 +333,16 @@ inline void fillBinarySliceBatchFromVolume(
                 detail::distributeChunk<NormalGridSliceDirection::YZ>(
                     bytes->data(), sourceChunkShape, validD, validH, validW,
                     rowOffset, colOffset,
-                    std::span<const int>(sliceForLocal), targets);
+                    std::span<const int>(sliceForLocal), targets,
+                    std::span<std::atomic<uint8_t>>(anyFlags));
                 break;
             }
+        }
+    }
+
+    for (size_t i = 0; i < targets.size(); ++i) {
+        if (anyFlags[i].load(std::memory_order_relaxed) != 0) {
+            targets[i].anyNonZero = true;
         }
     }
 }

--- a/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
+++ b/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
@@ -246,6 +246,14 @@ inline void fillBinarySliceBatchFromVolume(
         throw std::runtime_error(
             "fillBinarySliceBatchFromVolume currently supports uint8 volumes only");
     }
+    if (volume.fillValue() != 0.0) {
+        throw std::runtime_error(
+            "input volume has non-zero zarr fill_value (" +
+            std::to_string(volume.fillValue()) +
+            "); vc_gen_normalgrids requires fill_value=0 so that missing or "
+            "all-fill chunks can be treated as background. Re-export the "
+            "volume with fill_value=0 and retry.");
+    }
 
     const int sliceAxis = static_cast<int>(normalGridSliceAxis(direction));
     const int sourceSliceAxisLen = sourceChunkShape[sliceAxis];

--- a/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
+++ b/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
@@ -285,57 +285,67 @@ inline void fillBinarySliceBatchFromVolume(
         f.store(0, std::memory_order_relaxed);
     }
 
-    #pragma omp parallel for collapse(2) schedule(dynamic)
-    for (int ca = 0; ca < Ca; ++ca) {
-        for (int cb = 0; cb < Cb; ++cb) {
-            std::array<size_t, 3> chunkKey{};
-            chunkKey[static_cast<size_t>(sliceAxis)] = static_cast<size_t>(sliceAxisChunkIndex);
-            chunkKey[static_cast<size_t>(axisA)] = static_cast<size_t>(ca);
-            chunkKey[static_cast<size_t>(axisB)] = static_cast<size_t>(cb);
+    const size_t chunkBytes = volume.chunkByteSize(level);
 
-            auto bytes = volume.readChunk(level, chunkKey);
-            if (!bytes) {
-                continue;  // missing or AllFill
-            }
+    // Per-thread reusable decode scratch: each thread owns one chunk-sized
+    // buffer for the lifetime of the parallel region, so blosc decompress
+    // writes into a hot, already-resident allocation instead of mmap/munmap-ing
+    // a fresh page-aligned vector for every chunk.
+    #pragma omp parallel
+    {
+        std::vector<std::byte> scratch(chunkBytes);
 
-            const int rowOffset = ca * chunkSizeA;
-            const int colOffset = cb * chunkSizeB;
+        #pragma omp for collapse(2) schedule(dynamic)
+        for (int ca = 0; ca < Ca; ++ca) {
+            for (int cb = 0; cb < Cb; ++cb) {
+                std::array<size_t, 3> chunkKey{};
+                chunkKey[static_cast<size_t>(sliceAxis)] = static_cast<size_t>(sliceAxisChunkIndex);
+                chunkKey[static_cast<size_t>(axisA)] = static_cast<size_t>(ca);
+                chunkKey[static_cast<size_t>(axisB)] = static_cast<size_t>(cb);
 
-            int validD = D;
-            int validH = H;
-            int validW = W;
+                if (!volume.readChunkInto(level, chunkKey, scratch)) {
+                    continue;  // missing or AllFill
+                }
 
-            switch (direction) {
-            case NormalGridSliceDirection::XY:
-                validD = std::min(D, std::max(0, volZ - sliceAxisChunkIndex * D));
-                validH = std::min(H, std::max(0, volY - rowOffset));
-                validW = std::min(W, std::max(0, volX - colOffset));
-                detail::distributeChunk<NormalGridSliceDirection::XY>(
-                    bytes->data(), sourceChunkShape, validD, validH, validW,
-                    rowOffset, colOffset,
-                    std::span<const int>(sliceForLocal), targets,
-                    std::span<std::atomic<uint8_t>>(anyFlags));
-                break;
-            case NormalGridSliceDirection::XZ:
-                validD = std::min(D, std::max(0, volZ - rowOffset));
-                validH = std::min(H, std::max(0, volY - sliceAxisChunkIndex * H));
-                validW = std::min(W, std::max(0, volX - colOffset));
-                detail::distributeChunk<NormalGridSliceDirection::XZ>(
-                    bytes->data(), sourceChunkShape, validD, validH, validW,
-                    rowOffset, colOffset,
-                    std::span<const int>(sliceForLocal), targets,
-                    std::span<std::atomic<uint8_t>>(anyFlags));
-                break;
-            case NormalGridSliceDirection::YZ:
-                validD = std::min(D, std::max(0, volZ - rowOffset));
-                validH = std::min(H, std::max(0, volY - colOffset));
-                validW = std::min(W, std::max(0, volX - sliceAxisChunkIndex * W));
-                detail::distributeChunk<NormalGridSliceDirection::YZ>(
-                    bytes->data(), sourceChunkShape, validD, validH, validW,
-                    rowOffset, colOffset,
-                    std::span<const int>(sliceForLocal), targets,
-                    std::span<std::atomic<uint8_t>>(anyFlags));
-                break;
+                const int rowOffset = ca * chunkSizeA;
+                const int colOffset = cb * chunkSizeB;
+
+                int validD = D;
+                int validH = H;
+                int validW = W;
+
+                switch (direction) {
+                case NormalGridSliceDirection::XY:
+                    validD = std::min(D, std::max(0, volZ - sliceAxisChunkIndex * D));
+                    validH = std::min(H, std::max(0, volY - rowOffset));
+                    validW = std::min(W, std::max(0, volX - colOffset));
+                    detail::distributeChunk<NormalGridSliceDirection::XY>(
+                        scratch.data(), sourceChunkShape, validD, validH, validW,
+                        rowOffset, colOffset,
+                        std::span<const int>(sliceForLocal), targets,
+                        std::span<std::atomic<uint8_t>>(anyFlags));
+                    break;
+                case NormalGridSliceDirection::XZ:
+                    validD = std::min(D, std::max(0, volZ - rowOffset));
+                    validH = std::min(H, std::max(0, volY - sliceAxisChunkIndex * H));
+                    validW = std::min(W, std::max(0, volX - colOffset));
+                    detail::distributeChunk<NormalGridSliceDirection::XZ>(
+                        scratch.data(), sourceChunkShape, validD, validH, validW,
+                        rowOffset, colOffset,
+                        std::span<const int>(sliceForLocal), targets,
+                        std::span<std::atomic<uint8_t>>(anyFlags));
+                    break;
+                case NormalGridSliceDirection::YZ:
+                    validD = std::min(D, std::max(0, volZ - rowOffset));
+                    validH = std::min(H, std::max(0, volY - colOffset));
+                    validW = std::min(W, std::max(0, volX - sliceAxisChunkIndex * W));
+                    detail::distributeChunk<NormalGridSliceDirection::YZ>(
+                        scratch.data(), sourceChunkShape, validD, validH, validW,
+                        rowOffset, colOffset,
+                        std::span<const int>(sliceForLocal), targets,
+                        std::span<std::atomic<uint8_t>>(anyFlags));
+                    break;
+                }
             }
         }
     }

--- a/volume-cartographer/core/include/vc/core/util/Thinning.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Thinning.hpp
@@ -25,6 +25,21 @@ struct ThinningStats {
     }
 };
 
+// Reusable per-thread scratch for customThinning. Letting one thread
+// keep these across calls avoids ~5 slice-sized cv::Mat allocations
+// per invocation; the kernel page-fault tax of the freshly-mmapped
+// output buffers was the dominant non-CPU cost in profiles.
+struct ThinningScratch {
+    cv::Mat distTransform;
+    cv::Mat dilated;
+    cv::Mat localMaxima;
+    cv::Mat seeds;
+    cv::Mat visited;
+    std::vector<cv::Point> seedPoints;
+    std::vector<cv::Point> firstPath;
+    std::vector<cv::Point> secondPath;
+};
+
 void customThinning(const cv::Mat& inputImage, cv::Mat& outputImage, std::vector<std::vector<cv::Point>>* traces = nullptr);
 void customThinning(const cv::Mat& inputImage,
                     cv::Mat& outputImage,
@@ -33,3 +48,7 @@ void customThinning(const cv::Mat& inputImage,
 void customThinningTraceOnly(const cv::Mat& inputImage,
                              std::vector<std::vector<cv::Point>>& traces,
                              ThinningStats* stats = nullptr);
+void customThinningTraceOnly(const cv::Mat& inputImage,
+                             std::vector<std::vector<cv::Point>>& traces,
+                             ThinningStats* stats,
+                             ThinningScratch& scratch);

--- a/volume-cartographer/core/src/Thinning.cpp
+++ b/volume-cartographer/core/src/Thinning.cpp
@@ -58,9 +58,12 @@ struct TraceResult {
     uint64_t candidateEvaluations = 0;
 };
 
-static void nonMaximumSuppression(const cv::Mat& src, cv::Mat& dst, int size)
+// Reuses `dilated` as scratch so callers can keep the buffer across
+// calls; avoids the per-call slice-sized cv::Mat allocation that NMS
+// would otherwise do on every customThinning invocation.
+static void nonMaximumSuppression(const cv::Mat& src, cv::Mat& dst,
+                                  cv::Mat& dilated, int size)
 {
-    cv::Mat dilated;
     cv::dilate(src, dilated, cv::getStructuringElement(cv::MORPH_RECT, cv::Size(size, size)));
     cv::compare(src, dilated, dst, cv::CMP_EQ);
 }
@@ -161,7 +164,8 @@ static void customThinningImpl(
     const cv::Mat& inputImage,
     cv::Mat* outputImage,
     std::vector<std::vector<cv::Point>>* traces,
-    ThinningStats* stats)
+    ThinningStats* stats,
+    ThinningScratch& scratch)
 {
     if (inputImage.empty() || inputImage.type() != CV_8UC1) {
         if (outputImage != nullptr) {
@@ -176,43 +180,44 @@ static void customThinningImpl(
     ThinningStats localStats;
 
     const auto dtStart = std::chrono::steady_clock::now();
-    cv::Mat distTransform;
-    cv::distanceTransform(inputImage, distTransform, cv::DIST_L1, cv::DIST_MASK_5, CV_8U);
-    CV_Assert(distTransform.type() == CV_8U);
+    // Mat::create is a no-op when the existing buffer already matches
+    // size+type, so passing scratch.* as out-params keeps the same
+    // backing storage across calls — opencv writes into it instead of
+    // mmapping a fresh slice-sized buffer per call.
+    cv::distanceTransform(inputImage, scratch.distTransform, cv::DIST_L1, cv::DIST_MASK_5, CV_8U);
+    CV_Assert(scratch.distTransform.type() == CV_8U);
     localStats.distanceTransformSeconds = std::chrono::duration<double>(
         std::chrono::steady_clock::now() - dtStart).count();
 
     const auto seedStart = std::chrono::steady_clock::now();
-    cv::Mat localMaxima;
-    nonMaximumSuppression(distTransform, localMaxima, 3);
+    nonMaximumSuppression(scratch.distTransform, scratch.localMaxima, scratch.dilated, 3);
 
-    cv::Mat seeds;
-    cv::bitwise_and(localMaxima, inputImage, seeds);
+    cv::bitwise_and(scratch.localMaxima, inputImage, scratch.seeds);
 
-    std::vector<cv::Point> seedPoints;
-    cv::findNonZero(seeds, seedPoints);
-    localStats.seedCount = seedPoints.size();
+    cv::findNonZero(scratch.seeds, scratch.seedPoints);
+    localStats.seedCount = scratch.seedPoints.size();
     localStats.seedDetectionSeconds = std::chrono::duration<double>(
         std::chrono::steady_clock::now() - seedStart).count();
 
     cv::Mat visited;
     if (outputImage != nullptr) {
-        *outputImage = cv::Mat::zeros(inputImage.size(), CV_8UC1);
+        outputImage->create(inputImage.size(), CV_8UC1);
+        outputImage->setTo(0);
         visited = *outputImage;
     } else {
-        visited = cv::Mat::zeros(inputImage.size(), CV_8UC1);
+        scratch.visited.create(inputImage.size(), CV_8UC1);
+        scratch.visited.setTo(0);
+        visited = scratch.visited;
     }
 
     if (traces != nullptr) {
         traces->clear();
-        traces->reserve(seedPoints.size());
+        traces->reserve(scratch.seedPoints.size());
     }
 
     const auto traceStart = std::chrono::steady_clock::now();
-    std::vector<cv::Point> firstPath;
-    std::vector<cv::Point> secondPath;
 
-    for (const auto& seed : seedPoints) {
+    for (const auto& seed : scratch.seedPoints) {
         auto* visitedRow = visited.ptr<uint8_t>(seed.y);
         if (visitedRow[seed.x] != 0) {
             continue;
@@ -223,7 +228,7 @@ static void customThinningImpl(
 
         if (traces != nullptr) {
             const auto firstResult = tracePath<true>(
-                seed, distTransform, visited, outputImage, initialHistory, seed, &firstPath);
+                seed, scratch.distTransform, visited, outputImage, initialHistory, seed, &scratch.firstPath);
             localStats.traceSteps += firstResult.steps;
             localStats.candidateEvaluations += firstResult.candidateEvaluations;
 
@@ -232,23 +237,26 @@ static void customThinningImpl(
                 secondHistory.push_back(firstResult.secondPoint);
             }
             const auto secondResult = tracePath<true>(
-                seed, distTransform, visited, outputImage, secondHistory, seed, &secondPath);
+                seed, scratch.distTransform, visited, outputImage, secondHistory, seed, &scratch.secondPath);
             localStats.traceSteps += secondResult.steps;
             localStats.candidateEvaluations += secondResult.candidateEvaluations;
 
-            std::vector<cv::Point> fullTrace;
-            fullTrace.reserve(secondPath.size() + firstPath.size() - (firstPath.empty() ? 0 : 1));
-            fullTrace.insert(fullTrace.end(), secondPath.rbegin(), secondPath.rend());
-            if (!firstPath.empty()) {
-                fullTrace.insert(fullTrace.end(), firstPath.begin() + 1, firstPath.end());
+            // Build fullTrace directly inside traces' next slot to skip
+            // the fullTrace→traces move/copy step entirely.
+            auto& dst = traces->emplace_back();
+            dst.reserve(scratch.secondPath.size() + scratch.firstPath.size() - (scratch.firstPath.empty() ? 0 : 1));
+            dst.insert(dst.end(), scratch.secondPath.rbegin(), scratch.secondPath.rend());
+            if (!scratch.firstPath.empty()) {
+                dst.insert(dst.end(), scratch.firstPath.begin() + 1, scratch.firstPath.end());
             }
-            if (!fullTrace.empty()) {
-                traces->push_back(std::move(fullTrace));
+            if (dst.empty()) {
+                traces->pop_back();
+            } else {
                 ++localStats.traceCount;
             }
         } else {
             const auto firstResult = tracePath<false>(
-                seed, distTransform, visited, outputImage, initialHistory, seed, nullptr);
+                seed, scratch.distTransform, visited, outputImage, initialHistory, seed, nullptr);
             localStats.traceSteps += firstResult.steps;
             localStats.candidateEvaluations += firstResult.candidateEvaluations;
 
@@ -257,7 +265,7 @@ static void customThinningImpl(
                 secondHistory.push_back(firstResult.secondPoint);
             }
             const auto secondResult = tracePath<false>(
-                seed, distTransform, visited, outputImage, secondHistory, seed, nullptr);
+                seed, scratch.distTransform, visited, outputImage, secondHistory, seed, nullptr);
             localStats.traceSteps += secondResult.steps;
             localStats.candidateEvaluations += secondResult.candidateEvaluations;
         }
@@ -285,12 +293,22 @@ void customThinning(const cv::Mat& inputImage,
                     std::vector<std::vector<cv::Point>>* traces,
                     ThinningStats* stats)
 {
-    customThinningImpl(inputImage, &outputImage, traces, stats);
+    ThinningScratch scratch;
+    customThinningImpl(inputImage, &outputImage, traces, stats, scratch);
 }
 
 void customThinningTraceOnly(const cv::Mat& inputImage,
                              std::vector<std::vector<cv::Point>>& traces,
                              ThinningStats* stats)
 {
-    customThinningImpl(inputImage, nullptr, &traces, stats);
+    ThinningScratch scratch;
+    customThinningImpl(inputImage, nullptr, &traces, stats, scratch);
+}
+
+void customThinningTraceOnly(const cv::Mat& inputImage,
+                             std::vector<std::vector<cv::Point>>& traces,
+                             ThinningStats* stats,
+                             ThinningScratch& scratch)
+{
+    customThinningImpl(inputImage, nullptr, &traces, stats, scratch);
 }


### PR DESCRIPTION
(on top of #882 and #883 which need to be merged first)

 - revamped basic processing:
   - choose a number of slices of a chunk as a batch that fits into the memory target
   - read and iterate chunk slab and fill the whole batch in one go
   - extract normalgrids for slices in batch
   - repeat
 - optimize memory handling:
  - reuse thread-local chunk load buffers and (more importantly) large internal buffers for thinning to avoid excessive buffer churn
  - for the large slice batch buffer use anon mapping (with automatic lazy zeroing on first access), that will automatically avoid allocating and zeroing memory for parts of slices that are completely empty

I'll probably remove the fine-grained logging again.