### PR TITLE
Force remote cache to /volpkgs or /ephemeral when present

### DIFF
--- a/.github/workflows/vc3d-ci.yml
+++ b/.github/workflows/vc3d-ci.yml
@@ -42,33 +42,18 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends \
-            build-essential git cmake ninja-build ccache pkg-config \
+            build-essential git cmake ninja-build pkg-config \
             qt6-base-dev libboost-system-dev libboost-program-options-dev \
             libceres-dev libcgal-dev xtensor-dev libopencv-dev libxsimd-dev libblosc-dev libspdlog-dev \
             libgsl-dev libsdl2-dev libcurl4-openssl-dev \
             libde265-dev libx265-dev liblz4-dev nlohmann-json3-dev
 
-      - name: Restore ccache
-        if: ${{ steps.changes.outputs.vc == 'true' }}
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.ccache
-          key: ccache-${{ runner.os }}-vc3d-ci-${{ hashFiles('volume-cartographer/**/CMakeLists.txt','volume-cartographer/**/*.cmake','.github/workflows/vc3d-ci.yml') }}
-          restore-keys: |
-            ccache-${{ runner.os }}-vc3d-ci-
-
-      - name: Enable ccache
-        if: ${{ steps.changes.outputs.vc == 'true' }}
-        run: |
-          mkdir -p ~/.ccache
-          echo 'max_size = 5G' >> ~/.ccache/ccache.conf || true
-          echo 'hash_dir = true' >> ~/.ccache/ccache.conf || true
-          echo 'compiler_check = content' >> ~/.ccache/ccache.conf || true
-          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE/volume-cartographer" >> $GITHUB_ENV
-
-      - name: Reset ccache stats
-        if: ${{ steps.changes.outputs.vc == 'true' }}
-        run: ccache -z || true
+      # ccache was previously wired up here, but in practice every PR ran with
+      # 0% hit rate (Cache not found for input keys: ...). GitHub-hosted runners
+      # scope caches per-branch, the primary key hashes every CMakeLists.txt,
+      # and main never saves a cache for PRs to restore from — so the only
+      # effect was the ~30s of upload/download + apt overhead, with no win on
+      # compile time. Remove until we can fix the caching strategy properly.
 
       - name: Configure smoke build
         if: ${{ steps.changes.outputs.vc == 'true' }}
@@ -81,22 +66,9 @@ jobs:
                 -DBUILD_TESTING=OFF \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DCMAKE_C_COMPILER=gcc \
-                -DCMAKE_CXX_COMPILER=g++ \
-                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+                -DCMAKE_CXX_COMPILER=g++
 
       - name: Build smoke target set
         if: ${{ steps.changes.outputs.vc == 'true' }}
         working-directory: ./volume-cartographer
         run: cmake --build build --parallel
-
-      - name: Show ccache stats
-        if: ${{ always() && steps.changes.outputs.vc == 'true' }}
-        run: ccache -s || true
-
-      - name: Save ccache
-        if: ${{ always() && steps.changes.outputs.vc == 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.ccache
-          key: ccache-${{ runner.os }}-vc3d-ci-${{ hashFiles('volume-cartographer/**/CMakeLists.txt','volume-cartographer/**/*.cmake','.github/workflows/vc3d-ci.yml') }}

--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -477,18 +477,23 @@ QString MenuActionController::suggestedRemoteCacheDirectory() const
     if (_window && _window->_state && _window->_state->vpkg()) {
         const QString projectDir = QString::fromStdString(_window->_state->vpkg()->getVolpkgDirectory());
         if (!projectDir.isEmpty()) {
-            return QDir(projectDir).filePath("remote_cache");
+            // remoteCachePath() will ignore this suggestion if /volpkgs or
+            // /ephemeral is mounted.
+            return vc3d::remoteCachePath(QDir(projectDir).filePath("remote_cache"));
         }
     }
 
-    return vc3d::defaultCacheBase() + "/remote_cache";
+    return vc3d::remoteCachePath();
 }
 
 QString MenuActionController::configuredRemoteCacheDirectory() const
 {
     if (_window && _window->_state && _window->_state->vpkg()) {
-        return QString::fromStdString(
+        const QString persisted = QString::fromStdString(
             _window->_state->vpkg()->remoteCacheRootOrEmpty()).trimmed();
+        // Run the persisted value through remoteCachePath() so /volpkgs and
+        // /ephemeral win even if the project JSON points somewhere else.
+        return vc3d::remoteCachePath(persisted);
     }
     return {};
 }
@@ -510,15 +515,20 @@ QString MenuActionController::remoteCacheDirectory(bool allowPrompt)
         if (!ok) {
             return {};
         }
+        // Send the prompted value through the resolver too — keeps the host
+        // mount authoritative even if the user typed something else.
+        cacheDir = vc3d::remoteCachePath(cacheDir);
         shouldPersistCacheRoot = !cacheDir.isEmpty();
     }
 
     if (cacheDir.isEmpty()) {
-        // Fallback for projects with no persisted cache root yet. Non-prompting
-        // so startup and persisted remote loading stay quiet.
+        // No project- or prompt-supplied path: honor the persisted user
+        // setting (or fall back to ~/.VC3D/remote_cache) — unless host
+        // mounts override.
         QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
-        const QString defaultCache = vc3d::defaultCacheBase() + "/remote_cache";
-        cacheDir = settings.value(vc3d::settings::viewer::REMOTE_CACHE_DIR, defaultCache).toString();
+        const QString stored =
+            settings.value(vc3d::settings::viewer::REMOTE_CACHE_DIR).toString();
+        cacheDir = vc3d::remoteCachePath(stored);
     }
 
     if (QDir::isRelativePath(cacheDir)) {

--- a/volume-cartographer/apps/VC3D/SettingsDialog.cpp
+++ b/volume-cartographer/apps/VC3D/SettingsDialog.cpp
@@ -58,8 +58,9 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
     // Cache settings
     spinRamCacheSizeGB->setValue(settings.value(perf::RAM_CACHE_SIZE_GB, perf::RAM_CACHE_SIZE_GB_DEFAULT).toInt());
     {
-        QString defaultCache = vc3d::defaultCacheBase() + "/remote_cache";
-        edtRemoteCachePath->setText(settings.value(viewer::REMOTE_CACHE_DIR, defaultCache).toString());
+        const QString stored =
+            settings.value(viewer::REMOTE_CACHE_DIR).toString();
+        edtRemoteCachePath->setText(vc3d::remoteCachePath(stored));
     }
 
     // IO threads is no longer user-configurable (tracks hardware_concurrency).

--- a/volume-cartographer/apps/VC3D/VCAppMain.cpp
+++ b/volume-cartographer/apps/VC3D/VCAppMain.cpp
@@ -145,6 +145,8 @@ auto main(int argc, char* argv[]) -> int
     QApplication::setWindowIcon(QIcon(":/images/logo.png"));
     QApplication::setApplicationVersion(QString::fromStdString(ProjectInfo::VersionString()));
     std::cout << "VC3D commit: " << ProjectInfo::RepositoryHash() << std::endl;
+    std::cout << "creating remote volume cache at "
+              << vc3d::remoteCachePath().toStdString() << std::endl;
 
     QCommandLineParser parser;
     parser.setApplicationDescription("VC3D - Volume Cartographer 3D Viewer");

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -1,30 +1,64 @@
 #pragma once
 
+#include <QDebug>
 #include <QDir>
 #include <QFileInfo>
 #include <QString>
 
 namespace vc3d {
 
-// Prefer fast local storage when available — /ephemeral (NVMe instance store
-// set up by scripts/build_dependencies.sh) or /volpkgs (manually-mounted
-// scratch volume), whichever exists first. Fall back to ~/.VC3D.
-// Cached on first call because filesystem state doesn't change during a run.
-inline QString defaultCacheBase()
+// Single source of truth for where downloaded remote-volume chunks land.
+//
+// Priority — first match wins:
+//   1. /volpkgs/remote_cache    (typical EBS mount on EC2 dev hosts)
+//   2. /ephemeral/remote_cache  (NVMe instance store, scripts/ec2_setup.sh)
+//   3. `suggestion` if non-empty
+//   4. ~/.VC3D/remote_cache
+//
+// If /volpkgs or /ephemeral exists, the cache is forced there and any
+// `suggestion` is ignored: these mounts are the whole point of the host
+// being provisioned, and a stale per-volpkg or per-user setting pointing
+// elsewhere silently fills the root disk.
+//
+// Fail-fast: if /volpkgs or /ephemeral exists but isn't writable by the
+// running user (typical: directory owned by root, mode 0755), we abort
+// rather than fall through — that masks the real problem.
+//
+// The chosen path is created on disk before return.
+inline QString remoteCachePath(const QString& suggestion = {})
 {
-    static const QString base = []() {
-        for (const QString& root : {QStringLiteral("/ephemeral"),
-                                    QStringLiteral("/volpkgs")}) {
-            QFileInfo fi(root);
-            if (fi.isDir() && fi.isWritable()) {
-                QString p = root + "/VC3D";
-                QDir().mkpath(p);
-                return p;
-            }
+    for (const QString& root : {QStringLiteral("/volpkgs"),
+                                QStringLiteral("/ephemeral")}) {
+        QFileInfo fi(root);
+        if (!fi.exists()) {
+            continue;
         }
-        return QDir::homePath() + "/.VC3D";
-    }();
-    return base;
+        if (!fi.isDir()) {
+            qFatal("remoteCachePath: %s exists but is not a directory",
+                   qUtf8Printable(root));
+        }
+        // QFileInfo::isWritable() is unreliable on some FUSE/NFS mounts,
+        // so probe by trying to create the cache subtree.
+        const QString p = root + "/remote_cache";
+        if (!QDir().mkpath(p)) {
+            qFatal("remoteCachePath: %s exists but remote_cache/ cannot be "
+                   "created (check ownership/perms — must be writable by "
+                   "this user)",
+                   qUtf8Printable(root));
+        }
+        if (!QFileInfo(p).isWritable()) {
+            qFatal("remoteCachePath: %s is not writable by this user",
+                   qUtf8Printable(p));
+        }
+        return p;
+    }
+
+    QString p = suggestion.trimmed();
+    if (p.isEmpty()) {
+        p = QDir::homePath() + "/.VC3D/remote_cache";
+    }
+    QDir().mkpath(p);
+    return p;
 }
 
 inline QString settingsFilePath()
@@ -135,10 +169,9 @@ namespace viewer {
     constexpr bool USE_AXIS_ALIGNED_SLICES_DEFAULT = true;
     constexpr int SLICE_STEP_SIZE_DEFAULT = 1;
 
-    // Remote volume chunk cache directory
+    // Remote volume chunk cache directory. Resolved through
+    // vc3d::remoteCachePath() — see that function for the priority rules.
     constexpr auto REMOTE_CACHE_DIR = "viewer/remote_cache_dir";
-    // Default: vc3d::defaultCacheBase() + "/remote_cache" — uses /ephemeral
-    // when mounted, else ~/.VC3D.
 
     // Recent remote zarr URLs used to pre-fill attach dialog
     constexpr auto REMOTE_RECENT_URLS = "viewer/remote_recent_urls";

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -480,18 +480,20 @@ float scaleForCoarsestPlaneRenderLevel(int numLevels)
 
 std::filesystem::path remoteCacheRootForState(const CState* state)
 {
+    // Suggestion order: per-volpkg setting first (so projects with an
+    // explicit cache stay co-located when no host mount is present), then
+    // the user's persisted setting. remoteCachePath() ignores both when
+    // /volpkgs or /ephemeral is mounted.
+    QString suggestion;
     if (state && state->vpkg()) {
-        const auto projectCache = state->vpkg()->remoteCacheRootOrEmpty();
-        if (!projectCache.empty()) {
-            return projectCache;
-        }
+        suggestion = QString::fromStdString(state->vpkg()->remoteCacheRootOrEmpty()).trimmed();
     }
-
-    QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
-    const QString defaultCache = vc3d::defaultCacheBase() + "/remote_cache";
-    return settings.value(vc3d::settings::viewer::REMOTE_CACHE_DIR, defaultCache)
-        .toString()
-        .toStdString();
+    if (suggestion.isEmpty()) {
+        QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
+        suggestion =
+            settings.value(vc3d::settings::viewer::REMOTE_CACHE_DIR).toString();
+    }
+    return vc3d::remoteCachePath(suggestion).toStdString();
 }
 
 std::shared_ptr<vc::render::ChunkCache> makeChunkCacheForVolume(const std::shared_ptr<Volume>& volume,


### PR DESCRIPTION
Force the remote cache in this order

1. `/volpkgs/remote_cache`
2. `/ephemeral/remote_cache`
3. user preference
4. `~/.VC3D/remote_cache`
