### PR TITLE
ci: disable ccache (0% hit rate in practice)

### DIFF
--- a/.github/workflows/vc3d-ci.yml
+++ b/.github/workflows/vc3d-ci.yml
@@ -42,33 +42,18 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends \
-            build-essential git cmake ninja-build ccache pkg-config \
+            build-essential git cmake ninja-build pkg-config \
             qt6-base-dev libboost-system-dev libboost-program-options-dev \
             libceres-dev libcgal-dev xtensor-dev libopencv-dev libxsimd-dev libblosc-dev libspdlog-dev \
             libgsl-dev libsdl2-dev libcurl4-openssl-dev \
             libde265-dev libx265-dev liblz4-dev nlohmann-json3-dev
 
-      - name: Restore ccache
-        if: ${{ steps.changes.outputs.vc == 'true' }}
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.ccache
-          key: ccache-${{ runner.os }}-vc3d-ci-${{ hashFiles('volume-cartographer/**/CMakeLists.txt','volume-cartographer/**/*.cmake','.github/workflows/vc3d-ci.yml') }}
-          restore-keys: |
-            ccache-${{ runner.os }}-vc3d-ci-
-
-      - name: Enable ccache
-        if: ${{ steps.changes.outputs.vc == 'true' }}
-        run: |
-          mkdir -p ~/.ccache
-          echo 'max_size = 5G' >> ~/.ccache/ccache.conf || true
-          echo 'hash_dir = true' >> ~/.ccache/ccache.conf || true
-          echo 'compiler_check = content' >> ~/.ccache/ccache.conf || true
-          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE/volume-cartographer" >> $GITHUB_ENV
-
-      - name: Reset ccache stats
-        if: ${{ steps.changes.outputs.vc == 'true' }}
-        run: ccache -z || true
+      # ccache was previously wired up here, but in practice every PR ran with
+      # 0% hit rate (Cache not found for input keys: ...). GitHub-hosted runners
+      # scope caches per-branch, the primary key hashes every CMakeLists.txt,
+      # and main never saves a cache for PRs to restore from — so the only
+      # effect was the ~30s of upload/download + apt overhead, with no win on
+      # compile time. Remove until we can fix the caching strategy properly.
 
       - name: Configure smoke build
         if: ${{ steps.changes.outputs.vc == 'true' }}
@@ -81,22 +66,9 @@ jobs:
                 -DBUILD_TESTING=OFF \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DCMAKE_C_COMPILER=gcc \
-                -DCMAKE_CXX_COMPILER=g++ \
-                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+                -DCMAKE_CXX_COMPILER=g++
 
       - name: Build smoke target set
         if: ${{ steps.changes.outputs.vc == 'true' }}
         working-directory: ./volume-cartographer
         run: cmake --build build --parallel
-
-      - name: Show ccache stats
-        if: ${{ always() && steps.changes.outputs.vc == 'true' }}
-        run: ccache -s || true
-
-      - name: Save ccache
-        if: ${{ always() && steps.changes.outputs.vc == 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.ccache
-          key: ccache-${{ runner.os }}-vc3d-ci-${{ hashFiles('volume-cartographer/**/CMakeLists.txt','volume-cartographer/**/*.cmake','.github/workflows/vc3d-ci.yml') }}


### PR DESCRIPTION
## Summary

Surveyed the last two weeks of CI runs. **ccache hit rate is consistently 0%.** Every PR run logs:

```
Cache not found for input keys: ccache-Linux-vc3d-ci-<hash>, ccache-Linux-vc3d-ci-
```

…and the post-build \`ccache -s\` confirms 0/N hits — for example run [25497425960](https://github.com/ScrollPrize/villa/actions/runs/25497425960) (8m12s, success):

```
Hits:    0 / 219 ( 0.00%)
Misses:  219 / 219 (100.0%)
```

### Why the cache never hits

1. The primary key hashes every \`volume-cartographer/**/CMakeLists.txt\` and \`*.cmake\`. Any CMake-touching merge into main invalidates it for new PRs.
2. GitHub Actions caches are **scoped per-branch** — a cache saved on PR branch X cannot be restored on PR branch Y. The workflow only triggers on \`pull_request\`, so main never runs it and never saves a cache that other PRs could fall back to via \`restore-keys\`.

### Net effect

Each PR was paying ~30s of cache upload + the apt install of ccache (already installed on ubuntu-24.04 runners as a dep, but explicitly listed in our apt line) for zero compile-time savings. Compile time is dominated by the cold smoke build itself: ~8 min on the 4-vCPU runner for PRs touching little, 25–40 min when most TUs need rebuilding.

This patch removes:
- the explicit \`ccache\` apt package
- \`actions/cache/restore@v4\` and \`actions/cache/save@v4\` steps
- \`Enable ccache\` and \`Reset ccache stats\` steps
- \`-DCMAKE_C_COMPILER_LAUNCHER=ccache\` / \`CXX\` cmake flags
- \`Show ccache stats\` step

Plan to revisit once we can either:
- add a \`push\` trigger to main so it populates the cache, or
- move to a coarser cache key that survives CMake edits

## Test plan

- [x] CI passes on this PR
- [x] Build time on this PR is comparable to recent same-size PRs (workflow is just a strict subset of what was running before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)