### PR TITLE
chore: minimal s1_ds2.volpkg download script + load smoke test

### DIFF
--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -32,6 +32,13 @@ add_executable(test_atomic_imwrite_multi test_atomic_imwrite_multi.cpp)
 target_link_libraries(test_atomic_imwrite_multi PRIVATE doctest::doctest vc_core)
 add_test(NAME test_atomic_imwrite_multi COMMAND test_atomic_imwrite_multi)
 
+# Opt-in smoke test that opens the minimal s1_ds2 volpkg pulled by
+# scripts/download_minimal_volpkg.sh. Skips at runtime when VC_TEST_VOLPKG
+# is unset, so the default ctest run remains hermetic.
+add_executable(test_volpkg_minimal_load test_volpkg_minimal_load.cpp)
+target_link_libraries(test_volpkg_minimal_load PRIVATE doctest::doctest vc_core)
+add_test(NAME test_volpkg_minimal_load COMMAND test_volpkg_minimal_load)
+
 add_executable(bench_volume_sample bench_volume_sample.cpp)
 target_link_libraries(bench_volume_sample PRIVATE doctest::doctest vc_core)
 # Bench has a generous wall-clock assertion; not part of default ctest

--- a/volume-cartographer/core/test/test_volpkg_minimal_load.cpp
+++ b/volume-cartographer/core/test/test_volpkg_minimal_load.cpp
@@ -1,0 +1,60 @@
+// Smoke test for opening the minimal s1_ds2 volpkg downloaded by
+// scripts/download_minimal_volpkg.sh. Opt-in via VC_TEST_VOLPKG (path
+// to the volpkg directory). Skips silently if the env var is unset, so
+// the default ctest run remains hermetic.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "vc/core/types/VolumePkg.hpp"
+
+#include <cstdlib>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace {
+fs::path findVolpkgJson(const fs::path& root)
+{
+    if (fs::is_regular_file(root) && root.extension() == ".json") {
+        return root;
+    }
+    if (!fs::is_directory(root)) return {};
+    for (const auto& entry : fs::directory_iterator(root)) {
+        if (!entry.is_regular_file()) continue;
+        const auto& p = entry.path();
+        const auto name = p.filename().string();
+        if (name.size() >= 12 &&
+            name.compare(name.size() - 12, 12, ".volpkg.json") == 0) {
+            return p;
+        }
+    }
+    return {};
+}
+}
+
+TEST_CASE("VolumePkg::load on minimal s1_ds2 pull")
+{
+    const char* root = std::getenv("VC_TEST_VOLPKG");
+    if (!root || !*root) {
+        MESSAGE("VC_TEST_VOLPKG unset; skipping (set it to test-data/s1_ds2.volpkg)");
+        return;
+    }
+    const fs::path volpkgRoot{root};
+    REQUIRE_MESSAGE(fs::exists(volpkgRoot), "VC_TEST_VOLPKG path missing: " << root);
+
+    const fs::path jsonFile = findVolpkgJson(volpkgRoot);
+    REQUIRE_MESSAGE(!jsonFile.empty(),
+                    "no *.volpkg.json found at " << volpkgRoot.string()
+                    << " (download_minimal_volpkg.sh should have pulled it)");
+
+    auto pkg = VolumePkg::load(jsonFile);
+    REQUIRE(pkg);
+    // Volumes are listed in the project JSON as remote entries; with no
+    // chunks on disk they cannot be opened, but the entries should still
+    // resolve.
+    CHECK_FALSE(pkg->volumeEntries().empty());
+    // Segments are local; the download pulls a couple of tifxyz dirs from
+    // paths_2um_ds2/ and traces/.
+    CHECK_FALSE(pkg->segmentEntries().empty());
+}

--- a/volume-cartographer/scripts/download_minimal_volpkg.sh
+++ b/volume-cartographer/scripts/download_minimal_volpkg.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Download a minimal local copy of s3://volpkgs/s1_ds2.volpkg/ for vc3d testing.
 # Zarr volumes are streamed via VC3D's remote-cache code path; only metadata
-# files, the normalgrids_2um_ds folder, and a handful of tifxyz directories
+# files, the normalgrids_2um_ds2 folder, and a handful of tifxyz directories
 # from paths_2um_ds2/ and traces/ are pulled.
 #
 # Usage:
@@ -102,15 +102,15 @@ if (( USE_RCLONE )); then
   rclone copy "${SRC}" "$DEST" \
     --s3-provider AWS --s3-env-auth \
     --transfers 8 --size-only --fast-list \
-    --include "*.json" --max-depth 1 \
+    --filter "+ *.json" --filter "- *" --max-depth 1 \
     $( (( DRY_RUN )) && echo --dry-run )
 else
   aws_sync "" "$DEST" --exclude "*" --include "*.json" --no-progress
 fi
 
-# --- 2) normalgrids_2um_ds (full) -------------------------------------------
-echo "== normalgrids_2um_ds (full) =="
-pull_dir "normalgrids_2um_ds/"
+# --- 2) normalgrids_2um_ds2 (full) -------------------------------------------
+echo "== normalgrids_2um_ds2 (full) =="
+pull_dir "normalgrids_2um_ds2/"
 
 # --- 3) volumes/<vol>/ metadata only ----------------------------------------
 echo "== volumes (metadata only, chunks excluded) =="
@@ -122,9 +122,13 @@ if (( USE_RCLONE )); then
     v="${v%/}"
     [[ -z "$v" ]] && continue
     echo "  -> volumes/$v"
+    # --max-depth 2 caps the walk at <vol>.zarr/<level>/<file>, where
+    # the .zarray + meta.json live. Without it, rclone walks every chunk
+    # subdir under each level just to discover tiny metadata files.
     rclone_copy "volumes/${v}/" "$DEST/volumes/${v}/" \
-      --include "*.json" --include "*.zarray" --include "*.zgroup" --include "*.zattrs" \
-      --exclude "*"
+      --filter "+ *.json" --filter "+ *.zarray" --filter "+ *.zgroup" \
+      --filter "+ *.zattrs" --filter "- *" \
+      --max-depth 2
   done
 else
   aws_sync "volumes/" "$DEST/volumes/" \
@@ -133,54 +137,36 @@ else
     --no-progress
 fi
 
-# --- 4) Smallest N tifxyz dirs from paths_2um_ds2/ and traces/ --------------
-pull_smallest_tifxyz() {
+# --- 4) First N tifxyz dirs (alphabetically) from paths_2um_ds2/ and traces/
+# Note: we take the first N alphabetically rather than the smallest by size.
+# Per-dir `rclone size --json` calls were too slow on volpkgs with hundreds
+# of tifxyz dirs (one S3 listing per call); a single `rclone lsf --dirs-only`
+# is sub-second. Real tifxyz dirs at this resolution are uniformly small
+# enough that picking by name is fine for testing/benchmarking.
+pull_first_tifxyz() {
   local sub="$1"
-  echo "== ${sub} (${KEEP} smallest tifxyz dirs) =="
-  if ! (( USE_RCLONE )); then
-    # aws CLI cannot easily sort by size; fall back to alphabetical first N.
-    local names
+  echo "== ${sub} (${KEEP} first dirs alphabetically) =="
+  local names
+  if (( USE_RCLONE )); then
+    names=$(rclone lsf --dirs-only --max-depth 1 "${SRC}/${sub}/" \
+            --s3-provider AWS --s3-env-auth 2>/dev/null \
+            | sed 's:/$::' | sort | head -n "$KEEP" || true)
+  else
     names=$(aws s3 ls "s3://${SRC_BUCKET}/${SRC_KEY}/${sub}/" \
-            | awk '$1=="PRE"{print $2}' | sort | head -n "$KEEP")
-    for n in $names; do
-      n="${n%/}"
-      pull_dir "${sub}/${n}/"
-    done
-    return
+            | awk '$1=="PRE"{print $2}' | sed 's:/$::' | sort | head -n "$KEEP" || true)
   fi
-  # rclone path: enumerate dir sizes and take the smallest N.
-  local sizes
-  sizes=$(rclone size --json "${SRC}/${sub}/" \
-          --s3-provider AWS --s3-env-auth 2>/dev/null || true)
-  local children
-  children=$(rclone lsf --dirs-only --max-depth 1 "${SRC}/${sub}/" \
-             --s3-provider AWS --s3-env-auth 2>/dev/null || true)
-  if [[ -z "$children" ]]; then
+  if [[ -z "$names" ]]; then
     echo "  (no children under ${sub}/, skipping)"
     return
   fi
-  # For each child, query its size; sort ascending; take N.
-  local picks=()
-  while read -r name; do
-    name="${name%/}"
-    [[ -z "$name" ]] && continue
-    local b
-    b=$(rclone size "${SRC}/${sub}/${name}/" \
-        --s3-provider AWS --s3-env-auth --json 2>/dev/null \
-        | sed -n 's/.*"bytes":\([0-9]*\).*/\1/p' | head -n1)
-    [[ -z "$b" ]] && b=0
-    picks+=("$b $name")
-  done <<<"$children"
-  printf '  candidates: %d\n' "${#picks[@]}"
-  local chosen
-  chosen=$(printf '%s\n' "${picks[@]}" | sort -n | head -n "$KEEP" | awk '{print $2}')
-  for n in $chosen; do
+  while IFS= read -r n; do
+    [[ -z "$n" ]] && continue
     echo "  -> ${sub}/${n}"
     pull_dir "${sub}/${n}/"
-  done
+  done <<<"$names"
 }
-pull_smallest_tifxyz "paths_2um_ds2"
-pull_smallest_tifxyz "traces"
+pull_first_tifxyz "paths_2um_ds2"
+pull_first_tifxyz "traces"
 
 # --- 5) Verifier -------------------------------------------------------------
 if (( DRY_RUN )); then
@@ -199,9 +185,9 @@ top_jsons=("$DEST"/*.json)
 shopt -u nullglob
 (( ${#top_jsons[@]} >= 1 )) || { echo "MISS: no top-level *.json under $DEST"; fail=1; }
 
-# normalgrids_2um_ds populated.
-ng_count=$(find "$DEST/normalgrids_2um_ds" -type f 2>/dev/null | wc -l | tr -d ' ')
-(( ng_count >= 1 )) || { echo "MISS: normalgrids_2um_ds empty"; fail=1; }
+# normalgrids_2um_ds2 populated.
+ng_count=$(find "$DEST/normalgrids_2um_ds2" -type f 2>/dev/null | wc -l | tr -d ' ')
+(( ng_count >= 1 )) || { echo "MISS: normalgrids_2um_ds2 empty"; fail=1; }
 
 # At least one .zarray under volumes/ (some Zarr volume metadata).
 zarray_count=$(find "$DEST/volumes" -name '.zarray' -o -name 'zarr.json' 2>/dev/null | wc -l | tr -d ' ')
@@ -229,3 +215,38 @@ if (( fail )); then
   exit 5
 fi
 echo "Verification OK: ${tifxyz_ok} tifxyz dirs, ${ng_count} normalgrid files, ${zarray_count} zarr metadata files."
+
+# --- 6) Convert legacy volpkg to .volpkg.json so VC3D can open it directly --
+# s1_ds2.volpkg ships as a legacy directory layout (config.json + folders);
+# vc_volpkg_convert writes a project JSON next to it that VolumePkg::load
+# accepts. Skip if a .volpkg.json already exists, or the binary is missing.
+shopt -s nullglob
+existing=("$DEST"/*.volpkg.json)
+shopt -u nullglob
+if (( ${#existing[@]} > 0 )); then
+  echo "(.volpkg.json already present; skipping convert)"
+else
+  vc_convert_bin=""
+  if command -v vc_volpkg_convert >/dev/null 2>&1; then
+    vc_convert_bin="$(command -v vc_volpkg_convert)"
+  else
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    for cand in "$here/../build-macos/bin/vc_volpkg_convert" \
+                "$here/../build/bin/vc_volpkg_convert" \
+                "$here/../build-macos-rel/bin/vc_volpkg_convert"; do
+      if [[ -x "$cand" ]]; then vc_convert_bin="$cand"; break; fi
+    done
+  fi
+  if [[ -n "$vc_convert_bin" ]]; then
+    out_name="$(basename "$DEST")"
+    case "$out_name" in
+      *.volpkg) out_name="${out_name%.volpkg}.volpkg.json" ;;
+      *)        out_name="${out_name}.volpkg.json" ;;
+    esac
+    echo "== converting legacy volpkg via $vc_convert_bin =="
+    "$vc_convert_bin" "$DEST" "$DEST/$out_name"
+  else
+    warn "vc_volpkg_convert not found on PATH or in build-macos/bin; "
+    warn "build VC3D first, then run: vc_volpkg_convert $DEST $DEST/<name>.volpkg.json"
+  fi
+fi

--- a/volume-cartographer/scripts/download_minimal_volpkg.sh
+++ b/volume-cartographer/scripts/download_minimal_volpkg.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Download a minimal local copy of s3://volpkgs/s1_ds2.volpkg/ for vc3d testing.
+# Zarr volumes are streamed via VC3D's remote-cache code path; only metadata
+# files, the normalgrids_2um_ds folder, and a handful of tifxyz directories
+# from paths_2um_ds2/ and traces/ are pulled.
+#
+# Usage:
+#   AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_SESSION_TOKEN=... \
+#   AWS_DEFAULT_REGION=us-east-1 \
+#   scripts/download_minimal_volpkg.sh [--dest PATH] [--dry-run] [--keep N]
+#
+#   --dest PATH   Local destination (default: ./test-data/s1_ds2.volpkg)
+#   --dry-run     List what would be pulled and exit.
+#   --keep N      Keep N smallest tifxyz dirs from each of paths_2um_ds2/
+#                 and traces/ (default: 2).
+set -euo pipefail
+
+SRC_BUCKET="volpkgs"
+SRC_KEY="s1_ds2.volpkg"
+SRC=":s3:${SRC_BUCKET}/${SRC_KEY}"
+
+DEST="./test-data/s1_ds2.volpkg"
+DRY_RUN=0
+KEEP=2
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dest)    DEST="${2:?missing value}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --keep)    KEEP="${2:?missing value}"; shift 2 ;;
+    -h|--help) sed -n '2,16p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# --- Credentials check -------------------------------------------------------
+for v in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION; do
+  if [[ -z "${!v:-}" ]]; then
+    echo "ERROR: $v is not set in the environment." >&2
+    echo "Source your STS creds (e.g. via 'aws configure export-credentials')." >&2
+    exit 3
+  fi
+done
+# AWS_SESSION_TOKEN is required for STS but not for IAM-user creds.
+if [[ -z "${AWS_SESSION_TOKEN:-}" ]]; then
+  echo "warning: AWS_SESSION_TOKEN is unset (assuming non-STS creds)." >&2
+fi
+
+# --- Tool selection ----------------------------------------------------------
+USE_RCLONE=1
+if ! command -v rclone >/dev/null 2>&1; then
+  USE_RCLONE=0
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "ERROR: need either rclone or aws CLI." >&2
+    exit 4
+  fi
+fi
+
+rclone_copy() {
+  # rclone_copy <subpath> <local_subdest> [extra rclone args...]
+  local sub="$1"; shift
+  local dst="$1"; shift
+  local cmd=(rclone copy
+             "${SRC}/${sub}" "${dst}"
+             --s3-provider AWS --s3-env-auth
+             --transfers 64 --buffer-size 2M --size-only --fast-list)
+  cmd+=("$@")
+  if (( DRY_RUN )); then
+    echo "DRY: ${cmd[*]}"
+  else
+    "${cmd[@]}"
+  fi
+}
+
+aws_sync() {
+  local sub="$1"; shift
+  local dst="$1"; shift
+  local cmd=(aws s3 sync
+             "s3://${SRC_BUCKET}/${SRC_KEY}/${sub}" "${dst}")
+  cmd+=("$@")
+  if (( DRY_RUN )); then
+    echo "DRY: ${cmd[*]}"
+  else
+    "${cmd[@]}"
+  fi
+}
+
+pull_dir() {
+  local sub="$1"; shift
+  local dst="$DEST/${sub%/}"
+  mkdir -p "$dst"
+  if (( USE_RCLONE )); then rclone_copy "$sub" "$dst" "$@"
+  else                      aws_sync    "$sub" "$dst" "$@"
+  fi
+}
+
+# --- 1) Top-level volpkg metadata -------------------------------------------
+echo "== top-level metadata =="
+mkdir -p "$DEST"
+if (( USE_RCLONE )); then
+  # Single-level top dir; --max-depth 1 keeps it light.
+  rclone copy "${SRC}" "$DEST" \
+    --s3-provider AWS --s3-env-auth \
+    --transfers 8 --size-only --fast-list \
+    --include "*.json" --max-depth 1 \
+    $( (( DRY_RUN )) && echo --dry-run )
+else
+  aws_sync "" "$DEST" --exclude "*" --include "*.json" --no-progress
+fi
+
+# --- 2) normalgrids_2um_ds (full) -------------------------------------------
+echo "== normalgrids_2um_ds (full) =="
+pull_dir "normalgrids_2um_ds/"
+
+# --- 3) volumes/<vol>/ metadata only ----------------------------------------
+echo "== volumes (metadata only, chunks excluded) =="
+if (( USE_RCLONE )); then
+  # List immediate children of volumes/ to discover individual zarr roots.
+  vols=$(rclone lsf --dirs-only --max-depth 1 "${SRC}/volumes/" \
+         --s3-provider AWS --s3-env-auth 2>/dev/null || true)
+  for v in $vols; do
+    v="${v%/}"
+    [[ -z "$v" ]] && continue
+    echo "  -> volumes/$v"
+    rclone_copy "volumes/${v}/" "$DEST/volumes/${v}/" \
+      --include "*.json" --include "*.zarray" --include "*.zgroup" --include "*.zattrs" \
+      --exclude "*"
+  done
+else
+  aws_sync "volumes/" "$DEST/volumes/" \
+    --exclude "*" \
+    --include "*.json" --include "*.zarray" --include "*.zgroup" --include "*.zattrs" \
+    --no-progress
+fi
+
+# --- 4) Smallest N tifxyz dirs from paths_2um_ds2/ and traces/ --------------
+pull_smallest_tifxyz() {
+  local sub="$1"
+  echo "== ${sub} (${KEEP} smallest tifxyz dirs) =="
+  if ! (( USE_RCLONE )); then
+    # aws CLI cannot easily sort by size; fall back to alphabetical first N.
+    local names
+    names=$(aws s3 ls "s3://${SRC_BUCKET}/${SRC_KEY}/${sub}/" \
+            | awk '$1=="PRE"{print $2}' | sort | head -n "$KEEP")
+    for n in $names; do
+      n="${n%/}"
+      pull_dir "${sub}/${n}/"
+    done
+    return
+  fi
+  # rclone path: enumerate dir sizes and take the smallest N.
+  local sizes
+  sizes=$(rclone size --json "${SRC}/${sub}/" \
+          --s3-provider AWS --s3-env-auth 2>/dev/null || true)
+  local children
+  children=$(rclone lsf --dirs-only --max-depth 1 "${SRC}/${sub}/" \
+             --s3-provider AWS --s3-env-auth 2>/dev/null || true)
+  if [[ -z "$children" ]]; then
+    echo "  (no children under ${sub}/, skipping)"
+    return
+  fi
+  # For each child, query its size; sort ascending; take N.
+  local picks=()
+  while read -r name; do
+    name="${name%/}"
+    [[ -z "$name" ]] && continue
+    local b
+    b=$(rclone size "${SRC}/${sub}/${name}/" \
+        --s3-provider AWS --s3-env-auth --json 2>/dev/null \
+        | sed -n 's/.*"bytes":\([0-9]*\).*/\1/p' | head -n1)
+    [[ -z "$b" ]] && b=0
+    picks+=("$b $name")
+  done <<<"$children"
+  printf '  candidates: %d\n' "${#picks[@]}"
+  local chosen
+  chosen=$(printf '%s\n' "${picks[@]}" | sort -n | head -n "$KEEP" | awk '{print $2}')
+  for n in $chosen; do
+    echo "  -> ${sub}/${n}"
+    pull_dir "${sub}/${n}/"
+  done
+}
+pull_smallest_tifxyz "paths_2um_ds2"
+pull_smallest_tifxyz "traces"
+
+# --- 5) Verifier -------------------------------------------------------------
+if (( DRY_RUN )); then
+  echo "(dry-run: skipping verifier)"
+  exit 0
+fi
+
+echo "== verifier =="
+fail=0
+warn() { echo "WARN: $*"; }
+check() { [[ -e "$1" ]] || { echo "MISS: $1"; fail=1; }; }
+
+# Top-level metadata: at least one *.json (the volpkg config).
+shopt -s nullglob
+top_jsons=("$DEST"/*.json)
+shopt -u nullglob
+(( ${#top_jsons[@]} >= 1 )) || { echo "MISS: no top-level *.json under $DEST"; fail=1; }
+
+# normalgrids_2um_ds populated.
+ng_count=$(find "$DEST/normalgrids_2um_ds" -type f 2>/dev/null | wc -l | tr -d ' ')
+(( ng_count >= 1 )) || { echo "MISS: normalgrids_2um_ds empty"; fail=1; }
+
+# At least one .zarray under volumes/ (some Zarr volume metadata).
+zarray_count=$(find "$DEST/volumes" -name '.zarray' -o -name 'zarr.json' 2>/dev/null | wc -l | tr -d ' ')
+(( zarray_count >= 1 )) || warn "no .zarray / zarr.json found under $DEST/volumes (volumes may be missing)"
+
+# At least 2 tifxyz dirs across paths_2um_ds2/ + traces/ with x.tif/y.tif/z.tif.
+tifxyz_ok=0
+for d in "$DEST"/paths_2um_ds2/*/ "$DEST"/traces/*/; do
+  [[ -d "$d" ]] || continue
+  if [[ -f "$d/x.tif" && -f "$d/y.tif" && -f "$d/z.tif" ]]; then
+    tifxyz_ok=$((tifxyz_ok + 1))
+  fi
+done
+(( tifxyz_ok >= 2 )) || { echo "MISS: fewer than 2 complete tifxyz dirs (have $tifxyz_ok)"; fail=1; }
+
+total=$(du -sh "$DEST" 2>/dev/null | awk '{print $1}')
+total_bytes=$(du -sk "$DEST" 2>/dev/null | awk '{print $1}')
+echo "Total size: ${total:-?}"
+if [[ -n "${total_bytes:-}" ]] && (( total_bytes > 2 * 1024 * 1024 )); then
+  warn "downloaded set is >2 GB; consider --keep 1"
+fi
+
+if (( fail )); then
+  echo "Verification FAILED."
+  exit 5
+fi
+echo "Verification OK: ${tifxyz_ok} tifxyz dirs, ${ng_count} normalgrid files, ${zarray_count} zarr metadata files."


### PR DESCRIPTION
## Summary
- New `scripts/download_minimal_volpkg.sh`: pulls a minimal local copy of `s3://volpkgs/s1_ds2.volpkg/` for vc3d testing/benchmarking. Reads STS creds from env, prefers `rclone` (falls back to `aws s3 sync`), pulls **only** zarr metadata (no chunks — they stream via the existing remote-cache code path), `normalgrids_2um_ds2/` in full, and the first N tifxyz dirs from `paths_2um_ds2/` and `traces/` alphabetically (default N=2).
- Auto-runs `vc_volpkg_convert` at the end so VC3D / `VolumePkg::load` opens the legacy directory layout directly.
- New `core/test/test_volpkg_minimal_load.cpp` (doctest): opt-in via `VC_TEST_VOLPKG=<path>`; calls `VolumePkg::load` and asserts non-empty volume + segment entries. Skips silently when env var unset.

## Test plan
- [ ] `bash scripts/download_minimal_volpkg.sh` with STS creds in env succeeds; verifier prints OK.
- [ ] `cmake -S . -B build -DVC_BUILD_TESTS=ON && cmake --build build -j` builds clean.
- [ ] `VC_TEST_VOLPKG=$(pwd)/test-data/s1_ds2.volpkg ctest --test-dir build -R volpkg_minimal_load --output-on-failure` passes.
- [ ] `build/bin/VC3D test-data/s1_ds2.volpkg/s1_ds2.volpkg.json` opens; chunks stream from S3 via the remote cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)