### PR TITLE
feat(VC3D): GUI for vc_merge_tifxyz (context menu + Actions menu)

### DIFF
--- a/volume-cartographer/apps/CMakeLists.txt
+++ b/volume-cartographer/apps/CMakeLists.txt
@@ -99,8 +99,15 @@ target_link_libraries(vc_tifxyz_mmap_prepare TIFF::TIFF)
 add_executable(vc_create_segment_mask src/vc_create_segment_mask.cpp)
 target_link_libraries(vc_create_segment_mask vc_core Boost::program_options)
 
+# Grid-resolution helpers split into a static lib so the unit tests can
+# link them without spawning the binary. No behavior change vs. having the
+# code inline in vc_merge_tifxyz.cpp.
+add_library(vc_merge_grid STATIC src/vc_merge_tifxyz_grid.cpp)
+target_link_libraries(vc_merge_grid PUBLIC vc_core)
+target_include_directories(vc_merge_grid PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
 add_executable(vc_merge_tifxyz src/vc_merge_tifxyz.cpp)
-target_link_libraries(vc_merge_tifxyz vc_core Boost::program_options opencv_imgcodecs opencv_imgproc opencv_flann Eigen3::Eigen)
+target_link_libraries(vc_merge_tifxyz vc_merge_grid Boost::program_options opencv_imgcodecs opencv_imgproc opencv_flann Eigen3::Eigen)
 
 add_executable(vc_visualize src/vc_visualize.cpp)
 target_link_libraries(vc_visualize vc_core Boost::program_options)

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -452,6 +452,13 @@ CWindow::CWindow(size_t cacheSizeGB) :
     // create menus/actions controller
     _menuController = std::make_unique<MenuActionController>(this);
     _menuController->populateMenus(menuBar());
+    // Wire the Actions -> Merge tifxyz... menu entry to the handler.
+    // Has to happen here (not inside CreateWidgets) because
+    // _menuController is created after CreateWidgets() returns.
+    connect(_menuController.get(), &MenuActionController::mergeTifxyzFromMenuRequested,
+            this, [this]() {
+                _segmentationCommandHandler->onMergeTifxyz(QStringList{});
+            });
 
     if (isDarkMode()) {
         applyDarkPalette();
@@ -1480,6 +1487,13 @@ void CWindow::CreateWidgets(void)
             this, [this](const QString& segmentId) {
                 _segmentationCommandHandler->onConvertToObj(segmentId.toStdString());
             });
+    connect(_surfacePanel.get(), &SurfacePanelController::mergeTifxyzRequested,
+            this, [this](const QStringList& segmentIds) {
+                _segmentationCommandHandler->onMergeTifxyz(segmentIds);
+            });
+    // Note: the Actions -> Merge tifxyz... menu wiring lives in the
+    // constructor after _menuController is initialized -- _menuController
+    // is null inside CreateWidgets().
     connect(_surfacePanel.get(), &SurfacePanelController::visLasagnaObjRequested,
             this, [this](const QString& segmentId) {
                 onVisLasagnaObj(segmentId.toStdString());

--- a/volume-cartographer/apps/VC3D/CommandLineToolRunner.cpp
+++ b/volume-cartographer/apps/VC3D/CommandLineToolRunner.cpp
@@ -230,7 +230,9 @@ bool CommandLineToolRunner::execute(Tool tool)
         return false;
     }
 
-    if (!isCustom) {
+    // vc_merge_tifxyz operates on segment paths only; no volume required.
+    const bool needsVolume = !isCustom && tool != Tool::MergeTifxyz;
+    if (needsVolume) {
         if (_explicitVolumePath) {
             if (_volumePath.isEmpty()) {
                 QMessageBox::warning(nullptr, tr("Error"), tr("Volume path not specified."));
@@ -250,6 +252,11 @@ bool CommandLineToolRunner::execute(Tool tool)
             }
             _volumePath = resolvedVolumePath;
         }
+    }
+
+    if (tool == Tool::MergeTifxyz && _mergeJsonPath.isEmpty()) {
+        QMessageBox::warning(nullptr, tr("Error"), tr("merge.json path not specified."));
+        return false;
     }
 
     if (tool == Tool::RenderTifXYZ && _segmentPath.isEmpty()) {
@@ -643,6 +650,22 @@ QStringList CommandLineToolRunner::buildArguments(Tool tool)
                 args << "--resume-opt" << _resumeOpt;
             }
             break;
+        case Tool::MergeTifxyz:
+            args << "--merge" << _mergeJsonPath;
+            // Empty refSurface -> let vc_merge_tifxyz auto-pick the
+            // surface with the largest valid-cell count. Otherwise pass
+            // the user's pick straight through.
+            if (!_mergeRefSurface.isEmpty()) {
+                args << "--ref" << _mergeRefSurface;
+            }
+            args << "--ransac-iters"      << QString::number(_mergeRansacIters)
+                 << "--ransac-min-thresh" << QString::number(_mergeRansacMinThresh, 'g', 10)
+                 << "--ransac-max-thresh" << QString::number(_mergeRansacMaxThresh, 'g', 10)
+                 << "--ransac-mad-k"      << QString::number(_mergeRansacMadK,      'g', 10)
+                 << "--ransac-seed"       << QString::number(_mergeRansacSeed)
+                 << "--anchor-cap"        << QString::number(_mergeAnchorCap)
+                 << "--strip-cols"        << QString::number(_mergeStripCols);
+            break;
         case Tool::CustomCommand:
             args = _customArgs;
             break;
@@ -673,6 +696,9 @@ QString CommandLineToolRunner::toolName(Tool tool) const
         case Tool::NeighborCopy:
             return basePath + "vc_grow_seg_from_seed";
 
+        case Tool::MergeTifxyz:
+            return basePath + "vc_merge_tifxyz";
+
         case Tool::CustomCommand:
             return _customCommand.isEmpty() ? "custom_command" : _customCommand;
 
@@ -689,12 +715,38 @@ QString CommandLineToolRunner::getOutputPath() const
     if (_currentTool == Tool::NeighborCopy) {
         return _tgtDir;
     }
+    if (_currentTool == Tool::MergeTifxyz) {
+        // The tool auto-names the output dir under <volpkg>/paths/; we
+        // surface the merge.json instead so the user can find the run.
+        return _mergeJsonPath;
+    }
     if (_currentTool == Tool::CustomCommand) {
         return QString();
     }
 
     QFileInfo outputInfo(_outputPattern);
     return outputInfo.dir().path();
+}
+
+void CommandLineToolRunner::setMergeParams(const QString& mergeJsonPath,
+                                           const QString& refSurface,
+                                           int ransacIters,
+                                           double ransacMinThresh,
+                                           double ransacMaxThresh,
+                                           double ransacMadK,
+                                           int ransacSeed,
+                                           int anchorCap,
+                                           int stripCols)
+{
+    _mergeJsonPath        = mergeJsonPath;
+    _mergeRefSurface      = refSurface;
+    _mergeRansacIters     = ransacIters;
+    _mergeRansacMinThresh = ransacMinThresh;
+    _mergeRansacMaxThresh = ransacMaxThresh;
+    _mergeRansacMadK      = ransacMadK;
+    _mergeRansacSeed      = ransacSeed;
+    _mergeAnchorCap       = anchorCap;
+    _mergeStripCols       = stripCols;
 }
 
 void CommandLineToolRunner::setObj2TifxyzParams(const QString& objPath, const QString& outputDir,

--- a/volume-cartographer/apps/VC3D/CommandLineToolRunner.cpp
+++ b/volume-cartographer/apps/VC3D/CommandLineToolRunner.cpp
@@ -652,6 +652,12 @@ QStringList CommandLineToolRunner::buildArguments(Tool tool)
             break;
         case Tool::MergeTifxyz:
             args << "--merge" << _mergeJsonPath;
+            // The tool defaults paths-dir to <merge.parent>/paths; pass
+            // the resolved segments dir (e.g. paths_2um_ds2/) explicitly
+            // so this works regardless of the volpkg's directory layout.
+            if (!_mergePathsDir.isEmpty()) {
+                args << "--paths-dir" << _mergePathsDir;
+            }
             // Empty refSurface -> let vc_merge_tifxyz auto-pick the
             // surface with the largest valid-cell count. Otherwise pass
             // the user's pick straight through.
@@ -729,6 +735,7 @@ QString CommandLineToolRunner::getOutputPath() const
 }
 
 void CommandLineToolRunner::setMergeParams(const QString& mergeJsonPath,
+                                           const QString& pathsDir,
                                            const QString& refSurface,
                                            int ransacIters,
                                            double ransacMinThresh,
@@ -739,6 +746,7 @@ void CommandLineToolRunner::setMergeParams(const QString& mergeJsonPath,
                                            int stripCols)
 {
     _mergeJsonPath        = mergeJsonPath;
+    _mergePathsDir        = pathsDir;
     _mergeRefSurface      = refSurface;
     _mergeRansacIters     = ransacIters;
     _mergeRansacMinThresh = ransacMinThresh;

--- a/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
+++ b/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
@@ -36,6 +36,7 @@ public:
         obj2tifxyz,
         AlphaCompRefine,
         NeighborCopy,
+        MergeTifxyz,
         CustomCommand
     };
 
@@ -73,6 +74,17 @@ public:
                                const QString& resumeSurface,
                                const QString& outputDir,
                                const QString& resumeOpt);
+    // vc_merge_tifxyz: only --merge is required; the remaining args are
+    // RANSAC + blend tunables that all have working defaults.
+    void setMergeParams(const QString& mergeJsonPath,
+                        const QString& refSurface,
+                        int ransacIters,
+                        double ransacMinThresh,
+                        double ransacMaxThresh,
+                        double ransacMadK,
+                        int ransacSeed,
+                        int anchorCap,
+                        int stripCols);
     bool execute(Tool tool);
     void cancel();
     bool isRunning() const;
@@ -167,4 +179,15 @@ private:
     int _objStepSize = 20;
     QString _refineDst;
     bool _preserveConsoleOutput{false};
+
+    // vc_merge_tifxyz parameters
+    QString _mergeJsonPath;
+    QString _mergeRefSurface;
+    int     _mergeRansacIters{3000};
+    double  _mergeRansacMinThresh{5.0};
+    double  _mergeRansacMaxThresh{10.0};
+    double  _mergeRansacMadK{3.0};
+    int     _mergeRansacSeed{0};
+    int     _mergeAnchorCap{0};
+    int     _mergeStripCols{0};
 };

--- a/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
+++ b/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
@@ -75,8 +75,12 @@ public:
                                const QString& outputDir,
                                const QString& resumeOpt);
     // vc_merge_tifxyz: only --merge is required; the remaining args are
-    // RANSAC + blend tunables that all have working defaults.
+    // RANSAC + blend tunables that all have working defaults. pathsDir
+    // is forwarded as --paths-dir so the volpkg's actual segments
+    // directory (e.g. paths_2um_ds2/, traces/) is used instead of the
+    // tool's `<merge.parent>/paths` default.
     void setMergeParams(const QString& mergeJsonPath,
+                        const QString& pathsDir,
                         const QString& refSurface,
                         int ransacIters,
                         double ransacMinThresh,
@@ -182,6 +186,7 @@ private:
 
     // vc_merge_tifxyz parameters
     QString _mergeJsonPath;
+    QString _mergePathsDir;
     QString _mergeRefSurface;
     int     _mergeRansacIters{3000};
     double  _mergeRansacMinThresh{5.0};

--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -160,6 +160,10 @@ void MenuActionController::populateMenus(QMenuBar* menuBar)
     _rotateSurfaceAct = new QAction(QObject::tr("Rotate"), this);
     connect(_rotateSurfaceAct, &QAction::triggered, this, &MenuActionController::beginRotateSurfaceTransform);
 
+    _mergeTifxyzAct = new QAction(QObject::tr("Merge tifxyz..."), this);
+    connect(_mergeTifxyzAct, &QAction::triggered,
+            this, &MenuActionController::mergeTifxyzFromMenuRequested);
+
     // Build menus
     _fileMenu = new QMenu(QObject::tr("&File"), qWindow);
     _fileMenu->addAction(_newProjectAct);
@@ -209,6 +213,8 @@ void MenuActionController::populateMenus(QMenuBar* menuBar)
 
     _actionsMenu = new QMenu(QObject::tr("&Actions"), qWindow);
     _actionsMenu->addAction(_drawBBoxAct);
+    _actionsMenu->addSeparator();
+    _actionsMenu->addAction(_mergeTifxyzAct);
     _actionsMenu->addSeparator();
     _transformsMenu = new QMenu(QObject::tr("&Transforms"), _actionsMenu);
     _transformsMenu->addAction(_rotateSurfaceAct);

--- a/volume-cartographer/apps/VC3D/MenuActionController.hpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.hpp
@@ -55,6 +55,12 @@ private slots:
     void beginRotateSurfaceTransform();
     void exitApplication();
 
+signals:
+    // Emitted when the user picks Actions -> Merge tifxyz... CWindow
+    // wires this to SegmentationCommandHandler::onMergeTifxyz with an
+    // empty seed list so the dialog opens with an empty grid.
+    void mergeTifxyzFromMenuRequested();
+
 private:
     QStringList loadRecentPaths() const;
     void saveRecentPaths(const QStringList& paths);
@@ -116,6 +122,7 @@ private:
     QAction* _selectionClearAct{nullptr};
     QAction* _importObjAct{nullptr};
     QAction* _rotateSurfaceAct{nullptr};
+    QAction* _mergeTifxyzAct{nullptr};
 
     QPointer<QDialog> _keybindsDialog;
 };

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -2649,6 +2649,66 @@ void SegmentationCommandHandler::onRasterizeSegments(const QStringList& segmentI
         tr("Rasterization started for %1 segment(s)...").arg(validIds.size()), 0);
 }
 
+void SegmentationCommandHandler::onMergeTifxyz(const QStringList& segmentIds)
+{
+    if (!_state || !_state->vpkg()) {
+        QMessageBox::warning(_parentWidget, tr("Merge TIFXYZ"),
+                             tr("Open a volpkg first."));
+        return;
+    }
+    if (!_cmdRunner) {
+        QMessageBox::warning(_parentWidget, tr("Merge TIFXYZ"),
+                             tr("Command runner is not initialized."));
+        return;
+    }
+    if (_cmdRunner->isRunning()) {
+        QMessageBox::warning(_parentWidget, tr("Merge TIFXYZ"),
+                             tr("A command-line tool is already running."));
+        return;
+    }
+
+    auto vpkg = _state->vpkg();
+    const QString volpkgDir = QString::fromStdString(vpkg->getVolpkgDirectory());
+    const std::string segDirName = vpkg->getSegmentationDirectory();
+    const QString pathsDir = QString::fromStdString(
+        (std::filesystem::path(vpkg->getVolpkgDirectory()) / segDirName).string());
+
+    QStringList availableSegments;
+    {
+        const auto ids = vpkg->segmentationIDs();
+        availableSegments.reserve(static_cast<int>(ids.size()));
+        for (const auto& s : ids) availableSegments << QString::fromStdString(s);
+    }
+    if (availableSegments.size() < 2) {
+        QMessageBox::warning(_parentWidget, tr("Merge TIFXYZ"),
+                             tr("This volpkg has fewer than 2 segments in '%1'; "
+                                "merge needs at least 2.")
+                                 .arg(QString::fromStdString(segDirName)));
+        return;
+    }
+
+    MergeTifxyzDialog dlg(_parentWidget, segmentIds, availableSegments,
+                          volpkgDir, pathsDir);
+    if (dlg.exec() != QDialog::Accepted) {
+        emit statusMessage(tr("Merge cancelled"), 3000);
+        return;
+    }
+
+    _cmdRunner->setMergeParams(dlg.mergeJsonPath(),
+                               dlg.refSurface(),
+                               dlg.ransacIters(),
+                               dlg.ransacMinThresh(),
+                               dlg.ransacMaxThresh(),
+                               dlg.ransacMadK(),
+                               dlg.ransacSeed(),
+                               dlg.anchorCap(),
+                               dlg.stripCols());
+    if (dlg.ompThreads() > 0) _cmdRunner->setOmpThreads(dlg.ompThreads());
+    _cmdRunner->showConsoleOutput();
+    _cmdRunner->execute(CommandLineToolRunner::Tool::MergeTifxyz);
+    emit statusMessage(tr("Merging tifxyz surfaces..."), 0);
+}
+
 void SegmentationCommandHandler::onAddIgnoreLabel()
 {
     if (!_state || !_state->vpkg()) {

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -2668,10 +2668,23 @@ void SegmentationCommandHandler::onMergeTifxyz(const QStringList& segmentIds)
     }
 
     auto vpkg = _state->vpkg();
-    const QString volpkgDir = QString::fromStdString(vpkg->getVolpkgDirectory());
+    // Use the volpkg's resolved output-segments path so it works for
+    // both the `<volpkg-dir>/<segdir>` layout and the freshly-introduced
+    // .volpkg.json form where the project file lives outside the data
+    // directory and segment locations are relative.
+    const std::filesystem::path resolvedSeg = vpkg->outputSegmentsPath();
+    if (resolvedSeg.empty() || !std::filesystem::is_directory(resolvedSeg)) {
+        QMessageBox::warning(_parentWidget, tr("Merge TIFXYZ"),
+                             tr("No active segmentation directory; pick one "
+                                "before running merge."));
+        return;
+    }
+    const QString pathsDir = QString::fromStdString(resolvedSeg.string());
+    // The merge.json + output dir live alongside the resolved segments
+    // dir (the actual volpkg data root), not the .volpkg.json directory.
+    const QString volpkgDir = QString::fromStdString(
+        resolvedSeg.parent_path().string());
     const std::string segDirName = vpkg->getSegmentationDirectory();
-    const QString pathsDir = QString::fromStdString(
-        (std::filesystem::path(vpkg->getVolpkgDirectory()) / segDirName).string());
 
     QStringList availableSegments;
     {
@@ -2695,6 +2708,7 @@ void SegmentationCommandHandler::onMergeTifxyz(const QStringList& segmentIds)
     }
 
     _cmdRunner->setMergeParams(dlg.mergeJsonPath(),
+                               pathsDir,
                                dlg.refSurface(),
                                dlg.ransacIters(),
                                dlg.ransacMinThresh(),

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.hpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.hpp
@@ -122,6 +122,9 @@ public slots:
     void onABFFlatten(const std::string& segmentId);
     void onExportWidthChunks(const std::string& segmentId);
     void onRasterizeSegments(const QStringList& segmentIds);
+    // Open the MergeTifxyzDialog seeded with `segmentIds` (empty = open
+    // dialog with empty grid for the user to populate via "Add segments").
+    void onMergeTifxyz(const QStringList& segmentIds);
     void onAddIgnoreLabel();
     void onNeighborCopyRequested(const QString& segmentId, bool copyOut);
     void onResumeLocalGrowPatchRequested(const QString& segmentId);

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
@@ -826,6 +826,15 @@ void SurfacePanelController::showContextMenu(const QPoint& pos)
         emit rasterizeSegmentsRequested(rasterizeTargets);
     });
 
+    // Merge tifxyz only makes sense for >=2 surfaces; gate on selection
+    // so it doesn't appear when the user right-clicks a single segment.
+    if (selectedSegmentIds.size() >= 2) {
+        QAction* mergeAction = contextMenu.addAction(tr("Merge tifxyz..."));
+        connect(mergeAction, &QAction::triggered, this, [this, selectedSegmentIds]() {
+            emit mergeTifxyzRequested(selectedSegmentIds);
+        });
+    }
+
     QAction* addIgnoreLabelAction = contextMenu.addAction(tr("Add ignore label"));
     connect(addIgnoreLabelAction, &QAction::triggered, this, [this]() {
         emit addIgnoreLabelRequested();

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.hpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.hpp
@@ -122,6 +122,7 @@ signals:
     void exportTifxyzChunksRequested(const QString& segmentId);
     void alphaCompRefineRequested(const QString& segmentId);
     void rasterizeSegmentsRequested(const QStringList& segmentIds);
+    void mergeTifxyzRequested(const QStringList& segmentIds);
     void addIgnoreLabelRequested();
     void statusMessageRequested(const QString& message, int timeoutMs);
     void moveToPathsRequested(const QString& segmentId);

--- a/volume-cartographer/apps/VC3D/ToolDialogs.cpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.cpp
@@ -1615,3 +1615,594 @@ void VisLasagnaObjDialog::updateSessionFromUI()
     s_mesh = chkMesh_->isChecked();
     s_conn = chkConn_->isChecked();
 }
+
+// ============================================================================
+// MergeTifxyzDialog
+//
+// Edits a 2D grid of tifxyz directory names plus the RANSAC tunables for
+// vc_merge_tifxyz, writes a merge.json into <volpkg>/, and exposes the
+// path + tunables to the caller. Each cell holds a name resolved against
+// <volpkg>/<paths_dir>/. Empty cells are allowed; adjacency in the grid
+// drives RANSAC alignment.
+// ============================================================================
+
+#include <QHeaderView>
+#include <QInputDialog>
+#include <QListWidget>
+#include <QSet>
+#include <QTableWidget>
+
+#include <algorithm>
+#include <fstream>
+
+bool   MergeTifxyzDialog::s_haveSession = false;
+int    MergeTifxyzDialog::s_iters       = 3000;
+double MergeTifxyzDialog::s_min         = 5.0;
+double MergeTifxyzDialog::s_max         = 10.0;
+double MergeTifxyzDialog::s_madK        = 3.0;
+int    MergeTifxyzDialog::s_seed        = 0;
+int    MergeTifxyzDialog::s_anchorCap   = 0;
+int    MergeTifxyzDialog::s_stripCols   = 0;
+int    MergeTifxyzDialog::s_lastRows    = 0;
+int    MergeTifxyzDialog::s_lastCols    = 0;
+int    MergeTifxyzDialog::s_ompThreads  = -1;
+
+namespace {
+
+// Layout: row-major, take ceil(sqrt(N)) columns so the seed selection
+// fits a roughly-square block (matches typical scroll segment topology
+// where the user picks adjacent overlapping patches).
+QPair<int, int> defaultGridShape(int n)
+{
+    if (n <= 0) return {1, 1};
+    int cols = static_cast<int>(std::ceil(std::sqrt(static_cast<double>(n))));
+    int rows = (n + cols - 1) / cols;
+    return {std::max(1, rows), std::max(1, cols)};
+}
+
+QString alphaFirst(const QStringList& names)
+{
+    QString out;
+    for (const auto& n : names) {
+        if (n.isEmpty()) continue;
+        if (out.isEmpty() || n < out) out = n;
+    }
+    return out;
+}
+
+QString resolveOutputName(const QString& volpkgDir, const QString& base)
+{
+    if (volpkgDir.isEmpty() || base.isEmpty()) return base;
+    namespace fs = std::filesystem;
+    const fs::path paths = fs::path(volpkgDir.toStdString()) / "paths";
+    auto exists = [&](const std::string& name) {
+        return fs::exists(paths / name);
+    };
+    if (!exists(base.toStdString())) return base;
+    for (int v = 2; v < 1000; ++v) {
+        QString candidate = base + QStringLiteral("_v%1").arg(v);
+        if (!exists(candidate.toStdString())) return candidate;
+    }
+    return base + QStringLiteral("_v?");
+}
+
+}
+
+MergeTifxyzDialog::MergeTifxyzDialog(QWidget* parent,
+                                     const QStringList& seedSegmentIds,
+                                     const QStringList& availableSegments,
+                                     const QString& volpkgDir,
+                                     const QString& pathsDir)
+    : QDialog(parent),
+      _availableSegments(availableSegments),
+      _volpkgDir(volpkgDir),
+      _pathsDir(pathsDir)
+{
+    setWindowTitle("Merge TIFXYZ Surfaces");
+    auto main = new QVBoxLayout(this);
+
+    // --- Grid editor -------------------------------------------------------
+    auto grpGrid = new QGroupBox("Layout (row-major; adjacency drives RANSAC alignment)", this);
+    auto gridLay = new QVBoxLayout(grpGrid);
+
+    tblGrid_ = new QTableWidget(grpGrid);
+    tblGrid_->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    tblGrid_->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    tblGrid_->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    auto gridButtons = new QHBoxLayout();
+    btnAddRow_     = new QPushButton(tr("+ Row"), grpGrid);
+    btnAddCol_     = new QPushButton(tr("+ Col"), grpGrid);
+    btnRemoveRow_  = new QPushButton(tr("− Row"), grpGrid);
+    btnRemoveCol_  = new QPushButton(tr("− Col"), grpGrid);
+    btnAddSegments_ = new QPushButton(tr("Add segments..."), grpGrid);
+    gridButtons->addWidget(btnAddRow_);
+    gridButtons->addWidget(btnAddCol_);
+    gridButtons->addWidget(btnRemoveRow_);
+    gridButtons->addWidget(btnRemoveCol_);
+    gridButtons->addStretch(1);
+    gridButtons->addWidget(btnAddSegments_);
+
+    gridLay->addLayout(gridButtons);
+    gridLay->addWidget(tblGrid_);
+    main->addWidget(grpGrid, 1);
+
+    // --- Output / reference ------------------------------------------------
+    auto formTop = new QFormLayout();
+    cmbRef_ = new QComboBox(this);
+    cmbRef_->setEditable(false);
+    lblOutName_ = new QLabel(this);
+    lblOutName_->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    formTop->addRow(tr("Reference surface:"), cmbRef_);
+    formTop->addRow(tr("Output:"), lblOutName_);
+    main->addLayout(formTop);
+
+    // --- Advanced ----------------------------------------------------------
+    auto grpAdv = new QGroupBox(tr("Advanced"), this);
+    grpAdv->setCheckable(true);
+    grpAdv->setChecked(false);
+    auto advForm = new QFormLayout(grpAdv);
+
+    spIters_ = new QSpinBox(grpAdv);
+    spIters_->setRange(1, 1'000'000);
+    spIters_->setValue(s_iters);
+    spIters_->setSingleStep(100);
+
+    spMin_ = new QDoubleSpinBox(grpAdv);
+    spMin_->setRange(0.1, 1000.0); spMin_->setDecimals(2); spMin_->setSingleStep(0.5);
+    spMin_->setValue(s_min);
+
+    spMax_ = new QDoubleSpinBox(grpAdv);
+    spMax_->setRange(0.1, 1000.0); spMax_->setDecimals(2); spMax_->setSingleStep(0.5);
+    spMax_->setValue(s_max);
+
+    spMadK_ = new QDoubleSpinBox(grpAdv);
+    spMadK_->setRange(0.1, 20.0); spMadK_->setDecimals(2); spMadK_->setSingleStep(0.1);
+    spMadK_->setValue(s_madK);
+
+    spSeed_ = new QSpinBox(grpAdv);
+    spSeed_->setRange(0, std::numeric_limits<int>::max());
+    spSeed_->setValue(s_seed);
+
+    spAnchorCap_ = new QSpinBox(grpAdv);
+    spAnchorCap_->setRange(0, 1'000'000);
+    spAnchorCap_->setValue(s_anchorCap);
+    spAnchorCap_->setToolTip(tr("0 = no cap"));
+
+    spStripCols_ = new QSpinBox(grpAdv);
+    spStripCols_->setRange(0, 1024);
+    spStripCols_->setValue(s_stripCols);
+    spStripCols_->setToolTip(tr("0 = single-pass blend"));
+
+    edtThreads_ = new QLineEdit(grpAdv);
+    edtThreads_->setPlaceholderText(tr("optional"));
+    edtThreads_->setValidator(new QRegularExpressionValidator(
+        QRegularExpression("^\\s*\\d*\\s*$"), edtThreads_));
+    if (s_ompThreads > 0) edtThreads_->setText(QString::number(s_ompThreads));
+
+    advForm->addRow(tr("RANSAC iterations:"), spIters_);
+    advForm->addRow(tr("RANSAC min threshold (vox):"), spMin_);
+    advForm->addRow(tr("RANSAC max threshold (vox):"), spMax_);
+    advForm->addRow(tr("RANSAC MAD k:"), spMadK_);
+    advForm->addRow(tr("RANSAC seed (0 = random):"), spSeed_);
+    advForm->addRow(tr("Anchor cap:"), spAnchorCap_);
+    advForm->addRow(tr("Strip cols:"), spStripCols_);
+    advForm->addRow(tr("OMP threads:"), edtThreads_);
+    main->addWidget(grpAdv);
+
+    // --- merge.json preview -----------------------------------------------
+    auto grpPrev = new QGroupBox(tr("merge.json preview"), this);
+    auto prevLay = new QVBoxLayout(grpPrev);
+    lblPreview_ = new QLabel(grpPrev);
+    lblPreview_->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    lblPreview_->setStyleSheet("font-family: monospace;");
+    lblPreview_->setWordWrap(true);
+    prevLay->addWidget(lblPreview_);
+    main->addWidget(grpPrev);
+
+    // --- Buttons -----------------------------------------------------------
+    auto btns = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    auto btnReset = btns->addButton(tr("Reset to Defaults"), QDialogButtonBox::ResetRole);
+    connect(btns, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(btns, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(btnReset, &QPushButton::clicked, this, [this]() { applyCodeDefaults(); });
+    main->addWidget(btns);
+
+    // --- Wiring ------------------------------------------------------------
+    connect(btnAddRow_,    &QPushButton::clicked, this, [this]() {
+        resizeGrid(tblGrid_->rowCount() + 1, tblGrid_->columnCount());
+    });
+    connect(btnAddCol_,    &QPushButton::clicked, this, [this]() {
+        resizeGrid(tblGrid_->rowCount(), tblGrid_->columnCount() + 1);
+    });
+    connect(btnRemoveRow_, &QPushButton::clicked, this, [this]() {
+        resizeGrid(std::max(1, tblGrid_->rowCount() - 1), tblGrid_->columnCount());
+    });
+    connect(btnRemoveCol_, &QPushButton::clicked, this, [this]() {
+        resizeGrid(tblGrid_->rowCount(), std::max(1, tblGrid_->columnCount() - 1));
+    });
+    connect(btnAddSegments_, &QPushButton::clicked, this, [this]() {
+        promptAddSegments();
+    });
+    connect(tblGrid_, &QTableWidget::itemChanged, this, [this](QTableWidgetItem*) {
+        rebuildPreview();
+        updateRefCombo();
+    });
+
+    // --- Initial population ----------------------------------------------
+    seedGrid(seedSegmentIds);
+    applySessionDefaults();
+    rebuildPreview();
+    updateRefCombo();
+
+    // Reasonable initial sizing.
+    resize(720, 600);
+}
+
+void MergeTifxyzDialog::applyCodeDefaults()
+{
+    spIters_->setValue(3000);
+    spMin_->setValue(5.0);
+    spMax_->setValue(10.0);
+    spMadK_->setValue(3.0);
+    spSeed_->setValue(0);
+    spAnchorCap_->setValue(0);
+    spStripCols_->setValue(0);
+    edtThreads_->setText(QString());
+}
+
+void MergeTifxyzDialog::applySessionDefaults()
+{
+    if (!s_haveSession) return;
+    spIters_->setValue(s_iters);
+    spMin_->setValue(s_min);
+    spMax_->setValue(s_max);
+    spMadK_->setValue(s_madK);
+    spSeed_->setValue(s_seed);
+    spAnchorCap_->setValue(s_anchorCap);
+    spStripCols_->setValue(s_stripCols);
+    edtThreads_->setText(s_ompThreads > 0 ? QString::number(s_ompThreads) : QString());
+}
+
+void MergeTifxyzDialog::updateSessionFromUI()
+{
+    s_haveSession = true;
+    s_iters       = spIters_->value();
+    s_min         = spMin_->value();
+    s_max         = spMax_->value();
+    s_madK        = spMadK_->value();
+    s_seed        = spSeed_->value();
+    s_anchorCap   = spAnchorCap_->value();
+    s_stripCols   = spStripCols_->value();
+    s_lastRows    = tblGrid_->rowCount();
+    s_lastCols    = tblGrid_->columnCount();
+    s_ompThreads  = ompThreads();
+}
+
+void MergeTifxyzDialog::resizeGrid(int newRows, int newCols)
+{
+    newRows = std::max(1, newRows);
+    newCols = std::max(1, newCols);
+    tblGrid_->setRowCount(newRows);
+    tblGrid_->setColumnCount(newCols);
+    for (int r = 0; r < newRows; ++r) {
+        for (int c = 0; c < newCols; ++c) {
+            if (!tblGrid_->item(r, c)) {
+                tblGrid_->setItem(r, c, new QTableWidgetItem(QString()));
+            }
+        }
+    }
+    rebuildPreview();
+    updateRefCombo();
+}
+
+void MergeTifxyzDialog::seedGrid(const QStringList& seedSegmentIds)
+{
+    QStringList seeds;
+    for (const auto& s : seedSegmentIds) if (!s.isEmpty()) seeds << s;
+
+    int rows, cols;
+    if (s_haveSession && s_lastRows > 0 && s_lastCols > 0 &&
+        s_lastRows * s_lastCols >= seeds.size())
+    {
+        rows = s_lastRows;
+        cols = s_lastCols;
+    } else {
+        const auto rc = defaultGridShape(std::max(1, static_cast<int>(seeds.size())));
+        rows = rc.first;
+        cols = rc.second;
+    }
+
+    resizeGrid(rows, cols);
+
+    int idx = 0;
+    for (int r = 0; r < rows && idx < seeds.size(); ++r) {
+        for (int c = 0; c < cols && idx < seeds.size(); ++c) {
+            tblGrid_->item(r, c)->setText(seeds[idx++]);
+        }
+    }
+    rebuildPreview();
+    updateRefCombo();
+}
+
+void MergeTifxyzDialog::promptAddSegments()
+{
+    // Open a small modal that lists every available segment; chosen
+    // names are appended into the first empty cells (row-major).
+    // Segments already in the grid are NOT filtered out -- the merge
+    // tool's parser treats duplicate cells as the same surface and
+    // wires neighbors through them, which is what you want when a tall
+    // segment (e.g. wrap31) borders two stacked half-height neighbors
+    // (wrap32a / wrap32b) and needs to sit at the start of both rows.
+    QDialog dlg(this);
+    dlg.setWindowTitle(tr("Add segments to grid"));
+    auto lay = new QVBoxLayout(&dlg);
+    auto list = new QListWidget(&dlg);
+    list->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    QSet<QString> alreadyInGrid;
+    for (const auto& n : collectGridNames()) if (!n.isEmpty()) alreadyInGrid.insert(n);
+    for (const auto& s : _availableSegments) {
+        auto* item = new QListWidgetItem(list);
+        item->setData(Qt::UserRole, s);
+        if (alreadyInGrid.contains(s)) {
+            item->setText(s + tr("  (already in grid)"));
+            QFont f = item->font();
+            f.setItalic(true);
+            item->setFont(f);
+        } else {
+            item->setText(s);
+        }
+    }
+    auto btns = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dlg);
+    connect(btns, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    connect(btns, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+    lay->addWidget(list);
+    lay->addWidget(btns);
+    dlg.resize(380, 460);
+    if (dlg.exec() != QDialog::Accepted) return;
+
+    QStringList chosen;
+    for (auto* item : list->selectedItems()) {
+        chosen << item->data(Qt::UserRole).toString();
+    }
+    if (chosen.isEmpty()) return;
+
+    // Drop chosen names into empty cells. If we run out, grow the grid
+    // by one column at a time (keeps row count stable).
+    int idx = 0;
+    auto fillNext = [&]() {
+        for (int r = 0; r < tblGrid_->rowCount(); ++r) {
+            for (int c = 0; c < tblGrid_->columnCount(); ++c) {
+                auto* it = tblGrid_->item(r, c);
+                if (it && it->text().isEmpty()) {
+                    it->setText(chosen[idx++]);
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+    while (idx < chosen.size()) {
+        if (!fillNext()) {
+            resizeGrid(tblGrid_->rowCount(), tblGrid_->columnCount() + 1);
+        }
+    }
+    rebuildPreview();
+    updateRefCombo();
+}
+
+QStringList MergeTifxyzDialog::collectGridNames() const
+{
+    QStringList out;
+    for (int r = 0; r < tblGrid_->rowCount(); ++r) {
+        for (int c = 0; c < tblGrid_->columnCount(); ++c) {
+            auto* it = tblGrid_->item(r, c);
+            out << (it ? it->text().trimmed() : QString());
+        }
+    }
+    return out;
+}
+
+QString MergeTifxyzDialog::buildMergeJsonText() const
+{
+    const int rows = tblGrid_->rowCount();
+    const int cols = tblGrid_->columnCount();
+
+    // Whitespace-delimited string rows can't represent interior empty
+    // cells -- the parser splits the row on whitespace and looks each
+    // token up as a directory under <paths_dir>, so a literal "" token
+    // would be searched for as the directory `""` and the run would
+    // fail. Switch to JSON array rows (with `null` for empty cells)
+    // whenever the grid has any blank, which is the form gmResolveGrid
+    // already handles. Solid grids keep the more compact string form.
+    bool hasEmpty = false;
+    for (int r = 0; r < rows && !hasEmpty; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            auto* it = tblGrid_->item(r, c);
+            if (!it || it->text().trimmed().isEmpty()) {
+                hasEmpty = true;
+                break;
+            }
+        }
+    }
+
+    QString out;
+    out += QStringLiteral("{\n  \"rows\": [\n");
+
+    if (hasEmpty) {
+        for (int r = 0; r < rows; ++r) {
+            QStringList cells;
+            cells.reserve(cols);
+            for (int c = 0; c < cols; ++c) {
+                auto* it = tblGrid_->item(r, c);
+                const QString name = it ? it->text().trimmed() : QString();
+                if (name.isEmpty()) {
+                    cells << QStringLiteral("null");
+                } else {
+                    cells << QStringLiteral("\"") + name + QLatin1Char('"');
+                }
+            }
+            out += QStringLiteral("    [")
+                 + cells.join(QStringLiteral(", "))
+                 + QLatin1Char(']');
+            if (r + 1 < rows) out += QLatin1Char(',');
+            out += QLatin1Char('\n');
+        }
+    } else {
+        // Pad each cell so visual columns line up in the preview.
+        QVector<int> widths(cols, 0);
+        for (int r = 0; r < rows; ++r) {
+            for (int c = 0; c < cols; ++c) {
+                auto* it = tblGrid_->item(r, c);
+                int w = it ? static_cast<int>(it->text().trimmed().size()) : 0;
+                if (w > widths[c]) widths[c] = w;
+            }
+        }
+        for (int r = 0; r < rows; ++r) {
+            QStringList tokens;
+            tokens.reserve(cols);
+            for (int c = 0; c < cols; ++c) {
+                auto* it = tblGrid_->item(r, c);
+                const QString name = it ? it->text().trimmed() : QString();
+                tokens << name.leftJustified(std::max(widths[c], 1), ' ');
+            }
+            out += QStringLiteral("    \"")
+                 + tokens.join(' ').trimmed()
+                 + QLatin1Char('"');
+            if (r + 1 < rows) out += QLatin1Char(',');
+            out += QLatin1Char('\n');
+        }
+    }
+
+    out += QStringLiteral("  ]\n}\n");
+    return out;
+}
+
+void MergeTifxyzDialog::rebuildPreview()
+{
+    lblPreview_->setText(buildMergeJsonText());
+    QStringList names = collectGridNames();
+    QString af = alphaFirst(names);
+    if (af.isEmpty()) {
+        lblOutName_->setText(tr("(grid is empty)"));
+    } else {
+        const QString base = af + QStringLiteral("_merged");
+        const QString name = resolveOutputName(_volpkgDir, base);
+        lblOutName_->setText(QStringLiteral("%1/paths/%2/")
+            .arg(_volpkgDir, name));
+    }
+}
+
+void MergeTifxyzDialog::updateRefCombo()
+{
+    QString prev = cmbRef_->currentText();
+    QStringList names = collectGridNames();
+    QStringList unique;
+    for (const auto& n : names) {
+        if (!n.isEmpty() && !unique.contains(n)) unique << n;
+    }
+    cmbRef_->blockSignals(true);
+    cmbRef_->clear();
+    cmbRef_->addItem(tr("<auto: largest valid-cell count>"), QString());
+    for (const auto& n : unique) cmbRef_->addItem(n, n);
+    if (!prev.isEmpty()) {
+        const int idx = cmbRef_->findData(prev);
+        if (idx >= 0) cmbRef_->setCurrentIndex(idx);
+    }
+    cmbRef_->blockSignals(false);
+}
+
+QString MergeTifxyzDialog::mergeJsonPath() const { return _mergeJsonPath; }
+QString MergeTifxyzDialog::refSurface()    const { return cmbRef_->currentData().toString(); }
+int     MergeTifxyzDialog::ransacIters()   const { return spIters_->value(); }
+double  MergeTifxyzDialog::ransacMinThresh() const { return spMin_->value(); }
+double  MergeTifxyzDialog::ransacMaxThresh() const { return spMax_->value(); }
+double  MergeTifxyzDialog::ransacMadK()    const { return spMadK_->value(); }
+int     MergeTifxyzDialog::ransacSeed()    const { return spSeed_->value(); }
+int     MergeTifxyzDialog::anchorCap()     const { return spAnchorCap_->value(); }
+int     MergeTifxyzDialog::stripCols()     const { return spStripCols_->value(); }
+int     MergeTifxyzDialog::ompThreads() const {
+    const QString t = edtThreads_->text().trimmed();
+    if (t.isEmpty()) return -1;
+    bool ok = false; int v = t.toInt(&ok); return (ok && v > 0) ? v : -1;
+}
+
+void MergeTifxyzDialog::accept()
+{
+    // --- validate grid -----------------------------------------------------
+    QStringList names = collectGridNames();
+    QStringList unique;
+    int nonEmpty = 0;
+    for (const auto& n : names) {
+        if (n.isEmpty()) continue;
+        ++nonEmpty;
+        if (!unique.contains(n)) unique << n;
+    }
+    if (unique.size() < 2) {
+        QMessageBox::warning(this, tr("Merge TIFXYZ"),
+            tr("Merge requires at least 2 distinct surfaces in the grid; "
+               "currently %1.").arg(unique.size()));
+        return;
+    }
+    QSet<QString> avail(_availableSegments.begin(), _availableSegments.end());
+    QStringList missing;
+    for (const auto& n : unique) {
+        if (!avail.contains(n)) missing << n;
+    }
+    if (!missing.isEmpty()) {
+        QMessageBox::warning(this, tr("Merge TIFXYZ"),
+            tr("These names are not present under %1:\n  %2")
+                .arg(_pathsDir, missing.join(QLatin1String(", "))));
+        return;
+    }
+    for (const auto& n : unique) {
+        if (n.contains(QRegularExpression("\\s"))) {
+            QMessageBox::warning(this, tr("Merge TIFXYZ"),
+                tr("Surface name '%1' contains whitespace; the merge.json "
+                   "format does not support that. Rename the surface first.")
+                    .arg(n));
+            return;
+        }
+    }
+    if (spMin_->value() >= spMax_->value()) {
+        QMessageBox::warning(this, tr("Merge TIFXYZ"),
+            tr("RANSAC min threshold must be strictly less than max."));
+        return;
+    }
+    const QString ref = refSurface();
+    if (!ref.isEmpty() && !unique.contains(ref)) {
+        QMessageBox::warning(this, tr("Merge TIFXYZ"),
+            tr("Reference '%1' is not in the grid.").arg(ref));
+        return;
+    }
+    (void)nonEmpty;
+
+    // --- write merge.json --------------------------------------------------
+    if (_volpkgDir.isEmpty()) {
+        QMessageBox::critical(this, tr("Merge TIFXYZ"),
+            tr("No volpkg directory available; cannot write merge.json."));
+        return;
+    }
+    namespace fs = std::filesystem;
+    const fs::path af   = fs::path(alphaFirst(names).toStdString());
+    const QString stem  = QString::fromStdString(af.string()) + QStringLiteral("_merged");
+    const QString outName = resolveOutputName(_volpkgDir, stem);
+    const fs::path mj   = fs::path(_volpkgDir.toStdString()) /
+                          (outName.toStdString() + ".merge.json");
+    try {
+        std::ofstream f(mj);
+        if (!f) throw std::runtime_error("ofstream failed to open " + mj.string());
+        const QString text = buildMergeJsonText();
+        const std::string s = text.toStdString();
+        f.write(s.data(), static_cast<std::streamsize>(s.size()));
+        if (!f) throw std::runtime_error("ofstream write failed for " + mj.string());
+    } catch (const std::exception& e) {
+        QMessageBox::critical(this, tr("Merge TIFXYZ"),
+            tr("Failed to write merge.json: %1").arg(QString::fromUtf8(e.what())));
+        return;
+    }
+    _mergeJsonPath = QString::fromStdString(mj.string());
+
+    updateSessionFromUI();
+    QDialog::accept();
+}

--- a/volume-cartographer/apps/VC3D/ToolDialogs.hpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.hpp
@@ -218,6 +218,90 @@ private:
     QDoubleSpinBox* spCleanK_{nullptr};
 };
 
+class QTableWidget;
+class QPushButton;
+class QLabel;
+
+// MergeTifxyzDialog
+//
+// Edits a 2D grid of tifxyz directory names and the RANSAC tunables for
+// vc_merge_tifxyz, then writes a merge.json into the volpkg root and
+// returns its path. The grid layout encodes the surface adjacency that
+// the merge tool RANSAC-aligns; empty cells are allowed; selection in
+// the segment list is used as the seed but the user can edit / append.
+class MergeTifxyzDialog : public QDialog {
+    Q_OBJECT
+public:
+    MergeTifxyzDialog(QWidget* parent,
+                      const QStringList& seedSegmentIds,
+                      const QStringList& availableSegments,
+                      const QString& volpkgDir,
+                      const QString& pathsDir);
+
+    QString mergeJsonPath() const;     // populated by accept() on success
+    QString refSurface() const;        // empty -> auto (largest valid-cell count)
+    int ransacIters() const;
+    double ransacMinThresh() const;
+    double ransacMaxThresh() const;
+    double ransacMadK() const;
+    int ransacSeed() const;
+    int anchorCap() const;
+    int stripCols() const;
+    int ompThreads() const; // -1 if unset
+
+protected:
+    void accept() override;
+
+private:
+    QStringList collectGridNames() const;          // row-major, empties as ""
+    QString buildMergeJsonText() const;            // pretty JSON for preview + write
+    void rebuildPreview();
+    void updateRefCombo();
+    void resizeGrid(int newRows, int newCols);
+    void seedGrid(const QStringList& seedSegmentIds);
+    void promptAddSegments();
+
+    void applyCodeDefaults();
+    void applySessionDefaults();
+    void updateSessionFromUI();
+
+    QStringList _availableSegments;
+    QString _volpkgDir;
+    QString _pathsDir;
+    QString _mergeJsonPath;
+
+    QTableWidget* tblGrid_{nullptr};
+    QPushButton* btnAddRow_{nullptr};
+    QPushButton* btnAddCol_{nullptr};
+    QPushButton* btnRemoveRow_{nullptr};
+    QPushButton* btnRemoveCol_{nullptr};
+    QPushButton* btnAddSegments_{nullptr};
+    QComboBox* cmbRef_{nullptr};
+    QLabel* lblOutName_{nullptr};
+    QSpinBox* spIters_{nullptr};
+    QDoubleSpinBox* spMin_{nullptr};
+    QDoubleSpinBox* spMax_{nullptr};
+    QDoubleSpinBox* spMadK_{nullptr};
+    QSpinBox* spSeed_{nullptr};
+    QSpinBox* spAnchorCap_{nullptr};
+    QSpinBox* spStripCols_{nullptr};
+    QLineEdit* edtThreads_{nullptr};
+    QLabel* lblPreview_{nullptr};
+
+    // Session defaults (in-memory only; persist across one VC3D run).
+    static bool   s_haveSession;
+    static int    s_iters;
+    static double s_min;
+    static double s_max;
+    static double s_madK;
+    static int    s_seed;
+    static int    s_anchorCap;
+    static int    s_stripCols;
+    static int    s_lastRows;
+    static int    s_lastCols;
+    static int    s_ompThreads;
+};
+
 class AlphaCompRefineDialog : public QDialog {
     Q_OBJECT
 public:

--- a/volume-cartographer/apps/src/vc_merge_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_merge_tifxyz.cpp
@@ -17,6 +17,7 @@
 #include "vc/core/util/Surface.hpp"
 #include "vc/core/util/QuadSurface.hpp"
 #include "vc/core/util/SurfacePatchIndex.hpp"
+#include "vc_merge_tifxyz_grid.hpp"
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgcodecs.hpp>
@@ -336,8 +337,12 @@ std::vector<Anchor> pickAnchors(const std::shared_ptr<QuadSurface>& A,
 using Mat1f = cv::Mat_<float>;
 using Mat1b = cv::Mat_<uint8_t>;
 
-struct GMSurfaceSpec { std::string name; fs::path path; };
-struct GMEdgeSpec    { std::string a; std::string b; };
+// Grid parser + connectivity check live in vc_merge_tifxyz_grid.{hpp,cpp}
+// so the unit tests can link them without spawning the binary.
+using vc::merge::GMSurfaceSpec;
+using vc::merge::GMEdgeSpec;
+using vc::merge::gmResolveGrid;
+using vc::merge::gmCheckConnected;
 
 // Hard-coded stage params (no flag, no JSON). Match the long-tuned values that
 // have been working across volpkgs; expose only the knobs that actually vary.
@@ -366,153 +371,6 @@ struct GMConfig {
     std::vector<GMSurfaceSpec> surfaces;
     std::vector<GMEdgeSpec>    edges;
 };
-
-// -----------------------------------------------------------------------------
-// Grid input: <volpkg>/merge.json holds a `rows` array. Each row is either a
-// JSON array of strings or (preferred, easier to hand-edit) a single
-// whitespace-delimited string. Each cell is a full tifxyz directory name
-// under <paths_dir>/, or null/"" for an empty slot. Surfaces are deduplicated;
-// edges are derived from horizontal + vertical adjacency, skipping self-edges
-// and edges incident to empty cells. The duplicate-cell case (same name twice)
-// resolves to the same surface and produces no self-edge, so adjacent
-// neighbors above and beside still connect.
-// -----------------------------------------------------------------------------
-
-void gmResolveGrid(const fs::path& merge_path,
-                   const fs::path& paths_dir,
-                   std::vector<GMSurfaceSpec>& surfaces,
-                   std::vector<GMEdgeSpec>& edges)
-{
-    const fs::path& mj = merge_path;
-    std::ifstream f(mj);
-    if (!f) throw std::runtime_error("cannot open " + mj.string());
-    json j; f >> j;
-
-    if (j.size() != 1 || !j.contains("rows"))
-        throw std::runtime_error(mj.string() +
-            ": only the 'rows' key is accepted");
-    const auto& rows_j = j.at("rows");
-    if (!rows_j.is_array() || rows_j.empty())
-        throw std::runtime_error(mj.string() + ": 'rows' must be a non-empty array");
-
-    const size_t R = rows_j.size();
-    std::vector<std::vector<std::string>> grid(R);
-    std::unordered_map<std::string, fs::path> name_to_path;
-
-    // Each row may be either a JSON array of strings (legacy) OR a single
-    // whitespace-delimited string. The string form is easier to hand-edit:
-    //   "rows": ["name_a name_b name_c", "name_d name_e name_f"]
-    auto splitWhitespace = [](const std::string& s) {
-        std::vector<std::string> out;
-        std::istringstream iss(s);
-        std::string tok;
-        while (iss >> tok) out.push_back(std::move(tok));
-        return out;
-    };
-
-    for (size_t r = 0; r < R; ++r) {
-        const auto& row_j = rows_j[r];
-        std::vector<std::string> row_names;
-        if (row_j.is_array()) {
-            row_names.reserve(row_j.size());
-            for (size_t c = 0; c < row_j.size(); ++c) {
-                const auto& cell = row_j[c];
-                if (cell.is_null()) { row_names.emplace_back(); continue; }
-                if (!cell.is_string())
-                    throw std::runtime_error(mj.string() + ": rows[" +
-                        std::to_string(r) + "][" + std::to_string(c) +
-                        "] must be a string or null");
-                row_names.push_back(cell.get<std::string>());
-            }
-        } else if (row_j.is_string()) {
-            row_names = splitWhitespace(row_j.get<std::string>());
-        } else {
-            throw std::runtime_error(mj.string() + ": rows[" + std::to_string(r) +
-                "] must be an array or a whitespace-delimited string");
-        }
-
-        const size_t C = row_names.size();
-        grid[r].resize(C);
-        for (size_t c = 0; c < C; ++c) {
-            const std::string& name = row_names[c];
-            if (name.empty()) continue;
-            if (name_to_path.count(name)) {
-                grid[r][c] = name;  // duplicate cell -> same surface
-                continue;
-            }
-            const fs::path dir = paths_dir / name;
-            if (!fs::is_directory(dir))
-                throw std::runtime_error(mj.string() + ": rows[" +
-                    std::to_string(r) + "][" + std::to_string(c) + "] = '" +
-                    name + "' is not a directory under " + paths_dir.string());
-            name_to_path[name] = dir;
-            grid[r][c] = name;
-        }
-    }
-
-    surfaces.clear();
-    surfaces.reserve(name_to_path.size());
-    std::set<std::string> seen;
-    for (size_t r = 0; r < R; ++r) {
-        for (size_t c = 0; c < grid[r].size(); ++c) {
-            const std::string& n = grid[r][c];
-            if (n.empty() || !seen.insert(n).second) continue;
-            GMSurfaceSpec s;
-            s.name = n;
-            s.path = name_to_path.at(n);
-            surfaces.push_back(std::move(s));
-        }
-    }
-
-    if (surfaces.size() < 2)
-        throw std::runtime_error(mj.string() + ": need at least 2 distinct "
-            "surfaces in the grid; got " + std::to_string(surfaces.size()));
-
-    auto edgeKey = [](const std::string& a, const std::string& b) {
-        return a < b ? a + "\t" + b : b + "\t" + a;
-    };
-    std::set<std::string> edge_seen;
-    edges.clear();
-    auto addEdge = [&](const std::string& a, const std::string& b) {
-        if (a.empty() || b.empty() || a == b) return;
-        if (edge_seen.insert(edgeKey(a, b)).second) edges.push_back({a, b});
-    };
-    for (size_t r = 0; r < R; ++r) {
-        const auto& row = grid[r];
-        for (size_t c = 0; c + 1 < row.size(); ++c) addEdge(row[c], row[c + 1]);
-    }
-    for (size_t r = 0; r + 1 < R; ++r) {
-        const size_t C = std::min(grid[r].size(), grid[r + 1].size());
-        for (size_t c = 0; c < C; ++c) addEdge(grid[r][c], grid[r + 1][c]);
-    }
-}
-
-void gmCheckConnected(const std::vector<GMSurfaceSpec>& surfaces,
-                      const std::vector<GMEdgeSpec>& edges)
-{
-    std::unordered_map<std::string, std::vector<std::string>> adj;
-    for (const auto& s : surfaces) adj[s.name];
-    for (const auto& e : edges) {
-        adj[e.a].push_back(e.b);
-        adj[e.b].push_back(e.a);
-    }
-    std::unordered_set<std::string> visited;
-    std::deque<std::string> q;
-    q.push_back(surfaces.front().name);
-    visited.insert(surfaces.front().name);
-    while (!q.empty()) {
-        const std::string u = q.front(); q.pop_front();
-        for (const auto& v : adj[u])
-            if (visited.insert(v).second) q.push_back(v);
-    }
-    if (visited.size() == surfaces.size()) return;
-    std::ostringstream msg;
-    msg << "edge graph from merge.json is disconnected; "
-           "unreachable surfaces:";
-    for (const auto& s : surfaces)
-        if (!visited.count(s.name)) msg << "\n  " << s.name;
-    throw std::runtime_error(msg.str());
-}
 
 // -----------------------------------------------------------------------------
 // Surface holder: rawPoints from QuadSurface (already mask.tif-aware) split

--- a/volume-cartographer/apps/src/vc_merge_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_merge_tifxyz.cpp
@@ -1642,10 +1642,15 @@ GMAlignState gmAlignAll(const fs::path& merge_path, GMConfig cfg)
     GMAlignState st;
     st.merge_path = merge_path;
     st.cfg        = std::move(cfg);
-    st.cfg.paths_dir = merge_path.parent_path() / "paths";
+    // Preserve a caller-supplied paths_dir (e.g. --paths-dir from the CLI
+    // or the GUI handler); fall back to <merge.parent>/paths only when
+    // unset, matching the legacy default.
+    if (st.cfg.paths_dir.empty())
+        st.cfg.paths_dir = merge_path.parent_path() / "paths";
     if (!fs::is_directory(st.cfg.paths_dir))
-        throw std::runtime_error("expected " + st.cfg.paths_dir.string() +
-            " (sibling of " + merge_path.string() + ") to be a directory");
+        throw std::runtime_error("expected paths_dir " +
+            st.cfg.paths_dir.string() + " to be a directory (override "
+            "with --paths-dir, default is <merge.parent>/paths)");
 
     std::cout << "[0/6] grid -> surfaces+edges from " << merge_path << "\n";
     gmResolveGrid(merge_path, st.cfg.paths_dir, st.cfg.surfaces, st.cfg.edges);
@@ -2148,8 +2153,14 @@ int main(int argc, char** argv)
     desc.add_options()
         ("help,h", "print help")
         ("merge,m", po::value<std::string>(),
-         "Path to <volpkg>/merge.json (required). The volpkg dir is its "
-         "parent and paths_dir is <volpkg>/paths.")
+         "Path to <volpkg>/merge.json (required). By default the volpkg "
+         "dir is its parent and paths_dir is <volpkg>/paths; pass "
+         "--paths-dir to override.")
+        ("paths-dir", po::value<std::string>()->default_value(""),
+         "Override the directory holding the input tifxyz subdirs. "
+         "Defaults to <merge.json parent>/paths. Useful when the volpkg "
+         "stores segments under a non-default name like paths_2um_ds2/ "
+         "or traces/, or when the merge.json lives outside the data dir.")
         ("obj2tifxyz", po::value<std::string>()->default_value(""),
          "Path to vc_obj2tifxyz_legacy. Default: sibling binary next to "
          "vc_merge_tifxyz, falling back to PATH lookup.")
@@ -2208,6 +2219,10 @@ int main(int argc, char** argv)
     cfg.ransac_mad_k          = vm["ransac-mad-k"].as<double>();
     cfg.ransac_seed           = vm["ransac-seed"].as<uint32_t>();
     cfg.anchor_cap            = vm["anchor-cap"].as<int>();
+    {
+        const std::string pd = vm["paths-dir"].as<std::string>();
+        if (!pd.empty()) cfg.paths_dir = fs::path(pd);
+    }
     const int strip_cols      = vm["strip-cols"].as<int>();
 
     try {

--- a/volume-cartographer/apps/src/vc_merge_tifxyz_grid.cpp
+++ b/volume-cartographer/apps/src/vc_merge_tifxyz_grid.cpp
@@ -1,0 +1,161 @@
+// Implementation of the merge.json grid parser and connectivity check,
+// factored out of vc_merge_tifxyz.cpp for testability. No behavior change
+// from the previous in-place definitions.
+
+#include "vc_merge_tifxyz_grid.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <deque>
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace vc::merge {
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+
+void gmResolveGrid(const fs::path& merge_path,
+                   const fs::path& paths_dir,
+                   std::vector<GMSurfaceSpec>& surfaces,
+                   std::vector<GMEdgeSpec>& edges)
+{
+    const fs::path& mj = merge_path;
+    std::ifstream f(mj);
+    if (!f) throw std::runtime_error("cannot open " + mj.string());
+    json j; f >> j;
+
+    if (j.size() != 1 || !j.contains("rows"))
+        throw std::runtime_error(mj.string() +
+            ": only the 'rows' key is accepted");
+    const auto& rows_j = j.at("rows");
+    if (!rows_j.is_array() || rows_j.empty())
+        throw std::runtime_error(mj.string() + ": 'rows' must be a non-empty array");
+
+    const size_t R = rows_j.size();
+    std::vector<std::vector<std::string>> grid(R);
+    std::unordered_map<std::string, fs::path> name_to_path;
+
+    // Each row may be either a JSON array of strings (legacy) OR a single
+    // whitespace-delimited string. The string form is easier to hand-edit:
+    //   "rows": ["name_a name_b name_c", "name_d name_e name_f"]
+    auto splitWhitespace = [](const std::string& s) {
+        std::vector<std::string> out;
+        std::istringstream iss(s);
+        std::string tok;
+        while (iss >> tok) out.push_back(std::move(tok));
+        return out;
+    };
+
+    for (size_t r = 0; r < R; ++r) {
+        const auto& row_j = rows_j[r];
+        std::vector<std::string> row_names;
+        if (row_j.is_array()) {
+            row_names.reserve(row_j.size());
+            for (size_t c = 0; c < row_j.size(); ++c) {
+                const auto& cell = row_j[c];
+                if (cell.is_null()) { row_names.emplace_back(); continue; }
+                if (!cell.is_string())
+                    throw std::runtime_error(mj.string() + ": rows[" +
+                        std::to_string(r) + "][" + std::to_string(c) +
+                        "] must be a string or null");
+                row_names.push_back(cell.get<std::string>());
+            }
+        } else if (row_j.is_string()) {
+            row_names = splitWhitespace(row_j.get<std::string>());
+        } else {
+            throw std::runtime_error(mj.string() + ": rows[" + std::to_string(r) +
+                "] must be an array or a whitespace-delimited string");
+        }
+
+        const size_t C = row_names.size();
+        grid[r].resize(C);
+        for (size_t c = 0; c < C; ++c) {
+            const std::string& name = row_names[c];
+            if (name.empty()) continue;
+            if (name_to_path.count(name)) {
+                grid[r][c] = name;  // duplicate cell -> same surface
+                continue;
+            }
+            const fs::path dir = paths_dir / name;
+            if (!fs::is_directory(dir))
+                throw std::runtime_error(mj.string() + ": rows[" +
+                    std::to_string(r) + "][" + std::to_string(c) + "] = '" +
+                    name + "' is not a directory under " + paths_dir.string());
+            name_to_path[name] = dir;
+            grid[r][c] = name;
+        }
+    }
+
+    surfaces.clear();
+    surfaces.reserve(name_to_path.size());
+    std::set<std::string> seen;
+    for (size_t r = 0; r < R; ++r) {
+        for (size_t c = 0; c < grid[r].size(); ++c) {
+            const std::string& n = grid[r][c];
+            if (n.empty() || !seen.insert(n).second) continue;
+            GMSurfaceSpec s;
+            s.name = n;
+            s.path = name_to_path.at(n);
+            surfaces.push_back(std::move(s));
+        }
+    }
+
+    if (surfaces.size() < 2)
+        throw std::runtime_error(mj.string() + ": need at least 2 distinct "
+            "surfaces in the grid; got " + std::to_string(surfaces.size()));
+
+    auto edgeKey = [](const std::string& a, const std::string& b) {
+        return a < b ? a + "\t" + b : b + "\t" + a;
+    };
+    std::set<std::string> edge_seen;
+    edges.clear();
+    auto addEdge = [&](const std::string& a, const std::string& b) {
+        if (a.empty() || b.empty() || a == b) return;
+        if (edge_seen.insert(edgeKey(a, b)).second) edges.push_back({a, b});
+    };
+    for (size_t r = 0; r < R; ++r) {
+        const auto& row = grid[r];
+        for (size_t c = 0; c + 1 < row.size(); ++c) addEdge(row[c], row[c + 1]);
+    }
+    for (size_t r = 0; r + 1 < R; ++r) {
+        const size_t C = std::min(grid[r].size(), grid[r + 1].size());
+        for (size_t c = 0; c < C; ++c) addEdge(grid[r][c], grid[r + 1][c]);
+    }
+}
+
+void gmCheckConnected(const std::vector<GMSurfaceSpec>& surfaces,
+                      const std::vector<GMEdgeSpec>& edges)
+{
+    std::unordered_map<std::string, std::vector<std::string>> adj;
+    for (const auto& s : surfaces) adj[s.name];
+    for (const auto& e : edges) {
+        adj[e.a].push_back(e.b);
+        adj[e.b].push_back(e.a);
+    }
+    std::unordered_set<std::string> visited;
+    std::deque<std::string> q;
+    q.push_back(surfaces.front().name);
+    visited.insert(surfaces.front().name);
+    while (!q.empty()) {
+        const std::string u = q.front(); q.pop_front();
+        for (const auto& v : adj[u])
+            if (visited.insert(v).second) q.push_back(v);
+    }
+    if (visited.size() == surfaces.size()) return;
+    std::ostringstream msg;
+    msg << "edge graph from merge.json is disconnected; "
+           "unreachable surfaces:";
+    for (const auto& s : surfaces)
+        if (!visited.count(s.name)) msg << "\n  " << s.name;
+    throw std::runtime_error(msg.str());
+}
+
+} // namespace vc::merge

--- a/volume-cartographer/apps/src/vc_merge_tifxyz_grid.hpp
+++ b/volume-cartographer/apps/src/vc_merge_tifxyz_grid.hpp
@@ -1,0 +1,41 @@
+// Grid-resolution helpers for vc_merge_tifxyz.
+//
+// Exposes the merge.json parser and edge-graph connectivity check so that
+// they can be unit-tested without spawning the full binary. The merge tool
+// itself includes this header and uses these symbols directly.
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace vc::merge {
+
+struct GMSurfaceSpec {
+    std::string name;
+    std::filesystem::path path;
+};
+
+struct GMEdgeSpec {
+    std::string a;
+    std::string b;
+};
+
+// Parse a row-major grid of tifxyz directory names from merge.json and
+// emit deduplicated surfaces + horizontal/vertical adjacency edges. The
+// grid is loaded from `merge_path`; cell strings are resolved as
+// `paths_dir / name` and validated to be directories. Throws
+// std::runtime_error on malformed input, missing directories, or a grid
+// containing fewer than 2 distinct surfaces.
+void gmResolveGrid(const std::filesystem::path& merge_path,
+                   const std::filesystem::path& paths_dir,
+                   std::vector<GMSurfaceSpec>& surfaces,
+                   std::vector<GMEdgeSpec>& edges);
+
+// Verify that `edges` connects every surface in `surfaces`. Throws
+// std::runtime_error listing the unreachable surfaces if not.
+void gmCheckConnected(const std::vector<GMSurfaceSpec>& surfaces,
+                      const std::vector<GMEdgeSpec>& edges);
+
+} // namespace vc::merge

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -39,6 +39,19 @@ add_executable(test_merge_grid_resolve test_merge_grid_resolve.cpp)
 target_link_libraries(test_merge_grid_resolve PRIVATE doctest::doctest vc_merge_grid)
 add_test(NAME test_merge_grid_resolve COMMAND test_merge_grid_resolve)
 
+# End-to-end test that spawns the built vc_merge_tifxyz binary on two
+# synthetic 16x16 tifxyz dirs. Opt-in via VC_RUN_E2E=1; the test skips
+# itself if unset, so the default ctest run stays fast.
+add_executable(test_merge_e2e_small test_merge_e2e_small.cpp)
+target_link_libraries(test_merge_e2e_small PRIVATE doctest::doctest vc_core nlohmann_json::nlohmann_json)
+if(VC_RUN_E2E)
+    add_test(NAME test_merge_e2e_small COMMAND test_merge_e2e_small)
+    # The binary path probe in the test prefers VC_MERGE_TIFXYZ_BIN, so
+    # CTest runs reliably regardless of the working directory.
+    set_tests_properties(test_merge_e2e_small PROPERTIES
+        ENVIRONMENT "VC_RUN_E2E=1;VC_MERGE_TIFXYZ_BIN=$<TARGET_FILE:vc_merge_tifxyz>")
+endif()
+
 add_executable(bench_volume_sample bench_volume_sample.cpp)
 target_link_libraries(bench_volume_sample PRIVATE doctest::doctest vc_core)
 # Bench has a generous wall-clock assertion; not part of default ctest

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -32,6 +32,13 @@ add_executable(test_atomic_imwrite_multi test_atomic_imwrite_multi.cpp)
 target_link_libraries(test_atomic_imwrite_multi PRIVATE doctest::doctest vc_core)
 add_test(NAME test_atomic_imwrite_multi COMMAND test_atomic_imwrite_multi)
 
+# Parser-only regression tests for vc_merge_tifxyz: link the small static
+# lib that holds gmResolveGrid + gmCheckConnected so the failure-message
+# assertions are exact, without spawning the binary.
+add_executable(test_merge_grid_resolve test_merge_grid_resolve.cpp)
+target_link_libraries(test_merge_grid_resolve PRIVATE doctest::doctest vc_merge_grid)
+add_test(NAME test_merge_grid_resolve COMMAND test_merge_grid_resolve)
+
 add_executable(bench_volume_sample bench_volume_sample.cpp)
 target_link_libraries(bench_volume_sample PRIVATE doctest::doctest vc_core)
 # Bench has a generous wall-clock assertion; not part of default ctest

--- a/volume-cartographer/core/test/test_merge_e2e_small.cpp
+++ b/volume-cartographer/core/test/test_merge_e2e_small.cpp
@@ -1,0 +1,193 @@
+// End-to-end smoke test for vc_merge_tifxyz on a synthetic 2-cell grid.
+//
+// Builds two trivial 16x16 tifxyz directories under a temp paths dir,
+// places them so they share spatial overlap, writes merge.json, and
+// invokes the built binary via std::system. Asserts exit==0, the
+// expected output files exist, and the summary JSON has a non-
+// degenerate bounding box.
+//
+// Opt-in: only runs when VC_RUN_E2E is set to "1". Skips silently
+// otherwise so default ctest stays fast and hermetic.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "vc/core/util/QuadSurface.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <opencv2/core.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+cv::Mat_<cv::Vec3f> makePlane(int rows, int cols, int xOffset)
+{
+    // QuadSurface's loader treats z<=0 as the (-1,-1,-1) sentinel,
+    // so points must sit at strictly positive z to count as valid.
+    cv::Mat_<cv::Vec3f> pts(rows, cols);
+    for (int r = 0; r < rows; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            pts(r, c) = cv::Vec3f(static_cast<float>(c + xOffset),
+                                  static_cast<float>(r),
+                                  100.f);
+        }
+    }
+    return pts;
+}
+
+fs::path locateBinary(const fs::path& candidate)
+{
+    if (fs::exists(candidate) && fs::is_regular_file(candidate)) return candidate;
+    return {};
+}
+
+fs::path findVcMergeTifxyz()
+{
+    // 1) explicit override
+    if (const char* env = std::getenv("VC_MERGE_TIFXYZ_BIN")) {
+        if (auto p = locateBinary(env); !p.empty()) return p;
+    }
+    // 2) sibling in build/bin/ relative to common source-tree layouts
+    for (const fs::path& base : {fs::path("build/bin"),
+                                 fs::path("build-macos/bin"),
+                                 fs::path("build-macos-rel/bin")}) {
+        if (auto p = locateBinary(base / "vc_merge_tifxyz"); !p.empty()) return p;
+    }
+    // 3) PATH lookup
+    if (const char* path = std::getenv("PATH")) {
+        std::string s = path;
+        std::string::size_type from = 0;
+        while (from <= s.size()) {
+            auto next = s.find(':', from);
+            std::string seg = s.substr(from, next == std::string::npos ? std::string::npos
+                                                                       : next - from);
+            if (!seg.empty()) {
+                if (auto p = locateBinary(fs::path(seg) / "vc_merge_tifxyz"); !p.empty()) return p;
+            }
+            if (next == std::string::npos) break;
+            from = next + 1;
+        }
+    }
+    return {};
+}
+
+}
+
+TEST_CASE("vc_merge_tifxyz end-to-end on a synthetic 2-cell grid")
+{
+    const char* run = std::getenv("VC_RUN_E2E");
+    if (!run || std::string(run) != "1") {
+        MESSAGE("VC_RUN_E2E != 1; skipping (set VC_RUN_E2E=1 to enable)");
+        return;
+    }
+
+    const fs::path bin = findVcMergeTifxyz();
+    REQUIRE_MESSAGE(!bin.empty(),
+                    "vc_merge_tifxyz binary not found; build first or set "
+                    "VC_MERGE_TIFXYZ_BIN");
+
+    std::random_device rd;
+    std::mt19937_64 rng(rd());
+    const std::string tag = "vc_merge_e2e_" + std::to_string(rng());
+    const fs::path root  = fs::temp_directory_path() / tag;
+    const fs::path paths = root / "paths";
+    fs::create_directories(paths);
+
+    // surface_a fills [0,16) x [0,16); surface_b fills [8,24) x [0,16).
+    // The 8-wide overlap on the right of A == left of B is what the
+    // merge tool aligns.
+    const std::string nameA = "surface_a";
+    const std::string nameB = "surface_b";
+    const fs::path dirA = paths / nameA;
+    const fs::path dirB = paths / nameB;
+
+    {
+        QuadSurface a(makePlane(16, 16, 0), cv::Vec2f(1.f, 1.f));
+        a.path = dirA;
+        a.id   = nameA;
+        a.save(dirA.string(), nameA, /*force_overwrite=*/false);
+    }
+    {
+        QuadSurface b(makePlane(16, 16, 8), cv::Vec2f(1.f, 1.f));
+        b.path = dirB;
+        b.id   = nameB;
+        b.save(dirB.string(), nameB, /*force_overwrite=*/false);
+    }
+
+    const fs::path mj = root / "merge.json";
+    {
+        std::ofstream f(mj);
+        f << R"({"rows":["surface_a surface_b"]})" << std::endl;
+    }
+
+    // Run the binary. Tunables stay at defaults; only --merge is required.
+    // Redirect stdout/stderr to a log file in the temp dir for triage.
+    const fs::path log = root / "merge.log";
+    const std::string cmd =
+        bin.string() + " --merge " + mj.string() +
+        " > " + log.string() + " 2>&1";
+    const int rc = std::system(cmd.c_str());
+
+    INFO("vc_merge_tifxyz log: ", log.string());
+    REQUIRE_MESSAGE(rc == 0, "vc_merge_tifxyz exited non-zero; see " << log.string());
+
+    // Output dir is auto-named under <volpkg>/paths/ as
+    // <alpha_first>_merged[_vN]. <volpkg> here is `root` (the parent of
+    // merge.json), so the output lives under paths/. We just probe the
+    // surface_a_merged variants in order.
+    fs::path outDir;
+    for (const auto& cand : {std::string("surface_a_merged"),
+                              std::string("surface_a_merged_v2"),
+                              std::string("surface_a_merged_v3")}) {
+        if (fs::is_directory(paths / cand)) { outDir = paths / cand; break; }
+    }
+    REQUIRE_MESSAGE(!outDir.empty(),
+                    "no surface_a_merged[_vN] directory under " << paths.string());
+
+    CHECK(fs::is_regular_file(outDir / "x.tif"));
+    CHECK(fs::is_regular_file(outDir / "y.tif"));
+    CHECK(fs::is_regular_file(outDir / "z.tif"));
+    // mask.tif is emitted only when vc_obj2tifxyz_legacy detects an
+    // invalid region; for the all-valid synthetic case there isn't
+    // necessarily one. Inspect when present, otherwise skip.
+    if (fs::is_regular_file(outDir / "mask.tif")) {
+        MESSAGE("mask.tif present at " << (outDir / "mask.tif").string());
+    }
+
+    // Locate the *_summary.json that the tool writes alongside the OBJ.
+    fs::path summary;
+    for (const auto& entry : fs::directory_iterator(outDir)) {
+        const auto& p = entry.path();
+        if (p.extension() == ".json" &&
+            p.filename().string().find("_summary") != std::string::npos)
+        {
+            summary = p;
+            break;
+        }
+    }
+    REQUIRE_MESSAGE(!summary.empty(), "no *_summary.json under " << outDir.string());
+
+    nlohmann::json j;
+    {
+        std::ifstream f(summary);
+        REQUIRE(f.good());
+        f >> j;
+    }
+    CHECK(j.contains("merge_json"));
+    CHECK(j.contains("surfaces"));
+    CHECK(j["surfaces"].is_array());
+    CHECK(j["surfaces"].size() == 2);
+
+    // Cleanup happens via TmpDir-style remove_all only on success; on
+    // failure leave it so the operator can poke at the log.
+    std::error_code ec;
+    fs::remove_all(root, ec);
+}

--- a/volume-cartographer/core/test/test_merge_grid_resolve.cpp
+++ b/volume-cartographer/core/test/test_merge_grid_resolve.cpp
@@ -1,0 +1,200 @@
+// Unit tests for the merge.json grid parser
+// (vc::merge::gmResolveGrid / gmCheckConnected).
+//
+// Each case stages an empty <tmp>/paths/<name>/ directory tree so the
+// parser's is_directory() check passes, writes a minimal merge.json,
+// and asserts the resulting surface/edge sets.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "vc_merge_tifxyz_grid.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+using vc::merge::GMSurfaceSpec;
+using vc::merge::GMEdgeSpec;
+
+namespace {
+
+struct TmpPaths {
+    fs::path root;
+    fs::path pathsDir;
+
+    explicit TmpPaths(const std::string& tag)
+    {
+        std::random_device rd;
+        std::mt19937_64 rng(rd());
+        root = fs::temp_directory_path() /
+               ("vc_merge_grid_" + tag + "_" + std::to_string(rng()));
+        pathsDir = root / "paths";
+        fs::create_directories(pathsDir);
+    }
+    ~TmpPaths()
+    {
+        std::error_code ec;
+        fs::remove_all(root, ec);
+    }
+
+    void mkSurface(const std::string& name)
+    {
+        fs::create_directories(pathsDir / name);
+    }
+
+    fs::path writeMerge(const std::string& body)
+    {
+        const fs::path p = root / "merge.json";
+        std::ofstream f(p);
+        f << body;
+        return p;
+    }
+};
+
+bool hasEdge(const std::vector<GMEdgeSpec>& edges,
+             const std::string& a,
+             const std::string& b)
+{
+    auto canon = [](std::string x, std::string y) {
+        if (x > y) std::swap(x, y);
+        return std::pair{x, y};
+    };
+    const auto target = canon(a, b);
+    return std::any_of(edges.begin(), edges.end(),
+        [&](const GMEdgeSpec& e) { return canon(e.a, e.b) == target; });
+}
+
+}
+
+TEST_CASE("2x2 valid grid yields 4 surfaces and 4 (2H+2V) edges")
+{
+    TmpPaths t{"twoxtwo"};
+    for (auto n : {"a", "b", "c", "d"}) t.mkSurface(n);
+    const auto mj = t.writeMerge(R"({"rows":["a b","c d"]})");
+
+    std::vector<GMSurfaceSpec> surfaces;
+    std::vector<GMEdgeSpec> edges;
+    REQUIRE_NOTHROW(vc::merge::gmResolveGrid(mj, t.pathsDir, surfaces, edges));
+
+    CHECK(surfaces.size() == 4);
+    CHECK(edges.size() == 4);
+    CHECK(hasEdge(edges, "a", "b"));
+    CHECK(hasEdge(edges, "c", "d"));
+    CHECK(hasEdge(edges, "a", "c"));
+    CHECK(hasEdge(edges, "b", "d"));
+    CHECK_FALSE(hasEdge(edges, "a", "d")); // no diagonals
+}
+
+TEST_CASE("Ragged rows: vertical edges only over min(C0,C1) columns")
+{
+    TmpPaths t{"ragged"};
+    for (auto n : {"a", "b", "c", "d", "e"}) t.mkSurface(n);
+    // row0 has 3 cells (a,b,c), row1 has 2 (d,e). Vertical edges are
+    // a-d and b-e; c has no vertical neighbour.
+    const auto mj = t.writeMerge(R"({"rows":["a b c","d e"]})");
+
+    std::vector<GMSurfaceSpec> surfaces;
+    std::vector<GMEdgeSpec> edges;
+    REQUIRE_NOTHROW(vc::merge::gmResolveGrid(mj, t.pathsDir, surfaces, edges));
+
+    CHECK(surfaces.size() == 5);
+    CHECK(hasEdge(edges, "a", "b"));
+    CHECK(hasEdge(edges, "b", "c"));
+    CHECK(hasEdge(edges, "d", "e"));
+    CHECK(hasEdge(edges, "a", "d"));
+    CHECK(hasEdge(edges, "b", "e"));
+    CHECK_FALSE(hasEdge(edges, "c", "e"));
+    CHECK(edges.size() == 5);
+}
+
+TEST_CASE("Empty cells (null and \"\") drop their edges")
+{
+    TmpPaths t{"empty"};
+    for (auto n : {"a", "b", "c"}) t.mkSurface(n);
+    // null in row0 col1, "" in row1 col1: both forms must skip edges
+    // touching that slot.
+    const auto mj = t.writeMerge(
+        R"({"rows":[["a", null, "b"],["c", "", "b"]]})");
+
+    std::vector<GMSurfaceSpec> surfaces;
+    std::vector<GMEdgeSpec> edges;
+    REQUIRE_NOTHROW(vc::merge::gmResolveGrid(mj, t.pathsDir, surfaces, edges));
+
+    CHECK(surfaces.size() == 3); // a, b, c
+    // Column-0 vertical: a-c. Row-1 horizontal: c-(empty)-b -> c not
+    // adjacent to b through the empty cell. b is in both rows col2 so
+    // self-edge is suppressed.
+    CHECK(hasEdge(edges, "a", "c"));
+    CHECK_FALSE(hasEdge(edges, "a", "b")); // separated by empty cell
+    CHECK_FALSE(hasEdge(edges, "c", "b")); // separated by empty cell
+    CHECK_FALSE(hasEdge(edges, "b", "b")); // no self-edge
+}
+
+TEST_CASE("Duplicate cell name dedups surface and avoids self-edge")
+{
+    TmpPaths t{"dup"};
+    for (auto n : {"a", "b", "c"}) t.mkSurface(n);
+    // 'b' appears in (0,1) and (0,2) -- adjacent cells with the SAME
+    // name produce no self-edge but the rest of the grid still wires
+    // up through it.
+    const auto mj = t.writeMerge(R"({"rows":["a b b","a b b"]})");
+
+    std::vector<GMSurfaceSpec> surfaces;
+    std::vector<GMEdgeSpec> edges;
+    REQUIRE_NOTHROW(vc::merge::gmResolveGrid(mj, t.pathsDir, surfaces, edges));
+
+    CHECK(surfaces.size() == 2); // a and b
+    CHECK(hasEdge(edges, "a", "b"));
+    // The self-edge b-b in (0,1)-(0,2) and (1,1)-(1,2) and the vertical
+    // b-b along col1/col2 must not appear.
+    for (const auto& e : edges) CHECK(e.a != e.b);
+}
+
+TEST_CASE("Disconnected graph throws from gmCheckConnected")
+{
+    TmpPaths t{"disc"};
+    for (auto n : {"a", "b", "c", "d"}) t.mkSurface(n);
+    // Two disjoint 2-cell rows separated by a row of empties.
+    const auto mj = t.writeMerge(
+        R"({"rows":["a b",["",""], "c d"]})");
+
+    std::vector<GMSurfaceSpec> surfaces;
+    std::vector<GMEdgeSpec> edges;
+    REQUIRE_NOTHROW(vc::merge::gmResolveGrid(mj, t.pathsDir, surfaces, edges));
+    CHECK(surfaces.size() == 4);
+    CHECK_THROWS_WITH_AS(vc::merge::gmCheckConnected(surfaces, edges),
+                         doctest::Contains("disconnected"),
+                         std::runtime_error);
+}
+
+TEST_CASE("Fewer than 2 distinct surfaces throws")
+{
+    TmpPaths t{"small"};
+    t.mkSurface("only");
+    const auto mj = t.writeMerge(R"({"rows":["only only","only only"]})");
+
+    std::vector<GMSurfaceSpec> surfaces;
+    std::vector<GMEdgeSpec> edges;
+    CHECK_THROWS_WITH_AS(vc::merge::gmResolveGrid(mj, t.pathsDir, surfaces, edges),
+                         doctest::Contains("at least 2 distinct"),
+                         std::runtime_error);
+}
+
+TEST_CASE("Missing tifxyz directory throws with the offending path")
+{
+    TmpPaths t{"missing"};
+    t.mkSurface("a"); // 'b' deliberately not created
+    const auto mj = t.writeMerge(R"({"rows":["a b"]})");
+
+    std::vector<GMSurfaceSpec> surfaces;
+    std::vector<GMEdgeSpec> edges;
+    CHECK_THROWS_WITH_AS(vc::merge::gmResolveGrid(mj, t.pathsDir, surfaces, edges),
+                         doctest::Contains("'b'"),
+                         std::runtime_error);
+}

--- a/volume-cartographer/docs/benchmarks/vc_merge_tifxyz.md
+++ b/volume-cartographer/docs/benchmarks/vc_merge_tifxyz.md
@@ -1,0 +1,52 @@
+# `vc_merge_tifxyz` benchmarks
+
+This file tracks wall-clock and peak resident-set-size numbers for
+`vc_merge_tifxyz` runs. Add a new row whenever a PR may shift its cost.
+
+## Methodology
+
+Build with **`Release`** for headline numbers (`RelWithDebInfo` is
+acceptable for relative comparisons across PRs as long as the row
+records the build type — same `-O3` codegen with debug info added).
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j --target vc_merge_tifxyz vc_obj2tifxyz_legacy
+```
+
+Run, on the dataset under measurement:
+
+```sh
+for i in 1 2 3; do
+  /usr/bin/time -v build/bin/vc_merge_tifxyz --merge <volpkg>/<run>.merge.json
+done 2>&1 | tee docs/benchmarks/raw-$(date +%Y%m%d).txt
+```
+
+`/usr/bin/time` flags vary by platform: GNU `time` uses `-v`, BSD/macOS
+`time` uses `-l`. Both report wall-clock and peak resident-set size;
+only the format of the output differs.
+
+Report the **median** of the three runs for both wall-clock and peak
+RSS. Record CPU model and arch (e.g. via `lscpu` / `uname -m` on Linux,
+`sysctl -n machdep.cpu.brand_string` on macOS).
+
+## GUI
+
+The Qt feature wired into VC3D launches `vc_merge_tifxyz` as a
+subprocess via `CommandLineToolRunner`; it adds dialog construction,
+JSON pretty-printing, and `QProcess` startup but no hot loop. There is
+**no separate GUI benchmark** — latency from button click to first
+stdout line is dominated by `vc_merge_tifxyz` startup (covered above).
+Re-litigate this only if a profiler shows otherwise.
+
+## Results
+
+| Date       | Git SHA  | Build type | CPU       | Arch    | Dataset       | Median wall-clock | Median peak RSS | Notes |
+|------------|----------|------------|-----------|---------|---------------|-------------------|-----------------|-------|
+| _add row_  | _short_  | _Release_  | _model_   | _e.g._  | _path / size_ | _e.g. 8.4s_       | _e.g. 612 MiB_  | _N=3, default flags_ |
+
+When the `s1_ds2.volpkg` minimal pull (see
+`scripts/download_minimal_volpkg.sh`) is available locally, the
+canonical baseline is a 1×2 horizontal merge of the two tifxyz dirs
+the script downloads. Document in the row which two surfaces were
+used.


### PR DESCRIPTION
## Summary
- Adds **`MergeTifxyzDialog`** in `apps/VC3D/ToolDialogs.{hpp,cpp}` — a 2D grid editor for tifxyz directory names (the row-major grid encodes RANSAC adjacency), reference-surface dropdown, collapsible Advanced section with all the RANSAC tunables (`--ransac-iters`, `--ransac-min/max-thresh`, `--ransac-mad-k`, `--ransac-seed`, `--anchor-cap`, `--strip-cols`, OMP threads), and a live `merge.json` preview. Session statics persist tunables across runs in the same VC3D session, mirroring `ConvertToObjDialog`.
- **Two entry points** sharing one dialog:
  - **Context menu** in the segments tree, gated to ≥2 selected items (mirrors the existing multi-select pattern used by `Rasterize` and `Recalculate Area`).
  - **Top `Actions → Merge tifxyz...`** entry, always discoverable; opens an empty dialog with an "Add segments..." picker.
- **`Tool::MergeTifxyz`** in `CommandLineToolRunner` spawns `vc_merge_tifxyz` via `QProcess` with live stdout in `ConsoleOutputWidget`. Skips the auto-volume guard since the tool operates on segment paths only.
- **`SegmentationCommandHandler::onMergeTifxyz(QStringList)`** validates the volpkg, computes the resolved segments dir via `VolumePkg::outputSegmentsPath()`, and forwards both the merge.json path and the resolved paths-dir to the runner.

### vc_merge_tifxyz CLI changes
- **New `--paths-dir <path>`** flag overrides the default `<merge.parent>/paths`. Two real cases broke without it: volpkgs that store segments under names like `paths_2um_ds2/` or `traces/`, and `.volpkg.json` files that live outside the data directory and reference segments via relative paths. `gmAlignAll` now respects a caller-supplied `cfg.paths_dir`, falling back to the legacy default only when unset (so existing CLI users see no change).

### Refactor
- **`vc_merge_grid` static lib** carved out of `apps/src/vc_merge_tifxyz.cpp`: `gmResolveGrid`, `gmCheckConnected`, `GMSurfaceSpec`, `GMEdgeSpec` move to `apps/src/vc_merge_tifxyz_grid.{hpp,cpp}` under `namespace vc::merge`. No behavior change; enables the unit test below to link the parser directly.

### Tests + docs
- `core/test/test_merge_grid_resolve.cpp` (doctest) — 7 cases covering valid grids, ragged rows, empty cells (null and `""`), duplicate names, disconnected graph, fewer-than-2 surfaces, missing tifxyz dir.
- `core/test/test_merge_e2e_small.cpp` (doctest, opt-in `VC_RUN_E2E=1`) — synthesizes 2 16×16 tifxyz dirs, spawns `vc_merge_tifxyz` via `std::system`, asserts exit==0 + expected output files + summary JSON shape. Auto-points `VC_MERGE_TIFXYZ_BIN` at the in-tree binary via `$<TARGET_FILE:vc_merge_tifxyz>`.
- `docs/benchmarks/vc_merge_tifxyz.md` — methodology + empty results table.

## Test plan
- [ ] Build clean: `cmake -S . -B build -DVC_BUILD_TESTS=ON && cmake --build build -j`.
- [ ] `ctest --test-dir build --output-on-failure` — all 7 tests pass.
- [ ] `VC_RUN_E2E=1 ctest --test-dir build -R merge_e2e_small --output-on-failure` passes.
- [ ] Open VC3D + a volpkg, multi-select 2 overlapping tifxyz dirs in the left panel → right-click → **Merge tifxyz...** → dialog opens pre-filled.
- [ ] Top **Actions → Merge tifxyz...** → empty dialog opens; **Add segments...** populates the grid; OK runs.
- [ ] Edge: select 1 surface → context-menu entry hidden.
- [ ] Edge: select 2 disconnected (non-overlapping) surfaces → tool exits non-zero, error visible in console.
- [ ] Edge: cancel mid-run via console → no orphan output dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)