### PR TITLE
vc_gen_normalgrids: prune short thinning traces

### DIFF
--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -268,6 +268,8 @@ static void write_metrics_json(const fs::path& path, const RunMetrics& metrics) 
                 {"trace_count", dir.thinningStats.traceCount},
                 {"trace_steps", dir.thinningStats.traceSteps},
                 {"candidate_evaluations", dir.thinningStats.candidateEvaluations},
+                {"traces_pruned", dir.thinningStats.tracesPruned},
+                {"traces_kept", dir.thinningStats.tracesKept},
             };
         }
         out["directions"].push_back(std::move(d));
@@ -516,6 +518,7 @@ int main(int argc, char* argv[]) {
             ("verify-grid-save", po::bool_switch()->default_value(false), "Verify GridStore files by reloading after save")
             ("debug-per-slice", po::bool_switch()->default_value(false), "Emit a stdout log line for every slice processed (existing/empty_binary/empty_trace/written)")
             ("metrics-json", po::value<std::string>(), "Write structured metrics json")
+            ("prune-min-length-px", po::value<double>()->default_value(0.0), "Drop thinning traces shorter than this many pixels (polyline length); 0 disables pruning (default)")
             ("print-plan", po::bool_switch()->default_value(false), "Print partition plan as JSON to stdout and exit (no work done)");
 
         std::vector<std::string> opts = po::collect_unrecognized(parsed.options, po::include_positional);
@@ -704,6 +707,12 @@ void run_generate(const po::variables_map& vm) {
         ? std::optional<fs::path>(fs::path(vm["metrics-json"].as<std::string>()))
         : std::nullopt;
 
+    ThinningPruneParams prune_params;
+    prune_params.minLengthPx = vm["prune-min-length-px"].as<double>();
+    if (prune_params.minLengthPx < 0.0) {
+        throw std::runtime_error("--prune-min-length-px must be >= 0");
+    }
+
     std::vector<SliceDirection> directions_to_run;
     if (vm.count("direction")) {
         const std::string& d = vm["direction"].as<std::string>();
@@ -862,6 +871,7 @@ void run_generate(const po::variables_map& vm) {
         metadata["preview-every"] = preview_every;
         metadata["verify-grid-save"] = verify_grid_save;
         metadata["debug-per-slice"] = debug_per_slice;
+        metadata["prune-min-length-px"] = prune_params.minLengthPx;
         std::ofstream o(output_fs_path / "metadata.json");
         o << metadata.dump(4) << std::endl;
     }
@@ -1162,7 +1172,8 @@ void run_generate(const po::variables_map& vm) {
                     scratch.traces.clear();
                     const auto thinning_start = std::chrono::steady_clock::now();
                     ThinningStats thinning_stats;
-                    customThinningTraceOnly(assembled.binarySlice, scratch.traces, &thinning_stats, scratch.thinning);
+                    customThinningTraceOnly(assembled.binarySlice, scratch.traces,
+                        &thinning_stats, scratch.thinning, prune_params);
                     const double thinning_seconds = seconds_since(thinning_start);
                     record_timing(local_stats, "thinning", thinning_seconds);
                     local_stats.thinningStats.accumulate(thinning_stats);

--- a/volume-cartographer/core/include/vc/core/util/Thinning.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Thinning.hpp
@@ -10,9 +10,11 @@ struct ThinningStats {
     double seedDetectionSeconds = 0.0;
     double tracePathsSeconds = 0.0;
     uint64_t seedCount = 0;
-    uint64_t traceCount = 0;
+    uint64_t traceCount = 0;        // raw traces produced before pruning
     uint64_t traceSteps = 0;
     uint64_t candidateEvaluations = 0;
+    uint64_t tracesPruned = 0;      // traces dropped by pruning pass
+    uint64_t tracesKept = 0;        // traces retained after pruning
 
     void accumulate(const ThinningStats& other) {
         distanceTransformSeconds += other.distanceTransformSeconds;
@@ -22,7 +24,16 @@ struct ThinningStats {
         traceCount += other.traceCount;
         traceSteps += other.traceSteps;
         candidateEvaluations += other.candidateEvaluations;
+        tracesPruned += other.tracesPruned;
+        tracesKept += other.tracesKept;
     }
+};
+
+// Short-trace filter for thinning output. A trace is dropped when its
+// polyline length (sum of 8-connected step distances) is below minLengthPx.
+// Set minLengthPx to 0 to skip the pruning pass entirely.
+struct ThinningPruneParams {
+    double minLengthPx = 0.0;
 };
 
 // Reusable per-thread scratch for customThinning. Letting one thread
@@ -44,11 +55,20 @@ void customThinning(const cv::Mat& inputImage, cv::Mat& outputImage, std::vector
 void customThinning(const cv::Mat& inputImage,
                     cv::Mat& outputImage,
                     std::vector<std::vector<cv::Point>>* traces,
-                    ThinningStats* stats);
+                    ThinningStats* stats,
+                    const ThinningPruneParams& pruneParams = ThinningPruneParams{});
 void customThinningTraceOnly(const cv::Mat& inputImage,
                              std::vector<std::vector<cv::Point>>& traces,
-                             ThinningStats* stats = nullptr);
+                             ThinningStats* stats = nullptr,
+                             const ThinningPruneParams& pruneParams = ThinningPruneParams{});
 void customThinningTraceOnly(const cv::Mat& inputImage,
                              std::vector<std::vector<cv::Point>>& traces,
                              ThinningStats* stats,
-                             ThinningScratch& scratch);
+                             ThinningScratch& scratch,
+                             const ThinningPruneParams& pruneParams = ThinningPruneParams{});
+
+// Drop traces shorter than params.minLengthPx. Runs unconditionally —
+// caller decides whether to invoke.
+void pruneThinningTraces(std::vector<std::vector<cv::Point>>& traces,
+                         const ThinningPruneParams& params,
+                         ThinningStats* stats = nullptr);

--- a/volume-cartographer/core/src/Thinning.cpp
+++ b/volume-cartographer/core/src/Thinning.cpp
@@ -165,7 +165,8 @@ static void customThinningImpl(
     cv::Mat* outputImage,
     std::vector<std::vector<cv::Point>>* traces,
     ThinningStats* stats,
-    ThinningScratch& scratch)
+    ThinningScratch& scratch,
+    const ThinningPruneParams& pruneParams)
 {
     if (inputImage.empty() || inputImage.type() != CV_8UC1) {
         if (outputImage != nullptr) {
@@ -274,6 +275,25 @@ static void customThinningImpl(
     localStats.tracePathsSeconds = std::chrono::duration<double>(
         std::chrono::steady_clock::now() - traceStart).count();
 
+    if (traces != nullptr) {
+        if (pruneParams.minLengthPx > 0.0) {
+            pruneThinningTraces(*traces, pruneParams, &localStats);
+
+            if (outputImage != nullptr) {
+                // Re-rasterise from kept traces. The visit-index encoding is
+                // sacrificed when pruning is enabled in image+trace mode.
+                outputImage->setTo(0);
+                for (const auto& trace : *traces) {
+                    for (const auto& p : trace) {
+                        outputImage->at<uint8_t>(p.y, p.x) = 255;
+                    }
+                }
+            }
+        } else {
+            localStats.tracesKept += traces->size();
+        }
+    }
+
     if (stats != nullptr) {
         stats->accumulate(localStats);
     }
@@ -291,24 +311,66 @@ void customThinning(const cv::Mat& inputImage,
 void customThinning(const cv::Mat& inputImage,
                     cv::Mat& outputImage,
                     std::vector<std::vector<cv::Point>>* traces,
-                    ThinningStats* stats)
+                    ThinningStats* stats,
+                    const ThinningPruneParams& pruneParams)
 {
     ThinningScratch scratch;
-    customThinningImpl(inputImage, &outputImage, traces, stats, scratch);
-}
-
-void customThinningTraceOnly(const cv::Mat& inputImage,
-                             std::vector<std::vector<cv::Point>>& traces,
-                             ThinningStats* stats)
-{
-    ThinningScratch scratch;
-    customThinningImpl(inputImage, nullptr, &traces, stats, scratch);
+    customThinningImpl(inputImage, &outputImage, traces, stats, scratch, pruneParams);
 }
 
 void customThinningTraceOnly(const cv::Mat& inputImage,
                              std::vector<std::vector<cv::Point>>& traces,
                              ThinningStats* stats,
-                             ThinningScratch& scratch)
+                             const ThinningPruneParams& pruneParams)
 {
-    customThinningImpl(inputImage, nullptr, &traces, stats, scratch);
+    ThinningScratch scratch;
+    customThinningImpl(inputImage, nullptr, &traces, stats, scratch, pruneParams);
+}
+
+void customThinningTraceOnly(const cv::Mat& inputImage,
+                             std::vector<std::vector<cv::Point>>& traces,
+                             ThinningStats* stats,
+                             ThinningScratch& scratch,
+                             const ThinningPruneParams& pruneParams)
+{
+    customThinningImpl(inputImage, nullptr, &traces, stats, scratch, pruneParams);
+}
+
+void pruneThinningTraces(std::vector<std::vector<cv::Point>>& traces,
+                         const ThinningPruneParams& params,
+                         ThinningStats* stats)
+{
+    uint64_t pruned = 0;
+    size_t out = 0;
+    for (size_t i = 0; i < traces.size(); ++i) {
+        auto& trace = traces[i];
+
+        if (trace.size() < 2) {
+            ++pruned;
+            continue;
+        }
+
+        double length = 0.0;
+        for (size_t k = 1; k < trace.size(); ++k) {
+            const int dx = trace[k].x - trace[k - 1].x;
+            const int dy = trace[k].y - trace[k - 1].y;
+            length += std::sqrt(static_cast<double>(dx * dx + dy * dy));
+        }
+
+        if (length < params.minLengthPx) {
+            ++pruned;
+            continue;
+        }
+
+        if (out != i) {
+            traces[out] = std::move(trace);
+        }
+        ++out;
+    }
+    traces.resize(out);
+
+    if (stats != nullptr) {
+        stats->tracesPruned += pruned;
+        stats->tracesKept += out;
+    }
 }


### PR DESCRIPTION
Drop thinning traces whose polyline length is below --prune-min-length-px. Short stubs from the seed-based thinning produce noisy artifacts downstream; pruning them removes the worst of those without measurably hurting useful traces. Pass --prune-min-length-px=0 to keep all raw traces (default).