### PR TITLE
community_projects: add Vesuvius Autoresearch listing

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -249,6 +249,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [Inkalyzer](https://github.com/younader/Inkalyzer) by Youssef Nader. XAI package for Ink models to explain predictions and generate volumetric labels.
 
+- [Vesuvius Autoresearch](https://github.com/jonmarrs/vesuvius-autoresearch) by Jon Marrs. Autonomous architecture-search loop plus one-command launchers for villa's prize-track trainers (LeJEPA fine-tune, mutex-affinity sheet segmentation, neural_tracing service, GP-2023 TimeSformer recipe). Includes an architecture-aware `submission_package` builder for Primus fine-tuned checkpoints; companion upstream PR [#899](https://github.com/ScrollPrize/villa/pull/899) adds the matching `model_primus.py` loader to `ink-detection/optimized_inference`.
+
 #### 📦 Materials
 
 - [3D Ink labels](https://discord.com/channels/1079907749569237093/1079907750265499772/1223357870762889308) by Sean Johnsonn


### PR DESCRIPTION
## Summary

Adds a one-bullet entry to `scrollprize.org/docs/20_community_projects.md` under **3D Ink Detection > Tools** pointing at the Vesuvius Autoresearch repo. Submitted as part of the May 2026 Progress Prize submission workflow per the form's request ("please submit a pull request to awesome-scroll-tools to link to your contribution").

The listed contribution is an autonomous architecture-search loop plus a family of one-command launchers for villa's prize-track trainers (LeJEPA fine-tune, mutex-affinity sheet segmentation, neural_tracing service, GP-2023 TimeSformer recipe), and an architecture-aware `submission_package` builder for Primus fine-tuned checkpoints. The companion upstream PR is ScrollPrize/villa#899 which adds the matching `model_primus.py` loader to `ink-detection/optimized_inference`.

## Diffstat

```
 scrollprize.org/docs/20_community_projects.md | 2 ++
 1 file changed, 2 insertions(+)
```

## Test plan

- [x] Bullet renders as a sibling of the existing `Inkalyzer` entry in the same section.
- [x] All linked URLs are publicly resolvable (`jonmarrs/vesuvius-autoresearch` is now public under MIT; PR #899 is open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)