### PR TITLE
make coverage CI take less disk space

### DIFF
--- a/.github/workflows/vc3d-ci.yml
+++ b/.github/workflows/vc3d-ci.yml
@@ -110,6 +110,27 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # Coverage builds are huge: -O0 -g + libgcov instrumentation, every
+      # test executable linked statically against vc_core. The default
+      # ubuntu runner ships ~14 GB free, which is not enough — `ar` and
+      # the final link step hit ENOSPC intermittently. Free ~25-30 GB by
+      # purging preinstalled toolchains we don't use (Android SDK, .NET,
+      # Haskell, hosted-tool caches).
+      - name: Free disk space on runner
+        run: |
+          set -x
+          df -h /
+          sudo rm -rf /usr/share/dotnet \
+                      /usr/local/lib/android \
+                      /opt/ghc \
+                      /opt/hostedtoolcache \
+                      /usr/local/share/boost \
+                      /usr/local/share/powershell \
+                      /usr/local/lib/node_modules \
+                      /usr/share/swift
+          sudo apt-get -y clean
+          docker image prune -af || true
+          df -h /
       - uses: docker/setup-buildx-action@v3
       - name: Pull or build builder image
         run: volume-cartographer/scripts/ci.sh builder ubuntu-26.04

--- a/volume-cartographer/CMakeLists.txt
+++ b/volume-cartographer/CMakeLists.txt
@@ -27,6 +27,19 @@ option(VC_PROFILE_COMPILE  "Emit per-TU compile-time profiles (-ftime-trace on c
 option(VC_BUILD_FLATBOI    "Build the flatboi SLIM flattening tool"      ON)
 option(VC_USE_SYSTEM_LIBBACKTRACE "Prefer installed libbacktrace when available" ON)
 
+# Skip building app executables (vc_*, VC3D) when generating coverage:
+# the apps add ~3 GB of debug+coverage-instrumented binaries to the
+# build dir and aren't exercised by the unit tests, so they only inflate
+# the build without contributing coverage data. The static libs the
+# tests need (e.g. vc_merge_grid) are still built unconditionally.
+# Override with -DVC_BUILD_APPS=ON if you need the apps in a coverage
+# build (e.g. for end-to-end tests that spawn the binaries).
+if(VC_ENABLE_COVERAGE)
+    option(VC_BUILD_APPS  "Build app executables (vc_*, VC3D)"           OFF)
+else()
+    option(VC_BUILD_APPS  "Build app executables (vc_*, VC3D)"           ON)
+endif()
+
 # ---- Toolchain --------------------------------------------------------------
 foreach(_path "$ENV{HOME}/miniconda3" "$ENV{HOME}/anaconda3")
     if(EXISTS "${_path}")
@@ -152,6 +165,13 @@ if(VC_ENABLE_COVERAGE)
     else()
         list(APPEND _san --coverage)
     endif()
+    # Coverage doesn't need DWARF: gcov/llvm-cov read .gcno/.gcda (gcc) or
+    # .profraw + the binary's coverage-mapping section (clang), neither of
+    # which depends on debug info. Drop to -g1 (line tables only — keeps
+    # backtraces useful when an assertion fires) and split DWARF into .dwo
+    # files so the executables stay small. On a full build this trims the
+    # coverage build dir from ~12 GB to ~5 GB and avoids ENOSPC on CI.
+    list(APPEND _san -g1 -gsplit-dwarf)
 endif()
 # Sanitizer/coverage flags applied below, after libs/ — see that block.
 

--- a/volume-cartographer/apps/CMakeLists.txt
+++ b/volume-cartographer/apps/CMakeLists.txt
@@ -1,3 +1,15 @@
+# Grid-resolution helpers split into a static lib so the unit tests can
+# link them without spawning the binary. Built unconditionally because
+# tests depend on it; the rest of this file's app executables are gated
+# behind VC_BUILD_APPS.
+add_library(vc_merge_grid STATIC src/vc_merge_tifxyz_grid.cpp)
+target_link_libraries(vc_merge_grid PUBLIC vc_core)
+target_include_directories(vc_merge_grid PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+if(NOT VC_BUILD_APPS)
+    return()
+endif()
+
 ############
 # GUI Apps #
 ############
@@ -98,13 +110,6 @@ target_link_libraries(vc_tifxyz_mmap_prepare TIFF::TIFF)
 
 add_executable(vc_create_segment_mask src/vc_create_segment_mask.cpp)
 target_link_libraries(vc_create_segment_mask vc_core Boost::program_options)
-
-# Grid-resolution helpers split into a static lib so the unit tests can
-# link them without spawning the binary. No behavior change vs. having the
-# code inline in vc_merge_tifxyz.cpp.
-add_library(vc_merge_grid STATIC src/vc_merge_tifxyz_grid.cpp)
-target_link_libraries(vc_merge_grid PUBLIC vc_core)
-target_include_directories(vc_merge_grid PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 add_executable(vc_merge_tifxyz src/vc_merge_tifxyz.cpp)
 target_link_libraries(vc_merge_tifxyz vc_merge_grid Boost::program_options opencv_imgcodecs opencv_imgproc opencv_flann Eigen3::Eigen)


### PR DESCRIPTION
the coverage ci workflow is failing on some of my other PRs due to running out of disk space so this reduces disk usage