### PR TITLE
community_projects: add vesuvius-c Python bindings listing

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -63,6 +63,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [vesuvius-c](https://github.com/ScrollPrize/villa/tree/main/vesuvius-c): C library for accessing Vesuvius Challenge data. Allows direct access to scroll data without managing download scripts or storing terabytes of CT scans locally.
 
+- [vesuvius-c Python bindings](https://github.com/jonmarrs/vesuvius-autoresearch/tree/main/vesuvius_c_wrapper) by Jon Marrs. `ctypes` wrapper around villa's `vesuvius-c` library; parses `.zarray` JSON and reads Blosc2 chunks directly via C pointers, bypassing fsspec and the standard Zarr Python stack. Measured ≈31.77M voxels/sec on local storage. Drop-in compatible with autoresearch's `Volume` loader.
+
 - [vesuvius-gui](https://github.com/jrudolph/vesuvius-gui) is a single binary GUI to render volumes and segments on-the-fly. By Johannes Rudolph
 
 - [vesuvius-phalanx](https://github.com/mvrcii/phalanx): Python library / CLI for accessing Vesuvius data. Allows flexible access to volume and fragment scroll data. By Marcel Roth


### PR DESCRIPTION
## Summary

Adds a one-bullet entry to `scrollprize.org/docs/20_community_projects.md` under **Data access/visualization > 🛠️ Tools** for the `ctypes` Python wrapper around villa's `vesuvius-c` C library. Sits as a sibling to the existing `vesuvius-c` entry, since the wrapper is purely a Python-side data-access layer that consumes the upstream C library.

The wrapper parses `.zarray` JSON directly and reads Blosc2-compressed chunks into NumPy arrays via C pointers, bypassing `fsspec` and the standard Zarr Python stack. Measured ≈31.77M voxels/sec on local storage. Drop-in compatible with the `Volume` class used by autoresearch data loaders.

Submitted in coordination with the May 2026 Progress Prize submission (Part 1 of 2 — Vesuvius-C bindings + autoresearch loop). Companion PR ScrollPrize/villa#901 covers the May Part 2 listing under "3D Ink Detection > Tools" for the autoresearch loop + villa-baseline launcher family.

## Diffstat

```
 scrollprize.org/docs/20_community_projects.md | 2 ++
 1 file changed, 2 insertions(+)
```

## Test plan

- [x] Bullet renders as a sibling of the existing villa `vesuvius-c` entry.
- [x] Linked URL `jonmarrs/vesuvius-autoresearch/tree/main/vesuvius_c_wrapper` is publicly resolvable (repo is public, MIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)