### PR TITLE
fix(vesuvius-c): accept file:// URLs in vs_download

### DIFF
--- a/vesuvius-c/vesuvius-c.h
+++ b/vesuvius-c/vesuvius-c.h
@@ -846,7 +846,8 @@ long vs_download(const char* url, void** out_buffer) {
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
     curl_easy_cleanup(curl);
 
-    if (http_code != 200) {
+    // file:// urls will have http_code == 0
+    if (http_code != 200 && http_code != 0) {
         free(chunk.buffer);
         return -1;
     }


### PR DESCRIPTION
`vs_download` rejected any response where libcurl reported a non-200 HTTP
status code. For non-HTTP transports (notably `file://`), libcurl leaves
`CURLINFO_RESPONSE_CODE` at `0`, so local-file fetches were treated as
failures even when the buffer was populated successfully.

This change allows `http_code == 0` through the success path so
`vs_download` works for `file://` URLs (useful for local datasets, tests,
and offline mirroring). HTTP behavior is unchanged.

```diff
-    if (http_code != 200) {
+    // file:// urls will have http_code == 0
+    if (http_code != 200 && http_code != 0) {
         free(chunk.buffer);
         return -1;
     }
```