### PR TITLE
ec2_setup.sh: add CGAL/MPFR/GMP + scotch-metis apt deps

### DIFF
--- a/volume-cartographer/scripts/ec2_setup.sh
+++ b/volume-cartographer/scripts/ec2_setup.sh
@@ -25,12 +25,13 @@ apt-get install -y \
     build-essential git clang llvm ninja-build lld cmake pkg-config \
     qt6-base-dev libboost-system-dev libboost-program-options-dev \
     libceres-dev libsuitesparse-dev \
+    libcgal-dev libmpfr-dev libgmp-dev \
     libopencv-dev libopencv-contrib-dev \
     libblosc-dev libcurl4-openssl-dev \
     libavahi-client-dev nlohmann-json3-dev \
     liblz4-dev libtiff-dev \
     zlib1g-dev gfortran libopenblas-dev liblapack-dev liblapacke-dev libomp-dev \
-    libscotch-dev libhwloc-dev \
+    libscotch-dev libscotchmetis-dev libhwloc-dev \
     file curl unzip ca-certificates bzip2 wget jq rclone fuse gimp \
     desktop-file-utils \
     mdadm nvme-cli


### PR DESCRIPTION
## Summary
- `scripts/ec2_setup.sh` was missing `libcgal-dev`, `libmpfr-dev`, `libgmp-dev`. The top-level `CMakeLists.txt` does `find_package(CGAL REQUIRED)` (CGAL transitively needs MPFR/GMP), so on a fresh EC2 host `cmake --preset ci-release-gcc` fails configure with *"Could not find a package configuration file provided by CGAL"*.
- Also add `libscotchmetis-dev` alongside the existing `libscotch-dev`.

## Test plan
- [x] Fresh aarch64 Ubuntu 26.04 EC2 host: run `ec2_setup.sh`, then `cmake --preset ci-release-gcc && cmake --build --preset ci-release-gcc --target vc_zarr_recompress` — configure + build succeed.