### PR TITLE
Add DBbun executable companion examples as related resource

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -55,6 +55,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 ### 🌟 Highlighted
 
+- [DBbun Companions](https://github.com/DBbun/dbbun-companions): A collection of executable companion examples for transforming visual and document-based materials into reproducible simulation packages. Not Vesuvius-specific, but potentially relevant as a related workflow for organizing complex artifact-analysis outputs.
+
 - [vesuvius](https://github.com/scrollprize/vesuvius): Python library for accessing Vesuvius Challenge data. Allows direct access to scroll data without managing download scripts or storing terabytes of CT scans locally.
 
 - [Segment browser](https://github.com/jrudolph/vesuvius-browser) is a web-based tool to browse layers and open source ink detection results of all released segments. By Johannes Rudolph


### PR DESCRIPTION
This pull request adds DBbun Companions as a related resource. DBbun Companions is a collection of executable companion examples that transform documents, images, papers, patents, articles, and other source materials into reproducible simulation packages with generated outputs, figures, structured data, and documentation.

This resource is not Vesuvius-specific, but may be relevant as a related workflow pattern for organizing complex visual/document-based analysis outputs into reproducible packages.