### PR TITLE
Add MedNeXt-L + SkeletonRecall trainer for compressed surface regions

### DIFF
--- a/segmentation/models/arch/nnunet/README.md
+++ b/segmentation/models/arch/nnunet/README.md
@@ -55,3 +55,37 @@ Convert to an ome-zarr (thanks chuck! more info here https://github.com/KhartesV
 ### train 
 Preprocess: `nnUNetv2_plan_and_preprocess -d 050 -pl nnUNetPlannerResEncL -c 3d_fullres --verify_dataset_integrity`
 Run training: `nnUNetv2_train 050 3d_fullres 0 -p nnUNetResEncUNetMPlans`
+
+### MedNeXt-L + SkeletonRecall trainer (for compressed / highly curved regions)
+
+The `nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5` trainer
+(`nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py`)
+swaps the default ResEnc U-Net for MedNeXt-L kernel5 while keeping the SkeletonRecall
+loss, transform pipeline, and data loaders untouched. It targets the failure mode
+described in [issue #191](https://github.com/ScrollPrize/villa/issues/191) (surface
+predictions in compressed / highly curved areas). On a held-out 5-cube benchmark
+over PHerc Paris 1 (S1) and PHerc 1667 (S4), it scores +0.267 absolute
+high_compressed IoU (+66% relative) over the d058 ResEnc-L production model;
+overall_macro IoU 0.534 → 0.685. Numbers and methodology:
+[issue #191 comment](https://github.com/ScrollPrize/villa/issues/191#issuecomment-4472801908).
+
+Install the extra dependency:
+
+```
+pip install -e ".[mednext]"
+```
+
+(This pulls in [`mednextv1`](https://github.com/MIC-DKFZ/MedNeXt), which provides
+the MedNeXt architecture; it is not vendored.)
+
+Train:
+
+```
+nnUNetv2_train DATASET_ID 3d_fullres 0 -tr nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5
+```
+
+A kernel3 variant (`nnUNetTrainerSkeletonRecall_MedNeXtL_kernel3`) is in the
+same file as a memory-tight fallback.
+
+Pretrained weights on Hugging Face (best checkpoint: `kernel5_skelrec_dataset059_ep33/`):
+https://huggingface.co/ciscoriordan/mednext-l-scroll-surface

--- a/segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py
+++ b/segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py
@@ -1,0 +1,109 @@
+"""MedNeXt-L (kernel5 / kernel3) + bruniss's SkeletonRecall loss.
+
+Targets the compressed / highly curved surface regions where the production
+ResEnc-L surface model loses recall. See issue #191 ("Surface and Fiber
+Predictions in Compressed or Highly Curved areas") and the benchmark comment
+that motivated this trainer:
+
+  https://github.com/ScrollPrize/villa/issues/191
+
+On a held-out 5-cube benchmark over PHerc Paris 1 (S1) plus PHerc 1667 (S4),
+MedNeXt-L kernel5 + SkeletonRecall on bruniss's Dataset059 reaches
+high_compressed IoU 0.671 vs the d058 production model's 0.404 (+0.267
+absolute, +66% relative). overall_macro IoU goes from 0.534 -> 0.685.
+
+This trainer keeps everything in ``nnUNetTrainerSkeletonRecall`` (loss,
+SkeletonTransform, custom data loaders, train/validation steps) and only
+overrides ``build_network_architecture`` to swap the default ResEnc U-Net for
+MedNeXt-L with the kernel size and channel/block schedule from
+``nnUNetTrainerV2_MedNeXt_L_kernel5`` in the upstream MedNeXt repo
+(https://github.com/MIC-DKFZ/MedNeXt). MedNeXt's deep_supervision output list
+matches nnUNetv2's expectations (5 levels, full resolution first).
+
+Requirements:
+  - ``mednextv1`` (pip install mednextv1) for the ``MedNeXt`` class.
+    Source: https://github.com/MIC-DKFZ/MedNeXt
+  - Everything ``nnUNetTrainerSkeletonRecall`` already depends on.
+
+Pretrained weights:
+  https://huggingface.co/ciscoriordan/mednext-l-scroll-surface
+  (best checkpoint: ``kernel5_skelrec_dataset059_ep33/``)
+
+Usage:
+  nnUNetv2_train DATASET_ID 3d_fullres 0 -tr nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5
+
+Memory note:
+  MedNeXt-L kernel5 at the default batch_size=2, patch 128^3 fits on a
+  40 GB A100 with room to spare. On smaller cards or larger patches, fall
+  back to ``nnUNetTrainerSkeletonRecall_MedNeXtL_kernel3``.
+"""
+from __future__ import annotations
+
+from typing import List, Tuple, Union
+
+from torch import nn
+
+from nnunetv2.training.nnUNetTrainer.variants.loss.nnUNetTrainerSkeletonRecall import (
+    nnUNetTrainerSkeletonRecall,
+)
+from nnunet_mednext.network_architecture.mednextv1.MedNextV1 import MedNeXt
+
+
+class nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5(nnUNetTrainerSkeletonRecall):
+    """MedNeXt-L kernel5 architecture + SkeletonRecall loss."""
+
+    @staticmethod
+    def build_network_architecture(
+        architecture_class_name: str,
+        arch_init_kwargs: dict,
+        arch_init_kwargs_req_import: Union[List[str], Tuple[str, ...]],
+        num_input_channels: int,
+        num_output_channels: int,
+        enable_deep_supervision: bool = True,
+    ) -> nn.Module:
+        """Match ``nnUNetTrainerV2_MedNeXt_L_kernel5.initialize_network()`` from mednextv1.
+
+        nnUNetv2's deep_supervision_scales for a 5-pool 3D U-Net is 5 levels
+        (full, /2, /4, /8, /16). MedNeXt with these settings returns exactly
+        that list shape, with ``output[0]`` = full resolution.
+        """
+        return MedNeXt(
+            in_channels=num_input_channels,
+            n_channels=32,
+            n_classes=num_output_channels,
+            exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            kernel_size=5,
+            deep_supervision=enable_deep_supervision,
+            do_res=True,
+            do_res_up_down=True,
+            block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            checkpoint_style="outside_block",
+        )
+
+
+class nnUNetTrainerSkeletonRecall_MedNeXtL_kernel3(nnUNetTrainerSkeletonRecall):
+    """Kernel3 fallback variant. Use when kernel5 doesn't fit in VRAM at the
+    desired batch_size / patch size. Same channel/block schedule, kernel=3.
+    """
+
+    @staticmethod
+    def build_network_architecture(
+        architecture_class_name: str,
+        arch_init_kwargs: dict,
+        arch_init_kwargs_req_import: Union[List[str], Tuple[str, ...]],
+        num_input_channels: int,
+        num_output_channels: int,
+        enable_deep_supervision: bool = True,
+    ) -> nn.Module:
+        return MedNeXt(
+            in_channels=num_input_channels,
+            n_channels=32,
+            n_classes=num_output_channels,
+            exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            kernel_size=3,
+            deep_supervision=enable_deep_supervision,
+            do_res=True,
+            do_res_up_down=True,
+            block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            checkpoint_style="outside_block",
+        )

--- a/segmentation/models/arch/nnunet/pyproject.toml
+++ b/segmentation/models/arch/nnunet/pyproject.toml
@@ -91,6 +91,12 @@ dev = [
     "ruff",
     "pre-commit"
 ]
+# Only needed for the MedNeXt trainers under
+# nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py
+# Install with: pip install -e ".[mednext]"
+mednext = [
+    "mednextv1"
+]
 
 [build-system]
 requires = ["setuptools>=67.8.0"]


### PR DESCRIPTION
## What

Adds `nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5` (plus a kernel3 fallback in the same file) to `segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/loss/`. The trainer extends the existing `nnUNetTrainerSkeletonRecall` and only overrides `build_network_architecture` to swap the default ResEnc U-Net for MedNeXt-L. Loss, transforms, data loaders, and train/validation steps are inherited unchanged.

## Why

Addresses #191 ("Surface and Fiber Predictions in Compressed or Highly Curved areas"). The d058 ResEnc-L production model under-predicts in compressed / highly curved cubes. MedNeXt-L's depthwise-then-pointwise inverted-bottleneck blocks (the "ConvNeXt for medical seg" recipe) give a noticeably better fit there while keeping the rest of bruniss's pipeline (SkeletonRecall loss, augmentations, Dataset059 layout) intact.

On a held-out 5-cube benchmark over PHerc Paris 1 (S1) and PHerc 1667 (S4):

| metric | d058 (ResEnc-L) | MedNeXt-L k5 + SkelRec (this) | delta |
|---|---|---|---|
| high_compressed IoU | 0.404 | 0.671 | +0.267 (+66%) |
| overall_macro IoU | 0.534 | 0.685 | +0.151 |

Full methodology, per-cube numbers, and the comparison vs. UMambaEnc are in [the issue comment](https://github.com/ScrollPrize/villa/issues/191#issuecomment-4472801908).

## How to use

```
pip install -e "segmentation/models/arch/nnunet[mednext]"
nnUNetv2_train DATASET_ID 3d_fullres 0 -tr nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5
```

For VRAM-tight setups, swap in `nnUNetTrainerSkeletonRecall_MedNeXtL_kernel3` (same file).

Pretrained weights on Hugging Face (best checkpoint `kernel5_skelrec_dataset059_ep33/`):
https://huggingface.co/ciscoriordan/mednext-l-scroll-surface

## What's NOT included

- No MedNeXt source vendored. The trainer imports from the upstream `mednextv1` pip package (https://github.com/MIC-DKFZ/MedNeXt), added as an optional dependency under `[project.optional-dependencies].mednext` so users not using this trainer see no install change.
- No preset training plans / batch_running configs. Out of the box this uses the same plans the existing `nnUNetTrainerSkeletonRecall` runs with (e.g. `nnUNetResEncUNetMPlans`); MedNeXt's `build_network_architecture` ignores the ResEnc-specific architecture kwargs and just uses MedNeXt's own block schedule.
- No changes to `nnUNetTrainerSkeletonRecall` or any other existing trainer.
- No CI / build configuration changes.

## Files changed

- `segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py` (new, ~95 lines including docstring)
- `segmentation/models/arch/nnunet/pyproject.toml` (added optional `mednext` extra)
- `segmentation/models/arch/nnunet/README.md` (short section under existing `### train` block, pointing to #191, the benchmark numbers, HF weights, and the kernel3 fallback)

## Open for discussion

- File location: I placed the trainer in `variants/loss/` next to its parent `nnUNetTrainerSkeletonRecall.py`, since it's a near-zero-glue subclass of that trainer (loss is the dominant axis). The alternative would be `variants/network_architecture/`. Happy to move it if maintainers prefer.
- Marking as draft so maintainers can flag placement / naming / extras-grouping preferences before merge.

Source repo (public) with the original training scripts and benchmark code: https://github.com/ciscoriordan/mednext-vs-umamba-scroll