### PR TITLE
vc: cache zarr metadata and reuse for chunk reads

### DIFF
--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -1147,7 +1147,17 @@ void run_generate(const po::variables_map& vm) {
 
                 std::vector<ThreadSliceStats> thread_stats(static_cast<size_t>(num_threads));
 
-                #pragma omp parallel for schedule(dynamic)
+                // Cap the team size to the batch — each ThinningScratch slot
+                // holds 5 slice-sized CV_8U mats once a thread touches it,
+                // and slots are never freed. Letting OMP scatter 4 work items
+                // across 15 tids leaks ~5 GiB of resident scratch per fresh
+                // tid that happens to grab a slice.
+                const int slice_team_threads = std::max<int>(
+                    1,
+                    std::min<int>(num_threads,
+                                  static_cast<int>(assembled_slices.size())));
+
+                #pragma omp parallel for schedule(dynamic) num_threads(slice_team_threads)
                 for (size_t batch_index = 0; batch_index < assembled_slices.size(); ++batch_index) {
                     const int tid = omp_get_thread_num();
                     ThreadSliceStats& local_stats = thread_stats[static_cast<size_t>(tid)];

--- a/volume-cartographer/core/include/vc/core/types/Volume.hpp
+++ b/volume-cartographer/core/include/vc/core/types/Volume.hpp
@@ -20,6 +20,7 @@
 #include "vc/core/util/RemoteAuth.hpp"
 
 namespace vc::render { class IChunkedArray; }
+namespace utils { class ZarrArray; }
 
 struct CompositeParams;
 
@@ -268,6 +269,14 @@ protected:
     mutable std::mutex cacheMutex_;
     size_t cacheBudgetHot_ = 8ULL << 30;   // 8 GB default
     int ioThreads_ = 0;  // 0 = use default
+
+    // Per-level read-side ZarrArray cache. Avoids reparsing .zarray/zarr.json
+    // and rebuilding the codec registry on every chunk read. ZarrArray is
+    // read-only after open and serialises its own shard I/O internally, so a
+    // shared instance is safe to use concurrently from OMP workers.
+    mutable std::vector<std::shared_ptr<utils::ZarrArray>> readArrayCache_;
+    mutable std::mutex readArrayCacheMutex_;
+    std::shared_ptr<utils::ZarrArray> cachedZarrArrayForRead(int level) const;
 
     void loadMetadata();
 

--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -1753,6 +1753,22 @@ void Volume::writeXYZ(const Array3D<uint16_t>& data,
     writeZYX(data, xyzToZyx(offsetXYZ), level);
 }
 
+std::shared_ptr<utils::ZarrArray>
+Volume::cachedZarrArrayForRead(int level) const
+{
+    std::lock_guard<std::mutex> lk(readArrayCacheMutex_);
+    if (readArrayCache_.size() <= static_cast<size_t>(level)) {
+        readArrayCache_.resize(static_cast<size_t>(level) + 1);
+    }
+    auto& slot = readArrayCache_[static_cast<size_t>(level)];
+    if (!slot) {
+        slot = std::make_shared<utils::ZarrArray>(
+            openLocalZarrArrayForRead(zarrArrayPathForLevel(path(), level),
+                                      static_cast<int>(dtypeSize())));
+    }
+    return slot;
+}
+
 std::optional<std::vector<std::byte>> Volume::readChunk(
     int level,
     const std::array<size_t, 3>& chunkZYX) const
@@ -1764,9 +1780,8 @@ std::optional<std::vector<std::byte>> Volume::readChunk(
     if (!hasScaleLevel(level))
         throw std::out_of_range("Volume::readChunk requested missing zarr scale level " + std::to_string(level));
 
-    auto array = openLocalZarrArrayForRead(zarrArrayPathForLevel(path(), level),
-                                           static_cast<int>(dtypeSize()));
-    return array.read_chunk(chunkZYX);
+    auto arrayPtr = cachedZarrArrayForRead(level);
+    return arrayPtr->read_chunk(chunkZYX);
 }
 
 bool Volume::readChunkInto(
@@ -1781,9 +1796,8 @@ bool Volume::readChunkInto(
     if (!hasScaleLevel(level))
         throw std::out_of_range("Volume::readChunkInto requested missing zarr scale level " + std::to_string(level));
 
-    auto array = openLocalZarrArrayForRead(zarrArrayPathForLevel(path(), level),
-                                           static_cast<int>(dtypeSize()));
-    return array.read_chunk_into(chunkZYX, output);
+    auto arrayPtr = cachedZarrArrayForRead(level);
+    return arrayPtr->read_chunk_into(chunkZYX, output);
 }
 
 size_t Volume::chunkByteSize(int level) const
@@ -1800,9 +1814,8 @@ std::vector<std::byte> Volume::readChunkOrFill(
     if (auto chunk = readChunk(level, chunkZYX))
         return std::move(*chunk);
 
-    auto array = openLocalZarrArrayForRead(zarrArrayPathForLevel(path(), level),
-                                           static_cast<int>(dtypeSize()));
-    return filledChunkBytes(array);
+    auto arrayPtr = cachedZarrArrayForRead(level);
+    return filledChunkBytes(*arrayPtr);
 }
 
 bool Volume::chunkExists(
@@ -1816,11 +1829,10 @@ bool Volume::chunkExists(
     if (!hasScaleLevel(level))
         throw std::out_of_range("Volume::chunkExists requested missing zarr scale level " + std::to_string(level));
 
-    auto array = openLocalZarrArrayForRead(zarrArrayPathForLevel(path(), level),
-                                           static_cast<int>(dtypeSize()));
-    if (array.is_sharded())
-        return array.inner_chunk_exists(chunkZYX);
-    return array.chunk_exists(chunkZYX);
+    auto arrayPtr = cachedZarrArrayForRead(level);
+    if (arrayPtr->is_sharded())
+        return arrayPtr->inner_chunk_exists(chunkZYX);
+    return arrayPtr->chunk_exists(chunkZYX);
 }
 
 void Volume::writeChunk(int level,


### PR DESCRIPTION
Some final optimizations used for the normalgrids run