### PR TITLE
vc3d: split approval intersection refresh modes

### DIFF
--- a/volume-cartographer/apps/VC3D/overlays/SegmentationIntersectionInvalidation.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationIntersectionInvalidation.hpp
@@ -8,7 +8,14 @@
 
 namespace vc3d::segmentation {
 
-inline void invalidateApprovalPlaneIntersections(const std::vector<VolumeViewerBase*>& viewers)
+enum class ApprovalIntersectionRefresh {
+    Immediate,
+    Deferred,
+};
+
+inline void invalidateApprovalPlaneIntersections(
+    const std::vector<VolumeViewerBase*>& viewers,
+    ApprovalIntersectionRefresh refresh)
 {
     for (auto* viewer : viewers) {
         if (!viewer) {
@@ -16,7 +23,11 @@ inline void invalidateApprovalPlaneIntersections(const std::vector<VolumeViewerB
         }
         if (dynamic_cast<PlaneSurface*>(viewer->currentSurface())) {
             viewer->invalidateIntersect("segmentation");
-            viewer->scheduleIntersectionRender("approval mask changed");
+            if (refresh == ApprovalIntersectionRefresh::Immediate) {
+                viewer->renderIntersections("approval mask changed");
+            } else {
+                viewer->scheduleIntersectionRender("approval mask changed");
+            }
         }
     }
 }

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationIntersectionInvalidation.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationIntersectionInvalidation.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../volume_viewers/VolumeViewerBase.hpp"
+
+#include <vector>
+
+#include "vc/core/util/PlaneSurface.hpp"
+
+namespace vc3d::segmentation {
+
+inline void invalidateApprovalPlaneIntersections(const std::vector<VolumeViewerBase*>& viewers)
+{
+    for (auto* viewer : viewers) {
+        if (!viewer) {
+            continue;
+        }
+        if (dynamic_cast<PlaneSurface*>(viewer->currentSurface())) {
+            viewer->invalidateIntersect("segmentation");
+            viewer->scheduleIntersectionRender("approval mask changed");
+        }
+    }
+}
+
+} // namespace vc3d::segmentation

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
@@ -1,6 +1,7 @@
 #include "SegmentationOverlayController.hpp"
 
 #include "../CState.hpp"
+#include "SegmentationIntersectionInvalidation.hpp"
 #include "../volume_viewers/VolumeViewerBase.hpp"
 #include "../ViewerManager.hpp"
 #include "../segmentation/tools/SegmentationEditManager.hpp"
@@ -18,11 +19,13 @@
 #include <exception>
 #include <filesystem>
 #include <limits>
+#include <string>
 #include <tuple>
 #include <unordered_set>
 
 #include <opencv2/imgcodecs.hpp>
 
+#include "vc/core/util/Logging.hpp"
 #include "vc/core/util/PlaneSurface.hpp"
 #include "vc/core/util/QuadSurface.hpp"
 #include "vc/core/util/Surface.hpp"
@@ -55,6 +58,43 @@ constexpr float kManualAddIntersectionMinWidthDelta = 0.75f;
 
 // Full opacity for mask pixels - the slider controls overall opacity via QGraphicsPixmapItem::setOpacity
 constexpr int kApprovalMaskAlpha = 255;
+
+class OverlayProfileScope {
+public:
+    OverlayProfileScope(const char* event, const char* detail = "")
+        : event_(event)
+        , detail_(detail)
+        , enabled_(ProfileLoggingEnabled())
+    {
+        if (!enabled_) {
+            return;
+        }
+        timer_.start();
+        Logger()->info("[vc3d-profile] {} begin{}", event_, detailSuffix());
+    }
+
+    ~OverlayProfileScope()
+    {
+        if (!enabled_) {
+            return;
+        }
+        Logger()->info("[vc3d-profile] {} end elapsed_ms={}{}",
+                       event_,
+                       timer_.elapsed(),
+                       detailSuffix());
+    }
+
+private:
+    std::string detailSuffix() const
+    {
+        return detail_.empty() ? std::string{} : " detail='" + detail_ + "'";
+    }
+
+    const char* event_;
+    std::string detail_;
+    bool enabled_{false};
+    QElapsedTimer timer_;
+};
 
 QColor manualAddIntersectionColor()
 {
@@ -363,6 +403,8 @@ void SegmentationOverlayController::paintApprovalMaskDirect(
     float heightSteps,
     bool isAutoApproval)
 {
+    OverlayProfileScope profile("paintApprovalMaskDirect",
+                                isAutoApproval ? "auto_approval" : "manual");
     if (_pendingApprovalMaskImage.isNull()) {
         qWarning() << "paintApprovalMaskDirect: pending image is NULL!";
         return;
@@ -477,6 +519,7 @@ void SegmentationOverlayController::paintApprovalMaskDirect(
 
 void SegmentationOverlayController::saveApprovalMaskToSurface(QuadSurface* surface)
 {
+    OverlayProfileScope profile("saveApprovalMaskToSurface");
     if (!surface || (_savedApprovalMaskImage.isNull() && _pendingApprovalMaskImage.isNull())) {
         return;
     }
@@ -1390,21 +1433,12 @@ void SegmentationOverlayController::forceRefreshAllOverlays()
 
 void SegmentationOverlayController::invalidatePlaneIntersections()
 {
+    OverlayProfileScope profile("invalidatePlaneIntersections");
     if (!_viewerManager) {
         return;
     }
 
-    _viewerManager->forEachBaseViewer([](VolumeViewerBase* viewer) {
-        if (!viewer) {
-            return;
-        }
-        // Only invalidate for plane surface viewers (XY, XZ, YZ)
-        if (dynamic_cast<PlaneSurface*>(viewer->currentSurface())) {
-            // Invalidate the intersection cache for segmentation so approval colors get recomputed
-            viewer->invalidateIntersect("segmentation");
-            viewer->renderIntersections();
-        }
-    });
+    vc3d::segmentation::invalidateApprovalPlaneIntersections(_viewerManager->baseViewers());
 }
 
 void SegmentationOverlayController::setApprovalMaskOpacity(int opacity)

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
@@ -513,8 +513,12 @@ void SegmentationOverlayController::paintApprovalMaskDirect(
     // Invalidate pending version since we modified the pending image
     ++_pendingImageVersion;
 
-    // Trigger re-rendering of intersection lines on plane viewers
-    invalidatePlaneIntersections();
+    // Manual painting should update interactively; auto-approval bursts are coalesced.
+    if (isAutoApproval) {
+        schedulePlaneIntersectionRefresh();
+    } else {
+        invalidatePlaneIntersections();
+    }
 }
 
 void SegmentationOverlayController::saveApprovalMaskToSurface(QuadSurface* surface)
@@ -1433,12 +1437,26 @@ void SegmentationOverlayController::forceRefreshAllOverlays()
 
 void SegmentationOverlayController::invalidatePlaneIntersections()
 {
-    OverlayProfileScope profile("invalidatePlaneIntersections");
+    OverlayProfileScope profile("invalidatePlaneIntersections", "immediate");
     if (!_viewerManager) {
         return;
     }
 
-    vc3d::segmentation::invalidateApprovalPlaneIntersections(_viewerManager->baseViewers());
+    vc3d::segmentation::invalidateApprovalPlaneIntersections(
+        _viewerManager->baseViewers(),
+        vc3d::segmentation::ApprovalIntersectionRefresh::Immediate);
+}
+
+void SegmentationOverlayController::schedulePlaneIntersectionRefresh()
+{
+    OverlayProfileScope profile("invalidatePlaneIntersections", "deferred");
+    if (!_viewerManager) {
+        return;
+    }
+
+    vc3d::segmentation::invalidateApprovalPlaneIntersections(
+        _viewerManager->baseViewers(),
+        vc3d::segmentation::ApprovalIntersectionRefresh::Deferred);
 }
 
 void SegmentationOverlayController::setApprovalMaskOpacity(int opacity)

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
@@ -195,6 +195,7 @@ private slots:
     void onSurfaceChanged(std::string name, std::shared_ptr<Surface> surface);
 
 private:
+    void schedulePlaneIntersectionRefresh();
     void buildRadiusOverlay(const State& state,
                             VolumeViewerBase* viewer,
                             ViewerOverlayControllerBase::OverlayBuilder& builder) const;

--- a/volume-cartographer/apps/VC3D/segmentation/SegmentationModule.cpp
+++ b/volume-cartographer/apps/VC3D/segmentation/SegmentationModule.cpp
@@ -945,7 +945,7 @@ void SegmentationModule::performAutoApproval(const std::vector<std::pair<int, in
     const QColor brushColor = approvalBrushColor();
     _overlay->paintApprovalMaskDirect(vertices, _autoApprovalRadius, kApproved, brushColor, false, 0.0f, 0.0f, kIsAutoApproval);
     _overlay->scheduleDebouncedSave(_editManager->baseSurface().get());
-    qCInfo(lcSegModule) << "Auto-approved" << vertices.size() << "vertices with radius" << _autoApprovalRadius;
+    qCDebug(lcSegModule) << "Auto-approved" << vertices.size() << "vertices with radius" << _autoApprovalRadius;
 }
 
 void SegmentationModule::saveApprovalMaskToDisk()

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -132,6 +132,9 @@ public:
     void renderIntersections(
         const char* reason = "external caller",
         std::source_location caller = std::source_location::current()) override;
+    void scheduleIntersectionRender(
+        const char* reason = "external caller",
+        std::source_location caller = std::source_location::current()) override;
     void invalidateIntersect(const std::string& = "") override;
     void invalidateIntersectRegion(const std::string& name, const cv::Rect& changedCells) override;
     float intersectionOpacity() const override { return _intersectionOpacity; }
@@ -213,9 +216,6 @@ signals:
 
 private:
     void scheduleRender(
-        const char* reason = "internal caller",
-        std::source_location caller = std::source_location::current());
-    void scheduleIntersectionRender(
         const char* reason = "internal caller",
         std::source_location caller = std::source_location::current());
     void quiesceForClose();

--- a/volume-cartographer/apps/VC3D/volume_viewers/VolumeViewerBase.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/VolumeViewerBase.hpp
@@ -148,6 +148,9 @@ public:
     virtual void renderIntersections(
         const char* reason = "external caller",
         std::source_location caller = std::source_location::current()) = 0;
+    virtual void scheduleIntersectionRender(
+        const char* reason = "external caller",
+        std::source_location caller = std::source_location::current()) = 0;
     virtual void invalidateIntersect(const std::string& name = "") = 0;
     virtual void invalidateIntersectRegion(const std::string& name, const cv::Rect& changedCells)
     {

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -12,6 +12,8 @@ if(NOT TARGET doctest::doctest)
     FetchContent_MakeAvailable(doctest)
 endif()
 
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Test)
+
 add_executable(test_smoke test_smoke.cpp)
 target_link_libraries(test_smoke PRIVATE doctest::doctest)
 add_test(NAME test_smoke COMMAND test_smoke)
@@ -32,6 +34,11 @@ add_executable(test_segmentation_autosave_state test_segmentation_autosave_state
 target_include_directories(test_segmentation_autosave_state PRIVATE ${PROJECT_SOURCE_DIR}/apps/VC3D)
 target_link_libraries(test_segmentation_autosave_state PRIVATE doctest::doctest)
 add_test(NAME test_segmentation_autosave_state COMMAND test_segmentation_autosave_state)
+
+add_executable(test_segmentation_intersection_invalidation test_segmentation_intersection_invalidation.cpp)
+target_include_directories(test_segmentation_intersection_invalidation PRIVATE ${PROJECT_SOURCE_DIR}/apps/VC3D)
+target_link_libraries(test_segmentation_intersection_invalidation PRIVATE Qt6::Core Qt6::Gui Qt6::Test vc_core)
+add_test(NAME test_segmentation_intersection_invalidation COMMAND test_segmentation_intersection_invalidation)
 
 add_executable(test_quadsurface_save_roundtrip test_quadsurface_save_roundtrip.cpp)
 target_link_libraries(test_quadsurface_save_roundtrip PRIVATE doctest::doctest vc_core)

--- a/volume-cartographer/core/test/test_segmentation_intersection_invalidation.cpp
+++ b/volume-cartographer/core/test/test_segmentation_intersection_invalidation.cpp
@@ -1,0 +1,221 @@
+#include <QSignalSpy>
+#include <QTest>
+
+#include "overlays/SegmentationIntersectionInvalidation.hpp"
+
+#include "vc/core/util/PlaneSurface.hpp"
+#include "vc/core/util/Surface.hpp"
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace {
+
+class DummySurface final : public Surface {
+public:
+    void move(cv::Vec3f&, const cv::Vec3f&) override {}
+    bool valid(const cv::Vec3f&, const cv::Vec3f& = {0, 0, 0}) override { return true; }
+    cv::Vec3f loc(const cv::Vec3f& ptr, const cv::Vec3f& = {0, 0, 0}) override { return ptr; }
+    cv::Vec3f coord(const cv::Vec3f& ptr, const cv::Vec3f& = {0, 0, 0}) const override { return ptr; }
+    cv::Vec3f normal(const cv::Vec3f&, const cv::Vec3f& = {0, 0, 0}) override { return {0, 0, 1}; }
+    float pointTo(cv::Vec3f&, const cv::Vec3f&, float, int, SurfacePatchIndex*, PointIndex*) override { return 0.0f; }
+    void gen(cv::Mat_<cv::Vec3f>*, cv::Mat_<cv::Vec3f>*, cv::Size, const cv::Vec3f&, float, const cv::Vec3f&) const override {}
+};
+
+class FakeViewer final : public QObject, public VolumeViewerBase {
+    Q_OBJECT
+
+public:
+    explicit FakeViewer(Surface* surface)
+        : surface_(surface)
+    {
+    }
+
+    QPointF volumeToScene(const cv::Vec3f&) override { return {}; }
+    cv::Vec3f sceneToVolume(const QPointF&) const override { return {}; }
+    cv::Vec2f sceneToSurfaceCoords(const QPointF&) const override { return {}; }
+    QPointF surfaceCoordsToScene(float, float) const override { return {}; }
+    QPointF lastScenePosition() const override { return {}; }
+    void setLinkedCursorVolumePoint(const std::optional<cv::Vec3f>&) override {}
+
+    void setSurface(const std::string&) override {}
+    void setIntersects(const std::set<std::string>&) override {}
+    void renderVisible(bool, const char*, std::source_location) override {}
+    void requestRender(const char*, std::source_location) override {}
+    void invalidateVis() override {}
+    void centerOnVolumePoint(const cv::Vec3f&, bool) override {}
+    void centerOnSurfacePoint(const cv::Vec2f&, bool) override {}
+    void adjustZoomByFactor(float) override {}
+    void adjustSurfaceOffset(float) override {}
+    void resetSurfaceOffsets() override {}
+    void fitSurfaceInView() override {}
+
+    Surface* currentSurface() const override { return surface_; }
+    std::string surfName() const override { return "fake"; }
+    std::shared_ptr<Volume> currentVolume() const override { return {}; }
+    VCCollection* pointCollection() const override { return nullptr; }
+
+    float getCurrentScale() const override { return 1.0f; }
+    float dsScale() const override { return 1.0f; }
+    float normalOffset() const override { return 0.0f; }
+    int datasetScaleIndex() const override { return 0; }
+    float datasetScaleFactor() const override { return 1.0f; }
+
+    bool isShowDirectionHints() const override { return false; }
+    bool isShowSurfaceNormals() const override { return false; }
+    float normalArrowLengthScale() const override { return 1.0f; }
+    int normalMaxArrows() const override { return 0; }
+    void setNormalArrowLengthScale(float) override {}
+    void setNormalMaxArrows(int) override {}
+
+    const CompositeRenderSettings& compositeRenderSettings() const override { return compositeSettings_; }
+    bool isCompositeEnabled() const override { return false; }
+    bool isPlaneCompositeEnabled() const override { return false; }
+    void setCompositeRenderSettings(const CompositeRenderSettings& settings) override { compositeSettings_ = settings; }
+    void setVolumeWindow(float, float) override {}
+    void setBaseColormap(const std::string&) override {}
+    void setResetViewOnSurfaceChange(bool) override {}
+    void setPlaneIntersectionLinesVisible(bool) override {}
+    void setShowDirectionHints(bool) override {}
+    void setShowSurfaceNormals(bool) override {}
+    void setSegmentationEditActive(bool) override {}
+    void setSegmentationIntersectionDeferral(bool) override {}
+    void setSegmentationCursorMirroring(bool) override {}
+    void setOverlayVolume(std::shared_ptr<Volume>) override {}
+    void setOverlayOpacity(float) override {}
+    void setOverlayColormap(const std::string&) override {}
+    void setOverlayThreshold(float) override {}
+    void setOverlayWindow(float, float) override {}
+    void reloadPerfSettings() override {}
+
+    uint64_t highlightedPointId() const override { return 0; }
+    uint64_t selectedPointId() const override { return 0; }
+    uint64_t selectedCollectionId() const override { return 0; }
+    bool isPointDragActive() const override { return false; }
+    const std::vector<ViewerOverlayControllerBase::PathPrimitive>& drawingPaths() const override { return paths_; }
+
+    void setOverlayGroup(const std::string&, const std::vector<QGraphicsItem*>&) override {}
+    void clearOverlayGroup(const std::string&) override {}
+    void clearAllOverlayGroups() override {}
+
+    std::vector<std::pair<QRectF, QColor>> selections() const override { return {}; }
+    std::optional<QRectF> activeBBoxSceneRect() const override { return std::nullopt; }
+    void setBBoxMode(bool) override {}
+    QuadSurface* makeBBoxFilteredSurfaceFromSceneRect(const QRectF&) override { return nullptr; }
+    void clearSelections() override {}
+
+    void renderIntersections(const char*, std::source_location) override
+    {
+        ++renderCount;
+        emit rendered();
+    }
+
+    void scheduleIntersectionRender(const char*, std::source_location) override
+    {
+        ++scheduleRequestCount;
+        if (intersectionScheduled_) {
+            return;
+        }
+        intersectionScheduled_ = true;
+        ++scheduleStartCount;
+        emit scheduleStarted();
+    }
+
+    void invalidateIntersect(const std::string& name = "") override
+    {
+        ++invalidateCount;
+        lastInvalidatedName = name;
+    }
+
+    float intersectionOpacity() const override { return 1.0f; }
+    float intersectionThickness() const override { return 1.0f; }
+    int surfacePatchSamplingStride() const override { return 1; }
+    void setIntersectionOpacity(float) override {}
+    void setIntersectionThickness(float) override {}
+    void setHighlightedSurfaceIds(const std::vector<std::string>&) override {}
+    void setSurfacePatchSamplingStride(int) override {}
+
+    bool surfaceOverlayEnabled() const override { return false; }
+    const std::map<std::string, cv::Vec3b>& surfaceOverlays() const override { return overlays_; }
+    float surfaceOverlapThreshold() const override { return 0.0f; }
+    void setSurfaceOverlayEnabled(bool) override {}
+    void setSurfaceOverlays(const std::map<std::string, cv::Vec3b>& overlays) override { overlays_ = overlays; }
+    void setSurfaceOverlapThreshold(float) override {}
+
+    const ActiveSegmentationHandle& activeSegmentationHandle() const override { return activeSegmentation_; }
+    CVolumeViewerView* graphicsView() const override { return nullptr; }
+    QObject* asQObject() override { return this; }
+    QMetaObject::Connection connectOverlaysUpdated(QObject*, const std::function<void()>&) override { return {}; }
+
+    int invalidateCount{0};
+    int scheduleRequestCount{0};
+    int scheduleStartCount{0};
+    int renderCount{0};
+    std::string lastInvalidatedName;
+
+signals:
+    void scheduleStarted();
+    void rendered();
+
+private:
+    Surface* surface_{nullptr};
+    bool intersectionScheduled_{false};
+    CompositeRenderSettings compositeSettings_;
+    std::vector<ViewerOverlayControllerBase::PathPrimitive> paths_;
+    std::map<std::string, cv::Vec3b> overlays_;
+    ActiveSegmentationHandle activeSegmentation_;
+};
+
+} // namespace
+
+class SegmentationIntersectionInvalidationTest final : public QObject {
+    Q_OBJECT
+
+private slots:
+    void repeatedPlaneInvalidationsAreDebounced()
+    {
+        PlaneSurface plane;
+        FakeViewer viewer(&plane);
+        std::vector<VolumeViewerBase*> viewers{&viewer};
+        QSignalSpy scheduleStarted(&viewer, &FakeViewer::scheduleStarted);
+        QSignalSpy rendered(&viewer, &FakeViewer::rendered);
+
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(viewers);
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(viewers);
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(viewers);
+
+        QCOMPARE(viewer.invalidateCount, 3);
+        QCOMPARE(QString::fromStdString(viewer.lastInvalidatedName), QString("segmentation"));
+        QCOMPARE(viewer.scheduleRequestCount, 3);
+        QCOMPARE(viewer.scheduleStartCount, 1);
+        QTRY_COMPARE(scheduleStarted.count(), 1);
+        QCOMPARE(viewer.renderCount, 0);
+        QCOMPARE(rendered.count(), 0);
+    }
+
+    void nonPlaneViewersAreIgnored()
+    {
+        DummySurface surface;
+        FakeViewer viewer(&surface);
+        std::vector<VolumeViewerBase*> viewers{nullptr, &viewer};
+        QSignalSpy scheduleStarted(&viewer, &FakeViewer::scheduleStarted);
+        QSignalSpy rendered(&viewer, &FakeViewer::rendered);
+
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(viewers);
+
+        QCOMPARE(viewer.invalidateCount, 0);
+        QCOMPARE(viewer.scheduleRequestCount, 0);
+        QCOMPARE(viewer.scheduleStartCount, 0);
+        QCOMPARE(viewer.renderCount, 0);
+        QCOMPARE(scheduleStarted.count(), 0);
+        QCOMPARE(rendered.count(), 0);
+    }
+};
+
+QTEST_APPLESS_MAIN(SegmentationIntersectionInvalidationTest)
+
+#include "test_segmentation_intersection_invalidation.moc"

--- a/volume-cartographer/core/test/test_segmentation_intersection_invalidation.cpp
+++ b/volume-cartographer/core/test/test_segmentation_intersection_invalidation.cpp
@@ -176,7 +176,7 @@ class SegmentationIntersectionInvalidationTest final : public QObject {
     Q_OBJECT
 
 private slots:
-    void repeatedPlaneInvalidationsAreDebounced()
+    void repeatedAutoApprovalPlaneInvalidationsAreDebounced()
     {
         PlaneSurface plane;
         FakeViewer viewer(&plane);
@@ -184,9 +184,12 @@ private slots:
         QSignalSpy scheduleStarted(&viewer, &FakeViewer::scheduleStarted);
         QSignalSpy rendered(&viewer, &FakeViewer::rendered);
 
-        vc3d::segmentation::invalidateApprovalPlaneIntersections(viewers);
-        vc3d::segmentation::invalidateApprovalPlaneIntersections(viewers);
-        vc3d::segmentation::invalidateApprovalPlaneIntersections(viewers);
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(
+            viewers, vc3d::segmentation::ApprovalIntersectionRefresh::Deferred);
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(
+            viewers, vc3d::segmentation::ApprovalIntersectionRefresh::Deferred);
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(
+            viewers, vc3d::segmentation::ApprovalIntersectionRefresh::Deferred);
 
         QCOMPARE(viewer.invalidateCount, 3);
         QCOMPARE(QString::fromStdString(viewer.lastInvalidatedName), QString("segmentation"));
@@ -197,6 +200,28 @@ private slots:
         QCOMPARE(rendered.count(), 0);
     }
 
+    void manualPlaneInvalidationsRenderSynchronously()
+    {
+        PlaneSurface plane;
+        FakeViewer viewer(&plane);
+        std::vector<VolumeViewerBase*> viewers{&viewer};
+        QSignalSpy scheduleStarted(&viewer, &FakeViewer::scheduleStarted);
+        QSignalSpy rendered(&viewer, &FakeViewer::rendered);
+
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(
+            viewers, vc3d::segmentation::ApprovalIntersectionRefresh::Immediate);
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(
+            viewers, vc3d::segmentation::ApprovalIntersectionRefresh::Immediate);
+
+        QCOMPARE(viewer.invalidateCount, 2);
+        QCOMPARE(QString::fromStdString(viewer.lastInvalidatedName), QString("segmentation"));
+        QCOMPARE(viewer.scheduleRequestCount, 0);
+        QCOMPARE(viewer.scheduleStartCount, 0);
+        QCOMPARE(scheduleStarted.count(), 0);
+        QCOMPARE(viewer.renderCount, 2);
+        QCOMPARE(rendered.count(), 2);
+    }
+
     void nonPlaneViewersAreIgnored()
     {
         DummySurface surface;
@@ -205,7 +230,8 @@ private slots:
         QSignalSpy scheduleStarted(&viewer, &FakeViewer::scheduleStarted);
         QSignalSpy rendered(&viewer, &FakeViewer::rendered);
 
-        vc3d::segmentation::invalidateApprovalPlaneIntersections(viewers);
+        vc3d::segmentation::invalidateApprovalPlaneIntersections(
+            viewers, vc3d::segmentation::ApprovalIntersectionRefresh::Deferred);
 
         QCOMPARE(viewer.invalidateCount, 0);
         QCOMPARE(viewer.scheduleRequestCount, 0);


### PR DESCRIPTION
## Summary

Splits approval-mask intersection refresh into two explicit modes:

- manual approval painting uses the immediate refresh path so brush feedback remains interactive;
- auto-approval uses deferred/coalesced scheduling through `VolumeViewerBase::scheduleIntersectionRender`, implemented by `CChunkedVolumeViewer`, so auto-approval bursts do not synchronously churn `renderIntersections()`.

This keeps approval mask pixels, geometry, save semantics, and numeric behavior unchanged while removing repeated synchronous renderer work from auto-approval bursts. It also downgrades per-edit auto-approval logging from info to debug and adds profiling around approval painting, approval saves, and intersection invalidation; existing viewer profiling covers `scheduleIntersectionRender` and `renderIntersections`.

## Performance Evaluation

The local machine did not have `/volpkgs/PHercParis4.volpkg/paths/20231210121321_v5`, and the supplied logs did not include `--profile` render timings. I evaluated the targeted auto-approval code-path pressure with a temporary Qt/fake-viewer benchmark using the auto-approval counts from the logs:

- `error1.txt`: 1,388 auto-approval events
- `error2.txt`: 4,259 auto-approval events
- 3 plane viewers, 1 non-plane viewer

Results:

| Case | Old sync `renderIntersections()` calls | New auto-approval sync `renderIntersections()` calls | New coalesced timer starts while active |
| --- | ---: | ---: | ---: |
| `error1`-like | 4,164 | 0 | 3 |
| `error2`-like | 12,777 | 0 | 3 |

The improvement is the removal of `auto_approvals * plane_viewers` synchronous renderer work from the auto-approval UI path during bursts. The Qt test asserts both sides of the split: deferred auto-approval invalidation coalesces scheduling without synchronous renders, while immediate/manual invalidation still renders synchronously.

## Validation

Built and ran:

```bash
cmake -S . -B build-codex-tests -DVC_TESTING=ON -DVC_BUILD_APPS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build-codex-tests --target test_segmentation_intersection_invalidation VC3D -j$(nproc)
ctest --test-dir build-codex-tests -R '^(test_volume_chunk_errors|test_chunk_cache|test_zarr_chunk_fetcher|test_segmentation_autosave_state|test_segmentation_intersection_invalidation)$' --output-on-failure
git diff --check
```

Result: all 5 focused tests passed, and `VC3D` built successfully. Build emitted existing warnings in `CrashHandler.cpp` and `SurfacePatchIndex.cpp`, unrelated to this change.

## Manual Follow-Up

Run VC3D with `--profile` on the actual `20231210121321_v5` workflow to compare real `renderIntersections` count and timing before final review.