### PR TITLE
build: fix concurrency in vc3d-publish-ghcr.yml

### DIFF
--- a/.github/workflows/vc3d-publish-ghcr.yml
+++ b/.github/workflows/vc3d-publish-ghcr.yml
@@ -23,15 +23,14 @@ permissions:
   contents: read
   packages: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ matrix.image }}
-  cancel-in-progress: false
-
 jobs:
   publish:
     name: Publish ${{ matrix.image }} builder
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.image }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Always only build the latest HEAD, no need to publish for old commits.