### PR TITLE
Add DBbun PHerc.Paris.4 Ink-Contrast Simulation Companion

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -69,7 +69,9 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [llfio-chunkloader](https://github.com/climbmax123/LLFIOCunkloadingTestingAndBenching): A Methode to access Data in chunks of (x,y,z) that is by lot faster and compute efficient than Zarr. (Written in C++ but it is possible to integrate in Python).
 
-- [preprocessed-data](https://github.com/usc-caisplusplus/scroll-data-preprocessing): Data preprocessing code and a fully processed version of the dataset in .zarr format to allow for faster training of ink detection models. 
+- [preprocessed-data](https://github.com/usc-caisplusplus/scroll-data-preprocessing): Data preprocessing code and a fully processed version of the dataset in .zarr format to allow for faster training of ink detection models.
+
+- [DBbun PHerc.Paris.4 Ink-Contrast Simulation Companion](https://github.com/DBbun/dbbun-companions/blob/main/DBbun_PHerc_Paris_4_Ink_Contrast_Simulation_Companion.zip): an exploratory synthetic executable companion for released PHerc.Paris.4 Vesuvius-style CT tile imagery. It includes a Python simulator, generated CSV outputs, figures, and summary metrics for documenting how contrast, noise, damage, and patch-level SNR affect synthetic ink-visibility workflows. By Uri Kartoun.
 
 ## Segmentation
 


### PR DESCRIPTION
Adds a DBbun-generated PHerc.Paris.4 ink-contrast simulation companion as a community data-access/visualization resource.

The linked bundle includes a Python simulator, generated CSV outputs, figures, and summary metrics for exploring contrast, noise, damage, and patch-level SNR in Vesuvius-style CT tile workflows.

This is an exploratory synthetic workflow-documentation artifact, not an official ScrollPrize result and not a claim of validated ink detection or text recovery.