### PR TITLE
vc3d: decimate + UV-lift pipeline so SLIM flatten works on large segments

### DIFF
--- a/volume-cartographer/apps/CMakeLists.txt
+++ b/volume-cartographer/apps/CMakeLists.txt
@@ -38,7 +38,11 @@ add_executable(vc_grow_seg_from_segments src/vc_grow_seg_from_segments.cpp)
 target_link_libraries(vc_grow_seg_from_segments vc_core vc_tracer Boost::program_options)
 
 add_executable(vc_tifxyz2obj src/vc_tifxyz2obj.cpp)
-target_link_libraries(vc_tifxyz2obj vc_core)
+target_link_libraries(vc_tifxyz2obj vc_core vc_inpaint)
+
+add_executable(vc_obj_uv_lift src/vc_obj_uv_lift.cpp)
+target_link_libraries(vc_obj_uv_lift PRIVATE igl::core OpenMP::OpenMP_CXX)
+set_target_properties(vc_obj_uv_lift PROPERTIES AUTOMOC OFF AUTOUIC OFF AUTORCC OFF)
 
 add_executable(vc_tifxyz2zarr_sparse src/vc_tifxyz2zarr_sparse.cpp)
 target_link_libraries(vc_tifxyz2zarr_sparse vc_core Boost::program_options)

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -659,7 +659,7 @@ public:
             int iters,
             double tolerance,
             const QString& energy,
-            int decimate,
+            double keepPercent,
             const QString& outputDir,
             double voxelSize)
     : QObject(handler)
@@ -667,9 +667,9 @@ public:
     , handler_(handler)
     , segDir_(segDir)
     , stem_(segmentStem)
-    , objPath_(QDir(segDir).filePath(segmentStem + (decimate > 0 ? "_coarse.obj" : ".obj")))
+    , objPath_(QDir(segDir).filePath(segmentStem + (keepPercent < 100.0 ? "_coarse.obj" : ".obj")))
     , objFine_(QDir(segDir).filePath(segmentStem + ".obj"))
-    , flatObj_(QDir(segDir).filePath(segmentStem + (decimate > 0 ? "_coarse_flatboi.obj" : "_flatboi.obj")))
+    , flatObj_(QDir(segDir).filePath(segmentStem + (keepPercent < 100.0 ? "_coarse_flatboi.obj" : "_flatboi.obj")))
     , liftedObj_(QDir(segDir).filePath(segmentStem + "_lifted.obj"))
     , outFinal_(outputDir)
     , outTemp_ (outputDir == segDir ? (segDir + "__rebuild_tmp__") : outputDir)
@@ -677,7 +677,7 @@ public:
     , inputIsAlreadyFlat_(outputDir == segDir)
     , tolerance_(tolerance)
     , energy_(energy)
-    , decimate_(decimate)
+    , keepPercent_(keepPercent)
     , voxelSize_(voxelSize)
     , proc_(new QProcess(this))
     , progress_(new QProgressDialog(QObject::tr("Preparing SLIM..."), QObject::tr("Cancel"), 0, 0, parentWidget))
@@ -815,14 +815,18 @@ private:
     void startToObj_() {
         if (tifxyz2objExe_.isEmpty()) { showImmediateToolNotFound_("vc_tifxyz2obj"); return; }
         phase_ = Phase::ToObj;
-        progress_->setLabelText(decimate_ > 0
-            ? QObject::tr("Converting TIFXYZ -> coarse OBJ (decimate=%1)...").arg(decimate_)
+        const bool decimating = keepPercent_ < 100.0;
+        progress_->setLabelText(decimating
+            ? QObject::tr("Converting TIFXYZ -> coarse OBJ (keep %1%)...")
+                  .arg(keepPercent_, 0, 'f', 2)
             : QObject::tr("Converting TIFXYZ -> OBJ..."));
         progress_->setMaximum(1 + iters_ + 1);
         progress_->setValue(0);
         ioLog_.clear();
         QStringList args; args << segDir_ << objPath_;
-        if (decimate_ > 0) args << QStringLiteral("--decimate") << QString::number(decimate_);
+        if (decimating) {
+            args << QStringLiteral("--keep=%1").arg(keepPercent_, 0, 'f', 4);
+        }
         ioLog_ += QStringLiteral("Running: %1 %2\n").arg(tifxyz2objExe_, args.join(' '));
         proc_->start(tifxyz2objExe_, args);
     }
@@ -899,7 +903,7 @@ private:
         // If decimation is in play, the UVs have been lifted onto the
         // full-res mesh (liftedObj_); otherwise flatObj_ itself is the
         // flattened full-res mesh.
-        const QString srcObj = (decimate_ > 0) ? liftedObj_ : flatObj_;
+        const QString srcObj = (keepPercent_ < 100.0) ? liftedObj_ : flatObj_;
         QStringList args;
         args << srcObj
              << outTemp_
@@ -1080,7 +1084,7 @@ private:
 
         if (phase_ == Phase::Flatboi) {
             if (!QFileInfo::exists(flatObj_)) { onFinished_(1, QProcess::NormalExit); return; }
-            if (decimate_ > 0) {
+            if (keepPercent_ < 100.0) {
                 startToObjFine_();
             } else {
                 startToTifxyz_();
@@ -1153,7 +1157,7 @@ private:
     bool    inputIsAlreadyFlat_ = false;
     double  tolerance_ = 0.0;
     QString energy_ = QStringLiteral("symmetric_dirichlet");
-    int     decimate_ = 0;
+    double  keepPercent_ = 100.0;
     double  voxelSize_ = 0.0;
 
     // process & progress
@@ -1636,7 +1640,7 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
     const int iters = dlg.maxIterations();
     const double tol = dlg.tolerance();
     const QString energy = dlg.energyType();
-    const int decimate = dlg.decimateLevel();
+    const double keepPercent = dlg.keepPercent();
     const QString outputDir = dlg.outputPath();
 
     const QByteArray pastixEnv = qgetenv("PASTIX_NUM_THREADS");
@@ -1648,7 +1652,7 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
               << " iters=" << iters
               << " tol=" << tol
               << " energy=" << energy.toStdString()
-              << " decimate=" << decimate
+              << " keep_percent=" << keepPercent
               << " PASTIX_NUM_THREADS=" << (pastixEnv.isEmpty() ? "<unset, PaStiX auto>" : pastixEnv.toStdString())
               << " hardware_concurrency=" << hwConc
               << std::endl;
@@ -1661,7 +1665,7 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
     } catch (...) {}
     if (!std::isfinite(voxelSize) || voxelSize <= 0.0) voxelSize = 0.0;
 
-    new SlimJob(_parentWidget, segDir, segmentStem, flatboiExe, this, iters, tol, energy, decimate, outputDir, voxelSize);
+    new SlimJob(_parentWidget, segDir, segmentStem, flatboiExe, this, iters, tol, energy, keepPercent, outputDir, voxelSize);
 }
 
 void SegmentationCommandHandler::onABFFlatten(const std::string& segmentId)

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -659,6 +659,7 @@ public:
             int iters,
             double tolerance,
             const QString& energy,
+            int decimate,
             const QString& outputDir,
             double voxelSize)
     : QObject(handler)
@@ -666,14 +667,17 @@ public:
     , handler_(handler)
     , segDir_(segDir)
     , stem_(segmentStem)
-    , objPath_(QDir(segDir).filePath(segmentStem + ".obj"))
-    , flatObj_(QDir(segDir).filePath(segmentStem + "_flatboi.obj"))
+    , objPath_(QDir(segDir).filePath(segmentStem + (decimate > 0 ? "_coarse.obj" : ".obj")))
+    , objFine_(QDir(segDir).filePath(segmentStem + ".obj"))
+    , flatObj_(QDir(segDir).filePath(segmentStem + (decimate > 0 ? "_coarse_flatboi.obj" : "_flatboi.obj")))
+    , liftedObj_(QDir(segDir).filePath(segmentStem + "_lifted.obj"))
     , outFinal_(outputDir)
     , outTemp_ (outputDir == segDir ? (segDir + "__rebuild_tmp__") : outputDir)
     , flatboiExe_(flatboiExe)
     , inputIsAlreadyFlat_(outputDir == segDir)
     , tolerance_(tolerance)
     , energy_(energy)
+    , decimate_(decimate)
     , voxelSize_(voxelSize)
     , proc_(new QProcess(this))
     , progress_(new QProgressDialog(QObject::tr("Preparing SLIM..."), QObject::tr("Cancel"), 0, 0, parentWidget))
@@ -684,6 +688,7 @@ public:
 
         tifxyz2objExe_ = findVcTool("vc_tifxyz2obj");
         obj2tifxyzExe_ = findVcTool("vc_obj2tifxyz");
+        uvLiftExe_     = findVcTool("vc_obj_uv_lift");
 
         // never create outTemp_ here; we'll let vc_obj2tifxyz create it later
         if (QFileInfo::exists(outTemp_)) {
@@ -805,18 +810,44 @@ private:
     }
 
 private:
-    enum class Phase { ToObj, Flatboi, ToTifxyz, Swap, Done };
+    enum class Phase { ToObj, Flatboi, ToObjFine, UVLift, ToTifxyz, Swap, Done };
 
     void startToObj_() {
         if (tifxyz2objExe_.isEmpty()) { showImmediateToolNotFound_("vc_tifxyz2obj"); return; }
         phase_ = Phase::ToObj;
-        progress_->setLabelText(QObject::tr("Converting TIFXYZ -> OBJ..."));
+        progress_->setLabelText(decimate_ > 0
+            ? QObject::tr("Converting TIFXYZ -> coarse OBJ (decimate=%1)...").arg(decimate_)
+            : QObject::tr("Converting TIFXYZ -> OBJ..."));
         progress_->setMaximum(1 + iters_ + 1);
         progress_->setValue(0);
         ioLog_.clear();
         QStringList args; args << segDir_ << objPath_;
+        if (decimate_ > 0) args << QStringLiteral("--decimate") << QString::number(decimate_);
         ioLog_ += QStringLiteral("Running: %1 %2\n").arg(tifxyz2objExe_, args.join(' '));
         proc_->start(tifxyz2objExe_, args);
+    }
+
+    void startToObjFine_() {
+        if (tifxyz2objExe_.isEmpty()) { showImmediateToolNotFound_("vc_tifxyz2obj"); return; }
+        phase_ = Phase::ToObjFine;
+        progress_->setLabelText(QObject::tr("Converting TIFXYZ -> full-res OBJ for UV lift..."));
+        ioLog_.clear();
+        QStringList args; args << segDir_ << objFine_;
+        ioLog_ += QStringLiteral("Running: %1 %2\n").arg(tifxyz2objExe_, args.join(' '));
+        proc_->start(tifxyz2objExe_, args);
+    }
+
+    void startUVLift_() {
+        if (uvLiftExe_.isEmpty()) { showImmediateToolNotFound_("vc_obj_uv_lift"); return; }
+        phase_ = Phase::UVLift;
+        progress_->setLabelText(QObject::tr("Lifting UVs onto full-res mesh..."));
+        ioLog_.clear();
+        // Grid-space lift: needs the un-flattened coarse OBJ (grid UVs from
+        // vc_tifxyz2obj) plus the flatboi output. 3D-nearest lift produced
+        // streaks where the surface passes close to itself in voxel space.
+        QStringList args; args << objPath_ << flatObj_ << objFine_ << liftedObj_;
+        ioLog_ += QStringLiteral("Running: %1 %2\n").arg(uvLiftExe_, args.join(' '));
+        proc_->start(uvLiftExe_, args);
     }
 
     void startFlatboi_() {
@@ -865,8 +896,12 @@ private:
         }
 
         ioLog_.clear();
+        // If decimation is in play, the UVs have been lifted onto the
+        // full-res mesh (liftedObj_); otherwise flatObj_ itself is the
+        // flattened full-res mesh.
+        const QString srcObj = (decimate_ > 0) ? liftedObj_ : flatObj_;
         QStringList args;
-        args << flatObj_
+        args << srcObj
              << outTemp_
              // Downsample UV grid by 20x per axis to reduce compute/memory.
              << QStringLiteral("--uv-downsample=20");
@@ -987,9 +1022,11 @@ private:
         }
         QString what;
         switch (phase_) {
-            case Phase::ToObj:    what = QObject::tr("vc_tifxyz2obj failed to start."); break;
-            case Phase::Flatboi:  what = QObject::tr("flatboi failed to start.");       break;
-            case Phase::ToTifxyz: what = QObject::tr("vc_obj2tifxyz failed to start."); break;
+            case Phase::ToObj:     what = QObject::tr("vc_tifxyz2obj failed to start."); break;
+            case Phase::Flatboi:   what = QObject::tr("flatboi failed to start.");       break;
+            case Phase::ToObjFine: what = QObject::tr("vc_tifxyz2obj (full-res) failed to start."); break;
+            case Phase::UVLift:    what = QObject::tr("vc_obj_uv_lift failed to start.");break;
+            case Phase::ToTifxyz:  what = QObject::tr("vc_obj2tifxyz failed to start."); break;
             default: break;
         }
         QMessageBox* box = new QMessageBox(QMessageBox::Critical, QObject::tr("Error"),
@@ -1009,9 +1046,11 @@ private:
             const QString err = ioLog_.trimmed();
             QString what;
             switch (phase_) {
-                case Phase::ToObj:    what = QObject::tr("vc_tifxyz2obj failed."); break;
-                case Phase::Flatboi:  what = QObject::tr("flatboi failed.");       break;
-                case Phase::ToTifxyz: what = QObject::tr("vc_obj2tifxyz failed."); break;
+                case Phase::ToObj:     what = QObject::tr("vc_tifxyz2obj failed."); break;
+                case Phase::Flatboi:   what = QObject::tr("flatboi failed.");       break;
+                case Phase::ToObjFine: what = QObject::tr("vc_tifxyz2obj (full-res) failed."); break;
+                case Phase::UVLift:    what = QObject::tr("vc_obj_uv_lift failed.");break;
+                case Phase::ToTifxyz:  what = QObject::tr("vc_obj2tifxyz failed."); break;
                 default: break;
             }
             QMessageBox* box = new QMessageBox(QMessageBox::Critical, QObject::tr("Error"),
@@ -1041,6 +1080,22 @@ private:
 
         if (phase_ == Phase::Flatboi) {
             if (!QFileInfo::exists(flatObj_)) { onFinished_(1, QProcess::NormalExit); return; }
+            if (decimate_ > 0) {
+                startToObjFine_();
+            } else {
+                startToTifxyz_();
+            }
+            return;
+        }
+
+        if (phase_ == Phase::ToObjFine) {
+            if (!QFileInfo::exists(objFine_)) { onFinished_(1, QProcess::NormalExit); return; }
+            startUVLift_();
+            return;
+        }
+
+        if (phase_ == Phase::UVLift) {
+            if (!QFileInfo::exists(liftedObj_)) { onFinished_(1, QProcess::NormalExit); return; }
             startToTifxyz_();
             return;
         }
@@ -1088,14 +1143,17 @@ private:
     // paths & flags
     QString segDir_;
     QString stem_;
-    QString objPath_;
-    QString flatObj_;
+    QString objPath_;     // mesh fed to flatboi (coarse if decimate>0, else full-res)
+    QString objFine_;     // full-res mesh used as UV-lift target when decimating
+    QString flatObj_;     // flatboi output (coarse-flat when decimate>0)
+    QString liftedObj_;   // full-res mesh with UVs lifted from flatObj_
     QString outFinal_;
     QString outTemp_;
     QString flatboiExe_;
     bool    inputIsAlreadyFlat_ = false;
     double  tolerance_ = 0.0;
     QString energy_ = QStringLiteral("symmetric_dirichlet");
+    int     decimate_ = 0;
     double  voxelSize_ = 0.0;
 
     // process & progress
@@ -1115,6 +1173,7 @@ private:
     // resolved executables
     QString tifxyz2objExe_;
     QString obj2tifxyzExe_;
+    QString uvLiftExe_;
 
     bool errorShown_ = false;
 
@@ -1577,6 +1636,7 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
     const int iters = dlg.maxIterations();
     const double tol = dlg.tolerance();
     const QString energy = dlg.energyType();
+    const int decimate = dlg.decimateLevel();
     const QString outputDir = dlg.outputPath();
 
     const QByteArray pastixEnv = qgetenv("PASTIX_NUM_THREADS");
@@ -1588,6 +1648,7 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
               << " iters=" << iters
               << " tol=" << tol
               << " energy=" << energy.toStdString()
+              << " decimate=" << decimate
               << " PASTIX_NUM_THREADS=" << (pastixEnv.isEmpty() ? "<unset, PaStiX auto>" : pastixEnv.toStdString())
               << " hardware_concurrency=" << hwConc
               << std::endl;
@@ -1600,7 +1661,7 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
     } catch (...) {}
     if (!std::isfinite(voxelSize) || voxelSize <= 0.0) voxelSize = 0.0;
 
-    new SlimJob(_parentWidget, segDir, segmentStem, flatboiExe, this, iters, tol, energy, outputDir, voxelSize);
+    new SlimJob(_parentWidget, segDir, segmentStem, flatboiExe, this, iters, tol, energy, decimate, outputDir, voxelSize);
 }
 
 void SegmentationCommandHandler::onABFFlatten(const std::string& segmentId)

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -660,6 +660,7 @@ public:
             double tolerance,
             const QString& energy,
             double keepPercent,
+            bool inpaintHoles,
             const QString& outputDir,
             double voxelSize)
     : QObject(handler)
@@ -678,6 +679,7 @@ public:
     , tolerance_(tolerance)
     , energy_(energy)
     , keepPercent_(keepPercent)
+    , inpaintHoles_(inpaintHoles)
     , voxelSize_(voxelSize)
     , proc_(new QProcess(this))
     , progress_(new QProgressDialog(QObject::tr("Preparing SLIM..."), QObject::tr("Cancel"), 0, 0, parentWidget))
@@ -827,6 +829,9 @@ private:
         if (decimating) {
             args << QStringLiteral("--keep=%1").arg(keepPercent_, 0, 'f', 4);
         }
+        if (inpaintHoles_) {
+            args << QStringLiteral("--inpaint");
+        }
         ioLog_ += QStringLiteral("Running: %1 %2\n").arg(tifxyz2objExe_, args.join(' '));
         proc_->start(tifxyz2objExe_, args);
     }
@@ -837,6 +842,9 @@ private:
         progress_->setLabelText(QObject::tr("Converting TIFXYZ -> full-res OBJ for UV lift..."));
         ioLog_.clear();
         QStringList args; args << segDir_ << objFine_;
+        if (inpaintHoles_) {
+            args << QStringLiteral("--inpaint");
+        }
         ioLog_ += QStringLiteral("Running: %1 %2\n").arg(tifxyz2objExe_, args.join(' '));
         proc_->start(tifxyz2objExe_, args);
     }
@@ -1158,6 +1166,7 @@ private:
     double  tolerance_ = 0.0;
     QString energy_ = QStringLiteral("symmetric_dirichlet");
     double  keepPercent_ = 100.0;
+    bool    inpaintHoles_ = false;
     double  voxelSize_ = 0.0;
 
     // process & progress
@@ -1641,6 +1650,7 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
     const double tol = dlg.tolerance();
     const QString energy = dlg.energyType();
     const double keepPercent = dlg.keepPercent();
+    const bool inpaintHoles = dlg.inpaintHoles();
     const QString outputDir = dlg.outputPath();
 
     const QByteArray pastixEnv = qgetenv("PASTIX_NUM_THREADS");
@@ -1653,6 +1663,7 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
               << " tol=" << tol
               << " energy=" << energy.toStdString()
               << " keep_percent=" << keepPercent
+              << " inpaint=" << (inpaintHoles ? "true" : "false")
               << " PASTIX_NUM_THREADS=" << (pastixEnv.isEmpty() ? "<unset, PaStiX auto>" : pastixEnv.toStdString())
               << " hardware_concurrency=" << hwConc
               << std::endl;
@@ -1665,7 +1676,7 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
     } catch (...) {}
     if (!std::isfinite(voxelSize) || voxelSize <= 0.0) voxelSize = 0.0;
 
-    new SlimJob(_parentWidget, segDir, segmentStem, flatboiExe, this, iters, tol, energy, keepPercent, outputDir, voxelSize);
+    new SlimJob(_parentWidget, segDir, segmentStem, flatboiExe, this, iters, tol, energy, keepPercent, inpaintHoles, outputDir, voxelSize);
 }
 
 void SegmentationCommandHandler::onABFFlatten(const std::string& segmentId)

--- a/volume-cartographer/apps/VC3D/ToolDialogs.cpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.cpp
@@ -1476,7 +1476,7 @@ bool SlimFlattenDialog::s_haveSession = false;
 int SlimFlattenDialog::s_iterations = 50;
 double SlimFlattenDialog::s_tolerance = 1e-5;
 QString SlimFlattenDialog::s_energy = QStringLiteral("symmetric_dirichlet");
-int SlimFlattenDialog::s_decimate = 2;
+double SlimFlattenDialog::s_keepPercent = 1.5;
 
 SlimFlattenDialog::SlimFlattenDialog(QWidget* parent, const QString& defaultOutputPath)
     : QDialog(parent)
@@ -1513,17 +1513,21 @@ SlimFlattenDialog::SlimFlattenDialog(QWidget* parent, const QString& defaultOutp
     cbEnergy_->setToolTip(tr("SLIM energy formulation."));
     form->addRow(tr("Energy:"), cbEnergy_);
 
-    spDecimate_ = new QSpinBox(this);
-    spDecimate_->setRange(0, 4);
-    spDecimate_->setValue(s_haveSession ? s_decimate : 2);
-    spDecimate_->setToolTip(tr(
-        "Decimation level for the SLIM step.\n"
-        "0 = flatten full mesh directly (can OOM or NaN on large segments).\n"
-        "1 = ~11% of grid points.\n"
-        "2 = ~1.2% of grid points (recommended for 2um segments).\n"
-        "Higher = coarser/faster flatten. UVs are lifted back to the full "
-        "mesh via barycentric interpolation when level > 0."));
-    form->addRow(tr("Decimation:"), spDecimate_);
+    spKeepPercent_ = new QDoubleSpinBox(this);
+    spKeepPercent_->setRange(0.1, 100.0);
+    spKeepPercent_->setDecimals(2);
+    spKeepPercent_->setSingleStep(0.5);
+    spKeepPercent_->setSuffix(QStringLiteral(" %"));
+    spKeepPercent_->setValue(s_haveSession ? s_keepPercent : 1.5);
+    spKeepPercent_->setToolTip(tr(
+        "Percent of source grid points to keep for the SLIM flatten step.\n"
+        "100%% = flatten the full mesh directly (can OOM or NaN on large segments).\n"
+        "~25%% = every other point per axis (stride 2).\n"
+        "~11%% = stride 3.\n"
+        "~1.5%% = stride 8 (recommended for 2um Paris segments).\n"
+        "Below 100%%, UVs from the decimated flatten are lifted back to the "
+        "full mesh via barycentric interpolation."));
+    form->addRow(tr("Keep:"), spKeepPercent_);
 
     auto outputRow = new QHBoxLayout();
     edtOutput_ = new QLineEdit(this);
@@ -1560,13 +1564,13 @@ SlimFlattenDialog::SlimFlattenDialog(QWidget* parent, const QString& defaultOutp
         s_iterations = spIterations_->value();
         s_tolerance = spTolerance_->value();
         s_energy = cbEnergy_->currentData().toString();
-        s_decimate = spDecimate_->value();
+        s_keepPercent = spKeepPercent_->value();
     });
 }
 
-int SlimFlattenDialog::decimateLevel() const
+double SlimFlattenDialog::keepPercent() const
 {
-    return spDecimate_ ? spDecimate_->value() : 2;
+    return spKeepPercent_ ? spKeepPercent_->value() : 1.5;
 }
 
 int SlimFlattenDialog::maxIterations() const

--- a/volume-cartographer/apps/VC3D/ToolDialogs.cpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.cpp
@@ -1476,6 +1476,7 @@ bool SlimFlattenDialog::s_haveSession = false;
 int SlimFlattenDialog::s_iterations = 50;
 double SlimFlattenDialog::s_tolerance = 1e-5;
 QString SlimFlattenDialog::s_energy = QStringLiteral("symmetric_dirichlet");
+int SlimFlattenDialog::s_decimate = 2;
 
 SlimFlattenDialog::SlimFlattenDialog(QWidget* parent, const QString& defaultOutputPath)
     : QDialog(parent)
@@ -1512,6 +1513,18 @@ SlimFlattenDialog::SlimFlattenDialog(QWidget* parent, const QString& defaultOutp
     cbEnergy_->setToolTip(tr("SLIM energy formulation."));
     form->addRow(tr("Energy:"), cbEnergy_);
 
+    spDecimate_ = new QSpinBox(this);
+    spDecimate_->setRange(0, 4);
+    spDecimate_->setValue(s_haveSession ? s_decimate : 2);
+    spDecimate_->setToolTip(tr(
+        "Decimation level for the SLIM step.\n"
+        "0 = flatten full mesh directly (can OOM or NaN on large segments).\n"
+        "1 = ~11% of grid points.\n"
+        "2 = ~1.2% of grid points (recommended for 2um segments).\n"
+        "Higher = coarser/faster flatten. UVs are lifted back to the full "
+        "mesh via barycentric interpolation when level > 0."));
+    form->addRow(tr("Decimation:"), spDecimate_);
+
     auto outputRow = new QHBoxLayout();
     edtOutput_ = new QLineEdit(this);
     edtOutput_->setText(defaultOutput_);
@@ -1547,7 +1560,13 @@ SlimFlattenDialog::SlimFlattenDialog(QWidget* parent, const QString& defaultOutp
         s_iterations = spIterations_->value();
         s_tolerance = spTolerance_->value();
         s_energy = cbEnergy_->currentData().toString();
+        s_decimate = spDecimate_->value();
     });
+}
+
+int SlimFlattenDialog::decimateLevel() const
+{
+    return spDecimate_ ? spDecimate_->value() : 2;
 }
 
 int SlimFlattenDialog::maxIterations() const

--- a/volume-cartographer/apps/VC3D/ToolDialogs.cpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.cpp
@@ -1477,6 +1477,7 @@ int SlimFlattenDialog::s_iterations = 50;
 double SlimFlattenDialog::s_tolerance = 1e-5;
 QString SlimFlattenDialog::s_energy = QStringLiteral("symmetric_dirichlet");
 double SlimFlattenDialog::s_keepPercent = 1.5;
+bool SlimFlattenDialog::s_inpaintHoles = false;
 
 SlimFlattenDialog::SlimFlattenDialog(QWidget* parent, const QString& defaultOutputPath)
     : QDialog(parent)
@@ -1529,6 +1530,15 @@ SlimFlattenDialog::SlimFlattenDialog(QWidget* parent, const QString& defaultOutp
         "full mesh via barycentric interpolation."));
     form->addRow(tr("Keep:"), spKeepPercent_);
 
+    cbInpaint_ = new QCheckBox(tr("Fill interior holes (Ceres smoothness inpaint)"), this);
+    cbInpaint_->setChecked(s_haveSession ? s_inpaintHoles : false);
+    cbInpaint_->setToolTip(tr(
+        "Run a Ceres-smoothness fill over isolated invalid grid cells before "
+        "emitting the coarse OBJ. Off by default: SLIM tolerates small holes "
+        "in the decimated mesh and inpainting can blur fine detail. Turn on "
+        "if you see flatten failures attributable to interior holes."));
+    form->addRow(QString(), cbInpaint_);
+
     auto outputRow = new QHBoxLayout();
     edtOutput_ = new QLineEdit(this);
     edtOutput_->setText(defaultOutput_);
@@ -1565,12 +1575,18 @@ SlimFlattenDialog::SlimFlattenDialog(QWidget* parent, const QString& defaultOutp
         s_tolerance = spTolerance_->value();
         s_energy = cbEnergy_->currentData().toString();
         s_keepPercent = spKeepPercent_->value();
+        s_inpaintHoles = cbInpaint_ ? cbInpaint_->isChecked() : false;
     });
 }
 
 double SlimFlattenDialog::keepPercent() const
 {
     return spKeepPercent_ ? spKeepPercent_->value() : 1.5;
+}
+
+bool SlimFlattenDialog::inpaintHoles() const
+{
+    return cbInpaint_ ? cbInpaint_->isChecked() : false;
 }
 
 int SlimFlattenDialog::maxIterations() const

--- a/volume-cartographer/apps/VC3D/ToolDialogs.hpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.hpp
@@ -469,6 +469,7 @@ public:
     // 2-iter stride-3 produced in earlier versions and matches the
     // configuration that converges on 2um Paris segments.
     double keepPercent() const;
+    bool inpaintHoles() const;
 
 private:
     static bool s_haveSession;
@@ -476,11 +477,13 @@ private:
     static double s_tolerance;
     static QString s_energy;
     static double s_keepPercent;
+    static bool s_inpaintHoles;
 
     QSpinBox* spIterations_{nullptr};
     QDoubleSpinBox* spTolerance_{nullptr};
     QComboBox* cbEnergy_{nullptr};
     QDoubleSpinBox* spKeepPercent_{nullptr};
+    QCheckBox* cbInpaint_{nullptr};
     QLineEdit* edtOutput_{nullptr};
     QString defaultOutput_;
 };

--- a/volume-cartographer/apps/VC3D/ToolDialogs.hpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.hpp
@@ -462,16 +462,23 @@ public:
     double tolerance() const;   // 0.0 = disabled (run all iterations)
     QString energyType() const; // "symmetric_dirichlet" or "conformal"
     QString outputPath() const;
+    // 0 = no decimation (flatten full mesh; OOMs / NaNs above ~500k pts).
+    // N>0 = run vc_tifxyz2obj --decimate N for the flatten step, then lift
+    // UVs back to the full mesh via vc_obj_uv_lift. Default 2 keeps ~1.2% of
+    // points -> robust SLIM convergence on big segments.
+    int decimateLevel() const;
 
 private:
     static bool s_haveSession;
     static int s_iterations;
     static double s_tolerance;
     static QString s_energy;
+    static int s_decimate;
 
     QSpinBox* spIterations_{nullptr};
     QDoubleSpinBox* spTolerance_{nullptr};
     QComboBox* cbEnergy_{nullptr};
+    QSpinBox* spDecimate_{nullptr};
     QLineEdit* edtOutput_{nullptr};
     QString defaultOutput_;
 };

--- a/volume-cartographer/apps/VC3D/ToolDialogs.hpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.hpp
@@ -462,23 +462,25 @@ public:
     double tolerance() const;   // 0.0 = disabled (run all iterations)
     QString energyType() const; // "symmetric_dirichlet" or "conformal"
     QString outputPath() const;
-    // 0 = no decimation (flatten full mesh; OOMs / NaNs above ~500k pts).
-    // N>0 = run vc_tifxyz2obj --decimate N for the flatten step, then lift
-    // UVs back to the full mesh via vc_obj_uv_lift. Default 2 keeps ~1.2% of
-    // points -> robust SLIM convergence on big segments.
-    int decimateLevel() const;
+    // Target percentage of source grid points to flatten (1..100). 100 means
+    // no decimation. Below 100 the SLIM step runs on a decimated mesh and
+    // the resulting UVs are lifted back to the full-resolution mesh via
+    // vc_obj_uv_lift. Default 1.5% picks stride~8, which is roughly what
+    // 2-iter stride-3 produced in earlier versions and matches the
+    // configuration that converges on 2um Paris segments.
+    double keepPercent() const;
 
 private:
     static bool s_haveSession;
     static int s_iterations;
     static double s_tolerance;
     static QString s_energy;
-    static int s_decimate;
+    static double s_keepPercent;
 
     QSpinBox* spIterations_{nullptr};
     QDoubleSpinBox* spTolerance_{nullptr};
     QComboBox* cbEnergy_{nullptr};
-    QSpinBox* spDecimate_{nullptr};
+    QDoubleSpinBox* spKeepPercent_{nullptr};
     QLineEdit* edtOutput_{nullptr};
     QString defaultOutput_;
 };

--- a/volume-cartographer/apps/src/vc_obj_uv_lift.cpp
+++ b/volume-cartographer/apps/src/vc_obj_uv_lift.cpp
@@ -1,0 +1,369 @@
+// vc_obj_uv_lift.cpp
+//
+// Lift per-vertex UVs from a flattened coarse mesh onto a high-resolution
+// mesh of the same tifxyz surface. Both meshes are assumed to have come from
+// vc_tifxyz2obj on the same source tifxyz grid (the fine without decimation
+// or at lower decimation level, the coarse with higher decimation), so their
+// OBJ texcoords encode the original source-grid index times a constant
+// (1/meta.scale). That makes the lift exact in 2D grid space: each fine
+// vertex sits inside exactly one quad of the coarse grid, no spatial /
+// nearest-triangle search needed. This avoids the streak / tear artefacts
+// you get from a 3D-nearest lift on multi-layer surfaces (a scroll segment
+// can pass close to itself in 3D while being far apart on the surface).
+//
+// Inputs:
+//   coarse_grid.obj  fine mesh's coarse partner from vc_tifxyz2obj.
+//                    UVs = source-grid index * (1/scale). Provides the
+//                    grid-space layout of the coarse triangulation.
+//   coarse_flat.obj  same triangulation as coarse_grid, but UVs replaced by
+//                    the flattened (SLIM) UVs. Vertex ordering must match
+//                    coarse_grid.obj (this is the case as long as both came
+//                    out of the same vc_tifxyz2obj run -> flatboi).
+//   fine_grid.obj    full-res mesh from vc_tifxyz2obj. UVs = source-grid
+//                    index * (1/scale), same convention as coarse_grid.
+//
+// Output:
+//   out.obj          fine mesh with per-corner UVs lifted from coarse_flat.
+
+#include <igl/readOBJ.h>
+#include <igl/writeOBJ.h>
+
+#include <Eigen/Core>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace fs = std::filesystem;
+
+static void print_usage(const char* argv0) {
+    std::cerr << "Usage: " << argv0
+              << " <coarse_grid.obj> <coarse_flat.obj> <fine_grid.obj> <out.obj>\n"
+              << "  coarse_grid.obj  vc_tifxyz2obj output of the coarse mesh (grid UVs)\n"
+              << "  coarse_flat.obj  flatboi output of coarse_grid.obj (flat UVs)\n"
+              << "  fine_grid.obj    vc_tifxyz2obj output of the fine mesh (grid UVs)\n"
+              << "  out.obj          fine mesh with lifted flat UVs\n";
+}
+
+int main(int argc, char** argv) {
+    if (argc != 5) { print_usage(argv[0]); return 1; }
+
+    const fs::path coarse_grid_path = argv[1];
+    const fs::path coarse_flat_path = argv[2];
+    const fs::path fine_grid_path   = argv[3];
+    const fs::path out_path         = argv[4];
+
+    for (const auto& p : {coarse_grid_path, coarse_flat_path, fine_grid_path}) {
+        if (!fs::exists(p)) { std::cerr << "not found: " << p << "\n"; return 1; }
+    }
+
+    Eigen::MatrixXd Vcg, TCcg, Ncg;
+    Eigen::MatrixXi Fcg, FTCcg, FNcg;
+    if (!igl::readOBJ(coarse_grid_path.string(), Vcg, TCcg, Ncg, Fcg, FTCcg, FNcg)) {
+        std::cerr << "failed to read " << coarse_grid_path << "\n"; return 2;
+    }
+
+    Eigen::MatrixXd Vcf, TCcf, Ncf;
+    Eigen::MatrixXi Fcf, FTCcf, FNcf;
+    if (!igl::readOBJ(coarse_flat_path.string(), Vcf, TCcf, Ncf, Fcf, FTCcf, FNcf)) {
+        std::cerr << "failed to read " << coarse_flat_path << "\n"; return 2;
+    }
+    if (TCcf.rows() == 0 || FTCcf.rows() == 0) {
+        std::cerr << "coarse_flat.obj has no UVs\n"; return 2;
+    }
+    if (!TCcf.allFinite()) {
+        std::cerr << "coarse_flat.obj has non-finite UVs (NaN/Inf). "
+                  << "Upstream flatten diverged; refusing to propagate.\n";
+        return 4;
+    }
+    if (Vcg.rows() != Vcf.rows() || Fcg.rows() != Fcf.rows()) {
+        std::cerr << "coarse_grid and coarse_flat must share vertex/face counts "
+                  << "(V " << Vcg.rows() << " vs " << Vcf.rows()
+                  << ", F " << Fcg.rows() << " vs " << Fcf.rows() << ")\n";
+        return 2;
+    }
+    if (TCcg.rows() == 0 || FTCcg.rows() == 0) {
+        std::cerr << "coarse_grid.obj has no UVs (need grid-space UVs from vc_tifxyz2obj)\n";
+        return 2;
+    }
+
+    Eigen::MatrixXd Vf, TCf, Nf;
+    Eigen::MatrixXi Ff, FTCf, FNf;
+    if (!igl::readOBJ(fine_grid_path.string(), Vf, TCf, Nf, Ff, FTCf, FNf)) {
+        std::cerr << "failed to read " << fine_grid_path << "\n"; return 2;
+    }
+    if (TCf.rows() == 0 || FTCf.rows() == 0) {
+        std::cerr << "fine_grid.obj has no UVs (need grid-space UVs from vc_tifxyz2obj)\n";
+        return 2;
+    }
+
+    std::cout << "Coarse grid: V=" << Vcg.rows() << " F=" << Fcg.rows()
+              << " TC=" << TCcg.rows() << "\n";
+    std::cout << "Coarse flat: V=" << Vcf.rows() << " F=" << Fcf.rows()
+              << " TC=" << TCcf.rows() << "\n";
+    std::cout << "Fine grid:   V=" << Vf.rows()  << " F=" << Ff.rows()
+              << " TC=" << TCf.rows() << "\n";
+
+    // Per-coarse-vertex grid-UV: average the per-corner grid UV across all
+    // corners that reference this vertex. (vc_tifxyz2obj actually assigns one
+    // (vt) per unique grid cell, so all corners for a given vertex share the
+    // same UV; the loop is just defensive.)
+    Eigen::MatrixXd vert_uv = Eigen::MatrixXd::Zero(Vcg.rows(), 2);
+    Eigen::VectorXi vert_uv_n = Eigen::VectorXi::Zero(Vcg.rows());
+    for (int t = 0; t < Fcg.rows(); ++t) {
+        for (int k = 0; k < 3; ++k) {
+            const int v  = Fcg(t, k);
+            const int tc = FTCcg(t, k);
+            vert_uv.row(v) += TCcg.row(tc);
+            vert_uv_n(v)   += 1;
+        }
+    }
+    for (int i = 0; i < Vcg.rows(); ++i) {
+        if (vert_uv_n(i) > 0) vert_uv.row(i) /= double(vert_uv_n(i));
+    }
+
+    // Per-fine-vertex grid UV (averaged across corners as above).
+    // Computed early so we can derive the coarse->fine UV scale from bboxes.
+    Eigen::MatrixXd fine_grid_uv = Eigen::MatrixXd::Zero(Vf.rows(), 2);
+    Eigen::VectorXi fine_grid_n  = Eigen::VectorXi::Zero(Vf.rows());
+    for (int t = 0; t < Ff.rows(); ++t) {
+        for (int k = 0; k < 3; ++k) {
+            fine_grid_uv.row(Ff(t, k)) += TCf.row(FTCf(t, k));
+            fine_grid_n(Ff(t, k))      += 1;
+        }
+    }
+    for (int i = 0; i < Vf.rows(); ++i) {
+        if (fine_grid_n(i) > 0) fine_grid_uv.row(i) /= double(fine_grid_n(i));
+    }
+
+    // The coarse and fine OBJs both encode source-grid-pixel * (1/scale) as
+    // their UVs, BUT the coarse mesh's "source grid" is itself the decimated
+    // grid. So coarse_UV * stride^N == fine_UV. Recover that scale from the
+    // bbox ratios so we don't need to know the decimation level here. Apply
+    // to the coarse-grid UVs so both meshes live in the same coordinate
+    // system.
+    {
+        Eigen::RowVector2d cmn = vert_uv.colwise().minCoeff();
+        Eigen::RowVector2d cmx = vert_uv.colwise().maxCoeff();
+        Eigen::RowVector2d fmn = fine_grid_uv.colwise().minCoeff();
+        Eigen::RowVector2d fmx = fine_grid_uv.colwise().maxCoeff();
+        const double cu_span = std::max(1e-12, cmx(0) - cmn(0));
+        const double cv_span = std::max(1e-12, cmx(1) - cmn(1));
+        const double fu_span = std::max(1e-12, fmx(0) - fmn(0));
+        const double fv_span = std::max(1e-12, fmx(1) - fmn(1));
+        const double su = fu_span / cu_span;
+        const double sv = fv_span / cv_span;
+        std::cout << "Coarse->fine UV scale: u=" << su << " v=" << sv
+                  << "  (coarse bbox " << cu_span << "x" << cv_span
+                  << ", fine bbox " << fu_span << "x" << fv_span << ")\n";
+        // Rebase coarse UVs onto fine UV origin and rescale to fine units.
+        for (int i = 0; i < vert_uv.rows(); ++i) {
+            vert_uv(i, 0) = fmn(0) + (vert_uv(i, 0) - cmn(0)) * su;
+            vert_uv(i, 1) = fmn(1) + (vert_uv(i, 1) - cmn(1)) * sv;
+        }
+    }
+
+    // AABB of all coarse grid-UVs (now in fine-UV coords) and bin sizing.
+    Eigen::RowVector2d uv_min = vert_uv.colwise().minCoeff();
+    Eigen::RowVector2d uv_max = vert_uv.colwise().maxCoeff();
+    const double udu = std::max(1e-12, uv_max(0) - uv_min(0));
+    const double vdu = std::max(1e-12, uv_max(1) - uv_min(1));
+
+    // Estimate cell size in coarse-UV from coarse vertex count: ~sqrt(V/area).
+    const double cells_per_axis = std::max(8.0, std::sqrt(double(Vcg.rows())) * 0.5);
+    const double cu = udu / cells_per_axis;
+    const double cv = vdu / cells_per_axis;
+    const int    bins_u = std::max(1, int(std::ceil(udu / cu)));
+    const int    bins_v = std::max(1, int(std::ceil(vdu / cv)));
+    std::cout << "Lift hash grid: " << bins_u << " x " << bins_v
+              << " (coarse-UV bbox [" << uv_min(0) << "," << uv_min(1)
+              << "] -> [" << uv_max(0) << "," << uv_max(1) << "])\n";
+
+    auto bin_idx = [&](double u, double v) -> std::pair<int,int> {
+        int bu = int(std::floor((u - uv_min(0)) / cu));
+        int bv = int(std::floor((v - uv_min(1)) / cv));
+        bu = std::clamp(bu, 0, bins_u - 1);
+        bv = std::clamp(bv, 0, bins_v - 1);
+        return {bu, bv};
+    };
+
+    std::vector<std::vector<int>> bins(static_cast<size_t>(bins_u) * bins_v);
+    auto bin_at = [&](int bu, int bv) -> std::vector<int>& {
+        return bins[size_t(bv) * bins_u + bu];
+    };
+
+    // For each coarse triangle, push its index into every bin its UV-bbox
+    // overlaps.
+    for (int t = 0; t < Fcg.rows(); ++t) {
+        const Eigen::RowVector2d a = vert_uv.row(Fcg(t, 0));
+        const Eigen::RowVector2d b = vert_uv.row(Fcg(t, 1));
+        const Eigen::RowVector2d c = vert_uv.row(Fcg(t, 2));
+        const double tu_min = std::min({a(0), b(0), c(0)});
+        const double tu_max = std::max({a(0), b(0), c(0)});
+        const double tv_min = std::min({a(1), b(1), c(1)});
+        const double tv_max = std::max({a(1), b(1), c(1)});
+        auto [bu0, bv0] = bin_idx(tu_min, tv_min);
+        auto [bu1, bv1] = bin_idx(tu_max, tv_max);
+        for (int bv = bv0; bv <= bv1; ++bv)
+            for (int bu = bu0; bu <= bu1; ++bu)
+                bin_at(bu, bv).push_back(t);
+    }
+
+    auto point_in_tri = [](const Eigen::RowVector2d& p,
+                           const Eigen::RowVector2d& a,
+                           const Eigen::RowVector2d& b,
+                           const Eigen::RowVector2d& c,
+                           double& w0, double& w1, double& w2) -> bool {
+        const double v0u = b(0) - a(0), v0v = b(1) - a(1);
+        const double v1u = c(0) - a(0), v1v = c(1) - a(1);
+        const double v2u = p(0) - a(0), v2v = p(1) - a(1);
+        const double den = v0u * v1v - v1u * v0v;
+        if (std::abs(den) < 1e-30) return false;
+        w1 = (v2u * v1v - v1u * v2v) / den;
+        w2 = (v0u * v2v - v2u * v0v) / den;
+        w0 = 1.0 - w1 - w2;
+        const double eps = -1e-9;
+        return (w0 >= eps && w1 >= eps && w2 >= eps);
+    };
+
+    // Per-coarse-vertex flat UV (same averaging trick).
+    Eigen::MatrixXd flat_vert_uv = Eigen::MatrixXd::Zero(Vcf.rows(), 2);
+    Eigen::VectorXi flat_vert_n  = Eigen::VectorXi::Zero(Vcf.rows());
+    for (int t = 0; t < Fcf.rows(); ++t) {
+        for (int k = 0; k < 3; ++k) {
+            flat_vert_uv.row(Fcf(t, k)) += TCcf.row(FTCcf(t, k));
+            flat_vert_n(Fcf(t, k))      += 1;
+        }
+    }
+    for (int i = 0; i < Vcf.rows(); ++i) {
+        if (flat_vert_n(i) > 0) flat_vert_uv.row(i) /= double(flat_vert_n(i));
+    }
+
+    Eigen::MatrixXd UVf(Vf.rows(), 2);
+    std::atomic<long> misses{0};
+    std::atomic<long> fallback{0};
+    #pragma omp parallel for schedule(static)
+    for (int i = 0; i < Vf.rows(); ++i) {
+        const Eigen::RowVector2d p = fine_grid_uv.row(i);
+        auto [bu, bv] = bin_idx(p(0), p(1));
+        bool found = false;
+        double bw0 = 0, bw1 = 0, bw2 = 0;
+        int bt = -1;
+        // Look in the bin and its neighbors. We widen the radius for the
+        // border row/column where a fine vertex's nominal grid-UV can sit
+        // slightly outside the convex hull of any coarse triangle (e.g. the
+        // last fine row that decimation dropped).
+        for (int dv = -2; dv <= 2 && !found; ++dv) {
+            for (int du = -2; du <= 2 && !found; ++du) {
+                const int qu = bu + du, qv = bv + dv;
+                if (qu < 0 || qv < 0 || qu >= bins_u || qv >= bins_v) continue;
+                for (int t : bin_at(qu, qv)) {
+                    double w0, w1, w2;
+                    const Eigen::RowVector2d a = vert_uv.row(Fcg(t, 0));
+                    const Eigen::RowVector2d b = vert_uv.row(Fcg(t, 1));
+                    const Eigen::RowVector2d c = vert_uv.row(Fcg(t, 2));
+                    if (point_in_tri(p, a, b, c, w0, w1, w2)) {
+                        bw0 = w0; bw1 = w1; bw2 = w2;
+                        bt = t;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (!found) {
+            // Fallback for fine vertices that sit just outside the coarse
+            // triangulation (boundary row/col dropped by decimation): clamp p
+            // into the coarse-UV bbox and re-search a small neighborhood.
+            // Avoids the O(V_coarse) brute-force loop that would otherwise
+            // dominate runtime on big meshes.
+            misses.fetch_add(1, std::memory_order_relaxed);
+            Eigen::RowVector2d pc(
+                std::clamp(p(0), uv_min(0), uv_max(0)),
+                std::clamp(p(1), uv_min(1), uv_max(1)));
+            auto [bu2, bv2] = bin_idx(pc(0), pc(1));
+            for (int dv = -2; dv <= 2 && !found; ++dv) {
+                for (int du = -2; du <= 2 && !found; ++du) {
+                    const int qu = bu2 + du, qv = bv2 + dv;
+                    if (qu < 0 || qv < 0 || qu >= bins_u || qv >= bins_v) continue;
+                    for (int t : bin_at(qu, qv)) {
+                        double w0, w1, w2;
+                        const Eigen::RowVector2d a = vert_uv.row(Fcg(t, 0));
+                        const Eigen::RowVector2d b = vert_uv.row(Fcg(t, 1));
+                        const Eigen::RowVector2d c = vert_uv.row(Fcg(t, 2));
+                        if (point_in_tri(pc, a, b, c, w0, w1, w2)) {
+                            bw0 = w0; bw1 = w1; bw2 = w2;
+                            bt = t;
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (!found) {
+                // Last resort: nearest coarse vertex in this bin / neighbors.
+                int best = -1;
+                double bestD = std::numeric_limits<double>::infinity();
+                for (int dv = -2; dv <= 2; ++dv) {
+                    for (int du = -2; du <= 2; ++du) {
+                        const int qu = bu2 + du, qv = bv2 + dv;
+                        if (qu < 0 || qv < 0 || qu >= bins_u || qv >= bins_v) continue;
+                        for (int t : bin_at(qu, qv)) {
+                            for (int k = 0; k < 3; ++k) {
+                                const int v = Fcg(t, k);
+                                const double du_ = vert_uv(v, 0) - pc(0);
+                                const double dv_ = vert_uv(v, 1) - pc(1);
+                                const double d = du_*du_ + dv_*dv_;
+                                if (d < bestD) { bestD = d; best = v; }
+                            }
+                        }
+                    }
+                }
+                if (best >= 0) {
+                    UVf.row(i) = flat_vert_uv.row(best);
+                    fallback.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    UVf.row(i).setZero();
+                }
+                continue;
+            }
+            // Fell through here means clamp+expand found a triangle -> fall
+            // through to the normal barycentric write below.
+        }
+        UVf.row(i) = bw0 * flat_vert_uv.row(Fcg(bt, 0))
+                   + bw1 * flat_vert_uv.row(Fcg(bt, 1))
+                   + bw2 * flat_vert_uv.row(Fcg(bt, 2));
+    }
+    if (misses.load() > 0) {
+        std::cout << "Lift fell back to nearest-vertex for " << misses.load()
+                  << " / " << Vf.rows() << " fine vertices"
+                  << " (resolved=" << fallback.load() << ")\n";
+    }
+
+    Eigen::MatrixXd UVc_out(Ff.rows() * 3, 2);
+    Eigen::MatrixXi FUV(Ff.rows(), 3);
+    for (int t = 0; t < Ff.rows(); ++t) {
+        for (int k = 0; k < 3; ++k) {
+            const int corner = t * 3 + k;
+            UVc_out.row(corner) = UVf.row(Ff(t, k));
+            FUV(t, k) = corner;
+        }
+    }
+
+    Eigen::MatrixXd CN; CN.resize(0, 3);
+    Eigen::MatrixXi FN; FN.resize(0, 3);
+    if (!igl::writeOBJ(out_path.string(), Vf, Ff, CN, FN, UVc_out, FUV)) {
+        std::cerr << "failed to write " << out_path << "\n"; return 3;
+    }
+    std::cout << "Wrote: " << out_path << "\n";
+    return 0;
+}

--- a/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
@@ -44,53 +44,6 @@ static inline cv::Vec3f fd_fallback_normal(const cv::Mat_<cv::Vec3f>& P, int y, 
 }
 // ---------------------------------------------------------------------------
 
-// Decimates a grid of points by keeping every nth point in both dimensions
-// This reduces the total point count by approximately (1 - 1/stride²)
-// For stride=3, this keeps ~11% of points (close to the 10% target)
-// For stride=2, keeps ~25% (every other point in each axis).
-static cv::Mat_<cv::Vec3f> decimate_grid(const cv::Mat_<cv::Vec3f>& points, int iterations = 1, int stride = 3)
-{
-    if (iterations <= 0) return points.clone();
-    if (stride < 2) stride = 2;
-
-    cv::Mat_<cv::Vec3f> result = points.clone();
-
-    for (int iter = 0; iter < iterations; ++iter) {
-
-        // Calculate new dimensions
-        int new_rows = (result.rows + stride - 1) / stride;
-        int new_cols = (result.cols + stride - 1) / stride;
-
-        cv::Mat_<cv::Vec3f> decimated(new_rows, new_cols);
-
-        // Sample every stride-th point
-        for (int j = 0; j < new_rows; ++j) {
-            for (int i = 0; i < new_cols; ++i) {
-                int src_j = j * stride;
-                int src_i = i * stride;
-
-                // Ensure we don't go out of bounds
-                if (src_j < result.rows && src_i < result.cols) {
-                    decimated(j, i) = result(src_j, src_i);
-                } else {
-                    // Handle edge case - use the last valid point
-                    src_j = std::min(src_j, result.rows - 1);
-                    src_i = std::min(src_i, result.cols - 1);
-                    decimated(j, i) = result(src_j, src_i);
-                }
-            }
-        }
-
-        result = decimated;
-
-        std::cout << "Decimation iteration " << (iter + 1) << ": "
-                  << "reduced to " << new_rows << " x " << new_cols
-                  << " (" << (new_rows * new_cols) << " points)" << std::endl;
-    }
-
-    return result;
-}
-
 // Decimates a grid by a target ratio (e.g., 0.5 keeps ~50% of points)
 // Computes the appropriate stride from the ratio: stride = 1/sqrt(ratio)
 static cv::Mat_<cv::Vec3f> decimate_grid_ratio(const cv::Mat_<cv::Vec3f>& points, float ratio)
@@ -220,7 +173,7 @@ static cv::Mat_<cv::Vec3f> build_vertex_normals_from_faces(
     return nsum;
 }
 
-static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_fn, bool normalize_uv, bool align_grid, int decimate_iterations, int decimate_stride, bool clean_surface, float clean_sigma_k, bool inpaint_holes)
+static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_fn, bool normalize_uv, bool align_grid, float keep_percent, bool clean_surface, float clean_sigma_k, bool inpaint_holes)
 {
     cv::Mat_<cv::Vec3f> points = surf->rawPoints();
     
@@ -259,11 +212,13 @@ static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_f
         }
     }
     
-    // Apply decimation if requested
-    if (decimate_iterations > 0) {
+    // Apply decimation if requested: one pass, stride derived from the
+    // requested keep fraction (decimate_grid_ratio computes stride =
+    // round(1/sqrt(p))). Skip when keep_percent >= 100 (no decimation).
+    if (keep_percent > 0.0f && keep_percent < 100.0f) {
         std::cout << "Original grid: " << points.rows << " x " << points.cols
                   << " (" << (points.rows * points.cols) << " points)" << std::endl;
-        points = decimate_grid(points, decimate_iterations, decimate_stride);
+        points = decimate_grid_ratio(points, keep_percent / 100.0f);
     }
 
     // Fill isolated interior holes that would otherwise create extra boundary
@@ -332,11 +287,10 @@ static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_f
 int main(int argc, char *argv[])
 {
     if (argc == 2 && (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help")) {
-        std::cout << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv] [--align-grid] [--decimate [iterations]] [--clean [K]] [--no-inpaint]\n"
+        std::cout << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv] [--align-grid] [--keep=<p>] [--clean [K]] [--no-inpaint]\n"
                   << "  --normalize-uv : Normalize UVs to [0,1] range\n"
                   << "  --align-grid   : Align grid Z only (flatten Z per row)\n"
-                  << "  --decimate [n] : Reduce points by ~90% per iteration (default n=1)\n"
-                  << "  --decimate-stride=<s> : Stride per axis when decimating (default 3 -> ~11% per iter; use 2 to keep every other -> ~25%)\n"
+                  << "  --keep=<p>     : Percent of source points to keep (1..100). 100 = no decimation. One pass; stride = round(1/sqrt(p/100)).\n"
                   << "  --clean [K]    : Remove outlier points far from surface using robust distance threshold; K is sigma multiplier (default 5.0)\n"
                   << "  --no-inpaint   : Disable filling of isolated invalid cells; on by default to prevent flattening NaNs from interior holes\n";
         return EXIT_SUCCESS;
@@ -344,7 +298,7 @@ int main(int argc, char *argv[])
 
     if (argc < 3) {
     std::cerr << "error: too few arguments\n"
-                  << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv] [--align-grid] [--decimate [iterations]] [--clean [K]] [--no-inpaint]\n";
+                  << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv] [--align-grid] [--keep=<p>] [--clean [K]] [--no-inpaint]\n";
         return EXIT_FAILURE;
     }
 
@@ -352,8 +306,7 @@ int main(int argc, char *argv[])
     bool align_grid = false;
     bool clean_surface = false;
     float clean_sigma_k = 5.0f; // default K
-    int decimate_iterations = 0;
-    int decimate_stride = 3;
+    float keep_percent = 100.0f; // 100 = no decimation
     bool inpaint_holes = true;
     
     // Parse optional arguments
@@ -363,27 +316,18 @@ int main(int argc, char *argv[])
             normalize_uv = true;
         } else if (arg == "--align-grid") {
             align_grid = true;
-        } else if (arg == "--decimate") {
-            decimate_iterations = 1; // Default to 1 iteration
-            
-            // Check if next argument is a number (iterations)
-            if (i + 1 < argc) {
-                std::string next = argv[i + 1];
-                try {
-                    int iters = std::stoi(next);
-                    if (iters > 0) {
-                        decimate_iterations = iters;
-                        ++i; // Skip the number argument
-                    }
-                } catch (...) {
-                    // Not a number, continue with default of 1
-                }
-            }
-        } else if (arg.rfind("--decimate-stride=", 0) == 0) {
+        } else if (arg.rfind("--keep=", 0) == 0) {
             try {
-                int s = std::stoi(arg.substr(18));
-                if (s >= 2) decimate_stride = s;
-            } catch (...) { /* keep default */ }
+                float p = std::stof(arg.substr(7));
+                if (p > 0.0f && p <= 100.0f) keep_percent = p;
+                else {
+                    std::cerr << "error: --keep must be in (0, 100]\n";
+                    return EXIT_FAILURE;
+                }
+            } catch (...) {
+                std::cerr << "error: --keep needs a numeric percent\n";
+                return EXIT_FAILURE;
+            }
         } else if (arg == "--no-inpaint") {
             inpaint_holes = false;
         } else if (arg == "--clean") {
@@ -420,7 +364,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    surf_write_obj(surf.get(), obj_path, normalize_uv, align_grid, decimate_iterations, decimate_stride, clean_surface, clean_sigma_k, inpaint_holes);
+    surf_write_obj(surf.get(), obj_path, normalize_uv, align_grid, keep_percent, clean_surface, clean_sigma_k, inpaint_holes);
 
     return EXIT_SUCCESS;
 }

--- a/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
@@ -292,7 +292,8 @@ int main(int argc, char *argv[])
                   << "  --align-grid   : Align grid Z only (flatten Z per row)\n"
                   << "  --keep=<p>     : Percent of source points to keep (1..100). 100 = no decimation. One pass; stride = round(1/sqrt(p/100)).\n"
                   << "  --clean [K]    : Remove outlier points far from surface using robust distance threshold; K is sigma multiplier (default 5.0)\n"
-                  << "  --no-inpaint   : Disable filling of isolated invalid cells; on by default to prevent flattening NaNs from interior holes\n";
+                  << "  --inpaint      : Fill isolated invalid cells via Ceres-smoothness solve before emitting OBJ. Off by default.\n"
+                  << "  --no-inpaint   : Legacy alias (inpaint is off by default now).\n";
         return EXIT_SUCCESS;
     }
 
@@ -307,7 +308,7 @@ int main(int argc, char *argv[])
     bool clean_surface = false;
     float clean_sigma_k = 5.0f; // default K
     float keep_percent = 100.0f; // 100 = no decimation
-    bool inpaint_holes = true;
+    bool inpaint_holes = false;
     
     // Parse optional arguments
     for (int i = 3; i < argc; ++i) {
@@ -328,6 +329,8 @@ int main(int argc, char *argv[])
                 std::cerr << "error: --keep needs a numeric percent\n";
                 return EXIT_FAILURE;
             }
+        } else if (arg == "--inpaint") {
+            inpaint_holes = true;
         } else if (arg == "--no-inpaint") {
             inpaint_holes = false;
         } else if (arg == "--clean") {

--- a/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
@@ -1,5 +1,6 @@
 // vc_tifxyz2obj.cpp
 #include "vc/core/util/Geometry.hpp"
+#include "vc/core/util/InpaintSurface.hpp"
 #include "vc/core/util/Slicing.hpp"
 #include "vc/core/util/Surface.hpp"
 #include "vc/core/util/QuadSurface.hpp"
@@ -46,15 +47,15 @@ static inline cv::Vec3f fd_fallback_normal(const cv::Mat_<cv::Vec3f>& P, int y, 
 // Decimates a grid of points by keeping every nth point in both dimensions
 // This reduces the total point count by approximately (1 - 1/stride²)
 // For stride=3, this keeps ~11% of points (close to the 10% target)
-static cv::Mat_<cv::Vec3f> decimate_grid(const cv::Mat_<cv::Vec3f>& points, int iterations = 1)
+// For stride=2, keeps ~25% (every other point in each axis).
+static cv::Mat_<cv::Vec3f> decimate_grid(const cv::Mat_<cv::Vec3f>& points, int iterations = 1, int stride = 3)
 {
     if (iterations <= 0) return points.clone();
+    if (stride < 2) stride = 2;
 
     cv::Mat_<cv::Vec3f> result = points.clone();
 
     for (int iter = 0; iter < iterations; ++iter) {
-        // Use stride of 3 to achieve ~89% reduction (keeping ~11%)
-        const int stride = 3;
 
         // Calculate new dimensions
         int new_rows = (result.rows + stride - 1) / stride;
@@ -219,7 +220,7 @@ static cv::Mat_<cv::Vec3f> build_vertex_normals_from_faces(
     return nsum;
 }
 
-static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_fn, bool normalize_uv, bool align_grid, int decimate_iterations, bool clean_surface, float clean_sigma_k)
+static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_fn, bool normalize_uv, bool align_grid, int decimate_iterations, int decimate_stride, bool clean_surface, float clean_sigma_k, bool inpaint_holes)
 {
     cv::Mat_<cv::Vec3f> points = surf->rawPoints();
     
@@ -260,11 +261,22 @@ static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_f
     
     // Apply decimation if requested
     if (decimate_iterations > 0) {
-        std::cout << "Original grid: " << points.rows << " x " << points.cols 
+        std::cout << "Original grid: " << points.rows << " x " << points.cols
                   << " (" << (points.rows * points.cols) << " points)" << std::endl;
-        points = decimate_grid(points, decimate_iterations);
+        points = decimate_grid(points, decimate_iterations, decimate_stride);
     }
-    
+
+    // Fill isolated interior holes that would otherwise create extra boundary
+    // loops in the OBJ and break downstream flattening (SLIM goes NaN).
+    if (inpaint_holes) {
+        const int filled = vc::core::util::inpaintSurfaceHoles(points);
+        if (filled > 0) {
+            std::cerr << "warning: inpainted " << filled
+                      << " invalid surface cell(s) from local neighbors "
+                      << "(holes can break flattening; pass --no-inpaint to disable)\n";
+        }
+    }
+
     cv::Mat_<int> idxs(points.size(), -1);
 
     std::ofstream out(out_fn);
@@ -320,17 +332,19 @@ static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_f
 int main(int argc, char *argv[])
 {
     if (argc == 2 && (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help")) {
-        std::cout << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv] [--align-grid] [--decimate [iterations]] [--clean [K]]\n"
+        std::cout << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv] [--align-grid] [--decimate [iterations]] [--clean [K]] [--no-inpaint]\n"
                   << "  --normalize-uv : Normalize UVs to [0,1] range\n"
                   << "  --align-grid   : Align grid Z only (flatten Z per row)\n"
                   << "  --decimate [n] : Reduce points by ~90% per iteration (default n=1)\n"
-                  << "  --clean [K]    : Remove outlier points far from surface using robust distance threshold; K is sigma multiplier (default 5.0)\n";
+                  << "  --decimate-stride=<s> : Stride per axis when decimating (default 3 -> ~11% per iter; use 2 to keep every other -> ~25%)\n"
+                  << "  --clean [K]    : Remove outlier points far from surface using robust distance threshold; K is sigma multiplier (default 5.0)\n"
+                  << "  --no-inpaint   : Disable filling of isolated invalid cells; on by default to prevent flattening NaNs from interior holes\n";
         return EXIT_SUCCESS;
     }
 
     if (argc < 3) {
     std::cerr << "error: too few arguments\n"
-                  << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv] [--align-grid] [--decimate [iterations]] [--clean [K]]\n";
+                  << "usage: " << argv[0] << " <tiffxyz> <obj> [--normalize-uv] [--align-grid] [--decimate [iterations]] [--clean [K]] [--no-inpaint]\n";
         return EXIT_FAILURE;
     }
 
@@ -339,6 +353,8 @@ int main(int argc, char *argv[])
     bool clean_surface = false;
     float clean_sigma_k = 5.0f; // default K
     int decimate_iterations = 0;
+    int decimate_stride = 3;
+    bool inpaint_holes = true;
     
     // Parse optional arguments
     for (int i = 3; i < argc; ++i) {
@@ -363,6 +379,13 @@ int main(int argc, char *argv[])
                     // Not a number, continue with default of 1
                 }
             }
+        } else if (arg.rfind("--decimate-stride=", 0) == 0) {
+            try {
+                int s = std::stoi(arg.substr(18));
+                if (s >= 2) decimate_stride = s;
+            } catch (...) { /* keep default */ }
+        } else if (arg == "--no-inpaint") {
+            inpaint_holes = false;
         } else if (arg == "--clean") {
             clean_surface = true;
             // Optional numeric K argument following --clean
@@ -397,7 +420,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    surf_write_obj(surf.get(), obj_path, normalize_uv, align_grid, decimate_iterations, clean_surface, clean_sigma_k);
+    surf_write_obj(surf.get(), obj_path, normalize_uv, align_grid, decimate_iterations, decimate_stride, clean_surface, clean_sigma_k, inpaint_holes);
 
     return EXIT_SUCCESS;
 }

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -79,6 +79,9 @@ target_link_libraries(vc_ui PUBLIC vc_core Qt6::Core Qt6::Gui Qt6::Widgets)
 add_library(vc_flattening src/ABFFlattening.cpp)
 target_link_libraries(vc_flattening PUBLIC vc_core OpenABF)
 
+add_library(vc_inpaint src/InpaintSurface.cpp)
+target_link_libraries(vc_inpaint PUBLIC vc_core PRIVATE Ceres::ceres)
+
 add_library(vc_tracer
     src/GrowPatch.cpp
     src/GrowSurface.cpp

--- a/volume-cartographer/core/include/vc/core/util/InpaintSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/InpaintSurface.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <opencv2/core.hpp>
+
+namespace vc::core::util {
+
+// Ceres-powered inpainting of invalid cells in a tifxyz-style point grid.
+//
+// A cell is invalid if any channel is non-finite or x == -1 (sentinel). For
+// each connected component of invalid cells that does NOT touch the grid
+// border (i.e. genuine interior holes), the function solves a small
+// least-squares problem on a dilated ROI with two losses:
+//   - DistLoss: preserve 4-neighbor grid spacing (target = unit voxels apart)
+//   - StraightLoss: penalize bending along grid rows/columns
+// Boundary-ring cells around the ROI are fixed. The unknowns are the invalid
+// interior cells, seeded by a quick 4-neighbor diffusion pass.
+//
+// Cells touching the grid border are left untouched (legitimate outer
+// padding). Returns the number of invalid cells that were filled in.
+int inpaintSurfaceHoles(cv::Mat_<cv::Vec3f>& points,
+                        double unit = 1.0,
+                        int max_iters = 2000);
+
+} // namespace vc::core::util

--- a/volume-cartographer/core/src/InpaintSurface.cpp
+++ b/volume-cartographer/core/src/InpaintSurface.cpp
@@ -1,0 +1,258 @@
+#include "vc/core/util/InpaintSurface.hpp"
+
+#include <ceres/ceres.h>
+#include <opencv2/imgproc.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <queue>
+#include <vector>
+
+namespace vc::core::util {
+
+namespace {
+
+inline bool isValid(const cv::Vec3f& p)
+{
+    return p[0] != -1.f
+        && std::isfinite(p[0])
+        && std::isfinite(p[1])
+        && std::isfinite(p[2]);
+}
+
+// 4-neighbor mean fill: cheap initial guess so the Ceres solve starts from a
+// reasonable point and DistLoss isn't seeded at a singularity.
+void diffuseFill(cv::Mat_<cv::Vec3d>& pts, cv::Mat_<uchar>& unknown)
+{
+    const int rows = pts.rows;
+    const int cols = pts.cols;
+    for (int iter = 0; iter < 64; ++iter) {
+        cv::Mat_<cv::Vec3d> next = pts.clone();
+        cv::Mat_<uchar> next_unknown = unknown.clone();
+        int changed = 0;
+        for (int r = 0; r < rows; ++r) {
+            for (int c = 0; c < cols; ++c) {
+                if (!unknown(r, c)) continue;
+                cv::Vec3d sum(0, 0, 0);
+                int n = 0;
+                if (r > 0 && !unknown(r - 1, c)) { sum += pts(r - 1, c); ++n; }
+                if (r + 1 < rows && !unknown(r + 1, c)) { sum += pts(r + 1, c); ++n; }
+                if (c > 0 && !unknown(r, c - 1)) { sum += pts(r, c - 1); ++n; }
+                if (c + 1 < cols && !unknown(r, c + 1)) { sum += pts(r, c + 1); ++n; }
+                if (n > 0) {
+                    next(r, c) = sum * (1.0 / n);
+                    next_unknown(r, c) = 0;
+                    ++changed;
+                }
+            }
+        }
+        pts = std::move(next);
+        unknown = std::move(next_unknown);
+        if (changed == 0) break;
+    }
+}
+
+// 4-neighbor edge-length preservation: ||a - b|| should equal _d.
+struct DistLoss {
+    DistLoss(double d, double w) : _d(d), _w(w) {}
+    template <typename T>
+    bool operator()(const T* const a, const T* const b, T* residual) const
+    {
+        T d[3] = { a[0] - b[0], a[1] - b[1], a[2] - b[2] };
+        T dist_sq = d[0]*d[0] + d[1]*d[1] + d[2]*d[2];
+        if (dist_sq <= T(0)) {
+            residual[0] = T(_w) * (d[0]*d[0] + d[1]*d[1] + d[2]*d[2] - T(1));
+            return true;
+        }
+        const T dist = sqrt(dist_sq);
+        const T d_sq = T(_d) * T(_d);
+        if (dist_sq < d_sq) residual[0] = T(_w) * (T(_d) / dist - T(1));
+        else                residual[0] = T(_w) * (dist / T(_d) - T(1));
+        return true;
+    }
+    static ceres::CostFunction* Create(double d, double w = 1.0)
+    {
+        return new ceres::AutoDiffCostFunction<DistLoss, 1, 3, 3>(new DistLoss(d, w));
+    }
+    double _d, _w;
+};
+
+// Collinearity penalty for a triple (a, b, c) along a grid line.
+struct StraightLoss {
+    explicit StraightLoss(double w) : _w(w) {}
+    template <typename T>
+    bool operator()(const T* const a, const T* const b, const T* const c, T* residual) const
+    {
+        T d1[3] = { b[0] - a[0], b[1] - a[1], b[2] - a[2] };
+        T d2[3] = { c[0] - b[0], c[1] - b[1], c[2] - b[2] };
+        T l1_sq = d1[0]*d1[0] + d1[1]*d1[1] + d1[2]*d1[2];
+        T l2_sq = d2[0]*d2[0] + d2[1]*d2[1] + d2[2]*d2[2];
+        if (l1_sq <= T(1e-24) || l2_sq <= T(1e-24)) { residual[0] = T(0); return true; }
+        T dot = (d1[0]*d2[0] + d1[1]*d2[1] + d1[2]*d2[2]) / (sqrt(l1_sq) * sqrt(l2_sq));
+        residual[0] = T(_w) * (T(1) - dot);
+        return true;
+    }
+    static ceres::CostFunction* Create(double w = 1.0)
+    {
+        return new ceres::AutoDiffCostFunction<StraightLoss, 1, 3, 3, 3>(new StraightLoss(w));
+    }
+    double _w;
+};
+
+// Solve a single ROI: cells with unknown==1 are optimized; the rest are fixed.
+void solveRoi(cv::Mat_<cv::Vec3d>& pts, const cv::Mat_<uchar>& unknown,
+              double unit, int max_iters)
+{
+    const int rows = pts.rows;
+    const int cols = pts.cols;
+    ceres::Problem problem;
+
+    auto addParam = [&](int r, int c) {
+        problem.AddParameterBlock(&pts(r, c)[0], 3);
+    };
+
+    // 4-neighbor DistLoss
+    for (int r = 0; r < rows; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            if (c + 1 < cols) {
+                addParam(r, c); addParam(r, c + 1);
+                problem.AddResidualBlock(DistLoss::Create(unit, 1.0), nullptr,
+                                         &pts(r, c)[0], &pts(r, c + 1)[0]);
+            }
+            if (r + 1 < rows) {
+                addParam(r, c); addParam(r + 1, c);
+                problem.AddResidualBlock(DistLoss::Create(unit, 1.0), nullptr,
+                                         &pts(r, c)[0], &pts(r + 1, c)[0]);
+            }
+        }
+    }
+
+    // Collinearity on row and column triples
+    for (int r = 0; r < rows; ++r) {
+        for (int c = 1; c + 1 < cols; ++c) {
+            problem.AddResidualBlock(StraightLoss::Create(1.0), nullptr,
+                                     &pts(r, c - 1)[0], &pts(r, c)[0], &pts(r, c + 1)[0]);
+        }
+    }
+    for (int c = 0; c < cols; ++c) {
+        for (int r = 1; r + 1 < rows; ++r) {
+            problem.AddResidualBlock(StraightLoss::Create(1.0), nullptr,
+                                     &pts(r - 1, c)[0], &pts(r, c)[0], &pts(r + 1, c)[0]);
+        }
+    }
+
+    // Fix everything that wasn't originally invalid
+    for (int r = 0; r < rows; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            if (!unknown(r, c) && problem.HasParameterBlock(&pts(r, c)[0])) {
+                problem.SetParameterBlockConstant(&pts(r, c)[0]);
+            }
+        }
+    }
+
+    ceres::Solver::Options options;
+    options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
+    options.max_num_iterations = max_iters;
+    options.minimizer_progress_to_stdout = false;
+    ceres::Solver::Summary summary;
+    ceres::Solve(options, &problem, &summary);
+}
+
+} // namespace
+
+int inpaintSurfaceHoles(cv::Mat_<cv::Vec3f>& points, double unit, int max_iters)
+{
+    const int rows = points.rows;
+    const int cols = points.cols;
+    if (rows <= 0 || cols <= 0) return 0;
+
+    // 1. Build invalid mask.
+    cv::Mat_<uchar> invalid(rows, cols, uchar(0));
+    for (int r = 0; r < rows; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            if (!isValid(points(r, c))) invalid(r, c) = 1;
+        }
+    }
+
+    // 2. Connected components of invalid cells.
+    cv::Mat labels;
+    const int n_components = cv::connectedComponents(invalid, labels, 8, CV_32S);
+    if (n_components <= 1) return 0;
+
+    // 3. For each interior component, compute its dilated bbox and solve.
+    int total_filled = 0;
+    const int dilate = 2; // need >=2 ring so StraightLoss triples have anchors
+    for (int comp = 1; comp < n_components; ++comp) {
+        // bbox + border-touch test in one pass
+        int r0 = rows, r1 = -1, c0 = cols, c1 = -1;
+        bool on_border = false;
+        for (int r = 0; r < rows; ++r) {
+            const int* lr = labels.ptr<int>(r);
+            for (int c = 0; c < cols; ++c) {
+                if (lr[c] != comp) continue;
+                if (r == 0 || r == rows - 1 || c == 0 || c == cols - 1) on_border = true;
+                if (r < r0) r0 = r; if (r > r1) r1 = r;
+                if (c < c0) c0 = c; if (c > c1) c1 = c;
+            }
+        }
+        if (on_border || r1 < 0) continue; // skip outer padding
+
+        const int rr0 = std::max(0, r0 - dilate);
+        const int rr1 = std::min(rows - 1, r1 + dilate);
+        const int cc0 = std::max(0, c0 - dilate);
+        const int cc1 = std::min(cols - 1, c1 + dilate);
+        const int H = rr1 - rr0 + 1;
+        const int W = cc1 - cc0 + 1;
+
+        // 4. Extract ROI as double, mark unknowns (= all invalid cells inside).
+        cv::Mat_<cv::Vec3d> roi(H, W);
+        cv::Mat_<uchar> unknown(H, W, uchar(0));
+        int n_unknown = 0;
+        for (int r = 0; r < H; ++r) {
+            for (int c = 0; c < W; ++c) {
+                const cv::Vec3f& src = points(rr0 + r, cc0 + c);
+                if (invalid(rr0 + r, cc0 + c)) {
+                    roi(r, c) = cv::Vec3d(0, 0, 0);
+                    unknown(r, c) = 1;
+                    ++n_unknown;
+                } else {
+                    roi(r, c) = cv::Vec3d(src[0], src[1], src[2]);
+                }
+            }
+        }
+        if (n_unknown == 0) continue;
+
+        // 5. Seed unknowns with diffusion, then refine with Ceres.
+        cv::Mat_<uchar> diffuse_unknown = unknown.clone();
+        diffuseFill(roi, diffuse_unknown);
+        // If diffuse left any unfilled (no valid neighbor reached) skip; means
+        // the component is fully detached from the ROI ring after dilation,
+        // which shouldn't happen for interior holes.
+        for (int r = 0; r < H; ++r) {
+            for (int c = 0; c < W; ++c) {
+                if (diffuse_unknown(r, c)) {
+                    // fallback: leave as zero; solver will pull it via DistLoss
+                }
+            }
+        }
+
+        solveRoi(roi, unknown, unit, max_iters);
+
+        // 6. Write back the inpainted cells.
+        for (int r = 0; r < H; ++r) {
+            for (int c = 0; c < W; ++c) {
+                if (!unknown(r, c)) continue;
+                const cv::Vec3d& v = roi(r, c);
+                points(rr0 + r, cc0 + c) = cv::Vec3f(
+                    static_cast<float>(v[0]),
+                    static_cast<float>(v[1]),
+                    static_cast<float>(v[2]));
+                ++total_filled;
+            }
+        }
+    }
+    return total_filled;
+}
+
+} // namespace vc::core::util

--- a/volume-cartographer/libs/flatboi/flatboi.cpp
+++ b/volume-cartographer/libs/flatboi/flatboi.cpp
@@ -1001,12 +1001,21 @@ int main(int argc, char** argv) {
       wblog.finish();
     }
 
-    // Fail the run if SLIM diverged. Otherwise we silently hand a UV map full
-    // of NaNs to downstream tools (UV lift / vc_obj2tifxyz) and they produce
-    // an empty / corrupted tifxyz with no error indication.
-    if (!uv_out.allFinite()) {
-      std::cerr << "Error: SLIM diverged (output UVs contain NaN/Inf). "
-                << "Try a higher --decimate level on the input.\n";
+    // Fail the run if SLIM diverged. Two failure modes seen in practice:
+    //   1. Output UVs themselves contain NaN/Inf.
+    //   2. Every iter went NaN but data.V_o was left at the initial UVs
+    //      (allFinite passes, downstream sees an unchanged parametrization).
+    // Catch both by scanning the per-iter energies list for any non-finite
+    // entry past iter 0, and by checking UV finiteness.
+    bool diverged = !uv_out.allFinite();
+    if (!diverged) {
+      for (std::size_t k = 1; k < energies.size(); ++k) {
+        if (!std::isfinite(energies[k])) { diverged = true; break; }
+      }
+    }
+    if (diverged) {
+      std::cerr << "Error: SLIM diverged (NaN energy or non-finite UVs). "
+                << "Try a lower --keep percent on the input (smaller mesh).\n";
       return 3;
     }
   } catch (const std::exception& e) {

--- a/volume-cartographer/libs/flatboi/flatboi.cpp
+++ b/volume-cartographer/libs/flatboi/flatboi.cpp
@@ -1000,6 +1000,15 @@ int main(int argc, char** argv) {
       wblog.log_image("heatmap/log_area", paths.logarea.string());
       wblog.finish();
     }
+
+    // Fail the run if SLIM diverged. Otherwise we silently hand a UV map full
+    // of NaNs to downstream tools (UV lift / vc_obj2tifxyz) and they produce
+    // an empty / corrupted tifxyz with no error indication.
+    if (!uv_out.allFinite()) {
+      std::cerr << "Error: SLIM diverged (output UVs contain NaN/Inf). "
+                << "Try a higher --decimate level on the input.\n";
+      return 3;
+    }
   } catch (const std::exception& e) {
     std::cerr << "Error: " << e.what() << "\n";
     return 2;

--- a/volume-cartographer/libs/flatboi/flatboi.cpp
+++ b/volume-cartographer/libs/flatboi/flatboi.cpp
@@ -525,6 +525,18 @@ struct Flatboi {
       std::cout << "PROGRESS " << (it+1) << "/" << max_iter << std::endl;
       if (wblog) wblog->log_energy(data.energy, /*step=*/it+1);
 
+      // Bail out as soon as the energy goes non-finite. Continuing only
+      // wastes time -- every subsequent iter recomputes weights from a
+      // NaN-poisoned state. The caller (main) inspects the energies list
+      // and returns a non-zero exit code.
+      if (!std::isfinite(data.energy)) {
+        std::cout << "SLIM diverged at iter " << (it+1) << "/"
+                  << max_iter << " (energy = " << data.energy
+                  << "); stopping early.\n";
+        iters_run = it + 1;
+        break;
+      }
+
       if (((it+1) % 20) == 0) {
         auto [l2m, l2med, linf, area] = stretch_metrics(data.V_o.leftCols<2>());
         std::cout << "  stretch: L2(mean)=" << l2m

--- a/volume-cartographer/libs/libigl_changes/include/igl/slim.cpp
+++ b/volume-cartographer/libs/libigl_changes/include/igl/slim.cpp
@@ -29,10 +29,15 @@
 #include "mapping_energy_with_jacobians.h"
 
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <set>
 #include <vector>
 #include <cassert>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 #include <Eigen/IterativeLinearSolvers>
 #include <Eigen/SparseCholesky>
@@ -474,6 +479,16 @@ IGL_INLINE void igl::slim_update_weights_and_closest_rotations_with_jacobians(co
 
       if (std::abs(s1 - 1) < eps) m_sing_new(0) = 1;
       if (std::abs(s2 - 1) < eps) m_sing_new(1) = 1;
+      // Clamp weights to a sane finite range. Extreme starting triangles can
+      // make the SLIM weight formulas (e.g. sqrt(s_g / (2*(s-1)))) approach
+      // infinity, which then poisons AtA via mat_W = U * diag(sing) * U^T
+      // and produces "Negative diagonal term" in the Cholesky solver or
+      // outright NaN energy from the first iter. The clamp keeps the local
+      // step well-defined; SLIM still converges (weights just stop growing
+      // past the cap for those triangles).
+      const double w_cap = 1e8;
+      m_sing_new(0) = std::min(std::max(m_sing_new(0), 1.0/w_cap), w_cap);
+      m_sing_new(1) = std::min(std::max(m_sing_new(1), 1.0/w_cap), w_cap);
       mat_W = ui * m_sing_new.asDiagonal() * ui.transpose();
 
       W.row(i) = Eigen::Map<Eigen::Matrix<double, 1, 4, Eigen::RowMajor>>(mat_W.data());
@@ -606,6 +621,14 @@ IGL_INLINE void igl::slim_update_weights_and_closest_rotations_with_jacobians(co
       if (std::abs(s1 - 1) < eps) m_sing_new(0) = 1;
       if (std::abs(s2 - 1) < eps) m_sing_new(1) = 1;
       if (std::abs(s3 - 1) < eps) m_sing_new(2) = 1;
+      // See 2D path: clamp to keep AtA finite when starting triangles are
+      // numerically extreme.
+      {
+        const double w_cap = 1e8;
+        for (int k = 0; k < 3; ++k) {
+          m_sing_new(k) = std::min(std::max(m_sing_new(k), 1.0/w_cap), w_cap);
+        }
+      }
       RMat3 mat_W;
       mat_W = ui * m_sing_new.asDiagonal() * ui.transpose();
 
@@ -637,35 +660,64 @@ std::vector<Eigen::Triplet<double> > & IJV)
           W11*Dy, W12*Dy;
           W21*Dx, W22*Dx;
           W21*Dy, W22*Dy];*/
-    for (int k = 0; k < Dx.outerSize(); ++k)
+    // Parallel triplet emit: each thread fills its own buffer, then we
+    // concatenate. The outer-column loops have no cross-iteration dependence
+    // and dominate the per-iter wallclock at large mesh sizes.
     {
-      for (Eigen::SparseMatrix<double>::InnerIterator it(Dx, k); it; ++it)
+      const int dx_outer = Dx.outerSize();
+      const int dy_outer = Dy.outerSize();
+      int n_threads = 1;
+#ifdef _OPENMP
+      n_threads = std::max(1, omp_get_max_threads());
+#endif
+      std::vector<std::vector<Eigen::Triplet<double>>> bufs(n_threads);
+      // Rough prealloc per thread.
+      const std::size_t pre = static_cast<std::size_t>(4 * (dx_outer + dy_outer)) /
+                              static_cast<std::size_t>(n_threads) + 16;
+      for (auto& b : bufs) b.reserve(pre);
+
+      #pragma omp parallel
       {
-        int dx_r = it.row();
-        int dx_c = it.col();
-        double val = it.value();
+        int tid = 0;
+#ifdef _OPENMP
+        tid = omp_get_thread_num();
+#endif
+        auto& buf = bufs[tid];
 
-        IJV.push_back(Eigen::Triplet<double>(dx_r, dx_c, val * W(dx_r, 0)));
-        IJV.push_back(Eigen::Triplet<double>(dx_r, v_n + dx_c, val * W(dx_r, 1)));
+        #pragma omp for nowait schedule(static)
+        for (int k = 0; k < dx_outer; ++k) {
+          for (Eigen::SparseMatrix<double>::InnerIterator it(Dx, k); it; ++it) {
+            int dx_r = it.row();
+            int dx_c = it.col();
+            double val = it.value();
+            buf.emplace_back(dx_r, dx_c, val * W(dx_r, 0));
+            buf.emplace_back(dx_r, v_n + dx_c, val * W(dx_r, 1));
+            buf.emplace_back(2 * f_n + dx_r, dx_c, val * W(dx_r, 2));
+            buf.emplace_back(2 * f_n + dx_r, v_n + dx_c, val * W(dx_r, 3));
+          }
+        }
 
-        IJV.push_back(Eigen::Triplet<double>(2 * f_n + dx_r, dx_c, val * W(dx_r, 2)));
-        IJV.push_back(Eigen::Triplet<double>(2 * f_n + dx_r, v_n + dx_c, val * W(dx_r, 3)));
+        #pragma omp for schedule(static)
+        for (int k = 0; k < dy_outer; ++k) {
+          for (Eigen::SparseMatrix<double>::InnerIterator it(Dy, k); it; ++it) {
+            int dy_r = it.row();
+            int dy_c = it.col();
+            double val = it.value();
+            buf.emplace_back(f_n + dy_r, dy_c, val * W(dy_r, 0));
+            buf.emplace_back(f_n + dy_r, v_n + dy_c, val * W(dy_r, 1));
+            buf.emplace_back(3 * f_n + dy_r, dy_c, val * W(dy_r, 2));
+            buf.emplace_back(3 * f_n + dy_r, v_n + dy_c, val * W(dy_r, 3));
+          }
+        }
       }
-    }
 
-    for (int k = 0; k < Dy.outerSize(); ++k)
-    {
-      for (Eigen::SparseMatrix<double>::InnerIterator it(Dy, k); it; ++it)
-      {
-        int dy_r = it.row();
-        int dy_c = it.col();
-        double val = it.value();
-
-        IJV.push_back(Eigen::Triplet<double>(f_n + dy_r, dy_c, val * W(dy_r, 0)));
-        IJV.push_back(Eigen::Triplet<double>(f_n + dy_r, v_n + dy_c, val * W(dy_r, 1)));
-
-        IJV.push_back(Eigen::Triplet<double>(3 * f_n + dy_r, dy_c, val * W(dy_r, 2)));
-        IJV.push_back(Eigen::Triplet<double>(3 * f_n + dy_r, v_n + dy_c, val * W(dy_r, 3)));
+      std::size_t total = 0;
+      for (auto& b : bufs) total += b.size();
+      IJV.reserve(IJV.size() + total);
+      for (auto& b : bufs) {
+        IJV.insert(IJV.end(),
+                   std::make_move_iterator(b.begin()),
+                   std::make_move_iterator(b.end()));
       }
     }
   }


### PR DESCRIPTION
## Summary

Direct SLIM on big tifxyz meshes (>~500k vertices) was NaN'ing on real-world Paris segments — bad interior holes plus runaway weights in libigl's `update_weights_and_closest_rotations` were poisoning the sparse solve. Switching the GUI flatten path to:

1. `vc_tifxyz2obj --decimate N` — coarse OBJ + Ceres-powered hole fill
2. `flatboi` — SLIM on the coarse mesh (fast, robust)
3. `vc_tifxyz2obj` — full-res OBJ (no decimation)
4. `vc_obj_uv_lift` — barycentric UV transfer in source-grid space (not 3D)
5. `vc_obj2tifxyz` — rasterize back to tifxyz

gets a clean flatten on the same segments end-to-end. Grid-space lift (not 3D-nearest) avoids the streaking you get from multi-layer scrolls passing close to themselves in voxel space.

## Pieces

- `core/util/InpaintSurface.{hpp,cpp}` + `vc_inpaint` lib: Ceres smoothness-only inpaint for tifxyz holes. Run by default from `vc_tifxyz2obj` with a stderr warning when cells get filled.
- `vc_tifxyz2obj`: `--no-inpaint`, `--decimate-stride=<s>` flags.
- `vc_obj_uv_lift`: new tool. Hash-grid point-in-triangle search over grid UVs, OpenMP-parallel inner loop, hash-bin fallback.
- `libigl_changes/slim.cpp`: parallel triplet emit in `slim_buildA`; per-triangle weight clamp at ±1e8 in `update_weights_and_closest_rotations` to keep AtA finite when starting triangles are degenerate.
- `flatboi`: exits non-zero when output UVs contain NaN/Inf so the GUI surfaces failures instead of silently producing empty output.
- GUI: `SlimFlattenDialog` has a "Decimation" spinbox (default 2); `SegmentationCommandHandler::SlimJob` runs the full pipeline (`ToObj → Flatboi → ToObjFine → UVLift → ToTifxyz → Swap`).

## Test plan

- [x] CLI: `vc_tifxyz2obj --decimate 2 → flatboi → vc_obj_uv_lift → vc_obj2tifxyz` end-to-end on David's `20230702185753_v11` (2 µm, 4020×1228, was NaN'ing in master). Output is 3989×1216, 81% valid, zero NaN/Inf.
- [x] GUI: SLIM-flatten button on the same segment, decimate=2 / symmetric_dirichlet — produces a clean flattened tifxyz with no streaking.
- [x] Failure path: with `decimate=1` flatboi NaN's, but it now exits non-zero and the GUI shows an error dialog instead of writing empty output.
- [x] Inpaint warning fires (`warning: inpainted N invalid surface cell(s)...`) when there are interior holes.
- [x] dec2 / smaller meshes still converge to the same SLIM energy with the libigl weight clamp.