### PR TITLE
tsan: install llvm-symbolizer and broaden QtTest watchdog suppression

### DIFF
--- a/volume-cartographer/misc/sanitizer_config.c
+++ b/volume-cartographer/misc/sanitizer_config.c
@@ -56,10 +56,14 @@ const char* __nsan_default_options(void)
 
 const char* __tsan_default_suppressions(void)
 {
-    // QtTest's internal watchdog thread is never joined before exit; the
-    // leak is entirely inside libQt6Core. Match by lib since CI has no symbols.
+    // QtTest's internal watchdog thread is never joined before exit. The
+    // creation stack's top frame is inlined into the test binary, so
+    // called_from_lib alone doesn't catch it; pair it with a thread:
+    // match on the QTest watchdog symbol (requires llvm-symbolizer on PATH).
     return
-        "called_from_lib:libQt6Core.so.6\n";
+        "called_from_lib:libQt6Core.so.6\n"
+        "thread:QTest::watchDog\n"
+        "thread:QTestLib\n";
 }
 
 const char* __lsan_default_suppressions(void)

--- a/volume-cartographer/ubuntu-24.04-noble.Dockerfile
+++ b/volume-cartographer/ubuntu-24.04-noble.Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  && add-apt-repository -y universe \
  && apt-get update -y \
  && apt-get install -y --no-install-recommends \
-        build-essential clang lld flang-18 libclang-rt-18-dev mold git cmake ninja-build pkg-config \
+        build-essential clang lld llvm flang-18 libclang-rt-18-dev mold git cmake ninja-build pkg-config \
         qt6-base-dev \
         libboost-system-dev libboost-program-options-dev \
         libceres-dev libsuitesparse-dev \

--- a/volume-cartographer/ubuntu-26.04.Dockerfile
+++ b/volume-cartographer/ubuntu-26.04.Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  && add-apt-repository -y universe \
  && apt-get update -y \
  && apt-get install -y --no-install-recommends \
-        build-essential clang lld flang-21 libclang-rt-21-dev mold git cmake ninja-build pkg-config \
+        build-essential clang lld llvm flang-21 libclang-rt-21-dev mold git cmake ninja-build pkg-config \
         qt6-base-dev \
         libboost-system-dev libboost-program-options-dev \
         libceres-dev libsuitesparse-dev \


### PR DESCRIPTION
## Summary
The QtTest watchdog thread-leak suppression added in #933 still doesn't fire — `test_segmentation_intersection_invalidation` keeps failing the TSan job. Two reasons:

1. The CI builder images install `clang` but not `llvm`, so `llvm-symbolizer` isn't on PATH. TSan logs `invalid path to external symbolizer` and the stack frames come back as `<null> <null>`.
2. Even with symbols, `called_from_lib:libQt6Core.so.6` doesn't match because the creation stack's **top** frame (`#0`) is the QTest watchdog helper inlined into the test binary itself; only frame `#1` lives in `libQt6Core`.

This PR:
- Adds `llvm` to the apt install list in both `ubuntu-26.04.Dockerfile` and `ubuntu-24.04-noble.Dockerfile` so TSan can symbolize.
- Adds `thread:QTest::watchDog` and `thread:QTestLib` entries to `__tsan_default_suppressions` so the leaked-thread creation stack is matched anywhere, not only at its outermost lib frame.

## Test plan
- [ ] CI's `test-ci-tsan-clang (ubuntu-26.04)` job passes on this PR.
- [ ] Other sanitizer jobs (asan-ubsan, tysan, nsan) still pass — the new suppressions only apply to TSan.