### PR TITLE
WIP optimize approval-mask writes

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -2810,6 +2810,12 @@ void CWindow::closeEvent(QCloseEvent* event)
     if (_viewerManager) {
         _viewerManager->beginShutdown();
     }
+    // Flush any pending debounced approval-mask save before teardown so the
+    // last few seconds of approvals aren't lost on exit. No-op if nothing
+    // is pending.
+    if (_segmentationModule && _segmentationModule->overlay()) {
+        _segmentationModule->overlay()->flushPendingApprovalMaskSave();
+    }
     if (_state && _state->vpkg()) {
         try { _state->vpkg()->saveAutosave(); } catch (...) {}
     }

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
@@ -462,44 +462,53 @@ void SegmentationOverlayController::paintApprovalMaskDirect(
         }
     }
 
-    // Paint directly into the images
+    // Paint directly into the images. Both masks are Format_ARGB32_Premultiplied,
+    // so we write packed QRgb straight into scanLine() rows -- far cheaper than
+    // setPixel() (no per-pixel detach/format dispatch). alpha is 255 (or 0), so
+    // the value equals its premultiplied form; no conversion needed.
+    const int imgH = _pendingApprovalMaskImage.height();
+    const int imgW = _pendingApprovalMaskImage.width();
+    const QRgb approveRgb = qRgba(brushColor.red(), brushColor.green(), brushColor.blue(), kApprovalMaskAlpha);
+    const QRgb clearRgb = qRgba(0, 0, 0, 0);
+    const float radiusSq = radiusSteps * radiusSteps;  // circle span uses the exact (float) radius
+
+    const bool clearSaved = (paintValue == 0) && !_savedApprovalMaskImage.isNull();
+    const int savedH = clearSaved ? _savedApprovalMaskImage.height() : 0;
+    const int savedW = clearSaved ? _savedApprovalMaskImage.width() : 0;
+
+    const QRgb writeRgb = (paintValue > 0) ? approveRgb : clearRgb;
+
     for (const auto& [centerRow, centerCol] : gridPositions) {
-        // For rectangle: iterate over explicit width/height
-        // For circle: iterate over full radius in both dimensions
         const int colRange = useRectangle ? rectHalfWidth : radius;
         const int rowRange = useRectangle ? rectHalfHeight : radius;
 
-        for (int dr = -rowRange; dr <= rowRange; ++dr) {
-            for (int dc = -colRange; dc <= colRange; ++dc) {
-                const int row = centerRow + dr;
-                const int col = centerCol + dc;
+        const int r0 = std::max(0, centerRow - rowRange);
+        const int r1 = std::min(imgH - 1, centerRow + rowRange);
 
-                if (row < 0 || row >= _pendingApprovalMaskImage.height() ||
-                    col < 0 || col >= _pendingApprovalMaskImage.width()) {
-                    continue;
-                }
+        for (int row = r0; row <= r1; ++row) {
+            // Per-row horizontal span. For a circle, solve the column extent once
+            // (dc^2 <= r^2 - dr^2) instead of testing every pixel; for a rectangle
+            // the span is the full colRange. Then fill the run contiguously.
+            int dcMax = colRange;
+            if (!useRectangle) {
+                const int dr = row - centerRow;
+                const float rem = radiusSq - static_cast<float>(dr * dr);
+                if (rem < 0.f) continue;  // row entirely outside the circle
+                dcMax = static_cast<int>(std::sqrt(rem));
+            }
+            const int c0 = std::max(0, centerCol - dcMax);
+            const int c1 = std::min(imgW - 1, centerCol + dcMax);
+            if (c1 < c0) continue;
 
-                // For circle mode, skip pixels outside the radius
-                if (!useRectangle) {
-                    const float distanceSq = static_cast<float>(dr * dr + dc * dc);
-                    if (distanceSq > static_cast<float>(radiusSteps * radiusSteps)) {
-                        continue;
-                    }
-                }
+            QRgb* pendRow = reinterpret_cast<QRgb*>(_pendingApprovalMaskImage.scanLine(row));
+            std::fill(pendRow + c0, pendRow + c1 + 1, writeRgb);
 
-                // Update pixel color based on paint mode:
-                // - Approval (paintValue > 0): paint with selected RGB color in pending
-                // - Unapproval (paintValue = 0): clear both saved and pending immediately
-                if (paintValue > 0) {
-                    _pendingApprovalMaskImage.setPixel(col, row, qRgba(brushColor.red(), brushColor.green(), brushColor.blue(), kApprovalMaskAlpha));
-                } else {
-                    // Unapproving: Clear both saved and pending images immediately (no red preview)
-                    _pendingApprovalMaskImage.setPixel(col, row, qRgba(0, 0, 0, 0));
-                    if (!_savedApprovalMaskImage.isNull() &&
-                        row < _savedApprovalMaskImage.height() &&
-                        col < _savedApprovalMaskImage.width()) {
-                        _savedApprovalMaskImage.setPixel(col, row, qRgba(0, 0, 0, 0));
-                    }
+            // Unapproving also clears the saved image directly (no red preview).
+            if (clearSaved && row < savedH) {
+                QRgb* savedRow = reinterpret_cast<QRgb*>(_savedApprovalMaskImage.scanLine(row));
+                const int sc1 = std::min(c1, savedW - 1);
+                if (sc1 >= c0) {
+                    std::fill(savedRow + c0, savedRow + sc1 + 1, clearRgb);
                 }
             }
         }

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
@@ -569,9 +569,10 @@ void SegmentationOverlayController::saveApprovalMaskToSurface(QuadSurface* surfa
         }
     }
 
-    // Save to surface
+    // Only approval.tif changed; saveChannel avoids the full-segment snapshot
+    // + x/y/z rewrite that saveOverwrite() would do on every update.
     surface->setChannel("approval", approvalMask);
-    surface->saveOverwrite();
+    surface->saveChannel("approval");
 
     // Update saved image to match what we just wrote and clear pending
     for (int row = 0; row < height; ++row) {

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
@@ -262,7 +262,7 @@ private:
     // Debounce timer for auto-saving approval mask after painting
     QTimer* _approvalSaveTimer{nullptr};
     QuadSurface* _approvalSaveSurface{nullptr};  // Surface to save to when timer fires
-    static constexpr int kApprovalSaveDelayMs = 500;
+    static constexpr int kApprovalSaveDelayMs = 5000;
     void scheduleApprovalMaskSave(QuadSurface* surface);
     void performDebouncedApprovalSave();
 

--- a/volume-cartographer/apps/VC3D/segmentation/SegmentationModule_Session.cpp
+++ b/volume-cartographer/apps/VC3D/segmentation/SegmentationModule_Session.cpp
@@ -407,9 +407,10 @@ bool SegmentationModule::applySurfaceUpdateFromGrowth(const cv::Rect& vertexRect
         }
 
         if (!gridPositions.empty()) {
+            // performAutoApproval() paints and schedules a debounced save.
+            // A synchronous save here would rewrite approval.tif per growth
+            // step on the GUI thread; the debounce coalesces the burst.
             performAutoApproval(gridPositions);
-            // Save immediately to persist the auto-approval
-            _overlay->saveApprovalMaskToSurface(baseSurf);
             _overlay->clearApprovalMaskUndoHistory();
             qCInfo(lcSegModule) << "Auto-approved growth region:" << gridPositions.size() << "vertices"
                                 << "(rect:" << vertexRect.width << "x" << vertexRect.height << ")";

--- a/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
@@ -378,6 +378,9 @@ public:
     cv::Mat channel(const std::string& name, int flags = 0);
     void invalidateCache();
     void saveOverwrite();
+    // Write a single ancillary channel to path/<name>.tif in place, without
+    // snapshotting or rewriting x/y/z. No-op if the channel is absent/empty.
+    void saveChannel(const std::string& name);
     void saveSnapshot(int maxBackups = 10);
     void invalidateMask();
     std::vector<std::string> channelNames() const;
@@ -436,6 +439,8 @@ protected:
 private:
     // Write surface data to directory without modifying state. skipChannel can be used to exclude a channel.
     void writeDataToDirectory(const std::filesystem::path& dir, const std::string& skipChannel = "");
+    // Write a single ancillary channel as dir/<name>.tif.
+    void writeChannelFile(const std::filesystem::path& dir, const std::string& name, const cv::Mat& mat);
     // Flag for lazy loading - true if points need to be loaded from path
     bool _needsLoad = false;
     // Mutex to protect lazy loading from concurrent access

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -1240,6 +1240,27 @@ void QuadSurface::invalidateMask()
     }
 }
 
+// Single-channel 8U/16U/32F -> untiled uncompressed TIFF; else cv::imwrite.
+void QuadSurface::writeChannelFile(const std::filesystem::path& dir, const std::string& name, const cv::Mat& mat)
+{
+    bool wrote = false;
+    if (mat.channels() == 1 &&
+        (mat.type() == CV_8UC1 || mat.type() == CV_16UC1 || mat.type() == CV_32FC1))
+    {
+        try {
+            writeTiff(dir / (name + ".tif"), mat, -1, 0, 0, -1.0f, COMPRESSION_NONE, dpi_);
+            wrote = true;
+        } catch (...) {
+            wrote = false; // Fall back to OpenCV
+        }
+    }
+
+    if (!wrote) {
+        std::vector<int> compression_params = { cv::IMWRITE_TIFF_COMPRESSION, COMPRESSION_NONE };
+        cv::imwrite((dir / (name + ".tif")).string(), mat, compression_params);
+    }
+}
+
 void QuadSurface::writeDataToDirectory(const std::filesystem::path& dir, const std::string& skipChannel)
 {
     // Split the points matrix into x, y, z channels
@@ -1251,32 +1272,29 @@ void QuadSurface::writeDataToDirectory(const std::filesystem::path& dir, const s
     writeTiff(dir / "y.tif", xyz[1], -1, 0, 0, -1.0f, COMPRESSION_NONE, dpi_);
     writeTiff(dir / "z.tif", xyz[2], -1, 0, 0, -1.0f, COMPRESSION_NONE, dpi_);
 
-    // OpenCV compression params for fallback
-    std::vector<int> compression_params = { cv::IMWRITE_TIFF_COMPRESSION, COMPRESSION_NONE };
-
     // Save additional channels
     for (auto const& [name, mat] : _channels) {
         if (!mat.empty() && (skipChannel.empty() || name != skipChannel)) {
-            bool wrote = false;
-
-            // Try untiled, uncompressed TIFF for single-channel ancillary data (8U/16U/32F)
-            if (mat.channels() == 1 &&
-                (mat.type() == CV_8UC1 || mat.type() == CV_16UC1 || mat.type() == CV_32FC1))
-            {
-                try {
-                    writeTiff(dir / (name + ".tif"), mat, -1, 0, 0, -1.0f, COMPRESSION_NONE, dpi_);
-                    wrote = true;
-                } catch (...) {
-                    wrote = false; // Fall back to OpenCV
-                }
-            }
-
-            // Fallback to OpenCV for multi-channel or other formats
-            if (!wrote) {
-                cv::imwrite((dir / (name + ".tif")).string(), mat, compression_params);
-            }
+            writeChannelFile(dir, name, mat);
         }
     }
+}
+
+void QuadSurface::saveChannel(const std::string& name)
+{
+    if (path.empty()) {
+        throw std::runtime_error("QuadSurface::saveChannel() requires a valid path");
+    }
+    auto it = _channels.find(name);
+    if (it == _channels.end() || it->second.empty()) {
+        return;
+    }
+
+    // Write only <name>.tif, no snapshot or x/y/z rewrite. tmp+rename so a
+    // crash mid-write can't tear the existing file.
+    const std::string tmpStem = "." + name + ".tmp" + std::to_string(::getpid());
+    writeChannelFile(path, tmpStem, it->second);
+    std::filesystem::rename(path / (tmpStem + ".tif"), path / (name + ".tif"));
 }
 
 void QuadSurface::saveSnapshot(int maxBackups)

--- a/volume-cartographer/core/test/test_quadsurface_save_paths.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_save_paths.cpp
@@ -60,6 +60,58 @@ TEST_CASE("save(path, uuid, force_overwrite=true): atomic-exchange replaces exis
     fs::remove_all(root);
 }
 
+TEST_CASE("saveChannel: writes only the channel tif, no snapshot, round-trips")
+{
+    auto root = tmpDir("savechannel");
+    auto segDir = root / "seg";
+
+    // Place the seg dir two levels deep so it mimics <volpkg>/paths/<seg>,
+    // which is where saveSnapshot() would write backups to (../../backups).
+    auto volpkg = root / "scroll.volpkg";
+    auto pathsDir = volpkg / "paths";
+    fs::create_directories(pathsDir);
+    segDir = pathsDir / "seg";
+
+    QuadSurface qs(grid(), cv::Vec2f(1.f, 1.f));
+    qs.save(segDir.string(), "uuid-a", /*force_overwrite=*/false);
+    REQUIRE(fs::exists(segDir / "x.tif"));
+
+    // Capture x.tif mtime so we can assert saveChannel leaves it untouched.
+    auto xMtimeBefore = fs::last_write_time(segDir / "x.tif");
+
+    cv::Mat_<cv::Vec3b> approval(8, 8, cv::Vec3b(0, 0, 0));
+    approval(2, 3) = cv::Vec3b(0, 255, 0);  // BGR
+    qs.setChannel("approval", approval);
+    qs.saveChannel("approval");
+
+    CHECK(fs::exists(segDir / "approval.tif"));
+    // No backups/ directory: saveChannel must not snapshot the segment.
+    CHECK_FALSE(fs::exists(volpkg / "backups"));
+    // x.tif untouched (not rewritten).
+    CHECK(fs::last_write_time(segDir / "x.tif") == xMtimeBefore);
+
+    QuadSurface reloaded(segDir);
+    cv::Mat got = reloaded.channel("approval", SURF_CHANNEL_NORESIZE);
+    REQUIRE(got.channels() == 3);
+    CHECK(got.at<cv::Vec3b>(2, 3) == cv::Vec3b(0, 255, 0));
+    CHECK(got.at<cv::Vec3b>(0, 0) == cv::Vec3b(0, 0, 0));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("saveChannel: absent or empty channel is a no-op")
+{
+    auto root = tmpDir("savechannel_noop");
+    auto segDir = root / "seg";
+    QuadSurface qs(grid(), cv::Vec2f(1.f, 1.f));
+    qs.save(segDir.string(), "uuid-a", /*force_overwrite=*/false);
+
+    qs.saveChannel("approval");  // never set
+    CHECK_FALSE(fs::exists(segDir / "approval.tif"));
+
+    fs::remove_all(root);
+}
+
 TEST_CASE("save without force_overwrite + existing dir throws (or overwrites)")
 {
     auto root = tmpDir("noforce");


### PR DESCRIPTION
the approval mask was getitng saved way too often, especially when using the auto approve setting when making edits, causing lots of churn to the approval mask write out. this makes it only save the approval mask instead of all of the tifs and extends the amount of time we wait before writing to 5 seconds for autosaves