### PR TITLE
Add DBbun PHerc.Paris.4 Ink-Contrast Simulation Companion

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -294,6 +294,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 - [Scroll pretraining](https://github.com/younader/VesuviusPretraining) by Youssef Nader. Youssef’s original idea for pretraining on the scrolls and finetuning on the fragments, which led him to winning the First Letters Prize.
 
 - [pre-trained DINOv2 models](https://github.com/SergeyPnev/dinov2-vesuvius) by Sergei Pnev. Self-supervised model pre-trained on scrolls 1-5 with predictions.
+
+- [DBbun PHerc.Paris.4 Ink-Contrast Simulation Companion](https://github.com/DBbun/vesuvius-phercparis4-simulator) by Uri Kartoun. Synthetic CT tile exploratory simulator for PHerc.Paris.4-style Vesuvius Challenge scroll imaging, with patch-level SNR analysis, ink-contrast scenarios, figures, and parameter sensitivity sweeps.
 #### 📦 Materials
 
 - [Scroll 1 Ink Labels](https://discord.com/channels/1079907749569237093/1223849912467460116). Nicola Bodill produced more accurate labels for ink detection based on the prediction of the Grand Prize winner model


### PR DESCRIPTION
This PR adds a standalone open-source DBbun simulator for PHerc.Paris.4-style Vesuvius Challenge scroll imaging.

The tool provides synthetic CT tile exploration, patch-level SNR analysis, ink-contrast scenarios, figures, and parameter sensitivity sweeps. It is intended as a reproducible exploratory framework for testing preprocessing and faint ink-like contrast assumptions.

Repository:
https://github.com/DBbun/vesuvius-phercparis4-simulator