### PR TITLE
use dynamic linking where possible

### DIFF
--- a/volume-cartographer/CMakeLists.txt
+++ b/volume-cartographer/CMakeLists.txt
@@ -11,6 +11,19 @@ set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Shared libs to shrink binaries and CI disk usage. (flatboi forces this
+# OFF locally for PaStiX.)
+set(BUILD_SHARED_LIBS ON CACHE BOOL "Build vc_* and FetchContent deps as .so")
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+# Exes default to -fPIE; force -fPIC to match the shared libs' PCH. -no-pie
+# only on exe links (mold/lld reject it on a .so).
+add_compile_options(-fPIC)
+add_link_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-no-pie>)
+# Find the .so via $ORIGIN without LD_LIBRARY_PATH.
+set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
+set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
+
 option(VC_MARCH_NATIVE     "Tune for the host CPU (-march=native)"        OFF)
 option(VC_WARNINGS        "Enable curated warning set"                   OFF)
 option(VC_WERROR          "Treat compiler warnings as errors"            OFF)

--- a/volume-cartographer/apps/CMakeLists.txt
+++ b/volume-cartographer/apps/CMakeLists.txt
@@ -1,11 +1,3 @@
-# Grid-resolution helpers split into a static lib so the unit tests can
-# link them without spawning the binary. Built unconditionally because
-# tests depend on it; the rest of this file's app executables are gated
-# behind VC_BUILD_APPS.
-add_library(vc_merge_grid STATIC src/vc_merge_tifxyz_grid.cpp)
-target_link_libraries(vc_merge_grid PUBLIC vc_core)
-target_include_directories(vc_merge_grid PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-
 if(NOT VC_BUILD_APPS)
     return()
 endif()
@@ -172,7 +164,7 @@ add_executable(vc_create_segment_mask src/vc_create_segment_mask.cpp)
 target_link_libraries(vc_create_segment_mask vc_core Boost::program_options)
 
 add_executable(vc_merge_tifxyz src/vc_merge_tifxyz.cpp)
-target_link_libraries(vc_merge_tifxyz vc_merge_grid Boost::program_options opencv_imgcodecs opencv_imgproc opencv_flann Eigen3::Eigen)
+target_link_libraries(vc_merge_tifxyz vc_core Boost::program_options opencv_imgcodecs opencv_imgproc opencv_flann Eigen3::Eigen)
 
 add_executable(vc_visualize src/vc_visualize.cpp)
 target_link_libraries(vc_visualize vc_core Boost::program_options)

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -35,8 +35,13 @@ add_library(vc_core
         src/render/Colormaps.cpp
         src/render/PostProcess.cpp
         src/render/ZarrChunkFetcher.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../apps/src/vc_merge_tifxyz_grid.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/Version.cpp
 )
+
+# Grid-resolution helpers (vc_merge_tifxyz_grid) live in apps/src but are
+# compiled into vc_core so the unit tests link them without the binary.
+target_include_directories(vc_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../apps/src)
 
 target_link_libraries(vc_core
         PUBLIC

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -63,11 +63,11 @@ add_executable(test_blosc1_compat test_blosc1_compat.cpp)
 target_link_libraries(test_blosc1_compat PRIVATE doctest::doctest vc_core Blosc::blosc)
 add_test(NAME test_blosc1_compat COMMAND test_blosc1_compat)
 
-# Parser-only regression tests for vc_merge_tifxyz: link the small static
-# lib that holds gmResolveGrid + gmCheckConnected so the failure-message
-# assertions are exact, without spawning the binary.
+# Parser-only regression tests for vc_merge_tifxyz: gmResolveGrid +
+# gmCheckConnected are compiled into vc_core, so link that and assert the
+# failure messages exactly without spawning the binary.
 add_executable(test_merge_grid_resolve test_merge_grid_resolve.cpp)
-target_link_libraries(test_merge_grid_resolve PRIVATE doctest::doctest vc_merge_grid)
+target_link_libraries(test_merge_grid_resolve PRIVATE doctest::doctest vc_core)
 add_test(NAME test_merge_grid_resolve COMMAND test_merge_grid_resolve)
 
 # End-to-end test that spawns the built vc_merge_tifxyz binary on two

--- a/volume-cartographer/libs/c3d/CMakeLists.txt
+++ b/volume-cartographer/libs/c3d/CMakeLists.txt
@@ -1,6 +1,6 @@
 # c3d — 3D volumetric u8 compression codec (single TU, C23, libc only).
 # Upstream: ~/c3d (vendored as a copy of c3d.c + c3d.h).
-add_library(c3d STATIC c3d.c)
+add_library(c3d c3d.c)
 
 target_include_directories(c3d PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -22,6 +22,3 @@ target_compile_options(c3d PRIVATE
 )
 
 target_link_libraries(c3d PRIVATE m)
-
-# -fPIC so vc_core (potentially built as a shared lib downstream) can link it.
-set_target_properties(c3d PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/volume-cartographer/utils/CMakeLists.txt
+++ b/volume-cartographer/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(utils STATIC src/zarr.cpp src/Json.cpp src/aws_auth.cpp src/http_fetch.cpp)
+add_library(utils src/zarr.cpp src/Json.cpp src/aws_auth.cpp src/http_fetch.cpp)
 target_include_directories(utils PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
@@ -13,7 +13,7 @@ target_link_libraries(utils PUBLIC
 target_compile_definitions(utils PUBLIC UTILS_HAS_CURL=1)
 set_target_properties(utils PROPERTIES AUTOMOC OFF AUTORCC OFF AUTOUIC OFF)
 
-add_library(utils_c3d_codec STATIC src/c3d_codec.cpp)
+add_library(utils_c3d_codec src/c3d_codec.cpp)
 target_include_directories(utils_c3d_codec PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )


### PR DESCRIPTION
build and link dynamic libraries rather than static libraries where possible to reduce on disk sizes and reduce compile and CI times. Large amounts of static linking can cause the GHA CI runners to run out of disk and fail