### PR TITLE
use clang coverage instead of gcov

### DIFF
--- a/.github/workflows/vc3d-ci.yml
+++ b/.github/workflows/vc3d-ci.yml
@@ -98,7 +98,7 @@ jobs:
         run: volume-cartographer/scripts/ci.sh ${{ matrix.action }} ${{ matrix.image }} ${{ matrix.compiler }} ${{ matrix.preset }}
 
   coverage:
-    name: Coverage (gcc, gcov)
+    name: Coverage (clang, source-based)
     needs: [changes, builder]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -109,8 +109,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # Coverage builds are huge: -O0 -g + libgcov instrumentation, every
-      # test executable linked statically against vc_core. The default
+      # Coverage builds are huge: clang source-based instrumentation
+      # (-fprofile-instr-generate -fcoverage-mapping) on every test
+      # executable linked statically against vc_core. The default
       # ubuntu runner ships ~14 GB free, which is not enough — `ar` and
       # the final link step hit ENOSPC intermittently. Free ~25-30 GB by
       # purging preinstalled toolchains we don't use (Android SDK, .NET,

--- a/volume-cartographer/CMakeLists.txt
+++ b/volume-cartographer/CMakeLists.txt
@@ -173,18 +173,14 @@ if(VC_ENABLE_ASAN OR VC_ENABLE_UBSAN OR VC_ENABLE_TSAN
     list(APPEND _san -fno-sanitize-recover=all)
 endif()
 if(VC_ENABLE_COVERAGE)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        list(APPEND _san -fprofile-instr-generate -fcoverage-mapping)
-    else()
-        list(APPEND _san --coverage)
+    # clang source-based coverage only: accurate at any -O level, reads
+    # .profraw + the binary's coverage-mapping section. gcc/gcov was retired
+    # (only accurate at -O0). -g1 keeps line tables for useful backtraces.
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        message(FATAL_ERROR "VC_ENABLE_COVERAGE requires clang — gcc/gcov was retired (only accurate at -O0). Use the ci-coverage-clang preset.")
     endif()
-    # Coverage doesn't need DWARF: gcov/llvm-cov read .gcno/.gcda (gcc) or
-    # .profraw + the binary's coverage-mapping section (clang), neither of
-    # which depends on debug info. Drop to -g1 (line tables only — keeps
-    # backtraces useful when an assertion fires) and split DWARF into .dwo
-    # files so the executables stay small. On a full build this trims the
-    # coverage build dir from ~12 GB to ~5 GB and avoids ENOSPC on CI.
-    list(APPEND _san -g1 -gsplit-dwarf)
+    list(APPEND _san -fprofile-instr-generate -fcoverage-mapping)
+    list(APPEND _san -g1)
 endif()
 # Sanitizer/coverage flags applied below, after libs/ — see that block.
 

--- a/volume-cartographer/CMakePresets.json
+++ b/volume-cartographer/CMakePresets.json
@@ -104,8 +104,6 @@
     { "name": "ci-nsan-clang",           "displayName": "CI NumericalStabilitySanitizer (clang)",
       "inherits": ["_ci-base", "_clang"], "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug",          "VC_TESTING": "ON",   "VC_ENABLE_NSAN": "ON" } },
 
-    { "name": "ci-coverage-gcc",         "displayName": "CI Coverage (gcc, gcov)",
-      "inherits": ["_ci-base", "_gcc"],   "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug",          "VC_TESTING": "ON",   "VC_ENABLE_COVERAGE": "ON" } },
     { "name": "ci-coverage-clang",       "displayName": "CI Coverage (clang, source-based)",
       "inherits": ["_ci-base", "_clang"], "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug",          "VC_TESTING": "ON",   "VC_ENABLE_COVERAGE": "ON" } },
 
@@ -173,7 +171,6 @@
     { "name": "ci-tsan-clang",            "configurePreset": "ci-tsan-clang" },
     { "name": "ci-tysan-clang",           "configurePreset": "ci-tysan-clang" },
     { "name": "ci-nsan-clang",            "configurePreset": "ci-nsan-clang" },
-    { "name": "ci-coverage-gcc",          "configurePreset": "ci-coverage-gcc" },
     { "name": "ci-coverage-clang",        "configurePreset": "ci-coverage-clang" },
     { "name": "ci-strict-warnings-gcc",   "configurePreset": "ci-strict-warnings-gcc" },
     { "name": "ci-strict-warnings-clang", "configurePreset": "ci-strict-warnings-clang" },
@@ -197,7 +194,6 @@
     { "name": "ci-tysan-clang",           "configurePreset": "ci-tysan-clang",          "inherits": "_test-base" },
     { "name": "ci-nsan-clang",            "configurePreset": "ci-nsan-clang",           "inherits": "_test-base",
       "environment": { "NSAN_OPTIONS": "halt_on_error=0:print_stats_on_exit=1" } },
-    { "name": "ci-coverage-gcc",          "configurePreset": "ci-coverage-gcc",         "inherits": "_test-base" },
     { "name": "ci-coverage-clang",        "configurePreset": "ci-coverage-clang",       "inherits": "_test-base" },
     { "name": "ci-strict-warnings-gcc",   "configurePreset": "ci-strict-warnings-gcc",  "inherits": "_test-base" },
     { "name": "ci-strict-warnings-clang", "configurePreset": "ci-strict-warnings-clang","inherits": "_test-base" }

--- a/volume-cartographer/scripts/ci.sh
+++ b/volume-cartographer/scripts/ci.sh
@@ -73,28 +73,44 @@ run_in_builder() {
 
 coverage_in_dir() {
     local image=$1 src=$2
-    local build_dir="build/ci-coverage-gcc-$image"
+    local build_dir="build/ci-coverage-clang-$image"
     cmd_builder "$image"
     run_in_builder "$image" "$src" "
-        cmake --preset ci-coverage-gcc &&
-        cmake --build --preset ci-coverage-gcc &&
-        ctest --preset ci-coverage-gcc &&
+        set -o pipefail &&
+        cmake --preset ci-coverage-clang &&
+        cmake --build --preset ci-coverage-clang &&
+        rm -rf /src/$build_dir/coverage-raw && mkdir -p /src/$build_dir/coverage-raw &&
+        LLVM_PROFILE_FILE=\"/src/$build_dir/coverage-raw/%p-%m.profraw\" \
+            ctest --preset ci-coverage-clang &&
         mkdir -p coverage &&
-        gcovr --root . \
-          --filter '^core/' --filter '^apps/' --filter '^utils/' \
-          --exclude '.*/_deps/.*' --exclude 'build/.*' --exclude 'libs/.*' \
-          --gcov-ignore-errors=no_working_dir_found \
-          --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
-          --html-details coverage/index.html \
-          --cobertura coverage/cobertura.xml \
-          --txt coverage/summary.txt \
-          $build_dir &&
-        find . -name '*.gcov' -not -path './coverage/*' -delete"
+        llvm-profdata merge -sparse -o $build_dir/coverage.profdata \
+            $build_dir/coverage-raw/*.profraw &&
+        objects=( ) &&
+        for b in $build_dir/bin/test_*; do objects+=( -object \"\$b\" ); done &&
+        llvm-cov show \"\${objects[@]}\" \
+            -instr-profile=$build_dir/coverage.profdata \
+            -format=html -output-dir=coverage \
+            -ignore-filename-regex='(/_deps/|/build/|/libs/)' \
+            -show-line-counts-or-regions &&
+        llvm-cov export \"\${objects[@]}\" \
+            -instr-profile=$build_dir/coverage.profdata \
+            -format=lcov \
+            -ignore-filename-regex='(/_deps/|/build/|/libs/)' \
+            > coverage/lcov.info &&
+        llvm-cov report \"\${objects[@]}\" \
+            -instr-profile=$build_dir/coverage.profdata \
+            -ignore-filename-regex='(/_deps/|/build/|/libs/)' \
+            > coverage/summary.txt"
 }
 
-# Extract TOTAL line coverage % from a gcovr summary.txt.
+# Extract TOTAL line coverage % from an llvm-cov report.
+# The TOTAL row has 4 trailing %-columns (Region, Function, Line, Branch);
+# track the 3rd (Line).
 total_coverage_pct() {
-    awk '/^TOTAL/ { for (i=1;i<=NF;i++) if ($i ~ /%$/) { gsub("%","",$i); print $i; exit } }' "$1"
+    awk '/^TOTAL/ {
+        n = 0
+        for (i = 1; i <= NF; i++) if ($i ~ /%$/) { n++; if (n == 3) { gsub("%", "", $i); print $i; exit } }
+    }' "$1"
 }
 
 cmd_builder() {
@@ -203,9 +219,9 @@ cmd_patch_coverage() {
     # When volume-cartographer lives as a subdir of a larger repo the .git is
     # outside the docker mount and diff-cover dies with "not a git repository".
     local min_pct=${PATCH_COVERAGE_MIN:-0}
-    local cobertura="$REPO_ROOT/coverage/cobertura.xml"
-    if [[ ! -f "$cobertura" ]]; then
-        echo "patch-coverage: $cobertura missing — run 'ci.sh coverage' first" >&2
+    local lcov="$REPO_ROOT/coverage/lcov.info"
+    if [[ ! -f "$lcov" ]]; then
+        echo "patch-coverage: $lcov missing — run 'ci.sh coverage' first" >&2
         return 1
     fi
 
@@ -213,16 +229,16 @@ cmd_patch_coverage() {
     git_root=$(git -C "$REPO_ROOT" rev-parse --show-toplevel)
     git -C "$git_root" fetch --quiet origin "${base_ref#origin/}" || true
 
-    # gcovr emits paths relative to volume-cartographer with <source>.</source>.
-    # When the git root is a parent dir, prepend the subdir so diff-cover's
+    # llvm-cov export -format=lcov writes SF:/src/... absolute paths (cwd inside
+    # the docker mount is /src). Rewrite to git-root-relative so diff-cover's
     # path lookup matches what git reports as changed.
     local src_in_git fixed
     src_in_git=$(realpath --relative-to="$git_root" "$REPO_ROOT")
-    fixed=$(mktemp -t cobertura-diffcov.XXXXXX.xml)
+    fixed=$(mktemp -t lcov-diffcov.XXXXXX.info)
     if [[ "$src_in_git" == "." ]]; then
-        cp "$cobertura" "$fixed"
+        sed 's|^SF:/src/|SF:|' "$lcov" > "$fixed"
     else
-        sed "s|<source>\.</source>|<source>${src_in_git}</source>|" "$cobertura" > "$fixed"
+        sed "s|^SF:/src/|SF:${src_in_git}/|" "$lcov" > "$fixed"
     fi
 
     # Per-invocation venv so concurrent ci.sh runs on the same host don't
@@ -270,11 +286,11 @@ cmd_coverage_regression() {
         base_tree="$worktree_root/$subdir"
     fi
 
-    # Base branch may not have the ci-coverage-gcc preset (e.g. before this
+    # Base branch may not have the ci-coverage-clang preset (e.g. before this
     # CI lands). In that case, skip the regression gate with a warning rather
     # than failing — there's no meaningful "base coverage" to compare to.
-    if ! grep -q '"name": "ci-coverage-gcc"' "$base_tree/CMakePresets.json" 2>/dev/null; then
-        echo "::warning::base ($base_ref) has no ci-coverage-gcc preset; skipping non-regression gate"
+    if ! grep -q '"name": "ci-coverage-clang"' "$base_tree/CMakePresets.json" 2>/dev/null; then
+        echo "::warning::base ($base_ref) has no ci-coverage-clang preset; skipping non-regression gate"
         return 0
     fi
 
@@ -325,7 +341,7 @@ cmd_all() {
         echo "=== ubuntu-26.04: $preset-clang ==="
         cmd_test ubuntu-26.04 clang "$preset"
     done
-    echo "=== Coverage (gcc, gcov) ==="
+    echo "=== Coverage (clang, source-based) ==="
     cmd_coverage ubuntu-26.04
     echo "=== Dead-code report ==="
     cmd_dead_code ubuntu-26.04 clang

--- a/volume-cartographer/scripts/install_build_deps.sh
+++ b/volume-cartographer/scripts/install_build_deps.sh
@@ -22,7 +22,6 @@ apt-get install -y --no-install-recommends \
     zlib1g-dev gfortran libopenblas-dev liblapack-dev liblapacke-dev libomp-dev \
     libscotch-dev libscotchmetis-dev libhwloc-dev \
     file bzip2 wget jq \
-    gcovr lcov \
     python3 python3-venv
 
 ln -sf /usr/bin/flang-21 /usr/local/bin/flang


### PR DESCRIPTION
clang source-based coverage (llvm-profdata + llvm-cov) instead of gcov. gcov is only accurate at -O0; clang coverage works at all optimization levels. GCC coverage also takes tons of disk space which causes GHA CI failures