### PR TITLE
link sanitizer config into every test exe

### DIFF
--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -14,43 +14,65 @@ endif()
 
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Test)
 
-add_executable(test_smoke test_smoke.cpp)
-target_link_libraries(test_smoke PRIVATE doctest::doctest)
-add_test(NAME test_smoke COMMAND test_smoke)
+# vc_add_test(NAME ... [SOURCES ...] [LIBS ...] [INCLUDES ...] [DEFS ...])
+#
+# Wraps the add_executable / target_link_libraries / add_test trio. SOURCES
+# defaults to <name>.cpp, LIBS to "doctest::doctest vc_core" (pass LIBS to
+# override, e.g. Qt tests). Appends misc/sanitizer_config.c when any *San is
+# enabled so __tsan_default_suppressions et al. are present in the test exe
+# itself — otherwise the suppressions only land in the canary/VC3D and never
+# fire for the real tests. VC_TEST_FIXTURES_DIR is baked into every exe.
+function(vc_add_test)
+    cmake_parse_arguments(T "" "NAME" "SOURCES;LIBS;INCLUDES;DEFS" ${ARGN})
+    if(NOT T_NAME)
+        message(FATAL_ERROR "vc_add_test: NAME is required")
+    endif()
+    if(NOT T_SOURCES)
+        set(T_SOURCES ${T_NAME}.cpp)
+    endif()
+    if(NOT DEFINED T_LIBS)
+        set(T_LIBS doctest::doctest vc_core)
+    endif()
+    if(VC_ENABLE_ASAN OR VC_ENABLE_UBSAN OR VC_ENABLE_TSAN OR VC_ENABLE_LSAN
+       OR VC_ENABLE_TYSAN OR VC_ENABLE_NSAN)
+        list(APPEND T_SOURCES "${CMAKE_SOURCE_DIR}/misc/sanitizer_config.c")
+    endif()
+    add_executable(${T_NAME} ${T_SOURCES})
+    if(T_LIBS)
+        target_link_libraries(${T_NAME} PRIVATE ${T_LIBS})
+    endif()
+    if(T_INCLUDES)
+        target_include_directories(${T_NAME} PRIVATE ${T_INCLUDES})
+    endif()
+    target_compile_definitions(${T_NAME} PRIVATE
+        VC_TEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
+    if(T_DEFS)
+        target_compile_definitions(${T_NAME} PRIVATE ${T_DEFS})
+    endif()
+    add_test(NAME ${T_NAME} COMMAND ${T_NAME})
+endfunction()
 
-add_executable(test_appendmask_render test_appendmask_render.cpp)
-target_link_libraries(test_appendmask_render PRIVATE doctest::doctest vc_core)
-add_test(NAME test_appendmask_render COMMAND test_appendmask_render)
+vc_add_test(NAME test_smoke LIBS doctest::doctest)
 
-add_executable(test_chunked_plane_sampler_fallback test_chunked_plane_sampler_fallback.cpp)
-target_link_libraries(test_chunked_plane_sampler_fallback PRIVATE doctest::doctest vc_core)
-add_test(NAME test_chunked_plane_sampler_fallback COMMAND test_chunked_plane_sampler_fallback)
+vc_add_test(NAME test_appendmask_render)
 
-add_executable(test_volume_chunk_errors test_volume_chunk_errors.cpp)
-target_link_libraries(test_volume_chunk_errors PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volume_chunk_errors COMMAND test_volume_chunk_errors)
+vc_add_test(NAME test_chunked_plane_sampler_fallback)
 
-add_executable(test_segmentation_autosave_state test_segmentation_autosave_state.cpp)
-target_include_directories(test_segmentation_autosave_state PRIVATE ${PROJECT_SOURCE_DIR}/apps/VC3D)
-target_link_libraries(test_segmentation_autosave_state PRIVATE doctest::doctest)
-add_test(NAME test_segmentation_autosave_state COMMAND test_segmentation_autosave_state)
+vc_add_test(NAME test_volume_chunk_errors)
 
-add_executable(test_segmentation_intersection_invalidation test_segmentation_intersection_invalidation.cpp)
-target_include_directories(test_segmentation_intersection_invalidation PRIVATE ${PROJECT_SOURCE_DIR}/apps/VC3D)
-target_link_libraries(test_segmentation_intersection_invalidation PRIVATE Qt6::Core Qt6::Gui Qt6::Test vc_core)
-add_test(NAME test_segmentation_intersection_invalidation COMMAND test_segmentation_intersection_invalidation)
+vc_add_test(NAME test_segmentation_autosave_state
+    LIBS doctest::doctest
+    INCLUDES ${PROJECT_SOURCE_DIR}/apps/VC3D)
 
-add_executable(test_quadsurface_save_roundtrip test_quadsurface_save_roundtrip.cpp)
-target_link_libraries(test_quadsurface_save_roundtrip PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_save_roundtrip COMMAND test_quadsurface_save_roundtrip)
+vc_add_test(NAME test_segmentation_intersection_invalidation
+    LIBS Qt6::Core Qt6::Gui Qt6::Test vc_core
+    INCLUDES ${PROJECT_SOURCE_DIR}/apps/VC3D)
 
-add_executable(test_atomic_imwrite_multi test_atomic_imwrite_multi.cpp)
-target_link_libraries(test_atomic_imwrite_multi PRIVATE doctest::doctest vc_core)
-add_test(NAME test_atomic_imwrite_multi COMMAND test_atomic_imwrite_multi)
+vc_add_test(NAME test_quadsurface_save_roundtrip)
 
-add_executable(test_post_process test_post_process.cpp)
-target_link_libraries(test_post_process PRIVATE doctest::doctest vc_core)
-add_test(NAME test_post_process COMMAND test_post_process)
+vc_add_test(NAME test_atomic_imwrite_multi)
+
+vc_add_test(NAME test_post_process)
 
 # Pin the on-disk wire format: chunks must remain Blosc1-readable because
 # VcDataset writes Zarr v2 metadata advertising compressor_id = "blosc".
@@ -59,16 +81,12 @@ add_test(NAME test_post_process COMMAND test_post_process)
 #
 # Links vc_core directly so it can call vc::testing::bloscCompressForTest,
 # which exercises the *real* compress path used by VcDataset.
-add_executable(test_blosc1_compat test_blosc1_compat.cpp)
-target_link_libraries(test_blosc1_compat PRIVATE doctest::doctest vc_core Blosc::blosc)
-add_test(NAME test_blosc1_compat COMMAND test_blosc1_compat)
+vc_add_test(NAME test_blosc1_compat LIBS doctest::doctest vc_core Blosc::blosc)
 
 # Parser-only regression tests for vc_merge_tifxyz: gmResolveGrid +
 # gmCheckConnected are compiled into vc_core, so link that and assert the
 # failure messages exactly without spawning the binary.
-add_executable(test_merge_grid_resolve test_merge_grid_resolve.cpp)
-target_link_libraries(test_merge_grid_resolve PRIVATE doctest::doctest vc_core)
-add_test(NAME test_merge_grid_resolve COMMAND test_merge_grid_resolve)
+vc_add_test(NAME test_merge_grid_resolve)
 
 # End-to-end test that spawns the built vc_merge_tifxyz binary on two
 # synthetic 16x16 tifxyz dirs. Opt-in via VC_RUN_E2E=1; the test skips
@@ -142,302 +160,153 @@ if(VC_ENABLE_NSAN)
     _add_canary(sanitizer_canary_nsan  nsan  "NumericalStabilitySanitizer: inconsistent")
 endif()
 
-add_executable(test_gridstore test_gridstore.cpp)
-target_link_libraries(test_gridstore PRIVATE doctest::doctest vc_core)
-add_test(NAME test_gridstore COMMAND test_gridstore)
+vc_add_test(NAME test_gridstore)
 
-add_executable(test_gridstore_branches test_gridstore_branches.cpp)
-target_link_libraries(test_gridstore_branches PRIVATE doctest::doctest vc_core)
-add_test(NAME test_gridstore_branches COMMAND test_gridstore_branches)
+vc_add_test(NAME test_gridstore_branches)
 
 # Live network test: anonymous read of the PHerc 0172 zarr on AWS S3.
 # Soft-skips on network failure so offline runs still pass; set
 # VC_TEST_REQUIRE_NETWORK=1 to flip those skips into hard failures.
-add_executable(test_pherc0172_live test_pherc0172_live.cpp)
-target_link_libraries(test_pherc0172_live PRIVATE doctest::doctest vc_core)
-add_test(NAME test_pherc0172_live COMMAND test_pherc0172_live)
+vc_add_test(NAME test_pherc0172_live)
 
-add_executable(test_tiff test_tiff.cpp)
-target_link_libraries(test_tiff PRIVATE doctest::doctest vc_core)
-add_test(NAME test_tiff COMMAND test_tiff)
+vc_add_test(NAME test_tiff)
 
-add_executable(test_normalgridtools test_normalgridtools.cpp)
-target_link_libraries(test_normalgridtools PRIVATE doctest::doctest vc_core)
-add_test(NAME test_normalgridtools COMMAND test_normalgridtools)
+vc_add_test(NAME test_normalgridtools)
 
 # Live S3: opens the PHerc 0172 volume and reads small chunks.
-add_executable(test_volume_live_s3 test_volume_live_s3.cpp)
-target_link_libraries(test_volume_live_s3 PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volume_live_s3 COMMAND test_volume_live_s3)
+vc_add_test(NAME test_volume_live_s3)
 
-add_executable(test_normal_grid_volume test_normal_grid_volume.cpp)
-target_link_libraries(test_normal_grid_volume PRIVATE doctest::doctest vc_core)
-add_test(NAME test_normal_grid_volume COMMAND test_normal_grid_volume)
+vc_add_test(NAME test_normal_grid_volume)
 
-add_executable(test_surface_patch_index test_surface_patch_index.cpp)
-target_link_libraries(test_surface_patch_index PRIVATE doctest::doctest vc_core)
-add_test(NAME test_surface_patch_index COMMAND test_surface_patch_index)
+vc_add_test(NAME test_surface_patch_index)
 
-add_executable(test_tiff_merge test_tiff_merge.cpp)
-target_link_libraries(test_tiff_merge PRIVATE doctest::doctest vc_core)
-add_test(NAME test_tiff_merge COMMAND test_tiff_merge)
+vc_add_test(NAME test_tiff_merge)
 
-add_executable(test_http_fetch_errors test_http_fetch_errors.cpp)
-target_link_libraries(test_http_fetch_errors PRIVATE doctest::doctest vc_core)
-add_test(NAME test_http_fetch_errors COMMAND test_http_fetch_errors)
+vc_add_test(NAME test_http_fetch_errors)
 
 # Live S3: stages PHerc 0172 level 5 to a local zarr dir, then exercises
 # the NormalGridGenerate library API against it. Soft-skips on network.
-add_executable(test_normal_grid_live test_normal_grid_live.cpp)
-target_link_libraries(test_normal_grid_live PRIVATE doctest::doctest vc_core)
-add_test(NAME test_normal_grid_live COMMAND test_normal_grid_live)
+vc_add_test(NAME test_normal_grid_live)
 
-add_executable(test_normalgridtools_real test_normalgridtools_real.cpp)
-target_link_libraries(test_normalgridtools_real PRIVATE doctest::doctest vc_core)
-add_test(NAME test_normalgridtools_real COMMAND test_normalgridtools_real)
+vc_add_test(NAME test_normalgridtools_real)
 
-add_executable(test_tiff_more test_tiff_more.cpp)
-target_link_libraries(test_tiff_more PRIVATE doctest::doctest vc_core)
-add_test(NAME test_tiff_more COMMAND test_tiff_more)
+vc_add_test(NAME test_tiff_more)
 
-add_executable(test_geometry test_geometry.cpp)
-target_link_libraries(test_geometry PRIVATE doctest::doctest vc_core)
-add_test(NAME test_geometry COMMAND test_geometry)
+vc_add_test(NAME test_geometry)
 
-add_executable(test_affine_transform test_affine_transform.cpp)
-target_link_libraries(test_affine_transform PRIVATE doctest::doctest vc_core)
-add_test(NAME test_affine_transform COMMAND test_affine_transform)
+vc_add_test(NAME test_affine_transform)
 
-add_executable(test_point_index test_point_index.cpp)
-target_link_libraries(test_point_index PRIVATE doctest::doctest vc_core)
-add_test(NAME test_point_index COMMAND test_point_index)
+vc_add_test(NAME test_point_index)
 
-add_executable(test_plane_surface test_plane_surface.cpp)
-target_link_libraries(test_plane_surface PRIVATE doctest::doctest vc_core)
-add_test(NAME test_plane_surface COMMAND test_plane_surface)
+vc_add_test(NAME test_plane_surface)
 
-add_executable(test_compositing test_compositing.cpp)
-target_link_libraries(test_compositing PRIVATE doctest::doctest vc_core)
-add_test(NAME test_compositing COMMAND test_compositing)
+vc_add_test(NAME test_compositing)
 
-add_executable(test_quadsurface_basics test_quadsurface_basics.cpp)
-target_link_libraries(test_quadsurface_basics PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_basics COMMAND test_quadsurface_basics)
+vc_add_test(NAME test_quadsurface_basics)
 
-add_executable(test_load_json test_load_json.cpp)
-target_link_libraries(test_load_json PRIVATE doctest::doctest vc_core)
-add_test(NAME test_load_json COMMAND test_load_json)
+vc_add_test(NAME test_load_json)
 
-add_executable(test_remote_url test_remote_url.cpp)
-target_link_libraries(test_remote_url PRIVATE doctest::doctest vc_core)
-add_test(NAME test_remote_url COMMAND test_remote_url)
+vc_add_test(NAME test_remote_url)
 
-add_executable(test_logging test_logging.cpp)
-target_link_libraries(test_logging PRIVATE doctest::doctest vc_core)
-add_test(NAME test_logging COMMAND test_logging)
+vc_add_test(NAME test_logging)
 
-add_executable(test_plane_surface_branches test_plane_surface_branches.cpp)
-target_link_libraries(test_plane_surface_branches PRIVATE doctest::doctest vc_core)
-add_test(NAME test_plane_surface_branches COMMAND test_plane_surface_branches)
+vc_add_test(NAME test_plane_surface_branches)
 
-add_executable(test_affine_transform_surface test_affine_transform_surface.cpp)
-target_link_libraries(test_affine_transform_surface PRIVATE doctest::doctest vc_core)
-add_test(NAME test_affine_transform_surface COMMAND test_affine_transform_surface)
+vc_add_test(NAME test_affine_transform_surface)
 
-add_executable(test_quadsurface_more test_quadsurface_more.cpp)
-target_link_libraries(test_quadsurface_more PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_more COMMAND test_quadsurface_more)
+vc_add_test(NAME test_quadsurface_more)
 
-add_executable(test_thinning test_thinning.cpp)
-target_link_libraries(test_thinning PRIVATE doctest::doctest vc_core)
-add_test(NAME test_thinning COMMAND test_thinning)
+vc_add_test(NAME test_thinning)
 
-add_executable(test_umbilicus test_umbilicus.cpp)
-target_link_libraries(test_umbilicus PRIVATE doctest::doctest vc_core)
-add_test(NAME test_umbilicus COMMAND test_umbilicus)
+vc_add_test(NAME test_umbilicus)
 
-add_executable(test_colormaps test_colormaps.cpp)
-target_link_libraries(test_colormaps PRIVATE doctest::doctest vc_core)
-add_test(NAME test_colormaps COMMAND test_colormaps)
+vc_add_test(NAME test_colormaps)
 
-add_executable(test_quadsurface_io test_quadsurface_io.cpp)
-target_link_libraries(test_quadsurface_io PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_io COMMAND test_quadsurface_io)
+vc_add_test(NAME test_quadsurface_io)
 
-add_executable(test_quadsurface_pointto test_quadsurface_pointto.cpp)
-target_link_libraries(test_quadsurface_pointto PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_pointto COMMAND test_quadsurface_pointto)
+vc_add_test(NAME test_quadsurface_pointto)
 
-add_executable(test_quadsurface_snapshot test_quadsurface_snapshot.cpp)
-target_link_libraries(test_quadsurface_snapshot PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_snapshot COMMAND test_quadsurface_snapshot)
+vc_add_test(NAME test_quadsurface_snapshot)
 
-add_executable(test_quadsurface_save_paths test_quadsurface_save_paths.cpp)
-target_link_libraries(test_quadsurface_save_paths PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_save_paths COMMAND test_quadsurface_save_paths)
+vc_add_test(NAME test_quadsurface_save_paths)
 
-add_executable(test_segmentation test_segmentation.cpp)
-target_link_libraries(test_segmentation PRIVATE doctest::doctest vc_core)
-add_test(NAME test_segmentation COMMAND test_segmentation)
+vc_add_test(NAME test_segmentation)
 
-add_executable(test_chunked_tensor_meta test_chunked_tensor_meta.cpp)
-target_link_libraries(test_chunked_tensor_meta PRIVATE doctest::doctest vc_tracer)
-add_test(NAME test_chunked_tensor_meta COMMAND test_chunked_tensor_meta)
+vc_add_test(NAME test_chunked_tensor_meta LIBS doctest::doctest vc_tracer)
 
-add_executable(test_post_process_util test_post_process_util.cpp)
-target_link_libraries(test_post_process_util PRIVATE doctest::doctest vc_core)
-add_test(NAME test_post_process_util COMMAND test_post_process_util)
+vc_add_test(NAME test_post_process_util)
 
-add_executable(test_render test_render.cpp)
-target_link_libraries(test_render PRIVATE doctest::doctest vc_core)
-add_test(NAME test_render COMMAND test_render)
+vc_add_test(NAME test_render)
 
-add_executable(test_growth_config test_growth_config.cpp)
-target_include_directories(test_growth_config PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
-target_link_libraries(test_growth_config PRIVATE doctest::doctest vc_tracer)
-add_test(NAME test_growth_config COMMAND test_growth_config)
+vc_add_test(NAME test_growth_config
+    LIBS doctest::doctest vc_tracer
+    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-add_executable(test_growth_helpers test_growth_helpers.cpp)
-target_include_directories(test_growth_helpers PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
-target_link_libraries(test_growth_helpers PRIVATE doctest::doctest vc_tracer)
-add_test(NAME test_growth_helpers COMMAND test_growth_helpers)
+vc_add_test(NAME test_growth_helpers
+    LIBS doctest::doctest vc_tracer
+    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-add_executable(test_surf_tracker_data test_surf_tracker_data.cpp)
-target_include_directories(test_surf_tracker_data PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
-target_link_libraries(test_surf_tracker_data PRIVATE doctest::doctest vc_tracer)
-add_test(NAME test_surf_tracker_data COMMAND test_surf_tracker_data)
+vc_add_test(NAME test_surf_tracker_data
+    LIBS doctest::doctest vc_tracer
+    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-add_executable(test_sparse_chunk_spool test_sparse_chunk_spool.cpp)
-target_link_libraries(test_sparse_chunk_spool PRIVATE doctest::doctest vc_core)
-add_test(NAME test_sparse_chunk_spool COMMAND test_sparse_chunk_spool)
+vc_add_test(NAME test_sparse_chunk_spool)
 
-add_executable(test_neural_tracer_connection test_neural_tracer_connection.cpp)
-target_link_libraries(test_neural_tracer_connection PRIVATE doctest::doctest vc_tracer)
-add_test(NAME test_neural_tracer_connection COMMAND test_neural_tracer_connection)
+vc_add_test(NAME test_neural_tracer_connection LIBS doctest::doctest vc_tracer)
 
-add_executable(test_quadsurface_final test_quadsurface_final.cpp)
-target_link_libraries(test_quadsurface_final PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_final COMMAND test_quadsurface_final)
+vc_add_test(NAME test_quadsurface_final)
 
-add_executable(test_quadsurface_components test_quadsurface_components.cpp)
-target_link_libraries(test_quadsurface_components PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_components COMMAND test_quadsurface_components)
+vc_add_test(NAME test_quadsurface_components)
 
-add_executable(test_volume_local test_volume_local.cpp)
-target_link_libraries(test_volume_local PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volume_local COMMAND test_volume_local)
+vc_add_test(NAME test_volume_local)
 
-add_executable(test_zarr_helpers test_zarr_helpers.cpp)
-target_link_libraries(test_zarr_helpers PRIVATE doctest::doctest vc_core)
-add_test(NAME test_zarr_helpers COMMAND test_zarr_helpers)
+vc_add_test(NAME test_zarr_helpers)
 
-add_executable(test_chunked_plane_sampler test_chunked_plane_sampler.cpp)
-target_link_libraries(test_chunked_plane_sampler PRIVATE doctest::doctest vc_core)
-add_test(NAME test_chunked_plane_sampler COMMAND test_chunked_plane_sampler)
+vc_add_test(NAME test_chunked_plane_sampler)
 
-add_executable(test_slicing test_slicing.cpp)
-target_link_libraries(test_slicing PRIVATE doctest::doctest vc_core)
-add_test(NAME test_slicing COMMAND test_slicing)
+vc_add_test(NAME test_slicing)
 
-add_executable(test_volume_pkg test_volume_pkg.cpp)
-target_link_libraries(test_volume_pkg PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volume_pkg COMMAND test_volume_pkg)
+vc_add_test(NAME test_volume_pkg)
 
-add_executable(test_volpkg_convert test_volpkg_convert.cpp)
-target_link_libraries(test_volpkg_convert PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volpkg_convert COMMAND test_volpkg_convert)
+vc_add_test(NAME test_volpkg_convert)
 
-add_executable(test_vcdataset test_vcdataset.cpp)
-target_link_libraries(test_vcdataset PRIVATE doctest::doctest vc_core)
-add_test(NAME test_vcdataset COMMAND test_vcdataset)
+vc_add_test(NAME test_vcdataset)
 
-add_executable(test_zarr test_zarr.cpp)
-target_link_libraries(test_zarr PRIVATE doctest::doctest vc_core)
-add_test(NAME test_zarr COMMAND test_zarr)
+vc_add_test(NAME test_zarr)
 
-add_executable(test_chunk_cache test_chunk_cache.cpp)
-target_link_libraries(test_chunk_cache PRIVATE doctest::doctest vc_core)
-add_test(NAME test_chunk_cache COMMAND test_chunk_cache)
+vc_add_test(NAME test_chunk_cache)
 
-add_executable(test_volume_extras test_volume_extras.cpp)
-target_link_libraries(test_volume_extras PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volume_extras COMMAND test_volume_extras)
+vc_add_test(NAME test_volume_extras)
 
-add_executable(test_zarr_more test_zarr_more.cpp)
-target_link_libraries(test_zarr_more PRIVATE doctest::doctest vc_core)
-add_test(NAME test_zarr_more COMMAND test_zarr_more)
+vc_add_test(NAME test_zarr_more)
 
-add_executable(test_vcdataset_compressors test_vcdataset_compressors.cpp)
-target_link_libraries(test_vcdataset_compressors PRIVATE doctest::doctest vc_core)
-add_test(NAME test_vcdataset_compressors COMMAND test_vcdataset_compressors)
+vc_add_test(NAME test_vcdataset_compressors)
 
-add_executable(test_volume_static_read test_volume_static_read.cpp)
-target_link_libraries(test_volume_static_read PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volume_static_read COMMAND test_volume_static_read)
+vc_add_test(NAME test_volume_static_read)
 
-add_executable(test_volume_pyramid test_volume_pyramid.cpp)
-target_link_libraries(test_volume_pyramid PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volume_pyramid COMMAND test_volume_pyramid)
+vc_add_test(NAME test_volume_pyramid)
 
-add_executable(test_chunk_cache_persist test_chunk_cache_persist.cpp)
-target_link_libraries(test_chunk_cache_persist PRIVATE doctest::doctest vc_core)
-add_test(NAME test_chunk_cache_persist COMMAND test_chunk_cache_persist)
+vc_add_test(NAME test_chunk_cache_persist)
 
-add_executable(test_zarr_chunk_fetcher test_zarr_chunk_fetcher.cpp)
-target_link_libraries(test_zarr_chunk_fetcher PRIVATE doctest::doctest vc_core)
-add_test(NAME test_zarr_chunk_fetcher COMMAND test_zarr_chunk_fetcher)
+vc_add_test(NAME test_zarr_chunk_fetcher)
 
-add_executable(test_chunked_plane_sampler_more test_chunked_plane_sampler_more.cpp)
-target_link_libraries(test_chunked_plane_sampler_more PRIVATE doctest::doctest vc_core)
-add_test(NAME test_chunked_plane_sampler_more COMMAND test_chunked_plane_sampler_more)
+vc_add_test(NAME test_chunked_plane_sampler_more)
 
-add_executable(test_slicing_more test_slicing_more.cpp)
-target_link_libraries(test_slicing_more PRIVATE doctest::doctest vc_core)
-add_test(NAME test_slicing_more COMMAND test_slicing_more)
+vc_add_test(NAME test_slicing_more)
 
-add_executable(test_vcdataset_more test_vcdataset_more.cpp)
-target_link_libraries(test_vcdataset_more PRIVATE doctest::doctest vc_core)
-add_test(NAME test_vcdataset_more COMMAND test_vcdataset_more)
+vc_add_test(NAME test_vcdataset_more)
 
 # Real PHerc 0172 segments committed under core/test/data/segments/.
-add_executable(test_quadsurface_fixtures test_quadsurface_fixtures.cpp)
-target_compile_definitions(test_quadsurface_fixtures PRIVATE
-    VC_TEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
-target_link_libraries(test_quadsurface_fixtures PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_fixtures COMMAND test_quadsurface_fixtures)
+vc_add_test(NAME test_quadsurface_fixtures)
 
-add_executable(test_volume_pkg_full test_volume_pkg_full.cpp)
-target_compile_definitions(test_volume_pkg_full PRIVATE
-    VC_TEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
-target_link_libraries(test_volume_pkg_full PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volume_pkg_full COMMAND test_volume_pkg_full)
+vc_add_test(NAME test_volume_pkg_full)
 
-add_executable(test_load_quad_from_tifxyz test_load_quad_from_tifxyz.cpp)
-target_compile_definitions(test_load_quad_from_tifxyz PRIVATE
-    VC_TEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
-target_link_libraries(test_load_quad_from_tifxyz PRIVATE doctest::doctest vc_core)
-add_test(NAME test_load_quad_from_tifxyz COMMAND test_load_quad_from_tifxyz)
+vc_add_test(NAME test_load_quad_from_tifxyz)
 
-add_executable(test_surface_patch_index_more test_surface_patch_index_more.cpp)
-target_compile_definitions(test_surface_patch_index_more PRIVATE
-    VC_TEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
-target_link_libraries(test_surface_patch_index_more PRIVATE doctest::doctest vc_core)
-add_test(NAME test_surface_patch_index_more COMMAND test_surface_patch_index_more)
+vc_add_test(NAME test_surface_patch_index_more)
 
-add_executable(test_quadsurface_extras test_quadsurface_extras.cpp)
-target_compile_definitions(test_quadsurface_extras PRIVATE
-    VC_TEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
-target_link_libraries(test_quadsurface_extras PRIVATE doctest::doctest vc_core)
-add_test(NAME test_quadsurface_extras COMMAND test_quadsurface_extras)
+vc_add_test(NAME test_quadsurface_extras)
 
-add_executable(test_surface_patch_index_cache test_surface_patch_index_cache.cpp)
-target_compile_definitions(test_surface_patch_index_cache PRIVATE
-    VC_TEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
-target_link_libraries(test_surface_patch_index_cache PRIVATE doctest::doctest vc_core)
-add_test(NAME test_surface_patch_index_cache COMMAND test_surface_patch_index_cache)
+vc_add_test(NAME test_surface_patch_index_cache)
 
-add_executable(test_volume_pkg_more test_volume_pkg_more.cpp)
-target_compile_definitions(test_volume_pkg_more PRIVATE
-    VC_TEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
-target_link_libraries(test_volume_pkg_more PRIVATE doctest::doctest vc_core)
-add_test(NAME test_volume_pkg_more COMMAND test_volume_pkg_more)
+vc_add_test(NAME test_volume_pkg_more)

--- a/volume-cartographer/misc/sanitizer_config.c
+++ b/volume-cartographer/misc/sanitizer_config.c
@@ -54,19 +54,17 @@ const char* __nsan_default_options(void)
            "print_stacktrace=1";
 }
 
-// QtTest's internal watchdog thread is never joined before exit (leak is
-// entirely inside libQt6Core). The system libtbb is not built with tsan
-// instrumentation, so its internal acquire/release fences are invisible and
-// any worker-vs-main handoff in the task scheduler is flagged as a data race
-// even though TBB's atomics make it safe; OpenCV uses TBB internally (cv::LUT,
-// connected-components, parallel_for), so the racing frames land in
-// libopencv_* with libtbb only on the thread-creation stack — hence
-// called_from_lib:libtbb is what actually matches.
+// QtTest's internal watchdog thread is never joined before exit. pthread_create
+// is frame #0 in the test binary, QThread::start frame #1 in libQt6Core, so
+// called_from_lib (immediate-caller only) misses it — thread:QThread::start
+// matches the creation stack instead. libtbb isn't tsan-instrumented, so its
+// internal fences are invisible and TBB-backed OpenCV work (cv::LUT,
+// parallel_for) gets flagged as races in libopencv_*.
 const char* __tsan_default_suppressions(void)
 {
     return
-        "called_from_lib:libQt6Core.so.6\n"
-        "called_from_lib:libtbb\n"
+        "thread:QThread::start\n"
+        "called_from_lib:libtbb.so.12\n"
         "race:libtbb.so\n"
         "race:libtbbmalloc.so\n"
         "race:tbb::detail::\n"


### PR DESCRIPTION
wrap tests in a vc_add_test() that appends misc/sanitizer_config.c when a sanitizer is on, so the tsan/lsan suppressions actually land in each test exe (they were only in the canary/VC3D before). also swaps the QtTest watchdog suppression to thread:QThread::start since called_from_lib didn't match it