### PR TITLE
drop the ci builder gate

### DIFF
--- a/.github/workflows/vc3d-ci.yml
+++ b/.github/workflows/vc3d-ci.yml
@@ -44,30 +44,9 @@ jobs:
     steps:
       - run: echo "No volume-cartographer changes — skipping build."
 
-  builder:
-    name: Builder image (${{ matrix.image }})
-    needs: changes
-    if: needs.changes.outputs.vc == 'true'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        image: ["ubuntu-26.04"]
-    env:
-      # If the PR touched a Dockerfile (or ci.sh), the published ghcr image
-      # is stale for this PR. Force a local build with the GHA buildx cache.
-      # Otherwise ci.sh builder will docker pull the published image.
-      VC_BUILDER_FORCE_LOCAL: ${{ needs.changes.outputs.dockerfile == 'true' && '1' || '0' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - name: Pull or build builder image
-        run: volume-cartographer/scripts/ci.sh builder ${{ matrix.image }}
-
   build-test:
     name: ${{ matrix.action }}-${{ matrix.preset }}-${{ matrix.compiler }} (${{ matrix.image }})
-    needs: [changes, builder]
+    needs: changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     continue-on-error: ${{ matrix.blocking != true }}
@@ -99,7 +78,7 @@ jobs:
 
   coverage:
     name: Coverage (clang, source-based)
-    needs: [changes, builder]
+    needs: changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     continue-on-error: true
@@ -228,7 +207,7 @@ jobs:
 
   dead-code:
     name: Dead-code report (clang, nm + --print-gc-sections)
-    needs: [changes, builder]
+    needs: changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     continue-on-error: true
@@ -256,7 +235,7 @@ jobs:
 
   ci:
     name: CI
-    needs: [changes, skip, builder, build-test, coverage, macos-build, dead-code]
+    needs: [changes, skip, build-test, coverage, macos-build, dead-code]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 2
@@ -265,18 +244,17 @@ jobs:
         env:
           R_CHANGES: ${{ needs.changes.result }}
           R_SKIP: ${{ needs.skip.result }}
-          R_BUILDER: ${{ needs.builder.result }}
           R_BUILD_TEST: ${{ needs.build-test.result }}
           R_COVERAGE: ${{ needs.coverage.result }}
           R_MACOS: ${{ needs.macos-build.result }}
           R_DEAD_CODE: ${{ needs.dead-code.result }}
         run: |
           set -e
-          echo "changes=$R_CHANGES skip=$R_SKIP builder=$R_BUILDER build-test=$R_BUILD_TEST coverage=$R_COVERAGE macos=$R_MACOS dead-code=$R_DEAD_CODE"
+          echo "changes=$R_CHANGES skip=$R_SKIP build-test=$R_BUILD_TEST coverage=$R_COVERAGE macos=$R_MACOS dead-code=$R_DEAD_CODE"
           # coverage and dead-code are continue-on-error, so accept any result.
           # All other non-skipped jobs must succeed (or be skipped legitimately).
           fail=0
-          for r in "$R_CHANGES" "$R_SKIP" "$R_BUILDER" "$R_BUILD_TEST" "$R_MACOS"; do
+          for r in "$R_CHANGES" "$R_SKIP" "$R_BUILD_TEST" "$R_MACOS"; do
             case "$r" in
               success|skipped) ;;
               *) fail=1 ;;


### PR DESCRIPTION
the builder job only pre-warmed the docker image and passed no artifact. build-test/coverage/dead-code each already run ci.sh builder (pull from ghcr, or build locally on a dockerfile change), so gating them on it just made every job wait ~1min for a pull they'd do anyway. they now start immediately off 'changes'.