### PR TITLE
firewall cgal to speed up vc_add_ignore_label compiles

### DIFF
--- a/volume-cartographer/apps/CMakeLists.txt
+++ b/volume-cartographer/apps/CMakeLists.txt
@@ -95,7 +95,7 @@ set_target_properties(vc_obj_uv_lift PROPERTIES AUTOMOC OFF AUTOUIC OFF AUTORCC 
 add_executable(vc_tifxyz2zarr_sparse src/vc_tifxyz2zarr_sparse.cpp)
 target_link_libraries(vc_tifxyz2zarr_sparse vc_core Boost::program_options)
 
-add_executable(vc_add_ignore_label src/vc_add_ignore_label.cpp)
+add_executable(vc_add_ignore_label src/vc_add_ignore_label.cpp src/alpha_wrap.cpp)
 target_link_libraries(vc_add_ignore_label
     vc_core
     Boost::program_options

--- a/volume-cartographer/apps/src/alpha_wrap.cpp
+++ b/volume-cartographer/apps/src/alpha_wrap.cpp
@@ -1,0 +1,118 @@
+#include "alpha_wrap.hpp"
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/bbox.h>
+#include <CGAL/Side_of_triangle_mesh.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/alpha_wrap_3.h>
+
+using AlphaWrapKernel = CGAL::Exact_predicates_inexact_constructions_kernel;
+using AlphaWrapPoint = AlphaWrapKernel::Point_3;
+using AlphaWrapMesh = CGAL::Surface_mesh<AlphaWrapPoint>;
+
+namespace {
+
+std::size_t countNonZero(const uint8_t* data, std::size_t n)
+{
+    std::size_t c = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        if (data[i] != 0) {
+            ++c;
+        }
+    }
+    return c;
+}
+
+std::size_t volumeElements(const Shape3& shape)
+{
+    return shape[0] * shape[1] * shape[2];
+}
+
+std::size_t linearIndex(const Shape3& shape, std::size_t z, std::size_t y, std::size_t x)
+{
+    return (z * shape[1] + y) * shape[2] + x;
+}
+
+Shape3 relativeOrigin(const Box3& inner, const Box3& outer)
+{
+    return {inner.origin[0] - outer.origin[0],
+            inner.origin[1] - outer.origin[1],
+            inner.origin[2] - outer.origin[2]};
+}
+
+AlphaWrapPoint voxelCenterPoint(std::size_t z, std::size_t y, std::size_t x)
+{
+    return AlphaWrapPoint(static_cast<double>(z) + 0.5,
+                          static_cast<double>(y) + 0.5,
+                          static_cast<double>(x) + 0.5);
+}
+
+bool bboxContains(const CGAL::Bbox_3& bbox, const AlphaWrapPoint& p)
+{
+    return p.x() >= bbox.xmin() && p.x() <= bbox.xmax() &&
+           p.y() >= bbox.ymin() && p.y() <= bbox.ymax() &&
+           p.z() >= bbox.zmin() && p.z() <= bbox.zmax();
+}
+
+}  // namespace
+
+std::vector<uint8_t> classifyOuterAlphaWrap(const std::vector<uint8_t>& halo,
+                                            const Box3& haloBox,
+                                            const Box3& coreBox,
+                                            double alpha,
+                                            double offset)
+{
+    std::vector<AlphaWrapPoint> points;
+    points.reserve(countNonZero(halo.data(), halo.size()));
+    for (std::size_t z = 0; z < haloBox.shape[0]; ++z) {
+        for (std::size_t y = 0; y < haloBox.shape[1]; ++y) {
+            const std::size_t base = linearIndex(haloBox.shape, z, y, 0);
+            for (std::size_t x = 0; x < haloBox.shape[2]; ++x) {
+                if (halo[base + x] == 0) {
+                    continue;
+                }
+                points.push_back(voxelCenterPoint(haloBox.origin[0] + z,
+                                                  haloBox.origin[1] + y,
+                                                  haloBox.origin[2] + x));
+            }
+        }
+    }
+
+    const Shape3 coreRel = relativeOrigin(coreBox, haloBox);
+    std::vector<uint8_t> ignore(volumeElements(coreBox.shape), 0);
+    if (points.size() < 4) {
+        return ignore;
+    }
+
+    AlphaWrapMesh wrap;
+    CGAL::alpha_wrap_3(points, alpha, offset, wrap);
+    if (num_faces(wrap) == 0) {
+        return ignore;
+    }
+
+    const CGAL::Bbox_3 bbox = CGAL::Polygon_mesh_processing::bbox(wrap);
+    CGAL::Side_of_triangle_mesh<AlphaWrapMesh, AlphaWrapKernel> sideOfMesh(wrap);
+
+    for (std::size_t z = 0; z < coreBox.shape[0]; ++z) {
+        for (std::size_t y = 0; y < coreBox.shape[1]; ++y) {
+            for (std::size_t x = 0; x < coreBox.shape[2]; ++x) {
+                const std::size_t haloIdx = linearIndex(haloBox.shape,
+                                                        coreRel[0] + z,
+                                                        coreRel[1] + y,
+                                                        coreRel[2] + x);
+                if (halo[haloIdx] != 0) {
+                    continue;
+                }
+
+                const AlphaWrapPoint p = voxelCenterPoint(coreBox.origin[0] + z,
+                                                          coreBox.origin[1] + y,
+                                                          coreBox.origin[2] + x);
+                if (!bboxContains(bbox, p) || sideOfMesh(p) == CGAL::ON_UNBOUNDED_SIDE) {
+                    ignore[linearIndex(coreBox.shape, z, y, x)] = 255;
+                }
+            }
+        }
+    }
+
+    return ignore;
+}

--- a/volume-cartographer/apps/src/alpha_wrap.hpp
+++ b/volume-cartographer/apps/src/alpha_wrap.hpp
@@ -1,0 +1,26 @@
+// CGAL firewall for vc_add_ignore_label. The 3D alpha-wrap + point-in-mesh
+// classification is the heaviest TU in the build (~120s, all CGAL template
+// instantiation). Keeping the CGAL include behind this CGAL-free boundary
+// confines that cost to alpha_wrap.cpp so edits to the main tool stay fast.
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+using Shape3 = std::array<std::size_t, 3>;
+
+struct Box3 {
+    Shape3 origin = {0, 0, 0};
+    Shape3 shape = {0, 0, 0};
+};
+
+// Wrap the non-zero voxels of `halo` (in haloBox coords) with CGAL's
+// alpha_wrap_3, then mark every core voxel that falls outside the wrap.
+// Returns a coreBox-shaped mask (255 = ignore, 0 = keep).
+std::vector<uint8_t> classifyOuterAlphaWrap(const std::vector<uint8_t>& halo,
+                                            const Box3& haloBox,
+                                            const Box3& coreBox,
+                                            double alpha,
+                                            double offset);

--- a/volume-cartographer/apps/src/vc_add_ignore_label.cpp
+++ b/volume-cartographer/apps/src/vc_add_ignore_label.cpp
@@ -5,11 +5,7 @@
 
 #include <boost/program_options.hpp>
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Polygon_mesh_processing/bbox.h>
-#include <CGAL/Side_of_triangle_mesh.h>
-#include <CGAL/Surface_mesh.h>
-#include <CGAL/alpha_wrap_3.h>
+#include "alpha_wrap.hpp"
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgcodecs.hpp>
@@ -61,11 +57,6 @@ constexpr double kRadPerDeg = kPi / 180.0;
 constexpr double kDefaultRamBudgetGb = 0.0;   // 0 => auto
 constexpr double kDefaultAutoRamFraction = 0.60;
 
-using Shape3 = std::array<std::size_t, 3>;
-using AlphaWrapKernel = CGAL::Exact_predicates_inexact_constructions_kernel;
-using AlphaWrapPoint = AlphaWrapKernel::Point_3;
-using AlphaWrapMesh = CGAL::Surface_mesh<AlphaWrapPoint>;
-
 enum class MapMode {
     legacy,
     exact,
@@ -98,11 +89,6 @@ struct ChunkIndex {
     {
         return z == other.z && y == other.y && x == other.x;
     }
-};
-
-struct Box3 {
-    Shape3 origin = {0, 0, 0};
-    Shape3 shape = {0, 0, 0};
 };
 
 struct ChunkIndexHash {
@@ -2587,81 +2573,6 @@ static std::size_t countNonZeroInRelativeBox(const std::vector<uint8_t>& volume,
     return count;
 }
 
-static AlphaWrapPoint voxelCenterPoint(std::size_t z, std::size_t y, std::size_t x)
-{
-    return AlphaWrapPoint(static_cast<double>(z) + 0.5,
-                          static_cast<double>(y) + 0.5,
-                          static_cast<double>(x) + 0.5);
-}
-
-static bool bboxContains(const CGAL::Bbox_3& bbox, const AlphaWrapPoint& p)
-{
-    return p.x() >= bbox.xmin() && p.x() <= bbox.xmax() &&
-           p.y() >= bbox.ymin() && p.y() <= bbox.ymax() &&
-           p.z() >= bbox.zmin() && p.z() <= bbox.zmax();
-}
-
-static std::vector<uint8_t> classifyOuterAlphaWrapCore(const std::vector<uint8_t>& halo,
-                                                       const Box3& haloBox,
-                                                       const Box3& coreBox,
-                                                       double alpha,
-                                                       double offset)
-{
-    std::vector<AlphaWrapPoint> points;
-    points.reserve(countNonZero(halo.data(), halo.size()));
-    for (std::size_t z = 0; z < haloBox.shape[0]; ++z) {
-        for (std::size_t y = 0; y < haloBox.shape[1]; ++y) {
-            const std::size_t base = linearIndex(haloBox.shape, z, y, 0);
-            for (std::size_t x = 0; x < haloBox.shape[2]; ++x) {
-                if (halo[base + x] == 0) {
-                    continue;
-                }
-                points.push_back(voxelCenterPoint(haloBox.origin[0] + z,
-                                                  haloBox.origin[1] + y,
-                                                  haloBox.origin[2] + x));
-            }
-        }
-    }
-
-    const Shape3 coreRel = relativeOrigin(coreBox, haloBox);
-    std::vector<uint8_t> ignore(volumeElements(coreBox.shape), 0);
-    if (points.size() < 4) {
-        return ignore;
-    }
-
-    AlphaWrapMesh wrap;
-    CGAL::alpha_wrap_3(points, alpha, offset, wrap);
-    if (num_faces(wrap) == 0) {
-        return ignore;
-    }
-
-    const CGAL::Bbox_3 bbox = CGAL::Polygon_mesh_processing::bbox(wrap);
-    CGAL::Side_of_triangle_mesh<AlphaWrapMesh, AlphaWrapKernel> sideOfMesh(wrap);
-
-    for (std::size_t z = 0; z < coreBox.shape[0]; ++z) {
-        for (std::size_t y = 0; y < coreBox.shape[1]; ++y) {
-            for (std::size_t x = 0; x < coreBox.shape[2]; ++x) {
-                const std::size_t haloIdx = linearIndex(haloBox.shape,
-                                                        coreRel[0] + z,
-                                                        coreRel[1] + y,
-                                                        coreRel[2] + x);
-                if (halo[haloIdx] != 0) {
-                    continue;
-                }
-
-                const AlphaWrapPoint p = voxelCenterPoint(coreBox.origin[0] + z,
-                                                          coreBox.origin[1] + y,
-                                                          coreBox.origin[2] + x);
-                if (!bboxContains(bbox, p) || sideOfMesh(p) == CGAL::ON_UNBOUNDED_SIDE) {
-                    ignore[linearIndex(coreBox.shape, z, y, x)] = 255;
-                }
-            }
-        }
-    }
-
-    return ignore;
-}
-
 static void writeReplicatedCoreMaskToLevel0(
     vc::VcDataset& output,
     const Shape3& outShape,
@@ -3160,7 +3071,7 @@ static int processChunkAlphaWrap(
                     std::vector<uint8_t> ignoreCore;
                     {
                         ScopedTimer wrapTimer(localProfile.tMaskBuild);
-                        ignoreCore = classifyOuterAlphaWrapCore(haloBuf,
+                        ignoreCore = classifyOuterAlphaWrap(haloBuf,
                                                                 haloBox,
                                                                 coreBox,
                                                                 cfg.chunkAlpha,
@@ -3697,12 +3608,12 @@ static bool runSelfTest()
         const Box3 localHalo = expandAndClampBox(coreBox, 8, volumeShape);
         const Box3 refHalo = expandAndClampBox(coreBox, 20, volumeShape);
 
-        const auto localIgnore = classifyOuterAlphaWrapCore(extractBox(localHalo),
+        const auto localIgnore = classifyOuterAlphaWrap(extractBox(localHalo),
                                                             localHalo,
                                                             coreBox,
                                                             alpha,
                                                             offset);
-        const auto refIgnore = classifyOuterAlphaWrapCore(extractBox(refHalo),
+        const auto refIgnore = classifyOuterAlphaWrap(extractBox(refHalo),
                                                           refHalo,
                                                           coreBox,
                                                           alpha,


### PR DESCRIPTION
vc_add_ignore_label.cpp pulled the whole CGAL alpha_wrap/mesh template stack into one TU — ~120s to compile (~62s of it CGAL frontend). moved the single CGAL function behind a CGAL-free header in its own alpha_wrap.cpp. editing the tool now recompiles in ~39s instead of 120s; CGAL only recompiles when alpha_wrap.cpp changes. pure code move, no behavior change.