### PR TITLE
fix: drop vc_ui from PCH list (it was removed)

### DIFF
--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -123,7 +123,7 @@ target_link_libraries(vc_tracer PUBLIC vc_core vc_flattening Ceres::ceres)
 target_include_directories(vc_tracer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../libs/edt)
 
 if(VC_USE_PCH)
-    foreach(_lib vc_ui vc_flattening vc_inpaint vc_tracer)
+    foreach(_lib vc_flattening vc_inpaint vc_tracer)
         target_precompile_headers(${_lib} REUSE_FROM vc_core)
     endforeach()
 endif()


### PR DESCRIPTION
main is broken: #957 added vc_ui to the PCH REUSE_FROM foreach, #956 deleted the vc_ui lib. both merged, so cmake configure now fails with 'target_precompile_headers ... target vc_ui which is not built by this project' — breaking every build on main and every open PR. drop the stale vc_ui entry. verified configure+build with PCH on.