### PR TITLE
logging: move std::vformat out of the header

### DIFF
--- a/volume-cartographer/core/include/vc/core/util/Logging.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Logging.hpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <format>
 
 // Forward declaration
@@ -60,13 +61,16 @@ public:
     void add_file(const std::filesystem::path& path);
 
 private:
+    // The template stays trivial — make_format_args is cheap. The heavy
+    // std::vformat instantiation (the bulk of <format>'s compile cost) lives
+    // once in vlog() in Logging.cpp instead of in every TU that logs.
     template<typename... Args>
     void log(LogLevel level, std::format_string<Args...> fmt, Args&&... args) {
         if (level < current_level_) return;
-        std::string msg = std::format(fmt, std::forward<Args>(args)...);
-        write_log(level, msg);
+        vlog(level, fmt.get(), std::make_format_args(args...));
     }
 
+    void vlog(LogLevel level, std::string_view fmt, std::format_args args);
     void write_log(LogLevel level, const std::string& msg);
     const char* level_string(LogLevel level);
 

--- a/volume-cartographer/core/src/Logging.cpp
+++ b/volume-cartographer/core/src/Logging.cpp
@@ -58,6 +58,10 @@ const char* MinimalLogger::level_string(LogLevel level) {
     }
 }
 
+void MinimalLogger::vlog(LogLevel level, std::string_view fmt, std::format_args args) {
+    write_log(level, std::vformat(fmt, args));
+}
+
 void MinimalLogger::write_log(LogLevel level, const std::string& msg) {
     if (level < current_level_) return;
 


### PR DESCRIPTION
MinimalLogger's templated log() called std::format inline in the header, so every TU that logs re-instantiated the heavy <format> machinery (vformat_to for char AND wchar_t) — ~380s of template instantiation across the build, the largest cost after doctest. the template now only does the cheap make_format_args and forwards to a non-template vlog() that runs std::vformat once in Logging.cpp. 82/82 tests pass.