### PR TITLE
pch <format> + a separate Qt pch for VC3D

### DIFF
--- a/volume-cartographer/apps/VC3D/CMakeLists.txt
+++ b/volume-cartographer/apps/VC3D/CMakeLists.txt
@@ -226,5 +226,13 @@ target_link_libraries(VC3D
 )
 
 if(VC_USE_PCH)
-    target_precompile_headers(VC3D REUSE_FROM vc_core)
+    # VC3D gets its own PCH = vc_core's common headers + the heavy Qt umbrella
+    # headers. Qt stays out of vc_core's shared PCH so the Qt-free CLI apps that
+    # REUSE_FROM it don't pay to parse Qt. (Can't REUSE_FROM vc_core and add Qt
+    # — a target has one PCH — so build VC3D's directly from the same list.)
+    target_precompile_headers(VC3D PRIVATE
+        ${VC_PCH_HEADERS}
+        "$<$<COMPILE_LANGUAGE:CXX>:<QtCore/QtCore>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<QtWidgets/QtWidgets>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<QtConcurrent/QtConcurrent>>")
 endif()

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -93,8 +93,13 @@ if(VC_USE_PCH)
         "$<$<COMPILE_LANGUAGE:CXX>:<string>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<unordered_map>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<unordered_set>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<random>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<utility>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<vector>>"
+        # <format> is the heaviest std header in the build (~1.3k s of
+        # instantiation across TUs; libstdc++ 15 + Qt pull it in widely).
+        "$<$<COMPILE_LANGUAGE:CXX>:<format>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<string_view>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<opencv2/core.hpp>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<opencv2/imgproc.hpp>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<opencv2/imgcodecs.hpp>>"


### PR DESCRIPTION
<format> was the heaviest std header in the build (~1.3k s of template instantiation across ~265 TUs — libstdc++ 15 and Qt pull it in widely); precompiling it drops that to ~75s. also adds <random> (59 TUs). Qt umbrella headers go in a separate VC3D-only PCH rather than the shared vc_core one, so the Qt-free CLI apps that REUSE_FROM vc_core don't pay to parse Qt, while VC3D gets QtCore/QtWidgets/QtConcurrent precompiled. vc_core's PCH stays Qt-free (verified). 82/82 tests pass.