### PR TITLE
drop Tiff.hpp from QuadSurface.hpp

### DIFF
--- a/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "Surface.hpp"
-#include "Tiff.hpp"
 
 // Surface loading and channel flags
 #define SURF_LOAD_IGNORE_MASK 1

--- a/volume-cartographer/core/src/GrowPatch.cpp
+++ b/volume-cartographer/core/src/GrowPatch.cpp
@@ -8,6 +8,7 @@
 #include "vc/core/util/Surface.hpp"
 #include "vc/core/util/QuadSurface.hpp"
 #include "vc/core/util/SurfacePatchIndex.hpp"
+#include "vc/core/util/Tiff.hpp"
 #include "vc/tracer/SurfaceModeling.hpp"
 #include "vc/core/util/SurfaceArea.hpp"
 #include "vc/core/util/OMPThreadPointCollection.hpp"

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -6,6 +6,7 @@
 #include "vc/core/util/PointIndex.hpp"
 #include "vc/core/util/Slicing.hpp"
 #include "vc/core/util/SurfacePatchIndex.hpp"
+#include "vc/core/util/Tiff.hpp"
 
 #include <opencv2/imgproc.hpp>
 #include <opencv2/calib3d.hpp>


### PR DESCRIPTION
QuadSurface.hpp pulled in Tiff.hpp (and thus tiffio.h) for all 87 TUs that include it, but uses no Tiff symbols itself. Moved the include to the two .cpp files that actually use it.