### PR TITLE
trim heavy includes from Slicing/VolumePkg/VcDataset

### DIFF
--- a/volume-cartographer/apps/VC3D/FileWatcherService.cpp
+++ b/volume-cartographer/apps/VC3D/FileWatcherService.cpp
@@ -6,6 +6,7 @@
 #include "SurfacePanelController.hpp"
 #include "segmentation/SegmentationModule.hpp"
 #include "SurfaceTreeWidget.hpp"
+#include "vc/core/types/Segmentation.hpp"
 #include "vc/core/util/Logging.hpp"
 #include "VCSettings.hpp"
 #include <sys/inotify.h>

--- a/volume-cartographer/apps/VC3D/SeedingWidget.cpp
+++ b/volume-cartographer/apps/VC3D/SeedingWidget.cpp
@@ -18,6 +18,7 @@
 
 #include <opencv2/imgproc.hpp>
 
+#include "vc/core/types/Segmentation.hpp"
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/Slicing.hpp"

--- a/volume-cartographer/apps/VC3D/SurfaceAreaCalculator.cpp
+++ b/volume-cartographer/apps/VC3D/SurfaceAreaCalculator.cpp
@@ -1,6 +1,7 @@
 #include "SurfaceAreaCalculator.hpp"
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/types/Volume.hpp"
+#include "vc/core/util/QuadSurface.hpp"
 #include "vc/core/util/DateTime.hpp"
 #include "utils/Json.hpp"
 #include <opencv2/imgproc.hpp>

--- a/volume-cartographer/core/include/vc/core/types/VcDataset.hpp
+++ b/volume-cartographer/core/include/vc/core/types/VcDataset.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "utils/Json.hpp"
-#include "utils/zarr.hpp"
 
 namespace vc {
 
@@ -98,6 +97,7 @@ std::unique_ptr<VcDataset> createZarrDataset(
     const std::string& dimensionSeparator = ".",
     std::int64_t fillValue = 0);
 
-utils::ZarrArray::CodecRegistry buildZarrCodecRegistry(int dtypeSize);
+// buildZarrCodecRegistry() is declared in utils/zarr.hpp so its CodecRegistry
+// return type doesn't pull zarr.hpp into every VcDataset.hpp includer.
 
 }  // namespace vc

--- a/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
+++ b/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
@@ -12,8 +12,10 @@
 #include <vector>
 
 #include "utils/Json.hpp"
-#include "vc/core/types/Segmentation.hpp"
-#include "vc/core/types/Volume.hpp"
+
+class Volume;
+class Segmentation;
+class QuadSurface;
 
 namespace vc::project {
 

--- a/volume-cartographer/core/include/vc/core/util/Slicing.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Slicing.hpp
@@ -3,9 +3,10 @@
 #include <opencv2/core.hpp>
 #include <string>
 
-#include <vc/core/render/IChunkedArray.hpp>
-#include <vc/core/util/Compositing.hpp>
 #include <vc/core/types/Sampling.hpp>
+
+namespace vc::render { class IChunkedArray; }
+struct CompositeParams;
 
 // Read interpolated 3D data from a chunked zarr source.
 void readInterpolated3D(cv::Mat_<uint8_t> &out, vc::render::IChunkedArray* cache, int level, const cv::Mat_<cv::Vec3f> &coords, bool nearest_neighbor=false);

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -13,7 +13,10 @@
 #include <pwd.h>
 #include <unistd.h>
 
+#include "vc/core/types/Segmentation.hpp"
+#include "vc/core/types/Volume.hpp"
 #include "vc/core/util/Logging.hpp"
+#include "vc/core/util/QuadSurface.hpp"
 #include "vc/core/util/RemoteUrl.hpp"
 
 namespace fs = std::filesystem;

--- a/volume-cartographer/core/test/test_vcdataset_more.cpp
+++ b/volume-cartographer/core/test/test_vcdataset_more.cpp
@@ -5,6 +5,7 @@
 #include <doctest/doctest.h>
 
 #include "vc/core/types/VcDataset.hpp"
+#include "utils/zarr.hpp"
 
 #include <cstdint>
 #include <cstring>

--- a/volume-cartographer/utils/include/utils/zarr.hpp
+++ b/volume-cartographer/utils/include/utils/zarr.hpp
@@ -1037,3 +1037,9 @@ private:
 };
 
 } // namespace utils
+
+namespace vc {
+// Declared here (not VcDataset.hpp) so its CodecRegistry return type doesn't
+// drag zarr.hpp into every VcDataset.hpp includer; defined in VcDataset.cpp.
+utils::ZarrArray::CodecRegistry buildZarrCodecRegistry(int dtypeSize);
+}


### PR DESCRIPTION
More IWYU header cleanup. Forward-declare types used only by pointer/ref/shared_ptr instead of pulling their full headers:
- Slicing.hpp: IChunkedArray + CompositeParams
- VolumePkg.hpp: Volume, Segmentation, QuadSurface
- VcDataset.hpp: move buildZarrCodecRegistry's decl to zarr.hpp so the 1k-line zarr.hpp stops landing in all 22 includers

The few consumers that actually used the types directly now include the headers themselves.