### PR TITLE
Add GPU-safe scroll decohesion augmentation

### DIFF
--- a/segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/data_augmentation/nnUNetTrainerExtraDA.py
+++ b/segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/data_augmentation/nnUNetTrainerExtraDA.py
@@ -27,7 +27,7 @@ from batchgeneratorsv2.transforms.nnunet.remove_connected_components import \
     RemoveRandomConnectedComponentFromOneHotEncodingTransform
 from batchgeneratorsv2.transforms.nnunet.seg_to_onehot import MoveSegAsOneHotToDataTransform
 from batchgeneratorsv2.transforms.noise.gaussian_blur import GaussianBlurTransform
-from batchgeneratorsv2.transforms.noise.extranoisetransforms import BlankRectangleTransform
+from batchgeneratorsv2.transforms.noise.extranoisetransforms import BlankRectangleTransform, DecohesionTransform
 from batchgeneratorsv2.transforms.spatial.low_resolution import SimulateLowResolutionTransform
 from batchgeneratorsv2.transforms.spatial.mirroring import MirrorTransform
 from batchgeneratorsv2.transforms.spatial.spatial import SpatialTransform
@@ -753,6 +753,16 @@ class nnUNetTrainerExtraDA(nnUNetTrainer):
                 p_per_sample=0.4,  # same as original
                 p_per_channel=0.5  # same as original
             ), apply_probability=0.5
+        ))
+
+        transforms.append(RandomTransform(
+            DecohesionTransform(
+                shift=((-6, 6), (-6, 6)),
+                alpha=(0.15, 0.45),
+                num_prev_slices=(1, 3),
+                smear_axis=1,
+                p_per_channel=0.5
+            ), apply_probability=0.25
         ))
 
         transforms.append(RandomTransform(

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/benchmarks/decohesion_ablation.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/benchmarks/decohesion_ablation.py
@@ -1,0 +1,300 @@
+import argparse
+import csv
+import json
+import random
+from pathlib import Path
+from time import perf_counter
+
+import numpy as np
+import torch
+from torch import nn
+
+from batchgeneratorsv2.transforms.noise.extranoisetransforms import DecohesionTransform
+
+
+IGNORE_LABEL = 2
+
+
+def _default_dataset_root() -> Path:
+    workspace_root = Path(__file__).resolve().parents[7]
+    return workspace_root / "data" / "smoke" / "surface-detection" / "kaggle-mini-fixture"
+
+
+def _seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _read_volume(path: Path) -> torch.Tensor:
+    from tifffile import imread
+
+    arr = imread(path)
+    if arr.ndim != 3:
+        raise ValueError(f"Expected a 3D TIFF volume at {path}, got shape {arr.shape}")
+    arr = arr.astype(np.float32)
+    lo, hi = np.percentile(arr, (1, 99))
+    if hi > lo:
+        arr = np.clip((arr - lo) / (hi - lo), 0, 1)
+    else:
+        arr = np.zeros_like(arr, dtype=np.float32)
+    return torch.from_numpy(arr).unsqueeze(0)
+
+
+def _read_label(path: Path) -> tuple[torch.Tensor, torch.Tensor]:
+    from tifffile import imread
+
+    arr = imread(path)
+    if arr.ndim != 3:
+        raise ValueError(f"Expected a 3D TIFF label volume at {path}, got shape {arr.shape}")
+    label = torch.from_numpy((arr == 1).astype(np.float32)).unsqueeze(0)
+    valid_mask = torch.from_numpy((arr != IGNORE_LABEL).astype(np.float32)).unsqueeze(0)
+    return label, valid_mask
+
+
+class Tiny3DUNet(nn.Module):
+    def __init__(self, features: int = 6):
+        super().__init__()
+        self.enc1 = nn.Sequential(
+            nn.Conv3d(1, features, 3, padding=1),
+            nn.InstanceNorm3d(features),
+            nn.LeakyReLU(inplace=True),
+            nn.Conv3d(features, features, 3, padding=1),
+            nn.LeakyReLU(inplace=True),
+        )
+        self.down = nn.MaxPool3d(2)
+        self.mid = nn.Sequential(
+            nn.Conv3d(features, features * 2, 3, padding=1),
+            nn.InstanceNorm3d(features * 2),
+            nn.LeakyReLU(inplace=True),
+            nn.Conv3d(features * 2, features * 2, 3, padding=1),
+            nn.LeakyReLU(inplace=True),
+        )
+        self.up = nn.ConvTranspose3d(features * 2, features, 2, stride=2)
+        self.dec = nn.Sequential(
+            nn.Conv3d(features * 2, features, 3, padding=1),
+            nn.LeakyReLU(inplace=True),
+            nn.Conv3d(features, features, 3, padding=1),
+            nn.LeakyReLU(inplace=True),
+        )
+        self.out = nn.Conv3d(features, 1, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        enc = self.enc1(x)
+        mid = self.mid(self.down(enc))
+        up = self.up(mid)
+        return self.out(self.dec(torch.cat([up, enc], dim=1)))
+
+
+def _masked_bce_dice_loss(logits: torch.Tensor, target: torch.Tensor, valid_mask: torch.Tensor) -> torch.Tensor:
+    bce = nn.functional.binary_cross_entropy_with_logits(logits, target, reduction="none")
+    bce = (bce * valid_mask).sum() / valid_mask.sum().clamp_min(1)
+
+    probs = torch.sigmoid(logits) * valid_mask
+    target = target * valid_mask
+    intersection = (probs * target).sum()
+    dice = (2 * intersection + 1e-6) / (probs.sum() + target.sum() + 1e-6)
+    return bce + (1 - dice)
+
+
+def _dice_from_logits(logits: torch.Tensor, target: torch.Tensor, valid_mask: torch.Tensor) -> float:
+    pred = (torch.sigmoid(logits) >= 0.5).float() * valid_mask
+    target = target * valid_mask
+    intersection = (pred * target).sum()
+    dice = (2 * intersection + 1e-6) / (pred.sum() + target.sum() + 1e-6)
+    return float(dice.item())
+
+
+def _make_decohesion_transform() -> DecohesionTransform:
+    return DecohesionTransform(
+        shift=((-2, 2), (-2, 2)),
+        alpha=(0.15, 0.45),
+        num_prev_slices=(1, 2),
+        smear_axis=1,
+        p_per_channel=1.0,
+    )
+
+
+def _augment(image: torch.Tensor, transform: DecohesionTransform, seed: int) -> torch.Tensor:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    return transform(image=image.clone())["image"]
+
+
+def _train_variant(
+    name: str,
+    train_image: torch.Tensor,
+    train_label: torch.Tensor,
+    train_mask: torch.Tensor,
+    val_image: torch.Tensor,
+    val_label: torch.Tensor,
+    val_mask: torch.Tensor,
+    epochs: int,
+    lr: float,
+    seed: int,
+    device: torch.device,
+    use_decohesion: bool,
+) -> dict:
+    _seed_everything(seed)
+    model = Tiny3DUNet().to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr)
+    transform = _make_decohesion_transform()
+
+    train_image = train_image.to(device)
+    train_label = train_label.to(device)
+    train_mask = train_mask.to(device)
+    val_image = val_image.to(device)
+    val_label = val_label.to(device)
+    val_mask = val_mask.to(device)
+
+    rows = []
+    start = perf_counter()
+    for epoch in range(1, epochs + 1):
+        model.train()
+        optimizer.zero_grad(set_to_none=True)
+        image = train_image
+        if use_decohesion:
+            image = _augment(image[0], transform, seed + epoch).unsqueeze(0)
+        logits = model(image)
+        loss = _masked_bce_dice_loss(logits, train_label, train_mask)
+        loss.backward()
+        optimizer.step()
+
+        model.eval()
+        with torch.no_grad():
+            clean_val_logits = model(val_image)
+            clean_val_dice = _dice_from_logits(clean_val_logits, val_label, val_mask)
+            corrupted_val = _augment(val_image[0], transform, seed + 10000 + epoch).unsqueeze(0)
+            corrupted_val_logits = model(corrupted_val)
+            corrupted_val_dice = _dice_from_logits(corrupted_val_logits, val_label, val_mask)
+        rows.append({
+            "epoch": epoch,
+            "train_loss": float(loss.item()),
+            "clean_val_dice": clean_val_dice,
+            "decohesion_val_dice": corrupted_val_dice,
+        })
+
+    elapsed = perf_counter() - start
+    return {
+        "name": name,
+        "use_decohesion": use_decohesion,
+        "seconds": elapsed,
+        "final": rows[-1],
+        "epochs": rows,
+    }
+
+
+def _write_tsv(rows: list[dict], path: Path) -> None:
+    fieldnames = ["seed", "variant", "epoch", "train_loss", "clean_val_dice", "decohesion_val_dice"]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _parse_seeds(value: str) -> list[int]:
+    seeds = [int(v.strip()) for v in value.split(",") if v.strip()]
+    if not seeds:
+        raise ValueError("--seeds must contain at least one integer seed")
+    return seeds
+
+
+def _mean(values: list[float]) -> float:
+    return float(sum(values) / len(values))
+
+
+def _aggregate_runs(runs: list[dict]) -> dict:
+    by_variant = {}
+    for run in runs:
+        by_variant.setdefault(run["name"], []).append(run["final"])
+
+    aggregates = {}
+    for name, finals in by_variant.items():
+        aggregates[name] = {
+            "train_loss_mean": _mean([row["train_loss"] for row in finals]),
+            "clean_val_dice_mean": _mean([row["clean_val_dice"] for row in finals]),
+            "decohesion_val_dice_mean": _mean([row["decohesion_val_dice"] for row in finals]),
+        }
+
+    if {"baseline", "decohesion"}.issubset(aggregates):
+        aggregates["delta_decohesion_minus_baseline"] = {
+            "train_loss_mean": aggregates["decohesion"]["train_loss_mean"] - aggregates["baseline"]["train_loss_mean"],
+            "clean_val_dice_mean": aggregates["decohesion"]["clean_val_dice_mean"] -
+                                   aggregates["baseline"]["clean_val_dice_mean"],
+            "decohesion_val_dice_mean": aggregates["decohesion"]["decohesion_val_dice_mean"] -
+                                        aggregates["baseline"]["decohesion_val_dice_mean"],
+        }
+    return aggregates
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Tiny train/eval ablation for DecohesionTransform.")
+    parser.add_argument("--dataset-root", type=Path, default=_default_dataset_root())
+    parser.add_argument("--out-dir", type=Path, default=Path("decohesion-ablation-out"))
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--lr", type=float, default=3e-3)
+    parser.add_argument("--seeds", default="201,202,203")
+    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    args = parser.parse_args()
+
+    if args.epochs < 1:
+        raise ValueError("--epochs must be >= 1")
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested but is not available")
+
+    train_image = _read_volume(args.dataset_root / "train_images" / "synthetic_surface_000.tif").unsqueeze(0)
+    train_label, train_mask = _read_label(args.dataset_root / "train_labels" / "synthetic_surface_000.tif")
+    train_label, train_mask = train_label.unsqueeze(0), train_mask.unsqueeze(0)
+    val_image = _read_volume(args.dataset_root / "train_images" / "synthetic_surface_001.tif").unsqueeze(0)
+    val_label, val_mask = _read_label(args.dataset_root / "train_labels" / "synthetic_surface_001.tif")
+    val_label, val_mask = val_label.unsqueeze(0), val_mask.unsqueeze(0)
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    seeds = _parse_seeds(args.seeds)
+    runs = []
+    for seed in seeds:
+        baseline = _train_variant("baseline", train_image, train_label, train_mask, val_image, val_label, val_mask,
+                                  args.epochs, args.lr, seed, device, False)
+        baseline["seed"] = seed
+        runs.append(baseline)
+        decohesion = _train_variant("decohesion", train_image, train_label, train_mask, val_image, val_label, val_mask,
+                                    args.epochs, args.lr, seed, device, True)
+        decohesion["seed"] = seed
+        runs.append(decohesion)
+
+    epoch_rows = []
+    for variant in runs:
+        for row in variant["epochs"]:
+            epoch_rows.append({"seed": variant["seed"], "variant": variant["name"], **row})
+    _write_tsv(epoch_rows, args.out_dir / "decohesion_ablation_epochs.tsv")
+
+    aggregate = _aggregate_runs(runs)
+    report = {
+        "summary": "Tiny smoke-scale model-performance ablation for DecohesionTransform.",
+        "claim_safety": (
+            "Uses a two-case synthetic surface-detection fixture. This is real train/eval evidence for the "
+            "augmentation path, but not a production nnU-Net scroll-dataset ablation."
+        ),
+        "dataset_root": str(args.dataset_root),
+        "device": str(device),
+        "cuda_device": torch.cuda.get_device_name(0) if device.type == "cuda" else None,
+        "torch_version": torch.__version__,
+        "seeds": seeds,
+        "epochs": args.epochs,
+        "learning_rate": args.lr,
+        "runs": runs,
+        "aggregate": aggregate,
+    }
+    (args.out_dir / "decohesion_ablation_report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({
+        "aggregate": aggregate,
+        "report": str(args.out_dir / "decohesion_ablation_report.json"),
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/benchmarks/decohesion_smoke.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/benchmarks/decohesion_smoke.py
@@ -1,0 +1,135 @@
+import argparse
+import json
+from pathlib import Path
+from time import perf_counter
+
+import numpy as np
+import torch
+
+from batchgeneratorsv2.transforms.noise.extranoisetransforms import DecohesionTransform
+
+
+def _normalize_to_uint8(arr: np.ndarray) -> np.ndarray:
+    arr = arr.astype(np.float32)
+    lo, hi = np.percentile(arr, (1, 99))
+    if hi <= lo:
+        return np.zeros_like(arr, dtype=np.uint8)
+    arr = np.clip((arr - lo) / (hi - lo), 0, 1)
+    return (arr * 255).astype(np.uint8)
+
+
+def _synthetic_volume(shape: tuple[int, int, int]) -> torch.Tensor:
+    z, y, x = shape
+    zz = torch.linspace(-1, 1, z)[:, None, None]
+    yy = torch.linspace(-1, 1, y)[None, :, None]
+    xx = torch.linspace(-1, 1, x)[None, None, :]
+    fibers = torch.sin(42 * (xx + 0.4 * yy) + 9 * zz)
+    sheet = torch.exp(-((yy + 0.25 * torch.sin(4 * zz)) ** 2) / 0.02)
+    texture = 0.08 * torch.randn(shape)
+    return (sheet * (0.7 + 0.3 * fibers) + texture).unsqueeze(0).float()
+
+
+def _load_tiff_stack(layers_dir: Path, crop_size: int, max_slices: int) -> torch.Tensor:
+    from tifffile import imread
+
+    paths = sorted(p for p in layers_dir.iterdir() if p.suffix.lower() in {".tif", ".tiff"})
+    if not paths:
+        raise FileNotFoundError(f"No TIFF slices found in {layers_dir}")
+    slices = []
+    for path in paths[:max_slices]:
+        arr = imread(path)
+        if arr.ndim != 2:
+            raise ValueError(f"Expected 2D TIFF slice, got shape {arr.shape} for {path}")
+        y0 = max((arr.shape[0] - crop_size) // 2, 0)
+        x0 = max((arr.shape[1] - crop_size) // 2, 0)
+        slices.append(arr[y0:y0 + crop_size, x0:x0 + crop_size].astype(np.float32))
+    stack = np.stack(slices, axis=0)
+    stack -= float(stack.mean())
+    stack /= float(stack.std() + 1e-6)
+    return torch.from_numpy(stack).unsqueeze(0)
+
+
+def _time_transform(transform: DecohesionTransform, image: torch.Tensor, repeats: int) -> float:
+    if image.device.type == "cuda":
+        torch.cuda.synchronize()
+    start = perf_counter()
+    for _ in range(repeats):
+        transform(image=image.clone())
+    if image.device.type == "cuda":
+        torch.cuda.synchronize()
+    return (perf_counter() - start) / repeats
+
+
+def _save_contact_sheet(before: torch.Tensor, after: torch.Tensor, path: Path) -> None:
+    from PIL import Image, ImageDraw
+
+    before_np = before.detach().cpu().numpy()[0]
+    after_np = after.detach().cpu().numpy()[0]
+    idxs = sorted(set([0, before_np.shape[0] // 2, before_np.shape[0] - 1]))
+    tiles = []
+    for label, stack in [("before", before_np), ("after", after_np)]:
+        for idx in idxs:
+            img = Image.fromarray(_normalize_to_uint8(stack[idx])).convert("RGB")
+            draw = ImageDraw.Draw(img)
+            draw.rectangle((0, 0, 92, 18), fill=(0, 0, 0))
+            draw.text((4, 3), f"{label} z={idx}", fill=(255, 255, 255))
+            tiles.append(img)
+    width = max(tile.width for tile in tiles)
+    height = max(tile.height for tile in tiles)
+    sheet = Image.new("RGB", (width * len(idxs), height * 2), (0, 0, 0))
+    for n, tile in enumerate(tiles):
+        row = 0 if n < len(idxs) else 1
+        col = n % len(idxs)
+        sheet.paste(tile, (col * width, row * height))
+    sheet.save(path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Smoke benchmark for scroll decohesion augmentation.")
+    parser.add_argument("--layers-dir", type=Path, help="Optional directory containing TIFF slices.")
+    parser.add_argument("--crop-size", type=int, default=256)
+    parser.add_argument("--max-slices", type=int, default=9)
+    parser.add_argument("--synthetic-shape", default="9,256,256")
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--out-dir", type=Path, default=Path("decohesion-smoke-out"))
+    args = parser.parse_args()
+
+    if args.layers_dir:
+        image = _load_tiff_stack(args.layers_dir, args.crop_size, args.max_slices)
+        source = str(args.layers_dir)
+    else:
+        image = _synthetic_volume(tuple(int(i) for i in args.synthetic_shape.split(",")))
+        source = "synthetic"
+
+    transform = DecohesionTransform(
+        shift=(2, 0),
+        alpha=0.65,
+        num_prev_slices=2,
+        smear_axis=1,
+        p_per_channel=1.0,
+    )
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    cpu_time = _time_transform(transform, image.cpu(), args.repeats)
+    result = transform(image=image.clone())["image"]
+    _save_contact_sheet(image, result, args.out_dir / "decohesion_contact_sheet.png")
+
+    report = {
+        "source": source,
+        "shape": list(image.shape),
+        "dtype": str(image.dtype),
+        "cpu_seconds_per_run": cpu_time,
+        "cuda_seconds_per_run": None,
+        "contact_sheet": str(args.out_dir / "decohesion_contact_sheet.png"),
+    }
+    if torch.cuda.is_available():
+        cuda_image = image.cuda()
+        report["cuda_device"] = torch.cuda.get_device_name(0)
+        report["cuda_seconds_per_run"] = _time_transform(transform, cuda_image, args.repeats)
+
+    (args.out_dir / "decohesion_smoke_report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/extranoisetransforms.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/extranoisetransforms.py
@@ -1,6 +1,7 @@
 from typing import Union, Tuple, List, Callable
 import numpy as np
 import torch
+from batchgeneratorsv2.helpers.scalar_type import RandomScalar, sample_scalar
 from batchgeneratorsv2.transforms.base.basic_transform import BasicTransform, ImageOnlyTransform
 
 class ColorFunctionExtractor:
@@ -119,11 +120,6 @@ class BlankRectangleTransform(BasicTransform):
     def _apply_to_regr_target(self, regr_target: torch.Tensor, **kwargs) -> torch.Tensor:
         return regr_target  # Don't modify regression targets
     
-import numpy as np
-import torch
-from typing import Union, Tuple
-from batchgeneratorsv2.transforms.base.basic_transform import BasicTransform
-
 def augment_rician_noise(data: torch.Tensor, noise_variance: Tuple[float, float]) -> torch.Tensor:
     """
     Adds Rician noise to the input tensor.
@@ -182,72 +178,115 @@ class RicianNoiseTransform(BasicTransform):
         return regr_target  # Don't apply noise to regression targets
 
 
-class SmearTransform(ImageOnlyTransform):
-    def __init__(self, shift=(10, 0), alpha=0.5, num_prev_slices=1, smear_axis=1):
+def _sample_int(value: Union[int, Tuple[int, int], List[int]]) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (tuple, list)) and len(value) == 2:
+        lo, hi = int(value[0]), int(value[1])
+        if lo == hi:
+            return lo
+        return int(torch.randint(lo, hi + 1, (1,)).item())
+    raise RuntimeError(f"Expected int or inclusive int range, got {value!r}")
+
+
+def _sample_shift(shift, num_plane_dims: int) -> Tuple[int, ...]:
+    if isinstance(shift, int):
+        return (shift,) * num_plane_dims
+    if not isinstance(shift, (tuple, list)):
+        raise RuntimeError(f"Expected int, tuple, or list for shift, got {type(shift)}")
+    if len(shift) != num_plane_dims:
+        raise RuntimeError(f"Expected {num_plane_dims} shift entries, got {len(shift)}")
+    return tuple(_sample_int(s) for s in shift)
+
+
+class DecohesionTransform(ImageOnlyTransform):
+    def __init__(
+            self,
+            shift: Union[int, Tuple[int, ...], Tuple[Tuple[int, int], ...]] = (10, 0),
+            alpha: RandomScalar = 0.5,
+            num_prev_slices: Union[int, Tuple[int, int]] = 1,
+            smear_axis: int = 1,
+            p_per_channel: float = 1.0,
+    ):
         """
+        Simulate scroll-specific decohesion by blending shifted previous slices into
+        later slices. This is an image-only transform; labels are left untouched.
+
         Args:
-            shift : tuple of int
-                The (row_shift, col_shift) to apply to each previous slice (wrap-around is used).
-            alpha : float
+            shift:
+                Int shift applied to every in-slice dimension, a tuple of constant
+                shifts, or a tuple of inclusive integer ranges sampled per call.
+            alpha:
                 Blending factor for the aggregated shifted slices (0 = no influence, 1 = full replacement).
-            num_prev_slices : int
+            num_prev_slices:
                 The number of previous slices to aggregate and use for blending.
-            smear_axis : int
+            smear_axis:
                 The spatial axis (in the full tensor) along which to apply the smear.
                 For an input image with shape (C, X, Y) or (C, X, Y, Z), spatial dimensions are indices 1,2,(3).
                 Default: 1 (i.e. the first spatial axis).
+            p_per_channel:
+                Probability of applying the transform to each channel.
         """
         super().__init__()
         self.shift = shift
         self.alpha = alpha
         self.num_prev_slices = num_prev_slices
         self.smear_axis = smear_axis
+        self.p_per_channel = p_per_channel
 
     def get_parameters(self, **data_dict) -> dict:
-        # No extra parameters are needed.
-        return {}
+        img = data_dict["image"]
+        num_spatial_dims = img.ndim - 1
+        local_smear_axis = self.smear_axis - 1
+        if not (0 <= local_smear_axis < num_spatial_dims):
+            raise ValueError(f"smear_axis must be between 1 and {num_spatial_dims} for input with shape {tuple(img.shape)}")
+        num_plane_dims = num_spatial_dims - 1
+        return {
+            "apply_to_channel": torch.rand(img.shape[0], device=img.device) < self.p_per_channel,
+            "alpha": float(sample_scalar(self.alpha, image=img)),
+            "num_prev_slices": _sample_int(self.num_prev_slices),
+            "shift": _sample_shift(self.shift, num_plane_dims),
+            "local_smear_axis": local_smear_axis,
+        }
 
     def _apply_to_image(self, img: torch.Tensor, **params) -> torch.Tensor:
-        # Ensure the image is on CPU and convert to numpy.
-        device = img.device
-        img_np = img.detach().cpu().numpy()
-        # We assume the input image has shape (C, ...) where the remaining dimensions are spatial.
-        C = img_np.shape[0]
-        spatial_shape = img_np.shape[1:]
-        num_spatial_dims = len(spatial_shape)
-        # Validate smear_axis: must be between 1 and number of spatial dimensions.
-        if not (1 <= self.smear_axis <= num_spatial_dims):
-            raise ValueError(f"smear_axis must be between 1 and {num_spatial_dims} for input with shape {img_np.shape}")
-        # For each channel, we want to operate on the corresponding spatial image.
-        # Since the channel dimension is separate, we adjust the smear axis to a "local" axis in the channel image.
-        # (For example, if smear_axis is 1 in the full tensor, then for the channel image it is 0.)
-        local_smear_axis = self.smear_axis - 1
+        apply_to_channel = params["apply_to_channel"]
+        if not torch.any(apply_to_channel):
+            return img
 
-        transformed = np.copy(img_np)
-        for ch in range(C):
-            chan_img = img_np[ch]  # shape: spatial_shape (e.g., for a 3D image: (D, H, W))
-            # Proceed only if the size along the smear axis is greater than num_prev_slices.
-            if chan_img.shape[local_smear_axis] <= self.num_prev_slices:
-                continue
+        num_prev_slices = int(params["num_prev_slices"])
+        if num_prev_slices <= 0:
+            return img
 
-            # To iterate easily along the smear axis, bring that axis to the front.
-            moved = np.moveaxis(chan_img, local_smear_axis, 0)  # shape: (N, ...) where N = size along smear axis
-            N = moved.shape[0]
-            # Iterate over slices starting from index num_prev_slices.
-            for i in range(self.num_prev_slices, N):
-                aggregated = np.zeros_like(moved[i], dtype=np.float32)
-                count = 0
-                for j in range(i - self.num_prev_slices, i):
-                    # Shift the previous slice by the given offset.
-                    shifted = np.roll(moved[j], shift=self.shift, axis=(0, 1))
-                    aggregated += shifted.astype(np.float32)
-                    count += 1
-                if count > 0:
-                    aggregated /= count
-                # Blend the aggregated slice with the current slice.
-                moved[i] = ((1 - self.alpha) * moved[i].astype(np.float32) + self.alpha * aggregated).astype(moved[i].dtype)
-            # Restore the original axis order.
-            transformed[ch] = np.moveaxis(moved, 0, local_smear_axis)
-        # Convert back to a torch tensor (preserving dtype and device).
-        out = torch.from_numpy(transformed).to(device)
-        return out
+        local_smear_axis = params["local_smear_axis"]
+        selected = torch.where(apply_to_channel.to(img.device))[0]
+        work = img[selected]
+        moved = torch.movedim(work, local_smear_axis + 1, 1)
+        num_slices = moved.shape[1]
+        if num_slices <= 1:
+            return img
+
+        work_dtype = moved.dtype if moved.is_floating_point() else torch.float32
+        base = moved.to(work_dtype)
+        accumulated = torch.zeros_like(base)
+        counts = torch.zeros(num_slices, dtype=work_dtype, device=img.device)
+        plane_dims = tuple(range(2, moved.ndim))
+        max_lag = min(num_prev_slices, num_slices - 1)
+
+        for lag in range(1, max_lag + 1):
+            shifted_previous = torch.roll(base[:, :-lag], shifts=params["shift"], dims=plane_dims)
+            accumulated[:, lag:] += shifted_previous
+            counts[lag:] += 1
+
+        view_shape = (1, num_slices, *([1] * (moved.ndim - 2)))
+        mean_previous = accumulated / counts.clamp_min(1).view(view_shape)
+        alpha = float(params["alpha"])
+        blended = (1 - alpha) * base + alpha * mean_previous
+        blended[:, counts == 0] = base[:, counts == 0]
+
+        img[selected] = torch.movedim(blended.to(img.dtype), 1, local_smear_axis + 1)
+        return img
+
+
+class SmearTransform(DecohesionTransform):
+    """Backward-compatible name for the scroll decohesion smear transform."""

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/extranoisetransforms.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/extranoisetransforms.py
@@ -1,3 +1,4 @@
+from numbers import Integral, Real
 from typing import Union, Tuple, List, Callable
 import numpy as np
 import torch
@@ -178,24 +179,89 @@ class RicianNoiseTransform(BasicTransform):
         return regr_target  # Don't apply noise to regression targets
 
 
-def _sample_int(value: Union[int, Tuple[int, int], List[int]]) -> int:
-    if isinstance(value, int):
-        return value
-    if isinstance(value, (tuple, list)) and len(value) == 2:
+def _is_int(value) -> bool:
+    return isinstance(value, Integral) and not isinstance(value, bool)
+
+
+def _is_number(value) -> bool:
+    return isinstance(value, Real) and not isinstance(value, bool)
+
+
+def _validate_probability(value: float, name: str) -> None:
+    if not _is_number(value) or not (0 <= float(value) <= 1):
+        raise ValueError(f"{name} must be a number in [0, 1], got {value!r}")
+
+
+def _validate_random_scalar_range(value: RandomScalar, name: str) -> None:
+    if callable(value):
+        return
+    if _is_number(value):
+        _validate_probability(float(value), name)
+        return
+    if isinstance(value, (tuple, list)) and len(value) == 2 and all(_is_number(v) for v in value):
+        lo, hi = float(value[0]), float(value[1])
+        if not (0 <= lo <= hi <= 1):
+            raise ValueError(f"{name} range must satisfy 0 <= min <= max <= 1, got {value!r}")
+        return
+    raise ValueError(f"{name} must be a number, inclusive range, or callable, got {value!r}")
+
+
+def _validate_num_prev_slices(value: Union[int, Tuple[int, int], List[int]]) -> None:
+    if _is_int(value):
+        if int(value) < 1:
+            raise ValueError(f"num_prev_slices must be >= 1, got {value!r}")
+        return
+    if isinstance(value, (tuple, list)) and len(value) == 2 and all(_is_int(v) for v in value):
         lo, hi = int(value[0]), int(value[1])
+        if not (1 <= lo <= hi):
+            raise ValueError(f"num_prev_slices range must satisfy 1 <= min <= max, got {value!r}")
+        return
+    raise ValueError(f"num_prev_slices must be an int or inclusive int range, got {value!r}")
+
+
+def _validate_shift_ranges(shift) -> None:
+    if _is_int(shift):
+        return
+    if not isinstance(shift, (tuple, list)):
+        raise ValueError(f"shift must be an int, tuple, or list, got {type(shift)}")
+    for entry in shift:
+        if _is_int(entry):
+            continue
+        if isinstance(entry, (tuple, list)) and len(entry) == 2 and all(_is_int(v) for v in entry):
+            lo, hi = int(entry[0]), int(entry[1])
+            if lo > hi:
+                raise ValueError(f"shift ranges must satisfy min <= max, got {entry!r}")
+            continue
+        raise ValueError(f"shift entries must be ints or inclusive int ranges, got {entry!r}")
+
+
+def _validate_smear_axis(smear_axis: int) -> None:
+    if not _is_int(smear_axis):
+        raise ValueError(f"smear_axis must be a positive integer, got {smear_axis!r}")
+    if int(smear_axis) < 1:
+        raise ValueError(f"smear_axis must be >= 1, got {smear_axis!r}")
+
+
+def _sample_int(value: Union[int, Tuple[int, int], List[int]]) -> int:
+    if _is_int(value):
+        return int(value)
+    if isinstance(value, (tuple, list)) and len(value) == 2 and all(_is_int(v) for v in value):
+        lo, hi = int(value[0]), int(value[1])
+        if lo > hi:
+            raise ValueError(f"Expected inclusive int range with min <= max, got {value!r}")
         if lo == hi:
             return lo
         return int(torch.randint(lo, hi + 1, (1,)).item())
-    raise RuntimeError(f"Expected int or inclusive int range, got {value!r}")
+    raise ValueError(f"Expected int or inclusive int range, got {value!r}")
 
 
 def _sample_shift(shift, num_plane_dims: int) -> Tuple[int, ...]:
-    if isinstance(shift, int):
-        return (shift,) * num_plane_dims
+    if _is_int(shift):
+        return (int(shift),) * num_plane_dims
     if not isinstance(shift, (tuple, list)):
-        raise RuntimeError(f"Expected int, tuple, or list for shift, got {type(shift)}")
+        raise ValueError(f"Expected int, tuple, or list for shift, got {type(shift)}")
     if len(shift) != num_plane_dims:
-        raise RuntimeError(f"Expected {num_plane_dims} shift entries, got {len(shift)}")
+        raise ValueError(f"Expected {num_plane_dims} shift entries, got {len(shift)}")
     return tuple(_sample_int(s) for s in shift)
 
 
@@ -216,6 +282,8 @@ class DecohesionTransform(ImageOnlyTransform):
             shift:
                 Int shift applied to every in-slice dimension, a tuple of constant
                 shifts, or a tuple of inclusive integer ranges sampled per call.
+                For 2D (C, H, W) images, use an int shift because there is only one
+                non-smear plane dimension.
             alpha:
                 Blending factor for the aggregated shifted slices (0 = no influence, 1 = full replacement).
             num_prev_slices:
@@ -228,10 +296,15 @@ class DecohesionTransform(ImageOnlyTransform):
                 Probability of applying the transform to each channel.
         """
         super().__init__()
+        _validate_shift_ranges(shift)
+        _validate_random_scalar_range(alpha, "alpha")
+        _validate_num_prev_slices(num_prev_slices)
+        _validate_smear_axis(smear_axis)
+        _validate_probability(p_per_channel, "p_per_channel")
         self.shift = shift
         self.alpha = alpha
         self.num_prev_slices = num_prev_slices
-        self.smear_axis = smear_axis
+        self.smear_axis = int(smear_axis)
         self.p_per_channel = p_per_channel
 
     def get_parameters(self, **data_dict) -> dict:
@@ -241,10 +314,13 @@ class DecohesionTransform(ImageOnlyTransform):
         if not (0 <= local_smear_axis < num_spatial_dims):
             raise ValueError(f"smear_axis must be between 1 and {num_spatial_dims} for input with shape {tuple(img.shape)}")
         num_plane_dims = num_spatial_dims - 1
+        alpha = float(sample_scalar(self.alpha, image=img))
+        _validate_probability(alpha, "alpha")
+        num_prev_slices = _sample_int(self.num_prev_slices)
         return {
             "apply_to_channel": torch.rand(img.shape[0], device=img.device) < self.p_per_channel,
-            "alpha": float(sample_scalar(self.alpha, image=img)),
-            "num_prev_slices": _sample_int(self.num_prev_slices),
+            "alpha": alpha,
+            "num_prev_slices": num_prev_slices,
             "shift": _sample_shift(self.shift, num_plane_dims),
             "local_smear_axis": local_smear_axis,
         }

--- a/segmentation/models/batchgeneratorsv2/tests/test_decohesion_ablation.py
+++ b/segmentation/models/batchgeneratorsv2/tests/test_decohesion_ablation.py
@@ -1,0 +1,64 @@
+import unittest
+
+import torch
+
+from batchgeneratorsv2.benchmarks.decohesion_ablation import (
+    _aggregate_runs,
+    _parse_seeds,
+    _train_variant,
+)
+
+
+class DecohesionAblationTests(unittest.TestCase):
+    def test_parse_seeds_rejects_empty_values(self):
+        self.assertEqual(_parse_seeds("201, 202,203"), [201, 202, 203])
+        with self.assertRaisesRegex(ValueError, "seeds"):
+            _parse_seeds("")
+
+    def test_aggregate_reports_mean_delta(self):
+        runs = [
+            {"name": "baseline", "final": {"train_loss": 2.0, "clean_val_dice": 0.7, "decohesion_val_dice": 0.5}},
+            {"name": "baseline", "final": {"train_loss": 1.0, "clean_val_dice": 0.8, "decohesion_val_dice": 0.6}},
+            {"name": "decohesion", "final": {"train_loss": 1.5, "clean_val_dice": 0.6, "decohesion_val_dice": 0.7}},
+            {"name": "decohesion", "final": {"train_loss": 1.0, "clean_val_dice": 0.7, "decohesion_val_dice": 0.8}},
+        ]
+
+        aggregate = _aggregate_runs(runs)
+
+        self.assertAlmostEqual(aggregate["baseline"]["clean_val_dice_mean"], 0.75)
+        self.assertAlmostEqual(aggregate["decohesion"]["decohesion_val_dice_mean"], 0.75)
+        self.assertAlmostEqual(
+            aggregate["delta_decohesion_minus_baseline"]["decohesion_val_dice_mean"],
+            0.20,
+        )
+
+    def test_train_variant_smoke_runs_on_cpu(self):
+        train_image = torch.rand((1, 1, 4, 8, 8), dtype=torch.float32)
+        train_label = (train_image > 0.5).float()
+        train_mask = torch.ones_like(train_label)
+        val_image = torch.rand((1, 1, 4, 8, 8), dtype=torch.float32)
+        val_label = (val_image > 0.5).float()
+        val_mask = torch.ones_like(val_label)
+
+        result = _train_variant(
+            name="baseline",
+            train_image=train_image,
+            train_label=train_label,
+            train_mask=train_mask,
+            val_image=val_image,
+            val_label=val_label,
+            val_mask=val_mask,
+            epochs=1,
+            lr=1e-3,
+            seed=201,
+            device=torch.device("cpu"),
+            use_decohesion=False,
+        )
+
+        self.assertEqual(result["final"]["epoch"], 1)
+        self.assertGreaterEqual(result["final"]["clean_val_dice"], 0.0)
+        self.assertLessEqual(result["final"]["clean_val_dice"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/segmentation/models/batchgeneratorsv2/tests/test_decohesion_transform.py
+++ b/segmentation/models/batchgeneratorsv2/tests/test_decohesion_transform.py
@@ -47,6 +47,99 @@ class DecohesionTransformTests(unittest.TestCase):
 
         torch.testing.assert_close(out["segmentation"], segmentation)
 
+    def test_randomized_scroll_prize_config_path_runs(self):
+        image = torch.zeros((1, 5, 12, 12), dtype=torch.float32)
+        image[0, 0, 5, 5] = 1
+
+        out = DecohesionTransform(
+            shift=((-6, 6), (-6, 6)),
+            alpha=(0.15, 0.45),
+            num_prev_slices=(1, 3),
+            smear_axis=1,
+            p_per_channel=1.0,
+        )(image=image.clone())["image"]
+
+        self.assertEqual(out.shape, image.shape)
+        self.assertEqual(out.dtype, image.dtype)
+
+    def test_zero_channel_probability_is_noop(self):
+        image = torch.rand((2, 5, 6, 6), dtype=torch.float32)
+
+        out = DecohesionTransform(
+            shift=(1, 1),
+            alpha=1.0,
+            num_prev_slices=2,
+            smear_axis=1,
+            p_per_channel=0.0,
+        )(image=image.clone())["image"]
+
+        torch.testing.assert_close(out, image)
+
+    def test_2d_image_supports_integer_shift(self):
+        image = torch.zeros((1, 4, 5), dtype=torch.float32)
+        image[0, 0, 2] = 1
+
+        out = DecohesionTransform(
+            shift=1,
+            alpha=1.0,
+            num_prev_slices=1,
+            smear_axis=1,
+            p_per_channel=1.0,
+        )(image=image.clone())["image"]
+
+        expected_slice = torch.roll(image[0, 0], shifts=1, dims=0)
+        torch.testing.assert_close(out[0, 1], expected_slice)
+
+    def test_invalid_smear_axis_raises_clear_error(self):
+        image = torch.zeros((1, 4, 3, 3), dtype=torch.float32)
+
+        transform = DecohesionTransform(
+            shift=(1, 1),
+            alpha=0.5,
+            num_prev_slices=1,
+            smear_axis=4,
+            p_per_channel=1.0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "smear_axis"):
+            transform(image=image)
+
+        with self.assertRaisesRegex(ValueError, "smear_axis"):
+            DecohesionTransform(smear_axis=1.2)
+
+        with self.assertRaisesRegex(ValueError, "smear_axis"):
+            DecohesionTransform(smear_axis=True)
+
+        with self.assertRaisesRegex(ValueError, "smear_axis"):
+            DecohesionTransform(smear_axis="1")
+
+    def test_shift_dimension_must_match_non_smear_plane(self):
+        image = torch.zeros((1, 4, 3), dtype=torch.float32)
+
+        transform = DecohesionTransform(
+            shift=(1, 1),
+            alpha=0.5,
+            num_prev_slices=1,
+            smear_axis=1,
+            p_per_channel=1.0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "shift"):
+            transform(image=image)
+
+    def test_invalid_ranges_raise_clear_errors(self):
+        with self.assertRaisesRegex(ValueError, "alpha"):
+            DecohesionTransform(alpha=(0.8, 0.2))
+
+        with self.assertRaisesRegex(ValueError, "num_prev_slices"):
+            DecohesionTransform(num_prev_slices=(3, 1))
+
+        with self.assertRaisesRegex(ValueError, "p_per_channel"):
+            DecohesionTransform(p_per_channel=1.5)
+
+        with self.assertRaisesRegex(ValueError, "shift"):
+            DecohesionTransform(shift=((2, -2), (0, 1)))
+
     def test_smear_transform_keeps_backward_compatible_name(self):
         image = torch.zeros((1, 3, 2, 2), dtype=torch.float32)
         image[0, 0, 0, 0] = 2

--- a/segmentation/models/batchgeneratorsv2/tests/test_decohesion_transform.py
+++ b/segmentation/models/batchgeneratorsv2/tests/test_decohesion_transform.py
@@ -1,0 +1,81 @@
+import unittest
+
+import torch
+
+from batchgeneratorsv2.transforms.noise.extranoisetransforms import (
+    DecohesionTransform,
+    SmearTransform,
+)
+
+
+class DecohesionTransformTests(unittest.TestCase):
+    def test_smears_previous_slice_without_changing_shape_dtype_or_device(self):
+        image = torch.zeros((1, 4, 3, 3), dtype=torch.float32)
+        image[0, 0, 1, 1] = 1
+
+        transform = DecohesionTransform(
+            shift=(0, 1),
+            alpha=1.0,
+            num_prev_slices=1,
+            smear_axis=1,
+            p_per_channel=1.0,
+        )
+
+        out = transform(image=image.clone())["image"]
+
+        expected_slice = torch.roll(image[0, 0], shifts=(0, 1), dims=(0, 1))
+        self.assertEqual(out.shape, image.shape)
+        self.assertEqual(out.dtype, image.dtype)
+        self.assertEqual(out.device, image.device)
+        torch.testing.assert_close(out[0, 0], image[0, 0])
+        torch.testing.assert_close(out[0, 1], expected_slice)
+
+    def test_image_only_transform_leaves_segmentation_unchanged(self):
+        image = torch.zeros((1, 4, 3, 3), dtype=torch.float32)
+        image[0, 0, 1, 1] = 1
+        segmentation = torch.arange(4 * 3 * 3, dtype=torch.int64).reshape(1, 4, 3, 3)
+
+        transform = DecohesionTransform(
+            shift=(1, 0),
+            alpha=0.5,
+            num_prev_slices=2,
+            smear_axis=1,
+            p_per_channel=1.0,
+        )
+
+        out = transform(image=image.clone(), segmentation=segmentation.clone())
+
+        torch.testing.assert_close(out["segmentation"], segmentation)
+
+    def test_smear_transform_keeps_backward_compatible_name(self):
+        image = torch.zeros((1, 3, 2, 2), dtype=torch.float32)
+        image[0, 0, 0, 0] = 2
+
+        out = SmearTransform(
+            shift=(1, 0),
+            alpha=1.0,
+            num_prev_slices=1,
+            smear_axis=1,
+        )(image=image.clone())["image"]
+
+        expected_slice = torch.roll(image[0, 0], shifts=(1, 0), dims=(0, 1))
+        torch.testing.assert_close(out[0, 1], expected_slice)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+    def test_cuda_tensor_stays_on_cuda(self):
+        image = torch.zeros((1, 4, 8, 8), dtype=torch.float32, device="cuda")
+        image[0, 0, 3, 3] = 1
+
+        out = DecohesionTransform(
+            shift=(1, 1),
+            alpha=0.5,
+            num_prev_slices=1,
+            smear_axis=1,
+            p_per_channel=1.0,
+        )(image=image)["image"]
+
+        self.assertEqual(out.device.type, "cuda")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a torch-native scroll decohesion/smear augmentation for 3D training volumes.

## What changed

- Added `DecohesionTransform`, an image-only transform that blends shifted previous slices into later slices to simulate scroll decohesion / layer smear artifacts.
- Kept `SmearTransform` as a backward-compatible alias for existing trainer code.
- Wired the transform into the explicit `nnUNetTrainerExtraDA` augmentation variant, avoiding silent changes to the default trainer.
- Added a no-download benchmark/smoke script for synthetic volumes and optional local TIFF stacks.
- Added a tiny no-download train/eval ablation smoke benchmark that compares baseline training with decohesion-augmented training.
- Added focused `unittest` coverage for shape, dtype, device, CUDA retention, backward-compatible naming, label-safety, randomized config sampling, 2D `shift=int` compatibility, no-op channel probability, invalid config validation, and ablation benchmark helpers.

Contributes to #201.

## Validation

- `PYTHONPATH=segmentation/models/batchgeneratorsv2 python -m unittest discover -s segmentation/models/batchgeneratorsv2/tests`
  - `Ran 13 tests ... OK`
- `python -m py_compile` on the transform, benchmark scripts, tests, and `nnUNetTrainerExtraDA.py`
- `git diff --check fork/main..HEAD`
- Synthetic no-download smoke, `1 x 9 x 256 x 256`, RTX 3080 Laptop GPU:
  - CPU: `0.03164 s/run`
  - CUDA: `0.02771 s/run`
- Larger synthetic smoke, `1 x 32 x 512 x 512`, RTX 3080 Laptop GPU:
  - CPU: `0.05139 s/run`
  - CUDA: `0.03016 s/run`
- Local no-download TIFF smoke using `data/smoke/scroll2-3-candidate-factory/stage-b-representative-layers/20230503120034/layers`, cropped to `1 x 9 x 256 x 256`:
  - CPU: `0.03100 s/run`
  - CUDA: `0.03669 s/run`
- Tiny no-download train/eval ablation, `5 seeds x 40 epochs`, two-case synthetic surface-detection fixture, RTX 3080 Laptop GPU, `torch 2.5.1+cu121`:
  - Baseline clean val Dice mean: `0.95547`
  - Decohesion clean val Dice mean: `0.90287`
  - Clean val delta: `-0.05260`
  - Baseline decohesion-corrupted val Dice mean: `0.87926`
  - Decohesion decohesion-corrupted val Dice mean: `0.93277`
  - Decohesion-corrupted val delta: `+0.05351`

## CI / Deploy Notes

- The current Vercel status is failing at deployment authorization for the ScrollPrize team (`vercel.com/git/authorize?...team=scroll...`), not from a repo test failure.

## Notes

This PR adds a tested augmentation primitive, a local smoke/benchmark path, and a tiny train/eval ablation that exercises the augmentation during training. The ablation is deliberately smoke-scale and synthetic; it is evidence that the augmentation can improve robustness to decohesion-like corruption in this fixture, not a production nnU-Net scroll-dataset ablation or a claim of general model-quality improvement.