### PR TITLE
narrow opencv/json includes in headers

### DIFF
--- a/volume-cartographer/apps/VC3D/AxisAlignedSliceController.hpp
+++ b/volume-cartographer/apps/VC3D/AxisAlignedSliceController.hpp
@@ -2,7 +2,7 @@
 
 #include <QObject>
 #include <QPointF>
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <string>
 #include <unordered_map>
 

--- a/volume-cartographer/apps/VC3D/CState.cpp
+++ b/volume-cartographer/apps/VC3D/CState.cpp
@@ -5,6 +5,11 @@
 #include <thread>
 #include <QSettings>
 
+#include "vc/core/types/VolumePkg.hpp"
+#include "vc/core/types/Volume.hpp"
+#include "vc/core/util/QuadSurface.hpp"
+#include "vc/core/util/Surface.hpp"
+#include "vc/ui/VCCollection.hpp"
 #include "vc/core/util/PlaneSurface.hpp"
 #include "vc/core/util/Slicing.hpp"
 

--- a/volume-cartographer/apps/VC3D/CState.hpp
+++ b/volume-cartographer/apps/VC3D/CState.hpp
@@ -9,11 +9,11 @@
 
 #include <opencv2/core/mat.hpp>
 
-#include "vc/core/types/VolumePkg.hpp"
-#include "vc/core/types/Volume.hpp"
-#include "vc/core/util/QuadSurface.hpp"
-#include "vc/core/util/Surface.hpp"
-#include "vc/ui/VCCollection.hpp"
+class VolumePkg;
+class Volume;
+class QuadSurface;
+class Surface;
+class VCCollection;
 
 struct POI
 {

--- a/volume-cartographer/apps/VC3D/CState.hpp
+++ b/volume-cartographer/apps/VC3D/CState.hpp
@@ -7,7 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/types/Volume.hpp"

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -1,4 +1,10 @@
 #include "CWindow.hpp"
+
+#include "vc/core/types/Volume.hpp"
+#include "vc/core/types/VolumePkg.hpp"
+#include "vc/core/util/Surface.hpp"
+#include "vc/core/util/QuadSurface.hpp"
+
 #include <iostream>
 
 #include <functional>

--- a/volume-cartographer/apps/VC3D/CWindow.hpp
+++ b/volume-cartographer/apps/VC3D/CWindow.hpp
@@ -38,10 +38,11 @@ class CChunkedVolumeViewer;
 #include "segmentation/SegmentationWidget.hpp"
 #include "segmentation/growth/SegmentationGrowth.hpp"
 #include "SeedingWidget.hpp"
-#include "vc/core/types/Volume.hpp"
-#include "vc/core/types/VolumePkg.hpp"
-#include "vc/core/util/Surface.hpp"
-#include "vc/core/util/QuadSurface.hpp"
+
+class Volume;
+class VolumePkg;
+class Surface;
+class QuadSurface;
 
 #define MAX_RECENT_VOLPKG 10
 

--- a/volume-cartographer/apps/VC3D/CWindow.hpp
+++ b/volume-cartographer/apps/VC3D/CWindow.hpp
@@ -3,7 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <QComboBox>
 #include <QCheckBox>
 #include <QString>

--- a/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
+++ b/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
@@ -7,14 +7,10 @@
 #include <QDialog>
 #include <QFile>
 
-#include "CWindow.hpp"
 #include "elements/ProgressUtil.hpp"
 #include "ConsoleOutputWidget.hpp"
 
-
-
-// Forward declaration
-
+class CWindow;
 
 /**
  * @brief Class to manage execution of command-line tools

--- a/volume-cartographer/apps/VC3D/FiberAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/FiberAnnotationController.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QObject>
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <memory>
 #include <string>
 #include <vector>

--- a/volume-cartographer/apps/VC3D/FileWatcherService.cpp
+++ b/volume-cartographer/apps/VC3D/FileWatcherService.cpp
@@ -7,6 +7,7 @@
 #include "segmentation/SegmentationModule.hpp"
 #include "SurfaceTreeWidget.hpp"
 #include "vc/core/types/Segmentation.hpp"
+#include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/Logging.hpp"
 #include "VCSettings.hpp"
 #include <sys/inotify.h>

--- a/volume-cartographer/apps/VC3D/SeedingWidget.hpp
+++ b/volume-cartographer/apps/VC3D/SeedingWidget.hpp
@@ -13,7 +13,7 @@
 #include <QPointer>
 #include <QToolButton>
 #include <QFutureWatcher>
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <memory>
 
 #include "elements/ProgressUtil.hpp"

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -57,6 +57,7 @@
 
 #include "CommandLineToolRunner.hpp"
 #include "vc/core/types/VolumePkg.hpp"
+#include "vc/core/types/Volume.hpp"
 #include "vc/core/types/Segmentation.hpp"
 #include "vc/core/util/Surface.hpp"
 #include "vc/core/util/QuadSurface.hpp"

--- a/volume-cartographer/apps/VC3D/SurfaceAffineTransformController.hpp
+++ b/volume-cartographer/apps/VC3D/SurfaceAffineTransformController.hpp
@@ -3,7 +3,7 @@
 #include <QObject>
 #include <QString>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <filesystem>
 #include <functional>

--- a/volume-cartographer/apps/VC3D/SurfaceAreaCalculator.hpp
+++ b/volume-cartographer/apps/VC3D/SurfaceAreaCalculator.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <string>
 #include <vector>
 

--- a/volume-cartographer/apps/VC3D/ViewerManager.hpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.hpp
@@ -11,7 +11,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "vc/core/util/SurfacePatchIndex.hpp"
 

--- a/volume-cartographer/apps/VC3D/VolumeViewerCmaps.hpp
+++ b/volume-cartographer/apps/VC3D/VolumeViewerCmaps.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QString>
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <cstdint>
 #include <string>

--- a/volume-cartographer/apps/VC3D/overlays/PlaneSlicingOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/PlaneSlicingOverlayController.cpp
@@ -1,5 +1,7 @@
 #include "PlaneSlicingOverlayController.hpp"
 
+#include <opencv2/core.hpp>  // cv::normalize
+
 #include "../volume_viewers/CChunkedVolumeViewer.hpp"
 #include "../volume_viewers/VolumeViewerBase.hpp"
 #include "../CState.hpp"

--- a/volume-cartographer/apps/VC3D/overlays/RawPointsOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/RawPointsOverlayController.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <optional>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 struct POI;
 class CState;

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
@@ -12,7 +12,7 @@
 #include <optional>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 class CState;
 class SegmentationEditManager;

--- a/volume-cartographer/apps/VC3D/overlays/SurfaceRotationOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/SurfaceRotationOverlayController.cpp
@@ -6,6 +6,7 @@
 #include "../volume_viewers/VolumeViewerBase.hpp"
 
 #include "vc/core/util/QuadSurface.hpp"
+#include "vc/core/types/VolumePkg.hpp"
 
 #include <QApplication>
 #include <QDoubleSpinBox>

--- a/volume-cartographer/apps/VC3D/overlays/ViewerOverlayControllerBase.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/ViewerOverlayControllerBase.hpp
@@ -13,7 +13,7 @@
 #include <QString>
 #include <QTransform>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <cstddef>
 #include <functional>

--- a/volume-cartographer/apps/VC3D/segmentation/SegmentationModule.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/SegmentationModule.hpp
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "../volume_viewers/VolumeViewerBase.hpp"
 #include "tools/SegmentationEditManager.hpp"

--- a/volume-cartographer/apps/VC3D/segmentation/SegmentationUndoHistory.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/SegmentationUndoHistory.hpp
@@ -4,7 +4,7 @@
 #include <optional>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 namespace segmentation
 {

--- a/volume-cartographer/apps/VC3D/segmentation/growth/SegmentationCorrections.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/growth/SegmentationCorrections.hpp
@@ -7,7 +7,7 @@
 #include <QVector>
 #include <QString>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "SegmentationGrowth.hpp"
 

--- a/volume-cartographer/apps/VC3D/segmentation/growth/SegmentationGrowth.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/growth/SegmentationGrowth.hpp
@@ -12,7 +12,7 @@
 
 #include "utils/Json.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "vc/ui/VCCollection.hpp"
 

--- a/volume-cartographer/apps/VC3D/segmentation/tools/ApprovalMaskBrushTool.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/tools/ApprovalMaskBrushTool.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <QElapsedTimer>
 #include <QPointF>
 #include <unordered_set>

--- a/volume-cartographer/apps/VC3D/segmentation/tools/ManualAddTool.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/tools/ManualAddTool.hpp
@@ -2,7 +2,7 @@
 
 #include "SegmentationEditManager.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <optional>
 #include <string>

--- a/volume-cartographer/apps/VC3D/segmentation/tools/SegmentationBrushTool.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/tools/SegmentationBrushTool.hpp
@@ -2,7 +2,7 @@
 
 #include "SegmentationTool.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <vector>
 

--- a/volume-cartographer/apps/VC3D/segmentation/tools/SegmentationEditManager.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/tools/SegmentationEditManager.hpp
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 class QuadSurface;
 class ViewerManager;

--- a/volume-cartographer/apps/VC3D/segmentation/tools/SegmentationLineTool.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/tools/SegmentationLineTool.hpp
@@ -2,7 +2,7 @@
 
 #include "SegmentationTool.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <vector>
 

--- a/volume-cartographer/apps/VC3D/segmentation/tools/SegmentationPushPullTool.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/tools/SegmentationPushPullTool.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <QFutureWatcher>
 #include <QString>
 

--- a/volume-cartographer/apps/VC3D/segmentation/tools/SurfaceMaskBrushTool.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/tools/SurfaceMaskBrushTool.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QPointF>
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <optional>
 #include <unordered_set>

--- a/volume-cartographer/apps/VC3D/segmentation/tools/ThinPlateSpline3d.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/tools/ThinPlateSpline3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <optional>
 #include <vector>

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -9,6 +9,7 @@
 #include "vc/core/render/PostProcess.hpp"
 #include "render/ChunkCache.hpp"
 #include "vc/core/types/Volume.hpp"
+#include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/PlaneSurface.hpp"
 #include "vc/core/util/QuadSurface.hpp"
 #include "vc/core/util/Geometry.hpp"

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -19,7 +19,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "CVolumeViewerView.hpp"
 #include "VolumeViewerBase.hpp"

--- a/volume-cartographer/apps/VC3D/volume_viewers/VolumeViewerBase.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/VolumeViewerBase.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include "overlays/ViewerOverlayControllerBase.hpp"
 #include "vc/core/util/Compositing.hpp"
 

--- a/volume-cartographer/apps/VC3D/volume_viewers/annotation_tools/SameWrapAnnotationTool.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/annotation_tools/SameWrapAnnotationTool.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 class QGraphicsItem;
 class VCCollection;

--- a/volume-cartographer/apps/diffusion/common.hpp
+++ b/volume-cartographer/apps/diffusion/common.hpp
@@ -2,11 +2,11 @@
 
 #include <opencv2/core/mat.hpp>
 #include <vc/core/types/VcDataset.hpp>
-#include <boost/program_options.hpp>
 #include <vc/core/util/Slicing.hpp>
 
 #include <filesystem>
 
+namespace boost::program_options { class variables_map; }
 namespace po = boost::program_options;
 namespace fs = std::filesystem;
 

--- a/volume-cartographer/apps/diffusion/common.hpp
+++ b/volume-cartographer/apps/diffusion/common.hpp
@@ -5,6 +5,7 @@
 #include <vc/core/util/Slicing.hpp>
 
 #include <filesystem>
+#include <optional>
 
 namespace boost::program_options { class variables_map; }
 namespace po = boost::program_options;

--- a/volume-cartographer/apps/diffusion/common.hpp
+++ b/volume-cartographer/apps/diffusion/common.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core/mat.hpp>
 #include <vc/core/types/VcDataset.hpp>
 #include <boost/program_options.hpp>
 #include <vc/core/util/Slicing.hpp>

--- a/volume-cartographer/apps/diffusion/continous.cpp
+++ b/volume-cartographer/apps/diffusion/continous.cpp
@@ -1,6 +1,7 @@
 #include "continous.hpp"
 #include "support.hpp"
 
+#include <boost/program_options.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include "discrete.hpp"

--- a/volume-cartographer/apps/diffusion/continous.cpp
+++ b/volume-cartographer/apps/diffusion/continous.cpp
@@ -1,5 +1,8 @@
 #include "continous.hpp"
 #include "support.hpp"
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include "discrete.hpp"
 
 #include <iostream>

--- a/volume-cartographer/apps/diffusion/continuous3d.hpp
+++ b/volume-cartographer/apps/diffusion/continuous3d.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <boost/program_options.hpp>
+namespace boost::program_options { class variables_map; }
 
 int continuous3d_main(const boost::program_options::variables_map& vm);

--- a/volume-cartographer/apps/diffusion/discrete.cpp
+++ b/volume-cartographer/apps/diffusion/discrete.cpp
@@ -1,5 +1,7 @@
 #include "discrete.hpp"
 #include "support.hpp"
+
+#include <opencv2/imgcodecs.hpp>
 #include "spiral_common.hpp"
 
 #include <iostream>

--- a/volume-cartographer/apps/diffusion/spiral.cpp
+++ b/volume-cartographer/apps/diffusion/spiral.cpp
@@ -2,6 +2,7 @@
 #include "support.hpp"
 #include "spiral_ceres.hpp"
 
+#include <boost/program_options.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/imgcodecs.hpp>
 

--- a/volume-cartographer/apps/diffusion/spiral.cpp
+++ b/volume-cartographer/apps/diffusion/spiral.cpp
@@ -2,6 +2,9 @@
 #include "support.hpp"
 #include "spiral_ceres.hpp"
 
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+
 #include <iostream>
 #include <vector>
 #include <string>

--- a/volume-cartographer/apps/diffusion/spiral2.cpp
+++ b/volume-cartographer/apps/diffusion/spiral2.cpp
@@ -1,6 +1,7 @@
 #include "spiral2.hpp"
 #include "support.hpp"
 
+#include <boost/program_options.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/videoio.hpp>

--- a/volume-cartographer/apps/diffusion/spiral2.cpp
+++ b/volume-cartographer/apps/diffusion/spiral2.cpp
@@ -1,5 +1,9 @@
 #include "spiral2.hpp"
 #include "support.hpp"
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/videoio.hpp>
 #include "spiral_ceres.hpp"
 #include "spiral.hpp"
 

--- a/volume-cartographer/apps/diffusion/spiral2cont.cpp
+++ b/volume-cartographer/apps/diffusion/spiral2cont.cpp
@@ -1,6 +1,7 @@
 #include "spiral2cont.hpp"
 #include "support.hpp"
 
+#include <boost/program_options.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/videoio.hpp>

--- a/volume-cartographer/apps/diffusion/spiral2cont.cpp
+++ b/volume-cartographer/apps/diffusion/spiral2cont.cpp
@@ -1,5 +1,9 @@
 #include "spiral2cont.hpp"
 #include "support.hpp"
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/videoio.hpp>
 #include "spiral_ceres.hpp"
 #include "spiral.hpp"
 #include "spiral2.hpp"

--- a/volume-cartographer/apps/diffusion/spiral_ceres.hpp
+++ b/volume-cartographer/apps/diffusion/spiral_ceres.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ceres/ceres.h>
-#include <opencv2/opencv.hpp>
+#include <opencv2/core/mat.hpp>
 #include <vector>
 #include <string>
 #include <memory>

--- a/volume-cartographer/apps/diffusion/spiral_common.cpp
+++ b/volume-cartographer/apps/diffusion/spiral_common.cpp
@@ -2,6 +2,9 @@
 #include "spiral_common.hpp"
 #include "spiral_ceres.hpp"
 
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+
 #include "utils/Json.hpp"
 
 void to_json(utils::Json& j, const SpiralPoint& p) {
@@ -45,9 +48,6 @@ void visualize_spiral(
 #include <iostream>
 #include <iomanip>
 #include <sstream>
-
-#include <opencv2/imgproc.hpp>
-#include <opencv2/imgcodecs.hpp>
 
 
 bool find_intersections(

--- a/volume-cartographer/apps/diffusion/support.cpp
+++ b/volume-cartographer/apps/diffusion/support.cpp
@@ -1,4 +1,5 @@
 #include "support.hpp"
+#include <boost/program_options.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <iostream>

--- a/volume-cartographer/apps/diffusion/support.cpp
+++ b/volume-cartographer/apps/diffusion/support.cpp
@@ -1,4 +1,6 @@
 #include "support.hpp"
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <iostream>
 #include "spiral_ceres.hpp"
 #include "vc/core/util/LifeTime.hpp"

--- a/volume-cartographer/apps/diffusion/support.hpp
+++ b/volume-cartographer/apps/diffusion/support.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <opencv2/opencv.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <vector>
 
@@ -19,7 +18,7 @@ using SkeletonGraph = boost::adjacency_list<boost::vecS, boost::vecS, boost::und
 
 #include "common.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 struct PointHash {
     std::size_t operator()(const cv::Point& p) const {

--- a/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
@@ -1,4 +1,6 @@
 // vc_tifxyz2obj.cpp
+#include <opencv2/core.hpp>  // operator<<(ostream, cv::Size) for the debug prints below
+
 #include "vc/core/util/Geometry.hpp"
 #include "vc/core/util/InpaintSurface.hpp"
 #include "vc/core/util/Slicing.hpp"

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -96,6 +96,10 @@ if(VC_USE_PCH)
         "$<$<COMPILE_LANGUAGE:CXX>:<random>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<utility>>"
         "$<$<COMPILE_LANGUAGE:CXX>:<vector>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<functional>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<set>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<map>>"
+        "$<$<COMPILE_LANGUAGE:CXX>:<thread>>"
         # <format> is the heaviest std header in the build (~1.3k s of
         # instantiation across TUs; libstdc++ 15 + Qt pull it in widely).
         "$<$<COMPILE_LANGUAGE:CXX>:<format>>"

--- a/volume-cartographer/core/include/vc/core/PointCollections.hpp
+++ b/volume-cartographer/core/include/vc/core/PointCollections.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <chrono>
 #include <opencv2/core/mat.hpp>
 #include <string>
 #include <vector>

--- a/volume-cartographer/core/include/vc/core/PointCollections.hpp
+++ b/volume-cartographer/core/include/vc/core/PointCollections.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <chrono>
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <string>
 #include <vector>
 #include <unordered_map>

--- a/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
+++ b/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
@@ -2,8 +2,6 @@
 
 #include "vc/core/render/IChunkedArray.hpp"
 
-#include <utils/thread_pool.hpp>
-
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -95,7 +93,7 @@ private:
         bool persisted = false;
         bool inLru = false;
         int basePriority = 0;
-        utils::PriorityThreadPool::Priority priority = 0;
+        std::int64_t priority = 0;
         std::uint64_t fetchSerial = 0;
         std::list<ChunkKey>::iterator lruIt;
     };
@@ -125,7 +123,7 @@ private:
         std::list<ChunkKey> lru_;
         std::size_t decodedBytes_ = 0;
         std::uint64_t generation_ = 0;
-        utils::PriorityThreadPool::Priority viewEpoch_ = 1;
+        std::int64_t viewEpoch_ = 1;
         std::uint64_t nextFetchSerial_ = 1;
         ChunkReadyCallbackId nextCallbackId_ = 1;
         std::unordered_map<ChunkReadyCallbackId, ChunkReadyCallback> callbacks_;

--- a/volume-cartographer/core/include/vc/core/render/ChunkedPlaneSampler.hpp
+++ b/volume-cartographer/core/include/vc/core/render/ChunkedPlaneSampler.hpp
@@ -3,7 +3,7 @@
 #include "vc/core/render/IChunkedArray.hpp"
 #include "vc/core/types/Sampling.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <cstdint>
 

--- a/volume-cartographer/core/include/vc/core/render/Colormaps.hpp
+++ b/volume-cartographer/core/include/vc/core/render/Colormaps.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <cstdint>
 #include <string>

--- a/volume-cartographer/core/include/vc/core/types/ChunkedTensor.hpp
+++ b/volume-cartographer/core/include/vc/core/types/ChunkedTensor.hpp
@@ -7,7 +7,7 @@
 #include "vc/core/types/Array3D.hpp"
 #include "vc/core/types/Volume.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "vc/core/types/VcDataset.hpp"
 

--- a/volume-cartographer/core/include/vc/core/types/ChunkedTensor.hpp
+++ b/volume-cartographer/core/include/vc/core/types/ChunkedTensor.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include "vc/core/util/HashFunctions.hpp"
 #include "vc/core/render/ChunkCache.hpp"
 #include "vc/core/render/ZarrChunkFetcher.hpp"

--- a/volume-cartographer/core/include/vc/core/types/Volume.hpp
+++ b/volume-cartographer/core/include/vc/core/types/Volume.hpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 #include "utils/Json.hpp"
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "vc/core/types/Sampling.hpp"
 #include "vc/core/types/SampleParams.hpp"

--- a/volume-cartographer/core/include/vc/core/util/AffineTransform.hpp
+++ b/volume-cartographer/core/include/vc/core/util/AffineTransform.hpp
@@ -5,7 +5,7 @@
 #include <optional>
 #include <string>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "utils/Json.hpp"
 

--- a/volume-cartographer/core/include/vc/core/util/Compositing.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Compositing.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <string>
 #include <vector>
 #include <cstdint>

--- a/volume-cartographer/core/include/vc/core/util/Geometry.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Geometry.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 // Geometry utility functions
 cv::Vec3f grid_normal(const cv::Mat_<cv::Vec3f> &points, const cv::Vec3f &loc);

--- a/volume-cartographer/core/include/vc/core/util/GrowthMask.hpp
+++ b/volume-cartographer/core/include/vc/core/util/GrowthMask.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <algorithm>
 

--- a/volume-cartographer/core/include/vc/core/util/InpaintSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/InpaintSurface.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 namespace vc::core::util {
 

--- a/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
+++ b/volume-cartographer/core/include/vc/core/util/NormalGridGenerate.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <omp.h>
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <vc/core/types/Array3D.hpp>
 #include <vc/core/types/Volume.hpp>
 

--- a/volume-cartographer/core/include/vc/core/util/PlaneSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/PlaneSurface.hpp
@@ -2,7 +2,7 @@
 
 #include "Surface.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 class PlaneSurface : public Surface
 {

--- a/volume-cartographer/core/include/vc/core/util/PointIndex.hpp
+++ b/volume-cartographer/core/include/vc/core/util/PointIndex.hpp
@@ -6,7 +6,7 @@
 #include <tuple>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 class PointIndex
 {

--- a/volume-cartographer/core/include/vc/core/util/PostProcess.hpp
+++ b/volume-cartographer/core/include/vc/core/util/PostProcess.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <cstdint>
 
 namespace vc {

--- a/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "Surface.hpp"
+#include "Rect3D.hpp"
 
 // Surface loading and channel flags
 #define SURF_LOAD_IGNORE_MASK 1
@@ -19,14 +20,6 @@
 
 // Debug prefix for auto-generated surfaces
 #define Z_DBG_GEN_PREFIX "auto_grown_"
-
-struct Rect3D {
-    cv::Vec3f low = {0,0,0};
-    cv::Vec3f high = {0,0,0};
-};
-
-bool intersect(const Rect3D &a, const Rect3D &b);
-Rect3D expand_rect(const Rect3D &a, const cv::Vec3f &p);
 
 // Forward declarations
 class QuadSurface;

--- a/volume-cartographer/core/include/vc/core/util/Rect3D.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Rect3D.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <opencv2/core/matx.hpp>
+
+struct Rect3D {
+    cv::Vec3f low = {0,0,0};
+    cv::Vec3f high = {0,0,0};
+};
+
+bool intersect(const Rect3D &a, const Rect3D &b);
+Rect3D expand_rect(const Rect3D &a, const cv::Vec3f &p);

--- a/volume-cartographer/core/include/vc/core/util/Slicing.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Slicing.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <string>
 
 #include <vc/core/types/Sampling.hpp>

--- a/volume-cartographer/core/include/vc/core/util/Surface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Surface.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <string>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include "utils/Json.hpp"
 
 //base surface class

--- a/volume-cartographer/core/include/vc/core/util/SurfacePatchIndex.hpp
+++ b/volume-cartographer/core/include/vc/core/util/SurfacePatchIndex.hpp
@@ -12,7 +12,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "vc/core/util/QuadSurface.hpp"
 

--- a/volume-cartographer/core/include/vc/core/util/SurfacePatchIndex.hpp
+++ b/volume-cartographer/core/include/vc/core/util/SurfacePatchIndex.hpp
@@ -14,7 +14,7 @@
 
 #include <opencv2/core/mat.hpp>
 
-#include "vc/core/util/QuadSurface.hpp"
+#include "vc/core/util/Rect3D.hpp"
 
 class QuadSurface;
 class PlaneSurface;

--- a/volume-cartographer/core/include/vc/core/util/Thinning.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Thinning.hpp
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <vector>
 
 struct ThinningStats {

--- a/volume-cartographer/core/include/vc/core/util/Tiff.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Tiff.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <filesystem>
 #include <string>
 #include <vector>

--- a/volume-cartographer/core/include/vc/core/util/TriangleVoxelRaster.hpp
+++ b/volume-cartographer/core/include/vc/core/util/TriangleVoxelRaster.hpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <cstddef>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 namespace vc::core::util {
 

--- a/volume-cartographer/core/include/vc/core/util/Umbilicus.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Umbilicus.hpp
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 namespace vc::core::util {
 

--- a/volume-cartographer/core/include/vc/core/util/Zarr.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Zarr.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 namespace vc { class VcDataset; }
 

--- a/volume-cartographer/core/include/vc/flattening/ABFFlattening.hpp
+++ b/volume-cartographer/core/include/vc/flattening/ABFFlattening.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/volume-cartographer/core/include/vc/tracer/CostFunctions.hpp
+++ b/volume-cartographer/core/include/vc/tracer/CostFunctions.hpp
@@ -5,7 +5,7 @@
 #include "vc/core/util/NormalGridVolume.hpp"
 #include "vc/core/util/GridStore.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include "ceres/ceres.h"
 

--- a/volume-cartographer/core/include/vc/ui/surface_metrics.hpp
+++ b/volume-cartographer/core/include/vc/ui/surface_metrics.hpp
@@ -3,7 +3,7 @@
 #include "vc/core/PointCollections.hpp"
 
 #include "utils/Json.hpp"
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 // Forward declarations
 class QuadSurface;

--- a/volume-cartographer/core/src/SurfTrackerData.hpp
+++ b/volume-cartographer/core/src/SurfTrackerData.hpp
@@ -4,7 +4,7 @@
 #include "vc/core/util/QuadSurface.hpp"
 
 #include <ceres/ceres.h>
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <cstddef>
 #include <set>

--- a/volume-cartographer/core/src/growth_strategies/CandidateOrdering.hpp
+++ b/volume-cartographer/core/src/growth_strategies/CandidateOrdering.hpp
@@ -2,7 +2,7 @@
 
 #include "GrowthConfig.hpp"
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <functional>
 #include <vector>

--- a/volume-cartographer/core/src/growth_strategies/ComponentPruning.hpp
+++ b/volume-cartographer/core/src/growth_strategies/ComponentPruning.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
 #include <cstddef>
 #include <functional>

--- a/volume-cartographer/core/src/growth_strategies/GrowthConfig.cpp
+++ b/volume-cartographer/core/src/growth_strategies/GrowthConfig.cpp
@@ -1,5 +1,7 @@
 #include "GrowthConfig.hpp"
 
+#include <nlohmann/json.hpp>
+
 #include <algorithm>
 #include <cstdint>
 #include <iostream>

--- a/volume-cartographer/core/src/growth_strategies/GrowthConfig.hpp
+++ b/volume-cartographer/core/src/growth_strategies/GrowthConfig.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/mat.hpp>
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include <cstdint>
 #include <iosfwd>

--- a/volume-cartographer/core/src/render/ChunkCache.cpp
+++ b/volume-cartographer/core/src/render/ChunkCache.cpp
@@ -1,5 +1,7 @@
 #include "ChunkCache.hpp"
 
+#include <utils/thread_pool.hpp>
+
 #include "vc/core/util/Logging.hpp"
 
 #include <algorithm>

--- a/volume-cartographer/scripts/analyze_build_profile.py
+++ b/volume-cartographer/scripts/analyze_build_profile.py
@@ -161,8 +161,21 @@ def main():
         if cat in cat_total:
             print(f"  {cat_total[cat]:7.0f}  {cat}")
 
-    print("\n## Heaviest headers (inclusive top-level parse time; s, #TUs)")
+    # All headers incl. third-party — a heavy 3rd-party header is a candidate
+    # to replace or drop (e.g. doctest was swapped for an in-tree framework).
+    print("\n## Heaviest headers — all, incl. third-party (s, #TUs)")
     for det, s in sorted(header_total.items(), key=lambda x: -x[1])[:args.top]:
+        print(f"  {s:6.0f}  x{header_tus[det]:<4} {shorten(det, args.build_dir)}")
+
+    # First-party = under the repo but not the build dir (which holds _deps).
+    # These are the headers we can actually edit; ranking by cost x #TUs finds
+    # the highest-leverage include-trimming targets.
+    repo = os.path.dirname(os.path.dirname(os.path.abspath(args.build_dir)))
+    bdir = os.path.abspath(args.build_dir)
+    ours = {h: s for h, s in header_total.items()
+            if os.path.abspath(h).startswith(repo) and not os.path.abspath(h).startswith(bdir)}
+    print("\n## Heaviest first-party headers (ours to fix; s, #TUs)")
+    for det, s in sorted(ours.items(), key=lambda x: -x[1])[:args.top]:
         print(f"  {s:6.0f}  x{header_tus[det]:<4} {shorten(det, args.build_dir)}")
 
     print("\n## Heaviest template instantiations (s, summed)")


### PR DESCRIPTION
opencv2/core.hpp drags libstdc++ <format> into every includer (via core/cvstd.inl.hpp -> <ostream>), and <format> is ~37% of from-scratch compile CPU. The 57 headers that only use cv value types (Vec/Point/Rect/Mat) switch to opencv2/core/mat.hpp, which carries no <format>. Also drop the opencv2/opencv.hpp mega-umbrella from 3 diffusion headers and forward-declare nlohmann::json in GrowthConfig.hpp. The few .cpp that call cv algorithms (resize/normalize/imwrite/...) or stream a cv::Size get the full headers locally.