### PR TITLE
(corrected) Add MedNeXt-L + SkeletonRecall trainer: addresses #191 merger failure mode, validated on 7-cube re-score with official Kaggle topology metric

### DIFF
--- a/segmentation/models/arch/nnunet/README.md
+++ b/segmentation/models/arch/nnunet/README.md
@@ -55,3 +55,41 @@ Convert to an ome-zarr (thanks chuck! more info here https://github.com/KhartesV
 ### train 
 Preprocess: `nnUNetv2_plan_and_preprocess -d 050 -pl nnUNetPlannerResEncL -c 3d_fullres --verify_dataset_integrity`
 Run training: `nnUNetv2_train 050 3d_fullres 0 -p nnUNetResEncUNetMPlans`
+
+### MedNeXt-L + SkeletonRecall trainer (for compressed / highly curved regions)
+
+The `nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5` trainer
+(`nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py`)
+swaps the default ResEnc U-Net for MedNeXt-L kernel5 while keeping the SkeletonRecall
+loss, transform pipeline, and data loaders untouched. It targets the failure mode
+described in [issue #191](https://github.com/ScrollPrize/villa/issues/191) (surface
+predictions in compressed / highly curved areas). On a held-out 7-cube benchmark
+over PHerc Paris 1 (S1), scored with the official Kaggle Vesuvius Surface
+Detection metric (0.30 × TopoScore + 0.35 × SurfaceDice@τ + 0.35 × VOI_score,
+threshold 0.5), it scores 0.4397 vs the d058 ResEnc-L production model's 0.3996
+(+0.040, +10.0% relative) and wins on all 7 cubes. The recommended deployment is
+a voxel-wise `max(d058, MN)` ensemble (0.4437). Full methodology, per-cube
+breakdown, and a downstream ink-AUC sanity check:
+[PR #975](https://github.com/ScrollPrize/villa/pull/975) and the
+[supporting writeup](https://github.com/ciscoriordan/mednext-vs-umamba-scroll/blob/main/docs/pr925_re_pitch.md).
+
+Install the extra dependency:
+
+```
+pip install -e ".[mednext]"
+```
+
+(The `mednext` extra installs [`mednextv1`](https://github.com/MIC-DKFZ/MedNeXt)
+from its GitHub source; it is not on PyPI and not vendored here.)
+
+Train:
+
+```
+nnUNetv2_train DATASET_ID 3d_fullres 0 -tr nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5
+```
+
+A kernel3 variant (`nnUNetTrainerSkeletonRecall_MedNeXtL_kernel3`) is in the
+same file as a memory-tight fallback.
+
+Pretrained weights on Hugging Face (best checkpoint: `kernel5_skelrec_dataset059_ep33/`):
+https://huggingface.co/ciscoriordan/mednext-l-scroll-surface

--- a/segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py
+++ b/segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py
@@ -1,0 +1,170 @@
+"""MedNeXt-L (kernel5 / kernel3) + bruniss's SkeletonRecall loss.
+
+Targets the compressed / highly curved surface regions where the production
+ResEnc-L surface model loses recall. See issue #191 ("Surface and Fiber
+Predictions in Compressed or Highly Curved areas") and the re-pitch PR that
+motivated this trainer:
+
+  https://github.com/ScrollPrize/villa/issues/191
+  https://github.com/ScrollPrize/villa/pull/975
+
+On a held-out 7-cube benchmark over PHerc Paris 1 (S1), scored with the
+official Kaggle Vesuvius Surface Detection metric
+(0.30 * TopoScore + 0.35 * SurfaceDice@tau + 0.35 * VOI_score, threshold 0.5),
+MedNeXt-L kernel5 + SkeletonRecall on bruniss's Dataset059 scores 0.4397 vs
+the d058 production model's 0.3996 (+0.040, +10.0% relative) and wins on all
+7 cubes. The recommended deployment is a voxel-wise max(d058, MN) ensemble
+(0.4437), per the ensemble-not-swap design. Full methodology, per-cube
+breakdown, and a downstream ink-AUC sanity check are in PR #975 and the
+supporting writeup:
+
+  https://github.com/ciscoriordan/mednext-vs-umamba-scroll/blob/main/docs/pr925_re_pitch.md
+
+This trainer keeps everything in ``nnUNetTrainerSkeletonRecall`` (loss,
+SkeletonTransform, custom data loaders, train/validation steps) and only
+swaps the default ResEnc U-Net for MedNeXt-L, using the kernel size and
+channel/block schedule from ``nnUNetTrainerV2_MedNeXt_L_kernel5`` in the
+upstream MedNeXt repo (https://github.com/MIC-DKFZ/MedNeXt). MedNeXt's
+deep_supervision output list matches nnUNetv2's expectations (5 levels, full
+resolution first); see ``set_deep_supervision_enabled`` below for the one
+nnU-Net hook that MedNeXt needs overridden.
+
+Optional dependency:
+  The MedNeXt architecture lives in the ``mednextv1`` package, which is not
+  vendored here and is not on PyPI. It is imported lazily inside
+  ``build_network_architecture`` (see ``_load_mednext``) so that nnU-Net's
+  trainer discovery -- which imports every module in this folder -- does not
+  fail for users who never build this trainer. Install the extra with:
+
+    pip install -e ".[mednext]"
+
+  (the ``mednext`` extra pulls ``mednextv1`` from its GitHub source).
+
+Pretrained weights:
+  https://huggingface.co/ciscoriordan/mednext-l-scroll-surface
+  (best checkpoint: ``kernel5_skelrec_dataset059_ep33/``)
+
+Usage:
+  nnUNetv2_train DATASET_ID 3d_fullres 0 -tr nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5
+
+Memory note:
+  MedNeXt-L kernel5 at the default batch_size=2, patch 128^3 fits on a
+  40 GB A100 with room to spare. On smaller cards or larger patches, fall
+  back to ``nnUNetTrainerSkeletonRecall_MedNeXtL_kernel3``.
+"""
+from __future__ import annotations
+
+from typing import List, Tuple, Union
+
+from torch import nn
+from torch._dynamo import OptimizedModule
+
+from nnunetv2.training.nnUNetTrainer.variants.loss.nnUNetTrainerSkeletonRecall import (
+    nnUNetTrainerSkeletonRecall,
+)
+
+
+def _load_mednext():
+    """Import the MedNeXt class lazily.
+
+    nnU-Net's ``recursive_find_python_class`` imports every trainer module in
+    this folder during trainer discovery, even when the user is building a
+    completely different trainer. A top-level ``import nnunet_mednext`` would
+    therefore break discovery for everyone who has not installed this optional
+    dependency, so the import is deferred to here and accompanied by an
+    actionable error.
+    """
+    try:
+        from nnunet_mednext.network_architecture.mednextv1.MedNextV1 import MedNeXt
+    except ImportError as exc:
+        raise ImportError(
+            "The MedNeXt SkeletonRecall trainers require the optional 'mednext' "
+            "extra (the `mednextv1` package from "
+            "https://github.com/MIC-DKFZ/MedNeXt, which is not on PyPI). "
+            'Install it with:\n    pip install -e ".[mednext]"'
+        ) from exc
+    return MedNeXt
+
+
+class _MedNeXtSkeletonRecallTrainer(nnUNetTrainerSkeletonRecall):
+    """Shared MedNeXt + SkeletonRecall behavior.
+
+    Not selected directly; use one of the concrete ``..._kernel5`` /
+    ``..._kernel3`` subclasses with ``-tr``.
+    """
+
+    def set_deep_supervision_enabled(self, enabled: bool):
+        """Toggle deep supervision on a MedNeXt network.
+
+        nnU-Net's default implementation sets ``mod.decoder.deep_supervision``,
+        which only exists on nnU-Net's own decoder. MedNeXt exposes the same
+        switch as ``mod.do_ds`` instead, so without this override the
+        train/validation output-mode toggle would raise ``AttributeError``
+        (MedNeXt has no ``decoder`` attribute).
+        """
+        mod = self.network.module if self.is_ddp else self.network
+        if isinstance(mod, OptimizedModule):
+            mod = mod._orig_mod
+        mod.do_ds = enabled
+
+
+class nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5(_MedNeXtSkeletonRecallTrainer):
+    """MedNeXt-L kernel5 architecture + SkeletonRecall loss."""
+
+    @staticmethod
+    def build_network_architecture(
+        architecture_class_name: str,
+        arch_init_kwargs: dict,
+        arch_init_kwargs_req_import: Union[List[str], Tuple[str, ...]],
+        num_input_channels: int,
+        num_output_channels: int,
+        enable_deep_supervision: bool = True,
+    ) -> nn.Module:
+        """Match ``nnUNetTrainerV2_MedNeXt_L_kernel5.initialize_network()`` from mednextv1.
+
+        nnUNetv2's deep_supervision_scales for a 5-pool 3D U-Net is 5 levels
+        (full, /2, /4, /8, /16). MedNeXt with these settings returns exactly
+        that list shape, with ``output[0]`` = full resolution.
+        """
+        MedNeXt = _load_mednext()
+        return MedNeXt(
+            in_channels=num_input_channels,
+            n_channels=32,
+            n_classes=num_output_channels,
+            exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            kernel_size=5,
+            deep_supervision=enable_deep_supervision,
+            do_res=True,
+            do_res_up_down=True,
+            block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            checkpoint_style="outside_block",
+        )
+
+
+class nnUNetTrainerSkeletonRecall_MedNeXtL_kernel3(_MedNeXtSkeletonRecallTrainer):
+    """Kernel3 fallback variant. Use when kernel5 doesn't fit in VRAM at the
+    desired batch_size / patch size. Same channel/block schedule, kernel=3.
+    """
+
+    @staticmethod
+    def build_network_architecture(
+        architecture_class_name: str,
+        arch_init_kwargs: dict,
+        arch_init_kwargs_req_import: Union[List[str], Tuple[str, ...]],
+        num_input_channels: int,
+        num_output_channels: int,
+        enable_deep_supervision: bool = True,
+    ) -> nn.Module:
+        MedNeXt = _load_mednext()
+        return MedNeXt(
+            in_channels=num_input_channels,
+            n_channels=32,
+            n_classes=num_output_channels,
+            exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            kernel_size=3,
+            deep_supervision=enable_deep_supervision,
+            do_res=True,
+            do_res_up_down=True,
+            block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            checkpoint_style="outside_block",
+        )

--- a/segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py
+++ b/segmentation/models/arch/nnunet/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py
@@ -107,6 +107,46 @@ class _MedNeXtSkeletonRecallTrainer(nnUNetTrainerSkeletonRecall):
             mod = mod._orig_mod
         mod.do_ds = enabled
 
+    @staticmethod
+    def _build_mednext(
+        kernel_size: int,
+        num_input_channels: int,
+        num_output_channels: int,
+        enable_deep_supervision: bool,
+    ) -> nn.Module:
+        """Build MedNeXt-L with the deep-supervision heads ALWAYS constructed.
+
+        MedNeXt only registers its ``out_1``..``out_4`` deep-supervision heads when
+        it is constructed with ``deep_supervision=True`` (``out_0`` is always
+        present). nnU-Net's inference path (``predict_from_raw_data``) rebuilds the
+        network with ``enable_deep_supervision=False`` and then strict-loads a
+        checkpoint that was trained WITH deep supervision, so a ``False`` build is
+        missing those head weights and ``load_state_dict`` fails on unexpected
+        ``out_*`` keys. We therefore always construct the heads and use ``do_ds``
+        (set here, toggled by ``set_deep_supervision_enabled``) to select single-
+        vs deep-supervision output, so both kernel sizes load for inference.
+
+        Channel/block schedule matches ``nnUNetTrainerV2_MedNeXt_L_kernel5`` from the
+        upstream MedNeXt repo. nnUNetv2's deep_supervision_scales for a 5-pool 3D
+        U-Net is 5 levels (full, /2, /4, /8, /16); MedNeXt returns exactly that list
+        shape with ``output[0]`` = full resolution.
+        """
+        MedNeXt = _load_mednext()
+        network = MedNeXt(
+            in_channels=num_input_channels,
+            n_channels=32,
+            n_classes=num_output_channels,
+            exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            kernel_size=kernel_size,
+            deep_supervision=True,
+            do_res=True,
+            do_res_up_down=True,
+            block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
+            checkpoint_style="outside_block",
+        )
+        network.do_ds = enable_deep_supervision
+        return network
+
 
 class nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5(_MedNeXtSkeletonRecallTrainer):
     """MedNeXt-L kernel5 architecture + SkeletonRecall loss."""
@@ -120,25 +160,10 @@ class nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5(_MedNeXtSkeletonRecallTrainer
         num_output_channels: int,
         enable_deep_supervision: bool = True,
     ) -> nn.Module:
-        """Match ``nnUNetTrainerV2_MedNeXt_L_kernel5.initialize_network()`` from mednextv1.
-
-        nnUNetv2's deep_supervision_scales for a 5-pool 3D U-Net is 5 levels
-        (full, /2, /4, /8, /16). MedNeXt with these settings returns exactly
-        that list shape, with ``output[0]`` = full resolution.
-        """
-        MedNeXt = _load_mednext()
-        return MedNeXt(
-            in_channels=num_input_channels,
-            n_channels=32,
-            n_classes=num_output_channels,
-            exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
-            kernel_size=5,
-            deep_supervision=enable_deep_supervision,
-            do_res=True,
-            do_res_up_down=True,
-            block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
-            checkpoint_style="outside_block",
-        )
+        """MedNeXt-L, kernel size 5. See ``_build_mednext`` for the deep-supervision
+        head handling that lets a trained checkpoint load on the inference path."""
+        return _MedNeXtSkeletonRecallTrainer._build_mednext(
+            5, num_input_channels, num_output_channels, enable_deep_supervision)
 
 
 class nnUNetTrainerSkeletonRecall_MedNeXtL_kernel3(_MedNeXtSkeletonRecallTrainer):
@@ -155,16 +180,6 @@ class nnUNetTrainerSkeletonRecall_MedNeXtL_kernel3(_MedNeXtSkeletonRecallTrainer
         num_output_channels: int,
         enable_deep_supervision: bool = True,
     ) -> nn.Module:
-        MedNeXt = _load_mednext()
-        return MedNeXt(
-            in_channels=num_input_channels,
-            n_channels=32,
-            n_classes=num_output_channels,
-            exp_r=[3, 4, 8, 8, 8, 8, 8, 4, 3],
-            kernel_size=3,
-            deep_supervision=enable_deep_supervision,
-            do_res=True,
-            do_res_up_down=True,
-            block_counts=[3, 4, 8, 8, 8, 8, 8, 4, 3],
-            checkpoint_style="outside_block",
-        )
+        """MedNeXt-L, kernel size 3 (VRAM fallback). See ``_build_mednext``."""
+        return _MedNeXtSkeletonRecallTrainer._build_mednext(
+            3, num_input_channels, num_output_channels, enable_deep_supervision)

--- a/segmentation/models/arch/nnunet/pyproject.toml
+++ b/segmentation/models/arch/nnunet/pyproject.toml
@@ -91,6 +91,14 @@ dev = [
     "ruff",
     "pre-commit"
 ]
+# Only needed for the MedNeXt trainers under
+# nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerSkeletonRecall_MedNeXtL_kernel5.py
+# Install with: pip install -e ".[mednext]"
+# mednextv1 is not published to PyPI; install it from the upstream GitHub source
+# (MIC-DKFZ/MedNeXt documents `git clone` + `pip install -e .`).
+mednext = [
+    "mednextv1 @ git+https://github.com/MIC-DKFZ/MedNeXt.git"
+]
 
 [build-system]
 requires = ["setuptools>=67.8.0"]


### PR DESCRIPTION
Adds a MedNeXt-L + SkeletonRecall surface trainer for the compressed and highly curved regions where the ResEnc-L surface model loses recall (#191). This re-pitches #925 with the evaluation corrected: scored on the official Kaggle Vesuvius Surface Detection metric (0.30 TopoScore + 0.35 SurfaceDice@τ + 0.35 VOI) rather than binary IoU, on all 7 held-out S1 cubes at threshold 0.5.

| mean over 7 S1 cubes | d058 | MedNeXt-L SkelRec |
|---|---|---|
| Kaggle score | 0.3996 | 0.4397 |
| SurfaceDice@τ=2 | 0.508 | 0.580 |
| VOI | 0.567 | 0.667 |
| TopoScore | 0.084 | 0.022 |

![Per-cube topology-aware metrics across the 7 held-out S1 cubes (merger_rate, SurfaceDice@τ, pixel_dice), d058 vs MedNeXt-L SkelRec](https://raw.githubusercontent.com/ciscoriordan/mednext-vs-umamba-scroll/main/figures/pr925_re_pitch.png)

MedNeXt-L wins on all 7 cubes. d058 leads only on TopoScore, because MN's smoother predictions add spurious handles and cavities against the binary GT, and the SurfaceDice and VOI gains outweigh that. Following ensemble-not-swap, the recommended deployment is voxel-wise max(d058, MN) at 0.4437, which beat the mean and every weighted blend in a 6-op fusion sweep. Per-cube numbers, the fusion sweep, and the TopoScore sub-investigation are in the [supporting repo](https://github.com/ciscoriordan/mednext-vs-umamba-scroll).

Downstream check: feeding each surface into the v4 ink detector on the same crops, MN matches the hand-segmented bruniss surface within 3-5 AUC, while d058's argmax heightmap extraction gives sub-random ink.

![Downstream: v4 ink predictions on three crops with three surface choices (hand-segmented / d058 / MedNeXt-L) vs ink GT](https://raw.githubusercontent.com/ciscoriordan/mednext-vs-umamba-scroll/main/figures/ink_e2e_final_3crops.png)

The trainer subclasses nnUNetTrainerSkeletonRecall and only swaps in MedNeXt-L (kernel5, with a kernel3 VRAM fallback) from the optional `[mednext]` extra, lazy-imported so nnU-Net trainer discovery does not require it. It builds the deep-supervision heads unconditionally and toggles `do_ds` for the output mode, so a trained checkpoint strict-loads under `nnUNetv2_predict`. Pretrained weights are on HF (`kernel5_skelrec_dataset059_ep33`).
