### PR TITLE
Add reference volume warp pipeline for register-meshes-to-fibers

### DIFF
--- a/foundation/datasets/register-meshes-to-fibers/README.md
+++ b/foundation/datasets/register-meshes-to-fibers/README.md
@@ -6,9 +6,9 @@ Optimization-based registration to align 3D meshes with skeleton curves extracte
 
 - **registration_pipe.py**  
   Main script that:
-  - Recursively loads meshes.
+  - Recursively loads meshes and groups meshes that share a cube/TIFF context.
   - Extracts skeleton curves from corresponding TIFF volumes.
-  - Runs registration optimization.
+  - Runs registration optimization, including inter-mesh penalties within each group.
   - Saves registered meshes preserving the input folder structure.
 
 - **registration.py**  
@@ -26,6 +26,18 @@ Optimization-based registration to align 3D meshes with skeleton curves extracte
 
 - **extract_skeleton_tif.py**  
   Extracts and classifies skeleton curves from a TIFF volume using Kimimaro and PCA. Curves are categorized as "vertical" or "horizontal" based on their principal component.
+
+- **export_deformation_control_points.py**
+  Exports sparse displacement controls from original and registered OBJ vertex pairs. The output JSON records `source_xyz`, `target_xyz`, and `displacement_xyz` values that can seed downstream volume-deformation experiments.
+
+- **build_deformation_field.py**
+  Interpolates sparse deformation controls into a coarse displacement grid saved as a compressed `.npz` file. The field is stored as a `zyx` grid whose vectors are `xyz` displacements.
+
+- **warp_volume_with_field.py**
+  Applies a displacement field to a `.npy`, `.tif`, `.tiff`, or `.zarr` volume using backward trilinear sampling. This is a reference path for evaluating deformation fields before adding heavier tiled resampling.
+
+- **reference_volume_warp_pipeline.py**
+  Runs the lightweight reference workflow end to end: original/registered mesh pairs become sparse controls, a coarse displacement field, and a warped `.npy`, TIFF, or Zarr volume.
 
 - **environment.yml**  
   Conda environment specification for all required dependencies.
@@ -52,11 +64,76 @@ python registration_pipe.py --mesh_root example_data/meshes --tif_root example_d
 
 Use the `--help` flag to see all configurable parameters (e.g., number of iterations, learning rate, and energy term weights).
 
+### Export Deformation Controls
+
+After registering meshes, export sparse control points for downstream volume-warp experiments:
+```bash
+python export_deformation_control_points.py \
+  --mesh-pair example_data/meshes/cube_a/1_hz.obj registered-meshes/cube_a/1_hz_registered.obj \
+  --output deformation-controls.json \
+  --max-points-per-mesh 5000
+```
+
+Pass `--mesh-pair` multiple times to combine controls from several registered meshes. `--max-points-per-mesh 0` keeps every vertex.
+
+Build a coarse displacement field from those sparse controls:
+```bash
+python build_deformation_field.py \
+  --controls deformation-controls.json \
+  --output deformation-field.npz \
+  --grid-shape 256,256,128 \
+  --spacing 8,8,8 \
+  --origin 0,0,0 \
+  --k 8 \
+  --query-chunk-size 250000 \
+  --control-chunk-size 50000
+```
+
+The `.npz` output contains `displacement_xyz`, `origin_xyz`, `spacing_xyz`, and `coordinate_order`. This is not a final volume resampler; it is an explicit intermediate field for evaluating and iterating on whole-volume deformation strategies. Use `--query-chunk-size` to cap how many grid points are interpolated per IDW batch, and `--control-chunk-size` to cap how many sparse controls are compared per sub-batch. Together they avoid allocating one full query-by-control distance matrix for large fields.
+
+Apply a field to a test volume stored as a NumPy array, TIFF stack, or Zarr array:
+```bash
+python warp_volume_with_field.py \
+  --volume volume.npy \
+  --field deformation-field.npz \
+  --output warped-volume.npy \
+  --volume-spacing 1,1,1 \
+  --volume-origin 0,0,0 \
+  --fill-value 0 \
+  --chunk-depth 64
+```
+
+Use `.tif` or `.tiff` for `--volume` or `--output` to read or write TIFF stacks, and `.zarr` to read or write Zarr arrays. TIFF and Zarr support use lazy imports, so `.npy` workflows do not require those dependencies at import time. Zarr inputs stay backed by the Zarr store instead of being converted to a full NumPy array up front. When `--volume` points at a Zarr group, the warper reads array key `0` by default; pass `--zarr-array-key` to select another multiscale level, or include the array key in the path, such as `volume.zarr/1`.
+
+The reference warper resamples the displacement field onto the input volume grid and uses backward sampling, so a positive `x` displacement samples from lower input `x` coordinates. If `--volume-spacing` or `--volume-origin` are omitted, the field spacing and origin are reused. Use `--chunk-depth` to process the output volume in z-slice bands instead of allocating the full output sampling grid at once; chunked `.npy` output is written directly through a NumPy memmap, and chunked `.zarr` output is written directly to the Zarr store. `--chunk-depth 0` keeps the full-volume path.
+
+Run the reference workflow in one command:
+```bash
+python reference_volume_warp_pipeline.py \
+  --mesh-pair example_data/meshes/cube_a/1_hz.obj registered-meshes/cube_a/1_hz_registered.obj \
+  --volume volume.tif \
+  --output-dir deformation-run \
+  --warped-output warped-volume.tif \
+  --grid-shape auto \
+  --field-spacing 8,8,8 \
+  --field-origin 0,0,0 \
+  --volume-spacing 1,1,1 \
+  --volume-origin 0,0,0 \
+  --max-points-per-mesh 5000 \
+  --field-query-chunk-size 250000 \
+  --field-control-chunk-size 50000 \
+  --chunk-depth 64
+```
+
+This writes `deformation-controls.json`, `deformation-field.npz`, `warped-volume.npy`, `deformation-run-manifest.json`, and `deformation-run-metrics.json` into the output directory by default. Use `--grid-shape auto` to infer a field grid that covers the input volume extent from `--field-spacing` and `--volume-spacing`. Use `--field-query-chunk-size` and `--field-control-chunk-size` to pass chunked IDW interpolation through the end-to-end workflow. The manifest records the input volume, mesh pairs, actual field grid, requested spacing/origin metadata, effective volume spacing/origin used by the warp, field query/control chunk sizes, chunk depth, output paths, output write mode, and metrics for reproducible follow-up runs. The metrics file records control count, displacement-magnitude statistics, and the fraction of backward-sampled output voxels whose source coordinates remain inside the input volume. Use `--metrics-sample-step N` to estimate those sampling metrics from every Nth voxel per axis on large volumes; the default of `1` evaluates every voxel. The output filenames can be changed with `--controls-output`, `--field-output`, `--warped-output`, `--manifest-output`, and `--metrics-output`.
+
+Grid shapes, field spacing, volume spacing, IDW nearest-neighbor counts, and metrics sample steps must be positive. Chunk depth and mesh-control sampling limits must be non-negative. The CLIs reject invalid values before building intermediate outputs.
+
 ### Skeleton Extraction
 
 Extract and optionally visualize skeleton curves from a TIFF volume:
 ```bash
-python extract_skeleton_tif.py --tif path/to/file.tif --visualize
+python extract_skeleton_tif.py --tif path/to/fiber.tif --cube_label path/to/cube_mask.tif --label 1 --fiber_type hz --axis_order zyx --visualize
 ```
 
 ## Configuration
@@ -65,7 +142,16 @@ Adjust registration and skeleton extraction parameters via command-line argument
 - **Registration Hyperparameters:**  
   `--num_iters`, `--lr`, `--lambda_data`, `--lambda_disp`, `--lambda_elastic`, `--lambda_self`, `--lambda_lap`, `--lambda_arap`, `--lambda_sdf`, `--lambda_inter`, etc.
 - **Skeleton Processing:**  
-  `--skel_origin`, `--skel_axis`, `--target_skel_points`, etc.
+  `--skel_origin`, `--skel_axis`, `--curve_type`, `--target_skel_points`, etc.
+  `--curve_type auto` maps `*_hz.obj` meshes to horizontal curves and `*_vt.obj`
+  meshes to vertical curves in grouped runs; pass `horizontal` or `vertical` to
+  force one curve class for every mesh. `--skeleton_axis_order` is forwarded to
+  skeleton extraction and controls whether PCA interprets curves as NumPy-style
+  `zyx` coordinates or already converted `xyz` coordinates. For standalone
+  skeleton extraction, use `--axis_order` for the same PCA coordinate-order
+  control. The registration pipeline defaults `--skeleton_axis_order zyx` and
+  `--skel_axis zyx`, so extracted NumPy-style skeleton coordinates are classified
+  consistently and converted to mesh-style `xyz` before optimization.
 
 ## Visualization
 

--- a/foundation/datasets/register-meshes-to-fibers/build_deformation_field.py
+++ b/foundation/datasets/register-meshes-to-fibers/build_deformation_field.py
@@ -1,0 +1,237 @@
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def _parse_xyz(value: str, cast=float) -> tuple:
+    parts = value.split(",")
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("expected three comma-separated XYZ values")
+    return tuple(cast(part) for part in parts)
+
+
+def _require_positive(values: tuple, name: str) -> None:
+    if any(value <= 0 for value in values):
+        raise ValueError(f"{name} values must be positive")
+
+
+def _parse_positive_xyz(value: str, cast=float, name: str = "values") -> tuple:
+    parsed = _parse_xyz(value, cast)
+    try:
+        _require_positive(parsed, name)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    return parsed
+
+
+def _parse_positive_int(value: str, name: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"{name} must be positive")
+    return parsed
+
+
+def load_control_points(path: str | Path) -> tuple[np.ndarray, np.ndarray]:
+    with Path(path).open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    if data.get("coordinate_order") != "xyz":
+        raise ValueError("deformation controls must use coordinate_order='xyz'")
+
+    positions = []
+    displacements = []
+    for control in data.get("control_points", []):
+        source = np.asarray(control["source_xyz"], dtype=np.float64)
+        if "displacement_xyz" in control:
+            displacement = np.asarray(control["displacement_xyz"], dtype=np.float64)
+        else:
+            displacement = np.asarray(control["target_xyz"], dtype=np.float64) - source
+        positions.append(source)
+        displacements.append(displacement)
+
+    if not positions:
+        raise ValueError("control file does not contain any control_points")
+
+    return np.vstack(positions), np.vstack(displacements)
+
+
+def _select_nearest_by_distance_then_index(
+    dists: np.ndarray,
+    indices: np.ndarray,
+    k: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    nearest_dists = np.empty((dists.shape[0], k), dtype=dists.dtype)
+    nearest_indices = np.empty((indices.shape[0], k), dtype=indices.dtype)
+    for row in range(dists.shape[0]):
+        order = np.lexsort((indices[row], dists[row]))[:k]
+        nearest_dists[row] = dists[row, order]
+        nearest_indices[row] = indices[row, order]
+    return nearest_dists, nearest_indices
+
+
+def interpolate_idw(
+    query_xyz: np.ndarray,
+    controls_xyz: np.ndarray,
+    displacements_xyz: np.ndarray,
+    k: int = 8,
+    power: float = 2.0,
+    epsilon: float = 1e-12,
+    query_chunk_size: int | None = None,
+    control_chunk_size: int | None = None,
+) -> np.ndarray:
+    if controls_xyz.shape != displacements_xyz.shape:
+        raise ValueError("control positions and displacements must have matching shape")
+    if controls_xyz.ndim != 2 or controls_xyz.shape[1] != 3:
+        raise ValueError(f"expected controls with shape (N, 3), got {controls_xyz.shape}")
+    if query_xyz.ndim != 2 or query_xyz.shape[1] != 3:
+        raise ValueError(f"expected query points with shape (N, 3), got {query_xyz.shape}")
+    if controls_xyz.shape[0] == 0:
+        raise ValueError("at least one control point is required")
+    if int(k) <= 0:
+        raise ValueError("k must be positive")
+    if query_chunk_size is not None and int(query_chunk_size) <= 0:
+        raise ValueError("query_chunk_size must be positive")
+    if control_chunk_size is not None and int(control_chunk_size) <= 0:
+        raise ValueError("control_chunk_size must be positive")
+
+    k = min(int(k), controls_xyz.shape[0])
+    output = np.empty((query_xyz.shape[0], 3), dtype=np.float64)
+    if query_xyz.shape[0] == 0:
+        return output
+    step = query_xyz.shape[0] if query_chunk_size is None else int(query_chunk_size)
+    for start in range(0, query_xyz.shape[0], step):
+        stop = min(start + step, query_xyz.shape[0])
+        chunk = query_xyz[start:stop]
+        if control_chunk_size is None:
+            diff = chunk[:, None, :] - controls_xyz[None, :, :]
+            dists = np.linalg.norm(diff, axis=2)
+            control_indices = np.broadcast_to(np.arange(controls_xyz.shape[0], dtype=np.int64), dists.shape)
+            nearest_dists, nearest_indices = _select_nearest_by_distance_then_index(dists, control_indices, k)
+        else:
+            control_step = int(control_chunk_size)
+            nearest_dists = np.full((chunk.shape[0], k), np.inf, dtype=np.float64)
+            nearest_indices = np.full((chunk.shape[0], k), -1, dtype=np.int64)
+            for control_start in range(0, controls_xyz.shape[0], control_step):
+                control_stop = min(control_start + control_step, controls_xyz.shape[0])
+                control_chunk = controls_xyz[control_start:control_stop]
+                diff = chunk[:, None, :] - control_chunk[None, :, :]
+                candidate_dists = np.concatenate([nearest_dists, np.linalg.norm(diff, axis=2)], axis=1)
+                candidate_indices = np.concatenate(
+                    [
+                        nearest_indices,
+                        np.arange(control_start, control_stop, dtype=np.int64)[None, :].repeat(chunk.shape[0], axis=0),
+                    ],
+                    axis=1,
+                )
+                nearest_dists, nearest_indices = _select_nearest_by_distance_then_index(
+                    candidate_dists,
+                    candidate_indices,
+                    k,
+                )
+
+        for row, row_nearest_indices in enumerate(nearest_indices):
+            row_dists = nearest_dists[row]
+            exact = np.where(row_dists <= epsilon)[0]
+            if exact.size:
+                output[start + row] = displacements_xyz[row_nearest_indices[exact[0]]]
+                continue
+            weights = 1.0 / np.power(row_dists, power)
+            output[start + row] = (
+                weights[:, None] * displacements_xyz[row_nearest_indices]
+            ).sum(axis=0) / weights.sum()
+    return output
+
+
+def build_grid_field(
+    controls_xyz: np.ndarray,
+    displacements_xyz: np.ndarray,
+    grid_shape_xyz: tuple[int, int, int],
+    spacing_xyz: tuple[float, float, float],
+    origin_xyz: tuple[float, float, float],
+    k: int = 8,
+    power: float = 2.0,
+    query_chunk_size: int | None = None,
+    control_chunk_size: int | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    _require_positive(grid_shape_xyz, "grid shape")
+    _require_positive(spacing_xyz, "spacing")
+
+    x_count, y_count, z_count = grid_shape_xyz
+    x = origin_xyz[0] + np.arange(x_count, dtype=np.float64) * spacing_xyz[0]
+    y = origin_xyz[1] + np.arange(y_count, dtype=np.float64) * spacing_xyz[1]
+    z = origin_xyz[2] + np.arange(z_count, dtype=np.float64) * spacing_xyz[2]
+    zz, yy, xx = np.meshgrid(z, y, x, indexing="ij")
+    query_xyz = np.stack([xx.ravel(), yy.ravel(), zz.ravel()], axis=1)
+    interpolated = interpolate_idw(
+        query_xyz,
+        controls_xyz,
+        displacements_xyz,
+        k=k,
+        power=power,
+        query_chunk_size=query_chunk_size,
+        control_chunk_size=control_chunk_size,
+    )
+    field = interpolated.reshape((z_count, y_count, x_count, 3))
+    return (
+        field.astype(np.float32),
+        np.asarray(origin_xyz, dtype=np.float64),
+        np.asarray(spacing_xyz, dtype=np.float64),
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a coarse displacement field from sparse deformation controls."
+    )
+    parser.add_argument("--controls", required=True, help="Control-point JSON from export_deformation_control_points.py.")
+    parser.add_argument("--output", required=True, help="Output .npz file.")
+    parser.add_argument("--grid-shape", required=True, type=lambda value: _parse_positive_xyz(value, int, "grid shape"), help="Grid shape as x,y,z.")
+    parser.add_argument("--spacing", required=True, type=lambda value: _parse_positive_xyz(value, float, "spacing"), help="Grid spacing as x,y,z.")
+    parser.add_argument("--origin", default="0,0,0", type=lambda value: _parse_xyz(value, float), help="Grid origin as x,y,z.")
+    parser.add_argument("--k", type=lambda value: _parse_positive_int(value, "k"), default=8, help="Number of nearest controls used for IDW interpolation.")
+    parser.add_argument("--power", type=float, default=2.0, help="Inverse-distance power.")
+    parser.add_argument(
+        "--query-chunk-size",
+        type=lambda value: _parse_positive_int(value, "query-chunk-size"),
+        default=None,
+        help="Interpolate at most this many grid points per IDW batch; default processes the grid in one batch.",
+    )
+    parser.add_argument(
+        "--control-chunk-size",
+        type=lambda value: _parse_positive_int(value, "control-chunk-size"),
+        default=None,
+        help="Compare at most this many control points per IDW sub-batch; default compares all controls at once.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_arg_parser().parse_args(argv)
+    controls_xyz, displacements_xyz = load_control_points(args.controls)
+    field, origin, spacing = build_grid_field(
+        controls_xyz,
+        displacements_xyz,
+        grid_shape_xyz=args.grid_shape,
+        spacing_xyz=args.spacing,
+        origin_xyz=args.origin,
+        k=args.k,
+        power=args.power,
+        query_chunk_size=args.query_chunk_size,
+        control_chunk_size=args.control_chunk_size,
+    )
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        output_path,
+        displacement_xyz=field,
+        origin_xyz=origin,
+        spacing_xyz=spacing,
+        coordinate_order=np.array("zyx_grid_xyz_vectors"),
+        controls_path=np.array(str(args.controls)),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/foundation/datasets/register-meshes-to-fibers/environment.yml
+++ b/foundation/datasets/register-meshes-to-fibers/environment.yml
@@ -10,6 +10,8 @@ dependencies:
   - pytorch
   - tqdm
   - scikit-image
+  - tifffile
+  - zarr
   - posix_ipc
   - psutil
   - pip

--- a/foundation/datasets/register-meshes-to-fibers/export_deformation_control_points.py
+++ b/foundation/datasets/register-meshes-to-fibers/export_deformation_control_points.py
@@ -1,0 +1,140 @@
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def read_obj_vertices(path: str | Path) -> np.ndarray:
+    vertices = []
+    with Path(path).open("r", encoding="utf-8") as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) < 4 or parts[0] != "v":
+                continue
+            vertices.append([float(parts[1]), float(parts[2]), float(parts[3])])
+    return np.asarray(vertices, dtype=np.float64)
+
+
+def _sample_indices(vertex_count: int, max_points: int | None) -> np.ndarray:
+    if max_points is not None and max_points < 0:
+        raise ValueError("max_points must be non-negative")
+    if max_points is None or max_points == 0 or vertex_count <= max_points:
+        return np.arange(vertex_count, dtype=np.int64)
+    return np.linspace(0, vertex_count - 1, max_points, dtype=np.int64)
+
+
+def build_control_points(
+    source_vertices: np.ndarray,
+    registered_vertices: np.ndarray,
+    max_points: int | None = None,
+) -> list[dict]:
+    if source_vertices.shape != registered_vertices.shape:
+        raise ValueError(
+            "Source and registered meshes must have the same number of vertices "
+            f"and coordinates: {source_vertices.shape} != {registered_vertices.shape}"
+        )
+    if source_vertices.ndim != 2 or source_vertices.shape[1] != 3:
+        raise ValueError(f"Expected vertices with shape (N, 3), got {source_vertices.shape}")
+
+    controls = []
+    for vertex_index in _sample_indices(source_vertices.shape[0], max_points):
+        source = source_vertices[vertex_index]
+        target = registered_vertices[vertex_index]
+        displacement = target - source
+        controls.append(
+            {
+                "vertex_index": int(vertex_index),
+                "source_xyz": [float(value) for value in source],
+                "target_xyz": [float(value) for value in target],
+                "displacement_xyz": [float(value) for value in displacement],
+            }
+        )
+    return controls
+
+
+def export_control_points(
+    mesh_pairs: list[tuple[Path, Path]],
+    max_points_per_mesh: int | None = None,
+) -> dict:
+    output_pairs = []
+    output_controls = []
+    for mesh_pair_index, (source_path, registered_path) in enumerate(mesh_pairs):
+        source_vertices = read_obj_vertices(source_path)
+        registered_vertices = read_obj_vertices(registered_path)
+        controls = build_control_points(
+            source_vertices,
+            registered_vertices,
+            max_points=max_points_per_mesh,
+        )
+        output_pairs.append(
+            {
+                "source_mesh": str(source_path),
+                "registered_mesh": str(registered_path),
+                "source_vertex_count": int(source_vertices.shape[0]),
+                "registered_vertex_count": int(registered_vertices.shape[0]),
+                "sampled_control_points": len(controls),
+            }
+        )
+        for control in controls:
+            control_with_pair = dict(control)
+            control_with_pair["mesh_pair_index"] = mesh_pair_index
+            output_controls.append(control_with_pair)
+
+    return {
+        "schema_version": "1.0.0",
+        "coordinate_order": "xyz",
+        "description": (
+            "Sparse displacement controls derived from source and registered OBJ vertex pairs. "
+            "source_xyz + displacement_xyz = target_xyz."
+        ),
+        "mesh_pairs": output_pairs,
+        "control_points": output_controls,
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export sparse displacement control points from original and registered OBJ meshes."
+        )
+    )
+    parser.add_argument(
+        "--mesh-pair",
+        action="append",
+        nargs=2,
+        metavar=("SOURCE_OBJ", "REGISTERED_OBJ"),
+        required=True,
+        help="Source and registered OBJ pair.",
+    )
+    def parse_non_negative_int(value: str) -> int:
+        parsed = int(value)
+        if parsed < 0:
+            raise argparse.ArgumentTypeError("max-points-per-mesh must be non-negative")
+        return parsed
+
+    parser.add_argument("--output", required=True, help="Path for the output JSON file.")
+    parser.add_argument(
+        "--max-points-per-mesh",
+        type=parse_non_negative_int,
+        default=0,
+        help="Uniformly sample at most this many vertices per mesh; 0 keeps all vertices.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_arg_parser().parse_args(argv)
+    data = export_control_points(
+        [(Path(source), Path(registered)) for source, registered in args.mesh_pair],
+        max_points_per_mesh=args.max_points_per_mesh,
+    )
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/foundation/datasets/register-meshes-to-fibers/extract_skeleton_tif.py
+++ b/foundation/datasets/register-meshes-to-fibers/extract_skeleton_tif.py
@@ -3,9 +3,6 @@
 import numpy as np
 import argparse
 import os
-import open3d as o3d
-from skimage import io
-import kimimaro
 
 def extract_branches_from_kimimaro(vertices: np.ndarray, edges: np.ndarray) -> list:
     """
@@ -71,16 +68,25 @@ def extract_branches_from_kimimaro(vertices: np.ndarray, edges: np.ndarray) -> l
         curves.append(curve)
     return curves
 
-def classify_curve_pca(curve: np.ndarray, z_threshold: float = 1. / np.sqrt(2)) -> str:
+def z_axis_for_order(axis_order: str) -> np.ndarray:
+    if axis_order == "zyx":
+        return np.array([1, 0, 0], dtype=np.float32)
+    if axis_order == "xyz":
+        return np.array([0, 0, 1], dtype=np.float32)
+    raise ValueError(f"Unsupported axis order: {axis_order}")
+
+
+def classify_curve_pca(curve: np.ndarray, z_threshold: float = 1. / np.sqrt(2), axis_order: str = "zyx") -> str:
     """
     Classify a curve as 'vertical' or 'horizontal' using PCA on the curve coordinates.
     
-    The curve is assumed to be a NumPy array of shape (N, 3) in (x, y, z) order.
-    The classification compares the principal axis to the z-axis [0, 0, 1].
+    The curve is assumed to be a NumPy array of shape (N, 3). By default,
+    coordinates are interpreted as (z, y, x), matching NumPy volume indexing.
+    Use axis_order="xyz" for curves already converted to (x, y, z).
     
     Returns:
-        "vertical" if the absolute dot product between the principal axis and [0, 0, 1]
-        exceeds the threshold; "horizontal" otherwise.
+        "vertical" if the absolute dot product between the principal axis and the selected
+        z-axis exceeds the threshold; "horizontal" otherwise.
     """
     if curve.shape[0] < 2:
         return "horizontal"
@@ -96,11 +102,11 @@ def classify_curve_pca(curve: np.ndarray, z_threshold: float = 1. / np.sqrt(2)) 
     eigvecs = eigvecs[:, idx]
     principal_axis = eigvecs[:, 0]
     principal_axis /= np.linalg.norm(principal_axis)
-    z_axis = np.array([1, 0, 0], dtype=np.float32)
+    z_axis = z_axis_for_order(axis_order)
     cos_angle = abs(np.dot(principal_axis, z_axis))
     return "vertical" if cos_angle > z_threshold else "horizontal"
 
-def extract_skeleton_from_tif(tif_file: str, original_file: str, z_threshold: float = 1. / np.sqrt(2), label: int = 1, fiber_type: str = "hz") -> dict:
+def extract_skeleton_from_tif(tif_file: str, original_file: str, z_threshold: float = 1. / np.sqrt(2), label: int = 1, fiber_type: str = "hz", axis_order: str = "zyx") -> dict:
     """
     Loads a .tif volume, thresholds it, and performs 3D skeletonization using kimimaro.
     
@@ -111,6 +117,12 @@ def extract_skeleton_from_tif(tif_file: str, original_file: str, z_threshold: fl
         A dictionary with keys "vertical" and "horizontal". Each value is a list of NumPy arrays,
         where each array (of shape (N, 3)) represents an extracted skeleton curve.
     """
+    if fiber_type not in {"hz", "vt"}:
+        raise ValueError("fiber_type must be 'hz' or 'vt'")
+
+    from skimage import io
+    import kimimaro
+
     volume = io.imread(tif_file)
     label_volume = io.imread(original_file)
 
@@ -142,7 +154,7 @@ def extract_skeleton_from_tif(tif_file: str, original_file: str, z_threshold: fl
         branch_curves = extract_branches_from_kimimaro(vertices, edges)
         for curve in branch_curves:
             if curve.shape[0] > 1:
-                label_curve = classify_curve_pca(curve, z_threshold)
+                label_curve = classify_curve_pca(curve, z_threshold, axis_order=axis_order)
                 curves[label_curve].append(curve)
     return curves
 
@@ -154,6 +166,8 @@ def visualize_curves(curves_by_label: dict):
       - Vertical curves: red.
       - Horizontal curves: blue.
     """
+    import open3d as o3d
+
     line_sets = []
     color_map = {"vertical": [1, 0, 0], "horizontal": [0, 0, 1]}
     
@@ -169,19 +183,39 @@ def visualize_curves(curves_by_label: dict):
     
     o3d.visualization.draw_geometries(line_sets, window_name="Extracted Skeleton Curves")
 
-if __name__ == "__main__":
+def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Extract and classify skeleton curves from a .tif volume using kimimaro skeletonization."
     )
     parser.add_argument("--tif", type=str, required=True, help="Path to the .tif volume file.")
+    parser.add_argument("--cube_label", type=str, required=True,
+                        help="Path to the cube label mask used to select the mesh label.")
+    parser.add_argument("--label", type=int, default=1, help="Label value to extract from the cube label mask.")
+    parser.add_argument("--fiber_type", type=str, choices=["hz", "vt"], default="hz",
+                        help="Fiber inference channel to use: hz uses value 2, vt uses value 1.")
+    parser.add_argument("--z_threshold", type=float, default=1. / np.sqrt(2),
+                        help="PCA alignment threshold for classifying vertical curves.")
+    parser.add_argument("--axis_order", type=str, choices=["zyx", "xyz"], default="zyx",
+                        help="Coordinate order for skeleton vertices before PCA classification.")
     parser.add_argument("--visualize", action="store_true", help="Visualize the extracted skeleton curves.")
-    args = parser.parse_args()
+    return parser
+
+
+def main(argv=None):
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
 
     if not os.path.isfile(args.tif):
         raise FileNotFoundError(f"File not found: {args.tif}")
+    if not os.path.isfile(args.cube_label):
+        raise FileNotFoundError(f"File not found: {args.cube_label}")
 
     print(f"Loading volume from: {args.tif}")
-    curves_dict = extract_skeleton_from_tif(args.tif)
+    curves_dict = extract_skeleton_from_tif(args.tif, args.cube_label,
+                                            z_threshold=args.z_threshold,
+                                            label=args.label,
+                                            fiber_type=args.fiber_type,
+                                            axis_order=args.axis_order)
     
     n_vert = len(curves_dict.get("vertical", []))
     n_horz = len(curves_dict.get("horizontal", []))
@@ -191,3 +225,8 @@ if __name__ == "__main__":
     if args.visualize:
         print("Visualizing skeleton curves...")
         visualize_curves(curves_dict)
+    return curves_dict
+
+
+if __name__ == "__main__":
+    main()

--- a/foundation/datasets/register-meshes-to-fibers/reference_volume_warp_pipeline.py
+++ b/foundation/datasets/register-meshes-to-fibers/reference_volume_warp_pipeline.py
@@ -1,0 +1,577 @@
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from build_deformation_field import build_grid_field, load_control_points
+from export_deformation_control_points import export_control_points
+from warp_volume_with_field import (
+    _is_npy_path,
+    _is_zarr_path,
+    load_volume,
+    save_volume,
+    warp_sampling_diagnostics,
+    warp_volume_with_displacement_field,
+    warp_volume_with_displacement_field_chunked,
+    warp_volume_to_npy_memmap,
+    warp_volume_to_zarr,
+)
+
+
+def _parse_xyz(value: str, cast=float) -> tuple:
+    parts = value.split(",")
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("expected three comma-separated XYZ values")
+    return tuple(cast(part) for part in parts)
+
+
+def _require_positive(values: tuple, name: str) -> None:
+    if any(value <= 0 for value in values):
+        raise ValueError(f"{name} values must be positive")
+
+
+def _parse_positive_xyz(value: str, cast=float, name: str = "values") -> tuple:
+    parsed = _parse_xyz(value, cast)
+    try:
+        _require_positive(parsed, name)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    return parsed
+
+
+def _parse_positive_int(value: str, name: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"{name} must be positive")
+    return parsed
+
+
+def _parse_non_negative_int(value: str, name: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(f"{name} must be non-negative")
+    return parsed
+
+
+def _parse_grid_shape(value: str) -> tuple[int, int, int] | str:
+    if value.lower() == "auto":
+        return "auto"
+    return _parse_positive_xyz(value, int, "grid shape")
+
+
+def infer_grid_shape_from_volume(
+    volume_shape_zyx: tuple[int, int, int],
+    field_spacing_xyz: tuple[float, float, float],
+    volume_spacing_xyz: tuple[float, float, float],
+) -> tuple[int, int, int]:
+    z_size, y_size, x_size = volume_shape_zyx
+    volume_shape_xyz = (x_size, y_size, z_size)
+    shape_xyz = []
+    for size, volume_spacing, field_spacing in zip(
+        volume_shape_xyz,
+        volume_spacing_xyz,
+        field_spacing_xyz,
+    ):
+        if field_spacing <= 0.0:
+            raise ValueError("field spacing values must be positive")
+        if volume_spacing <= 0.0:
+            raise ValueError("volume spacing values must be positive")
+        extent = max(0.0, (size - 1) * volume_spacing)
+        shape_xyz.append(int(np.ceil(extent / field_spacing)) + 1)
+    return tuple(shape_xyz)
+
+
+def _resolve_output_path(output_dir: Path, output_name: str) -> Path:
+    path = Path(output_name)
+    if path.is_absolute():
+        return path
+    return output_dir / path
+
+
+def _as_json_list(values) -> list:
+    return [float(value) if isinstance(value, (float, np.floating)) else int(value) for value in values]
+
+
+def _write_manifest(
+    manifest_path: Path,
+    mesh_pairs: list[tuple[Path, Path]],
+    volume_path: Path,
+    volume: np.ndarray,
+    output_paths: dict[str, Path],
+    requested_grid_shape,
+    actual_grid_shape_xyz: tuple[int, int, int],
+    field_spacing_xyz: tuple[float, float, float],
+    field_origin_xyz: tuple[float, float, float],
+    volume_spacing_xyz: tuple[float, float, float] | None,
+    volume_origin_xyz: tuple[float, float, float] | None,
+    effective_volume_spacing_xyz: tuple[float, float, float],
+    effective_volume_origin_xyz: tuple[float, float, float],
+    zarr_array_key: str | None,
+    max_points_per_mesh: int | None,
+    k: int,
+    power: float,
+    field_query_chunk_size: int | None,
+    field_control_chunk_size: int | None,
+    fill_value: float,
+    chunk_depth: int,
+    output_write_mode: str,
+    metrics: dict,
+) -> None:
+    manifest = {
+        "schema_version": "1.0.0",
+        "coordinate_order": "xyz",
+        "input_volume": str(volume_path),
+        "volume_shape_zyx": [int(value) for value in volume.shape],
+        "volume_dtype": str(volume.dtype),
+        "mesh_pairs": [
+            {
+                "source_mesh": str(source),
+                "registered_mesh": str(registered),
+            }
+            for source, registered in mesh_pairs
+        ],
+        "output_paths": {name: str(path) for name, path in output_paths.items()},
+        "requested_grid_shape": requested_grid_shape,
+        "actual_grid_shape_xyz": [int(value) for value in actual_grid_shape_xyz],
+        "field_spacing_xyz": _as_json_list(field_spacing_xyz),
+        "field_origin_xyz": _as_json_list(field_origin_xyz),
+        "volume_spacing_xyz": None if volume_spacing_xyz is None else _as_json_list(volume_spacing_xyz),
+        "volume_origin_xyz": None if volume_origin_xyz is None else _as_json_list(volume_origin_xyz),
+        "effective_volume_spacing_xyz": _as_json_list(effective_volume_spacing_xyz),
+        "effective_volume_origin_xyz": _as_json_list(effective_volume_origin_xyz),
+        "zarr_array_key": zarr_array_key,
+        "max_points_per_mesh": max_points_per_mesh,
+        "idw_k": int(k),
+        "idw_power": float(power),
+        "field_query_chunk_size": field_query_chunk_size,
+        "field_control_chunk_size": field_control_chunk_size,
+        "fill_value": float(fill_value),
+        "chunk_depth": int(chunk_depth),
+        "output_write_mode": output_write_mode,
+        "metrics": metrics,
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with manifest_path.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+        f.write("\n")
+
+
+def run_pipeline(
+    mesh_pairs: list[tuple[Path, Path]],
+    volume_path: Path,
+    output_dir: Path,
+    controls_output: str = "deformation-controls.json",
+    field_output: str = "deformation-field.npz",
+    warped_output: str = "warped-volume.npy",
+    manifest_output: str = "deformation-run-manifest.json",
+    metrics_output: str = "deformation-run-metrics.json",
+    grid_shape_xyz: tuple[int, int, int] = (1, 1, 1),
+    field_spacing_xyz: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    field_origin_xyz: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    volume_spacing_xyz: tuple[float, float, float] | None = None,
+    volume_origin_xyz: tuple[float, float, float] | None = None,
+    zarr_array_key: str | None = None,
+    max_points_per_mesh: int | None = None,
+    k: int = 8,
+    power: float = 2.0,
+    field_query_chunk_size: int | None = None,
+    field_control_chunk_size: int | None = None,
+    fill_value: float = 0.0,
+    chunk_depth: int = 0,
+    metrics_sample_step: int = 1,
+) -> dict[str, Path]:
+    if grid_shape_xyz != "auto":
+        _require_positive(grid_shape_xyz, "grid shape")
+    _require_positive(field_spacing_xyz, "field spacing")
+    if volume_spacing_xyz is not None:
+        _require_positive(volume_spacing_xyz, "volume spacing")
+    if chunk_depth < 0:
+        raise ValueError("chunk_depth must be non-negative")
+    if metrics_sample_step <= 0:
+        raise ValueError("metrics_sample_step must be positive")
+    if k <= 0:
+        raise ValueError("k must be positive")
+    if field_query_chunk_size is not None and field_query_chunk_size <= 0:
+        raise ValueError("field_query_chunk_size must be positive")
+    if field_control_chunk_size is not None and field_control_chunk_size <= 0:
+        raise ValueError("field_control_chunk_size must be positive")
+    if max_points_per_mesh is not None and max_points_per_mesh < 0:
+        raise ValueError("max_points_per_mesh must be non-negative")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    controls_path = _resolve_output_path(output_dir, controls_output)
+    field_path = _resolve_output_path(output_dir, field_output)
+    warped_path = _resolve_output_path(output_dir, warped_output)
+    manifest_path = _resolve_output_path(output_dir, manifest_output)
+    metrics_path = _resolve_output_path(output_dir, metrics_output)
+    controls_path.parent.mkdir(parents=True, exist_ok=True)
+    field_path.parent.mkdir(parents=True, exist_ok=True)
+    warped_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    volume = load_volume(volume_path, zarr_array_key=zarr_array_key)
+    resolved_volume_spacing = volume_spacing_xyz if volume_spacing_xyz is not None else field_spacing_xyz
+    resolved_volume_origin = volume_origin_xyz if volume_origin_xyz is not None else field_origin_xyz
+    requested_grid_shape = "auto" if grid_shape_xyz == "auto" else [int(value) for value in grid_shape_xyz]
+    if grid_shape_xyz == "auto":
+        grid_shape_xyz = infer_grid_shape_from_volume(
+            volume.shape,
+            field_spacing_xyz=field_spacing_xyz,
+            volume_spacing_xyz=resolved_volume_spacing,
+        )
+
+    controls = export_control_points(
+        mesh_pairs,
+        max_points_per_mesh=max_points_per_mesh,
+    )
+    with controls_path.open("w", encoding="utf-8") as f:
+        json.dump(controls, f, indent=2)
+        f.write("\n")
+
+    controls_xyz, displacements_xyz = load_control_points(controls_path)
+    displacement_field, field_origin, field_spacing = build_grid_field(
+        controls_xyz,
+        displacements_xyz,
+        grid_shape_xyz=grid_shape_xyz,
+        spacing_xyz=field_spacing_xyz,
+        origin_xyz=field_origin_xyz,
+        k=k,
+        power=power,
+        query_chunk_size=field_query_chunk_size,
+        control_chunk_size=field_control_chunk_size,
+    )
+    np.savez_compressed(
+        field_path,
+        displacement_xyz=displacement_field,
+        origin_xyz=field_origin,
+        spacing_xyz=field_spacing,
+        coordinate_order=np.array("zyx_grid_xyz_vectors"),
+        controls_path=np.array(str(controls_path)),
+    )
+    metrics = warp_sampling_diagnostics(
+        volume,
+        displacement_field,
+        origin_xyz=field_origin,
+        spacing_xyz=field_spacing,
+        volume_origin_xyz=volume_origin_xyz,
+        volume_spacing_xyz=volume_spacing_xyz,
+        chunk_depth=chunk_depth,
+        sample_step=metrics_sample_step,
+    )
+    metrics["mesh_pair_count"] = len(mesh_pairs)
+    metrics["control_point_count"] = len(controls["control_points"])
+
+    if chunk_depth > 0 and _is_npy_path(warped_path):
+        warp_volume_to_npy_memmap(
+            warped_path,
+            volume,
+            displacement_field,
+            origin_xyz=field_origin,
+            spacing_xyz=field_spacing,
+            volume_origin_xyz=volume_origin_xyz,
+            volume_spacing_xyz=volume_spacing_xyz,
+            fill_value=fill_value,
+            chunk_depth=chunk_depth,
+        )
+        output_paths = {
+            "controls": controls_path,
+            "field": field_path,
+            "warped": warped_path,
+            "manifest": manifest_path,
+            "metrics": metrics_path,
+        }
+        metrics["output_write_mode"] = "chunked_npy_memmap"
+        with metrics_path.open("w", encoding="utf-8") as f:
+            json.dump(metrics, f, indent=2)
+            f.write("\n")
+        _write_manifest(
+            manifest_path,
+            mesh_pairs=mesh_pairs,
+            volume_path=volume_path,
+            volume=volume,
+            output_paths=output_paths,
+            requested_grid_shape=requested_grid_shape,
+            actual_grid_shape_xyz=grid_shape_xyz,
+            field_spacing_xyz=field_spacing_xyz,
+            field_origin_xyz=field_origin_xyz,
+            volume_spacing_xyz=volume_spacing_xyz,
+            volume_origin_xyz=volume_origin_xyz,
+            effective_volume_spacing_xyz=resolved_volume_spacing,
+            effective_volume_origin_xyz=resolved_volume_origin,
+            zarr_array_key=zarr_array_key,
+            max_points_per_mesh=max_points_per_mesh,
+            k=k,
+            power=power,
+            field_query_chunk_size=field_query_chunk_size,
+            field_control_chunk_size=field_control_chunk_size,
+            fill_value=fill_value,
+            chunk_depth=chunk_depth,
+            output_write_mode="chunked_npy_memmap",
+            metrics=metrics,
+        )
+        return {
+            "controls": controls_path,
+            "field": field_path,
+            "warped": warped_path,
+            "manifest": manifest_path,
+            "metrics": metrics_path,
+        }
+    if chunk_depth > 0 and _is_zarr_path(warped_path):
+        warp_volume_to_zarr(
+            warped_path,
+            volume,
+            displacement_field,
+            origin_xyz=field_origin,
+            spacing_xyz=field_spacing,
+            volume_origin_xyz=volume_origin_xyz,
+            volume_spacing_xyz=volume_spacing_xyz,
+            fill_value=fill_value,
+            chunk_depth=chunk_depth,
+        )
+        output_paths = {
+            "controls": controls_path,
+            "field": field_path,
+            "warped": warped_path,
+            "manifest": manifest_path,
+            "metrics": metrics_path,
+        }
+        metrics["output_write_mode"] = "chunked_zarr"
+        with metrics_path.open("w", encoding="utf-8") as f:
+            json.dump(metrics, f, indent=2)
+            f.write("\n")
+        _write_manifest(
+            manifest_path,
+            mesh_pairs=mesh_pairs,
+            volume_path=volume_path,
+            volume=volume,
+            output_paths=output_paths,
+            requested_grid_shape=requested_grid_shape,
+            actual_grid_shape_xyz=grid_shape_xyz,
+            field_spacing_xyz=field_spacing_xyz,
+            field_origin_xyz=field_origin_xyz,
+            volume_spacing_xyz=volume_spacing_xyz,
+            volume_origin_xyz=volume_origin_xyz,
+            effective_volume_spacing_xyz=resolved_volume_spacing,
+            effective_volume_origin_xyz=resolved_volume_origin,
+            zarr_array_key=zarr_array_key,
+            max_points_per_mesh=max_points_per_mesh,
+            k=k,
+            power=power,
+            field_query_chunk_size=field_query_chunk_size,
+            field_control_chunk_size=field_control_chunk_size,
+            fill_value=fill_value,
+            chunk_depth=chunk_depth,
+            output_write_mode="chunked_zarr",
+            metrics=metrics,
+        )
+        return {
+            "controls": controls_path,
+            "field": field_path,
+            "warped": warped_path,
+            "manifest": manifest_path,
+            "metrics": metrics_path,
+        }
+
+    warp_fn = warp_volume_with_displacement_field_chunked if chunk_depth > 0 else warp_volume_with_displacement_field
+    warp_kwargs = {"chunk_depth": chunk_depth} if chunk_depth > 0 else {}
+    warped = warp_fn(
+        volume,
+        displacement_field,
+        origin_xyz=field_origin,
+        spacing_xyz=field_spacing,
+        volume_origin_xyz=volume_origin_xyz,
+        volume_spacing_xyz=volume_spacing_xyz,
+        fill_value=fill_value,
+        **warp_kwargs,
+    )
+    save_volume(warped_path, warped)
+    output_write_mode = "chunked_volume_save" if chunk_depth > 0 else "full_volume_save"
+    output_paths = {
+        "controls": controls_path,
+        "field": field_path,
+        "warped": warped_path,
+        "manifest": manifest_path,
+        "metrics": metrics_path,
+    }
+    metrics["output_write_mode"] = output_write_mode
+    with metrics_path.open("w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2)
+        f.write("\n")
+    _write_manifest(
+        manifest_path,
+        mesh_pairs=mesh_pairs,
+        volume_path=volume_path,
+        volume=volume,
+        output_paths=output_paths,
+        requested_grid_shape=requested_grid_shape,
+        actual_grid_shape_xyz=grid_shape_xyz,
+        field_spacing_xyz=field_spacing_xyz,
+        field_origin_xyz=field_origin_xyz,
+        volume_spacing_xyz=volume_spacing_xyz,
+        volume_origin_xyz=volume_origin_xyz,
+        effective_volume_spacing_xyz=resolved_volume_spacing,
+        effective_volume_origin_xyz=resolved_volume_origin,
+        zarr_array_key=zarr_array_key,
+        max_points_per_mesh=max_points_per_mesh,
+        k=k,
+        power=power,
+        field_query_chunk_size=field_query_chunk_size,
+        field_control_chunk_size=field_control_chunk_size,
+        fill_value=fill_value,
+        chunk_depth=chunk_depth,
+        output_write_mode=output_write_mode,
+        metrics=metrics,
+    )
+    return {
+        "controls": controls_path,
+        "field": field_path,
+        "warped": warped_path,
+        "manifest": manifest_path,
+        "metrics": metrics_path,
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the reference mesh-to-volume deformation workflow: export sparse "
+            "controls, build a coarse field, and warp a .npy, .tif, .tiff, or .zarr volume."
+        )
+    )
+    parser.add_argument(
+        "--mesh-pair",
+        action="append",
+        nargs=2,
+        metavar=("SOURCE_OBJ", "REGISTERED_OBJ"),
+        required=True,
+        help="Source and registered OBJ pair. May be provided more than once.",
+    )
+    parser.add_argument("--volume", required=True, help="Input 3D .npy/.tif/.tiff/.zarr volume in z,y,x order.")
+    parser.add_argument(
+        "--zarr-array-key",
+        default=None,
+        help="Array key to read when --volume points at a Zarr group. Defaults to '0'.",
+    )
+    parser.add_argument("--output-dir", required=True, help="Directory for generated outputs.")
+    parser.add_argument(
+        "--controls-output",
+        default="deformation-controls.json",
+        help="Control-point JSON filename or absolute output path.",
+    )
+    parser.add_argument(
+        "--field-output",
+        default="deformation-field.npz",
+        help="Displacement-field .npz filename or absolute output path.",
+    )
+    parser.add_argument(
+        "--warped-output",
+        default="warped-volume.npy",
+        help="Warped .npy/.tif/.tiff/.zarr filename or absolute output path.",
+    )
+    parser.add_argument(
+        "--manifest-output",
+        default="deformation-run-manifest.json",
+        help="Run manifest JSON filename or absolute output path.",
+    )
+    parser.add_argument(
+        "--metrics-output",
+        default="deformation-run-metrics.json",
+        help="Run metrics JSON filename or absolute output path.",
+    )
+    parser.add_argument(
+        "--grid-shape",
+        required=True,
+        type=_parse_grid_shape,
+        help="Displacement field shape as x,y,z, or 'auto' to cover the input volume extent.",
+    )
+    parser.add_argument(
+        "--field-spacing",
+        required=True,
+        type=lambda value: _parse_positive_xyz(value, float, "field spacing"),
+        help="Displacement field spacing as x,y,z.",
+    )
+    parser.add_argument(
+        "--field-origin",
+        default="0,0,0",
+        type=lambda value: _parse_xyz(value, float),
+        help="Displacement field origin as x,y,z.",
+    )
+    parser.add_argument(
+        "--volume-spacing",
+        default=None,
+        type=lambda value: _parse_positive_xyz(value, float, "volume spacing"),
+        help="Input volume spacing as x,y,z. Defaults to field spacing.",
+    )
+    parser.add_argument(
+        "--volume-origin",
+        default=None,
+        type=lambda value: _parse_xyz(value, float),
+        help="Input volume origin as x,y,z. Defaults to field origin.",
+    )
+    parser.add_argument(
+        "--max-points-per-mesh",
+        type=lambda value: _parse_non_negative_int(value, "max-points-per-mesh"),
+        default=0,
+        help="Uniformly sample at most this many vertices per mesh; 0 keeps all vertices.",
+    )
+    parser.add_argument("--k", type=lambda value: _parse_positive_int(value, "k"), default=8, help="Nearest controls used for IDW interpolation.")
+    parser.add_argument("--power", type=float, default=2.0, help="Inverse-distance power.")
+    parser.add_argument(
+        "--field-query-chunk-size",
+        type=lambda value: _parse_positive_int(value, "field-query-chunk-size"),
+        default=None,
+        help="Interpolate at most this many displacement-field grid points per IDW batch.",
+    )
+    parser.add_argument(
+        "--field-control-chunk-size",
+        type=lambda value: _parse_positive_int(value, "field-control-chunk-size"),
+        default=None,
+        help="Compare at most this many deformation controls per IDW sub-batch.",
+    )
+    parser.add_argument("--fill-value", type=float, default=0.0, help="Value used outside the input volume.")
+    parser.add_argument(
+        "--chunk-depth",
+        type=lambda value: _parse_non_negative_int(value, "chunk-depth"),
+        default=0,
+        help="Warp this many z-slices at a time; 0 warps the whole volume at once.",
+    )
+    parser.add_argument(
+        "--metrics-sample-step",
+        type=lambda value: _parse_positive_int(value, "metrics-sample-step"),
+        default=1,
+        help="Sample every Nth voxel per axis for run metrics; 1 evaluates every voxel.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_arg_parser().parse_args(argv)
+    run_pipeline(
+        mesh_pairs=[(Path(source), Path(registered)) for source, registered in args.mesh_pair],
+        volume_path=Path(args.volume),
+        output_dir=Path(args.output_dir),
+        controls_output=args.controls_output,
+        field_output=args.field_output,
+        warped_output=args.warped_output,
+        manifest_output=args.manifest_output,
+        metrics_output=args.metrics_output,
+        grid_shape_xyz=args.grid_shape,
+        field_spacing_xyz=args.field_spacing,
+        field_origin_xyz=args.field_origin,
+        volume_spacing_xyz=args.volume_spacing,
+        volume_origin_xyz=args.volume_origin,
+        zarr_array_key=args.zarr_array_key,
+        max_points_per_mesh=args.max_points_per_mesh,
+        k=args.k,
+        power=args.power,
+        field_query_chunk_size=args.field_query_chunk_size,
+        field_control_chunk_size=args.field_control_chunk_size,
+        fill_value=args.fill_value,
+        chunk_depth=args.chunk_depth,
+        metrics_sample_step=args.metrics_sample_step,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/foundation/datasets/register-meshes-to-fibers/registration.py
+++ b/foundation/datasets/register-meshes-to-fibers/registration.py
@@ -377,10 +377,13 @@ def optimize_all_registration(meshes: List[MeshSurface],
                               lambda_inter: float = 0.1,
                               delta_inter: float = 0.05,
                               beta_inter: float = 10.0,
-                              batch_size: int = 8) -> List[torch.Tensor]:
+    batch_size: int = 8) -> List[torch.Tensor]:
     # Assign skeleton points for each mesh.
     for mesh in meshes:
-        mesh.skeleton_points = assign_skeletons_to_mesh(mesh.vertices_np, global_skel_curves, thresh_z=0.1)
+        mesh_skel_curves = mesh.skeleton_curves if mesh.skeleton_curves is not None else global_skel_curves
+        if len(mesh_skel_curves) == 0:
+            raise ValueError("mesh has no skeleton curves")
+        mesh.skeleton_points = assign_skeletons_to_mesh(mesh.vertices_np, mesh_skel_curves, thresh_z=0.1)
     
     displacement_list = [mesh.displacement for mesh in meshes]
     optimizer = torch.optim.AdamW(displacement_list, lr=lr)

--- a/foundation/datasets/register-meshes-to-fibers/registration_pipe.py
+++ b/foundation/datasets/register-meshes-to-fibers/registration_pipe.py
@@ -15,6 +15,8 @@ from registration import MeshSurface, optimize_all_registration, assign_skeleton
 
 # Global device (as defined in registration module)
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+VALID_FIBER_TYPES = {"hz", "vt"}
+MESH_NAME_FORMAT = "<label>_<hz|vt>.obj"
 
 
 def simplify_mesh_o3d(mesh_o3d: o3d.geometry.TriangleMesh, target_triangles: int) -> o3d.geometry.TriangleMesh:
@@ -67,6 +69,53 @@ def simplify_curve(curve: np.ndarray, target_points: int) -> np.ndarray:
     return curve[indices]
 
 
+def prepare_skeleton_curves(
+    curves_dict: dict,
+    curve_type: str,
+    origin: np.ndarray,
+    skel_axis: str,
+    target_points: int,
+) -> dict:
+    """
+    Select and normalize skeleton curves before registration.
+    """
+    prepared = {curve_type: []}
+    for curve in curves_dict.get(curve_type, []):
+        new_curve = np.asarray(curve, dtype=np.float32) - origin
+        if skel_axis == "zyx":
+            new_curve = new_curve[:, [2, 1, 0]]
+        if target_points > 0:
+            new_curve = simplify_curve(new_curve, target_points)
+        prepared[curve_type].append(new_curve)
+    return prepared
+
+
+def parse_mesh_label_and_fiber(mesh_file: str) -> tuple[int, str]:
+    filename = os.path.basename(mesh_file)
+    base, ext = os.path.splitext(filename)
+    parts = base.split("_")
+    if ext.lower() != ".obj" or len(parts) != 2:
+        raise ValueError(f"mesh filename must match '{MESH_NAME_FORMAT}', got {filename!r}")
+    try:
+        label = int(parts[0])
+    except ValueError as exc:
+        raise ValueError(f"mesh filename must match '{MESH_NAME_FORMAT}', got {filename!r}") from exc
+    fiber_type = parts[1]
+    if fiber_type not in VALID_FIBER_TYPES:
+        raise ValueError(f"mesh filename must match '{MESH_NAME_FORMAT}', got {filename!r}")
+    return label, fiber_type
+
+
+def curve_type_for_fiber(fiber_type: str, requested_curve_type: str) -> str:
+    if fiber_type not in VALID_FIBER_TYPES:
+        raise ValueError("fiber_type must be 'hz' or 'vt'")
+    if requested_curve_type != "auto":
+        return requested_curve_type
+    if fiber_type == "vt":
+        return "vertical"
+    return "horizontal"
+
+
 def unified_pipeline(args):
     """
     Pipeline for processing a single mesh. Expects that:
@@ -77,39 +126,50 @@ def unified_pipeline(args):
     It extracts skeleton curves (via kimimaro), assigns the curves to the mesh, runs registration,
     and finally visualizes the registered mesh with the skeleton curves in one combined window.
     """
-    print(f"Loading mesh from {args.mesh} ...")
-    meshes = load_mesh_from_file(args.mesh)
+    mesh_files = list(getattr(args, "meshes", None) or [args.mesh])
+    print(f"Loading {len(mesh_files)} mesh(es) ...")
+    meshes = []
+    for mesh_file in mesh_files:
+        loaded_meshes = load_mesh_from_file(mesh_file)
+        for mesh in loaded_meshes:
+            mesh._source_mesh_file = mesh_file
+        meshes.extend(loaded_meshes)
     if not meshes:
         print("No mesh was loaded. Exiting.")
         return
-    # Parse fiber type and label number from mesh filename (assumes format: "<label>_<fiber_type>.obj")
-    base = os.path.splitext(os.path.basename(args.mesh))[0]
-    parts = base.split("_")
-    label_number = int(parts[0])
-    fiber_type = parts[1]
 
-    print(f"Extracting skeleton curves from {args.tif} ...")
-    curves_dict = extract_skeleton_from_tif(args.tif, args.cube_label,
-                                            z_threshold=1. / np.sqrt(2),
-                                            label=label_number,
-                                            fiber_type=fiber_type)
+    curves_dict = {"vertical": [], "horizontal": []}
+    origin = np.array([float(x) for x in args.skel_origin.split(",")])
+    skeleton_axis_order = getattr(args, "skeleton_axis_order", "zyx")
+    for mesh_file in mesh_files:
+        # Parse fiber type and label number from mesh filename (assumes format: "<label>_<fiber_type>.obj")
+        label_number, fiber_type = parse_mesh_label_and_fiber(mesh_file)
+        mesh_curve_type = curve_type_for_fiber(fiber_type, args.curve_type)
+        print(f"Extracting skeleton curves from {args.tif} for {mesh_file} ...")
+        extracted_curves = extract_skeleton_from_tif(args.tif, args.cube_label,
+                                                     z_threshold=1. / np.sqrt(2),
+                                                     label=label_number,
+                                                     fiber_type=fiber_type,
+                                                     axis_order=skeleton_axis_order)
+        prepared_curves = prepare_skeleton_curves(
+            extracted_curves,
+            mesh_curve_type,
+            origin,
+            args.skel_axis,
+            args.target_skel_points,
+        )
+        mesh_curves = prepared_curves.get(mesh_curve_type, [])
+        curves_dict[mesh_curve_type].extend(mesh_curves)
+        for mesh in meshes:
+            if getattr(mesh, "_source_mesh_file", None) == mesh_file:
+                mesh.skeleton_curves = mesh_curves
+        if not mesh_curves:
+            print(f"No {mesh_curve_type} skeleton curves matched {mesh_file}; skipping this mesh.")
     n_vert = len(curves_dict.get("vertical", []))
     n_horz = len(curves_dict.get("horizontal", []))
     print(f"Skeleton extraction complete. Extracted {n_vert} vertical and {n_horz} horizontal curve(s).")
 
-    # (Optional) Update curves (translation, axis reordering, simplification)
-    origin = np.array([float(x) for x in args.skel_origin.split(",")])
-    for label in curves_dict:
-        for i, curve in enumerate(curves_dict[label]):
-            new_curve = curve - origin
-            if args.skel_axis == "zyx":
-                new_curve = new_curve[:, [2, 1, 0]]
-            # Optionally, simplify:
-            # new_curve = simplify_curve(new_curve, args.target_skel_points)
-            curves_dict[label][i] = new_curve
-
-    # For registration we use all curves (or you can filter by type)
-    global_skel_curves = curves_dict.get("vertical", []) + curves_dict.get("horizontal", [])
+    global_skel_curves = curves_dict["vertical"] + curves_dict["horizontal"]
     print("Final number of skeleton curves for registration: {}".format(len(global_skel_curves)))
     
     # Check if no curves were extracted and skip registration if so.
@@ -118,14 +178,19 @@ def unified_pipeline(args):
         return
 
     # Assign skeleton curves to the mesh.
-    for mesh in meshes:
-        skel_pts = assign_skeletons_to_mesh(mesh.vertices_np, global_skel_curves, thresh_z=0.1).to(device)
+    active_meshes = [mesh for mesh in meshes if getattr(mesh, "skeleton_curves", None)]
+    if not active_meshes:
+        print("No meshes had matching skeleton curves; skipping registration.")
+        return
+
+    for mesh in active_meshes:
+        skel_pts = assign_skeletons_to_mesh(mesh.vertices_np, mesh.skeleton_curves, thresh_z=0.1).to(device)
         mesh.skeleton_points = skel_pts
 
     # (Optional) Visualize initial mesh and skeleton curves.
     initial_meshes_geom = []
     color_mesh = [0, 0, 1]
-    for mesh in meshes:
+    for mesh in active_meshes:
         init_pcd = o3d.geometry.PointCloud()
         init_pcd.points = o3d.utility.Vector3dVector(mesh.vertices_np)
         init_pcd.paint_uniform_color(color_mesh)
@@ -148,7 +213,7 @@ def unified_pipeline(args):
 
     # Run registration optimization.
     print("Running registration optimization...")
-    registered_vertices_list = optimize_all_registration(meshes, global_skel_curves,
+    registered_vertices_list = optimize_all_registration(active_meshes, global_skel_curves,
                                                           num_iters=args.num_iters, lr=args.lr,
                                                           lambda_data=args.lambda_data, lambda_disp=args.lambda_disp,
                                                           lambda_elastic=args.lambda_elastic, lambda_self=args.lambda_self,
@@ -158,8 +223,7 @@ def unified_pipeline(args):
                                                           batch_size=args.batch_size)
     # Final visualization: combine the registered mesh and the skeleton curves.
     registered_meshes_geom = []
-    for mesh in meshes:
-        print(mesh.displacement)
+    for mesh in active_meshes:
         reg_vertices = (mesh.vertices + mesh.displacement).detach().cpu().numpy()
         reg_pcd = o3d.geometry.PointCloud()
         reg_pcd.points = o3d.utility.Vector3dVector(reg_vertices)
@@ -170,7 +234,7 @@ def unified_pipeline(args):
         o3d.visualization.draw_geometries(final_geoms, window_name="Registered Mesh + Skeleton Curves")
 
     # Return the updated meshes so that their displacement is taken into account.
-    return meshes
+    return active_meshes
 
 
 def process_one_mesh(mesh_file: str, tif_file: str, cube_label_file: str, output_root: str, global_args):
@@ -207,13 +271,11 @@ def process_one_mesh(mesh_file: str, tif_file: str, cube_label_file: str, output
     temp.target_triangles = global_args.target_triangles
     temp.skel_origin = global_args.skel_origin
     temp.skel_axis = global_args.skel_axis
+    temp.skeleton_axis_order = getattr(global_args, "skeleton_axis_order", "zyx")
     temp.curve_type = global_args.curve_type
     temp.target_skel_points = global_args.target_skel_points
     # Parse fiber type and label number from the mesh filename.
-    base = os.path.splitext(os.path.basename(mesh_file))[0]
-    parts = base.split("_")
-    temp.skeleton_label = int(parts[0])
-    temp.fiber_type = parts[1]
+    temp.skeleton_label, temp.fiber_type = parse_mesh_label_and_fiber(mesh_file)
     temp.visualize = global_args.visualize
 
     # Run the registration pipeline and get the updated meshes.
@@ -235,6 +297,62 @@ def process_one_mesh(mesh_file: str, tif_file: str, cube_label_file: str, output
     os.makedirs(os.path.dirname(out_file), exist_ok=True)
     print("Saving registered mesh to:", out_file)
     o3d.io.write_triangle_mesh(out_file, original_mesh)
+
+
+def process_mesh_group(mesh_files: list[str], tif_file: str, cube_label_file: str, output_root: str, global_args):
+    """
+    Process meshes that share one TIFF/cube-label context in a single optimization call.
+    """
+    if not mesh_files:
+        return
+    print("Processing mesh group:", mesh_files)
+
+    class TempArgs:
+        pass
+    temp = TempArgs()
+    temp.meshes = list(mesh_files)
+    temp.tif = tif_file
+    temp.cube_label = cube_label_file
+    temp.num_iters = global_args.num_iters
+    temp.lr = global_args.lr
+    temp.lambda_data = global_args.lambda_data
+    temp.lambda_disp = global_args.lambda_disp
+    temp.lambda_elastic = global_args.lambda_elastic
+    temp.lambda_self = global_args.lambda_self
+    temp.lambda_lap = global_args.lambda_lap
+    temp.lambda_arap = global_args.lambda_arap
+    temp.lambda_sdf = global_args.lambda_sdf
+    temp.batch_size = global_args.batch_size
+    temp.tau = global_args.tau
+    temp.delta = global_args.delta
+    temp.beta = global_args.beta
+    temp.tau_sdf = global_args.tau_sdf
+    temp.lambda_inter = global_args.lambda_inter
+    temp.delta_inter = global_args.delta_inter
+    temp.beta_inter = global_args.beta_inter
+    temp.target_triangles = global_args.target_triangles
+    temp.skel_origin = global_args.skel_origin
+    temp.skel_axis = global_args.skel_axis
+    temp.skeleton_axis_order = getattr(global_args, "skeleton_axis_order", "zyx")
+    temp.curve_type = global_args.curve_type
+    temp.target_skel_points = global_args.target_skel_points
+    temp.visualize = global_args.visualize
+
+    registered_meshes = unified_pipeline(temp)
+    if registered_meshes is None or len(registered_meshes) == 0:
+        print("Registration failed for mesh group", mesh_files)
+        return
+
+    for mesh_file, mesh_surface in zip(mesh_files, registered_meshes):
+        mesh_file = getattr(mesh_surface, "_source_mesh_file", mesh_file)
+        reg_vertices = (mesh_surface.vertices + mesh_surface.displacement).detach().cpu().numpy()
+        original_mesh = o3d.io.read_triangle_mesh(mesh_file)
+        original_mesh.vertices = o3d.utility.Vector3dVector(reg_vertices)
+        rel_path = os.path.relpath(mesh_file, global_args.mesh_root)
+        out_file = os.path.join(output_root, os.path.splitext(rel_path)[0] + "_registered.obj")
+        os.makedirs(os.path.dirname(out_file), exist_ok=True)
+        print("Saving registered mesh to:", out_file)
+        o3d.io.write_triangle_mesh(out_file, original_mesh)
 
 
 
@@ -270,14 +388,17 @@ def main():
     parser.add_argument("--lambda_inter", type=float, default=0.1, help="Inter-mesh intersection term weight.")
     parser.add_argument("--delta_inter", type=float, default=0.05, help="Delta parameter for inter-mesh intersection.")
     parser.add_argument("--beta_inter", type=float, default=10.0, help="Beta parameter for inter-mesh intersection.")
-    parser.add_argument("--target_triangles", type=int, default=1000, help="Target number of triangles for mesh decimation.")
+    parser.add_argument("--target_triangles", type=int, default=1000,
+                        help="Reserved for topology-aware mesh decimation; not applied by the current pipeline.")
     # Skeleton processing arguments.
     parser.add_argument("--skel_origin", type=str, default="0,0,0",
                         help="Origin offset for skeleton curves as comma-separated values, e.g., '0,0,0'.")
-    parser.add_argument("--skel_axis", type=str, choices=["xyz", "zyx"], default="xyz",
-                        help="Axis order for skeleton curves. If 'zyx', curves will be converted to 'xyz'.")
-    parser.add_argument("--curve_type", type=str, choices=["vertical", "horizontal"], default="horizontal",
-                        help="Type of skeleton curves to use for registration.")
+    parser.add_argument("--skel_axis", type=str, choices=["xyz", "zyx"], default="zyx",
+                        help="Axis order for skeleton curves before registration. The default 'zyx' matches the skeleton extraction default and converts curves to mesh-style 'xyz'.")
+    parser.add_argument("--curve_type", type=str, choices=["auto", "vertical", "horizontal"], default="auto",
+                        help="Type of skeleton curves to use for registration. 'auto' maps hz meshes to horizontal and vt meshes to vertical.")
+    parser.add_argument("--skeleton_axis_order", type=str, choices=["zyx", "xyz"], default="zyx",
+                        help="Coordinate order used for PCA classification during skeleton extraction.")
     parser.add_argument("--target_skel_points", type=int, default=512,
                         help="Target number of points for skeleton curve simplification.")
     # These two are needed for the current extraction routine.
@@ -286,24 +407,29 @@ def main():
                         help="(Temporary) skeleton label; will be parsed from mesh filename in batch mode.")
     
     args = parser.parse_args()
+    if args.target_triangles != 1000:
+        print("--target_triangles is reserved for a future topology-aware decimation pass and is not applied.")
 
-    # Traverse the mesh root folder recursively and process all .obj files.
+    # Traverse the mesh root folder recursively and process .obj files by cube context.
     for root, dirs, files in os.walk(args.mesh_root):
+        group_mesh_files = []
         for file in files:
             if file.lower().endswith(".obj"):
-                mesh_file = os.path.join(root, file)
-                # The subfolder name is assumed to be the name of the parent directory.
-                subfolder = os.path.basename(os.path.dirname(mesh_file))
-                # Build the corresponding tif and cube label paths.
-                tif_file = os.path.join(args.tif_root, subfolder + ".tif")
-                cube_label_file = os.path.join(args.cube_label_root, subfolder, subfolder + "_mask.tif")
-                if not os.path.isfile(tif_file):
-                    print(f"Skipping {mesh_file}: corresponding TIF file not found: {tif_file}")
-                    continue
-                if not os.path.isfile(cube_label_file):
-                    print(f"Skipping {mesh_file}: corresponding cube label not found: {cube_label_file}")
-                    continue
-                process_one_mesh(mesh_file, tif_file, cube_label_file, args.output_root, args)
+                group_mesh_files.append(os.path.join(root, file))
+        if not group_mesh_files:
+            continue
+
+        group_mesh_files.sort()
+        subfolder = os.path.basename(root)
+        tif_file = os.path.join(args.tif_root, subfolder + ".tif")
+        cube_label_file = os.path.join(args.cube_label_root, subfolder, subfolder + "_mask.tif")
+        if not os.path.isfile(tif_file):
+            print(f"Skipping {root}: corresponding TIF file not found: {tif_file}")
+            continue
+        if not os.path.isfile(cube_label_file):
+            print(f"Skipping {root}: corresponding cube label not found: {cube_label_file}")
+            continue
+        process_mesh_group(group_mesh_files, tif_file, cube_label_file, args.output_root, args)
     
 if __name__ == "__main__":
     main()

--- a/foundation/datasets/register-meshes-to-fibers/tests/test_build_deformation_field.py
+++ b/foundation/datasets/register-meshes-to-fibers/tests/test_build_deformation_field.py
@@ -1,0 +1,510 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = MODULE_DIR / "build_deformation_field.py"
+
+
+def _load_field_builder():
+    module_name = "_test_build_deformation_field"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class BuildDeformationFieldTest(unittest.TestCase):
+    def test_load_control_points_reads_positions_and_displacements(self):
+        builder = _load_field_builder()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            controls_path = Path(temp_dir) / "controls.json"
+            controls_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0.0",
+                        "coordinate_order": "xyz",
+                        "control_points": [
+                            {
+                                "source_xyz": [1.0, 2.0, 3.0],
+                                "displacement_xyz": [0.5, 0.0, -1.0],
+                            },
+                            {
+                                "source_xyz": [4.0, 5.0, 6.0],
+                                "target_xyz": [5.0, 7.0, 9.0],
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            positions, displacements = builder.load_control_points(controls_path)
+
+        np.testing.assert_allclose(
+            positions,
+            np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float64),
+        )
+        np.testing.assert_allclose(
+            displacements,
+            np.array([[0.5, 0.0, -1.0], [1.0, 2.0, 3.0]], dtype=np.float64),
+        )
+
+    def test_interpolate_idw_returns_exact_control_displacement_at_control_point(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]], dtype=np.float64)
+        displacements_xyz = np.array([[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]], dtype=np.float64)
+        query_xyz = np.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]], dtype=np.float64)
+
+        interpolated = builder.interpolate_idw(
+            query_xyz,
+            controls_xyz,
+            displacements_xyz,
+            k=2,
+            power=2.0,
+        )
+
+        np.testing.assert_allclose(interpolated[0], [1.0, 2.0, 3.0])
+        np.testing.assert_allclose(interpolated[1], [5.5, 11.0, 16.5])
+
+    def test_interpolate_idw_can_chunk_query_points(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array(
+            [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [8.0, 0.0, 0.0]],
+            dtype=np.float64,
+        )
+        displacements_xyz = np.array(
+            [[1.0, 0.0, 0.0], [5.0, 0.0, 0.0], [9.0, 0.0, 0.0]],
+            dtype=np.float64,
+        )
+        query_xyz = np.array(
+            [[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], [4.0, 0.0, 0.0], [6.0, 0.0, 0.0]],
+            dtype=np.float64,
+        )
+
+        full = builder.interpolate_idw(
+            query_xyz,
+            controls_xyz,
+            displacements_xyz,
+            k=2,
+        )
+        chunked = builder.interpolate_idw(
+            query_xyz,
+            controls_xyz,
+            displacements_xyz,
+            k=2,
+            query_chunk_size=1,
+        )
+
+        np.testing.assert_allclose(chunked, full)
+
+    def test_interpolate_idw_can_chunk_control_points(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array(
+            [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [8.0, 0.0, 0.0], [12.0, 0.0, 0.0]],
+            dtype=np.float64,
+        )
+        displacements_xyz = np.array(
+            [[1.0, 0.0, 0.0], [5.0, 0.0, 0.0], [9.0, 0.0, 0.0], [13.0, 0.0, 0.0]],
+            dtype=np.float64,
+        )
+        query_xyz = np.array(
+            [[1.0, 0.0, 0.0], [6.0, 0.0, 0.0], [11.0, 0.0, 0.0]],
+            dtype=np.float64,
+        )
+
+        full = builder.interpolate_idw(
+            query_xyz,
+            controls_xyz,
+            displacements_xyz,
+            k=3,
+        )
+        chunked_controls = builder.interpolate_idw(
+            query_xyz,
+            controls_xyz,
+            displacements_xyz,
+            k=3,
+            control_chunk_size=1,
+        )
+
+        np.testing.assert_allclose(chunked_controls, full)
+
+    def test_interpolate_idw_control_chunks_match_full_batch_for_distance_ties(self):
+        builder = _load_field_builder()
+
+        query_xyz = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+        controls_xyz = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, -1.0],
+            ],
+            dtype=np.float64,
+        )
+        displacements_xyz = np.arange(6, dtype=np.float64)[:, None].repeat(3, axis=1)
+
+        full = builder.interpolate_idw(
+            query_xyz,
+            controls_xyz,
+            displacements_xyz,
+            k=3,
+        )
+
+        np.testing.assert_allclose(full, [[1.0, 1.0, 1.0]])
+        for control_chunk_size in (1, 2, 3, 4, 5):
+            chunked = builder.interpolate_idw(
+                query_xyz,
+                controls_xyz,
+                displacements_xyz,
+                k=3,
+                control_chunk_size=control_chunk_size,
+            )
+            np.testing.assert_allclose(chunked, full)
+
+    def test_interpolate_idw_can_chunk_queries_and_controls_together(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array(
+            [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [8.0, 0.0, 0.0], [12.0, 0.0, 0.0]],
+            dtype=np.float64,
+        )
+        displacements_xyz = controls_xyz + np.array([1.0, 2.0, 3.0], dtype=np.float64)
+        query_xyz = np.array(
+            [[1.0, 0.0, 0.0], [3.0, 0.0, 0.0], [6.0, 0.0, 0.0], [11.0, 0.0, 0.0]],
+            dtype=np.float64,
+        )
+
+        full = builder.interpolate_idw(
+            query_xyz,
+            controls_xyz,
+            displacements_xyz,
+            k=2,
+        )
+        chunked = builder.interpolate_idw(
+            query_xyz,
+            controls_xyz,
+            displacements_xyz,
+            k=2,
+            query_chunk_size=2,
+            control_chunk_size=2,
+        )
+
+        np.testing.assert_allclose(chunked, full)
+
+    def test_interpolate_idw_rejects_non_positive_k(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+        displacements_xyz = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        query_xyz = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+
+        with self.assertRaisesRegex(ValueError, "k must be positive"):
+            builder.interpolate_idw(
+                query_xyz,
+                controls_xyz,
+                displacements_xyz,
+                k=0,
+            )
+
+    def test_interpolate_idw_rejects_non_positive_control_chunk_size(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+        displacements_xyz = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        query_xyz = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+
+        with self.assertRaisesRegex(ValueError, "control_chunk_size must be positive"):
+            builder.interpolate_idw(
+                query_xyz,
+                controls_xyz,
+                displacements_xyz,
+                control_chunk_size=0,
+            )
+
+    def test_interpolate_idw_rejects_empty_controls(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.empty((0, 3), dtype=np.float64)
+        displacements_xyz = np.empty((0, 3), dtype=np.float64)
+        query_xyz = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+
+        with self.assertRaisesRegex(ValueError, "at least one control point"):
+            builder.interpolate_idw(
+                query_xyz,
+                controls_xyz,
+                displacements_xyz,
+            )
+
+    def test_interpolate_idw_returns_empty_output_for_empty_query(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+        displacements_xyz = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        query_xyz = np.empty((0, 3), dtype=np.float64)
+
+        interpolated = builder.interpolate_idw(
+            query_xyz,
+            controls_xyz,
+            displacements_xyz,
+        )
+
+        self.assertEqual(interpolated.shape, (0, 3))
+
+    def test_build_grid_field_uses_xyz_shape_and_spacing(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float64)
+        displacements_xyz = np.array([[1.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=np.float64)
+
+        field, origin, spacing = builder.build_grid_field(
+            controls_xyz,
+            displacements_xyz,
+            grid_shape_xyz=(3, 1, 1),
+            spacing_xyz=(1.0, 1.0, 1.0),
+            origin_xyz=(0.0, 0.0, 0.0),
+            k=2,
+        )
+
+        self.assertEqual(field.shape, (1, 1, 3, 3))
+        np.testing.assert_allclose(origin, [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(spacing, [1.0, 1.0, 1.0])
+        np.testing.assert_allclose(field[0, 0, 0], [1.0, 0.0, 0.0])
+        np.testing.assert_allclose(field[0, 0, 2], [3.0, 0.0, 0.0])
+
+    def test_build_grid_field_accepts_query_chunk_size(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float64)
+        displacements_xyz = np.array([[1.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=np.float64)
+
+        field, _, _ = builder.build_grid_field(
+            controls_xyz,
+            displacements_xyz,
+            grid_shape_xyz=(3, 1, 1),
+            spacing_xyz=(1.0, 1.0, 1.0),
+            origin_xyz=(0.0, 0.0, 0.0),
+            k=2,
+            query_chunk_size=1,
+        )
+
+        self.assertEqual(field.shape, (1, 1, 3, 3))
+        np.testing.assert_allclose(field[0, 0, 0], [1.0, 0.0, 0.0])
+        np.testing.assert_allclose(field[0, 0, 2], [3.0, 0.0, 0.0])
+
+    def test_build_grid_field_accepts_control_chunk_size(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float64)
+        displacements_xyz = np.array([[1.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=np.float64)
+
+        field, _, _ = builder.build_grid_field(
+            controls_xyz,
+            displacements_xyz,
+            grid_shape_xyz=(3, 1, 1),
+            spacing_xyz=(1.0, 1.0, 1.0),
+            origin_xyz=(0.0, 0.0, 0.0),
+            k=2,
+            control_chunk_size=1,
+        )
+
+        self.assertEqual(field.shape, (1, 1, 3, 3))
+        np.testing.assert_allclose(field[0, 0, 0], [1.0, 0.0, 0.0])
+        np.testing.assert_allclose(field[0, 0, 2], [3.0, 0.0, 0.0])
+
+    def test_build_grid_field_rejects_non_positive_shape_or_spacing(self):
+        builder = _load_field_builder()
+
+        controls_xyz = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+        displacements_xyz = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+
+        with self.assertRaisesRegex(ValueError, "grid shape values must be positive"):
+            builder.build_grid_field(
+                controls_xyz,
+                displacements_xyz,
+                grid_shape_xyz=(0, 1, 1),
+                spacing_xyz=(1.0, 1.0, 1.0),
+                origin_xyz=(0.0, 0.0, 0.0),
+            )
+        with self.assertRaisesRegex(ValueError, "spacing values must be positive"):
+            builder.build_grid_field(
+                controls_xyz,
+                displacements_xyz,
+                grid_shape_xyz=(1, 1, 1),
+                spacing_xyz=(1.0, 0.0, 1.0),
+                origin_xyz=(0.0, 0.0, 0.0),
+            )
+
+    def test_parser_rejects_non_positive_k(self):
+        builder = _load_field_builder()
+        parser = builder.build_arg_parser()
+
+        with self.assertRaises(SystemExit):
+            parser.parse_args(
+                [
+                    "--controls",
+                    "controls.json",
+                    "--output",
+                    "field.npz",
+                    "--grid-shape",
+                    "1,1,1",
+                    "--spacing",
+                    "1,1,1",
+                    "--k",
+                    "0",
+                ]
+            )
+
+    def test_parser_accepts_query_chunk_size(self):
+        builder = _load_field_builder()
+        parser = builder.build_arg_parser()
+
+        args = parser.parse_args(
+            [
+                "--controls",
+                "controls.json",
+                "--output",
+                "field.npz",
+                "--grid-shape",
+                "1,1,1",
+                "--spacing",
+                "1,1,1",
+                "--query-chunk-size",
+                "2",
+            ]
+        )
+
+        self.assertEqual(args.query_chunk_size, 2)
+
+    def test_parser_accepts_control_chunk_size(self):
+        builder = _load_field_builder()
+        parser = builder.build_arg_parser()
+
+        args = parser.parse_args(
+            [
+                "--controls",
+                "controls.json",
+                "--output",
+                "field.npz",
+                "--grid-shape",
+                "1,1,1",
+                "--spacing",
+                "1,1,1",
+                "--control-chunk-size",
+                "2",
+            ]
+        )
+
+        self.assertEqual(args.control_chunk_size, 2)
+
+    def test_parser_rejects_non_positive_query_chunk_size(self):
+        builder = _load_field_builder()
+        parser = builder.build_arg_parser()
+
+        with self.assertRaises(SystemExit):
+            parser.parse_args(
+                [
+                    "--controls",
+                    "controls.json",
+                    "--output",
+                    "field.npz",
+                    "--grid-shape",
+                    "1,1,1",
+                    "--spacing",
+                    "1,1,1",
+                    "--query-chunk-size",
+                    "0",
+                ]
+            )
+
+    def test_parser_rejects_non_positive_control_chunk_size(self):
+        builder = _load_field_builder()
+        parser = builder.build_arg_parser()
+
+        with self.assertRaises(SystemExit):
+            parser.parse_args(
+                [
+                    "--controls",
+                    "controls.json",
+                    "--output",
+                    "field.npz",
+                    "--grid-shape",
+                    "1,1,1",
+                    "--spacing",
+                    "1,1,1",
+                    "--control-chunk-size",
+                    "0",
+                ]
+            )
+
+    def test_cli_writes_npz_with_displacement_field(self):
+        builder = _load_field_builder()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            controls_path = temp / "controls.json"
+            output_path = temp / "field.npz"
+            controls_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0.0",
+                        "coordinate_order": "xyz",
+                        "control_points": [
+                            {
+                                "source_xyz": [0.0, 0.0, 0.0],
+                                "displacement_xyz": [1.0, 2.0, 3.0],
+                            },
+                            {
+                                "source_xyz": [2.0, 0.0, 0.0],
+                                "displacement_xyz": [5.0, 6.0, 7.0],
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            builder.main(
+                [
+                    "--controls",
+                    str(controls_path),
+                    "--output",
+                    str(output_path),
+                    "--grid-shape",
+                    "3,1,1",
+                    "--spacing",
+                    "1,1,1",
+                    "--origin",
+                    "0,0,0",
+                    "--k",
+                    "2",
+                ]
+            )
+
+            with np.load(output_path) as data:
+                field = data["displacement_xyz"]
+                origin = data["origin_xyz"]
+                spacing = data["spacing_xyz"]
+                coordinate_order = data["coordinate_order"].item()
+
+        self.assertEqual(field.shape, (1, 1, 3, 3))
+        np.testing.assert_allclose(origin, [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(spacing, [1.0, 1.0, 1.0])
+        self.assertEqual(coordinate_order, "zyx_grid_xyz_vectors")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/foundation/datasets/register-meshes-to-fibers/tests/test_export_deformation_control_points.py
+++ b/foundation/datasets/register-meshes-to-fibers/tests/test_export_deformation_control_points.py
@@ -1,0 +1,144 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = MODULE_DIR / "export_deformation_control_points.py"
+
+
+def _load_exporter():
+    module_name = "_test_export_deformation_control_points"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ExportDeformationControlPointsTest(unittest.TestCase):
+    def test_read_obj_vertices_ignores_non_vertex_records(self):
+        exporter = _load_exporter()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            obj_path = Path(temp_dir) / "mesh.obj"
+            obj_path.write_text(
+                "\n".join(
+                    [
+                        "# comment",
+                        "v 1 2 3",
+                        "vt 0.1 0.2",
+                        "vn 0 0 1",
+                        "f 1 2 3",
+                        "v -1.5 0 4.25",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            vertices = exporter.read_obj_vertices(obj_path)
+
+        np.testing.assert_allclose(
+            vertices,
+            np.array([[1.0, 2.0, 3.0], [-1.5, 0.0, 4.25]], dtype=np.float64),
+        )
+
+    def test_build_control_points_computes_displacements_and_uniform_sample(self):
+        exporter = _load_exporter()
+
+        source = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+                [4.0, 0.0, 0.0],
+            ],
+            dtype=np.float64,
+        )
+        registered = source + np.array([0.5, -1.0, 2.0], dtype=np.float64)
+
+        controls = exporter.build_control_points(source, registered, max_points=3)
+
+        self.assertEqual(len(controls), 3)
+        self.assertEqual([control["vertex_index"] for control in controls], [0, 2, 4])
+        self.assertEqual(controls[1]["source_xyz"], [2.0, 0.0, 0.0])
+        self.assertEqual(controls[1]["target_xyz"], [2.5, -1.0, 2.0])
+        self.assertEqual(controls[1]["displacement_xyz"], [0.5, -1.0, 2.0])
+
+    def test_build_control_points_rejects_mismatched_vertex_counts(self):
+        exporter = _load_exporter()
+
+        with self.assertRaisesRegex(ValueError, "same number of vertices"):
+            exporter.build_control_points(
+                np.zeros((2, 3), dtype=np.float64),
+                np.zeros((3, 3), dtype=np.float64),
+            )
+
+    def test_parser_rejects_negative_max_points_per_mesh(self):
+        exporter = _load_exporter()
+        parser = exporter.build_arg_parser()
+
+        with self.assertRaises(SystemExit):
+            parser.parse_args(
+                [
+                    "--mesh-pair",
+                    "source.obj",
+                    "registered.obj",
+                    "--output",
+                    "controls.json",
+                    "--max-points-per-mesh",
+                    "-1",
+                ]
+            )
+
+    def test_cli_writes_control_point_json_for_mesh_pair(self):
+        exporter = _load_exporter()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "1_hz.obj"
+            registered_path = temp / "1_hz_registered.obj"
+            output_path = temp / "controls.json"
+            source_path.write_text(
+                "\n".join(["v 0 0 0", "v 10 0 0", "v 20 0 0"]),
+                encoding="utf-8",
+            )
+            registered_path.write_text(
+                "\n".join(["v 1 2 3", "v 11 2 3", "v 21 2 3"]),
+                encoding="utf-8",
+            )
+
+            exporter.main(
+                [
+                    "--mesh-pair",
+                    str(source_path),
+                    str(registered_path),
+                    "--output",
+                    str(output_path),
+                    "--max-points-per-mesh",
+                    "2",
+                ]
+            )
+
+            data = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(data["schema_version"], "1.0.0")
+        self.assertEqual(data["coordinate_order"], "xyz")
+        self.assertEqual(len(data["mesh_pairs"]), 1)
+        self.assertEqual(data["mesh_pairs"][0]["source_mesh"], str(source_path))
+        self.assertEqual(data["mesh_pairs"][0]["registered_mesh"], str(registered_path))
+        self.assertEqual(len(data["control_points"]), 2)
+        self.assertEqual(data["control_points"][0]["mesh_pair_index"], 0)
+        self.assertEqual(data["control_points"][0]["source_xyz"], [0.0, 0.0, 0.0])
+        self.assertEqual(data["control_points"][0]["target_xyz"], [1.0, 2.0, 3.0])
+        self.assertEqual(data["control_points"][0]["displacement_xyz"], [1.0, 2.0, 3.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/foundation/datasets/register-meshes-to-fibers/tests/test_extract_skeleton_tif_cli.py
+++ b/foundation/datasets/register-meshes-to-fibers/tests/test_extract_skeleton_tif_cli.py
@@ -1,0 +1,180 @@
+import importlib.util
+import subprocess
+import sys
+import types
+import unittest
+import warnings
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = MODULE_DIR / "extract_skeleton_tif.py"
+
+
+def _load_extract_skeleton_tif():
+    module_name = "_test_extract_skeleton_tif"
+    sys.modules.pop(module_name, None)
+
+    open3d_stub = types.ModuleType("open3d")
+    open3d_stub.geometry = types.SimpleNamespace(LineSet=object)
+    open3d_stub.utility = types.SimpleNamespace(
+        Vector3dVector=lambda value: value,
+        Vector2iVector=lambda value: value,
+    )
+    open3d_stub.visualization = types.SimpleNamespace(
+        draw_geometries=lambda *_args, **_kwargs: None,
+    )
+
+    skimage_stub = types.ModuleType("skimage")
+    skimage_io_stub = types.ModuleType("skimage.io")
+    skimage_io_stub.imread = lambda *_args, **_kwargs: None
+    skimage_stub.io = skimage_io_stub
+
+    kimimaro_stub = types.ModuleType("kimimaro")
+    kimimaro_stub.skeletonize = lambda *_args, **_kwargs: {}
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "open3d": open3d_stub,
+            "skimage": skimage_stub,
+            "skimage.io": skimage_io_stub,
+            "kimimaro": kimimaro_stub,
+            module_name: module,
+        },
+    ):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="The NumPy module was reloaded.*",
+                category=UserWarning,
+            )
+            spec.loader.exec_module(module)
+    return module
+
+
+class ExtractSkeletonTifCliTest(unittest.TestCase):
+    def test_help_does_not_import_heavy_optional_dependencies(self):
+        result = subprocess.run(
+            [sys.executable, str(MODULE_PATH), "--help"],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--cube_label", result.stdout)
+        self.assertIn("--fiber_type", result.stdout)
+
+    def test_parser_exposes_label_mask_and_fiber_options(self):
+        extract_cli = _load_extract_skeleton_tif()
+
+        parser = extract_cli.build_arg_parser()
+        args = parser.parse_args(
+            [
+                "--tif",
+                "fiber.tif",
+                "--cube_label",
+                "mask.tif",
+                "--label",
+                "7",
+                "--fiber_type",
+                "vt",
+                "--z_threshold",
+                "0.75",
+                "--axis_order",
+                "xyz",
+            ]
+        )
+
+        self.assertEqual(args.tif, "fiber.tif")
+        self.assertEqual(args.cube_label, "mask.tif")
+        self.assertEqual(args.label, 7)
+        self.assertEqual(args.fiber_type, "vt")
+        self.assertEqual(args.z_threshold, 0.75)
+        self.assertEqual(args.axis_order, "xyz")
+
+    def test_classify_curve_pca_defaults_to_zyx_compatible_axis(self):
+        extract_cli = _load_extract_skeleton_tif()
+
+        zyx_vertical = extract_cli.classify_curve_pca(
+            np.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]], dtype=np.float32)
+        )
+        xyz_vertical = extract_cli.classify_curve_pca(
+            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 5.0]], dtype=np.float32),
+            axis_order="xyz",
+        )
+        xyz_horizontal = extract_cli.classify_curve_pca(
+            np.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]], dtype=np.float32),
+            axis_order="xyz",
+        )
+
+        self.assertEqual(zyx_vertical, "vertical")
+        self.assertEqual(xyz_vertical, "vertical")
+        self.assertEqual(xyz_horizontal, "horizontal")
+
+    def test_extract_skeleton_rejects_unknown_fiber_type_before_reading_images(self):
+        extract_cli = _load_extract_skeleton_tif()
+        skimage_stub = types.ModuleType("skimage")
+        skimage_io_stub = types.ModuleType("skimage.io")
+        skimage_io_stub.imread = mock.Mock()
+        skimage_stub.io = skimage_io_stub
+        kimimaro_stub = types.ModuleType("kimimaro")
+        kimimaro_stub.skeletonize = mock.Mock(return_value={})
+
+        with mock.patch.dict(
+            sys.modules,
+            {"skimage": skimage_stub, "skimage.io": skimage_io_stub, "kimimaro": kimimaro_stub},
+        ):
+            with self.assertRaisesRegex(ValueError, "fiber_type must be 'hz' or 'vt'"):
+                extract_cli.extract_skeleton_from_tif("fiber.tif", "mask.tif", fiber_type="diag")
+
+        skimage_io_stub.imread.assert_not_called()
+
+    def test_main_passes_cli_options_to_extractor(self):
+        extract_cli = _load_extract_skeleton_tif()
+        captured = {}
+
+        def fake_extract(tif_file, original_file, **kwargs):
+            captured["tif_file"] = tif_file
+            captured["original_file"] = original_file
+            captured.update(kwargs)
+            return {"vertical": ["curve"], "horizontal": []}
+
+        with mock.patch.object(extract_cli.os.path, "isfile", return_value=True), \
+             mock.patch.object(extract_cli, "extract_skeleton_from_tif", side_effect=fake_extract), \
+             mock.patch.object(extract_cli, "visualize_curves") as visualize:
+            result = extract_cli.main(
+                [
+                    "--tif",
+                    "fiber.tif",
+                    "--cube_label",
+                    "mask.tif",
+                    "--label",
+                    "7",
+                    "--fiber_type",
+                    "vt",
+                    "--z_threshold",
+                    "0.75",
+                    "--axis_order",
+                    "xyz",
+                    "--visualize",
+                ]
+            )
+
+        self.assertEqual(result, {"vertical": ["curve"], "horizontal": []})
+        self.assertEqual(captured["tif_file"], "fiber.tif")
+        self.assertEqual(captured["original_file"], "mask.tif")
+        self.assertEqual(captured["label"], 7)
+        self.assertEqual(captured["fiber_type"], "vt")
+        self.assertEqual(captured["z_threshold"], 0.75)
+        self.assertEqual(captured["axis_order"], "xyz")
+        visualize.assert_called_once_with(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/foundation/datasets/register-meshes-to-fibers/tests/test_reference_volume_warp_pipeline.py
+++ b/foundation/datasets/register-meshes-to-fibers/tests/test_reference_volume_warp_pipeline.py
@@ -1,0 +1,839 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = MODULE_DIR / "reference_volume_warp_pipeline.py"
+
+
+def _import_real_zarr():
+    try:
+        import zarr
+    except ImportError as exc:
+        raise unittest.SkipTest("zarr is not installed") from exc
+    return zarr
+
+
+class FakeZarrArray:
+    def __init__(self, array, fail_on_array=False):
+        self.array = array
+        self.shape = array.shape
+        self.dtype = array.dtype
+        self.ndim = array.ndim
+        self.fail_on_array = fail_on_array
+        self.materialize_count = 0
+
+    def __array__(self, dtype=None):
+        self.materialize_count += 1
+        if self.fail_on_array:
+            raise AssertionError("zarr input should not be materialized as a full numpy array")
+        return np.asarray(self.array, dtype=dtype)
+
+    def __getitem__(self, item):
+        return self.array[item]
+
+    def __setitem__(self, item, value):
+        self.array[item] = value
+
+
+class FakeZarrModule:
+    def __init__(self):
+        self.stores = {}
+
+    def open(self, path, mode="r", shape=None, dtype=None, chunks=None):
+        if mode == "r":
+            return self.stores[str(path)]
+        if mode in {"w", "w+"}:
+            store = FakeZarrArray(np.zeros(shape, dtype=dtype))
+            self.stores[str(path)] = store
+            return store
+        raise AssertionError(f"unexpected zarr mode: {mode}")
+
+
+class FakeZarrGroup:
+    def __init__(self, arrays):
+        self.arrays = arrays
+
+    def keys(self):
+        return self.arrays.keys()
+
+    def __getitem__(self, key):
+        return self.arrays[str(key)]
+
+
+def _load_pipeline():
+    module_name = "_test_reference_volume_warp_pipeline"
+    sys.modules.pop(module_name, None)
+    sys.path.insert(0, str(MODULE_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(MODULE_DIR))
+
+
+class ReferenceVolumeWarpPipelineTest(unittest.TestCase):
+    def test_infer_grid_shape_from_volume_uses_zyx_volume_and_xyz_spacing(self):
+        pipeline = _load_pipeline()
+
+        shape_xyz = pipeline.infer_grid_shape_from_volume(
+            volume_shape_zyx=(3, 4, 5),
+            field_spacing_xyz=(2.0, 3.0, 4.0),
+            volume_spacing_xyz=(1.0, 2.0, 3.0),
+        )
+
+        self.assertEqual(shape_xyz, (3, 3, 3))
+
+    def test_parser_rejects_non_positive_grid_spacing_and_metrics_step(self):
+        pipeline = _load_pipeline()
+        parser = pipeline.build_arg_parser()
+        base_args = [
+            "--mesh-pair",
+            "source.obj",
+            "registered.obj",
+            "--volume",
+            "volume.npy",
+            "--output-dir",
+            "outputs",
+            "--grid-shape",
+            "1,1,1",
+            "--field-spacing",
+            "1,1,1",
+        ]
+
+        with self.assertRaises(SystemExit):
+            parser.parse_args(base_args[: base_args.index("--field-spacing") + 1] + ["0,1,1"])
+        with self.assertRaises(SystemExit):
+            parser.parse_args(base_args[: base_args.index("--grid-shape") + 1] + ["1,0,1"] + base_args[base_args.index("--field-spacing") :])
+        with self.assertRaises(SystemExit):
+            parser.parse_args(base_args + ["--metrics-sample-step", "0"])
+        with self.assertRaises(SystemExit):
+            parser.parse_args(base_args + ["--chunk-depth", "-1"])
+        with self.assertRaises(SystemExit):
+            parser.parse_args(base_args + ["--field-query-chunk-size", "0"])
+        with self.assertRaises(SystemExit):
+            parser.parse_args(base_args + ["--field-control-chunk-size", "0"])
+        with self.assertRaises(SystemExit):
+            parser.parse_args(base_args + ["--max-points-per-mesh", "-1"])
+
+    def test_run_pipeline_rejects_negative_chunk_depth_before_io(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\nv 1 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 0 0 0\nv 1 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.arange(2, dtype=np.float32).reshape(1, 1, 2))
+
+            with self.assertRaisesRegex(ValueError, "chunk_depth must be non-negative"):
+                pipeline.run_pipeline(
+                    mesh_pairs=[(source_path, registered_path)],
+                    volume_path=volume_path,
+                    output_dir=output_dir,
+                    grid_shape_xyz=(2, 1, 1),
+                    field_spacing_xyz=(1.0, 1.0, 1.0),
+                    chunk_depth=-1,
+                )
+
+            self.assertFalse(output_dir.exists())
+
+    def test_run_pipeline_rejects_non_positive_k_before_io(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\nv 1 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 0 0 0\nv 1 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.arange(2, dtype=np.float32).reshape(1, 1, 2))
+
+            with self.assertRaisesRegex(ValueError, "k must be positive"):
+                pipeline.run_pipeline(
+                    mesh_pairs=[(source_path, registered_path)],
+                    volume_path=volume_path,
+                    output_dir=output_dir,
+                    grid_shape_xyz=(2, 1, 1),
+                    field_spacing_xyz=(1.0, 1.0, 1.0),
+                    k=0,
+                )
+
+            self.assertFalse(output_dir.exists())
+
+    def test_run_pipeline_rejects_non_positive_field_query_chunk_size_before_io(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "out"
+            source_path.write_text("v 0 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 1 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.zeros((1, 1, 1), dtype=np.float32))
+
+            with self.assertRaisesRegex(ValueError, "field_query_chunk_size must be positive"):
+                pipeline.run_pipeline(
+                    mesh_pairs=[(source_path, registered_path)],
+                    volume_path=volume_path,
+                    output_dir=output_dir,
+                    field_query_chunk_size=0,
+                )
+
+            self.assertFalse(output_dir.exists())
+
+    def test_run_pipeline_rejects_non_positive_field_control_chunk_size_before_io(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 0 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.zeros((1, 1, 1), dtype=np.float32))
+
+            with self.assertRaisesRegex(ValueError, "field_control_chunk_size must be positive"):
+                pipeline.run_pipeline(
+                    mesh_pairs=[(source_path, registered_path)],
+                    volume_path=volume_path,
+                    output_dir=output_dir,
+                    field_control_chunk_size=0,
+                )
+
+            self.assertFalse(output_dir.exists())
+
+    def test_run_pipeline_rejects_negative_max_points_before_io(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\nv 1 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 0 0 0\nv 1 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.arange(2, dtype=np.float32).reshape(1, 1, 2))
+
+            with self.assertRaisesRegex(ValueError, "max_points_per_mesh must be non-negative"):
+                pipeline.run_pipeline(
+                    mesh_pairs=[(source_path, registered_path)],
+                    volume_path=volume_path,
+                    output_dir=output_dir,
+                    grid_shape_xyz=(2, 1, 1),
+                    field_spacing_xyz=(1.0, 1.0, 1.0),
+                    max_points_per_mesh=-1,
+                )
+
+            self.assertFalse(output_dir.exists())
+
+    def test_cli_writes_controls_field_and_warped_volume(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text(
+                "\n".join(["v 0 0 0", "v 4 0 0"]),
+                encoding="utf-8",
+            )
+            registered_path.write_text(
+                "\n".join(["v 1 0 0", "v 5 0 0"]),
+                encoding="utf-8",
+            )
+            np.save(volume_path, np.arange(5, dtype=np.float32).reshape(1, 1, 5))
+
+            pipeline.main(
+                [
+                    "--mesh-pair",
+                    str(source_path),
+                    str(registered_path),
+                    "--volume",
+                    str(volume_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--grid-shape",
+                    "5,1,1",
+                    "--field-spacing",
+                    "1,1,1",
+                    "--field-origin",
+                    "0,0,0",
+                    "--volume-spacing",
+                    "1,1,1",
+                    "--volume-origin",
+                    "0,0,0",
+                    "--max-points-per-mesh",
+                    "0",
+                    "--field-query-chunk-size",
+                    "1",
+                    "--field-control-chunk-size",
+                    "1",
+                    "--fill-value",
+                    "-1",
+                ]
+            )
+
+            controls_path = output_dir / "deformation-controls.json"
+            field_path = output_dir / "deformation-field.npz"
+            warped_path = output_dir / "warped-volume.npy"
+            manifest_path = output_dir / "deformation-run-manifest.json"
+            metrics_path = output_dir / "deformation-run-metrics.json"
+            controls = json.loads(controls_path.read_text(encoding="utf-8"))
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+            with np.load(field_path) as field_data:
+                field = field_data["displacement_xyz"]
+            warped = np.load(warped_path)
+
+        self.assertEqual(len(controls["control_points"]), 2)
+        self.assertEqual(field.shape, (1, 1, 5, 3))
+        self.assertEqual(manifest["schema_version"], "1.0.0")
+        self.assertEqual(manifest["input_volume"], str(volume_path))
+        self.assertEqual(manifest["output_paths"]["controls"], str(controls_path))
+        self.assertEqual(manifest["output_paths"]["field"], str(field_path))
+        self.assertEqual(manifest["output_paths"]["warped"], str(warped_path))
+        self.assertEqual(manifest["output_paths"]["metrics"], str(metrics_path))
+        self.assertEqual(manifest["volume_shape_zyx"], [1, 1, 5])
+        self.assertEqual(manifest["actual_grid_shape_xyz"], [5, 1, 1])
+        self.assertEqual(manifest["effective_volume_spacing_xyz"], [1.0, 1.0, 1.0])
+        self.assertEqual(manifest["effective_volume_origin_xyz"], [0.0, 0.0, 0.0])
+        self.assertEqual(manifest["chunk_depth"], 0)
+        self.assertEqual(manifest["field_query_chunk_size"], 1)
+        self.assertEqual(manifest["field_control_chunk_size"], 1)
+        self.assertEqual(metrics["control_point_count"], 2)
+        self.assertEqual(metrics["sample_count"], 5)
+        self.assertEqual(metrics["in_bounds_sample_count"], 4)
+        self.assertAlmostEqual(metrics["out_of_bounds_fraction"], 0.2)
+        self.assertAlmostEqual(metrics["displacement_magnitude"]["max"], 1.0)
+        np.testing.assert_allclose(field[0, 0, :, 0], np.ones(5))
+        np.testing.assert_allclose(warped[0, 0], [-1.0, 0.0, 1.0, 2.0, 3.0])
+
+    def test_cli_accepts_custom_output_filenames(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 0 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.zeros((1, 1, 1), dtype=np.float32))
+
+            pipeline.main(
+                [
+                    "--mesh-pair",
+                    str(source_path),
+                    str(registered_path),
+                    "--volume",
+                    str(volume_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--controls-output",
+                    "controls.custom.json",
+                    "--field-output",
+                    "field.custom.npz",
+                    "--warped-output",
+                    "warped.custom.npy",
+                    "--manifest-output",
+                    "manifest.custom.json",
+                    "--metrics-output",
+                    "metrics.custom.json",
+                    "--grid-shape",
+                    "1,1,1",
+                    "--field-spacing",
+                    "1,1,1",
+                ]
+            )
+
+            self.assertTrue((output_dir / "controls.custom.json").exists())
+            self.assertTrue((output_dir / "field.custom.npz").exists())
+            self.assertTrue((output_dir / "warped.custom.npy").exists())
+            self.assertTrue((output_dir / "manifest.custom.json").exists())
+            self.assertTrue((output_dir / "metrics.custom.json").exists())
+
+    def test_cli_auto_grid_shape_covers_volume_extent_at_field_spacing(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\nv 4 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 1 0 0\nv 5 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.arange(5, dtype=np.float32).reshape(1, 1, 5))
+
+            pipeline.main(
+                [
+                    "--mesh-pair",
+                    str(source_path),
+                    str(registered_path),
+                    "--volume",
+                    str(volume_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--grid-shape",
+                    "auto",
+                    "--field-spacing",
+                    "2,1,1",
+                    "--volume-spacing",
+                    "1,1,1",
+                    "--volume-origin",
+                    "0,0,0",
+                    "--fill-value",
+                    "-1",
+                ]
+            )
+
+            with np.load(output_dir / "deformation-field.npz") as field_data:
+                field = field_data["displacement_xyz"]
+            manifest = json.loads((output_dir / "deformation-run-manifest.json").read_text(encoding="utf-8"))
+            warped = np.load(output_dir / "warped-volume.npy")
+
+        self.assertEqual(field.shape, (1, 1, 3, 3))
+        self.assertEqual(manifest["requested_grid_shape"], "auto")
+        self.assertEqual(manifest["actual_grid_shape_xyz"], [3, 1, 1])
+        self.assertEqual(manifest["effective_volume_spacing_xyz"], [1.0, 1.0, 1.0])
+        self.assertEqual(manifest["effective_volume_origin_xyz"], [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(field[0, 0, :, 0], np.ones(3))
+        np.testing.assert_allclose(warped[0, 0], [-1.0, 0.0, 1.0, 2.0, 3.0])
+
+    def test_manifest_records_effective_volume_defaults(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\nv 1 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 0 0 0\nv 1 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.arange(2, dtype=np.float32).reshape(1, 1, 2))
+
+            pipeline.main(
+                [
+                    "--mesh-pair",
+                    str(source_path),
+                    str(registered_path),
+                    "--volume",
+                    str(volume_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--grid-shape",
+                    "2,1,1",
+                    "--field-spacing",
+                    "2,3,4",
+                    "--field-origin",
+                    "5,6,7",
+                ]
+            )
+
+            manifest = json.loads((output_dir / "deformation-run-manifest.json").read_text(encoding="utf-8"))
+
+        self.assertIsNone(manifest["volume_spacing_xyz"])
+        self.assertIsNone(manifest["volume_origin_xyz"])
+        self.assertEqual(manifest["effective_volume_spacing_xyz"], [2.0, 3.0, 4.0])
+        self.assertEqual(manifest["effective_volume_origin_xyz"], [5.0, 6.0, 7.0])
+
+    def test_cli_can_subsample_run_metrics(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\nv 4 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 1 0 0\nv 5 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.arange(5, dtype=np.float32).reshape(1, 1, 5))
+
+            pipeline.main(
+                [
+                    "--mesh-pair",
+                    str(source_path),
+                    str(registered_path),
+                    "--volume",
+                    str(volume_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--grid-shape",
+                    "5,1,1",
+                    "--field-spacing",
+                    "1,1,1",
+                    "--volume-spacing",
+                    "1,1,1",
+                    "--fill-value",
+                    "-1",
+                    "--metrics-sample-step",
+                    "2",
+                ]
+            )
+
+            metrics = json.loads((output_dir / "deformation-run-metrics.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(metrics["metrics_sample_step"], 2)
+        self.assertEqual(metrics["volume_voxel_count"], 5)
+        self.assertEqual(metrics["sample_count"], 3)
+        self.assertEqual(metrics["in_bounds_sample_count"], 2)
+        self.assertAlmostEqual(metrics["in_bounds_fraction"], 2.0 / 3.0)
+
+    def test_cli_passes_chunk_depth_to_reference_warper(self):
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\nv 4 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 1 0 0\nv 5 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.arange(10, dtype=np.float32).reshape(2, 1, 5))
+
+            pipeline.main(
+                [
+                    "--mesh-pair",
+                    str(source_path),
+                    str(registered_path),
+                    "--volume",
+                    str(volume_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--grid-shape",
+                    "auto",
+                    "--field-spacing",
+                    "1,1,1",
+                    "--volume-spacing",
+                    "1,1,1",
+                    "--fill-value",
+                    "-1",
+                    "--chunk-depth",
+                    "1",
+                ]
+            )
+
+            warped = np.load(output_dir / "warped-volume.npy")
+            manifest = json.loads((output_dir / "deformation-run-manifest.json").read_text(encoding="utf-8"))
+
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+        self.assertEqual(manifest["chunk_depth"], 1)
+        self.assertEqual(manifest["output_write_mode"], "chunked_npy_memmap")
+
+    def test_cli_chunked_npy_output_bypasses_full_array_save(self):
+        pipeline = _load_pipeline()
+
+        def fail_save_volume(path, volume):
+            raise AssertionError("chunked .npy output should write directly through a memmap")
+
+        pipeline.save_volume = fail_save_volume
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.npy"
+            output_dir = temp / "outputs"
+            source_path.write_text("v 0 0 0\nv 4 0 0\n", encoding="utf-8")
+            registered_path.write_text("v 1 0 0\nv 5 0 0\n", encoding="utf-8")
+            np.save(volume_path, np.arange(10, dtype=np.float32).reshape(2, 1, 5))
+
+            pipeline.main(
+                [
+                    "--mesh-pair",
+                    str(source_path),
+                    str(registered_path),
+                    "--volume",
+                    str(volume_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--grid-shape",
+                    "auto",
+                    "--field-spacing",
+                    "1,1,1",
+                    "--fill-value",
+                    "-1",
+                    "--chunk-depth",
+                    "1",
+                ]
+            )
+
+            warped = np.load(output_dir / "warped-volume.npy")
+
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+
+    def test_cli_can_read_and_write_tiff_volumes(self):
+        calls = []
+
+        def fake_imwrite(path, array):
+            calls.append(("imwrite", str(path), array.shape))
+            with Path(path).open("wb") as f:
+                np.save(f, array)
+
+        def fake_imread(path):
+            calls.append(("imread", str(path)))
+            with Path(path).open("rb") as f:
+                return np.load(f)
+
+        fake_tifffile = types.SimpleNamespace(imread=fake_imread, imwrite=fake_imwrite)
+        previous_tifffile = sys.modules.get("tifffile")
+        sys.modules["tifffile"] = fake_tifffile
+        try:
+            pipeline = _load_pipeline()
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp = Path(temp_dir)
+                source_path = temp / "source.obj"
+                registered_path = temp / "registered.obj"
+                volume_path = temp / "volume.tif"
+                output_dir = temp / "outputs"
+                source_path.write_text("v 0 0 0\nv 4 0 0\n", encoding="utf-8")
+                registered_path.write_text("v 1 0 0\nv 5 0 0\n", encoding="utf-8")
+                with volume_path.open("wb") as f:
+                    np.save(f, np.arange(5, dtype=np.float32).reshape(1, 1, 5))
+
+                pipeline.main(
+                    [
+                        "--mesh-pair",
+                        str(source_path),
+                        str(registered_path),
+                        "--volume",
+                        str(volume_path),
+                        "--output-dir",
+                        str(output_dir),
+                        "--warped-output",
+                        "warped-volume.tif",
+                        "--grid-shape",
+                        "5,1,1",
+                        "--field-spacing",
+                        "1,1,1",
+                        "--fill-value",
+                        "-1",
+                    ]
+                )
+
+                with (output_dir / "warped-volume.tif").open("rb") as f:
+                    warped = np.load(f)
+        finally:
+            if previous_tifffile is None:
+                sys.modules.pop("tifffile", None)
+            else:
+                sys.modules["tifffile"] = previous_tifffile
+
+        np.testing.assert_allclose(warped[0, 0], [-1.0, 0.0, 1.0, 2.0, 3.0])
+        self.assertEqual([call[0] for call in calls], ["imread", "imwrite"])
+
+    def test_cli_can_read_and_write_zarr_volumes(self):
+        fake_zarr = FakeZarrModule()
+        previous_zarr = sys.modules.get("zarr")
+        sys.modules["zarr"] = fake_zarr
+        try:
+            pipeline = _load_pipeline()
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp = Path(temp_dir)
+                source_path = temp / "source.obj"
+                registered_path = temp / "registered.obj"
+                volume_path = temp / "volume.zarr"
+                output_dir = temp / "outputs"
+                output_path = output_dir / "warped-volume.zarr"
+                source_path.write_text("v 0 0 0\nv 4 0 0\n", encoding="utf-8")
+                registered_path.write_text("v 1 0 0\nv 5 0 0\n", encoding="utf-8")
+                input_store = FakeZarrArray(
+                    np.arange(10, dtype=np.float32).reshape(2, 1, 5),
+                    fail_on_array=True,
+                )
+                fake_zarr.stores[str(volume_path)] = input_store
+
+                pipeline.main(
+                    [
+                        "--mesh-pair",
+                        str(source_path),
+                        str(registered_path),
+                        "--volume",
+                        str(volume_path),
+                        "--output-dir",
+                        str(output_dir),
+                        "--warped-output",
+                        "warped-volume.zarr",
+                        "--grid-shape",
+                        "auto",
+                        "--field-spacing",
+                        "1,1,1",
+                        "--fill-value",
+                        "-1",
+                        "--chunk-depth",
+                        "1",
+                    ]
+                )
+
+                warped = np.asarray(fake_zarr.stores[str(output_path)])
+                manifest = json.loads((output_dir / "deformation-run-manifest.json").read_text(encoding="utf-8"))
+        finally:
+            if previous_zarr is None:
+                sys.modules.pop("zarr", None)
+            else:
+                sys.modules["zarr"] = previous_zarr
+
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+        self.assertEqual(input_store.materialize_count, 0)
+        self.assertEqual(manifest["output_write_mode"], "chunked_zarr")
+        self.assertEqual(manifest["output_paths"]["warped"], str(output_path))
+
+    def test_cli_can_read_requested_zarr_group_array(self):
+        fake_zarr = FakeZarrModule()
+        previous_zarr = sys.modules.get("zarr")
+        sys.modules["zarr"] = fake_zarr
+        try:
+            pipeline = _load_pipeline()
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp = Path(temp_dir)
+                source_path = temp / "source.obj"
+                registered_path = temp / "registered.obj"
+                volume_path = temp / "volume.zarr"
+                output_dir = temp / "outputs"
+                output_path = output_dir / "warped-volume.zarr"
+                source_path.write_text("v 0 0 0\nv 4 0 0\n", encoding="utf-8")
+                registered_path.write_text("v 1 0 0\nv 5 0 0\n", encoding="utf-8")
+                level0 = FakeZarrArray(np.zeros((2, 1, 5), dtype=np.float32), fail_on_array=True)
+                level1 = FakeZarrArray(
+                    np.arange(10, dtype=np.float32).reshape(2, 1, 5),
+                    fail_on_array=True,
+                )
+                fake_zarr.stores[str(volume_path)] = FakeZarrGroup({"0": level0, "1": level1})
+
+                pipeline.main(
+                    [
+                        "--mesh-pair",
+                        str(source_path),
+                        str(registered_path),
+                        "--volume",
+                        str(volume_path),
+                        "--output-dir",
+                        str(output_dir),
+                        "--warped-output",
+                        "warped-volume.zarr",
+                        "--zarr-array-key",
+                        "1",
+                        "--grid-shape",
+                        "auto",
+                        "--field-spacing",
+                        "1,1,1",
+                        "--fill-value",
+                        "-1",
+                        "--chunk-depth",
+                        "1",
+                    ]
+                )
+
+                warped = np.asarray(fake_zarr.stores[str(output_path)])
+                manifest = json.loads((output_dir / "deformation-run-manifest.json").read_text(encoding="utf-8"))
+        finally:
+            if previous_zarr is None:
+                sys.modules.pop("zarr", None)
+            else:
+                sys.modules["zarr"] = previous_zarr
+
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+        self.assertEqual(level0.materialize_count, 0)
+        self.assertEqual(level1.materialize_count, 0)
+        self.assertEqual(manifest["zarr_array_key"], "1")
+        self.assertEqual(manifest["output_write_mode"], "chunked_zarr")
+
+    def test_cli_can_read_real_zarr_group_array(self):
+        zarr = _import_real_zarr()
+        pipeline = _load_pipeline()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            source_path = temp / "source.obj"
+            registered_path = temp / "registered.obj"
+            volume_path = temp / "volume.zarr"
+            output_dir = temp / "outputs"
+            source_path.write_text("\n".join(["v 0 0 0", "v 4 0 0"]), encoding="utf-8")
+            registered_path.write_text("\n".join(["v 0 0 0", "v 4 0 0"]), encoding="utf-8")
+            group = zarr.open_group(str(volume_path), mode="w")
+            group.create_dataset("0", shape=(1, 1, 5), chunks=(1, 1, 5), dtype="float32")[:] = 999
+            group.create_dataset("1", shape=(1, 1, 5), chunks=(1, 1, 5), dtype="float32")[:] = np.arange(
+                5, dtype=np.float32
+            ).reshape(1, 1, 5)
+
+            pipeline.main(
+                [
+                    "--mesh-pair",
+                    str(source_path),
+                    str(registered_path),
+                    "--volume",
+                    str(volume_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--warped-output",
+                    "warped-volume.zarr",
+                    "--zarr-array-key",
+                    "1",
+                    "--grid-shape",
+                    "5,1,1",
+                    "--field-spacing",
+                    "1,1,1",
+                    "--field-origin",
+                    "0,0,0",
+                    "--volume-spacing",
+                    "1,1,1",
+                    "--volume-origin",
+                    "0,0,0",
+                    "--max-points-per-mesh",
+                    "0",
+                    "--chunk-depth",
+                    "1",
+                ]
+            )
+
+            manifest = json.loads((output_dir / "deformation-run-manifest.json").read_text(encoding="utf-8"))
+            warped = np.asarray(zarr.open(str(output_dir / "warped-volume.zarr"), mode="r"))
+
+        self.assertEqual(manifest["zarr_array_key"], "1")
+        self.assertEqual(manifest["output_write_mode"], "chunked_zarr")
+        np.testing.assert_allclose(warped[0, 0], [0.0, 1.0, 2.0, 3.0, 4.0])
+
+    def test_help_mentions_tiff_and_zarr_volume_support(self):
+        pipeline = _load_pipeline()
+
+        help_text = pipeline.build_arg_parser().format_help()
+
+        self.assertIn(".tif", help_text)
+        self.assertIn(".zarr", help_text)
+        self.assertIn("--zarr-array-key", help_text)
+        self.assertIn("auto", help_text)
+        self.assertIn("--chunk-depth", help_text)
+        self.assertIn("--field-query-chunk-size", help_text)
+        self.assertIn("--field-control-chunk-size", help_text)
+        self.assertIn("--manifest-output", help_text)
+        self.assertIn("--metrics-output", help_text)
+        self.assertIn("--metrics-sample-step", help_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/foundation/datasets/register-meshes-to-fibers/tests/test_registration_pipe_scale_controls.py
+++ b/foundation/datasets/register-meshes-to-fibers/tests/test_registration_pipe_scale_controls.py
@@ -1,0 +1,937 @@
+import contextlib
+import io
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = MODULE_DIR / "registration_pipe.py"
+REGISTRATION_MODULE_PATH = MODULE_DIR / "registration.py"
+
+
+class _AssignedTensor:
+    def __init__(self, value):
+        self.value = np.asarray(value, dtype=np.float32)
+
+    @property
+    def device(self):
+        return types.SimpleNamespace(type="cpu")
+
+    def __add__(self, other):
+        if isinstance(other, _AssignedTensor):
+            other = other.value
+        return _AssignedTensor(self.value + other)
+
+
+def _load_registration_module():
+    module_name = "_test_registration"
+    sys.modules.pop(module_name, None)
+
+    class _Device:
+        def __init__(self, name):
+            self.type = name
+
+        def __str__(self):
+            return self.type
+
+    torch_stub = types.ModuleType("torch")
+    torch_stub.Tensor = _AssignedTensor
+    torch_stub.float32 = "float32"
+    torch_stub.long = "long"
+    torch_stub.manual_seed = lambda _seed: None
+    torch_stub.cuda = types.SimpleNamespace(is_available=lambda: False)
+    torch_stub.device = lambda name: _Device(name)
+    torch_stub.tensor = lambda value, **_kwargs: _AssignedTensor(value)
+    torch_stub.empty = lambda shape, **_kwargs: _AssignedTensor(np.empty(shape, dtype=np.float32))
+    torch_stub.zeros_like = lambda value, **_kwargs: _AssignedTensor(np.zeros_like(value.value, dtype=np.float32))
+    torch_stub.optim = types.SimpleNamespace(
+        AdamW=lambda *_args, **_kwargs: types.SimpleNamespace(
+            zero_grad=lambda: None,
+        ),
+        lr_scheduler=types.SimpleNamespace(
+            StepLR=lambda *_args, **_kwargs: types.SimpleNamespace(step=lambda: None),
+        ),
+    )
+    torch_stub.amp = types.SimpleNamespace(
+        GradScaler=lambda **_kwargs: types.SimpleNamespace(
+            scale=lambda value: types.SimpleNamespace(backward=lambda: None),
+            step=lambda _optimizer: None,
+            update=lambda: None,
+        ),
+        autocast=lambda **_kwargs: mock.MagicMock(),
+    )
+
+    torch_functional_stub = types.ModuleType("torch.nn.functional")
+    torch_nn_stub = types.ModuleType("torch.nn")
+    torch_nn_stub.functional = torch_functional_stub
+
+    open3d_stub = types.ModuleType("open3d")
+    open3d_stub.geometry = types.SimpleNamespace(LineSet=object, PointCloud=object)
+    tqdm_stub = types.ModuleType("tqdm")
+
+    class _Tqdm:
+        def __init__(self, iterable, **_kwargs):
+            self.iterable = iterable
+
+        def __iter__(self):
+            return iter(self.iterable)
+
+        def close(self):
+            return None
+
+        def set_postfix(self, *_args, **_kwargs):
+            return None
+
+        def write(self, *_args, **_kwargs):
+            return None
+
+    tqdm_stub.tqdm = _Tqdm
+
+    spec = importlib.util.spec_from_file_location(module_name, REGISTRATION_MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "torch": torch_stub,
+            "torch.nn": torch_nn_stub,
+            "torch.nn.functional": torch_functional_stub,
+            "open3d": open3d_stub,
+            "tqdm": tqdm_stub,
+            module_name: module,
+        },
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_registration_pipe():
+    module_name = "_test_registration_pipe"
+    sys.modules.pop(module_name, None)
+
+    class _Geometry:
+        def __init__(self):
+            self.points = None
+            self.lines = None
+            self.colors = None
+
+        def paint_uniform_color(self, _color):
+            return None
+
+    open3d_stub = types.ModuleType("open3d")
+    open3d_stub.geometry = types.SimpleNamespace(
+        PointCloud=_Geometry,
+        LineSet=_Geometry,
+        TriangleMesh=_Geometry,
+    )
+    open3d_stub.utility = types.SimpleNamespace(
+        Vector3dVector=lambda value: value,
+        Vector2iVector=lambda value: value,
+    )
+    open3d_stub.io = types.SimpleNamespace(
+        read_triangle_mesh=lambda *_args, **_kwargs: None,
+        write_triangle_mesh=lambda *_args, **_kwargs: True,
+    )
+    open3d_stub.visualization = types.SimpleNamespace(
+        draw_geometries=lambda *_args, **_kwargs: None,
+    )
+
+    torch_stub = types.ModuleType("torch")
+    torch_stub.cuda = types.SimpleNamespace(is_available=lambda: False)
+    torch_stub.device = lambda name: name
+    torch_stub.float32 = "float32"
+    torch_stub.tensor = lambda value, **_kwargs: np.asarray(value, dtype=np.float32)
+
+    extract_stub = types.ModuleType("extract_skeleton_tif")
+    extract_stub.extract_skeleton_from_tif = lambda *_args, **_kwargs: {}
+
+    registration_stub = types.ModuleType("registration")
+    registration_stub.MeshSurface = object
+    registration_stub.optimize_all_registration = lambda *_args, **_kwargs: []
+    registration_stub.assign_skeletons_to_mesh = lambda *_args, **_kwargs: None
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "open3d": open3d_stub,
+            "torch": torch_stub,
+            "extract_skeleton_tif": extract_stub,
+            "registration": registration_stub,
+            module_name: module,
+        },
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+class RegistrationPipeScaleControlsTest(unittest.TestCase):
+    def test_parse_mesh_label_and_fiber_accepts_only_supported_fiber_suffixes(self):
+        registration_pipe = _load_registration_pipe()
+
+        self.assertEqual(registration_pipe.parse_mesh_label_and_fiber("12_hz.obj"), (12, "hz"))
+        self.assertEqual(registration_pipe.parse_mesh_label_and_fiber("nested/34_vt.obj"), (34, "vt"))
+
+        for mesh_file in ["12_diag.obj", "bad.obj", "12.obj", "12_hz_extra.obj"]:
+            with self.subTest(mesh_file=mesh_file):
+                with self.assertRaisesRegex(ValueError, "<label>_<hz\\|vt>\\.obj"):
+                    registration_pipe.parse_mesh_label_and_fiber(mesh_file)
+
+    def test_curve_type_for_fiber_rejects_unknown_fiber_type_before_auto_mapping(self):
+        registration_pipe = _load_registration_pipe()
+
+        with self.assertRaisesRegex(ValueError, "fiber_type must be 'hz' or 'vt'"):
+            registration_pipe.curve_type_for_fiber("diag", "auto")
+
+    def test_process_one_mesh_rejects_invalid_mesh_filename_before_running_pipeline(self):
+        registration_pipe = _load_registration_pipe()
+        global_args = types.SimpleNamespace(
+            num_iters=1,
+            lr=1e-2,
+            lambda_data=1.0,
+            lambda_disp=1e-3,
+            lambda_elastic=0.0,
+            lambda_self=0.0,
+            lambda_lap=0.0,
+            lambda_arap=0.0,
+            lambda_sdf=0.0,
+            batch_size=1,
+            tau=1.0,
+            delta=1.0,
+            beta=1.0,
+            tau_sdf=1.0,
+            lambda_inter=0.0,
+            delta_inter=1.0,
+            beta_inter=1.0,
+            target_triangles=100,
+            skel_origin="0,0,0",
+            skel_axis="xyz",
+            skeleton_axis_order="zyx",
+            curve_type="auto",
+            target_skel_points=0,
+            visualize=False,
+            mesh_root="meshes",
+        )
+
+        with mock.patch.object(registration_pipe, "unified_pipeline", return_value=[]) as unified_pipeline:
+            with self.assertRaisesRegex(ValueError, "<label>_<hz\\|vt>\\.obj"):
+                registration_pipe.process_one_mesh(
+                    "meshes/cube/7_diag.obj",
+                    "fiber.tif",
+                    "mask.tif",
+                    "registered",
+                    global_args,
+                )
+
+        unified_pipeline.assert_not_called()
+
+    def test_optimizer_preserves_preassigned_mesh_skeleton_curves(self):
+        registration = _load_registration_module()
+
+        mesh_a_curve = np.array([[1.0, 0.0, 0.0]], dtype=np.float32)
+        mesh_b_curve = np.array([[2.0, 0.0, 0.0]], dtype=np.float32)
+        mesh_a = types.SimpleNamespace(
+            vertices_np=np.array([[0.0, 0.0, 0.0]], dtype=np.float32),
+            skeleton_curves=[mesh_a_curve],
+            vertices=_AssignedTensor([[0.0, 0.0, 0.0]]),
+            displacement=_AssignedTensor([[0.0, 0.0, 0.0]]),
+        )
+        mesh_b = types.SimpleNamespace(
+            vertices_np=np.array([[0.0, 0.0, 0.0]], dtype=np.float32),
+            skeleton_curves=[mesh_b_curve],
+            vertices=_AssignedTensor([[0.0, 0.0, 0.0]]),
+            displacement=_AssignedTensor([[0.0, 0.0, 0.0]]),
+        )
+
+        registration.optimize_all_registration(
+            [mesh_a, mesh_b],
+            [mesh_a_curve, mesh_b_curve],
+            num_iters=0,
+        )
+
+        np.testing.assert_allclose(mesh_a.skeleton_points.value, mesh_a_curve)
+        np.testing.assert_allclose(mesh_b.skeleton_points.value, mesh_b_curve)
+
+    def test_optimizer_rejects_explicit_empty_mesh_skeleton_curves(self):
+        registration = _load_registration_module()
+
+        global_curve = np.array([[2.0, 0.0, 0.0]], dtype=np.float32)
+        mesh = types.SimpleNamespace(
+            vertices_np=np.array([[0.0, 0.0, 0.0]], dtype=np.float32),
+            skeleton_curves=[],
+            vertices=_AssignedTensor([[0.0, 0.0, 0.0]]),
+            displacement=_AssignedTensor([[0.0, 0.0, 0.0]]),
+        )
+
+        with self.assertRaisesRegex(ValueError, "mesh has no skeleton curves"):
+            registration.optimize_all_registration(
+                [mesh],
+                [global_curve],
+                num_iters=0,
+            )
+
+    def test_prepare_skeleton_curves_filters_reorders_and_simplifies(self):
+        registration_pipe = _load_registration_pipe()
+
+        vertical_curve = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [2.0, 4.0, 6.0],
+                [3.0, 6.0, 9.0],
+                [4.0, 8.0, 12.0],
+            ],
+            dtype=np.float32,
+        )
+        horizontal_curve = np.array(
+            [
+                [10.0, 20.0, 30.0],
+                [11.0, 22.0, 33.0],
+                [12.0, 24.0, 36.0],
+            ],
+            dtype=np.float32,
+        )
+
+        prepared = registration_pipe.prepare_skeleton_curves(
+            {
+                "vertical": [vertical_curve],
+                "horizontal": [horizontal_curve],
+            },
+            curve_type="vertical",
+            origin=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            skel_axis="zyx",
+            target_points=2,
+        )
+
+        self.assertEqual(list(prepared.keys()), ["vertical"])
+        self.assertEqual(len(prepared["vertical"]), 1)
+        np.testing.assert_allclose(
+            prepared["vertical"][0],
+            np.array(
+                [
+                    [0.0, 0.0, 0.0],
+                    [9.0, 6.0, 3.0],
+                ],
+                dtype=np.float32,
+            ),
+        )
+
+    def test_parser_defaults_keep_skeleton_classification_and_registration_axes_consistent(self):
+        registration_pipe = _load_registration_pipe()
+        captured = {}
+        argv = [
+            "registration_pipe.py",
+            "--mesh_root",
+            "meshes",
+            "--tif_root",
+            "tifs",
+            "--cube_label_root",
+            "labels",
+            "--output_root",
+            "registered",
+        ]
+
+        def fake_process_group(_mesh_files, _tif_file, _cube_label_file, _output_root, args):
+            captured["skel_axis"] = args.skel_axis
+            captured["skeleton_axis_order"] = args.skeleton_axis_order
+
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(registration_pipe.os, "walk", return_value=[("meshes/cube_a", [], ["1_hz.obj"])]), \
+             mock.patch.object(registration_pipe.os.path, "isfile", return_value=True), \
+             mock.patch.object(registration_pipe, "process_mesh_group", side_effect=fake_process_group):
+            registration_pipe.main()
+
+        self.assertEqual(captured["skeleton_axis_order"], "zyx")
+        self.assertEqual(captured["skel_axis"], "zyx")
+
+    def test_unified_pipeline_passes_only_selected_simplified_curves_to_optimizer(self):
+        registration_pipe = _load_registration_pipe()
+
+        vertical_curve = np.stack(
+            [
+                np.arange(5, dtype=np.float32),
+                np.arange(5, dtype=np.float32) + 10.0,
+                np.arange(5, dtype=np.float32) + 20.0,
+            ],
+            axis=1,
+        )
+        horizontal_curve = np.stack(
+            [
+                np.arange(4, dtype=np.float32) + 100.0,
+                np.arange(4, dtype=np.float32) + 200.0,
+                np.arange(4, dtype=np.float32) + 300.0,
+            ],
+            axis=1,
+        )
+        captured = {}
+
+        class _ToDevice:
+            def to(self, _device):
+                return self
+
+        class _TensorLike:
+            def __init__(self, value):
+                self.value = np.asarray(value, dtype=np.float32)
+
+            def __add__(self, other):
+                if isinstance(other, _TensorLike):
+                    other = other.value
+                return _TensorLike(self.value + other)
+
+            def detach(self):
+                return self
+
+            def cpu(self):
+                return self
+
+            def numpy(self):
+                return self.value
+
+        class _FakeMesh:
+            def __init__(self):
+                self.vertices_np = np.zeros((3, 3), dtype=np.float32)
+                self.displacement = _TensorLike(np.zeros((3, 3), dtype=np.float32))
+                self.vertices = _TensorLike(np.zeros((3, 3), dtype=np.float32))
+                self.skeleton_points = None
+
+        def fake_optimize(meshes, global_skel_curves, **_kwargs):
+            captured["curves"] = global_skel_curves
+            return []
+
+        args = types.SimpleNamespace(
+            mesh="42_hz.obj",
+            tif="fiber.tif",
+            cube_label="mask.tif",
+            skel_origin="0,0,0",
+            skel_axis="xyz",
+            curve_type="horizontal",
+            target_skel_points=2,
+            visualize=False,
+            num_iters=1,
+            lr=1e-2,
+            lambda_data=1.0,
+            lambda_disp=1e-3,
+            lambda_elastic=1.0,
+            lambda_self=1e-1,
+            lambda_lap=5e-1,
+            lambda_arap=2.0,
+            lambda_sdf=1.0,
+            tau=0.01,
+            delta=0.05,
+            beta=10.0,
+            tau_sdf=0.01,
+            lambda_inter=0.1,
+            delta_inter=0.05,
+            beta_inter=10.0,
+            batch_size=8,
+        )
+
+        with mock.patch.object(registration_pipe, "load_mesh_from_file", return_value=[_FakeMesh()]), \
+             mock.patch.object(
+                 registration_pipe,
+                 "extract_skeleton_from_tif",
+                 return_value={"vertical": [vertical_curve], "horizontal": [horizontal_curve]},
+             ), \
+             mock.patch.object(registration_pipe, "assign_skeletons_to_mesh", return_value=_ToDevice()), \
+             mock.patch.object(registration_pipe, "optimize_all_registration", side_effect=fake_optimize):
+            registration_pipe.unified_pipeline(args)
+
+        self.assertEqual(len(captured["curves"]), 1)
+        np.testing.assert_allclose(
+            captured["curves"][0],
+            np.array(
+                [
+                    [100.0, 200.0, 300.0],
+                    [103.0, 203.0, 303.0],
+                ],
+                dtype=np.float32,
+            ),
+        )
+
+    def test_unified_pipeline_does_not_print_raw_displacement_objects(self):
+        registration_pipe = _load_registration_pipe()
+
+        class _ToDevice:
+            def to(self, _device):
+                return self
+
+        class _TensorLike:
+            def __init__(self, value):
+                self.value = np.asarray(value, dtype=np.float32)
+
+            def __add__(self, other):
+                if isinstance(other, _TensorLike):
+                    other = other.value
+                return _TensorLike(self.value + other)
+
+            def __repr__(self):
+                return "DISPLACEMENT_DEBUG_SENTINEL"
+
+            def detach(self):
+                return self
+
+            def cpu(self):
+                return self
+
+            def numpy(self):
+                return self.value
+
+        class _FakeMesh:
+            def __init__(self):
+                self.vertices_np = np.zeros((1, 3), dtype=np.float32)
+                self.vertices = _TensorLike(np.zeros((1, 3), dtype=np.float32))
+                self.displacement = _TensorLike(np.zeros((1, 3), dtype=np.float32))
+                self.skeleton_points = None
+
+        def fake_optimize(meshes, _global_skel_curves, **_kwargs):
+            return [mesh.displacement for mesh in meshes]
+
+        args = types.SimpleNamespace(
+            mesh="42_hz.obj",
+            tif="fiber.tif",
+            cube_label="mask.tif",
+            skel_origin="0,0,0",
+            skel_axis="xyz",
+            curve_type="horizontal",
+            target_skel_points=0,
+            visualize=False,
+            num_iters=1,
+            lr=1e-2,
+            lambda_data=1.0,
+            lambda_disp=1e-3,
+            lambda_elastic=1.0,
+            lambda_self=1e-1,
+            lambda_lap=5e-1,
+            lambda_arap=2.0,
+            lambda_sdf=1.0,
+            tau=0.01,
+            delta=0.05,
+            beta=10.0,
+            tau_sdf=0.01,
+            lambda_inter=0.1,
+            delta_inter=0.05,
+            beta_inter=10.0,
+            batch_size=8,
+        )
+
+        curve = np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+        stdout = io.StringIO()
+        with mock.patch.object(registration_pipe, "load_mesh_from_file", return_value=[_FakeMesh()]), \
+             mock.patch.object(
+                 registration_pipe,
+                 "extract_skeleton_from_tif",
+                 return_value={"vertical": [], "horizontal": [curve]},
+             ), \
+             mock.patch.object(registration_pipe, "assign_skeletons_to_mesh", return_value=_ToDevice()), \
+             mock.patch.object(registration_pipe, "optimize_all_registration", side_effect=fake_optimize), \
+             contextlib.redirect_stdout(stdout):
+            registration_pipe.unified_pipeline(args)
+
+        self.assertNotIn("DISPLACEMENT_DEBUG_SENTINEL", stdout.getvalue())
+
+    def test_unified_pipeline_registers_multiple_meshes_together(self):
+        registration_pipe = _load_registration_pipe()
+
+        class _ToDevice:
+            def to(self, _device):
+                return self
+
+        class _TensorLike:
+            def __init__(self, value):
+                self.value = np.asarray(value, dtype=np.float32)
+
+            def __add__(self, other):
+                if isinstance(other, _TensorLike):
+                    other = other.value
+                return _TensorLike(self.value + other)
+
+            def detach(self):
+                return self
+
+            def cpu(self):
+                return self
+
+            def numpy(self):
+                return self.value
+
+        class _FakeMesh:
+            def __init__(self, z):
+                self.vertices_np = np.array([[0.0, 0.0, z]], dtype=np.float32)
+                self.displacement = _TensorLike(np.zeros((1, 3), dtype=np.float32))
+                self.vertices = _TensorLike(np.zeros((1, 3), dtype=np.float32))
+                self.skeleton_points = None
+
+        captured = {"labels": []}
+
+        def fake_load_mesh(mesh_file):
+            z = 1.0 if mesh_file == "1_hz.obj" else 2.0
+            return [_FakeMesh(z)]
+
+        def fake_extract(_tif, _cube_label, **kwargs):
+            label = kwargs["label"]
+            captured["labels"].append(label)
+            curve = np.array(
+                [
+                    [float(label), 0.0, 0.0],
+                    [float(label), 1.0, 0.0],
+                    [float(label), 2.0, 0.0],
+                ],
+                dtype=np.float32,
+            )
+            return {"vertical": [], "horizontal": [curve]}
+
+        def fake_optimize(meshes, global_skel_curves, **_kwargs):
+            captured["mesh_count"] = len(meshes)
+            captured["curve_count"] = len(global_skel_curves)
+            captured["mesh_curves"] = [mesh.skeleton_curves for mesh in meshes]
+            return []
+
+        args = types.SimpleNamespace(
+            meshes=["1_hz.obj", "2_hz.obj"],
+            tif="fiber.tif",
+            cube_label="mask.tif",
+            skel_origin="0,0,0",
+            skel_axis="xyz",
+            curve_type="horizontal",
+            target_skel_points=2,
+            visualize=False,
+            num_iters=1,
+            lr=1e-2,
+            lambda_data=1.0,
+            lambda_disp=1e-3,
+            lambda_elastic=1.0,
+            lambda_self=1e-1,
+            lambda_lap=5e-1,
+            lambda_arap=2.0,
+            lambda_sdf=1.0,
+            tau=0.01,
+            delta=0.05,
+            beta=10.0,
+            tau_sdf=0.01,
+            lambda_inter=0.1,
+            delta_inter=0.05,
+            beta_inter=10.0,
+            batch_size=8,
+        )
+
+        with mock.patch.object(registration_pipe, "load_mesh_from_file", side_effect=fake_load_mesh), \
+             mock.patch.object(registration_pipe, "extract_skeleton_from_tif", side_effect=fake_extract), \
+             mock.patch.object(registration_pipe, "assign_skeletons_to_mesh", return_value=_ToDevice()), \
+             mock.patch.object(registration_pipe, "optimize_all_registration", side_effect=fake_optimize):
+            registration_pipe.unified_pipeline(args)
+
+        self.assertEqual(captured["labels"], [1, 2])
+        self.assertEqual(captured["mesh_count"], 2)
+        self.assertEqual(captured["curve_count"], 2)
+        np.testing.assert_allclose(captured["mesh_curves"][0][0], np.array([[1.0, 0.0, 0.0], [1.0, 2.0, 0.0]], dtype=np.float32))
+        np.testing.assert_allclose(captured["mesh_curves"][1][0], np.array([[2.0, 0.0, 0.0], [2.0, 2.0, 0.0]], dtype=np.float32))
+
+    def test_unified_pipeline_skips_meshes_without_matching_curves(self):
+        registration_pipe = _load_registration_pipe()
+
+        class _ToDevice:
+            def to(self, _device):
+                return self
+
+        class _TensorLike:
+            def __init__(self, value):
+                self.value = np.asarray(value, dtype=np.float32)
+
+            def __add__(self, other):
+                if isinstance(other, _TensorLike):
+                    other = other.value
+                return _TensorLike(self.value + other)
+
+            def detach(self):
+                return self
+
+            def cpu(self):
+                return self
+
+            def numpy(self):
+                return self.value
+
+        class _FakeMesh:
+            def __init__(self):
+                self.vertices_np = np.zeros((1, 3), dtype=np.float32)
+                self.displacement = _TensorLike(np.zeros((1, 3), dtype=np.float32))
+                self.vertices = _TensorLike(np.zeros((1, 3), dtype=np.float32))
+                self.skeleton_points = None
+
+        captured = {}
+
+        def fake_extract(_tif, _cube_label, **kwargs):
+            if kwargs["label"] == 1:
+                return {
+                    "vertical": [],
+                    "horizontal": [np.array([[1.0, 0.0, 0.0], [1.0, 1.0, 0.0]], dtype=np.float32)],
+                }
+            return {"vertical": [], "horizontal": []}
+
+        def fake_optimize(meshes, global_skel_curves, **_kwargs):
+            captured["mesh_count"] = len(meshes)
+            captured["curve_count"] = len(global_skel_curves)
+            captured["sources"] = [mesh._source_mesh_file for mesh in meshes]
+            return []
+
+        args = types.SimpleNamespace(
+            meshes=["1_hz.obj", "2_hz.obj"],
+            tif="fiber.tif",
+            cube_label="mask.tif",
+            skel_origin="0,0,0",
+            skel_axis="xyz",
+            skeleton_axis_order="zyx",
+            curve_type="horizontal",
+            target_skel_points=0,
+            visualize=False,
+            num_iters=1,
+            lr=1e-2,
+            lambda_data=1.0,
+            lambda_disp=1e-3,
+            lambda_elastic=1.0,
+            lambda_self=1e-1,
+            lambda_lap=5e-1,
+            lambda_arap=2.0,
+            lambda_sdf=1.0,
+            tau=0.01,
+            delta=0.05,
+            beta=10.0,
+            tau_sdf=0.01,
+            lambda_inter=0.1,
+            delta_inter=0.05,
+            beta_inter=10.0,
+            batch_size=8,
+        )
+
+        with mock.patch.object(registration_pipe, "load_mesh_from_file", side_effect=lambda _path: [_FakeMesh()]), \
+             mock.patch.object(registration_pipe, "extract_skeleton_from_tif", side_effect=fake_extract), \
+             mock.patch.object(registration_pipe, "assign_skeletons_to_mesh", return_value=_ToDevice()), \
+             mock.patch.object(registration_pipe, "optimize_all_registration", side_effect=fake_optimize):
+            registration_pipe.unified_pipeline(args)
+
+        self.assertEqual(captured["mesh_count"], 1)
+        self.assertEqual(captured["curve_count"], 1)
+        self.assertEqual(captured["sources"], ["1_hz.obj"])
+
+    def test_unified_pipeline_auto_curve_type_uses_mesh_fiber_type_and_axis_order(self):
+        registration_pipe = _load_registration_pipe()
+
+        class _ToDevice:
+            def to(self, _device):
+                return self
+
+        class _TensorLike:
+            def __init__(self, value):
+                self.value = np.asarray(value, dtype=np.float32)
+
+            def __add__(self, other):
+                if isinstance(other, _TensorLike):
+                    other = other.value
+                return _TensorLike(self.value + other)
+
+            def detach(self):
+                return self
+
+            def cpu(self):
+                return self
+
+            def numpy(self):
+                return self.value
+
+        class _FakeMesh:
+            def __init__(self):
+                self.vertices_np = np.zeros((1, 3), dtype=np.float32)
+                self.displacement = _TensorLike(np.zeros((1, 3), dtype=np.float32))
+                self.vertices = _TensorLike(np.zeros((1, 3), dtype=np.float32))
+                self.skeleton_points = None
+
+        captured = {"extract_calls": []}
+
+        def fake_extract(_tif, _cube_label, **kwargs):
+            captured["extract_calls"].append(kwargs)
+            label = kwargs["label"]
+            return {
+                "vertical": [np.array([[10.0 + label, 0.0, 0.0], [10.0 + label, 1.0, 0.0]], dtype=np.float32)],
+                "horizontal": [np.array([[20.0 + label, 0.0, 0.0], [20.0 + label, 1.0, 0.0]], dtype=np.float32)],
+            }
+
+        def fake_optimize(meshes, global_skel_curves, **_kwargs):
+            captured["mesh_curves"] = [mesh.skeleton_curves for mesh in meshes]
+            captured["curve_count"] = len(global_skel_curves)
+            return []
+
+        args = types.SimpleNamespace(
+            meshes=["1_hz.obj", "2_vt.obj"],
+            tif="fiber.tif",
+            cube_label="mask.tif",
+            skel_origin="0,0,0",
+            skel_axis="xyz",
+            skeleton_axis_order="xyz",
+            curve_type="auto",
+            target_skel_points=0,
+            visualize=False,
+            num_iters=1,
+            lr=1e-2,
+            lambda_data=1.0,
+            lambda_disp=1e-3,
+            lambda_elastic=1.0,
+            lambda_self=1e-1,
+            lambda_lap=5e-1,
+            lambda_arap=2.0,
+            lambda_sdf=1.0,
+            tau=0.01,
+            delta=0.05,
+            beta=10.0,
+            tau_sdf=0.01,
+            lambda_inter=0.1,
+            delta_inter=0.05,
+            beta_inter=10.0,
+            batch_size=8,
+        )
+
+        with mock.patch.object(registration_pipe, "load_mesh_from_file", side_effect=lambda _path: [_FakeMesh()]), \
+             mock.patch.object(registration_pipe, "extract_skeleton_from_tif", side_effect=fake_extract), \
+             mock.patch.object(registration_pipe, "assign_skeletons_to_mesh", return_value=_ToDevice()), \
+             mock.patch.object(registration_pipe, "optimize_all_registration", side_effect=fake_optimize):
+            registration_pipe.unified_pipeline(args)
+
+        self.assertEqual([call["fiber_type"] for call in captured["extract_calls"]], ["hz", "vt"])
+        self.assertEqual([call["axis_order"] for call in captured["extract_calls"]], ["xyz", "xyz"])
+        self.assertEqual(captured["curve_count"], 2)
+        np.testing.assert_allclose(captured["mesh_curves"][0][0], np.array([[21.0, 0.0, 0.0], [21.0, 1.0, 0.0]], dtype=np.float32))
+        np.testing.assert_allclose(captured["mesh_curves"][1][0], np.array([[12.0, 0.0, 0.0], [12.0, 1.0, 0.0]], dtype=np.float32))
+
+    def test_main_groups_meshes_by_cube_context(self):
+        registration_pipe = _load_registration_pipe()
+        captured = {}
+
+        def fake_process_group(mesh_files, tif_file, cube_label_file, output_root, _args):
+            captured["mesh_files"] = mesh_files
+            captured["tif_file"] = tif_file
+            captured["cube_label_file"] = cube_label_file
+            captured["output_root"] = output_root
+
+        argv = [
+            "registration_pipe.py",
+            "--mesh_root",
+            "meshes",
+            "--tif_root",
+            "tifs",
+            "--cube_label_root",
+            "labels",
+            "--output_root",
+            "registered",
+        ]
+        mesh_dir = "meshes/cube_a"
+
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(registration_pipe.os, "walk", return_value=[(mesh_dir, [], ["2_hz.obj", "1_hz.obj"])]), \
+             mock.patch.object(registration_pipe.os.path, "isfile", return_value=True), \
+             mock.patch.object(registration_pipe, "process_one_mesh") as process_one_mesh, \
+             mock.patch.object(registration_pipe, "process_mesh_group", side_effect=fake_process_group, create=True):
+            registration_pipe.main()
+
+        process_one_mesh.assert_not_called()
+        self.assertEqual(
+            captured["mesh_files"],
+            [
+                registration_pipe.os.path.join(mesh_dir, "1_hz.obj"),
+                registration_pipe.os.path.join(mesh_dir, "2_hz.obj"),
+            ],
+        )
+        self.assertEqual(captured["tif_file"], registration_pipe.os.path.join("tifs", "cube_a.tif"))
+        self.assertEqual(
+            captured["cube_label_file"],
+            registration_pipe.os.path.join("labels", "cube_a", "cube_a_mask.tif"),
+        )
+        self.assertEqual(captured["output_root"], "registered")
+
+    def test_process_mesh_group_saves_registered_mesh_to_its_source_path(self):
+        registration_pipe = _load_registration_pipe()
+
+        class _TensorLike:
+            def __init__(self, value):
+                self.value = np.asarray(value, dtype=np.float32)
+
+            def __add__(self, other):
+                if isinstance(other, _TensorLike):
+                    other = other.value
+                return _TensorLike(self.value + other)
+
+            def detach(self):
+                return self
+
+            def cpu(self):
+                return self
+
+            def numpy(self):
+                return self.value
+
+        class _FakeMeshSurface:
+            def __init__(self, source_file):
+                self._source_mesh_file = source_file
+                self.vertices = _TensorLike(np.array([[1.0, 2.0, 3.0]], dtype=np.float32))
+                self.displacement = _TensorLike(np.array([[0.5, 0.0, 0.0]], dtype=np.float32))
+
+        class _OriginalMesh:
+            def __init__(self):
+                self.vertices = None
+
+        global_args = types.SimpleNamespace(
+            mesh_root="meshes",
+            num_iters=1,
+            lr=1e-2,
+            lambda_data=1.0,
+            lambda_disp=1e-3,
+            lambda_elastic=1.0,
+            lambda_self=1e-1,
+            lambda_lap=5e-1,
+            lambda_arap=2.0,
+            lambda_sdf=1.0,
+            batch_size=8,
+            tau=0.01,
+            delta=0.05,
+            beta=10.0,
+            tau_sdf=0.01,
+            lambda_inter=0.1,
+            delta_inter=0.05,
+            beta_inter=10.0,
+            target_triangles=1000,
+            skel_origin="0,0,0",
+            skel_axis="xyz",
+            curve_type="horizontal",
+            target_skel_points=2,
+            visualize=False,
+        )
+        mesh_files = [
+            registration_pipe.os.path.join("meshes", "cube_a", "1_hz.obj"),
+            registration_pipe.os.path.join("meshes", "cube_a", "2_hz.obj"),
+        ]
+        registered_mesh = _FakeMeshSurface(mesh_files[1])
+        captured = {}
+
+        def fake_write_mesh(out_file, mesh):
+            captured["out_file"] = out_file
+            captured["vertices"] = mesh.vertices
+            return True
+
+        with mock.patch.object(registration_pipe, "unified_pipeline", return_value=[registered_mesh]), \
+             mock.patch.object(registration_pipe.o3d.io, "read_triangle_mesh", return_value=_OriginalMesh()) as read_mesh, \
+             mock.patch.object(registration_pipe.o3d.io, "write_triangle_mesh", side_effect=fake_write_mesh):
+            registration_pipe.process_mesh_group(mesh_files, "fiber.tif", "mask.tif", "registered", global_args)
+
+        read_mesh.assert_called_once_with(mesh_files[1])
+        self.assertEqual(
+            captured["out_file"],
+            registration_pipe.os.path.join("registered", "cube_a", "2_hz_registered.obj"),
+        )
+        np.testing.assert_allclose(captured["vertices"], np.array([[1.5, 2.0, 3.0]], dtype=np.float32))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/foundation/datasets/register-meshes-to-fibers/tests/test_warp_volume_with_field.py
+++ b/foundation/datasets/register-meshes-to-fibers/tests/test_warp_volume_with_field.py
@@ -1,0 +1,731 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = MODULE_DIR / "warp_volume_with_field.py"
+
+
+def _import_real_zarr():
+    try:
+        import zarr
+    except ImportError as exc:
+        raise unittest.SkipTest("zarr is not installed") from exc
+    return zarr
+
+
+class FakeZarrArray:
+    def __init__(self, array, fail_on_array=False):
+        self.array = array
+        self.shape = array.shape
+        self.dtype = array.dtype
+        self.ndim = array.ndim
+        self.fail_on_array = fail_on_array
+        self.materialize_count = 0
+
+    def __array__(self, dtype=None):
+        self.materialize_count += 1
+        if self.fail_on_array:
+            raise AssertionError("zarr input should not be materialized as a full numpy array")
+        return np.asarray(self.array, dtype=dtype)
+
+    def __getitem__(self, item):
+        return self.array[item]
+
+    def __setitem__(self, item, value):
+        self.array[item] = value
+
+
+class FakeZarrModule:
+    def __init__(self):
+        self.stores = {}
+        self.open_calls = []
+
+    def open(self, path, mode="r", shape=None, dtype=None, chunks=None):
+        self.open_calls.append((str(path), mode, shape, dtype, chunks))
+        if mode == "r":
+            return self.stores[str(path)]
+        if mode in {"w", "w+"}:
+            store = FakeZarrArray(np.zeros(shape, dtype=dtype))
+            self.stores[str(path)] = store
+            return store
+        raise AssertionError(f"unexpected zarr mode: {mode}")
+
+
+class FakeZarrGroup:
+    def __init__(self, arrays):
+        self.arrays = arrays
+
+    def keys(self):
+        return self.arrays.keys()
+
+    def __getitem__(self, key):
+        return self.arrays[str(key)]
+
+
+def _load_warper():
+    module_name = "_test_warp_volume_with_field"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class WarpVolumeWithFieldTest(unittest.TestCase):
+    def test_trilinear_sample_returns_exact_values_at_integer_points(self):
+        warper = _load_warper()
+
+        volume = np.arange(27, dtype=np.float32).reshape(3, 3, 3)
+        samples = warper.trilinear_sample_zyx(
+            volume,
+            np.array([[0.0, 0.0, 0.0], [2.0, 1.0, 1.0]], dtype=np.float64),
+            fill_value=-1.0,
+        )
+
+        np.testing.assert_allclose(samples, [0.0, volume[2, 1, 1]])
+
+    def test_trilinear_sample_interpolates_fractional_points(self):
+        warper = _load_warper()
+
+        volume = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+        samples = warper.trilinear_sample_zyx(
+            volume,
+            np.array([[0.5, 0.5, 0.5]], dtype=np.float64),
+            fill_value=-1.0,
+        )
+
+        self.assertAlmostEqual(float(samples[0]), float(volume.mean()))
+
+    def test_warp_volume_identity_field_returns_input(self):
+        warper = _load_warper()
+
+        volume = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+        field = np.zeros((2, 2, 2, 3), dtype=np.float32)
+
+        warped = warper.warp_volume_with_displacement_field(
+            volume,
+            field,
+            origin_xyz=(0.0, 0.0, 0.0),
+            spacing_xyz=(1.0, 1.0, 1.0),
+            fill_value=-1.0,
+        )
+
+        np.testing.assert_allclose(warped, volume)
+
+    def test_warp_volume_uses_backward_sampling_convention(self):
+        warper = _load_warper()
+
+        volume = np.arange(5, dtype=np.float32).reshape(1, 1, 5)
+        field = np.zeros((1, 1, 5, 3), dtype=np.float32)
+        field[..., 0] = 1.0
+
+        warped = warper.warp_volume_with_displacement_field(
+            volume,
+            field,
+            origin_xyz=(0.0, 0.0, 0.0),
+            spacing_xyz=(1.0, 1.0, 1.0),
+            fill_value=-1.0,
+        )
+
+        np.testing.assert_allclose(warped[0, 0], [-1.0, 0.0, 1.0, 2.0, 3.0])
+
+    def test_warp_sampling_diagnostics_reports_in_bounds_fraction(self):
+        warper = _load_warper()
+
+        volume = np.arange(5, dtype=np.float32).reshape(1, 1, 5)
+        field = np.zeros((1, 1, 5, 3), dtype=np.float32)
+        field[..., 0] = 1.0
+
+        diagnostics = warper.warp_sampling_diagnostics(
+            volume,
+            field,
+            origin_xyz=(0.0, 0.0, 0.0),
+            spacing_xyz=(1.0, 1.0, 1.0),
+            volume_origin_xyz=(0.0, 0.0, 0.0),
+            volume_spacing_xyz=(1.0, 1.0, 1.0),
+            chunk_depth=2,
+        )
+
+        self.assertEqual(diagnostics["sample_count"], 5)
+        self.assertEqual(diagnostics["in_bounds_sample_count"], 4)
+        self.assertAlmostEqual(diagnostics["in_bounds_fraction"], 0.8)
+        self.assertAlmostEqual(diagnostics["out_of_bounds_fraction"], 0.2)
+        self.assertAlmostEqual(diagnostics["displacement_magnitude"]["max"], 1.0)
+
+    def test_warp_sampling_diagnostics_can_subsample_large_volumes(self):
+        warper = _load_warper()
+
+        volume = np.arange(5, dtype=np.float32).reshape(1, 1, 5)
+        field = np.zeros((1, 1, 5, 3), dtype=np.float32)
+        field[..., 0] = 1.0
+
+        diagnostics = warper.warp_sampling_diagnostics(
+            volume,
+            field,
+            origin_xyz=(0.0, 0.0, 0.0),
+            spacing_xyz=(1.0, 1.0, 1.0),
+            volume_origin_xyz=(0.0, 0.0, 0.0),
+            volume_spacing_xyz=(1.0, 1.0, 1.0),
+            sample_step=2,
+        )
+
+        self.assertEqual(diagnostics["metrics_sample_step"], 2)
+        self.assertEqual(diagnostics["volume_voxel_count"], 5)
+        self.assertEqual(diagnostics["sample_count"], 3)
+        self.assertEqual(diagnostics["in_bounds_sample_count"], 2)
+        self.assertAlmostEqual(diagnostics["in_bounds_fraction"], 2.0 / 3.0)
+
+    def test_warp_volume_resamples_lower_resolution_field_to_volume_grid(self):
+        warper = _load_warper()
+
+        volume = np.arange(5, dtype=np.float32).reshape(1, 1, 5)
+        field = np.zeros((1, 1, 3, 3), dtype=np.float32)
+        field[..., 0] = 1.0
+
+        warped = warper.warp_volume_with_displacement_field(
+            volume,
+            field,
+            origin_xyz=(0.0, 0.0, 0.0),
+            spacing_xyz=(2.0, 1.0, 1.0),
+            volume_origin_xyz=(0.0, 0.0, 0.0),
+            volume_spacing_xyz=(1.0, 1.0, 1.0),
+            fill_value=-1.0,
+        )
+
+        np.testing.assert_allclose(warped[0, 0], [-1.0, 0.0, 1.0, 2.0, 3.0])
+
+    def test_warp_volume_rejects_non_positive_spacing(self):
+        warper = _load_warper()
+
+        volume = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+        field = np.zeros((2, 2, 2, 3), dtype=np.float32)
+
+        with self.assertRaisesRegex(ValueError, "field spacing values must be positive"):
+            warper.warp_volume_with_displacement_field(
+                volume,
+                field,
+                origin_xyz=(0.0, 0.0, 0.0),
+                spacing_xyz=(1.0, 0.0, 1.0),
+            )
+        with self.assertRaisesRegex(ValueError, "volume spacing values must be positive"):
+            warper.warp_volume_with_displacement_field(
+                volume,
+                field,
+                origin_xyz=(0.0, 0.0, 0.0),
+                spacing_xyz=(1.0, 1.0, 1.0),
+                volume_spacing_xyz=(1.0, -1.0, 1.0),
+            )
+
+    def test_chunked_warp_matches_full_volume_warp(self):
+        warper = _load_warper()
+
+        volume = np.arange(4 * 3 * 5, dtype=np.float32).reshape(4, 3, 5)
+        field = np.zeros((2, 2, 3, 3), dtype=np.float32)
+        field[..., 0] = 0.5
+        field[..., 2] = 0.25
+
+        full = warper.warp_volume_with_displacement_field(
+            volume,
+            field,
+            origin_xyz=(0.0, 0.0, 0.0),
+            spacing_xyz=(2.0, 2.0, 2.0),
+            volume_origin_xyz=(0.0, 0.0, 0.0),
+            volume_spacing_xyz=(1.0, 1.0, 1.0),
+            fill_value=-1.0,
+        )
+        chunked = warper.warp_volume_with_displacement_field_chunked(
+            volume,
+            field,
+            origin_xyz=(0.0, 0.0, 0.0),
+            spacing_xyz=(2.0, 2.0, 2.0),
+            volume_origin_xyz=(0.0, 0.0, 0.0),
+            volume_spacing_xyz=(1.0, 1.0, 1.0),
+            fill_value=-1.0,
+            chunk_depth=2,
+        )
+
+        np.testing.assert_allclose(chunked, full)
+
+    def test_cli_writes_warped_npy_volume(self):
+        warper = _load_warper()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            volume_path = temp / "volume.npy"
+            field_path = temp / "field.npz"
+            output_path = temp / "warped.npy"
+            np.save(volume_path, np.arange(5, dtype=np.float32).reshape(1, 1, 5))
+            field = np.zeros((1, 1, 5, 3), dtype=np.float32)
+            field[..., 0] = 1.0
+            np.savez_compressed(
+                field_path,
+                displacement_xyz=field,
+                origin_xyz=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+                spacing_xyz=np.array([1.0, 1.0, 1.0], dtype=np.float64),
+            )
+
+            warper.main(
+                [
+                    "--volume",
+                    str(volume_path),
+                    "--field",
+                    str(field_path),
+                    "--output",
+                    str(output_path),
+                    "--volume-spacing",
+                    "1,1,1",
+                    "--volume-origin",
+                    "0,0,0",
+                    "--fill-value",
+                    "-1",
+                ]
+            )
+
+            warped = np.load(output_path)
+
+        np.testing.assert_allclose(warped[0, 0], [-1.0, 0.0, 1.0, 2.0, 3.0])
+
+    def test_parser_rejects_non_positive_volume_spacing(self):
+        warper = _load_warper()
+        parser = warper.build_arg_parser()
+
+        with self.assertRaises(SystemExit):
+            parser.parse_args(
+                [
+                    "--volume",
+                    "volume.npy",
+                    "--field",
+                    "field.npz",
+                    "--output",
+                    "warped.npy",
+                    "--volume-spacing",
+                    "0,1,1",
+                ]
+            )
+
+        with self.assertRaises(SystemExit):
+            parser.parse_args(
+                [
+                    "--volume",
+                    "volume.npy",
+                    "--field",
+                    "field.npz",
+                    "--output",
+                    "warped.npy",
+                    "--chunk-depth",
+                    "-1",
+                ]
+            )
+
+    def test_cli_writes_chunked_warped_npy_volume(self):
+        warper = _load_warper()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            volume_path = temp / "volume.npy"
+            field_path = temp / "field.npz"
+            output_path = temp / "warped.npy"
+            np.save(volume_path, np.arange(10, dtype=np.float32).reshape(2, 1, 5))
+            field = np.zeros((2, 1, 5, 3), dtype=np.float32)
+            field[..., 0] = 1.0
+            np.savez_compressed(
+                field_path,
+                displacement_xyz=field,
+                origin_xyz=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+                spacing_xyz=np.array([1.0, 1.0, 1.0], dtype=np.float64),
+            )
+
+            warper.main(
+                [
+                    "--volume",
+                    str(volume_path),
+                    "--field",
+                    str(field_path),
+                    "--output",
+                    str(output_path),
+                    "--volume-spacing",
+                    "1,1,1",
+                    "--volume-origin",
+                    "0,0,0",
+                    "--fill-value",
+                    "-1",
+                    "--chunk-depth",
+                    "1",
+                ]
+            )
+
+            warped = np.load(output_path)
+
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+
+    def test_cli_chunked_npy_output_bypasses_full_array_save(self):
+        warper = _load_warper()
+
+        def fail_save_volume(path, volume):
+            raise AssertionError("chunked .npy output should write directly through a memmap")
+
+        warper.save_volume = fail_save_volume
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            volume_path = temp / "volume.npy"
+            field_path = temp / "field.npz"
+            output_path = temp / "warped.npy"
+            np.save(volume_path, np.arange(10, dtype=np.float32).reshape(2, 1, 5))
+            field = np.zeros((2, 1, 5, 3), dtype=np.float32)
+            field[..., 0] = 1.0
+            np.savez_compressed(
+                field_path,
+                displacement_xyz=field,
+                origin_xyz=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+                spacing_xyz=np.array([1.0, 1.0, 1.0], dtype=np.float64),
+            )
+
+            warper.main(
+                [
+                    "--volume",
+                    str(volume_path),
+                    "--field",
+                    str(field_path),
+                    "--output",
+                    str(output_path),
+                    "--fill-value",
+                    "-1",
+                    "--chunk-depth",
+                    "1",
+                ]
+            )
+
+            warped = np.load(output_path)
+
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+
+
+    def test_tiff_volume_io_uses_lazy_tifffile_dependency(self):
+        warper = _load_warper()
+
+        calls = []
+
+        def fake_imwrite(path, array):
+            calls.append(("imwrite", str(path), array.shape))
+            with Path(path).open("wb") as f:
+                np.save(f, array)
+
+        def fake_imread(path):
+            calls.append(("imread", str(path)))
+            with Path(path).open("rb") as f:
+                return np.load(f)
+
+        fake_tifffile = types.SimpleNamespace(imread=fake_imread, imwrite=fake_imwrite)
+        previous_tifffile = sys.modules.get("tifffile")
+        sys.modules["tifffile"] = fake_tifffile
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp = Path(temp_dir)
+                tiff_path = temp / "warped.tif"
+                expected = np.arange(6, dtype=np.uint16).reshape(1, 2, 3)
+
+                warper.save_volume(tiff_path, expected)
+                loaded = warper.load_volume(tiff_path)
+        finally:
+            if previous_tifffile is None:
+                sys.modules.pop("tifffile", None)
+            else:
+                sys.modules["tifffile"] = previous_tifffile
+
+        np.testing.assert_array_equal(loaded, expected)
+        self.assertEqual(calls[0][0], "imwrite")
+        self.assertEqual(calls[1][0], "imread")
+
+    def test_zarr_volume_io_uses_lazy_zarr_dependency(self):
+        warper = _load_warper()
+        fake_zarr = FakeZarrModule()
+        previous_zarr = sys.modules.get("zarr")
+        sys.modules["zarr"] = fake_zarr
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                zarr_path = Path(temp_dir) / "warped.zarr"
+                expected = np.arange(6, dtype=np.uint16).reshape(1, 2, 3)
+
+                warper.save_volume(zarr_path, expected)
+                loaded = warper.load_volume(zarr_path)
+        finally:
+            if previous_zarr is None:
+                sys.modules.pop("zarr", None)
+            else:
+                sys.modules["zarr"] = previous_zarr
+
+        np.testing.assert_array_equal(loaded, expected)
+        self.assertEqual(fake_zarr.open_calls[0][1], "w")
+        self.assertEqual(fake_zarr.open_calls[1][1], "r")
+
+    def test_chunked_zarr_input_is_not_materialized(self):
+        warper = _load_warper()
+        fake_zarr = FakeZarrModule()
+        previous_zarr = sys.modules.get("zarr")
+        sys.modules["zarr"] = fake_zarr
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp = Path(temp_dir)
+                volume_path = temp / "volume.zarr"
+                field_path = temp / "field.npz"
+                output_path = temp / "warped.zarr"
+                input_store = FakeZarrArray(
+                    np.arange(10, dtype=np.float32).reshape(2, 1, 5),
+                    fail_on_array=True,
+                )
+                fake_zarr.stores[str(volume_path)] = input_store
+                field = np.zeros((2, 1, 5, 3), dtype=np.float32)
+                field[..., 0] = 1.0
+                np.savez_compressed(
+                    field_path,
+                    displacement_xyz=field,
+                    origin_xyz=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+                    spacing_xyz=np.array([1.0, 1.0, 1.0], dtype=np.float64),
+                )
+
+                warper.main(
+                    [
+                        "--volume",
+                        str(volume_path),
+                        "--field",
+                        str(field_path),
+                        "--output",
+                        str(output_path),
+                        "--fill-value",
+                        "-1",
+                        "--chunk-depth",
+                        "1",
+                    ]
+                )
+
+                warped = np.asarray(fake_zarr.stores[str(output_path)])
+        finally:
+            if previous_zarr is None:
+                sys.modules.pop("zarr", None)
+            else:
+                sys.modules["zarr"] = previous_zarr
+
+        self.assertEqual(input_store.materialize_count, 0)
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+
+    def test_chunked_zarr_group_input_uses_requested_array_key(self):
+        warper = _load_warper()
+        fake_zarr = FakeZarrModule()
+        previous_zarr = sys.modules.get("zarr")
+        sys.modules["zarr"] = fake_zarr
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp = Path(temp_dir)
+                volume_path = temp / "volume.zarr"
+                field_path = temp / "field.npz"
+                output_path = temp / "warped.zarr"
+                level0 = FakeZarrArray(np.zeros((2, 1, 5), dtype=np.float32), fail_on_array=True)
+                level1 = FakeZarrArray(
+                    np.arange(10, dtype=np.float32).reshape(2, 1, 5),
+                    fail_on_array=True,
+                )
+                fake_zarr.stores[str(volume_path)] = FakeZarrGroup({"0": level0, "1": level1})
+                field = np.zeros((2, 1, 5, 3), dtype=np.float32)
+                field[..., 0] = 1.0
+                np.savez_compressed(
+                    field_path,
+                    displacement_xyz=field,
+                    origin_xyz=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+                    spacing_xyz=np.array([1.0, 1.0, 1.0], dtype=np.float64),
+                )
+
+                warper.main(
+                    [
+                        "--volume",
+                        str(volume_path),
+                        "--field",
+                        str(field_path),
+                        "--output",
+                        str(output_path),
+                        "--zarr-array-key",
+                        "1",
+                        "--fill-value",
+                        "-1",
+                        "--chunk-depth",
+                        "1",
+                    ]
+                )
+
+                warped = np.asarray(fake_zarr.stores[str(output_path)])
+        finally:
+            if previous_zarr is None:
+                sys.modules.pop("zarr", None)
+            else:
+                sys.modules["zarr"] = previous_zarr
+
+        self.assertEqual(level0.materialize_count, 0)
+        self.assertEqual(level1.materialize_count, 0)
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+
+    def test_chunked_zarr_group_input_accepts_array_key_in_path(self):
+        warper = _load_warper()
+        fake_zarr = FakeZarrModule()
+        previous_zarr = sys.modules.get("zarr")
+        sys.modules["zarr"] = fake_zarr
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp = Path(temp_dir)
+                volume_path = temp / "volume.zarr"
+                field_path = temp / "field.npz"
+                output_path = temp / "warped.zarr"
+                level0 = FakeZarrArray(np.zeros((2, 1, 5), dtype=np.float32), fail_on_array=True)
+                level1 = FakeZarrArray(
+                    np.arange(10, dtype=np.float32).reshape(2, 1, 5),
+                    fail_on_array=True,
+                )
+                fake_zarr.stores[str(volume_path)] = FakeZarrGroup({"0": level0, "1": level1})
+                field = np.zeros((2, 1, 5, 3), dtype=np.float32)
+                field[..., 0] = 1.0
+                np.savez_compressed(
+                    field_path,
+                    displacement_xyz=field,
+                    origin_xyz=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+                    spacing_xyz=np.array([1.0, 1.0, 1.0], dtype=np.float64),
+                )
+
+                warper.main(
+                    [
+                        "--volume",
+                        str(volume_path / "1"),
+                        "--field",
+                        str(field_path),
+                        "--output",
+                        str(output_path),
+                        "--fill-value",
+                        "-1",
+                        "--chunk-depth",
+                        "1",
+                    ]
+                )
+
+                warped = np.asarray(fake_zarr.stores[str(output_path)])
+        finally:
+            if previous_zarr is None:
+                sys.modules.pop("zarr", None)
+            else:
+                sys.modules["zarr"] = previous_zarr
+
+        self.assertEqual(level0.materialize_count, 0)
+        self.assertEqual(level1.materialize_count, 0)
+        self.assertEqual(fake_zarr.open_calls[0][0], str(volume_path))
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+
+    def test_real_zarr_group_input_uses_requested_array_key(self):
+        zarr = _import_real_zarr()
+        warper = _load_warper()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            volume_path = temp / "volume.zarr"
+            field_path = temp / "field.npz"
+            output_path = temp / "warped.zarr"
+            group = zarr.open_group(str(volume_path), mode="w")
+            group.create_dataset("0", shape=(1, 1, 5), chunks=(1, 1, 5), dtype="float32")[:] = 999
+            group.create_dataset("1", shape=(1, 1, 5), chunks=(1, 1, 5), dtype="float32")[:] = np.arange(
+                5, dtype=np.float32
+            ).reshape(1, 1, 5)
+            field = np.zeros((1, 1, 5, 3), dtype=np.float32)
+            field[..., 0] = 1.0
+            np.savez_compressed(
+                field_path,
+                displacement_xyz=field,
+                origin_xyz=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+                spacing_xyz=np.array([1.0, 1.0, 1.0], dtype=np.float64),
+            )
+
+            warper.main(
+                [
+                    "--volume",
+                    str(volume_path),
+                    "--field",
+                    str(field_path),
+                    "--output",
+                    str(output_path),
+                    "--zarr-array-key",
+                    "1",
+                    "--fill-value",
+                    "-1",
+                    "--chunk-depth",
+                    "1",
+                ]
+            )
+
+            warped = np.asarray(zarr.open(str(output_path), mode="r"))
+
+        np.testing.assert_allclose(warped[0, 0], [-1.0, 0.0, 1.0, 2.0, 3.0])
+
+    def test_cli_writes_chunked_zarr_output_without_full_array_save(self):
+        warper = _load_warper()
+        fake_zarr = FakeZarrModule()
+        previous_zarr = sys.modules.get("zarr")
+        sys.modules["zarr"] = fake_zarr
+
+        def fail_save_volume(path, volume):
+            raise AssertionError("chunked .zarr output should write directly to the zarr store")
+
+        warper.save_volume = fail_save_volume
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp = Path(temp_dir)
+                volume_path = temp / "volume.npy"
+                field_path = temp / "field.npz"
+                output_path = temp / "warped.zarr"
+                np.save(volume_path, np.arange(10, dtype=np.float32).reshape(2, 1, 5))
+                field = np.zeros((2, 1, 5, 3), dtype=np.float32)
+                field[..., 0] = 1.0
+                np.savez_compressed(
+                    field_path,
+                    displacement_xyz=field,
+                    origin_xyz=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+                    spacing_xyz=np.array([1.0, 1.0, 1.0], dtype=np.float64),
+                )
+
+                warper.main(
+                    [
+                        "--volume",
+                        str(volume_path),
+                        "--field",
+                        str(field_path),
+                        "--output",
+                        str(output_path),
+                        "--fill-value",
+                        "-1",
+                        "--chunk-depth",
+                        "1",
+                    ]
+                )
+
+                warped = np.asarray(fake_zarr.stores[str(output_path)])
+        finally:
+            if previous_zarr is None:
+                sys.modules.pop("zarr", None)
+            else:
+                sys.modules["zarr"] = previous_zarr
+
+        np.testing.assert_allclose(warped[:, 0], [[-1.0, 0.0, 1.0, 2.0, 3.0], [-1.0, 5.0, 6.0, 7.0, 8.0]])
+
+    def test_help_mentions_tiff_and_zarr_volume_support(self):
+        warper = _load_warper()
+
+        help_text = warper.build_arg_parser().format_help()
+
+        self.assertIn(".tif", help_text)
+        self.assertIn(".zarr", help_text)
+        self.assertIn("--zarr-array-key", help_text)
+        self.assertIn("--chunk-depth", help_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/foundation/datasets/register-meshes-to-fibers/warp_volume_with_field.py
+++ b/foundation/datasets/register-meshes-to-fibers/warp_volume_with_field.py
@@ -1,0 +1,564 @@
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+TIFF_SUFFIXES = {".tif", ".tiff"}
+ZARR_SUFFIX = ".zarr"
+
+
+def _parse_xyz(value: str) -> tuple[float, float, float]:
+    parts = value.split(",")
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("expected three comma-separated XYZ values")
+    return tuple(float(part) for part in parts)
+
+
+def _require_positive_xyz(values, name: str) -> None:
+    if any(float(value) <= 0.0 for value in values):
+        raise ValueError(f"{name} values must be positive")
+
+
+def _parse_positive_xyz(value: str, name: str) -> tuple[float, float, float]:
+    parsed = _parse_xyz(value)
+    try:
+        _require_positive_xyz(parsed, name)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    return parsed
+
+
+def _parse_non_negative_int(value: str, name: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(f"{name} must be non-negative")
+    return parsed
+
+
+def _is_tiff_path(path: str | Path) -> bool:
+    return Path(path).suffix.lower() in TIFF_SUFFIXES
+
+
+def _is_npy_path(path: str | Path) -> bool:
+    return Path(path).suffix.lower() == ".npy"
+
+
+def _is_zarr_path(path: str | Path) -> bool:
+    return _split_zarr_path(path)[0] is not None
+
+
+def _split_zarr_path(path: str | Path) -> tuple[Path | None, str | None]:
+    path = Path(path)
+    parts = path.parts
+    zarr_index = next((index for index, part in enumerate(parts) if Path(part).suffix.lower() == ZARR_SUFFIX), None)
+    if zarr_index is None:
+        return None, None
+    store_path = Path(*parts[: zarr_index + 1])
+    array_parts = parts[zarr_index + 1 :]
+    array_key = "/".join(array_parts) if array_parts else None
+    return store_path, array_key
+
+
+def _import_tifffile():
+    try:
+        import tifffile
+    except ImportError as exc:
+        raise ImportError("tifffile is required for .tif/.tiff volume I/O") from exc
+    return tifffile
+
+
+def _import_zarr():
+    try:
+        import zarr
+    except ImportError as exc:
+        raise ImportError("zarr is required for .zarr volume I/O") from exc
+    return zarr
+
+
+def _resolve_zarr_array(opened, array_key: str | None = None):
+    if hasattr(opened, "shape") and hasattr(opened, "ndim"):
+        return opened
+    key = "0" if array_key is None else str(array_key)
+    try:
+        return opened[key]
+    except (KeyError, TypeError) as exc:
+        available = ", ".join(str(item) for item in opened.keys()) if hasattr(opened, "keys") else "unknown"
+        raise ValueError(f"zarr group does not contain array key {key!r}; available keys: {available}") from exc
+
+
+def load_volume(path: str | Path, zarr_array_key: str | None = None) -> np.ndarray:
+    path = Path(path)
+    if _is_tiff_path(path):
+        return np.asarray(_import_tifffile().imread(str(path)))
+    zarr_store_path, path_array_key = _split_zarr_path(path)
+    if zarr_store_path is not None:
+        array_key = zarr_array_key if zarr_array_key is not None else path_array_key
+        return _resolve_zarr_array(_import_zarr().open(str(zarr_store_path), mode="r"), array_key)
+    return np.load(path)
+
+
+def save_volume(path: str | Path, volume: np.ndarray) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if _is_tiff_path(path):
+        _import_tifffile().imwrite(str(path), volume)
+        return
+    if _is_zarr_path(path):
+        output = _import_zarr().open(
+            str(path),
+            mode="w",
+            shape=volume.shape,
+            dtype=volume.dtype,
+            chunks=True,
+        )
+        output[:] = volume
+        return
+    np.save(path, volume)
+
+
+def _read_values_zyx(volume, z_index: np.ndarray, y_index: np.ndarray, x_index: np.ndarray) -> np.ndarray:
+    if hasattr(volume, "vindex"):
+        return volume.vindex[z_index, y_index, x_index]
+    try:
+        return volume[z_index, y_index, x_index]
+    except (IndexError, TypeError, ValueError):
+        return np.asarray(
+            [volume[int(z), int(y), int(x)] for z, y, x in zip(z_index, y_index, x_index)],
+            dtype=volume.dtype,
+        )
+
+
+def _volume_size(volume) -> int:
+    size = getattr(volume, "size", None)
+    if size is not None:
+        return int(size)
+    return int(np.prod(volume.shape))
+
+
+def trilinear_sample_zyx(
+    volume: np.ndarray,
+    points_zyx: np.ndarray,
+    fill_value: float = 0.0,
+) -> np.ndarray:
+    if volume.ndim != 3:
+        raise ValueError(f"expected a 3D volume, got shape {volume.shape}")
+    if points_zyx.ndim != 2 or points_zyx.shape[1] != 3:
+        raise ValueError(f"expected sample points with shape (N, 3), got {points_zyx.shape}")
+
+    z_size, y_size, x_size = volume.shape
+    z = points_zyx[:, 0]
+    y = points_zyx[:, 1]
+    x = points_zyx[:, 2]
+    inside = (
+        (z >= 0.0)
+        & (z <= z_size - 1)
+        & (y >= 0.0)
+        & (y <= y_size - 1)
+        & (x >= 0.0)
+        & (x <= x_size - 1)
+    )
+
+    samples = np.full(points_zyx.shape[0], fill_value, dtype=np.float64)
+    if not inside.any():
+        return samples.astype(volume.dtype, copy=False)
+
+    z_inside = z[inside]
+    y_inside = y[inside]
+    x_inside = x[inside]
+    z0 = np.floor(z_inside).astype(np.int64)
+    y0 = np.floor(y_inside).astype(np.int64)
+    x0 = np.floor(x_inside).astype(np.int64)
+    z1 = np.minimum(z0 + 1, z_size - 1)
+    y1 = np.minimum(y0 + 1, y_size - 1)
+    x1 = np.minimum(x0 + 1, x_size - 1)
+    dz = z_inside - z0
+    dy = y_inside - y0
+    dx = x_inside - x0
+
+    c000 = _read_values_zyx(volume, z0, y0, x0)
+    c001 = _read_values_zyx(volume, z0, y0, x1)
+    c010 = _read_values_zyx(volume, z0, y1, x0)
+    c011 = _read_values_zyx(volume, z0, y1, x1)
+    c100 = _read_values_zyx(volume, z1, y0, x0)
+    c101 = _read_values_zyx(volume, z1, y0, x1)
+    c110 = _read_values_zyx(volume, z1, y1, x0)
+    c111 = _read_values_zyx(volume, z1, y1, x1)
+
+    c00 = c000 * (1.0 - dx) + c001 * dx
+    c01 = c010 * (1.0 - dx) + c011 * dx
+    c10 = c100 * (1.0 - dx) + c101 * dx
+    c11 = c110 * (1.0 - dx) + c111 * dx
+    c0 = c00 * (1.0 - dy) + c01 * dy
+    c1 = c10 * (1.0 - dy) + c11 * dy
+    samples[inside] = c0 * (1.0 - dz) + c1 * dz
+    return samples.astype(volume.dtype, copy=False)
+
+
+def _warp_volume_z_range(
+    volume: np.ndarray,
+    displacement_xyz: np.ndarray,
+    origin_xyz: tuple[float, float, float] | np.ndarray,
+    spacing_xyz: tuple[float, float, float] | np.ndarray,
+    volume_origin_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    volume_spacing_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    fill_value: float = 0.0,
+    z_start: int = 0,
+    z_stop: int | None = None,
+) -> np.ndarray:
+    if displacement_xyz.ndim != 4 or displacement_xyz.shape[3] != 3:
+        raise ValueError(f"expected displacement field shape (Z, Y, X, 3), got {displacement_xyz.shape}")
+    if volume.ndim != 3:
+        raise ValueError(f"expected a 3D volume, got shape {volume.shape}")
+
+    field_origin = np.asarray(origin_xyz, dtype=np.float64)
+    field_spacing = np.asarray(spacing_xyz, dtype=np.float64)
+    volume_origin = field_origin if volume_origin_xyz is None else np.asarray(volume_origin_xyz, dtype=np.float64)
+    volume_spacing = field_spacing if volume_spacing_xyz is None else np.asarray(volume_spacing_xyz, dtype=np.float64)
+    _require_positive_xyz(field_spacing, "field spacing")
+    _require_positive_xyz(volume_spacing, "volume spacing")
+    z_size, y_size, x_size = volume.shape
+    z_stop = z_size if z_stop is None else z_stop
+    if z_start < 0 or z_stop < z_start or z_stop > z_size:
+        raise ValueError(f"invalid z range [{z_start}, {z_stop}) for volume depth {z_size}")
+    zz, yy, xx = np.meshgrid(
+        np.arange(z_start, z_stop, dtype=np.float64),
+        np.arange(y_size, dtype=np.float64),
+        np.arange(x_size, dtype=np.float64),
+        indexing="ij",
+    )
+    grid_xyz = np.stack(
+        [
+            volume_origin[0] + xx * volume_spacing[0],
+            volume_origin[1] + yy * volume_spacing[1],
+            volume_origin[2] + zz * volume_spacing[2],
+        ],
+        axis=-1,
+    )
+    field_x = (grid_xyz[..., 0] - field_origin[0]) / field_spacing[0]
+    field_y = (grid_xyz[..., 1] - field_origin[1]) / field_spacing[1]
+    field_z = (grid_xyz[..., 2] - field_origin[2]) / field_spacing[2]
+    field_points_zyx = np.stack([field_z.ravel(), field_y.ravel(), field_x.ravel()], axis=1)
+    sampled_components = [
+        trilinear_sample_zyx(displacement_xyz[..., channel], field_points_zyx, fill_value=0.0)
+        for channel in range(3)
+    ]
+    chunk_shape = (z_stop - z_start, y_size, x_size)
+    sampled_displacement_xyz = np.stack(sampled_components, axis=1).reshape(chunk_shape + (3,))
+    source_xyz = grid_xyz - sampled_displacement_xyz.astype(np.float64)
+    source_x = (source_xyz[..., 0] - volume_origin[0]) / volume_spacing[0]
+    source_y = (source_xyz[..., 1] - volume_origin[1]) / volume_spacing[1]
+    source_z = (source_xyz[..., 2] - volume_origin[2]) / volume_spacing[2]
+    points_zyx = np.stack([source_z.ravel(), source_y.ravel(), source_x.ravel()], axis=1)
+    warped = trilinear_sample_zyx(volume, points_zyx, fill_value=fill_value)
+    return warped.reshape(chunk_shape)
+
+
+def warp_sampling_diagnostics(
+    volume: np.ndarray,
+    displacement_xyz: np.ndarray,
+    origin_xyz: tuple[float, float, float] | np.ndarray,
+    spacing_xyz: tuple[float, float, float] | np.ndarray,
+    volume_origin_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    volume_spacing_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    chunk_depth: int = 0,
+    sample_step: int = 1,
+) -> dict:
+    if displacement_xyz.ndim != 4 or displacement_xyz.shape[3] != 3:
+        raise ValueError(f"expected displacement field shape (Z, Y, X, 3), got {displacement_xyz.shape}")
+    if volume.ndim != 3:
+        raise ValueError(f"expected a 3D volume, got shape {volume.shape}")
+
+    field_origin = np.asarray(origin_xyz, dtype=np.float64)
+    field_spacing = np.asarray(spacing_xyz, dtype=np.float64)
+    volume_origin = field_origin if volume_origin_xyz is None else np.asarray(volume_origin_xyz, dtype=np.float64)
+    volume_spacing = field_spacing if volume_spacing_xyz is None else np.asarray(volume_spacing_xyz, dtype=np.float64)
+    _require_positive_xyz(field_spacing, "field spacing")
+    _require_positive_xyz(volume_spacing, "volume spacing")
+    z_size, y_size, x_size = volume.shape
+    chunk_depth = z_size if int(chunk_depth) <= 0 else int(chunk_depth)
+    sample_step = int(sample_step)
+    if sample_step <= 0:
+        raise ValueError("sample_step must be positive")
+    y_indices = np.arange(0, y_size, sample_step, dtype=np.float64)
+    x_indices = np.arange(0, x_size, sample_step, dtype=np.float64)
+    z_indices = np.arange(0, z_size, sample_step, dtype=np.float64)
+    sample_count = int(len(z_indices) * len(y_indices) * len(x_indices))
+    in_bounds_count = 0
+
+    for z_start in range(0, z_size, chunk_depth):
+        z_stop = min(z_start + chunk_depth, z_size)
+        z_chunk_indices = z_indices[(z_indices >= z_start) & (z_indices < z_stop)]
+        if len(z_chunk_indices) == 0:
+            continue
+        zz, yy, xx = np.meshgrid(
+            z_chunk_indices,
+            y_indices,
+            x_indices,
+            indexing="ij",
+        )
+        grid_xyz = np.stack(
+            [
+                volume_origin[0] + xx * volume_spacing[0],
+                volume_origin[1] + yy * volume_spacing[1],
+                volume_origin[2] + zz * volume_spacing[2],
+            ],
+            axis=-1,
+        )
+        field_x = (grid_xyz[..., 0] - field_origin[0]) / field_spacing[0]
+        field_y = (grid_xyz[..., 1] - field_origin[1]) / field_spacing[1]
+        field_z = (grid_xyz[..., 2] - field_origin[2]) / field_spacing[2]
+        field_points_zyx = np.stack([field_z.ravel(), field_y.ravel(), field_x.ravel()], axis=1)
+        sampled_components = [
+            trilinear_sample_zyx(displacement_xyz[..., channel], field_points_zyx, fill_value=0.0)
+            for channel in range(3)
+        ]
+        chunk_shape = (len(z_chunk_indices), len(y_indices), len(x_indices))
+        sampled_displacement_xyz = np.stack(sampled_components, axis=1).reshape(chunk_shape + (3,))
+        source_xyz = grid_xyz - sampled_displacement_xyz.astype(np.float64)
+        source_x = (source_xyz[..., 0] - volume_origin[0]) / volume_spacing[0]
+        source_y = (source_xyz[..., 1] - volume_origin[1]) / volume_spacing[1]
+        source_z = (source_xyz[..., 2] - volume_origin[2]) / volume_spacing[2]
+        inside = (
+            (source_z >= 0.0)
+            & (source_z <= z_size - 1)
+            & (source_y >= 0.0)
+            & (source_y <= y_size - 1)
+            & (source_x >= 0.0)
+            & (source_x <= x_size - 1)
+        )
+        in_bounds_count += int(inside.sum())
+
+    magnitude = np.linalg.norm(displacement_xyz.astype(np.float64), axis=-1)
+    in_bounds_fraction = 1.0 if sample_count == 0 else in_bounds_count / sample_count
+    return {
+        "schema_version": "1.0.0",
+        "volume_shape_zyx": [int(value) for value in volume.shape],
+        "displacement_field_shape_zyx": [int(value) for value in displacement_xyz.shape[:3]],
+        "metrics_sample_step": int(sample_step),
+        "volume_voxel_count": _volume_size(volume),
+        "sample_count": sample_count,
+        "in_bounds_sample_count": int(in_bounds_count),
+        "in_bounds_fraction": float(in_bounds_fraction),
+        "out_of_bounds_fraction": float(1.0 - in_bounds_fraction),
+        "displacement_magnitude": {
+            "min": float(magnitude.min()),
+            "max": float(magnitude.max()),
+            "mean": float(magnitude.mean()),
+        },
+    }
+
+
+def warp_volume_with_displacement_field(
+    volume: np.ndarray,
+    displacement_xyz: np.ndarray,
+    origin_xyz: tuple[float, float, float] | np.ndarray,
+    spacing_xyz: tuple[float, float, float] | np.ndarray,
+    volume_origin_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    volume_spacing_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    fill_value: float = 0.0,
+) -> np.ndarray:
+    return _warp_volume_z_range(
+        volume,
+        displacement_xyz,
+        origin_xyz=origin_xyz,
+        spacing_xyz=spacing_xyz,
+        volume_origin_xyz=volume_origin_xyz,
+        volume_spacing_xyz=volume_spacing_xyz,
+        fill_value=fill_value,
+    )
+
+
+def warp_volume_with_displacement_field_chunked(
+    volume: np.ndarray,
+    displacement_xyz: np.ndarray,
+    origin_xyz: tuple[float, float, float] | np.ndarray,
+    spacing_xyz: tuple[float, float, float] | np.ndarray,
+    volume_origin_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    volume_spacing_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    fill_value: float = 0.0,
+    chunk_depth: int = 16,
+) -> np.ndarray:
+    chunk_depth = int(chunk_depth)
+    if chunk_depth <= 0:
+        raise ValueError("chunk_depth must be positive")
+
+    warped = np.empty_like(volume)
+    for z_start in range(0, volume.shape[0], chunk_depth):
+        z_stop = min(z_start + chunk_depth, volume.shape[0])
+        warped[z_start:z_stop] = _warp_volume_z_range(
+            volume,
+            displacement_xyz,
+            origin_xyz=origin_xyz,
+            spacing_xyz=spacing_xyz,
+            volume_origin_xyz=volume_origin_xyz,
+            volume_spacing_xyz=volume_spacing_xyz,
+            fill_value=fill_value,
+            z_start=z_start,
+            z_stop=z_stop,
+        )
+    return warped
+
+
+def warp_volume_to_npy_memmap(
+    output_path: str | Path,
+    volume: np.ndarray,
+    displacement_xyz: np.ndarray,
+    origin_xyz: tuple[float, float, float] | np.ndarray,
+    spacing_xyz: tuple[float, float, float] | np.ndarray,
+    volume_origin_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    volume_spacing_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    fill_value: float = 0.0,
+    chunk_depth: int = 16,
+) -> Path:
+    chunk_depth = int(chunk_depth)
+    if chunk_depth <= 0:
+        raise ValueError("chunk_depth must be positive")
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output = np.lib.format.open_memmap(
+        output_path,
+        mode="w+",
+        dtype=volume.dtype,
+        shape=volume.shape,
+    )
+    for z_start in range(0, volume.shape[0], chunk_depth):
+        z_stop = min(z_start + chunk_depth, volume.shape[0])
+        output[z_start:z_stop] = _warp_volume_z_range(
+            volume,
+            displacement_xyz,
+            origin_xyz=origin_xyz,
+            spacing_xyz=spacing_xyz,
+            volume_origin_xyz=volume_origin_xyz,
+            volume_spacing_xyz=volume_spacing_xyz,
+            fill_value=fill_value,
+            z_start=z_start,
+            z_stop=z_stop,
+        )
+    output.flush()
+    del output
+    return output_path
+
+
+def warp_volume_to_zarr(
+    output_path: str | Path,
+    volume: np.ndarray,
+    displacement_xyz: np.ndarray,
+    origin_xyz: tuple[float, float, float] | np.ndarray,
+    spacing_xyz: tuple[float, float, float] | np.ndarray,
+    volume_origin_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    volume_spacing_xyz: tuple[float, float, float] | np.ndarray | None = None,
+    fill_value: float = 0.0,
+    chunk_depth: int = 16,
+) -> Path:
+    chunk_depth = int(chunk_depth)
+    if chunk_depth <= 0:
+        raise ValueError("chunk_depth must be positive")
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    chunks = (min(chunk_depth, volume.shape[0]), volume.shape[1], volume.shape[2])
+    output = _import_zarr().open(
+        str(output_path),
+        mode="w",
+        shape=volume.shape,
+        dtype=volume.dtype,
+        chunks=chunks,
+    )
+    for z_start in range(0, volume.shape[0], chunk_depth):
+        z_stop = min(z_start + chunk_depth, volume.shape[0])
+        output[z_start:z_stop] = _warp_volume_z_range(
+            volume,
+            displacement_xyz,
+            origin_xyz=origin_xyz,
+            spacing_xyz=spacing_xyz,
+            volume_origin_xyz=volume_origin_xyz,
+            volume_spacing_xyz=volume_spacing_xyz,
+            fill_value=fill_value,
+            z_start=z_start,
+            z_stop=z_stop,
+        )
+    return output_path
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Apply a coarse displacement field to a .npy, .tif, .tiff, or .zarr volume."
+    )
+    parser.add_argument("--volume", required=True, help="Input 3D .npy/.tif/.tiff/.zarr volume in z,y,x order.")
+    parser.add_argument("--field", required=True, help=".npz displacement field from build_deformation_field.py.")
+    parser.add_argument("--output", required=True, help="Output warped .npy/.tif/.tiff/.zarr volume.")
+    parser.add_argument(
+        "--zarr-array-key",
+        default=None,
+        help="Array key to read when --volume points at a Zarr group. Defaults to '0'.",
+    )
+    parser.add_argument("--volume-origin", type=_parse_xyz, default=None, help="Input volume origin as x,y,z. Defaults to field origin.")
+    parser.add_argument(
+        "--volume-spacing",
+        type=lambda value: _parse_positive_xyz(value, "volume spacing"),
+        default=None,
+        help="Input volume spacing as x,y,z. Defaults to field spacing.",
+    )
+    parser.add_argument("--fill-value", type=float, default=0.0, help="Value used outside the input volume.")
+    parser.add_argument(
+        "--chunk-depth",
+        type=lambda value: _parse_non_negative_int(value, "chunk-depth"),
+        default=0,
+        help="Warp this many z-slices at a time; 0 warps the whole volume at once.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_arg_parser().parse_args(argv)
+    volume = load_volume(args.volume, zarr_array_key=args.zarr_array_key)
+    with np.load(args.field) as field_data:
+        displacement_xyz = field_data["displacement_xyz"]
+        origin_xyz = field_data["origin_xyz"]
+        spacing_xyz = field_data["spacing_xyz"]
+    if args.chunk_depth > 0 and _is_npy_path(args.output):
+        warp_volume_to_npy_memmap(
+            args.output,
+            volume,
+            displacement_xyz,
+            origin_xyz=origin_xyz,
+            spacing_xyz=spacing_xyz,
+            volume_origin_xyz=args.volume_origin,
+            volume_spacing_xyz=args.volume_spacing,
+            fill_value=args.fill_value,
+            chunk_depth=args.chunk_depth,
+        )
+        return
+    if args.chunk_depth > 0 and _is_zarr_path(args.output):
+        warp_volume_to_zarr(
+            args.output,
+            volume,
+            displacement_xyz,
+            origin_xyz=origin_xyz,
+            spacing_xyz=spacing_xyz,
+            volume_origin_xyz=args.volume_origin,
+            volume_spacing_xyz=args.volume_spacing,
+            fill_value=args.fill_value,
+            chunk_depth=args.chunk_depth,
+        )
+        return
+
+    warp_fn = warp_volume_with_displacement_field_chunked if args.chunk_depth > 0 else warp_volume_with_displacement_field
+    warp_kwargs = {"chunk_depth": args.chunk_depth} if args.chunk_depth > 0 else {}
+    warped = warp_fn(
+        volume,
+        displacement_xyz,
+        origin_xyz=origin_xyz,
+        spacing_xyz=spacing_xyz,
+        volume_origin_xyz=args.volume_origin,
+        volume_spacing_xyz=args.volume_spacing,
+        fill_value=args.fill_value,
+        **warp_kwargs,
+    )
+    save_volume(args.output, warped)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a reference whole-volume deformation workflow for `foundation/datasets/register-meshes-to-fibers`, connecting registered meshes to sparse displacement controls, a coarse displacement field, and warped `.npy`/TIFF/Zarr volumes.

This is meant as an executable baseline for the #203 idea: use newly available fibers and large meshes to start evaluating whole-volume deformation paths.

## What changed

- Adds `export_deformation_control_points.py` to export sparse displacement controls from original/registered OBJ vertex pairs.
- Adds `build_deformation_field.py` to interpolate controls onto a coarse displacement grid with chunked IDW query and control batches.
- Uses a deterministic `(distance, control index)` tie-break in IDW nearest-neighbor selection so control chunking preserves full-batch behavior even when controls are equidistant.
- Adds `warp_volume_with_field.py` for backward trilinear warping of `.npy`, `.tif/.tiff`, and `.zarr` volumes.
- Adds `reference_volume_warp_pipeline.py` to run controls -> field -> warped volume in one command, including manifest and metrics outputs.
- Extends registration pipeline usability for grouped mesh/fiber runs:
  - grouped multi-mesh registration by cube context
  - `--curve_type auto` mapping `*_hz.obj` to horizontal curves and `*_vt.obj` to vertical curves
  - strict mesh filename validation for `<label>_<hz|vt>.obj`
  - consistent default skeleton coordinate handling: classify extracted skeletons as `zyx` and convert them to mesh-style `xyz` before optimization
  - `--skeleton_axis_order` forwarding
  - skip meshes without matching skeleton curves instead of registering them against unrelated curves
- Updates README usage and environment dependencies for TIFF/Zarr workflows.
- Supports both `--zarr-array-key 1` and embedded Zarr array paths such as `volume.zarr/1`.

## Tests

- `python -m unittest discover foundation/datasets/register-meshes-to-fibers/tests` -> 84 OK, 2 skipped
- `python -m py_compile ...` over changed scripts -> OK
- `git diff --check` -> OK
- Deterministic randomized IDW equivalence audit -> 3500 chunked/full-batch comparisons OK
- Clean apply-smoke from `d940876bd184ea7661e82f460370ac246ac3d119`:
  - `git apply --check --whitespace=error-all` -> OK
  - `git apply --whitespace=error-all` -> OK
  - full discovery -> 84 OK, 2 skipped
  - py_compile -> OK
  - `git diff --check` -> OK

Refs #203
