### PR TITLE
Add tifxyz sample exporter

### DIFF
--- a/ink-detection/tests/test_tifxyz_sample_exporter.py
+++ b/ink-detection/tests/test_tifxyz_sample_exporter.py
@@ -1,0 +1,257 @@
+import json
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PROJECT_ROOT.parent
+VESUVIUS_SRC = REPO_ROOT / "vesuvius" / "src"
+for path in (PROJECT_ROOT, VESUVIUS_SRC):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+
+def _lightweight_dependency_modules():
+    torch = types.ModuleType("torch")
+    torch_utils = types.ModuleType("torch.utils")
+    torch_utils_data = types.ModuleType("torch.utils.data")
+
+    class Dataset:
+        pass
+
+    torch_utils_data.Dataset = Dataset
+    torch_utils.data = torch_utils_data
+    torch.utils = torch_utils
+
+    vesuvius = types.ModuleType("vesuvius")
+    tifxyz = types.ModuleType("vesuvius.tifxyz")
+    tifxyz.load_folder = lambda *args, **kwargs: []
+    tifxyz.interpolate_at_points = None
+
+    datasets_common = types.ModuleType("vesuvius.neural_tracing.datasets.common")
+    datasets_common.normalize_zscore = lambda arr: arr
+    datasets_common._parse_z_range = lambda value: value
+    datasets_common._segment_overlaps_z_range = lambda *args, **kwargs: True
+    datasets_common.open_zarr = lambda *args, **kwargs: None
+
+    cover_bboxes = types.ModuleType(
+        "vesuvius.neural_tracing.inference.generate_segment_cover_bboxes"
+    )
+    cover_bboxes._generate_segment_cover_records = lambda *args, **kwargs: []
+
+    training_transforms = types.ModuleType(
+        "vesuvius.models.augmentation.pipelines.training_transforms"
+    )
+    training_transforms.create_training_transforms = lambda *args, **kwargs: None
+
+    return {
+        "torch": torch,
+        "torch.utils": torch_utils,
+        "torch.utils.data": torch_utils_data,
+        "vesuvius": vesuvius,
+        "vesuvius.tifxyz": tifxyz,
+        "vesuvius.neural_tracing": types.ModuleType("vesuvius.neural_tracing"),
+        "vesuvius.neural_tracing.datasets": types.ModuleType("vesuvius.neural_tracing.datasets"),
+        "vesuvius.neural_tracing.datasets.common": datasets_common,
+        "vesuvius.neural_tracing.inference": types.ModuleType("vesuvius.neural_tracing.inference"),
+        "vesuvius.neural_tracing.inference.generate_segment_cover_bboxes": cover_bboxes,
+        "vesuvius.models": types.ModuleType("vesuvius.models"),
+        "vesuvius.models.augmentation": types.ModuleType("vesuvius.models.augmentation"),
+        "vesuvius.models.augmentation.pipelines": types.ModuleType("vesuvius.models.augmentation.pipelines"),
+        "vesuvius.models.augmentation.pipelines.training_transforms": training_transforms,
+    }
+
+
+_DEPENDENCY_PATCHER = patch.dict(sys.modules, _lightweight_dependency_modules())
+_DEPENDENCY_PATCHER.start()
+
+
+def tearDownModule():
+    for name in list(sys.modules):
+        if name == "tifxyz_dataset" or name.startswith("tifxyz_dataset."):
+            sys.modules.pop(name, None)
+    _DEPENDENCY_PATCHER.stop()
+
+
+import tifxyz_dataset.export_samples as export_samples_module  # noqa: E402
+from tifxyz_dataset.export_samples import (  # noqa: E402
+    export_sample,
+    export_samples,
+    main,
+    parse_indices,
+    sample_to_numpy,
+)
+
+
+class FakeTensor:
+    def __init__(self, array):
+        self._array = np.asarray(array)
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._array
+
+
+class FakeDataset:
+    def __init__(self):
+        self.samples = [
+            self._sample(0, 11.0),
+            self._sample(1, 22.0),
+            self._sample(2, 33.0),
+        ]
+
+    def _sample(self, idx, fill_value):
+        return {
+            "vol": FakeTensor(np.full((2, 3, 4), fill_value, dtype=np.float32)),
+            "labeled_vox_at_surface": np.full((2, 3, 4), idx, dtype=np.float32),
+            "surface_vox": np.ones((2, 3, 4), dtype=np.float32),
+            "projected_loss_mask": np.zeros((2, 3, 4), dtype=np.float32),
+            "patch": {
+                "world_bbox": [0, 1, 2, 4, 5, 8],
+                "dataset_idx": np.int64(idx),
+                "segment_uuid": f"segment-{idx}",
+                "segment": object(),
+            },
+            "idx": idx,
+        }
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        return self.samples[idx]
+
+
+class TifxyzSampleExporterTest(unittest.TestCase):
+    def test_sample_to_numpy_converts_tensor_like_arrays(self):
+        arrays = sample_to_numpy(FakeDataset()[0])
+
+        self.assertEqual(set(arrays), {
+            "vol",
+            "labeled_vox_at_surface",
+            "surface_vox",
+            "projected_loss_mask",
+        })
+        self.assertEqual(arrays["vol"].shape, (2, 3, 4))
+        self.assertEqual(arrays["vol"].dtype, np.float32)
+        self.assertEqual(float(arrays["vol"][0, 0, 0]), 11.0)
+
+    def test_export_sample_writes_arrays_and_json_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sample_dir = export_sample(FakeDataset(), 1, Path(tmpdir))
+
+            self.assertEqual(sample_dir.name, "sample_000001")
+            self.assertTrue((sample_dir / "vol.npy").is_file())
+            self.assertTrue((sample_dir / "labeled_vox_at_surface.npy").is_file())
+            self.assertTrue((sample_dir / "surface_vox.npy").is_file())
+            self.assertTrue((sample_dir / "projected_loss_mask.npy").is_file())
+
+            vol = np.load(sample_dir / "vol.npy")
+            self.assertEqual(float(vol[0, 0, 0]), 22.0)
+
+            metadata = json.loads((sample_dir / "metadata.json").read_text(encoding="utf-8"))
+            self.assertEqual(metadata["dataset_index"], 1)
+            self.assertEqual(metadata["sample_idx"], 1)
+            self.assertEqual(metadata["arrays"]["vol"]["shape"], [2, 3, 4])
+            self.assertEqual(metadata["arrays"]["vol"]["dtype"], "float32")
+            self.assertEqual(metadata["patch"]["dataset_idx"], 1)
+            self.assertIn("segment", metadata["patch"])
+
+    def test_export_sample_refuses_existing_output_without_overwrite(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            export_sample(FakeDataset(), 0, Path(tmpdir))
+
+            with self.assertRaisesRegex(FileExistsError, "sample_000000"):
+                export_sample(FakeDataset(), 0, Path(tmpdir))
+
+    def test_export_samples_writes_manifest_for_explicit_indices(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = export_samples(FakeDataset(), Path(tmpdir), indices=[2, 0])
+
+            self.assertEqual(manifest["sample_count"], 2)
+            self.assertEqual(
+                [sample["dataset_index"] for sample in manifest["samples"]],
+                [2, 0],
+            )
+            manifest_path = Path(tmpdir) / "manifest.json"
+            self.assertTrue(manifest_path.is_file())
+            self.assertEqual(
+                json.loads(manifest_path.read_text(encoding="utf-8"))["sample_count"],
+                2,
+            )
+
+    def test_parse_indices_accepts_comma_separated_non_negative_ints(self):
+        self.assertEqual(parse_indices("0, 4,9"), [0, 4, 9])
+
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            parse_indices("0,-1")
+
+    def test_cli_rejects_count_and_indices_together(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with redirect_stderr(StringIO()):
+                with self.assertRaises(SystemExit) as cm:
+                    main([
+                        "--config",
+                        "config.json",
+                        "--output",
+                        tmpdir,
+                        "--count",
+                        "1",
+                        "--indices",
+                        "0",
+                    ])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_cli_requires_count_or_indices(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(export_samples_module, "load_config", return_value={"datasets": []}), patch.object(
+                export_samples_module,
+                "build_dataset",
+                return_value=FakeDataset(),
+            ), redirect_stderr(StringIO()):
+                with self.assertRaises(SystemExit) as cm:
+                    main([
+                        "--config",
+                        "config.json",
+                        "--output",
+                        tmpdir,
+                    ])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_cli_exports_with_injected_dataset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(export_samples_module, "load_config", return_value={"datasets": []}), patch.object(
+                export_samples_module,
+                "build_dataset",
+                return_value=FakeDataset(),
+            ):
+                exit_code = main([
+                    "--config",
+                    "config.json",
+                    "--output",
+                    tmpdir,
+                    "--indices",
+                    "1",
+                ])
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue((Path(tmpdir) / "sample_000001" / "vol.npy").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ink-detection/tifxyz_dataset/README.md
+++ b/ink-detection/tifxyz_dataset/README.md
@@ -58,3 +58,21 @@ ___
 **augmentation**
 
 augmentations are handled by the vesuvius augmentation module, and support both isotropic and anisotropic 3d patch sizes automatically
+
+___
+
+**sample export**
+
+dataset samples can be exported as npy arrays for offline inspection or downstream tools without enabling augmentation:
+
+```bash
+python -m tifxyz_dataset.export_samples --config /path/to/config.json --output /path/to/exported_samples --count 10
+```
+
+specific sample indices can be selected instead of a count:
+
+```bash
+python -m tifxyz_dataset.export_samples --config /path/to/config.json --output /path/to/exported_samples --indices 0,4,9
+```
+
+each exported sample is written to `sample_000000` style folders containing `vol.npy`, `labeled_vox_at_surface.npy`, `surface_vox.npy`, `projected_loss_mask.npy`, and `metadata.json`. the output root also contains `manifest.json`.

--- a/ink-detection/tifxyz_dataset/export_samples.py
+++ b/ink-detection/tifxyz_dataset/export_samples.py
@@ -1,0 +1,221 @@
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from .tifxyz_dataset import TifxyzInkDataset
+
+
+ARRAY_KEYS = (
+    "vol",
+    "labeled_vox_at_surface",
+    "surface_vox",
+    "projected_loss_mask",
+)
+
+
+def _as_numpy_array(value):
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    if hasattr(value, "numpy"):
+        value = value.numpy()
+    return np.asarray(value)
+
+
+def sample_to_numpy(sample):
+    return {
+        key: _as_numpy_array(sample[key])
+        for key in ARRAY_KEYS
+    }
+
+
+def _json_safe(value):
+    if isinstance(value, dict):
+        return {
+            str(key): _json_safe(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, np.ndarray):
+        return {
+            "shape": [int(dim) for dim in value.shape],
+            "dtype": str(value.dtype),
+        }
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def build_sample_metadata(sample, dataset_index, arrays):
+    patch = sample.get("patch", {})
+    sample_idx = int(sample.get("idx", dataset_index))
+    return {
+        "dataset_index": int(dataset_index),
+        "sample_idx": sample_idx,
+        "arrays": {
+            key: {
+                "shape": [int(dim) for dim in array.shape],
+                "dtype": str(array.dtype),
+            }
+            for key, array in arrays.items()
+        },
+        "patch": _json_safe(patch),
+    }
+
+
+def export_sample(dataset, index, output_dir, overwrite=False):
+    output_dir = Path(output_dir)
+    sample_dir = output_dir / f"sample_{int(index):06d}"
+    if sample_dir.exists() and not overwrite:
+        raise FileExistsError(f"{sample_dir} already exists; pass --overwrite to replace files")
+
+    sample_dir.mkdir(parents=True, exist_ok=True)
+    sample = dataset[int(index)]
+    arrays = sample_to_numpy(sample)
+    for key, array in arrays.items():
+        np.save(sample_dir / f"{key}.npy", array)
+
+    metadata = build_sample_metadata(
+        sample,
+        dataset_index=int(index),
+        arrays=arrays,
+    )
+    (sample_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return sample_dir
+
+
+def parse_indices(value):
+    if value is None:
+        return None
+    indices = []
+    for raw_part in str(value).split(","):
+        part = raw_part.strip()
+        if not part:
+            raise ValueError("indices must be comma-separated non-negative integers")
+        try:
+            index = int(part)
+        except ValueError as exc:
+            raise ValueError("indices must be comma-separated non-negative integers") from exc
+        if index < 0:
+            raise ValueError("indices must be comma-separated non-negative integers")
+        indices.append(index)
+    return indices
+
+
+def _resolve_indices(dataset, count=None, indices=None):
+    if count is not None and indices is not None:
+        raise ValueError("count and indices are mutually exclusive")
+    if count is None and indices is None:
+        raise ValueError("count or indices is required")
+    dataset_len = len(dataset)
+    if indices is None:
+        if count < 0:
+            raise ValueError("count must be non-negative")
+        if count > dataset_len:
+            raise ValueError(f"count={count} exceeds dataset length {dataset_len}")
+        return list(range(count))
+
+    resolved = [int(index) for index in indices]
+    out_of_range = [
+        index
+        for index in resolved
+        if index < 0 or index >= dataset_len
+    ]
+    if out_of_range:
+        raise ValueError(f"indices out of range for dataset length {dataset_len}: {out_of_range}")
+    return resolved
+
+
+def export_samples(dataset, output_dir, count=None, indices=None, overwrite=False):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    resolved_indices = _resolve_indices(dataset, count=count, indices=indices)
+    samples = []
+    for index in resolved_indices:
+        sample_dir = export_sample(
+            dataset,
+            index,
+            output_dir,
+            overwrite=overwrite,
+        )
+        samples.append(
+            {
+                "dataset_index": int(index),
+                "path": sample_dir.name,
+            }
+        )
+
+    manifest = {
+        "sample_count": len(samples),
+        "samples": samples,
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def load_config(config_path):
+    with Path(config_path).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def build_dataset(config):
+    return TifxyzInkDataset(
+        config,
+        apply_augmentation=False,
+        apply_perturbation=False,
+    )
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(
+        description="Export TifxyzInkDataset samples as .npy arrays plus JSON metadata.",
+    )
+    parser.add_argument("--config", required=True, help="Path to a tifxyz dataset config JSON.")
+    parser.add_argument("--output", required=True, help="Directory to write exported samples.")
+    parser.add_argument("--count", type=int, help="Export the first N dataset samples.")
+    parser.add_argument("--indices", help="Comma-separated dataset indices to export, for example 0,4,9.")
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite files inside existing sample directories.",
+    )
+    return parser
+
+
+def main(argv=None):
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        indices = parse_indices(args.indices)
+        if args.count is not None and indices is not None:
+            parser.error("--count and --indices are mutually exclusive")
+        if args.count is None and indices is None:
+            parser.error("--count or --indices is required")
+        config = load_config(args.config)
+        dataset = build_dataset(config)
+        export_samples(
+            dataset,
+            args.output,
+            count=args.count,
+            indices=indices,
+            overwrite=args.overwrite,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a small `tifxyz_dataset.export_samples` utility that exports selected `TifxyzInkDataset` samples as `.npy` arrays plus JSON metadata for offline inspection and downstream tooling.

## What changed

- Adds `ink-detection/tifxyz_dataset/export_samples.py` with:
  - `sample_to_numpy` conversion for tensor-like and NumPy-backed sample values
  - per-sample export folders named `sample_000000` style
  - `vol.npy`, `labeled_vox_at_surface.npy`, `surface_vox.npy`, and `projected_loss_mask.npy`
  - per-sample `metadata.json` and root `manifest.json`
  - CLI support for explicit `--count` or `--indices`
  - overwrite protection for existing sample folders
- Requires `--count` or `--indices` in the CLI so accidental full-dataset exports do not produce large outputs by default.
- Adds lightweight unit tests that avoid large data and heavy runtime dependencies.
- Documents the sample-export command in the tifxyz dataset README.

This is a follow-up toward the tifxyz label-generation/debuggability work discussed in #192 and #193. It is intentionally data-free and does not change dataset sampling or label generation behavior.

Refs #192
Refs #193

## Tests

- `python -B -m unittest ink-detection\tests\test_tifxyz_sample_exporter.py -v`
- `python -B -m unittest discover ink-detection\tests -v`
- `python -m py_compile ink-detection\tifxyz_dataset\export_samples.py ink-detection\tests\test_tifxyz_sample_exporter.py`
- `git diff --cached --check`
