### PR TITLE
Fix regression target transform dispatch

### DIFF
--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/base/basic_transform.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/base/basic_transform.py
@@ -22,7 +22,7 @@ class BasicTransform(abc.ABC):
             data_dict['image'] = self._apply_to_image(data_dict['image'], **params)
 
         if data_dict.get('regression_target') is not None:
-            data_dict['regression_target'] = self._apply_to_segmentation(data_dict['regression_target'], **params)
+            data_dict['regression_target'] = self._apply_to_regr_target(data_dict['regression_target'], **params)
 
         if data_dict.get('segmentation') is not None:
             data_dict['segmentation'] = self._apply_to_segmentation(data_dict['segmentation'], **params)

--- a/segmentation/models/batchgeneratorsv2/tests/test_basic_transform_dispatch.py
+++ b/segmentation/models/batchgeneratorsv2/tests/test_basic_transform_dispatch.py
@@ -1,0 +1,54 @@
+import pathlib
+import sys
+import types
+import unittest
+
+import numpy as np
+
+torch_stub = types.ModuleType("torch")
+torch_stub.Tensor = np.ndarray
+sys.modules.setdefault("torch", torch_stub)
+
+sys.path.insert(0, str(pathlib.Path(__file__).parents[1]))
+
+from batchgeneratorsv2.transforms.base.basic_transform import BasicTransform
+
+
+class DispatchProbeTransform(BasicTransform):
+    def _apply_to_image(self, img, **params):
+        return img + 1
+
+    def _apply_to_regr_target(self, regression_target, **params):
+        return regression_target + 100
+
+    def _apply_to_segmentation(self, segmentation, **params):
+        return segmentation + 10
+
+    def _apply_to_dist_map(self, dist_map, **params):
+        return dist_map + 1000
+
+    def _apply_to_geols_labels(self, geols_labels, **params):
+        return geols_labels + 10000
+
+
+class BasicTransformDispatchTests(unittest.TestCase):
+    def test_regression_target_uses_regression_dispatch_hook(self):
+        sample = {
+            "image": np.array([1.0]),
+            "regression_target": np.array([1.0]),
+            "segmentation": np.array([1.0]),
+            "dist_map": np.array([1.0]),
+            "geols_labels": np.array([1.0]),
+        }
+
+        out = DispatchProbeTransform()(**sample)
+
+        np.testing.assert_allclose(out["image"], np.array([2.0]))
+        np.testing.assert_allclose(out["regression_target"], np.array([101.0]))
+        np.testing.assert_allclose(out["segmentation"], np.array([11.0]))
+        np.testing.assert_allclose(out["dist_map"], np.array([1001.0]))
+        np.testing.assert_allclose(out["geols_labels"], np.array([1001.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vesuvius/src/vesuvius/models/augmentation/transforms/base/basic_transform.py
+++ b/vesuvius/src/vesuvius/models/augmentation/transforms/base/basic_transform.py
@@ -63,7 +63,7 @@ class BasicTransform(abc.ABC):
         # Skip all label transforms for unlabeled data
         if not is_unlabeled:
             if data_dict.get('regression_target') is not None:
-                data_dict['regression_target'] = self._apply_to_segmentation(data_dict['regression_target'], **params)
+                data_dict['regression_target'] = self._apply_to_regr_target(data_dict['regression_target'], **params)
 
             if data_dict.get('segmentation') is not None:
                 data_dict['segmentation'] = self._apply_to_segmentation(data_dict['segmentation'], **params)

--- a/vesuvius/tests/models/test_basic_transform_dispatch.py
+++ b/vesuvius/tests/models/test_basic_transform_dispatch.py
@@ -1,0 +1,79 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+import numpy as np
+
+torch_stub = types.ModuleType("torch")
+torch_stub.Tensor = np.ndarray
+sys.modules.setdefault("torch", torch_stub)
+
+
+def _load_basic_transform_class():
+    path = (
+        pathlib.Path(__file__).parents[2]
+        / "src"
+        / "vesuvius"
+        / "models"
+        / "augmentation"
+        / "transforms"
+        / "base"
+        / "basic_transform.py"
+    )
+    spec = importlib.util.spec_from_file_location("vesuvius_basic_transform_for_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.BasicTransform
+
+
+BasicTransform = _load_basic_transform_class()
+
+
+class DispatchProbeTransform(BasicTransform):
+    def _apply_to_image(self, img, **params):
+        return img + 1
+
+    def _apply_to_regr_target(self, regression_target, **params):
+        return regression_target + 100
+
+    def _apply_to_segmentation(self, segmentation, **params):
+        return segmentation + 10
+
+    def _apply_to_dist_map(self, dist_map, **params):
+        return dist_map + 1000
+
+    def _apply_to_geols_labels(self, geols_labels, **params):
+        return geols_labels + 10000
+
+
+class BasicTransformDispatchTests(unittest.TestCase):
+    def test_named_regression_target_uses_regression_dispatch_hook(self):
+        out = DispatchProbeTransform()(
+            image=np.array([1.0]),
+            regression_target=np.array([1.0]),
+            segmentation=np.array([1.0]),
+            dist_map=np.array([1.0]),
+            geols_labels=np.array([1.0]),
+        )
+
+        np.testing.assert_allclose(out["image"], np.array([2.0]))
+        np.testing.assert_allclose(out["regression_target"], np.array([101.0]))
+        np.testing.assert_allclose(out["segmentation"], np.array([11.0]))
+        np.testing.assert_allclose(out["dist_map"], np.array([1001.0]))
+        np.testing.assert_allclose(out["geols_labels"], np.array([1001.0]))
+
+    def test_dynamic_regression_keys_still_use_regression_dispatch(self):
+        out = DispatchProbeTransform()(
+            aux=np.array([1.0]),
+            label=np.array([1.0]),
+            regression_keys=["aux"],
+        )
+
+        np.testing.assert_allclose(out["aux"], np.array([101.0]))
+        np.testing.assert_allclose(out["label"], np.array([11.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes `BasicTransform.apply()` so the named `regression_target` key is routed through the regression-target hook instead of the segmentation hook.

## What changed

- Updates the vendored `batchgeneratorsv2` transform copy to dispatch `regression_target` via `_apply_to_regr_target`.
- Applies the same fix to the Vesuvius augmentation transform copy.
- Adds focused regression tests for both copies.
- Keeps the existing `geols_labels` routing on the distance-map hook; this PR intentionally does not change that behavior.

## Why

`data_dict` already routes dynamically named `regression_target*` keys through `_apply_to_regr_target`, but the explicit `regression_target` key was accidentally using `_apply_to_segmentation`. That means transforms which distinguish segmentation masks from regression targets can apply the wrong logic to the named target.

## Validation

- `python -B -m unittest segmentation\models\batchgeneratorsv2\tests\test_basic_transform_dispatch.py -v`
- `python -B -m unittest vesuvius\tests\models\test_basic_transform_dispatch.py -v`
- `python -m py_compile segmentation\models\batchgeneratorsv2\batchgeneratorsv2\transforms\base\basic_transform.py segmentation\models\batchgeneratorsv2\tests\test_basic_transform_dispatch.py vesuvius\src\vesuvius\models\augmentation\transforms\base\basic_transform.py vesuvius\tests\models\test_basic_transform_dispatch.py`
- `git diff --check`