### PR TITLE
Fix evaluation metric shape handling and totals

### DIFF
--- a/segmentation/evaluation/metrics/connected_components.py
+++ b/segmentation/evaluation/metrics/connected_components.py
@@ -35,20 +35,23 @@ def compute(
         Dictionary with keys "connected_components_class_X" (for each class X not ignored) containing the average absolute difference 
         in connected component counts, and a key "connected_components_total" for the overall difference.
     """
-    # If prediction is a probability map, convert to hard labels.
-    if prediction.ndim == 4:
-        prediction = np.argmax(prediction, axis=1)
-    
     # Ensure label and prediction have a batch dimension.
     # For 3D volumes, add a new axis so the shape becomes [1, H, W, D]
     if label.ndim == 3:
         label = label[np.newaxis, ...]
     elif label.ndim != 4:
         raise ValueError("Label array must have shape [H, W, D] or [N, H, W, D].")
-        
-    if prediction.ndim == 3:
+
+    if prediction.ndim == 5 and prediction.shape[1] == num_classes:
+        prediction = np.argmax(prediction, axis=1)
+    elif prediction.ndim == 4 and prediction.shape == label.shape:
+        pass
+    elif prediction.ndim == 4 and prediction.shape[0] == num_classes and prediction.shape[1:] == label.shape[1:]:
+        prediction = np.argmax(prediction, axis=0)
         prediction = prediction[np.newaxis, ...]
-    elif prediction.ndim != 3 and prediction.ndim != 4:
+    elif prediction.ndim == 3:
+        prediction = prediction[np.newaxis, ...]
+    else:
         raise ValueError("Prediction array must have shape [H, W, D] or [N, H, W, D] after conversion.")
 
     batch_size = label.shape[0]
@@ -62,6 +65,7 @@ def compute(
 
     total_label_cc = 0
     total_pred_cc = 0
+    total_absdiff = 0
 
     # Loop over images in the batch.
     for i in range(batch_size):
@@ -82,6 +86,7 @@ def compute(
 
             diff = abs(num_cc_pred - num_cc_gt)
             diff_per_class[f"connected_components_difference_class_{c}"] += diff
+            total_absdiff += diff
 
             total_label_cc += num_cc_gt
             total_pred_cc += num_cc_pred
@@ -90,7 +95,7 @@ def compute(
     for key in diff_per_class:
         diff_per_class[key] /= batch_size
 
-    total_diff = abs(total_pred_cc - total_label_cc) / batch_size
+    total_diff = total_absdiff / batch_size
     diff_per_class["connected_components_difference_total"] = total_diff
 
     return diff_per_class

--- a/segmentation/evaluation/tests/test_connected_components.py
+++ b/segmentation/evaluation/tests/test_connected_components.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+METRIC_PATH = Path(__file__).resolve().parents[1] / "metrics" / "connected_components.py"
+
+
+def _load_compute():
+    cc3d_stub = types.ModuleType("cc3d")
+
+    def connected_components(mask, connectivity=26):
+        labels = np.zeros_like(mask, dtype=np.int32)
+        component_id = 0
+        for index in zip(*np.nonzero(mask)):
+            component_id += 1
+            labels[index] = component_id
+        return labels
+
+    cc3d_stub.connected_components = connected_components
+    saved_cc3d = sys.modules.get("cc3d")
+    module_name = "_segmentation_connected_components_metric_under_test"
+    saved_metric = sys.modules.get(module_name)
+    try:
+        sys.modules["cc3d"] = cc3d_stub
+        spec = importlib.util.spec_from_file_location(module_name, METRIC_PATH)
+        metric_module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = metric_module
+        spec.loader.exec_module(metric_module)
+        return metric_module.compute
+    finally:
+        if saved_cc3d is None:
+            sys.modules.pop("cc3d", None)
+        else:
+            sys.modules["cc3d"] = saved_cc3d
+        if saved_metric is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = saved_metric
+
+
+compute = _load_compute()
+
+
+def _labels_with_two_components(class_index: int) -> np.ndarray:
+    labels = np.zeros((1, 3, 5, 5), dtype=np.int32)
+    labels[0, 1, 1, 1] = class_index
+    labels[0, 1, 3, 3] = class_index
+    return labels
+
+
+class ConnectedComponentsMetricTest(unittest.TestCase):
+    def test_total_difference_sums_per_class_differences_without_class_cancellation(self):
+        result = compute(
+            label=_labels_with_two_components(class_index=2),
+            prediction=_labels_with_two_components(class_index=1),
+            num_classes=3,
+            ignore_index=0,
+        )
+
+        self.assertEqual(result["connected_components_difference_class_1"], 2.0)
+        self.assertEqual(result["connected_components_difference_class_2"], 2.0)
+        self.assertEqual(result["connected_components_difference_total"], 4.0)
+
+    def test_batched_hard_label_predictions_are_not_treated_as_probability_maps(self):
+        labels = np.zeros((1, 4, 5, 5), dtype=np.int32)
+        labels[0, 3, 2, 2] = 1
+        prediction = labels.copy()
+
+        result = compute(
+            label=labels,
+            prediction=prediction,
+            num_classes=2,
+            ignore_index=0,
+        )
+
+        self.assertEqual(result["connected_components_difference_class_1"], 0.0)
+        self.assertEqual(result["connected_components_difference_total"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vesuvius/src/vesuvius/models/evaluation/connected_components.py
+++ b/vesuvius/src/vesuvius/models/evaluation/connected_components.py
@@ -72,7 +72,16 @@ def get_connected_components_difference(
             pred_np = pred_np.squeeze(1)
     elif pred_np.ndim == 4:  # Could be (batch, depth, height, width) or (batch, channels, height, width)
         # Check if second dimension is channels (usually small) or spatial dimension
-        if pred_np.shape[1] <= 10:  # Likely channels dimension
+        if gt_np.ndim == 5 and gt_np.shape[1] == 1 and pred_np.shape == gt_np[:, 0].shape:
+            pass
+        elif pred_np.shape[1] == num_classes:
+            if pred_np.shape[1] > 1:
+                pred_np = np.argmax(pred_np, axis=1)
+            else:
+                pred_np = pred_np.squeeze(1)
+        elif gt_np.ndim == 4 and pred_np.shape == gt_np.shape:
+            pass
+        elif pred_np.shape[1] <= 10:  # Likely channels dimension
             if pred_np.shape[1] > 1:
                 pred_np = np.argmax(pred_np, axis=1)
             else:
@@ -96,6 +105,10 @@ def get_connected_components_difference(
     elif gt_np.ndim == 4:  # Could be (batch, depth, height, width) or (batch, 1, depth, height, width)
         if gt_np.shape[1] == 1:  # (batch, 1, height, width) for 2D or needs checking for 3D
             gt_np = gt_np.squeeze(1)
+            if mask_np is not None and mask_np.ndim == 4 and mask_np.shape[1] == 1:
+                mask_np = mask_np.squeeze(1)
+        elif gt_np.shape[1] == num_classes:
+            gt_np = np.argmax(gt_np, axis=1)
             if mask_np is not None and mask_np.ndim == 4 and mask_np.shape[1] == 1:
                 mask_np = mask_np.squeeze(1)
         # Otherwise assume it's already (batch, depth, height, width)
@@ -125,6 +138,7 @@ def get_connected_components_difference(
 
     total_gt_cc = 0
     total_pred_cc = 0
+    total_absdiff = 0
 
     for i in range(batch_size):
         current_valid = valid_mask[i]
@@ -143,6 +157,7 @@ def get_connected_components_difference(
 
             diff = abs(num_cc_pred - num_cc_gt)
             diff_per_class[f"connected_components_difference_class_{c}"] += diff
+            total_absdiff += diff
 
             total_gt_cc += num_cc_gt
             total_pred_cc += num_cc_pred
@@ -150,7 +165,7 @@ def get_connected_components_difference(
     for key in diff_per_class:
         diff_per_class[key] /= batch_size
 
-    total_diff = abs(total_pred_cc - total_gt_cc) / batch_size
+    total_diff = total_absdiff / batch_size
     diff_per_class["connected_components_difference_total"] = total_diff
     
     return diff_per_class

--- a/vesuvius/src/vesuvius/models/evaluation/critical_components.py
+++ b/vesuvius/src/vesuvius/models/evaluation/critical_components.py
@@ -62,7 +62,11 @@ class CriticalComponentsMetric(BaseMetric):
             else:
                 pred_np = pred_np.squeeze(1)
         elif pred_np.ndim == 4:  # (batch, depth, height, width) or (batch, channels, height, width)
-            if pred_np.shape[1] <= 10 and pred_np.shape[1] > 1:  # Likely channels
+            if gt_np.ndim == 5 and gt_np.shape[1] == 1 and pred_np.shape == gt_np[:, 0].shape:
+                pass
+            elif gt_np.ndim == 4 and pred_np.shape == gt_np.shape:
+                pass
+            elif pred_np.shape[1] <= 10 and pred_np.shape[1] > 1:  # Likely channels
                 pred_np = np.argmax(pred_np, axis=1)
             elif pred_np.shape[1] == 1:
                 pred_np = pred_np.squeeze(1)

--- a/vesuvius/src/vesuvius/models/evaluation/hausdorff.py
+++ b/vesuvius/src/vesuvius/models/evaluation/hausdorff.py
@@ -46,14 +46,25 @@ def compute_hausdorff_distance(pred: torch.Tensor,
             pred_np = pred_np.squeeze(1)
     elif pred_np.ndim == 4:  # Could be (batch, depth, height, width) or (batch, channels, height, width)
         # Check if second dimension is channels (usually small) or spatial dimension
-        if pred_np.shape[1] <= 10:  # Likely channels dimension
+        if gt_np.ndim == 5 and gt_np.shape[1] == 1 and pred_np.shape == gt_np[:, 0].shape:
+            pass
+        elif pred_np.shape[1] == num_classes:
+            if pred_np.shape[1] > 1:
+                pred_np = np.argmax(pred_np, axis=1)
+            else:
+                pred_np = pred_np.squeeze(1)
+        elif gt_np.ndim == 4 and pred_np.shape == gt_np.shape:
+            pass
+        elif pred_np.shape[1] <= 10:  # Likely channels dimension
             if pred_np.shape[1] > 1:
                 pred_np = np.argmax(pred_np, axis=1)
             else:
                 pred_np = pred_np.squeeze(1)
         # Otherwise assume it's already (batch, depth, height, width) or (batch, height, width)
-    elif pred_np.ndim == 3 and pred_np.shape[0] <= 10:  # (channels, height, width)
-        if pred_np.shape[0] > 1:
+    elif pred_np.ndim == 3 and pred_np.shape[0] <= 10:  # (channels, height, width) or (depth, height, width)
+        if gt_np.ndim == 3 and pred_np.shape == gt_np.shape:
+            pass
+        elif pred_np.shape[0] > 1:
             pred_np = np.argmax(pred_np, axis=0)
         else:
             pred_np = pred_np.squeeze(0)
@@ -67,13 +78,18 @@ def compute_hausdorff_distance(pred: torch.Tensor,
         else:
             gt_np = np.argmax(gt_np, axis=1)
     elif gt_np.ndim == 4:  # Could be (batch, depth, height, width) or (batch, channels, height, width)
-        if gt_np.shape[1] == 1:  # (batch, 1, height, width) for 2D
+        if pred_np.ndim == 4 and gt_np.shape == pred_np.shape:
+            pass
+        elif gt_np.shape[1] == 1:  # (batch, 1, height, width) for 2D
             gt_np = gt_np.squeeze(1)
         elif gt_np.shape[1] <= 10:  # Likely channels
             gt_np = np.argmax(gt_np, axis=1)
         # Otherwise assume it's already (batch, depth, height, width)
     elif gt_np.ndim == 2:  # (height, width)
         gt_np = gt_np[np.newaxis, ...]  # Add batch dimension
+
+    if pred_np.ndim == len(gt_np.shape) - 1:
+        pred_np = pred_np[np.newaxis, ...]
     
     # Ensure both have same number of dimensions
     if pred_np.ndim != gt_np.ndim:

--- a/vesuvius/src/vesuvius/models/evaluation/iou_dice.py
+++ b/vesuvius/src/vesuvius/models/evaluation/iou_dice.py
@@ -72,14 +72,25 @@ def compute_iou_dice(pred: torch.Tensor,
             pred_np = pred_np.squeeze(1)
     elif pred_np.ndim == 4:  # Could be (batch, depth, height, width) or (batch, channels, height, width)
         # Check if second dimension is channels (usually small) or spatial dimension
-        if pred_np.shape[1] <= 10:  # Likely channels dimension
+        if gt_np.ndim == 5 and gt_np.shape[1] == 1 and pred_np.shape == gt_np[:, 0].shape:
+            pass
+        elif pred_np.shape[1] == num_classes:
+            if pred_np.shape[1] > 1:
+                pred_np = np.argmax(pred_np, axis=1)
+            else:
+                pred_np = pred_np.squeeze(1)
+        elif gt_np.ndim == 4 and pred_np.shape == gt_np.shape:
+            pass
+        elif pred_np.shape[1] <= 10:  # Likely channels dimension
             if pred_np.shape[1] > 1:
                 pred_np = np.argmax(pred_np, axis=1)
             else:
                 pred_np = pred_np.squeeze(1)
         # Otherwise assume it's already (batch, depth, height, width) or (batch, height, width)
-    elif pred_np.ndim == 3 and pred_np.shape[0] <= 10:  # (channels, height, width)
-        if pred_np.shape[0] > 1:
+    elif pred_np.ndim == 3 and pred_np.shape[0] <= 10:  # (channels, height, width) or (depth, height, width)
+        if gt_np.ndim == 3 and pred_np.shape == gt_np.shape:
+            pass
+        elif pred_np.shape[0] > 1:
             pred_np = np.argmax(pred_np, axis=0)
         else:
             pred_np = pred_np.squeeze(0)
@@ -99,7 +110,9 @@ def compute_iou_dice(pred: torch.Tensor,
             if mask_np is not None and mask_np.ndim == 5 and mask_np.shape[1] == 1:
                 mask_np = mask_np.squeeze(1)
     elif gt_np.ndim == 4:  # Could be (batch, depth, height, width) or (batch, channels, height, width)
-        if gt_np.shape[1] == 1:  # (batch, 1, height, width) for 2D
+        if pred_np.ndim == 4 and gt_np.shape == pred_np.shape:
+            pass
+        elif gt_np.shape[1] == 1:  # (batch, 1, height, width) for 2D
             gt_np = gt_np.squeeze(1)
             if mask_np is not None and mask_np.ndim == 4 and mask_np.shape[1] == 1:
                 mask_np = mask_np.squeeze(1)
@@ -112,6 +125,9 @@ def compute_iou_dice(pred: torch.Tensor,
         gt_np = gt_np[np.newaxis, ...]  # Add batch dimension
         if mask_np is not None and mask_np.ndim == 2:
             mask_np = mask_np[np.newaxis, ...]
+
+    if pred_np.ndim == len(gt_np.shape) - 1:
+        pred_np = pred_np[np.newaxis, ...]
     
     # Ensure both have same number of dimensions
     if pred_np.ndim != gt_np.ndim:

--- a/vesuvius/src/vesuvius/models/evaluation/mean_average_precision.py
+++ b/vesuvius/src/vesuvius/models/evaluation/mean_average_precision.py
@@ -87,7 +87,16 @@ class MeanAveragePrecisionMetric(BaseMetric):
             else:
                 pred_lbl = (pred_np[:, 0] > 0.5).astype(np.int32)
         elif pred_np.ndim == 4:
-            if pred_np.shape[1] <= 10:
+            if gt_np.ndim == 5 and gt_np.shape[1] == 1 and pred_np.shape == gt_np[:, 0].shape:
+                pred_lbl = pred_np.astype(np.int32)
+            elif pred_np.shape[1] == self.num_classes:
+                if pred_np.shape[1] > 1:
+                    pred_lbl = np.argmax(pred_np, axis=1).astype(np.int32)
+                else:
+                    pred_lbl = (pred_np[:, 0] > 0.5).astype(np.int32)
+            elif gt_np.ndim == 4 and pred_np.shape == gt_np.shape:
+                pred_lbl = pred_np.astype(np.int32)
+            elif pred_np.shape[1] <= 10:
                 if pred_np.shape[1] > 1:
                     pred_lbl = np.argmax(pred_np, axis=1).astype(np.int32)
                 else:
@@ -104,7 +113,9 @@ class MeanAveragePrecisionMetric(BaseMetric):
             else:
                 gt_lbl = np.argmax(gt_np, axis=1).astype(np.int32)
         elif gt_np.ndim == 4:
-            if gt_np.shape[1] == 1:
+            if gt_np.shape == pred_lbl.shape:
+                gt_lbl = gt_np.astype(np.int32)
+            elif gt_np.shape[1] == 1:
                 gt_lbl = gt_np[:, 0].astype(np.int32)
             elif gt_np.shape[1] <= 10:
                 gt_lbl = np.argmax(gt_np, axis=1).astype(np.int32)

--- a/vesuvius/src/vesuvius/models/evaluation/precision_recall_f1.py
+++ b/vesuvius/src/vesuvius/models/evaluation/precision_recall_f1.py
@@ -29,7 +29,16 @@ class PrecisionRecallF1Metric(BaseMetric):
             else:
                 pred_lbl = (pred_np[:, 0] > 0.5).astype(np.int32)
         elif pred_np.ndim == 4:
-            if pred_np.shape[1] <= 10:  # treat as channels
+            if gt_np.ndim == 5 and gt_np.shape[1] == 1 and pred_np.shape == gt_np[:, 0].shape:
+                pred_lbl = pred_np.astype(np.int32)
+            elif pred_np.shape[1] == self.num_classes:
+                if pred_np.shape[1] > 1:
+                    pred_lbl = np.argmax(pred_np, axis=1).astype(np.int32)
+                else:
+                    pred_lbl = (pred_np[:, 0] > 0.5).astype(np.int32)
+            elif gt_np.ndim == 4 and pred_np.shape == gt_np.shape:
+                pred_lbl = pred_np.astype(np.int32)
+            elif pred_np.shape[1] <= 10:  # treat as channels
                 if pred_np.shape[1] > 1:
                     pred_lbl = np.argmax(pred_np, axis=1).astype(np.int32)
                 else:
@@ -45,7 +54,9 @@ class PrecisionRecallF1Metric(BaseMetric):
             else:
                 gt_lbl = np.argmax(gt_np, axis=1).astype(np.int32)
         elif gt_np.ndim == 4:
-            if gt_np.shape[1] == 1:
+            if gt_np.shape == pred_lbl.shape:
+                gt_lbl = gt_np.astype(np.int32)
+            elif gt_np.shape[1] == 1:
                 gt_lbl = gt_np[:, 0].astype(np.int32)
             elif gt_np.shape[1] <= 10:
                 gt_lbl = np.argmax(gt_np, axis=1).astype(np.int32)

--- a/vesuvius/src/vesuvius/models/evaluation/skeleton_branch_points.py
+++ b/vesuvius/src/vesuvius/models/evaluation/skeleton_branch_points.py
@@ -70,7 +70,22 @@ class SkeletonBranchPointsMetric(BaseMetric):
                 pred_lbl = (pred_np[:, 0] >= self.threshold).astype(np.int32)
         elif pred_np.ndim == 4:
             # Could be (B, C, H, W) or (B, Z, Y, X)
-            if pred_np.shape[1] <= 10:  # likely channels
+            if gt_np.ndim == 5 and gt_np.shape[1] == 1 and pred_np.shape == gt_np[:, 0].shape:
+                pred_lbl = pred_np.astype(np.int32)
+            elif pred_np.shape[1] == self.num_classes:
+                if pred_np.shape[1] > 1:
+                    if self.num_classes == 2:
+                        exps = np.exp(pred_np - np.max(pred_np, axis=1, keepdims=True))
+                        softmax = exps / np.sum(exps, axis=1, keepdims=True)
+                        pred_fg = softmax[:, 1]
+                        pred_lbl = (pred_fg >= self.threshold).astype(np.int32)
+                    else:
+                        pred_lbl = np.argmax(pred_np, axis=1).astype(np.int32)
+                else:
+                    pred_lbl = (pred_np[:, 0] >= self.threshold).astype(np.int32)
+            elif gt_np.ndim == 4 and pred_np.shape == gt_np.shape:
+                pred_lbl = pred_np.astype(np.int32)
+            elif pred_np.shape[1] <= 10:  # likely channels
                 if pred_np.shape[1] > 1:
                     if self.num_classes == 2:
                         exps = np.exp(pred_np - np.max(pred_np, axis=1, keepdims=True))
@@ -94,7 +109,9 @@ class SkeletonBranchPointsMetric(BaseMetric):
             else:
                 gt_lbl = np.argmax(gt_np, axis=1).astype(np.int32)
         elif gt_np.ndim == 4:
-            if gt_np.shape[1] == 1:  # (B,1,H,W)
+            if gt_np.shape == pred_lbl.shape:
+                gt_lbl = gt_np.astype(np.int32)
+            elif gt_np.shape[1] == 1:  # (B,1,H,W)
                 gt_lbl = gt_np[:, 0].astype(np.int32)
             elif gt_np.shape[1] <= 10:  # channels
                 gt_lbl = np.argmax(gt_np, axis=1).astype(np.int32)
@@ -130,6 +147,7 @@ class SkeletonBranchPointsMetric(BaseMetric):
 
         total_pred = 0.0
         total_gt = 0.0
+        total_absdiff = 0.0
 
         for b in range(batch_size):
             for c in classes:
@@ -165,6 +183,7 @@ class SkeletonBranchPointsMetric(BaseMetric):
                 results[f"branch_points_absdiff_class_{c}"] += abs(pred_bp - gt_bp)
                 total_pred += pred_bp
                 total_gt += gt_bp
+                total_absdiff += abs(pred_bp - gt_bp)
 
         # Average per batch
         valid_classes = [c for c in classes if (self.ignore_index is None or c != self.ignore_index)]
@@ -175,7 +194,7 @@ class SkeletonBranchPointsMetric(BaseMetric):
 
         results["branch_points_pred_total"] = total_pred / batch_size
         results["branch_points_gt_total"] = total_gt / batch_size
-        results["branch_points_absdiff_total"] = abs(total_pred - total_gt) / batch_size
+        results["branch_points_absdiff_total"] = total_absdiff / batch_size
 
         return results
 

--- a/vesuvius/src/vesuvius/models/evaluation/voi.py
+++ b/vesuvius/src/vesuvius/models/evaluation/voi.py
@@ -179,7 +179,11 @@ def compute_voi(
         else:  # Single channel, just squeeze
             pred_np = pred_np.squeeze(1)
     elif pred_np.ndim == 4:  # Could be (batch, depth, height, width) or (batch, channels, height, width)
-        if pred_np.shape[1] <= 10:  # Likely channels dimension
+        if gt_np.ndim == 5 and gt_np.shape[1] == 1 and pred_np.shape == gt_np[:, 0].shape:
+            pass
+        elif gt_np.ndim == 4 and pred_np.shape == gt_np.shape:
+            pass
+        elif pred_np.shape[1] <= 10:  # Likely channels dimension
             if pred_np.shape[1] > 1:
                 pred_np = np.argmax(pred_np, axis=1)
             else:
@@ -200,7 +204,9 @@ def compute_voi(
             if mask_np is not None and mask_np.ndim == 5 and mask_np.shape[1] == 1:
                 mask_np = mask_np.squeeze(1)
     elif gt_np.ndim == 4:
-        if gt_np.shape[1] == 1:
+        if pred_np.ndim == 4 and gt_np.shape == pred_np.shape:
+            pass
+        elif gt_np.shape[1] == 1:
             gt_np = gt_np.squeeze(1)
             if mask_np is not None and mask_np.ndim == 4 and mask_np.shape[1] == 1:
                 mask_np = mask_np.squeeze(1)

--- a/vesuvius/tests/models/evaluation/test_connected_components.py
+++ b/vesuvius/tests/models/evaluation/test_connected_components.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+VESUVIUS_SRC = Path(__file__).resolve().parents[3] / "src" / "vesuvius"
+
+
+def _metric_dependency_stubs() -> dict[str, types.ModuleType]:
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = object()
+    torch_stub.Tensor = object
+
+    cc3d_stub = types.ModuleType("cc3d")
+
+    def connected_components(mask, connectivity=26):
+        labels = np.zeros_like(mask, dtype=np.int32)
+        component_id = 0
+        for index in zip(*np.nonzero(mask)):
+            component_id += 1
+            labels[index] = component_id
+        return labels
+
+    cc3d_stub.connected_components = connected_components
+    return {
+        "torch": torch_stub,
+        "cc3d": cc3d_stub,
+    }
+
+
+def _load_metric_class():
+    package_name = "_connected_components_metric_under_test"
+    private_modules = (
+        package_name,
+        f"{package_name}.base_metric",
+        f"{package_name}.connected_components",
+    )
+    stub_modules = _metric_dependency_stubs()
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (*stub_modules.keys(), *private_modules)
+    }
+    try:
+        sys.modules.update(stub_modules)
+        evaluation_pkg = types.ModuleType(package_name)
+        evaluation_pkg.__path__ = [str(VESUVIUS_SRC / "models" / "evaluation")]
+        sys.modules[package_name] = evaluation_pkg
+
+        base_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.base_metric",
+            VESUVIUS_SRC / "models" / "evaluation" / "base_metric.py",
+        )
+        base_module = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_spec.name] = base_module
+        base_spec.loader.exec_module(base_module)
+
+        metric_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.connected_components",
+            VESUVIUS_SRC / "models" / "evaluation" / "connected_components.py",
+        )
+        metric_module = importlib.util.module_from_spec(metric_spec)
+        sys.modules[metric_spec.name] = metric_module
+        metric_spec.loader.exec_module(metric_module)
+        return metric_module.ConnectedComponentsMetric
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+ConnectedComponentsMetric = _load_metric_class()
+
+
+class FakeTensor:
+    def __init__(self, data):
+        self._data = np.asarray(data, dtype=np.float32)
+        self.dtype = np.float32
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._data
+
+    def float(self):
+        return self
+
+
+def _labels_with_two_components(class_index: int) -> np.ndarray:
+    labels = np.zeros((1, 1, 3, 5, 5), dtype=np.float32)
+    labels[0, 0, 1, 1, 1] = class_index
+    labels[0, 0, 1, 3, 3] = class_index
+    return labels
+
+
+class ConnectedComponentsMetricTest(unittest.TestCase):
+    def test_total_difference_sums_per_class_differences_without_class_cancellation(self):
+        metric = ConnectedComponentsMetric(num_classes=3, ignore_index=0)
+
+        result = metric.compute(
+            FakeTensor(_labels_with_two_components(class_index=1)),
+            FakeTensor(_labels_with_two_components(class_index=2)),
+        )
+
+        self.assertEqual(result["connected_components_difference_class_1"], 2.0)
+        self.assertEqual(result["connected_components_difference_class_2"], 2.0)
+        self.assertEqual(result["connected_components_difference_total"], 4.0)
+
+    def test_matching_channel_first_2d_maps_still_use_channel_argmax(self):
+        metric = ConnectedComponentsMetric(num_classes=2, ignore_index=0)
+        prediction = np.zeros((1, 2, 5, 5), dtype=np.float32)
+        ground_truth = np.zeros_like(prediction)
+        prediction[:, 0, :, :] = 1.0
+        ground_truth[:, 0, :, :] = 1.0
+        ground_truth[0, 0, 2, 2] = 0.0
+        ground_truth[0, 1, 2, 2] = 1.0
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertEqual(result["connected_components_difference_class_1"], 1.0)
+        self.assertEqual(result["connected_components_difference_total"], 1.0)
+
+    def test_batched_hard_label_predictions_are_not_treated_as_channel_maps(self):
+        metric = ConnectedComponentsMetric(num_classes=2, ignore_index=0)
+        labels = np.zeros((1, 3, 5, 5), dtype=np.float32)
+        labels[0, 2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(labels), FakeTensor(labels))
+
+        self.assertEqual(result["connected_components_difference_class_1"], 0.0)
+        self.assertEqual(result["connected_components_difference_total"], 0.0)
+
+    def test_hard_label_prediction_matches_singleton_channel_ground_truth(self):
+        metric = ConnectedComponentsMetric(num_classes=2, ignore_index=0)
+        prediction = np.zeros((1, 3, 5, 5), dtype=np.float32)
+        ground_truth = prediction[:, np.newaxis, :, :, :].copy()
+        prediction[0, 2, 2, 2] = 1
+        ground_truth[0, 0, 2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertEqual(result["connected_components_difference_class_1"], 0.0)
+        self.assertEqual(result["connected_components_difference_total"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vesuvius/tests/models/evaluation/test_critical_components.py
+++ b/vesuvius/tests/models/evaluation/test_critical_components.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+VESUVIUS_SRC = Path(__file__).resolve().parents[3] / "src" / "vesuvius"
+
+
+def _load_metric_class():
+    package_name = "_critical_components_metric_under_test"
+    private_modules = (
+        package_name,
+        f"{package_name}.base_metric",
+        f"{package_name}.critical_components",
+    )
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = object()
+    torch_stub.Tensor = object
+    scipy_stub = types.ModuleType("scipy")
+    scipy_ndimage_stub = types.ModuleType("scipy.ndimage")
+    scipy_ndimage_stub.label = lambda mask: (np.asarray(mask, dtype=np.int32), int(np.max(mask)))
+    numba_stub = types.ModuleType("numba")
+
+    def njit(*args, **kwargs):
+        if args and callable(args[0]):
+            return args[0]
+        return lambda func: func
+
+    numba_stub.njit = njit
+    numba_stub.prange = range
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (
+            "torch",
+            "scipy",
+            "scipy.ndimage",
+            "numba",
+            *private_modules,
+        )
+    }
+    try:
+        sys.modules["torch"] = torch_stub
+        sys.modules["scipy"] = scipy_stub
+        sys.modules["scipy.ndimage"] = scipy_ndimage_stub
+        sys.modules["numba"] = numba_stub
+        evaluation_pkg = types.ModuleType(package_name)
+        evaluation_pkg.__path__ = [str(VESUVIUS_SRC / "models" / "evaluation")]
+        sys.modules[package_name] = evaluation_pkg
+
+        base_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.base_metric",
+            VESUVIUS_SRC / "models" / "evaluation" / "base_metric.py",
+        )
+        base_module = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_spec.name] = base_module
+        base_spec.loader.exec_module(base_module)
+
+        metric_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.critical_components",
+            VESUVIUS_SRC / "models" / "evaluation" / "critical_components.py",
+        )
+        metric_module = importlib.util.module_from_spec(metric_spec)
+        sys.modules[metric_spec.name] = metric_module
+        metric_spec.loader.exec_module(metric_module)
+        return metric_module.CriticalComponentsMetric
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+CriticalComponentsMetric = _load_metric_class()
+
+
+class FakeTensor:
+    def __init__(self, data):
+        self._data = np.asarray(data, dtype=np.float32)
+        self.dtype = np.float32
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._data
+
+    def float(self):
+        return self
+
+
+class CriticalComponentsMetricTest(unittest.TestCase):
+    def test_batched_hard_label_volumes_are_not_argmaxed_as_channel_maps(self):
+        metric = CriticalComponentsMetric()
+        labels = np.zeros((1, 3, 5, 5), dtype=np.float32)
+        labels[0, 2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(labels), FakeTensor(labels))
+
+        self.assertEqual(result["critical components negative"], 0.0)
+        self.assertEqual(result["critical components positive"], 0.0)
+        self.assertEqual(result["critical components total"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vesuvius/tests/models/evaluation/test_hausdorff.py
+++ b/vesuvius/tests/models/evaluation/test_hausdorff.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+VESUVIUS_SRC = Path(__file__).resolve().parents[3] / "src" / "vesuvius"
+
+
+def _load_metric_class():
+    package_name = "_hausdorff_metric_under_test"
+    private_modules = (
+        package_name,
+        f"{package_name}.base_metric",
+        f"{package_name}.hausdorff",
+    )
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = object()
+    torch_stub.Tensor = object
+    scipy_stub = types.ModuleType("scipy")
+    scipy_ndimage_stub = types.ModuleType("scipy.ndimage")
+    scipy_ndimage_stub.distance_transform_edt = lambda mask: np.asarray(mask, dtype=np.float32)
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in ("torch", "scipy", "scipy.ndimage", *private_modules)
+    }
+    try:
+        sys.modules["torch"] = torch_stub
+        sys.modules["scipy"] = scipy_stub
+        sys.modules["scipy.ndimage"] = scipy_ndimage_stub
+        evaluation_pkg = types.ModuleType(package_name)
+        evaluation_pkg.__path__ = [str(VESUVIUS_SRC / "models" / "evaluation")]
+        sys.modules[package_name] = evaluation_pkg
+
+        base_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.base_metric",
+            VESUVIUS_SRC / "models" / "evaluation" / "base_metric.py",
+        )
+        base_module = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_spec.name] = base_module
+        base_spec.loader.exec_module(base_module)
+
+        metric_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.hausdorff",
+            VESUVIUS_SRC / "models" / "evaluation" / "hausdorff.py",
+        )
+        metric_module = importlib.util.module_from_spec(metric_spec)
+        sys.modules[metric_spec.name] = metric_module
+        metric_spec.loader.exec_module(metric_module)
+        return metric_module.HausdorffDistanceMetric
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+HausdorffDistanceMetric = _load_metric_class()
+
+
+class FakeTensor:
+    def __init__(self, data):
+        self._data = np.asarray(data, dtype=np.float32)
+        self.dtype = np.float32
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._data
+
+    def float(self):
+        return self
+
+
+class HausdorffDistanceMetricTest(unittest.TestCase):
+    def test_matching_channel_first_2d_maps_still_use_channel_argmax(self):
+        metric = HausdorffDistanceMetric(num_classes=2, ignore_index=0)
+        prediction = np.zeros((1, 2, 5, 5), dtype=np.float32)
+        ground_truth = np.zeros_like(prediction)
+        prediction[:, 0, :, :] = 1.0
+        ground_truth[:, 0, :, :] = 1.0
+        ground_truth[0, 0, 2, 2] = 0.0
+        ground_truth[0, 1, 2, 2] = 1.0
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertTrue(np.isinf(result["hausdorff_distance_class_1"]))
+        self.assertTrue(np.isinf(result["hausdorff_distance_95_class_1"]))
+
+    def test_unbatched_hard_label_volumes_are_not_argmaxed_as_channel_maps(self):
+        metric = HausdorffDistanceMetric(num_classes=2, ignore_index=0)
+        prediction = np.zeros((3, 5, 5), dtype=np.float32)
+        ground_truth = prediction.copy()
+        ground_truth[2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertTrue(np.isinf(result["hausdorff_distance_class_1"]))
+        self.assertTrue(np.isinf(result["hausdorff_distance_95_class_1"]))
+
+    def test_batched_hard_label_volumes_are_not_argmaxed_as_channel_maps(self):
+        metric = HausdorffDistanceMetric(num_classes=2, ignore_index=0)
+        prediction = np.zeros((1, 3, 5, 5), dtype=np.float32)
+        ground_truth = prediction.copy()
+        ground_truth[0, 2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertTrue(np.isinf(result["hausdorff_distance_class_1"]))
+        self.assertTrue(np.isinf(result["hausdorff_distance_95_class_1"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vesuvius/tests/models/evaluation/test_iou_dice.py
+++ b/vesuvius/tests/models/evaluation/test_iou_dice.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+VESUVIUS_SRC = Path(__file__).resolve().parents[3] / "src" / "vesuvius"
+
+
+def _metric_dependency_stubs() -> dict[str, types.ModuleType]:
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = object()
+    torch_stub.Tensor = object
+    return {"torch": torch_stub}
+
+
+def _load_metric_class():
+    package_name = "_iou_dice_metric_under_test"
+    private_modules = (
+        package_name,
+        f"{package_name}.base_metric",
+        f"{package_name}.iou_dice",
+    )
+    stub_modules = _metric_dependency_stubs()
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (*stub_modules.keys(), *private_modules)
+    }
+    try:
+        sys.modules.update(stub_modules)
+        evaluation_pkg = types.ModuleType(package_name)
+        evaluation_pkg.__path__ = [str(VESUVIUS_SRC / "models" / "evaluation")]
+        sys.modules[package_name] = evaluation_pkg
+
+        base_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.base_metric",
+            VESUVIUS_SRC / "models" / "evaluation" / "base_metric.py",
+        )
+        base_module = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_spec.name] = base_module
+        base_spec.loader.exec_module(base_module)
+
+        metric_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.iou_dice",
+            VESUVIUS_SRC / "models" / "evaluation" / "iou_dice.py",
+        )
+        metric_module = importlib.util.module_from_spec(metric_spec)
+        sys.modules[metric_spec.name] = metric_module
+        metric_spec.loader.exec_module(metric_module)
+        return metric_module.IOUDiceMetric
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+IOUDiceMetric = _load_metric_class()
+
+
+class FakeTensor:
+    def __init__(self, data):
+        self._data = np.asarray(data, dtype=np.float32)
+        self.dtype = np.float32
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._data
+
+    def float(self):
+        return self
+
+
+class IOUDiceMetricTest(unittest.TestCase):
+    def test_matching_channel_first_2d_maps_still_use_channel_argmax(self):
+        metric = IOUDiceMetric(num_classes=2)
+        prediction = np.zeros((1, 2, 5, 5), dtype=np.float32)
+        ground_truth = np.zeros_like(prediction)
+        prediction[:, 0, :, :] = 1.0
+        ground_truth[:, 0, :, :] = 1.0
+        ground_truth[0, 0, 2, 2] = 0.0
+        ground_truth[0, 1, 2, 2] = 1.0
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertLess(result["iou_class_1"], 1e-5)
+        self.assertLess(result["dice_class_1"], 1e-5)
+
+    def test_unbatched_hard_label_volumes_are_not_argmaxed_as_channel_maps(self):
+        metric = IOUDiceMetric(num_classes=2)
+        prediction = np.zeros((3, 5, 5), dtype=np.float32)
+        ground_truth = prediction.copy()
+        ground_truth[2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertLess(result["iou_class_1"], 1e-5)
+        self.assertLess(result["dice_class_1"], 1e-5)
+
+    def test_batched_hard_label_volumes_are_not_argmaxed_as_channel_maps(self):
+        metric = IOUDiceMetric(num_classes=2)
+        prediction = np.zeros((1, 3, 5, 5), dtype=np.float32)
+        ground_truth = prediction.copy()
+        ground_truth[0, 2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertLess(result["iou_class_1"], 1e-5)
+        self.assertLess(result["dice_class_1"], 1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vesuvius/tests/models/evaluation/test_mean_average_precision.py
+++ b/vesuvius/tests/models/evaluation/test_mean_average_precision.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+VESUVIUS_SRC = Path(__file__).resolve().parents[3] / "src" / "vesuvius"
+
+
+def _load_metric_class():
+    package_name = "_mean_average_precision_metric_under_test"
+    private_modules = (
+        package_name,
+        f"{package_name}.base_metric",
+        f"{package_name}.mean_average_precision",
+    )
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = object()
+    torch_stub.Tensor = object
+    cc3d_stub = types.ModuleType("cc3d")
+
+    def connected_components(mask, connectivity=26):
+        labels = np.zeros_like(mask, dtype=np.int32)
+        component_id = 0
+        for index in zip(*np.nonzero(mask)):
+            component_id += 1
+            labels[index] = component_id
+        return labels
+
+    cc3d_stub.connected_components = connected_components
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in ("torch", "cc3d", *private_modules)
+    }
+    try:
+        sys.modules["torch"] = torch_stub
+        sys.modules["cc3d"] = cc3d_stub
+        evaluation_pkg = types.ModuleType(package_name)
+        evaluation_pkg.__path__ = [str(VESUVIUS_SRC / "models" / "evaluation")]
+        sys.modules[package_name] = evaluation_pkg
+
+        base_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.base_metric",
+            VESUVIUS_SRC / "models" / "evaluation" / "base_metric.py",
+        )
+        base_module = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_spec.name] = base_module
+        base_spec.loader.exec_module(base_module)
+
+        metric_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.mean_average_precision",
+            VESUVIUS_SRC / "models" / "evaluation" / "mean_average_precision.py",
+        )
+        metric_module = importlib.util.module_from_spec(metric_spec)
+        sys.modules[metric_spec.name] = metric_module
+        metric_spec.loader.exec_module(metric_module)
+        return metric_module.MeanAveragePrecisionMetric
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+MeanAveragePrecisionMetric = _load_metric_class()
+
+
+class FakeTensor:
+    def __init__(self, data):
+        self._data = np.asarray(data, dtype=np.float32)
+        self.dtype = np.float32
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._data
+
+    def float(self):
+        return self
+
+
+class MeanAveragePrecisionMetricTest(unittest.TestCase):
+    def test_matching_channel_first_2d_maps_still_use_channel_argmax(self):
+        metric = MeanAveragePrecisionMetric(num_classes=2, ignore_index=0)
+        prediction = np.zeros((1, 2, 5, 5), dtype=np.float32)
+        ground_truth = np.zeros_like(prediction)
+        prediction[:, 0, :, :] = 1.0
+        ground_truth[:, 0, :, :] = 1.0
+        ground_truth[0, 0, 2, 2] = 0.0
+        ground_truth[0, 1, 2, 2] = 1.0
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertLess(result["map_class_1"], 0.01)
+        self.assertLess(result["map_mean"], 0.01)
+
+    def test_batched_hard_label_volumes_are_not_argmaxed_as_channel_maps(self):
+        metric = MeanAveragePrecisionMetric(num_classes=2, ignore_index=0)
+        prediction = np.zeros((1, 3, 5, 5), dtype=np.float32)
+        ground_truth = prediction.copy()
+        ground_truth[0, 2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertLess(result["map_class_1"], 0.01)
+        self.assertLess(result["map_mean"], 0.01)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vesuvius/tests/models/evaluation/test_precision_recall_f1.py
+++ b/vesuvius/tests/models/evaluation/test_precision_recall_f1.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+VESUVIUS_SRC = Path(__file__).resolve().parents[3] / "src" / "vesuvius"
+
+
+def _load_metric_class():
+    package_name = "_precision_recall_f1_metric_under_test"
+    private_modules = (
+        package_name,
+        f"{package_name}.base_metric",
+        f"{package_name}.precision_recall_f1",
+    )
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = object()
+    torch_stub.Tensor = object
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in ("torch", *private_modules)
+    }
+    try:
+        sys.modules["torch"] = torch_stub
+        evaluation_pkg = types.ModuleType(package_name)
+        evaluation_pkg.__path__ = [str(VESUVIUS_SRC / "models" / "evaluation")]
+        sys.modules[package_name] = evaluation_pkg
+
+        base_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.base_metric",
+            VESUVIUS_SRC / "models" / "evaluation" / "base_metric.py",
+        )
+        base_module = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_spec.name] = base_module
+        base_spec.loader.exec_module(base_module)
+
+        metric_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.precision_recall_f1",
+            VESUVIUS_SRC / "models" / "evaluation" / "precision_recall_f1.py",
+        )
+        metric_module = importlib.util.module_from_spec(metric_spec)
+        sys.modules[metric_spec.name] = metric_module
+        metric_spec.loader.exec_module(metric_module)
+        return metric_module.PrecisionRecallF1Metric
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+PrecisionRecallF1Metric = _load_metric_class()
+
+
+class FakeTensor:
+    def __init__(self, data):
+        self._data = np.asarray(data, dtype=np.float32)
+        self.dtype = np.float32
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._data
+
+    def float(self):
+        return self
+
+
+class PrecisionRecallF1MetricTest(unittest.TestCase):
+    def test_matching_channel_first_2d_maps_still_use_channel_argmax(self):
+        metric = PrecisionRecallF1Metric(num_classes=2, ignore_index=0)
+        prediction = np.zeros((1, 2, 5, 5), dtype=np.float32)
+        ground_truth = np.zeros_like(prediction)
+        prediction[:, 0, :, :] = 1
+        ground_truth[:, 0, :, :] = 1
+
+        result = metric.compute(FakeTensor(prediction), FakeTensor(ground_truth))
+
+        self.assertLess(result["precision_class_1"], 1e-5)
+        self.assertLess(result["recall_class_1"], 1e-5)
+        self.assertLess(result["f1_class_1"], 1e-5)
+
+    def test_batched_hard_label_volumes_are_not_argmaxed_as_channel_maps(self):
+        metric = PrecisionRecallF1Metric(num_classes=2, ignore_index=0)
+        labels = np.zeros((1, 3, 5, 5), dtype=np.float32)
+        labels[0, 2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(labels), FakeTensor(labels))
+
+        self.assertGreater(result["precision_class_1"], 0.99)
+        self.assertGreater(result["recall_class_1"], 0.99)
+        self.assertGreater(result["f1_class_1"], 0.99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vesuvius/tests/models/evaluation/test_skeleton_branch_points.py
+++ b/vesuvius/tests/models/evaluation/test_skeleton_branch_points.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+def _metric_dependency_stubs() -> dict[str, types.ModuleType]:
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = object()
+    torch_stub.Tensor = object
+
+    skimage_stub = types.ModuleType("skimage")
+    morphology_stub = types.ModuleType("skimage.morphology")
+    morphology_stub.skeletonize = lambda mask: mask
+    skimage_stub.morphology = morphology_stub
+
+    scipy_stub = types.ModuleType("scipy")
+    ndimage_stub = types.ModuleType("scipy.ndimage")
+
+    def convolve(values, kernel, mode="constant", cval=0):
+        if mode != "constant":
+            raise AssertionError(f"unexpected mode: {mode}")
+        padded = np.pad(values, ((0, 0), (1, 1), (1, 1)), constant_values=cval)
+        result = np.zeros_like(values, dtype=np.uint8)
+        for dy in range(3):
+            for dx in range(3):
+                if kernel[0, dy, dx]:
+                    result += padded[:, dy : dy + values.shape[1], dx : dx + values.shape[2]]
+        return result
+
+    ndimage_stub.convolve = convolve
+    scipy_stub.ndimage = ndimage_stub
+    return {
+        "torch": torch_stub,
+        "skimage": skimage_stub,
+        "skimage.morphology": morphology_stub,
+        "scipy": scipy_stub,
+        "scipy.ndimage": ndimage_stub,
+    }
+
+VESUVIUS_SRC = Path(__file__).resolve().parents[3] / "src" / "vesuvius"
+
+
+def _load_metric_class():
+    package_name = "_skeleton_branch_points_metric_under_test"
+    private_modules = (
+        package_name,
+        f"{package_name}.base_metric",
+        f"{package_name}.skeleton_branch_points",
+    )
+    stub_modules = _metric_dependency_stubs()
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (*stub_modules.keys(), *private_modules)
+    }
+    try:
+        sys.modules.update(stub_modules)
+        evaluation_pkg = types.ModuleType(package_name)
+        evaluation_pkg.__path__ = [str(VESUVIUS_SRC / "models" / "evaluation")]
+        sys.modules[package_name] = evaluation_pkg
+
+        base_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.base_metric",
+            VESUVIUS_SRC / "models" / "evaluation" / "base_metric.py",
+        )
+        base_module = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_spec.name] = base_module
+        base_spec.loader.exec_module(base_module)
+
+        metric_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.skeleton_branch_points",
+            VESUVIUS_SRC / "models" / "evaluation" / "skeleton_branch_points.py",
+        )
+        metric_module = importlib.util.module_from_spec(metric_spec)
+        sys.modules[metric_spec.name] = metric_module
+        metric_spec.loader.exec_module(metric_module)
+        return metric_module.SkeletonBranchPointsMetric
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+SkeletonBranchPointsMetric = _load_metric_class()
+
+
+class FakeTensor:
+    def __init__(self, data):
+        self._data = np.asarray(data, dtype=np.float32)
+        self.dtype = np.float32
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._data
+
+    def float(self):
+        return self
+
+
+def _branch_logits(class_index: int) -> np.ndarray:
+    logits = np.zeros((1, 3, 1, 5, 5), dtype=np.float32)
+    logits[:, 0, :, :, :] = 1.0
+    for y, x in ((2, 2), (1, 2), (3, 2), (2, 1), (2, 3)):
+        logits[0, class_index, 0, y, x] = 5.0
+    return logits
+
+
+class SkeletonBranchPointsMetricTest(unittest.TestCase):
+    def test_total_absdiff_sums_per_class_differences_without_class_cancellation(self):
+        metric = SkeletonBranchPointsMetric(num_classes=3, ignore_index=0)
+        metric._skeletonize_stack_2d = lambda mask: mask.astype(np.uint8)
+
+        result = metric.compute(
+            FakeTensor(_branch_logits(class_index=1)),
+            FakeTensor(_branch_logits(class_index=2)),
+        )
+
+        self.assertEqual(result["branch_points_absdiff_class_1"], 5.0)
+        self.assertEqual(result["branch_points_absdiff_class_2"], 5.0)
+        self.assertEqual(result["branch_points_pred_total"], 5.0)
+        self.assertEqual(result["branch_points_gt_total"], 5.0)
+        self.assertEqual(result["branch_points_absdiff_total"], 10.0)
+
+    def test_batched_hard_label_volumes_are_not_argmaxed_as_channel_maps(self):
+        metric = SkeletonBranchPointsMetric(num_classes=2, ignore_index=0)
+        metric._skeletonize_stack_2d = lambda mask: mask.astype(np.uint8)
+        labels = np.zeros((1, 3, 5, 5), dtype=np.float32)
+        for y, x in ((2, 2), (1, 2), (3, 2), (2, 1), (2, 3)):
+            labels[0, 2, y, x] = 1
+
+        result = metric.compute(FakeTensor(labels), FakeTensor(labels))
+
+        self.assertGreater(result["branch_points_pred_class_1"], 0.0)
+        self.assertGreater(result["branch_points_gt_class_1"], 0.0)
+        self.assertEqual(result["branch_points_absdiff_class_1"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vesuvius/tests/models/evaluation/test_voi.py
+++ b/vesuvius/tests/models/evaluation/test_voi.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+VESUVIUS_SRC = Path(__file__).resolve().parents[3] / "src" / "vesuvius"
+
+
+def _load_metric_class():
+    package_name = "_voi_metric_under_test"
+    private_modules = (
+        package_name,
+        f"{package_name}.base_metric",
+        f"{package_name}.voi",
+    )
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = object()
+    torch_stub.Tensor = object
+    cc3d_stub = types.ModuleType("cc3d")
+
+    def connected_components(mask, connectivity=26):
+        labels = np.zeros_like(mask, dtype=np.int32)
+        labels[np.asarray(mask).astype(bool)] = 1
+        return labels
+
+    cc3d_stub.connected_components = connected_components
+    skimage_stub = types.ModuleType("skimage")
+    skimage_metrics_stub = types.ModuleType("skimage.metrics")
+    skimage_metrics_stub.variation_of_information = lambda a, b: (0.0, 0.0)
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (
+            "torch",
+            "cc3d",
+            "skimage",
+            "skimage.metrics",
+            *private_modules,
+        )
+    }
+    try:
+        sys.modules["torch"] = torch_stub
+        sys.modules["cc3d"] = cc3d_stub
+        sys.modules["skimage"] = skimage_stub
+        sys.modules["skimage.metrics"] = skimage_metrics_stub
+        evaluation_pkg = types.ModuleType(package_name)
+        evaluation_pkg.__path__ = [str(VESUVIUS_SRC / "models" / "evaluation")]
+        sys.modules[package_name] = evaluation_pkg
+
+        base_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.base_metric",
+            VESUVIUS_SRC / "models" / "evaluation" / "base_metric.py",
+        )
+        base_module = importlib.util.module_from_spec(base_spec)
+        sys.modules[base_spec.name] = base_module
+        base_spec.loader.exec_module(base_module)
+
+        metric_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.voi",
+            VESUVIUS_SRC / "models" / "evaluation" / "voi.py",
+        )
+        metric_module = importlib.util.module_from_spec(metric_spec)
+        sys.modules[metric_spec.name] = metric_module
+        metric_spec.loader.exec_module(metric_module)
+        return metric_module.VOIMetric
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+VOIMetric = _load_metric_class()
+
+
+class FakeTensor:
+    def __init__(self, data):
+        self._data = np.asarray(data, dtype=np.float32)
+        self.dtype = np.float32
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._data
+
+    def float(self):
+        return self
+
+
+class VOIMetricTest(unittest.TestCase):
+    def test_batched_hard_label_volumes_are_not_argmaxed_as_channel_maps(self):
+        metric = VOIMetric(ignore_index=0)
+        labels = np.zeros((1, 3, 5, 5), dtype=np.float32)
+        labels[0, 2, 2, 2] = 1
+
+        result = metric.compute(FakeTensor(labels), FakeTensor(labels))
+
+        self.assertEqual(result["voi_total"], 0.0)
+        self.assertEqual(result["voi_score"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes several small evaluation-metric correctness issues related to multi-class totals and hard-label shape handling.

## What changed

- Makes topology-style total metrics sum per-class absolute differences instead of allowing class-level errors to cancel each other out.
- Applies that fix to:
  - Vesuvius `SkeletonBranchPointsMetric`
  - Vesuvius `ConnectedComponentsMetric`
  - the older `segmentation/evaluation` connected-components helper
- Preserves 4D hard-label batches shaped like `(B, Z, Y, X)` instead of treating small `Z` as a channel axis.
- Preserves matching unbatched 3D hard-label volumes where relevant.
- Keeps true `(B, C, H, W)` channel maps on the channel-first argmax path when `C == num_classes`.
- Handles `(B, Z, Y, X)` predictions paired with singleton-channel ground truth shaped like `(B, 1, Z, Y, X)`.
- Adds focused regression tests covering the aggregate cancellation and hard-label/channel-map ambiguity cases.

## Why

A few metrics used aggregate subtraction or small-axis channel heuristics that are reasonable for probability maps but wrong for hard-label volumes. This could hide errors when per-class differences cancel, or corrupt valid hard-label batch/volume inputs before the metric computation.

## Validation

- `python -B -m unittest discover vesuvius\tests\models\evaluation -v` — 18 tests OK
- `python -B -m unittest discover segmentation\evaluation\tests -v` — 2 tests OK
- `python -m py_compile ...` over all touched production and test files
- `git diff --check`

Note: this local workspace does not have the optional heavy evaluation dependencies (`torch`, `cc3d`, `scipy`, `skimage`, `numba`) installed, so the focused tests use small temporary dependency stubs to isolate these metric routing/aggregation behaviors.

Refs #191