### PR TITLE
throttle segment backups + make backup count configurable

### DIFF
--- a/volume-cartographer/apps/VC3D/SettingsDialog.cpp
+++ b/volume-cartographer/apps/VC3D/SettingsDialog.cpp
@@ -1,6 +1,7 @@
 #include "SettingsDialog.hpp"
 
 #include "VCSettings.hpp"
+#include "vc/core/util/QuadSurface.hpp"
 
 #include <algorithm>
 #include <thread>
@@ -61,6 +62,12 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
         const QString stored =
             settings.value(viewer::REMOTE_CACHE_DIR).toString();
         edtRemoteCachePath->setText(vc3d::remoteCachePath(stored));
+    }
+
+    // Per-segment rotating-backup count.
+    if (spinSegmentBackupCount) {
+        spinSegmentBackupCount->setValue(
+            settings.value(backup::SEGMENT_COUNT, backup::SEGMENT_COUNT_DEFAULT).toInt());
     }
 
     // IO threads is no longer user-configurable (tracks hardware_concurrency).
@@ -140,6 +147,13 @@ void SettingsDialog::accept()
     settings.setValue(perf::RAM_CACHE_SIZE_GB, spinRamCacheSizeGB->value());
     settings.setValue(viewer::REMOTE_CACHE_DIR, edtRemoteCachePath->text());
     settings.setValue(perf::DISK_CACHE_COMPRESSED, chkVideoRecompress->isChecked());
+
+    // Per-segment backup count: persist and apply live (no restart needed).
+    if (spinSegmentBackupCount) {
+        const int backupCount = spinSegmentBackupCount->value();
+        settings.setValue(backup::SEGMENT_COUNT, backupCount);
+        QuadSurface::setBackupCount(backupCount);
+    }
 
     // IO_THREADS setting removed — see CState::applyCacheBudget.
 

--- a/volume-cartographer/apps/VC3D/VCAppMain.cpp
+++ b/volume-cartographer/apps/VC3D/VCAppMain.cpp
@@ -16,6 +16,7 @@
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/CrashHandler.hpp"
 #include "vc/core/util/Logging.hpp"
+#include "vc/core/util/QuadSurface.hpp"
 
 #include <opencv2/core.hpp>
 #include <iostream>
@@ -203,6 +204,10 @@ auto main(int argc, char* argv[]) -> int
         using namespace vc3d::settings;
         QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
         cacheSizeGB = settings.value(perf::RAM_CACHE_SIZE_GB, perf::RAM_CACHE_SIZE_GB_DEFAULT).toULongLong();
+
+        // Per-segment rotating-backup count -> core (used by saveOverwrite/growth).
+        QuadSurface::setBackupCount(
+            settings.value(backup::SEGMENT_COUNT, backup::SEGMENT_COUNT_DEFAULT).toInt());
     }
     if (parser.isSet(cacheSizeOption)) {
         bool ok = false;

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -310,6 +310,15 @@ namespace tools {
 }
 
 // -----------------------------------------------------------------------------
+// Backup Settings
+// -----------------------------------------------------------------------------
+namespace backup {
+    // How many rotating snapshots to keep per segment under <volpkg>/backups/.
+    constexpr auto SEGMENT_COUNT = "backup/segment_count";
+    constexpr int  SEGMENT_COUNT_DEFAULT = 10;
+}
+
+// -----------------------------------------------------------------------------
 // Segmentation Tool Settings
 // -----------------------------------------------------------------------------
 namespace segmentation {

--- a/volume-cartographer/apps/VC3D/VCSettings.ui
+++ b/volume-cartographer/apps/VC3D/VCSettings.ui
@@ -692,6 +692,32 @@
             </property>
            </widget>
           </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="labelSegmentBackupCount">
+            <property name="text">
+             <string>Segment backups to keep</string>
+            </property>
+            <property name="toolTip">
+             <string>Number of rotating snapshots kept per segment under &lt;volpkg&gt;/backups/&lt;segment&gt;/. 0 disables backups. Snapshots are throttled to at most one every 2 minutes per segment.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QSpinBox" name="spinSegmentBackupCount">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>10</number>
+            </property>
+            <property name="toolTip">
+             <string>Number of rotating snapshots kept per segment (0 disables). Throttled to at most one snapshot per segment every 2 minutes.</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
@@ -583,6 +583,15 @@ void SegmentationOverlayController::saveApprovalMaskToSurface(QuadSurface* surfa
     surface->setChannel("approval", approvalMask);
     surface->saveChannel("approval");
 
+    // Also take a rotating backup so approval edits are recoverable. This is
+    // throttled to ~one snapshot per segment every couple minutes, so frequent
+    // approval writes coalesce instead of copying the whole segment each time.
+    try {
+        surface->saveSnapshot();
+    } catch (const std::exception& e) {
+        qWarning() << "saveApprovalMaskToSurface: backup snapshot failed:" << e.what();
+    }
+
     // Update saved image to match what we just wrote and clear pending
     for (int row = 0; row < height; ++row) {
         QRgb* savedRow = reinterpret_cast<QRgb*>(_savedApprovalMaskImage.scanLine(row));

--- a/volume-cartographer/apps/VC3D/segmentation/growth/SegmentationGrowth.cpp
+++ b/volume-cartographer/apps/VC3D/segmentation/growth/SegmentationGrowth.cpp
@@ -52,7 +52,8 @@ private:
     int _previousThreadCount{1};
 };
 
-void createRotatingBackup(QuadSurface* surface, int maxBackups = 10)
+// maxBackups < 0 -> use QuadSurface's app-configured count (the user setting).
+void createRotatingBackup(QuadSurface* surface, int maxBackups = -1)
 {
     if (!surface) {
         return;
@@ -61,8 +62,8 @@ void createRotatingBackup(QuadSurface* surface, int maxBackups = 10)
     qCInfo(lcSegGrowth) << "Creating backup for:" << QString::fromStdString(surface->path.string());
 
     try {
-        // Create a rotating backup snapshot
-        // This handles path normalization, rotation, and file copying automatically
+        // Rotating snapshot; handles path normalization, rotation, file copying,
+        // the per-segment count, and the per-minute throttle internally.
         surface->saveSnapshot(maxBackups);
         qCInfo(lcSegGrowth) << "Backup creation complete";
     } catch (const std::exception& e) {

--- a/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
@@ -378,7 +378,16 @@ public:
     cv::Mat channel(const std::string& name, int flags = 0);
     void invalidateCache();
     void saveOverwrite();
-    void saveSnapshot(int maxBackups = 10);
+    // Rotating backup under <volpkg>/backups/<seg>/. Throttled to at most one
+    // snapshot per segment every couple minutes; pass force=true to bypass.
+    // maxBackups < 0 means "use the configured default" (setBackupCount()).
+    void saveSnapshot(int maxBackups = -1, bool force = false);
+
+    // App-configurable number of rotating snapshots kept per segment. VC3D
+    // wires this to a user setting; defaults to 10 so non-GUI tools behave as
+    // before. Used by saveOverwrite() and saveSnapshot()'s default.
+    static void setBackupCount(int count);
+    static int backupCount();
     void invalidateMask();
     std::vector<std::string> channelNames() const;
 

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -25,6 +25,8 @@
 #include <vector>
 #include <fstream>
 #include <iomanip>
+#include <chrono>
+#include <atomic>
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -1214,7 +1216,7 @@ void QuadSurface::saveOverwrite()
     // Failures (disk full, permissions) are logged but never block the
     // user's edit — the backup is best-effort.
     try {
-        saveSnapshot(8);
+        saveSnapshot();  // configured count, throttled
     } catch (const std::exception& e) {
         Logger()->warn("saveOverwrite: snapshot failed for {}: {}",
                        final_path.string(), e.what());
@@ -1279,10 +1281,34 @@ void QuadSurface::writeDataToDirectory(const std::filesystem::path& dir, const s
     }
 }
 
-void QuadSurface::saveSnapshot(int maxBackups)
+// Minimum wall-clock gap between rotating snapshots of the same segment.
+// saveOverwrite()/autosave/growth all snapshot; without this, edit-cadence
+// saves would copy the whole segment dir into backups/ many times a second.
+static constexpr std::chrono::seconds kSnapshotThrottle{120};
+
+// App-configurable count of rotating snapshots kept per segment (see header).
+static std::atomic<int> g_backupCount{10};
+
+void QuadSurface::setBackupCount(int count)
+{
+    g_backupCount.store(std::max(0, count));
+}
+
+int QuadSurface::backupCount()
+{
+    return g_backupCount.load();
+}
+
+void QuadSurface::saveSnapshot(int maxBackups, bool force)
 {
     if (path.empty()) {
         throw std::runtime_error("QuadSurface::saveSnapshot() requires a valid path");
+    }
+    if (maxBackups < 0) {
+        maxBackups = g_backupCount.load();
+    }
+    if (maxBackups <= 0) {
+        return;  // backups disabled
     }
 
     // No on-disk state to back up yet — the first save will populate
@@ -1307,8 +1333,14 @@ void QuadSurface::saveSnapshot(int maxBackups)
         throw std::runtime_error("Failed to create backups directory: " + ec.message());
     }
 
-    // Find existing backup directories and determine next backup number
+    // Find existing backup directories and determine next backup number.
+    // Also track the newest slot's mtime so we can throttle: many operations
+    // (autosave, push-pull edits, growth steps) snapshot via saveOverwrite,
+    // which at edit cadence would copy the whole segment dir multiple times a
+    // second. Skip if a backup was taken within the throttle window.
     std::vector<int> existingBackups;
+    std::filesystem::file_time_type newestBackup{};
+    bool haveNewest = false;
     if (std::filesystem::exists(backupsDir)) {
         for (const auto& entry : std::filesystem::directory_iterator(backupsDir)) {
             if (entry.is_directory()) {
@@ -1316,11 +1348,25 @@ void QuadSurface::saveSnapshot(int maxBackups)
                     int backupNum = std::stoi(entry.path().filename().string());
                     if (backupNum >= 0 && backupNum < maxBackups) {
                         existingBackups.push_back(backupNum);
+                        std::error_code mtEc;
+                        const auto mt = std::filesystem::last_write_time(entry.path(), mtEc);
+                        if (!mtEc && (!haveNewest || mt > newestBackup)) {
+                            newestBackup = mt;
+                            haveNewest = true;
+                        }
                     }
                 } catch (...) {
                     // Skip non-numeric directories
                 }
             }
+        }
+    }
+
+    // Throttle: at most one snapshot per segment per kSnapshotThrottle.
+    if (!force && haveNewest) {
+        const auto age = std::filesystem::file_time_type::clock::now() - newestBackup;
+        if (age < kSnapshotThrottle) {
+            return;
         }
     }
 

--- a/volume-cartographer/core/test/test_quadsurface_snapshot.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_snapshot.cpp
@@ -72,18 +72,19 @@ TEST_CASE("saveSnapshot rotates when existing backups exceed maxBackups")
         return qs;
     };
 
-    // Take 3 snapshots with maxBackups=2 — third call must rotate.
+    // Take 3 snapshots with maxBackups=2 — third call must rotate. force=true
+    // bypasses the per-minute throttle so the rapid calls actually snapshot.
     {
         auto qs = reload();
-        qs->saveSnapshot(/*maxBackups=*/2);
+        qs->saveSnapshot(/*maxBackups=*/2, /*force=*/true);
     }
     {
         auto qs = reload();
-        qs->saveSnapshot(2);
+        qs->saveSnapshot(2, /*force=*/true);
     }
     {
         auto qs = reload();
-        qs->saveSnapshot(2);
+        qs->saveSnapshot(2, /*force=*/true);
     }
 
     auto backupsRoot = vol / "backups" / "seg1";
@@ -121,5 +122,40 @@ TEST_CASE("saveSnapshot copies all regular files (not just tifs)")
     REQUIRE(fs::exists(slot));
     CHECK(fs::exists(slot / "x.tif"));
     CHECK(fs::exists(slot / "extra.txt"));
+    fs::remove_all(vol);
+}
+
+TEST_CASE("saveSnapshot throttles rapid calls; force bypasses")
+{
+    auto vol = tmpDir("throttle");
+    auto paths = vol / "paths";
+    fs::create_directories(paths);
+    auto segDir = paths / "seg3";
+
+    {
+        QuadSurface qs(grid(), cv::Vec2f(1.f, 1.f));
+        qs.id = "seg3";
+        qs.save(segDir);
+    }
+    auto reload = [&](){
+        auto qs = std::make_unique<QuadSurface>(segDir);
+        qs->id = "seg3"; qs->path = segDir; return qs;
+    };
+
+    auto backupsRoot = vol / "backups" / "seg3";
+
+    // First snapshot creates slot 0.
+    reload()->saveSnapshot(10);
+    REQUIRE(fs::exists(backupsRoot / "0"));
+
+    // Immediate second snapshot is throttled (within the per-minute window):
+    // no new slot appears.
+    reload()->saveSnapshot(10);
+    CHECK_FALSE(fs::exists(backupsRoot / "1"));
+
+    // force=true bypasses the throttle and creates the next slot.
+    reload()->saveSnapshot(10, /*force=*/true);
+    CHECK(fs::exists(backupsRoot / "1"));
+
     fs::remove_all(vol);
 }


### PR DESCRIPTION
## Problem

Segment backup directories (`<volpkg>/backups/<seg>/{0..N}`) were being written far too often — observed churning roughly every second during interactive work.

`QuadSurface::saveSnapshot()` does a full copy of the segment directory (x/y/z + approval + mask + meta). It's reached by **9 paths**, none throttled:

- `saveOverwrite()` → snapshot, called by: **immediate autosave on `applyEdits`** (push-pull / manual-add — fires per edit, the main culprit), the 10s autosave timer, surface rotation, mask brush persist, approval-mask save, and `vc_merge_patch`.
- Direct `saveSnapshot` in **tracer / patch-tracer growth** (once per grow request).

At edit/growth cadence that's a whole-segment-dir copy multiple times a second.

Separately, the per-segment backup count was hardcoded and inconsistent (growth kept 10, `saveOverwrite` kept 8) with no way to change it.

## Fix

1. **Throttle** — `saveSnapshot` skips if the newest existing backup slot is younger than **2 minutes** (mtime-based, so it survives surface reloads and works for CLI tools). One central guard covers all 9 paths. `force=true` bypasses it.
2. **Configurable count** — `QuadSurface::setBackupCount()/backupCount()` back a static default used by `saveSnapshot(maxBackups<0)` and `saveOverwrite`. `0` disables backups. Unifies the old 8-vs-10 split (default 10).
3. **Settings UI** — new "Segment backups to keep" spinbox in the settings dialog's Cache group (key `backup/segment_count`, default 10). Read at startup (`VCAppMain`) and applied live on accept. `core/` stays free of QSettings — VC3D pushes the value in.

## Tests

`test_quadsurface_snapshot` gains a throttle case (rapid 2nd call is skipped; `force=true` creates the next slot); the existing rotation test now passes `force=true` to exercise rotation despite the throttle. All quadsurface tests pass.

## Notes

- This is independent of the approval-mask PRs (#944/#945) — the backup spam predates them (`createRotatingBackup` is from #536).