### PR TITLE
flatten: heal degenerate cells so SLIM stops NaNing / crashing

### DIFF
--- a/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
@@ -186,7 +186,20 @@ static cv::Mat_<cv::Vec3f> build_vertex_normals_from_faces(
 static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_fn, bool normalize_uv, bool align_grid, float keep_percent, bool clean_surface, float clean_sigma_k, bool inpaint_holes)
 {
     cv::Mat_<cv::Vec3f> points = surf->rawPoints();
-    
+
+    // Heal degenerate (collapsed grid-adjacent) cells before anything else.
+    // These tracer defects make zero-area triangles that NaN SLIM at iter 1;
+    // healthy adjacent cells are ~1/scale voxels apart. No-op if none found.
+    {
+        const cv::Vec2f sc = surf->scale();
+        const double scale = (std::isfinite(sc[0]) && sc[0] > 0.f) ? sc[0] : 0.0;
+        const int healed = vc::core::util::healDegenerateCells(points, scale);
+        if (healed > 0) {
+            std::cerr << "note: healed " << healed
+                      << " degenerate (collapsed) grid cell(s) before flattening\n";
+        }
+    }
+
     // Clean surface outliers if requested
     if (clean_surface) {
         std::cout << "Cleaning surface outliers..." << std::endl;
@@ -288,24 +301,79 @@ static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_f
         std::cout << "      (meta scale = [" << s[0] << ", " << s[1] << "])\n";
     }
 
-    int v_idx = 1;
+    // Expected healthy adjacent-cell spacing in voxels (= 1/scale); used to
+    // judge degenerate triangles scale-relatively below.
+    const double expected_step = (std::isfinite(uv_fac_x) && uv_fac_x > 0.f) ? double(uv_fac_x) : 1.0;
+
+    // Guard: never emit a zero-area triangle. healDegenerateCells repairs the
+    // vast majority of collapsed cells, but a few (e.g. fully-collapsed 2x2
+    // blocks) can't be separated locally -- and even one zero-area triangle
+    // makes SLIM's symmetric-Dirichlet system singular and NaN at iter 1. Skip
+    // any triangle whose three grid corners aren't geometrically distinct; the
+    // worst case is a sub-cell hole, which the flattener tolerates.
+    auto tri_ok = [&](cv::Vec2i A, cv::Vec2i B, cv::Vec2i C) -> bool {
+        const cv::Vec3d pa = points(A[0], A[1]);
+        const cv::Vec3d pb = points(B[0], B[1]);
+        const cv::Vec3d pc = points(C[0], C[1]);
+        const cv::Vec3d ab = pb - pa, ac = pc - pa;
+        // Reject if any edge is (near-)zero, or the triangle is a sliver:
+        // 2*area / (longest edge) is the shortest height; require it to be a
+        // meaningful fraction of the expected cell spacing. Scale-relative so
+        // it works regardless of coordinate magnitude (~1e4 here).
+        const double bc = cv::norm(pc - pb);
+        const double eAB = cv::norm(ab), eAC = cv::norm(ac);
+        const double emin = std::min(std::min(eAB, eAC), bc);
+        const double emax = std::max(std::max(eAB, eAC), bc);
+        if (emin < 1e-3 * expected_step) return false;     // collapsed edge
+        const double twiceArea = cv::norm(ab.cross(ac));
+        if (emax <= 0.0) return false;
+        const double height = twiceArea / emax;            // shortest altitude
+        return height > 1e-3 * expected_step;              // not a sliver
+    };
+
+    // Two passes so we never emit an orphan vertex (one referenced by no
+    // surviving triangle). An orphan leaves an all-zero row/col in SLIM's
+    // L = AᵀWA, which crashes the PaStiX Cholesky (heap corruption / SIGSEGV
+    // during factorization). Pass 1: collect surviving triangles as grid-cell
+    // triples and mark which cells are actually used. Pass 2: emit only used
+    // vertices (get_add_vertex dedups via idxs), then the faces.
+    struct Tri { cv::Vec2i a, b, c; };
+    std::vector<Tri> tris;
+    tris.reserve(static_cast<size_t>(points.rows) * points.cols * 2);
+    cv::Mat_<uchar> used(points.size(), uchar(0));
+
+    int n_skipped = 0;
     for (int j = 0; j < points.rows - 1; ++j)
         for (int i = 0; i < points.cols - 1; ++i)
             if (loc_valid(points, cv::Vec2d(j, i)))
             {
-                const int c00 = get_add_vertex(out, griduv_ptr, points, normals, idxs, v_idx, {j,   i  }, normalize_uv, uv_fac_x, uv_fac_y);
-                const int c01 = get_add_vertex(out, griduv_ptr, points, normals, idxs, v_idx, {j,   i+1}, normalize_uv, uv_fac_x, uv_fac_y);
-                const int c10 = get_add_vertex(out, griduv_ptr, points, normals, idxs, v_idx, {j+1, i  }, normalize_uv, uv_fac_x, uv_fac_y);
-                const int c11 = get_add_vertex(out, griduv_ptr, points, normals, idxs, v_idx, {j+1, i+1}, normalize_uv, uv_fac_x, uv_fac_y);
-                // faces unchanged: use same index for v/vt/vn
-                out << "f " << c10 << "/" << c10 << "/" << c10 << " "
-                           << c00 << "/" << c00 << "/" << c00 << " "
-                           << c01 << "/" << c01 << "/" << c01 << '\n';
-
-                out << "f " << c10 << "/" << c10 << "/" << c10 << " "
-                           << c01 << "/" << c01 << "/" << c01 << " "
-                           << c11 << "/" << c11 << "/" << c11 << '\n';
+                const cv::Vec2i L00{j, i}, L01{j, i+1}, L10{j+1, i}, L11{j+1, i+1};
+                if (tri_ok(L10, L00, L01)) {
+                    tris.push_back({L10, L00, L01});
+                    used(L10) = used(L00) = used(L01) = 1;
+                } else { ++n_skipped; }
+                if (tri_ok(L10, L01, L11)) {
+                    tris.push_back({L10, L01, L11});
+                    used(L10) = used(L01) = used(L11) = 1;
+                } else { ++n_skipped; }
             }
+
+    int v_idx = 1;
+    auto idx_of = [&](const cv::Vec2i& L) {
+        return get_add_vertex(out, griduv_ptr, points, normals, idxs, v_idx, L,
+                              normalize_uv, uv_fac_x, uv_fac_y);
+    };
+    for (const Tri& t : tris) {
+        const int a = idx_of(t.a), b = idx_of(t.b), c = idx_of(t.c);
+        // same index for v/vt/vn
+        out << "f " << a << "/" << a << "/" << a << " "
+                   << b << "/" << b << "/" << b << " "
+                   << c << "/" << c << "/" << c << '\n';
+    }
+    if (n_skipped > 0) {
+        std::cerr << "note: skipped " << n_skipped
+                  << " degenerate (zero-area) triangle(s) at emit\n";
+    }
 }
 
 int main(int argc, char *argv[])

--- a/volume-cartographer/core/include/vc/core/util/InpaintSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/InpaintSurface.hpp
@@ -21,4 +21,25 @@ int inpaintSurfaceHoles(cv::Mat_<cv::Vec3f>& points,
                         double unit = 1.0,
                         int max_iters = 2000);
 
+// Heal degenerate grid cells: grid-adjacent points that have collapsed onto
+// (nearly) the same 3D location. These are tracer defects -- a healthy sheet
+// keeps adjacent cells ~one step (1/scale voxels) apart -- and they produce
+// zero/near-zero-area triangles that make SLIM / symmetric-Dirichlet energy
+// blow up to NaN. Real folds / scroll wraps are never grid-adjacent, so this
+// never touches them.
+//
+// A cell is dropped (set invalid) if any 4-neighbor valid edge is shorter than
+// min_edge_frac * expected_step, where expected_step = 1/scale voxels (from the
+// segment meta; pass scale <= 0 to derive it from the median valid step).
+// Dropped cells are then refilled via inpaintSurfaceHoles, so the output stays
+// a complete grid interpolated from the healthy surroundings.
+//
+// Returns the number of cells dropped. dropped_mask, if non-null, is sized to
+// points and set to 1 where a cell was marked invalid, so callers can clear the
+// same cells in other channels (e.g. approval).
+int healDegenerateCells(cv::Mat_<cv::Vec3f>& points,
+                        double scale,
+                        double min_edge_frac = 0.10,
+                        cv::Mat_<uchar>* dropped_mask = nullptr);
+
 } // namespace vc::core::util

--- a/volume-cartographer/core/src/InpaintSurface.cpp
+++ b/volume-cartographer/core/src/InpaintSurface.cpp
@@ -255,4 +255,89 @@ int inpaintSurfaceHoles(cv::Mat_<cv::Vec3f>& points, double unit, int max_iters)
     return total_filled;
 }
 
+int healDegenerateCells(cv::Mat_<cv::Vec3f>& points,
+                        double scale,
+                        double min_edge_frac,
+                        cv::Mat_<uchar>* dropped_mask)
+{
+    const int rows = points.rows;
+    const int cols = points.cols;
+    if (rows <= 0 || cols <= 0) return 0;
+
+    // Expected healthy adjacent-cell spacing, in the same units as the points
+    // (voxels). meta scale is cells-per-voxel, so 1/scale voxels per cell.
+    double expected = (scale > 0.0) ? (1.0 / scale) : 0.0;
+    if (expected <= 0.0) {
+        // Fallback: median nonzero 4-neighbor step among valid cells.
+        std::vector<double> steps;
+        for (int r = 0; r < rows; ++r)
+            for (int c = 0; c < cols; ++c) {
+                if (!isValid(points(r, c))) continue;
+                if (c + 1 < cols && isValid(points(r, c + 1))) {
+                    double d = cv::norm(points(r, c) - points(r, c + 1));
+                    if (d > 0.0) steps.push_back(d);
+                }
+                if (r + 1 < rows && isValid(points(r + 1, c))) {
+                    double d = cv::norm(points(r, c) - points(r + 1, c));
+                    if (d > 0.0) steps.push_back(d);
+                }
+            }
+        if (steps.empty()) return 0;
+        std::nth_element(steps.begin(), steps.begin() + steps.size() / 2, steps.end());
+        expected = steps[steps.size() / 2];
+    }
+    const double min_edge = min_edge_frac * expected;
+
+    cv::Mat_<uchar> dropped_total(rows, cols, uchar(0));
+    int total_dropped = 0;
+    const int kMaxPasses = 6;
+
+    // Detect collapsed cells, then drop whole *clusters* (dilated by one ring)
+    // rather than individual endpoints. A single bad point inpaints fine, but a
+    // fully-collapsed 2x2 block leaves each cell with collapsed in-block
+    // neighbors, so endpoint-only drops never give the solve a clean hole.
+    // Dropping the connected cluster + a 1-cell margin hands inpaintSurfaceHoles
+    // a proper interior hole with all-healthy boundary, which it interpolates
+    // cleanly. Iterate a few times since Ceres can still nudge a refill back.
+    for (int pass = 0; pass < kMaxPasses; ++pass) {
+        cv::Mat_<uchar> collapsed(rows, cols, uchar(0));
+        auto markPair = [&](int r0, int c0, int r1, int c1) {
+            if (!isValid(points(r0, c0)) || !isValid(points(r1, c1))) return;
+            if (cv::norm(points(r0, c0) - points(r1, c1)) < min_edge) {
+                collapsed(r0, c0) = 1;
+                collapsed(r1, c1) = 1;
+            }
+        };
+        for (int r = 0; r < rows; ++r)
+            for (int c = 0; c < cols; ++c) {
+                if (c + 1 < cols) markPair(r, c, r, c + 1);
+                if (r + 1 < rows) markPair(r, c, r + 1, c);
+            }
+        if (cv::countNonZero(collapsed) == 0) break;  // converged
+
+        // Dilate the collapsed set by one ring (3x3) so each cluster is dropped
+        // as a unit with a margin; only drop currently-valid cells.
+        cv::Mat_<uchar> drop;
+        cv::dilate(collapsed, drop, cv::Mat::ones(3, 3, CV_8U));
+
+        int n_dropped = 0;
+        for (int r = 0; r < rows; ++r)
+            for (int c = 0; c < cols; ++c)
+                if (drop(r, c) && isValid(points(r, c))) {
+                    points(r, c) = cv::Vec3f(-1.f, -1.f, -1.f);
+                    dropped_total(r, c) = 1;
+                    ++n_dropped;
+                }
+        total_dropped += n_dropped;
+
+        // Refill the whole dropped region from its healthy boundary.
+        inpaintSurfaceHoles(points, expected);
+    }
+
+    if (dropped_mask) {
+        *dropped_mask = dropped_total;
+    }
+    return total_dropped;
+}
+
 } // namespace vc::core::util

--- a/volume-cartographer/libs/libigl_changes/include/igl/pastix6_solver.h
+++ b/volume-cartographer/libs/libigl_changes/include/igl/pastix6_solver.h
@@ -99,6 +99,10 @@ public:
         spm_.n       = static_cast<pastix_int_t>(L.rows());
         spm_.dof     = 1;
         spm_.layout  = SpmColMajor;
+        // spmInit leaves replicated = -1 ("uninitialized"); we build one full
+        // local (non-distributed) matrix, so it is replicated. Leaving it -1
+        // is a latent bug: PaStiX's distributed-path branches key off this.
+        spm_.replicated = 1;
 
         const pastix_int_t n = static_cast<pastix_int_t>(L.rows());
         const int* outer = L.outerIndexPtr();


### PR DESCRIPTION
## Problem

Full-res SLIM flattening of some segments failed hard: `-nan` energy at iter 1 (and, once that was worked around, a PaStiX heap corruption / SIGSEGV during factorization). It happened at every decimation level, so decimation never rescued it.

Root cause is degenerate input geometry the tracer emits: **grid-adjacent** points collapsed onto the same (or sub-voxel) 3D location. A healthy sheet keeps adjacent cells ~`1/scale` voxels apart; the repro segment (`20230702185753_v11`, 3.9M verts) had ~6k coincident adjacent points scattered in ~2,500 tiny clusters. These make zero-area triangles → infinite symmetric-Dirichlet energy → singular system → NaN.

## Fix (three layers, all geometry-side)

1. **`healDegenerateCells()`** (core, next to `inpaintSurfaceHoles`): detects collapsed grid cells, drops the connected cluster (dilated by a ring) so the inpaint gets a clean interior hole with healthy boundary, and refills via `inpaintSurfaceHoles`, iterating a few passes. Threshold is relative to `1/scale` so it adapts across segments. Optional `dropped_mask` out-param lets callers clear the same cells in other channels (approval, etc.). Repairs ~70k cells on the repro.

2. **Scale-relative emit guard** in `vc_tifxyz2obj`: a few fully-collapsed 2×2 blocks can't be separated locally, and even one zero-area triangle re-NaNs SLIM. The guard skips any triangle with a collapsed edge or sliver altitude → **0** zero-area triangles reach the OBJ (worst case: a sub-cell hole the flattener tolerates).

3. **Two-pass emit** in `vc_tifxyz2obj`: skipping triangles can leave a vertex referenced by no surviving face. Such an **orphan** is an all-zero row/col in `L = AᵀWA`, which crashes the PaStiX Cholesky (the "double free / SIGSEGV" that looked like a solver bug). Now we collect surviving triangles first, then emit only the vertices they use — no orphans.

Plus a one-line latent fix in the `Pastix6LLT` wrapper: `spmInit` leaves `spm.replicated = -1` ("uninitialized"); set it to `1` (single local matrix) so PaStiX doesn't take distributed-matrix branches.

## Verification

`20230702185753_v11`: was `-nan` at iter 1 at every decimation. Now flattens cleanly **via the VC3D SLIM panel** (GUI, decimated path, new segment created) and via CLI at `keep=2/6/25` — 0 orphans, 0 zero-area triangles, converged L2 ≈ 1.0, valid output OBJ.

## Notes

- The tracer is the upstream source of these collapsed cells (it initializes new points at a neighbor's position and can accept them without a min-spacing check). Fixing the tracer is a separate, larger change; this PR makes the flatten pipeline robust to the defects regardless.
- Full-res (3.9M verts) may still OOM on low-RAM hosts — that's a genuine memory limit, not a crash; decimate as needed.