### PR TITLE
skip VC CI compile/test jobs when no volume-cartographer changes

### DIFF
--- a/.github/workflows/vc3d-ci.yml
+++ b/.github/workflows/vc3d-ci.yml
@@ -47,6 +47,7 @@ jobs:
   build-test:
     name: ${{ matrix.action }}-${{ matrix.preset }}-${{ matrix.compiler }} (${{ matrix.image }})
     needs: changes
+    if: needs.changes.outputs.vc == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     continue-on-error: ${{ matrix.blocking != true }}
@@ -79,6 +80,7 @@ jobs:
   coverage:
     name: Coverage (clang, source-based)
     needs: changes
+    if: needs.changes.outputs.vc == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     continue-on-error: true
@@ -179,6 +181,7 @@ jobs:
   dead-code:
     name: Dead-code report (clang, nm + --print-gc-sections)
     needs: changes
+    if: needs.changes.outputs.vc == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     continue-on-error: true


### PR DESCRIPTION
## Summary
- Gate `build-test`, `coverage`, and `dead-code` jobs in `vc3d-ci.yml` on `needs.changes.outputs.vc == 'true'`, matching the existing `macos-build` pattern.
- PRs that don't touch `volume-cartographer/**` (e.g. #992, which only edits `scrollprize.org/`) currently still run the full compile/sanitizer/coverage matrix because the `changes` outputs were computed but never consulted by those jobs.
- The aggregate `CI` job already accepts `skipped` results, so the required check still passes for non-VC PRs.

## Test plan
- [ ] This PR touches `.github/workflows/vc3d-ci.yml`, so the `vc` filter matches and all gated jobs should still run here.