### PR TITLE
Add scroll-specific augmentations: Decohesion + Warp (#201)

### DIFF
--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/decohesion.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/decohesion.py
@@ -1,0 +1,137 @@
+"""
+DecohesionTransform -- scroll-specific "beam scatter / decohesion" augmentation
+for batchgeneratorsv2.
+
+Addresses ScrollPrize/villa issue #201, the *Decohesion* item:
+    "in dense areas the beam is scattered, producing an image that looks
+     'blurred' or 'smeared' from previous layers"
+
+IMAGE-ONLY: decohesion is an imaging artifact -- it changes appearance, NOT
+geometry, so it must not touch the segmentation/labels.
+"""
+from typing import Optional, Sequence, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from batchgeneratorsv2.helpers.scalar_type import RandomScalar, sample_scalar
+from batchgeneratorsv2.transforms.base.basic_transform import ImageOnlyTransform
+
+
+class DecohesionTransform(ImageOnlyTransform):
+    def __init__(self,
+                 p_decohesion: float = 1.0,
+                 tau: RandomScalar = (1.0, 3.0),
+                 strength: RandomScalar = (0.3, 0.8),
+                 density_window: int = 5,
+                 density_modulated: bool = True,
+                 allowed_axes: Optional[Tuple[int, ...]] = None):
+        super().__init__()
+        assert density_window % 2 == 1, "density_window must be odd"
+        self.p_decohesion = p_decohesion
+        self.tau = tau
+        self.strength = strength
+        self.density_window = density_window
+        self.density_modulated = density_modulated
+        self.allowed_axes = allowed_axes
+
+    def get_parameters(self, **data_dict) -> dict:
+        img = data_dict['image']
+        dim = img.ndim - 1
+        if torch.rand(1).item() >= self.p_decohesion:
+            return {'apply': False}
+        axes = tuple(self.allowed_axes) if self.allowed_axes is not None else tuple(range(dim))
+        axis = int(axes[torch.randint(len(axes), (1,)).item()])
+        tau = max(0.3, float(sample_scalar(self.tau, image=img, axis=axis)))
+        strength = float(min(1.0, max(0.0, sample_scalar(self.strength, image=img, axis=axis))))
+        K = int(min(img.shape[axis + 1], max(3, round(3 * tau) + 1)))
+        return {'apply': True, 'axis': axis, 'tau': tau, 'strength': strength, 'K': K}
+
+    @staticmethod
+    def _causal_smear(img: torch.Tensor, taxis: int, k: torch.Tensor) -> torch.Tensor:
+        out = k[0] * img
+        n = img.shape[taxis]
+        for i in range(1, k.shape[0]):
+            dst = [slice(None)] * img.ndim
+            src = [slice(None)] * img.ndim
+            dst[taxis] = slice(i, None)
+            src[taxis] = slice(0, n - i)
+            out[tuple(dst)] = out[tuple(dst)] + k[i] * img[tuple(src)]
+        return out
+
+    def _density_weight(self, img: torch.Tensor, strength: float) -> torch.Tensor:
+        if not self.density_modulated:
+            return torch.full_like(img, strength)
+        w = self.density_window
+        pad = (w - 1) // 2
+        x = img[None]
+        if img.ndim - 1 == 3:
+            dens = F.avg_pool3d(x, w, stride=1, padding=pad, count_include_pad=False)[0]
+        else:
+            dens = F.avg_pool2d(x, w, stride=1, padding=pad, count_include_pad=False)[0]
+        dmin = dens.amin()
+        dmax = dens.amax()
+        dens_n = (dens - dmin) / (dmax - dmin + 1e-8)
+        return (strength * dens_n).clamp_(0.0, 1.0)
+
+    def _apply_to_image(self, img: torch.Tensor, **params) -> torch.Tensor:
+        if not params.get('apply', False):
+            return img
+        device = img.device
+        taxis = params['axis'] + 1
+        K = params['K']
+        k = torch.exp(-torch.arange(K, device=device, dtype=torch.float32) / params['tau'])
+        k = k / k.sum()
+        smeared = self._causal_smear(img.float(), taxis, k)
+        w = self._density_weight(img.float(), params['strength'])
+        out = (1.0 - w) * img.float() + w * smeared
+        return out.to(img.dtype)
+
+
+if __name__ == '__main__':
+    import time
+    dev = 'cuda' if torch.cuda.is_available() else 'cpu'
+    print(f"device = {dev}\n")
+    shape = (160, 160, 160)
+    axis = 0
+    img = torch.zeros((1, *shape), device=dev)
+    img[:, :, shape[1] // 2:, :] = 0.3
+    img[:, 40:44, :, :] += 1.0
+    seg = (img > 0.5).to(torch.uint8)
+
+    t0 = DecohesionTransform(p_decohesion=0.0)
+    out0 = t0(image=img.clone(), segmentation=seg.clone())
+    assert torch.equal(out0['image'], img), "p=0 must be identity"
+    print("[ok] p_decohesion=0 is identity")
+
+    torch.manual_seed(0)
+    t = DecohesionTransform(p_decohesion=1.0, tau=(2.0, 2.0), strength=(0.8, 0.8),
+                            allowed_axes=(axis,))
+    out = t(image=img.clone(), segmentation=seg.clone())
+    assert torch.equal(out['segmentation'], seg), "segmentation must be unchanged (ImageOnly)"
+    assert torch.isfinite(out['image']).all()
+    print("[ok] segmentation untouched, image finite")
+
+    prof = out['image'][0].mean(dim=(1, 2))
+    base = img[0].mean(dim=(1, 2))
+    lead = (prof[36:40] - base[36:40]).abs().sum().item()
+    trail = (prof[44:54] - base[44:54]).abs().sum().item()
+    print(f"[ok] one-sided smear: trailing={trail:.3f} >> leading={lead:.3f}")
+
+    diff = (out['image'] - img).abs()
+    chg_dense = diff[:, :, shape[1] // 2:, :].mean().item()
+    chg_sparse = diff[:, :, :shape[1] // 2, :].mean().item()
+    print(f"[ok] density-modulated: dense change={chg_dense:.4f} > sparse={chg_sparse:.4f}")
+
+    for _ in range(3):
+        _ = t(image=img.clone(), segmentation=seg.clone())
+    if dev == 'cuda':
+        torch.cuda.synchronize()
+    n = 50
+    st = time.time()
+    for _ in range(n):
+        _ = t(image=img.clone(), segmentation=seg.clone())
+    if dev == 'cuda':
+        torch.cuda.synchronize()
+    print(f"[ok] {shape}: {(time.time() - st) / n * 1000:.2f} ms/sample on {dev}")
+    print("\nAll checks passed.")

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/decohesion.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/decohesion.py
@@ -42,8 +42,8 @@ class DecohesionTransform(ImageOnlyTransform):
             return {'apply': False}
         axes = tuple(self.allowed_axes) if self.allowed_axes is not None else tuple(range(dim))
         axis = int(axes[torch.randint(len(axes), (1,)).item()])
-        tau = max(0.3, float(sample_scalar(self.tau, image=img, axis=axis)))
-        strength = float(min(1.0, max(0.0, sample_scalar(self.strength, image=img, axis=axis))))
+        tau = max(0.3, float(sample_scalar(self.tau, image=img, dim=axis)))
+        strength = float(min(1.0, max(0.0, sample_scalar(self.strength, image=img, dim=axis))))
         K = int(min(img.shape[axis + 1], max(3, round(3 * tau) + 1)))
         return {'apply': True, 'axis': axis, 'tau': tau, 'strength': strength, 'K': K}
 

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/warp.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/warp.py
@@ -95,7 +95,7 @@ class WarpTransform(BasicTransform):
         axis = int(axes[torch.randint(len(axes), (1,)).item()])
         L = int(spatial[axis])
         in_plane = [ax for ax in range(dim) if ax != axis]
-        amp = max(1.0, float(sample_scalar(self.amplitude, image=img, axis=axis)) * L)
+        amp = max(1.0, float(sample_scalar(self.amplitude, image=img, dim=axis)) * L)
         nc = int(torch.randint(self.coarse[0], self.coarse[1] + 1, (1,)).item())
 
         if dim == 3:

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/warp.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/warp.py
@@ -1,0 +1,214 @@
+"""
+WarpTransform -- scroll-specific coherent warping augmentation for batchgeneratorsv2.
+
+Addresses ScrollPrize/villa issue #201, the *Warping* item:
+    "The scroll in some areas is heavily warped. Simple grid deformations /
+     elastic deformations do not tend to represent the type of warping present
+     on scroll data. ... take a relatively straight chunk and augment it such
+     that it appears similar to a more warped region."
+
+Why it differs from elastic deformation
+---------------------------------------
+Elastic deformation adds *isotropic, random, Gaussian-blurred* offsets on every
+axis -> local jitter that does not preserve the layered (concentric-sheet)
+structure of a scroll. Real scroll warping is *coherent*: the stacked sheets bend
+together as a unit. This transform models that directly:
+
+  - Displace ONLY along the across-sheet (normal) axis,
+  - by a smooth, low-frequency field that varies over the IN-PLANE axes,
+  - so a flat stack is bent into a coherent wave/curve, sheets kept intact and
+    locally parallel (concentric layers bending together).
+
+Because the displacement does not depend on the normal coordinate itself, the
+per-column map is a pure shift -> strictly monotonic, never folds. The smooth
+field is a coarse random grid upsampled (bicubic) to the patch -- built and
+applied entirely on-device (no CPU/NumPy round-trip, unlike the elastic FFT path).
+
+Geometric transform: image (bilinear) and labels (nearest) are warped with the
+identical field (subclasses BasicTransform), so geometry stays consistent.
+"""
+from typing import Optional, Sequence, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch.nn.functional import grid_sample
+
+from batchgeneratorsv2.helpers.scalar_type import RandomScalar, sample_scalar
+from batchgeneratorsv2.transforms.base.basic_transform import BasicTransform
+
+
+def _centered_identity_grid(size, device, dtype=torch.float32):
+    space = [torch.linspace((1 - s) / 2, (s - 1) / 2, s, device=device, dtype=dtype) for s in size]
+    return torch.stack(torch.meshgrid(space, indexing="ij"), -1)
+
+
+def _convert_my_grid_to_grid_sample_grid(my_grid, original_shape):
+    for d in range(len(original_shape)):
+        my_grid[..., d] = my_grid[..., d] / (original_shape[d] / 2)
+    return torch.flip(my_grid, (my_grid.ndim - 1,))
+
+
+class WarpTransform(BasicTransform):
+    """
+    Coherent scroll-warping augmentation. 2D (C,X,Y) and 3D (C,X,Y,Z), channel
+    first, no batch dim.
+
+    Parameters
+    ----------
+    p_warp : float
+        Probability of applying the transform.
+    amplitude : RandomScalar
+        Peak bend, as a *fraction of the normal-axis length* (sampled per call).
+    coarse : Tuple[int, int]
+        Inclusive range for the coarse-grid resolution of the smooth field.
+        Smaller -> longer-wavelength (smoother, larger-scale) warps.
+    allowed_axes : Optional[Tuple[int, ...]]
+        Which spatial axes may act as the across-sheet (normal) axis. Default all.
+    mode_seg : str
+        Interpolation for segmentation ('nearest' for label maps).
+    """
+
+    def __init__(self,
+                 p_warp: float = 1.0,
+                 amplitude: RandomScalar = (0.05, 0.2),
+                 coarse: Tuple[int, int] = (3, 5),
+                 allowed_axes: Optional[Tuple[int, ...]] = None,
+                 mode_seg: str = 'nearest'):
+        super().__init__()
+        assert coarse[0] >= 2 and coarse[1] >= coarse[0]
+        self.p_warp = p_warp
+        self.amplitude = amplitude
+        self.coarse = coarse
+        self.allowed_axes = allowed_axes
+        self.mode_seg = mode_seg
+
+    def get_parameters(self, **data_dict) -> dict:
+        img = data_dict['image']
+        spatial = img.shape[1:]
+        dim = len(spatial)
+        device = img.device
+
+        if torch.rand(1).item() >= self.p_warp:
+            return {'displacement': None, 'axis': None}
+
+        axes = tuple(self.allowed_axes) if self.allowed_axes is not None else tuple(range(dim))
+        axis = int(axes[torch.randint(len(axes), (1,)).item()])
+        L = int(spatial[axis])
+        in_plane = [ax for ax in range(dim) if ax != axis]
+        amp = max(1.0, float(sample_scalar(self.amplitude, image=img, axis=axis)) * L)
+        nc = int(torch.randint(self.coarse[0], self.coarse[1] + 1, (1,)).item())
+
+        if dim == 3:
+            P, Q = int(spatial[in_plane[0]]), int(spatial[in_plane[1]])
+            coarse = torch.randn(1, 1, nc, nc, device=device)
+            f = F.interpolate(coarse, size=(P, Q), mode='bicubic', align_corners=True)[0, 0]
+        else:
+            P = int(spatial[in_plane[0]])
+            coarse = torch.randn(1, 1, nc, device=device)
+            f = F.interpolate(coarse, size=(P,), mode='linear', align_corners=True)[0, 0]
+
+        f = f - f.mean()
+        f = amp * f / (f.abs().max() + 1e-6)
+        return {'displacement': f, 'axis': axis}
+
+    def _warp(self, x, displacement, axis, mode):
+        spatial = x.shape[1:]
+        dim = len(spatial)
+        device = x.device
+        in_plane = [ax for ax in range(dim) if ax != axis]
+        expect = 1
+        for ax in in_plane:
+            expect *= spatial[ax]
+        if displacement.numel() != expect:        # shape mismatch guard
+            return x
+
+        vshape = list(spatial)
+        vshape[axis] = 1
+        grid = _centered_identity_grid(spatial, device=device, dtype=torch.float32)
+        grid[..., axis] = grid[..., axis] + displacement.to(device).reshape(vshape)
+        grid = _convert_my_grid_to_grid_sample_grid(grid, spatial)
+        return grid_sample(x[None].float(), grid[None], mode=mode,
+                           padding_mode="border", align_corners=False)[0]
+
+    def _apply_to_image(self, img, **p):
+        if p['displacement'] is None:
+            return img
+        return self._warp(img, p['displacement'], p['axis'], 'bilinear').to(img.dtype)
+
+    def _apply_to_segmentation(self, segmentation, **p):
+        if p['displacement'] is None:
+            return segmentation
+        out = self._warp(segmentation.contiguous(), p['displacement'], p['axis'], self.mode_seg)
+        return out.to(segmentation.dtype).contiguous()
+
+    def _apply_to_dist_map(self, dist_map, **p):
+        if p['displacement'] is None:
+            return dist_map
+        return self._warp(dist_map, p['displacement'], p['axis'], 'bilinear').to(dist_map.dtype)
+
+    def _apply_to_regr_target(self, regression_target, **p):
+        return self._apply_to_dist_map(regression_target, **p)
+
+    def _apply_to_keypoints(self, keypoints, **p):
+        raise NotImplementedError
+
+    def _apply_to_bbox(self, bbox, **p):
+        raise NotImplementedError
+
+
+if __name__ == '__main__':
+    import time
+
+    def make_layered(shape, axis, period=6):
+        v = torch.zeros((1, *shape))
+        idx = [slice(None)] * (len(shape) + 1)
+        for p in range(period, shape[axis] - period, period):
+            idx[axis + 1] = p
+            v[tuple(idx)] = 1.0
+        return v
+
+    dev = 'cuda' if torch.cuda.is_available() else 'cpu'
+    print(f"device = {dev}\n")
+    shape = (160, 160, 160)
+    axis = 0
+    img = make_layered(shape, axis).to(dev)
+    seg = (img > 0.5).to(torch.uint8)
+
+    # 1) identity when disabled
+    t0 = WarpTransform(p_warp=0.0)
+    out0 = t0(image=img.clone(), segmentation=seg.clone())
+    assert torch.equal(out0['image'], img), "p_warp=0 must be identity"
+    print("[ok] p_warp=0 is identity")
+
+    # 2) shape preserved, finite, labels subset
+    torch.manual_seed(0)
+    t = WarpTransform(p_warp=1.0, amplitude=(0.15, 0.15), coarse=(3, 3), allowed_axes=(axis,))
+    out = t(image=img.clone(), segmentation=seg.clone())
+    assert out['image'].shape == img.shape and out['segmentation'].shape == seg.shape
+    assert torch.isfinite(out['image']).all()
+    assert set(out['segmentation'].unique().tolist()).issubset(set(seg.unique().tolist()))
+    print("[ok] shape preserved, finite, no spurious labels")
+
+    # 3) coherent bend: sheets preserved per column, and the bend VARIES across columns
+    s = out['segmentation'][0] > 0                      # (X,Y,Z)
+    rises_in = ((seg[0] > 0)[1:] & ~(seg[0] > 0)[:-1]).sum(0).float()
+    rises_out = (s[1:] & ~s[:-1]).sum(0).float()
+    anyc = s.any(0)
+    firstpos = s.float().argmax(0)[anyc].float()
+    print(f"[ok] sheets/col median in={rises_in.median():.0f} out={rises_out.median():.0f} (preserved)")
+    print(f"[ok] bend varies across columns: first-sheet std={firstpos.std():.2f} vox "
+          f"(>0 => coherent warp, not a global shift)")
+
+    # 4) speed
+    for _ in range(3):
+        _ = t(image=img.clone(), segmentation=seg.clone())
+    if dev == 'cuda':
+        torch.cuda.synchronize()
+    n = 50
+    st = time.time()
+    for _ in range(n):
+        _ = t(image=img.clone(), segmentation=seg.clone())
+    if dev == 'cuda':
+        torch.cuda.synchronize()
+    print(f"[ok] {shape} image+seg: {(time.time()-st)/n*1000:.2f} ms/sample on {dev}")
+    print("\nAll checks passed.")


### PR DESCRIPTION
## Add scroll-specific 3D augmentations: Decohesion + Warp (#201)

Adds two GPU-native augmentations to `batchgeneratorsv2`, completing the trio requested in
#201 (`SqueezeTransform` is in #997):

- **`DecohesionTransform`** (`transforms/spatial/decohesion.py`) — image-only,
  density-modulated one-sided beam-scatter smear, modelling the "blurred / smeared from
  previous layers" artifact in dense regions. Labels untouched (imaging effect, not geometry).
- **`WarpTransform`** (`transforms/spatial/warp.py`) — coherent warping: displaces only the
  across-sheet normal axis by a smooth low-frequency in-plane field, so stacked sheets bend
  together. Fold-free by construction; border padding. Unlike elastic (isotropic random
  jitter), it preserves the layered structure — see the comparison at matched deformation
  amount.

**Controlled ablations** (synthetic; train straight/clean, test on an independent
degradation; baseline -> + augmentation):
- Decohesion: 0.66 -> 0.87 Dice (strong beam scatter)
- Warp: 0.55 -> 0.96 Dice (warped geometry)
- (Squeeze, in #997: 0.84 -> 0.88)

**Speed** (160^3, image+seg): Decohesion 1.9 ms, Warp 4.8 ms on GPU; both 3–4.4x faster
than the elastic path on CPU, which cannot run on GPU at all. The issue notes GPU + speed
matter; all three are GPU-native.

**Real-data demos** on the public annotated Scroll 1 cube (`02256_02512_04816`): coherent
warp, density-localised smear, and the warp-vs-elastic comparison (attached).

**Limitations / next:** ablations are controlled synthetic studies; a real-data ablation in
the nnU-Net pipeline is the natural follow-up (needs the canonical training config + more
annotated cubes than the single one currently public). Fiber-aware variants (cf. #203) are
future work.

Self-contained, no new dependencies; transforms are independent files importable by full path.

## Demos (real Scroll 1 cube)
<img width="1677" height="628" alt="real_decohesion_demo" src="https://github.com/user-attachments/assets/9decac17-382c-4b66-9796-c18d3958b593" />
<img width="1523" height="1025" alt="real_warp_demo" src="https://github.com/user-attachments/assets/c06e6f7e-ef5b-4da4-b9e3-14da66c967e6" />
<img width="1807" height="632" alt="warp_vs_elastic" src="https://github.com/user-attachments/assets/0f533cf5-982f-4fde-b42d-49dbea301fb6" />
