### PR TITLE
Anchor segment backups to the volpkg.json directory

### DIFF
--- a/volume-cartographer/CMakeLists.txt
+++ b/volume-cartographer/CMakeLists.txt
@@ -142,6 +142,26 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(_lto -flto=thin)
     if(APPLE)
         set(_link "")
+        # ld64.lld (the LLVM Mach-O linker the macOS preset selects via
+        # -fuse-ld=lld) mishandles C++ exception unwind info for our large
+        # ThinLTO shared libraries: a `throw` inside e.g. libvc_core that should
+        # be caught in an executable instead unwinds past every handler into
+        # std::terminate (SIGABRT) once it crosses the dylib boundary. The
+        # failure is in how lld lays out the dylib's unwind tables — relinking
+        # the *same* objects with Apple's ld makes cross-dylib exceptions
+        # propagate correctly, and no ld64.lld flag (-keep_dwarf_unwind,
+        # -no_compact_unwind, -dead_strip) reliably fixes it for a library this
+        # size. So on macOS we link shared libraries with Apple's system ld
+        # (always available via the SDK) while keeping lld for executables.
+        # -fuse-ld= with an empty value selects the driver default (Apple ld).
+        # A later -fuse-ld= (empty) on the link line overrides the preset's
+        # earlier -fuse-ld=lld for shared-library targets only; clang honors the
+        # last one. Applied per-target via a genex so it's idempotent across
+        # reconfigures and leaves executables on lld.
+        if(CMAKE_EXE_LINKER_FLAGS MATCHES "lld" OR CMAKE_SHARED_LINKER_FLAGS MATCHES "lld")
+            add_link_options(
+                "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:-fuse-ld=>")
+        endif()
     else()
         set(_link -fuse-ld=lld -Wl,--gc-sections -Wl,--as-needed)
     endif()

--- a/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
+++ b/volume-cartographer/apps/VC3D/CommandLineToolRunner.hpp
@@ -90,7 +90,7 @@ public:
     // child by valid-cell count unless explicitRoles is set, in which case
     // we pass --parent / --child explicitly. The parent tifxyz is
     // overwritten in place (the binary snapshots the pre-patch state to
-    // <volpkg>/backups/<parent_name>/{0..7}/ first).
+    // <parent_dir>/backups/<parent_name>/{0..7}/ first).
     void setMergePatchParams(const QString& parentPath,
                              const QString& childPath,
                              bool explicitRoles,

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -3652,11 +3652,12 @@ void SegmentationCommandHandler::onReloadFromBackup(const QString& segmentId, in
         return;
     }
 
-    // Build paths
+    // Backups live under <backupRoot>/backups/<id>/<index> (backupRoot is the
+    // volpkg.json's directory), matching QuadSurface::saveSnapshot().
     namespace fs = std::filesystem;
-    fs::path volpkgRoot = _state->vpkg()->getVolpkgDirectory();
-    fs::path backupDir = volpkgRoot / "backups" / segIdStd / std::to_string(backupIndex);
     fs::path segmentDir = surf->path;
+    fs::path backupRoot = surf->backupRoot.empty() ? segmentDir.parent_path() : surf->backupRoot;
+    fs::path backupDir = backupRoot / "backups" / segmentDir.filename() / std::to_string(backupIndex);
 
     if (!fs::exists(backupDir)) {
         QMessageBox::warning(_parentWidget, tr("Error"),

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
@@ -719,10 +719,17 @@ void SurfacePanelController::showContextMenu(const QPoint& pos)
             emit resumeLocalGrowPatchRequested(segmentId);
         });
 
-        // Reload from Backup submenu
-        std::filesystem::path backupsDir =
-            std::filesystem::path(_volumePkg->getVolpkgDirectory()) / "backups" / segmentId.toStdString();
-        if (std::filesystem::exists(backupsDir) && std::filesystem::is_directory(backupsDir)) {
+        // Reload from Backup submenu. Backups live under
+        // <backupRoot>/backups/<id> (backupRoot is the volpkg.json's directory),
+        // matching QuadSurface::saveSnapshot().
+        auto backupSurf = getSurfaceById(segmentId.toStdString());
+        std::filesystem::path backupsDir;
+        if (backupSurf && !backupSurf->path.empty()) {
+            std::filesystem::path root = backupSurf->backupRoot.empty()
+                ? backupSurf->path.parent_path() : backupSurf->backupRoot;
+            backupsDir = root / "backups" / backupSurf->path.filename();
+        }
+        if (!backupsDir.empty() && std::filesystem::exists(backupsDir) && std::filesystem::is_directory(backupsDir)) {
             std::vector<int> availableBackups;
             for (const auto& entry : std::filesystem::directory_iterator(backupsDir)) {
                 if (entry.is_directory()) {

--- a/volume-cartographer/apps/VC3D/ToolDialogs.cpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.cpp
@@ -2670,8 +2670,9 @@ void MergePatchDialog::refreshOverwriteBanner()
         tr("Parent <b>%1</b> will be overwritten in place. "
            "x/y/z/mask/meta are replaced atomically; aux files "
            "(approval.tif, generations.tif, ...) are preserved. "
-           "The pre-patch state is snapshotted to "
-           "<code>%2/backups/%1/{0..7}/</code>.").arg(parentId, _volpkgDir));
+           "The pre-patch state is snapshotted to a "
+           "<code>backups/%1/{0..7}/</code> folder beside the volpkg "
+           "file.").arg(parentId));
 }
 
 QString MergePatchDialog::parentPath() const { return _parentPath; }

--- a/volume-cartographer/apps/VC3D/ToolDialogs.hpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.hpp
@@ -317,7 +317,7 @@ class VolumePkg;
 // auto-detect / explicit-override the binary supports. The parent dir is
 // overwritten in place by the binary; the dialog shows a banner up front so
 // the user knows. Recovery is via the rotating backup ring
-// (<volpkg>/backups/<parent_name>/{0..7}/) that the binary populates via
+// (<parent_dir>/backups/<parent_name>/{0..7}/) that the binary populates via
 // QuadSurface::saveOverwrite.
 class MergePatchDialog : public QDialog {
     Q_OBJECT

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -313,7 +313,7 @@ namespace tools {
 // Backup Settings
 // -----------------------------------------------------------------------------
 namespace backup {
-    // How many rotating snapshots to keep per segment under <volpkg>/backups/.
+    // How many rotating snapshots to keep per segment under <volpkg_dir>/backups/.
     constexpr auto SEGMENT_COUNT = "backup/segment_count";
     constexpr int  SEGMENT_COUNT_DEFAULT = 10;
 }

--- a/volume-cartographer/apps/VC3D/VCSettings.ui
+++ b/volume-cartographer/apps/VC3D/VCSettings.ui
@@ -698,7 +698,7 @@
              <string>Segment backups to keep</string>
             </property>
             <property name="toolTip">
-             <string>Number of rotating snapshots kept per segment under &lt;volpkg&gt;/backups/&lt;segment&gt;/. 0 disables backups. Snapshots are throttled to at most one every 2 minutes per segment.</string>
+             <string>Number of rotating snapshots kept per segment in a backups/ folder beside the volpkg file. 0 disables backups. Snapshots are throttled to at most one every 2 minutes per segment.</string>
             </property>
            </widget>
           </item>

--- a/volume-cartographer/apps/src/vc_merge_patch.cpp
+++ b/volume-cartographer/apps/src/vc_merge_patch.cpp
@@ -21,7 +21,7 @@
 //         outermost `blend_cells` of the child. Inside that thin rim the
 //         child fully replaces the parent.
 //   [6/6] parent->saveOverwrite() + writeValidMask. The save snapshots
-//         the last-persisted state into <volpkg>/backups/<parent>/{0..7}/
+//         the last-persisted state into <parent_dir>/backups/<parent>/{0..7}/
 //         (rotating 8-slot ring, same convention as grow / brush /
 //         rotation edits) and then atomically swaps the new
 //         x/y/z/mask/meta into place. Cells outside the footprint are
@@ -1155,8 +1155,9 @@ int pmRun(PMSurface parent, PMSurface child, const PMConfig& cfg)
     // Overwrite the parent tifxyz in place via QuadSurface::saveOverwrite.
     // That call:
     //   1. saveSnapshot(8) -- copies the LAST-PERSISTED on-disk state
-    //      into <volpkg>/backups/<parent_name>/{0..7}/ (rotating ring),
-    //      same convention used by grow / brush / rotation edits. Snapshot
+    //      into <parent_dir>/backups/<parent_name>/{0..7}/ (rotating ring,
+    //      a sibling of the segment dir), same convention used by grow /
+    //      brush / rotation edits. Snapshot
     //      failures are logged via the QuadSurface logger but never block
     //      the actual save.
     //   2. save(force_overwrite=true) -- writes new x/y/z/meta to a
@@ -1168,7 +1169,8 @@ int pmRun(PMSurface parent, PMSurface child, const PMConfig& cfg)
     // invalidateMask + writeValidMask re-derive mask.tif from the patched
     // points so any newly valid cells are reflected.
     std::cout << "[6/6] overwriting parent tifxyz at " << parent.path
-              << " (snapshot to <volpkg>/backups/" << parent.name << "/)\n";
+              << " (snapshot to " << parent.path.parent_path().string()
+              << "/backups/" << parent.name << "/)\n";
 
     parent.qs->invalidateMask();
     parent.qs->saveOverwrite();
@@ -1246,7 +1248,7 @@ int main(int argc, char** argv)
         "sizes, or for scripts).\n"
         "\n"
         "Backups: before overwriting, the parent's last-persisted on-disk "
-        "state is snapshotted to <volpkg>/backups/<parent_name>/{0..7}/ "
+        "state is snapshotted to <parent_dir>/backups/<parent_name>/{0..7}/ "
         "(rotating 8-slot ring, same convention as grow / brush / rotation "
         "edits in VC3D)");
     desc.add_options()

--- a/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
@@ -381,9 +381,10 @@ public:
     // Write a single ancillary channel to path/<name>.tif in place, without
     // snapshotting or rewriting x/y/z. No-op if the channel is absent/empty.
     void saveChannel(const std::string& name);
-    // Rotating backup under <volpkg>/backups/<seg>/. Throttled to at most one
-    // snapshot per segment every couple minutes; pass force=true to bypass.
-    // maxBackups < 0 means "use the configured default" (setBackupCount()).
+    // Rotating backup under <backupRoot>/backups/<seg>/ (backupRoot defaults to
+    // the segment's parent dir; VolumePkg sets it to the volpkg.json's dir).
+    // Throttled to at most one snapshot per segment every couple minutes; pass
+    // force=true to bypass. maxBackups < 0 means "use the configured default".
     void saveSnapshot(int maxBackups = -1, bool force = false);
 
     // App-configurable number of rotating snapshots kept per segment. VC3D

--- a/volume-cartographer/core/include/vc/core/util/Surface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Surface.hpp
@@ -35,4 +35,10 @@ public:
     utils::Json meta;
     std::filesystem::path path;
     std::string id;
+    // Directory under which rotating backups are written, as
+    // <backupRoot>/backups/<id>/{0..N-1}/. VolumePkg sets this to the directory
+    // holding the volpkg.json so backups stay a sibling of the project file no
+    // matter where the segment itself lives (a segments dir, an explicit path,
+    // etc.). When empty, saveSnapshot() falls back to the segment's parent dir.
+    std::filesystem::path backupRoot;
 };

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -1211,7 +1211,7 @@ void QuadSurface::saveOverwrite()
     }
 
     // Snapshot the on-disk state before overwriting. saveSnapshot() writes
-    // a rotating backup at <volpkg>/backups/<segname>/{0..N-1}/ so a
+    // a rotating backup at <backupRoot>/backups/<segname>/{0..N-1}/ so a
     // destructive save (e.g. corrupted in-memory _points) is recoverable.
     // Failures (disk full, permissions) are logged but never block the
     // user's edit — the backup is best-effort.
@@ -1338,12 +1338,14 @@ void QuadSurface::saveSnapshot(int maxBackups, bool force)
         return;
     }
 
-    // Path is expected to be: /path/to/scroll.volpkg/paths/segment_name
-    std::filesystem::path volpkgRoot = path.parent_path().parent_path();
-    std::string segmentName = path.filename().string();
-
-    // Create centralized backups directory structure
-    std::filesystem::path backupsDir = volpkgRoot / "backups" / segmentName;
+    // Backups live in a "backups/" dir under backupRoot — VolumePkg sets this to
+    // the directory holding the volpkg.json, so backups are always a sibling of
+    // the project file regardless of where the segment dir actually lives. If no
+    // root was supplied (e.g. standalone CLI tools), fall back to the segment's
+    // own parent dir.
+    const std::filesystem::path root =
+        backupRoot.empty() ? path.parent_path() : backupRoot;
+    std::filesystem::path backupsDir = root / "backups" / path.filename();
 
     std::error_code ec;
     std::filesystem::create_directories(backupsDir, ec);
@@ -1458,6 +1460,12 @@ void QuadSurface::saveSnapshot(int maxBackups, bool force)
         Logger()->warn("saveSnapshot: directory iteration failed for {}: {}",
                        path.string(), ec.message());
     }
+
+    // e.g. "autosaved seg_1234/3 -> /path/to/paths/backups/seg_1234/3"
+    Logger()->info("autosaved {}/{} -> {}",
+                   path.filename().string(),
+                   snapshot_dest.filename().string(),
+                   snapshot_dest.string());
 }
 
 

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -685,7 +685,11 @@ std::shared_ptr<QuadSurface> VolumePkg::loadSurface(const std::string& id)
         }
         seg = it->second;
     }
-    return seg->loadSurface();
+    auto surf = seg->loadSurface();
+    if (surf) {
+        surf->backupRoot = path_.parent_path();
+    }
+    return surf;
 }
 
 std::shared_ptr<QuadSurface> VolumePkg::getSurface(const std::string& id)
@@ -697,7 +701,11 @@ std::shared_ptr<QuadSurface> VolumePkg::getSurface(const std::string& id)
         if (it == loadedSegmentations_.end()) return nullptr;
         seg = it->second;
     }
-    return seg->getSurface();
+    auto surf = seg->getSurface();
+    if (surf) {
+        surf->backupRoot = path_.parent_path();
+    }
+    return surf;
 }
 
 bool VolumePkg::unloadSurface(const std::string& id)

--- a/volume-cartographer/core/test/test_point_collections.cpp
+++ b/volume-cartographer/core/test/test_point_collections.cpp
@@ -12,6 +12,8 @@
 #include <fstream>
 #include <vector>
 
+#include <unistd.h>  // ::getpid for unique temp file names
+
 namespace fs = std::filesystem;
 
 TEST_CASE("add/query points and collections")

--- a/volume-cartographer/core/test/test_quadsurface_io.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_io.cpp
@@ -182,12 +182,12 @@ TEST_CASE("saveSnapshot: copies prior on-disk state into backups/<id>/0")
         qs.path = t.segDir;
         qs.save(t.segDir);
     }
-    // saveSnapshot stores into <root>/backups/<id>/0
+    // saveSnapshot stores into <segDir-parent>/backups/<id>/0
     QuadSurface qs2(t.segDir);
     qs2.id = t.segId;
     qs2.path = t.segDir;
     qs2.saveSnapshot(/*maxBackups=*/3);
 
-    auto backupsRoot = t.root / "backups" / t.segId;
+    auto backupsRoot = t.segDir.parent_path() / "backups" / t.segId;
     CHECK(fs::exists(backupsRoot / "0"));
 }

--- a/volume-cartographer/core/test/test_quadsurface_save_paths.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_save_paths.cpp
@@ -65,8 +65,8 @@ TEST_CASE("saveChannel: writes only the channel tif, no snapshot, round-trips")
     auto root = tmpDir("savechannel");
     auto segDir = root / "seg";
 
-    // Place the seg dir two levels deep so it mimics <volpkg>/paths/<seg>,
-    // which is where saveSnapshot() would write backups to (../../backups).
+    // Place the seg dir under a paths/ dir so it mimics <volpkg>/paths/<seg>.
+    // saveSnapshot() would write backups beside the seg dir (paths/backups/).
     auto volpkg = root / "scroll.volpkg";
     auto pathsDir = volpkg / "paths";
     fs::create_directories(pathsDir);
@@ -86,6 +86,7 @@ TEST_CASE("saveChannel: writes only the channel tif, no snapshot, round-trips")
 
     CHECK(fs::exists(segDir / "approval.tif"));
     // No backups/ directory: saveChannel must not snapshot the segment.
+    CHECK_FALSE(fs::exists(pathsDir / "backups"));
     CHECK_FALSE(fs::exists(volpkg / "backups"));
     // x.tif untouched (not rewritten).
     CHECK(fs::last_write_time(segDir / "x.tif") == xMtimeBefore);

--- a/volume-cartographer/core/test/test_quadsurface_save_roundtrip.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_save_roundtrip.cpp
@@ -33,7 +33,7 @@ struct TmpVolpkg {
     fs::path root;        // <root>
     fs::path pathsDir;    // <root>/paths
     fs::path segDir;      // <root>/paths/<segName>
-    fs::path backupsDir;  // <root>/backups/<segName>
+    fs::path backupsDir;  // <root>/paths/backups/<segName> (sibling of segDir)
     std::string segName;
 
     explicit TmpVolpkg(const std::string& tag)
@@ -45,7 +45,7 @@ struct TmpVolpkg {
         pathsDir = root / "paths";
         segName = "seg_" + std::to_string(rng());
         segDir = pathsDir / segName;
-        backupsDir = root / "backups" / segName;
+        backupsDir = pathsDir / "backups" / segName;
         fs::create_directories(pathsDir);
     }
 

--- a/volume-cartographer/core/test/test_quadsurface_snapshot.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_snapshot.cpp
@@ -87,7 +87,8 @@ TEST_CASE("saveSnapshot rotates when existing backups exceed maxBackups")
         qs->saveSnapshot(2, /*force=*/true);
     }
 
-    auto backupsRoot = vol / "backups" / "seg1";
+    // Backups are a sibling of the segment dir, not under the volpkg root.
+    auto backupsRoot = paths / "backups" / "seg1";
     REQUIRE(fs::exists(backupsRoot));
     // After 3 calls with maxBackups=2 we still have slots 0 and 1.
     CHECK(fs::exists(backupsRoot / "0"));
@@ -118,7 +119,7 @@ TEST_CASE("saveSnapshot copies all regular files (not just tifs)")
     qs->path = segDir;
     qs->saveSnapshot(3);
 
-    auto slot = vol / "backups" / "seg2" / "0";
+    auto slot = paths / "backups" / "seg2" / "0";
     REQUIRE(fs::exists(slot));
     CHECK(fs::exists(slot / "x.tif"));
     CHECK(fs::exists(slot / "extra.txt"));
@@ -142,7 +143,7 @@ TEST_CASE("saveSnapshot throttles rapid calls; force bypasses")
         qs->id = "seg3"; qs->path = segDir; return qs;
     };
 
-    auto backupsRoot = vol / "backups" / "seg3";
+    auto backupsRoot = paths / "backups" / "seg3";
 
     // First snapshot creates slot 0.
     reload()->saveSnapshot(10);
@@ -158,4 +159,84 @@ TEST_CASE("saveSnapshot throttles rapid calls; force bypasses")
     CHECK(fs::exists(backupsRoot / "1"));
 
     fs::remove_all(vol);
+}
+
+TEST_CASE("saveSnapshot: no backupRoot falls back to the segment's parent dir")
+{
+    // With backupRoot unset (e.g. standalone CLI tools), backups land in a
+    // backups/ dir beside the segment directory.
+    auto base = tmpDir("fallback");
+    auto segDir = base / "paths" / "seg1";
+    fs::create_directories(base / "paths");
+
+    {
+        QuadSurface qs(grid(), cv::Vec2f(1.f, 1.f));
+        qs.id = "seg1";
+        qs.save(segDir);
+    }
+
+    auto qs = std::make_unique<QuadSurface>(segDir);
+    qs->id = "seg1";
+    qs->path = segDir;
+    REQUIRE(qs->backupRoot.empty());
+    qs->saveSnapshot(3, /*force=*/true);
+
+    CHECK(fs::exists(segDir.parent_path() / "backups" / "seg1" / "0" / "x.tif"));
+
+    fs::remove_all(base);
+}
+
+TEST_CASE("saveSnapshot: backupRoot anchors backups regardless of segment location")
+{
+    // VolumePkg sets backupRoot to the volpkg.json's directory. Backups must go
+    // under <backupRoot>/backups/<id>/ even when the segment lives in a
+    // subdirectory (paths/) or somewhere else entirely.
+    auto volpkgDir = tmpDir("volpkg");
+    auto segDir = volpkgDir / "paths" / "seg1";
+    fs::create_directories(volpkgDir / "paths");
+
+    {
+        QuadSurface qs(grid(), cv::Vec2f(1.f, 1.f));
+        qs.id = "seg1";
+        qs.save(segDir);
+    }
+
+    auto qs = std::make_unique<QuadSurface>(segDir);
+    qs->id = "seg1";
+    qs->path = segDir;
+    qs->backupRoot = volpkgDir;  // as VolumePkg would set it
+    qs->saveSnapshot(3, /*force=*/true);
+
+    // Backup is a sibling of the volpkg dir's contents, NOT next to the segment.
+    CHECK(fs::exists(volpkgDir / "backups" / "seg1" / "0" / "x.tif"));
+    CHECK_FALSE(fs::exists(segDir.parent_path() / "backups"));
+
+    fs::remove_all(volpkgDir);
+}
+
+TEST_CASE("saveSnapshot: backupRoot with a segment outside the volpkg dir")
+{
+    // The volpkg.json may point at an explicit segment path anywhere on disk.
+    // Backups still go under backupRoot, not beside the far-flung segment.
+    auto volpkgDir = tmpDir("volpkg_explicit");
+    auto segParent = tmpDir("elsewhere");
+    auto segDir = segParent / "seg1";
+
+    {
+        QuadSurface qs(grid(), cv::Vec2f(1.f, 1.f));
+        qs.id = "seg1";
+        qs.save(segDir);
+    }
+
+    auto qs = std::make_unique<QuadSurface>(segDir);
+    qs->id = "seg1";
+    qs->path = segDir;
+    qs->backupRoot = volpkgDir;
+    qs->saveSnapshot(3, /*force=*/true);
+
+    CHECK(fs::exists(volpkgDir / "backups" / "seg1" / "0" / "x.tif"));
+    CHECK_FALSE(fs::exists(segParent / "backups"));
+
+    fs::remove_all(volpkgDir);
+    fs::remove_all(segParent);
 }

--- a/volume-cartographer/core/test/test_volume_pkg_more.cpp
+++ b/volume-cartographer/core/test/test_volume_pkg_more.cpp
@@ -10,6 +10,7 @@
 
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/types/Volume.hpp"
+#include "vc/core/util/QuadSurface.hpp"
 
 #include <filesystem>
 #include <fstream>
@@ -104,6 +105,41 @@ TEST_CASE("save + load: getVolpkgDirectory returns the parent")
     auto loaded = VolumePkg::load(jsonPath);
     REQUIRE(loaded);
     CHECK(loaded->getVolpkgDirectory() == d.string());
+    fs::remove_all(d);
+}
+
+TEST_CASE("getSurface/loadSurface set backupRoot to the volpkg.json directory")
+{
+    // The autosave/backup system anchors backups at <backupRoot>/backups/<id>.
+    // VolumePkg must stamp backupRoot with the directory holding the volpkg.json
+    // so backups land beside the project file even though the segments live in a
+    // paths/ subdir. See QuadSurface::saveSnapshot.
+    auto d = tmpDir("backuproot");
+    stageSegments(d);                       // segments under <d>/paths/<id>
+    auto jsonPath = d / "project.json";
+    {
+        auto p = VolumePkg::newEmpty();
+        p->addSegmentsEntry((d / "paths").string());
+        p->save(jsonPath);
+    }
+    auto p = VolumePkg::load(jsonPath);
+    REQUIRE(p);
+    auto ids = p->segmentationIDs();
+    if (ids.empty()) { fs::remove_all(d); return; }
+    const auto& id = ids[0];
+
+    SUBCASE("loadSurface") {
+        auto surf = p->loadSurface(id);
+        REQUIRE(surf);
+        CHECK(surf->backupRoot == d);                 // == volpkg.json's dir
+        CHECK(surf->backupRoot != surf->path.parent_path());  // not the paths/ dir
+    }
+    SUBCASE("getSurface") {
+        REQUIRE(p->loadSurface(id));
+        auto surf = p->getSurface(id);
+        REQUIRE(surf);
+        CHECK(surf->backupRoot == d);
+    }
     fs::remove_all(d);
 }
 


### PR DESCRIPTION
## Problem

The autosave/backup system (snapshots every ~2 min, plus the manual **Reload from Backup** flow) derived the `backups/` location by walking two directories up from the segment path (`path.parent_path().parent_path()`), assuming the legacy `<volpkg>/paths/<seg>` layout.

With **JSON volpkgs** the `volpkg.json` references segments by an arbitrary `location` — a segments dir, or an explicit/absolute path that may live anywhere on disk. There is no longer a guaranteed volpkg directory two levels above a segment, so the `../..` guess could resolve to an unrelated directory or even the filesystem root.

## Fix

Backups now always live in **`<volpkg_dir>/backups/<id>/{0..N-1}/`** — a sibling of the `volpkg.json`, regardless of where the segment itself lives.

- New `Surface::backupRoot`. `VolumePkg::getSurface`/`loadSurface` stamp it with the directory holding the `volpkg.json` (`getVolpkgDirectory()`).
- `QuadSurface::saveSnapshot()` and both reader call sites (`SurfacePanelController` reload menu, `SegmentationCommandHandler` restore) use `backupRoot`.
- Falls back to the segment's own parent dir for standalone CLI tools (e.g. `vc_merge_patch`) that have no volpkg context.
- Autosave now logs `autosaved <id>/<n> -> <full path>`.

## Drive-by build/test fixes

- **ld64.lld cross-dylib exceptions**: a C++ exception thrown inside one of our large ThinLTO shared libraries unwound past every handler into `std::terminate` (SIGABRT) once it crossed the dylib boundary, which made the QuadSurface snapshot tests unrunnable on the macOS Homebrew-LLVM build. Shared libraries are now linked with Apple's system `ld` (executables stay on `lld`), which propagates cross-dylib exceptions correctly.
- Add the missing `<unistd.h>` include in `test_point_collections` (`::getpid`).

## Tests

- `backupRoot` fallback (no volpkg) and override, including a segment located **outside** the volpkg dir.
- `VolumePkg` stamps `backupRoot` from the `volpkg.json` directory (and that it differs from the segment's `paths/` parent).
- Existing snapshot/io/save_paths/roundtrip suites updated for the new anchor.
- **Full suite: 90/90 passing** on macOS ARM64 (Homebrew LLVM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)