### PR TITLE
VC3D record/replay render bench

### DIFF
--- a/volume-cartographer/apps/VC3D/CMakeLists.txt
+++ b/volume-cartographer/apps/VC3D/CMakeLists.txt
@@ -16,6 +16,10 @@ set(srcs
     Keybinds.hpp
     CWindow.cpp
     CWindowContextMenu.cpp
+    RenderBenchRecorder.cpp
+    RenderBenchRecorder.hpp
+    RenderBenchReplay.cpp
+    RenderBenchReplay.hpp
     FileWatcherService.cpp
     FileWatcherService.hpp
     AxisAlignedSliceController.cpp

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -1,5 +1,8 @@
 #include "CWindow.hpp"
 
+#include "RenderBenchRecorder.hpp"
+#include "RenderBenchReplay.hpp"
+
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/Surface.hpp"
@@ -367,8 +370,9 @@ static bool windowStateMetaMatches(const QSettings& settings,
 }
 
 // Constructor
-CWindow::CWindow(size_t cacheSizeGB) :
+CWindow::CWindow(size_t cacheSizeGB, RenderBenchOptions benchOptions) :
     _cmdRunner(nullptr),
+    _benchOptions(std::move(benchOptions)),
     _seedingWidget(nullptr),
     _point_collection_widget(nullptr)
 {
@@ -910,6 +914,20 @@ CWindow::CWindow(size_t cacheSizeGB) :
             _segmentationCommandHandler.get(), &SegmentationCommandHandler::onRenameSurface);
     connect(_surfacePanel.get(), &SurfacePanelController::copySurfaceRequested,
             _segmentationCommandHandler.get(), &SegmentationCommandHandler::onCopySurfaceRequested);
+
+    // Render-bench: kick off replay once the event loop is running, or arm the
+    // recorder to attach when a volume+segment becomes active.
+    if (!_benchOptions.replayPath.isEmpty()) {
+        _benchReplay = std::make_unique<RenderBenchReplay>();
+        if (_benchReplay->load(_benchOptions.replayPath)) {
+            _benchReplay->setWarmPass(_benchOptions.replayWarm);
+            QTimer::singleShot(0, this, [this] { _benchReplay->run(*this); });
+        } else {
+            _benchReplay.reset();
+        }
+    } else if (!_benchOptions.recordPath.isEmpty()) {
+        _benchRecorder = std::make_unique<RenderBenchRecorder>(_benchOptions.recordPath);
+    }
 }
 
 // Destructor
@@ -2802,6 +2820,10 @@ void CWindow::saveWindowState()
 
 void CWindow::closeEvent(QCloseEvent* event)
 {
+    // Flush a render-bench recording (if any) before teardown.
+    if (_benchRecorder && _benchRecorder->attached()) {
+        _benchRecorder->save();
+    }
     // Tell ViewerManager to stop maintaining the SurfacePatchIndex. The
     // CState teardown below iterates every tracked surface and sets it to
     // nullptr, which would otherwise trigger an O(N) rtree->remove() per
@@ -3328,6 +3350,32 @@ void CWindow::onSurfaceActivated(const QString& surfaceId, QuadSurface* surface)
     if (_surfaceAffineTransforms) {
         _surfaceAffineTransforms->refresh();
     }
+
+    maybeAttachBenchRecorder();
+}
+
+void CWindow::maybeAttachBenchRecorder()
+{
+    if (!_benchRecorder || _benchRecorder->attached())
+        return;
+    auto* viewer = segmentationViewer();
+    if (!viewer || !viewer->currentVolume() || !viewer->currentSurface())
+        return;
+
+    RenderBenchRecorder::Header h;
+    h.volpkgPath = _state ? _state->vpkgPath() : QString();
+    h.volpkgIsRemote = h.volpkgPath.startsWith("s3://");
+    h.volumeId = QString::fromStdString(viewer->currentVolume()->id());
+    h.segmentId = QString::fromStdString(viewer->surfName() == "segmentation"
+                                             ? _state->activeSurfaceId()
+                                             : viewer->surfName());
+    if (auto* gv = viewer->graphicsView()) {
+        h.viewportW = gv->viewport()->width();
+        h.viewportH = gv->viewport()->height();
+    }
+    h.cacheSizeGB = _cacheSizeBytes / (1024ULL * 1024ULL * 1024ULL);
+    h.vc3dCommit = QString::fromStdString(ProjectInfo::RepositoryShortHash()).trimmed();
+    _benchRecorder->attach(viewer, std::move(h));
 }
 
 void CWindow::onSurfaceActivatedPreserveEditing(const QString& surfaceId, QuadSurface* surface)

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -3363,9 +3363,12 @@ void CWindow::maybeAttachBenchRecorder()
         return;
 
     RenderBenchRecorder::Header h;
-    h.volpkgPath = _state ? _state->vpkgPath() : QString();
-    h.volpkgIsRemote = h.volpkgPath.startsWith("s3://");
+    // The replay driver reopens via OpenVolume(), which wants the .volpkg.json
+    // file path (vpkg()->path()), not the parent directory vpkgPath() returns.
+    auto vpkg = _state ? _state->vpkg() : nullptr;
+    h.volpkgPath = vpkg ? QString::fromStdString(vpkg->path().string()) : QString();
     h.volumeId = QString::fromStdString(viewer->currentVolume()->id());
+    h.volpkgIsRemote = viewer->currentVolume()->isRemote();
     h.segmentId = QString::fromStdString(viewer->surfName() == "segmentation"
                                              ? _state->activeSurfaceId()
                                              : viewer->surfName());

--- a/volume-cartographer/apps/VC3D/CWindow.hpp
+++ b/volume-cartographer/apps/VC3D/CWindow.hpp
@@ -43,6 +43,15 @@ class Volume;
 class VolumePkg;
 class Surface;
 class QuadSurface;
+class RenderBenchRecorder;
+class RenderBenchReplay;
+
+// Render-bench profiling modes (see RenderBenchRecorder/RenderBenchReplay).
+struct RenderBenchOptions {
+    QString recordPath;   // non-empty: record camera-state timeline to this file
+    QString replayPath;   // non-empty: replay a recorded timeline then quit
+    bool replayWarm = false;
+};
 
 #define MAX_RECENT_VOLPKG 10
 
@@ -75,6 +84,7 @@ class CWindow : public QMainWindow
     Q_OBJECT
 
     friend class MenuActionController;
+    friend class RenderBenchReplay;
 
 public:
 signals:
@@ -93,7 +103,8 @@ public slots:
     void onFocusViewsRequested(uint64_t collectionId, uint64_t pointId);
 
 public:
-    explicit CWindow(size_t cacheSizeGB = CHUNK_CACHE_SIZE_GB);
+    explicit CWindow(size_t cacheSizeGB = CHUNK_CACHE_SIZE_GB,
+                     RenderBenchOptions benchOptions = {});
     ~CWindow(void);
 
     // Helper method to get the current volume path
@@ -174,6 +185,9 @@ private slots:
     void clearSurfaceSelection();
     void onSurfaceActivated(const QString& surfaceId, QuadSurface* surface);
     void onSurfaceActivatedPreserveEditing(const QString& surfaceId, QuadSurface* surface);
+    // Attaches the render-bench recorder once a volume+segment are active (no-op
+    // unless --record was passed and the recorder isn't already attached).
+    void maybeAttachBenchRecorder();
     void onSegmentationGrowthStatusChanged(bool running);
     void onSliceStepSizeChanged(int newSize);
     void onSurfaceWillBeDeleted(std::string name, std::shared_ptr<Surface> surf);
@@ -245,6 +259,10 @@ private:
     std::unique_ptr<SurfaceAffineTransformController> _surfaceAffineTransforms;
     // runner for command line tools
     CommandLineToolRunner* _cmdRunner;
+    // Render-bench profiling harness (record/replay navigation timelines).
+    RenderBenchOptions _benchOptions;
+    std::unique_ptr<RenderBenchRecorder> _benchRecorder;
+    std::unique_ptr<RenderBenchReplay> _benchReplay;
     bool _normalGridAvailable{false};
     QString _normalGridPath;
 

--- a/volume-cartographer/apps/VC3D/RenderBenchRecorder.cpp
+++ b/volume-cartographer/apps/VC3D/RenderBenchRecorder.cpp
@@ -1,0 +1,135 @@
+#include "RenderBenchRecorder.hpp"
+
+#include <cmath>
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "vc/core/util/Logging.hpp"
+
+namespace
+{
+// Quantized equality so chunk-stream re-renders (same viewpoint) collapse to one
+// keyframe. Tolerances mirror the JSON precision we care about for replay.
+bool sameCamera(const RenderBenchRecorder::Keyframe& a,
+                const RenderBenchRecorder::Keyframe& b)
+{
+    auto close = [](float x, float y, float tol) { return std::abs(x - y) <= tol; };
+    return a.surface == b.surface
+        && close(a.surfacePtrX, b.surfacePtrX, 1e-3f)
+        && close(a.surfacePtrY, b.surfacePtrY, 1e-3f)
+        && close(a.scale, b.scale, 1e-4f)
+        && close(a.zOffset, b.zOffset, 1e-3f)
+        && close(a.zDirX, b.zDirX, 1e-4f)
+        && close(a.zDirY, b.zDirY, 1e-4f)
+        && close(a.zDirZ, b.zDirZ, 1e-4f);
+}
+}  // namespace
+
+RenderBenchRecorder::RenderBenchRecorder(QString outPath, QObject* parent)
+    : QObject(parent), _outPath(std::move(outPath))
+{
+}
+
+void RenderBenchRecorder::attach(CChunkedVolumeViewer* viewer, Header header)
+{
+    if (_attached || !viewer)
+        return;
+    _viewer = viewer;
+    _header = std::move(header);
+    _clock.start();
+    connect(viewer, &CChunkedVolumeViewer::overlaysUpdated,
+            this, &RenderBenchRecorder::onRender);
+    connect(viewer, &CChunkedVolumeViewer::sendZSliceChanged,
+            this, &RenderBenchRecorder::onZSliceChanged);
+    _attached = true;
+    Logger()->info("[vc3d-record] attached volume='{}' segment='{}' -> {}",
+                   _header.volumeId.toStdString(), _header.segmentId.toStdString(),
+                   _outPath.toStdString());
+}
+
+void RenderBenchRecorder::onZSliceChanged(int z)
+{
+    _lastZSlice = z;
+}
+
+void RenderBenchRecorder::onRender()
+{
+    if (!_viewer)
+        return;
+    const auto cam = _viewer->cameraState();
+    Keyframe kf;
+    kf.tMs = _clock.elapsed();
+    kf.surface = QString::fromStdString(_viewer->surfName());
+    kf.surfacePtrX = cam.surfacePtrX;
+    kf.surfacePtrY = cam.surfacePtrY;
+    kf.scale = cam.scale;
+    kf.zOffset = cam.zOffset;
+    kf.zDirX = cam.zOffsetWorldDir[0];
+    kf.zDirY = cam.zOffsetWorldDir[1];
+    kf.zDirZ = cam.zOffsetWorldDir[2];
+    kf.zSlice = _lastZSlice;
+    kf.dsScaleIdx = _viewer->datasetScaleIndex();
+
+    if (_haveLast && sameCamera(kf, _last))
+        return;
+    _keyframes.push_back(kf);
+    _last = kf;
+    _haveLast = true;
+}
+
+bool RenderBenchRecorder::save() const
+{
+    QJsonObject header;
+    header["volpkgPath"] = _header.volpkgPath;
+    header["volpkgIsRemote"] = _header.volpkgIsRemote;
+    header["volumeId"] = _header.volumeId;
+    header["segmentId"] = _header.segmentId;
+    QJsonObject viewport;
+    viewport["width"] = _header.viewportW;
+    viewport["height"] = _header.viewportH;
+    header["viewport"] = viewport;
+    header["cacheSizeGB"] = static_cast<double>(_header.cacheSizeGB);
+    header["samplingMethod"] = _header.samplingMethod;
+    header["vc3dCommit"] = _header.vc3dCommit;
+
+    QJsonArray keyframes;
+    int i = 0;
+    for (const auto& kf : _keyframes) {
+        QJsonObject o;
+        o["i"] = i++;
+        o["tMs"] = static_cast<double>(kf.tMs);
+        o["surface"] = kf.surface;
+        o["surfacePtrX"] = kf.surfacePtrX;
+        o["surfacePtrY"] = kf.surfacePtrY;
+        o["scale"] = kf.scale;
+        o["zOffset"] = kf.zOffset;
+        QJsonArray dir;
+        dir.append(kf.zDirX);
+        dir.append(kf.zDirY);
+        dir.append(kf.zDirZ);
+        o["zOffsetWorldDir"] = dir;
+        o["zSlice"] = kf.zSlice;
+        o["dsScaleIdx"] = kf.dsScaleIdx;
+        keyframes.append(o);
+    }
+
+    QJsonObject root;
+    root["version"] = 1;
+    root["header"] = header;
+    root["keyframes"] = keyframes;
+
+    QFile f(_outPath);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        Logger()->error("[vc3d-record] failed to open {} for writing",
+                        _outPath.toStdString());
+        return false;
+    }
+    f.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+    f.close();
+    Logger()->info("[vc3d-record] wrote {} keyframes to {}",
+                   _keyframes.size(), _outPath.toStdString());
+    return true;
+}

--- a/volume-cartographer/apps/VC3D/RenderBenchRecorder.hpp
+++ b/volume-cartographer/apps/VC3D/RenderBenchRecorder.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <QElapsedTimer>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+
+#include <vector>
+
+#include "volume_viewers/CChunkedVolumeViewer.hpp"
+
+// Records a timeline of viewer camera states while the user navigates, for
+// deterministic replay under --profile. One keyframe per completed stable
+// render; identical consecutive camera states (chunk-stream re-renders) are
+// deduped. See RenderBenchReplay for playback.
+class RenderBenchRecorder : public QObject
+{
+    Q_OBJECT
+
+public:
+    struct Header {
+        QString volpkgPath;
+        bool volpkgIsRemote = false;
+        QString volumeId;
+        QString segmentId;
+        int viewportW = 0;
+        int viewportH = 0;
+        std::size_t cacheSizeGB = 0;
+        QString samplingMethod = "trilinear";
+        QString vc3dCommit;
+    };
+
+    struct Keyframe {
+        qint64 tMs = 0;
+        QString surface;
+        float surfacePtrX = 0.0f;
+        float surfacePtrY = 0.0f;
+        float scale = 1.0f;
+        float zOffset = 0.0f;
+        float zDirX = 0.0f, zDirY = 0.0f, zDirZ = 0.0f;
+        int zSlice = 0;
+        int dsScaleIdx = 0;
+    };
+
+    explicit RenderBenchRecorder(QString outPath, QObject* parent = nullptr);
+
+    bool attached() const { return _attached; }
+    // Connects to the viewer's render signal and stamps the session header.
+    void attach(CChunkedVolumeViewer* viewer, Header header);
+    // Writes the recorded session to the output path as JSON. Returns false on
+    // I/O error. Safe to call with no keyframes.
+    bool save() const;
+
+private slots:
+    void onRender();
+    void onZSliceChanged(int z);
+
+private:
+    QString _outPath;
+    bool _attached = false;
+    QPointer<CChunkedVolumeViewer> _viewer;
+    Header _header;
+    QElapsedTimer _clock;
+    std::vector<Keyframe> _keyframes;
+    int _lastZSlice = 0;
+    bool _haveLast = false;
+    Keyframe _last;
+};

--- a/volume-cartographer/apps/VC3D/RenderBenchReplay.cpp
+++ b/volume-cartographer/apps/VC3D/RenderBenchReplay.cpp
@@ -1,0 +1,245 @@
+#include "RenderBenchReplay.hpp"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "CState.hpp"
+#include "CWindow.hpp"
+#include "volume_viewers/CChunkedVolumeViewer.hpp"
+
+#include "vc/core/types/Volume.hpp"
+#include "vc/core/types/VolumePkg.hpp"
+#include "vc/core/util/Logging.hpp"
+#include "vc/core/util/QuadSurface.hpp"
+#include "vc/core/util/Surface.hpp"
+
+namespace
+{
+constexpr int kReadyTimeoutMs = 30000;   // wait for volume/surface to come up
+constexpr int kMaxFrameMs = 30000;       // hard ceiling per keyframe settle
+constexpr int kQuietWindowMs = 150;      // continuous quiescence before "settled"
+constexpr int kPumpSliceMs = 5;          // event-loop poll granularity
+}  // namespace
+
+bool RenderBenchReplay::load(const QString& path)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly)) {
+        Logger()->error("[vc3d-replay] cannot open {}", path.toStdString());
+        return false;
+    }
+    QJsonParseError err;
+    const auto doc = QJsonDocument::fromJson(f.readAll(), &err);
+    f.close();
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        Logger()->error("[vc3d-replay] parse error in {}: {}",
+                        path.toStdString(), err.errorString().toStdString());
+        return false;
+    }
+    const auto root = doc.object();
+    const auto h = root["header"].toObject();
+    _header.volpkgPath = h["volpkgPath"].toString();
+    _header.volumeId = h["volumeId"].toString();
+    _header.segmentId = h["segmentId"].toString();
+    const auto vp = h["viewport"].toObject();
+    _header.viewportW = vp["width"].toInt();
+    _header.viewportH = vp["height"].toInt();
+
+    _keyframes.clear();
+    for (const auto v : root["keyframes"].toArray()) {
+        const auto o = v.toObject();
+        Keyframe kf;
+        kf.surface = o["surface"].toString();
+        kf.surfacePtrX = static_cast<float>(o["surfacePtrX"].toDouble());
+        kf.surfacePtrY = static_cast<float>(o["surfacePtrY"].toDouble());
+        kf.scale = static_cast<float>(o["scale"].toDouble());
+        kf.zOffset = static_cast<float>(o["zOffset"].toDouble());
+        const auto dir = o["zOffsetWorldDir"].toArray();
+        if (dir.size() == 3) {
+            kf.zDirX = static_cast<float>(dir[0].toDouble());
+            kf.zDirY = static_cast<float>(dir[1].toDouble());
+            kf.zDirZ = static_cast<float>(dir[2].toDouble());
+        }
+        kf.dsScaleIdx = o["dsScaleIdx"].toInt();
+        _keyframes.push_back(kf);
+    }
+    Logger()->info("[vc3d-replay] loaded {} keyframes volume='{}' segment='{}'",
+                   _keyframes.size(), _header.volumeId.toStdString(),
+                   _header.segmentId.toStdString());
+    return true;
+}
+
+bool RenderBenchReplay::waitForCondition(const std::function<bool()>& pred, int timeoutMs)
+{
+    QElapsedTimer t;
+    t.start();
+    while (!pred()) {
+        if (t.elapsed() >= timeoutMs)
+            return pred();
+        QCoreApplication::processEvents(QEventLoop::AllEvents, kPumpSliceMs);
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+    }
+    return true;
+}
+
+bool RenderBenchReplay::settleFrame(QPointer<CChunkedVolumeViewer> viewer, int maxFrameMs, int quietWindowMs)
+{
+    QElapsedTimer total;
+    total.start();
+    QElapsedTimer quiet;
+    bool quietRunning = false;
+    forever {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, kPumpSliceMs);
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+
+        if (!viewer)
+            return false;  // viewer torn down mid-settle
+        const bool quiescent = viewer->isRenderQuiescent()
+                            && viewer->chunkFetchesInFlight() == 0;
+        if (quiescent) {
+            if (!quietRunning) {
+                quiet.start();
+                quietRunning = true;
+            }
+            if (quiet.elapsed() >= quietWindowMs)
+                return true;
+        } else {
+            quietRunning = false;
+        }
+        if (total.elapsed() >= maxFrameMs)
+            return false;
+    }
+}
+
+void RenderBenchReplay::run(CWindow& window)
+{
+    auto fail = [](const QString& msg) {
+        Logger()->error("[vc3d-replay] {}", msg.toStdString());
+        QApplication::exit(1);
+    };
+
+    // 1. Open the recorded project.
+    window.OpenVolume(_header.volpkgPath);
+    if (!window._state || !window._state->vpkg()) {
+        fail("failed to open volpkg " + _header.volpkgPath);
+        return;
+    }
+
+    // 2. Select the recorded volume.
+    auto vpkg = window._state->vpkg();
+    const std::string volId = _header.volumeId.toStdString();
+    if (!volId.empty() && vpkg->hasVolume(volId)) {
+        window.setVolume(vpkg->volume(volId));
+    }
+
+    QPointer<CChunkedVolumeViewer> viewer = window.segmentationViewer();
+    if (!viewer) {
+        fail("no segmentation viewer");
+        return;
+    }
+
+    // 3. Wait for the volume to be live on the viewer.
+    const bool volReady = waitForCondition([&] {
+        if (!viewer)
+            return false;
+        auto v = viewer->currentVolume();
+        return v && (volId.empty() || v->id() == volId);
+    }, kReadyTimeoutMs);
+    if (!volReady) {
+        fail("timed out waiting for volume " + _header.volumeId);
+        return;
+    }
+
+    // 4. Activate the recorded segment (ensure it's loaded first).
+    const std::string segId = _header.segmentId.toStdString();
+    if (!segId.empty()) {
+        auto surf = vpkg->getSurface(segId);
+        if (!surf)
+            surf = vpkg->loadSurface(segId);
+        if (!surf) {
+            fail("segment not found in volpkg: " + _header.segmentId);
+            return;
+        }
+        window.onSurfaceActivated(_header.segmentId, surf.get());
+        // onSurfaceActivated marks the active surface; the segmentation viewer
+        // shows whatever is bound to the "segmentation" slot, so drive that too.
+        window._state->setSurface("segmentation", surf, false, false);
+    }
+
+    // 5. Wait for the surface to be set on the viewer.
+    const bool surfReady = waitForCondition([&] {
+        return viewer && viewer->currentSurface() != nullptr
+            && (segId.empty() || viewer->surfName() == "segmentation");
+    }, kReadyTimeoutMs);
+    if (!surfReady) {
+        fail("timed out waiting for segment " + _header.segmentId);
+        return;
+    }
+
+    // 6. Pin the viewport size for deterministic framebuffer dims / pyramid level.
+    // The framebuffer is sized from graphicsView()->viewport()->size(), and the
+    // view lives inside an MDI subwindow + layout, so resizing the viewport alone
+    // gets overridden on the next layout pass. setFixedSize on the view itself
+    // forces the viewport to match and survives relayout; we leave it fixed for
+    // the whole replay since we never need it resizable here.
+    if (viewer && _header.viewportW > 0 && _header.viewportH > 0) {
+        if (auto* gv = viewer->graphicsView()) {
+            gv->setFixedSize(_header.viewportW, _header.viewportH);
+            QCoreApplication::processEvents(QEventLoop::AllEvents, kPumpSliceMs);
+            const QSize got = gv->viewport()->size();
+            if (got.width() != _header.viewportW || got.height() != _header.viewportH) {
+                Logger()->warn("[vc3d-replay] viewport pinned to {}x{} but got {}x{} "
+                               "(framebuffer follows the actual viewport size)",
+                               _header.viewportW, _header.viewportH,
+                               got.width(), got.height());
+            }
+        }
+    }
+
+    auto driveFrame = [&](int i, const Keyframe& kf, bool timed) {
+        if (!viewer)
+            return;
+        CChunkedVolumeViewer::CameraState cs;
+        cs.surfacePtrX = kf.surfacePtrX;
+        cs.surfacePtrY = kf.surfacePtrY;
+        cs.scale = kf.scale;
+        cs.zOffset = kf.zOffset;
+        cs.zOffsetWorldDir = {kf.zDirX, kf.zDirY, kf.zDirZ};
+        if (timed) {
+            Logger()->info("[vc3d-replay] frame={} begin scale={:.4f} zOff={:.3f}",
+                           i, kf.scale, kf.zOffset);
+        }
+        QElapsedTimer frameTimer;
+        frameTimer.start();
+        viewer->applyCameraState(cs, /*forceRender=*/true);
+        const bool settled = settleFrame(viewer, kMaxFrameMs, kQuietWindowMs);
+        if (timed) {
+            const QSize fb = viewer->graphicsView()
+                ? viewer->graphicsView()->viewport()->size() : QSize(0, 0);
+            Logger()->info("[vc3d-replay] frame={} end wall_ms={} dsLevel={} "
+                           "recordedDs={} fb={}x{} settled={}",
+                           i, frameTimer.elapsed(), viewer->datasetScaleIndex(),
+                           kf.dsScaleIdx, fb.width(), fb.height(), settled);
+        }
+    };
+
+    // 7. Optional warm pass (discard timings).
+    if (_warm) {
+        Logger()->info("[vc3d-replay] warm pass over {} keyframes", _keyframes.size());
+        for (std::size_t i = 0; i < _keyframes.size(); ++i)
+            driveFrame(static_cast<int>(i), _keyframes[i], /*timed=*/false);
+    }
+
+    // 8. Timed pass.
+    Logger()->info("[vc3d-replay] timed pass over {} keyframes", _keyframes.size());
+    for (std::size_t i = 0; i < _keyframes.size(); ++i)
+        driveFrame(static_cast<int>(i), _keyframes[i], /*timed=*/true);
+
+    Logger()->info("[vc3d-replay] done");
+    QApplication::quit();
+}

--- a/volume-cartographer/apps/VC3D/RenderBenchReplay.cpp
+++ b/volume-cartographer/apps/VC3D/RenderBenchReplay.cpp
@@ -20,10 +20,11 @@
 
 namespace
 {
-constexpr int kReadyTimeoutMs = 30000;   // wait for volume/surface to come up
-constexpr int kMaxFrameMs = 30000;       // hard ceiling per keyframe settle
-constexpr int kQuietWindowMs = 150;      // continuous quiescence before "settled"
-constexpr int kPumpSliceMs = 5;          // event-loop poll granularity
+constexpr int kReadyTimeoutMs = 60000;     // wait for volume/surface to come up
+constexpr int kMaxFrameMsLocal = 30000;    // per-keyframe settle ceiling, local data
+constexpr int kMaxFrameMsRemote = 180000;  // per-keyframe ceiling for S3 (slow/flaky net)
+constexpr int kQuietWindowMs = 150;        // continuous quiescence before "settled"
+constexpr int kPumpSliceMs = 5;            // event-loop poll granularity
 }  // namespace
 
 bool RenderBenchReplay::load(const QString& path)
@@ -46,6 +47,7 @@ bool RenderBenchReplay::load(const QString& path)
     _header.volpkgPath = h["volpkgPath"].toString();
     _header.volumeId = h["volumeId"].toString();
     _header.segmentId = h["segmentId"].toString();
+    _header.volpkgIsRemote = h["volpkgIsRemote"].toBool();
     const auto vp = h["viewport"].toObject();
     _header.viewportW = vp["width"].toInt();
     _header.viewportH = vp["height"].toInt();
@@ -201,6 +203,12 @@ void RenderBenchReplay::run(CWindow& window)
         }
     }
 
+    // Remote (S3) data streams chunks in over the network and can stall on a
+    // flaky connection; give it a much longer settle ceiling than local data.
+    const int maxFrameMs = _header.volpkgIsRemote ? kMaxFrameMsRemote : kMaxFrameMsLocal;
+    Logger()->info("[vc3d-replay] remote={} per-frame settle ceiling={}ms",
+                   _header.volpkgIsRemote, maxFrameMs);
+
     auto driveFrame = [&](int i, const Keyframe& kf, bool timed) {
         if (!viewer)
             return;
@@ -217,7 +225,7 @@ void RenderBenchReplay::run(CWindow& window)
         QElapsedTimer frameTimer;
         frameTimer.start();
         viewer->applyCameraState(cs, /*forceRender=*/true);
-        const bool settled = settleFrame(viewer, kMaxFrameMs, kQuietWindowMs);
+        const bool settled = settleFrame(viewer, maxFrameMs, kQuietWindowMs);
         if (timed) {
             const QSize fb = viewer->graphicsView()
                 ? viewer->graphicsView()->viewport()->size() : QSize(0, 0);

--- a/volume-cartographer/apps/VC3D/RenderBenchReplay.hpp
+++ b/volume-cartographer/apps/VC3D/RenderBenchReplay.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <QPointer>
+#include <QString>
+
+#include <functional>
+#include <vector>
+
+class CWindow;
+class CChunkedVolumeViewer;
+
+// Drives the viewer through a recorded camera-state timeline (see
+// RenderBenchRecorder) so the existing [vc3d-profile] render logs measure an
+// identical workload every run. Each frame is settled to a warm, stable render
+// before advancing. Emits [vc3d-replay] frame markers and quits when done.
+class RenderBenchReplay
+{
+public:
+    struct Header {
+        QString volpkgPath;
+        QString volumeId;
+        QString segmentId;
+        int viewportW = 0;
+        int viewportH = 0;
+    };
+
+    struct Keyframe {
+        QString surface;
+        float surfacePtrX = 0.0f, surfacePtrY = 0.0f;
+        float scale = 1.0f, zOffset = 0.0f;
+        float zDirX = 0.0f, zDirY = 0.0f, zDirZ = 0.0f;
+        int dsScaleIdx = 0;
+    };
+
+    // Loads a recording from JSON. Returns false on parse/IO error.
+    bool load(const QString& path);
+
+    void setWarmPass(bool warm) { _warm = warm; }
+
+    // Opens the recorded volume+segment in the window, then replays every
+    // keyframe. Calls QApplication::quit() on completion. Blocking (pumps the
+    // event loop internally); call after the event loop is running.
+    void run(CWindow& window);
+
+private:
+    bool _warm = false;
+    Header _header;
+    std::vector<Keyframe> _keyframes;
+
+    // Pump the event loop until pred() is true or timeoutMs elapses. Returns
+    // pred()'s final value.
+    static bool waitForCondition(const std::function<bool()>& pred, int timeoutMs);
+    // Pump until the viewer is quiescent for quietWindowMs continuously, or
+    // maxFrameMs elapses. Returns true if it settled, false on timeout or if the
+    // viewer is destroyed mid-settle.
+    static bool settleFrame(QPointer<CChunkedVolumeViewer> viewer, int maxFrameMs, int quietWindowMs);
+};

--- a/volume-cartographer/apps/VC3D/RenderBenchReplay.hpp
+++ b/volume-cartographer/apps/VC3D/RenderBenchReplay.hpp
@@ -22,6 +22,7 @@ public:
         QString segmentId;
         int viewportW = 0;
         int viewportH = 0;
+        bool volpkgIsRemote = false;
     };
 
     struct Keyframe {

--- a/volume-cartographer/apps/VC3D/VCAppMain.cpp
+++ b/volume-cartographer/apps/VC3D/VCAppMain.cpp
@@ -183,13 +183,36 @@ auto main(int argc, char* argv[]) -> int
         "Enable VC3D render profiling logs.");
     parser.addOption(profileOption);
 
+    QCommandLineOption recordOption(
+        "record",
+        "Record a navigation camera-state timeline to the given JSON file.",
+        "file");
+    parser.addOption(recordOption);
+
+    QCommandLineOption replayOption(
+        "replay",
+        "Replay a recorded navigation timeline (implies --profile), then exit.",
+        "file");
+    parser.addOption(replayOption);
+
+    QCommandLineOption replayWarmOption(
+        "replay-warm",
+        "With --replay, run a discarded warm-up pass before the timed pass.");
+    parser.addOption(replayWarmOption);
+
     parser.process(app);
 
     if (parser.isSet(debugOption)) {
         SetDebugLoggingEnabled(true);
         SetLogLevel("debug");
     }
-    if (parser.isSet(profileOption)) {
+
+    RenderBenchOptions benchOptions;
+    benchOptions.recordPath = parser.value(recordOption).trimmed();
+    benchOptions.replayPath = parser.value(replayOption).trimmed();
+    benchOptions.replayWarm = parser.isSet(replayWarmOption);
+
+    if (parser.isSet(profileOption) || !benchOptions.replayPath.isEmpty()) {
         SetProfileLoggingEnabled(true);
         Logger()->info("[vc3d-profile] enabled");
     }
@@ -230,7 +253,7 @@ auto main(int argc, char* argv[]) -> int
         }
     }
 
-    CWindow aWin(cacheSizeGB);
+    CWindow aWin(cacheSizeGB, benchOptions);
     aWin.show();
     return QApplication::exec();
 }

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -833,6 +833,20 @@ void CChunkedVolumeViewer::applyCameraState(const CameraState& state, bool force
     emit overlaysUpdated();
 }
 
+bool CChunkedVolumeViewer::isRenderQuiescent() const
+{
+    return !_renderWorkerBusy.load(std::memory_order_acquire)
+        && !_renderPendingAfterWorker
+        && !_renderPending
+        && !(_renderTimer && _renderTimer->isActive())
+        && !(_settleRenderTimer && _settleRenderTimer->isActive());
+}
+
+std::size_t CChunkedVolumeViewer::chunkFetchesInFlight() const
+{
+    return _chunkArray ? _chunkArray->stats().remoteFetchesInFlight : 0;
+}
+
 void CChunkedVolumeViewer::rebuildChunkArray()
 {
     if (_chunkCbId != 0 && _chunkArray) {

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -89,6 +89,10 @@ public:
     float normalOffset() const override { return _zOff; }
     CameraState cameraState() const;
     void applyCameraState(const CameraState& state, bool forceRender = true);
+    // Render-bench helpers: true when no render is running/queued/pending; count of
+    // remote chunk fetches still outstanding. Used by replay to settle each frame.
+    bool isRenderQuiescent() const;
+    std::size_t chunkFetchesInFlight() const;
     int datasetScaleIndex() const override { return _dsScaleIdx; }
     float datasetScaleFactor() const override { return _dsScale; }
     Surface* currentSurface() const override;


### PR DESCRIPTION
Adds `--record <file>` and `--replay <file>` to VC3D for deterministic render profiling. Record captures the flattened QuadSurface camera (pan/zoom/depth) as you navigate; replay drives the same path and settles each frame so `--profile` numbers are comparable run to run. Works headless and for local + S3 volpkgs.

Flattened QuadSurface view only — the xy/xz/yz plane viewers aren't recorded or replayed.

`--replay` implies `--profile` and exits when done.