### PR TITLE
VC3D: fix approval-mask autosave crash, unify into one autosave

### DIFF
--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.cpp
@@ -307,13 +307,9 @@ void SegmentationOverlayController::detachViewer(VolumeViewerBase* viewer)
 
 void SegmentationOverlayController::loadApprovalMaskImage(QuadSurface* surface)
 {
-    // If there are unsaved pending changes and a debounced save is active,
-    // save immediately before loading new data to avoid losing auto-approvals
-    if (_approvalSaveTimer && _approvalSaveTimer->isActive() && _approvalSaveSurface) {
-        _approvalSaveTimer->stop();
-        saveApprovalMaskToSurface(_approvalSaveSurface);
-        _approvalSaveSurface = nullptr;
-    }
+    // Segment switch: flush pending approval edits to the OLD surface now,
+    // before its pointer changes, so they aren't lost.
+    flushPendingApprovalMaskSave();
 
     // Clear undo stack - old entries are for a different surface
     clearApprovalMaskUndoHistory();
@@ -530,9 +526,9 @@ void SegmentationOverlayController::paintApprovalMaskDirect(
     }
 }
 
-void SegmentationOverlayController::saveApprovalMaskToSurface(QuadSurface* surface)
+void SegmentationOverlayController::composeApprovalMaskToSurface(QuadSurface* surface)
 {
-    OverlayProfileScope profile("saveApprovalMaskToSurface");
+    OverlayProfileScope profile("composeApprovalMaskToSurface");
     if (!surface || (_savedApprovalMaskImage.isNull() && _pendingApprovalMaskImage.isNull())) {
         return;
     }
@@ -578,19 +574,10 @@ void SegmentationOverlayController::saveApprovalMaskToSurface(QuadSurface* surfa
         }
     }
 
-    // Only approval.tif changed; saveChannel avoids the full-segment snapshot
-    // + x/y/z rewrite that saveOverwrite() would do on every update.
+    // Stash the composited mask onto the surface's approval channel. Disk
+    // persistence is the single SegmentationModule autosave's job (saveOverwrite
+    // writes x/y/z + meta + all channels incl. approval every 10s).
     surface->setChannel("approval", approvalMask);
-    surface->saveChannel("approval");
-
-    // Also take a rotating backup so approval edits are recoverable. This is
-    // throttled to ~one snapshot per segment every couple minutes, so frequent
-    // approval writes coalesce instead of copying the whole segment each time.
-    try {
-        surface->saveSnapshot();
-    } catch (const std::exception& e) {
-        qWarning() << "saveApprovalMaskToSurface: backup snapshot failed:" << e.what();
-    }
 
     // Update saved image to match what we just wrote and clear pending
     for (int row = 0; row < height; ++row) {
@@ -713,46 +700,32 @@ void SegmentationOverlayController::clearApprovalMaskUndoHistory()
 
 void SegmentationOverlayController::scheduleDebouncedSave(QuadSurface* surface)
 {
-    scheduleApprovalMaskSave(surface);
+    // Compose the edited mask onto the surface's approval channel and remember
+    // the surface for the boundary flush. The caller (which owns the module)
+    // triggers the single autosave; there is no separate approval timer.
+    if (!surface) {
+        return;
+    }
+    composeApprovalMaskToSurface(surface);
+    _approvalSaveSurface = surface;
 }
 
 void SegmentationOverlayController::flushPendingApprovalMaskSave()
 {
-    // If there's a pending debounced save, execute it immediately
-    // This ensures changes are saved to the correct surface before segment switching
-    if (_approvalSaveTimer && _approvalSaveTimer->isActive() && _approvalSaveSurface) {
-        _approvalSaveTimer->stop();
-        saveApprovalMaskToSurface(_approvalSaveSurface);
-        _approvalSaveSurface = nullptr;
-    }
-}
-
-void SegmentationOverlayController::scheduleApprovalMaskSave(QuadSurface* surface)
-{
-    if (!surface) {
-        return;
-    }
-
-    _approvalSaveSurface = surface;
-
-    if (!_approvalSaveTimer) {
-        _approvalSaveTimer = new QTimer(this);
-        _approvalSaveTimer->setSingleShot(true);
-        connect(_approvalSaveTimer, &QTimer::timeout, this, &SegmentationOverlayController::performDebouncedApprovalSave);
-    }
-
-    // Restart the timer (debounce)
-    _approvalSaveTimer->start(kApprovalSaveDelayMs);
-}
-
-void SegmentationOverlayController::performDebouncedApprovalSave()
-{
+    // Boundary flush (segment switch / app close): write the pending approval
+    // edits to disk synchronously before the surface pointer changes. Uses the
+    // full saveOverwrite so it shares the per-dir lock with the autosave.
     if (!_approvalSaveSurface) {
         return;
     }
-
-    saveApprovalMaskToSurface(_approvalSaveSurface);
+    QuadSurface* surface = _approvalSaveSurface;
     _approvalSaveSurface = nullptr;
+    composeApprovalMaskToSurface(surface);
+    try {
+        surface->saveOverwrite();
+    } catch (const std::exception& e) {
+        qWarning() << "flushPendingApprovalMaskSave: save failed:" << e.what();
+    }
 }
 
 bool SegmentationOverlayController::isOverlayEnabledFor(VolumeViewerBase* viewer) const
@@ -1122,13 +1095,8 @@ void SegmentationOverlayController::onSurfaceChanged(std::string name, std::shar
 {
     Q_UNUSED(surface);
 
-    // If there are unsaved pending changes and a debounced save is active,
-    // save immediately before the surface pointer becomes dangling
-    if (_approvalSaveTimer && _approvalSaveTimer->isActive() && _approvalSaveSurface) {
-        _approvalSaveTimer->stop();
-        saveApprovalMaskToSurface(_approvalSaveSurface);
-        _approvalSaveSurface = nullptr;
-    }
+    // Surface changing: flush pending approval edits before the pointer dangles.
+    flushPendingApprovalMaskSave();
 
     if (name == "segmentation") {
         refreshAll();

--- a/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/SegmentationOverlayController.hpp
@@ -137,14 +137,16 @@ public:
                                   float heightSteps = 0.0f,
                                   bool isAutoApproval = false);
 
-    // Save the approval mask QImage back to the surface
-    void saveApprovalMaskToSurface(QuadSurface* surface);
+    // Composite the pending+saved approval QImages into the surface's "approval"
+    // channel (in memory only). Disk persistence is the SegmentationModule
+    // autosave's job (saveOverwrite writes all channels).
+    void composeApprovalMaskToSurface(QuadSurface* surface);
 
-    // Schedule a debounced save of the approval mask (saves after kApprovalSaveDelayMs of inactivity)
+    // Compose the edited mask onto the surface channel and record it for the
+    // boundary flush. The caller triggers the autosave.
     void scheduleDebouncedSave(QuadSurface* surface);
 
-    // Flush any pending approval mask saves immediately (uses the surface from scheduleDebouncedSave)
-    // Call this before segment switching to ensure changes are saved to the correct surface
+    // Synchronously persist pending approval edits before a segment switch/close.
     void flushPendingApprovalMaskSave();
 
     // Undo support for approval mask painting
@@ -259,12 +261,9 @@ private:
     // Match segmentation undo history size to keep auto-approval undo in sync.
     static constexpr size_t kMaxUndoEntries = 10;
 
-    // Debounce timer for auto-saving approval mask after painting
-    QTimer* _approvalSaveTimer{nullptr};
-    QuadSurface* _approvalSaveSurface{nullptr};  // Surface to save to when timer fires
-    static constexpr int kApprovalSaveDelayMs = 5000;
-    void scheduleApprovalMaskSave(QuadSurface* surface);
-    void performDebouncedApprovalSave();
+    // Surface holding pending (composed-but-unsaved) approval edits, for the
+    // boundary flush before a segment switch / close.
+    QuadSurface* _approvalSaveSurface{nullptr};
 
     // Approval mask overlay opacity (0-100, where 50 is default)
     int _approvalMaskOpacity{50};

--- a/volume-cartographer/apps/VC3D/segmentation/SegmentationModule.cpp
+++ b/volume-cartographer/apps/VC3D/segmentation/SegmentationModule.cpp
@@ -964,12 +964,10 @@ void SegmentationModule::saveApprovalMaskToDisk()
     }
 
     if (_overlay && surface) {
-        _overlay->saveApprovalMaskToSurface(surface);
-        emit statusMessageRequested(tr("Saved approval mask."), kStatusShort);
-        qCInfo(lcSegModule) << "  Approval mask saved to disk";
-
-        // Emit signal so CWindow can mark this segment as recently edited
-        // (to prevent inotify from triggering unwanted removals/reloads)
+        // Compose the mask onto the surface channel and let the single autosave
+        // persist it (x/y/z + meta + all channels) on its next tick.
+        _overlay->composeApprovalMaskToSurface(surface);
+        markAutosaveNeeded();
         if (!surface->id.empty()) {
             emit approvalMaskSaved(surface->id);
         }
@@ -2695,14 +2693,10 @@ bool SegmentationModule::applyPushPullStep()
 
 void SegmentationModule::markAutosaveNeeded(bool immediate)
 {
-    if (!_editManager || !_editManager->hasSession()) {
-        return;
-    }
-
     _autosaveState.markPending();
 
     ensureAutosaveTimer();
-    if (_editingEnabled && _autosaveTimer && !_autosaveTimer->isActive()) {
+    if (_autosaveTimer && !_autosaveTimer->isActive()) {
         _autosaveTimer->start();
     }
 
@@ -2733,31 +2727,25 @@ void SegmentationModule::performAutosave()
     if (!_autosaveState.pending()) {
         return;
     }
-    if (!_editManager) {
-        _autosaveState.clearDeferred();
-        _pendingAutosaveVertexUpdates.clear();
-        return;
-    }
 
     // If a save is already running, mark dirty so we re-save when it finishes
     if (_autosaveState.markDirtyIfSaving()) {
         return;
     }
 
-    if (!_editManager->hasSession()) {
-        if (!_editingEnabled) {
-            _autosaveState.clearDeferred();
-            _pendingAutosaveVertexUpdates.clear();
-        }
-        return;
+    // The single autosave persists the whole segment (x/y/z + meta + all
+    // channels incl. approval). Resolve the live surface from the edit session
+    // if there is one, else from the active "segmentation" surface — approval
+    // edits happen with editing disabled / no session and must still save.
+    std::shared_ptr<QuadSurface> surfacePtr;
+    if (_editManager && _editManager->hasSession()) {
+        surfacePtr = _editManager->baseSurface();
+    } else if (_state) {
+        surfacePtr = std::dynamic_pointer_cast<QuadSurface>(_state->surface("segmentation"));
     }
-
-    auto surfacePtr = _editManager->baseSurface();
     if (!surfacePtr) {
-        if (!_editingEnabled) {
-            _autosaveState.clearDeferred();
-            _pendingAutosaveVertexUpdates.clear();
-        }
+        _autosaveState.clearDeferred();
+        _pendingAutosaveVertexUpdates.clear();
         return;
     }
     if (surfacePtr->path.empty() || surfacePtr->id.empty()) {
@@ -2772,7 +2760,8 @@ void SegmentationModule::performAutosave()
 
     ensureSurfaceMetaObject(surfacePtr.get());
 
-    if (_pendingAutosaveVertexUpdates.empty() && _editManager->hasPendingChanges()) {
+    if (_pendingAutosaveVertexUpdates.empty() && _editManager && _editManager->hasSession()
+        && _editManager->hasPendingChanges()) {
         queueAutosaveVertexUpdates(_editManager->editedVertices());
     }
 
@@ -2922,7 +2911,10 @@ void SegmentationModule::updateAutosaveState()
         return;
     }
 
-    const bool shouldRun = _editingEnabled && _editManager && _editManager->hasSession();
+    // Keep the single autosave timer running while editing a segment OR while
+    // any save is still pending (approval edits happen with editing disabled).
+    const bool shouldRun = (_editingEnabled && _editManager && _editManager->hasSession())
+                        || _autosaveState.pending();
     if (shouldRun) {
         if (!_autosaveTimer->isActive()) {
             _autosaveTimer->start();

--- a/volume-cartographer/apps/VC3D/segmentation/tools/ApprovalMaskBrushTool.cpp
+++ b/volume-cartographer/apps/VC3D/segmentation/tools/ApprovalMaskBrushTool.cpp
@@ -307,11 +307,13 @@ void ApprovalMaskBrushTool::finishStroke()
     }
     _module.refreshOverlay();
 
-    // Schedule debounced save to disk so brush strokes auto-persist
+    // Compose the painted mask onto the surface channel; the single autosave
+    // persists it on its next 10s tick.
     if (_surface) {
         if (auto overlay = _module.overlay()) {
             overlay->scheduleDebouncedSave(_surface);
         }
+        _module.markAutosaveNeeded();
     }
 }
 
@@ -329,17 +331,17 @@ bool ApprovalMaskBrushTool::applyPending(float /*dragRadiusSteps*/)
         finishStroke();
     }
 
-    // Since we're painting in real-time, just save the QImage to disk
     auto overlay = _module.overlay();
     if (!overlay) {
         qCWarning(lcApprovalMask) << "Cannot apply: no overlay controller";
         return false;
     }
 
-    // Save the approval mask QImage to disk
-    overlay->saveApprovalMaskToSurface(_surface);
+    // Compose the mask onto the surface channel; the single autosave persists it.
+    overlay->composeApprovalMaskToSurface(_surface);
+    _module.markAutosaveNeeded();
 
-    qCDebug(lcApprovalMask) << "Saved approval mask to disk in" << totalTimer.elapsed() << "ms";
+    qCDebug(lcApprovalMask) << "Applied approval mask in" << totalTimer.elapsed() << "ms";
 
     // Clear pending strokes and overlay segments (but keep the painted QImage)
     _strokeActive = false;
@@ -835,11 +837,13 @@ void ApprovalMaskBrushTool::finishStrokeFromWorld()
     }
     _module.refreshOverlay();
 
-    // Schedule debounced save to disk so brush strokes auto-persist
+    // Compose the painted mask onto the surface channel; the single autosave
+    // persists it on its next 10s tick.
     if (_surface) {
         if (auto overlay = _module.overlay()) {
             overlay->scheduleDebouncedSave(_surface);
         }
+        _module.markAutosaveNeeded();
     }
 }
 

--- a/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
@@ -455,6 +455,16 @@ private:
     bool _needsLoad = false;
     // Mutex to protect lazy loading from concurrent access
     mutable std::mutex _loadMutex;
+
+    // Serializes all on-disk writes targeting a given segment directory, keyed by
+    // the directory path so it works across separate QuadSurface objects pointing
+    // at the same dir (e.g. the autosave worker's snapshot vs. the live surface).
+    // Without it, a worker-thread saveOverwrite() directory swap can delete a tmp
+    // file out from under a main-thread saveChannel() rename -> uncaught
+    // filesystem_error -> std::terminate. Recursive so a public entry point
+    // (saveOverwrite) can hold it across nested saveSnapshot()/save() calls on
+    // the same thread without self-deadlock.
+    static std::recursive_mutex& dirWriteMutex(const std::filesystem::path& dir);
 };
 
 std::unique_ptr<QuadSurface> load_quad_from_tifxyz(const std::string &path, int flags = 0);

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -699,6 +699,7 @@ void QuadSurface::writeValidMask(const cv::Mat& img)
     if (path.empty()) {
         return;
     }
+    std::lock_guard<std::recursive_mutex> dirLock(dirWriteMutex(path));
     std::filesystem::path maskPath = path / "mask.tif";
     cv::Mat_<uint8_t> mask = validMask();
 
@@ -1198,11 +1199,24 @@ void QuadSurface::save(const std::filesystem::path &path_, bool force_overwrite)
         save(path_, path_.filename(), force_overwrite);
 }
 
+std::recursive_mutex& QuadSurface::dirWriteMutex(const std::filesystem::path& dir)
+{
+    // Keyed by normalized dir string so separate QuadSurface objects pointing at
+    // the same segment dir share one lock. Grows by one entry per distinct dir
+    // touched this session (tiny, never pruned); a mutex guards the map itself.
+    static std::mutex mapMutex;
+    static std::unordered_map<std::string, std::recursive_mutex> locks;
+    const std::string key = dir.lexically_normal().string();
+    std::lock_guard<std::mutex> g(mapMutex);
+    return locks[key];
+}
+
 void QuadSurface::saveOverwrite()
 {
     if (path.empty()) {
         throw std::runtime_error("QuadSurface::saveOverwrite() requires a valid path");
     }
+    std::lock_guard<std::recursive_mutex> dirLock(dirWriteMutex(path));
 
     std::filesystem::path final_path = path;
     std::string uuid = !id.empty() ? id : final_path.filename().string();
@@ -1287,16 +1301,29 @@ void QuadSurface::saveChannel(const std::string& name)
     if (path.empty()) {
         throw std::runtime_error("QuadSurface::saveChannel() requires a valid path");
     }
+    std::lock_guard<std::recursive_mutex> dirLock(dirWriteMutex(path));
+
     auto it = _channels.find(name);
     if (it == _channels.end() || it->second.empty()) {
         return;
     }
 
     // Write only <name>.tif, no snapshot or x/y/z rewrite. tmp+rename so a
-    // crash mid-write can't tear the existing file.
-    const std::string tmpStem = "." + name + ".tmp" + std::to_string(::getpid());
+    // crash mid-write can't tear the existing file. Unique tmp (pid+counter) so
+    // overlapping saves don't reuse a name; non-throwing rename so a lost race
+    // degrades to a logged warning instead of std::terminate.
+    static std::atomic<uint64_t> tmpCounter{0};
+    const std::string tmpStem = "." + name + ".tmp" + std::to_string(::getpid())
+        + "_" + std::to_string(tmpCounter.fetch_add(1, std::memory_order_relaxed));
     writeChannelFile(path, tmpStem, it->second);
-    std::filesystem::rename(path / (tmpStem + ".tif"), path / (name + ".tif"));
+    std::error_code ec;
+    std::filesystem::rename(path / (tmpStem + ".tif"), path / (name + ".tif"), ec);
+    if (ec) {
+        Logger()->warn("saveChannel: rename {}.tif -> {}.tif failed: {}",
+                       tmpStem, name, ec.message());
+        std::error_code rmEc;
+        std::filesystem::remove(path / (tmpStem + ".tif"), rmEc);
+    }
 }
 
 // Minimum wall-clock gap between rotating snapshots of the same segment.
@@ -1322,6 +1349,7 @@ void QuadSurface::saveSnapshot(int maxBackups, bool force)
     if (path.empty()) {
         throw std::runtime_error("QuadSurface::saveSnapshot() requires a valid path");
     }
+    std::lock_guard<std::recursive_mutex> dirLock(dirWriteMutex(path));
     if (maxBackups < 0) {
         maxBackups = g_backupCount.load();
     }
@@ -1473,6 +1501,10 @@ void QuadSurface::save(const std::string &path_, const std::string &uuid, bool f
 {
     std::filesystem::path target_path = path_;
     std::filesystem::path final_path = path_;
+
+    // Serialize on the TARGET dir (may differ from this->path for new-dir saves)
+    // so the atomic directory swap can't race another writer to the same dir.
+    std::lock_guard<std::recursive_mutex> dirLock(dirWriteMutex(final_path));
 
     if (!force_overwrite && std::filesystem::exists(final_path))
         throw std::runtime_error("path already exists!");

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -314,6 +314,8 @@ vc_add_test(NAME test_quadsurface_pointto)
 
 vc_add_test(NAME test_quadsurface_snapshot)
 
+vc_add_test(NAME test_quadsurface_save_concurrency)
+
 vc_add_test(NAME test_quadsurface_save_paths)
 
 vc_add_test(NAME test_segmentation)

--- a/volume-cartographer/core/test/test_quadsurface_save_concurrency.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_save_concurrency.cpp
@@ -1,0 +1,98 @@
+// Regression test for the approval-mask autosave crash: a worker-thread
+// saveOverwrite() (directory swap) racing a main-thread saveChannel() (in-place
+// rename) on the SAME segment dir used to delete the tmp out from under the
+// rename -> uncaught filesystem_error -> std::terminate. The per-directory
+// write lock (QuadSurface::dirWriteMutex) must serialize them.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "vc/core/util/QuadSurface.hpp"
+
+#include <opencv2/core.hpp>
+
+#include <atomic>
+#include <filesystem>
+#include <random>
+#include <thread>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+fs::path tmpDir(const std::string& tag)
+{
+    std::mt19937_64 rng(std::random_device{}());
+    auto p = fs::temp_directory_path() /
+             ("vc_qs_save_conc_" + tag + "_" + std::to_string(rng()));
+    fs::create_directories(p);
+    return p;
+}
+
+cv::Mat_<cv::Vec3f> grid(int rows = 8, int cols = 8, float z = 0.f)
+{
+    cv::Mat_<cv::Vec3f> m(rows, cols);
+    for (int r = 0; r < rows; ++r)
+        for (int c = 0; c < cols; ++c)
+            m(r, c) = cv::Vec3f(float(c), float(r), z);
+    return m;
+}
+
+cv::Mat_<uint8_t> mask(uint8_t v) { return cv::Mat_<uint8_t>(8, 8, v); }
+
+} // namespace
+
+TEST_CASE("concurrent saveChannel + saveOverwrite on same dir does not crash or throw")
+{
+    auto root = tmpDir("race");
+    auto seg = root / "seg";
+    {
+        QuadSurface qs(grid(), cv::Vec2f(1.f, 1.f));
+        qs.save(seg.string(), "uuid-a", false);
+    }
+
+    constexpr int kIters = 200;
+    std::atomic<bool> failed{false};
+    std::atomic<int> done{0};
+
+    // Worker A: approval channel writes (the main-thread equivalent).
+    std::thread a([&] {
+        try {
+            QuadSurface qs(seg);
+            qs.ensureLoaded();
+            for (int i = 0; i < kIters; ++i) {
+                qs.setChannel("approval", mask(static_cast<uint8_t>(i)));
+                qs.saveChannel("approval");
+            }
+        } catch (...) { failed = true; }
+        ++done;
+    });
+
+    // Worker B: full-dir overwrites (the autosave-worker equivalent), a separate
+    // QuadSurface object pointing at the same on-disk dir.
+    std::thread b([&] {
+        try {
+            QuadSurface qs(seg);
+            qs.ensureLoaded();
+            for (int i = 0; i < kIters; ++i) {
+                *qs.rawPointsPtr() = grid(8, 8, static_cast<float>(i));
+                qs.invalidateCache();
+                qs.saveOverwrite();
+            }
+        } catch (...) { failed = true; }
+        ++done;
+    });
+
+    a.join();
+    b.join();
+    CHECK(done == 2);
+    CHECK_FALSE(failed);
+
+    // Surface remains loadable + intact after the contention.
+    QuadSurface reloaded(seg);
+    reloaded.ensureLoaded();
+    CHECK(fs::exists(seg / "x.tif"));
+    CHECK(fs::exists(seg / "approval.tif"));
+
+    fs::remove_all(root);
+}


### PR DESCRIPTION
Fixes the crash hitting annotators constantly: a worker-thread `saveOverwrite()` (segment dir swap) raced a main-thread approval `saveChannel()` (in-place rename) on the same dir, deleting the tmp out from under the rename → uncaught `filesystem_error` → `std::terminate`.

- **QuadSurface**: per-directory recursive write lock serializes all segment-dir writes (across threads + separate QuadSurface objects); the channel rename is now non-throwing.
- **One autosave**: deleted the separate 5s approval-mask save timer. Approval edits compose the mask onto the surface channel; the single 10s autosave (`saveOverwrite`) writes x/y/z + meta + all channels incl. approval. Session-optional so approval persists with editing disabled; segment-switch/close flush synchronously.
- Regression test: concurrent `saveChannel` + `saveOverwrite` on one dir.

Note: there is a separate, pre-existing close-time crash (unrelated to this save path — reproduces without painting) still to be diagnosed.