### PR TITLE
flatboi: harmonic initial-condition fallback for UV-less meshes

### DIFF
--- a/volume-cartographer/libs/flatboi/flatboi.cpp
+++ b/volume-cartographer/libs/flatboi/flatboi.cpp
@@ -1008,8 +1008,14 @@ int main(int argc, char** argv) {
 
     WBLogger wblog(obj_path, iters); // optional; becomes no-op if unavailable
 
-    // Run SLIM from original UVs (matches Python default), with W&B logging
-    auto [uv_out, energies] = fb.slim_run("original", wblog.enabled()? &wblog : nullptr);
+    // Use the input's UVs as the initial condition when present (matches the
+    // Python/VC3D default); otherwise fall back to a harmonic parametrization
+    // so flatboi can flatten a raw mesh that has no UVs (e.g. a scrollfiesta
+    // surface mesh streamed straight from the mesher).
+    const std::string ic = fb.have_per_corner_uv ? "original" : "harmonic";
+    if (!fb.have_per_corner_uv)
+      std::cout << "No per-corner UVs in input; using harmonic initial condition.\n";
+    auto [uv_out, energies] = fb.slim_run(ic, wblog.enabled()? &wblog : nullptr);
 
     // Persist
     save_energies(obj_path, energies);


### PR DESCRIPTION
## What
`flatboi`'s `main()` unconditionally ran `slim_run("original")`, which seeds SLIM
from the input mesh's per-corner texture coords. On a mesh with **no UVs** the
initial UV is all-zeros, so SLIM starts from a degenerate map.

This selects the **harmonic** initial condition (already implemented in flatboi:
`boundary_loop` → `map_vertices_to_circle` → `harmonic`) when the input has no
per-corner UVs, so flatboi can flatten a raw mesh directly — e.g. a scrollfiesta
surface mesh that has geometry but no UVs.

## Change
One spot in `libs/flatboi/flatboi.cpp` `main()`:
`ic = have_per_corner_uv ? "original" : "harmonic"` (8 insertions, 2 deletions).
Meshes that already carry UVs are unaffected (still `"original"`, matching the
prior/Python default).

## Test
Built the `flatboi` target and ran it on a UV-less OBJ: it logs "using harmonic
initial condition", converges, and writes `<stem>_flatboi.obj` with per-corner
UVs (`v`/`vt`/`f v/vt`). Used downstream to flatten scrollfiesta meshes into
tifxyz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)