### PR TITLE
Community Projects: add Plumbline (segmentation trace-quality checker)

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -164,7 +164,7 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
   
 - [ScrollFiesta -- virtual meshing & unwrapping for the Herculaneum papyri](https://github.com/Hob3rMallow/scrollfiesta_public) by HariSeldon and friends
 
-- [Plumbline](https://github.com/GitHwwb/plumbline) by GitHwwb. CPU-only trace-quality checker: reads a segment's ink-detection prediction and flags where the trace likely drifted — orientation breaks, row-spacing jumps, garble, and pure vertical sheet-jumps (sheet-to-sheet drift) — as a self-contained HTML dashboard + JSON sidecar. Targets the wishlist item "integrate ink detection to help see if an area was segmented correctly." [Live demo](https://githwwb.github.io/plumbline/).
+- [Plumbline](https://github.com/GitHwwb/plumbline) by GitHwwb. CPU-only trace-quality checker: reads a segment's ink-detection prediction and flags where the trace likely drifted — orientation breaks, row-spacing jumps, garble, and pure vertical sheet-jumps (sheet-to-sheet drift) — as a self-contained HTML dashboard + JSON sidecar. Targets the wishlist item "integrate ink detection to help see if an area was segmented correctly."
 
 ### 📦 Materials
 

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -164,7 +164,9 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
   
 - [ScrollFiesta -- virtual meshing & unwrapping for the Herculaneum papyri](https://github.com/Hob3rMallow/scrollfiesta_public) by HariSeldon and friends
 
-- [Plumbline](https://github.com/GitHwwb/plumbline) by GitHwwb. CPU-only trace-quality checker: reads a segment's ink-detection prediction and flags where the trace likely drifted — orientation breaks, row-spacing jumps, garble, and pure vertical sheet-jumps (sheet-to-sheet drift) — as a self-contained HTML dashboard + JSON sidecar. [Live demo](https://githwwb.github.io/plumbline/).
+- [Plumbline](https://github.com/GitHwwb/plumbline) by GitHwwb:
+    - CPU-only trace-quality checker that reads a segment's ink-detection prediction and flags where the trace likely drifted (orientation breaks, row-spacing jumps, garble, and vertical sheet-jumps), output as a self-contained HTML dashboard and JSON sidecar.
+    - [Live demo](https://githwwb.github.io/plumbline/)
 
 ### 📦 Materials
 

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -164,6 +164,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
   
 - [ScrollFiesta -- virtual meshing & unwrapping for the Herculaneum papyri](https://github.com/Hob3rMallow/scrollfiesta_public) by HariSeldon and friends
 
+- [Plumbline](https://github.com/GitHwwb/plumbline) by GitHwwb. CPU-only trace-quality checker: reads a segment's ink-detection prediction and flags where the trace likely drifted — orientation breaks, row-spacing jumps, garble, and pure vertical sheet-jumps (sheet-to-sheet drift) — as a self-contained HTML dashboard + JSON sidecar. Targets the wishlist item "integrate ink detection to help see if an area was segmented correctly." [Live demo](https://githwwb.github.io/plumbline/).
+
 ### 📦 Materials
 
 #### 🌟 Highlighted

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -164,7 +164,7 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
   
 - [ScrollFiesta -- virtual meshing & unwrapping for the Herculaneum papyri](https://github.com/Hob3rMallow/scrollfiesta_public) by HariSeldon and friends
 
-- [Plumbline](https://github.com/GitHwwb/plumbline) by GitHwwb. CPU-only trace-quality checker: reads a segment's ink-detection prediction and flags where the trace likely drifted — orientation breaks, row-spacing jumps, garble, and pure vertical sheet-jumps (sheet-to-sheet drift) — as a self-contained HTML dashboard + JSON sidecar. [Live demo](https://githwwb.github.io/plumbline/). Targets the wishlist item "integrate ink detection to help see if an area was segmented correctly."
+- [Plumbline](https://github.com/GitHwwb/plumbline) by GitHwwb. CPU-only trace-quality checker: reads a segment's ink-detection prediction and flags where the trace likely drifted — orientation breaks, row-spacing jumps, garble, and pure vertical sheet-jumps (sheet-to-sheet drift) — as a self-contained HTML dashboard + JSON sidecar. [Live demo](https://githwwb.github.io/plumbline/).
 
 ### 📦 Materials
 

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -164,7 +164,7 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
   
 - [ScrollFiesta -- virtual meshing & unwrapping for the Herculaneum papyri](https://github.com/Hob3rMallow/scrollfiesta_public) by HariSeldon and friends
 
-- [Plumbline](https://github.com/GitHwwb/plumbline) by GitHwwb. CPU-only trace-quality checker: reads a segment's ink-detection prediction and flags where the trace likely drifted — orientation breaks, row-spacing jumps, garble, and pure vertical sheet-jumps (sheet-to-sheet drift) — as a self-contained HTML dashboard + JSON sidecar. Targets the wishlist item "integrate ink detection to help see if an area was segmented correctly."
+- [Plumbline](https://github.com/GitHwwb/plumbline) by GitHwwb. CPU-only trace-quality checker: reads a segment's ink-detection prediction and flags where the trace likely drifted — orientation breaks, row-spacing jumps, garble, and pure vertical sheet-jumps (sheet-to-sheet drift) — as a self-contained HTML dashboard + JSON sidecar. [Live demo](https://githwwb.github.io/plumbline/). Targets the wishlist item "integrate ink detection to help see if an area was segmented correctly."
 
 ### 📦 Materials
 


### PR DESCRIPTION
Adds Plumbline to Segmentation → Tools.

Plumbline is a CPU-only tool that reads a segment's ink-detection prediction and flags where the trace likely went wrong (orientation breaks, row-spacing jumps, garble, and vertical sheet-jumps), output as a self-contained HTML trace-quality dashboard and JSON sidecar. No model inference, GPU, 3D, or server.

- Repo: https://github.com/GitHwwb/plumbline (Apache-2.0)
- Live demo: https://githwwb.github.io/plumbline/

This PR edits only `scrollprize.org/docs/20_community_projects.md` (one entry).
