### PR TITLE
Add RingArtifactTransform: GPU CT ring-artifact augmentation (#201)

### DIFF
--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/ring_artifact.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/ring_artifact.py
@@ -51,6 +51,8 @@ class RingArtifactTransform(ImageOnlyTransform):
         Gaussian sigma of a ring, in voxels.
     radius_range : Tuple[float, float]
         Fraction of the maximum in-plane radius where ring centers may fall.
+        Kept strictly inside (0, 1) so a ring never degenerates into a central
+        blob (r -> 0) or a corner-only arc (r -> r_max).
     center_offset : RandomScalar
         Center-of-rotation jitter as a fraction of the plane half-size, applied
         independently to each in-plane axis.
@@ -63,6 +65,11 @@ class RingArtifactTransform(ImageOnlyTransform):
         rings are extruded. One is sampled per affected channel from the
         non-singleton subset. None -> all non-singleton spatial axes are
         candidates. Ignored for 2-D input.
+        For anisotropic data with a distinct acquisition axis (e.g. scroll CT,
+        where the scan/rotation axis is the long axis), set this to that axis so
+        rings lie in the true reconstruction plane; leaving it None randomizes
+        the plane across all spatial axes, which on anisotropic patches can place
+        artifacts in non-physical orientations.
     p_per_channel : float
         Probability of applying the transform to each channel.
     synchronize_channels : bool
@@ -77,7 +84,7 @@ class RingArtifactTransform(ImageOnlyTransform):
                  num_rings: RandomScalar = (1, 5),
                  intensity: RandomScalar = (0.05, 0.3),
                  ring_width: RandomScalar = (0.5, 3.0),
-                 radius_range: Tuple[float, float] = (0.0, 1.0),
+                 radius_range: Tuple[float, float] = (0.1, 0.9),
                  center_offset: RandomScalar = (-0.05, 0.05),
                  p_negative: float = 0.5,
                  relative_to_std: bool = True,

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/ring_artifact.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/ring_artifact.py
@@ -1,0 +1,262 @@
+from typing import List, Optional, Tuple
+
+import torch
+
+from batchgeneratorsv2.helpers.scalar_type import RandomScalar, sample_scalar
+from batchgeneratorsv2.transforms.base.basic_transform import ImageOnlyTransform
+
+
+class RingArtifactTransform(ImageOnlyTransform):
+    """
+    Simulates CT ring artifacts directly on the GPU.
+
+    Physics
+    -------
+    In reconstructed CT volumes, a miscalibrated or defective detector element
+    produces a concentric ring centered on the center of rotation, lying in the
+    axial (reconstruction) plane and extruded along the rotation/scan axis,
+    consistent across all slices stacked along that axis. Several defective
+    elements produce several rings at different radii. The perturbation is
+    additive in the reconstructed intensity, narrow (a few voxels wide) and can
+    be brighter or darker than the surrounding tissue.
+
+    This is a strong domain-specific augmentation for scroll CT, where ring
+    artifacts are a real and common acquisition artifact that the network must
+    learn to ignore when segmenting papyrus sheets.
+
+    Implementation
+    --------------
+    Per call we build a 1-D radial perturbation profile ``p(r)`` as a sum of
+    Gaussian-shaped rings, then map it onto the volume by gathering ``p`` at the
+    per-voxel radius (linear interpolation). Cost of the profile build scales
+    with the number of rings; cost of the field evaluation is a single gather
+    over the axial plane, broadcast (not materialized) along the rotation axis.
+    Amplitudes are expressed in per-channel standard-deviation units by default,
+    so the transform behaves consistently regardless of intensity normalization
+    (e.g. nnU-Net z-scored inputs).
+
+    Accepts (C, X, Y) and (C, X, Y, Z) inputs. Singleton spatial axes are never
+    used to define the axial plane (avoids a degenerate radius map on pseudo-2D
+    patches); if fewer than two non-singleton spatial axes exist the transform
+    is a no-op.
+
+    Parameters
+    ----------
+    num_rings : RandomScalar
+        Number of rings to draw per affected channel (rounded to int).
+    intensity : RandomScalar
+        Ring amplitude magnitude. In std units when ``relative_to_std`` (default),
+        otherwise in absolute intensity units. The sign is drawn separately.
+    ring_width : RandomScalar
+        Gaussian sigma of a ring, in voxels.
+    radius_range : Tuple[float, float]
+        Fraction of the maximum in-plane radius where ring centers may fall.
+    center_offset : RandomScalar
+        Center-of-rotation jitter as a fraction of the plane half-size, applied
+        independently to each in-plane axis.
+    p_negative : float
+        Probability that a given ring is dark (negative amplitude).
+    relative_to_std : bool
+        If True, amplitudes are multiplied by the per-channel spatial std.
+    ring_axes : Optional[List[int]]
+        Candidate rotation/scan axes (spatial-axis indices, 0-based) along which
+        rings are extruded. One is sampled per affected channel from the
+        non-singleton subset. None -> all non-singleton spatial axes are
+        candidates. Ignored for 2-D input.
+    p_per_channel : float
+        Probability of applying the transform to each channel.
+    synchronize_channels : bool
+        If True, identical rings are applied to all affected channels (physically
+        natural: same detector defects affect every reconstructed channel).
+    benchmark : bool
+        If True, reuse cached coordinate grids keyed by plane shape/device only
+        (skips per-call allocation); set False if input shapes vary wildly.
+    """
+
+    def __init__(self,
+                 num_rings: RandomScalar = (1, 5),
+                 intensity: RandomScalar = (0.05, 0.3),
+                 ring_width: RandomScalar = (0.5, 3.0),
+                 radius_range: Tuple[float, float] = (0.0, 1.0),
+                 center_offset: RandomScalar = (-0.05, 0.05),
+                 p_negative: float = 0.5,
+                 relative_to_std: bool = True,
+                 ring_axes: Optional[List[int]] = None,
+                 p_per_channel: float = 1.0,
+                 synchronize_channels: bool = False,
+                 benchmark: bool = True):
+        super().__init__()
+        self.num_rings = num_rings
+        self.intensity = intensity
+        self.ring_width = ring_width
+        self.radius_range = radius_range
+        self.center_offset = center_offset
+        self.p_negative = p_negative
+        self.relative_to_std = relative_to_std
+        self.ring_axes = ring_axes
+        self.p_per_channel = p_per_channel
+        self.synchronize_channels = synchronize_channels
+        self.benchmark = benchmark
+        # cache: (H, W, device, dtype) -> (xx, yy) integer coordinate grids
+        self._grid_cache = {}
+
+    # ------------------------------------------------------------------ params
+    def get_parameters(self, **data_dict) -> dict:
+        img = data_dict["image"]
+        c = img.shape[0]
+        spatial = img.shape[1:]
+        ndim = len(spatial)
+
+        # non-singleton spatial axes only (skip singletons; see docstring)
+        valid_axes = [i for i in range(ndim) if spatial[i] > 1]
+        if len(valid_axes) < 2:
+            return {"apply_idx": None}
+
+        apply = torch.rand(c, device=img.device) < self.p_per_channel
+        idx = apply.nonzero(as_tuple=False).flatten()
+        n = int(idx.numel())
+        if n == 0:
+            return {"apply_idx": None}
+
+        # Candidate rotation axes. The axial plane must be two NON-singleton
+        # axes, so a rotation axis is only a free choice when all three spatial
+        # axes are non-singleton. With exactly two valid axes the plane is
+        # forced and the rotation axis is the remaining (singleton) axis.
+        if ndim == 2 or len(valid_axes) == 2:
+            cand_rot = None  # forced; resolved per-channel
+        else:  # ndim == 3 and all three axes non-singleton
+            cand = self.ring_axes if self.ring_axes is not None else list(range(ndim))
+            cand_rot = [a for a in cand if a in valid_axes]
+            if len(cand_rot) == 0:
+                cand_rot = list(valid_axes)
+
+        n_specs = 1 if self.synchronize_channels else n
+        specs = [self._sample_one_channel(valid_axes, cand_rot, ndim) for _ in range(n_specs)]
+
+        return {"apply_idx": idx, "num_apply": n, "specs": specs}
+
+    def _sample_one_channel(self, valid_axes, cand_rot, ndim) -> dict:
+        # The axial plane is always two non-singleton axes; the rotation axis
+        # (extrusion direction) is whatever spatial axis remains.
+        if ndim == 2:
+            rot_axis = None
+            plane_axes = (valid_axes[0], valid_axes[1])
+        elif cand_rot is None:  # exactly two valid axes -> plane forced
+            plane_axes = (valid_axes[0], valid_axes[1])
+            rem = [a for a in range(ndim) if a not in valid_axes]
+            rot_axis = rem[0] if rem else None
+        else:  # free choice among non-singleton axes
+            rot_axis = int(cand_rot[int(torch.randint(len(cand_rot), (1,)).item())])
+            plane = [a for a in valid_axes if a != rot_axis]
+            plane_axes = (plane[0], plane[1])
+
+        k = max(1, int(round(sample_scalar(self.num_rings))))
+        rings = []
+        for _ in range(k):
+            mag = abs(float(sample_scalar(self.intensity)))
+            sign = -1.0 if torch.rand(1).item() < self.p_negative else 1.0
+            rings.append({
+                "r_frac": sample_scalar(self.radius_range),     # in [0, 1] of r_max
+                "amp": sign * mag,
+                "width": max(1e-3, float(sample_scalar(self.ring_width))),
+            })
+        return {
+            "rot_axis": rot_axis,
+            "plane_axes": plane_axes,
+            "rings": rings,
+            "off0": float(sample_scalar(self.center_offset)),
+            "off1": float(sample_scalar(self.center_offset)),
+        }
+
+    # ------------------------------------------------------------------- apply
+    def _coords(self, H, W, device, dtype):
+        key = (H, W, device, dtype)
+        if self.benchmark and key in self._grid_cache:
+            return self._grid_cache[key]
+        yy = torch.arange(H, device=device, dtype=dtype).view(H, 1)
+        xx = torch.arange(W, device=device, dtype=dtype).view(1, W)
+        if self.benchmark:
+            self._grid_cache[key] = (yy, xx)
+        return yy, xx
+
+    def _build_field(self, spec, spatial, device, dtype) -> torch.Tensor:
+        a0, a1 = spec["plane_axes"]
+        H, W = spatial[a0], spatial[a1]
+        yy, xx = self._coords(H, W, device, dtype)
+
+        cy = (H - 1) / 2.0 * (1.0 + spec["off0"])
+        cx = (W - 1) / 2.0 * (1.0 + spec["off1"])
+        radius = torch.sqrt((yy - cy) ** 2 + (xx - cx) ** 2)  # (H, W)
+        r_max = float(radius.max().item())
+        if r_max <= 0:
+            return None
+
+        # 1-D radial profile p(r), r = 0 .. r_max
+        L = int(r_max) + 2
+        rgrid = torch.arange(L, device=device, dtype=dtype)
+        profile = torch.zeros(L, device=device, dtype=dtype)
+        for ring in spec["rings"]:
+            r0 = ring["r_frac"] * r_max
+            w = ring["width"]
+            profile += ring["amp"] * torch.exp(-((rgrid - r0) ** 2) / (2.0 * w * w))
+
+        # gather profile at per-voxel radius with linear interpolation
+        rf = radius.reshape(-1)
+        lo = torch.floor(rf).long().clamp_(0, L - 2)
+        frac = (rf - lo.to(dtype))
+        field = profile[lo] * (1.0 - frac) + profile[lo + 1] * frac
+        field = field.reshape(H, W)
+
+        # reshape to broadcast over channel-stripped spatial layout
+        view = [1] * len(spatial)
+        view[a0] = H
+        view[a1] = W
+        return field.view(view)  # broadcasts along the rotation axis for free
+
+    def _apply_to_image(self, img: torch.Tensor, **params) -> torch.Tensor:
+        idx = params.get("apply_idx")
+        if idx is None:
+            return img
+
+        spatial = img.shape[1:]
+        device, dtype = img.device, img.dtype
+        specs = params["specs"]
+
+        for j, ch in enumerate(idx.tolist()):
+            spec = specs[0] if self.synchronize_channels else specs[j]
+            field = self._build_field(spec, spatial, device, dtype)
+            if field is None:
+                continue
+            if self.relative_to_std:
+                scale = img[ch].std()
+                if not torch.isfinite(scale) or scale <= 0:
+                    scale = torch.ones((), device=device, dtype=dtype)
+                field = field * scale
+            img[ch] += field
+        return img
+
+
+if __name__ == "__main__":
+    from time import time
+    import numpy as np
+
+    torch.set_num_threads(1)
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
+
+    rat = RingArtifactTransform(num_rings=(2, 6), intensity=(0.1, 0.4), p_per_channel=1.0)
+
+    # warmup + correctness
+    out = rat(image=torch.randn((1, 192, 192, 64), device=dev))["image"]
+    assert out.shape == (1, 192, 192, 64) and torch.isfinite(out).all()
+
+    times = []
+    for _ in range(200):
+        data_dict = {"image": torch.randn((1, 192, 192, 64), device=dev)}
+        if dev == "cuda":
+            torch.cuda.synchronize()
+        st = time()
+        _ = rat(**data_dict)
+        if dev == "cuda":
+            torch.cuda.synchronize()
+        times.append(time() - st)
+    print(f"{dev}: {np.mean(times) * 1e3:.3f} ms/call  (192x192x64)")

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/seam_artifact.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/seam_artifact.py
@@ -1,0 +1,219 @@
+from typing import List, Optional
+
+import torch
+
+from batchgeneratorsv2.helpers.scalar_type import RandomScalar, sample_scalar
+from batchgeneratorsv2.transforms.base.basic_transform import ImageOnlyTransform
+
+
+class SeamArtifactTransform(ImageOnlyTransform):
+    """
+    Simulates CT grid-scan / tiling SEAM artifacts on the GPU.
+
+    Physics
+    -------
+    Herculaneum scrolls are larger than the synchrotron detector field of view,
+    so they are scanned with a "grid scan" technique and the high-resolution
+    parallel-beam projections are tiled (stitched) together before / during
+    filtered backprojection. Adjacent tiles can carry a small relative gain /
+    offset mismatch, leaving a faint planar intensity STEP at the stitch boundary;
+    across many tiles this accumulates into a low-amplitude staircase. A
+    segmentation network that has never seen such a step can mistake the seam for
+    a sheet boundary, or lose the surface as it crosses one. Training with
+    simulated seams builds robustness to exactly the cube-boundary discontinuities
+    the downstream meshing has to weld across.
+
+    Why this is not an existing transform
+    -------------------------------------
+    The discontinuity is the point. `InhomogeneousSliceIlluminationTransform`
+    applies a SMOOTH multiplicative illumination field; a seam is a C0 step (high
+    spatial frequency localized at a plane). `BlankRectangleTransform` makes filled
+    boxes, `SmearTransform` makes a directional blur, and brightness/gamma shift the
+    whole patch. None of them produce a sharp planar level change at an arbitrary
+    in-plane orientation. The accompanying ablation tests this directly: it is a
+    fair, magnitude-matched comparison of this step against a smooth illumination
+    field, and the transform is only worth adding if the step specifically helps.
+
+    Implementation
+    --------------
+    Reuses the projected-coordinate machinery of the ring/streak transforms. Per
+    call: pick an in-plane orientation theta, project plane coordinates onto it
+    (t = a*cos(theta) + b*sin(theta)), build a 1-D profile that is a cumulative sum
+    of smoothed Heaviside steps over t (a staircase), mean-center it so it is a
+    planar redistribution rather than a global brightness shift, and gather it onto
+    the volume by the per-voxel projected coordinate (linear interpolation),
+    broadcast along the scan axis. Amplitudes are in per-channel std units by
+    default (consistent with the relative / unitless reconstruction values and with
+    z-scored nnU-Net inputs). Image-only; handles (C,X,Y) and (C,X,Y,Z); singleton
+    spatial axes are never used to define the plane (no-op if < 2 non-singleton
+    spatial axes).
+
+    Parameters
+    ----------
+    num_seams : RandomScalar
+        Number of seam planes (rounded to int) -> number of staircase steps.
+    intensity : RandomScalar
+        Per-step magnitude (std units if relative_to_std). Sign drawn per step.
+    seam_softness : RandomScalar
+        Width of the smoothed step transition, in voxels (0 -> nearly hard step,
+        larger -> a gentler ramp). Real recon seams are 1-3 voxels.
+    p_negative : float
+        Probability a step is downward (darker beyond the seam).
+    relative_to_std : bool
+        Scale amplitudes by per-channel spatial std.
+    seam_axes : Optional[List[int]]
+        Candidate scan/extrusion axes (0-based spatial). None -> all non-singleton.
+    p_per_channel : float
+    synchronize_channels : bool
+    benchmark : bool
+        Cache plane coordinate grids keyed by shape/device.
+    """
+
+    def __init__(self,
+                 num_seams: RandomScalar = (1, 3),
+                 intensity: RandomScalar = (0.05, 0.3),
+                 seam_softness: RandomScalar = (0.5, 2.5),
+                 p_negative: float = 0.5,
+                 relative_to_std: bool = True,
+                 seam_axes: Optional[List[int]] = None,
+                 p_per_channel: float = 1.0,
+                 synchronize_channels: bool = False,
+                 benchmark: bool = True):
+        super().__init__()
+        self.num_seams = num_seams
+        self.intensity = intensity
+        self.seam_softness = seam_softness
+        self.p_negative = p_negative
+        self.relative_to_std = relative_to_std
+        self.seam_axes = seam_axes
+        self.p_per_channel = p_per_channel
+        self.synchronize_channels = synchronize_channels
+        self.benchmark = benchmark
+        self._grid_cache = {}
+
+    def get_parameters(self, **data_dict) -> dict:
+        img = data_dict["image"]
+        c = img.shape[0]
+        spatial = img.shape[1:]
+        ndim = len(spatial)
+        valid = [i for i in range(ndim) if spatial[i] > 1]
+        if len(valid) < 2:
+            return {"apply_idx": None}
+        apply = torch.rand(c, device=img.device) < self.p_per_channel
+        idx = apply.nonzero(as_tuple=False).flatten()
+        n = int(idx.numel())
+        if n == 0:
+            return {"apply_idx": None}
+
+        if ndim == 2 or len(valid) == 2:
+            cand_rot = None
+        else:
+            cand = self.seam_axes if self.seam_axes is not None else list(range(ndim))
+            cand_rot = [a for a in cand if a in valid] or list(valid)
+
+        n_specs = 1 if self.synchronize_channels else n
+        specs = [self._sample_one(valid, cand_rot, ndim) for _ in range(n_specs)]
+        return {"apply_idx": idx, "specs": specs}
+
+    def _sample_one(self, valid, cand_rot, ndim) -> dict:
+        if ndim == 2:
+            rot_axis = None
+            plane_axes = (valid[0], valid[1])
+        elif cand_rot is None:
+            plane_axes = (valid[0], valid[1])
+            rem = [a for a in range(ndim) if a not in valid]
+            rot_axis = rem[0] if rem else None
+        else:
+            rot_axis = int(cand_rot[int(torch.randint(len(cand_rot), (1,)).item())])
+            plane = [a for a in valid if a != rot_axis]
+            plane_axes = (plane[0], plane[1])
+
+        theta = float(torch.rand(1).item()) * 3.141592653589793  # [0, pi)
+        k = max(1, int(round(sample_scalar(self.num_seams))))
+        seams = []
+        for _ in range(k):
+            mag = abs(float(sample_scalar(self.intensity)))
+            sign = -1.0 if torch.rand(1).item() < self.p_negative else 1.0
+            seams.append({"pos": float(torch.rand(1).item()),  # fraction along t-range
+                          "amp": sign * mag,
+                          "soft": max(1e-3, float(sample_scalar(self.seam_softness)))})
+        return {"rot_axis": rot_axis, "plane_axes": plane_axes, "theta": theta, "seams": seams}
+
+    def _coords(self, H, W, device, dtype):
+        key = (H, W, device, dtype)
+        if self.benchmark and key in self._grid_cache:
+            return self._grid_cache[key]
+        a = torch.arange(H, device=device, dtype=dtype).view(H, 1)
+        b = torch.arange(W, device=device, dtype=dtype).view(1, W)
+        if self.benchmark:
+            self._grid_cache[key] = (a, b)
+        return a, b
+
+    def _build_field(self, spec, spatial, device, dtype):
+        a0, a1 = spec["plane_axes"]
+        H, W = spatial[a0], spatial[a1]
+        a, b = self._coords(H, W, device, dtype)
+        import math
+        t = a * math.cos(spec["theta"]) + b * math.sin(spec["theta"])  # (H,W)
+        tmin = float(t.min().item())
+        tmax = float(t.max().item())
+        span = tmax - tmin
+        if span <= 0:
+            return None
+        L = int(span) + 2
+        grid = torch.arange(L, device=device, dtype=dtype) + tmin
+        profile = torch.zeros(L, device=device, dtype=dtype)
+        for s in spec["seams"]:
+            tc = tmin + s["pos"] * span
+            soft = s["soft"]
+            # smoothed Heaviside step (sigmoid): 0 -> amp across ~few*soft voxels
+            profile += s["amp"] * torch.sigmoid((grid - tc) / soft)
+        tf = (t - tmin).reshape(-1)
+        lo = torch.floor(tf).long().clamp_(0, L - 2)
+        frac = tf - lo.to(dtype)
+        field = (profile[lo] * (1.0 - frac) + profile[lo + 1] * frac).reshape(H, W)
+        field = field - field.mean()  # planar redistribution, not a global brightness shift
+        view = [1] * len(spatial)
+        view[a0] = H
+        view[a1] = W
+        return field.view(view)
+
+    def _apply_to_image(self, img: torch.Tensor, **params) -> torch.Tensor:
+        idx = params.get("apply_idx")
+        if idx is None:
+            return img
+        spatial = img.shape[1:]
+        device, dtype = img.device, img.dtype
+        specs = params["specs"]
+        for j, ch in enumerate(idx.tolist()):
+            spec = specs[0] if self.synchronize_channels else specs[j]
+            field = self._build_field(spec, spatial, device, dtype)
+            if field is None:
+                continue
+            if self.relative_to_std:
+                sc = img[ch].std()
+                if not torch.isfinite(sc) or sc <= 0:
+                    sc = torch.ones((), device=device, dtype=dtype)
+                field = field * sc
+            img[ch] = img[ch] + field
+        return img
+
+
+if __name__ == "__main__":
+    from time import time
+    import numpy as np
+    torch.set_num_threads(1)
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
+    t = SeamArtifactTransform(num_seams=(1, 3), intensity=(0.1, 0.4), p_per_channel=1.0)
+    out = t(image=torch.randn((1, 192, 192, 64), device=dev))["image"]
+    assert out.shape == (1, 192, 192, 64) and torch.isfinite(out).all()
+    times = []
+    for _ in range(200):
+        d = {"image": torch.randn((1, 192, 192, 64), device=dev)}
+        if dev == "cuda":
+            torch.cuda.synchronize()
+        st = time(); t(**d)
+        if dev == "cuda":
+            torch.cuda.synchronize()
+        times.append(time() - st)
+    print(f"{dev}: {np.mean(times) * 1e3:.3f} ms/call (192x192x64)")


### PR DESCRIPTION
# RingArtifactTransform: GPU CT ring-artifact augmentation

Adds a scroll/CT-specific augmentation that simulates **ring artifacts** — the
concentric rings produced by miscalibrated or defective detector elements in
reconstructed CT. They appear in the axial plane, centered on the center of
rotation, extruded along the scan axis and consistent across stacked slices.
This is a real, common scroll-CT acquisition artifact, and follows the
"additional augmentations welcome" note in #201 (after the merged Squeeze /
Decohesion / Warp transforms).

**Grounding in the Vesuvius pipeline.** Per the project FAQ, the scrolls are
reconstructed with filtered backprojection from synchrotron parallel-beam scans.
Ring artifacts are the classic FBP signature of detector-element inconsistency,
so this models an artifact actually present in the reconstructed volumes (this is
augmentation for robustness on the reconstructed images, not reconstruction).
Amplitudes are kept in per-channel std units because the released reconstructions
are unitless / relative intensities (raw floats ~[-0.1, 0.1]); a fixed absolute
amplitude would not transfer across scans. The transform is additive and
non-destructive, consistent with the project keeping reconstruction values
unaltered.

## Design

- `ImageOnlyTransform` (batchgeneratorsv2 style), fully on-device, in-place.
- Builds a 1-D radial profile (sum of Gaussian-shaped rings) and gathers it onto
  the volume by per-voxel radius with linear interpolation; the field is H×W and
  broadcasts along the rotation axis (no per-voxel materialization).
- Amplitudes in per-channel std units by default → consistent under z-scored
  nnU-Net inputs.
- Handles `(C,X,Y)` and `(C,X,Y,Z)`; singleton spatial axes are never used for
  the axial plane (pseudo-2D safe); no-op when < 2 non-singleton spatial axes.
- Configurable: ring count, amplitude, width, radius range, center-of-rotation
  jitter, sign probability, rotation axis, per-channel prob, channel sync.

## Speed (RTX 5070, Blackwell sm_120, single sample)

| patch (C,X,Y,Z)   | Ring ms/sample | Ring Mvox/s |
|-------------------|----------------|-------------|
| (1,192,192,1)     | 0.346          | 107         |
| (1,192,192,64)    | 0.322          | 7319        |
| (1,128,128,128)   | 0.374          | 5603        |
| (1,256,256,96)    | 0.423          | 14874       |

Sub-millisecond per sample at every size, up to ~14.9 Gvox/s. Cost is
essentially flat as the stack (rotation) axis grows (64→128 in Z stays
~0.32–0.37 ms) because a single 2-D radial field is broadcast along that axis
rather than generating per-voxel values. Runs natively on GPU. (Benchmark
script included; `GaussianNoiseTransform` in the vendored 0.2.1 build is CPU-only,
so it is reported as a CPU reference rather than a GPU comparison.)

## Ablation (controlled, synthetic — same format as the merged transforms)

Two identical `SmallSeg3D` nets, same seed/data/steps (400, patch 64³, RTX 5070).
A = baseline (flips only); B = baseline + `RingArtifactTransform`. Both are
evaluated on a sweep of test-time ring severities. Crucially the test rings are
generated by an **independent** mechanism (hard-edged top-hat annuli, absolute
amplitude) — not by the trained transform — so this is not testing on the
training augmentation.

| test ring amp | A (flips) | B (+ring) | Δ Dice  |
|---------------|-----------|-----------|---------|
| 0.00 (clean)  | 1.0000    | 1.0000    | +0.0000 |
| 0.40          | 0.9931    | 1.0000    | +0.0069 |
| 0.80          | 0.9542    | 0.9995    | +0.0453 |
| 1.20          | 0.9062    | 0.9986    | +0.0924 |

The augmentation buys monotonically increasing robustness as ring severity rises
(the baseline degrades to 0.906 Dice while B holds at ~0.999), with **zero
clean-data cost**. A sweep rather than a single operating point avoids a
cherry-picked result.

## Figure
<img width="780" height="256" alt="ring_triptych" src="https://github.com/user-attachments/assets/cf73ca11-9ae8-4461-8689-784b7ad379b1" />

*Illustrative effect of `RingArtifactTransform`, rendered at 256² for visibility
(training patches are 64³). Left: clean synthetic papyrus. Centre: the additive
field (after − before) — concentric rings as produced by the transform. Right:
corrupted result. Parameters here are stronger than the proposed training
defaults (`intensity=(0.05,0.3)`) to make the rings legible.*

## Open questions for bruniss / giorgioangel

- Default rotation axis: pin to Z (`ring_axes=[2]`) to match the scan geometry,
  or leave axis-agnostic (`None`) for robustness? Defaulting to Z for now.
- Preferred wrapper probability in the training list (defaulting to ~0.15–0.25).