### PR TITLE
Add StreakArtifactTransform: GPU CT streak-artifact augmentation (#201)

### DIFF
--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/streak_artifact.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/streak_artifact.py
@@ -44,6 +44,10 @@ class StreakArtifactTransform(ImageOnlyTransform):
         Scale amplitudes by per-channel spatial std.
     streak_axes : Optional[List[int]]
         Candidate scan/extrusion axes (0-based spatial). None -> all non-singleton.
+        For anisotropic data with a distinct acquisition axis (e.g. scroll CT),
+        set this to the scan/rotation axis so streaks lie in the true
+        reconstruction plane; None randomizes across all spatial axes and can
+        place streaks in non-physical orientations on anisotropic patches.
     p_per_channel : float
     synchronize_channels : bool
     benchmark : bool

--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/streak_artifact.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/noise/streak_artifact.py
@@ -1,0 +1,198 @@
+from typing import List, Optional
+
+import torch
+
+from batchgeneratorsv2.helpers.scalar_type import RandomScalar, sample_scalar
+from batchgeneratorsv2.transforms.base.basic_transform import ImageOnlyTransform
+
+
+class StreakArtifactTransform(ImageOnlyTransform):
+    """
+    Simulates CT streak artifacts on the GPU (directional / undersampling streaks).
+
+    Physics
+    -------
+    Streak artifacts are straight bright/dark lines that cross the reconstructed
+    axial plane. They arise from sparse-angle / limited-angle acquisition
+    (aliasing streaks) and from highly attenuating inclusions. Like rings, they
+    live in the axial (reconstruction) plane and are extruded along the scan axis.
+    Unlike rings (concentric) they are linear: a family of parallel lines at some
+    in-plane orientation. They create spurious straight structures the network can
+    mistake for sheet boundaries; training with them as an augmentation builds
+    robustness.
+
+    Implementation
+    --------------
+    Per call: pick an in-plane orientation theta, project the plane coordinates
+    onto it (t = a·cosθ + b·sinθ), build a 1-D profile of Gaussian-shaped streaks
+    over t, and gather it onto the volume by the per-voxel projected coordinate
+    (linear interpolation), broadcast along the scan axis. Amplitudes are in
+    per-channel std units by default. Image-only; (C,X,Y) and (C,X,Y,Z); singleton
+    spatial axes are never used for the plane (no-op if < 2 non-singleton axes).
+
+    Parameters
+    ----------
+    num_streaks : RandomScalar
+        Number of streak lines (rounded to int).
+    intensity : RandomScalar
+        Streak amplitude magnitude (std units if relative_to_std). Sign drawn.
+    streak_width : RandomScalar
+        Gaussian sigma of a streak, in voxels.
+    p_negative : float
+        Probability a streak is dark.
+    relative_to_std : bool
+        Scale amplitudes by per-channel spatial std.
+    streak_axes : Optional[List[int]]
+        Candidate scan/extrusion axes (0-based spatial). None -> all non-singleton.
+    p_per_channel : float
+    synchronize_channels : bool
+    benchmark : bool
+        Cache plane coordinate grids keyed by shape/device.
+    """
+
+    def __init__(self,
+                 num_streaks: RandomScalar = (1, 6),
+                 intensity: RandomScalar = (0.05, 0.3),
+                 streak_width: RandomScalar = (0.5, 2.0),
+                 p_negative: float = 0.5,
+                 relative_to_std: bool = True,
+                 streak_axes: Optional[List[int]] = None,
+                 p_per_channel: float = 1.0,
+                 synchronize_channels: bool = False,
+                 benchmark: bool = True):
+        super().__init__()
+        self.num_streaks = num_streaks
+        self.intensity = intensity
+        self.streak_width = streak_width
+        self.p_negative = p_negative
+        self.relative_to_std = relative_to_std
+        self.streak_axes = streak_axes
+        self.p_per_channel = p_per_channel
+        self.synchronize_channels = synchronize_channels
+        self.benchmark = benchmark
+        self._grid_cache = {}
+
+    def get_parameters(self, **data_dict) -> dict:
+        img = data_dict["image"]
+        c = img.shape[0]
+        spatial = img.shape[1:]
+        ndim = len(spatial)
+        valid = [i for i in range(ndim) if spatial[i] > 1]
+        if len(valid) < 2:
+            return {"apply_idx": None}
+        apply = torch.rand(c, device=img.device) < self.p_per_channel
+        idx = apply.nonzero(as_tuple=False).flatten()
+        n = int(idx.numel())
+        if n == 0:
+            return {"apply_idx": None}
+
+        if ndim == 2 or len(valid) == 2:
+            cand_rot = None
+        else:
+            cand = self.streak_axes if self.streak_axes is not None else list(range(ndim))
+            cand_rot = [a for a in cand if a in valid] or list(valid)
+
+        n_specs = 1 if self.synchronize_channels else n
+        specs = [self._sample_one(valid, cand_rot, ndim) for _ in range(n_specs)]
+        return {"apply_idx": idx, "specs": specs}
+
+    def _sample_one(self, valid, cand_rot, ndim) -> dict:
+        if ndim == 2:
+            rot_axis = None
+            plane_axes = (valid[0], valid[1])
+        elif cand_rot is None:
+            plane_axes = (valid[0], valid[1])
+            rem = [a for a in range(ndim) if a not in valid]
+            rot_axis = rem[0] if rem else None
+        else:
+            rot_axis = int(cand_rot[int(torch.randint(len(cand_rot), (1,)).item())])
+            plane = [a for a in valid if a != rot_axis]
+            plane_axes = (plane[0], plane[1])
+
+        theta = float(torch.rand(1).item()) * 3.141592653589793  # [0, pi)
+        k = max(1, int(round(sample_scalar(self.num_streaks))))
+        streaks = []
+        for _ in range(k):
+            mag = abs(float(sample_scalar(self.intensity)))
+            sign = -1.0 if torch.rand(1).item() < self.p_negative else 1.0
+            streaks.append({"pos": float(torch.rand(1).item()),  # fraction along t-range
+                            "amp": sign * mag,
+                            "width": max(1e-3, float(sample_scalar(self.streak_width)))})
+        return {"rot_axis": rot_axis, "plane_axes": plane_axes, "theta": theta, "streaks": streaks}
+
+    def _coords(self, H, W, device, dtype):
+        key = (H, W, device, dtype)
+        if self.benchmark and key in self._grid_cache:
+            return self._grid_cache[key]
+        a = torch.arange(H, device=device, dtype=dtype).view(H, 1)
+        b = torch.arange(W, device=device, dtype=dtype).view(1, W)
+        if self.benchmark:
+            self._grid_cache[key] = (a, b)
+        return a, b
+
+    def _build_field(self, spec, spatial, device, dtype):
+        a0, a1 = spec["plane_axes"]
+        H, W = spatial[a0], spatial[a1]
+        a, b = self._coords(H, W, device, dtype)
+        import math
+        t = a * math.cos(spec["theta"]) + b * math.sin(spec["theta"])  # (H,W)
+        tmin = float(t.min().item())
+        tmax = float(t.max().item())
+        span = tmax - tmin
+        if span <= 0:
+            return None
+        L = int(span) + 2
+        grid = torch.arange(L, device=device, dtype=dtype) + tmin
+        profile = torch.zeros(L, device=device, dtype=dtype)
+        for s in spec["streaks"]:
+            tc = tmin + s["pos"] * span
+            w = s["width"]
+            profile += s["amp"] * torch.exp(-((grid - tc) ** 2) / (2.0 * w * w))
+        tf = (t - tmin).reshape(-1)
+        lo = torch.floor(tf).long().clamp_(0, L - 2)
+        frac = tf - lo.to(dtype)
+        field = (profile[lo] * (1.0 - frac) + profile[lo + 1] * frac).reshape(H, W)
+        view = [1] * len(spatial)
+        view[a0] = H
+        view[a1] = W
+        return field.view(view)
+
+    def _apply_to_image(self, img: torch.Tensor, **params) -> torch.Tensor:
+        idx = params.get("apply_idx")
+        if idx is None:
+            return img
+        spatial = img.shape[1:]
+        device, dtype = img.device, img.dtype
+        specs = params["specs"]
+        for j, ch in enumerate(idx.tolist()):
+            spec = specs[0] if self.synchronize_channels else specs[j]
+            field = self._build_field(spec, spatial, device, dtype)
+            if field is None:
+                continue
+            if self.relative_to_std:
+                sc = img[ch].std()
+                if not torch.isfinite(sc) or sc <= 0:
+                    sc = torch.ones((), device=device, dtype=dtype)
+                field = field * sc
+            img[ch] = img[ch] + field
+        return img
+
+
+if __name__ == "__main__":
+    from time import time
+    import numpy as np
+    torch.set_num_threads(1)
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
+    t = StreakArtifactTransform(num_streaks=(2, 6), intensity=(0.1, 0.4), p_per_channel=1.0)
+    out = t(image=torch.randn((1, 192, 192, 64), device=dev))["image"]
+    assert out.shape == (1, 192, 192, 64) and torch.isfinite(out).all()
+    times = []
+    for _ in range(200):
+        d = {"image": torch.randn((1, 192, 192, 64), device=dev)}
+        if dev == "cuda":
+            torch.cuda.synchronize()
+        st = time(); t(**d)
+        if dev == "cuda":
+            torch.cuda.synchronize()
+        times.append(time() - st)
+    print(f"{dev}: {np.mean(times) * 1e3:.3f} ms/call (192x192x64)")


### PR DESCRIPTION
# StreakArtifactTransform: GPU CT streak-artifact augmentation

Adds a scroll/CT-specific augmentation that simulates **streak artifacts** — the
straight bright/dark lines that cross the reconstructed axial plane from
sparse/limited-angle acquisition (aliasing streaks) or from highly attenuating
inclusions. Like rings they lie in the axial plane and are extruded along the
scan axis, but they are linear rather than concentric. They create spurious
straight structures a segmentation network can mistake for sheet boundaries.
Follows the "additional augmentations welcome" note in #201.

No existing transform produces line streaks: `BlankRectangleTransform` makes
filled boxes, `SmearTransform` makes a directional blur — neither generates thin
straight lines. So this fills a real gap.

**Grounding in the Vesuvius pipeline.** Per the project FAQ, reconstruction is
filtered backprojection from synchrotron parallel-beam scans. Streaks are a
textbook FBP artifact from angular undersampling / limited-angle and from highly
attenuating inclusions, so this models an artifact present in the reconstructed
volumes (augmentation for robustness, not reconstruction). As with rings,
amplitudes are in per-channel std units because the released intensities are
unitless / relative (raw floats ~[-0.1, 0.1]); the transform is additive and
non-destructive.

## Design

- `ImageOnlyTransform` (batchgeneratorsv2 style), fully on-device, in-place.
- Per call: pick an in-plane orientation θ, project plane coordinates onto it
  (t = a·cosθ + b·sinθ), build a 1-D profile of Gaussian-shaped streaks over t,
  and gather it onto the volume by the per-voxel projected coordinate (linear
  interpolation), broadcast along the scan axis (no per-voxel materialization).
- Amplitudes in per-channel std units by default (consistent under z-scored
  nnU-Net inputs). Sign drawn per streak (bright/dark).
- Handles `(C,X,Y)` and `(C,X,Y,Z)`; singleton spatial axes are never used to
  define the plane (no-op if < 2 non-singleton spatial axes).

## Speed (RTX 5070, Blackwell sm_120, single sample)

| patch (C,X,Y,Z)   | Streak ms/sample | Streak Mvox/s |
|-------------------|------------------|---------------|
| (1,192,192,1)     | 0.391            | 94            |
| (1,192,192,64)    | 0.405            | 5821          |
| (1,128,128,128)   | 0.333            | 6292          |
| (1,256,256,96)    | 0.469            | 13418         |

Sub-millisecond per sample (up to ~13.4 Gvox/s); cost is flat as the scan axis
grows because a single 2-D field is broadcast along it. The vendored 0.2.1
`GaussianNoiseTransform` is CPU-only, so it is shown as a CPU reference.

## Ablation (controlled synthetic, multi-seed, RTX 5070)

Two identical `SmallSeg3D` nets per seed, same init / data / steps (400, patch
64³). A = baseline (flips only); B = baseline + `StreakArtifactTransform`. Both
evaluated across a sweep of test-time streak severities. The test streaks are
produced by an **independent** operator (hard-edged top-hat lines, vs the
transform's Gaussian-profiled lines), so this is not testing on the training
augmentation. 5 seeds; mean ± std across seeds, with the paired B − A.

| test streak amp | A (flips)       | B (+streak)     | B − A (paired)    | seeds B>A |
|-----------------|-----------------|-----------------|-------------------|-----------|
| 0.00 (clean)    | 0.9808 ± 0.0074 | 0.9863 ± 0.0051 | +0.0055 ± 0.0056  | 4/5       |
| 0.20            | 0.9328 ± 0.0124 | 0.9486 ± 0.0079 | +0.0158 ± 0.0089  | 5/5       |
| 0.40            | 0.8296 ± 0.0265 | 0.8640 ± 0.0218 | +0.0344 ± 0.0177  | 5/5       |
| 0.60            | 0.7421 ± 0.0297 | 0.7936 ± 0.0331 | +0.0514 ± 0.0254  | 5/5       |

Pooled (amp>0): **B − A = +0.0339 ± 0.0236, 15/15 runs favour streak-aug**. The
gain grows monotonically with streak severity (the streak is a strong confounder —
the flips-only baseline falls to 0.74 Dice at high severity, and the augmentation
recovers +0.05), with no clean-data cost (clean is a slight gain). The real
magnitude is for the villa pipeline on scroll data; this synthetic ablation
matches the format of the merged Squeeze / Decohesion / Warp contributions.

## Figure
<img width="780" height="256" alt="streak_triptych" src="https://github.com/user-attachments/assets/53fc0383-afd8-4b4f-83b3-77e2bfc46cc6" />

*Illustrative effect of `StreakArtifactTransform`, rendered at 256² for visibility
(training patches are 64³). Left: clean synthetic papyrus. Centre: the additive
field (after − before) — straight bright/dark line streaks at an in-plane
orientation. Right: result, with streaks crossing the sheets. Parameters here are
stronger than the proposed training defaults (`intensity=(0.05,0.3)`) for
legibility.*

## Open questions for bruniss / giorgioangel

- Default streak orientation is uniform random in-plane; pin to a range if a
  specific acquisition geometry dominates.
- Scan axis: defaults to any non-singleton axis; set `streak_axes=[2]` to pin to Z.
- Wrapper probability in the training list (defaulting to ~0.15–0.25).