### PR TITLE
WarpTransform: reflection padding to remove edge striping at warped-axis faces

### DIFF
--- a/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/warp.py
+++ b/segmentation/models/batchgeneratorsv2/batchgeneratorsv2/transforms/spatial/warp.py
@@ -128,7 +128,7 @@ class WarpTransform(BasicTransform):
         grid[..., axis] = grid[..., axis] + displacement.to(device).reshape(vshape)
         grid = _convert_my_grid_to_grid_sample_grid(grid, spatial)
         return grid_sample(x[None].float(), grid[None], mode=mode,
-                           padding_mode="border", align_corners=False)[0]
+                           padding_mode="reflection", align_corners=False)[0]
 
     def _apply_to_image(self, img, **p):
         if p['displacement'] is None:


### PR DESCRIPTION
Follow-up to the scroll-specific Warp augmentation (merged in #999, issue #201).

While validating `WarpTransform` on a real Scroll 5 CT crop, I found a thin striped band along the warped-axis end-faces. Root cause: the coherent displacement is constant along the normal axis (by design — the stacked sheets bend together as a unit), so at the two end-faces the shift pushes the sampling grid off-volume. With `padding_mode="border"`, those out-of-bounds samples clamp to the single edge value; since the displacement varies in-plane, adjacent columns clamp by different amounts, leaving a striped band at the face.

Fix: switch the `grid_sample` in `_warp` from `padding_mode="border"` to `"reflection"`. Out-of-bounds samples now mirror interior texture instead of replicating the edge value, so the band disappears. The displacement field is untouched, so the coherent (constant-along-normal) bend and the strictly-monotonic / no-fold guarantee are preserved. One-line change.

Validation on a real Scroll 5 crop `(1, 48, 512, 512)`, with the normal axis forced to an in-plane axis so the face is visible in the viewed plane:

- **before** (`border`): striped band at the warped-axis face
- **after** (`reflection`): face is clean; interior warp unchanged

The `__main__` self-test still passes (identity when disabled, shape preserved, finite values, labels a subset, coherent bend).
<img width="1142" height="831" alt="warp_before" src="https://github.com/user-attachments/assets/e5b30532-19f9-47f6-8ecc-505ef25854a2" />
<img width="1152" height="840" alt="warp_after" src="https://github.com/user-attachments/assets/b3125491-5022-4858-b104-7eb8f0a90d08" />
