### PR TITLE
[codex] update prize winners and totals

### DIFF
--- a/scrollprize.org/docs/00_landing.md
+++ b/scrollprize.org/docs/00_landing.md
@@ -3,7 +3,7 @@ title: "Overview"
 hide_title: true
 slug: /
 hide_table_of_contents: true
-description: "A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+description: "A machine learning and computer vision competition with $1,800,500 awarded in prizes"
 image: "/img/social/opengraph.jpg"
 ---
 
@@ -13,7 +13,7 @@ image: "/img/social/opengraph.jpg"
   <meta name="title" content="Vesuvius Challenge" />
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -21,7 +21,7 @@ image: "/img/social/opengraph.jpg"
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -33,7 +33,7 @@ image: "/img/social/opengraph.jpg"
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/00_landing.md
+++ b/scrollprize.org/docs/00_landing.md
@@ -3,7 +3,7 @@ title: "Overview"
 hide_title: true
 slug: /
 hide_table_of_contents: true
-description: "A $1,700,000+ machine learning and computer vision competition"
+description: "A machine learning and computer vision competition with $1,793,500 awarded in prizes"
 image: "/img/social/opengraph.jpg"
 ---
 
@@ -13,7 +13,7 @@ image: "/img/social/opengraph.jpg"
   <meta name="title" content="Vesuvius Challenge" />
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -21,7 +21,7 @@ image: "/img/social/opengraph.jpg"
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -33,7 +33,7 @@ image: "/img/social/opengraph.jpg"
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/01_get_started.md
+++ b/scrollprize.org/docs/01_get_started.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/01_get_started.md
+++ b/scrollprize.org/docs/01_get_started.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/02_data.md
+++ b/scrollprize.org/docs/02_data.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/02_data.md
+++ b/scrollprize.org/docs/02_data.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/02_data_datasets.md
+++ b/scrollprize.org/docs/02_data_datasets.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/02_data_datasets.md
+++ b/scrollprize.org/docs/02_data_datasets.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/02_data_fragments.md
+++ b/scrollprize.org/docs/02_data_fragments.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/02_data_fragments.md
+++ b/scrollprize.org/docs/02_data_fragments.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/02_data_segments.md
+++ b/scrollprize.org/docs/02_data_segments.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/02_data_segments.md
+++ b/scrollprize.org/docs/02_data_segments.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/03_tutorial.md
+++ b/scrollprize.org/docs/03_tutorial.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/03_tutorial.md
+++ b/scrollprize.org/docs/03_tutorial.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/04_tutorial1.md
+++ b/scrollprize.org/docs/04_tutorial1.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/04_tutorial1.md
+++ b/scrollprize.org/docs/04_tutorial1.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/05_tutorial2.md
+++ b/scrollprize.org/docs/05_tutorial2.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/05_tutorial2.md
+++ b/scrollprize.org/docs/05_tutorial2.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/06_tutorial3.md
+++ b/scrollprize.org/docs/06_tutorial3.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/06_tutorial3.md
+++ b/scrollprize.org/docs/06_tutorial3.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/06_tutorial_VC.md
+++ b/scrollprize.org/docs/06_tutorial_VC.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/06_tutorial_VC.md
+++ b/scrollprize.org/docs/06_tutorial_VC.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/06_tutorial_thaumato.md
+++ b/scrollprize.org/docs/06_tutorial_thaumato.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/06_tutorial_thaumato.md
+++ b/scrollprize.org/docs/06_tutorial_thaumato.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/07_tutorial5.md
+++ b/scrollprize.org/docs/07_tutorial5.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/07_tutorial5.md
+++ b/scrollprize.org/docs/07_tutorial5.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/09_faq.md
+++ b/scrollprize.org/docs/09_faq.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"
@@ -53,7 +53,7 @@ After their discovery in the 1750s, some were opened physically, mostly destroyi
 A few hundred scrolls were excavated that were never opened, and remain rolled up with their contents sealed away.
 Our community is building methods to read these scrolls using micro-CT and an algorithmic pipeline using machine learning and computer vision.
 
-We've awarded \$1,793,500 in prizes and broken through, revealing complete passages of Greek philosophy from the inside of a closed Herculaneum scroll for the first time.
+We've awarded \$1,800,500 in prizes and broken through, revealing complete passages of Greek philosophy from the inside of a closed Herculaneum scroll for the first time.
 Now we are continuing - we want to go from reading 5% of one scroll to reading multiple complete scrolls.
 Join us to win prizes and be a part of history!
 

--- a/scrollprize.org/docs/09_faq.md
+++ b/scrollprize.org/docs/09_faq.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"
@@ -53,7 +53,7 @@ After their discovery in the 1750s, some were opened physically, mostly destroyi
 A few hundred scrolls were excavated that were never opened, and remain rolled up with their contents sealed away.
 Our community is building methods to read these scrolls using micro-CT and an algorithmic pipeline using machine learning and computer vision.
 
-We've awarded over \$1,000,000 in prizes and broken through, revealing complete passages of Greek philosophy from the inside of a closed Herculaneum scroll for the first time.
+We've awarded \$1,793,500 in prizes and broken through, revealing complete passages of Greek philosophy from the inside of a closed Herculaneum scroll for the first time.
 Now we are continuing - we want to go from reading 5% of one scroll to reading multiple complete scrolls.
 Join us to win prizes and be a part of history!
 

--- a/scrollprize.org/docs/10_background.md
+++ b/scrollprize.org/docs/10_background.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/10_background.md
+++ b/scrollprize.org/docs/10_background.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/11_livestream.md
+++ b/scrollprize.org/docs/11_livestream.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/11_livestream.md
+++ b/scrollprize.org/docs/11_livestream.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/12_grand_prize.md
+++ b/scrollprize.org/docs/12_grand_prize.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/12_grand_prize.md
+++ b/scrollprize.org/docs/12_grand_prize.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/13_ink_detection.md
+++ b/scrollprize.org/docs/13_ink_detection.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/13_ink_detection.md
+++ b/scrollprize.org/docs/13_ink_detection.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/15_winners.md
+++ b/scrollprize.org/docs/15_winners.md
@@ -10,7 +10,7 @@ import PrizeCard from '@site/src/components/PrizeCard';
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -18,7 +18,7 @@ import PrizeCard from '@site/src/components/PrizeCard';
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -30,7 +30,7 @@ import PrizeCard from '@site/src/components/PrizeCard';
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"
@@ -38,7 +38,7 @@ import PrizeCard from '@site/src/components/PrizeCard';
   />
 </head>
 
-Vesuvius Challenge has awarded **\$1,793,500** in prizes!
+Vesuvius Challenge has awarded **\$1,800,500** in prizes!
 
 This page lists all the prizes awarded so far:
 

--- a/scrollprize.org/docs/15_winners.md
+++ b/scrollprize.org/docs/15_winners.md
@@ -10,7 +10,7 @@ import PrizeCard from '@site/src/components/PrizeCard';
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -18,7 +18,7 @@ import PrizeCard from '@site/src/components/PrizeCard';
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -30,7 +30,7 @@ import PrizeCard from '@site/src/components/PrizeCard';
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"
@@ -38,9 +38,25 @@ import PrizeCard from '@site/src/components/PrizeCard';
   />
 </head>
 
-Vesuvius Challenge has awarded **\$1,781,500** in prizes!
+Vesuvius Challenge has awarded **\$1,793,500** in prizes!
 
 This page lists all the prizes awarded so far:
+
+### \$12,000 Progress Prizes (May, 2026)
+
+**Goal:** Improve the tools and training methods needed to read the scrolls.<br/>
+**Announcement:** <a href="https://scrollprize.substack.com/p/the-hard-parts-are-getting-clearer">Blog post</a>
+
+<div className="flex flex-row flex-wrap">
+  <a className="max-w-[200px] mr-4 mb-4 text-gray-100 bg-[#444] hover:bg-[#555] hover:text-[unset] p-4 rounded-lg flex flex-col justify-between" href="https://github.com/Hob3rMallow/scrollfiesta_public">
+    <div className="mb-4"><div className="text-sm font-bold text-gray-300">\$10,000</div><span className="font-bold">Scroll Fiesta</span>: Ben Kyles</div>
+    <div className="text-sm text-gray-300">An automatic mesher of surface predictions that attempts to fix topological mistakes.</div>
+  </a>
+  <a className="max-w-[200px] mr-4 mb-4 text-gray-100 bg-[#444] hover:bg-[#555] hover:text-[unset] p-4 rounded-lg flex flex-col justify-between" href="https://github.com/ScrollPrize/villa/tree/main/vesuvius">
+    <div className="mb-4"><div className="text-sm font-bold text-gray-300">\$2,000</div><span className="font-bold">3D augmentations</span>: Paulo Sergio Camillo</div>
+    <div className="text-sm text-gray-300">Scroll Decohesion, Realistic Warp, and Squeeze transforms for training ML models on CT scans.</div>
+  </a>
+</div>
 
 ### \$200,000 Kaggle Surface Detection (March, 2026) {#surface-detection-kaggle-winners}
 

--- a/scrollprize.org/docs/15_winners.md
+++ b/scrollprize.org/docs/15_winners.md
@@ -782,7 +782,7 @@ This page lists all the prizes awarded so far:
     <img src="/img/progress/os-nov23/7.webp"/>
   </a>
   <a className="max-w-[200px] mr-4 mb-4 text-gray-100 bg-[#444] hover:bg-[#555] hover:text-[unset] p-4 rounded-lg flex flex-col justify-between" href="https://github.com/tomhsiao1260/segment-viewer">
-    <div className="mb-4"><div className="text-sm font-bold text-gray-300">\$5,000</div><span className="font-bold">Segment Viewer</span> by Yao Hsiao / @Yao_Hsiao and Dalufishe / @Dalufish</div>
+    <div className="mb-4"><div className="text-sm font-bold text-gray-300">\$1,000</div><span className="font-bold">Segment Viewer</span> by Yao Hsiao / @Yao_Hsiao and Dalufishe / @Dalufish</div>
     <img src="/img/progress/os-nov23/8.webp"/>
   </a>
   <a className="max-w-[200px] mr-4 mb-4 text-gray-100 bg-[#444] hover:bg-[#555] hover:text-[unset] p-4 rounded-lg flex flex-col justify-between" href="https://discord.com/channels/1079907749569237093/1179216516697296906/1179216516697296906">

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -9,7 +9,7 @@ hide_title: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_title: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_title: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -9,7 +9,7 @@ hide_title: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_title: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_title: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/23_open_source_prizes.md
+++ b/scrollprize.org/docs/23_open_source_prizes.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/23_open_source_prizes.md
+++ b/scrollprize.org/docs/23_open_source_prizes.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/24_private_prizes.md
+++ b/scrollprize.org/docs/24_private_prizes.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/24_private_prizes.md
+++ b/scrollprize.org/docs/24_private_prizes.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/27_master_plan.md
+++ b/scrollprize.org/docs/27_master_plan.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/27_master_plan.md
+++ b/scrollprize.org/docs/27_master_plan.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/28_2024_prizes.md
+++ b/scrollprize.org/docs/28_2024_prizes.md
@@ -10,7 +10,7 @@ slug: "2024_prizes"
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -18,7 +18,7 @@ slug: "2024_prizes"
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -30,7 +30,7 @@ slug: "2024_prizes"
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/28_2024_prizes.md
+++ b/scrollprize.org/docs/28_2024_prizes.md
@@ -10,7 +10,7 @@ slug: "2024_prizes"
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -18,7 +18,7 @@ slug: "2024_prizes"
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -30,7 +30,7 @@ slug: "2024_prizes"
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/29_tutorial4.md
+++ b/scrollprize.org/docs/29_tutorial4.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/29_tutorial4.md
+++ b/scrollprize.org/docs/29_tutorial4.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/30_2024_gp_submissions.md
+++ b/scrollprize.org/docs/30_2024_gp_submissions.md
@@ -9,7 +9,7 @@ slug: "2024_gp_submissions"
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ slug: "2024_gp_submissions"
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ slug: "2024_gp_submissions"
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/30_2024_gp_submissions.md
+++ b/scrollprize.org/docs/30_2024_gp_submissions.md
@@ -9,7 +9,7 @@ slug: "2024_gp_submissions"
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ slug: "2024_gp_submissions"
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ slug: "2024_gp_submissions"
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/31_jobs.md
+++ b/scrollprize.org/docs/31_jobs.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/31_jobs.md
+++ b/scrollprize.org/docs/31_jobs.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/32_unwrapping.mdx
+++ b/scrollprize.org/docs/32_unwrapping.mdx
@@ -8,16 +8,16 @@ import Head from '@docusaurus/Head';
 
 <Head>
   <html data-theme="dark" />
-  <meta name="description" content="A $1,700,000+ machine learning and computer vision competition" />
+  <meta name="description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://scrollprize.org" />
   <meta property="og:title" content="Vesuvius Challenge" />
-  <meta property="og:description" content="A $1,700,000+ machine learning and computer vision competition" />
+  <meta property="og:description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
   <meta property="og:image" content="https://scrollprize.org/img/social/opengraph.jpg" />
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="https://scrollprize.org" />
   <meta property="twitter:title" content="Vesuvius Challenge" />
-  <meta property="twitter:description" content="A $1,700,000+ machine learning and computer vision competition" />
+  <meta property="twitter:description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
   <meta property="twitter:image" content="https://scrollprize.org/img/social/opengraph.jpg" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js" async></script>

--- a/scrollprize.org/docs/32_unwrapping.mdx
+++ b/scrollprize.org/docs/32_unwrapping.mdx
@@ -8,16 +8,16 @@ import Head from '@docusaurus/Head';
 
 <Head>
   <html data-theme="dark" />
-  <meta name="description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
+  <meta name="description" content="A machine learning and computer vision competition with $1,800,500 awarded in prizes" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://scrollprize.org" />
   <meta property="og:title" content="Vesuvius Challenge" />
-  <meta property="og:description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
+  <meta property="og:description" content="A machine learning and computer vision competition with $1,800,500 awarded in prizes" />
   <meta property="og:image" content="https://scrollprize.org/img/social/opengraph.jpg" />
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="https://scrollprize.org" />
   <meta property="twitter:title" content="Vesuvius Challenge" />
-  <meta property="twitter:description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
+  <meta property="twitter:description" content="A machine learning and computer vision competition with $1,800,500 awarded in prizes" />
   <meta property="twitter:image" content="https://scrollprize.org/img/social/opengraph.jpg" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js" async></script>

--- a/scrollprize.org/docs/33_villa_model.md
+++ b/scrollprize.org/docs/33_villa_model.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/33_villa_model.md
+++ b/scrollprize.org/docs/33_villa_model.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -28,7 +28,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/34_prizes.md
+++ b/scrollprize.org/docs/34_prizes.md
@@ -10,7 +10,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -18,7 +18,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -30,7 +30,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/34_prizes.md
+++ b/scrollprize.org/docs/34_prizes.md
@@ -10,7 +10,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -18,7 +18,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -30,7 +30,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/35_segmentation.md
+++ b/scrollprize.org/docs/35_segmentation.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/35_segmentation.md
+++ b/scrollprize.org/docs/35_segmentation.md
@@ -9,7 +9,7 @@ hide_table_of_contents: true
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@ hide_table_of_contents: true
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -29,7 +29,7 @@ hide_table_of_contents: true
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/open_problem_rep.md
+++ b/scrollprize.org/docs/open_problem_rep.md
@@ -3,7 +3,7 @@
 
   <meta
     name="description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -11,7 +11,7 @@
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -23,7 +23,7 @@
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A $1,700,000+ machine learning and computer vision competition"
+    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docs/open_problem_rep.md
+++ b/scrollprize.org/docs/open_problem_rep.md
@@ -3,7 +3,7 @@
 
   <meta
     name="description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
 
   <meta property="og:type" content="website" />
@@ -11,7 +11,7 @@
   <meta property="og:title" content="Vesuvius Challenge" />
   <meta
     property="og:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="og:image"
@@ -23,7 +23,7 @@
   <meta property="twitter:title" content="Vesuvius Challenge" />
   <meta
     property="twitter:description"
-    content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+    content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
   />
   <meta
     property="twitter:image"

--- a/scrollprize.org/docusaurus.config.js
+++ b/scrollprize.org/docusaurus.config.js
@@ -9,7 +9,7 @@ const remarkMath = require("remark-math").default; // Extract default export for
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Vesuvius Challenge",
-  tagline: "A machine learning and computer vision competition with $1,793,500 awarded in prizes",
+  tagline: "A machine learning and computer vision competition with $1,800,500 awarded in prizes",
   url: "https://scrollprize.org",
   baseUrl: "/",
   onBrokenAnchors: "throw",
@@ -132,7 +132,7 @@ const config = {
           {
             name: "description",
             content:
-                "A machine learning and computer vision competition with $1,793,500 awarded in prizes",
+                "A machine learning and computer vision competition with $1,800,500 awarded in prizes",
           },
           {
             property: "og:type",

--- a/scrollprize.org/docusaurus.config.js
+++ b/scrollprize.org/docusaurus.config.js
@@ -9,7 +9,7 @@ const remarkMath = require("remark-math").default; // Extract default export for
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Vesuvius Challenge",
-  tagline: "A $1,700,000+ machine learning and computer vision competition",
+  tagline: "A machine learning and computer vision competition with $1,793,500 awarded in prizes",
   url: "https://scrollprize.org",
   baseUrl: "/",
   onBrokenAnchors: "throw",
@@ -132,7 +132,7 @@ const config = {
           {
             name: "description",
             content:
-                "A $1,700,000+ machine learning and computer vision competition",
+                "A machine learning and computer vision competition with $1,793,500 awarded in prizes",
           },
           {
             property: "og:type",

--- a/scrollprize.org/src/components/Landing.js
+++ b/scrollprize.org/src/components/Landing.js
@@ -1604,7 +1604,7 @@ export function Landing() {
         <title>Vesuvius Challenge</title>
         <meta
           name="description"
-          content="A $1,700,000+ machine learning and computer vision competition"
+          content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
         />
         <link rel="canonical" href={canonicalUrl} />
         {/* Preload the LCP poster image */}
@@ -1613,13 +1613,13 @@ export function Landing() {
         <meta property="og:type" content="website" />
         <meta property="og:url" content={siteUrl} />
         <meta property="og:title" content="Vesuvius Challenge" />
-        <meta property="og:description" content="A $1,700,000+ machine learning and computer vision competition" />
+        <meta property="og:description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
         <meta property="og:image" content={siteUrl + "img/social/opengraph.jpg"} />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content="Vesuvius Challenge" />
-        <meta name="twitter:description" content="A $1,700,000+ machine learning and computer vision competition" />
+        <meta name="twitter:description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
         <meta name="twitter:image" content={siteUrl + "img/social/opengraph.jpg"} />
         {/* JSON-LD */}
         <script type="application/ld+json"
@@ -1673,7 +1673,7 @@ export function Landing() {
                     <a href="/grandprize">reading</a>&nbsp;
                   </span>
                   <span className="opacity-80 md:opacity-60">
-                    the carbonized Herculaneum scrolls & has awarded $1,700,000 in prizes.
+                    the carbonized Herculaneum scrolls & has awarded $1,793,500 in prizes.
                   </span>
                   <br />
                   <br />

--- a/scrollprize.org/src/components/Landing.js
+++ b/scrollprize.org/src/components/Landing.js
@@ -1604,7 +1604,7 @@ export function Landing() {
         <title>Vesuvius Challenge</title>
         <meta
           name="description"
-          content="A machine learning and computer vision competition with $1,793,500 awarded in prizes"
+          content="A machine learning and computer vision competition with $1,800,500 awarded in prizes"
         />
         <link rel="canonical" href={canonicalUrl} />
         {/* Preload the LCP poster image */}
@@ -1613,13 +1613,13 @@ export function Landing() {
         <meta property="og:type" content="website" />
         <meta property="og:url" content={siteUrl} />
         <meta property="og:title" content="Vesuvius Challenge" />
-        <meta property="og:description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
+        <meta property="og:description" content="A machine learning and computer vision competition with $1,800,500 awarded in prizes" />
         <meta property="og:image" content={siteUrl + "img/social/opengraph.jpg"} />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content="Vesuvius Challenge" />
-        <meta name="twitter:description" content="A machine learning and computer vision competition with $1,793,500 awarded in prizes" />
+        <meta name="twitter:description" content="A machine learning and computer vision competition with $1,800,500 awarded in prizes" />
         <meta name="twitter:image" content={siteUrl + "img/social/opengraph.jpg"} />
         {/* JSON-LD */}
         <script type="application/ld+json"
@@ -1673,7 +1673,7 @@ export function Landing() {
                     <a href="/grandprize">reading</a>&nbsp;
                   </span>
                   <span className="opacity-80 md:opacity-60">
-                    the carbonized Herculaneum scrolls & has awarded $1,793,500 in prizes.
+                    the carbonized Herculaneum scrolls & has awarded $1,800,500 in prizes.
                   </span>
                   <br />
                   <br />

--- a/scrollprize.org/src/components/LatestPosts.js
+++ b/scrollprize.org/src/components/LatestPosts.js
@@ -67,7 +67,7 @@ const LatestPosts = () => {
       <TopCard
         title="Get Started"
         href="/get_started"
-        subtext="$1.79M+ already awarded"
+        subtext="$1.8M+ already awarded"
         useArrow={true}
       />
       {posts.map((post, index) => (

--- a/scrollprize.org/src/components/LatestPosts.js
+++ b/scrollprize.org/src/components/LatestPosts.js
@@ -67,7 +67,7 @@ const LatestPosts = () => {
       <TopCard
         title="Get Started"
         href="/get_started"
-        subtext="$1.7M+ already awarded"
+        subtext="$1.79M+ already awarded"
         useArrow={true}
       />
       {posts.map((post, index) => (


### PR DESCRIPTION
## Summary
- Add the May 2026 Progress Prizes from the Substack post to `scrollprize.org/docs/15_winners.md`.
- Update the awarded prize total from `$1,781,500` to `$1,800,500`, matching the sum of prize section headings after adding the new `$12,000` section.
- Correct the November 30, 2023 Segment Viewer card from `$5,000` to `$1,000`, matching the source post's `$25k` prize pool and making the card-level sum match the section headings.
- Refresh sitewide awarded-prize copy and metadata that still referenced `$1,700,000+`, plus the FAQ copy that still said over `$1,000,000`.

## Source
- https://scrollprize.substack.com/p/the-hard-parts-are-getting-clearer
- https://scrollprize.substack.com/p/many-open-source-prize-winners-25

## Validation
- Python audit of `scrollprize.org/docs/15_winners.md`:
  - headline total: `$1,800,500`
  - section-heading total: `$1,800,500`
  - award-card total: `$1,800,500`
  - section mismatches: `0`
- Confirmed no stale `$1,781,500`, `$1,793,500`, `$1,700,000`, `$1.7M`, or old `$1,000,000` awarded-total strings remain in `scrollprize.org` docs/src/config.
- Ran `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,cr-at-eol diff --check -- scrollprize.org`.
- Parsed changed JSX files with the installed Babel parser.
- Ran `node --check scrollprize.org/docusaurus.config.js`.

Full `yarn build` could not run in this shell: global Yarn is `1.22.22` while the project requires Yarn `4.6.0`, `corepack` is unavailable, and the local Docusaurus binary requires Node `>=20.0` while this shell has Node `18.19.1`.