### PR TITLE
VC3D: fix scalebar to track zoom + voxel size

### DIFF
--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -746,6 +746,9 @@ void MenuActionController::showSettingsDialog()
         _window->_viewerManager->forEachBaseViewer([showDirHints](VolumeViewerBase* viewer) {
             if (viewer) {
                 viewer->setShowDirectionHints(showDirHints);
+                // Re-read viewer settings (sensitivities, scalebar voxel size, ...)
+                // so changes made in the dialog take effect immediately.
+                viewer->reloadPerfSettings();
             }
         });
     }

--- a/volume-cartographer/apps/VC3D/SettingsDialog.cpp
+++ b/volume-cartographer/apps/VC3D/SettingsDialog.cpp
@@ -29,6 +29,9 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
     edtScanRange->setText(settings.value(viewer::SCAN_RANGE_STEPS, viewer::SCAN_RANGE_STEPS_DEFAULT).toString());
     spinScrollSpeed->setValue(settings.value(viewer::SCROLL_SPEED, viewer::SCROLL_SPEED_DEFAULT).toInt());
     spinZoomSensitivity->setValue(settings.value(viewer::ZOOM_SENSITIVITY, viewer::ZOOM_SENSITIVITY_DEFAULT).toDouble());
+    if (auto* spin = findChild<QDoubleSpinBox*>("spinVoxelSize")) {
+        spin->setValue(settings.value(viewer::VOXEL_SIZE_UM, viewer::VOXEL_SIZE_UM_DEFAULT).toDouble());
+    }
     spinDisplayOpacity->setValue(settings.value(viewer::DISPLAY_SEGMENT_OPACITY, viewer::DISPLAY_SEGMENT_OPACITY_DEFAULT).toInt());
     chkPlaySoundAfterSegRun->setChecked(settings.value(viewer::PLAY_SOUND_AFTER_SEG_RUN, viewer::PLAY_SOUND_AFTER_SEG_RUN_DEFAULT).toInt() != 0);
     edtUsername->setText(settings.value(viewer::USERNAME, viewer::USERNAME_DEFAULT).toString());
@@ -120,6 +123,9 @@ void SettingsDialog::accept()
     settings.setValue(viewer::SCAN_RANGE_STEPS, edtScanRange->text());
     settings.setValue(viewer::SCROLL_SPEED, spinScrollSpeed->value());
     settings.setValue(viewer::ZOOM_SENSITIVITY, spinZoomSensitivity->value());
+    if (auto* spin = findChild<QDoubleSpinBox*>("spinVoxelSize")) {
+        settings.setValue(viewer::VOXEL_SIZE_UM, spin->value());
+    }
     settings.setValue(viewer::DISPLAY_SEGMENT_OPACITY, spinDisplayOpacity->value());
     settings.setValue(viewer::PLAY_SOUND_AFTER_SEG_RUN, chkPlaySoundAfterSegRun->isChecked() ? "1" : "0");
     settings.setValue(viewer::USERNAME, edtUsername->text());

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -105,6 +105,9 @@ namespace viewer {
     constexpr auto ZSCROLL_SENSITIVITY = "viewer/zscroll_sensitivity";
     constexpr auto IMPACT_RANGE_STEPS = "viewer/impact_range_steps";
     constexpr auto SCAN_RANGE_STEPS = "viewer/scan_range_steps";
+    // Fallback voxel size (µm per level-0 voxel) for the scalebar when the loaded
+    // volume's metadata has none (e.g. .vca archives). 0 = unset (no fallback).
+    constexpr auto VOXEL_SIZE_UM = "viewer/voxel_size_um";
 
     constexpr int FWD_BACK_STEP_MS_DEFAULT = 25;
     constexpr bool CENTER_ON_ZOOM_DEFAULT = false;
@@ -112,6 +115,7 @@ namespace viewer {
     constexpr float PAN_SENSITIVITY_DEFAULT = 1.0f;
     constexpr float ZOOM_SENSITIVITY_DEFAULT = 1.0f;
     constexpr float ZSCROLL_SENSITIVITY_DEFAULT = 1.0f;
+    constexpr double VOXEL_SIZE_UM_DEFAULT = 0.0;   // unset; scalebar falls back to volume metadata only
     constexpr auto IMPACT_RANGE_STEPS_DEFAULT = "1-3, 5, 8, 11, 15, 20, 28, 40, 60, 100, 200";
     constexpr auto SCAN_RANGE_STEPS_DEFAULT = "1, 2, 5, 10, 20, 50, 100, 200, 500, 1000";
 

--- a/volume-cartographer/apps/VC3D/VCSettings.ui
+++ b/volume-cartographer/apps/VC3D/VCSettings.ui
@@ -325,6 +325,38 @@
             </property>
            </widget>
           </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="labelVoxelSize">
+            <property name="text">
+             <string>Voxel size (µm)</string>
+            </property>
+            <property name="toolTip">
+             <string>Physical size of one volume voxel in micrometres, used by the scalebar. Falls back to the volume metadata; set here for volumes (e.g. .vca) that don't carry it. 0 = use metadata only.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+           <widget class="QDoubleSpinBox" name="spinVoxelSize">
+            <property name="decimals">
+             <number>4</number>
+            </property>
+            <property name="minimum">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>100000.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="suffix">
+             <string> µm</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -779,6 +779,8 @@ void CChunkedVolumeViewer::reloadPerfSettings()
     _panSensitivity = std::max(0.01f, s.value(viewer::PAN_SENSITIVITY, viewer::PAN_SENSITIVITY_DEFAULT).toFloat());
     _zoomSensitivity = std::max(0.01f, s.value(viewer::ZOOM_SENSITIVITY, viewer::ZOOM_SENSITIVITY_DEFAULT).toFloat());
     _zScrollSensitivity = std::max(0.01f, s.value(viewer::ZSCROLL_SENSITIVITY, viewer::ZSCROLL_SENSITIVITY_DEFAULT).toFloat());
+    _voxelSizeOverrideUm = std::max(0.0, s.value(viewer::VOXEL_SIZE_UM, viewer::VOXEL_SIZE_UM_DEFAULT).toDouble());
+    updateScalebarScale();   // override may have changed -> refresh the scalebar
     const int interpIdx = s.value(perf::INTERPOLATION_METHOD, 1).toInt();
     _samplingMethod = static_cast<vc::Sampling>(std::clamp(interpIdx, 0, 1));
     _maxDisplayedResolution = std::clamp(
@@ -932,11 +934,7 @@ void CChunkedVolumeViewer::OnVolumeChanged(std::shared_ptr<Volume> vol)
                                   : static_cast<int>(_volume->numScales());
         _scale = scaleForCoarsestPlaneRenderLevel(n);
     }
-    recalcPyramidLevel();
-    if (_volume) {
-        const double vs = _volume->voxelSize() / static_cast<double>(_dsScale);
-        _view->setVoxelSize(vs, vs);
-    }
+    recalcPyramidLevel();   // also pushes the scalebar µm/px (updateScalebarScale)
     updateContentBounds();
     resizeFramebuffer();
     scheduleRender("volume changed");
@@ -1213,6 +1211,36 @@ void CChunkedVolumeViewer::recalcPyramidLevel()
         static_cast<int>(std::floor(std::max(0.0f, std::log2(1.0f / lodScale)))),
         0, std::max(0, n - 1));
     _dsScale = static_cast<float>(std::uint64_t{1} << _dsScaleIdx);
+    updateScalebarScale();
+}
+
+void CChunkedVolumeViewer::updateScalebarScale()
+{
+    // The scalebar overlay (CVolumeViewerView::drawForeground) needs µm per scene
+    // pixel, where one scene pixel == one rendered framebuffer pixel (the framebuffer
+    // is blitted 1:1, so the view transform m11 ~= 1 and does NOT carry the zoom).
+    // The zoom + LOD live in the FRAMEBUFFER render, not the view transform:
+    //   - 1 framebuffer px = 1/_scale render-LOD voxels (gen steps gridScale/_scale).
+    //   - 1 render-LOD voxel = _dsScale level-0 voxels = _dsScale * voxelSize µm.
+    // => µm/px = voxelSize * _dsScale / _scale. Must be recomputed on every zoom AND
+    // LOD change (both happen here) -- the old code set it once at volume-load with
+    // the wrong formula (voxelSize/_dsScale, zoom ignored), so the bar was wrong at
+    // every zoom level.
+    if (!_view || !_volume)
+        return;
+    // Voxel size (µm per level-0 voxel): prefer the volume's own metadata, but many
+    // .vca archives don't carry one (voxelSize()==0). Fall back to the user-set
+    // override (viewer/voxel_size_um in settings) so the scalebar still shows real
+    // units. If neither is available the bar can't be physical -> leave the view's
+    // default and the overlay shows nothing meaningful.
+    double voxel = _volume->voxelSize();
+    if (!(voxel > 0.0))
+        voxel = _voxelSizeOverrideUm;                 // 0 if unset
+    if (!(voxel > 0.0) || !(_scale > 0.0f))
+        return;
+    const double umPerScenePx =
+        voxel * static_cast<double>(_dsScale) / static_cast<double>(_scale);
+    _view->setVoxelSize(umPerScenePx, umPerScenePx);
 }
 
 void CChunkedVolumeViewer::resizeFramebuffer()

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -258,6 +258,7 @@ private:
     bool shouldRefreshInteractivePreview();
     void resizeFramebuffer();
     void recalcPyramidLevel();
+    void updateScalebarScale();   // push µm/scene-px to the view's scalebar overlay
     void panByF(float dx, float dy);
     void zoomStepsAt(int steps, const QPointF& scenePos);
     bool isAxisAlignedView() const;
@@ -385,6 +386,7 @@ private:
     float _panSensitivity = 1.0f;
     float _zoomSensitivity = 1.0f;
     float _zScrollSensitivity = 1.0f;
+    double _voxelSizeOverrideUm = 0.0;   // scalebar fallback when volume metadata lacks voxelsize
     vc::Sampling _samplingMethod = vc::Sampling::Trilinear;
     int _maxDisplayedResolution = 0;
     bool _showDirectionHints = true;

--- a/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.cpp
@@ -49,13 +49,21 @@ void CVolumeViewerView::drawForeground(QPainter* p, const QRectF& sceneRect)
         double barUm = chooseNiceLength(wUm / 4.0);
         _cachedBarPx = barUm * pxPerUm;
 
+        // Pick the natural unit by magnitude: nm < 1 µm, µm < 1 mm (1e3), mm < 1 cm
+        // (1e4), cm < 1 m (1e6), then m. barUm is already a "nice" 1/2/5 value, so the
+        // displayed number stays clean. Trim trailing zeros (0.5 not 0.500000).
         double displayLength = barUm;
         QString unit = QStringLiteral(" µm");
-        if (barUm >= 1000.0) {
-            displayLength = barUm / 1000.0;
-            unit = QStringLiteral(" mm");
+        if (barUm < 1.0) {
+            displayLength = barUm * 1000.0;   unit = QStringLiteral(" nm");
+        } else if (barUm >= 1.0e6) {
+            displayLength = barUm / 1.0e6;    unit = QStringLiteral(" m");
+        } else if (barUm >= 1.0e4) {
+            displayLength = barUm / 1.0e4;    unit = QStringLiteral(" cm");
+        } else if (barUm >= 1.0e3) {
+            displayLength = barUm / 1.0e3;    unit = QStringLiteral(" mm");
         }
-        _cachedBarLabel = QString::number(displayLength) + unit;
+        _cachedBarLabel = QString::number(displayLength, 'g', 4) + unit;
     }
 
     p->save();


### PR DESCRIPTION
the bottom-left scalebar was broken - it was set once at volume load with the wrong formula (zoom ignored) so it only changed with the window size, never the zoom. Not all volumes have the "voxelsize" metadata either

- correct the µm/pixel math: zoom + LOD live in the framebuffer render (m11~=1), so µm/px = voxelsize * dsScale / scale, recomputed on every zoom/LOD change
- add a persisted "voxel size (µm)" setting used as a fallback when the volume metadata has none (e.g. .vca), applied live on settings close
- unit selection nm / µm / mm / cm / m (was only µm/mm)

verified: LOD0, 1.03x zoom, voxel 2.4µm, 1156px window -> 500µm bar measures 217px on screen, predicted 215px. matches to ~1%.