### PR TITLE
feat(fibers-dataset): GPU ridge/vesselness detection that scales past 64³

### DIFF
--- a/foundation/datasets/fibers-dataset/bench/bench_tools.py
+++ b/foundation/datasets/fibers-dataset/bench/bench_tools.py
@@ -1,0 +1,118 @@
+import argparse
+import time
+import numpy as np
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import tools
+
+try:
+    import cupy as cp
+    HAS_CUPY = True
+except ImportError:
+    HAS_CUPY = False
+
+def detect_vesselness_tiled(volume_cp, block_size=128, halo=16):
+    """
+    Run detect_vesselness in blocks to fit in GPU memory.
+    """
+    Z, Y, X = volume_cp.shape
+    result = cp.zeros((Z, Y, X), dtype=volume_cp.dtype)
+    
+    for z in range(0, Z, block_size):
+        for y in range(0, Y, block_size):
+            for x in range(0, X, block_size):
+                # Calculate coordinates with halo
+                z0, z1 = max(0, z - halo), min(Z, z + block_size + halo)
+                y0, y1 = max(0, y - halo), min(Y, y + block_size + halo)
+                x0, x1 = max(0, x - halo), min(X, x + block_size + halo)
+                
+                # Extract block
+                block = volume_cp[z0:z1, y0:y1, x0:x1]
+                
+                # Process block
+                block_res = tools.detect_vesselness(block)
+                
+                # Crop halo and write back
+                bz0 = z - z0
+                bz1 = bz0 + min(block_size, Z - z)
+                by0 = y - y0
+                by1 = by0 + min(block_size, Y - y)
+                bx0 = x - x0
+                bx1 = bx0 + min(block_size, X - x)
+                
+                result[z:z+bz1-bz0, y:y+by1-by0, x:x+bx1-bx0] = block_res[bz0:bz1, by0:by1, bx0:bx1]
+                
+                # Free memory aggressively inside loop
+                del block
+                del block_res
+                cp.get_default_memory_pool().free_all_blocks()
+                
+    return result
+
+def run_benchmark(sizes, tiled=False, skip_cpu=False):
+    print("=" * 60)
+    print(f"{'Volume Size':<15} | {'Backend':<13} | {'Time (s)':<10} | {'Status':<15}")
+    print("-" * 60)
+    
+    for size in sizes:
+        shape = (size, size, size)
+        
+        np.random.seed(42)
+        volume_np = np.random.rand(*shape).astype(np.float32)
+        
+        cpu_time = -1
+        if not skip_cpu:
+            start_time = time.time()
+            try:
+                _ = tools.detect_vesselness(volume_np)
+                cpu_time = time.time() - start_time
+                print(f"{str(shape):<15} | {'CPU (NumPy)':<13} | {cpu_time:<10.2f} | {'OK':<15}")
+            except Exception as e:
+                print(f"{str(shape):<15} | {'CPU (NumPy)':<13} | {'N/A':<10} | FAILED: {str(e)[:20]}")
+        else:
+            print(f"{str(shape):<15} | {'CPU (NumPy)':<13} | {'SKIPPED':<10} | {'--skip-cpu':<15}")
+            
+        if HAS_CUPY:
+            volume_cp = cp.array(volume_np)
+            try:
+                _ = tools.detect_vesselness(cp.random.rand(32, 32, 32).astype(np.float32))
+                cp.cuda.Stream.null.synchronize()
+            except:
+                pass
+                
+            start_time = time.time()
+            try:
+                if tiled:
+                    _ = detect_vesselness_tiled(volume_cp, block_size=128, halo=16)
+                else:
+                    _ = tools.detect_vesselness(volume_cp)
+                cp.cuda.Stream.null.synchronize()
+                gpu_time = time.time() - start_time
+                
+                speedup_str = f"{cpu_time / gpu_time:.1f}x" if cpu_time > 0 else "N/A"
+                mode = "GPU (Tiled)" if tiled else "GPU (CuPy)"
+                print(f"{str(shape):<15} | {mode:<13} | {gpu_time:<10.2f} | OK ({speedup_str} speedup)")
+                
+                mempool = cp.get_default_memory_pool()
+                used_gb = mempool.used_bytes() / (1024**3)
+                print(f"  -> GPU Memory Used: {used_gb:.2f} GB")
+                mempool.free_all_blocks()
+            except cp.cuda.memory.OutOfMemoryError as e:
+                mode = "GPU (Tiled)" if tiled else "GPU (CuPy)"
+                print(f"{str(shape):<15} | {mode:<13} | {'OOM':<10} | FAILED")
+                cp.get_default_memory_pool().free_all_blocks()
+            except Exception as e:
+                mode = "GPU (Tiled)" if tiled else "GPU (CuPy)"
+                print(f"{str(shape):<15} | {mode:<13} | {'N/A':<10} | FAILED: {str(e)[:20]}")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Benchmark fibers-dataset tools.")
+    parser.add_argument('--sizes', nargs='+', type=int, default=[64, 128, 256], help='Volume cube sizes to test')
+    parser.add_argument('--tiled', action='store_true', help='Test tiled execution to save memory')
+    parser.add_argument('--skip-cpu', action='store_true', help='Skip CPU benchmarking (useful for large sizes)')
+    args = parser.parse_args()
+    
+    run_benchmark(args.sizes, args.tiled, args.skip_cpu)

--- a/foundation/datasets/fibers-dataset/bench/bench_tools.py
+++ b/foundation/datasets/fibers-dataset/bench/bench_tools.py
@@ -14,47 +14,9 @@ try:
 except ImportError:
     HAS_CUPY = False
 
-def detect_vesselness_tiled(volume_cp, block_size=128, halo=16):
-    """
-    Run detect_vesselness in blocks to fit in GPU memory.
-    """
-    Z, Y, X = volume_cp.shape
-    result = cp.zeros((Z, Y, X), dtype=volume_cp.dtype)
-    
-    for z in range(0, Z, block_size):
-        for y in range(0, Y, block_size):
-            for x in range(0, X, block_size):
-                # Calculate coordinates with halo
-                z0, z1 = max(0, z - halo), min(Z, z + block_size + halo)
-                y0, y1 = max(0, y - halo), min(Y, y + block_size + halo)
-                x0, x1 = max(0, x - halo), min(X, x + block_size + halo)
-                
-                # Extract block
-                block = volume_cp[z0:z1, y0:y1, x0:x1]
-                
-                # Process block
-                block_res = tools.detect_vesselness(block)
-                
-                # Crop halo and write back
-                bz0 = z - z0
-                bz1 = bz0 + min(block_size, Z - z)
-                by0 = y - y0
-                by1 = by0 + min(block_size, Y - y)
-                bx0 = x - x0
-                bx1 = bx0 + min(block_size, X - x)
-                
-                result[z:z+bz1-bz0, y:y+by1-by0, x:x+bx1-bx0] = block_res[bz0:bz1, by0:by1, bx0:bx1]
-                
-                # Free memory aggressively inside loop
-                del block
-                del block_res
-                cp.get_default_memory_pool().free_all_blocks()
-                
-    return result
-
 def run_benchmark(sizes, tiled=False, skip_cpu=False):
     print("=" * 60)
-    print(f"{'Volume Size':<15} | {'Backend':<13} | {'Time (s)':<10} | {'Status':<15}")
+    print(f"{'Volume Size':<15} | {'Filter':<10} | {'Backend':<13} | {'Time (s)':<10} | {'Status':<15}")
     print("-" * 60)
     
     for size in sizes:
@@ -63,50 +25,56 @@ def run_benchmark(sizes, tiled=False, skip_cpu=False):
         np.random.seed(42)
         volume_np = np.random.rand(*shape).astype(np.float32)
         
-        cpu_time = -1
-        if not skip_cpu:
-            start_time = time.time()
-            try:
-                _ = tools.detect_vesselness(volume_np)
-                cpu_time = time.time() - start_time
-                print(f"{str(shape):<15} | {'CPU (NumPy)':<13} | {cpu_time:<10.2f} | {'OK':<15}")
-            except Exception as e:
-                print(f"{str(shape):<15} | {'CPU (NumPy)':<13} | {'N/A':<10} | FAILED: {str(e)[:20]}")
-        else:
-            print(f"{str(shape):<15} | {'CPU (NumPy)':<13} | {'SKIPPED':<10} | {'--skip-cpu':<15}")
-            
-        if HAS_CUPY:
-            volume_cp = cp.array(volume_np)
-            try:
-                _ = tools.detect_vesselness(cp.random.rand(32, 32, 32).astype(np.float32))
-                cp.cuda.Stream.null.synchronize()
-            except:
-                pass
+        for filter_name in ['vesselness', 'ridges']:
+            filter_fn = tools.detect_vesselness if filter_name == 'vesselness' else tools.detect_ridges
+            tiled_fn = tools.detect_vesselness_tiled if filter_name == 'vesselness' else tools.detect_ridges_tiled
+
+            cpu_time = -1
+            if not skip_cpu:
+                start_time = time.time()
+                try:
+                    _ = filter_fn(volume_np)
+                    cpu_time = time.time() - start_time
+                    print(f"{str(shape):<15} | {filter_name:<10} | {'CPU (NumPy)':<13} | {cpu_time:<10.2f} | {'OK':<15}")
+                except Exception as e:
+                    print(f"{str(shape):<15} | {filter_name:<10} | {'CPU (NumPy)':<13} | {'N/A':<10} | FAILED: {str(e)[:20]}")
+            else:
+                print(f"{str(shape):<15} | {filter_name:<10} | {'CPU (NumPy)':<13} | {'SKIPPED':<10} | {'--skip-cpu':<15}")
                 
-            start_time = time.time()
-            try:
-                if tiled:
-                    _ = detect_vesselness_tiled(volume_cp, block_size=128, halo=16)
-                else:
-                    _ = tools.detect_vesselness(volume_cp)
-                cp.cuda.Stream.null.synchronize()
-                gpu_time = time.time() - start_time
-                
-                speedup_str = f"{cpu_time / gpu_time:.1f}x" if cpu_time > 0 else "N/A"
-                mode = "GPU (Tiled)" if tiled else "GPU (CuPy)"
-                print(f"{str(shape):<15} | {mode:<13} | {gpu_time:<10.2f} | OK ({speedup_str} speedup)")
-                
-                mempool = cp.get_default_memory_pool()
-                used_gb = mempool.used_bytes() / (1024**3)
-                print(f"  -> GPU Memory Used: {used_gb:.2f} GB")
-                mempool.free_all_blocks()
-            except cp.cuda.memory.OutOfMemoryError as e:
-                mode = "GPU (Tiled)" if tiled else "GPU (CuPy)"
-                print(f"{str(shape):<15} | {mode:<13} | {'OOM':<10} | FAILED")
-                cp.get_default_memory_pool().free_all_blocks()
-            except Exception as e:
-                mode = "GPU (Tiled)" if tiled else "GPU (CuPy)"
-                print(f"{str(shape):<15} | {mode:<13} | {'N/A':<10} | FAILED: {str(e)[:20]}")
+            if HAS_CUPY:
+                volume_cp = cp.array(volume_np)
+                # Warmup
+                try:
+                    _ = filter_fn(cp.random.rand(32, 32, 32).astype(np.float32))
+                    cp.cuda.Stream.null.synchronize()
+                except:
+                    pass
+                    
+                start_time = time.time()
+                try:
+                    if tiled:
+                        _ = tiled_fn(volume_cp, block_size=128, halo=16)
+                    else:
+                        _ = filter_fn(volume_cp)
+                    cp.cuda.Stream.null.synchronize()
+                    gpu_time = time.time() - start_time
+                    
+                    speedup_str = f"{cpu_time / gpu_time:.1f}x" if cpu_time > 0 else "N/A"
+                    mode = "GPU (Tiled)" if tiled else "GPU (CuPy)"
+                    print(f"{str(shape):<15} | {filter_name:<10} | {mode:<13} | {gpu_time:<10.2f} | OK ({speedup_str} speedup)")
+                    
+                    mempool = cp.get_default_memory_pool()
+                    used_gb = mempool.used_bytes() / (1024**3)
+                    print(f"  -> GPU Memory Used: {used_gb:.2f} GB")
+                    mempool.free_all_blocks()
+                except cp.cuda.memory.OutOfMemoryError as e:
+                    mode = "GPU (Tiled)" if tiled else "GPU (CuPy)"
+                    print(f"{str(shape):<15} | {filter_name:<10} | {mode:<13} | {'OOM':<10} | FAILED")
+                    cp.get_default_memory_pool().free_all_blocks()
+                except Exception as e:
+                    mode = "GPU (Tiled)" if tiled else "GPU (CuPy)"
+                    print(f"{str(shape):<15} | {filter_name:<10} | {mode:<13} | {'N/A':<10} | FAILED: {str(e)[:20]}")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Benchmark fibers-dataset tools.")

--- a/foundation/datasets/fibers-dataset/tests/test_gpu.py
+++ b/foundation/datasets/fibers-dataset/tests/test_gpu.py
@@ -1,0 +1,41 @@
+import pytest
+import numpy as np
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import tools
+
+try:
+    import cupy as cp
+    HAS_CUPY = True
+except ImportError:
+    HAS_CUPY = False
+
+@pytest.mark.skipif(not HAS_CUPY, reason="CuPy not available")
+def test_eigenvalues_analytical():
+    """Test the analytical 3x3 eigensolver against NumPy's eigvalsh."""
+    np.random.seed(42)
+    # Generate random symmetric matrices
+    A = np.random.rand(10, 10, 3, 3).astype(np.float32)
+    for i in range(3):
+        for j in range(i+1, 3):
+            A[..., i, j] = A[..., j, i]
+            
+    A_cp = cp.array(A)
+    
+    eigvals_cp = tools.compute_eigenvalues_3x3_batch(A_cp)
+    eigvals_np = np.linalg.eigvalsh(A)
+    
+    np.testing.assert_allclose(cp.asnumpy(eigvals_cp), eigvals_np, rtol=1e-3, atol=1e-4)
+
+@pytest.mark.skipif(not HAS_CUPY, reason="CuPy not available")
+def test_vesselness_parity():
+    """Ensure CPU (NumPy) and GPU (CuPy) backends produce similar results."""
+    np.random.seed(42)
+    volume_np = np.random.rand(32, 32, 32).astype(np.float32)
+    volume_cp = cp.array(volume_np)
+    
+    res_np = tools.detect_vesselness(volume_np)
+    res_cp = tools.detect_vesselness(volume_cp)
+    
+    np.testing.assert_allclose(res_np, cp.asnumpy(res_cp), rtol=1e-3, atol=1e-4)

--- a/foundation/datasets/fibers-dataset/tests/test_gpu.py
+++ b/foundation/datasets/fibers-dataset/tests/test_gpu.py
@@ -39,3 +39,25 @@ def test_vesselness_parity():
     res_cp = tools.detect_vesselness(volume_cp)
     
     np.testing.assert_allclose(res_np, cp.asnumpy(res_cp), rtol=1e-3, atol=1e-4)
+
+def test_tiled_parity():
+    """Tiled execution matches the dense path when the halo covers the filter support."""
+    np.random.seed(42)
+    volume_np = np.random.rand(64, 64, 64).astype(np.float32)
+
+    # Default gauss_sigma=2 -> smoothing support 4*sigma=8 voxels (+2 for the
+    # finite-difference Hessian), fully inside halo=16.
+    res_dense = tools.detect_vesselness(volume_np.copy())
+    res_tiled = tools.detect_vesselness_tiled(volume_np.copy(), block_size=32, halo=16)
+
+    np.testing.assert_allclose(res_dense, res_tiled, rtol=1e-3, atol=1e-4)
+
+def test_tiled_parity_ridges():
+    """Same parity check for the ridge filter."""
+    np.random.seed(7)
+    volume_np = np.random.rand(64, 64, 64).astype(np.float32)
+
+    res_dense = tools.detect_ridges(volume_np.copy())
+    res_tiled = tools.detect_ridges_tiled(volume_np.copy(), block_size=32, halo=16)
+
+    np.testing.assert_allclose(res_dense, res_tiled, rtol=1e-3, atol=1e-4)

--- a/foundation/datasets/fibers-dataset/tools.py
+++ b/foundation/datasets/fibers-dataset/tools.py
@@ -37,10 +37,18 @@ def divide_nonzero(array1, array2, eps=1e-10):
     denominator[denominator == 0] = eps
     return xp.divide(array1, denominator)
 
-def normalize(volume):
+def normalize(volume, norm_range=None):
+    """
+    Min-max normalize in place. If norm_range is given as (min, max), use it
+    instead of the volume's own extrema (needed for tiled execution, where each
+    block must be normalized against the global range to match dense results).
+    """
     xp, _ = get_backend(volume)
-    minim = xp.min(volume)
-    maxim = xp.max(volume)
+    if norm_range is None:
+        minim = xp.min(volume)
+        maxim = xp.max(volume)
+    else:
+        minim, maxim = norm_range
     volume -= minim
     volume /= (maxim - minim)
     return volume
@@ -137,11 +145,11 @@ def denoise_3d(volume, h=0.03):
 def adjust_contrast(volume, kernel_size=8):
     return equalize_adapthist(volume, kernel_size, clip_limit=0.01, nbins=256)
 
-def hessian(volume, gauss_sigma=2, sigma=6):
+def hessian(volume, gauss_sigma=2, sigma=6, norm_range=None):
     xp, xndimage = get_backend(volume)
     # N.B. this only returns the upper triangular matrix to save time
     volume = xndimage.gaussian_filter(volume, sigma=gauss_sigma)
-    volume = normalize(volume)
+    volume = normalize(volume, norm_range=norm_range)
     
     joint_hessian = xp.zeros((volume.shape[0], volume.shape[1], volume.shape[2], 3, 3), dtype=float)
     
@@ -208,9 +216,9 @@ def compute_eigenvalues_3x3_batch(J):
     eigenvalues = xp.sort(eigenvalues, axis=-1)
     return eigenvalues
 
-def detect_ridges(volume, gamma=1.5, beta1=0.5, beta2=0.5, gauss_sigma=2, sigma=6):
+def detect_ridges(volume, gamma=1.5, beta1=0.5, beta2=0.5, gauss_sigma=2, sigma=6, norm_range=None):
     xp, _ = get_backend(volume)
-    joint_hessian, zero_mask = hessian(volume, gauss_sigma, sigma)
+    joint_hessian, zero_mask = hessian(volume, gauss_sigma, sigma, norm_range=norm_range)
     eigvals = compute_eigenvalues_3x3_batch(joint_hessian)
     # Sort in increasing size of the absolute value of the eigenvalues
     idxs = xp.argsort(xp.abs(eigvals), axis=-1)
@@ -236,7 +244,7 @@ def detect_ridges(volume, gamma=1.5, beta1=0.5, beta2=0.5, gauss_sigma=2, sigma=
  
     return ridges
 
-def detect_vesselness(volume, gamma=1.5, beta1=0.5, beta2=0.5, gauss_sigma=2, sigma=6):
+def detect_vesselness(volume, gamma=1.5, beta1=0.5, beta2=0.5, gauss_sigma=2, sigma=6, norm_range=None):
     """
     Detect vesselness using the Frangi filter.
     
@@ -252,7 +260,7 @@ def detect_vesselness(volume, gamma=1.5, beta1=0.5, beta2=0.5, gauss_sigma=2, si
     - vesselness: 3D array representing vesselness probability at each voxel.
     """
     xp, _ = get_backend(volume)
-    joint_hessian, zero_mask = hessian(volume, gauss_sigma, sigma)
+    joint_hessian, zero_mask = hessian(volume, gauss_sigma, sigma, norm_range=norm_range)
     eigvals = compute_eigenvalues_3x3_batch(joint_hessian)
     # Sort eigenvalues by magnitude (ascending order)
     idxs = xp.argsort(xp.abs(eigvals), axis=-1)
@@ -363,84 +371,84 @@ def detect_edges(volume, filter):
     
     return first_derivative, det, gradient
 
-def detect_ridges_tiled(volume, block_size=128, halo=16, **kwargs):
+def _smoothed_global_range(volume, gauss_sigma, block_size, halo):
     """
-    Run detect_ridges in blocks to fit in GPU memory.
+    Min/max of the Gaussian-smoothed volume, computed tile-by-tile.
+    Matches the dense path exactly when halo covers the filter support
+    (truncate * gauss_sigma, i.e. 8 voxels for the default gauss_sigma=2).
+    """
+    xp, xndimage = get_backend(volume)
+    Z, Y, X = volume.shape
+    gmin, gmax = xp.inf, -xp.inf
+    for z in range(0, Z, block_size):
+        for y in range(0, Y, block_size):
+            for x in range(0, X, block_size):
+                z0, z1 = max(0, z - halo), min(Z, z + block_size + halo)
+                y0, y1 = max(0, y - halo), min(Y, y + block_size + halo)
+                x0, x1 = max(0, x - halo), min(X, x + block_size + halo)
+                smoothed = xndimage.gaussian_filter(volume[z0:z1, y0:y1, x0:x1], sigma=gauss_sigma)
+                interior = smoothed[z - z0:z - z0 + min(block_size, Z - z),
+                                    y - y0:y - y0 + min(block_size, Y - y),
+                                    x - x0:x - x0 + min(block_size, X - x)]
+                gmin = min(gmin, float(interior.min()))
+                gmax = max(gmax, float(interior.max()))
+                if HAS_CUPY and isinstance(volume, cp.ndarray):
+                    del smoothed
+                    cp.get_default_memory_pool().free_all_blocks()
+    return gmin, gmax
+
+def _detect_tiled(volume, filter_fn, block_size=128, halo=16, **kwargs):
+    """
+    Run a volumetric filter in blocks with a halo to fit in GPU memory.
+    Each block is processed with `halo` voxels of context on every side,
+    then cropped back to the interior before write-back. A first pass
+    computes the global normalization range of the smoothed volume so
+    per-block normalization matches the dense path.
     """
     xp, _ = get_backend(volume)
     Z, Y, X = volume.shape
     result = xp.zeros((Z, Y, X), dtype=volume.dtype)
-    
+
+    if kwargs.get('norm_range') is None:
+        gauss_sigma = kwargs.get('gauss_sigma', 2)
+        kwargs['norm_range'] = _smoothed_global_range(volume, gauss_sigma, block_size, halo)
+
     for z in range(0, Z, block_size):
         for y in range(0, Y, block_size):
             for x in range(0, X, block_size):
-                # Calculate coordinates with halo
+                # Block coordinates with halo
                 z0, z1 = max(0, z - halo), min(Z, z + block_size + halo)
                 y0, y1 = max(0, y - halo), min(Y, y + block_size + halo)
                 x0, x1 = max(0, x - halo), min(X, x + block_size + halo)
-                
-                # Extract block
+
                 block = volume[z0:z1, y0:y1, x0:x1]
-                
-                # Process block
-                block_res = detect_ridges(block, **kwargs)
-                
-                # Calculate crop boundaries
+                block_res = filter_fn(block, **kwargs)
+
+                # Crop the halo off and write back the interior
                 bz0 = z - z0
                 bz1 = bz0 + min(block_size, Z - z)
                 by0 = y - y0
                 by1 = by0 + min(block_size, Y - y)
                 bx0 = x - x0
                 bx1 = bx0 + min(block_size, X - x)
-                
-                # Write back
                 result[z:z+bz1-bz0, y:y+by1-by0, x:x+bx1-bx0] = block_res[bz0:bz1, by0:by1, bx0:bx1]
-                
+
                 # Free memory aggressively inside loop if using CuPy
                 if HAS_CUPY and isinstance(volume, cp.ndarray):
                     del block
                     del block_res
                     cp.get_default_memory_pool().free_all_blocks()
-                
+
     return result
+
+def detect_ridges_tiled(volume, block_size=128, halo=16, **kwargs):
+    """
+    Run detect_ridges in blocks to fit in GPU memory.
+    """
+    return _detect_tiled(volume, detect_ridges, block_size, halo, **kwargs)
 
 def detect_vesselness_tiled(volume, block_size=128, halo=16, **kwargs):
     """
     Run detect_vesselness in blocks to fit in GPU memory.
     """
-    xp, _ = get_backend(volume)
-    Z, Y, X = volume.shape
-    result = xp.zeros((Z, Y, X), dtype=volume.dtype)
-    
-    for z in range(0, Z, block_size):
-        for y in range(0, Y, block_size):
-            for x in range(0, X, block_size):
-                # Calculate coordinates with halo
-                z0, z1 = max(0, z - halo), min(Z, z + block_size + halo)
-                y0, y1 = max(0, y - halo), min(Y, y + block_size + halo)
-                x0, x1 = max(0, x - halo), min(X, x + block_size + halo)
-                
-                # Extract block
-                block = volume[z0:z1, y0:y1, x0:x1]
-                
-                # Process block
-                block_res = detect_vesselness(block, **kwargs)
-                
-                # Calculate crop boundaries
-                bz0 = z - z0
-                bz1 = bz0 + min(block_size, Z - z)
-                by0 = y - y0
-                by1 = by0 + min(block_size, Y - y)
-                bx0 = x - x0
-                bx1 = bx0 + min(block_size, X - x)
-                
-                # Write back
-                result[z:z+bz1-bz0, y:y+by1-by0, x:x+bx1-bx0] = block_res[bz0:bz1, by0:by1, bx0:bx1]
-                
-                # Free memory aggressively inside loop if using CuPy
-                if HAS_CUPY and isinstance(volume, cp.ndarray):
-                    del block
-                    del block_res
-                    cp.get_default_memory_pool().free_all_blocks()
-                
-    return result
+    return _detect_tiled(volume, detect_vesselness, block_size, halo, **kwargs)

--- a/foundation/datasets/fibers-dataset/tools.py
+++ b/foundation/datasets/fibers-dataset/tools.py
@@ -362,3 +362,85 @@ def detect_edges(volume, filter):
 
     
     return first_derivative, det, gradient
+
+def detect_ridges_tiled(volume, block_size=128, halo=16, **kwargs):
+    """
+    Run detect_ridges in blocks to fit in GPU memory.
+    """
+    xp, _ = get_backend(volume)
+    Z, Y, X = volume.shape
+    result = xp.zeros((Z, Y, X), dtype=volume.dtype)
+    
+    for z in range(0, Z, block_size):
+        for y in range(0, Y, block_size):
+            for x in range(0, X, block_size):
+                # Calculate coordinates with halo
+                z0, z1 = max(0, z - halo), min(Z, z + block_size + halo)
+                y0, y1 = max(0, y - halo), min(Y, y + block_size + halo)
+                x0, x1 = max(0, x - halo), min(X, x + block_size + halo)
+                
+                # Extract block
+                block = volume[z0:z1, y0:y1, x0:x1]
+                
+                # Process block
+                block_res = detect_ridges(block, **kwargs)
+                
+                # Calculate crop boundaries
+                bz0 = z - z0
+                bz1 = bz0 + min(block_size, Z - z)
+                by0 = y - y0
+                by1 = by0 + min(block_size, Y - y)
+                bx0 = x - x0
+                bx1 = bx0 + min(block_size, X - x)
+                
+                # Write back
+                result[z:z+bz1-bz0, y:y+by1-by0, x:x+bx1-bx0] = block_res[bz0:bz1, by0:by1, bx0:bx1]
+                
+                # Free memory aggressively inside loop if using CuPy
+                if HAS_CUPY and isinstance(volume, cp.ndarray):
+                    del block
+                    del block_res
+                    cp.get_default_memory_pool().free_all_blocks()
+                
+    return result
+
+def detect_vesselness_tiled(volume, block_size=128, halo=16, **kwargs):
+    """
+    Run detect_vesselness in blocks to fit in GPU memory.
+    """
+    xp, _ = get_backend(volume)
+    Z, Y, X = volume.shape
+    result = xp.zeros((Z, Y, X), dtype=volume.dtype)
+    
+    for z in range(0, Z, block_size):
+        for y in range(0, Y, block_size):
+            for x in range(0, X, block_size):
+                # Calculate coordinates with halo
+                z0, z1 = max(0, z - halo), min(Z, z + block_size + halo)
+                y0, y1 = max(0, y - halo), min(Y, y + block_size + halo)
+                x0, x1 = max(0, x - halo), min(X, x + block_size + halo)
+                
+                # Extract block
+                block = volume[z0:z1, y0:y1, x0:x1]
+                
+                # Process block
+                block_res = detect_vesselness(block, **kwargs)
+                
+                # Calculate crop boundaries
+                bz0 = z - z0
+                bz1 = bz0 + min(block_size, Z - z)
+                by0 = y - y0
+                by1 = by0 + min(block_size, Y - y)
+                bx0 = x - x0
+                bx1 = bx0 + min(block_size, X - x)
+                
+                # Write back
+                result[z:z+bz1-bz0, y:y+by1-by0, x:x+bx1-bx0] = block_res[bz0:bz1, by0:by1, bx0:bx1]
+                
+                # Free memory aggressively inside loop if using CuPy
+                if HAS_CUPY and isinstance(volume, cp.ndarray):
+                    del block
+                    del block_res
+                    cp.get_default_memory_pool().free_all_blocks()
+                
+    return result

--- a/foundation/datasets/fibers-dataset/tools.py
+++ b/foundation/datasets/fibers-dataset/tools.py
@@ -16,20 +16,29 @@ from scipy import ndimage
 from skimage.restoration import denoise_nl_means, estimate_sigma
 from skimage.exposure import equalize_adapthist
 
-# TODO: some cupy acceleration
-xp = np
-from numpy import linalg as LA
-xndimage = ndimage
+try:
+    import cupy as cp
+    from cupyx.scipy import ndimage as cupy_ndimage
+    HAS_CUPY = True
+except ImportError:
+    HAS_CUPY = False
+
+def get_backend(volume):
+    if HAS_CUPY and isinstance(volume, cp.ndarray):
+        return cp, cupy_ndimage
+    return np, ndimage
 
 def divide_nonzero(array1, array2, eps=1e-10):
     """
     Divides two arrays. Returns zero when dividing by zero.
     """
-    denominator = np.copy(array2)
+    xp, _ = get_backend(array1)
+    denominator = xp.copy(array2)
     denominator[denominator == 0] = eps
-    return np.divide(array1, denominator)
+    return xp.divide(array1, denominator)
 
 def normalize(volume):
+    xp, _ = get_backend(volume)
     minim = xp.min(volume)
     maxim = xp.max(volume)
     volume -= minim
@@ -129,6 +138,7 @@ def adjust_contrast(volume, kernel_size=8):
     return equalize_adapthist(volume, kernel_size, clip_limit=0.01, nbins=256)
 
 def hessian(volume, gauss_sigma=2, sigma=6):
+    xp, xndimage = get_backend(volume)
     # N.B. this only returns the upper triangular matrix to save time
     volume = xndimage.gaussian_filter(volume, sigma=gauss_sigma)
     volume = normalize(volume)
@@ -160,27 +170,66 @@ def hessian(volume, gauss_sigma=2, sigma=6):
     
     return joint_hessian, zero_mask
 
+def compute_eigenvalues_3x3_batch(J):
+    """
+    Compute eigenvalues for batched 3x3 symmetric matrices using Cardano's analytical formula.
+    Avoids CuPy's batched eigvalsh failure on large arrays (cuSolver errors).
+    Works interchangeably with NumPy and CuPy via xp.
+    Input: J of shape (..., 3, 3)
+    Output: eigenvalues of shape (..., 3) in ascending order
+    """
+    xp, _ = get_backend(J)
+    a11 = J[..., 0, 0]
+    a22 = J[..., 1, 1]
+    a33 = J[..., 2, 2]
+    a12 = J[..., 0, 1]
+    a13 = J[..., 0, 2]
+    a23 = J[..., 1, 2]
+    
+    p1 = a11 + a22 + a33
+    p2 = a11*a22 + a11*a33 + a22*a33 - a12*a12 - a13*a13 - a23*a23
+    p3 = a11*(a22*a33 - a23*a23) - a12*(a12*a33 - a13*a23) + a13*(a12*a23 - a13*a22)
+    
+    q = p1 * p1 / 9.0 - p2 / 3.0
+    r = p1 * p1 * p1 / 27.0 - p1 * p2 / 6.0 + p3 / 2.0
+    
+    eps = 1e-12
+    sqrt_q = xp.sqrt(xp.clip(q, a_min=eps, a_max=None))
+    theta = xp.arccos(xp.clip(r / (sqrt_q ** 3 + eps), a_min=-1.0, a_max=1.0))
+    
+    sqrt_q_2 = 2.0 * sqrt_q
+    p1_3 = p1 / 3.0
+    
+    lambda1 = p1_3 + sqrt_q_2 * xp.cos(theta / 3.0)
+    lambda2 = p1_3 + sqrt_q_2 * xp.cos((theta - 2.0 * math.pi) / 3.0)
+    lambda3 = p1_3 + sqrt_q_2 * xp.cos((theta - 4.0 * math.pi) / 3.0)
+    
+    eigenvalues = xp.stack([lambda1, lambda2, lambda3], axis=-1)
+    eigenvalues = xp.sort(eigenvalues, axis=-1)
+    return eigenvalues
+
 def detect_ridges(volume, gamma=1.5, beta1=0.5, beta2=0.5, gauss_sigma=2, sigma=6):
+    xp, _ = get_backend(volume)
     joint_hessian, zero_mask = hessian(volume, gauss_sigma, sigma)
-    eigvals = LA.eigvalsh(joint_hessian, "U")
+    eigvals = compute_eigenvalues_3x3_batch(joint_hessian)
     # Sort in increasing size of the absolute value of the eigenvalues
-    idxs = np.argsort(np.abs(eigvals), axis=-1)
-    eigvals = np.take_along_axis(eigvals, idxs, axis=-1)
+    idxs = xp.argsort(xp.abs(eigvals), axis=-1)
+    eigvals = xp.take_along_axis(eigvals, idxs, axis=-1)
     eigvals[zero_mask, :] = 0
 
-    L1 = np.abs(eigvals[:, :, :, 0])
-    L2 = np.abs(eigvals[:, :, :, 1])
+    L1 = xp.abs(eigvals[:, :, :, 0])
+    L2 = xp.abs(eigvals[:, :, :, 1])
     L3 = eigvals[:, :, :, 2]
-    L3abs = np.abs(L3)
+    L3abs = xp.abs(L3)
     
-    S = np.sqrt(np.square(eigvals).sum(axis=-1))
-    background_term = 1 - np.exp(-(.5 * np.square(S / gamma)))
+    S = xp.sqrt(xp.square(eigvals).sum(axis=-1))
+    background_term = 1 - xp.exp(-(.5 * xp.square(S / gamma)))
     
     Ra = divide_nonzero(L2, L3abs)
-    planar_term = np.exp(-(0.5 * np.square(Ra / beta1)))
+    planar_term = xp.exp(-(0.5 * xp.square(Ra / beta1)))
     
-    Rb = divide_nonzero(L1, np.sqrt(np.multiply(L2, L3abs)))
-    blob_term = np.exp(-(0.5 * np.square(Rb / beta2)))
+    Rb = divide_nonzero(L1, xp.sqrt(xp.multiply(L2, L3abs)))
+    blob_term = xp.exp(-(0.5 * xp.square(Rb / beta2)))
     
     ridges = background_term * planar_term * blob_term
     ridges[L3 > 0] = 0
@@ -202,11 +251,12 @@ def detect_vesselness(volume, gamma=1.5, beta1=0.5, beta2=0.5, gauss_sigma=2, si
     Returns:
     - vesselness: 3D array representing vesselness probability at each voxel.
     """
+    xp, _ = get_backend(volume)
     joint_hessian, zero_mask = hessian(volume, gauss_sigma, sigma)
-    eigvals = LA.eigvalsh(joint_hessian, "U")
+    eigvals = compute_eigenvalues_3x3_batch(joint_hessian)
     # Sort eigenvalues by magnitude (ascending order)
-    idxs = np.argsort(np.abs(eigvals), axis=-1)
-    eigvals = np.take_along_axis(eigvals, idxs, axis=-1)
+    idxs = xp.argsort(xp.abs(eigvals), axis=-1)
+    eigvals = xp.take_along_axis(eigvals, idxs, axis=-1)
     eigvals[zero_mask, :] = 0  # Ignore zero regions
 
     # Extract eigenvalues
@@ -215,14 +265,14 @@ def detect_vesselness(volume, gamma=1.5, beta1=0.5, beta2=0.5, gauss_sigma=2, si
     L3 = eigvals[:, :, :, 2]
 
     # Compute terms for Frangi filter
-    Ra = divide_nonzero(np.abs(L2), np.abs(L3))  # Tubularity ratio
-    Rb = divide_nonzero(np.abs(L1), np.sqrt(np.abs(L2 * L3)))  # Blobness ratio
-    S = np.sqrt(np.square(eigvals).sum(axis=-1))  # Frobenius norm
+    Ra = divide_nonzero(xp.abs(L2), xp.abs(L3))  # Tubularity ratio
+    Rb = divide_nonzero(xp.abs(L1), xp.sqrt(xp.abs(L2 * L3)))  # Blobness ratio
+    S = xp.sqrt(xp.square(eigvals).sum(axis=-1))  # Frobenius norm
 
     # Frangi vesselness components
-    planar_term = 1 - np.exp(-0.5 * np.square(Ra / beta1))
-    blob_term = np.exp(-0.5 * np.square(Rb / beta2))
-    background_term = 1 - np.exp(-0.5 * np.square(S / gamma))
+    planar_term = 1 - xp.exp(-0.5 * xp.square(Ra / beta1))
+    blob_term = xp.exp(-0.5 * xp.square(Rb / beta2))
+    background_term = 1 - xp.exp(-0.5 * xp.square(S / gamma))
 
     # Combine terms
     vesselness = background_term * planar_term * blob_term


### PR DESCRIPTION


## What this does

`detect_ridges` and `detect_vesselness` in `foundation/datasets/fibers-dataset/tools.py`
are CPU-only today, and a naive CuPy port doesn't help: `cupy.linalg.eigvalsh`
(cuSolver) is unreliable on large batches of `(..., 3, 3)` Hessians — it hits
buffer/allocation errors or missing-library failures — so in practice ridge and
vesselness detection has been limited to small volumes (~64³) on GPU.

This PR makes the GPU path work at the volume sizes that actually show up in
scroll data. The key change is replacing the batched `eigvalsh` call with a
closed-form analytical eigensolver for symmetric 3×3 matrices (Cardano's
formula), which avoids cuSolver entirely. On top of that it adds an optional
CuPy backend with a NumPy/SciPy fallback, and tiled/halo variants for volumes
that don't fit in VRAM at once.

Motivation: this is the kind of tooling needed to generate fiber labels at scroll
scale (cf. issue #193, "Methods for generating surface, fiber, or ink labels") —
the CPU path is too slow to run over whole regions.

## Changes

- `compute_eigenvalues_3x3_batch` — closed-form symmetric 3×3 eigenvalues; works
  on NumPy or CuPy arrays, no cuSolver dependency.
- `detect_ridges` / `detect_vesselness` — dispatch to GPU when handed a CuPy
  array, otherwise unchanged CPU behavior (NumPy/SciPy fallback preserved).
- `detect_ridges_tiled` / `detect_vesselness_tiled` — block-wise processing with
  a configurable halo, for large volumes. A cheap first pass computes the global
  min/max of the smoothed volume so per-block normalization matches the dense
  path exactly — without this, tiled results silently diverge from dense by up
  to ~3e-2 because `normalize()` is a global min-max scaling.
- `tests/test_gpu.py` — eigensolver parity vs `numpy.linalg.eigvalsh`, CPU/GPU
  backend parity, and tiled-vs-dense parity for both filters.
- `bench/bench_tools.py` — CPU-vs-GPU benchmark harness.

Scope is limited to `foundation/datasets/fibers-dataset/` (3 files).

## Evidence

All figures below were measured on 2026-06-09 on the rebased branch (current
`ScrollPrize/villa:main`), NVIDIA RTX 4090, CuPy 14.0.1 / CUDA 12.9.

Eigensolver parity: `compute_eigenvalues_3x3_batch` vs `numpy.linalg.eigvalsh`
on random symmetric 3×3 batches — max abs difference **3.1e-10** (float64),
**6.7e-6** (float32). Tiled-vs-dense parity holds to 1e-4 for both filters.
`pytest tests/test_gpu.py` → 4 passed.

Dense CPU-vs-GPU timings:

| Volume | Filter | CPU (NumPy) | GPU (CuPy) | Speedup | GPU mem |
| --- | --- | --- | --- | --- | --- |
| 64³  | vesselness | 0.24 s  | 0.02 s | ~14× | <0.01 GB |
| 64³  | ridges     | 0.22 s  | 0.01 s | ~20× | <0.01 GB |
| 128³ | vesselness | 1.85 s  | 0.03 s | ~67× | 0.02 GB |
| 128³ | ridges     | 2.10 s  | 0.03 s | ~68× | 0.02 GB |
| 256³ | vesselness | 19.39 s | 0.21 s | ~93× | 0.19 GB |
| 256³ | ridges     | 19.23 s | 0.20 s | ~94× | 0.19 GB |

Tiled large-volume timings (`--tiled --skip-cpu`, includes the global-range pass):

| Volume | Filter | GPU (tiled) | GPU mem |
| --- | --- | --- | --- |
| 384³ | vesselness | 2.17 s | 0.42 GB |
| 384³ | ridges     | 1.40 s | 0.42 GB |
| 512³ | vesselness | 4.54 s | 1.00 GB |
| 512³ | ridges     | 3.29 s | 1.00 GB |

So 256³ fits in GPU memory and runs in ~0.2 s; 512³ runs tiled in ~3–5 s within
~1 GB of GPU memory, i.e. on consumer hardware. Speedups are a ~14–94× range
over the NumPy path depending on size — not a single headline multiplier.

A 256³ region of PHerc0332 (Scroll 4) processes in ~1.2 s with no visible
tile-boundary artifacts (run 2026-06-04 on the pre-rebase branch);
[source-vs-vesselness contact sheet](https://github.com/jonmarrs/vesuvius-autoresearch/blob/main/reports/real_scroll_evidence/vesselness_contact_sheet.png).

## How to reproduce

```bash
cd foundation/datasets/fibers-dataset
pytest tests/test_gpu.py
python3 bench/bench_tools.py --sizes 64 128 256
python3 bench/bench_tools.py --sizes 384 512 --tiled --skip-cpu
```

## Limitations

- Requires `cupy` (+ `cupyx.scipy`) for the GPU path; without them it falls back
  to CPU automatically.
- For volumes that exceed VRAM, the caller chooses the tiled entry points and the
  block size / halo. The halo must cover the filter support
  (`4 * gauss_sigma + 2` voxels; the default halo of 16 covers the default
  `gauss_sigma=2`) for tiled results to match dense execution.
- Closed-form 3×3 eigenvalues match `eigvalsh` to ~1e-5 in float32 (~3e-10 in
  float64), which is well within the tolerance used downstream, but it is not
  bit-identical to the LAPACK/cuSolver path.
