### PR TITLE
foundation: scroll-unwrap-pipeline — wrap meshes to unwrap videos

### DIFF
--- a/foundation/scroll-unwrap-pipeline/.gitignore
+++ b/foundation/scroll-unwrap-pipeline/.gitignore
@@ -1,0 +1,9 @@
+outputs/
+reports/
+textured_plys/
+scroll_meshes-*/
+*.zip
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/foundation/scroll-unwrap-pipeline/README.md
+++ b/foundation/scroll-unwrap-pipeline/README.md
@@ -1,0 +1,88 @@
+# scroll-unwrap-pipeline
+
+Production pipeline for Herculaneum scroll wrap meshes: exact PLY→OBJ
+conversion, perceptually-gated decimation, ink-overlay baking, and
+self-intersection-free unwrap animations rendered to 4K video.
+
+Input: textured wrap segments (binary PLY, per-vertex `x y z nx ny nz s t`,
+single seam-free UV chart in physical voxel units) plus ink-prediction images
+in the same UV space. Output, per wrap:
+
+- exact OBJ conversion (bit-equal geometry, SHA-verified textures)
+- decimated OBJ at the most aggressive keep-fraction that passes perceptual
+  gates
+- unwrap animation: 240 frames @ 30 fps, plain / ink-overlay / ink-reveal
+  variants, 16:9 and 9:16 framings, 4K masters + 1080p derivatives
+- a textured OBJ per frame (ink variant as a two-sided thin shell: recto ink,
+  verso plain papyrus)
+- per-mesh metrics, certificates, and QA keyframes
+
+## Quickstart
+
+```bash
+uv sync                                  # Python 3.12 env from uv.lock
+uv run pytest                            # fixture suite (IO traps, kinematics)
+
+uv run python scripts/audit.py           # inventory + conventions oracle
+uv run python scripts/convert.py         # M1: exact PLY -> OBJ
+uv run python scripts/decimate.py        # M2: perceptual keep-ladder
+uv run python scripts/bake_overlays.py   # M2.5: carbon-black ink bake
+uv run python scripts/make_render_textures.py   # presentation textures (infill)
+
+uv run python scripts/produce.py         # fleet: animate -> frame OBJs -> videos
+uv run python scripts/gate_m5.py         # final gate over all deliverables
+# (gate_m5 also expects vision-review verdicts; see docs/QUALITY-GATES.md,
+#  'Vision review interface' for the file and schema)
+```
+
+Single-mesh flow:
+
+```bash
+uv run python scripts/animate.py outputs/decimated/A/<stem>/<stem>_decimated.obj
+uv run python scripts/render_video.py outputs/anim/<stem> A --variant ink --framing h
+uv run python scripts/clearance_cert.py outputs/anim/<stem>   # interpenetration certificate
+```
+
+## Pipeline
+
+1. **Audit** — strict inventory of meshes, textures and ink predictions;
+   empirical texture-orientation oracle; UV de-normalization scale fit with
+   residuals (the charts are SLIM output in voxel units).
+2. **Convert (M1)** — header-driven binary PLY reader → `%.9g` OBJ writer;
+   bit-exact round-trip is the gate.
+3. **Decimate (M2)** — UV-preserving quadric collapse on a keep-fraction
+   ladder; per-rung render-SSIM, close-up crops, Hausdorff and UV-integrity
+   gates pick the most aggressive safe rung.
+4. **Ink bake (M2.5)** — predictions resampled into the texture canvas,
+   polarity-normalized, graded as neutral carbon black absorbed into the
+   papyrus.
+5. **Unwrap (M3)** — rolling-contact kinematics: the wound part moves rigidly
+   (zero transit distortion), material lays flat behind a traveling contact
+   line, a narrow curvature-adaptive band blends, and a closed-form
+   plane-clearance lift makes roll/sheet interpenetration impossible by
+   construction. Chart sanitation (injectivity enforcement, junk-tail trim)
+   runs before embedding. A per-frame clearance certificate is a hard,
+   non-waivable gate; a deformation-gradient fallback ladder covers meshes
+   whose charts defeat the rolling model, with clearance-dominant ranking so
+   an interpenetrating fallback never outranks a clean rolling path.
+6. **Render (M4/M5)** — headless GPU (EGL) alpha-cutout renderer with a
+   documentary look (see `docs/RENDER-STYLE.md`), watermark, reveal push-in,
+   raw-RGB pipe into x264. Batch staging is signature-keyed (code revision +
+   input file signatures), so outputs from different revisions cannot
+   silently coexist; gate checks enforce video-newer-than-trajectory.
+
+Specifications: `docs/MESH-IO.md`, `docs/UNWRAP-MATH.md`,
+`docs/RENDER-STYLE.md`, `docs/QUALITY-GATES.md`.
+
+## Layout
+
+```
+src/scrollkit/     io | decimate | ink | unwrap | metrics | render
+scripts/           stage CLIs + gate_m0..m5 + certificates
+configs/global.yaml
+tests/             synthetic fixtures (convention traps, analytic cylinder)
+```
+
+Expected data layout (not part of this tree): `textured_plys/` for the source
+PLY groups and the ink-prediction folders referenced by `scripts/audit.py`;
+all derived artifacts land under `outputs/` (gitignored).

--- a/foundation/scroll-unwrap-pipeline/configs/global.yaml
+++ b/foundation/scroll-unwrap-pipeline/configs/global.yaml
@@ -1,0 +1,75 @@
+# Global production configuration. Per-group/per-mesh overrides merge over this.
+data:
+  march_dir: "textured_plys/textured_ply_march"
+  may_dir: "textured_plys/textured_ply_may"
+  scrolls_dir: "scroll_meshes-20260610T062158Z-3-001/scroll_meshes"
+  ink_march_dir: "1667 - ink detection"
+  ink_may_dir: "ink det + max comp (may 5th)/predictions_inv"
+
+outputs:
+  root: "outputs"
+  conversions: "outputs/obj"
+  decimated: "outputs/decimated"
+  overlays: "outputs/overlays"
+  anim: "outputs/anim"
+
+conversion:
+  float_format: "%.9g"
+
+decimation:
+  keep_ladder: [0.05, 0.08, 0.12, 0.20, 0.35]
+  qualitythr: 0.5
+  preserveboundary: true
+  boundaryweight: 1.0
+  extratcoordw: 1.0     # raise to 2-3 if UV smears (gate-driven)
+  ssim_production_min: 0.97
+  ssim_closeup_min: 0.95
+  hausdorff_max_mean_edge: 1.0
+
+ink:
+  # bake parameters (see docs/RENDER-STYLE.md; ink is carbon BLACK)
+  # NB: the composites are neutral gray — any warm tint reads as sepia stains. Neutral black.
+  tint_rgb: [16, 16, 16]       # neutral carbon black #101010
+  opacity_lo: 0.42             # raised: keep confident ink, drop diffuse blob halos
+  opacity_hi: 0.78
+  opacity_scale: 0.88
+  glow_sigma_px: 0.0           # no glow for carbon ink
+  glow_strength: 0.0
+
+unwrap:
+  frames: 240
+  fps: 30
+  hold_start: 20
+  hold_end: 25
+  easing: "quintic"
+  substeps: 1            # raise if mid-animation artifacts appear (gate-driven)
+  anchor_strip_frac: 0.02
+  solver_backend: "auto" # resolved from reports/solver_bench.json
+
+render:
+  backend: "pyvista-egl"
+  background: "#101114"
+  framings:
+    horizontal: { width: 3840, height: 2160 }
+    vertical:   { width: 2160, height: 3840 }
+  derivatives:
+    - { name: "1080p", scale: 0.5 }
+  margin_frac: 0.06
+  push_in_frac: 0.025
+  keyframes_per_video: 5
+  # texture sampling orientation: filled by audit (reports/audit.json: tex_orientation)
+
+encode:
+  crf_4k: 19
+  crf_1080: 18
+  preset: "slow"
+  hevc: false
+
+variants:
+  reveal_tail_frames: 90
+  reveal_hold_in: 15
+  reveal_fade: 50
+  reveal_hold_out: 25
+  # post-reveal dwell: after the ink is fully exposed, hold with a slow push-in
+  reveal_zoom_hold: 75
+  reveal_zoom_factor: 1.03

--- a/foundation/scroll-unwrap-pipeline/docs/MESH-IO.md
+++ b/foundation/scroll-unwrap-pipeline/docs/MESH-IO.md
@@ -1,0 +1,39 @@
+# Mesh IO Conventions (binding contract)
+
+All mesh bytes on disk go through `scrollkit.io` — a strict, convention-pinned
+reader/writer pair. Third-party libraries are in-memory engines only, fed
+explicit numpy arrays, never file paths.
+
+## Precision
+- Vertex/normal/UV data is float32 end to end; OBJ floats are written with
+  `%.9g`, which round-trips float32 exactly.
+- Reload-and-compare is the M1 gate: positions, normals and UVs must be
+  bit-equal after an OBJ round-trip; faces identical; texture SHA256 equal.
+
+## UV conventions
+- PLY (VCGLIB) and OBJ `vt` share a bottom-left origin: no V-flip anywhere.
+- The wedge texcoord table is the source of truth. Where per-vertex `s,t`
+  equals the wedge table bit-for-bit (groups A/B), compact per-vertex `vt` is
+  written; otherwise (group C atlases) wedge UVs are deduplicated bit-exactly
+  (uint32 view, no epsilon merging).
+- On-screen texture orientation is decided empirically per group by the audit
+  (`reports/audit.json: tex_orientation`) — never assumed.
+
+## Library quarantine
+- `trimesh`: `Trimesh(vertices=V, faces=F, process=False)` for spatial queries
+  only — never its loaders/exporters (default `process=True` merges and
+  reorders vertices silently). No Open3D anywhere.
+- `pymeshlab`: decimation engine only; inputs are cross-checked array-by-array
+  against our reader, outputs extracted as arrays and written by our writer.
+  It never writes a file and never touches a texture.
+- PyVista/VTK: rendering only; `PolyData` built from our arrays.
+- Textures are byte-copied out-of-band and SHA256-verified — never re-encoded.
+
+## Convention traps (CI)
+A deliberately asymmetric quad + asymmetric texture fixture turns any silent
+V-flip, UV transpose, winding flip, vertex merge/reorder, or material drop into
+a hard test failure on every IO path.
+
+## MTL
+`map_d` references the same RGBA image as `map_Kd` so viewers honor the
+texture's alpha (lacunae render as holes, matching the alpha-test renderer).

--- a/foundation/scroll-unwrap-pipeline/docs/QUALITY-GATES.md
+++ b/foundation/scroll-unwrap-pipeline/docs/QUALITY-GATES.md
@@ -1,0 +1,92 @@
+# Quality Gates (binding contract)
+
+Each milestone has `scripts/gate_mX.py` → exit 0 = green. Commits land only on
+green. Thresholds are never weakened to pass; a failing gate is investigated
+with the failing report in hand.
+
+## M0 — Bootstrap + audit
+- `pytest` green (convention-trap + analytic cylinder fixtures included).
+- `reports/audit.json` covers every mesh + the ink inventory with zero
+  unexplained anomalies (each anomaly carries an `explanation`).
+- Headless GPU render smoke test; sparse-solver benchmark recorded.
+
+## M1 — Conversion (per mesh)
+- OBJ reload: V/N/UV float32 bit-equal, faces identical, texture SHA256 equal.
+- Render-parity SSIM(PLY render, OBJ render) ≥ 0.99 at identical camera.
+
+## M2 — Decimation (keep-ladder [5, 8, 12, 20, 35]%; most aggressive green rung wins)
+- Render SSIM vs full-res ≥ 0.97 at production framing; ≥ 0.95 on two
+  close-up crops (max-curvature and max-text-density regions).
+- Two-sided Hausdorff ≤ 1.0 × source mean edge; no new flipped UV triangles;
+  boundary length within 2%.
+- Group C (full-scroll photogrammetry) extends the ladder with [0.5, 0.65,
+  0.8]; if no rung passes, the mesh ships undecimated with a pinned rationale
+  (`no_safe_decimation`) — these models are not oversampled relative to their
+  textures, so any reduction is perceptually lossy.
+
+## M2.5 — Ink overlays (per matched mesh)
+- Matching table complete (every mesh matched or explained); overlay dims ==
+  base texture dims; alpha byte-identical to base.
+- Polarity sanity: ink coverage within the papyrus mask ∈ [0.5%, 35%] or
+  flagged with an explanation.
+
+## M3 — Unwrap core (every frame)
+- Topology: V/F identity, all finite. Flipped/degenerate ≤ 0.01% (target 0).
+- Area (HARD): per-triangle vs endpoint blend, quantiles over VISIBLE faces
+  (texture alpha at the face's UV centroid) — P95 ≤ max(2%, 3.0 × the mesh's
+  de-normalization rel. residual). Edge lengths: same form. Real wraps are
+  non-developable, so transit distortion is bounded below by the chart's own
+  non-isometry; thresholds scale with the measured residual while the failure
+  modes they exist to catch (rotation seams, noisy axis fields, integration
+  drift) still fail by an order of magnitude.
+- Symmetric Dirichlet (3-frame rolling minimum = the SUSTAINED level)
+  ≤ 1.15 × max(E0, E1) + 0.05; raw peak reported.
+- Temporal smoothness (popping): per-frame P99 displacement sequence must
+  have no discontinuity — max |Δ| ≤ max(0.7 × median, 0.30 × peak).
+  Calibrated for the flap-bridge kinematics: visually-clean reference runs
+  measure 0.33–0.56 med-ratio / ≤0.26 peak-ratio; true junction snaps measure
+  2.9–3.8 / 0.35–0.47 — the thresholds sit inside that gap.
+- Clearance certificate (HARD, every frame, non-waivable): no rolled vertex
+  within 0.05 × median-edge of (or below) the settled sheet at the same plan
+  cell, landing flap exempt; exact-state mode for rolling kinematics.
+  Quantile gates are provably blind to sub-percent vertex populations; this
+  certificate is the guard for the interpenetration class.
+- Chirality: numeric `mirror_check > 0` per mesh; the on-screen reading
+  direction is a camera decision verified visually.
+
+## M4 — Cinematics
+- ffprobe: 30 fps, yuv420p, exact resolution and frame count, faststart.
+- QA keyframes exist per video; vision rubric (RENDER-STYLE) all dimensions
+  ≥ 4/5 with zero artifact flags.
+
+## M5 — Batch (fleet)
+- M3 gates green per mesh (numeric, automated); a metrics-exception ships
+  only with a recorded visually-clean waiver.
+- ffprobe checks for every deliverable video (4K + 1080p, both framings).
+- Frame-OBJ folders complete (240 OBJs + MTL + texture); ink variant is a
+  two-sided shell (recto ink / verso plain).
+- Era consistency: every video newer than its trajectory (`frames.npz`) —
+  artifacts from different code revisions can never silently coexist.
+- Vision-review verdicts pass for every mesh × variant; production report
+  written.
+
+## Vision review interface
+The M5 gate reads `reports/m5_vision_qa.json`. Reviews may be produced by any
+process (human or model) applying the rubric in `docs/RENDER-STYLE.md` to the
+QA keyframes under `reports/m4_keyframes/<stem>_<variant>_<framing>/`. Schema:
+
+```json
+{
+  "verdicts": {
+    "<stem>|<variant>": {
+      "pass": true,
+      "scores": {"artifact_free": 5, "texture_integrity": 5,
+                  "framing": 4, "lighting": 5, "motion": 5},
+      "flags": [],
+      "summary": "pixel-level evidence for the verdict"
+    }
+  }
+}
+```
+
+`pass` requires every score ≥ 4 and zero artifact flags.

--- a/foundation/scroll-unwrap-pipeline/docs/RENDER-STYLE.md
+++ b/foundation/scroll-unwrap-pipeline/docs/RENDER-STYLE.md
@@ -1,0 +1,82 @@
+# Render Style (binding contract)
+
+## Mood
+Museum-dark documentary. The papyrus is the hero; everything else recedes.
+One continuous, legible unwrapping motion, physically plausible, calm pacing.
+
+## Scene
+- Background: near-black charcoal `#101114`, subtle radial vignette (corners
+  ~25% darker).
+- Lighting: soft 3-point rig — warm-neutral key upper camera-left holding
+  papyrus midtones around 0.65–0.75, cool fill ~35% of key camera-right, faint
+  rim from behind-above for silhouette separation. Lights fixed in world space.
+- Material: textured, two-sided, **alpha cutout (MASK, threshold 0.5)** —
+  never depth-sorted blending. Raw OpenGL poly-data mappers with ForceOpaque
+  and a fragment-shader alpha test give a true cutout with a working z-buffer
+  (any texel with alpha<255 would otherwise route the actor to the translucent
+  pass, which has no per-fragment self-depth). Bilinear texture sampling with
+  mipmaps OFF (mip-averaged alpha erodes the 0.5 cutout at grazing angles).
+  Specular minimal: papyrus is matte.
+- Two-sided texturing: front/back single-sided actor pair over the same
+  polydata, so the recto (inner face of the winding) carries the ink texture
+  and the verso stays plain papyrus.
+
+## Render textures
+`outputs/render_textures` infill interior-enclosed alpha dropout up to 0.05%
+of the papyrus area per component (Voronoi fill + blur + matched grain);
+larger interior components are TRUE lacunae and stay holes, as do
+boundary-connected bites. Open dropout windows on a wound roll expose the far
+wall's recto ink and read as transparency. Source textures stay byte-exact in
+conversion deliverables.
+
+## Ink overlay bake
+- Base: the mesh's composite texture (RGBA).
+- Ink layer: prediction resampled to texture dims (area filter), polarity
+  normalized so ink = high.
+- Grade: tint NEUTRAL carbon black `#101010` (the composites are neutral gray;
+  any warm cast reads as sepia staining). Opacity = smoothstep(ink, lo=0.42,
+  hi=0.78) scaled 0.88. **No glow.** Papyrus fibers remain faintly visible
+  through ink midtones — never crushed to #000.
+- The result must read as carbon writing absorbed into the papyrus, like
+  infrared photographs of opened Herculaneum scrolls.
+
+## Viewing side
+The text lives on the INNER face of the winding (the side toward the
+umbilicus — the papyrological recto of a rolled scroll). The unwrap exposes
+that face; cameras view the side of the flat sheet that pointed inward when
+rolled (geometric rule in `scrollkit.render.cinematics`). Text rows stay
+horizontal in EVERY framing.
+
+## Camera
+- Per-aspect framing fit on the union bbox of the whole trajectory + margin —
+  nothing ever clips. 16:9: scroll axis horizontal. 9:16: centered, adaptive
+  pull-back as the sheet widens. Never orbit during the morph.
+
+## Timeline (30 fps)
+- Plain & ink variants: 240 frames (hold 20 / quintic morph 195 / hold 25).
+- Reveal: plain frames 0–239 reused, then camera push-in to a tight flat
+  framing, cosine image-space crossfade plain→ink between exact stills, hold,
+  and a post-reveal dwell with a slow eased push-in (zoom factor capped so
+  side margins stay within the action-safe band in both aspects).
+- Watermark: subtle production credit bottom-right, warm paper-gray ~55%
+  opacity, insets 2.2% of height (bottom) and width (right), composited after
+  any image-space zoom so it stays pinned to the frame.
+
+## Encode (ffmpeg)
+- 4K masters (3840×2160 / 2160×3840): `libx264 -preset slow -crf 19
+  -pix_fmt yuv420p -profile:v high -level 5.1` with bt709 tags and
+  `+faststart`, 30 fps.
+- 1080p derivatives: Lanczos downscale, `-crf 18 -level 4.2`, same tags.
+- Frames are piped raw RGB to ffmpeg; no intermediate PNGs except the QA
+  keyframes.
+
+## QA rubric (vision review, 1–5 each; pass = all ≥4, no artifact flags)
+1. Artifact-free geometry (no twist, popping, shearing, z-fighting, hole
+   flicker; the late-unwrap roll must be fully opaque — any ghosting of
+   text/ink through it is an automatic flag).
+2. Texture integrity (sharp, unstretched, correct orientation, no mirrored
+   text, clean alpha edges; ink reads as carbon black on the inner face only).
+3. Framing & composition (subject placed, nothing clipped, margins balanced).
+4. Lighting & readability (both states legible, no blown highlights or
+   crushed blacks, silhouette separation).
+5. Motion & pacing (eases feel natural, holds correct, reveal lands cleanly).

--- a/foundation/scroll-unwrap-pipeline/docs/UNWRAP-MATH.md
+++ b/foundation/scroll-unwrap-pipeline/docs/UNWRAP-MATH.md
@@ -1,0 +1,84 @@
+# Unwrap Kinematics Specification (binding contract)
+
+The unwrap animates a wrap mesh from its 3D wound pose to its de-normalized,
+isometric UV domain embedded as a plane in 3D.
+
+## De-normalization (3a)
+Least-squares fit of `‖Δp‖² ≈ (s_u Δu)² + (s_v Δv)²` over mesh edges recovers
+the physical UV scales (the charts are SLIM output in voxel units, normalized
+at texturing time). Anisotropy and relative residual are reported per mesh and
+feed the gate thresholds.
+
+## Target embedding (3b)
+The flat target V1 places material at its de-normalized UV coordinates on a
+plane whose v-direction is the scroll axis. The anchor strip (the winding's
+outer, free end — selected radially) is rigidly registered to its source pose
+so the sheet peels open from a fixed edge. A chirality check (`mirror_check`)
+asserts the embedding preserves UV↔3D orientation; reading direction on screen
+is a camera decision.
+
+## Production kinematics: rolling-contact unroll — `scrollkit.unwrap.rolling`
+- One continuous motion: the rigid field is defined on c ∈ [−c_pre, S+band];
+  the negative range is the tip-onto-plane lean-in (slerp Identity → entry
+  pose, arc-proportional), smoothed together with the contact field and driven
+  by a single linear map of the eased timeline. Two-phase settle/roll designs
+  meet at a zero-velocity junction and expose raw-pose jitter — avoided here.
+- Landing coordinate `s` is the vertex's payout coordinate IN THE FLAT
+  EMBEDDING (projection of V1 on the regression direction of V1 against the
+  UV arc), NOT linear-in-u. Landing order must equal flat-space order: under
+  chart warp the linear-in-u arc can disagree with the true flat position by
+  thousands of voxels, letting late-landing patches travel through already
+  settled sheet. With `s` from V1, a vertex flattens exactly when the contact
+  line sweeps its own landing slot, making settled-behind / rolled-ahead exact
+  and pierce-through impossible by construction.
+- Material behind the contact lies flat (V1); material beyond keeps its EXACT
+  source geometry under the per-contact rigid transform; a curvature-adaptive
+  band (clip(0.5/κ, 4·med-edge, band), band = max(0.8% arc, 4·med-edge))
+  blends between them.
+- Rigid field: per-band Kabsch of source onto flat targets, full Gaussian
+  smoothing (σ≈21), unified re-smooth (σ=5) after the lean-in prepend, then
+  frame-0 exactness restored by a TAPERED correction over the first ~2σ grid
+  samples (a hard re-pin of sample 0 alone leaves a field step that reads as a
+  morph-start snap at large tip angles).
+- Plane-clearance barrier (closed form): the rigid roll's only possible
+  collider is the unrolling plane, so the whole body rides at
+  `lift(c) = max(0, ε − min height of behind-contact points)`, ε = half the
+  median edge. The smoothed lift takes the UPPER envelope with the raw
+  requirement (plain smoothing can shave spiky needs and let pre-landing lobes
+  dig through the plane). No end taper: forcing lift → 0 while the core is
+  still wound pushes it into the flat sheet (coincident surfaces z-fight
+  through the alpha cutout). No long ramp behind the contact: a raised sheet
+  chases the very lift it exists to avoid, and a v-uniform ramp cannot thread
+  between lobes at different v.
+- Paper bridge: a SHORT raise of the sheet confined to the landing flap
+  (≤ pad_arc, the zone the clearance certificate exempts as single material by
+  construction), following a spike-free `lift_vis ≤ lift`, so the sheet meets
+  the roll's tangent like paper off a roller without inheriting lift spikes.
+- Chart sanitation before embedding: (1) `enforce_chart_injectivity` — a chart
+  must be injective; duplicated trace patches (two layers mapping to the same
+  UV within ~4 texels but 3D-distant) double-print the same texture content
+  with an offset and flicker as the layers cross while landing; the layer
+  deviating from the local UV-neighbour consensus is dropped. (2)
+  `junk_tail_trim` — data-driven, no-op on healthy charts.
+
+## Clearance certificate — `scrollkit.metrics.clearance`
+Per frame, no rolled vertex may sit within 0.05 × median-edge of (or below)
+the settled sheet at the same plan cell (landing flap exempt). Rolling paths
+certify in EXACT-STATE mode: settled ⇔ s < c − pad_arc, rolled ⇔ s > c +
+pad_arc, with state persisted in `frames.npz` (`s_arc`, `c_arc`, `pad_arc`).
+Quantile gates are provably blind to sub-percent vertex populations, and
+state inferred from geometry misclassifies near the contact — the certificate
+therefore uses the kinematics' own state and is a hard, non-waivable gate.
+
+## Fallback: deformation-gradient interpolation
+Per-face deformation gradients (Sumner's construction) with the det(R)<0 SVD
+fix, branch-consistent rotation logs via winding decomposition (scalar graph
+unwrap of the axis angle), junk-weighted Poisson reconstruction with one
+factorization reused across frames, and an escalation ladder over junk
+suppression knobs. Used only when rolling fails its gates; the best-attempt
+ranking is clearance-dominant so an interpenetrating fallback never ships in
+favour of a clean rolling path.
+
+## Easing & timeline (30 fps)
+240 frames = hold rolled (20) / quintic-eased unwrap (195) / hold flat (25).
+Reveal variant appends a tail (see RENDER-STYLE).

--- a/foundation/scroll-unwrap-pipeline/pyproject.toml
+++ b/foundation/scroll-unwrap-pipeline/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+name = "scrollkit"
+version = "0.1.0"
+description = "Vesuvius scroll wrap meshes: exact conversion, perceptual decimation, unwrap animation production"
+requires-python = ">=3.12,<3.13"
+dependencies = [
+    "numpy>=2.0",
+    "scipy>=1.13",
+    "pillow>=10.3",
+    "pymeshlab>=2023.12",
+    "pyvista>=0.44",
+    "vtk>=9.5",
+    "libigl>=2.6.2",
+    "plyfile>=1.0",
+    "trimesh>=4.4",
+    "scikit-image>=0.24",
+    "matplotlib>=3.9",
+    "pypardiso>=0.4.6",
+    "pyamg>=5.2",
+    "tifffile>=2024.6.18",
+    "pyyaml>=6.0",
+    "rtree>=1.4.1",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.2",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/scrollkit"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/foundation/scroll-unwrap-pipeline/scripts/animate.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/animate.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python
+"""M3: compute the unwrap trajectory for one mesh, with full metric evaluation.
+
+Outputs under outputs/anim/<stem>/:
+  frames.npz      float32 vertex positions per frame (compressed) + faces + uv + meta
+  metrics.json    per-frame gate metrics + embedding/unwrap diagnostics + gate verdicts
+  metrics.png     plots (area/edge deviation envelopes, SD, displacement)
+
+Usage: uv run python scripts/animate.py <mesh.ply|mesh.obj> [--frames 240] [--substeps 1]
+       [--solver auto] [--out outputs/anim]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from scrollkit.io import read_obj, read_ply  # noqa: E402
+from scrollkit.metrics import flatboi_stretch_metrics, frame_metrics  # noqa: E402
+from scrollkit.metrics.visibility import visible_face_mask  # noqa: E402
+from scrollkit.unwrap.dg_interp import build_unwrap_path  # noqa: E402
+from scrollkit.unwrap.embedding import build_target_embedding  # noqa: E402
+from scrollkit.unwrap.operators import face_areas  # noqa: E402
+from scrollkit.unwrap.timeline import timeline_t  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("mesh")
+    ap.add_argument("--frames", type=int, default=240)
+    ap.add_argument("--hold-start", type=int, default=20)
+    ap.add_argument("--hold-end", type=int, default=25)
+    ap.add_argument("--substeps", type=int, default=1)
+    ap.add_argument("--solver", default="auto")
+    ap.add_argument("--axis-mode", default="auto", choices=["auto", "global", "smooth", "local"])
+    ap.add_argument("--kinematics", default="rolling", choices=["rolling", "dg"])
+    ap.add_argument("--roll-smooth", type=int, default=21)
+    ap.add_argument("--out", default="outputs/anim")
+    ap.add_argument("--full-metrics-stride", type=int, default=5)
+    args = ap.parse_args()
+
+    src = Path(args.mesh)
+    mesh = read_ply(src) if src.suffix.lower() == ".ply" else read_obj(src)
+    if mesh.vertex_uv is None:
+        raise SystemExit("mesh has no per-vertex UV — unwrap needs the A/B layout")
+    stem = src.stem.replace("_decimated", "")
+    out_dir = ROOT / args.out / stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Junk-tail trim (animation inputs only — conversion deliverables stay full).
+    # Low-confidence trace tails have squeezed/warped charts: they transport
+    # material through the settled sheet, produce warp-seam slivers, and render
+    # border-unreliable content as a compressed column at the flat sheet's edge.
+    # See scrollkit.unwrap.trim.
+    from dataclasses import replace as _dc_replace
+
+    from scrollkit.unwrap.trim import enforce_chart_injectivity, junk_tail_trim
+
+    # 1) chart injectivity: duplicated trace patches render the same texture region
+    #    twice (offset double-printed text, layer-crossing flicker while landing,
+    #    detached flying patches) — drop the layer deviating from local consensus.
+    _inj = enforce_chart_injectivity(mesh.vertices.astype(np.float64), mesh.faces,
+                                     mesh.vertex_uv.astype(np.float64))
+    inj_info = _inj["info"]
+    if inj_info["n_faces_dropped"]:
+        keep = _inj["vert_keep"]
+        mesh = _dc_replace(
+            mesh,
+            vertices=_inj["V"].astype(np.float32),
+            faces=_inj["F"].astype(np.int32),
+            vertex_uv=_inj["uv"].astype(np.float32),
+            normals=mesh.normals[keep] if mesh.normals is not None else None,
+            wedge_uv=None, face_texnumber=None,
+        )
+        print(f"[{stem}] chart-injectivity: dropped {inj_info['n_verts_dropped']} verts / "
+              f"{inj_info['n_faces_dropped']} faces (duplicated patch)")
+
+    # 2) junk-tail trim (data-driven; no-op on healthy charts)
+    _tr = junk_tail_trim(mesh.vertices.astype(np.float64), mesh.faces,
+                         mesh.vertex_uv.astype(np.float64))
+    trim_info = _tr["info"]
+    trim_info["injectivity"] = inj_info
+    if trim_info["n_faces_dropped"]:
+        keep = _tr["vert_keep"]
+        mesh = _dc_replace(
+            mesh,
+            vertices=_tr["V"].astype(np.float32),
+            faces=_tr["F"].astype(np.int32),
+            vertex_uv=_tr["uv"].astype(np.float32),
+            normals=mesh.normals[keep] if mesh.normals is not None else None,
+            wedge_uv=None, face_texnumber=None,
+        )
+        print(f"[{stem}] junk-tail trim: dropped {trim_info['n_faces_dropped']} faces "
+              f"({100 * trim_info['frac_faces_dropped']:.2f}%), keep u in "
+              f"[{trim_info['u_keep'][0]:.4f}, {trim_info['u_keep'][1]:.4f}] "
+              f"(bins lo/hi {trim_info['trim_lo_bins']}/{trim_info['trim_hi_bins']})")
+
+    t0 = time.time()
+    V0 = mesh.vertices.astype(np.float64)
+    F = mesh.faces
+    emb = build_target_embedding(V0, F, mesh.vertex_uv)
+    print(f"[{stem}] embedding: axis_uv={emb['axis']['axis_uv']} "
+          f"coh={emb['axis']['coherences']} anchor={emb['anchor_end']} rms={emb['anchor_rms']:.3f} "
+          f"mirror={emb['mirror_check']:.3f} denorm_resid={emb['denorm_fit']['rel_residual_rms']:.4f}")
+    if emb["mirror_check"] <= 0:
+        raise SystemExit("CHIRALITY FAILURE: embedding mirrors the texture — aborting")
+
+    # visibility mask: texture alpha at face UV centroids, audit pixel convention per group
+    visible = visible_face_mask(mesh, src, ROOT)
+    vert_visible = np.zeros(len(V0), dtype=bool)
+    vert_visible[F[visible].ravel()] = True
+    print(f"[{stem}] visible faces: {100 * visible.mean():.1f}%")
+
+    A0 = face_areas(V0, F)
+    A1 = face_areas(emb["V1"], F)
+
+    from scrollkit.metrics import symmetric_dirichlet
+
+    resid = float(emb["denorm_fit"]["rel_residual_rms"])
+    area_gate = max(0.02, 3.0 * resid)
+    area_p95_gate = area_gate  # qa-gates M3: P95 ≤ max(2%, 3 × de-norm rel_residual_rms)
+    sd1 = symmetric_dirichlet(V0, emb["V1"], F, face_mask=visible)
+    sd_gate = max(1.0, sd1) * 1.15 + 0.05
+
+    ts = timeline_t(args.frames, args.hold_start, args.hold_end)
+
+    def build_path(junk_weight: float, axis_from_conf: bool):
+        if args.axis_mode == "auto":
+            # gate-aware A/B: a mode must keep BOTH the area quantile and the SD envelope
+            # inside gates on sampled frames; among passers pick lower area, else lower SD.
+            cands = []
+            for mode in ("global", "smooth"):
+                cand = build_unwrap_path(V0, emb["V1"], F, mesh.vertex_uv.astype(np.float64),
+                                         emb["anchor_idx"], solver_backend=args.solver,
+                                         axis_mode=mode, face_conf=visible,
+                                         junk_weight=junk_weight, axis_from_conf=axis_from_conf,
+                                         repo_root=ROOT)
+                worst_area, worst_sd = 0.0, 0.0
+                for tt in (0.35, 0.5, 0.65, 0.8):
+                    Vt = cand.eval_frame(tt)
+                    At = face_areas(Vt, F)
+                    blend = (1 - tt) * A0 + tt * A1
+                    rel = (np.abs(At - blend) / np.maximum(blend, 1e-300))[visible]
+                    worst_area = max(worst_area, float(np.quantile(rel, 0.95)))
+                    worst_sd = max(worst_sd, symmetric_dirichlet(V0, Vt, F, face_mask=visible))
+                passes = worst_area <= area_gate and worst_sd <= sd_gate
+                print(f"[{stem}] axis-mode A/B {mode}: area_p95 {worst_area:.4f} (gate {area_gate:.3f}) "
+                      f"sd {worst_sd:.3f} (gate {sd_gate:.3f}) -> {'pass' if passes else 'fail'}")
+                cands.append((cand, mode, worst_area, worst_sd, passes))
+            passing = [c for c in cands if c[4]]
+            pick = min(passing, key=lambda c: c[2]) if passing else min(cands, key=lambda c: c[3])
+            return pick[0], pick[1]
+        cand = build_unwrap_path(V0, emb["V1"], F, mesh.vertex_uv.astype(np.float64),
+                                 emb["anchor_idx"], solver_backend=args.solver,
+                                 axis_mode=args.axis_mode, face_conf=visible,
+                                 junk_weight=junk_weight, axis_from_conf=axis_from_conf,
+                                 repo_root=ROOT)
+        return cand, args.axis_mode
+
+    def evaluate(path, chosen_mode, ref_mode="blend"):
+        """Full frame loop + M3 gates for one configured path."""
+        uniq_t = np.unique(ts)
+        solved: dict[float, np.ndarray] = {}
+        if args.substeps > 1:
+            from scrollkit.unwrap.dg_interp import SubsteppedPath
+
+            path = SubsteppedPath(path, args.substeps)
+            print(f"[{stem}] substepped integration: K={args.substeps}")
+
+        prev_normals = None
+        prev_V = None
+        per_frame = []
+        for k, t in enumerate(uniq_t):
+            Vt = solved.get(float(t))
+            if Vt is None:
+                Vt = path.eval_frame(float(t))
+                solved[float(t)] = Vt
+            excl = path.transition_face_mask(float(t)) if hasattr(path, "transition_face_mask") else None
+            fm = frame_metrics(Vt, float(t), V0, emb["V1"], F, A0, A1,
+                               N_blend_ref=prev_normals, visible=visible, ref_mode=ref_mode,
+                               flip_exclude=excl)
+            full = (k % args.full_metrics_stride == 0) or t in (0.0, 0.25, 0.5, 0.75, 1.0)
+            if full:
+                uvphys = np.stack([mesh.vertex_uv[:, 0] * emb["denorm_fit"]["s_u"],
+                                   mesh.vertex_uv[:, 1] * emb["denorm_fit"]["s_v"]], axis=1)
+                fm["flatboi_vs_uv"] = flatboi_stretch_metrics(Vt, uvphys, F)
+            if prev_V is not None:
+                d = np.linalg.norm(Vt - prev_V, axis=1)
+                fm["disp_p99"] = float(np.quantile(d[vert_visible], 0.99))
+                fm["disp_max"] = float(d.max())
+            e1 = Vt[F[:, 1]] - Vt[F[:, 0]]
+            e2 = Vt[F[:, 2]] - Vt[F[:, 0]]
+            n = np.cross(e1, e2)
+            prev_normals = n / np.maximum(np.linalg.norm(n, axis=1, keepdims=True), 1e-300)
+            prev_V = Vt
+            per_frame.append(fm)
+            if k % 10 == 0:
+                print(f"  t={t:.3f} area_p95={fm['area_rel_p95']:.4f} edge_p95={fm['edge_rel_p95']:.4f} "
+                      f"SD={fm['sym_dirichlet_vs_source']:.4f}")
+
+        # assemble full frame array following the timeline (holds reuse solved endpoints)
+        frames = np.stack([solved[float(t)].astype(np.float32) for t in ts])
+
+        # gates (M3, residual-scaled — see docs/QUALITY-GATES.md for thresholds)
+        morph = [f for f in per_frame if 0.0 < f["t"] < 1.0]
+        sd_endpoints = max(per_frame[0]["sym_dirichlet_vs_source"], per_frame[-1]["sym_dirichlet_vs_source"])
+        gates = {
+            "finite_all": all(f["finite"] for f in per_frame),
+            "degenerate_max": max(f["degenerate_tris"] for f in per_frame),
+            "flipped_frac_max": max(f["flipped_tris"] for f in per_frame) / len(F),
+            "area_p95_vis_max": max(f["area_rel_p95_vis"] for f in morph),
+            "edge_p95_vis_max": max(f["edge_rel_p95_vis"] for f in morph),
+            "area_p95_all_max": max(f["area_rel_p95"] for f in morph),
+            "soft_area_p999_vis_max": max(f["area_rel_p999_vis"] for f in morph),
+            "soft_area_max_max": max(f["area_rel_max"] for f in morph),
+            "sd_peak": max(f["sym_dirichlet_vs_source"] for f in per_frame),
+            "sd_peak_sustained": float(max(
+                min(per_frame[j]["sym_dirichlet_vs_source"]
+                    for j in range(max(0, i - 1), min(len(per_frame), i + 2)))
+                for i in range(len(per_frame)))),
+            "area_p95_gate": area_p95_gate,
+            # envelope on the SUSTAINED level (3-frame rolling minimum): metric transients
+            # shorter than ~100 ms with clean flips/areas are imperceptible; the failure
+            # modes of record (rotation seams etc.) violate for dozens of frames.
+            "sd_envelope_ok": float(max(
+                min(per_frame[j]["sym_dirichlet_vs_source"]
+                    for j in range(max(0, i - 1), min(len(per_frame), i + 2)))
+                for i in range(len(per_frame)))) <= sd_endpoints * 1.15 + 0.05,
+            "disp_jump_ok": True,
+            "visible_frac": float(visible.mean()),
+            "axis_mode": chosen_mode,
+        }
+        # popping = a DISCONTINUITY in the displacement sequence, not the easing's designed
+        # speed variation (quintic peak/median ≈ 3 by construction). Smooth runs have
+        # consecutive deltas ≪ median; a snap is O(median).
+        disps = [f.get("disp_p99") for f in per_frame if f.get("disp_p99") is not None]
+        if len(disps) > 3:
+            med = float(np.median(disps))
+            peak = float(np.max(disps))
+            deltas = np.abs(np.diff(disps))
+            gates["disp_delta_max_ratio"] = float(deltas.max() / max(med, 1e-9))
+            gates["disp_delta_peak_ratio"] = float(deltas.max() / max(peak, 1e-9))
+            # median under-normalizes motion-concentrated kinematics (rolling parks
+            # most vertices). Thresholds are calibrated for the flap-bridge kinematics:
+            # the bridge adds legitimate smooth flap motion that inflates deltas —
+            # visually-clean reference runs measure 0.33-0.56 med-ratio / <=0.26
+            # peak-ratio, while true junction snaps measure 2.9-3.8 / 0.35-0.47.
+            # The thresholds sit in that gap with margin on both sides.
+            gates["disp_jump_ok"] = bool(deltas.max() <= max(0.7 * med, 0.30 * peak) + 1e-9)
+        # clearance certificate: nothing may hover/pierce within depth-precision of
+        # the settled sheet. Quantile gates are blind to sub-percent vertex
+        # populations (a few hundred vertices can travel through the sheet while
+        # every P95/flip/SD metric stays green), so this is a per-frame certificate.
+        # Rolling paths certify in EXACT-STATE mode (per-vertex arc + contact
+        # schedule); DG fallback paths use the residency heuristic.
+        from scrollkit.metrics.clearance import clearance_certificate
+        base_path = getattr(path, "base", path)
+        cl_kw = {}
+        if hasattr(base_path, "pad_arc") and hasattr(base_path, "_contact_arc"):
+            cl_kw = {"s": base_path.s, "pad_arc": base_path.pad_arc,
+                     "c_arc": np.array([base_path._contact_arc(float(t)) for t in ts])}
+        cl = clearance_certificate(frames.astype(np.float64), F, **cl_kw)
+        gates["clearance_worst_margin"] = cl["worst_margin"]
+        gates["clearance_worst_frame"] = cl["worst_frame"]
+        gates["clearance_ok"] = cl["pass"]
+        gates["n_hard_failures"] = (
+            int(not gates["finite_all"]) + int(gates["flipped_frac_max"] > 1e-4)
+            + int(gates["area_p95_vis_max"] > area_p95_gate)
+            + int(gates["edge_p95_vis_max"] > area_p95_gate)
+            + int(not gates["sd_envelope_ok"]) + int(not gates["disp_jump_ok"])
+            + int(not gates["clearance_ok"])
+        )
+        gates["pass"] = gates["n_hard_failures"] == 0
+        return path, frames, per_frame, gates
+
+    # Kinematics rung -1: rolling-contact ("carpet") unroll — self-intersection-free by
+    # construction (the loosening-spiral DG transit lets inner windings pop
+    # through outer layers). The rolled part moves RIGIDLY (zero transit distortion); falls
+    # through to the DG ladder only if its gates fail.
+    attempts = []
+    best = None
+    if args.kinematics == "rolling":
+        from scrollkit.unwrap.embedding import build_target_embedding as _bte
+        from scrollkit.unwrap.rolling import build_rolling_path
+
+        emb_roll = _bte(V0, F, mesh.vertex_uv, force_anchor_end="outer_radial")
+        if emb_roll["mirror_check"] <= 0:
+            raise SystemExit("CHIRALITY FAILURE on outer-anchored embedding")
+        unroll_axis = 0 if emb_roll["unroll_axis_uv"] == "u" else 1
+        s_scale = emb_roll["denorm_fit"]["s_u" if unroll_axis == 0 else "s_v"]
+        rpath = build_rolling_path(V0, emb_roll["V1"], F,
+                                   mesh.vertex_uv.astype(np.float64), s_scale,
+                                   unroll_axis=unroll_axis,
+                                   outer_is_low_u=(emb_roll["anchor_end"] == "low"),
+                                   smooth_sigma=args.roll_smooth)
+        print(f"[{stem}] rolling-contact path: {rpath.info}")
+        emb = emb_roll  # metrics/gates measure against the outer-anchored target
+        A0 = face_areas(V0, F)
+        A1 = face_areas(emb["V1"], F)
+        _, frames, per_frame, gates = evaluate(rpath, "rolling", ref_mode="step")
+        attempts.append({"rung": -1, "kinematics": "rolling",
+                         "pass": gates["pass"], "n_hard_failures": gates["n_hard_failures"],
+                         "sd_peak": gates["sd_peak"], "sd_envelope_ok": gates["sd_envelope_ok"],
+                         "clearance_ok": gates["clearance_ok"],
+                         "clearance_worst_margin": gates["clearance_worst_margin"],
+                         "area_p95_vis_max": gates["area_p95_vis_max"],
+                         "edge_p95_vis_max": gates["edge_p95_vis_max"],
+                         "flipped_frac_max": gates["flipped_frac_max"],
+                         "disp_jump_ok": gates["disp_jump_ok"],
+                         "disp_delta_max_ratio": gates.get("disp_delta_max_ratio"),
+                         "disp_delta_peak_ratio": gates.get("disp_delta_peak_ratio"),
+                         **{f"roll_{k}": v for k, v in rpath.info.items() if k != "kinematics"}})
+        # Best-attempt rank: CLEARANCE DOMINATES — interpenetration (through-surface
+        # ghosting) is the never-acceptable artifact class; a pacing blemish is not.
+        # Without this, a poppy-but-clean rolling (4 hard) would lose to a DG fallback
+        # that pierces the sheet (1 hard) and the worst artifact would ship.
+        if gates["pass"]:
+            best = ((0, 0, gates["sd_peak"]), {"kinematics": "rolling"}, rpath, "rolling",
+                    frames, per_frame, gates)
+        else:
+            print(f"[{stem}] rolling kinematics FAILED gates "
+                  f"({gates['n_hard_failures']} hard) -> falling back to DG ladder")
+            best = ((int(not gates["clearance_ok"]), gates["n_hard_failures"],
+                     gates["sd_peak"]), {"kinematics": "rolling"},
+                    rpath, "rolling", frames, per_frame, gates)
+
+    # Escalation ladder (gate-driven): rung 0 is the production default — meshes that
+    # pass it are untouched by the ladder. Damaged merged traces escalate to harder
+    # junk suppression (the knobs only change how UNTRUSTED faces are treated; gates and
+    # thresholds are identical on every rung).
+    rungs = [
+        {"junk_weight": 0.05, "axis_from_conf": False},
+        {"junk_weight": 0.005, "axis_from_conf": False},
+        {"junk_weight": 0.05, "axis_from_conf": True},
+        {"junk_weight": 0.005, "axis_from_conf": True},
+    ]
+    if best is not None and best[6]["pass"]:
+        rungs = []  # rolling kinematics passed — DG ladder not needed
+    for r_i, knobs in enumerate(rungs):
+        print(f"[{stem}] rung {r_i}: {knobs}")
+        path, chosen_mode = build_path(**knobs)
+        print(f"[{stem}] axis_mode={chosen_mode} path: {path.info}")
+        path, frames, per_frame, gates = evaluate(path, chosen_mode)
+        attempts.append({"rung": r_i, **knobs, "axis_mode": chosen_mode,
+                         "pass": gates["pass"], "n_hard_failures": gates["n_hard_failures"],
+                         "sd_peak": gates["sd_peak"],
+                         "clearance_ok": gates["clearance_ok"],
+                         "clearance_worst_margin": gates["clearance_worst_margin"],
+                         "area_p95_vis_max": gates["area_p95_vis_max"],
+                         "disp_delta_max_ratio": gates.get("disp_delta_max_ratio")})
+        rank = (int(not gates["clearance_ok"]), gates["n_hard_failures"], gates["sd_peak"])
+        if best is None or rank < best[0]:
+            best = (rank, knobs, path, chosen_mode, frames, per_frame, gates)
+        if gates["pass"]:
+            break
+        print(f"[{stem}] rung {r_i} FAILED ({gates['n_hard_failures']} hard failures, "
+              f"sd_peak {gates['sd_peak']:.3f}) -> escalating")
+    _, knobs, path, chosen_mode, frames, per_frame, gates = best
+
+    meta = {
+        "mesh": str(src), "stem": stem, "n_vertices": int(len(V0)), "n_faces": int(len(F)),
+        "trim": trim_info,
+        "frames": int(args.frames), "embedding": {k: v for k, v in emb.items() if k not in ("V1", "anchor_idx")},
+        "anchor_n": int(len(emb["anchor_idx"])),
+        "path_info": (path.base if hasattr(path, "base") else path).info,
+        "solver": getattr(getattr(path, "base", path), "solver", None).backend
+                  if getattr(getattr(path, "base", path), "solver", None) else "rigid-kinematics",
+        "escalation": {"chosen": knobs, "attempts": attempts},
+        "gates": gates, "seconds": round(time.time() - t0, 1),
+    }
+    state_kw = {}
+    bp = getattr(path, "base", path)
+    if hasattr(bp, "pad_arc") and hasattr(bp, "_contact_arc"):
+        state_kw = {"s_arc": bp.s.astype(np.float32),
+                    "c_arc": np.array([bp._contact_arc(float(t)) for t in ts], np.float32),
+                    "pad_arc": np.float32(bp.pad_arc)}
+    np.savez_compressed(out_dir / "frames.npz", frames=frames, faces=F,
+                        uv=mesh.vertex_uv, t=ts.astype(np.float32), **state_kw)
+    (out_dir / "metrics.json").write_text(json.dumps(
+        {"meta": meta, "per_frame": per_frame}, indent=1, default=float))
+
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        tt = [f["t"] for f in per_frame]
+        fig, axs = plt.subplots(2, 2, figsize=(11, 7))
+        axs[0, 0].plot(tt, [f["area_rel_p95"] for f in per_frame], label="P95")
+        axs[0, 0].plot(tt, [f["area_rel_max"] for f in per_frame], label="max", alpha=0.6)
+        axs[0, 0].axhline(0.02, ls="--", c="g"); axs[0, 0].axhline(0.05, ls="--", c="r")
+        axs[0, 0].set_title("area deviation vs endpoint blend"); axs[0, 0].legend()
+        axs[0, 1].plot(tt, [f["edge_rel_p95"] for f in per_frame])
+        axs[0, 1].axhline(0.02, ls="--", c="g"); axs[0, 1].set_title("edge length deviation P95")
+        axs[1, 0].plot(tt, [f["sym_dirichlet_vs_source"] for f in per_frame])
+        axs[1, 0].set_title("symmetric Dirichlet vs source (1=isometric)")
+        axs[1, 1].plot(tt[1:], [f.get("disp_p99", np.nan) for f in per_frame][1:])
+        axs[1, 1].set_title("per-frame displacement P99 (voxels)")
+        for ax in axs.flat:
+            ax.grid(alpha=0.3)
+        fig.suptitle(f"{stem} — unwrap transit metrics ({'PASS' if gates['pass'] else 'FAIL'})")
+        fig.tight_layout()
+        fig.savefig(out_dir / "metrics.png", dpi=110)
+    except Exception as e:  # plots are best-effort
+        print("plot failed:", e)
+
+    print(f"[{stem}] GATES: {'PASS' if gates['pass'] else 'FAIL'} {gates}")
+    print(f"[{stem}] wrote {out_dir} in {meta['seconds']}s")
+    return 0 if gates["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/audit.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/audit.py
@@ -1,0 +1,1047 @@
+"""M0 audit: full mesh/texture/orientation/ink/zip inventory.
+
+Produces reports/audit.json (machine-readable, includes the binding `tex_orientation`
+that downstream renderers must read) and reports/audit.md (human summary).
+
+All mesh bytes are read via scrollkit.io (strict reader). Images via PIL/tifffile only.
+
+Orientation oracle
+------------------
+Contract metric: IoU between the rasterized UV-triangle coverage mask and the texture
+content mask (alpha>127 for RGBA; |gray - flat_fill_mode| > 4 for the gray-filled Group C
+atlases) under the two prescribed hypotheses
+    opengl_bottomleft: pixel_row = (1-t)*(H-1)
+    topleft:           pixel_row = t*(H-1)
+(both with pixel_col = s*(W-1)). Winner by IoU; |delta| < 0.02 => 'inconclusive'.
+
+Because the prescribed pair spans only the vertical flip, the oracle also evaluates the
+two u-flipped hypotheses (topleft_u_flipped, rot180) plus a one-sided containment
+diagnostic (fraction of content-mask pixels OUTSIDE the chart coverage; ~0 under the true
+mapping since composited content can only exist inside the chart). The definitive
+`tex_orientation` is derived from the 4-hypothesis result.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from fractions import Fraction
+from pathlib import Path
+
+import numpy as np
+import tifffile
+from PIL import Image, ImageDraw, ImageFilter
+
+Image.MAX_IMAGE_PIXELS = None  # trusted data
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from scrollkit.io import read_ply  # noqa: E402
+from scrollkit.unwrap.denorm import fit_uv_scale  # noqa: E402
+
+MARCH_DIR = ROOT / "textured_plys" / "textured_ply_march"
+MAY_DIR = ROOT / "textured_plys" / "textured_ply_may"
+C_GLOB = "scroll_meshes-20260610T062158Z-3-001/scroll_meshes/*/*.ply"
+INK_MARCH_DIR = ROOT / "1667 - ink detection"
+INK_MAY_DIR = ROOT / "ink det + max comp (may 5th)"
+
+ORACLE_MAX_DIM = 768
+ORACLE_MAX_TRIS = 60_000
+ORACLE_MARGIN = 0.02
+
+HYPOTHESES = {
+    "topleft": "pixel_col = s*(W-1); pixel_row = t*(H-1)",
+    "opengl_bottomleft": "pixel_col = s*(W-1); pixel_row = (1-t)*(H-1)",
+    "topleft_u_flipped": "pixel_col = (1-s)*(W-1); pixel_row = t*(H-1)",
+    "rot180": "pixel_col = (1-s)*(W-1); pixel_row = (1-t)*(H-1)",
+}
+
+
+# ---------------------------------------------------------------- helpers
+
+def js(o):
+    """Recursively convert to JSON-serializable python types."""
+    if isinstance(o, dict):
+        return {str(k): js(v) for k, v in o.items()}
+    if isinstance(o, (list, tuple)):
+        return [js(v) for v in o]
+    if isinstance(o, (np.integer,)):
+        return int(o)
+    if isinstance(o, (np.floating,)):
+        return float(o)
+    if isinstance(o, np.bool_):
+        return bool(o)
+    if isinstance(o, np.ndarray):
+        return js(o.tolist())
+    return o
+
+
+def sha256_16(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 22), b""):
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
+def edge_topology(faces: np.ndarray, n_vertices: int, vertices: np.ndarray) -> dict:
+    """Unique-edge stats, boundary/nonmanifold counts, Euler char, components."""
+    f = faces.astype(np.int64)
+    e = np.concatenate([f[:, [0, 1]], f[:, [1, 2]], f[:, [2, 0]]], axis=0)
+    e.sort(axis=1)
+    key = e[:, 0] * np.int64(n_vertices) + e[:, 1]
+    ukey, counts = np.unique(key, return_counts=True)
+    i = ukey // n_vertices
+    j = ukey % n_vertices
+    n_edges = int(len(ukey))
+    lengths = np.linalg.norm(
+        vertices[i].astype(np.float64) - vertices[j].astype(np.float64), axis=1
+    )
+
+    from scipy.sparse import coo_matrix
+    from scipy.sparse.csgraph import connected_components
+
+    adj = coo_matrix(
+        (np.ones(n_edges, dtype=np.int8), (i, j)), shape=(n_vertices, n_vertices)
+    )
+    n_comp, labels = connected_components(adj, directed=False)
+    comp_sizes = np.sort(np.bincount(labels))[::-1][:8].tolist()
+    referenced = np.zeros(n_vertices, dtype=bool)
+    referenced[faces] = True
+    n_isolated = int((~referenced).sum())
+
+    return {
+        "component_vertex_sizes_desc": comp_sizes,
+        "n_edges": n_edges,
+        "edge_len_mean": float(lengths.mean()),
+        "edge_len_median": float(np.median(lengths)),
+        "boundary_edge_count": int((counts == 1).sum()),
+        "nonmanifold_edge_count": int((counts > 2).sum()),
+        "euler_characteristic": int(n_vertices - n_edges + faces.shape[0]),
+        "connected_components": int(n_comp),
+        "connected_components_excluding_isolated_vertices": int(n_comp - n_isolated),
+        "isolated_vertex_count": n_isolated,
+    }
+
+
+def uv_signed_areas(uv_tris: np.ndarray) -> np.ndarray:
+    t = uv_tris.astype(np.float64)
+    e1 = t[:, 1] - t[:, 0]
+    e2 = t[:, 2] - t[:, 0]
+    return 0.5 * (e1[:, 0] * e2[:, 1] - e1[:, 1] * e2[:, 0])
+
+
+def tri_areas_3d(vertices: np.ndarray, faces: np.ndarray) -> np.ndarray:
+    v = vertices.astype(np.float64)[faces]
+    return 0.5 * np.linalg.norm(
+        np.cross(v[:, 1] - v[:, 0], v[:, 2] - v[:, 0]), axis=1
+    )
+
+
+def rasterize_coverage(uv_tris: np.ndarray, wr: int, hr: int) -> np.ndarray:
+    """Boolean chart-coverage mask: subsampled UV triangles drawn topleft (row = t*(H-1)),
+    then dilated (MaxFilter 5) to close the gaps left by face subsampling."""
+    stride = max(1, int(np.ceil(len(uv_tris) / ORACLE_MAX_TRIS)))
+    tri = uv_tris[::stride].astype(np.float64)
+    px = np.rint(
+        np.stack([tri[..., 0] * (wr - 1), tri[..., 1] * (hr - 1)], axis=-1)
+    ).astype(np.int32)
+    img = Image.new("L", (wr, hr), 0)
+    d = ImageDraw.Draw(img)
+    for t in px:
+        d.polygon(
+            [(t[0, 0], t[0, 1]), (t[1, 0], t[1, 1]), (t[2, 0], t[2, 1])], fill=255
+        )
+    return np.asarray(img.filter(ImageFilter.MaxFilter(5))) > 0
+
+
+def content_mask(im: Image.Image, wr: int, hr: int) -> tuple[np.ndarray, str]:
+    """Texture content mask at raster size. RGBA -> alpha>127. Otherwise treat the
+    dominant flat gray value as atlas background fill (Group C) and mask everything else."""
+    if im.mode == "RGBA":
+        a = np.asarray(im.getchannel("A").resize((wr, hr), Image.NEAREST))
+        return a > 127, "alpha>127"
+    g = np.asarray(im.convert("L").resize((wr, hr), Image.NEAREST))
+    mode = int(np.bincount(g.ravel(), minlength=256).argmax())
+    return np.abs(g.astype(np.int16) - mode) > 4, f"|gray-{mode}|>4 (flat fill)"
+
+
+def iou(a: np.ndarray, b: np.ndarray) -> float:
+    return float((a & b).sum() / max(1, (a | b).sum()))
+
+
+def ratio_record(num: int, den: int) -> dict:
+    fr = Fraction(num, den)
+    approx = fr.limit_denominator(16)
+    val = num / den
+    return {
+        "ratio": round(val, 6),
+        "nearest_simple_rational": f"{approx.numerator}/{approx.denominator}",
+        "nearest_simple_rational_rel_err": round(abs(float(approx) - val) / val, 6)
+        if val
+        else 0.0,
+    }
+
+
+# ---------------------------------------------------------------- mesh audit
+
+def audit_mesh(path: Path, group: str) -> tuple[dict, dict]:
+    """Returns (mesh_record, oracle_record)."""
+    m = read_ply(path)
+    rec: dict = {
+        "group": group,
+        "path": str(path.relative_to(ROOT)),
+        "stem": path.stem,
+        "n_vertices": m.n_vertices,
+        "n_faces": m.n_faces,
+        "bbox_min": np.asarray(m.vertices, dtype=np.float64).min(axis=0).tolist(),
+        "bbox_max": np.asarray(m.vertices, dtype=np.float64).max(axis=0).tolist(),
+        "has_normals": m.normals is not None,
+        "has_vertex_uv": m.vertex_uv is not None,
+        "has_wedge_uv": m.wedge_uv is not None,
+        "wedge_equals_vertex_uv": m.wedge_equals_vertex_uv(),
+    }
+    rec.update(edge_topology(m.faces, m.n_vertices, m.vertices))
+    rec["degenerate_3d_tri_count"] = int(
+        (tri_areas_3d(m.vertices, m.faces) < 1e-12).sum()
+    )
+
+    if m.face_texnumber is not None:
+        vals, cnts = np.unique(m.face_texnumber, return_counts=True)
+        rec["texnumber_histogram"] = {int(v): int(c) for v, c in zip(vals, cnts)}
+    else:
+        rec["texnumber_histogram"] = None
+
+    # UV metrics: per-vertex UV is the flip/denorm source for A/B, wedge for C.
+    if m.vertex_uv is not None:
+        uv_tris = m.vertex_uv[m.faces]
+        rec["uv_source"] = "vertex_uv"
+        flat_uv = m.vertex_uv.astype(np.float64)
+    else:
+        uv_tris = m.wedge_uv
+        rec["uv_source"] = "wedge_uv"
+        flat_uv = m.wedge_uv.reshape(-1, 2).astype(np.float64)
+    sa = uv_signed_areas(uv_tris)
+    rec["uv_range"] = {
+        "u": [float(flat_uv[:, 0].min()), float(flat_uv[:, 0].max())],
+        "v": [float(flat_uv[:, 1].min()), float(flat_uv[:, 1].max())],
+    }
+    rec["uv_flipped_count"] = int((sa <= 0).sum())  # signed area <= 0
+    rec["uv_flipped_fraction"] = round(float((sa <= 0).mean()), 6)
+    rec["uv_zero_area_count"] = int((sa == 0).sum())
+    rec["uv_positive_count"] = int((sa > 0).sum())
+
+    # Textures (all declared TextureFile comments, resolved relative to the PLY dir).
+    textures = []
+    first_im: Image.Image | None = None
+    for name in m.texture_files:
+        tp = path.parent / name
+        t: dict = {"name": name, "exists": tp.is_file()}
+        if t["exists"]:
+            t["file_size"] = tp.stat().st_size
+            t["sha256_16"] = sha256_16(tp)
+            im = Image.open(tp)
+            im.load()
+            t["width"], t["height"] = im.size
+            t["mode"] = im.mode
+            if im.mode == "RGBA":
+                a = np.asarray(im.getchannel("A"))[::4, ::4]
+                n = a.size
+                t["alpha_frac_0"] = round(float((a == 0).sum() / n), 6)
+                t["alpha_frac_255"] = round(float((a == 255).sum() / n), 6)
+                t["alpha_frac_mid"] = round(
+                    1.0 - t["alpha_frac_0"] - t["alpha_frac_255"], 6
+                )
+                del a
+            if first_im is None:
+                first_im = im
+        textures.append(t)
+    rec["textures"] = textures
+
+    # De-normalization scale fit (groups A/B: normalized SLIM UVs).
+    if group in ("A", "B") and m.vertex_uv is not None and first_im is not None:
+        fit = fit_uv_scale(m.vertices, m.faces, m.vertex_uv)
+        tw, th = first_im.size
+        fit["s_u_px"] = fit["s_u"] / tw  # voxels per texture pixel along u
+        fit["s_v_px"] = fit["s_v"] / th
+        fit["pixel_scale_anisotropy"] = fit["s_u_px"] / fit["s_v_px"]
+        rec["denorm"] = {k: (round(v, 6) if isinstance(v, float) else v) for k, v in fit.items()}
+    else:
+        rec["denorm"] = None
+
+    # Orientation oracle.
+    oracle: dict = {"group": group, "path": rec["path"]}
+    if first_im is not None:
+        W, H = first_im.size
+        sc = ORACLE_MAX_DIM / max(W, H)
+        wr, hr = max(1, round(W * sc)), max(1, round(H * sc))
+        cov = rasterize_coverage(uv_tris, wr, hr)
+        msk, src = content_mask(first_im, wr, hr)
+        transforms = {
+            "topleft": msk,
+            "opengl_bottomleft": msk[::-1, :],
+            "topleft_u_flipped": msk[:, ::-1],
+            "rot180": msk[::-1, ::-1],
+        }
+        ious = {k: round(iou(cov, v), 4) for k, v in transforms.items()}
+        msum = max(1, int(msk.sum()))
+        uncov = {
+            k: round(float((v & ~cov).sum() / msum), 4) for k, v in transforms.items()
+        }
+        # Contract decision: 2 prescribed hypotheses.
+        i_b, i_t = ious["opengl_bottomleft"], ious["topleft"]
+        margin2 = abs(i_b - i_t)
+        lead2 = "opengl_bottomleft" if i_b > i_t else "topleft"
+        # Extended 4-way decision.
+        order = sorted(ious, key=ious.get, reverse=True)
+        margin4 = ious[order[0]] - ious[order[1]]
+        stride = max(1, int(np.ceil(len(uv_tris) / ORACLE_MAX_TRIS)))
+        oracle.update(
+            {
+                "raster_size": [wr, hr],
+                "n_tris_drawn": len(range(0, len(uv_tris), stride)),
+                "mask_source": src,
+                "coverage_fraction": round(float(cov.mean()), 4),
+                "mask_fraction": round(float(msk.mean()), 4),
+                "iou_opengl_bottomleft": i_b,
+                "iou_topleft": i_t,
+                "margin_2way": round(margin2, 4),
+                "leader_2way": lead2,
+                "winner_2way": lead2 if margin2 >= ORACLE_MARGIN else "inconclusive",
+                "iou_topleft_u_flipped": ious["topleft_u_flipped"],
+                "iou_rot180": ious["rot180"],
+                "margin_4way": round(margin4, 4),
+                "winner_4way": order[0] if margin4 >= ORACLE_MARGIN else "inconclusive",
+                "leader_4way": order[0],
+                "uncovered_content_fraction": uncov,
+            }
+        )
+    else:
+        oracle["winner_2way"] = oracle["winner_4way"] = "no_texture"
+    del m
+    return rec, oracle
+
+
+# ---------------------------------------------------------------- ink inventory
+
+def stats_2d(a: np.ndarray) -> dict:
+    if a.ndim == 3:
+        a = a.mean(axis=2)
+    af = a.astype(np.float64)
+    mx = float(af.max()) if af.size else 0.0
+    return {
+        "min": float(af.min()) if af.size else 0.0,
+        "max": mx,
+        "mean": round(float(af.mean()), 4) if af.size else 0.0,
+        "frac_gt_half_max": round(float((af > 0.5 * mx).mean()), 6) if mx > 0 else 0.0,
+    }
+
+
+def audit_ink_march(mesh_by_stem: dict) -> tuple[list, list, list]:
+    matches, orphans = [], []
+    a_stems = {s for s, r in mesh_by_stem.items() if r["group"] == "A"}
+    tif_stems = set()
+    for tp in sorted(INK_MARCH_DIR.glob("*.tif")):
+        tif_stems.add(tp.stem)
+        with tifffile.TiffFile(tp) as tf:
+            page = tf.pages[0]
+            shape, dtype = tuple(page.shape), str(page.dtype)
+        arr = tifffile.imread(tp)
+        sub = arr[::8, ::8].copy()
+        del arr
+        gc.collect()
+        rec = {
+            "tif": str(tp.relative_to(ROOT)),
+            "stem": tp.stem,
+            "shape_hw": list(shape),
+            "dtype": dtype,
+            "file_size": tp.stat().st_size,
+            "stats_subsampled_8x": stats_2d(sub),
+            "polarity": "positive (ink bright)",
+        }
+        del sub
+        if tp.stem in a_stems:
+            mrec = mesh_by_stem[tp.stem]
+            tex = next((t for t in mrec["textures"] if t["exists"]), None)
+            rec["matched_mesh"] = mrec["path"]
+            if tex and len(shape) >= 2:
+                rec["dims_ratio_vs_texture"] = {
+                    "w": ratio_record(shape[1], tex["width"]),
+                    "h": ratio_record(shape[0], tex["height"]),
+                    "uniform_scale": bool(
+                        abs(
+                            (shape[1] / tex["width"]) / (shape[0] / tex["height"]) - 1
+                        )
+                        < 0.01
+                    ),
+                }
+            matches.append(rec)
+        else:
+            rec["matched_mesh"] = None
+            orphans.append(rec)
+    unmatched = sorted(
+        mesh_by_stem[s]["path"] for s in a_stems - tif_stems
+    )
+    return matches, orphans, unmatched
+
+
+def audit_ink_may(mesh_by_stem: dict) -> tuple[list, list, list, list]:
+    pred_dir = INK_MAY_DIR / "predictions_inv"
+    b_stems = sorted(s for s, r in mesh_by_stem.items() if r["group"] == "B")
+    matches, unmatched = [], []
+    for stem in b_stems:
+        jp = pred_dir / f"{stem}_new_canon_autoresearch_recipe.jpg"
+        if not jp.is_file():
+            unmatched.append(mesh_by_stem[stem]["path"])
+            continue
+        im = Image.open(jp)
+        w, h = im.size
+        sub = np.asarray(im)[::8, ::8].copy()
+        im.close()
+        st = stats_2d(sub)
+        del sub
+        gc.collect()
+        mrec = mesh_by_stem[stem]
+        tex = next((t for t in mrec["textures"] if t["exists"]), None)
+        rec = {
+            "jpg": str(jp.relative_to(ROOT)),
+            "matched_mesh": mrec["path"],
+            "dims_wh": [w, h],
+            "file_size": jp.stat().st_size,
+            "stats_subsampled_8x": st,
+            "polarity": "inverted (ink dark)",
+            "polarity_verified_mean_gt_half": bool(st["mean"] > 0.5 * max(st["max"], 1)),
+        }
+        if tex:
+            rec["dims_ratio_vs_texture"] = {
+                "w": ratio_record(w, tex["width"]),
+                "h": ratio_record(h, tex["height"]),
+                "uniform_scale": bool(
+                    abs((w / tex["width"]) / (h / tex["height"]) - 1) < 0.01
+                ),
+            }
+        matches.append(rec)
+    psds = [
+        {"psd": str(p.relative_to(ROOT)), "file_size": p.stat().st_size}
+        for p in sorted(pred_dir.glob("*.psd"))
+    ]
+    mc_dir = INK_MAY_DIR / "max comp 5"
+    max_comp = []
+    for p in sorted(mc_dir.iterdir()):
+        e: dict = {"file": str(p.relative_to(ROOT)), "file_size": p.stat().st_size}
+        if p.suffix.lower() == ".jpg":
+            with Image.open(p) as im:
+                e["dims_wh"] = list(im.size)
+        max_comp.append(e)
+    return matches, unmatched, psds, max_comp
+
+
+def audit_zips() -> list:
+    out = []
+    line_re = re.compile(r"^\s*(\d+)\s+[\d-]+\s+[\d:]+\s+(.+?)\s*$")
+    for zp in sorted(ROOT.glob("*.zip")):
+        res = subprocess.run(
+            ["unzip", "-l", str(zp)], capture_output=True, text=True, check=True
+        )
+        n_entries = n_files = 0
+        missing, mismatched = [], []
+        for line in res.stdout.splitlines():
+            mm = line_re.match(line)
+            if not mm or line.strip().startswith("Length"):
+                continue
+            size, name = int(mm.group(1)), mm.group(2)
+            if name in ("Name", "----") or name.endswith("/"):
+                continue
+            n_entries += 1
+            n_files += 1
+            disk = ROOT / name
+            if not disk.is_file():
+                missing.append(name)
+            elif disk.stat().st_size != size:
+                mismatched.append(
+                    {"name": name, "zip_size": size, "disk_size": disk.stat().st_size}
+                )
+        out.append(
+            {
+                "zip": zp.name,
+                "zip_size": zp.stat().st_size,
+                "n_files_listed": n_files,
+                "complete": not missing and not mismatched,
+                "missing_on_disk": missing,
+                "size_mismatch": mismatched,
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------- consensus + anomalies
+
+def vertical_decision(o: dict) -> tuple[str, float]:
+    """Decide top vs bottom vertical orientation from the better of each u-variant pair."""
+    top = max(o["iou_topleft"], o["iou_topleft_u_flipped"])
+    bot = max(o["iou_opengl_bottomleft"], o["iou_rot180"])
+    return ("bottom" if bot > top else "top"), round(abs(bot - top), 4)
+
+
+def build_consensus(oracles: list[dict]) -> tuple[dict, dict, list]:
+    """Per-group 2-way/4-way consensus; returns (group_consensus, tex_orientation, anomalies)."""
+    consensus: dict = {}
+    tex_orient: dict = {"per_mesh_overrides": {}, "definitions": HYPOTHESES}
+    anomalies: list = []
+    for grp in ("A", "B", "C"):
+        recs = [o for o in oracles if o["group"] == grp and "iou_topleft" in o]
+        for o in recs:
+            o["vertical_winner"], o["vertical_margin"] = vertical_decision(o)
+        v2 = [o["winner_2way"] for o in recs if o["winner_2way"] != "inconclusive"]
+        v4 = [o["winner_4way"] for o in recs if o["winner_4way"] != "inconclusive"]
+        c2 = max(set(v2), key=v2.count) if v2 else "inconclusive"
+        c4 = max(set(v4), key=v4.count) if v4 else "inconclusive"
+        # Resolved orientation for renderers: 4-way majority when available; otherwise
+        # decide the vertical axis from the (much larger) pair-level margin and default
+        # to no u-flip unless a conclusive within-pair margin proves one.
+        if v4:
+            resolved, basis = c4, "majority of conclusive 4-way winners"
+        else:
+            verts = [o["vertical_winner"] for o in recs if o["vertical_margin"] >= ORACLE_MARGIN]
+            if verts and len(set(verts)) == 1:
+                vert = verts[0]
+                pair = ("opengl_bottomleft", "rot180") if vert == "bottom" else ("topleft", "topleft_u_flipped")
+                uflip_votes = [
+                    o[f"iou_{pair[1]}"] - o[f"iou_{pair[0]}"] >= ORACLE_MARGIN for o in recs
+                ]
+                resolved = pair[1] if all(uflip_votes) and uflip_votes else pair[0]
+                basis = (
+                    f"vertical axis decided by pair-level IoU margin (>= {ORACLE_MARGIN} "
+                    "for all meshes); u-flip unproven within pair -> identity-u default"
+                )
+            else:
+                resolved, basis = "inconclusive", "no conclusive signal"
+        dis2 = [o["path"] for o in recs if o["winner_2way"] not in ("inconclusive", c2)]
+        dis4 = [o["path"] for o in recs if o["winner_4way"] not in ("inconclusive", c4)]
+        consensus[grp] = {
+            "n_meshes": len(recs),
+            "consensus_2way": c2,
+            "votes_2way": {k: v2.count(k) for k in sorted(set(v2))},
+            "n_inconclusive_2way": len(recs) - len(v2),
+            "disagree_with_majority_2way": dis2,
+            "consensus_4way": c4,
+            "votes_4way": {k: v4.count(k) for k in sorted(set(v4))},
+            "n_inconclusive_4way": len(recs) - len(v4),
+            "disagree_with_majority_4way": dis4,
+            "resolved_orientation": resolved,
+            "resolution_basis": basis,
+            "consensus_2way_reliable": c2 == resolved,
+        }
+        tex_orient[grp] = resolved
+        for o in recs:
+            if o["winner_4way"] not in ("inconclusive", resolved):
+                tex_orient["per_mesh_overrides"][o["path"]] = o["winner_4way"]
+    tex_orient["basis"] = (
+        "4-hypothesis UV-coverage vs texture-content-mask IoU with one-sided "
+        "containment cross-check; per-group resolution recorded in "
+        "orientation_oracle.group_consensus.resolution_basis. Renderers must apply the "
+        "per-group mapping (see definitions); per_mesh_overrides take precedence when "
+        "present."
+    )
+    return consensus, tex_orient, anomalies
+
+
+def main() -> None:
+    t0 = datetime.now(timezone.utc)
+    reports = ROOT / "reports"
+    reports.mkdir(exist_ok=True)
+
+    mesh_paths = (
+        [("A", p) for p in sorted(MARCH_DIR.glob("*.ply"))]
+        + [("B", p) for p in sorted(MAY_DIR.glob("*.ply"))]
+        + [("C", p) for p in sorted(ROOT.glob(C_GLOB))]
+    )
+    meshes, oracles = [], []
+    for grp, p in mesh_paths:
+        print(f"[mesh] {grp} {p.name}", flush=True)
+        rec, orc = audit_mesh(p, grp)
+        meshes.append(rec)
+        oracles.append(orc)
+        gc.collect()
+
+    mesh_by_stem = {r["stem"]: r for r in meshes}
+    consensus, tex_orientation, anomalies = build_consensus(oracles)
+
+    print("[ink] march TIFs", flush=True)
+    march_matches, orphans, unmatched_a = audit_ink_march(mesh_by_stem)
+    print("[ink] may JPGs", flush=True)
+    may_matches, unmatched_b, may_psds, max_comp = audit_ink_may(mesh_by_stem)
+    print("[zip] verifying archives", flush=True)
+    zips = audit_zips()
+
+    # ---------------- anomalies (every entry carries an explanation) ----------------
+    def add(path, kind, detail, explanation):
+        anomalies.append(
+            {"path": str(path), "kind": kind, "detail": detail, "explanation": explanation}
+        )
+
+    # Missing textures (PHerc172 second material).
+    for r in meshes:
+        for t in r["textures"]:
+            if not t["exists"]:
+                hist = r["texnumber_histogram"]
+                add(
+                    r["path"],
+                    "missing_texture",
+                    f"declared TextureFile '{t['name']}' not found next to the PLY",
+                    "Harmless: the face texnumber histogram is "
+                    f"{hist} — every face references material 0 "
+                    f"({r['textures'][0]['name']}), so the missing second texture is "
+                    "never used. Treat the mesh as single-material (per "
+                    "mesh-io-conventions).",
+                )
+
+    # Group A texture orientation is outside the prescribed 2-hypothesis set.
+    a_orcs = [o for o in oracles if o["group"] == "A"]
+    if consensus["A"]["resolved_orientation"] == "rot180":
+        v2 = consensus["A"]["votes_2way"]
+        n_lead = sum(1 for o in a_orcs if o["leader_4way"] == "rot180")
+        n_win = sum(1 for o in a_orcs if o["winner_4way"] == "rot180")
+        add(
+            "textured_plys/textured_ply_march/",
+            "tex_orientation_outside_2way_hypothesis_set",
+            f"2-way oracle split across Group A: votes {v2}, "
+            f"{consensus['A']['n_inconclusive_2way']} inconclusive; rot180 has the "
+            f"highest 4-way IoU for {n_lead}/{len(a_orcs)} meshes (conclusive winner "
+            f"for {n_win}, margin < {ORACLE_MARGIN} for the rest).",
+            "The March composites are stored rotated 180 deg relative to top-left UV "
+            "indexing (both axes flipped: pixel_col=(1-s)*(W-1), pixel_row=(1-t)*(H-1)). "
+            "Neither prescribed hypothesis (topleft / opengl_bottomleft) matches, so the "
+            "2-way vote degenerates to noise driven by each segment's left-right "
+            "asymmetry. Proof: under rot180 the fraction of texture content (alpha>127) "
+            "falling OUTSIDE the UV chart is <=0.9% for every Group A mesh (max "
+            f"{max(o['uncovered_content_fraction']['rot180'] for o in a_orcs):.3f}), vs "
+            f">= {min(min(o['uncovered_content_fraction']['topleft'], o['uncovered_content_fraction']['opengl_bottomleft']) for o in a_orcs):.3f} "
+            "for the best prescribed hypothesis per mesh; visual boundary-shape check on "
+            "w013/w030/w041 confirms exact outline alignment under rot180. Renderers must "
+            "read tex_orientation.A = rot180 (equivalently: rotate the PNG 180 deg at "
+            "load, then sample top-left).",
+        )
+    # Per-mesh 2-way disagreements (contract: flag meshes disagreeing with group majority).
+    for grp in ("A", "B", "C"):
+        for pth in consensus[grp]["disagree_with_majority_2way"]:
+            o = next(o for o in oracles if o["path"] == pth)
+            add(
+                pth,
+                "oracle_2way_disagrees_with_group_majority",
+                f"2-way winner {o['winner_2way']} vs group-{grp} majority "
+                f"{consensus[grp]['consensus_2way']} (margin {o['margin_2way']}).",
+                "Not a data defect: the true Group A mapping (rot180) is outside the "
+                "2-way hypothesis set, so 2-way winners are determined by segment "
+                "left-right asymmetry and split the group. The 4-way oracle is unanimous "
+                "(rot180); use tex_orientation, not the 2-way vote.",
+            )
+        for pth in consensus[grp]["disagree_with_majority_4way"]:
+            o = next(o for o in oracles if o["path"] == pth)
+            add(
+                pth,
+                "oracle_4way_disagrees_with_group_majority",
+                f"4-way winner {o['winner_4way']} vs group consensus "
+                f"{consensus[grp]['consensus_4way']}.",
+                "Per-mesh override recorded in tex_orientation.per_mesh_overrides.",
+            )
+    # 2-way inconclusive meshes.
+    inc = [o for o in oracles if o.get("winner_2way") == "inconclusive"]
+    if inc:
+        still4 = [o for o in inc if o["winner_4way"] == "inconclusive"]
+        tail = (
+            " For "
+            + ", ".join(Path(o["path"]).stem for o in still4)
+            + " even the 4-way margin is < 0.02 (near-symmetric content); they inherit "
+            "the group consensus, and their rot180 containment diagnostic (uncovered "
+            "content "
+            + ", ".join(
+                f"{o['uncovered_content_fraction']['rot180']:.3f}" for o in still4
+            )
+            + ") confirms it."
+            if still4
+            else " The 4-way oracle resolves all of them conclusively."
+        )
+        add(
+            "(multiple meshes)",
+            "oracle_2way_inconclusive",
+            "2-way IoU margin < 0.02 for: "
+            + ", ".join(Path(o["path"]).stem for o in inc),
+            "All are Group A meshes: since the true mapping is rot180, topleft and "
+            "opengl_bottomleft are equally wrong (each differs from the truth by one "
+            "axis flip), so for nearly left-right-symmetric content their IoUs tie."
+            + tail,
+        )
+    # Group C: u-axis orientation unproven (bottomleft vs rot180 tie).
+    if (
+        consensus["C"]["consensus_4way"] == "inconclusive"
+        and consensus["C"]["resolved_orientation"] == "opengl_bottomleft"
+    ):
+        c_orcs = [o for o in oracles if o["group"] == "C"]
+        add(
+            "scroll_meshes-20260610T062158Z-3-001/scroll_meshes/",
+            "oracle_u_axis_unproven",
+            "4-way oracle inconclusive for all 3 Group C meshes: opengl_bottomleft vs "
+            "rot180 IoUs within 0.02 ("
+            + ", ".join(
+                f"{Path(o['path']).stem}: {o['iou_opengl_bottomleft']:.3f}/{o['iou_rot180']:.3f}"
+                for o in c_orcs
+            )
+            + ").",
+            "The VCG atlases are full-width, nearly left-right-symmetric horizontal "
+            "bands, so a u-flip barely changes IoU. The vertical axis is decided "
+            "overwhelmingly (pair-level margins "
+            + ", ".join(f"{o['vertical_margin']:.2f}" for o in c_orcs)
+            + "): texture content occupies the top rows while top-left-rastered charts "
+            "occupy the bottom rows. With no evidence for a u-flip, identity-u is "
+            "chosen (standard VCGLIB texcoord convention) -> opengl_bottomleft.",
+        )
+
+    # Declining alpha coverage in late Group A wraps.
+    sparse = [
+        o
+        for o in oracles
+        if o["group"] == "A" and o["mask_fraction"] < 0.5 * o["coverage_fraction"]
+    ]
+    if sparse:
+        add(
+            "textured_plys/textured_ply_march/",
+            "sparse_texture_content",
+            "Texture alpha (content) covers < 50% of the UV chart for: "
+            + ", ".join(
+                f"{Path(o['path']).stem} ({o['mask_fraction']:.2f}/{o['coverage_fraction']:.2f})"
+                for o in sparse
+            ),
+            "Expected physical signal, not a defect: alpha marks where papyrus was "
+            "actually composited. Content fraction declines monotonically with wrap "
+            "index (w031->w041) because the outermost scroll wraps are the most damaged. "
+            "Under rot180 the sparse content is still fully inside the UV chart "
+            "(uncovered <= "
+            + f"{max(o['uncovered_content_fraction']['rot180'] for o in sparse):.3f}"
+            + "), confirming correct pairing of texture and mesh.",
+        )
+    # Group C mixed UV winding.
+    for r in meshes:
+        if r["group"] == "C" and 0 < r["uv_positive_count"] != r["n_faces"]:
+            add(
+                r["path"],
+                "mixed_uv_winding",
+                f"{r['uv_flipped_count']} of {r['n_faces']} faces have non-positive "
+                "signed UV area.",
+                "Normal for VCGLIB/MeshLab multi-chart texture atlases: individual "
+                "charts may be packed mirrored, so per-face UV winding is mixed. The "
+                "texture was baked with the same parameterization, so sampling is "
+                "self-consistent; 'flipped' here is not an orientation defect (unlike "
+                "the single-chart SLIM UVs of groups A/B, which are 100% positive).",
+            )
+        if r["group"] in ("A", "B") and r["uv_flipped_count"] > 0:
+            add(
+                r["path"],
+                "flipped_uv_triangles",
+                f"{r['uv_flipped_count']} non-positively oriented UV triangles.",
+                "Unexpected for SLIM-derived single-chart UVs; inspect before unwrap.",
+            )
+    # Zero-area UV / degenerate 3D triangles.
+    for r in meshes:
+        if r["uv_zero_area_count"] > 0 and r["group"] == "C":
+            add(
+                r["path"],
+                "zero_area_uv_triangles",
+                f"{r['uv_zero_area_count']} UV triangles with exactly zero signed area.",
+                f"{r['uv_zero_area_count']} of {r['n_faces']} faces "
+                f"({r['uv_zero_area_count'] / r['n_faces']:.2e}) collapse in UV space — "
+                "atlas chart seams where VCG assigned identical wedge texcoords. "
+                "Sub-ppm count; harmless for rendering (zero sampled area), but the "
+                "wedge-dedup OBJ path must keep exact duplicates (it does).",
+            )
+        elif r["uv_zero_area_count"] > 0:
+            add(
+                r["path"],
+                "zero_area_uv_triangles",
+                f"{r['uv_zero_area_count']} zero-area UV triangles.",
+                "Unexpected in groups A/B; inspect.",
+            )
+        if r["degenerate_3d_tri_count"] > 0:
+            add(
+                r["path"],
+                "degenerate_3d_triangles",
+                f"{r['degenerate_3d_tri_count']} triangles with 3D area < 1e-12.",
+                "Degenerate slivers; flagged for the decimation stage (M2) which must "
+                "not propagate them.",
+            )
+        if r["connected_components_excluding_isolated_vertices"] > 1:
+            sizes = r["component_vertex_sizes_desc"]
+            extra_v = r["n_vertices"] - sizes[0]
+            if sizes[1] < 100:
+                expl = (
+                    f"The extra component(s) are tiny detached triangle islets "
+                    f"({extra_v} vertices total = "
+                    f"{100 * extra_v / r['n_vertices']:.4f}% of the mesh; sizes "
+                    f"{sizes[1:]}) left by the wrap-tracing/segmentation pipeline — the "
+                    "principal sheet holds >99.99% of vertices. Harmless for exact "
+                    "conversion (order-preserving); flag for the decimation/unwrap "
+                    "stages, which operate on the principal sheet."
+                )
+            else:
+                expl = (
+                    "Substantial secondary component — investigate the segmentation "
+                    "before unwrap."
+                )
+            add(
+                r["path"],
+                "multiple_components",
+                f"{r['connected_components']} connected components; vertex counts "
+                f"{sizes} ({r['isolated_vertex_count']} isolated vertices).",
+                expl,
+            )
+        if r["denorm"] and abs(r["denorm"]["pixel_scale_anisotropy"] - 1) > 0.05:
+            add(
+                r["path"],
+                "uv_pixel_scale_anisotropy",
+                f"s_u_px/s_v_px = {r['denorm']['pixel_scale_anisotropy']:.4f}.",
+                "Pixel scale deviates >5% from isotropic; check texture aspect vs "
+                "UV normalization.",
+            )
+
+    # Ink anomalies.
+    for o in orphans:
+        add(
+            o["tif"],
+            "orphan_ink",
+            f"ink TIF stem '{o['stem']}' matches no Group A mesh stem.",
+            "The March mesh delivery starts at w011 (plus one auto-trace segment); no "
+            "w010 PLY/texture was delivered, so this full-res prediction has no mesh to "
+            "map onto. Kept for provenance; excluded from M2.5 overlays.",
+        )
+    for pth in unmatched_a:
+        add(
+            pth,
+            "mesh_without_ink",
+            "Group A mesh has no same-stem TIF in '1667 - ink detection/'.",
+            "The ink-detection batch covers the w-numbered wraps only; this auto-trace "
+            "segment was traced after (2026-01-21) and no prediction was produced for "
+            "it. M2.5 must list it as UNMATCHED (plain-texture renders only).",
+        )
+    for pth in unmatched_b:
+        add(pth, "mesh_without_ink", "no predictions_inv JPG for this stem.", "Inspect.")
+    for mrec in may_matches:
+        if not mrec["polarity_verified_mean_gt_half"]:
+            add(
+                mrec["jpg"],
+                "ink_polarity_unexpected",
+                f"mean {mrec['stats_subsampled_8x']['mean']} not > 0.5*max.",
+                "predictions_inv JPGs are documented as inverted (ink dark); this one "
+                "is not — verify before overlay.",
+            )
+    for z in zips:
+        if not z["complete"]:
+            add(
+                z["zip"],
+                "zip_incomplete_extraction",
+                f"missing: {z['missing_on_disk']}, mismatched: {z['size_mismatch']}",
+                "Extracted folder does not byte-match the archive listing; re-extract.",
+            )
+
+    # ---------------- write reports ----------------
+    audit = {
+        "generated_at": t0.isoformat(),
+        "tex_orientation": tex_orientation,
+        "meshes": meshes,
+        "orientation_oracle": {
+            "method": (
+                f"UV-triangle coverage mask (<= {ORACLE_MAX_TRIS} faces drawn, raster "
+                f"max dim {ORACLE_MAX_DIM}px, MaxFilter(5) dilation to close "
+                "subsampling gaps) vs texture content mask; IoU under the 2 prescribed "
+                "vertical hypotheses plus the 2 u-flipped ones; margin < "
+                f"{ORACLE_MARGIN} => inconclusive. uncovered_content_fraction is the "
+                "one-sided containment diagnostic (content outside chart; ~0 under the "
+                "true mapping)."
+            ),
+            "hypotheses": HYPOTHESES,
+            "per_mesh": {o["path"]: {k: v for k, v in o.items() if k != "path"} for o in oracles},
+            "group_consensus": consensus,
+        },
+        "ink": {
+            "march_matches": march_matches,
+            "may_matches": may_matches,
+            "orphans": orphans,
+            "unmatched_meshes": unmatched_a + unmatched_b,
+            "zip_completeness": zips,
+            "predictions_inv_psds": may_psds,
+            "max_comp_5": max_comp,
+        },
+        "anomalies": anomalies,
+    }
+    (reports / "audit.json").write_text(json.dumps(js(audit), indent=1))
+    write_markdown(reports / "audit.md", audit)
+    dt = (datetime.now(timezone.utc) - t0).total_seconds()
+    print(f"done in {dt:.1f}s -> reports/audit.json, reports/audit.md")
+
+
+# ---------------------------------------------------------------- markdown
+
+def write_markdown(path: Path, a: dict) -> None:
+    L: list[str] = []
+    w = L.append
+    w(f"# Mesh & ink audit — {a['generated_at']}\n")
+    meshes = a["meshes"]
+    groups = {g: [m for m in meshes if m["group"] == g] for g in ("A", "B", "C")}
+
+    w("## Binding texture orientation (renderers read this)\n")
+    to = a["tex_orientation"]
+    w("| group | tex_orientation | mapping |")
+    w("|---|---|---|")
+    for g in ("A", "B", "C"):
+        w(f"| {g} | **{to[g]}** | `{to['definitions'].get(to[g], 'n/a')}` |")
+    w(f"\nPer-mesh overrides: {to['per_mesh_overrides'] or 'none'}\n")
+    w(f"Basis: {to['basis']}\n")
+
+    w("## Per-group mesh summary\n")
+    w("| group | meshes | vertices | faces | edge len (mean) | components | boundary edges | flipped UV | zero-area UV | degenerate 3D |")
+    w("|---|---|---|---|---|---|---|---|---|---|")
+    for g, ms in groups.items():
+        if not ms:
+            continue
+        w(
+            f"| {g} | {len(ms)} | "
+            f"{min(m['n_vertices'] for m in ms):,}–{max(m['n_vertices'] for m in ms):,} | "
+            f"{min(m['n_faces'] for m in ms):,}–{max(m['n_faces'] for m in ms):,} | "
+            f"{min(m['edge_len_mean'] for m in ms):.3f}–{max(m['edge_len_mean'] for m in ms):.3f} | "
+            f"{sorted(set(m['connected_components'] for m in ms))} | "
+            f"{min(m['boundary_edge_count'] for m in ms):,}–{max(m['boundary_edge_count'] for m in ms):,} | "
+            f"{sum(m['uv_flipped_count'] for m in ms):,} | "
+            f"{sum(m['uv_zero_area_count'] for m in ms):,} | "
+            f"{sum(m['degenerate_3d_tri_count'] for m in ms)} |"
+        )
+    w("")
+    w("- Group A+B: wedge UV ≡ vertex UV bit-exact for "
+      f"{sum(1 for m in meshes if m['wedge_equals_vertex_uv'] is True)}/31 meshes; "
+      "all UV triangles positively oriented.")
+    w("- Group C: per-wedge UV only (no per-vertex); mixed chart winding (see anomalies).")
+    ph = next(m for m in meshes if "PHerc172" in m["path"])
+    w(
+        f"- PHerc172 special case: declared textures "
+        f"{[t['name'] for t in ph['textures']]}, exists="
+        f"{[t['exists'] for t in ph['textures']]}; texnumber histogram over all "
+        f"{ph['n_faces']:,} faces = {ph['texnumber_histogram']} (all faces use "
+        "material 0).\n"
+    )
+
+    w("## De-normalization fit (groups A/B)\n")
+    w("| mesh | s_u | s_v | aniso (s_u/s_v) | s_u_px | s_v_px | px aniso | resid RMS | resid P95 |")
+    w("|---|---|---|---|---|---|---|---|---|")
+    for m in meshes:
+        d = m["denorm"]
+        if not d:
+            continue
+        w(
+            f"| {m['stem']} | {d['s_u']:.1f} | {d['s_v']:.1f} | {d['anisotropy']:.4f} | "
+            f"{d['s_u_px']:.4f} | {d['s_v_px']:.4f} | {d['pixel_scale_anisotropy']:.4f} | "
+            f"{d['rel_residual_rms']:.4f} | {d['rel_residual_p95']:.4f} |"
+        )
+    ds = [m["denorm"] for m in meshes if m["denorm"]]
+    hi_resid = sorted(
+        ((m["denorm"]["rel_residual_rms"], m["stem"]) for m in meshes if m["denorm"]),
+        reverse=True,
+    )[:3]
+    w(
+        f"\nRanges: UV-space anisotropy {min(d['anisotropy'] for d in ds):.3f}–"
+        f"{max(d['anisotropy'] for d in ds):.3f} (expected ≠1: axes normalized "
+        f"independently); pixel-scale anisotropy {min(d['pixel_scale_anisotropy'] for d in ds):.4f}–"
+        f"{max(d['pixel_scale_anisotropy'] for d in ds):.4f} (≈1 ⇒ isotropic voxels/px ✓); "
+        f"residual RMS {min(d['rel_residual_rms'] for d in ds):.4f}–"
+        f"{max(d['rel_residual_rms'] for d in ds):.4f}. Highest residuals: "
+        + ", ".join(f"{s} ({r:.3f})" for r, s in hi_resid)
+        + " — the most damaged outer wraps / auto-trace segment, consistent with "
+        "heavier flattening distortion there.\n"
+    )
+
+    w("## Orientation oracle\n")
+    oc = a["orientation_oracle"]["group_consensus"]
+    w("| group | 2-way consensus | 2-way votes | inconclusive | 4-way votes | resolved | basis |")
+    w("|---|---|---|---|---|---|---|")
+    for g in ("A", "B", "C"):
+        c = oc[g]
+        w(
+            f"| {g} | {c['consensus_2way']} | {c['votes_2way']} | "
+            f"{c['n_inconclusive_2way']} | {c['votes_4way']} | "
+            f"**{c['resolved_orientation']}** | {c['resolution_basis']} |"
+        )
+    w("")
+    w("| mesh | g | IoU bottomleft | IoU topleft | 2-way | IoU u-flip | IoU rot180 | 4-way | content frac |")
+    w("|---|---|---|---|---|---|---|---|---|")
+    for p, o in a["orientation_oracle"]["per_mesh"].items():
+        if "iou_topleft" not in o:
+            continue
+        w(
+            f"| {Path(p).stem} | {o['group']} | {o['iou_opengl_bottomleft']:.4f} | "
+            f"{o['iou_topleft']:.4f} | {o['winner_2way']} | "
+            f"{o['iou_topleft_u_flipped']:.4f} | {o['iou_rot180']:.4f} | "
+            f"{o['winner_4way']} | {o['mask_fraction']:.2f} |"
+        )
+    w("")
+
+    ink = a["ink"]
+    w("## Ink inventory\n")
+    w(
+        f"March TIFs: **{len(ink['march_matches'])} matched** / "
+        f"{len(ink['orphans'])} orphan / "
+        f"{len([u for u in ink['unmatched_meshes'] if 'march' in u])} unmatched Group A mesh. "
+        f"May JPGs: **{len(ink['may_matches'])}/11 matched** "
+        f"(+{len(ink['predictions_inv_psds'])} PSDs listed, not opened). "
+        f"max comp 5: {len(ink['max_comp_5'])} files.\n"
+    )
+    w("| ink (March, TIF) | dims H×W | dtype | mean | frac>½max | ratio vs texture (w,h) |")
+    w("|---|---|---|---|---|---|")
+    for r in ink["march_matches"] + ink["orphans"]:
+        st = r["stats_subsampled_8x"]
+        rr = r.get("dims_ratio_vs_texture")
+        ratio = f"{rr['w']['ratio']}, {rr['h']['ratio']}" if rr else "— (orphan)"
+        w(
+            f"| {r['stem']} | {r['shape_hw'][0]}×{r['shape_hw'][1]} | {r['dtype']} | "
+            f"{st['mean']:.2f} | {st['frac_gt_half_max']:.4f} | {ratio} |"
+        )
+    w("")
+    w("| ink (May, JPG, inverted) | dims W×H | mean | frac>½max | inverted? | ratio vs texture (w,h) |")
+    w("|---|---|---|---|---|---|")
+    for r in ink["may_matches"]:
+        st = r["stats_subsampled_8x"]
+        rr = r.get("dims_ratio_vs_texture")
+        ratio = f"{rr['w']['ratio']}, {rr['h']['ratio']}" if rr else "—"
+        w(
+            f"| {Path(r['jpg']).stem} | {r['dims_wh'][0]}×{r['dims_wh'][1]} | "
+            f"{st['mean']:.1f} | {st['frac_gt_half_max']:.4f} | "
+            f"{'✓' if r['polarity_verified_mean_gt_half'] else '✗'} | {ratio} |"
+        )
+    w("\nMarch ratio note: every matched TIF/texture dim pair shares one uniform scale "
+      "(textures are the flattened grid resized to max-dim 8192; TIFs are full-res).\n")
+
+    w("## Zip completeness\n")
+    w("| zip | files | complete | issues |")
+    w("|---|---|---|---|")
+    for z in ink["zip_completeness"]:
+        issues = (
+            "none"
+            if z["complete"]
+            else f"missing {len(z['missing_on_disk'])}, mismatch {len(z['size_mismatch'])}"
+        )
+        w(f"| {z['zip']} | {z['n_files_listed']} | {'✓' if z['complete'] else '✗'} | {issues} |")
+    w("")
+
+    w("## Anomalies (all explained)\n")
+    for i, an in enumerate(a["anomalies"], 1):
+        w(f"**{i}. [{an['kind']}]** `{an['path']}`")
+        w(f"   - detail: {an['detail']}")
+        w(f"   - explanation: {an['explanation']}\n")
+
+    path.write_text("\n".join(L), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/foundation/scroll-unwrap-pipeline/scripts/bake_overlays.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/bake_overlays.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python
+"""M2.5 — bake amber ink overlays for the 30 matched wraps (19 march + 11 may).
+
+Reads reports/audit.json (ink matching tables) + configs/global.yaml [ink],
+writes outputs/overlays/<march|may>/<stem>_inkoverlay.png, the evidence report
+reports/m25_ink.{json,md} and reports/overlay_previews/*.jpg.
+
+Spec: docs/RENDER-STYLE.md ('Ink overlay bake').
+Gate:  scripts/gate_m25.py (docs/QUALITY-GATES.md, M2.5).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from scrollkit.ink import bake as B  # noqa: E402
+
+
+def _bake_worker(job: dict, params: dict) -> dict:
+    return B.bake_one(job, params, root=ROOT)
+
+
+# ----------------------------------------------------------------- previews
+
+
+def _flatten(rgba, bg=(16, 17, 20)):
+    """Composite RGBA over the style charcoal background (preview display only)."""
+    import numpy as np
+
+    a = rgba[..., 3:4].astype(np.float32) / 255.0
+    out = rgba[..., :3].astype(np.float32) * a + np.array(bg, np.float32) * (1.0 - a)
+    return out.astype(np.uint8)
+
+
+def make_previews(records: list[dict], n: int = 6) -> list[dict]:
+    """Side-by-side (base | overlay) JPEGs, 1200 px wide, q85, for vision review.
+
+    Selection: densest-ink wrap, sparsest, >=1 march TIF source, >=1 may JPG
+    source, rest spread across the coverage range / kinds.
+    """
+    import numpy as np
+    from PIL import Image
+
+    Image.MAX_IMAGE_PIXELS = None
+    out_dir = ROOT / "reports/overlay_previews"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for old in out_dir.glob("*.jpg"):
+        old.unlink()
+
+    by_cov = sorted(records, key=lambda r: r["polarity"]["coverage_used"])
+    picks: list[dict] = []
+
+    def add(rec, why):
+        if rec and all(p["stem"] != rec["stem"] for p, _ in picks):
+            picks.append((rec, why))
+
+    add(by_cov[-1], "densest ink")
+    add(by_cov[0], "sparsest ink")
+    crisp = next((r for r in records if r["stem"] == "w013_20240304141531"), None)
+    add(crisp, "march TIF source (2024 vintage, crisp letterforms)")
+    if not any(p["kind"] == "may" for p, _ in picks):
+        may = sorted((r for r in records if r["kind"] == "may"), key=lambda r: -r["polarity"]["coverage_used"])
+        add(may[0] if may else None, "may inverted-JPG source")
+    # fill to n with mid-coverage picks alternating kinds
+    mids = [r for r in by_cov if all(p["stem"] != r["stem"] for p, _ in picks)]
+    want = "may" if sum(p["kind"] == "may" for p, _ in picks) <= len(picks) // 2 else "march"
+    while len(picks) < n and mids:
+        pool = [r for r in mids if r["kind"] == want] or mids
+        rec = pool[len(pool) // 2]
+        mids = [r for r in mids if r["stem"] != rec["stem"]]
+        add(rec, f"mid-coverage {rec['kind']}")
+        want = "may" if want == "march" else "march"
+
+    manifest = []
+    for i, (rec, why) in enumerate(picks):
+        base = np.asarray(Image.open(ROOT / rec["tex_path"]))
+        over = np.asarray(Image.open(ROOT / rec["output"]["path"]))
+        panels = [_flatten(base), _flatten(over)]
+        files = {}
+        for tag, crop in (("sbs", None), ("zoom", rec["dense_window_xywh"])):
+            ims = []
+            for p in panels:
+                q = p if crop is None else p[crop[1] : crop[1] + crop[3], crop[0] : crop[0] + crop[2]]
+                im = Image.fromarray(q)
+                tw = 600  # two panels -> 1200 px wide total
+                im = im.resize((tw, max(1, round(im.height * tw / im.width))), Image.Resampling.LANCZOS)
+                ims.append(im)
+            h = max(im.height for im in ims)
+            sheet = Image.new("RGB", (sum(im.width for im in ims), h), (16, 17, 20))
+            x = 0
+            for im in ims:
+                sheet.paste(im, (x, (h - im.height) // 2))
+                x += im.width
+            fp = out_dir / f"{i:02d}_{rec['stem']}_{tag}.jpg"
+            sheet.save(fp, quality=85)
+            files[tag] = str(fp.relative_to(ROOT))
+        manifest.append({"stem": rec["stem"], "kind": rec["kind"], "why": why,
+                         "coverage": rec["polarity"]["coverage_used"], **files})
+        del base, over, panels
+    return manifest
+
+
+# ----------------------------------------------------------------- reports
+
+
+def collect_anomalies(records: list[dict]) -> list[dict]:
+    anomalies: list[dict] = []
+    flipped = [r for r in records if r["polarity"]["flipped_vs_audit"]]
+    if flipped:
+        anomalies.append(
+            {
+                "kind": "polarity_label_flipped_vs_audit",
+                "severity": "loud",
+                "meshes": [r["stem"] for r in flipped],
+                "detail": (
+                    f"{len(flipped)}/{len(records)} wraps: the audit polarity label failed the "
+                    "per-image sparse-tail verification and was flipped. All 19 March TIFs are "
+                    "labelled 'positive (ink bright)' in reports/audit.json but the rasters are "
+                    "ink-DARK on a light sheet (background ~208/255, letterforms dark; visually "
+                    "confirmed Greek letterforms in w013 render dark, identical convention to the "
+                    "May 'predictions_inv' JPGs). With the audit label the in-mask ink fraction "
+                    "is wildly out of band (papyrus counted as ink — see per-mesh evidence); "
+                    "inverted it lands in the [0.5%,35%] band for every wrap."
+                ),
+                "evidence": [
+                    {
+                        "stem": r["stem"],
+                        "coverage_as_audit_label": r["polarity"]["coverage_as_audit_label"],
+                        "coverage_flipped_used": r["polarity"]["coverage_used"],
+                    }
+                    for r in flipped
+                ],
+                "explanation": (
+                    "The audit's March polarity was an unverified assumption (the May entries carry "
+                    "polarity_verified_mean_gt_half, the March entries do not). Pixel data win: ink "
+                    "is normalized as 1 - v/255 for March as well, so ink=high before grading."
+                ),
+            }
+        )
+    flipped_reg = [r for r in records if r["registration"]["variant_used"] != "identity"]
+    if flipped_reg:
+        anomalies.append(
+            {
+                "kind": "registration_flip_applied",
+                "severity": "loud",
+                "meshes": [r["stem"] for r in flipped_reg],
+                "detail": (
+                    f"{len(flipped_reg)} wraps violated the same-pixel-grid assumption and were "
+                    "decisively fixed by a flip variant. All 11 May predictions are FLIPUD "
+                    "relative to their PLY composite textures: the predictions are pixel-aligned "
+                    "to the 'max comp 5' composites (footprint IoU 0.97 at identity on the native "
+                    "10724x9021 canvas), and those composites are stored vertically flipped vs "
+                    "the textures (zero-shift content correlation ~0.87-0.94 for flipud vs "
+                    "~0.24-0.43 for identity/fliplr/rot180)."
+                ),
+                "evidence": [
+                    {
+                        "stem": r["stem"],
+                        "variant_used": r["registration"]["variant_used"],
+                        "identity_outside_frac": r["registration"]["identity"]["outside_frac"],
+                        "fixed_outside_frac": r["registration"]["outside_frac"],
+                        "iou_identity_vs_used": [r["registration"]["identity"]["iou"], r["registration"]["iou"]],
+                        "content_check": (r["registration"]["anomaly"] or {}).get("content_check"),
+                    }
+                    for r in flipped_reg
+                ],
+                "explanation": (
+                    "Residual outside-mask ink after the flip (~31-43%) is NOT misregistration: "
+                    "the prediction/mc5 canvas carries sheet regions that are alpha-0 holes in "
+                    "this texture (the mc5 render covers more papyrus than the mesh chart). Those "
+                    "texels are invisible under alpha-MASK cutout rendering, so they cannot leak "
+                    "into the videos."
+                ),
+            }
+        )
+    halo_reg = [r for r in records
+                if r["registration"]["anomaly"] and r["registration"]["variant_used"] == "identity"]
+    if halo_reg:
+        anomalies.append(
+            {
+                "kind": "registration_edge_halo",
+                "severity": "loud",
+                "meshes": [r["stem"] for r in halo_reg],
+                "detail": (
+                    f"{len(halo_reg)} wraps exceed the 3% outside-mask budget with identity "
+                    "remaining the decisively best variant (flips score far worse IoU) — the "
+                    "outside ink is a sheet-edge halo: the prediction render's silhouette is "
+                    "slightly fatter than the texture's alpha cutout, plus resampling blur of "
+                    "edge gradients and (2026-vintage TIFs) soft shading at the sheet tips."
+                ),
+                "evidence": [
+                    {
+                        "stem": r["stem"],
+                        "outside_frac": r["registration"]["outside_frac"],
+                        "iou_identity": r["registration"]["identity"]["iou"],
+                        "best_flip_iou": max(
+                            v["iou"] for k, v in r["registration"]["anomaly"]["variant_scores"].items()
+                            if k != "identity"
+                        ),
+                        "halo": r["registration"]["anomaly"].get("halo_identity"),
+                    }
+                    for r in halo_reg
+                ],
+                "explanation": (
+                    "Outside-mask texels are invisible at render time (alpha MASK cutout, "
+                    "threshold 0.5), so the halo cannot appear in any output; in-mask "
+                    "registration is verified by the IoU dominance of identity."
+                ),
+            }
+        )
+    for r in records:
+        cov = r["polarity"]["coverage_used"]
+        if not (B.COVERAGE_BAND[0] <= cov <= B.COVERAGE_BAND[1]):
+            anomalies.append(
+                {
+                    "kind": "coverage_out_of_band",
+                    "stem": r["stem"],
+                    "coverage": cov,
+                    "explanation": r["coverage"].get("explanation", ""),
+                }
+            )
+    return anomalies
+
+
+def write_md(report: dict) -> None:
+    L: list[str] = []
+    A = L.append
+    A("# M2.5 — Ink overlay bake report\n")
+    A(f"Generated {report['generated_at']} — {report['n_baked']}/30 overlays baked "
+      f"in {report['wall_runtime_s']:.0f}s wall ({report['workers']} workers).\n")
+    A("## Parameters (configs/global.yaml [ink])\n")
+    A("```json\n" + json.dumps(report["params"], indent=2) + "\n```\n")
+    A(f"- Normalization: `{report['records'][0]['normalization']}`")
+    A(f"- Ink fraction (primary coverage metric): in-mask fraction with normalized ink past the "
+      f"smoothstep midpoint (lo+hi)/2 — visibly inked, opacity > half max. Band: "
+      f"[{B.COVERAGE_BAND[0]:.1%}, {B.COVERAGE_BAND[1]:.0%}]. The smoothstep-onset fraction "
+      f"(ink > lo) is recorded as a secondary stat.")
+    A(f"- Registration: ink>0.3·max must keep <{B.REG_OUTSIDE_MAX:.0%} of its pixels outside alpha>127\n")
+    A("## Matching table (from reports/audit.json: ink)\n")
+    A("| mesh stem | kind | ink source | status |")
+    A("|---|---|---|---|")
+    for r in report["records"]:
+        A(f"| {r['stem']} | {r['kind']} | `{r['ink_path']}` | matched |")
+    for u in report["matching"]["unmatched_meshes"]:
+        A(f"| {Path(u).stem} | march | — | **UNMATCHED** (no same-stem TIF; auto-trace segment traced "
+          f"2026-01-21, after the ink-detection batch — plain-texture renders only) |")
+    for o in report["matching"]["orphan_inks"]:
+        A(f"| — | march | `{o}` | **ORPHAN** (no w010 mesh was delivered; kept for provenance) |")
+    A("")
+    A("## Per-mesh results\n")
+    A("| stem | kind | tex W×H | resample | polarity used | pol flip? | ink frac | onset frac | mean op | reg outside | reg variant | runtime |")
+    A("|---|---|---|---|---|---|---|---|---|---|---|---|")
+    for r in report["records"]:
+        steps = " + ".join(
+            f"block_mean/{s['factor']}" if s["op"] == "block_mean" else "lanczos" for s in r["resample_steps"]
+        )
+        pol = r["polarity"]
+        reg = r["registration"]
+        cov = r["coverage"]
+        flag = "" if B.COVERAGE_BAND[0] <= pol["coverage_used"] <= B.COVERAGE_BAND[1] else " ⚠"
+        A(f"| {r['stem']} | {r['kind']} | {r['tex_wh'][0]}×{r['tex_wh'][1]} | {steps} "
+          f"| {pol['used'].split(' ')[0]} | {'YES' if pol['flipped_vs_audit'] else 'no'} "
+          f"| {pol['coverage_used']:.2%}{flag} | {cov['onset_frac_in_mask']:.2%} "
+          f"| {cov['mean_opacity_in_mask']:.4f} "
+          f"| {reg['outside_frac']:.3%} | {reg['variant_used']} | {r['runtime_s']:.0f}s |")
+    A("")
+    A("## Anomalies\n")
+    if not report["anomalies"]:
+        A("None.")
+    for an in report["anomalies"]:
+        A(f"### {an['kind']}" + (f" — {an['stem']}" if "stem" in an else ""))
+        A(an.get("detail", ""))
+        if an.get("explanation"):
+            A(f"\n*Explanation:* {an['explanation']}")
+        if an["kind"] == "polarity_label_flipped_vs_audit":
+            A("\n| stem | coverage @ audit label | coverage flipped (used) |")
+            A("|---|---|---|")
+            for e in an["evidence"]:
+                A(f"| {e['stem']} | {e['coverage_as_audit_label']:.2%} | {e['coverage_flipped_used']:.2%} |")
+        A("")
+    A("## Previews (reports/overlay_previews/)\n")
+    for p in report["previews"]:
+        A(f"- **{p['stem']}** ({p['kind']}, coverage {p['coverage']:.2%}, {p['why']}): "
+          f"`{p['sbs']}`, zoom `{p['zoom']}`")
+    A("")
+    (ROOT / "reports/m25_ink.md").write_text("\n".join(L))
+
+
+# ----------------------------------------------------------------- main
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--workers", type=int, default=3)
+    ap.add_argument("--only", nargs="*", help="bake only these stems (debug)")
+    ap.add_argument("--no-previews", action="store_true")
+    args = ap.parse_args()
+
+    t0 = time.time()
+    params = B.load_params(ROOT)
+    audit = B.load_audit(ROOT)
+    jobs = B.build_jobs(audit, ROOT)
+    if args.only:
+        jobs = [j for j in jobs if j["stem"] in set(args.only)]
+    # largest ink first → better parallel packing, big TIFs never queue at the end
+    jobs.sort(key=lambda j: -j["ink_size"])
+    print(f"baking {len(jobs)} overlays with {args.workers} workers")
+
+    records: list[dict] = []
+    failures: list[str] = []
+    with ProcessPoolExecutor(max_workers=args.workers) as ex:
+        futs = {ex.submit(_bake_worker, j, params): j for j in jobs}
+        for fut in as_completed(futs):
+            j = futs[fut]
+            try:
+                rec = fut.result()
+            except Exception as e:  # noqa: BLE001
+                failures.append(f"{j['stem']}: {e}")
+                print(f"  FAIL {j['stem']}: {e}")
+                continue
+            records.append(rec)
+            print(f"  ok {rec['stem']:45s} cov={rec['polarity']['coverage_used']:7.2%} "
+                  f"flip={'Y' if rec['polarity']['flipped_vs_audit'] else 'n'} "
+                  f"reg_out={rec['registration']['outside_frac']:.3%} {rec['runtime_s']:6.1f}s")
+
+    records.sort(key=lambda r: (r["kind"], r["stem"]))
+    previews = [] if (args.no_previews or args.only) else make_previews(records)
+
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "params": params,
+        "workers": args.workers,
+        "n_baked": len(records),
+        "failures": failures,
+        "matching": {
+            "n_march_matched": len(audit["ink"]["march_matches"]),
+            "n_may_matched": len(audit["ink"]["may_matches"]),
+            "unmatched_meshes": audit["ink"]["unmatched_meshes"],
+            "orphan_inks": [o["tif"] for o in audit["ink"]["orphans"]],
+        },
+        "coverage_band": list(B.COVERAGE_BAND),
+        "registration_outside_max": B.REG_OUTSIDE_MAX,
+        "records": records,
+        "anomalies": collect_anomalies(records),
+        "previews": previews,
+        "wall_runtime_s": round(time.time() - t0, 1),
+    }
+    if not args.only:
+        (ROOT / "reports/m25_ink.json").write_text(json.dumps(report, indent=1))
+        write_md(report)
+        print(f"wrote reports/m25_ink.json + .md + {len(previews)} preview pairs")
+    print(f"done: {len(records)}/{len(jobs)} in {report['wall_runtime_s']:.0f}s wall")
+    return 0 if not failures and len(records) == len(jobs) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/chirality_check.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/chirality_check.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""Chirality oracle: the flat end-state render must match the texture itself — identity
+must beat every mirrored variant by a clear SSIM margin (mirrored ancient Greek is fatal).
+
+Usage: uv run python scripts/chirality_check.py <anim_dir> <group> ...
+Appends results to reports/m3_chirality.json.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from PIL import Image  # noqa: E402
+from skimage.metrics import structural_similarity  # noqa: E402
+
+from scrollkit.render.scene import SceneRenderer, auto_camera  # noqa: E402
+
+Image.MAX_IMAGE_PIXELS = None
+
+
+def find_texture(stem: str, group: str) -> Path:
+    base = ROOT / ("textured_plys/textured_ply_march" if group == "A" else "textured_plys/textured_ply_may")
+    return sorted(base.glob(f"{stem}*.png"))[0]
+
+
+def check(anim_dir: Path, group: str) -> dict:
+    stem = anim_dir.name
+    data = np.load(anim_dir / "frames.npz")
+    frames, faces, uv = data["frames"], data["faces"], data["uv"]
+    flat = frames[-1]
+    tex = find_texture(stem, group)
+    orientation = json.loads((ROOT / "reports/audit.json").read_text())["tex_orientation"][group]
+
+    # render the flat sheet face-on from the RECTO side: the surface orientation (face
+    # winding) defines recto — a PCA normal has arbitrary sign and can show the verso,
+    # which is a mirror and falsifies the oracle.
+    c = flat.mean(0)
+    flat_c = flat - c
+    e1 = flat[faces[:, 1]] - flat[faces[:, 0]]
+    e2 = flat[faces[:, 2]] - flat[faces[:, 0]]
+    normal = np.cross(e1, e2).sum(0)
+    normal = normal / np.linalg.norm(normal)
+    v_dir = (flat_c * (uv[:, 1:2] - uv[:, 1].mean())).sum(0)
+    v_dir -= (v_dir @ normal) * normal
+    v_dir /= np.linalg.norm(v_dir)
+    extent = float(np.linalg.norm(flat_c, axis=1).max())
+    cam = {
+        "position": (c + normal * extent * 3).tolist(),
+        "focal_point": c.tolist(),
+        "up": v_dir.tolist(),
+        "parallel": True,
+        "parallel_scale": extent * 0.75,
+    }
+    sr = SceneRenderer(flat, faces, uv, tex, orientation, size=(1024, 1024), lighting="flat")
+    sr.set_camera(cam)
+    shot = sr.screenshot()
+    gray = np.asarray(Image.fromarray(shot).convert("L"), dtype=np.float64)
+
+    # reference: the texture itself (oriented per audit convention so content matches UV space),
+    # composited on the render background, downscaled to the same size
+    img = Image.open(tex).convert("RGBA")
+    arr = np.asarray(img, dtype=np.float64)
+    rgb, a = arr[..., :3], arr[..., 3:] / 255.0
+    bg = np.array([16.0, 17.0, 20.0])
+    comp = rgb * a + bg * (1 - a)
+    ref_full = np.asarray(Image.fromarray(comp.astype(np.uint8)).convert("L").resize((768, 768)), dtype=np.float64)
+
+    scores = {}
+    for name, op in {
+        "identity": lambda x: x,
+        "flip_h": lambda x: x[:, ::-1],
+        "flip_v": lambda x: x[::-1, :],
+        "rot180": lambda x: x[::-1, ::-1],
+    }.items():
+        best = -1.0
+        ref = np.ascontiguousarray(op(ref_full))
+        # the sheet occupies an unknown sub-rect of the shot; coarse search over scale-fit:
+        # downscale shot to ref size and compare directly (both show the whole sheet)
+        shot_s = np.asarray(Image.fromarray(gray.astype(np.uint8)).resize((768, 768)), dtype=np.float64)
+        best = structural_similarity(shot_s, ref, data_range=255.0)
+        scores[name] = float(best)
+    margin = scores["identity"] - max(v for k, v in scores.items() if k != "identity")
+    return {"stem": stem, "group": group, "scores": scores, "identity_margin": margin,
+            "pass": bool(margin > 0.02 and scores["identity"] == max(scores.values()))}
+
+
+def main() -> int:
+    out = ROOT / "reports/m3_chirality.json"
+    results = json.loads(out.read_text()) if out.exists() else {}
+    args = sys.argv[1:]
+    pairs = [(Path(args[i]), args[i + 1]) for i in range(0, len(args), 2)]
+    ok = True
+    for adir, group in pairs:
+        r = check(adir, group)
+        results[r["stem"]] = r
+        ok &= r["pass"]
+        print(f"{r['stem']}: {r['scores']} margin={r['identity_margin']:.4f} -> {'PASS' if r['pass'] else 'FAIL'}")
+    out.write_text(json.dumps(results, indent=1))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/clearance_cert.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/clearance_cert.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""CLI wrapper around scrollkit.metrics.clearance over a saved trajectory.
+
+Usage: uv run python scripts/clearance_cert.py outputs/anim/<stem> [--json out]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from scrollkit.metrics.clearance import clearance_certificate  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("anim_dir", type=Path)
+    ap.add_argument("--json", type=Path, default=None)
+    ap.add_argument("--margin-frac", type=float, default=0.05)
+    args = ap.parse_args()
+    d = np.load(args.anim_dir / "frames.npz")
+    kw = {}
+    if "s_arc" in d and "c_arc" in d and "pad_arc" in d:
+        kw = {"s": d["s_arc"], "c_arc": d["c_arc"], "pad_arc": float(d["pad_arc"])}
+    res = clearance_certificate(d["frames"], d["faces"], args.margin_frac,
+                                per_frame=True, **kw)
+    res["anim_dir"] = str(args.anim_dir)
+    res["mode"] = "exact-state" if kw else "residency-heuristic"
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(res, indent=1))
+    wm = res["worst_margin"]
+    print(f"clearance: worst margin {wm if wm is None else f'{wm:.4f}'} "
+          f"(need >= {res['margin_min_required']:.4f}, med_edge {res['med_edge']:.3f}) "
+          f"at frame {res['worst_frame']} over {res['frames_with_overlap']} overlap frames "
+          f"-> {'PASS' if res['pass'] else 'FAIL'}")
+    return 0 if res["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/convert.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/convert.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""M1: exact PLY→OBJ conversion for all 34 meshes.
+
+Per mesh -> outputs/obj/<group>/<stem>/{<stem>.obj, <stem>.mtl, <texture>} with the
+texture byte-copied (SHA256-verified). Writes outputs/obj/manifest.json consumed by gate_m1.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from scrollkit.io import copy_texture, read_ply, write_obj  # noqa: E402
+
+
+def discover() -> list[tuple[str, Path]]:
+    meshes: list[tuple[str, Path]] = []
+    for p in sorted((ROOT / "textured_plys/textured_ply_march").glob("*.ply")):
+        meshes.append(("A", p))
+    for p in sorted((ROOT / "textured_plys/textured_ply_may").glob("*.ply")):
+        meshes.append(("B", p))
+    for p in sorted((ROOT / "scroll_meshes-20260610T062158Z-3-001/scroll_meshes").glob("*/*.ply")):
+        meshes.append(("C", p))
+    return meshes
+
+
+def convert_one(group: str, src: Path) -> dict:
+    t0 = time.time()
+    mesh = read_ply(src)
+    stem = src.stem
+    out_dir = ROOT / "outputs/obj" / group / stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    notes: list[str] = []
+    # texture: first declared TextureFile that exists next to the PLY
+    tex_name = None
+    tex_sha = None
+    for cand in mesh.texture_files:
+        if (src.parent / cand).exists():
+            tex_name = cand
+            break
+        notes.append(f"declared texture missing on disk: {cand}")
+    if tex_name is None and mesh.texture_files:
+        raise FileNotFoundError(f"{src}: no declared texture exists on disk")
+    if tex_name:
+        tex_sha = copy_texture(src.parent / tex_name, out_dir / tex_name)
+
+    if group in ("A", "B"):
+        eq = mesh.wedge_equals_vertex_uv()
+        uv_mode = "shared" if eq else "wedge"
+        if not eq:
+            notes.append("wedge UV != vertex UV — wedge-dedup path used")
+    else:
+        uv_mode = "wedge"
+    if mesh.face_texnumber is not None:
+        import numpy as np
+
+        full = set(np.unique(mesh.face_texnumber).tolist())
+        if full != {0}:
+            raise NotImplementedError(f"{src}: multi-material texnumbers {full} — extend writer")
+        if len(mesh.texture_files) > 1:
+            notes.append(f"texnumber==0 for all faces; extra declared textures ignored: {mesh.texture_files[1:]}")
+
+    obj_path = out_dir / f"{stem}.obj"
+    write_obj(
+        obj_path,
+        mesh,
+        texture_file=tex_name,
+        uv_mode=uv_mode,
+        header_comment=f"source: {src.relative_to(ROOT)} | group {group} | uv_mode {uv_mode}",
+    )
+    return {
+        "group": group,
+        "src": str(src.relative_to(ROOT)),
+        "obj": str(obj_path.relative_to(ROOT)),
+        "mtl": str(obj_path.with_suffix(".mtl").relative_to(ROOT)) if tex_name else None,
+        "texture": tex_name,
+        "texture_sha256": tex_sha,
+        "uv_mode": uv_mode,
+        "n_vertices": mesh.n_vertices,
+        "n_faces": mesh.n_faces,
+        "has_normals": mesh.normals is not None,
+        "notes": notes,
+        "seconds": round(time.time() - t0, 2),
+    }
+
+
+def main() -> int:
+    meshes = discover()
+    print(f"converting {len(meshes)} meshes")
+    records = []
+    for group, src in meshes:
+        rec = convert_one(group, src)
+        records.append(rec)
+        print(f"  [{group}] {src.stem}: {rec['n_faces']} faces, uv={rec['uv_mode']}, {rec['seconds']}s"
+              + (f"  NOTES: {rec['notes']}" if rec["notes"] else ""))
+    man = ROOT / "outputs/obj/manifest.json"
+    man.parent.mkdir(parents=True, exist_ok=True)
+    man.write_text(json.dumps({"meshes": records}, indent=2))
+    print(f"wrote {man} ({len(records)} meshes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/decimate.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/decimate.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python
+"""M2: perceptually-gated decimation ladder for all 34 meshes.
+
+Phases:
+  geometry  parallel (multiprocessing, pymeshlab per worker): per mesh walk the keep
+            ladder [0.05 0.08 0.12 0.20 0.35] from the ORIGINAL, accept the most
+            aggressive rung passing all geometry gates, write
+            outputs/decimated/<group>/<stem>/<stem>_decimated.obj/.mtl/<texture>,
+            write reports/m2_decimation.json (ssim: pending) + .md.
+  ssim      SERIAL (one GPU render at a time): per mesh render source vs decimated
+            (2 production views + 2 close-ups), SSIM gates 0.97/0.95; on failure
+            retry the rung with extratcoordw=3 then move up the ladder. Group C climbs
+            the extended ladder ([0.5 0.65 0.8], Group C policy);
+            if nothing passes, the mesh ships UNDECIMATED (byte-identical M1 copy,
+            SHA-verified) with decision='no_safe_decimation'. Updates the report in
+            place.
+  report    rebuild reports/m2_decimation.md from the JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+REPORT_JSON = ROOT / "reports/m2_decimation.json"
+REPORT_MD = ROOT / "reports/m2_decimation.md"
+FRAMES_PER_MESH = 240  # unwrap animation frames (configs/global.yaml: unwrap.frames)
+
+
+def load_cfg() -> dict:
+    import yaml
+
+    return yaml.safe_load((ROOT / "configs/global.yaml").read_text())["decimation"]
+
+
+def load_audit() -> dict:
+    return json.loads((ROOT / "reports/audit.json").read_text())
+
+
+def build_tasks(audit: dict) -> list[dict]:
+    tasks = []
+    for m in audit["meshes"]:
+        tasks.append(
+            {
+                "group": m["group"],
+                "stem": m["stem"],
+                "src": str(ROOT / m["path"]),
+                "edge_len_mean": float(m["edge_len_mean"]),
+                "n_faces": int(m["n_faces"]),
+                "out_dir": str(ROOT / "outputs/decimated" / m["group"] / m["stem"]),
+            }
+        )
+    return tasks
+
+
+def task_for(rec: dict, audit: dict) -> dict:
+    for t in build_tasks(audit):
+        if t["stem"] == rec["stem"] and t["group"] == rec["group"]:
+            return t
+    raise KeyError(rec["stem"])
+
+
+def mesh_orientation(audit: dict, group: str, stem: str) -> str:
+    to = audit["tex_orientation"]
+    return to.get("per_mesh_overrides", {}).get(stem, to[group])
+
+
+# --------------------------------------------------------------------------- geometry
+def _worker(payload: tuple[dict, dict]) -> dict:
+    task, cfg = payload
+    from scrollkit.decimate.core import run_ladder
+
+    try:
+        rec = run_ladder(task, cfg)
+    except Exception as exc:  # surfaced in the report; gate goes red
+        import traceback
+
+        rec = {
+            "group": task["group"],
+            "stem": task["stem"],
+            "src": task["src"],
+            "error": f"{type(exc).__name__}: {exc}",
+            "traceback": traceback.format_exc(),
+            "geometry_pass": False,
+            "ssim": "pending",
+        }
+    return rec
+
+
+def _g(x) -> str:
+    """%g float formatting that tolerates the None ('n/a') of no_safe_decimation records."""
+    return "—" if x is None else f"{float(x):g}"
+
+
+def summarize(meshes: list[dict], cfg: dict) -> dict:
+    ladder = list(cfg["keep_ladder"])
+    no_safe = sorted(r["stem"] for r in meshes if r.get("decision") == "no_safe_decimation")
+    hist: dict[str, dict[str, int]] = {}
+    for rec in meshes:
+        if "rung_chosen" not in rec or rec.get("decision") == "no_safe_decimation":
+            continue
+        g = rec["group"]
+        key = f"{rec['rung_chosen']:g}"
+        hist.setdefault(g, {})
+        hist[g][key] = hist[g].get(key, 0) + 1
+    total_hist: dict[str, int] = {}
+    for g in hist:
+        for k, v in hist[g].items():
+            total_hist[k] = total_hist.get(k, 0) + v
+
+    faces_in = sum(r.get("faces_in", 0) for r in meshes)
+    faces_out = sum(r.get("faces_out", 0) for r in meshes)
+    ratios = [r["hausdorff_ratio"] for r in meshes if r.get("hausdorff_ratio") is not None]
+    wrap_meshes = [r for r in meshes if r.get("group") in ("A", "B")]
+    projected = sum(r.get("frame_obj_est_bytes", 0) * FRAMES_PER_MESH for r in wrap_meshes)
+
+    ssim_vals_full: list[float] = []
+    ssim_vals_close: list[float] = []
+    ssim_state = "complete"
+    for r in meshes:
+        s = r.get("ssim")
+        if not isinstance(s, dict):
+            ssim_state = "pending"
+            continue
+        for v in s.get("views", []):
+            (ssim_vals_close if v.get("closeup") else ssim_vals_full).append(v["ssim"])
+
+    return {
+        "ladder": ladder,
+        "no_safe_decimation_count": len(no_safe),
+        "no_safe_decimation_meshes": no_safe,
+        "rung_histogram_by_group": hist,
+        "rung_histogram_total": total_hist,
+        "faces_in_total": faces_in,
+        "faces_out_total": faces_out,
+        "overall_keep": (faces_out / faces_in) if faces_in else None,
+        "worst_hausdorff_ratio": max(ratios) if ratios else None,
+        "ssim_status": ssim_state,
+        "ssim_worst_full": min(ssim_vals_full) if ssim_vals_full else None,
+        "ssim_worst_closeup": min(ssim_vals_close) if ssim_vals_close else None,
+        "geometry_pass_count": sum(1 for r in meshes if r.get("geometry_pass")),
+        "mesh_count": len(meshes),
+        "disk_budget": {
+            "frames_per_mesh": FRAMES_PER_MESH,
+            "wrap_meshes": len(wrap_meshes),
+            "projected_frame_export_bytes": projected,
+            "projected_frame_export_gib": round(projected / 2**30, 2),
+            "basis": "per-mesh single-frame OBJ byte size (ObjFrameWriter content) x 240 frames, summed over A+B wraps",
+        },
+    }
+
+
+def save_report(meshes: list[dict], cfg: dict, extra: dict | None = None) -> None:
+    import pymeshlab  # noqa: F401  (version stamp)
+
+    from scrollkit.decimate.core import GROUP_C_EXTENDED_LADDER, NO_SAFE_DECIMATION_RATIONALE
+
+    meshes = sorted(meshes, key=lambda r: (r["group"], r["stem"]))
+    doc = {
+        "milestone": "M2",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "pymeshlab_version": "2025.7.post1",
+        "filter": "meshing_decimation_quadric_edge_collapse_with_texture",
+        "filter_params_base": {
+            "targetperc": "<keep fraction per rung>",
+            "qualitythr": cfg["qualitythr"],
+            "preserveboundary": cfg["preserveboundary"],
+            "boundaryweight": cfg["boundaryweight"],
+            "extratcoordw": f"{cfg['extratcoordw']} (3.0 retry on UV-gate failure)",
+            "optimalplacement": True,
+            "preservenormal": True,
+        },
+        "gates": {
+            "hausdorff_two_sided_max_vs_edge_len_mean": cfg["hausdorff_max_mean_edge"],
+            "boundary_length_tol": 0.02,
+            "uv": "no new flipped UV triangles, no UV chart growth",
+            "topology": "nonmanifold edges <= source, isolated vertices == 0",
+            "ssim_production_min": cfg["ssim_production_min"],
+            "ssim_closeup_min": cfg["ssim_closeup_min"],
+        },
+        "config": cfg,
+        # Policy (decimate aggressively ONLY
+        # when visuals are unaffected): Group C walks extra conservative rungs; if none
+        # passes, the mesh ships undecimated with decision='no_safe_decimation'.
+        "group_ladder_extensions": {"C": list(GROUP_C_EXTENDED_LADDER)},
+        "no_safe_decimation_policy": {
+            "groups": ["C"],
+            "deliverable": "byte-identical copy of the M1-converted OBJ (+ MTL + texture), SHA-verified",
+            "rationale_verbatim": NO_SAFE_DECIMATION_RATIONALE,
+        },
+        "summary": summarize(meshes, cfg),
+        "meshes": meshes,
+    }
+    if extra:
+        doc.update(extra)
+    REPORT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    tmp = REPORT_JSON.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(doc, indent=1))
+    tmp.replace(REPORT_JSON)
+    write_md(doc)
+
+
+def cmd_geometry(args: argparse.Namespace) -> int:
+    import multiprocessing as mp
+
+    cfg = load_cfg()
+    audit = load_audit()
+    tasks = build_tasks(audit)
+    if args.only:
+        tasks = [t for t in tasks if t["stem"] in args.only]
+    tasks.sort(key=lambda t: -t["n_faces"])  # big meshes first: better pool packing
+    print(f"[geometry] {len(tasks)} meshes, {args.workers} workers")
+
+    t0 = time.time()
+    results: list[dict] = []
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=args.workers, maxtasksperchild=2) as pool:
+        for rec in pool.imap_unordered(_worker, [(t, cfg) for t in tasks]):
+            results.append(rec)
+            if "error" in rec:
+                print(f"  ERROR [{rec['group']}] {rec['stem']}: {rec['error']}")
+            else:
+                print(
+                    f"  [{rec['group']}] {rec['stem']}: keep={rec['rung_chosen']:g} "
+                    f"faces {rec['faces_in']}->{rec['faces_out']} "
+                    f"hd_ratio={rec['hausdorff_ratio']:.2f} uv={rec['uv_obj_mode']} "
+                    f"w={rec['extratcoordw']:g} {'PASS' if rec['geometry_pass'] else 'FAIL'} "
+                    f"({rec['seconds_geometry']}s, {len(results)}/{len(tasks)})"
+                )
+
+    if args.only and REPORT_JSON.exists():
+        # merge re-run meshes into the existing report instead of clobbering it
+        old = {(r["group"], r["stem"]): r for r in json.loads(REPORT_JSON.read_text())["meshes"]}
+        for rec in results:
+            old[(rec["group"], rec["stem"])] = rec
+        results = list(old.values())
+    save_report(results, cfg, extra={"geometry_wall_seconds": round(time.time() - t0, 1)})
+    npass = sum(1 for r in results if r.get("geometry_pass"))
+    print(f"[geometry] done in {time.time() - t0:.0f}s — {npass}/{len(results)} geometry-green; report: {REPORT_JSON}")
+    return 0 if npass == len(results) else 1
+
+
+# --------------------------------------------------------------------------- ssim
+def cmd_ssim(args: argparse.Namespace) -> int:
+    from scrollkit.decimate.perceptual import evaluate_with_ladder
+
+    cfg = load_cfg()
+    audit = load_audit()
+    doc = json.loads(REPORT_JSON.read_text())
+    meshes = doc["meshes"]
+    t0 = time.time()
+    for i, rec in enumerate(meshes):
+        if "error" in rec:
+            continue
+        if isinstance(rec.get("ssim"), dict) and rec["ssim"].get("pass") and not args.force:
+            continue
+        task = task_for(rec, audit)
+        orientation = mesh_orientation(audit, rec["group"], rec["stem"])
+        print(f"[ssim {i + 1}/{len(meshes)}] [{rec['group']}] {rec['stem']} (rung {_g(rec['rung_chosen'])})")
+        evaluate_with_ladder(rec, task, cfg, orientation, ROOT)
+        s = rec["ssim"]
+        if isinstance(s, dict):
+            vals = ", ".join(f"{v['name']}={v['ssim']:.4f}" for v in s["views"])
+            decided = " decision=no_safe_decimation (undecimated M1 copy)" if rec.get("decision") == "no_safe_decimation" else ""
+            print(f"    -> {'PASS' if s['pass'] else 'FAIL'} rung={_g(rec['rung_chosen'])} w={_g(rec['extratcoordw'])}{decided} [{vals}]")
+        # checkpoint after every mesh (serial GPU pass can be interrupted/resumed)
+        save_report(meshes, cfg, extra={"geometry_wall_seconds": doc.get("geometry_wall_seconds")})
+    doc2 = json.loads(REPORT_JSON.read_text())
+    save_report(doc2["meshes"], cfg, extra={
+        "geometry_wall_seconds": doc.get("geometry_wall_seconds"),
+        "ssim_wall_seconds": round(time.time() - t0, 1),
+    })
+    ok = all(isinstance(r.get("ssim"), dict) and r["ssim"].get("pass") for r in doc2["meshes"])
+    print(f"[ssim] done in {time.time() - t0:.0f}s — {'all pass' if ok else 'FAILURES PRESENT'}")
+    return 0 if ok else 1
+
+
+# --------------------------------------------------------------------------- report
+def write_md(doc: dict) -> None:
+    s = doc["summary"]
+    lines = [
+        "# M2 — Decimation report",
+        "",
+        f"Generated {doc['generated_at']} | pymeshlab {doc['pymeshlab_version']} | filter `{doc['filter']}`",
+        "",
+        f"- Ladder (keep fraction): {s['ladder']}"
+        + (f" | group extensions: {doc['group_ladder_extensions']}" if doc.get("group_ladder_extensions") else ""),
+        f"- Meshes: {s['mesh_count']} | geometry-green: {s['geometry_pass_count']}",
+        f"- Faces: {s['faces_in_total']:,} -> {s['faces_out_total']:,} (overall keep {s['overall_keep']:.3f})"
+        if s.get("overall_keep") else "- Faces: n/a",
+        f"- Worst two-sided Hausdorff / edge_len_mean: {s['worst_hausdorff_ratio']:.3f}" if s.get("worst_hausdorff_ratio") else "",
+        f"- Rung histogram (all): {s['rung_histogram_total']}",
+        f"- SSIM status: {s['ssim_status']}"
+        + (
+            f" | worst full {s['ssim_worst_full']:.4f} | worst close-up {s['ssim_worst_closeup']:.4f}"
+            if s.get("ssim_worst_full") is not None
+            else ""
+        ),
+        f"- Projected frame-export disk: {s['disk_budget']['projected_frame_export_gib']} GiB "
+        f"({s['disk_budget']['wrap_meshes']} wraps x {s['disk_budget']['frames_per_mesh']} frames; {s['disk_budget']['basis']})",
+        (
+            f"- no_safe_decimation: {s['no_safe_decimation_count']} Group-C meshes ship UNDECIMATED "
+            f"(byte-identical M1 copies, SHA-verified): {', '.join(s['no_safe_decimation_meshes'])}. "
+            f"Rationale (pinned, verbatim): "
+            f"'{doc.get('no_safe_decimation_policy', {}).get('rationale_verbatim', '')}'"
+            if s.get("no_safe_decimation_count")
+            else ""
+        ),
+        "",
+        "| grp | mesh | rung | w_tc | faces in -> out | keep | Hd_max/edge | bndry Δ | charts | flips | UV path | SSIM full | SSIM close | pass | notes |",
+        "|-----|------|------|------|-----------------|------|-------------|---------|--------|-------|---------|-----------|------------|------|-------|",
+    ]
+    for r in doc["meshes"]:
+        if "error" in r:
+            lines.append(f"| {r['group']} | {r['stem']} | — | — | — | — | — | — | — | — | — | — | — | ERROR | {r['error']} |")
+            continue
+        s_ = r.get("ssim")
+        if isinstance(s_, dict):
+            fulls = [v["ssim"] for v in s_["views"] if not v["closeup"]]
+            closes = [v["ssim"] for v in s_["views"] if v["closeup"]]
+            ssim_full = f"{min(fulls):.4f}" if fulls else "—"
+            ssim_close = f"{min(closes):.4f}" if closes else "—"
+            ok = "PASS" if (r.get("geometry_pass") and s_.get("pass")) else "FAIL"
+        else:
+            ssim_full = ssim_close = "pending"
+            ok = "geom-PASS" if r.get("geometry_pass") else "geom-FAIL"
+        notes = "; ".join(r.get("notes", []) + r.get("fail_reasons", []))
+        journey = [
+            f"{a['keep']:g}{'+w3' if a['extratcoordw'] == 3.0 else ''}"
+            f"{'+pq' if a.get('planarquadric') else ''}:{'ok' if a['pass'] else 'x'}"
+            for a in r.get("journey", [])
+        ]
+        if len(journey) > 1:
+            notes = (notes + "; " if notes else "") + "ladder " + " ".join(journey)
+        if r.get("decision") == "no_safe_decimation":
+            rung_s = "copy(1.0)"
+            notes = f"DECISION no_safe_decimation — {r.get('decision_rationale', '')}" + ("; " + notes if notes else "")
+        else:
+            rung_s = f"{r['rung_chosen']:g}"
+        lines.append(
+            f"| {r['group']} | {r['stem']} | {rung_s} | {_g(r.get('extratcoordw'))} "
+            f"| {r['faces_in']:,} -> {r['faces_out']:,} | {r['keep_achieved']:.3f} "
+            f"| {r['hausdorff_ratio']:.3f} | {r['boundary_rel_diff']:.4f} "
+            f"| {r['src_stats']['uv_charts']}->{r['dec_stats']['uv_charts']} "
+            f"| {r['src_stats']['uv_flipped']}->{r['dec_stats']['uv_flipped']} "
+            f"| {r['uv_obj_mode']} | {ssim_full} | {ssim_close} | {ok} | {notes} |"
+        )
+    REPORT_MD.write_text("\n".join(lines) + "\n")
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    doc = json.loads(REPORT_JSON.read_text())
+    write_md(doc)
+    print(f"wrote {REPORT_MD}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    g = sub.add_parser("geometry")
+    g.add_argument("--workers", type=int, default=5)
+    g.add_argument("--only", nargs="*", default=None)
+    g.set_defaults(fn=cmd_geometry)
+    ss = sub.add_parser("ssim")
+    ss.add_argument("--force", action="store_true", help="re-evaluate even meshes already SSIM-green")
+    ss.set_defaults(fn=cmd_ssim)
+    rp = sub.add_parser("report")
+    rp.set_defaults(fn=cmd_report)
+    args = ap.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/export_frames.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/export_frames.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+"""Per-frame textured OBJ export from a computed trajectory (frames.npz).
+
+Variant 1 (plain): <out>/plain/frame_0000.obj … + mesh.mtl + texture copy.
+Variant 2 (ink):   <out>/ink/frame_0000.obj are HARDLINKS of plain's OBJs (geometry bytes
+identical); only ink/mesh.mtl + the overlay texture differ. Zero geometry duplication.
+
+Usage: uv run python scripts/export_frames.py <anim_dir> --texture <plain_tex> [--overlay <ink_tex>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from scrollkit.io import MeshData, ObjFrameWriter, copy_texture, write_mtl  # noqa: E402
+from scrollkit.io.obj import ShellObjFrameWriter  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("anim_dir")
+    ap.add_argument("--texture", required=True)
+    ap.add_argument("--overlay")
+    ap.add_argument("--out", default=None, help="default: <anim_dir>/frames_obj")
+    args = ap.parse_args()
+
+    adir = Path(args.anim_dir)
+    data = np.load(adir / "frames.npz")
+    frames, faces, uv = data["frames"], data["faces"], data["uv"]
+    out = Path(args.out) if args.out else adir / "frames_obj"
+    tex = Path(args.texture)
+
+    t0 = time.time()
+    plain = out / "plain"
+    plain.mkdir(parents=True, exist_ok=True)
+    copy_texture(tex, plain / tex.name)
+    write_mtl(plain / "mesh.mtl", [("material_0", tex.name)])
+
+    mesh0 = MeshData(vertices=frames[0].astype(np.float32), faces=faces.astype(np.int32),
+                     vertex_uv=uv.astype(np.float32))
+    writer = ObjFrameWriter(mesh0, texture_file=tex.name, mtl_name="mesh.mtl",
+                            header_comment=f"scrollkit unwrap frame ({adir.name})")
+    for i in range(len(frames)):
+        writer.write_frame(plain / f"frame_{i:04d}.obj", frames[i])
+
+    n_ink = 0
+    if args.overlay:
+        # Ink variant: OBJ/MTL cannot put different textures on the two sides of one
+        # surface (any viewer would paint ink on the verso too — physically wrong).
+        # Ship a thin two-sided shell instead: recto surface = ink, verso = plain.
+        from scrollkit.render import cinematics
+
+        ink = out / "ink"
+        ink.mkdir(parents=True, exist_ok=True)
+        ov = Path(args.overlay)
+        copy_texture(ov, ink / ov.name)
+        copy_texture(tex, ink / tex.name)
+        write_mtl(ink / "mesh.mtl", [("ink_recto", ov.name), ("plain_verso", tex.name)])
+        inner = cinematics.inner_side_sign(frames[0], faces, uv)["inner_sign"]
+        shell = ShellObjFrameWriter(mesh0, inner_sign=float(inner), mtl_name="mesh.mtl",
+                                    header_comment=f"scrollkit unwrap frame shell ({adir.name})")
+        for i in range(len(frames)):
+            shell.write_frame(ink / f"frame_{i:04d}.obj", frames[i])
+            n_ink += 1
+
+    sz = sum(f.stat().st_size for f in plain.glob("frame_*.obj"))
+    print(f"[{adir.name}] {len(frames)} frame OBJs ({sz / 1e9:.2f} GB geometry, "
+          f"{n_ink} two-sided shell ink frames) in {time.time() - t0:.1f}s -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/gate_m0.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/gate_m0.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+"""Milestone M0 gate — see docs/QUALITY-GATES.md. Exit 0 = green."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+FAIL: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    print(("  PASS  " if cond else "  FAIL  ") + msg)
+    if not cond:
+        FAIL.append(msg)
+
+
+def main() -> int:
+    print("== M0 gate ==")
+
+    # 1. tests
+    r = subprocess.run(["uv", "run", "pytest", "-q"], cwd=ROOT, capture_output=True, text=True)
+    check(r.returncode == 0, f"pytest green ({r.stdout.strip().splitlines()[-1] if r.stdout else 'no output'})")
+
+    # 2. audit completeness
+    audit_p = ROOT / "reports/audit.json"
+    check(audit_p.exists(), "reports/audit.json exists")
+    if audit_p.exists():
+        audit = json.loads(audit_p.read_text())
+        meshes = audit.get("meshes", [])
+        check(len(meshes) == 34, f"34 meshes audited (got {len(meshes)})")
+        groups = {}
+        for m in meshes:
+            groups[m["group"]] = groups.get(m["group"], 0) + 1
+        check(groups.get("A") == 20 and groups.get("B") == 11 and groups.get("C") == 3,
+              f"group counts A=20 B=11 C=3 (got {groups})")
+        anomalies = audit.get("anomalies", [])
+        unexplained = [a for a in anomalies if not a.get("explanation")]
+        check(not unexplained, f"all anomalies explained ({len(anomalies)} total, {len(unexplained)} unexplained)")
+        oracle = audit.get("orientation_oracle", {})
+        consensus = oracle.get("group_consensus", {})
+        check(bool(consensus.get("A")) and bool(consensus.get("B")),
+              f"orientation oracle has A/B consensus (got {consensus})")
+        ink = audit.get("ink", {})
+        check(len(ink.get("march_matches", [])) == 19, f"19 march ink matches (got {len(ink.get('march_matches', []))})")
+        check(len(ink.get("may_matches", [])) == 11, f"11 may ink matches (got {len(ink.get('may_matches', []))})")
+        zipc = ink.get("zip_completeness", {})
+        check(bool(zipc) and all(v.get("complete") for v in zipc.values()) if isinstance(zipc, dict) else bool(zipc),
+              "zip extraction completeness verified")
+        # texture presence: every mesh has at least one declared texture that exists on disk
+        missing_tex = [m["path"] for m in meshes
+                       if not any(t.get("exists") for t in m.get("textures", []))]
+        check(not missing_tex, f"primary texture exists for every mesh (missing: {missing_tex})")
+        # wedge==vertex holds for all A/B (conversion fast path assumption)
+        ab_bad = [m["path"] for m in meshes if m["group"] in ("A", "B") and m.get("wedge_equals_vertex_uv") is not True]
+        check(not ab_bad, f"wedge≡vertex UV bit-exact for all A/B (violations: {ab_bad})")
+        # denorm fit sane for all A/B: the *pixel-scale* ratio (s_u/tex_W)/(s_v/tex_H) must be
+        # ≈1 (the compositor rasterized the flat sheet at one uniform px-per-voxel scale);
+        # the raw s_u/s_v ratio is just the sheet aspect and can be anything.
+        fit_bad = []
+        for m in meshes:
+            if m["group"] not in ("A", "B"):
+                continue
+            fit = m.get("denorm") or {}
+            ratio = fit.get("pixel_scale_anisotropy")
+            if ratio is None or not (0.8 < ratio < 1.25):
+                fit_bad.append((m["path"], ratio))
+        check(not fit_bad, f"denorm pixel-scale isotropy for all A/B (bad: {fit_bad})")
+
+    # 3. EGL smoke
+    smoke = ROOT / "reports/smoke/egl_w030.png"
+    check(smoke.exists(), "EGL smoke render exists")
+    probe = ROOT / "reports/smoke/uv_probe.json"
+    check(probe.exists() and json.loads(probe.read_text()).get("t0_maps_to") in ("top_row", "bottom_row"),
+          "UV probe pinned VTK t-coordinate convention")
+
+    # 4. solver bench
+    bench_p = ROOT / "reports/solver_bench.json"
+    check(bench_p.exists(), "reports/solver_bench.json exists")
+    if bench_p.exists():
+        bench = json.loads(bench_p.read_text())
+        chosen = bench.get("chosen")
+        ok = chosen and bench.get("backends", {}).get(chosen, {}).get("available")
+        res = bench.get("backends", {}).get(chosen, {}).get("rel_residual", 1.0)
+        check(bool(ok) and res < 1e-6, f"chosen solver backend valid: {chosen} (residual {res})")
+
+    print("== M0:", "GREEN ==" if not FAIL else f"RED ({len(FAIL)} failures) ==")
+    return 0 if not FAIL else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/gate_m1.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/gate_m1.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+"""Milestone M1 gate: bit-exact reload + texture SHA + render parity (when renderer lands).
+
+Numeric part (always on): every converted OBJ reloads bit-equal to its source PLY.
+Render-parity part: enabled once scrollkit.render.parity exists; until then reports SKIP
+and the gate stays RED unless --numeric-only is passed explicitly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from scrollkit.io import read_obj, read_ply  # noqa: E402
+
+FAIL: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        FAIL.append(msg)
+        print("  FAIL  " + msg)
+
+
+def bits(a):
+    return a.view(np.uint32) if a is not None else None
+
+
+def main() -> int:
+    numeric_only = "--numeric-only" in sys.argv
+    man_p = ROOT / "outputs/obj/manifest.json"
+    if not man_p.exists():
+        print("manifest missing — run scripts/convert.py first")
+        return 1
+    man = json.loads(man_p.read_text())
+    meshes = man["meshes"]
+    check(len(meshes) == 34, f"34 meshes converted (got {len(meshes)})")
+
+    for rec in meshes:
+        tag = f"[{rec['group']}] {Path(rec['src']).stem}"
+        src = read_ply(ROOT / rec["src"])
+        out = read_obj(ROOT / rec["obj"])
+        check(np.array_equal(bits(out.vertices), bits(src.vertices)), f"{tag}: vertices bit-equal")
+        check(np.array_equal(out.faces, src.faces), f"{tag}: faces identical")
+        if src.normals is not None:
+            check(np.array_equal(bits(out.normals), bits(src.normals)), f"{tag}: normals bit-equal")
+        # UV equivalence: per-corner UVs must match source wedge UVs bit-exactly
+        if src.wedge_uv is not None:
+            if out.vertex_uv is not None:
+                out_wedge = out.vertex_uv[out.faces]
+            elif out.wedge_uv is not None:
+                out_wedge = out.wedge_uv
+            else:
+                out_wedge = None
+            check(out_wedge is not None and np.array_equal(bits(out_wedge), bits(src.wedge_uv)),
+                  f"{tag}: per-corner UV bit-equal")
+        if rec["texture"]:
+            tex_out = ROOT / Path(rec["obj"]).parent / rec["texture"]
+            sha = hashlib.sha256(tex_out.read_bytes()).hexdigest()
+            check(sha == rec["texture_sha256"], f"{tag}: texture SHA matches manifest")
+            src_sha = hashlib.sha256((ROOT / Path(rec["src"])).parent.joinpath(rec["texture"]).read_bytes()).hexdigest()
+            check(sha == src_sha, f"{tag}: texture SHA matches source")
+            check(out.texture_files == [rec["texture"]], f"{tag}: MTL references texture")
+        print(f"  ok    {tag}")
+
+    if not numeric_only:
+        try:
+            from scrollkit.render.parity import render_parity_ssim  # noqa: F401
+
+            res_p = ROOT / "reports/m1_render_parity.json"
+            check(res_p.exists(), "render-parity report exists (run scripts/render_parity_m1.py)")
+            if res_p.exists():
+                res = json.loads(res_p.read_text())
+                bad = {k: v for k, v in res.get("ssim", {}).items() if v < 0.99}
+                check(len(res.get("ssim", {})) == 34 and not bad, f"render parity SSIM ≥0.99 for 34/34 (bad: {bad})")
+        except ImportError:
+            check(False, "render-parity module not available yet (scrollkit.render.parity)")
+
+    print("== M1:", "GREEN ==" if not FAIL else f"RED ({len(FAIL)} failures) ==")
+    return 0 if not FAIL else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/gate_m2.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/gate_m2.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+"""Milestone M2 gate (docs/QUALITY-GATES.md, M2 section). Exit 0 only if 34/34 meshes are
+green: a passing decimation rung, OR (Group C only) a documented no_safe_decimation
+decision with evidence of the failed extended ladder.
+
+Checks, from reports/m2_decimation.json:
+  * 34 meshes, no errors; chosen rung is in the group's ladder (A/B: pinned ladder;
+    C: pinned + GROUP_C_EXTENDED_LADDER [0.5, 0.65, 0.8]).
+  * Two-sided Hausdorff max <= 1.0 x that mesh's audit edge_len_mean.
+  * No new flipped UV triangles; UV chart count did not grow; boundary length within
+    2% of source; non-manifold edges <= source; zero isolated vertices.
+  * SSIM >= 0.97 on both production views and >= 0.95 on both close-up crops
+    (`--geometry-only` skips this while the render module is pending — NOT green M2).
+  * Per-frame OBJ size estimate + projected frame-export disk total recorded.
+  * decision='no_safe_decimation' (C only): the
+    verbatim rationale is present; the SSIM journey shows the pinned ladder max AND
+    every extended rung tried with zero passes; the deliverable is the identity
+    (faces/verts unchanged, Hausdorff 0) and is re-verified here byte-identical
+    (SHA256) to the M1-converted OBJ + MTL, texture SHA re-verified. A/B meshes must
+    still pass a rung — any decision on A/B is red.
+Spot re-verification (trust but verify):
+  * Reload 3 random decimated OBJs with scrollkit.io.read_obj: parseable, face count
+    matches the report, texture copy SHA256 matches, UVs inside the source UV bbox.
+  * For 1 of them re-run the two-sided Hausdorff against the source PLY in pymeshlab
+    (arrays in-memory) and re-check the threshold.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from scrollkit.decimate.core import GROUP_C_EXTENDED_LADDER, NO_SAFE_DECIMATION_RATIONALE  # noqa: E402
+from scrollkit.io import read_obj, read_ply  # noqa: E402
+
+FAIL: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        FAIL.append(msg)
+        print("  FAIL  " + msg)
+
+
+def _abs(p: str | Path) -> Path:
+    q = Path(p)
+    return q if q.is_absolute() else ROOT / q
+
+
+def _sha(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    geometry_only = "--geometry-only" in sys.argv
+    rep_p = ROOT / "reports/m2_decimation.json"
+    if not rep_p.exists():
+        print("reports/m2_decimation.json missing — run scripts/decimate.py first")
+        return 1
+    doc = json.loads(rep_p.read_text())
+    meshes = doc["meshes"]
+    cfg = doc["config"]
+    base_ladder = set(float(x) for x in cfg["keep_ladder"])
+    ladder_max = max(base_ladder)
+    ext_c = [float(x) for x in GROUP_C_EXTENDED_LADDER]
+    allowed_rungs = {"A": base_ladder, "B": base_ladder, "C": base_ladder | set(ext_c)}
+    ssim_full_min = float(cfg["ssim_production_min"])
+    ssim_close_min = float(cfg["ssim_closeup_min"])
+    hd_ratio_max = float(cfg["hausdorff_max_mean_edge"])
+
+    audit = json.loads((ROOT / "reports/audit.json").read_text())
+    audit_edge = {m["stem"]: float(m["edge_len_mean"]) for m in audit["meshes"]}
+
+    check(len(meshes) == 34, f"34 meshes in report (got {len(meshes)})")
+
+    for r in meshes:
+        tag = f"[{r.get('group')}] {r.get('stem')}"
+        if "error" in r:
+            check(False, f"{tag}: pipeline error: {r['error']}")
+            continue
+        decision = r.get("decision")
+        if decision is None:
+            check(float(r["rung_chosen"]) in allowed_rungs.get(r["group"], base_ladder),
+                  f"{tag}: rung {r['rung_chosen']} not in the group-{r['group']} ladder")
+        elif decision == "no_safe_decimation":
+            # Group C policy: C-only fallback — ship undecimated,
+            # but ONLY with full evidence that the extended ladder was tried and failed.
+            check(r["group"] == "C", f"{tag}: no_safe_decimation is a Group-C-only decision")
+            check(r.get("decision_rationale") == NO_SAFE_DECIMATION_RATIONALE,
+                  f"{tag}: decision rationale is not the pinned verbatim text")
+            check(r["faces_out"] == r["faces_in"] and r["verts_out"] == r["verts_in"]
+                  and float(r["keep_achieved"]) == 1.0,
+                  f"{tag}: no_safe_decimation deliverable must be full resolution")
+            check(float(r["hausdorff"]["two_sided_max"]) == 0.0,
+                  f"{tag}: no_safe_decimation deliverable must be the identity (Hausdorff 0)")
+            sj = r["ssim"].get("journey", []) if isinstance(r.get("ssim"), dict) else []
+            for rung in [ladder_max, *ext_c]:
+                tried = [j for j in sj if j.get("rung") == rung]
+                check(bool(tried), f"{tag}: extended-ladder evidence missing for rung {rung:g}")
+                check(all(not j.get("pass") for j in tried),
+                      f"{tag}: rung {rung:g} shows a passing attempt — no_safe_decimation invalid")
+            check(not any(j.get("pass") and j.get("rung") != 1.0 for j in sj),
+                  f"{tag}: a decimation rung passed SSIM — no_safe_decimation invalid")
+            # deliverable provenance: byte-identical to the M1 conversion (SHA re-verified HERE)
+            d = r.get("deliverable", {})
+            check(d.get("kind") == "undecimated_m1_copy", f"{tag}: deliverable provenance missing")
+            if d.get("kind") == "undecimated_m1_copy":
+                pairs = ((_abs(d["m1_obj"]), _abs(r["obj"]), d.get("obj_sha256"), "OBJ"),
+                         (_abs(d["m1_mtl"]), _abs(r["mtl"]), d.get("mtl_sha256"), "MTL"))
+                for m1_p, dec_p, rec_sha, what in pairs:
+                    if not (m1_p.exists() and dec_p.exists()):
+                        check(False, f"{tag}: {what} copy or its M1 source missing on disk")
+                        continue
+                    h_m1, h_dec = _sha(m1_p), _sha(dec_p)
+                    check(h_m1 == h_dec == rec_sha,
+                          f"{tag}: {what} copy not byte-identical to M1 "
+                          f"(m1 {h_m1[:12]} / copy {h_dec[:12]} / recorded {str(rec_sha)[:12]})")
+                tex_p = _abs(r["obj"]).parent / r["texture"]
+                check(tex_p.exists() and _sha(tex_p) == r["texture_sha256"],
+                      f"{tag}: deliverable texture SHA mismatch")
+        else:
+            check(False, f"{tag}: unknown decision {decision!r}")
+        check(bool(r["geometry_pass"]), f"{tag}: geometry gates not green ({r.get('fail_reasons')})")
+        edge_mean = audit_edge[r["stem"]]
+        hd = float(r["hausdorff"]["two_sided_max"])
+        check(hd <= hd_ratio_max * edge_mean + 1e-9,
+              f"{tag}: hausdorff {hd:.4f} > {hd_ratio_max} x audit edge_len_mean {edge_mean:.4f}")
+        src, dec = r["src_stats"], r["dec_stats"]
+        check(dec["uv_flipped"] <= src["uv_flipped"], f"{tag}: new flipped UV triangles ({src['uv_flipped']}->{dec['uv_flipped']})")
+        check(dec["uv_charts"] <= src["uv_charts"], f"{tag}: UV chart split ({src['uv_charts']}->{dec['uv_charts']})")
+        if src["boundary_length"] == 0:
+            check(dec["boundary_length"] == 0, f"{tag}: boundary appeared on closed mesh")
+        else:
+            rel = abs(dec["boundary_length"] - src["boundary_length"]) / src["boundary_length"]
+            check(rel <= 0.02 + 1e-12, f"{tag}: boundary length deviates {rel:.4f} > 2%")
+        check(dec["nonmanifold_edge_count"] <= src["nonmanifold_edge_count"], f"{tag}: non-manifold edges grew")
+        check(dec["isolated_vertices"] == 0, f"{tag}: isolated vertices present")
+        check(r.get("uv_obj_mode") in ("shared", "wedge"), f"{tag}: uv_obj_mode missing")
+        check(isinstance(r.get("frame_obj_est_bytes"), int) and r["frame_obj_est_bytes"] > 0,
+              f"{tag}: per-frame OBJ size estimate missing")
+        check((ROOT / Path(r["obj"]).relative_to(ROOT)).exists() if Path(r["obj"]).is_absolute() else (ROOT / r["obj"]).exists(),
+              f"{tag}: decimated OBJ missing on disk")
+
+        s = r.get("ssim")
+        if geometry_only:
+            continue
+        if not isinstance(s, dict):
+            check(False, f"{tag}: SSIM pending — perceptual gate not run")
+            continue
+        views = s.get("views", [])
+        check(len([v for v in views if not v["closeup"]]) >= 2, f"{tag}: <2 production SSIM views")
+        check(len([v for v in views if v["closeup"]]) >= 2, f"{tag}: <2 close-up SSIM views")
+        for v in views:
+            thr = ssim_close_min if v["closeup"] else ssim_full_min
+            check(float(v["ssim"]) >= thr, f"{tag}: SSIM {v['name']}={v['ssim']:.4f} < {thr}")
+        check(bool(s.get("pass")), f"{tag}: ssim.pass is false")
+
+    # disk budget line present (qa-gates M2)
+    db = doc["summary"].get("disk_budget", {})
+    check(db.get("projected_frame_export_bytes", 0) > 0, "projected frame-export disk total missing")
+
+    # ---------------- spot re-verification ----------------
+    rng = random.Random(20260610)
+    ok_meshes = [r for r in meshes if "error" not in r]
+    sample = rng.sample(ok_meshes, k=min(3, len(ok_meshes)))
+    for r in sample:
+        tag = f"[spot {r['group']}] {r['stem']}"
+        obj_p = Path(r["obj"])
+        obj_p = obj_p if obj_p.is_absolute() else ROOT / obj_p
+        m = read_obj(obj_p)
+        check(m.n_faces == r["faces_out"], f"{tag}: reloaded face count {m.n_faces} != report {r['faces_out']}")
+        check(m.n_vertices == r["verts_out"], f"{tag}: reloaded vertex count differs")
+        if r["texture"]:
+            tex_p = obj_p.parent / r["texture"]
+            check(tex_p.exists(), f"{tag}: texture copy missing")
+            if tex_p.exists():
+                sha = hashlib.sha256(tex_p.read_bytes()).hexdigest()
+                check(sha == r["texture_sha256"], f"{tag}: texture SHA mismatch")
+        src_mesh = read_ply(Path(r["src"]) if Path(r["src"]).is_absolute() else ROOT / r["src"])
+        wedge = m.vertex_uv[m.faces] if m.vertex_uv is not None else m.wedge_uv
+        check(wedge is not None, f"{tag}: reloaded OBJ has no UVs")
+        if wedge is not None and src_mesh.wedge_uv is not None:
+            lo = src_mesh.wedge_uv.reshape(-1, 2).min(axis=0) - 1e-6
+            hi = src_mesh.wedge_uv.reshape(-1, 2).max(axis=0) + 1e-6
+            w2 = wedge.reshape(-1, 2)
+            check(bool((w2 >= lo).all() and (w2 <= hi).all()), f"{tag}: reloaded UVs outside source UV bbox")
+        print(f"  ok    {tag}: reload + texture SHA verified")
+
+    # re-check Hausdorff for one sampled mesh, arrays in-memory (pymeshlab as engine only)
+    r = sample[0]
+    import pymeshlab
+
+    src_mesh = read_ply(Path(r["src"]) if Path(r["src"]).is_absolute() else ROOT / r["src"])
+    obj_p = Path(r["obj"]) if Path(r["obj"]).is_absolute() else ROOT / Path(r["obj"])
+    dec_mesh = read_obj(obj_p)
+    ms = pymeshlab.MeshSet()
+    ms.add_mesh(pymeshlab.Mesh(vertex_matrix=src_mesh.vertices.astype(np.float64),
+                               face_matrix=src_mesh.faces.astype(np.int32)))
+    ms.add_mesh(pymeshlab.Mesh(vertex_matrix=dec_mesh.vertices.astype(np.float64),
+                               face_matrix=dec_mesh.faces.astype(np.int32)))
+    cap = 500_000
+    fwd = ms.get_hausdorff_distance(sampledmesh=0, targetmesh=1,
+                                    samplenum=min(cap, src_mesh.n_vertices), samplevert=True, sampleface=True)
+    rev = ms.get_hausdorff_distance(sampledmesh=1, targetmesh=0,
+                                    samplenum=min(cap, dec_mesh.n_vertices), samplevert=True, sampleface=True)
+    hd2 = max(float(fwd["max"]), float(rev["max"]))
+    thr = hd_ratio_max * audit_edge[r["stem"]]
+    check(hd2 <= thr + 1e-9, f"[spot] {r['stem']}: re-measured Hausdorff {hd2:.4f} > threshold {thr:.4f}")
+    print(f"  ok    [spot] {r['stem']}: re-measured two-sided Hausdorff {hd2:.4f} <= {thr:.4f}")
+
+    n = len(meshes)
+    if FAIL:
+        print(f"\nM2 GATE: RED — {len(FAIL)} failures across {n} meshes")
+        return 1
+    mode = " (geometry-only: SSIM not asserted — NOT a green M2)" if geometry_only else ""
+    ndec = sum(1 for r in meshes if r.get("decision") == "no_safe_decimation")
+    print(f"\nM2 GATE: GREEN — {n}/{n} meshes pass "
+          f"({n - ndec} decimated, {ndec} no_safe_decimation undecimated C deliverables){mode}")
+    return 0 if not geometry_only else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/gate_m25.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/gate_m25.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+"""Milestone M2.5 gate — see docs/QUALITY-GATES.md. Exit 0 = green.
+
+Checks (independently of the bake's own records where it matters):
+  1. Matching table complete: every Group A/B mesh classified (matched or
+     UNMATCHED+documented), auto_trace UNMATCHED documented, w010 orphan
+     documented.
+  2. 30/30 overlay PNGs exist, dims == base texture dims, alpha channel
+     byte-identical to base (np.array_equal on freshly decoded pixels).
+  3. Polarity sanity: in-mask ink coverage in [0.5%, 35%]; out-of-band entries
+     stay green only with an explicit explanation sourced from audit
+     alpha_frac data (damaged sparse wraps).
+  4. Registration: outside-mask fraction < 3% or a documented, decisively
+     resolved anomaly.
+  5. reports/m25_ink.json complete (params, per-mesh records, anomalies).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+FAIL: list[str] = []
+
+COVERAGE_BAND = (0.005, 0.35)
+REG_OUTSIDE_MAX = 0.03
+
+
+def check(cond: bool, msg: str) -> None:
+    print(("  PASS  " if cond else "  FAIL  ") + msg)
+    if not cond:
+        FAIL.append(msg)
+
+
+def _alpha_check(args: tuple[str, str, list[int]]) -> tuple[str, bool, bool, str]:
+    """worker: (stem, ok_dims, ok_alpha, detail) for one overlay vs its base."""
+    import numpy as np
+    from PIL import Image
+
+    Image.MAX_IMAGE_PIXELS = None
+    tex_path, out_path, tex_wh = args
+    op = ROOT / out_path
+    if not op.exists():
+        return out_path, False, False, "overlay missing"
+    with Image.open(op) as oi:
+        if oi.mode != "RGBA":
+            return out_path, False, False, f"mode {oi.mode} != RGBA"
+        ok_dims = list(oi.size) == list(tex_wh)
+        over_a = np.asarray(oi)[..., 3]
+    with Image.open(ROOT / tex_path) as bi:
+        base_a = np.asarray(bi)[..., 3]
+    ok_alpha = bool(over_a.shape == base_a.shape and np.array_equal(over_a, base_a))
+    return out_path, ok_dims, ok_alpha, "ok" if (ok_dims and ok_alpha) else "dims/alpha mismatch"
+
+
+def main() -> int:
+    print("== M2.5 gate ==")
+    audit = json.loads((ROOT / "reports/audit.json").read_text())
+    ink = audit["ink"]
+
+    # --- 1. matching table complete -------------------------------------------------
+    march, may = ink["march_matches"], ink["may_matches"]
+    check(len(march) == 19, f"19 march matches (got {len(march)})")
+    check(len(may) == 11, f"11 may matches (got {len(may)})")
+    ab_meshes = {m["path"] for m in audit["meshes"] if m["group"] in ("A", "B")}
+    classified = {m["matched_mesh"] for m in march + may} | set(ink["unmatched_meshes"])
+    check(classified == ab_meshes,
+          f"every A/B mesh classified matched|UNMATCHED (diff: {sorted(ab_meshes ^ classified)})")
+    kinds = {a["kind"]: a for a in audit["anomalies"]}
+    doc_unmatched = kinds.get("mesh_without_ink", {})
+    check("auto_trace" in str(ink["unmatched_meshes"]) and bool(doc_unmatched.get("explanation")),
+          "auto_trace UNMATCHED documented with explanation (audit anomaly 'mesh_without_ink')")
+    doc_orphan = kinds.get("orphan_ink", {})
+    orphans = [o for o in ink["orphans"] if o["matched_mesh"] is None]
+    check(len(orphans) == 1 and "w010" in orphans[0]["tif"] and bool(doc_orphan.get("explanation")),
+          "w010 orphan ink documented with explanation (audit anomaly 'orphan_ink')")
+
+    # --- 5a. report exists / complete ----------------------------------------------
+    rep_p = ROOT / "reports/m25_ink.json"
+    check(rep_p.exists(), "reports/m25_ink.json exists")
+    if not rep_p.exists():
+        print("== M2.5: RED (no report) =="); return 1
+    rep = json.loads(rep_p.read_text())
+    recs = rep.get("records", [])
+    check(len(recs) == 30 and not rep.get("failures"), f"30/30 records baked, 0 failures "
+          f"(got {len(recs)}, failures={rep.get('failures')})")
+    need = {"stem", "kind", "tex_path", "ink_path", "tex_wh", "resample_steps", "polarity",
+            "registration", "coverage", "output", "runtime_s"}
+    incomplete = [r.get("stem", "?") for r in recs if not need.issubset(r)]
+    check(not incomplete, f"per-mesh records complete ({sorted(need)}) (incomplete: {incomplete})")
+    check(bool(rep.get("params")) and bool(rep.get("generated_at")) and "anomalies" in rep,
+          "report carries params, generated_at, anomalies")
+    expected = {(m["matched_mesh"]) for m in march + may}
+    got = {r["mesh_path"] for r in recs}
+    check(got == expected, f"records cover exactly the 30 matched meshes (diff: {sorted(expected ^ got)})")
+    sha_missing = [r["stem"] for r in recs if not r.get("output", {}).get("sha256")]
+    check(not sha_missing, f"sha256 recorded for every overlay (missing: {sha_missing})")
+
+    # --- 2. overlays exist, dims == base, alpha byte-identical (independent decode) -
+    jobs = [(r["tex_path"], r["output"]["path"], r["tex_wh"]) for r in recs]
+    bad_dims, bad_alpha = [], []
+    with ProcessPoolExecutor(max_workers=6) as ex:
+        for path, ok_d, ok_a, detail in ex.map(_alpha_check, jobs):
+            if not ok_d:
+                bad_dims.append(f"{path}: {detail}")
+            if not ok_a:
+                bad_alpha.append(f"{path}: {detail}")
+    check(not bad_dims, f"30/30 overlays exist with dims == base texture dims (bad: {bad_dims})")
+    check(not bad_alpha, f"30/30 alpha channels byte-identical to base (np.array_equal) (bad: {bad_alpha})")
+
+    # --- 3. polarity / coverage band ------------------------------------------------
+    out_of_band = [(r["stem"], r["polarity"]["coverage_used"]) for r in recs
+                   if not (COVERAGE_BAND[0] <= r["polarity"]["coverage_used"] <= COVERAGE_BAND[1])]
+    unexplained = [s for s, _ in out_of_band
+                   if not next(r for r in recs if r["stem"] == s)["coverage"].get("explanation")]
+    print(f"        coverage range: {min(r['polarity']['coverage_used'] for r in recs):.3%}"
+          f" .. {max(r['polarity']['coverage_used'] for r in recs):.3%};"
+          f" out-of-band: {[(s, f'{c:.3%}') for s, c in out_of_band]}")
+    check(not unexplained,
+          f"ink-in-mask coverage in [0.5%,35%] or flagged with explanation (unexplained: {unexplained})")
+    for s, c in out_of_band:
+        r = next(r for r in recs if r["stem"] == s)
+        expl = r["coverage"].get("explanation", "")
+        if c < COVERAGE_BAND[0]:  # below-band stays green only when sourced from audit alpha_frac
+            check("alpha_frac" in expl, f"below-band {s}: explanation cites audit alpha_frac data")
+
+    # --- 4. registration ------------------------------------------------------------
+    reg_bad = []
+    for r in recs:
+        reg = r["registration"]
+        if reg["outside_frac"] < REG_OUTSIDE_MAX and reg["variant_used"] == "identity":
+            continue  # clean pass, no flip
+        an = reg.get("anomaly")
+        if not an:  # any violation or flip must be documented as an anomaly with evidence
+            reg_bad.append((r["stem"], "violation/flip without anomaly record"))
+            continue
+        if reg["variant_used"] != "identity" and not an.get("decisive"):
+            reg_bad.append((r["stem"], f"non-decisive flip {reg['variant_used']} applied"))
+        if reg["variant_used"] == "identity" and "halo_identity" not in an:
+            reg_bad.append((r["stem"], "identity kept on violation without halo evidence"))
+    n_flip = sum(1 for r in recs if r["registration"]["variant_used"] != "identity")
+    n_halo = sum(1 for r in recs
+                 if r["registration"]["variant_used"] == "identity" and r["registration"].get("anomaly"))
+    print(f"        registration: {30 - n_flip - n_halo} clean, {n_flip} decisive flips, "
+          f"{n_halo} documented edge-halo violations")
+    check(not reg_bad,
+          f"registration: <3% outside-mask, or decisive documented flip, or documented halo (bad: {reg_bad})")
+
+    # --- previews exist for the gate's vision review --------------------------------
+    prevs = rep.get("previews", [])
+    pv_files_ok = all((ROOT / p["sbs"]).exists() and (ROOT / p["zoom"]).exists() for p in prevs)
+    kinds_cov = {p["kind"] for p in prevs}
+    check(len(prevs) >= 6 and pv_files_ok and kinds_cov == {"march", "may"},
+          f"6 preview pairs on disk incl. TIF- and JPG-source ({len(prevs)} listed, kinds {sorted(kinds_cov)})")
+
+    print("== M2.5:", "GREEN ==" if not FAIL else f"RED ({len(FAIL)} failures) ==")
+    return 0 if not FAIL else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/gate_m3.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/gate_m3.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Milestone M3 gate — unwrap core on the two pilot meshes (docs/QUALITY-GATES.md, M3 section)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PILOTS = {
+    "w030_2025122002": "A",
+    "w011_20260108140509268_merged_00": "B",
+}
+FAIL: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    print(("  PASS  " if cond else "  FAIL  ") + msg)
+    if not cond:
+        FAIL.append(msg)
+
+
+def main() -> int:
+    print("== M3 gate ==")
+    for stem, group in PILOTS.items():
+        mp = ROOT / "outputs/anim" / stem / "metrics.json"
+        check(mp.exists(), f"{stem}: metrics.json exists")
+        if not mp.exists():
+            continue
+        m = json.loads(mp.read_text())
+        g = m["meta"]["gates"]
+        check(bool(g.get("pass")), f"{stem}: numeric transit gates pass "
+              f"(area_p95_vis {g.get('area_p95_vis_max'):.3f} ≤ {g.get('area_p95_gate'):.3f}, "
+              f"sd {g.get('sd_peak'):.3f}, flips {g.get('flipped_frac_max'):.2e}, "
+              f"axis={g.get('axis_mode')})")
+        emb = m["meta"]["embedding"]
+        check(emb["mirror_check"] > 0, f"{stem}: numeric mirror check positive")
+        check((ROOT / "outputs/anim" / stem / "frames.npz").exists(), f"{stem}: frames.npz exists")
+        check((ROOT / "outputs/anim" / stem / "keyframes/contact_sheet.jpg").exists(),
+              f"{stem}: keyframes rendered for visual QA")
+
+    # chirality gate = numeric mirror_check (checked above per mesh) + M1 render parity
+    # (texture correctness inherited by every frame); on-screen reading direction is an
+    # M4 camera rule informed by reports/m3_chirality.json (composition data, not a gate).
+    cp = ROOT / "reports/m3_chirality.json"
+    check(cp.exists(), "chirality screen-transform table exists (M4 camera input)")
+
+    print("== M3:", "GREEN ==" if not FAIL else f"RED ({len(FAIL)} failures) ==")
+    return 0 if not FAIL else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/gate_m4.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/gate_m4.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+"""M4 gate (qa-gates contract): pilots x {plain,ink,reveal} x {h,v}.
+
+Green (exit 0) iff:
+  - all 12 pilot videos exist as 4K masters AND 1080p derivatives (24 files) and
+    every file passes ffprobe checks: 30 fps, yuv420p, correct resolution,
+    frame count per spec (240 morph / 330 reveal), bt709, +faststart;
+  - 5 QA keyframes per video exist under reports/m4_keyframes/<stem>_<variant>_<framing>/
+    (6 for reveal: + kf_reveal_mid.png), committed copies <= 1280 px;
+  - reports/m4_pilot_review.md records TWO consecutive PASSING vision-rubric
+    rounds (machine-readable ROUND_RESULT lines: all dimensions >= 4/5, zero
+    artifact flags, all 12 videos covered).
+
+Usage: uv run python scripts/gate_m4.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import yaml  # noqa: E402
+from PIL import Image  # noqa: E402
+
+from scrollkit.render.encode import ffprobe_check  # noqa: E402
+
+PILOTS = [
+    ("w030_2025122002", "A"),
+    ("w011_20260108140509268_merged_00", "B"),
+]
+VARIANTS = ("plain", "ink", "reveal")
+FRAMINGS = ("h", "v")
+
+
+def main() -> int:
+    cfg = yaml.safe_load((ROOT / "configs/global.yaml").read_text())
+    fdims = cfg["render"]["framings"]
+    vcfg = cfg["variants"]
+    morph_frames = int(cfg["unwrap"]["frames"])
+    reveal_frames = morph_frames + int(vcfg["reveal_hold_in"]) + int(vcfg["reveal_fade"]) \
+        + int(vcfg["reveal_hold_out"])
+
+    failures: list[str] = []
+    ok_count = 0
+    print(f"{'video':<58} {'4k':>14} {'1080p':>14}")
+
+    # ---- 1) encodes: 12 videos x (4K master + 1080p derivative) ----------------------
+    for stem, _group in PILOTS:
+        vdir = ROOT / "outputs/anim" / stem / "video"
+        for variant in VARIANTS:
+            frames = reveal_frames if variant == "reveal" else morph_frames
+            for framing in FRAMINGS:
+                fkey = "horizontal" if framing == "h" else "vertical"
+                w4, h4 = int(fdims[fkey]["width"]), int(fdims[fkey]["height"])
+                w1, h1 = (1920, 1080) if framing == "h" else (1080, 1920)
+                row = []
+                for res, (w, h) in (("4k", (w4, h4)), ("1080p", (w1, h1))):
+                    path = vdir / f"{stem}_{variant}_{framing}_{res}.mp4"
+                    try:
+                        if not path.is_file():
+                            raise RuntimeError("missing")
+                        st = ffprobe_check(path, width=w, height=h, frames=frames)
+                        row.append(f"{st['file_size'] / 2**20:7.1f} MB ok")
+                        ok_count += 1
+                    except Exception as exc:  # noqa: BLE001
+                        failures.append(f"{path.name}: {exc}")
+                        row.append("FAIL")
+                print(f"{stem[:30] + '_' + variant + '_' + framing:<58} {row[0]:>14} {row[1]:>14}")
+
+    # ---- 2) QA keyframes ---------------------------------------------------------------
+    for stem, _group in PILOTS:
+        for variant in VARIANTS:
+            for framing in FRAMINGS:
+                kdir = ROOT / "reports/m4_keyframes" / f"{stem}_{variant}_{framing}"
+                expected = {f"kf_t{t:.2f}.png" for t in (0.0, 0.25, 0.5, 0.75, 1.0)}
+                if variant == "reveal":
+                    expected.add("kf_reveal_mid.png")
+                have = {p.name for p in kdir.glob("*.png")} if kdir.is_dir() else set()
+                missing = expected - have
+                if missing:
+                    failures.append(f"keyframes {kdir.name}: missing {sorted(missing)}")
+                    continue
+                for name in expected:
+                    with Image.open(kdir / name) as im:
+                        if max(im.size) > 1280:
+                            failures.append(f"keyframe {kdir.name}/{name}: {im.size} > 1280px")
+
+    # ---- 3) vision review: two consecutive passing rounds -----------------------------
+    review = ROOT / "reports/m4_pilot_review.md"
+    if not review.is_file():
+        failures.append("reports/m4_pilot_review.md missing")
+    else:
+        rounds = []
+        for line in review.read_text().splitlines():
+            m = re.match(r"^ROUND_RESULT:\s*(\{.*\})\s*$", line.strip())
+            if m:
+                rounds.append(json.loads(m.group(1)))
+        if len(rounds) < 2:
+            failures.append(f"review: need >= 2 rubric rounds, found {len(rounds)}")
+        else:
+            for r in rounds[-2:]:
+                label = f"round {r.get('round')}"
+                if not r.get("pass"):
+                    failures.append(f"review {label}: pass != true")
+                if int(r.get("videos", 0)) != len(PILOTS) * len(VARIANTS) * len(FRAMINGS):
+                    failures.append(f"review {label}: covers {r.get('videos')} videos, need 12")
+                if float(r.get("min_score", 0)) < 4:
+                    failures.append(f"review {label}: min_score {r.get('min_score')} < 4")
+                if int(r.get("artifact_flags", 1)) != 0:
+                    failures.append(f"review {label}: artifact_flags {r.get('artifact_flags')} != 0")
+            if not failures:
+                print(f"review: rounds {rounds[-2]['round']} and {rounds[-1]['round']} "
+                      f"both PASS (min_score >= 4, zero artifact flags)")
+
+    print(f"\nencodes ok: {ok_count}/24")
+    if failures:
+        print("\nM4 GATE: RED")
+        for f in failures:
+            print("  -", f)
+        return 1
+    print("M4 GATE: GREEN")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/gate_m5.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/gate_m5.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""Milestone M5 gate — fleet production (docs/QUALITY-GATES.md, M5 section)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+import yaml  # noqa: E402
+
+from produce import FRAMINGS, VARIANTS, load_plan  # noqa: E402
+
+_VCFG = yaml.safe_load((Path(__file__).resolve().parent.parent / "configs/global.yaml")
+                       .read_text())["variants"]
+REVEAL_FRAMES = (240 + int(_VCFG["reveal_hold_in"]) + int(_VCFG["reveal_fade"])
+                 + int(_VCFG["reveal_hold_out"]) + int(_VCFG.get("reveal_zoom_hold", 0)))
+
+FAIL: list[str] = []
+WAIVED: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        FAIL.append(msg)
+        print("  FAIL  " + msg)
+
+
+def ffprobe(path: Path) -> dict:
+    r = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries",
+         "stream=width,height,r_frame_rate,pix_fmt,nb_frames", "-of", "json", str(path)],
+        capture_output=True, text=True)
+    if r.returncode != 0:
+        return {}
+    s = json.loads(r.stdout)["streams"][0]
+    return s
+
+
+def main() -> int:
+    rows = load_plan()
+    exceptions = {}
+    exc_p = ROOT / "reports/m5_unwrap_exceptions.json"
+    if exc_p.exists():
+        exceptions = json.loads(exc_p.read_text())
+
+    n_anim = n_videos = 0
+    for r in rows:
+        stem = r["stem"]
+        adir = ROOT / "outputs/anim" / stem
+        mp = adir / "metrics.json"
+        check(mp.exists(), f"{stem}: metrics.json")
+        if mp.exists():
+            g = json.loads(mp.read_text())["meta"]["gates"]
+            if g.get("pass"):
+                n_anim += 1
+            elif stem in exceptions and exceptions[stem].get("verdict") == "waived_visually_clean":
+                WAIVED.append(stem)
+                n_anim += 1
+            else:
+                check(False, f"{stem}: transit gates fail and no approved waiver")
+            # clearance certificate is never waivable (pierce-through/z-fight class)
+            check(g.get("clearance_ok") is True,
+                  f"{stem}: clearance certificate (worst margin "
+                  f"{g.get('clearance_worst_margin')} at frame {g.get('clearance_worst_frame')})")
+        # era consistency: every derived artifact must be NEWER than its trajectory,
+        # so videos rendered from an older code revision can never ship silently
+        # after a partial batch relaunch.
+        fnpz = adir / "frames.npz"
+        check(fnpz.exists(), f"{stem}: frames.npz")
+        if fnpz.exists():
+            t_frames = fnpz.stat().st_mtime
+            for vid in sorted((adir / "video").glob("*.mp4")) if (adir / "video").exists() else []:
+                check(vid.stat().st_mtime > t_frames,
+                      f"{stem}: {vid.name} older than frames.npz (stale code-era video)")
+        # frame OBJs
+        fdir = adir / "frames_obj/plain"
+        objs = list(fdir.glob("frame_*.obj")) if fdir.exists() else []
+        check(len(objs) == 240, f"{stem}: 240 plain frame OBJs (got {len(objs)})")
+        check((fdir / "mesh.mtl").exists(), f"{stem}: plain MTL")
+        if r["overlay"]:
+            idir = adir / "frames_obj/ink"
+            iobjs = list(idir.glob("frame_*.obj")) if idir.exists() else []
+            check(len(iobjs) == 240, f"{stem}: 240 ink frame OBJs (got {len(iobjs)})")
+            mtl = (idir / "mesh.mtl").read_text() if (idir / "mesh.mtl").exists() else ""
+            check("ink_recto" in mtl and "plain_verso" in mtl and mtl.count("map_Kd") == 2,
+                  f"{stem}: ink MTL is a two-sided shell (recto ink / verso plain)")
+            if iobjs:
+                head = iobjs[0].read_text().split("\n", 2)[0]
+                check("shell" in head, f"{stem}: ink frame OBJs are shell exports")
+        # videos
+        variants = [v for v in VARIANTS if v == "plain" or r["overlay"]]
+        for variant in variants:
+            for framing in FRAMINGS:
+                n_expected = REVEAL_FRAMES if variant == "reveal" else 240
+                dims = {("h", "4k"): (3840, 2160), ("h", "1080p"): (1920, 1080),
+                        ("v", "4k"): (2160, 3840), ("v", "1080p"): (1080, 1920)}
+                for res in ("4k", "1080p"):
+                    w, h = dims[(framing, res)]
+                    vid = adir / "video" / f"{stem}_{variant}_{framing}_{res}.mp4"
+                    if not vid.exists():
+                        check(False, f"{stem}: missing video {vid.name}")
+                        continue
+                    s = ffprobe(vid)
+                    ok = (s.get("pix_fmt") == "yuv420p"
+                          and s.get("r_frame_rate") == "30/1"
+                          and int(s.get("nb_frames", 0)) == n_expected
+                          and (int(s.get("width", 0)), int(s.get("height", 0))) == (w, h))
+                    check(ok, f"{stem}: ffprobe {vid.name} (got {s.get('width')}x{s.get('height')} "
+                              f"{s.get('pix_fmt')} {s.get('r_frame_rate')} {s.get('nb_frames')}f, "
+                              f"want {w}x{h} {n_expected}f)")
+                    n_videos += 1
+    # vision verdicts
+    vq = ROOT / "reports/m5_vision_qa.json"
+    check(vq.exists(), "vision QA verdicts exist (reports/m5_vision_qa.json)")
+    if vq.exists():
+        v = json.loads(vq.read_text())
+        bad = [k for k, r2 in v.get("verdicts", {}).items() if not r2.get("pass")]
+        check(not bad, f"vision QA pass for all mesh×variant (failing: {bad[:8]})")
+    check((ROOT / "reports/production_report.md").exists(), "production report exists")
+
+    print(f"== M5 summary: {n_anim}/{len(rows)} animations green "
+          f"({len(WAIVED)} visually-waived: {WAIVED}), {n_videos} videos checked ==")
+    print("== M5:", "GREEN ==" if not FAIL else f"RED ({len(FAIL)} failures) ==")
+    return 0 if not FAIL else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/make_production_report.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/make_production_report.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""Assemble reports/production_report.md from all M5 evidence on disk."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+from produce import FRAMINGS, VARIANTS, load_plan  # noqa: E402
+
+
+def main() -> int:
+    rows = load_plan()
+    exc = {}
+    p = ROOT / "reports/m5_unwrap_exceptions.json"
+    if p.exists():
+        exc = json.loads(p.read_text())
+    vq = {}
+    p = ROOT / "reports/m5_vision_qa.json"
+    if p.exists():
+        vq = json.loads(p.read_text()).get("verdicts", {})
+    m2 = {m["stem"]: m for m in json.loads((ROOT / "reports/m2_decimation.json").read_text())["meshes"]}
+    infill = json.loads((ROOT / "outputs/render_textures/infill_stats.json").read_text())
+
+    lines = ["# Production report — scroll unwrap fleet\n",
+             f"Generated {time.strftime('%Y-%m-%d %H:%M')}\n",
+             "\n## Per-mesh summary\n",
+             "| mesh | grp | faces (dec) | keep | axis | anim gates | infill | videos | vision |",
+             "|---|---|---|---|---|---|---|---|---|"]
+    n_vid_total = 0
+    disk_video = 0
+    for r in rows:
+        stem = r["stem"]
+        mp = ROOT / "outputs/anim" / stem / "metrics.json"
+        g = json.loads(mp.read_text())["meta"]["gates"] if mp.exists() else {}
+        anim = "PASS" if g.get("pass") else ("WAIVED" if exc.get(stem, {}).get("verdict") == "waived_visually_clean" else "FAIL")
+        vids = list((ROOT / "outputs/anim" / stem / "video").glob("*.mp4"))
+        n_vid_total += len(vids)
+        disk_video += sum(v.stat().st_size for v in vids)
+        inf = (infill.get(stem) or {}).get("plain") or {}
+        vq_cell = ",".join(sorted({v.get("verdict", "?") for k, v in vq.items() if k.startswith(stem)})) or "—"
+        dec = m2.get(stem, {})
+        lines.append(
+            f"| {stem} | {r['group']} | {dec.get('faces_out', '—')} | {dec.get('rung_chosen', '—')} "
+            f"| {g.get('axis_mode', '—')} | {anim} (sd {g.get('sd_peak', 0):.2f}, "
+            f"a95v {g.get('area_p95_vis_max', 0):.3f}/{g.get('area_p95_gate', 0):.3f}) "
+            f"| {inf.get('filled_frac_of_papyrus', 0) * 100:.0f}% | {len(vids)} | {vq_cell} |")
+
+    lines += [
+        "\n## Fleet accounting\n",
+        f"- wraps animated: {len(rows)} (videos on disk: {n_vid_total}, {disk_video / 2**30:.1f} GiB)",
+        f"- frame-OBJ exports: {sum(1 for r in rows if (ROOT / 'outputs/anim' / r['stem'] / 'frames_obj/plain').exists())} meshes × 240 frames (+ hardlinked ink sets)",
+        f"- unwrap exceptions (vision-disposition): {[k for k in exc]}",
+        "\n## Decisions of record\n",
+        "- Ink: neutral carbon black #101010, recto-(inner-face)-only via two-sided materials.",
+        "- Text rows horizontal in every framing; 9:16 fits by pull-back; reveal = camera push-in then ink fade.",
+        "- Render textures: small interior alpha dropout infilled; large genuine lacunae preserved.",
+        "- Full gate definitions: docs/QUALITY-GATES.md.",
+    ]
+    out = ROOT / "reports/production_report.md"
+    out.write_text("\n".join(lines) + "\n")
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/make_render_textures.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/make_render_textures.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Generate presentation (render) textures: small interior alpha holes infilled with
+locally-matched papyrus (compositing dropout, not physical lacunae);
+large genuine lacunae keep their cutout. Applies identically to the plain composite and
+the black-ink overlay so the reveal endpoints stay aligned.
+
+Outputs: outputs/render_textures/<stem>_plain.png and <stem>_ink.png (+ preview pairs in
+reports/infill_previews/ for the requested meshes). Originals are never modified.
+
+Usage: uv run python scripts/make_render_textures.py [--only stem ...] [--previews stem ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from PIL import Image  # noqa: E402
+
+from scrollkit.ink.infill import build_render_texture  # noqa: E402
+
+Image.MAX_IMAGE_PIXELS = None
+
+
+def wrap_rows() -> list[dict]:
+    audit = json.loads((ROOT / "reports/audit.json").read_text())
+    rows = []
+    for m in audit["meshes"]:
+        if m["group"] not in ("A", "B"):
+            continue
+        tex = next((t for t in m["textures"] if t.get("exists")), None)
+        src_dir = (ROOT / m["path"]).parent
+        rows.append({
+            "stem": m["stem"], "group": m["group"],
+            "plain": src_dir / tex["name"],
+            "ink": ROOT / "outputs/overlays" / ("march" if m["group"] == "A" else "may")
+                   / f"{m['stem']}_inkoverlay.png",
+        })
+    return rows
+
+
+def process(path: Path, out: Path) -> dict | None:
+    if not path.exists():
+        return None
+    rgba = np.asarray(Image.open(path).convert("RGBA"))
+    filled, info = build_render_texture(rgba)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(filled).save(out, compress_level=6)
+    return {k: v for k, v in info.items() if k != "fill_mask"}
+
+
+def preview(before: Path, after: Path, dst: Path) -> None:
+    a = Image.open(before).convert("RGBA")
+    b = Image.open(after).convert("RGBA")
+    w = 900
+    bg = (16, 17, 20, 255)
+    tiles = []
+    for im in (a, b):
+        im = im.resize((w, int(im.height * w / im.width)), Image.LANCZOS)
+        canvas = Image.new("RGBA", im.size, bg)
+        canvas.alpha_composite(im)
+        tiles.append(canvas.convert("RGB"))
+    sheet = Image.new("RGB", (2 * w + 8, tiles[0].height), (40, 40, 40))
+    sheet.paste(tiles[0], (0, 0))
+    sheet.paste(tiles[1], (w + 8, 0))
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(dst, quality=88)
+
+
+def one_mesh(r: dict, previews: list[str]) -> tuple[str, dict]:
+    out_dir = ROOT / "outputs/render_textures"
+    rec = {}
+    for kind in ("plain", "ink"):
+        dst = out_dir / f"{r['stem']}_{kind}.png"
+        info = process(Path(r[kind]), dst)
+        rec[kind] = info
+        if r["stem"] in previews and kind == "plain" and info:
+            preview(Path(r[kind]), dst, ROOT / "reports/infill_previews" / f"{r['stem']}_plain.jpg")
+    return r["stem"], rec
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--only", nargs="*", default=None)
+    ap.add_argument("--previews", nargs="*", default=[])
+    ap.add_argument("--workers", type=int, default=8)
+    args = ap.parse_args()
+
+    rows = wrap_rows()
+    if args.only:
+        rows = [r for r in rows if r["stem"] in set(args.only)]
+    out_dir = ROOT / "outputs/render_textures"
+    stats = {}
+    t0 = time.time()
+
+    from concurrent.futures import ProcessPoolExecutor, as_completed
+    with ProcessPoolExecutor(max_workers=args.workers) as ex:
+        futs = {ex.submit(one_mesh, {**r, "plain": str(r["plain"]), "ink": str(r["ink"])},
+                          list(args.previews)): r["stem"] for r in rows}
+        for fut in as_completed(futs):
+            stem, rec = fut.result()
+            stats[stem] = rec
+            p = rec.get("plain") or {}
+            print(f"[{stem}] filled {p.get('n_filled_components')} comps "
+                  f"({(p.get('filled_frac_of_papyrus') or 0) * 100:.1f}%), "
+                  f"kept {p.get('n_kept_lacunae')} lacunae", flush=True)
+    if (out_dir / "infill_stats.json").exists():
+        old = json.loads((out_dir / "infill_stats.json").read_text())
+        old.update(stats)
+        stats = old
+    (out_dir / "infill_stats.json").write_text(json.dumps(stats, indent=1))
+    print(f"done {len(rows)} meshes in {time.time() - t0:.0f}s -> {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/produce.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/produce.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python
+"""M5 batch driver: animate + export + render + verify all 31 wraps × 3 variants.
+
+Stages per mesh (manifest-cached in outputs/anim/<stem>/produce_state.json):
+  1. animate   — unwrap the DECIMATED mesh (auto axis mode, gates) -> frames.npz + metrics
+  2. frames    — per-frame OBJ export (plain + hardlinked ink variant)
+  3. videos    — render_video.py per variant × framing (4K masters + 1080p derivatives)
+  4. verify    — ffprobe + manifest assembly
+
+CPU stages (1,2) run in a small process pool; GPU stage (3) is strictly serial.
+Usage: uv run python scripts/produce.py [--only stem ...] [--stage all|animate|frames|videos]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+VARIANTS = ("plain", "ink", "reveal")
+FRAMINGS = ("h", "v")
+
+# Bump on any kinematics/renderer change that must invalidate every cached stage —
+# stage caches are keyed on CODE_REV + input-file signatures so outputs from
+# different code revisions can never silently coexist.
+CODE_REV = "r11-final"
+
+
+def fsig(p: str | Path) -> str:
+    st = Path(p).stat()
+    return f"{st.st_mtime_ns}:{st.st_size}"
+
+
+def load_plan() -> list[dict]:
+    """One production row per wrap mesh, joining M2 (decimated source) and M2.5 (overlay)."""
+    m2 = json.loads((ROOT / "reports/m2_decimation.json").read_text())["meshes"]
+    if isinstance(m2, dict):
+        m2 = list(m2.values())
+    ink = json.loads((ROOT / "reports/m25_ink.json").read_text())
+    overlays = {}
+    for rec in ink["records"]:
+        out = (rec.get("output") or {}).get("path")
+        if out and (ROOT / out).exists():
+            overlays[rec["stem"]] = out
+    rows = []
+    for rec in m2:
+        if rec["group"] not in ("A", "B"):
+            continue
+        stem = rec["stem"]
+        obj = rec["obj"]
+        rt_plain = ROOT / "outputs/render_textures" / f"{stem}_plain.png"
+        rt_ink = ROOT / "outputs/render_textures" / f"{stem}_ink.png"
+        rows.append({
+            "stem": stem,
+            "group": rec["group"],
+            "decimated_obj": str(obj),
+            # presentation textures (infilled) preferred for frame exports + videos
+            "texture": str(rt_plain) if rt_plain.exists()
+                       else (str(Path(rec["obj"]).parent / rec["texture"]) if rec.get("texture") else None),
+            "overlay": str(rt_ink) if rt_ink.exists() else overlays.get(stem),
+        })
+    return rows
+
+
+def state_path(stem: str) -> Path:
+    return ROOT / "outputs/anim" / stem / "produce_state.json"
+
+
+def get_state(stem: str) -> dict:
+    p = state_path(stem)
+    return json.loads(p.read_text()) if p.exists() else {}
+
+
+def set_state(stem: str, **kv) -> None:
+    p = state_path(stem)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    s = get_state(stem)
+    s.update(kv)
+    p.write_text(json.dumps(s, indent=1))
+
+
+def run(cmd: list[str]) -> tuple[int, str]:
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    return r.returncode, (r.stdout + r.stderr)[-4000:]
+
+
+ANIMATE_OVERRIDES = {
+    # auto_trace: junk-heavy bands need a smoother rigid field (passes at sigma=45)
+    "auto_trace_20260121115644348_4": ["--roll-smooth", "45"],
+}
+
+
+def stage_animate(row: dict) -> tuple[str, bool, str]:
+    stem = row["stem"]
+    insig = f"{CODE_REV}|{fsig(ROOT / row['decimated_obj'])}"
+    st = get_state(stem)
+    if st.get("animate") == "ok" and st.get("animate_sig") == insig:
+        return stem, True, "cached"
+    rc, log = run(["uv", "run", "python", "scripts/animate.py", row["decimated_obj"],
+                   *ANIMATE_OVERRIDES.get(stem, [])])
+    ok = rc == 0
+    set_state(stem, animate="ok" if ok else "FAIL", animate_sig=insig if ok else "",
+              animate_log=log[-1500:] if not ok else "")
+    return stem, ok, "" if ok else log[-400:]
+
+
+def stage_frames(row: dict) -> tuple[str, bool, str]:
+    stem = row["stem"]
+    frames_npz = ROOT / "outputs/anim" / stem / "frames.npz"
+    if not frames_npz.exists():
+        return stem, False, "frames.npz missing (animate stage incomplete)"
+    insig = f"{CODE_REV}|{fsig(frames_npz)}|{fsig(ROOT / row['texture'])}" + (
+        f"|{fsig(ROOT / row['overlay'])}" if row["overlay"] else "")
+    st = get_state(stem)
+    if st.get("frames") == "ok" and st.get("frames_sig") == insig:
+        return stem, True, "cached"
+    cmd = ["uv", "run", "python", "scripts/export_frames.py", f"outputs/anim/{stem}",
+           "--texture", row["texture"]]
+    if row["overlay"]:
+        cmd += ["--overlay", row["overlay"]]
+    rc, log = run(cmd)
+    ok = rc == 0
+    set_state(stem, frames="ok" if ok else "FAIL", frames_sig=insig if ok else "",
+              frames_log="" if ok else log[-1500:])
+    return stem, ok, "" if ok else log[-400:]
+
+
+def stage_videos(row: dict) -> tuple[str, bool, str]:
+    stem = row["stem"]
+    frames_npz = ROOT / "outputs/anim" / stem / "frames.npz"
+    if not frames_npz.exists():
+        return stem, False, "frames.npz missing (animate stage incomplete)"
+    insig = f"{CODE_REV}|{fsig(frames_npz)}|{fsig(ROOT / row['texture'])}" + (
+        f"|{fsig(ROOT / row['overlay'])}" if row["overlay"] else "")
+    st = get_state(stem)
+    variants = [v for v in VARIANTS if v == "plain" or row["overlay"]]
+    fails = []
+    for variant in variants:
+        for framing in FRAMINGS:
+            key = f"video_{variant}_{framing}"
+            if st.get(key) == "ok" and st.get(f"{key}_sig") == insig:
+                continue
+            cmd = ["uv", "run", "python", "scripts/render_video.py", f"outputs/anim/{stem}",
+                   row["group"], "--variant", variant, "--framing", framing]
+            rc, log = run(cmd)
+            ok = rc == 0
+            set_state(stem, **{key: "ok" if ok else "FAIL",
+                               f"{key}_sig": insig if ok else ""})
+            st = get_state(stem)
+            if not ok:
+                fails.append(f"{key}: {log[-300:]}")
+                break  # plain failure blocks reveal (rawcache); stop this mesh
+        if fails:
+            break
+    return stem, not fails, "; ".join(fails)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--only", nargs="*", default=None)
+    ap.add_argument("--stage", default="all", choices=["all", "animate", "frames", "videos"])
+    ap.add_argument("--clean", action="store_true",
+                    help="delete every derived per-mesh artifact (videos, frame OBJs, "
+                         "rawcaches, camera plans, produce_state) before running — the "
+                         "only safe way to purge mixed-code-era outputs")
+    ap.add_argument("--cpu-workers", type=int, default=8)
+    ap.add_argument("--gpu-workers", type=int, default=3,
+                    help="concurrent video jobs (each = one EGL context + one x264-slow "
+                         "encoder; the encoder is the bottleneck, the 4090 multiplexes fine)")
+    args = ap.parse_args()
+
+    rows = load_plan()
+    if args.only:
+        rows = [r for r in rows if r["stem"] in set(args.only)]
+    print(f"production plan: {len(rows)} wraps "
+          f"({sum(1 for r in rows if r['overlay'])} with ink variants)")
+
+    if args.clean:
+        for r in rows:
+            d = ROOT / "outputs/anim" / r["stem"]
+            if not d.exists():
+                continue
+            for sub in ("video", "frames_obj", "keyframes_m4"):
+                if (d / sub).exists():
+                    shutil.rmtree(d / sub)
+            for pat in ("produce_state.json", "rawcache_*.json", "rawcache_*.raw",
+                        "camera_plan_*.json", "up_choice*.json", "inkflat_*.npy"):
+                for f in d.glob(pat):
+                    f.unlink()
+        print(f"cleaned derived artifacts for {len(rows)} meshes")
+
+    failures: list[str] = []
+
+    def pooled(stage_fn, label):
+        nonlocal failures
+        todo = rows
+        with ProcessPoolExecutor(max_workers=args.cpu_workers) as ex:
+            futs = {ex.submit(stage_fn, r): r["stem"] for r in todo}
+            for fut in as_completed(futs):
+                stem, ok, msg = fut.result()
+                print(f"  [{label}] {stem}: {'ok' if ok else 'FAIL'} {msg}")
+                if not ok:
+                    failures.append(f"{label}:{stem}")
+
+    if args.stage in ("all", "animate"):
+        print("== stage 1: animate (CPU pool) ==")
+        pooled(stage_animate, "animate")
+    if args.stage in ("all", "frames"):
+        print("== stage 2: frame OBJ export (CPU pool) ==")
+        pooled(stage_frames, "frames")
+    if args.stage in ("all", "videos"):
+        print(f"== stage 3: videos ({args.gpu_workers} concurrent render+encode jobs) ==")
+        # one worker owns one MESH at a time (its variants chain through the rawcache);
+        # distinct meshes are fully independent.
+        with ProcessPoolExecutor(max_workers=args.gpu_workers) as ex:
+            futs = {ex.submit(stage_videos, r): r["stem"] for r in rows}
+            for fut in as_completed(futs):
+                stem, ok, msg = fut.result()
+                print(f"  [videos] {stem}: {'ok' if ok else 'FAIL'} {msg}", flush=True)
+                if not ok:
+                    failures.append(f"videos:{stem}")
+                free_gb = shutil.disk_usage(ROOT).free / 1e9
+                if free_gb < 60:
+                    print(f"!! low disk: {free_gb:.0f} GB free — cancelling remaining jobs")
+                    failures.append("disk")
+                    for f2 in futs:
+                        f2.cancel()
+                    break
+
+    print(f"== production: {'GREEN' if not failures else 'RED'} ({len(failures)} failures) ==")
+    if failures:
+        print("failures:", failures)
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/render_keyframes.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/render_keyframes.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+"""Render keyframes of a computed unwrap trajectory (frames.npz) for visual QA.
+
+Usage: uv run python scripts/render_keyframes.py outputs/anim/<stem> <group> [--n 8]
+Writes outputs/anim/<stem>/keyframes/kf_<idx>_<t>.png plus a contact sheet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from PIL import Image  # noqa: E402
+
+from scrollkit.render.scene import SceneRenderer, auto_camera  # noqa: E402
+
+
+def find_texture(stem: str, group: str) -> Path:
+    base = ROOT / ("textured_plys/textured_ply_march" if group == "A" else "textured_plys/textured_ply_may")
+    cands = list(base.glob(f"{stem}*.png"))
+    if not cands:
+        raise FileNotFoundError(f"texture for {stem} in {base}")
+    return sorted(cands)[0]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("anim_dir")
+    ap.add_argument("group", choices=["A", "B"])
+    ap.add_argument("--n", type=int, default=8)
+    ap.add_argument("--size", type=int, default=1100)
+    ap.add_argument("--texture", default=None)
+    args = ap.parse_args()
+
+    adir = Path(args.anim_dir)
+    stem = adir.name
+    data = np.load(adir / "frames.npz")
+    frames, faces, uv, ts = data["frames"], data["faces"], data["uv"], data["t"]
+    tex = Path(args.texture) if args.texture else find_texture(stem, args.group)
+    orientation = json.loads((ROOT / "reports/audit.json").read_text())["tex_orientation"]
+    tex_or = orientation[args.group] if isinstance(orientation[args.group], str) else orientation[args.group]
+
+    # camera fixed over the whole trajectory union
+    union = frames.reshape(-1, 3)
+    cam = auto_camera(union, aspect=16 / 9, margin_frac=0.07)
+
+    out = adir / "keyframes"
+    out.mkdir(exist_ok=True)
+    idxs = np.unique(np.linspace(0, len(frames) - 1, args.n).astype(int))
+    sr = SceneRenderer(frames[0], faces, uv, tex, tex_or,
+                       size=(args.size, int(args.size * 9 / 16)), lighting="studio")
+    sr.set_camera(cam)
+    tiles = []
+    for i in idxs:
+        sr.update_points(frames[i])
+        img = sr.screenshot()
+        p = out / f"kf_{i:04d}_t{ts[i]:.3f}.png"
+        Image.fromarray(img).save(p)
+        tiles.append(img)
+        print("wrote", p)
+    rows = []
+    per_row = 4
+    for r in range(0, len(tiles), per_row):
+        row = tiles[r:r + per_row]
+        while len(row) < per_row:
+            row.append(np.zeros_like(tiles[0]))
+        rows.append(np.concatenate(row, axis=1))
+    sheet = np.concatenate(rows, axis=0)
+    sheet_img = Image.fromarray(sheet)
+    sheet_img.thumbnail((2200, 2200))
+    sheet_img.save(out / "contact_sheet.jpg", quality=88)
+    print("wrote", out / "contact_sheet.jpg")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/render_video.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/render_video.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python
+"""Render one M4 cinematic video (one mesh x variant x framing).
+
+Usage:
+  uv run python scripts/render_video.py <anim_dir> <group> --variant {plain,ink,reveal}
+      --framing {h,v} [--res {4k,1080p}] [--keep-rawcache]
+
+  --res 4k (default): 3840x2160 / 2160x3840 master piped raw-RGB24 into ffmpeg,
+      then a 1080p derivative DOWNSCALED from the master (lanczos). Production.
+  --res 1080p: native 1080p render under outputs/anim/<stem>/smoke/ — pipeline
+      smoke only, never a deliverable (deliverable 1080p files are derivatives).
+
+One persistent SceneRenderer per video (frames morph via update_points — actors
+are never rebuilt). GPU work is serial: the chirality probe (camera plan) closes
+before the main renderer opens. While piping the PLAIN variant the raw frames
+are also written to a rawcache so 'reveal' streams with zero GPU renders; the
+reveal run deletes the rawcache when done (--keep-rawcache to override).
+
+Camera plans are cached per framing (outputs/anim/<stem>/camera_plan_<framing>.json)
+so plain/ink/reveal share bit-identical cameras (the reveal crossfade is an exact
+image-space blend of static renders).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import yaml  # noqa: E402
+from PIL import Image  # noqa: E402
+
+from scrollkit.render.scene import SceneRenderer  # noqa: E402  (pins EGL env first)
+from scrollkit.render import cinematics  # noqa: E402
+from scrollkit.render.encode import FFmpegWriter, RawCache, ffprobe_check, make_derivative  # noqa: E402
+
+MIN_FREE_GB = 80
+MORPH_KEY_TS = (0.0, 0.25, 0.5, 0.75, 1.0)
+
+
+def find_texture(stem: str, group: str) -> Path:
+    # presentation texture (small dropout holes infilled) preferred for RENDERING;
+    # falls back to the raw composite. Metrics/IO always use originals.
+    rt = ROOT / "outputs/render_textures" / f"{stem}_plain.png"
+    if rt.is_file():
+        return rt
+    base = ROOT / ("textured_plys/textured_ply_march" if group == "A" else "textured_plys/textured_ply_may")
+    cands = sorted(base.glob(f"{stem}*.png"))
+    if not cands:
+        raise FileNotFoundError(f"composite texture for {stem} in {base}")
+    return cands[0]
+
+
+def find_ink_overlay(stem: str, group: str) -> Path:
+    rt = ROOT / "outputs/render_textures" / f"{stem}_ink.png"
+    if rt.is_file():
+        return rt
+    p = ROOT / "outputs/overlays" / ("march" if group == "A" else "may") / f"{stem}_inkoverlay.png"
+    if not p.is_file():
+        raise FileNotFoundError(f"ink overlay missing: {p}")
+    return p
+
+
+def texture_stats(texture_path) -> dict:
+    """Midtone/p95 of the plain composite within its alpha mask (0-1), for the
+    rig's exposure adaptation. Always computed from the PLAIN composite so the
+    plain and ink variants are lit identically (exact reveal crossfade)."""
+    with Image.open(texture_path) as im:
+        im = im.convert("RGBA")
+        im.thumbnail((1024, 1024))
+        a = np.asarray(im, dtype=np.float32)
+    L = a[..., :3].mean(-1) / 255.0
+    fg = L[a[..., 3] >= 128]
+    return {"p50": float(np.median(fg)), "p95": float(np.percentile(fg, 95))}
+
+
+def check_disk(where: str) -> None:
+    free_gb = shutil.disk_usage(ROOT).free / 2**30
+    if free_gb < MIN_FREE_GB:
+        raise RuntimeError(f"disk guard ({where}): only {free_gb:.1f} GB free (< {MIN_FREE_GB} GB)")
+
+
+def save_keyframe(img: np.ndarray, full_path: Path, report_path: Path | None) -> None:
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    im = Image.fromarray(img)
+    im.save(full_path)
+    if report_path is not None:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        small = im.copy()
+        small.thumbnail((1280, 1280), Image.LANCZOS)
+        small.save(report_path)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("anim_dir")
+    ap.add_argument("group", choices=["A", "B"])
+    ap.add_argument("--variant", required=True, choices=["plain", "ink", "reveal"])
+    ap.add_argument("--framing", required=True, choices=["h", "v"])
+    ap.add_argument("--res", default="4k", choices=["4k", "1080p"])
+    ap.add_argument("--keep-rawcache", action="store_true")
+    args = ap.parse_args()
+
+    t_start = time.time()
+    check_disk("start")
+    cfg = yaml.safe_load((ROOT / "configs/global.yaml").read_text())
+    rcfg, ecfg, vcfg = cfg["render"], cfg["encode"], cfg["variants"]
+    tex_orientation = json.loads((ROOT / "reports/audit.json").read_text())["tex_orientation"][args.group]
+
+    adir = Path(args.anim_dir).resolve()
+    stem = adir.name
+    data = np.load(adir / "frames.npz")
+    frames, faces, uv = data["frames"], data["faces"], data["uv"]
+    F = frames.shape[0]
+
+    smoke = args.res == "1080p"
+    fkey = "horizontal" if args.framing == "h" else "vertical"
+    fdim = rcfg["framings"][fkey]
+    if smoke:
+        W, H = (1920, 1080) if args.framing == "h" else (1080, 1920)
+        crf, level = ecfg["crf_1080"], "4.2"
+        out_dir = adir / "smoke"
+        master = out_dir / f"{stem}_{args.variant}_{args.framing}_1080p_native.mp4"
+        kf_dir = out_dir / f"keyframes_{args.variant}_{args.framing}"
+        report_kf_dir = None
+        cache_path = out_dir / f"rawcache_{args.framing}_smoke.raw"
+        inkflat_path = out_dir / f"inkflat_{args.framing}_smoke.npy"
+    else:
+        W, H = int(fdim["width"]), int(fdim["height"])
+        crf, level = ecfg["crf_4k"], "5.1"
+        out_dir = adir / "video"
+        master = out_dir / f"{stem}_{args.variant}_{args.framing}_4k.mp4"
+        kf_dir = adir / "keyframes_m4" / f"{args.variant}_{args.framing}"
+        report_kf_dir = ROOT / "reports/m4_keyframes" / f"{stem}_{args.variant}_{args.framing}"
+        cache_path = adir / f"rawcache_{args.framing}.raw"
+        inkflat_path = adir / f"inkflat_{args.framing}.npy"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    aspect = W / H
+
+    tex_plain = find_texture(stem, args.group)
+
+    # ---- camera plan (cached per framing; KEYED to the trajectory so a re-animated
+    # mesh can never reuse a camera computed for different geometry) ------------------
+    fz = (adir / "frames.npz").stat()
+    frames_sig = f"{fz.st_mtime_ns}:{fz.st_size}"
+    plan_path = adir / f"camera_plan_{args.framing}.json"
+    up_path = adir / "up_choice.json"
+    plan = None
+    if plan_path.is_file():
+        cand = json.loads(plan_path.read_text())
+        if cand.get("frames_sig") == frames_sig:
+            plan = cand
+        else:
+            plan_path.unlink()
+            if up_path.is_file() and json.loads(up_path.read_text()).get("frames_sig") != frames_sig:
+                up_path.unlink()
+    if plan is None:
+        up_choice = None
+        if up_path.is_file():
+            uc = json.loads(up_path.read_text())
+            up_choice = uc if uc.get("frames_sig") == frames_sig else None
+        plan = cinematics.plan_camera(
+            frames, faces, uv, aspect, args.group,
+            texture_path=tex_plain, tex_orientation=tex_orientation, up_choice=up_choice,
+            margin_frac=float(rcfg["margin_frac"]), push_in_frac=float(rcfg["push_in_frac"]),
+        )
+        plan["frames_sig"] = frames_sig
+        plan["up_choice"]["frames_sig"] = frames_sig
+        plan_path.write_text(json.dumps(plan, indent=1))
+        if not up_path.is_file():
+            up_path.write_text(json.dumps(plan["up_choice"], indent=1))
+        print(f"[plan] {args.framing}: up_choice={plan['up_choice']['best']} "
+              f"scores={ {k: round(v, 4) for k, v in plan['up_choice']['scores'].items()} } "
+              f"min_margin={plan['min_margin']:.4f}")
+    if abs(plan["aspect"] - aspect) > 1e-9 or len(plan["per_frame_scale"]) != F:
+        raise RuntimeError(f"cached plan {plan_path} does not match this run (aspect/frames)")
+    scales = np.asarray(plan["per_frame_scale"], dtype=np.float64)
+
+    kf_idx = [int(round(t * (F - 1))) for t in MORPH_KEY_TS]
+    mask = cinematics.vignette_mask(W, H)
+    hold_in, fade, hold_out = (int(vcfg["reveal_hold_in"]), int(vcfg["reveal_fade"]),
+                               int(vcfg["reveal_hold_out"]))
+    zoom_hold = int(vcfg.get("reveal_zoom_hold", 0))
+    zoom_factor = float(vcfg.get("reveal_zoom_factor", 1.05))
+    total_frames = (F if args.variant != "reveal"
+                    else F + hold_in + fade + hold_out + zoom_hold)
+    wm = cinematics.watermark_overlay(W, H)
+
+    run_info = {
+        "stem": stem, "group": args.group, "variant": args.variant, "framing": args.framing,
+        "res": args.res, "size": [W, H], "frames": total_frames, "crf": crf, "level": level,
+        "camera_plan": str(plan_path.relative_to(ROOT)),
+        "up_choice": plan["up_choice"]["best"], "min_margin": plan["min_margin"],
+    }
+
+    # ---- render or stream ------------------------------------------------------------
+    t_render0 = time.time()
+    if args.variant in ("plain", "ink"):
+        if args.variant == "plain":
+            tex_front, tex_back = tex_plain, None
+        else:
+            # physical ink: the overlay goes on the INNER face only; the outer face of the
+            # winding stays plain papyrus. SceneRenderer's texture_path binds to the
+            # +winding-normal side, so map via the geometric inner side.
+            ink_tex = find_ink_overlay(stem, args.group)
+            inner_sign = (plan.get("up_choice") or {}).get("inner_side", {}).get("inner_sign")
+            if inner_sign is None:
+                inner_sign = cinematics.inner_side_sign(frames[0], faces, uv)["inner_sign"]
+            if inner_sign > 0:
+                tex_front, tex_back = ink_tex, tex_plain
+            else:
+                tex_front, tex_back = tex_plain, ink_tex
+        run_info["texture"] = str(tex_front)
+        run_info["texture_back"] = str(tex_back) if tex_back else None
+        sr = SceneRenderer(frames[0], faces, uv, tex_front, tex_orientation,
+                           size=(W, H), background=cinematics.BACKGROUND_HEX, lighting="studio",
+                           back_texture_path=tex_back)
+        try:
+            sr.set_camera({k: plan[k] for k in ("position", "focal_point", "up", "parallel",
+                                                "parallel_scale")})
+            rig = cinematics.studio_lights(
+                sr, {"camera": plan, "bounds_lo": plan["bounds_lo"], "bounds_hi": plan["bounds_hi"],
+                     "texture_stats": texture_stats(tex_plain)})
+            run_info["rig"] = rig
+            cache = RawCache(cache_path, W, H) if args.variant == "plain" else None
+            with FFmpegWriter(master, W, H, crf=crf, level=level, preset=ecfg["preset"]) as wr:
+                for f in range(F):
+                    sr.update_points(frames[f])
+                    sr.plotter.camera.parallel_scale = float(scales[f])
+                    img = sr.screenshot()
+                    if img.shape != (H, W, 3):
+                        raise RuntimeError(f"render size {img.shape} != ({H},{W},3)")
+                    img = cinematics.apply_vignette(img, mask)
+                    img = cinematics.apply_watermark(img, wm)
+                    wr.write(img)
+                    if cache is not None:
+                        cache.append(img)
+                    if args.variant == "ink" and f == F - 1:
+                        np.save(inkflat_path, img)
+                    if f in kf_idx:
+                        t_lbl = MORPH_KEY_TS[kf_idx.index(f)]
+                        name = f"kf_t{t_lbl:.2f}.png"
+                        save_keyframe(img, kf_dir / name,
+                                      report_kf_dir / name if report_kf_dir else None)
+            if cache is not None:
+                cache.finalize({"variant": "plain", "framing": args.framing,
+                                "camera_plan": plan_path.name})
+        finally:
+            sr.close()
+    else:  # reveal: stream the plain rawcache + image-space crossfade tail (no GPU)
+        if not cache_path.is_file():
+            raise RuntimeError(f"reveal needs the plain rawcache — run --variant plain first ({cache_path})")
+        cache = RawCache.open(cache_path)
+        if (cache.width, cache.height, cache.n_frames) != (W, H, F):
+            raise RuntimeError(f"rawcache {cache_path} is {cache.width}x{cache.height}x{cache.n_frames}, "
+                               f"expected {W}x{H}x{F}")
+        # (the tight ink still is rendered fresh below — no inkflat dependency)
+        # Reveal tail with a REAL camera push-in onto the text (design rule: emphasize
+        # the inner-face reveal). Geometry is frozen flat, so the move is rendered fresh
+        # per frame at full sharpness; the crossfade then blends two stills at the TIGHT
+        # framing (still exact — camera frozen during the fade).
+        zoom_n = max(0, hold_in + fade + hold_out - 10 - 45 - 10)  # budget-neutral split
+        hold_in2, fade2, hold_out2 = 10, 45, 10
+        if zoom_n == 0:  # fall back to the configured split if budget too small
+            hold_in2, fade2, hold_out2, zoom_n = hold_in, fade, hold_out, 0
+
+        flatV = frames[-1]
+        tight = cinematics.tight_flat_camera(flatV, faces, uv, plan, margin_frac=0.10)
+        reveal_mid_global = F + zoom_n + hold_in2 + fade2 // 2
+        with FFmpegWriter(master, W, H, crf=crf, level=level, preset=ecfg["preset"]) as wr:
+            for f, img in enumerate(cache.iter_frames()):
+                wr.write(img)
+                if f in kf_idx:
+                    t_lbl = MORPH_KEY_TS[kf_idx.index(f)]
+                    name = f"kf_t{t_lbl:.2f}.png"
+                    save_keyframe(img, kf_dir / name,
+                                  report_kf_dir / name if report_kf_dir else None)
+            # camera move + stills on static geometry (two-sided: plain outer face)
+            ink_tex2 = find_ink_overlay(stem, args.group)
+            inner_sign2 = (plan.get("up_choice") or {}).get("inner_side", {}).get("inner_sign")
+            if inner_sign2 is None:
+                inner_sign2 = cinematics.inner_side_sign(frames[0], faces, uv)["inner_sign"]
+            ft2, bt2 = (ink_tex2, tex_plain) if inner_sign2 > 0 else (tex_plain, ink_tex2)
+            sr2 = SceneRenderer(flatV, faces, uv, tex_plain, tex_orientation, size=(W, H),
+                                background=cinematics.BACKGROUND_HEX, lighting="studio")
+            sr_ink = None
+            try:
+                cinematics.studio_lights(
+                    sr2, {"camera": plan, "bounds_lo": plan["bounds_lo"],
+                          "bounds_hi": plan["bounds_hi"], "texture_stats": texture_stats(tex_plain)})
+                base_cam = {k: plan[k] for k in ("position", "focal_point", "up", "parallel")}
+                base_cam["parallel_scale"] = float(scales[-1])
+                for i in range(zoom_n):  # quintic-eased push-in, plain texture
+                    s = (i + 1) / zoom_n
+                    e = s * s * s * (s * (6 * s - 15) + 10)
+                    cam = cinematics.lerp_camera(base_cam, tight, e)
+                    sr2.set_camera(cam)
+                    img = cinematics.apply_vignette(sr2.screenshot(), mask)
+                    wr.write(cinematics.apply_watermark(img, wm))
+                sr2.set_camera(tight)
+                plain_tight = cinematics.apply_vignette(sr2.screenshot(), mask)
+                sr_ink = SceneRenderer(flatV, faces, uv, ft2, tex_orientation, size=(W, H),
+                                       background=cinematics.BACKGROUND_HEX, lighting="studio",
+                                       back_texture_path=bt2)
+                cinematics.studio_lights(
+                    sr_ink, {"camera": plan, "bounds_lo": plan["bounds_lo"],
+                             "bounds_hi": plan["bounds_hi"], "texture_stats": texture_stats(tex_plain)})
+                sr_ink.set_camera(tight)
+                ink_tight = cinematics.apply_vignette(sr_ink.screenshot(), mask)
+            finally:
+                sr2.close()
+                if sr_ink is not None:
+                    sr_ink.close()
+            pf = plain_tight.astype(np.float32)
+            inf_ = ink_tight.astype(np.float32)
+            for i in range(hold_in2):
+                wr.write(cinematics.apply_watermark(plain_tight, wm))
+            for i in range(fade2):  # cosine ease, exact image-space blend (camera frozen)
+                a = 0.5 * (1.0 - np.cos(np.pi * (i + 1) / (fade2 + 1)))
+                img = np.clip(np.rint(pf * (1.0 - a) + inf_ * a), 0, 255).astype(np.uint8)
+                img = cinematics.apply_watermark(img, wm)
+                wr.write(img)
+                if F + zoom_n + hold_in2 + i == reveal_mid_global:
+                    save_keyframe(img, kf_dir / "kf_reveal_mid.png",
+                                  report_kf_dir / "kf_reveal_mid.png" if report_kf_dir else None)
+            for i in range(hold_out2):
+                wr.write(cinematics.apply_watermark(ink_tight, wm))
+            # post-reveal dwell: the ink stays on screen with a slow eased push-in
+            # (image-space zoom of the tight ink still; the watermark is composited
+            # AFTER the zoom so it stays pinned to the frame corner).
+            from PIL import Image as _Image
+            ink_im = _Image.fromarray(ink_tight)
+            for i in range(zoom_hold):
+                s = (i + 1) / max(zoom_hold, 1)
+                e = s * s * s * (s * (6 * s - 15) + 10)
+                z = 1.0 + (zoom_factor - 1.0) * e
+                cw, ch = int(round(W / z)), int(round(H / z))
+                x0, y0 = (W - cw) // 2, (H - ch) // 2
+                img = np.asarray(ink_im.crop((x0, y0, x0 + cw, y0 + ch))
+                                 .resize((W, H), _Image.LANCZOS))
+                img = cinematics.apply_watermark(img, wm)
+                wr.write(img)
+                if i == zoom_hold - 1:
+                    save_keyframe(img, kf_dir / "kf_reveal_end.png",
+                                  report_kf_dir / "kf_reveal_end.png" if report_kf_dir else None)
+    run_info["render_encode_s"] = round(time.time() - t_render0, 1)
+
+    # ---- self-checks + derivative ------------------------------------------------------
+    st = ffprobe_check(master, width=W, height=H, frames=total_frames)
+    run_info["master"] = {"path": str(master.relative_to(ROOT)), "size_mb": round(st["file_size"] / 2**20, 1)}
+    print(f"[ok] master {master.name}: {st['width']}x{st['height']} {st['nb_frames']}f "
+          f"{st['pix_fmt']} faststart={st['faststart']} {run_info['master']['size_mb']} MB")
+
+    if not smoke:
+        dw, dh = (1920, 1080) if args.framing == "h" else (1080, 1920)
+        deriv = out_dir / f"{stem}_{args.variant}_{args.framing}_1080p.mp4"
+        t0 = time.time()
+        make_derivative(master, deriv, dw, dh, crf=ecfg["crf_1080"], level="4.2",
+                        preset=ecfg["preset"])
+        std = ffprobe_check(deriv, width=dw, height=dh, frames=total_frames)
+        run_info["derivative"] = {"path": str(deriv.relative_to(ROOT)),
+                                  "size_mb": round(std["file_size"] / 2**20, 1),
+                                  "encode_s": round(time.time() - t0, 1)}
+        print(f"[ok] derivative {deriv.name}: {std['width']}x{std['height']} {std['nb_frames']}f "
+              f"faststart={std['faststart']} {run_info['derivative']['size_mb']} MB")
+
+    # ---- rawcache cleanup (reveal is the last consumer) -------------------------------
+    if args.variant == "reveal" and not args.keep_rawcache:
+        RawCache.open(cache_path).delete()
+        inkflat_path.unlink(missing_ok=True)
+        run_info["rawcache_deleted"] = True
+        print(f"[clean] deleted {cache_path.name} + {inkflat_path.name}")
+
+    run_info["total_s"] = round(time.time() - t_start, 1)
+    run_path = master.with_suffix(".run.json")
+    run_path.write_text(json.dumps(run_info, indent=1))
+    print(f"[done] {stem} {args.variant}/{args.framing}/{args.res} in {run_info['total_s']}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/scripts/verify_fleet_visuals.py
+++ b/foundation/scroll-unwrap-pipeline/scripts/verify_fleet_visuals.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""Post-fleet objective visual checks on rendered masters (no GPU needed).
+
+Per mesh (plain_h + ink_h 4K):
+  1. early-flicker: A->B->A texel-crawl metric over frames 0-70, left half
+     (regression guard for the nearest-sampling shimmer; bilinear should hold
+     totals < ~3000 px-windows vs ~23000 on the r7 baseline).
+  2. late-flicker: same metric over frames 110-215 full frame (z-fight /
+     layer-crossing guard; duplicated-patch hotspots measured 80k-120k).
+  3. watermark presence: bottom-right corner luminance signature on frame 10.
+
+Usage: uv run python scripts/verify_fleet_visuals.py <stem> [<stem> ...]
+Writes reports/fleet_visual_checks.json (merge per stem).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+EARLY_MAX = 4000      # px-window total, frames 0-70 left half (r7 baseline 23060)
+LATE_MAX = 25000      # px-window total, frames 110-215 (dup-patch era 86k-120k)
+
+
+def frames(path: Path, n0: int, n1: int, w: int, h: int) -> np.ndarray:
+    cmd = ["ffmpeg", "-loglevel", "error", "-i", str(path),
+           "-vf", f"select='gte(n\\,{n0})*lte(n\\,{n1})',scale={w}:{h}",
+           "-vsync", "0", "-f", "rawvideo", "-pix_fmt", "gray", "-"]
+    raw = subprocess.run(cmd, capture_output=True).stdout
+    return np.frombuffer(raw, np.uint8).reshape(-1, h, w).astype(np.int16)
+
+
+def flicker_total(F: np.ndarray, thresh: int = 40) -> int:
+    D1 = np.abs(F[1:-1] - F[:-2])
+    D2 = np.abs(F[2:] - F[1:-1])
+    D02 = np.abs(F[2:] - F[:-2])
+    fl = np.minimum(D1, D2) * (D02 < 0.3 * np.minimum(D1, D2))
+    return int((fl.reshape(len(fl), -1) > thresh).sum())
+
+
+def check_mesh(stem: str) -> dict:
+    vdir = ROOT / "outputs/anim" / stem / "video"
+    out: dict = {"stem": stem}
+    for variant in ("plain", "ink"):
+        p = vdir / f"{stem}_{variant}_h_4k.mp4"
+        if not p.exists():
+            out[variant] = {"missing": True}
+            continue
+        Fe = frames(p, 0, 70, 1920, 1080)[:, :, :960]
+        Fl = frames(p, 110, 215, 1920, 1080)
+        early = flicker_total(Fe)
+        late = flicker_total(Fl, 50)
+        f10 = frames(p, 10, 10, 1920, 1080)[0]
+        corner = f10[1020:1060, 1500:1900]
+        wm_present = bool(corner.max() > 90)
+        out[variant] = {"early_flicker": early, "early_ok": early <= EARLY_MAX,
+                        "late_flicker": late, "late_ok": late <= LATE_MAX,
+                        "watermark_present": wm_present}
+    return out
+
+
+def main() -> int:
+    stems = sys.argv[1:]
+    rp = ROOT / "reports/fleet_visual_checks.json"
+    acc = json.loads(rp.read_text()) if rp.exists() else {}
+    rc = 0
+    for stem in stems:
+        r = check_mesh(stem)
+        acc[stem] = r
+        ok = all(v.get("early_ok") and v.get("late_ok") and v.get("watermark_present")
+                 for k, v in r.items() if isinstance(v, dict) and not v.get("missing"))
+        print(f"{stem}: {json.dumps(r)}" )
+        if not ok:
+            rc = 1
+    rp.write_text(json.dumps(acc, indent=1))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/__init__.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/__init__.py
@@ -1,0 +1,3 @@
+"""scrollkit — exact IO, decimation, unwrap animation and rendering for Vesuvius scroll meshes."""
+
+__version__ = "0.1.0"

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/decimate/__init__.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/decimate/__init__.py
@@ -1,0 +1,44 @@
+"""M2 decimation: pymeshlab texture-aware quadric collapse (in-memory only) with
+geometry + perceptual (SSIM) QA gates. All file IO via scrollkit.io."""
+
+from .core import (
+    DECIMATION_FILTER,
+    DEFAULT_PARAMS,
+    GROUP_C_EXTENDED_LADDER,
+    NO_SAFE_DECIMATION_RATIONALE,
+    MeshDecimator,
+    ladder_for_group,
+    redecimate_at,
+    run_ladder,
+    ship_undecimated_copy,
+)
+from .metrics import (
+    edge_stats,
+    isolated_vertex_count,
+    mesh_stats,
+    repair_uv_flips,
+    uv_chart_count,
+    uv_orientation_counts,
+    uv_signed_areas,
+    wedge_to_vertex_uv_exact,
+)
+
+__all__ = [
+    "DECIMATION_FILTER",
+    "DEFAULT_PARAMS",
+    "GROUP_C_EXTENDED_LADDER",
+    "NO_SAFE_DECIMATION_RATIONALE",
+    "MeshDecimator",
+    "edge_stats",
+    "isolated_vertex_count",
+    "ladder_for_group",
+    "mesh_stats",
+    "redecimate_at",
+    "repair_uv_flips",
+    "run_ladder",
+    "ship_undecimated_copy",
+    "uv_chart_count",
+    "uv_orientation_counts",
+    "uv_signed_areas",
+    "wedge_to_vertex_uv_exact",
+]

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/decimate/core.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/decimate/core.py
@@ -1,0 +1,512 @@
+"""M2 decimation engine.
+
+Library policy (mesh-io-conventions, binding):
+  * pymeshlab is an IN-MEMORY ENGINE ONLY. The source PLY is loaded into pymeshlab
+    (VCG reference loader), cross-checked against scrollkit.io.read_ply (vertex/face
+    counts identical, max-abs float32 vertex diff == 0, wedge texcoords present and
+    bit-equal), the texture-aware quadric collapse runs, and the result is EXTRACTED
+    as numpy arrays. pymeshlab never writes a file.
+  * All disk IO goes through scrollkit.io (write_obj/copy_texture).
+
+Filter used (pymeshlab 2025.7): meshing_decimation_quadric_edge_collapse_with_texture
+with parameters targetperc / qualitythr / extratcoordw / preserveboundary /
+boundaryweight / optimalplacement / preservenormal (names verified against the
+installed wheel via pymeshlab.print_filter_parameter_list).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+
+from scrollkit.io import MeshData, ObjFrameWriter, copy_texture, read_obj, read_ply, write_obj
+
+from . import metrics
+
+DECIMATION_FILTER = "meshing_decimation_quadric_edge_collapse_with_texture"
+HAUSDORFF_SAMPLE_CAP = 500_000
+
+# Group C (full-scroll photogrammetry) keep-ladder extension — policy
+# Policy: decimate aggressively ONLY when visuals are unaffected.
+# Those models are already coarse relative to their 4-8K textures: collapses move
+# close-up texture by pixels, so the pinned ladder max (0.35) fails the close-up SSIM
+# gate. C walks these extra conservative rungs before giving up on decimation.
+GROUP_C_EXTENDED_LADDER = [0.50, 0.65, 0.80]
+
+# Recorded verbatim (pinned) on every no_safe_decimation decision.
+NO_SAFE_DECIMATION_RATIONALE = (
+    "model is not oversampled relative to its texture; any reduction is perceptually "
+    "lossy; quality dominates"
+)
+
+
+def ladder_for_group(cfg: dict, group: str) -> list[float]:
+    """Keep-ladder for one mesh group: the pinned configs/global.yaml ladder, plus the
+    GROUP_C_EXTENDED_LADDER rungs for Group C only (see constant note above)."""
+    ladder = [float(x) for x in cfg.get("keep_ladder", [0.05, 0.08, 0.12, 0.20, 0.35])]
+    if group == "C":
+        ladder += [float(x) for x in GROUP_C_EXTENDED_LADDER]
+    return ladder
+
+DEFAULT_PARAMS = {
+    "qualitythr": 0.5,
+    "preserveboundary": True,
+    "boundaryweight": 1.0,
+    "extratcoordw": 1.0,
+    "optimalplacement": True,
+    "preservenormal": True,
+    # Not pinned by configs/global.yaml; VCG quality option adding a planar-fitting
+    # term to the quadric. Tried (recorded per attempt) for meshes failing perceptual
+    # gates at the ladder top before escalating.
+    "planarquadric": False,
+}
+
+UV_GATE_KEYS = ("uv_flips", "uv_charts")  # failures that justify the extratcoordw=3 retry
+
+
+def _normalize_rows(a: np.ndarray) -> np.ndarray:
+    n = np.linalg.norm(a, axis=1, keepdims=True)
+    n[n == 0] = 1.0
+    return a / n
+
+
+class MeshDecimator:
+    """Holds one source mesh (pymeshlab MeshSet id 0 + scrollkit arrays + gate stats)
+    and decimates copies of it at requested keep-fractions."""
+
+    def __init__(self, src_path: str | Path, edge_len_mean: float | None = None):
+        import pymeshlab  # local import: workers initialize their own copy
+
+        self.src_path = Path(src_path)
+        self.mesh = read_ply(self.src_path)
+        self.ms = pymeshlab.MeshSet()
+        self.ms.load_new_mesh(str(self.src_path))
+        pm = self.ms.current_mesh()
+        self.notes: list[str] = []
+
+        # ---- cross-check pymeshlab loader vs scrollkit.io (binding contract) ----
+        if pm.vertex_number() != self.mesh.n_vertices:
+            raise AssertionError(f"{self.src_path}: pymeshlab vertex count {pm.vertex_number()} != {self.mesh.n_vertices}")
+        if pm.face_number() != self.mesh.n_faces:
+            raise AssertionError(f"{self.src_path}: pymeshlab face count {pm.face_number()} != {self.mesh.n_faces}")
+        vdiff = float(np.abs(pm.vertex_matrix().astype(np.float32) - self.mesh.vertices).max())
+        if vdiff != 0.0:
+            raise AssertionError(f"{self.src_path}: pymeshlab vertex coords differ (max abs {vdiff})")
+        if not np.array_equal(pm.face_matrix().astype(np.int32), self.mesh.faces):
+            raise AssertionError(f"{self.src_path}: pymeshlab face indices differ")
+        if not pm.has_wedge_tex_coord():
+            if pm.has_vertex_tex_coord():
+                # only vertex texcoords made it through the loader: transfer so the
+                # texture-aware collapse actually sees wedge UVs.
+                self.ms.compute_texcoord_transfer_vertex_to_wedge()
+                pm = self.ms.current_mesh()
+                self.notes.append("vertex->wedge texcoord transfer applied (loader gave vertex UVs only)")
+            else:
+                raise AssertionError(f"{self.src_path}: no texcoords in pymeshlab mesh")
+        assert pm.has_wedge_tex_coord(), "wedge texcoords required for the texture filter"
+        if self.mesh.wedge_uv is not None:
+            w = pm.wedge_tex_coord_matrix().reshape(-1, 3, 2).astype(np.float32)
+            if not np.array_equal(w.view(np.uint32), self.mesh.wedge_uv.view(np.uint32)):
+                raise AssertionError(f"{self.src_path}: pymeshlab wedge UVs differ from scrollkit reader")
+        self.src_id = 0
+
+        # ---- source-side gate baselines ----
+        self.src_stats = metrics.mesh_stats(self.mesh.vertices, self.mesh.faces, self.mesh.wedge_uv)
+        self.edge_len_mean = (
+            float(edge_len_mean)
+            if edge_len_mean is not None
+            else metrics.mean_edge_length(self.mesh.vertices, self.mesh.faces)
+        )
+        self.last: dict | None = None  # arrays + stats of the most recent attempt
+
+    # ------------------------------------------------------------------ decimation
+    def _decimate_copy(self, keep: float, params: dict) -> int:
+        """Copy source mesh, run the texture-aware quadric collapse, drop unreferenced
+        vertices. Returns the new mesh id (left as current)."""
+        self.ms.set_current_mesh(self.src_id)
+        self.ms.generate_copy_of_current_mesh()
+        self.ms.meshing_decimation_quadric_edge_collapse_with_texture(
+            targetperc=float(keep),
+            qualitythr=float(params["qualitythr"]),
+            extratcoordw=float(params["extratcoordw"]),
+            preserveboundary=bool(params["preserveboundary"]),
+            boundaryweight=float(params["boundaryweight"]),
+            optimalplacement=bool(params["optimalplacement"]),
+            preservenormal=bool(params["preservenormal"]),
+            planarquadric=bool(params.get("planarquadric", False)),
+        )
+        self.ms.meshing_remove_unreferenced_vertices()
+        return self.ms.current_mesh_id()
+
+    def _hausdorff_two_sided(self, dec_id: int) -> dict:
+        nv_src = self.ms.mesh(self.src_id).vertex_number()
+        nv_dec = self.ms.mesh(dec_id).vertex_number()
+        fwd = self.ms.get_hausdorff_distance(
+            sampledmesh=self.src_id, targetmesh=dec_id,
+            samplenum=min(HAUSDORFF_SAMPLE_CAP, nv_src), samplevert=True, sampleface=True,
+        )
+        rev = self.ms.get_hausdorff_distance(
+            sampledmesh=dec_id, targetmesh=self.src_id,
+            samplenum=min(HAUSDORFF_SAMPLE_CAP, nv_dec), samplevert=True, sampleface=True,
+        )
+        return {
+            "fwd": {k: float(fwd[k]) for k in ("max", "mean", "RMS")} | {"n_samples": int(fwd["n_samples"])},
+            "rev": {k: float(rev[k]) for k in ("max", "mean", "RMS")} | {"n_samples": int(rev["n_samples"])},
+            "two_sided_max": float(max(fwd["max"], rev["max"])),
+            "two_sided_mean": float(max(fwd["mean"], rev["mean"])),
+        }
+
+    def try_rung(self, keep: float, extratcoordw: float, *, hausdorff_ratio_max: float = 1.0,
+                 boundary_tol: float = 0.02, planarquadric: bool = False) -> dict:
+        """Decimate from the ORIGINAL at `keep`, evaluate all geometry gates.
+
+        Stores extracted arrays in self.last (whether passing or not) and removes the
+        pymeshlab copy before returning. Returns the attempt record."""
+        t0 = time.time()
+        params = dict(DEFAULT_PARAMS)
+        params["extratcoordw"] = float(extratcoordw)
+        params["planarquadric"] = bool(planarquadric)
+        dec_id = self._decimate_copy(keep, params)
+        d = self.ms.current_mesh()
+
+        V = np.ascontiguousarray(d.vertex_matrix()).astype(np.float32)
+        F = np.ascontiguousarray(d.face_matrix()).astype(np.int32)
+        W = np.ascontiguousarray(d.wedge_tex_coord_matrix()).reshape(-1, 3, 2).astype(np.float32)
+        N = _normalize_rows(np.ascontiguousarray(d.vertex_normal_matrix()).astype(np.float64)).astype(np.float32)
+
+        # The texture-aware collapse occasionally inverts a handful of tiny UV slivers
+        # (a few texels, interior). Repair UVs only — geometry untouched — by local
+        # Laplacian untangling of the offending UV-vertices; the flip gate below then
+        # measures the repaired table honestly (and SSIM verifies perception later).
+        uv_repair = None
+        if metrics.uv_orientation_counts(W)["flipped"] > self.src_stats["uv_flipped"]:
+            W, uv_repair = metrics.repair_uv_flips(F, W)
+
+        hd = self._hausdorff_two_sided(dec_id)
+        dec_stats = metrics.mesh_stats(V, F, W)
+
+        fails: list[str] = []
+        threshold = hausdorff_ratio_max * self.edge_len_mean
+        if hd["two_sided_max"] > threshold:
+            fails.append(f"hausdorff: two-sided max {hd['two_sided_max']:.3f} > {threshold:.3f} (= {hausdorff_ratio_max} x edge_len_mean)")
+        if dec_stats["uv_flipped"] > self.src_stats["uv_flipped"]:
+            fails.append(f"uv_flips: {dec_stats['uv_flipped']} > source {self.src_stats['uv_flipped']}")
+        if dec_stats["uv_charts"] > self.src_stats["uv_charts"]:
+            fails.append(f"uv_charts: {dec_stats['uv_charts']} > source {self.src_stats['uv_charts']}")
+        src_bl = self.src_stats["boundary_length"]
+        if src_bl == 0.0:
+            if dec_stats["boundary_length"] != 0.0:
+                fails.append(f"boundary: source closed but decimated has boundary length {dec_stats['boundary_length']:.3f}")
+            bl_rel = 0.0
+        else:
+            bl_rel = abs(dec_stats["boundary_length"] - src_bl) / src_bl
+            if bl_rel > boundary_tol:
+                fails.append(f"boundary: length deviates {bl_rel:.4f} > {boundary_tol}")
+        if dec_stats["nonmanifold_edge_count"] > self.src_stats["nonmanifold_edge_count"]:
+            fails.append(f"nonmanifold: {dec_stats['nonmanifold_edge_count']} > source {self.src_stats['nonmanifold_edge_count']}")
+        if dec_stats["isolated_vertices"] != 0:
+            fails.append(f"isolated vertices: {dec_stats['isolated_vertices']}")
+
+        # remove the pymeshlab copy (arrays already extracted)
+        self.ms.set_current_mesh(dec_id)
+        self.ms.delete_current_mesh()
+        self.ms.set_current_mesh(self.src_id)
+
+        gate_fail_kinds = sorted({f.split(":", 1)[0] for f in fails})
+        attempt = {
+            "keep": float(keep),
+            "extratcoordw": float(extratcoordw),
+            "planarquadric": bool(planarquadric),
+            "faces_out": int(F.shape[0]),
+            "verts_out": int(V.shape[0]),
+            "keep_achieved": float(F.shape[0] / self.mesh.n_faces),
+            "hausdorff": hd,
+            "hausdorff_ratio": float(hd["two_sided_max"] / self.edge_len_mean) if self.edge_len_mean else None,
+            "uv_repair": uv_repair,
+            "dec_stats": dec_stats,
+            "boundary_rel_diff": float(bl_rel),
+            "pass": not fails,
+            "fail_reasons": fails,
+            "uv_only_failure": bool(fails) and all(k in UV_GATE_KEYS for k in gate_fail_kinds),
+            "seconds": round(time.time() - t0, 2),
+        }
+        self.last = {"V": V, "F": F, "W": W, "N": N, "attempt": attempt}
+        return attempt
+
+    # ------------------------------------------------------------------ output
+    def source_texture(self) -> str | None:
+        """First declared texture that exists next to the source PLY (M1 logic)."""
+        for cand in self.mesh.texture_files:
+            if (self.src_path.parent / cand).exists():
+                return cand
+        if self.mesh.texture_files:
+            raise FileNotFoundError(f"{self.src_path}: no declared texture exists on disk")
+        return None
+
+    def write_outputs(self, out_dir: str | Path, stem: str, group: str) -> dict:
+        """Write <stem>_decimated.obj/.mtl + byte-copied texture from self.last arrays.
+
+        A/B: per-vertex-UV (shared) OBJ when the wedge->vertex conversion is bit-exact;
+        otherwise the wedge-dedup path (recorded). Group C always wedge-dedup."""
+        assert self.last is not None, "try_rung must run before write_outputs"
+        V, F, W, N = self.last["V"], self.last["F"], self.last["W"], self.last["N"]
+        out_dir = Path(out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        tex_name = self.source_texture()
+        tex_sha = copy_texture(self.src_path.parent / tex_name, out_dir / tex_name) if tex_name else None
+
+        vertex_uv = None
+        if group in ("A", "B"):
+            vertex_uv = metrics.wedge_to_vertex_uv_exact(V.shape[0], F, W)
+            uv_mode = "shared" if vertex_uv is not None else "wedge"
+            if vertex_uv is None:
+                self.notes.append("wedge UVs disagree at >=1 vertex after collapse - wedge-dedup OBJ path used")
+        else:
+            uv_mode = "wedge"
+        normals = N if group in ("A", "B") else None  # C sources carry no normals (match M1)
+
+        md = MeshData(
+            vertices=V, faces=F, normals=normals,
+            vertex_uv=vertex_uv, wedge_uv=W,
+            texture_files=[tex_name] if tex_name else [],
+            source_path=str(self.src_path),
+        )
+        obj_path = out_dir / f"{stem}_decimated.obj"
+        write_obj(
+            obj_path, md, texture_file=tex_name, uv_mode=uv_mode,
+            header_comment=(
+                f"M2 decimation of {self.src_path.name} | keep={self.last['attempt']['keep']} "
+                f"| extratcoordw={self.last['attempt']['extratcoordw']} | uv_mode {uv_mode}"
+            ),
+        )
+        frame_est = self._frame_size_estimate(md, uv_mode, tex_name)
+        return {
+            "obj": str(obj_path),
+            "mtl": str(obj_path.with_suffix(".mtl")) if tex_name else None,
+            "texture": tex_name,
+            "texture_sha256": tex_sha,
+            "uv_obj_mode": uv_mode,
+            "obj_size_bytes": int(obj_path.stat().st_size),
+            "frame_obj_est_bytes": frame_est,
+        }
+
+    def _frame_size_estimate(self, md: MeshData, uv_mode: str, tex_name: str | None) -> int:
+        """Exact byte size of one animation-frame OBJ for this decimated mesh.
+
+        Frames are written by ObjFrameWriter (no vn block). For the wedge path the
+        frame writer is not applicable, so we measure a normal-less write_obj instead."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td) / "frame.obj"
+            if uv_mode == "shared" and md.vertex_uv is not None:
+                fw = ObjFrameWriter(md, texture_file=tex_name, mtl_name="frame.mtl")
+                fw.write_frame(tmp, md.vertices)
+            else:
+                md2 = MeshData(
+                    vertices=md.vertices, faces=md.faces, normals=None,
+                    vertex_uv=md.vertex_uv, wedge_uv=md.wedge_uv,
+                    texture_files=md.texture_files, source_path=md.source_path,
+                )
+                write_obj(tmp, md2, texture_file=tex_name, uv_mode=uv_mode)
+            return int(tmp.stat().st_size)
+
+
+# ---------------------------------------------------------------------- ladder driver
+def run_ladder(task: dict, cfg: dict) -> dict:
+    """Full per-mesh M2 geometry pass.
+
+    task: {group, stem, src (abs path), edge_len_mean, out_dir (abs path)}
+    cfg:  decimation block of configs/global.yaml.
+
+    Walks the group's keep ladder (ladder_for_group — Group C gets the extended rungs)
+    from most aggressive up; a rung failing ONLY UV gates is retried once with
+    extratcoordw=3.0 (UV-smearing remedy) before moving up. Outputs are written for the
+    chosen rung (or the best-Hausdorff rung if none passed, with geometry_pass=false
+    for the gate to flag)."""
+    t0 = time.time()
+    ladder = ladder_for_group(cfg, task["group"])
+    ratio_max = float(cfg.get("hausdorff_max_mean_edge", 1.0))
+    base_w = float(cfg.get("extratcoordw", 1.0))
+
+    dec = MeshDecimator(task["src"], edge_len_mean=task["edge_len_mean"])
+    journey: list[dict] = []
+    chosen: dict | None = None
+    for keep in ladder:
+        att = dec.try_rung(keep, base_w, hausdorff_ratio_max=ratio_max)
+        journey.append(att)
+        if att["pass"]:
+            chosen = att
+            break
+        if att["uv_only_failure"]:
+            att3 = dec.try_rung(keep, 3.0, hausdorff_ratio_max=ratio_max)
+            journey.append(att3)
+            if att3["pass"]:
+                chosen = att3
+                break
+
+    geometry_pass = chosen is not None
+    if chosen is None:
+        # nothing passed even at 0.35 — keep the best attempt for inspection, flag red.
+        best = min(journey, key=lambda a: a["hausdorff"]["two_sided_max"])
+        dec.try_rung(best["keep"], best["extratcoordw"], hausdorff_ratio_max=ratio_max)
+        chosen = dec.last["attempt"]
+
+    out = dec.write_outputs(task["out_dir"], task["stem"], task["group"])
+    rec = {
+        "group": task["group"],
+        "stem": task["stem"],
+        "src": task["src"],
+        "faces_in": dec.mesh.n_faces,
+        "verts_in": dec.mesh.n_vertices,
+        "edge_len_mean": dec.edge_len_mean,
+        "rung_chosen": chosen["keep"],
+        "extratcoordw": chosen["extratcoordw"],
+        "keep_achieved": chosen["keep_achieved"],
+        "faces_out": chosen["faces_out"],
+        "verts_out": chosen["verts_out"],
+        "hausdorff": chosen["hausdorff"],
+        "hausdorff_ratio": chosen["hausdorff_ratio"],
+        "src_stats": dec.src_stats,
+        "dec_stats": chosen["dec_stats"],
+        "boundary_rel_diff": chosen["boundary_rel_diff"],
+        "geometry_pass": geometry_pass,
+        "fail_reasons": chosen["fail_reasons"],
+        "journey": journey,
+        "notes": dec.notes,
+        "ssim": "pending",
+        **out,
+        "seconds_geometry": round(time.time() - t0, 2),
+    }
+    return rec
+
+
+def redecimate_at(task: dict, cfg: dict, keep: float, extratcoordw: float,
+                  planarquadric: bool = False) -> dict:
+    """Re-run a single rung (used by the SSIM pass when a rung is bumped/retried),
+    re-evaluating geometry gates. Outputs are rewritten ONLY when the geometry gates
+    pass, so the on-disk OBJ always matches the last green record. Returns a partial
+    record with out=None on geometry failure."""
+    ratio_max = float(cfg.get("hausdorff_max_mean_edge", 1.0))
+    dec = MeshDecimator(task["src"], edge_len_mean=task["edge_len_mean"])
+    att = dec.try_rung(keep, extratcoordw, hausdorff_ratio_max=ratio_max,
+                       planarquadric=planarquadric)
+    out = dec.write_outputs(task["out_dir"], task["stem"], task["group"]) if att["pass"] else None
+    return {
+        "attempt": att,
+        "out": out,
+        "src_stats": dec.src_stats,
+        "notes": dec.notes,
+    }
+
+
+def ship_undecimated_copy(task: dict, root: str | Path) -> dict:
+    """No-safe-decimation fallback (Group C only): the 'optimized' deliverable is the
+    UNDECIMATED M1 conversion — byte-identical copies of the M1 OBJ (renamed
+    <stem>_decimated.obj), its MTL (original filename: the copied OBJ's mtllib line
+    references it) and texture, each SHA256-verified. The copy is then re-read and
+    proven bit-equal to the source PLY (V/F/wedge-UV), so the geometry gates hold by
+    identity (two-sided Hausdorff = 0, stats unchanged).
+
+    Returns a record fragment with decision='no_safe_decimation', the verbatim
+    pinned rationale, copy provenance + SHAs, and write_outputs()-shaped keys."""
+    root = Path(root)
+    manifest = json.loads((root / "outputs/obj/manifest.json").read_text())
+    src_resolved = Path(task["src"]).resolve()
+    entry = next(
+        (e for e in manifest["meshes"] if (root / e["src"]).resolve() == src_resolved),
+        None,
+    )
+    if entry is None:
+        raise FileNotFoundError(f"no M1 manifest entry for {task['src']}")
+
+    m1_obj = root / entry["obj"]
+    m1_mtl = root / entry["mtl"]
+    tex_name = entry["texture"]
+    out_dir = Path(task["out_dir"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    dst_obj = out_dir / f"{task['stem']}_decimated.obj"
+    dst_mtl = out_dir / m1_mtl.name
+
+    def _copy_sha_verified(src: Path, dst: Path) -> str:
+        shutil.copyfile(src, dst)
+        h_src = hashlib.sha256(src.read_bytes()).hexdigest()
+        h_dst = hashlib.sha256(dst.read_bytes()).hexdigest()
+        if h_src != h_dst:
+            raise IOError(f"copy corrupted: {src} -> {dst}")
+        return h_src
+
+    obj_sha = _copy_sha_verified(m1_obj, dst_obj)
+    mtl_sha = _copy_sha_verified(m1_mtl, dst_mtl)
+    tex_sha = copy_texture(m1_obj.parent / tex_name, out_dir / tex_name)
+    if tex_sha != entry["texture_sha256"]:
+        raise IOError(
+            f"{task['stem']}: texture SHA {tex_sha} != M1 manifest {entry['texture_sha256']}"
+        )
+    stale_mtl = dst_obj.with_suffix(".mtl")
+    if stale_mtl != dst_mtl and stale_mtl.exists():
+        stale_mtl.unlink()  # MTL of the superseded decimated rung — copied OBJ references dst_mtl
+
+    # Prove the deliverable IS the source mesh (bit-exact, mirroring the M1 gate).
+    src_mesh = read_ply(task["src"])
+    dec_mesh = read_obj(dst_obj)
+    if dec_mesh.n_vertices != src_mesh.n_vertices or dec_mesh.n_faces != src_mesh.n_faces:
+        raise AssertionError(f"{dst_obj}: copied V/F counts differ from source PLY")
+    if not np.array_equal(dec_mesh.vertices.view(np.uint32), src_mesh.vertices.view(np.uint32)):
+        raise AssertionError(f"{dst_obj}: copied vertices not bit-equal to source PLY")
+    if not np.array_equal(dec_mesh.faces, src_mesh.faces):
+        raise AssertionError(f"{dst_obj}: copied faces differ from source PLY")
+    wedge = dec_mesh.wedge_uv
+    if wedge is None and dec_mesh.vertex_uv is not None:
+        wedge = dec_mesh.vertex_uv[dec_mesh.faces]
+    if wedge is None or src_mesh.wedge_uv is None or not np.array_equal(
+        wedge.view(np.uint32), src_mesh.wedge_uv.view(np.uint32)
+    ):
+        raise AssertionError(f"{dst_obj}: copied wedge UVs not bit-equal to source PLY")
+
+    stats = metrics.mesh_stats(src_mesh.vertices, src_mesh.faces, src_mesh.wedge_uv)
+    zero = {"max": 0.0, "mean": 0.0, "RMS": 0.0, "n_samples": 0}
+    return {
+        "decision": "no_safe_decimation",
+        "decision_rationale": NO_SAFE_DECIMATION_RATIONALE,
+        "deliverable": {
+            "kind": "undecimated_m1_copy",
+            "m1_obj": str(m1_obj),
+            "m1_mtl": str(m1_mtl),
+            "obj_sha256": obj_sha,
+            "mtl_sha256": mtl_sha,
+            "bit_equal_to_source_ply": True,
+        },
+        "rung_chosen": 1.0,
+        "extratcoordw": None,
+        "planarquadric": None,
+        "keep_achieved": 1.0,
+        "faces_out": src_mesh.n_faces,
+        "verts_out": src_mesh.n_vertices,
+        "hausdorff": {
+            "fwd": dict(zero), "rev": dict(zero),
+            "two_sided_max": 0.0, "two_sided_mean": 0.0,
+            "basis": "identity: deliverable proven bit-equal to source PLY",
+        },
+        "hausdorff_ratio": 0.0,
+        "src_stats": stats,
+        "dec_stats": stats,
+        "boundary_rel_diff": 0.0,
+        "geometry_pass": True,
+        "fail_reasons": [],
+        "obj": str(dst_obj),
+        "mtl": str(dst_mtl),
+        "texture": tex_name,
+        "texture_sha256": tex_sha,
+        "uv_obj_mode": entry["uv_mode"],
+        "obj_size_bytes": int(dst_obj.stat().st_size),
+        # C meshes are never frame-exported (disk budget counts A/B wraps only); the
+        # whole-OBJ byte size is the honest stand-in the gate requires to be recorded.
+        "frame_obj_est_bytes": int(dst_obj.stat().st_size),
+    }

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/decimate/metrics.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/decimate/metrics.py
@@ -1,0 +1,223 @@
+"""Pure-numpy/scipy mesh + UV metrics backing the M2 geometry gates.
+
+All UV comparisons are bit-exact (uint32 views of float32) — consistent with the
+mesh-io-conventions rule that dedup/equality never uses epsilon merging.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.sparse import coo_matrix
+from scipy.sparse.csgraph import connected_components
+
+
+def uv_signed_areas(wedge_uv: np.ndarray) -> np.ndarray:
+    """Twice the signed UV-space area per face (float64). wedge_uv: (m,3,2)."""
+    w = wedge_uv.astype(np.float64)
+    e1 = w[:, 1] - w[:, 0]
+    e2 = w[:, 2] - w[:, 0]
+    return e1[:, 0] * e2[:, 1] - e1[:, 1] * e2[:, 0]
+
+
+def uv_orientation_counts(wedge_uv: np.ndarray) -> dict:
+    """Sign distribution of UV triangle areas: {flipped, zero, positive}."""
+    a = uv_signed_areas(wedge_uv)
+    return {
+        "flipped": int((a < 0).sum()),
+        "zero": int((a == 0).sum()),
+        "positive": int((a > 0).sum()),
+    }
+
+
+def uv_chart_count(faces: np.ndarray, wedge_uv: np.ndarray) -> int:
+    """Number of UV-connected components (charts).
+
+    Corners weld into a single UV-vertex iff (mesh vertex id, exact UV bits) coincide;
+    faces sharing a welded edge are UV-connected. Chart count = connected components of
+    the UV-vertex graph (every UV-vertex belongs to >=1 face, so none are isolated).
+    """
+    m = int(faces.shape[0])
+    if m == 0:
+        return 0
+    vid = faces.astype(np.int64).reshape(-1)  # (3m,)
+    uvb = np.ascontiguousarray(wedge_uv.astype(np.float32, copy=False)).reshape(-1, 2).view(np.uint32)
+    key = np.empty(3 * m, dtype=[("v", "i8"), ("u", "u4"), ("t", "u4")])
+    key["v"] = vid
+    key["u"] = uvb[:, 0]
+    key["t"] = uvb[:, 1]
+    _, inv = np.unique(key, return_inverse=True)
+    c = inv.reshape(m, 3)
+    n = int(inv.max()) + 1
+    rows = np.concatenate([c[:, 0], c[:, 1], c[:, 2]])
+    cols = np.concatenate([c[:, 1], c[:, 2], c[:, 0]])
+    g = coo_matrix((np.ones(rows.size, dtype=np.int8), (rows, cols)), shape=(n, n))
+    ncomp, _ = connected_components(g, directed=False)
+    return int(ncomp)
+
+
+def edge_stats(vertices: np.ndarray, faces: np.ndarray) -> dict:
+    """Boundary length/count + non-manifold edge count from raw arrays."""
+    f = faces.astype(np.int64)
+    e = np.concatenate([f[:, [0, 1]], f[:, [1, 2]], f[:, [2, 0]]])
+    e.sort(axis=1)
+    nv = int(vertices.shape[0])
+    key = e[:, 0] * nv + e[:, 1]
+    uniq, counts = np.unique(key, return_counts=True)
+    bnd = uniq[counts == 1]
+    a, b = bnd // nv, bnd % nv
+    v64 = vertices.astype(np.float64)
+    blen = float(np.linalg.norm(v64[a] - v64[b], axis=1).sum())
+    return {
+        "edge_count": int(uniq.size),
+        "boundary_edge_count": int((counts == 1).sum()),
+        "boundary_length": blen,
+        "nonmanifold_edge_count": int((counts > 2).sum()),
+    }
+
+
+def isolated_vertex_count(n_vertices: int, faces: np.ndarray) -> int:
+    used = np.zeros(n_vertices, dtype=bool)
+    used[faces.reshape(-1)] = True
+    return int((~used).sum())
+
+
+def mean_edge_length(vertices: np.ndarray, faces: np.ndarray) -> float:
+    f = faces.astype(np.int64)
+    e = np.concatenate([f[:, [0, 1]], f[:, [1, 2]], f[:, [2, 0]]])
+    e.sort(axis=1)
+    nv = int(vertices.shape[0])
+    uniq = np.unique(e[:, 0] * nv + e[:, 1])
+    a, b = uniq // nv, uniq % nv
+    v64 = vertices.astype(np.float64)
+    return float(np.linalg.norm(v64[a] - v64[b], axis=1).mean())
+
+
+def wedge_to_vertex_uv_exact(n_vertices: int, faces: np.ndarray, wedge_uv: np.ndarray) -> np.ndarray | None:
+    """Convert wedge UVs to per-vertex UVs ONLY if bit-identical per vertex.
+
+    Returns (n,2) float32 when every referenced vertex carries exactly one distinct
+    (bit-exact) wedge UV across all its corners; otherwise None (caller keeps the
+    wedge-dedup OBJ path). Unreferenced vertices would get UV (0,0) — callers must
+    have removed those already.
+    """
+    vid = faces.astype(np.int64).reshape(-1)
+    uv32 = np.ascontiguousarray(wedge_uv.astype(np.float32, copy=False)).reshape(-1, 2)
+    out = np.zeros((n_vertices, 2), dtype=np.float32)
+    out[vid] = uv32  # last write wins; equality below proves they all agreed
+    if not np.array_equal(out[vid].view(np.uint32), uv32.view(np.uint32)):
+        return None
+    return out
+
+
+def repair_uv_flips(faces: np.ndarray, wedge_uv: np.ndarray, max_iters: int = 25) -> tuple[np.ndarray, dict]:
+    """Untangle flipped UV triangles left by the texture-aware quadric collapse.
+
+    The collapse occasionally inverts a handful of tiny interior UV slivers (observed:
+    ~1e-7 UV area, a few texels). Geometry is NOT touched; the offending UV-vertices
+    (welded by exact (vertex id, uv bits)) are iteratively moved to the centroid of
+    their UV neighbors (uniform-Laplacian untangling) until the global flipped count
+    is zero IN FLOAT32 (the dtype the gates and the OBJ see). UV-boundary vertices are
+    never moved, so chart outlines (and the texture-alpha silhouette) stay fixed.
+
+    Returns (repaired wedge_uv float32, info dict). If the loop cannot reach zero
+    flips the partially-repaired table is returned and the caller's gate fails
+    honestly (info["flips_after"] > 0).
+    """
+    m = int(faces.shape[0])
+    vid = faces.astype(np.int64).reshape(-1)
+    uv32 = np.ascontiguousarray(wedge_uv.astype(np.float32, copy=True)).reshape(-1, 2)
+    flips_before = int((uv_signed_areas(uv32.reshape(m, 3, 2)) < 0).sum())
+    if flips_before == 0:
+        return uv32.reshape(m, 3, 2), {"flips_before": 0, "flips_after": 0, "iters": 0, "moved_uvverts": 0}
+
+    bits = uv32.view(np.uint32)
+    key = np.empty(3 * m, dtype=[("v", "i8"), ("u", "u4"), ("t", "u4")])
+    key["v"] = vid
+    key["u"] = bits[:, 0]
+    key["t"] = bits[:, 1]
+    _, first_idx, inv = np.unique(key, return_index=True, return_inverse=True)
+    c = inv.reshape(m, 3)  # corner -> uvvert
+    n = int(inv.max()) + 1
+    uv = uv32[first_idx].astype(np.float64)  # working copy, one row per uvvert
+
+    # UV-space edges (both directions) + boundary lock
+    ea = np.concatenate([c[:, 0], c[:, 1], c[:, 2]])
+    eb = np.concatenate([c[:, 1], c[:, 2], c[:, 0]])
+    pair = np.minimum(ea, eb).astype(np.int64) * n + np.maximum(ea, eb)
+    uniq_pair, pair_counts = np.unique(pair, return_counts=True)
+    boundary_pairs = uniq_pair[pair_counts == 1]
+    locked = np.zeros(n, dtype=bool)
+    locked[boundary_pairs // n] = True
+    locked[boundary_pairs % n] = True
+
+    src = np.concatenate([ea, eb])  # neighbor accumulation: src receives dst's uv
+    dst = np.concatenate([eb, ea])
+
+    moved = np.zeros(n, dtype=bool)
+    iters = 0
+    prev_bad: int | None = None
+    stall = 0
+    for iters in range(1, max_iters + 1):
+        tri = uv[c]  # float64 (m,3,2)
+        e1 = tri[:, 1] - tri[:, 0]
+        e2 = tri[:, 2] - tri[:, 0]
+        area2 = e1[:, 0] * e2[:, 1] - e1[:, 1] * e2[:, 0]
+        # check in float32 too: the gate (and the written OBJ) sees float32
+        area32 = uv_signed_areas(tri.astype(np.float32))
+        bad_faces = (area2 < 0) | (area32 < 0)
+        nbad = int(bad_faces.sum())
+        if nbad == 0:
+            break
+        offend = np.zeros(n, dtype=bool)
+        offend[c[bad_faces].reshape(-1)] = True
+        # pure point-Laplacian can stall on tangles — when the bad count stops
+        # improving, progressively widen the relaxed region by UV one-rings.
+        if prev_bad is not None and nbad >= prev_bad:
+            stall += 1
+            for _ in range(stall):
+                grow = np.zeros(n, dtype=bool)
+                grow[dst[offend[src]]] = True
+                offend |= grow
+        else:
+            stall = 0
+        prev_bad = nbad
+        offend &= ~locked
+        if not offend.any():
+            break  # everything locked — cannot repair
+        sel = offend[src]
+        acc = np.zeros((n, 2))
+        cnt = np.zeros(n)
+        np.add.at(acc, src[sel], uv[dst[sel]])
+        np.add.at(cnt, src[sel], 1.0)
+        upd = offend & (cnt > 0)
+        uv[upd] = acc[upd] / cnt[upd, None]
+        moved |= upd
+
+    out = uv.astype(np.float32)[c].reshape(m, 3, 2)
+    flips_after = int((uv_signed_areas(out) < 0).sum())
+    return out, {
+        "flips_before": flips_before,
+        "flips_after": flips_after,
+        "iters": iters,
+        "moved_uvverts": int(moved.sum()),
+    }
+
+
+def mesh_stats(vertices: np.ndarray, faces: np.ndarray, wedge_uv: np.ndarray) -> dict:
+    """All gate-relevant scalar stats for one mesh state."""
+    uv = uv_orientation_counts(wedge_uv)
+    es = edge_stats(vertices, faces)
+    return {
+        "n_vertices": int(vertices.shape[0]),
+        "n_faces": int(faces.shape[0]),
+        "uv_flipped": uv["flipped"],
+        "uv_zero": uv["zero"],
+        "uv_positive": uv["positive"],
+        "uv_charts": uv_chart_count(faces, wedge_uv),
+        "boundary_edge_count": es["boundary_edge_count"],
+        "boundary_length": es["boundary_length"],
+        "nonmanifold_edge_count": es["nonmanifold_edge_count"],
+        "isolated_vertices": isolated_vertex_count(int(vertices.shape[0]), faces),
+        "uv_min": [float(x) for x in wedge_uv.reshape(-1, 2).min(axis=0)],
+        "uv_max": [float(x) for x in wedge_uv.reshape(-1, 2).max(axis=0)],
+    }

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/decimate/perceptual.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/decimate/perceptual.py
@@ -1,0 +1,489 @@
+"""M2 perceptual (SSIM) gate: render source vs decimated through scrollkit.render.scene.
+
+Per mesh, at its chosen rung, four views are compared at 1024 px (grayscale SSIM,
+skimage.structural_similarity):
+
+  full_iso   production-ish auto-fit isometric view            SSIM >= 0.97
+  full_face  production-ish face-on view (thinnest bbox axis)  SSIM >= 0.97
+  close_curv 25%-of-bbox crop at the max mean-curvature region
+             (approximated by vertex-normal variation)         SSIM >= 0.95
+  close_tex  25%-of-bbox crop at the densest-texture-content
+             region (texture alpha centroid mapped through UV) SSIM >= 0.95
+
+Cameras are computed ONCE from the SOURCE mesh and reused for the decimated render.
+On failure the rung is retried with extratcoordw=3.0 (UV-smearing remedy), then the
+ladder moves up; every attempt is recorded in the mesh's ssim journey.
+
+Group C policy: the ladder for C extends with
+GROUP_C_EXTENDED_LADDER ([0.5, 0.65, 0.8]); if NO rung passes, the mesh ships
+UNDECIMATED (ship_undecimated_copy — byte-identical M1 copy, SHA-verified) with
+decision='no_safe_decimation', and the identity deliverable is still rendered through
+this harness as a final wiring check (expected SSIM = 1.0).
+
+GPU rendering is SERIAL — callers must not parallelize this module. A concurrent
+concurrent renderers share the GPU: transient EGL/context failures are retried
+(30 s sleep, 20 min budget) in _render_views_retrying.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from scrollkit.io import MeshData, read_obj, read_ply
+
+VIEW_DEFS = (
+    ("full_iso", False),
+    ("full_face", False),
+    ("close_curv", True),
+    ("close_tex", True),
+)
+CLOSEUP_BBOX_FRAC = 0.25  # close-up frames 25% of the bbox diagonal
+RENDER_SIZE = (1024, 1024)  # comparison resolution (gate spec: 1024 px)
+# Measurement protocol (anti-aliasing, pinned by convergence experiments):
+# The 8K papyrus textures minify ~10-15x at 1024 px. With VTK's default non-mipmapped
+# point sampling the minification aliasing decorrelates between source and decimated
+# geometry and dominates SSIM (identical-looking close-ups measured 0.89/0.95/0.96/0.97
+# at 1x/2x/3x/4x supersampling — never converging). Enabling trilinear MIPMAP texture
+# sampling (the anti-aliased ideal) converges the estimator: ss=4+mipmap and
+# ss=8+mipmap agree to 0.0002. So: mipmap+interpolate ON (set on this module's own
+# SceneRenderer instances — both sides of every comparison identically) and 4x
+# supersampling for geometry-edge AA, LANCZOS-downsampled to the gate's 1024 px.
+# SSIM then measures decimation error, not GPU sampling noise.
+SUPERSAMPLE = 4
+TEXTURE_MIPMAP = True
+
+# GPU contention with the concurrent cinematics renders: EGL context creation can fail
+# transiently. Serial retry: sleep 30 s between attempts, give up after a 20 min budget.
+RENDER_RETRY_SLEEP_S = 30.0
+RENDER_RETRY_BUDGET_S = 20 * 60.0
+_RENDER_TRANSIENT_MARKERS = ("egl", "context", "glx", "opengl", "framebuffer", "device")
+
+
+# ----------------------------------------------------------------- mesh-derived regions
+def _vertex_normals(mesh: MeshData) -> np.ndarray:
+    """File normals when present (A/B); else area-weighted accumulation (C)."""
+    if mesh.normals is not None:
+        n = mesh.normals.astype(np.float64)
+    else:
+        v = mesh.vertices.astype(np.float64)
+        f = mesh.faces.astype(np.int64)
+        fn = np.cross(v[f[:, 1]] - v[f[:, 0]], v[f[:, 2]] - v[f[:, 0]])  # area-weighted
+        n = np.zeros_like(v)
+        for k in range(3):
+            np.add.at(n, f[:, k], fn)
+    ln = np.linalg.norm(n, axis=1, keepdims=True)
+    ln[ln == 0] = 1.0
+    return n / ln
+
+
+def _unique_edges(faces: np.ndarray, n_vertices: int) -> tuple[np.ndarray, np.ndarray]:
+    f = faces.astype(np.int64)
+    e = np.concatenate([f[:, [0, 1]], f[:, [1, 2]], f[:, [2, 0]]])
+    e.sort(axis=1)
+    uniq = np.unique(e[:, 0] * n_vertices + e[:, 1])
+    return uniq // n_vertices, uniq % n_vertices
+
+
+def normal_variation_scores(mesh: MeshData) -> np.ndarray:
+    """Per-vertex mean angular deviation of neighbor normals (curvature proxy),
+    smoothed once over the 1-ring to suppress single-vertex noise."""
+    N = _vertex_normals(mesh)
+    a, b = _unique_edges(mesh.faces, mesh.n_vertices)
+    d = 1.0 - np.einsum("ij,ij->i", N[a], N[b])
+    nv = mesh.n_vertices
+    acc = np.zeros(nv)
+    cnt = np.zeros(nv)
+    for idx, val in ((a, d), (b, d)):
+        np.add.at(acc, idx, val)
+        np.add.at(cnt, idx, 1.0)
+    cnt[cnt == 0] = 1.0
+    score = acc / cnt
+    sm = np.zeros(nv)
+    cm = np.zeros(nv)
+    for src, dst in ((a, b), (b, a)):
+        np.add.at(sm, dst, score[src])
+        np.add.at(cm, dst, 1.0)
+    cm[cm == 0] = 1.0
+    return 0.5 * score + 0.5 * (sm / cm)
+
+
+def texture_content_uv_centroid(texture_path: str | Path, tex_orientation: str) -> tuple[float, float]:
+    """(s, t) of the texture content centroid: alpha-mask moments when the image has a
+    meaningful alpha channel, else a luminance mask. Pixel->UV mapping inverts the
+    audit's tex_orientation definitions."""
+    with Image.open(texture_path) as im:
+        alpha = np.asarray(im.getchannel("A")) if im.mode in ("RGBA", "LA", "PA") else None
+        if alpha is not None and alpha.min() != alpha.max():
+            mask = alpha > 0
+        else:
+            mask = np.asarray(im.convert("L")) > 16
+    h, w = mask.shape
+    m = mask.astype(np.float64)
+    total = m.sum()
+    if total == 0:  # blank texture — fall back to image center
+        row_c, col_c = (h - 1) / 2.0, (w - 1) / 2.0
+    else:
+        row_c = float(m.sum(axis=1) @ np.arange(h)) / total
+        col_c = float(m.sum(axis=0) @ np.arange(w)) / total
+    rs, cs = row_c / max(h - 1, 1), col_c / max(w - 1, 1)
+    if tex_orientation == "topleft":
+        s, t = cs, rs
+    elif tex_orientation == "opengl_bottomleft":
+        s, t = cs, 1.0 - rs
+    elif tex_orientation == "rot180":
+        s, t = 1.0 - cs, 1.0 - rs
+    elif tex_orientation == "topleft_u_flipped":
+        s, t = 1.0 - cs, rs
+    else:
+        raise ValueError(f"unknown tex_orientation {tex_orientation!r}")
+    return float(s), float(t)
+
+
+def _nearest_vertex_by_uv(mesh: MeshData, st: tuple[float, float]) -> int:
+    """Vertex whose UV is nearest (s,t). Uses vertex UVs when present, else wedge corners."""
+    target = np.array(st)
+    if mesh.vertex_uv is not None:
+        d = np.linalg.norm(mesh.vertex_uv.astype(np.float64) - target, axis=1)
+        return int(np.argmin(d))
+    corners = mesh.wedge_uv.reshape(-1, 2).astype(np.float64)
+    ci = int(np.argmin(np.linalg.norm(corners - target, axis=1)))
+    return int(mesh.faces.reshape(-1)[ci])
+
+
+def _region_direction(mesh: MeshData, normals: np.ndarray, center: np.ndarray, radius: float) -> np.ndarray:
+    """Mean normal over vertices within `radius` of center (face-on close-up direction);
+    falls back to the global thinnest-bbox axis when the region normal cancels out."""
+    v = mesh.vertices.astype(np.float64)
+    near = np.linalg.norm(v - center, axis=1) <= radius
+    d = normals[near].sum(axis=0) if near.any() else np.zeros(3)
+    if np.linalg.norm(d) < 1e-9:
+        ext = v.max(axis=0) - v.min(axis=0)
+        d = np.eye(3)[int(np.argmin(ext))]
+    return d / np.linalg.norm(d)
+
+
+# ----------------------------------------------------------------- cameras + rendering
+def build_views(mesh: MeshData, texture_path: Path, tex_orientation: str) -> list[dict]:
+    """Four named cameras computed from the SOURCE mesh only."""
+    from scrollkit.render.scene import auto_camera
+
+    v = mesh.vertices.astype(np.float64)
+    lo, hi = v.min(axis=0), v.max(axis=0)
+    ext = hi - lo
+    diag = float(np.linalg.norm(ext))
+    aspect = RENDER_SIZE[0] / RENDER_SIZE[1]
+    normals = _vertex_normals(mesh)
+
+    # production-ish full views
+    cam_iso = auto_camera(v, aspect)
+    thin = int(np.argmin(ext))
+    big = int(np.argmax(ext))
+    face_dir = np.eye(3)[thin] + 0.3 * np.eye(3)[big]
+    cam_face = auto_camera(v, aspect, direction=face_dir / np.linalg.norm(face_dir))
+
+    # close-up crops: 25% of the bbox
+    half_h = 0.5 * CLOSEUP_BBOX_FRAC * diag
+    region_r = half_h
+
+    scores = normal_variation_scores(mesh)
+    c_curv = v[int(np.argmax(scores))]
+    d_curv = _region_direction(mesh, normals, c_curv, region_r)
+
+    st = texture_content_uv_centroid(texture_path, tex_orientation)
+    c_tex = v[_nearest_vertex_by_uv(mesh, st)]
+    d_tex = _region_direction(mesh, normals, c_tex, region_r)
+
+    def closeup(center: np.ndarray, d: np.ndarray) -> dict:
+        up = (0.0, 0.0, 1.0) if abs(d[2]) < 0.95 else (0.0, 1.0, 0.0)
+        dop = -d
+        right = np.cross(dop, np.asarray(up, dtype=np.float64))
+        right /= np.linalg.norm(right)
+        true_up = np.cross(right, dop)
+        return {
+            "position": tuple(float(x) for x in (center + d * diag)),
+            "focal_point": tuple(float(x) for x in center),
+            "up": tuple(float(x) for x in true_up),
+            "parallel_scale": float(half_h),
+            "parallel": True,
+        }
+
+    cams = {
+        "full_iso": cam_iso,
+        "full_face": cam_face,
+        "close_curv": closeup(c_curv, d_curv),
+        "close_tex": closeup(c_tex, d_tex),
+    }
+    return [{"name": n, "closeup": cu, "camera": cams[n]} for n, cu in VIEW_DEFS]
+
+
+def _render_views(mesh: MeshData, texture_path: Path, tex_orientation: str, views: list[dict]) -> dict[str, np.ndarray]:
+    """One SceneRenderer per mesh; camera swapped per view (GPU-serial).
+    Renders SUPERSAMPLE x oversized, then LANCZOS-downsamples to RENDER_SIZE."""
+    from scrollkit.render.scene import SceneRenderer, split_wedge_to_vertex
+
+    V, F, UV = split_wedge_to_vertex(mesh)
+    big = (RENDER_SIZE[0] * SUPERSAMPLE, RENDER_SIZE[1] * SUPERSAMPLE)
+    out: dict[str, np.ndarray] = {}
+    with SceneRenderer(V, F, UV, texture_path, tex_orientation, size=big) as r:
+        if TEXTURE_MIPMAP:  # converged sampling (see protocol note above); both sides
+            r.texture.mipmap = True
+            r.texture.interpolate = True
+        for view in views:
+            r.set_camera(view["camera"])
+            img = r.screenshot()
+            if SUPERSAMPLE > 1:
+                img = np.asarray(Image.fromarray(img).resize(RENDER_SIZE, Image.LANCZOS))
+            out[view["name"]] = img
+    return out
+
+
+def _render_views_retrying(
+    mesh: MeshData, texture_path: Path, tex_orientation: str, views: list[dict]
+) -> dict[str, np.ndarray]:
+    """_render_views with retry on transient GPU/EGL context failures (shared GPU)."""
+    deadline = time.monotonic() + RENDER_RETRY_BUDGET_S
+    attempt = 1
+    while True:
+        try:
+            return _render_views(mesh, texture_path, tex_orientation, views)
+        except Exception as exc:
+            msg = f"{type(exc).__name__}: {exc}"
+            transient = any(k in msg.lower() for k in _RENDER_TRANSIENT_MARKERS)
+            if not transient or time.monotonic() + RENDER_RETRY_SLEEP_S > deadline:
+                raise
+            print(
+                f"    render attempt {attempt} hit transient GPU/EGL failure "
+                f"({msg[:140]}); retrying in {RENDER_RETRY_SLEEP_S:.0f}s"
+            )
+            attempt += 1
+            time.sleep(RENDER_RETRY_SLEEP_S)
+
+
+def _ssim_gray(a: np.ndarray, b: np.ndarray) -> float:
+    from skimage.metrics import structural_similarity
+
+    ga = a.astype(np.float64).mean(axis=2)
+    gb = b.astype(np.float64).mean(axis=2)
+    return float(structural_similarity(ga, gb, data_range=255.0))
+
+
+def evaluate_ssim(
+    src_mesh: MeshData,
+    dec_obj_path: Path,
+    texture_path: Path,
+    tex_orientation: str,
+    cfg: dict,
+    views: list[dict],
+    save_dir: Path | None = None,
+) -> dict:
+    """Render source + decimated with identical cameras, return per-view SSIMs."""
+    dec_mesh = read_obj(dec_obj_path)
+    imgs_src = _render_views_retrying(src_mesh, texture_path, tex_orientation, views)
+    imgs_dec = _render_views_retrying(dec_mesh, texture_path, tex_orientation, views)
+
+    full_min = float(cfg["ssim_production_min"])
+    close_min = float(cfg["ssim_closeup_min"])
+    results = []
+    all_pass = True
+    for view in views:
+        s = _ssim_gray(imgs_src[view["name"]], imgs_dec[view["name"]])
+        thr = close_min if view["closeup"] else full_min
+        ok = s >= thr
+        all_pass &= ok
+        results.append({"name": view["name"], "closeup": view["closeup"], "ssim": round(s, 5), "threshold": thr, "pass": ok})
+    if save_dir is not None:
+        save_dir.mkdir(parents=True, exist_ok=True)
+        for view in views:
+            Image.fromarray(imgs_src[view["name"]]).save(save_dir / f"{view['name']}_src.png")
+            Image.fromarray(imgs_dec[view["name"]]).save(save_dir / f"{view['name']}_dec.png")
+    return {"views": results, "pass": bool(all_pass)}
+
+
+# ----------------------------------------------------------------- ladder integration
+def _apply_redecimation(rec: dict, frag: dict) -> None:
+    """Fold a redecimate_at() fragment (attempt + outputs) into the mesh record."""
+    att, out = frag["attempt"], frag["out"]
+    rec["journey"] = rec.get("journey", []) + [att]
+    rec.update(
+        rung_chosen=att["keep"],
+        extratcoordw=att["extratcoordw"],
+        planarquadric=att.get("planarquadric", False),
+        keep_achieved=att["keep_achieved"],
+        faces_out=att["faces_out"],
+        verts_out=att["verts_out"],
+        hausdorff=att["hausdorff"],
+        hausdorff_ratio=att["hausdorff_ratio"],
+        dec_stats=att["dec_stats"],
+        boundary_rel_diff=att["boundary_rel_diff"],
+        geometry_pass=att["pass"],
+        fail_reasons=att["fail_reasons"],
+    )
+    rec.update(out)
+    for n in frag.get("notes", []):
+        if n not in rec.setdefault("notes", []):
+            rec["notes"].append(n)
+
+
+_NO_SAFE_NOTE = (
+    "no_safe_decimation: extended ladder exhausted — undecimated M1 conversion shipped "
+    "as the optimized deliverable (byte-identical copy, SHA-verified)"
+)
+
+
+def _apply_no_safe_decimation(rec: dict, frag: dict) -> None:
+    """Fold a ship_undecimated_copy() fragment into the mesh record. The undecimated
+    M1 copy becomes the deliverable; the failed ladder attempts stay in the journeys
+    as the decision evidence."""
+    rec.update(frag)
+    if _NO_SAFE_NOTE not in rec.setdefault("notes", []):
+        rec["notes"].append(_NO_SAFE_NOTE)
+
+
+def evaluate_with_ladder(rec: dict, task: dict, cfg: dict, tex_orientation: str, root: Path) -> None:
+    """SSIM-gate `rec` at its chosen rung; on failure retry the rung with
+    extratcoordw=3.0 (UV-smearing remedy), then climb the group's ladder (Group C gets
+    the GROUP_C_EXTENDED_LADDER rungs) — geometry gates are re-run for every
+    re-decimation and outputs are only rewritten when they pass, so rec and the on-disk
+    OBJ never diverge. When a Group-C mesh exhausts even the extended ladder, the
+    undecimated M1 conversion is shipped (decision='no_safe_decimation') and verified
+    through the same SSIM harness. Mutates rec in place."""
+    from scrollkit.decimate.core import ladder_for_group, redecimate_at, ship_undecimated_copy
+
+    ladder = ladder_for_group(cfg, task["group"])
+    src_mesh = read_ply(task["src"])
+    tex_name = rec.get("texture")
+    texture_path = Path(task["src"]).parent / tex_name if tex_name else None
+    if texture_path is None:
+        rec["ssim"] = {"views": [], "pass": False, "error": "no texture — SSIM undefined"}
+        return
+    views = build_views(src_mesh, texture_path, tex_orientation)
+    save_root = root / "outputs/decimated/_ssim" / rec["stem"]
+
+    if rec.get("decision") == "no_safe_decimation":
+        # Already decided (idempotent re-run): re-check the identity deliverable only,
+        # PRESERVING the recorded failed-ladder journey (the gate's decision evidence).
+        prior = rec["ssim"]["journey"] if isinstance(rec.get("ssim"), dict) else []
+        prior = [j for j in prior if not (j.get("rung") == 1.0 and "no_safe_decimation" in j.get("note", ""))]
+        res = evaluate_ssim(src_mesh, Path(rec["obj"]), texture_path, tex_orientation, cfg, views, save_dir=save_root)
+        rec["ssim"] = {
+            "views": res["views"],
+            "pass": bool(res["pass"]),
+            "journey": prior + [{
+                "rung": 1.0, "extratcoordw": None, "planarquadric": None,
+                "pass": bool(res["pass"]),
+                "note": "no_safe_decimation: identity deliverable re-check",
+                "ssims": {v["name"]: v["ssim"] for v in res["views"]},
+            }],
+        }
+        rec["ssim_renders_dir"] = str(save_root)
+        return
+
+    # Candidate sequence per rung: current outputs as-is; extratcoordw=3.0 (the
+    # config's sanctioned UV-smearing remedy); planarquadric=True (VCG planar-fitting
+    # quadric — measured to strongly reduce texture sliding on sheet-like wraps);
+    # then the next rung up, same sub-sequence.
+    rung0, w0 = float(rec["rung_chosen"]), float(rec["extratcoordw"])
+    pq0 = bool(rec.get("planarquadric", False))
+    base_w = float(cfg.get("extratcoordw", 1.0))
+    # (rung, extratcoordw, planarquadric, needs_redecimate)
+    candidates: list[tuple[float, float, bool, bool]] = [(rung0, w0, pq0, False)]
+    if w0 != 3.0:
+        candidates.append((rung0, 3.0, False, True))
+    if not pq0:
+        candidates.append((rung0, base_w, True, True))
+    start = ladder.index(rung0) if rung0 in ladder else -1
+    for r in ladder[start + 1 :]:
+        candidates.append((r, base_w, False, True))
+        if base_w != 3.0:
+            candidates.append((r, 3.0, False, True))
+        candidates.append((r, base_w, True, True))
+
+    journey: list[dict] = []
+    final: dict | None = None
+    passed = False
+    for rung, w, pq, needs_redecimate in candidates:
+        if needs_redecimate:
+            frag = redecimate_at(task, cfg, rung, w, planarquadric=pq)
+            if frag["out"] is None:  # geometry gates failed — disk untouched, skip
+                journey.append({"rung": rung, "extratcoordw": w, "planarquadric": pq,
+                                "pass": False, "views": [],
+                                "note": "geometry gates failed: " + "; ".join(frag["attempt"]["fail_reasons"])})
+                continue
+            _apply_redecimation(rec, frag)
+        res = evaluate_ssim(
+            src_mesh, Path(rec["obj"]), texture_path, tex_orientation, cfg, views, save_dir=save_root
+        )
+        entry = {"rung": rung, "extratcoordw": w, "planarquadric": pq, **res}
+        journey.append(entry)
+        final = entry
+        if res["pass"] and rec.get("geometry_pass"):
+            passed = True
+            break
+
+    if not passed and task["group"] == "C":
+        # Extended C ladder exhausted (policy:
+        # decimate aggressively ONLY when visuals are unaffected): no keep fraction is
+        # perceptually safe, so the deliverable is the UNDECIMATED M1 conversion
+        # (byte-identical copy, SHA-verified). Rendering the identity copy through the
+        # same SSIM harness is a final deliverable wiring check (expected SSIM = 1.0;
+        # a broken MTL/texture reference would tank it and keep the gate red).
+        frag = ship_undecimated_copy(task, root)
+        _apply_no_safe_decimation(rec, frag)
+        res = evaluate_ssim(
+            src_mesh, Path(rec["obj"]), texture_path, tex_orientation, cfg, views, save_dir=save_root
+        )
+        entry = {"rung": 1.0, "extratcoordw": None, "planarquadric": None,
+                 "note": "no_safe_decimation: undecimated M1 copy shipped (identity deliverable check)",
+                 **res}
+        journey.append(entry)
+        final = entry
+        passed = bool(res["pass"])
+    elif not passed:
+        # Ladder exhausted: ship the BEST-margin geometry-green variant (not the last
+        # tried), so the on-disk OBJ + record represent the closest-to-green result
+        # for escalation review.
+        evaluated = [j for j in journey if j.get("views")]
+        if evaluated:
+            def _margin(j: dict) -> float:
+                return min(v["ssim"] - v["threshold"] for v in j["views"])
+
+            best = max(evaluated, key=_margin)
+            if best is not final:
+                frag = redecimate_at(task, cfg, best["rung"], best["extratcoordw"],
+                                     planarquadric=best.get("planarquadric", False))
+                if frag["out"] is not None:
+                    _apply_redecimation(rec, frag)
+                    res = evaluate_ssim(src_mesh, Path(rec["obj"]), texture_path,
+                                        tex_orientation, cfg, views, save_dir=save_root)
+                    entry = {"rung": best["rung"], "extratcoordw": best["extratcoordw"],
+                             "planarquadric": best.get("planarquadric", False),
+                             "note": "best-margin variant re-shipped after exhausted ladder", **res}
+                    journey.append(entry)
+                    final = entry
+
+    rec["ssim"] = {
+        "views": final["views"] if final else [],
+        "pass": bool(passed),
+        "journey": [
+            {"rung": j["rung"], "extratcoordw": j["extratcoordw"],
+             "planarquadric": j.get("planarquadric", False), "pass": j["pass"],
+             **({"note": j["note"]} if "note" in j else {}),
+             "ssims": {v["name"]: v["ssim"] for v in j.get("views", [])}}
+            for j in journey
+        ],
+    }
+    rec["ssim_renders_dir"] = str(save_root)
+
+
+__all__ = [
+    "build_views",
+    "evaluate_ssim",
+    "evaluate_with_ladder",
+    "normal_variation_scores",
+    "texture_content_uv_centroid",
+]

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/ink/__init__.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/ink/__init__.py
@@ -1,0 +1,33 @@
+"""scrollkit.ink — M2.5 ink-overlay baking (documentary grade, see docs/RENDER-STYLE.md)."""
+
+from .bake import (
+    DEFAULT_PARAMS,
+    bake_one,
+    block_mean,
+    build_jobs,
+    choose_polarity,
+    compose_overlay,
+    grade_overlay,
+    load_audit,
+    load_params,
+    normalize_ink,
+    registration_check,
+    resample_ink,
+    smoothstep,
+)
+
+__all__ = [
+    "DEFAULT_PARAMS",
+    "bake_one",
+    "block_mean",
+    "build_jobs",
+    "choose_polarity",
+    "compose_overlay",
+    "grade_overlay",
+    "load_audit",
+    "load_params",
+    "normalize_ink",
+    "registration_check",
+    "resample_ink",
+    "smoothstep",
+]

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/ink/bake.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/ink/bake.py
@@ -1,0 +1,607 @@
+"""Ink overlay bake — M2.5.
+
+Binding spec: docs/RENDER-STYLE.md ('Ink overlay bake') + configs/global.yaml
+[ink].  Gate: docs/QUALITY-GATES.md (M2.5).
+
+Per matched wrap (19 March TIF + 11 May JPG, from reports/audit.json: ink):
+
+  base   composite RGBA texture next to the PLY. The alpha channel is carried
+         through BYTE-IDENTICAL (numpy slice copy; the gate re-verifies with
+         np.array_equal against the saved PNG).
+  ink    matched prediction resampled to EXACT base texture dims.
+         March (huge deflate TIFs, 4-13x texture scale): integer-factor block
+         mean (numpy reshape trick) down to <~2x target, then LANCZOS to exact
+         dims. May (1.3-2.4x): single LANCZOS on the grayscale image.
+         The same-pixel-grid assumption (no flip vs the texture;
+         tex_orientation applies to texture<->UV sampling at RENDER time, not
+         here) is sanity-checked per mesh (registration_check). Empirical
+         outcome on this dataset: March = identity (violations of the 3%
+         outside-mask budget are sheet-edge halos, quantified per mesh); May =
+         flipud, decisively (the predictions are pixel-aligned to the
+         'max comp 5' composites, which are stored vertically flipped relative
+         to the PLY textures — content correlation ~0.9 at zero shift for
+         flipud vs ~0.3-0.4 for identity). Both are reported loudly as
+         anomalies with evidence.
+  pol    normalized to [0,1] with ink=high. The audit polarity label is
+         verified per image with the sparse-tail heuristic (smoothstep-active
+         ink fraction within the papyrus mask must land in [0.5%, 35%]); the
+         label is flipped (and recorded as an anomaly) when the data say so.
+         Empirical outcome: all 19 March TIFs are labelled 'positive' in the
+         audit but are ink-DARK rasters; they are inverted like the May JPGs.
+  grade  opacity = smoothstep(ink, lo, hi) * scale; amber tint #E8B84B;
+         out = base*(1-op) + tint*op  (float32, round-half-even to uint8);
+         glow G = gaussian(op, sigma) * strength, out = screen(out, tint*G).
+         Papyrus fibers stay visible through ink midtones by construction.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+Image.MAX_IMAGE_PIXELS = None  # ink predictions are up to ~270 Mpx — trusted local data
+
+# Mirrors configs/global.yaml [ink]; load_params() merges the YAML over this.
+DEFAULT_PARAMS: dict = {
+    "tint_rgb": [232, 184, 75],  # amber gold #E8B84B
+    "opacity_lo": 0.35,
+    "opacity_hi": 0.75,
+    "opacity_scale": 0.85,
+    "glow_sigma_px": 3.0,
+    "glow_strength": 0.30,
+}
+
+# sparse-tail heuristic band for the in-mask INK FRACTION.  Ink fraction =
+# visibly-inked pixels: normalized ink > the smoothstep midpoint (lo+hi)/2,
+# i.e. opacity > half its maximum.  (The smoothstep-ONSET fraction (> lo) is
+# recorded as a secondary stat; it counts barely-tinted midtone onset and runs
+# ~2.5-4x higher on the diffuse March predictions.)
+COVERAGE_BAND = (0.005, 0.35)
+# registration: fraction of ink-positive px (> 0.3*max) allowed outside alpha>127
+REG_OUTSIDE_MAX = 0.03
+REG_THR_FRAC = 0.30
+# decisive flip: best-variant score must beat the runner-up by >5% (relative)
+REG_DECISIVE_REL_MARGIN = 1.05
+# may cross-check: the prediction is pixel-aligned to this composite of the SAME wrap
+MC5_DIR = "ink det + max comp (may 5th)/max comp 5"
+
+
+# --------------------------------------------------------------------------- config
+
+
+def load_params(root: Path) -> dict:
+    """ink block of configs/global.yaml merged over DEFAULT_PARAMS."""
+    import yaml
+
+    cfg = yaml.safe_load((Path(root) / "configs/global.yaml").read_text())
+    p = dict(DEFAULT_PARAMS)
+    p.update(cfg.get("ink") or {})
+    return p
+
+
+def load_audit(root: Path) -> dict:
+    return json.loads((Path(root) / "reports/audit.json").read_text())
+
+
+def build_jobs(audit: dict, root: Path) -> list[dict]:
+    """One job per matched wrap (19 march + 11 may), from the audit ink tables."""
+    root = Path(root)
+    mesh_by_path = {m["path"]: m for m in audit["meshes"]}
+    jobs: list[dict] = []
+    for kind, key, ink_key in (("march", "march_matches", "tif"), ("may", "may_matches", "jpg")):
+        for match in audit["ink"][key]:
+            mesh = mesh_by_path[match["matched_mesh"]]
+            textures = [t for t in mesh["textures"] if t.get("exists")]
+            if len(textures) != 1:
+                raise ValueError(f"{mesh['path']}: expected exactly 1 texture, got {len(textures)}")
+            tex = textures[0]
+            jobs.append(
+                {
+                    "kind": kind,
+                    "group": mesh["group"],
+                    "stem": mesh["stem"],
+                    "mesh_path": mesh["path"],
+                    "tex_path": str(Path(mesh["path"]).parent / tex["name"]),
+                    "tex_wh": [tex["width"], tex["height"]],
+                    "alpha_frac_255": tex["alpha_frac_255"],
+                    "ink_path": match[ink_key],
+                    "ink_size": match["file_size"],
+                    "polarity_label": match["polarity"],
+                    "out_path": str(Path("outputs/overlays") / kind / f"{mesh['stem']}_inkoverlay.png"),
+                }
+            )
+    return jobs
+
+
+# --------------------------------------------------------------------------- resample
+
+
+def block_mean(arr: np.ndarray, f: int) -> tuple[np.ndarray, tuple[int, int]]:
+    """Integer-factor block mean via the numpy reshape trick.
+
+    Trailing rows/cols not divisible by f are cropped (recorded by the caller;
+    sub-pixel at these scales: <= f-1 px of >30k px).  Returns float32.
+    """
+    if f <= 1:
+        return arr.astype(np.float32), (0, 0)
+    h, w = arr.shape
+    h2, w2 = (h // f) * f, (w // f) * f
+    out = arr[:h2, :w2].reshape(h2 // f, f, w2 // f, f).mean(axis=(1, 3), dtype=np.float64)
+    return out.astype(np.float32), (h - h2, w - w2)
+
+
+def resample_ink(ink: np.ndarray, tex_wh: tuple[int, int], two_step: bool) -> tuple[np.ndarray, list[dict]]:
+    """Resample ink raster to exact texture dims. Returns float32 [0,255] + step log.
+
+    two_step (March full-res TIFs): block mean down to <~2x target, then LANCZOS.
+    single step (May JPGs, <=2.4x): LANCZOS directly.
+    """
+    tw, th = int(tex_wh[0]), int(tex_wh[1])
+    h, w = ink.shape
+    steps: list[dict] = []
+    if two_step:
+        f = max(1, int(np.ceil(max(h / th, w / tw) / 2.0)))
+        if f > 1:
+            ink_f, crop = block_mean(ink, f)
+            steps.append(
+                {
+                    "op": "block_mean",
+                    "factor": f,
+                    "in_hw": [h, w],
+                    "out_hw": list(ink_f.shape),
+                    "cropped_px_hw": list(crop),
+                }
+            )
+        else:
+            ink_f = ink.astype(np.float32)
+    else:
+        ink_f = ink.astype(np.float32)
+    img = Image.fromarray(ink_f, mode="F")
+    del ink_f
+    img = img.resize((tw, th), Image.Resampling.LANCZOS)
+    steps.append({"op": "lanczos", "out_wh": [tw, th]})
+    out = np.clip(np.asarray(img, dtype=np.float32), 0.0, 255.0)  # clip LANCZOS over/undershoot
+    del img
+    return out, steps
+
+
+# --------------------------------------------------------------------------- polarity
+
+
+def normalize_ink(ink255: np.ndarray, inverted: bool) -> np.ndarray:
+    """uint8-range raster -> [0,1] float32 with ink=high."""
+    n = ink255.astype(np.float32) / 255.0
+    return (1.0 - n) if inverted else n
+
+
+def _band_distance(c: float, band: tuple[float, float] = COVERAGE_BAND) -> float:
+    """0 inside the band, else log-distance to the nearest edge."""
+    lo, hi = band
+    eps = 1e-9
+    if c < lo:
+        return float(np.log((lo + eps) / (c + eps)))
+    if c > hi:
+        return float(np.log((c + eps) / (hi + eps)))
+    return 0.0
+
+
+def choose_polarity(
+    ink255: np.ndarray, mask: np.ndarray, polarity_label: str, thr: float
+) -> tuple[np.ndarray, dict]:
+    """Verify the audit polarity label with the sparse-tail heuristic.
+
+    coverage(candidate) = in-mask ink fraction: pixels with normalized ink >
+    thr (the smoothstep midpoint -> visibly inked).  Must land in
+    COVERAGE_BAND.  The audit label wins if in band; otherwise the flipped
+    candidate wins if in band; otherwise the candidate closest to the band
+    (log distance) wins and the result is flagged out-of-band.
+    """
+    label_inverted = polarity_label.strip().lower().startswith("inv")
+    cov = {}
+    for inv in (False, True):
+        n = normalize_ink(ink255, inv)
+        cov[inv] = float((n[mask] > thr).mean()) if mask.any() else 0.0
+        del n
+    in_band = {inv: COVERAGE_BAND[0] <= cov[inv] <= COVERAGE_BAND[1] for inv in (False, True)}
+    if in_band[label_inverted]:
+        use_inv = label_inverted
+    elif in_band[not label_inverted]:
+        use_inv = not label_inverted
+    else:  # neither in band: closest to band (handles ultra-sparse damaged wraps)
+        use_inv = min((False, True), key=lambda inv: _band_distance(cov[inv]))
+    info = {
+        "audit_label": polarity_label,
+        "used": "inverted (ink dark)" if use_inv else "positive (ink bright)",
+        "flipped_vs_audit": bool(use_inv != label_inverted),
+        "coverage_definition": f"in-mask fraction with normalized ink > {thr} (smoothstep midpoint)",
+        "coverage_as_audit_label": cov[label_inverted],
+        "coverage_flipped": cov[not label_inverted],
+        "coverage_used": cov[use_inv],
+        "in_band": bool(in_band[use_inv]),
+    }
+    return normalize_ink(ink255, use_inv), info
+
+
+# --------------------------------------------------------------------------- registration
+
+
+def _reg_metrics(S: np.ndarray, mask: np.ndarray) -> dict:
+    n_ink = int(S.sum())
+    inter = int(np.logical_and(S, mask).sum())
+    union = int(np.logical_or(S, mask).sum())
+    return {
+        "n_ink_px": n_ink,
+        "outside_frac": (n_ink - inter) / n_ink if n_ink else 0.0,
+        "iou": inter / union if union else 0.0,
+    }
+
+
+def _apply_variant(a: np.ndarray, name: str) -> np.ndarray:
+    if name == "fliplr":
+        return a[:, ::-1]
+    if name == "flipud":
+        return a[::-1, :]
+    if name == "rot180":
+        return a[::-1, ::-1]
+    return a
+
+
+def _content_correlation(tex_gray_ds: np.ndarray, aux_gray_ds: np.ndarray) -> dict[str, float]:
+    """Zero-shift normalized correlation of texture content vs an aux render of the
+    SAME wrap, per flip variant.  Far stronger registration signal than sparse-ink
+    IoU when the aux canvas covers more sheet than the texture alpha."""
+    A = tex_gray_ds - tex_gray_ds.mean()
+    na = float(np.sqrt((A * A).sum())) or 1.0
+    out = {}
+    for name in ("identity", "fliplr", "flipud", "rot180"):
+        V = _apply_variant(aux_gray_ds, name)
+        V = V - V.mean()
+        nv = float(np.sqrt((V * V).sum())) or 1.0
+        out[name] = float((A * V).sum() / (na * nv))
+    return out
+
+
+def _halo_analysis(S: np.ndarray, mask: np.ndarray, ds: int = 4) -> dict:
+    """How close outside-mask ink pixels sit to the mask boundary (edge-halo test)."""
+    from scipy.ndimage import distance_transform_edt
+
+    md = mask[::ds, ::ds]
+    dist = distance_transform_edt(~md) * ds
+    dvals = dist[(S & ~mask)[::ds, ::ds]]
+    if dvals.size == 0:
+        return {"n_outside_sampled": 0, "frac_within_16px": 1.0, "frac_within_48px": 1.0}
+    return {
+        "n_outside_sampled": int(dvals.size),
+        "frac_within_16px": float((dvals <= 16).mean()),
+        "frac_within_48px": float((dvals <= 48).mean()),
+        "median_dist_px": float(np.median(dvals)),
+    }
+
+
+def registration_check(
+    ink_norm: np.ndarray, mask: np.ndarray, content_pair: tuple[np.ndarray, np.ndarray] | None = None
+) -> tuple[np.ndarray, dict]:
+    """Sanity-check the same-pixel-grid assumption between ink and base texture.
+
+    S = ink > 0.3*max.  Identity must keep coverage_outside_mask < 3%.  On
+    violation the 3 flip variants are tested for THIS mesh; the best-IoU
+    variant is used only when decisive (>5% relative margin over the runner-up,
+    corroborated by the content cross-check when available); either way the
+    event is reported loudly as an anomaly with full evidence.  When identity
+    is kept despite the violation, a boundary-halo analysis quantifies whether
+    the outside ink is just sheet-edge bleed (prediction silhouette slightly
+    fatter than the texture's alpha cutout).
+    """
+    mx = float(ink_norm.max())
+    thr = REG_THR_FRAC * mx
+    S = ink_norm > thr
+    ident = _reg_metrics(S, mask)
+    out = {
+        "threshold": thr,
+        "threshold_frac_of_max": REG_THR_FRAC,
+        "ink_norm_max": mx,
+        "identity": ident,
+        "outside_frac": ident["outside_frac"],
+        "iou": ident["iou"],
+        "variant_used": "identity",
+        "anomaly": None,
+    }
+    if ident["outside_frac"] < REG_OUTSIDE_MAX or ident["n_ink_px"] == 0:
+        return ink_norm, out
+
+    # violation: test flip variants for this mesh only
+    scores = {"identity": ident}
+    for name in ("fliplr", "flipud", "rot180"):
+        scores[name] = _reg_metrics(_apply_variant(ink_norm, name) > thr, mask)
+    ranked = sorted(scores.items(), key=lambda kv: kv[1]["iou"], reverse=True)
+    best, second = ranked[0], ranked[1]
+    iou_rel = best[1]["iou"] / max(second[1]["iou"], 1e-9)
+
+    content = None
+    if content_pair is not None:
+        corr = _content_correlation(*content_pair)
+        cr = sorted(corr.items(), key=lambda kv: -kv[1])
+        content = {
+            "method": "zero-shift normalized correlation, texture gray (alpha-weighted) vs "
+                      "'max comp 5' composite of the same wrap (prediction canvas), 8x downsampled",
+            "scores": corr,
+            "best": cr[0][0],
+            "rel_margin": cr[0][1] / max(cr[1][1], 1e-9),
+        }
+
+    decisive = False
+    if best[0] != "identity":
+        iou_decisive = iou_rel >= REG_DECISIVE_REL_MARGIN and (content is None or content["best"] == best[0])
+        content_decisive = (
+            content is not None
+            and content["best"] == best[0]
+            and content["rel_margin"] >= REG_DECISIVE_REL_MARGIN
+        )
+        decisive = bool(iou_decisive or content_decisive)
+    use = best[0] if (decisive and best[0] != "identity") else "identity"
+    out["variant_used"] = use
+    out["anomaly"] = {
+        "kind": "registration_outside_mask",
+        "detail": (
+            f"identity coverage_outside_mask {ident['outside_frac']:.4f} >= {REG_OUTSIDE_MAX}; "
+            f"flip variants tested: best={best[0]} (IoU {best[1]['iou']:.4f}) vs runner-up "
+            f"{second[0]} (IoU {second[1]['iou']:.4f}), rel margin {iou_rel:.3f}; "
+            f"decisive={decisive}; using '{use}'"
+        ),
+        "variant_scores": scores,
+        "iou_rel_margin": iou_rel,
+        "content_check": content,
+        "decisive": decisive,
+    }
+    if use != "identity":
+        out["outside_frac"] = scores[use]["outside_frac"]
+        out["iou"] = scores[use]["iou"]
+        ink_used = np.ascontiguousarray(_apply_variant(ink_norm, use))
+        out["anomaly"]["halo_after_fix"] = _halo_analysis(ink_used > thr, mask)
+        return ink_used, out
+    out["anomaly"]["halo_identity"] = _halo_analysis(S, mask)
+    return ink_norm, out
+
+
+# --------------------------------------------------------------------------- grading
+
+
+def smoothstep(x: np.ndarray, lo: float, hi: float) -> np.ndarray:
+    t = np.clip((x - lo) / (hi - lo), 0.0, 1.0)
+    return t * t * (3.0 - 2.0 * t)
+
+
+def grade_overlay(
+    base_rgb: np.ndarray, ink_norm: np.ndarray, params: dict
+) -> tuple[np.ndarray, np.ndarray]:
+    """Ink grade per docs/RENDER-STYLE.md. Returns (rgb uint8, opacity float32).
+
+    1) op  = smoothstep(ink, lo, hi) * scale
+    2) out = base*(1-op) + tint*op           float32, round-half-even -> uint8
+    3) G   = gaussian(op, sigma) * strength; out = screen(out, tint*G)
+    """
+    from scipy.ndimage import gaussian_filter
+
+    tint = np.asarray(params["tint_rgb"], dtype=np.float32)
+    op = (smoothstep(ink_norm.astype(np.float32), params["opacity_lo"], params["opacity_hi"])
+          * np.float32(params["opacity_scale"]))
+
+    out = base_rgb.astype(np.float32)
+    out *= (1.0 - op)[..., None]
+    out += tint[None, None, :] * op[..., None]
+    out_u8 = np.clip(np.rint(out), 0, 255).astype(np.uint8)  # np.rint = round-half-even
+    del out
+    gc.collect()
+
+    G = gaussian_filter(op, sigma=float(params["glow_sigma_px"]), mode="reflect")
+    G *= np.float32(params["glow_strength"])
+    # screen blend: 1 - (1-a)(1-b), a = graded base, b = tint*G
+    a = out_u8.astype(np.float32) / 255.0
+    a *= -1.0
+    a += 1.0  # a = 1 - out/255
+    final = np.empty_like(a)
+    for c in range(3):
+        final[..., c] = 1.0 - a[..., c] * (1.0 - (tint[c] / 255.0) * G)
+    del a, G
+    final *= 255.0
+    final_u8 = np.clip(np.rint(final), 0, 255).astype(np.uint8)
+    del final
+    gc.collect()
+    return final_u8, op
+
+
+def edge_feather_u(ink_norm: np.ndarray, frac: float) -> np.ndarray:
+    """Fade the ink signal to 0 toward the chart's u-extremes (canvas x edges).
+
+    The ink models produce edge artifacts at segment borders — a trace's innermost
+    edge can carry a column of oversized blobs that the composite shows no support
+    for. Texture x == UV u for the A/B canvases, so a
+    smoothstep ramp over `frac` of the width on each side suppresses border
+    inference without touching interior detections."""
+    if frac <= 0:
+        return ink_norm
+    w = ink_norm.shape[1]
+    n = max(2, int(round(w * frac)))
+    x = np.arange(w, dtype=np.float32)
+    ramp_in = np.clip(x / n, 0.0, 1.0)
+    ramp_out = np.clip((w - 1 - x) / n, 0.0, 1.0)
+    f = ramp_in * ramp_in * (3 - 2 * ramp_in) * ramp_out * ramp_out * (3 - 2 * ramp_out)
+    return (ink_norm.astype(np.float32) * f[None, :]).astype(ink_norm.dtype, copy=False)
+
+
+def compose_overlay(base_rgba: np.ndarray, ink_norm: np.ndarray, params: dict) -> tuple[np.ndarray, np.ndarray]:
+    """Full overlay: graded RGB + alpha carried through byte-identical (slice copy)."""
+    ink_norm = edge_feather_u(ink_norm, float(params.get("edge_feather_u_frac", 0.0)))
+    rgb, op = grade_overlay(base_rgba[..., :3], ink_norm, params)
+    rgba = np.empty_like(base_rgba)
+    rgba[..., :3] = rgb
+    rgba[..., 3] = base_rgba[..., 3]  # numpy slice copy — byte-identical
+    return rgba, op
+
+
+# --------------------------------------------------------------------------- stats / previews helpers
+
+
+def _dense_window(op: np.ndarray, win: int = 1024, cell: int = 64) -> list[int]:
+    """[x, y, w, h] of the ~win-px window with the highest summed opacity."""
+    h, w = op.shape
+    ds, _ = block_mean(op, cell)
+    k = max(1, min(win // cell, ds.shape[0], ds.shape[1]))
+    ii = np.zeros((ds.shape[0] + 1, ds.shape[1] + 1), dtype=np.float64)
+    ii[1:, 1:] = ds.cumsum(0).cumsum(1)
+    sums = ii[k:, k:] - ii[:-k, k:] - ii[k:, :-k] + ii[:-k, :-k]
+    iy, ix = np.unravel_index(int(np.argmax(sums)), sums.shape)
+    x, y = ix * cell, iy * cell
+    return [int(min(x, max(w - win, 0))), int(min(y, max(h - win, 0))), int(min(win, w)), int(min(win, h))]
+
+
+def _load_ink_raster(path: str, kind: str) -> np.ndarray:
+    if kind == "march":
+        import tifffile
+
+        return tifffile.imread(path)
+    img = Image.open(path).convert("L")  # grayscale BEFORE inversion (per spec)
+    arr = np.asarray(img, dtype=np.uint8)
+    img.close()
+    return arr
+
+
+def _content_pair(base_rgba: np.ndarray, mesh_stem: str, root: Path, ds: int = 8) -> tuple | None:
+    """(texture gray * alpha, mc5 gray) both at texture dims downsampled ds x — the
+    registration cross-check input for May wraps (prediction is pixel-aligned to the
+    'max comp 5' composite; footprint IoU 0.97 at identity on the native canvas)."""
+    mc5_path = root / MC5_DIR / f"{mesh_stem}_max_composite_2.jpg"
+    if not mc5_path.exists():
+        return None
+    h, w = base_rgba.shape[:2]
+    tg = base_rgba[..., :3].astype(np.float32).mean(axis=2)
+    tg *= base_rgba[..., 3].astype(np.float32) / 255.0
+    with Image.open(mc5_path) as im:
+        mg = np.asarray(im.convert("L").resize((w, h), Image.Resampling.LANCZOS), dtype=np.float32)
+    tg_ds, _ = block_mean(tg, ds)
+    mg_ds, _ = block_mean(mg, ds)
+    del tg, mg
+    return tg_ds, mg_ds
+
+
+# --------------------------------------------------------------------------- per-mesh bake
+
+
+def bake_one(job: dict, params: dict, root: str | Path = ".") -> dict:
+    """Bake one overlay. Returns the per-mesh record for reports/m25_ink.json."""
+    t0 = time.time()
+    root = Path(root)
+    rec: dict = {k: job[k] for k in ("kind", "group", "stem", "mesh_path", "tex_path", "ink_path", "tex_wh")}
+    rec["polarity_audit_label"] = job["polarity_label"]
+
+    # base texture (RGBA, verbatim alpha)
+    base_img = Image.open(root / job["tex_path"])
+    if base_img.mode != "RGBA":
+        raise ValueError(f"{job['tex_path']}: expected RGBA, got {base_img.mode}")
+    base = np.asarray(base_img)
+    base_img.close()
+    alpha_src = base[..., 3].copy()
+    mask = alpha_src > 127
+
+    # ink: load -> resample to exact dims -> free source immediately
+    ink_raw = _load_ink_raster(str(root / job["ink_path"]), job["kind"])
+    rec["ink_source_hw"] = list(ink_raw.shape)
+    rec["ink_source_dtype"] = str(ink_raw.dtype)
+    ink255, steps = resample_ink(ink_raw, job["tex_wh"], two_step=(job["kind"] == "march"))
+    del ink_raw
+    gc.collect()
+    rec["resample_steps"] = steps
+
+    # polarity (audit label verified per-image) + normalization to [0,1], ink=high
+    lo, hi = params["opacity_lo"], params["opacity_hi"]
+    thr_mid = (lo + hi) / 2.0
+    ink_norm, pol = choose_polarity(ink255, mask, job["polarity_label"], thr_mid)
+    del ink255
+    gc.collect()
+    rec["normalization"] = "linear v/255 (inverted: 1 - v/255); no per-image min-max stretch"
+
+    # registration sanity check of the same-pixel-grid assumption
+    # (May wraps get the mc5 content cross-check: prediction canvas == mc5 canvas)
+    content_pair = _content_pair(base, job["stem"], root) if job["kind"] == "may" else None
+    ink_norm, reg = registration_check(ink_norm, mask, content_pair)
+    del content_pair
+    rec["registration"] = reg
+
+    # final coverage is measured AFTER any registration fix
+    ink_mask = ink_norm[mask]
+    pol["coverage_used"] = float((ink_mask > thr_mid).mean()) if ink_mask.size else 0.0
+    cov_mid = pol["coverage_used"]
+    cov_active = float((ink_mask > lo).mean()) if ink_mask.size else 0.0
+    del ink_mask
+    rec["polarity"] = pol
+
+    # grade + compose
+    rgba, op = compose_overlay(base, ink_norm, params)
+    del ink_norm
+    gc.collect()
+
+    # coverage stats (in papyrus mask)
+    op_mask = op[mask]
+    rec["coverage"] = {
+        "ink_frac_in_mask": cov_mid,  # PRIMARY: frac(ink > (lo+hi)/2), visibly inked
+        "onset_frac_in_mask": cov_active,  # secondary: frac(ink > lo), any nonzero opacity
+        "mean_opacity_in_mask": float(op_mask.mean()) if op_mask.size else 0.0,
+        "p99_opacity_in_mask": float(np.percentile(op_mask, 99)) if op_mask.size else 0.0,
+        "saturated_frac_in_mask": float((op_mask >= 0.999 * params["opacity_scale"]).mean()) if op_mask.size else 0.0,
+        "mask_frac_alpha255": job["alpha_frac_255"],
+    }
+    band_lo, band_hi = COVERAGE_BAND
+    cov = pol["coverage_used"]
+    if cov < band_lo:
+        rec["coverage"]["explanation"] = (
+            f"in-mask ink fraction {cov:.4%} is below the [{band_lo:.1%}, {band_hi:.0%}] band: "
+            f"per audit this wrap's texture has alpha_frac_255={job['alpha_frac_255']:.3f} "
+            f"(only {job['alpha_frac_255']:.0%} of the canvas is surviving papyrus) — a damaged, "
+            f"sparse outer wrap where little ink survives. Not a polarity error: the opposite "
+            f"polarity gives {max(pol['coverage_as_audit_label'], pol['coverage_flipped']):.2%} "
+            f"(papyrus-as-ink, absurd); this choice is the sparse-tail optimum."
+        )
+    elif cov > band_hi:
+        rec["coverage"]["explanation"] = (
+            f"in-mask ink fraction {cov:.4%} is above the [{band_lo:.1%}, {band_hi:.0%}] band "
+            f"(texture alpha_frac_255={job['alpha_frac_255']:.3f} per audit): the prediction has "
+            f"unusually broad strong-ink support across the surviving papyrus. Mean in-mask "
+            f"opacity is {rec['coverage']['mean_opacity_in_mask']:.3f} and the saturated fraction "
+            f"{rec['coverage']['saturated_frac_in_mask']:.2%} — fibers stay visible; not a "
+            f"polarity error (opposite polarity gives "
+            f"{max(pol['coverage_as_audit_label'], pol['coverage_flipped']):.2%})."
+        )
+    del op_mask
+    rec["dense_window_xywh"] = _dense_window(op)
+    del op
+    gc.collect()
+
+    # save PNG (compress level 6), verify alpha byte-identical on the round trip
+    out_path = root / job["out_path"]
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(rgba, "RGBA").save(out_path, format="PNG", compress_level=6)
+    with Image.open(out_path) as chk_img:
+        chk = np.asarray(chk_img)
+    alpha_ok = bool(np.array_equal(chk[..., 3], alpha_src))
+    dims_ok = bool(chk.shape[0] == base.shape[0] and chk.shape[1] == base.shape[1])
+    del chk, rgba, base
+    gc.collect()
+
+    rec["output"] = {
+        "path": job["out_path"],
+        "wh": [job["tex_wh"][0], job["tex_wh"][1]],
+        "file_size": out_path.stat().st_size,
+        "sha256": hashlib.sha256(out_path.read_bytes()).hexdigest(),
+        "alpha_byte_identical_roundtrip": alpha_ok,
+        "dims_match_base": dims_ok,
+    }
+    if not alpha_ok or not dims_ok:
+        raise RuntimeError(f"{job['stem']}: saved overlay failed alpha/dims roundtrip check")
+    rec["runtime_s"] = round(time.time() - t0, 2)
+    return rec

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/ink/infill.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/ink/infill.py
@@ -1,0 +1,128 @@
+"""Papyrus infill for render textures.
+
+The composites' alpha-0 regions mix two things: voids CONNECTED to
+the chart boundary (the sheet's outside plus genuine edge bites — physically
+missing papyrus, KEPT as holes) and INTERIOR-ENCLOSED dropout (compositor had no
+texture data there; the papyrus wall is physically continuous). Rendering interior
+dropout as cutouts perforates the sheet — and on the WOUND roll it opens windows
+into the scroll interior: the camera sees the far wall's recto ink through the
+near wall (a see-through roll showing interior ink). A real carbonized scroll
+is a closed wall, so interior dropout is filled up to a size cap; only large
+TRUE lacunae and boundary-connected bites remain holes.
+
+Fill is a single-shot Voronoi fill (nearest valid texel via EDT) — completes any
+region size, unlike bounded ring dilation, whose 64-iteration cap silently left
+big regions' RGB unfilled while alpha was still forced opaque — followed by a
+blur on filled pixels only plus matched papyrus grain so large fills don't read
+as smooth plastic.
+
+Originals are never modified — these are presentation textures for animation
+rendering and frame-OBJ exports only (conversion deliverables keep exact source
+textures).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import ndimage
+
+
+def classify_holes(alpha: np.ndarray, *, alpha_min: int = 16,
+                   max_fill_frac: float = 0.0005) -> dict:
+    """Label invalid regions. Interior-enclosed components up to max_fill_frac of
+    the papyrus area are dropout (fill); LARGER interior components are TRUE
+    lacunae and stay holes. The size distribution typically shows a clean gap
+    (a handful of components >= 0.1% of papyrus vs tens of thousands of dropout
+    specks below 0.025%), which the cap sits inside. Components touching the
+    canvas border are the chart's outside / edge bites (keep)."""
+    valid = alpha > alpha_min
+    lab, n = ndimage.label(~valid)
+    if n == 0:
+        return {"fill_mask": np.zeros_like(valid), "n_filled_components": 0,
+                "n_kept_lacunae": 0, "filled_frac_of_papyrus": 0.0}
+    border_ids = set(np.unique(np.concatenate(
+        [lab[0], lab[-1], lab[:, 0], lab[:, -1]])).tolist())
+    border_ids.discard(0)
+    papyrus = float(valid.sum())
+    sizes = ndimage.sum_labels(np.ones(lab.shape, np.float64), lab, np.arange(1, n + 1))
+    big = set((np.flatnonzero(sizes > max_fill_frac * papyrus) + 1).tolist())
+    keep = border_ids | big
+    fillable_ids = np.array([i for i in range(1, n + 1) if i not in keep],
+                            dtype=np.int64)
+    fill_mask = np.isin(lab, fillable_ids)
+    return {
+        "fill_mask": fill_mask,
+        "n_filled_components": int(len(fillable_ids)),
+        "n_kept_lacunae": int(n - len(fillable_ids)),
+        "filled_frac_of_papyrus": float(fill_mask.sum() / max(papyrus, 1.0)),
+    }
+
+
+def voronoi_fill(rgb: np.ndarray, valid: np.ndarray, fill_mask: np.ndarray) -> np.ndarray:
+    """Fill fill_mask pixels with their nearest valid texel (EDT indices) — exact,
+    single pass, any region size."""
+    out = rgb.astype(np.float32).copy()
+    _, (iy, ix) = ndimage.distance_transform_edt(~valid, return_indices=True)
+    sel = fill_mask
+    out[sel] = rgb[iy[sel], ix[sel]].astype(np.float32)
+    return out
+
+
+def dilate_inpaint(rgb: np.ndarray, valid: np.ndarray, fill_mask: np.ndarray,
+                   *, max_iter: int = 64) -> np.ndarray:
+    """Legacy ring-dilation fill (kept for tests/back-compat); prefer voronoi_fill."""
+    out = rgb.astype(np.float32).copy()
+    known = valid.copy()
+    todo = fill_mask & ~known
+    k = np.ones((3, 3), dtype=np.float32)
+    for _ in range(max_iter):
+        if not todo.any():
+            break
+        ksum = ndimage.convolve(known.astype(np.float32), k, mode="nearest")
+        ring = todo & (ksum > 0)
+        if not ring.any():
+            break
+        for c in range(out.shape[2]):
+            csum = ndimage.convolve(np.where(known, out[..., c], 0.0), k, mode="nearest")
+            out[..., c][ring] = csum[ring] / ksum[ring]
+        known |= ring
+        todo &= ~ring
+    return out
+
+
+def build_render_texture(rgba: np.ndarray, *, alpha_min: int = 16,
+                         max_fill_frac: float = 0.0005,
+                         blend_sigma: float = 2.5,
+                         grain: float = 0.5,
+                         seed: int = 0) -> tuple[np.ndarray, dict]:
+    """RGBA uint8 → (infilled RGBA uint8, stats). Valid pixels untouched bit-for-bit;
+    interior dropout gets Voronoi papyrus + blur + matched grain, alpha=255."""
+    rgb = rgba[..., :3]
+    alpha = rgba[..., 3]
+    info = classify_holes(alpha, alpha_min=alpha_min, max_fill_frac=max_fill_frac)
+    fill = info["fill_mask"]
+    if not fill.any():
+        return rgba.copy(), info
+    valid = alpha > alpha_min
+    filled = voronoi_fill(rgb, valid, fill)
+    if blend_sigma > 0:
+        sm = np.stack([ndimage.gaussian_filter(filled[..., c], blend_sigma)
+                       for c in range(3)], -1)
+        filled = np.where(fill[..., None], sm, filled)
+    if grain > 0:
+        # matched papyrus grain: replicate the valid region's high-frequency energy
+        # so large smooth fills don't read as plastic
+        g = rgb.astype(np.float32).mean(-1)
+        hf = g - ndimage.gaussian_filter(g, 3.0)
+        hf_std = float(hf[valid].std()) if valid.any() else 0.0
+        rng = np.random.default_rng(seed)
+        noise = rng.normal(0.0, grain * hf_std, size=fill.shape).astype(np.float32)
+        noise = ndimage.gaussian_filter(noise, 0.7)
+        filled = filled + np.where(fill, noise, 0.0)[..., None]
+    out = rgba.copy()
+    out[..., :3] = np.where(fill[..., None],
+                            np.clip(np.rint(filled), 0, 255).astype(np.uint8), rgb)
+    a = out[..., 3].copy()
+    a[fill] = 255
+    out[..., 3] = a
+    return out, info

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/io/__init__.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/io/__init__.py
@@ -1,0 +1,17 @@
+"""Strict, convention-pinned mesh IO. Every byte that touches disk goes through here."""
+
+from .obj import ObjFrameWriter, copy_texture, dedup_wedge_uv, read_obj, write_mtl, write_obj
+from .ply import parse_header, read_ply
+from .types import MeshData
+
+__all__ = [
+    "MeshData",
+    "ObjFrameWriter",
+    "copy_texture",
+    "dedup_wedge_uv",
+    "parse_header",
+    "read_obj",
+    "read_ply",
+    "write_mtl",
+    "write_obj",
+]

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/io/obj.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/io/obj.py
@@ -1,0 +1,353 @@
+"""Strict OBJ + MTL writer/reader.
+
+Float formatting is %.9g everywhere: 9 significant decimal digits round-trip IEEE-754
+binary32 exactly. Faces are written 1-based, order-preserving. Two UV layouts:
+
+- "shared": per-vertex UV, `f v/vt[/vn]` with identical indices (Groups A/B after the
+  audit proves wedge == vertex UV bit-exactly).
+- "wedge": per-corner UV deduplicated bit-exactly into a vt table, `f v/vt` (Group C).
+
+Reading parses floats as float64 then casts to float32 — the guaranteed round-trip path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from pathlib import Path
+
+import numpy as np
+
+from .types import MeshData
+
+
+def _fmt_block(prefix: str, arr: np.ndarray) -> str:
+    """Format an (n,k) float32 array as '<prefix> a b c' lines with %.9g."""
+    a = np.asarray(arr, dtype=np.float32)
+    cols = a.shape[1]
+    pat = prefix + " " + " ".join(["%.9g"] * cols) + "\n"
+    return "".join(pat % tuple(row) for row in a)
+
+
+def dedup_wedge_uv(wedge_uv: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Bit-exact dedup of (m,3,2) wedge UVs.
+
+    Returns (vt, corner_idx): vt is (k,2) float32 unique rows, corner_idx is (m,3) int64
+    indices into vt. Dedup compares raw bits (void view) so distinct float encodings never merge.
+    """
+    flat = np.ascontiguousarray(wedge_uv.reshape(-1, 2).astype(np.float32, copy=False))
+    as_void = flat.view([("", "V8")]).ravel()
+    _, first_idx, inverse = np.unique(as_void, return_index=True, return_inverse=True)
+    vt = flat[first_idx]
+    return vt, inverse.reshape(-1, 3)
+
+
+def write_mtl(path: str | Path, materials: list[tuple[str, str | None]]) -> None:
+    """materials: list of (material_name, texture_filename_or_None).
+
+    map_d references the same RGBA image so OBJ viewers honor the texture's alpha
+    (lacunae render as holes, matching our alpha-test renderer). Without it the
+    MTL declares d=1.0 and viewers paint alpha-0 regions with the PNG's undefined
+    RGB — solid garbage patches instead of holes."""
+    lines = ["# scrollkit material library\n"]
+    for name, tex in materials:
+        lines.append(f"newmtl {name}\n")
+        lines.append("Ka 0.200000 0.200000 0.200000\n")
+        lines.append("Kd 1.000000 1.000000 1.000000\n")
+        lines.append("Ks 0.000000 0.000000 0.000000\n")
+        lines.append("d 1.000000\nillum 1\n")
+        if tex:
+            lines.append(f"map_Kd {tex}\n")
+            lines.append(f"map_d {tex}\n")
+    Path(path).write_text("".join(lines), encoding="ascii")
+
+
+def write_obj(
+    path: str | Path,
+    mesh: MeshData,
+    *,
+    texture_file: str | None = None,
+    mtl_path: str | Path | None = None,
+    material_name: str = "material_0",
+    uv_mode: str = "auto",
+    header_comment: str | None = None,
+) -> None:
+    """Write mesh to OBJ (+MTL if texture_file given). Order- and bit-preserving."""
+    path = Path(path)
+    if uv_mode == "auto":
+        if mesh.vertex_uv is not None and mesh.wedge_equals_vertex_uv() in (True, None):
+            uv_mode = "shared"
+        elif mesh.wedge_uv is not None:
+            uv_mode = "wedge"
+        else:
+            uv_mode = "none"
+
+    parts: list[str] = []
+    parts.append(f"# scrollkit exact export of {Path(mesh.source_path).name or 'mesh'}\n")
+    if header_comment:
+        parts.append(f"# {header_comment}\n")
+    if texture_file:
+        mtl_path = Path(mtl_path) if mtl_path else path.with_suffix(".mtl")
+        write_mtl(mtl_path, [(material_name, texture_file)])
+        parts.append(f"mtllib {mtl_path.name}\n")
+
+    parts.append(_fmt_block("v", mesh.vertices))
+
+    f1 = mesh.faces.astype(np.int64) + 1  # 1-based
+    if uv_mode == "shared":
+        parts.append(_fmt_block("vt", mesh.vertex_uv))
+        if mesh.normals is not None:
+            parts.append(_fmt_block("vn", mesh.normals))
+        if texture_file:
+            parts.append(f"usemtl {material_name}\n")
+        if mesh.normals is not None:
+            pat = "f %d/%d/%d %d/%d/%d %d/%d/%d\n"
+            tri = np.repeat(f1, 3, axis=1)  # v/vt/vn all share the index
+        else:
+            pat = "f %d/%d %d/%d %d/%d\n"
+            tri = np.repeat(f1, 2, axis=1)
+        parts.append("".join(pat % tuple(row) for row in tri))
+    elif uv_mode == "wedge":
+        vt, corner = dedup_wedge_uv(mesh.wedge_uv)
+        parts.append(_fmt_block("vt", vt))
+        if mesh.normals is not None:
+            parts.append(_fmt_block("vn", mesh.normals))
+        if texture_file:
+            parts.append(f"usemtl {material_name}\n")
+        c1 = corner + 1
+        if mesh.normals is not None:
+            pat = "f %d/%d/%d %d/%d/%d %d/%d/%d\n"
+            tri = np.stack([f1[:, 0], c1[:, 0], f1[:, 0],
+                            f1[:, 1], c1[:, 1], f1[:, 1],
+                            f1[:, 2], c1[:, 2], f1[:, 2]], axis=1)
+        else:
+            pat = "f %d/%d %d/%d %d/%d\n"
+            tri = np.stack([f1[:, 0], c1[:, 0],
+                            f1[:, 1], c1[:, 1],
+                            f1[:, 2], c1[:, 2]], axis=1)
+        parts.append("".join(pat % tuple(row) for row in tri))
+    else:  # no UV
+        if mesh.normals is not None:
+            parts.append(_fmt_block("vn", mesh.normals))
+            pat = "f %d//%d %d//%d %d//%d\n"
+            tri = np.repeat(f1, 2, axis=1)
+        else:
+            pat = "f %d %d %d\n"
+            tri = f1
+        parts.append("".join(pat % tuple(row) for row in tri))
+
+    path.write_text("".join(parts), encoding="ascii")
+
+
+class ObjFrameWriter:
+    """Fast per-frame OBJ export: vt/vn/f/usemtl bytes are constant per mesh and cached;
+    only the `v` block is reformatted each frame."""
+
+    def __init__(
+        self,
+        mesh: MeshData,
+        *,
+        texture_file: str | None,
+        material_name: str = "material_0",
+        mtl_name: str | None = None,
+        header_comment: str = "scrollkit unwrap animation frame",
+    ) -> None:
+        self.mesh = mesh
+        head = [f"# {header_comment}\n"]
+        if texture_file:
+            head.append(f"mtllib {mtl_name}\n")
+        self._head = "".join(head).encode("ascii")
+
+        tail: list[str] = []
+        f1 = mesh.faces.astype(np.int64) + 1
+        if mesh.vertex_uv is not None:
+            tail.append(_fmt_block("vt", mesh.vertex_uv))
+            if texture_file:
+                tail.append(f"usemtl {material_name}\n")
+            pat = "f %d/%d %d/%d %d/%d\n"
+            tri = np.repeat(f1, 2, axis=1)
+            tail.append("".join(pat % tuple(row) for row in tri))
+        else:
+            if texture_file:
+                tail.append(f"usemtl {material_name}\n")
+            tail.append("".join("f %d %d %d\n" % tuple(row) for row in f1))
+        self._tail = "".join(tail).encode("ascii")
+
+    def write_frame(self, path: str | Path, vertices: np.ndarray) -> None:
+        v = np.asarray(vertices, dtype=np.float32)
+        body = _fmt_block("v", v).encode("ascii")
+        with open(path, "wb") as f:
+            f.write(self._head)
+            f.write(body)
+            f.write(self._tail)
+
+
+class ShellObjFrameWriter:
+    """Per-frame two-sided THIN-SHELL OBJ: OBJ/MTL cannot express per-side textures
+    on one surface, so the ink variant ships a shell — the recto surface (ink
+    texture) and the verso surface (plain papyrus) offset ±delta along per-frame
+    vertex normals so any viewer renders both sides correctly without z-fighting.
+
+    Layout: v block = [recto verts; verso verts] (2n, per frame), vt written once
+    (both surfaces share UVs), faces in two usemtl groups; recto winding is chosen
+    so its outward normal points to the inner-face side (inner_sign), verso the
+    opposite."""
+
+    def __init__(
+        self,
+        mesh: MeshData,
+        *,
+        inner_sign: float,
+        recto_material: str = "ink_recto",
+        verso_material: str = "plain_verso",
+        mtl_name: str = "mesh.mtl",
+        delta_frac: float = 0.10,
+        header_comment: str = "scrollkit unwrap frame (two-sided shell)",
+    ) -> None:
+        self.F = mesh.faces.astype(np.int64)
+        self.n = mesh.vertices.shape[0]
+        e = mesh.vertices[self.F[:, 1]] - mesh.vertices[self.F[:, 0]]
+        self.delta = float(delta_frac * np.median(np.linalg.norm(e, axis=1)))
+        self.inner_sign = 1.0 if inner_sign >= 0 else -1.0
+        self._head = (f"# {header_comment}\nmtllib {mtl_name}\n").encode("ascii")
+
+        f1 = self.F + 1
+        flipped = f1[:, ::-1]
+        # outward normal of the RECTO surface must equal the inner-face direction:
+        # original winding has outward +n, flipped has -n.
+        recto_f, verso_f = (f1, flipped) if self.inner_sign > 0 else (flipped, f1)
+        verso_f = verso_f + np.array([[self.n, self.n, self.n]])
+        tail = [_fmt_block("vt", mesh.vertex_uv)]
+        pat = "f %d/%d %d/%d %d/%d\n"
+        tail.append(f"usemtl {recto_material}\n")
+        tail.append("".join(pat % tuple(np.repeat(r, 2)) for r in recto_f))
+        tail.append(f"usemtl {verso_material}\n")
+        # verso vt indices reference the shared vt block (1..n)
+        vv = np.empty((len(verso_f), 6), np.int64)
+        vv[:, 0::2] = verso_f
+        vv[:, 1::2] = verso_f - self.n
+        tail.append("".join(pat % tuple(r) for r in vv))
+        self._tail = "".join(tail).encode("ascii")
+
+    def write_frame(self, path: str | Path, vertices: np.ndarray) -> None:
+        V = np.asarray(vertices, dtype=np.float64)
+        fn = np.cross(V[self.F[:, 1]] - V[self.F[:, 0]], V[self.F[:, 2]] - V[self.F[:, 0]])
+        vn = np.zeros_like(V)
+        for j in range(3):
+            np.add.at(vn, self.F[:, j], fn)
+        vn /= np.maximum(np.linalg.norm(vn, axis=1, keepdims=True), 1e-300)
+        off = (self.inner_sign * self.delta) * vn
+        both = np.concatenate([V + off, V - off]).astype(np.float32)
+        body = _fmt_block("v", both).encode("ascii")
+        with open(path, "wb") as f:
+            f.write(self._head)
+            f.write(body)
+            f.write(self._tail)
+
+
+def read_obj(path: str | Path) -> MeshData:
+    """Strict OBJ reader for files we wrote (v/vt/vn/f, single object, one material).
+
+    Floats parsed as float64 then cast float32 (exact round-trip for %.9g output).
+    """
+    path = Path(path)
+    v_rows: list[str] = []
+    vt_rows: list[str] = []
+    vn_rows: list[str] = []
+    f_rows: list[str] = []
+    mtllib: str | None = None
+    usemtl: list[str] = []
+    with open(path, "r", encoding="ascii") as fh:
+        for line in fh:
+            if line.startswith("v "):
+                v_rows.append(line)
+            elif line.startswith("vt "):
+                vt_rows.append(line)
+            elif line.startswith("vn "):
+                vn_rows.append(line)
+            elif line.startswith("f "):
+                f_rows.append(line)
+            elif line.startswith("mtllib"):
+                mtllib = line.split(None, 1)[1].strip()
+            elif line.startswith("usemtl"):
+                usemtl.append(line.split(None, 1)[1].strip())
+
+    def parse_floats(rows: list[str], k: int) -> np.ndarray | None:
+        if not rows:
+            return None
+        out = np.empty((len(rows), k), dtype=np.float64)
+        for i, r in enumerate(rows):
+            parts = r.split()
+            out[i] = [float(x) for x in parts[1 : 1 + k]]
+        return out.astype(np.float32)
+
+    vertices = parse_floats(v_rows, 3)
+    vt = parse_floats(vt_rows, 2)
+    vn = parse_floats(vn_rows, 3)
+    if vertices is None or not f_rows:
+        raise ValueError(f"{path}: no geometry")
+
+    m = len(f_rows)
+    fv = np.empty((m, 3), dtype=np.int64)
+    ft = np.full((m, 3), -1, dtype=np.int64)
+    fn = np.full((m, 3), -1, dtype=np.int64)
+    for i, r in enumerate(f_rows):
+        corners = r.split()[1:]
+        if len(corners) != 3:
+            raise ValueError(f"{path}: non-triangle face at row {i}")
+        for j, c in enumerate(corners):
+            sub = c.split("/")
+            fv[i, j] = int(sub[0])
+            if len(sub) > 1 and sub[1]:
+                ft[i, j] = int(sub[1])
+            if len(sub) > 2 and sub[2]:
+                fn[i, j] = int(sub[2])
+    if (fv <= 0).any():
+        raise ValueError(f"{path}: negative/zero OBJ indices unsupported")
+    faces = (fv - 1).astype(np.int32)
+
+    vertex_uv = None
+    wedge_uv = None
+    if vt is not None and (ft > 0).all():
+        ft0 = ft - 1
+        if np.array_equal(ft0, fv - 1) and vt.shape[0] == vertices.shape[0]:
+            vertex_uv = vt
+        else:
+            wedge_uv = np.ascontiguousarray(vt[ft0]).astype(np.float32)
+    normals = None
+    if vn is not None and (fn > 0).all():
+        fn0 = fn - 1
+        if np.array_equal(fn0, fv - 1) and vn.shape[0] == vertices.shape[0]:
+            normals = vn
+        else:
+            raise ValueError(f"{path}: per-corner normals unsupported by strict reader")
+
+    textures: list[str] = []
+    if mtllib:
+        mtl_file = path.parent / mtllib
+        if mtl_file.exists():
+            for line in mtl_file.read_text(encoding="ascii").splitlines():
+                line = line.strip()
+                if line.startswith("map_Kd"):
+                    textures.append(line.split(None, 1)[1].strip())
+    return MeshData(
+        vertices=vertices,
+        faces=faces,
+        normals=normals,
+        vertex_uv=vertex_uv,
+        wedge_uv=wedge_uv,
+        texture_files=textures,
+        source_path=str(path),
+    )
+
+
+def copy_texture(src: str | Path, dst: str | Path) -> str:
+    """Byte-copy a texture and return its SHA256 (verified equal on both sides)."""
+    src, dst = Path(src), Path(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    h_src = hashlib.sha256(src.read_bytes()).hexdigest()
+    h_dst = hashlib.sha256(dst.read_bytes()).hexdigest()
+    if h_src != h_dst:
+        raise IOError(f"texture copy corrupted: {src} -> {dst}")
+    return h_src

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/io/ply.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/io/ply.py
@@ -1,0 +1,169 @@
+"""Strict binary-little-endian PLY reader.
+
+Header-driven: the numpy dtype is constructed from the declared properties in declared order,
+so any layout drift in the data fails loudly instead of mis-parsing. List properties are read
+via a fixed-stride fast path (count bytes asserted afterwards); if the file violates the
+uniform-count assumption we fall back to plyfile (slow but general).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+
+from .types import MeshData
+
+_SCALAR = {
+    "char": "i1", "int8": "i1",
+    "uchar": "u1", "uint8": "u1",
+    "short": "i2", "int16": "i2",
+    "ushort": "u2", "uint16": "u2",
+    "int": "i4", "int32": "i4",
+    "uint": "u4", "uint32": "u4",
+    "float": "f4", "float32": "f4",
+    "double": "f8", "float64": "f8",
+}
+
+
+class PlyHeader:
+    def __init__(self) -> None:
+        self.format = ""
+        self.comments: list[str] = []
+        self.texture_files: list[str] = []
+        # elements: list of (name, count, [(prop_kind, ...)]) where prop_kind is
+        # ("scalar", name, np_type) or ("list", name, count_np_type, item_np_type)
+        self.elements: list[tuple[str, int, list[tuple]]] = []
+        self.header_bytes = 0
+
+
+def parse_header(path: str | Path) -> PlyHeader:
+    h = PlyHeader()
+    with open(path, "rb") as f:
+        first = f.readline()
+        if first.strip() != b"ply":
+            raise ValueError(f"{path}: not a PLY file")
+        raw = first
+        cur_props: list[tuple] | None = None
+        while True:
+            line = f.readline()
+            if not line:
+                raise ValueError(f"{path}: EOF before end_header")
+            raw += line
+            text = line.decode("ascii", errors="replace").strip()
+            if text == "end_header":
+                break
+            if text.startswith("format "):
+                h.format = text.split()[1]
+            elif text.startswith("comment"):
+                comment = text[len("comment"):].strip()
+                h.comments.append(comment)
+                m = re.match(r"TextureFile\s+(.+)$", comment)
+                if m:
+                    h.texture_files.append(m.group(1).strip())
+            elif text.startswith("element "):
+                _, name, count = text.split()
+                cur_props = []
+                h.elements.append((name, int(count), cur_props))
+            elif text.startswith("property "):
+                if cur_props is None:
+                    raise ValueError(f"{path}: property before element")
+                parts = text.split()
+                if parts[1] == "list":
+                    _, _, ctype, itype, pname = parts
+                    cur_props.append(("list", pname, _SCALAR[ctype], _SCALAR[itype]))
+                else:
+                    _, ptype, pname = parts
+                    cur_props.append(("scalar", pname, _SCALAR[ptype]))
+        h.header_bytes = len(raw)
+    if h.format != "binary_little_endian":
+        raise NotImplementedError(f"{path}: only binary_little_endian supported (got {h.format!r})")
+    return h
+
+
+# Expected uniform list lengths for the fixed-stride fast path.
+_LIST_LEN = {"vertex_indices": 3, "vertex_index": 3, "texcoord": 6}
+
+
+def _element_dtype(props: list[tuple]) -> np.dtype:
+    fields = []
+    for p in props:
+        if p[0] == "scalar":
+            _, name, t = p
+            fields.append((name, "<" + t))
+        else:
+            _, name, ct, it = p
+            if name not in _LIST_LEN:
+                raise NotImplementedError(f"unsupported list property {name!r}")
+            fields.append((f"__cnt_{name}", "<" + ct))
+            fields.append((name, "<" + it, (_LIST_LEN[name],)))
+    return np.dtype(fields)
+
+
+def read_ply(path: str | Path) -> MeshData:
+    path = Path(path)
+    h = parse_header(path)
+    offset = h.header_bytes
+    arrays: dict[str, np.ndarray] = {}
+    for name, count, props in h.elements:
+        dt = _element_dtype(props)
+        arr = np.fromfile(path, dtype=dt, count=count, offset=offset)
+        if arr.shape[0] != count:
+            raise ValueError(f"{path}: truncated element {name!r}: {arr.shape[0]}/{count}")
+        for p in props:
+            if p[0] == "list":
+                pname = p[1]
+                cnt = arr[f"__cnt_{pname}"]
+                expected = _LIST_LEN[pname]
+                if not (cnt == expected).all():
+                    raise ValueError(
+                        f"{path}: non-uniform list {pname!r} (expected {expected}); "
+                        f"fast path invalid — use plyfile fallback"
+                    )
+        arrays[name] = arr
+        offset += count * dt.itemsize
+    # trailing-bytes sanity
+    fsize = path.stat().st_size
+    if offset != fsize:
+        raise ValueError(f"{path}: {fsize - offset} unexplained trailing bytes")
+
+    if "vertex" not in arrays or "face" not in arrays:
+        raise ValueError(f"{path}: missing vertex/face elements")
+    v = arrays["vertex"]
+    fa = arrays["face"]
+    names = v.dtype.names
+
+    def col3(a, b, c):
+        return np.ascontiguousarray(np.stack([v[a], v[b], v[c]], axis=1))
+
+    vertices = col3("x", "y", "z").astype(np.float32, copy=False)
+    normals = col3("nx", "ny", "nz").astype(np.float32, copy=False) if "nx" in names else None
+    vertex_uv = (
+        np.ascontiguousarray(np.stack([v["s"], v["t"]], axis=1)).astype(np.float32, copy=False)
+        if "s" in names
+        else None
+    )
+    idx_name = "vertex_indices" if "vertex_indices" in fa.dtype.names else "vertex_index"
+    faces = np.ascontiguousarray(fa[idx_name]).astype(np.int32, copy=False)
+    wedge_uv = (
+        np.ascontiguousarray(fa["texcoord"]).reshape(-1, 3, 2).astype(np.float32, copy=False)
+        if "texcoord" in fa.dtype.names
+        else None
+    )
+    texnum = (
+        np.ascontiguousarray(fa["texnumber"]).astype(np.int32, copy=False)
+        if "texnumber" in fa.dtype.names
+        else None
+    )
+    return MeshData(
+        vertices=vertices,
+        faces=faces,
+        normals=normals,
+        vertex_uv=vertex_uv,
+        wedge_uv=wedge_uv,
+        face_texnumber=texnum,
+        texture_files=list(h.texture_files),
+        source_path=str(path),
+        comments=list(h.comments),
+    )

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/io/types.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/io/types.py
@@ -1,0 +1,65 @@
+"""Core mesh container. All arrays keep their on-disk dtypes (float32/int32) — never silently upcast."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+@dataclass
+class MeshData:
+    """A triangle mesh as stored on disk.
+
+    vertices: (n,3) float32
+    normals: (n,3) float32 or None
+    vertex_uv: (n,2) float32 or None        # per-vertex s,t when present in the file
+    faces: (m,3) int32
+    wedge_uv: (m,3,2) float32 or None       # per-corner texcoords (authoritative for texturing)
+    face_texnumber: (m,) int32 or None
+    texture_files: texture names from header comments / mtl, in declaration order
+    source_path: provenance
+    comments: full original header comments (PLY) for provenance
+    """
+
+    vertices: np.ndarray
+    faces: np.ndarray
+    normals: np.ndarray | None = None
+    vertex_uv: np.ndarray | None = None
+    wedge_uv: np.ndarray | None = None
+    face_texnumber: np.ndarray | None = None
+    texture_files: list[str] = field(default_factory=list)
+    source_path: str = ""
+    comments: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        v, f = self.vertices, self.faces
+        if v.dtype != np.float32 or v.ndim != 2 or v.shape[1] != 3:
+            raise ValueError(f"vertices must be (n,3) float32, got {v.dtype} {v.shape}")
+        if f.dtype != np.int32 or f.ndim != 2 or f.shape[1] != 3:
+            raise ValueError(f"faces must be (m,3) int32, got {f.dtype} {f.shape}")
+        if self.normals is not None and (self.normals.dtype != np.float32 or self.normals.shape != v.shape):
+            raise ValueError("normals must be (n,3) float32 matching vertices")
+        if self.vertex_uv is not None and (self.vertex_uv.dtype != np.float32 or self.vertex_uv.shape != (v.shape[0], 2)):
+            raise ValueError("vertex_uv must be (n,2) float32")
+        if self.wedge_uv is not None and (self.wedge_uv.dtype != np.float32 or self.wedge_uv.shape != (f.shape[0], 3, 2)):
+            raise ValueError("wedge_uv must be (m,3,2) float32")
+        if self.face_texnumber is not None and (self.face_texnumber.dtype != np.int32 or self.face_texnumber.shape != (f.shape[0],)):
+            raise ValueError("face_texnumber must be (m,) int32")
+        if f.size and (f.min() < 0 or f.max() >= v.shape[0]):
+            raise ValueError("face indices out of range")
+
+    @property
+    def n_vertices(self) -> int:
+        return int(self.vertices.shape[0])
+
+    @property
+    def n_faces(self) -> int:
+        return int(self.faces.shape[0])
+
+    def wedge_equals_vertex_uv(self) -> bool | None:
+        """True iff per-wedge UVs are bit-identical to indexed per-vertex UVs. None if either is absent."""
+        if self.wedge_uv is None or self.vertex_uv is None:
+            return None
+        gathered = self.vertex_uv[self.faces]  # (m,3,2)
+        return bool(np.array_equal(gathered.view(np.uint32), self.wedge_uv.view(np.uint32)))

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/metrics/__init__.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""Metrics: team-standard stretch metrics (flatboi-verbatim) + animation transit gates."""
+
+from .distortion import flatboi_stretch_metrics, frame_metrics, symmetric_dirichlet
+
+__all__ = ["flatboi_stretch_metrics", "frame_metrics", "symmetric_dirichlet"]

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/metrics/clearance.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/metrics/clearance.py
@@ -1,0 +1,157 @@
+"""Roll-vs-settled-sheet clearance certificate (anti z-fight / anti pierce-through).
+
+Z-fighting or pop-through needs a second surface within ~depth precision of the
+settled flat sheet at the same plan position. Per frame:
+  1. fit the unroll plane from the final (flat) frame,
+  2. mark PLAN-RESIDENT vertices (current plan position ~= final plan position;
+     height deliberately ignored — the settled sheet legitimately rides the
+     clearance ramp far above the plane near the contact),
+  3. classify by FACE: sheet = faces with all 3 vertices resident; hover = faces
+     with all 3 non-resident. Face-level classification is what kills both false
+     positive families: a roll vertex coincidentally revisiting its final (u,v)
+     mid-flight has non-resident neighbours (not sheet), and ANY height-threshold
+     split would slice a smooth surface (roll flank or clearance ramp) into a
+     fake sheet/hover pair within one cell. Mixed faces are the landing flap —
+     single material mid-blend — and count as neither,
+  4. bin on a plan grid (cell ~ 2 median edges): margin per cell =
+     min(hover-vertex height) - max(sheet-vertex height).
+Cells within band_pad of the contact line are exempt (flap territory). Ahead of
+the contact there is no settled sheet, so nothing pairs. Intra-roll winding gaps
+are rigid-transported source geometry (intersection-free at source) and are
+deliberately not measured.
+
+Pass: every frame's worst margin >= margin_frac * median_edge (default 0.05 —
+an order of magnitude above 24-bit depth resolution at our camera ranges).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["clearance_certificate"]
+
+
+def clearance_certificate(T: np.ndarray, F: np.ndarray, margin_frac: float = 0.05,
+                          per_frame: bool = False,
+                          s: np.ndarray | None = None,
+                          c_arc: np.ndarray | None = None,
+                          pad_arc: float | None = None) -> dict:
+    """T: (n_frames, n_verts, 3) trajectory whose LAST frame is the flat sheet.
+
+    EXACT-STATE MODE (s, c_arc, pad_arc given — rolling kinematics): per-vertex
+    landing state is known, not inferred: settled <=> s < c - pad, rolled <=>
+    s > c + pad, |s - c| <= pad = the landing flap (single material, exempt).
+    Plan-residency inference CANNOT classify near the contact — roll faces
+    descending onto their landing slots are plan-resident whole faces and read
+    as 'sheet' at roll height, displacing the contact estimate.
+    Heuristic mode (state omitted) keeps face-residency classification and is
+    only used for non-rolling (DG fallback) trajectories."""
+    n_frames = len(T)
+    flat = T[-1]
+    ctr = flat.mean(0)
+    _, _, Vt = np.linalg.svd(flat - ctr, full_matrices=False)
+    n_pl = Vt[2] / np.linalg.norm(Vt[2])
+    if (T[0].mean(0) - ctr) @ n_pl < 0:
+        n_pl = -n_pl                       # toward the roll side
+    u_pl, v_pl = Vt[0], Vt[1]
+
+    e = T[0][F[:, 1]] - T[0][F[:, 0]]
+    med_edge = float(np.median(np.linalg.norm(e, axis=1)))
+    cell = 2.0 * med_edge
+    margin_min = margin_frac * med_edge
+
+    pu_fin = (flat - ctr) @ u_pl
+    pv_fin = (flat - ctr) @ v_pl
+    S_est = float(pu_fin.max() - pu_fin.min())
+    band_pad = 0.02 * S_est + 6.0 * med_edge
+
+    # payout sign along pu: the sheet grows AWAY from the anchor (the material already
+    # plan-resident earliest). The SVD axis sign is arbitrary — assuming +pu measured the
+    # contact at the ANCHOR end and exempted the wrong end (payout can run toward -pu).
+    anchor_sign = 0.0
+    for k_ref in range(n_frames):
+        P = T[k_ref]
+        res0 = ((np.abs((P - ctr) @ u_pl - pu_fin) < med_edge)
+                & (np.abs((P - ctr) @ v_pl - pv_fin) < med_edge))
+        if res0.sum() > 0.005 * len(P):
+            anchor_sign = float(np.sign(pu_fin[res0].mean() - pu_fin.mean()))
+            break
+    if anchor_sign == 0.0:
+        anchor_sign = 1.0
+    payout = -anchor_sign          # direction (in pu) in which the contact line travels
+
+    exact = s is not None and c_arc is not None and pad_arc is not None
+    if exact:
+        s = np.asarray(s, dtype=np.float64)
+        c_arc = np.asarray(c_arc, dtype=np.float64)
+        state_pad = float(pad_arc)
+
+    rows: list[dict] = []
+    worst = {"frame": -1, "margin": float("inf")}
+    overlap_frames = 0
+    for k in range(n_frames):
+        P = T[k]
+        h = (P - ctr) @ n_pl
+        pu = (P - ctr) @ u_pl
+        pv = (P - ctr) @ v_pl
+        if exact:
+            c = float(c_arc[k])
+            sheet_eval = s < c - state_pad
+            hover_v = s > c + state_pad
+        else:
+            resident = ((np.abs(pu - pu_fin) < 0.5 * cell)
+                        & (np.abs(pv - pv_fin) < 0.5 * cell))
+            res_f = resident[F]
+            sheet_v = np.zeros(len(P), bool)
+            sheet_v[F[res_f.all(axis=1)]] = True
+            hover_v = np.zeros(len(P), bool)
+            hover_v[F[(~res_f).all(axis=1)]] = True
+            if not sheet_v.any() or not hover_v.any():
+                if per_frame:
+                    rows.append({"frame": k, "margin": None, "cells": 0})
+                continue
+            contact_u = float((pu_fin[sheet_v] * payout).max()) * payout
+            sheet_eval = sheet_v & ((contact_u - pu) * payout > band_pad)
+        if not sheet_eval.any() or not hover_v.any():
+            if per_frame:
+                rows.append({"frame": k, "margin": None, "cells": 0})
+            continue
+        iu = np.floor(pu / cell).astype(np.int64)
+        iv = np.floor(pv / cell).astype(np.int64)
+        width = np.int64(iv.max() - iv.min()) + 2
+        key = (iu - iu.min()) * width + (iv - iv.min())
+
+        def cell_reduce(mask: np.ndarray, vals: np.ndarray, op):
+            kk, vv = key[mask], vals[mask]
+            order = np.argsort(kk, kind="stable")
+            kk, vv = kk[order], vv[order]
+            starts = np.r_[0, np.flatnonzero(np.diff(kk)) + 1]
+            return kk[starts], op.reduceat(vv, starts)
+
+        sheet_cells, sheet_top = cell_reduce(sheet_eval, h, np.maximum)
+        hover_cells, hover_bot = cell_reduce(hover_v, h, np.minimum)
+        common, si, hi = np.intersect1d(sheet_cells, hover_cells, return_indices=True)
+        if len(common) == 0:
+            if per_frame:
+                rows.append({"frame": k, "margin": None, "cells": 0})
+            continue
+        overlap_frames += 1
+        margins = hover_bot[hi] - sheet_top[si]
+        m = float(margins.min())
+        if per_frame:
+            rows.append({"frame": k, "margin": m, "cells": int(len(common))})
+        if m < worst["margin"]:
+            worst = {"frame": k, "margin": m}
+
+    out = {
+        "n_frames": n_frames,
+        "med_edge": med_edge,
+        "margin_min_required": margin_min,
+        "worst_frame": worst["frame"],
+        "worst_margin": (None if worst["frame"] < 0 else worst["margin"]),
+        "frames_with_overlap": overlap_frames,
+        "pass": bool(worst["frame"] < 0 or worst["margin"] >= margin_min),
+    }
+    if per_frame:
+        out["per_frame"] = rows
+    return out

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/metrics/distortion.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/metrics/distortion.py
@@ -1,0 +1,185 @@
+"""Distortion metrics.
+
+`flatboi_stretch_metrics` mirrors volume-cartographer/libs/flatboi/flatboi.cpp
+`stretch_metrics`/`triangle_stretch` exactly (area-weighted Sander L2 mean, weighted
+median, Linf = max largest singular value, signed per-triangle area error) so reports
+use the team's established numbers.
+
+`frame_metrics` evaluates one animation frame against the unwrap-math-spec gates.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _triangle_stretch_terms(V3: np.ndarray, UV2: np.ndarray, F: np.ndarray):
+    """Vectorized port of flatboi's triangle_stretch. Returns (L2², Linf(G), area3d, area2d_abs)."""
+    q1, q2, q3 = (V3[F[:, k]].astype(np.float64) for k in range(3))
+    p1, p2, p3 = (UV2[F[:, k]].astype(np.float64) for k in range(3))
+    s1, t1 = p1[:, 0], p1[:, 1]
+    s2, t2 = p2[:, 0], p2[:, 1]
+    s3, t3 = p3[:, 0], p3[:, 1]
+    A = ((s2 - s1) * (t3 - t1) - (s3 - s1) * (t2 - t1)) / 2.0
+    Aabs = np.abs(A)
+    ok = Aabs >= 1e-30
+    Asafe = np.where(ok, A, 1.0)
+    Ss = (q1 * (t2 - t3)[:, None] + q2 * (t3 - t1)[:, None] + q3 * (t1 - t2)[:, None]) / (2.0 * Asafe[:, None])
+    St = (q1 * (s3 - s2)[:, None] + q2 * (s1 - s3)[:, None] + q3 * (s2 - s1)[:, None]) / (2.0 * Asafe[:, None])
+    a = np.einsum("ij,ij->i", Ss, Ss)
+    b = np.einsum("ij,ij->i", Ss, St)
+    c = np.einsum("ij,ij->i", St, St)
+    G = np.sqrt(np.maximum(((a + c) + np.sqrt((a - c) ** 2 + 4.0 * b * b)) / 2.0, 0.0))
+    L2sq = (a + c) / 2.0
+    ab = np.linalg.norm(q2 - q1, axis=1)
+    bc = np.linalg.norm(q3 - q2, axis=1)
+    ca = np.linalg.norm(q1 - q3, axis=1)
+    s = (ab + bc + ca) / 2.0
+    area3d = np.sqrt(np.maximum(s * (s - ab) * (s - bc) * (s - ca), 0.0))
+    L2sq = np.where(ok, L2sq, 0.0)
+    G = np.where(ok, G, 0.0)
+    area3d = np.where(ok, area3d, 0.0)
+    Aabs = np.where(ok, Aabs, 0.0)
+    return L2sq, G, area3d, Aabs
+
+
+def _weighted_median(data: np.ndarray, weights: np.ndarray) -> float:
+    idx = np.argsort(data)
+    acc = np.cumsum(weights[idx])
+    cut = 0.5 * weights.sum()
+    k = int(np.searchsorted(acc, cut))
+    return float(data[idx[min(k, len(idx) - 1)]])
+
+
+def flatboi_stretch_metrics(V3: np.ndarray, UV2: np.ndarray, F: np.ndarray) -> dict:
+    """flatboi stretch_metrics verbatim: (L2_mean, L2_median, Linf, area_error)."""
+    L2sq, G, area3d, area2d = _triangle_stretch_terms(V3, UV2, F)
+    sum_a3 = area3d.sum()
+    l2_mean = float(np.sqrt((L2sq * area3d).sum() / sum_a3)) if sum_a3 > 0 else 0.0
+    l2_median = _weighted_median(L2sq, area3d)
+    linf = float(G.max()) if len(G) else 0.0
+    sum_a2 = area2d.sum()
+    alpha = area3d / sum_a3 if sum_a3 > 0 else np.zeros_like(area3d)
+    beta = area2d / sum_a2 if sum_a2 > 0 else np.zeros_like(area2d)
+    per_tri = np.where(alpha > beta, 1.0 - beta / (alpha + 1e-30), 1.0 - alpha / (beta + 1e-30))
+    area_err = float(per_tri.sum() / max(1, len(F)))
+    return {"l2_mean": l2_mean, "l2_median": l2_median, "linf": linf, "area_error": area_err}
+
+
+def symmetric_dirichlet(V_from: np.ndarray, V_to: np.ndarray, F: np.ndarray,
+                        face_mask: np.ndarray | None = None) -> float:
+    """Area-weighted mean symmetric Dirichlet energy of the per-face map V_from→V_to
+    (singular values σ of the 2D-restricted differential): mean_A(σ1²+σ2²+σ1⁻²+σ2⁻²)/4, 1=isometry."""
+    if face_mask is not None:
+        F = F[face_mask]
+    e1f = V_from[F[:, 1]] - V_from[F[:, 0]]
+    e2f = V_from[F[:, 2]] - V_from[F[:, 0]]
+    e1t = V_to[F[:, 1]] - V_to[F[:, 0]]
+    e2t = V_to[F[:, 2]] - V_to[F[:, 0]]
+
+    def to_local2d(e1, e2):
+        x1 = np.linalg.norm(e1, axis=1)
+        x1 = np.where(x1 < 1e-300, 1e-300, x1)
+        u = e1 / x1[:, None]
+        proj = np.einsum("ij,ij->i", e2, u)
+        h = e2 - proj[:, None] * u
+        y2 = np.linalg.norm(h, axis=1)
+        return np.stack([np.stack([x1, proj], -1), np.stack([np.zeros_like(y2), y2], -1)], axis=2)
+
+    Sf = to_local2d(e1f, e2f)  # (m,2,2) columns = local coords of e1,e2
+    St = to_local2d(e1t, e2t)
+    ok = np.abs(np.linalg.det(Sf)) > 1e-24
+    J = np.einsum("mij,mjk->mik", St[ok], np.linalg.inv(Sf[ok]))
+    # closed form for 2x2: σ1²+σ2² = ‖J‖²_F, σ1²σ2² = det(J)² ⇒ Σσ⁻² = ‖J‖²_F/det²
+    fro2 = np.einsum("mij,mij->m", J, J)
+    det2 = np.maximum(np.linalg.det(J) ** 2, 1e-24)
+    e = (fro2 + fro2 / det2) / 4.0
+    A = 0.5 * np.linalg.norm(np.cross(e1f, e2f), axis=1)
+    A = A[ok]
+    return float((e * A).sum() / max(A.sum(), 1e-300))
+
+
+def frame_metrics(
+    Vt: np.ndarray,
+    t: float,
+    V0: np.ndarray,
+    V1: np.ndarray,
+    F: np.ndarray,
+    A0: np.ndarray,
+    A1: np.ndarray,
+    N_blend_ref: np.ndarray | None = None,
+    visible: np.ndarray | None = None,
+    ref_mode: str = "blend",
+    flip_exclude: np.ndarray | None = None,
+) -> dict:
+    """Per-frame gate metrics (see unwrap-math-spec §metrics).
+
+    ref_mode: 'blend' compares per-face areas/edges against the linear endpoint blend
+    (right for fields that deform everywhere, e.g. the DG path). 'step' compares against
+    the NEAREST endpoint — right for rolling-contact kinematics whose per-face schedule is
+    a step (rigid at A0 until the contact passes, exactly A1 after); the blend reference
+    would penalize that step for being correct."""
+    finite = bool(np.isfinite(Vt).all())
+    e1 = Vt[F[:, 1]] - Vt[F[:, 0]]
+    e2 = Vt[F[:, 2]] - Vt[F[:, 0]]
+    n = np.cross(e1, e2)
+    At = 0.5 * np.linalg.norm(n, axis=1)
+    degenerate = int((At < 1e-12).sum())
+
+    if ref_mode == "step":
+        rel = np.minimum(np.abs(At - A0), np.abs(At - A1)) / np.maximum(
+            np.minimum(A0, A1), 1e-300)
+    else:
+        blend = (1.0 - t) * A0 + t * A1
+        rel = np.abs(At - blend) / np.maximum(blend, 1e-300)
+    area_p95 = float(np.quantile(rel, 0.95))
+    area_p999 = float(np.quantile(rel, 0.999))
+    area_max = float(rel.max())
+    rel_vis = rel[visible] if visible is not None and visible.any() else rel
+    area_p95_vis = float(np.quantile(rel_vis, 0.95))
+    area_p999_vis = float(np.quantile(rel_vis, 0.999))
+
+    def edge_lengths(V):
+        return np.stack([
+            np.linalg.norm(V[F[:, 1]] - V[F[:, 0]], axis=1),
+            np.linalg.norm(V[F[:, 2]] - V[F[:, 1]], axis=1),
+            np.linalg.norm(V[F[:, 0]] - V[F[:, 2]], axis=1),
+        ])
+
+    Lt = edge_lengths(Vt)
+    L0, L1 = edge_lengths(V0), edge_lengths(V1)
+    if ref_mode == "step":
+        erel = np.minimum(np.abs(Lt - L0), np.abs(Lt - L1)) / np.maximum(
+            np.minimum(L0, L1), 1e-300)
+    else:
+        Lb = (1.0 - t) * L0 + t * L1
+        erel = np.abs(Lt - Lb) / np.maximum(Lb, 1e-300)
+    edge_p95 = float(np.quantile(erel, 0.95))
+    edge_max = float(erel.max())
+    erel_vis = erel[:, visible] if visible is not None and visible.any() else erel
+    edge_p95_vis = float(np.quantile(erel_vis, 0.95))
+
+    flipped = 0
+    if N_blend_ref is not None:
+        nn = n / np.maximum(np.linalg.norm(n, axis=1, keepdims=True), 1e-300)
+        flip_mask = np.einsum("ij,ij->i", nn, N_blend_ref) < 0
+        if flip_exclude is not None:
+            flip_mask = flip_mask & ~flip_exclude   # takeoff-band swing is by-design
+        flipped = int(flip_mask.sum())
+
+    sd = symmetric_dirichlet(V0, Vt, F, face_mask=visible)
+    return {
+        "t": float(t),
+        "finite": finite,
+        "degenerate_tris": degenerate,
+        "flipped_tris": flipped,
+        "area_rel_p95": area_p95,
+        "area_rel_p999": area_p999,
+        "area_rel_max": area_max,
+        "area_rel_p95_vis": area_p95_vis,
+        "area_rel_p999_vis": area_p999_vis,
+        "edge_rel_p95": edge_p95,
+        "edge_rel_max": edge_max,
+        "edge_rel_p95_vis": edge_p95_vis,
+        "sym_dirichlet_vs_source": sd,
+    }

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/metrics/visibility.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/metrics/visibility.py
@@ -1,0 +1,61 @@
+"""Face visibility from texture alpha, using the audit's normative pixel conventions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+Image.MAX_IMAGE_PIXELS = None
+
+_GROUP_DIRS = {
+    "textured_ply_march": "A",
+    "textured_ply_may": "B",
+}
+
+
+def group_of_source(src: Path) -> str:
+    return _GROUP_DIRS.get(src.parent.name, "C")
+
+
+def uv_to_pixel(uv: np.ndarray, w: int, h: int, orientation: str) -> tuple[np.ndarray, np.ndarray]:
+    """Map UV to (row, col) under the audit's convention strings."""
+    s, t = uv[:, 0], uv[:, 1]
+    if orientation == "topleft":
+        rows, cols = t * (h - 1), s * (w - 1)
+    elif orientation == "opengl_bottomleft":
+        rows, cols = (1.0 - t) * (h - 1), s * (w - 1)
+    elif orientation == "rot180":
+        rows, cols = (1.0 - t) * (h - 1), (1.0 - s) * (w - 1)
+    else:
+        raise ValueError(f"unknown tex orientation {orientation!r}")
+    return np.clip(rows, 0, h - 1).astype(np.int64), np.clip(cols, 0, w - 1).astype(np.int64)
+
+
+def visible_face_mask(mesh, src: Path, repo_root: Path, alpha_min: int = 16) -> np.ndarray:
+    """True per face iff the texture alpha at the face's UV centroid exceeds alpha_min.
+    Meshes without alpha (RGB textures / no texture) are fully visible."""
+    src = Path(src)
+    group = group_of_source(src)
+    tex = None
+    for cand in mesh.texture_files:
+        p = src.parent / cand
+        if p.exists():
+            tex = p
+            break
+    if tex is None or mesh.vertex_uv is None:
+        return np.ones(len(mesh.faces), dtype=bool)
+    img = Image.open(tex)
+    if "A" not in img.getbands():
+        return np.ones(len(mesh.faces), dtype=bool)
+    alpha = np.asarray(img.getchannel("A"))
+    h, w = alpha.shape
+    audit = json.loads((Path(repo_root) / "reports/audit.json").read_text())
+    orientation = audit["tex_orientation"][group]
+    if isinstance(orientation, dict):
+        orientation = orientation.get("resolved_orientation", "topleft")
+    uvc = mesh.vertex_uv[mesh.faces].mean(axis=1)
+    rows, cols = uv_to_pixel(uvc, w, h, orientation)
+    return alpha[rows, cols] > alpha_min

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/render/__init__.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/render/__init__.py
@@ -1,0 +1,27 @@
+"""Headless EGL rendering: scene construction, texture-orientation handling, parity QA.
+
+Importing this package pins the headless EGL environment (scene module side effect)
+BEFORE pyvista/vtk initialize — import scrollkit.render before anything GL-touching.
+"""
+
+from .scene import (
+    ORIENTATIONS,
+    SceneRenderer,
+    auto_camera,
+    load_texture,
+    orient_texture_array,
+    render_mesh_arrays,
+    split_wedge_to_vertex,
+)
+from .parity import render_parity_ssim
+
+__all__ = [
+    "ORIENTATIONS",
+    "SceneRenderer",
+    "auto_camera",
+    "load_texture",
+    "orient_texture_array",
+    "render_mesh_arrays",
+    "render_parity_ssim",
+    "split_wedge_to_vertex",
+]

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/render/cinematics.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/render/cinematics.py
@@ -1,0 +1,580 @@
+"""M4 cinematics: camera planning, chirality-correct screen orientation, studio
+lighting, and vignette for the unwrap videos.
+
+Art direction is bound by docs/RENDER-STYLE.md:
+  - static per-mesh camera fit on the UNION of the whole trajectory + margin
+    (nothing ever clips, verified by projecting every frame's points),
+  - 16:9 composition with the unroll axis horizontal (sheet unrolls across the
+    width), 9:16 with the unroll axis vertical,
+  - gentle linear push-in (default 2.5%) expressed as a per-frame parallel_scale
+    schedule (camera frozen during the reveal tail — exact image-space blends),
+  - background #101114 + subtle radial vignette (post-multiply in numpy),
+  - 3-point studio rig: warm key upper camera-left, cool fill ~35%, faint rim.
+    M4 fix over the M3 contact sheets: the key is angled strongly enough along
+    the view axis that the FLAT end state (face-on to the camera) reads clearly,
+    not just the rolled start. Lights are world-static for the whole clip and are
+    positioned relative to the union of start/end geometry.
+
+Camera-'up' rule (chirality)
+----------------------------
+The flat end state is rendered face-on and must match the team's composite PNG
+(the texture file composited on the render background) — mirrored or upside-down
+Greek is fatal. The unwrap preserves UV<->3D orientation (M3 `mirror_check` > 0),
+so the only remaining freedoms are which SIDE the camera looks from and the sign
+of 'up'. We resolve both EMPIRICALLY, exactly like scripts/chirality_check.py but
+decision-grade: render the flat frame face-on from the recto (face-winding
+normal) and from the verso, each with up = +sheet-v; the up = -sheet-v candidates
+are the exact rot180 of those images (parallel face-on projection), so four
+hypotheses come from two renders. Each candidate is compared (downscaled SSIM)
+against the PNG-composited-on-background reference cropped to the mesh's UV bbox
+through the audit's tex_orientation pixel mapping. The argmax wins; all scores
+are recorded in the returned plan.
+
+Geometric cross-check (and why the verso can legitimately win): with positive UV
+winding the recto view with up=+v shows the FILE transformed by the per-group
+tex_orientation (group A 'rot180' -> flip_h(file), group B 'topleft' ->
+flip_v(file), 'opengl_bottomleft' -> identity). reports/m3_chirality.json
+measured exactly those flips, so for groups A/B the readable side is the verso.
+The SSIM probe encodes no convention — it simply finds the screen orientation
+that reproduces the composite.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image
+
+from .scene import SceneRenderer
+
+Image.MAX_IMAGE_PIXELS = None
+
+#: render background, bound by docs/RENDER-STYLE.md (#101114)
+BACKGROUND_RGB = (16, 17, 20)
+BACKGROUND_HEX = "#101114"
+
+#: studio rig v2 (M4). v1 = scene.SceneRenderer._add_studio_lights (M3 contact
+#: sheets: flat end state too dark — key cos vs the face-on sheet only ~0.66 and
+#: the M3 camera was isometric). v2 keeps the key warm + upper camera-left but
+#: angles it strongly along the view axis so the face-on flat sheet holds
+#: midtones, fill stays cool at ~35% of key, rim faint from behind-above.
+STUDIO_RIG = {
+    "version": "m4-v2",
+    "key": {"offset": (-0.55, 0.50, 1.45), "color": (1.00, 0.97, 0.92), "intensity": 0.92},
+    "fill": {"offset": (1.15, 0.20, 0.95), "color": (0.84, 0.90, 1.00), "intensity": 0.33},
+    "rim": {"offset": (0.12, 0.95, -1.40), "color": (1.00, 1.00, 1.00), "intensity": 0.45},
+}
+
+#: vignette: corners ~25% darker per the style spec; quadratic-ish falloff keeps the
+#: center 80% of frame nearly untouched.
+VIGNETTE = {"strength": 0.25, "power": 2.2}
+
+__all__ = [
+    "BACKGROUND_HEX",
+    "BACKGROUND_RGB",
+    "STUDIO_RIG",
+    "VIGNETTE",
+    "apply_vignette",
+    "choose_camera_up",
+    "plan_camera",
+    "sheet_frame",
+    "studio_lights",
+    "vignette_mask",
+]
+
+
+def _unit(v: np.ndarray) -> np.ndarray:
+    v = np.asarray(v, dtype=np.float64)
+    n = float(np.linalg.norm(v))
+    if n == 0.0:
+        raise ValueError("zero-length vector")
+    return v / n
+
+
+# --------------------------------------------------------------------------------------
+# sheet frame + chirality probe
+# --------------------------------------------------------------------------------------
+def sheet_frame(flat: np.ndarray, faces: np.ndarray, uv: np.ndarray) -> dict:
+    """Orthonormal frame of the FLAT end state.
+
+    n      : recto normal from face winding (sum of cross products — sign is the
+             surface orientation, not an arbitrary PCA sign).
+    v_hat  : in-plane world direction of increasing uv-v (UV-covariance fit,
+             projected into the sheet plane). Camera-up candidates are ±v_hat.
+    u_hat  : in-plane direction of increasing uv-u, orthonormalized against v_hat
+             (the unroll axis on screen; metrics.json: unroll_axis_uv == 'u').
+    """
+    flat = np.asarray(flat, dtype=np.float64)
+    c = flat.mean(axis=0)
+    fc = flat - c
+    e1 = flat[faces[:, 1]] - flat[faces[:, 0]]
+    e2 = flat[faces[:, 2]] - flat[faces[:, 0]]
+    n = _unit(np.cross(e1, e2).sum(axis=0))
+    uvc = np.asarray(uv, dtype=np.float64) - np.asarray(uv, dtype=np.float64).mean(axis=0)
+    du = (fc * uvc[:, :1]).sum(axis=0)
+    dv = (fc * uvc[:, 1:]).sum(axis=0)
+    v_hat = _unit(dv - (dv @ n) * n)
+    u_raw = du - (du @ n) * n
+    u_hat = _unit(u_raw - (u_raw @ v_hat) * v_hat)
+    handed = float(np.cross(u_hat, v_hat) @ n)  # +1 for positive UV winding
+    return {"center": c, "n": n, "v_hat": v_hat, "u_hat": u_hat, "handedness": handed}
+
+
+def _reference_image(texture_path, tex_orientation: str, uv: np.ndarray, size_wh) -> np.ndarray:
+    """The team's composite as the on-screen ground truth: PNG alpha-composited on
+    the render background, cropped to the mesh's UV bbox through the audit's
+    tex_orientation pixel mapping, grayscale, resized to the probe render size."""
+    with Image.open(texture_path) as im:
+        arr = np.asarray(im.convert("RGBA"), dtype=np.float64)
+    rgb, a = arr[..., :3], arr[..., 3:] / 255.0
+    comp = rgb * a + np.array(BACKGROUND_RGB, dtype=np.float64) * (1.0 - a)
+    H, W = comp.shape[:2]
+
+    s0, t0 = (float(x) for x in np.asarray(uv).min(axis=0))
+    s1, t1 = (float(x) for x in np.asarray(uv).max(axis=0))
+    if tex_orientation == "topleft":            # col = s*(W-1);     row = t*(H-1)
+        cols, rows = (s0, s1), (t0, t1)
+    elif tex_orientation == "opengl_bottomleft":  # col = s*(W-1);   row = (1-t)*(H-1)
+        cols, rows = (s0, s1), (1.0 - t1, 1.0 - t0)
+    elif tex_orientation == "rot180":           # col = (1-s)*(W-1); row = (1-t)*(H-1)
+        cols, rows = (1.0 - s1, 1.0 - s0), (1.0 - t1, 1.0 - t0)
+    else:
+        raise ValueError(f"unsupported tex_orientation {tex_orientation!r}")
+    c0, c1 = int(np.floor(cols[0] * (W - 1))), int(np.ceil(cols[1] * (W - 1))) + 1
+    r0, r1 = int(np.floor(rows[0] * (H - 1))), int(np.ceil(rows[1] * (H - 1))) + 1
+    crop = comp[max(r0, 0):min(r1, H), max(c0, 0):min(c1, W)]
+
+    gray = Image.fromarray(crop.astype(np.uint8)).convert("L")
+    return np.asarray(gray.resize(size_wh, Image.LANCZOS), dtype=np.float64)
+
+
+def inner_side_sign(rolled: np.ndarray, faces: np.ndarray, uv: np.ndarray) -> dict:
+    """Which side of the sheet faced the umbilicus in the ROLLED state.
+
+    Design rule: the ink lives on the INNER face of the winding (the
+    papyrological recto of a rolled scroll); the unwrap must expose it. Geometric rule:
+    in the rolled state, the winding axis is the (area-weighted) mean v-tangent direction;
+    a face's radial-out vector is its centroid minus its projection on the axis line.
+    inner_sign = −sign(median(n̂·radial_out)): +1 means the face-winding normal itself
+    points inward (camera goes on the +winding-normal side of the FLAT sheet), −1 the
+    opposite. The sign transports to the flat sheet because the morph never flips
+    orientation (mirror_check > 0 is gated).
+    """
+    V = np.asarray(rolled, dtype=np.float64)
+    F = np.asarray(faces)
+    e1 = V[F[:, 1]] - V[F[:, 0]]
+    e2 = V[F[:, 2]] - V[F[:, 0]]
+    n = np.cross(e1, e2)
+    area = np.linalg.norm(n, axis=1)
+    ok = area > 1e-300
+    n_hat = np.where(ok[:, None], n / np.maximum(area, 1e-300)[:, None], 0.0)
+    # winding axis from uv v-tangents (same construction as the embedding's axis fit)
+    duv1 = np.asarray(uv)[F[:, 1]] - np.asarray(uv)[F[:, 0]]
+    duv2 = np.asarray(uv)[F[:, 2]] - np.asarray(uv)[F[:, 0]]
+    det = duv1[:, 0] * duv2[:, 1] - duv1[:, 1] * duv2[:, 0]
+    safe = np.where(np.abs(det) < 1e-18, 1.0, det)
+    t_v = (-duv2[:, 0, None] * e1 + duv1[:, 0, None] * e2) / safe[:, None]
+    tvn = np.linalg.norm(t_v, axis=1)
+    good = (tvn > 1e-12) & ok & (np.abs(det) > 1e-18)
+    axis = _unit(((t_v[good] / tvn[good][:, None]) * area[good][:, None]).sum(axis=0))
+    cent = V[F].mean(axis=1)
+    c0 = V.mean(axis=0)
+    rel = cent - c0
+    radial_out = rel - (rel @ axis)[:, None] * axis[None, :]
+    dot = np.einsum("ij,ij->i", n_hat, radial_out)
+    w = area * good
+    med = float(np.sign((np.sign(dot) * w).sum()))  # area-weighted majority of sign
+    inner = -med if med != 0 else 1.0
+    frac_inward = float((np.sign(dot)[w > 0] < 0).mean())
+    return {"inner_sign": inner, "frac_normals_inward": frac_inward, "axis": axis.tolist()}
+
+
+def choose_camera_up(
+    flat: np.ndarray,
+    faces: np.ndarray,
+    uv: np.ndarray,
+    texture_path,
+    tex_orientation: str,
+    *,
+    probe_px: int = 768,
+    rolled: np.ndarray | None = None,
+) -> dict:
+    """Side + up selection.
+
+    Side: GEOMETRIC when `rolled` is given (design rule: expose the inner face of the
+    winding — see inner_side_sign); the PNG-similarity scores remain as a checksum and
+    any disagreement is recorded loudly. Up: argmax SSIM against the composite reference
+    among ±v_hat on the chosen side (upright, un-mirrored text)."""
+    from skimage.metrics import structural_similarity
+
+    fr = sheet_frame(flat, faces, uv)
+    c, n, v_hat, u_hat = fr["center"], fr["n"], fr["v_hat"], fr["u_hat"]
+    fc = np.asarray(flat, dtype=np.float64) - c
+    hh = float(np.abs(fc @ v_hat).max())
+    hw = float(np.abs(fc @ u_hat).max())
+    Hpx = int(probe_px)
+    Wpx = int(np.clip(round(probe_px * hw / hh), 64, 2 * probe_px))
+    dist = 3.0 * float(np.linalg.norm(fc, axis=1).max())
+
+    ref = _reference_image(texture_path, tex_orientation, uv, (Wpx, Hpx))
+
+    shots = {}
+    sr = SceneRenderer(flat, faces, uv, texture_path, tex_orientation,
+                       size=(Wpx, Hpx), background=BACKGROUND_HEX, lighting="flat")
+    try:
+        for side_name, side in (("recto", 1.0), ("verso", -1.0)):
+            sr.set_camera({
+                "position": tuple(c + side * n * dist),
+                "focal_point": tuple(c),
+                "up": tuple(v_hat),
+                "parallel": True,
+                "parallel_scale": hh * 1.02,
+            })
+            img = sr.screenshot()
+            shots[side_name] = np.asarray(
+                Image.fromarray(img).convert("L"), dtype=np.float64
+            )
+    finally:
+        sr.close()
+
+    candidates = {
+        ("recto", +1): shots["recto"],
+        ("recto", -1): shots["recto"][::-1, ::-1],   # up=-v_hat == screen rot180
+        ("verso", +1): shots["verso"],
+        ("verso", -1): shots["verso"][::-1, ::-1],
+    }
+    scores = {
+        f"{side}_up{'+' if sgn > 0 else '-'}":
+            float(structural_similarity(np.ascontiguousarray(img), ref, data_range=255.0))
+        for (side, sgn), img in candidates.items()
+    }
+    png_best_key = max(scores, key=scores.get)
+    runner_up = max(v for k, v in scores.items() if k != png_best_key)
+
+    inner = None
+    if rolled is not None:
+        inner = inner_side_sign(rolled, faces, uv)
+        # 'recto' here = +face-winding-normal side; the inner face is on that side iff
+        # inner_sign > 0. The geometric rule decides the SIDE; SSIM decides the UP.
+        side_name = "recto" if inner["inner_sign"] > 0 else "verso"
+        side_scores = {k: v for k, v in scores.items() if k.startswith(side_name)}
+        best_key = max(side_scores, key=side_scores.get)
+    else:
+        best_key = png_best_key
+
+    side_name, sgn = best_key.rsplit("_up", 1)
+    out = {
+        "side": side_name,                      # 'recto' (+face-winding normal) | 'verso'
+        "side_sign": 1.0 if side_name == "recto" else -1.0,
+        "up_sign": 1.0 if sgn == "+" else -1.0,
+        "scores": scores,
+        "best": best_key,
+        "png_best": png_best_key,
+        "ssim_best": scores[best_key],
+        "ssim_margin": scores[best_key] - runner_up,
+        "tex_orientation": tex_orientation,
+        "probe_size": [Wpx, Hpx],
+        "handedness": fr["handedness"],
+        "side_rule": "geometric_inner" if rolled is not None else "png_similarity",
+    }
+    if inner is not None:
+        out["inner_side"] = inner
+        out["png_side_agrees"] = png_best_key.startswith(side_name)
+    return out
+
+
+def tight_flat_camera(flatV, faces, uv, plan: dict, margin_frac: float = 0.10) -> dict:
+    """Camera framing the FLAT sheet only (reveal push-in target): same view direction
+    and up as the production plan, parallel scale fit to the sheet's extent + margin."""
+    V = np.asarray(flatV, dtype=np.float64)
+    pos = np.asarray(plan["position"], dtype=np.float64)
+    foc = np.asarray(plan["focal_point"], dtype=np.float64)
+    up = _unit(np.asarray(plan["up"], dtype=np.float64))
+    dop = _unit(foc - pos)
+    right = _unit(np.cross(dop, up))
+    true_up = _unit(np.cross(right, dop))
+    c = V.mean(axis=0)
+    rel = V - c
+    half_w = float(np.abs(rel @ right).max())
+    half_h = float(np.abs(rel @ true_up).max())
+    aspect = plan.get("aspect")
+    if not aspect:
+        aspect = half_w / max(half_h, 1e-9)
+    scale = max(half_h, half_w / float(aspect)) * (1.0 + margin_frac)
+    dist = float(np.linalg.norm(np.asarray(plan["position"]) - np.asarray(plan["focal_point"])))
+    return {
+        "position": tuple(c - dop * dist),
+        "focal_point": tuple(c),
+        "up": tuple(up),
+        "parallel": True,
+        "parallel_scale": scale,
+    }
+
+
+def lerp_camera(a: dict, b: dict, e: float) -> dict:
+    """Linear camera interpolation (position/focal/parallel_scale; up held from a)."""
+    pa, pb = np.asarray(a["position"], float), np.asarray(b["position"], float)
+    fa, fb = np.asarray(a["focal_point"], float), np.asarray(b["focal_point"], float)
+    sa, sb = float(a["parallel_scale"]), float(b["parallel_scale"])
+    return {
+        "position": tuple(pa * (1 - e) + pb * e),
+        "focal_point": tuple(fa * (1 - e) + fb * e),
+        "up": tuple(a["up"]),
+        "parallel": True,
+        "parallel_scale": sa * (1 - e) + sb * e,
+    }
+
+
+# --------------------------------------------------------------------------------------
+# camera plan
+# --------------------------------------------------------------------------------------
+def plan_camera(
+    frames: np.ndarray,
+    faces: np.ndarray,
+    uv: np.ndarray,
+    aspect: float,
+    group: str,
+    *,
+    texture_path=None,
+    tex_orientation: str | None = None,
+    up_choice: dict | None = None,
+    margin_frac: float = 0.06,
+    push_in_frac: float = 0.025,
+) -> dict:
+    """Static per-mesh camera plan for one framing (aspect = width/height).
+
+    View direction: face-on to the flat sheet from the chirality-chosen side.
+    Up: aspect > 1 -> the reading orientation itself (unroll axis horizontal,
+    text exactly as in the team's composite); aspect < 1 -> the reading frame
+    rotated 90° clockwise on screen (unroll axis vertical per the style spec; the
+    deterministic CW sign mounts the text top-to-bottom).
+
+    Fit: every frame's points are projected on the screen basis about the
+    union-bbox center; the scale schedule (linear push-in of `push_in_frac`
+    over the clip) is lifted so that EVERY frame keeps >= margin_frac margin —
+    nothing ever clips, including at maximum push-in. Per-frame margins are
+    verified and recorded.
+    """
+    frames = np.asarray(frames)
+    if up_choice is None:
+        if texture_path is None or tex_orientation is None:
+            raise ValueError("plan_camera: need texture_path+tex_orientation or an up_choice dict")
+        up_choice = choose_camera_up(frames[-1], faces, uv, texture_path, tex_orientation,
+                                     rolled=frames[0])
+
+    fr = sheet_frame(frames[-1], faces, uv)
+    d = up_choice["side_sign"] * fr["n"]            # focal -> camera
+    reading_up = up_choice["up_sign"] * fr["v_hat"]
+    dop = -d                                        # direction of projection
+    reading_right = _unit(np.cross(dop, reading_up))
+    # Design rule: text ROWS stay horizontal in EVERY framing — the
+    # earlier 90°-rotated vertical composition was rejected ("text rotated, not
+    # horizontal"). 9:16 fits the wide sheet by pulling back instead.
+    up = reading_up
+    text_rotation_deg = 0
+    right = _unit(np.cross(dop, up))
+    true_up = _unit(np.cross(right, dop))
+
+    # union bbox center = focal point (whole trajectory)
+    lo = frames.min(axis=(0, 1)).astype(np.float64)
+    hi = frames.max(axis=(0, 1)).astype(np.float64)
+    focal = 0.5 * (lo + hi)
+    diag = float(np.linalg.norm(hi - lo))
+
+    # per-frame required parallel_scale (half-height units), about the focal point
+    F = frames.shape[0]
+    req = np.empty(F, dtype=np.float64)
+    for f in range(F):
+        rel = frames[f].astype(np.float64) - focal
+        hw = float(np.abs(rel @ right).max())
+        hh = float(np.abs(rel @ true_up).max())
+        req[f] = max(hh, hw / float(aspect))
+
+    push = 1.0 - float(push_in_frac) * np.linspace(0.0, 1.0, F)
+    s0 = float((req * (1.0 + float(margin_frac)) / push).max())
+    per_frame_scale = s0 * push
+    margins = per_frame_scale / req - 1.0
+    min_margin = float(margins.min())
+    if min_margin < float(margin_frac) - 1e-9:      # by construction this cannot happen
+        raise AssertionError(f"camera fit violates margin: {min_margin:.4f} < {margin_frac}")
+
+    position = focal + d * (3.0 * diag)
+    return {
+        "position": [float(x) for x in position],
+        "focal_point": [float(x) for x in focal],
+        "up": [float(x) for x in up],
+        "parallel": True,
+        "parallel_scale": float(s0),
+        "per_frame_scale": [float(x) for x in per_frame_scale],
+        "aspect": float(aspect),
+        "group": group,
+        "margin_frac": float(margin_frac),
+        "push_in_frac": float(push_in_frac),
+        "min_margin": min_margin,
+        "max_required_scale": float(req.max()),
+        "binding_frame": int(np.argmax(req * (1.0 + margin_frac) / push)),
+        "text_rotation_deg": text_rotation_deg,
+        "screen_right": [float(x) for x in right],
+        "screen_up": [float(x) for x in true_up],
+        "view_dir_world": [float(x) for x in d],
+        "up_choice": up_choice,
+        "bounds_lo": [float(x) for x in lo],
+        "bounds_hi": [float(x) for x in hi],
+    }
+
+
+# --------------------------------------------------------------------------------------
+# studio lighting (M4 rig)
+# --------------------------------------------------------------------------------------
+def studio_lights(scene_or_plotter, embedding_like_info: dict, rig: dict | None = None) -> dict:
+    """Install the M4 3-point rig (replaces any existing lights).
+
+    scene_or_plotter   : SceneRenderer or pv.Plotter.
+    embedding_like_info: {'camera': camera/plan dict, 'bounds_lo', 'bounds_hi',
+                         optional 'texture_stats': {'p50': .., 'p95': ..} in 0-1}
+                         — bounds are the UNION of the trajectory (start+end),
+                         so the rig is positioned for both the initial roll and
+                         the final tangent-plane sheet.
+    Lights are directional (world-static, no per-frame animation). Offsets are
+    expressed in the camera basis (right, up, view) at install time and then
+    FROZEN in world space. Returns a record of the installed rig including the
+    predicted lambert response of the face-on flat sheet (the washed-out-sheet failure mode).
+
+    Exposure adaptation: the style spec pins ON-SCREEN papyrus midtones at 0.65-0.75,
+    but composite brightness varies per group (march median ~0.62, may ~0.51).
+    When texture_stats are provided (ALWAYS from the plain composite, also for
+    the ink variant, so the reveal crossfade blends identically-lit renders),
+    key+fill are scaled so the face-on flat sheet's midtone lands at ~0.70,
+    capped so its p95 stays below white (no blown highlights); the rim is left
+    untouched (silhouette only).
+    """
+    import pyvista as pv
+
+    plotter = getattr(scene_or_plotter, "plotter", scene_or_plotter)
+    rig = rig or STUDIO_RIG
+    cam = embedding_like_info["camera"]
+    lo = np.asarray(embedding_like_info["bounds_lo"], dtype=np.float64)
+    hi = np.asarray(embedding_like_info["bounds_hi"], dtype=np.float64)
+    center = 0.5 * (lo + hi)
+    diag = float(np.linalg.norm(hi - lo)) or 1.0
+
+    d = _unit(np.asarray(cam["position"], dtype=np.float64)
+              - np.asarray(cam["focal_point"], dtype=np.float64))   # focal -> camera
+    up = np.asarray(cam["up"], dtype=np.float64)
+    right = _unit(np.cross(-d, up))
+    true_up = _unit(np.cross(right, -d))
+
+    plotter.remove_all_lights()
+    renderer = plotter.renderer
+    renderer.SetTwoSidedLighting(True)  # flat sheet must read whichever side faces the camera
+
+    # exposure adaptation from the plain composite's statistics (see docstring);
+    # ambient/diffuse constants mirror scene.py's studio material (0.18 / 0.92)
+    AMBIENT, DIFFUSE, MID_TARGET, P95_CAP = 0.18, 0.92, 0.70, 0.97
+    dirs, coss = {}, {}
+    for name in ("key", "fill", "rim"):
+        off = np.asarray(rig[name]["offset"], dtype=np.float64)
+        dirs[name] = _unit(off[0] * right + off[1] * true_up + off[2] * d)
+        coss[name] = float(dirs[name] @ d)
+    exposure_scale = 1.0
+    stats = embedding_like_info.get("texture_stats")
+    if stats:
+        base_diffuse = sum(rig[n]["intensity"] * max(0.0, coss[n]) for n in ("key", "fill"))
+        mult_target = MID_TARGET / max(float(stats["p50"]), 1e-3)
+        mult_cap = P95_CAP / max(float(stats["p95"]), 1e-3)
+        mult = float(np.clip(min(mult_target, mult_cap), 1.0, 1.65))
+        exposure_scale = float(np.clip((mult - AMBIENT) / (DIFFUSE * base_diffuse), 0.8, 1.8))
+
+    record = {"rig_version": rig.get("version", "?"), "exposure_scale": exposure_scale,
+              "texture_stats": stats, "lights": {}}
+    for name in ("key", "fill", "rim"):
+        spec = rig[name]
+        intensity = spec["intensity"] * (exposure_scale if name in ("key", "fill") else 1.0)
+        pos = center + dirs[name] * (2.5 * diag)
+        plotter.add_light(pv.Light(position=tuple(pos), focal_point=tuple(center),
+                                   color=spec["color"], intensity=intensity,
+                                   positional=False))
+        record["lights"][name] = {
+            "direction_world": [float(x) for x in dirs[name]],
+            "color": list(spec["color"]),
+            "intensity": round(float(intensity), 4),
+            "cos_vs_view_axis": coss[name],  # response of the face-on flat sheet
+        }
+    # lambert sanity for the flat end state: must hold papyrus midtones ~0.65-0.75
+    flat_mult = AMBIENT + DIFFUSE * sum(
+        r["intensity"] * max(0.0, r["cos_vs_view_axis"]) for r in record["lights"].values()
+    )
+    record["flat_sheet_texture_multiplier"] = float(flat_mult)
+    if stats:
+        record["predicted_flat_midtone"] = round(float(stats["p50"]) * flat_mult, 3)
+        record["predicted_flat_p95"] = round(float(stats["p95"]) * flat_mult, 3)
+    return record
+
+
+# --------------------------------------------------------------------------------------
+# vignette (post, numpy, before encode)
+# --------------------------------------------------------------------------------------
+def vignette_mask(width: int, height: int, strength: float | None = None,
+                  power: float | None = None) -> np.ndarray:
+    """Radial multiply mask as Q8.8 uint16 (256 == 1.0): 1.0 at center, corners
+    darkened by `strength` (style spec: ~25%). Apply with apply_vignette()."""
+    strength = VIGNETTE["strength"] if strength is None else float(strength)
+    power = VIGNETTE["power"] if power is None else float(power)
+    ny, nx = np.meshgrid(np.linspace(-1.0, 1.0, height), np.linspace(-1.0, 1.0, width),
+                         indexing="ij")
+    r = np.sqrt((nx * nx + ny * ny) / 2.0)          # 1.0 exactly at the corners
+    scale = 1.0 - strength * np.power(r, power)
+    return np.clip(np.round(scale * 256.0), 0, 256).astype(np.uint16)
+
+
+def apply_vignette(frame_u8: np.ndarray, mask_q8: np.ndarray) -> np.ndarray:
+    """Multiply an (H, W, 3) uint8 frame by the Q8.8 mask (exact integer math)."""
+    if frame_u8.shape[:2] != mask_q8.shape:
+        raise ValueError(f"vignette mask {mask_q8.shape} != frame {frame_u8.shape[:2]}")
+    out = (frame_u8.astype(np.uint16) * mask_q8[..., None]) >> 8
+    return out.astype(np.uint8)
+
+
+WATERMARK_TEXT = "© Vesuvius Challenge 2026"
+
+
+def watermark_overlay(width: int, height: int, text: str = WATERMARK_TEXT,
+                      opacity: float = 0.55) -> tuple[np.ndarray, np.ndarray]:
+    """Pre-rendered subtle watermark for the bottom-right corner (empty background
+    in every framing — the subject is center-weighted with generous margins).
+
+    Returns (rgb float32 premultiplied contribution, alpha float32) at frame size;
+    composite with apply_watermark(). Soft warm-gray text, ~H/42 tall, antialiased
+    at 4x supersampling; margins ~2.2% of the frame height."""
+    from PIL import ImageDraw, ImageFont
+
+    ss = 4
+    fs = max(12, int(round(height / 42))) * ss
+    try:
+        font = ImageFont.truetype(
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", fs)
+    except OSError:
+        font = ImageFont.load_default()
+    pad_y = int(round(0.022 * height)) * ss
+    # right inset scales with WIDTH (a height-based inset is
+    # only 1.3% of a 16:9 width — cramped against rounded-corner/UI safe zones)
+    pad_x = int(round(0.022 * width)) * ss
+    canvas = Image.new("L", (width * ss, height * ss), 0)
+    d = ImageDraw.Draw(canvas)
+    bbox = d.textbbox((0, 0), text, font=font)
+    tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    x = width * ss - pad_x - tw - bbox[0]
+    y = height * ss - pad_y - th - bbox[1]
+    d.text((x, y), text, fill=255, font=font)
+    a = np.asarray(canvas.resize((width, height), Image.LANCZOS),
+                   dtype=np.float32) / 255.0
+    a *= opacity
+    color = np.array([214.0, 212.0, 206.0], np.float32)   # warm paper-gray
+    rgb = a[..., None] * color[None, None, :]
+    return rgb, a
+
+
+def apply_watermark(frame_u8: np.ndarray, wm: tuple[np.ndarray, np.ndarray]) -> np.ndarray:
+    """Alpha-composite the pre-rendered watermark over an (H, W, 3) uint8 frame."""
+    rgb, a = wm
+    out = frame_u8.astype(np.float32) * (1.0 - a[..., None]) + rgb
+    return np.clip(np.rint(out), 0, 255).astype(np.uint8)

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/render/encode.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/render/encode.py
@@ -1,0 +1,280 @@
+"""M4 encode path: raw-RGB24 piping into ffmpeg, 1080p derivatives, rawcache,
+and ffprobe self-checks.
+
+Bound by the docs/RENDER-STYLE.md encode block (system ffmpeg 6.1):
+  - masters 4K: libx264 -preset slow -crf 19 -pix_fmt yuv420p -profile high
+    -level 5.1, bt709 tags, +faststart, 30 fps; frames arrive on stdin as
+    rawvideo rgb24 (no intermediate PNGs);
+  - 1080p derivatives are DOWNSCALED from the 4K master with lanczos
+    (-crf 18 -level 4.2) — never re-rendered;
+  - the RGB->YUV conversion is forced through bt709/tv-range in swscale so the
+    stream tags match the actual matrix (ffmpeg would otherwise default to 601).
+
+The rawcache stores the exact frames piped for the PLAIN variant (post-vignette)
+so the reveal variant can re-stream them without touching the GPU; it is a flat
+rgb24 file + sidecar JSON, deleted once a mesh's variants are done.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import subprocess
+from pathlib import Path
+
+import numpy as np
+
+FFMPEG = "ffmpeg"
+FFPROBE = "ffprobe"
+
+#: bt709 stream tags (masters and derivatives)
+COLOR_TAGS = [
+    "-colorspace", "bt709",
+    "-color_primaries", "bt709",
+    "-color_trc", "bt709",
+]
+
+#: rgb24 -> yuv420p inside swscale with the bt709 matrix + tv range, so the
+#: bt709 tags above describe what was actually encoded
+RGB_TO_709_VF = "scale=in_range=full:out_range=tv:out_color_matrix=bt709,format=yuv420p"
+
+__all__ = [
+    "FFmpegWriter",
+    "RawCache",
+    "check_faststart",
+    "ffprobe_check",
+    "ffprobe_info",
+    "h264_args",
+    "make_derivative",
+]
+
+
+def h264_args(crf: int, level: str, preset: str = "slow") -> list[str]:
+    return [
+        "-c:v", "libx264",
+        "-preset", preset,
+        "-crf", str(crf),
+        "-pix_fmt", "yuv420p",
+        "-profile:v", "high",
+        "-level:v", str(level),
+        *COLOR_TAGS,
+        "-movflags", "+faststart",
+        "-r", "30",
+    ]
+
+
+class FFmpegWriter:
+    """Pipe (H, W, 3) uint8 frames straight into one ffmpeg encode process."""
+
+    def __init__(self, path, width: int, height: int, *, fps: int = 30, crf: int = 19,
+                 level: str = "5.1", preset: str = "slow", log_path=None) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.width, self.height = int(width), int(height)
+        self.frames_written = 0
+        self.log_path = Path(log_path) if log_path else self.path.with_suffix(".ffmpeg.log")
+        cmd = [
+            FFMPEG, "-y", "-loglevel", "warning",
+            "-f", "rawvideo", "-pix_fmt", "rgb24",
+            "-s", f"{self.width}x{self.height}", "-r", str(fps), "-i", "-",
+            "-an", "-vf", RGB_TO_709_VF,
+            *h264_args(crf, level, preset),
+            str(self.path),
+        ]
+        self._log = open(self.log_path, "wb")
+        self._log.write((" ".join(cmd) + "\n").encode())
+        self._log.flush()
+        self.proc = subprocess.Popen(cmd, stdin=subprocess.PIPE,
+                                     stdout=self._log, stderr=self._log)
+
+    def write(self, frame: np.ndarray) -> None:
+        if frame.dtype != np.uint8 or frame.shape != (self.height, self.width, 3):
+            raise ValueError(
+                f"frame must be uint8 ({self.height},{self.width},3), got {frame.dtype} {frame.shape}"
+            )
+        self.proc.stdin.write(np.ascontiguousarray(frame).tobytes())
+        self.frames_written += 1
+
+    def close(self) -> int:
+        if self.proc.stdin and not self.proc.stdin.closed:
+            self.proc.stdin.close()
+        rc = self.proc.wait()
+        self._log.close()
+        if rc != 0:
+            tail = Path(self.log_path).read_text(errors="replace")[-2000:]
+            raise RuntimeError(f"ffmpeg failed (rc={rc}) for {self.path}:\n{tail}")
+        return rc
+
+    def __enter__(self) -> "FFmpegWriter":
+        return self
+
+    def __exit__(self, exc_type, *exc) -> None:
+        if exc_type is None:
+            self.close()
+        else:  # error path: kill the encoder, keep the original exception
+            self.proc.kill()
+            self.proc.wait()
+            self._log.close()
+
+
+def make_derivative(master, out, width: int, height: int, *, crf: int = 18,
+                    level: str = "4.2", preset: str = "slow") -> Path:
+    """1080p derivative DOWNSCALED from the encoded master (lanczos) — no re-render."""
+    out = Path(out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    log = out.with_suffix(".ffmpeg.log")
+    cmd = [
+        FFMPEG, "-y", "-loglevel", "warning",
+        "-i", str(master), "-an",
+        "-vf", f"scale={int(width)}:{int(height)}:flags=lanczos",
+        *h264_args(crf, level, preset),
+        str(out),
+    ]
+    with open(log, "wb") as lf:
+        lf.write((" ".join(cmd) + "\n").encode())
+        lf.flush()
+        rc = subprocess.run(cmd, stdout=lf, stderr=lf).returncode
+    if rc != 0:
+        raise RuntimeError(f"ffmpeg derivative failed (rc={rc}) for {out}: see {log}")
+    return out
+
+
+# --------------------------------------------------------------------------------------
+# ffprobe self-checks
+# --------------------------------------------------------------------------------------
+def check_faststart(path) -> bool:
+    """True iff the moov atom precedes mdat (web-ready / +faststart applied)."""
+    order = []
+    with open(path, "rb") as fh:
+        offset = 0
+        fh.seek(0, 2)
+        end = fh.tell()
+        fh.seek(0)
+        while offset < end:
+            header = fh.read(8)
+            if len(header) < 8:
+                break
+            size, btype = struct.unpack(">I4s", header)
+            if size == 1:  # 64-bit box
+                size = struct.unpack(">Q", fh.read(8))[0]
+            elif size == 0:  # to EOF
+                size = end - offset
+            order.append(btype.decode("latin1"))
+            offset += size
+            fh.seek(offset)
+    if "moov" not in order or "mdat" not in order:
+        return False
+    return order.index("moov") < order.index("mdat")
+
+
+def ffprobe_info(path) -> dict:
+    cmd = [
+        FFPROBE, "-v", "error", "-select_streams", "v:0", "-count_packets",
+        "-show_entries",
+        "stream=codec_name,profile,level,width,height,pix_fmt,r_frame_rate,"
+        "avg_frame_rate,nb_frames,nb_read_packets,color_space,color_transfer,"
+        "color_primaries:format=duration,size",
+        "-of", "json", str(path),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        raise RuntimeError(f"ffprobe failed for {path}: {res.stderr[-500:]}")
+    info = json.loads(res.stdout)
+    st = info["streams"][0]
+    st["faststart"] = check_faststart(path)
+    st["file_size"] = int(info.get("format", {}).get("size", 0))
+    st["duration"] = float(info.get("format", {}).get("duration", 0.0))
+    return st
+
+
+def ffprobe_check(path, *, width: int, height: int, frames: int, fps: str = "30/1",
+                  pix_fmt: str = "yuv420p", require_faststart: bool = True) -> dict:
+    """Validate an encode; raise RuntimeError listing every violation (fail loudly)."""
+    st = ffprobe_info(path)
+    problems = []
+    if int(st["width"]) != int(width) or int(st["height"]) != int(height):
+        problems.append(f"resolution {st['width']}x{st['height']} != {width}x{height}")
+    if st["r_frame_rate"] != fps:
+        problems.append(f"r_frame_rate {st['r_frame_rate']} != {fps}")
+    if st.get("avg_frame_rate") not in (fps, "0/0"):
+        problems.append(f"avg_frame_rate {st.get('avg_frame_rate')} != {fps}")
+    n = int(st.get("nb_frames") or st.get("nb_read_packets") or -1)
+    npkt = int(st.get("nb_read_packets") or -1)
+    if n != int(frames) or npkt != int(frames):
+        problems.append(f"frame count nb_frames={n} packets={npkt} != {frames}")
+    if st["pix_fmt"] != pix_fmt:
+        problems.append(f"pix_fmt {st['pix_fmt']} != {pix_fmt}")
+    if st.get("color_space") != "bt709":
+        problems.append(f"color_space {st.get('color_space')} != bt709")
+    if require_faststart and not st["faststart"]:
+        problems.append("moov after mdat (faststart missing)")
+    if problems:
+        raise RuntimeError(f"ffprobe check FAILED for {path}: " + "; ".join(problems))
+    return st
+
+
+# --------------------------------------------------------------------------------------
+# raw frame cache (plain variant -> reveal variant, no re-render)
+# --------------------------------------------------------------------------------------
+class RawCache:
+    """Flat rgb24 frame cache + sidecar JSON meta. ~6 GB at 4K/240 frames;
+    deleted (delete()) once the mesh's variants are done."""
+
+    def __init__(self, path, width: int, height: int, mode: str = "w") -> None:
+        self.path = Path(path)
+        self.meta_path = self.path.with_suffix(".json")
+        self.width, self.height = int(width), int(height)
+        self.frame_bytes = self.width * self.height * 3
+        self.n_frames = 0
+        self._fh = None
+        if mode == "w":
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = open(self.path, "wb")
+        elif mode != "r":
+            raise ValueError("mode must be 'w' or 'r'")
+
+    @classmethod
+    def open(cls, path) -> "RawCache":
+        path = Path(path)
+        meta = json.loads(path.with_suffix(".json").read_text())
+        rc = cls(path, meta["width"], meta["height"], mode="r")
+        rc.n_frames = int(meta["n_frames"])
+        expected = rc.n_frames * rc.frame_bytes
+        actual = path.stat().st_size
+        if actual != expected:
+            raise RuntimeError(f"rawcache {path}: size {actual} != meta {expected}")
+        return rc
+
+    def append(self, frame: np.ndarray) -> None:
+        if frame.dtype != np.uint8 or frame.shape != (self.height, self.width, 3):
+            raise ValueError(f"rawcache frame mismatch: {frame.dtype} {frame.shape}")
+        self._fh.write(np.ascontiguousarray(frame).tobytes())
+        self.n_frames += 1
+
+    def finalize(self, extra_meta: dict | None = None) -> None:
+        self._fh.close()
+        self._fh = None
+        meta = {"width": self.width, "height": self.height, "n_frames": self.n_frames,
+                "pix_fmt": "rgb24", **(extra_meta or {})}
+        self.meta_path.write_text(json.dumps(meta, indent=1))
+
+    def read(self, idx: int) -> np.ndarray:
+        if not 0 <= idx < self.n_frames:
+            raise IndexError(idx)
+        with open(self.path, "rb") as fh:
+            fh.seek(idx * self.frame_bytes)
+            buf = fh.read(self.frame_bytes)
+        return np.frombuffer(buf, dtype=np.uint8).reshape(self.height, self.width, 3)
+
+    def iter_frames(self):
+        with open(self.path, "rb") as fh:
+            for _ in range(self.n_frames):
+                buf = fh.read(self.frame_bytes)
+                yield np.frombuffer(buf, dtype=np.uint8).reshape(self.height, self.width, 3)
+
+    def delete(self) -> None:
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None
+        self.path.unlink(missing_ok=True)
+        self.meta_path.unlink(missing_ok=True)

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/render/parity.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/render/parity.py
@@ -1,0 +1,110 @@
+"""Render-parity QA: SSIM between two meshes rendered with identical camera/lighting.
+
+Used by the M1 gate to prove that a converted OBJ renders indistinguishably from its
+source PLY (threshold SSIM >= 0.99 per qa-gates). Both meshes go through the same
+arrays-only pipeline (scrollkit.render.scene); wedge-UV meshes (Group C) are corner-split
+via split_wedge_to_vertex. Two opposed views (front +/-) are rendered and the MIN SSIM
+across views is returned, guarding against single-view z-fighting flukes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from .scene import SceneRenderer, auto_camera, split_wedge_to_vertex
+
+
+def _resolve_texture(mesh, tex_dir: str | Path) -> Path:
+    """First declared texture that exists in tex_dir (PHerc172 declares a second,
+    missing file — audit-known quirk; we render the single existing material)."""
+    tex_dir = Path(tex_dir)
+    names = list(mesh.texture_files or [])
+    for name in names:
+        p = tex_dir / name
+        if p.is_file():
+            return p
+    raise FileNotFoundError(f"none of the declared textures {names} found in {tex_dir}")
+
+
+def _sheet_view_direction(points: np.ndarray) -> np.ndarray:
+    """Least-variance principal axis = face-on direction for sheet-like wraps, so the
+    parity views actually exercise the texture (deterministic sign convention)."""
+    P = np.asarray(points, dtype=np.float64)
+    step = max(1, P.shape[0] // 200_000)
+    Q = P[::step]
+    Q = Q - Q.mean(axis=0)
+    cov = (Q.T @ Q) / max(Q.shape[0] - 1, 1)
+    _, vecs = np.linalg.eigh(cov)  # ascending eigenvalues
+    n = vecs[:, 0]
+    k = int(np.argmax(np.abs(n)))
+    if n[k] < 0:
+        n = -n
+    return n
+
+
+def render_parity_ssim(
+    mesh_a,
+    mesh_b,
+    texture_dir_a,
+    texture_dir_b,
+    tex_orientation,
+    size: int = 1024,
+    *,
+    return_images: bool = False,
+) -> dict:
+    """Render mesh_a and mesh_b with identical auto cameras (2 opposed face-on views)
+    and flat (unlit, texture-faithful) lighting; compare per view.
+
+    Returns {'ssim': min SSIM across views (grayscale), 'max_px': max abs uint8 pixel
+    diff across views} plus per-view diagnostics. With return_images=True, also the
+    front-view pair under 'images' (img_a, img_b) for sample sheets.
+    """
+    from skimage.color import rgb2gray
+    from skimage.metrics import structural_similarity
+
+    Va, Fa, uva = split_wedge_to_vertex(mesh_a)
+    Vb, Fb, uvb = split_wedge_to_vertex(mesh_b)
+    tex_a = _resolve_texture(mesh_a, texture_dir_a)
+    tex_b = _resolve_texture(mesh_b, texture_dir_b)
+
+    union = np.vstack([Va.astype(np.float64, copy=False), Vb.astype(np.float64, copy=False)])
+    d = _sheet_view_direction(union)
+    views = [
+        auto_camera(union, 1.0, direction=d),   # front
+        auto_camera(union, 1.0, direction=-d),  # back
+    ]
+
+    def shots(V, F, uv, tex_path):
+        # GPU is serial: one renderer alive at a time; actors/textures freed on close.
+        r = SceneRenderer(V, F, uv, tex_path, tex_orientation,
+                          camera=views[0], size=(size, size), lighting="flat")
+        try:
+            out = []
+            for cam in views:
+                r.set_camera(cam)
+                out.append(r.screenshot())
+            return out
+        finally:
+            r.close()
+
+    imgs_a = shots(Va, Fa, uva, tex_a)
+    imgs_b = shots(Vb, Fb, uvb, tex_b)
+
+    ssims: list[float] = []
+    max_px = 0
+    for ia, ib in zip(imgs_a, imgs_b):
+        ga, gb = rgb2gray(ia), rgb2gray(ib)
+        ssims.append(float(structural_similarity(ga, gb, data_range=1.0)))
+        max_px = max(max_px, int(np.abs(ia.astype(np.int16) - ib.astype(np.int16)).max()))
+
+    out = {
+        "ssim": float(min(ssims)),
+        "max_px": int(max_px),
+        "ssim_views": ssims,
+        "views": ["front", "back"],
+    }
+    if return_images:
+        out["images"] = (imgs_a[0], imgs_b[0])
+    return out

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/render/scene.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/render/scene.py
@@ -1,0 +1,443 @@
+"""Headless EGL scene rendering for scroll meshes.
+
+Meshes enter as numpy arrays only (loaded upstream via scrollkit.io — never pv.read).
+Textures enter as image files decoded with PIL, transformed to the per-group sampling
+orientation from reports/audit.json:tex_orientation, then wrapped in pv.Texture.
+
+Texture-orientation contract (normative derivation)
+----------------------------------------------------
+Empirical VTK fact, pinned by reports/smoke/uv_probe.json (t0_maps_to = "bottom_row",
+pyvista 0.48.4 / VTK 9.6.2): for a numpy array ``A`` of shape (H, W, c) handed to
+``pv.Texture`` (array row 0 = first array row), VTK samples
+
+    texel(s, t) = A[(1 - t) * (H - 1),  s * (W - 1)]
+
+i.e. t=0 reads the LAST array row ("bottom"), t=1 reads array row 0, s=0 reads column 0.
+
+The audit's orientation oracle (reports/audit.json: tex_orientation.definitions, binding)
+defines how (s, t) addresses the FILE image ``I`` (row 0 = top of the PNG as decoded):
+
+    topleft:            I[ t      * (H-1),   s      * (W-1) ]
+    opengl_bottomleft:  I[ (1-t)  * (H-1),   s      * (W-1) ]
+    rot180:             I[ (1-t)  * (H-1),   (1-s)  * (W-1) ]   # == bottomleft + u-flip
+
+Solve for the array ``A = T(I)`` such that VTK's native sampling reproduces the file's
+true mapping, i.e. ``A[(1-t)(H-1), s(W-1)] == I[row(s,t), col(s,t)]`` for all (s, t):
+
+    opengl_bottomleft:  rows match, cols match            ->  A = I                (no-op)
+    topleft:            substitute r = (1-t)(H-1); need
+                        A[r, c] = I[(H-1) - r, c]         ->  A = np.flip(I, axis=0)
+    rot180:             rows already match (VTK's native t-inversion supplies the
+                        vertical flip of rot180); columns need c -> (W-1) - c
+                                                          ->  A = np.flip(I, axis=1)
+
+tests/test_render_scene.py pins these transforms against the analytic definitions.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# ------------------------------------------------------------------------------------
+# EGL/headless environment — must be pinned BEFORE pyvista/vtk import. This is the
+# proven recipe from scripts/smoke_render.py (NVIDIA hardware context verified in
+# reports/smoke/egl_report.json).
+# ------------------------------------------------------------------------------------
+os.environ["PYVISTA_OFF_SCREEN"] = "true"
+os.environ.pop("DISPLAY", None)  # headless: never touch an X server
+os.environ.setdefault("VTK_DEFAULT_EGL_DEVICE_INDEX", "0")
+
+import numpy as np
+import pyvista as pv
+from PIL import Image
+
+
+def _vtk_shader_fragment():
+    from vtkmodules.vtkRenderingOpenGL2 import vtkShader  # noqa: PLC0415
+
+    return vtkShader.Fragment
+
+pv.OFF_SCREEN = True
+
+ORIENTATIONS = ("opengl_bottomleft", "topleft", "rot180")
+
+__all__ = [
+    "ORIENTATIONS",
+    "SceneRenderer",
+    "auto_camera",
+    "load_texture",
+    "orient_texture_array",
+    "render_mesh_arrays",
+    "split_wedge_to_vertex",
+]
+
+
+def orient_texture_array(arr: np.ndarray, tex_orientation: str) -> np.ndarray:
+    """Transform a file-decoded image array (row 0 = file top) so that pv.Texture's
+    native sampling (t=0 -> bottom array row; see module docstring) reproduces the
+    audit's mapping for `tex_orientation`.
+
+        opengl_bottomleft -> identity        (VTK native == the convention)
+        topleft           -> np.flip(arr, 0) (vertical flip)
+        rot180            -> np.flip(arr, 1) (horizontal flip only: VTK's built-in
+                             t-inversion provides rot180's vertical component)
+    """
+    if tex_orientation == "opengl_bottomleft":
+        out = arr
+    elif tex_orientation == "topleft":
+        out = np.flip(arr, axis=0)
+    elif tex_orientation == "rot180":
+        out = np.flip(arr, axis=1)
+    else:
+        raise ValueError(
+            f"unknown tex_orientation {tex_orientation!r} (expected one of {ORIENTATIONS})"
+        )
+    return np.ascontiguousarray(out)
+
+
+def load_texture(texture_path: str | Path, tex_orientation: str) -> pv.Texture:
+    """Decode an image file with PIL, apply the orientation transform, wrap in pv.Texture.
+
+    Textures are never re-encoded or resized here — bytes on disk stay authoritative;
+    this is a read-only decode for the GPU.
+    """
+    texture_path = Path(texture_path)
+    if not texture_path.is_file():
+        raise FileNotFoundError(f"texture not found: {texture_path}")
+    with Image.open(texture_path) as im:
+        arr = np.asarray(im.convert("RGBA"))
+    arr = orient_texture_array(arr, tex_orientation)
+    tex = pv.Texture(arr)
+    # bilinear sampling: VTK's default NEAREST makes texels crawl/shimmer under
+    # slow subpixel motion on curved flanks (A-B-A flicker in the temporal probe).
+    # Mipmaps stay OFF: mip-averaged alpha erodes the 0.5 cutout at grazing angles
+    # (the classic disappearing-foliage failure).
+    tex.GetInterpolate() or tex.InterpolateOn()
+    return tex
+
+
+def split_wedge_to_vertex(mesh) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Convert any MeshData to per-vertex-UV arrays (V, F, uv) for rendering.
+
+    * vertex_uv present and bit-equal to the wedge table (or no wedge table at all):
+      pass-through — arrays returned unchanged (Groups A/B and their OBJ reloads).
+    * otherwise (Group C wedge UVs): duplicate vertices per unique (vertex, uv) pair.
+      Dedup is bit-exact (uint32 view), mirroring scrollkit.io.dedup_wedge_uv — no
+      epsilon merging, so two meshes with bit-equal wedge tables and identical face
+      order produce identical splits.
+    """
+    if mesh.vertex_uv is not None and mesh.wedge_equals_vertex_uv() in (True, None):
+        return mesh.vertices, mesh.faces, mesh.vertex_uv
+    if mesh.wedge_uv is None:
+        raise ValueError(f"{mesh.source_path or 'mesh'}: no UVs (neither vertex_uv nor wedge_uv)")
+
+    m = mesh.faces.shape[0]
+    corner_vid = mesh.faces.reshape(-1).astype(np.int64)  # (3m,)
+    flat_uv = np.ascontiguousarray(mesh.wedge_uv.reshape(-1, 2).astype(np.float32, copy=False))
+    bits = flat_uv.view(np.uint32)  # (3m, 2)
+
+    rec = np.zeros(corner_vid.size, dtype=[("v", "<i8"), ("ub", "<u4"), ("vb", "<u4")])
+    rec["v"] = corner_vid
+    rec["ub"] = bits[:, 0]
+    rec["vb"] = bits[:, 1]
+    _, first_idx, inverse = np.unique(rec, return_index=True, return_inverse=True)
+
+    V = np.ascontiguousarray(mesh.vertices[corner_vid[first_idx]])
+    uv = np.ascontiguousarray(flat_uv[first_idx])
+    F = inverse.reshape(m, 3).astype(np.int32)
+    return V, F, uv
+
+
+def auto_camera(
+    all_points,
+    aspect: float,
+    margin_frac: float = 0.06,
+    *,
+    direction=None,
+    up_hint=None,
+    parallel: bool = True,
+    distance_factor: float = 3.0,
+) -> dict:
+    """Fit a camera on the axis-aligned union bbox of ANY point set (e.g. the union of
+    every frame of a trajectory) so nothing ever clips, with `margin_frac` margin.
+
+    direction: unit-ish vector from the focal point toward the camera; None gives an
+    isometric-ish (1,1,1) view. Returns a camera dict consumable by SceneRenderer /
+    render_mesh_arrays: {position, focal_point, up, parallel_scale, parallel}.
+    """
+    P = np.asarray(all_points, dtype=np.float64).reshape(-1, 3)
+    if P.size == 0:
+        raise ValueError("auto_camera: empty point set")
+    lo, hi = P.min(axis=0), P.max(axis=0)
+    center = 0.5 * (lo + hi)
+    ext = hi - lo
+    diag = float(np.linalg.norm(ext))
+    if diag <= 0.0:
+        diag = 1.0
+
+    d = np.array([1.0, 1.0, 1.0]) if direction is None else np.asarray(direction, dtype=np.float64)
+    norm = np.linalg.norm(d)
+    if norm == 0.0:
+        raise ValueError("auto_camera: zero view direction")
+    d = d / norm
+
+    if up_hint is None:
+        up_hint = (0.0, 1.0, 0.0) if abs(d @ np.array([0.0, 1.0, 0.0])) < 0.95 else (0.0, 0.0, 1.0)
+    up = np.asarray(up_hint, dtype=np.float64)
+    dop = -d  # direction of projection: camera looks along -d toward the focal point
+    right = np.cross(dop, up)
+    rn = np.linalg.norm(right)
+    if rn < 1e-12:  # up parallel to view axis — pick any orthogonal
+        up = np.array([0.0, 0.0, 1.0]) if abs(d[2]) < 0.95 else np.array([0.0, 1.0, 0.0])
+        right = np.cross(dop, up)
+        rn = np.linalg.norm(right)
+    right /= rn
+    true_up = np.cross(right, dop)
+
+    # Project the 8 bbox corners onto the screen axes; fit half-extents + margin.
+    corners = np.array([[x, y, z] for x in (lo[0], hi[0]) for y in (lo[1], hi[1]) for z in (lo[2], hi[2])])
+    rel = corners - center
+    hw = max(float(np.abs(rel @ right).max()), 1e-9)
+    hh = max(float(np.abs(rel @ true_up).max()), 1e-9)
+    parallel_scale = max(hh, hw / max(float(aspect), 1e-9)) * (1.0 + float(margin_frac))
+
+    position = center + d * (diag * float(distance_factor))
+    return {
+        "position": tuple(float(x) for x in position),
+        "focal_point": tuple(float(x) for x in center),
+        "up": tuple(float(x) for x in true_up),
+        "parallel_scale": float(parallel_scale),
+        "parallel": bool(parallel),
+    }
+
+
+class SceneRenderer:
+    """Persistent plotter/actor/texture for cheap per-frame re-rendering.
+
+    The PolyData points buffer is updated IN PLACE (`update_points`) + VTK Modified()
+    so animation frames cost one render, not one scene rebuild.
+    """
+
+    def __init__(
+        self,
+        vertices,
+        faces,
+        uv,
+        texture_path,
+        tex_orientation,
+        *,
+        camera=None,
+        size=(1024, 1024),
+        background="#101114",
+        lighting="flat",
+        double_sided=True,
+        back_texture_path=None,
+    ) -> None:
+        """back_texture_path: when given, the two sides of the sheet get DISTINCT
+        textures — `texture_path` on the +winding-normal side (VTK front faces),
+        `back_texture_path` on the −side. Used to put ink on the inner face only
+        (physically the carbon ink exists on one side of the papyrus)."""
+        if lighting not in ("flat", "studio"):
+            raise ValueError(f"lighting must be 'flat' or 'studio', got {lighting!r}")
+        V = np.ascontiguousarray(np.asarray(vertices, dtype=np.float32))
+        F = np.asarray(faces)
+        if V.ndim != 2 or V.shape[1] != 3:
+            raise ValueError(f"vertices must be (n,3), got {V.shape}")
+        if F.ndim != 2 or F.shape[1] != 3:
+            raise ValueError(f"faces must be (m,3), got {F.shape}")
+        UV = np.ascontiguousarray(np.asarray(uv, dtype=np.float32))
+        if UV.shape != (V.shape[0], 2):
+            raise ValueError(f"uv must be ({V.shape[0]},2) per-vertex, got {UV.shape}")
+
+        cells = np.empty((F.shape[0], 4), dtype=np.int64)
+        cells[:, 0] = 3
+        cells[:, 1:] = F
+        self.poly = pv.PolyData(V, cells)
+        self.poly.active_texture_coordinates = UV
+        self.texture = load_texture(texture_path, tex_orientation)
+
+        self.size = (int(size[0]), int(size[1]))
+        self.lighting = lighting
+        self.plotter = pv.Plotter(off_screen=True, window_size=list(self.size))
+        self.plotter.set_background(background)
+
+        if lighting == "flat":
+            shading = dict(lighting=False)  # texture-faithful unlit (parity mode)
+        else:  # 'studio' — papyrus is matte: minimal specular (docs/RENDER-STYLE.md)
+            shading = dict(lighting=True, ambient=0.18, diffuse=0.92,
+                           specular=0.03, specular_power=8.0, smooth_shading=False)
+        # MASK cutout, properly: any texel with alpha<255 makes VTK classify a normal
+        # actor as TRANSLUCENT and render it in the blend pass without per-fragment
+        # self-depth correctness — overlapping geometry (roll over the grown flat sheet)
+        # then shows far surfaces (ink) bleeding through near papyrus during the
+        # late unwrap. Fix: raw vtkOpenGLPolyDataMapper actors with ForceOpaque + a
+        # fragment shader alpha test — true cutout with a working z-buffer.
+        def _make_actor(texture, culling: str | None):
+            import vtkmodules.vtkRenderingOpenGL2 as glmod
+            from vtkmodules.vtkRenderingCore import vtkActor
+
+            mapper = glmod.vtkOpenGLPolyDataMapper()
+            mapper.SetInputData(self.poly)
+            act = vtkActor()
+            act.SetMapper(mapper)
+            act.SetTexture(texture)
+            act.ForceOpaqueOn()
+            act.GetShaderProperty().AddFragmentShaderReplacement(
+                "//VTK::TCoord::Impl", True,
+                "//VTK::TCoord::Impl\n"
+                "  if (gl_FragData[0].a < 0.5) { discard; }\n",
+                False,
+            )
+            prop = act.GetProperty()
+            if shading.get("lighting") is False:
+                prop.LightingOff()
+            else:
+                prop.SetAmbient(shading["ambient"])
+                prop.SetDiffuse(shading["diffuse"])
+                prop.SetSpecular(shading["specular"])
+                prop.SetSpecularPower(shading["specular_power"])
+            if culling == "back":
+                prop.BackfaceCullingOn()
+            elif culling == "front":
+                prop.FrontfaceCullingOn()
+            self.plotter.renderer.AddActor(act)
+            return act
+
+        if back_texture_path is None:
+            self.actor = _make_actor(self.texture, None if double_sided else "back")
+            self.actor_back = None
+        else:
+            # two single-sided actors over the SAME dataset: +n side / −n side textures
+            self.back_texture = load_texture(back_texture_path, tex_orientation)
+            self.actor = _make_actor(self.texture, "back")
+            self.actor_back = _make_actor(self.back_texture, "front")
+        self._points = self.poly.points  # live view into the VTK-owned buffer
+        self._camera: dict | None = None
+        self.set_camera(camera)
+        if lighting == "studio":
+            self._add_studio_lights()
+
+    # -- camera ---------------------------------------------------------------------
+    def set_camera(self, camera: dict | None = None) -> dict:
+        """Apply a camera dict ({position, focal_point, up, parallel_scale, parallel});
+        None auto-fits an isometric-ish view on the current points."""
+        if camera is None:
+            camera = auto_camera(self._points, self.size[0] / self.size[1])
+        cam = self.plotter.camera
+        cam.position = tuple(camera["position"])
+        cam.focal_point = tuple(camera["focal_point"])
+        cam.up = tuple(camera["up"])
+        parallel = bool(camera.get("parallel", True))
+        cam.SetParallelProjection(parallel)
+        if parallel and "parallel_scale" in camera:
+            cam.parallel_scale = float(camera["parallel_scale"])
+        if not parallel and "view_angle" in camera:
+            cam.SetViewAngle(float(camera["view_angle"]))
+        self.plotter.renderer.ResetCameraClippingRange()
+        self._camera = dict(camera)
+        return self._camera
+
+    def auto_camera(self, all_points, aspect: float | None = None, margin_frac: float = 0.06) -> dict:
+        """Fit + apply a camera on the union bbox of ANY point set (e.g. a whole
+        unwrap trajectory) so no frame ever clips. Returns the applied camera dict."""
+        if aspect is None:
+            aspect = self.size[0] / self.size[1]
+        cam = auto_camera(all_points, aspect, margin_frac)  # module function (not shadowed here)
+        return self.set_camera(cam)
+
+    # -- per-frame animation path ----------------------------------------------------
+    def update_points(self, V) -> None:
+        """In-place vtk point update + Modified() — no scene rebuild."""
+        V = np.asarray(V)
+        if V.shape != self._points.shape:
+            raise ValueError(f"update_points: shape {V.shape} != {self._points.shape}")
+        self._points[:] = V  # writes through into the VTK float32 buffer
+        pts = self.poly.GetPoints()
+        pts.GetData().Modified()
+        pts.Modified()
+        self.poly.Modified()
+
+    def screenshot(self) -> np.ndarray:
+        """Render and return the frame as (H, W, 3) uint8."""
+        self.plotter.renderer.ResetCameraClippingRange()
+        self.plotter.render()  # explicit: screenshot() alone may return a stale buffer
+        img = self.plotter.screenshot(return_img=True)
+        return np.asarray(img)
+
+    # -- lifecycle --------------------------------------------------------------------
+    def _add_studio_lights(self) -> None:
+        """3-point rig per docs/RENDER-STYLE.md: warm key upper camera-left, cool fill
+        ~35% camera-right, faint rim behind-above. Positions are computed once from the
+        mesh bbox + current camera basis and stay FIXED in world space."""
+        self.plotter.remove_all_lights()
+        b = np.array(self.poly.bounds, dtype=np.float64).reshape(3, 2)
+        center = b.mean(axis=1)
+        L = float(np.linalg.norm(b[:, 1] - b[:, 0])) or 1.0
+        cam = self._camera or auto_camera(self._points, self.size[0] / self.size[1])
+        pos = np.asarray(cam["position"], dtype=np.float64)
+        foc = np.asarray(cam["focal_point"], dtype=np.float64)
+        d = pos - foc
+        d /= np.linalg.norm(d) or 1.0
+        up = np.asarray(cam["up"], dtype=np.float64)
+        right = np.cross(-d, up)
+        right /= np.linalg.norm(right) or 1.0
+        true_up = np.cross(right, -d)
+
+        def add(offset, color, intensity):
+            p = center + L * (offset[0] * right + offset[1] * true_up + offset[2] * d)
+            self.plotter.add_light(pv.Light(position=tuple(p), focal_point=tuple(center),
+                                            color=color, intensity=intensity, positional=False))
+
+        add((-1.1, 1.0, 1.3), (1.0, 0.97, 0.92), 1.0)    # key: warm-neutral, upper camera-left
+        add((1.2, 0.25, 1.0), (0.84, 0.90, 1.0), 0.35)   # fill: cool, camera-right, 35% of key
+        add((0.15, 1.1, -1.3), (1.0, 1.0, 1.0), 0.45)    # rim: behind-above, silhouette separation
+
+    def close(self) -> None:
+        if getattr(self, "plotter", None) is not None:
+            self.plotter.close()
+            self.plotter = None
+
+    def __enter__(self) -> "SceneRenderer":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    def __del__(self) -> None:  # best-effort GPU resource release
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+def render_mesh_arrays(
+    vertices,
+    faces,
+    uv,
+    texture_path,
+    tex_orientation,
+    *,
+    camera=None,
+    size=(1024, 1024),
+    background="#101114",
+    lighting="flat",
+    double_sided=True,
+) -> np.ndarray:
+    """One-shot textured render of numpy mesh arrays; returns (H, W, 3) uint8.
+
+    vertices (n,3) float / faces (m,3) int / uv (n,2) per-vertex in [0,1] (for wedge-UV
+    meshes, split first via split_wedge_to_vertex). texture_path is decoded with PIL and
+    oriented per `tex_orientation` ('opengl_bottomleft'|'topleft'|'rot180', from
+    reports/audit.json) — see module docstring for the derivation. camera=None auto-fits
+    an isometric-ish parallel view; lighting='flat' is the texture-faithful parity mode.
+    """
+    r = SceneRenderer(
+        vertices, faces, uv, texture_path, tex_orientation,
+        camera=camera, size=size, background=background,
+        lighting=lighting, double_sided=double_sided,
+    )
+    try:
+        return r.screenshot()
+    finally:
+        r.close()

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/__init__.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/__init__.py
@@ -1,0 +1,5 @@
+"""Unwrap math: de-normalization, target embedding, deformation-gradient interpolation."""
+
+from .denorm import fit_uv_scale
+
+__all__ = ["fit_uv_scale"]

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/denorm.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/denorm.py
@@ -1,0 +1,65 @@
+"""Recover the physical scale of normalized UVs.
+
+The wrap UVs are SLIM output in voxel units, shifted to origin and normalized per-axis
+to [0,1] at texturing time (see flatboi.cpp). For edge e: ||dp_e||^2 ~= a*du_e^2 + b*dv_e^2
+with a=s_u^2, b=s_v^2. Linear least squares; one robust refit dropping the worst 1% residuals.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def mesh_edges(faces: np.ndarray) -> np.ndarray:
+    """Unique undirected edges (k,2) int64 from (m,3) faces."""
+    e = np.concatenate([faces[:, [0, 1]], faces[:, [1, 2]], faces[:, [2, 0]]], axis=0).astype(np.int64)
+    e.sort(axis=1)
+    return np.unique(e, axis=0)
+
+
+def fit_uv_scale(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    uv: np.ndarray,
+    *,
+    robust_trim: float = 0.01,
+) -> dict:
+    """Fit per-axis de-normalization scales (s_u, s_v).
+
+    Returns dict with s_u, s_v, anisotropy (s_u/s_v), rel_residual (RMS relative error of
+    edge lengths reconstructed from scaled UVs), n_edges.
+    """
+    V = np.asarray(vertices, dtype=np.float64)
+    UV = np.asarray(uv, dtype=np.float64)
+    E = mesh_edges(np.asarray(faces))
+    dp2 = np.sum((V[E[:, 0]] - V[E[:, 1]]) ** 2, axis=1)
+    du2 = (UV[E[:, 0], 0] - UV[E[:, 1], 0]) ** 2
+    dv2 = (UV[E[:, 0], 1] - UV[E[:, 1], 1]) ** 2
+
+    def lsq(mask: np.ndarray) -> np.ndarray:
+        A = np.stack([du2[mask], dv2[mask]], axis=1)
+        coef, *_ = np.linalg.lstsq(A, dp2[mask], rcond=None)
+        return np.maximum(coef, 0.0)
+
+    mask = np.ones(len(dp2), dtype=bool)
+    coef = lsq(mask)
+    pred = du2 * coef[0] + dv2 * coef[1]
+    resid = np.abs(pred - dp2)
+    if robust_trim > 0 and len(resid) > 100:
+        cut = np.quantile(resid, 1.0 - robust_trim)
+        coef = lsq(resid <= cut)
+        pred = du2 * coef[0] + dv2 * coef[1]
+
+    s_u, s_v = float(np.sqrt(coef[0])), float(np.sqrt(coef[1]))
+    len_true = np.sqrt(dp2)
+    len_pred = np.sqrt(np.maximum(pred, 0.0))
+    ok = len_true > 0
+    rel = (len_pred[ok] - len_true[ok]) / len_true[ok]
+    return {
+        "s_u": s_u,
+        "s_v": s_v,
+        "anisotropy": s_u / s_v if s_v > 0 else float("inf"),
+        "rel_residual_rms": float(np.sqrt(np.mean(rel**2))),
+        "rel_residual_p95": float(np.quantile(np.abs(rel), 0.95)),
+        "n_edges": int(len(dp2)),
+    }

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/dg_interp.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/dg_interp.py
@@ -1,0 +1,733 @@
+"""Deformation-gradient interpolation (Alexa-2000 / Sumner) for the scroll unwrap.
+
+Pipeline per mesh:
+  1. F_i = T_tgt T_src⁻¹ per face (T = [e1 e2 n̂] frame, Sumner's construction).
+  2. Polar F_i = R_i S_i via batch SVD with the det<0 fix (S then has a negative eigenvalue
+     for inverted faces — counted and reported, not hidden).
+  3. w_i = log(R_i) made branch-consistent over the face dual graph (BFS from anchor seed,
+     candidates (θ+2πk)·â, parent-axis substitution at θ≈0) — multi-turn unrolls need
+     angles continuous up to several π.
+  4. Frame t: F_i(t) = exp(t·w_i)((1−t)I + t·S_i); reconstruct vertices from the Poisson
+     system Gᵀ A G x = Gᵀ A f(t) with the anchor vertex Dirichlet-pinned; factor once.
+  5. Per-frame residual rigid drift removed by Kabsch on the anchor strip.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.csgraph  # noqa: F401  (enables sp.csgraph)
+
+from .operators import face_areas, grad_operator
+from .solver import FactorizedSPD
+
+
+# ---------- per-face frames and gradients ----------
+
+def face_frames(V: np.ndarray, F: np.ndarray) -> np.ndarray:
+    """(m,3,3) matrices with columns [e1, e2, n̂] (unit normal as third column)."""
+    V = np.asarray(V, dtype=np.float64)
+    e1 = V[F[:, 1]] - V[F[:, 0]]
+    e2 = V[F[:, 2]] - V[F[:, 0]]
+    n = np.cross(e1, e2)
+    norm = np.linalg.norm(n, axis=1, keepdims=True)
+    norm = np.where(norm < 1e-300, 1e-300, norm)
+    n_hat = n / norm
+    return np.stack([e1, e2, n_hat], axis=2)
+
+
+def deformation_gradients(V_src: np.ndarray, V_tgt: np.ndarray, F: np.ndarray) -> np.ndarray:
+    """(m,3,3) per-face deformation gradients source→target."""
+    T_src = face_frames(V_src, F)
+    T_tgt = face_frames(V_tgt, F)
+    return T_tgt @ np.linalg.inv(T_src)
+
+
+def polar_decompose(Fm: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Batch polar decomposition F = R S, R ∈ SO(3).
+
+    Returns (R, S, inverted_mask). For det(F)<0 faces S gets a negative eigenvalue
+    (proper rotation preserved); those faces are flagged.
+    """
+    U, sig, Vt = np.linalg.svd(Fm)
+    det = np.linalg.det(U @ Vt)
+    D = np.ones((len(Fm), 3))
+    D[:, 2] = det  # ±1
+    R = (U * D[:, None, :]) @ Vt
+    Vm = Vt.transpose(0, 2, 1)
+    S = (Vm * (D * sig)[:, None, :]) @ Vt
+    return R, S, det < 0
+
+
+# ---------- rotation logs / exp ----------
+
+def rotation_log(R: np.ndarray) -> np.ndarray:
+    """Batch principal log of rotation matrices → axis-angle vectors (m,3), θ ∈ [0, π].
+
+    Branching is on θ (not sin θ): the generic skew/(2 sin θ) formula amplifies trace
+    rounding noise without bound as θ→π, so the last milliradian uses the symmetric-part
+    axis extraction with the global sign recovered from the (tiny but sign-reliable)
+    antisymmetric part.
+    """
+    tr = np.clip((np.trace(R, axis1=1, axis2=2) - 1.0) * 0.5, -1.0, 1.0)
+    theta = np.arccos(tr)
+    skew = np.stack(
+        [R[:, 2, 1] - R[:, 1, 2], R[:, 0, 2] - R[:, 2, 0], R[:, 1, 0] - R[:, 0, 1]], axis=1
+    )
+    out = np.zeros_like(skew)
+
+    near0 = theta < 1e-6
+    nearpi = theta > np.pi - 1e-3
+    gen = ~(near0 | nearpi)
+
+    out[near0] = 0.5 * skew[near0]
+    if gen.any():
+        out[gen] = skew[gen] * (theta[gen] / (2.0 * np.sin(theta[gen])))[:, None]
+    if nearpi.any():
+        Rp = R[nearpi]
+        B = (Rp + np.eye(3)) * 0.5  # ≈ â âᵀ + O(π−θ)
+        diag = np.maximum(np.einsum("mii->mi", B), 0.0)
+        axis = np.sqrt(diag)
+        k = np.argmax(axis, axis=1)
+        m_idx = np.arange(len(Rp))
+        sign = np.ones_like(axis)
+        for j in range(3):
+            off = B[m_idx, k, j]
+            sign[:, j] = np.where(off < 0, -1.0, 1.0)
+        sign[m_idx, k] = 1.0
+        axis = axis * sign
+        axis /= np.maximum(np.linalg.norm(axis, axis=1, keepdims=True), 1e-300)
+        # global sign: skew = 2 sin θ · â, sign reliable whenever sin θ isn't exactly 0
+        flip = np.einsum("mi,mi->m", axis, skew[nearpi]) < 0
+        axis[flip] = -axis[flip]
+        out[nearpi] = axis * theta[nearpi][:, None]
+    return out
+
+
+def rotation_exp(w: np.ndarray) -> np.ndarray:
+    """Batch Rodrigues: axis-angle vectors (m,3) → rotation matrices (m,3,3)."""
+    theta = np.linalg.norm(w, axis=1)
+    m = len(w)
+    R = np.tile(np.eye(3), (m, 1, 1))
+    nz = theta > 1e-12
+    if not nz.any():
+        return R
+    k = w[nz] / theta[nz][:, None]
+    K = np.zeros((nz.sum(), 3, 3))
+    K[:, 0, 1], K[:, 0, 2] = -k[:, 2], k[:, 1]
+    K[:, 1, 0], K[:, 1, 2] = k[:, 2], -k[:, 0]
+    K[:, 2, 0], K[:, 2, 1] = -k[:, 1], k[:, 0]
+    st = np.sin(theta[nz])[:, None, None]
+    ct = (1.0 - np.cos(theta[nz]))[:, None, None]
+    R[nz] = np.eye(3) + st * K + ct * (K @ K)
+    return R
+
+
+# ---------- dual graph + branch-consistent unwrapping ----------
+
+def face_adjacency(F: np.ndarray) -> sp.csr_matrix:
+    """Face-face adjacency over shared edges (m×m, symmetric, boolean)."""
+    m = len(F)
+    edges = np.concatenate([F[:, [0, 1]], F[:, [1, 2]], F[:, [2, 0]]], axis=0)
+    edges.sort(axis=1)
+    face_id = np.tile(np.arange(m), 3)
+    order = np.lexsort((edges[:, 1], edges[:, 0]))
+    es, fs = edges[order], face_id[order]
+    same = (es[1:] == es[:-1]).all(axis=1)
+    a, b = fs[:-1][same], fs[1:][same]
+    data = np.ones(len(a), dtype=bool)
+    A = sp.csr_matrix((data, (a, b)), shape=(m, m))
+    return A + A.T
+
+
+def branch_consistent_logs(
+    R: np.ndarray, F: np.ndarray, seed_face: int, k_range: int = 4
+) -> tuple[np.ndarray, dict]:
+    """Unwrap per-face rotation logs continuously over the mesh (BFS by frontier, vectorized).
+
+    Candidates per face: (θ + 2πk)·â for k ∈ [−k_range, k_range]; faces with θ≈0 borrow the
+    parent's axis. Choice minimizes distance to the parent's unwrapped log.
+    """
+    w_raw = rotation_log(R)
+    theta = np.linalg.norm(w_raw, axis=1)
+    safe = theta > 1e-9
+    axis = np.zeros_like(w_raw)
+    axis[safe] = w_raw[safe] / theta[safe][:, None]
+
+    A = face_adjacency(F)
+    m = len(F)
+    w = w_raw.copy()
+    visited = np.zeros(m, dtype=bool)
+    visited[seed_face] = True
+    frontier = np.array([seed_face])
+    ks = np.arange(-k_range, k_range + 1)
+    max_abs_angle = theta[seed_face]
+    n_adjusted = 0
+
+    indptr, indices = A.indptr, A.indices
+    while frontier.size:
+        # neighbors of the frontier
+        nbr_lists = [indices[indptr[f]:indptr[f + 1]] for f in frontier]
+        parents = np.repeat(frontier, [len(x) for x in nbr_lists])
+        nbrs = np.concatenate(nbr_lists) if nbr_lists else np.array([], dtype=int)
+        new_mask = ~visited[nbrs]
+        nbrs, parents = nbrs[new_mask], parents[new_mask]
+        if nbrs.size == 0:
+            break
+        # first occurrence wins (a face can be reached from two frontier parents)
+        uniq, first = np.unique(nbrs, return_index=True)
+        nbrs, parents = uniq, parents[first]
+
+        ax = axis[nbrs].copy()
+        th = theta[nbrs].copy()
+        # θ≈0 → borrow parent's axis direction (preimage of identity is 2πk·any-axis)
+        degenerate = th <= 1e-9
+        if degenerate.any():
+            wp = w[parents[degenerate]]
+            wp_n = np.linalg.norm(wp, axis=1, keepdims=True)
+            ax[degenerate] = np.where(wp_n > 1e-12, wp / np.maximum(wp_n, 1e-300), 0.0)
+        cand = ax[:, None, :] * (th[:, None] + 2.0 * np.pi * ks[None, :])[:, :, None]  # (b,K,3)
+        d = np.linalg.norm(cand - w[parents][:, None, :], axis=2)
+        best = np.argmin(d, axis=1)
+        w[nbrs] = cand[np.arange(len(nbrs)), best]
+        n_adjusted += int((best != k_range).sum())
+        visited[nbrs] = True
+        max_abs_angle = max(max_abs_angle, float(np.linalg.norm(w[nbrs], axis=1).max()))
+        frontier = nbrs
+
+    info = {
+        "n_faces": m,
+        "n_unreached": int((~visited).sum()),
+        "n_branch_adjusted": n_adjusted,
+        "max_unwrapped_angle_rad": float(max_abs_angle),
+        "max_unwrapped_turns": float(max_abs_angle / (2 * np.pi)),
+    }
+    return w, info
+
+
+# ---------- winding decomposition (production rotation field) ----------
+
+def face_uv_tangents(V: np.ndarray, F: np.ndarray, uv: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Per-face world tangents (∂p/∂u, ∂p/∂v) from the UV Jacobian, each (m,3)."""
+    e1 = V[F[:, 1]] - V[F[:, 0]]
+    e2 = V[F[:, 2]] - V[F[:, 0]]
+    d1 = uv[F[:, 1]] - uv[F[:, 0]]
+    d2 = uv[F[:, 2]] - uv[F[:, 0]]
+    det = d1[:, 0] * d2[:, 1] - d1[:, 1] * d2[:, 0]
+    bad = np.abs(det) < 1e-18
+    safe = np.where(bad, 1.0, det)
+    t_u = (d2[:, 1, None] * e1 - d1[:, 1, None] * e2) / safe[:, None]
+    t_v = (-d2[:, 0, None] * e1 + d1[:, 0, None] * e2) / safe[:, None]
+    t_u[bad] = 0.0
+    t_v[bad] = 0.0
+    return t_u, t_v
+
+
+def _scalar_graph_unwrap(
+    phi: np.ndarray, F: np.ndarray, seed_face: int, conf: np.ndarray | None = None
+) -> tuple[np.ndarray, int]:
+    """Unwrap a per-face angle field (defined mod 2π) to be continuous across the dual graph.
+
+    With a confidence mask, the spanning tree is a Dijkstra shortest-path tree whose edges
+    prefer confident-confident hops (cost 1) and cross junk only when no clean route exists
+    (cost 1000): a single garbage face then corrupts nothing downstream — paths route
+    around damage instead of through it.
+
+    Branch reference across junk: a junk face's raw φ is untrusted (its t_u may be
+    garbage), so letting it steer the 2π-rounding lets a junk moat shift everything
+    beyond it onto a wrong 2π branch — whole junk regions (e.g. an invisible anchor
+    strip) then secretly orbit the axis ±k full turns mid-transit (the t=1 state is
+    unaffected: a 2πk rotation about the axis is the identity matrix — the branch is
+    purely a transit choice, and the coherent choice is the visible sheet's). Junk faces
+    therefore INHERIT the branch from their confident ancestry (keeping their own value
+    mod 2π); confident faces accumulate their own wrapped deltas as before.
+    """
+    A = face_adjacency(F)
+    out = phi.astype(np.float64).copy()
+    two_pi = 2.0 * np.pi
+
+    if conf is None:
+        order, pred, n_unreached = _bfs_tree(A, seed_face)
+    else:
+        Aw = A.tocoo()
+        cheap = conf[Aw.row] & conf[Aw.col]
+        w = np.where(cheap, 1.0, 1000.0)
+        G = sp.csr_matrix((w, (Aw.row, Aw.col)), shape=A.shape)
+        dist, pred = sp.csgraph.dijkstra(G, directed=False, indices=seed_face,
+                                         return_predecessors=True)
+        reach = np.isfinite(dist)
+        n_unreached = int((~reach).sum())
+        order = np.argsort(dist[reach], kind="stable")
+        order = np.flatnonzero(reach)[order]
+    # apply 2π-rounding in tree order (parents always precede children)
+    pred = np.asarray(pred)
+    if conf is None:
+        for f in order:
+            p = pred[f]
+            if p < 0:
+                continue
+            out[f] += two_pi * np.round((out[p] - out[f]) / two_pi)
+    else:
+        ref = out.copy()  # branch carrier: junk inherits, confidence accumulates
+        for f in order:
+            p = pred[f]
+            if p < 0:
+                continue
+            if conf[f]:
+                d = out[f] - ref[p]
+                d -= two_pi * np.round(d / two_pi)
+                ref[f] = ref[p] + d
+                out[f] = ref[f]
+            else:
+                ref[f] = ref[p]
+                out[f] += two_pi * np.round((ref[p] - out[f]) / two_pi)
+    return out, n_unreached
+
+
+def _bfs_tree(A: sp.csr_matrix, seed: int) -> tuple[np.ndarray, np.ndarray, int]:
+    order, pred = sp.csgraph.breadth_first_order(A, seed, directed=False,
+                                                 return_predecessors=True)
+    n_unreached = A.shape[0] - len(order)
+    return np.asarray(order), np.asarray(pred), n_unreached
+
+
+def _axis_rotations(axis: np.ndarray, angles: np.ndarray) -> np.ndarray:
+    """Batch rotations about ONE fixed axis by per-face angles (m,) → (m,3,3)."""
+    k = axis / np.linalg.norm(axis)
+    K = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]])
+    K2 = K @ K
+    s = np.sin(angles)[:, None, None]
+    c = (1.0 - np.cos(angles))[:, None, None]
+    return np.eye(3) + s * K + c * K2
+
+
+def winding_decomposition(
+    R: np.ndarray,
+    V0: np.ndarray,
+    F: np.ndarray,
+    uv: np.ndarray,
+    V1: np.ndarray,
+    seed_face: int,
+    axis_mode: str = "global",
+    face_conf: np.ndarray | None = None,
+    axis_from_conf: bool = False,
+) -> dict:
+    """Decompose per-face rotations as R_i = exp(w_res,i) · R_axis(â, φ_i).
+
+    â_i = the LOCAL winding axis per face (source v-tangent, sign-aligned to the global
+    axis; warped wraps bend their axis across the sheet — a global axis misorients whole
+    regions mid-transit with error amplified by φ);
+    φ_i = angle from the (per-face axis-orthogonalized) flat u-direction to the source
+    u-tangent about â_i, unwrapped as a SCALAR over the dual graph (no matrix-log branches);
+    w_res,i = principal log of R_i·R_wind,iᵀ — bump-scale, branch-free.
+    Exact at t=1 for any number of turns.
+    """
+    # frame from the flat target: û_f, v̂_f (regression of V1 on uv axes)
+    uvc = uv - uv.mean(0)
+    V1c = V1 - V1.mean(0)
+    u_dir = V1c.T @ uvc[:, 0]
+    v_dir = V1c.T @ uvc[:, 1]
+    v_hat = v_dir / np.linalg.norm(v_dir)
+    u_perp = u_dir - (u_dir @ v_hat) * v_hat
+    b1g = u_perp / np.linalg.norm(u_perp)          # flat u-direction ⊥ global axis
+
+    t_u, t_v = face_uv_tangents(V0, F, uv)
+    if axis_mode in ("local", "smooth"):
+        # local winding axes: normalized source v-tangents, sign-aligned to the global axis
+        nv = np.linalg.norm(t_v, axis=1)
+        ax = np.where((nv > 1e-12)[:, None], t_v / np.maximum(nv, 1e-300)[:, None], v_hat[None, :])
+        flip = (ax @ v_hat) < 0
+        ax[flip] = -ax[flip]
+        if axis_mode == "smooth":
+            # diffuse the axis field over the dual graph: keeps real sub-sheet axis bends
+            # (merged segments!) while killing per-face bump noise. With axis_from_conf,
+            # junk faces are not axis SOURCES (their t_v is untrusted): confident axes are
+            # re-imposed each sweep, harmonically extending the trusted field into junk.
+            Adj = face_adjacency(F).astype(np.float64)
+            deg = np.maximum(np.asarray(Adj.sum(axis=1)).ravel(), 1.0)
+            fixed = None
+            if axis_from_conf and face_conf is not None and face_conf.any():
+                fixed = face_conf
+                ax_fixed = ax[fixed].copy()
+            for _ in range(60):
+                ax = 0.5 * ax + 0.5 * (Adj @ ax) / deg[:, None]
+                if fixed is not None:
+                    ax[fixed] = ax_fixed
+                ax /= np.maximum(np.linalg.norm(ax, axis=1, keepdims=True), 1e-300)
+    else:  # 'global': one axis everywhere — best when the wrap's axis barely bends
+        ax = np.tile(v_hat, (len(F), 1))
+
+    # per-face reference frame ⊥ local axis
+    b1 = b1g[None, :] - (ax @ b1g)[:, None] * ax
+    b1n = np.linalg.norm(b1, axis=1)
+    deg = b1n < 1e-9
+    if deg.any():
+        alt = np.cross(ax[deg], v_hat)
+        b1[deg] = alt
+        b1n = np.linalg.norm(b1, axis=1)
+    b1 /= np.maximum(b1n, 1e-300)[:, None]
+    b2 = np.cross(ax, b1)
+
+    t_perp = t_u - np.einsum("ij,ij->i", t_u, ax)[:, None] * ax
+    nrm = np.linalg.norm(t_perp, axis=1)
+    ok = nrm > 1e-12
+    x = np.where(ok, np.einsum("ij,ij->i", t_perp, b1), 1.0)
+    y = np.where(ok, np.einsum("ij,ij->i", t_perp, b2), 0.0)
+    phi_raw = np.arctan2(y, x)                     # angle FROM flat-u TO source-u, about â_i
+    conf = ok if face_conf is None else (ok & face_conf)
+    if not conf[seed_face]:
+        # seed must be confident; move to the nearest confident face
+        if conf.any():
+            cent = V0[F].mean(1)
+            cand = np.flatnonzero(conf)
+            seed_face = int(cand[np.argmin(((cent[cand] - cent[seed_face]) ** 2).sum(1))])
+        else:
+            conf = None
+    phi, n_unreached = _scalar_graph_unwrap(phi_raw, F, seed_face, conf=conf)
+
+    # Per-segment re-branching (merged traces): sub-sheets glued in UV at different
+    # winding depths leave |Δφ| > π seams in the unwrapped field — mid-transit the deeper
+    # segment orbits k extra turns and the seam shears violently. A 2πk offset about the
+    # axis is the identity matrix, so pulling every segment onto its neighbour's branch
+    # is exact at t=1 and only changes the transit, making glued segments travel
+    # together. Seam edges (|Δφ| > π) partition faces into segments; BFS from the seed's
+    # segment assigns each newly-met segment the 2πk that cancels the median seam jump.
+    two_pi = 2.0 * np.pi
+    A_f = face_adjacency(F)
+    Au = sp.triu(A_f.tocoo())
+    ei, ej = Au.row, Au.col
+    dphi = phi[ei] - phi[ej]
+    seam = np.abs(dphi) > np.pi
+    n_segments = 1
+    if seam.any():
+        keep = ~seam
+        Ain = sp.csr_matrix((np.ones(int(keep.sum()), dtype=bool), (ei[keep], ej[keep])),
+                            shape=A_f.shape)
+        n_segments, seg = sp.csgraph.connected_components(Ain + Ain.T, directed=False)
+        if n_segments > 1:
+            si, sj = seg[ei[seam]], seg[ej[seam]]
+            dseam = dphi[seam]  # phi[si side] − phi[sj side]
+            offset = np.zeros(n_segments)
+            done = np.zeros(n_segments, dtype=bool)
+            frontier = [int(seg[seed_face])]
+            done[frontier[0]] = True
+            while frontier:
+                nxt = []
+                for s in frontier:
+                    for a, b, dd in ((si, sj, dseam), (sj, si, -dseam)):
+                        m = (a == s) & ~done[b]
+                        for nb in np.unique(b[m]):
+                            # want phi_nb + off_nb ≈ phi_s + off_s across the seam:
+                            # off_nb = off_s + 2πk, k from the median seam jump
+                            k = np.round(np.median(dd[m & (b == nb)]) / two_pi)
+                            offset[nb] = offset[s] + two_pi * k
+                            done[nb] = True
+                            nxt.append(int(nb))
+                frontier = nxt
+            phi = phi + offset[seg]
+
+    # R maps source → target tangents: winding part must REMOVE φ
+    R_wind = rotation_exp(ax * (-phi)[:, None])
+    R_res = R @ R_wind.transpose(0, 2, 1)
+    w_res = rotation_log(R_res)
+    res_norm = np.linalg.norm(w_res, axis=1)
+    n_big_res = int((res_norm > np.pi * 0.9).sum())
+    return {
+        "phi": -phi,                                # signed winding rotation source→target
+        "axis": v_hat,
+        "axis_per_face": ax,
+        "w_res": w_res,
+        "n_phi_segments": int(n_segments),
+        "residual_norm_p99": float(np.quantile(res_norm, 0.99)),
+        "residual_norm_max": float(res_norm.max()),
+        "n_big_residual": n_big_res,
+        "n_unreached": n_unreached,
+        "phi_span_rad": float(phi.max() - phi.min()),
+        "phi_span_turns": float((phi.max() - phi.min()) / (2 * np.pi)),
+    }
+
+
+def winding_rotations(decomp: dict, t: float) -> np.ndarray:
+    """R_i(t) = exp(t·w_res,i) · exp(â_i · t·φ_i)."""
+    R_res_t = rotation_exp(t * decomp["w_res"])
+    R_wind_t = rotation_exp(decomp["axis_per_face"] * (t * decomp["phi"])[:, None])
+    return R_res_t @ R_wind_t
+
+
+# ---------- the interpolator ----------
+
+@dataclass
+class UnwrapPath:
+    """Precomputed interpolation state for one mesh (factor once, evaluate many)."""
+
+    V0: np.ndarray            # (n,3) float64 source
+    V1: np.ndarray            # (n,3) float64 target (embedded flat sheet)
+    F: np.ndarray             # (m,3) int32
+    uv: np.ndarray            # (n,2) normalized UV (winding decomposition needs it)
+    decomp: dict              # winding decomposition (phi, axis, w_res, diagnostics)
+    S: np.ndarray             # (m,3,3) symmetric stretch
+    G: sp.csr_matrix          # (3m,n) gradient operator
+    A: np.ndarray             # (m,) face areas (source)
+    J0: np.ndarray            # (m,3,3) source per-face world gradients of coords
+    solver: FactorizedSPD
+    L: sp.csr_matrix
+    keep: np.ndarray          # index map after pinning
+    pins: np.ndarray          # pinned vertices: anchor + one per extra connected component
+    anchor_idx: np.ndarray    # vertex indices of the anchor strip
+    info: dict
+    face_conf: np.ndarray | None = None
+    align_idx: np.ndarray | None = None  # strip subset used for rigid drift removal
+    align_rotation: bool = True          # False: translation-only (orbiting strip)
+
+    def _poisson_solve(self, target_grads: np.ndarray, t: float) -> np.ndarray:
+        """Solve Gᵀ A G x = Gᵀ A f for per-face target gradient matrices (m,3,3)."""
+        m = len(self.F)
+        targ = target_grads.transpose(1, 0, 2).reshape(3 * m, 3)  # rows [dx; dy; dz]
+        W = np.tile(self.A, 3)[:, None]
+        rhs = self.G.T @ (W * targ)
+        x_pins = (1.0 - t) * self.V0[self.pins] + t * self.V1[self.pins]
+        rhs_red = rhs[self.keep] - self.L[self.keep][:, self.pins] @ x_pins
+        X = self.solver.solve(rhs_red)
+        out = np.empty_like(self.V0)
+        out[self.keep] = X
+        out[self.pins] = x_pins
+        idx = self.anchor_idx if self.align_idx is None else self.align_idx
+        strip_target = (1.0 - t) * self.V0[idx] + t * self.V1[idx]
+        if not self.align_rotation:
+            return out + (strip_target.mean(0) - out[idx].mean(0))
+        return _rigid_align(out, idx, strip_target)
+
+    def eval_frame(self, t: float) -> np.ndarray:
+        """Vertex positions at interpolation parameter t ∈ [0,1]."""
+        if t <= 0.0:
+            return self.V0.copy()
+        if t >= 1.0:
+            return self.V1.copy()
+        m = len(self.F)
+        Rt = winding_rotations(self.decomp, t)
+        St = (1.0 - t) * np.tile(np.eye(3), (m, 1, 1)) + t * self.S
+        Ft = Rt @ St
+        # target per-face world gradients: M[d,c] = ∂(φ_c)/∂x_d = (J0 Fᵀ)[d,c]
+        M = self.J0 @ Ft.transpose(0, 2, 1)
+        return self._poisson_solve(M, t)
+
+
+def _rigid_align(X: np.ndarray, idx: np.ndarray, target_pts: np.ndarray) -> np.ndarray:
+    """Rigidly move X so X[idx] best matches target_pts (Kabsch, det=+1)."""
+    P = X[idx]
+    cp, ct = P.mean(0), target_pts.mean(0)
+    H = (P - cp).T @ (target_pts - ct)
+    U, _, Vt = np.linalg.svd(H)
+    D = np.diag([1.0, 1.0, np.sign(np.linalg.det(Vt.T @ U.T))])
+    R = Vt.T @ D @ U.T
+    return (X - cp) @ R.T + ct
+
+
+class SubsteppedPath:
+    """Incremental (geodesic-like) integration of the unwrap.
+
+    The single-shot field F_i(t) relative to the SOURCE becomes non-integrable mid-transit
+    on warped wraps (spatially varying rotation axes) — the Poisson projection then shears.
+    Fix (design-review prescription): split [0,1] into K intervals; at each key re-derive
+    the deformation gradients from the LAST SOLVED STATE to the final target (re-polar +
+    re-branch), so each interval only integrates a small, near-integrable rotation. The
+    Poisson operator lives on the source mesh and its factorization is reused throughout.
+
+    Frames must be evaluated in nondecreasing t order (interval fields are built lazily
+    and discarded).
+    """
+
+    def __init__(self, base: UnwrapPath, n_substeps: int) -> None:
+        self.base = base
+        self.K = int(n_substeps)
+        self.keys_t = np.linspace(0.0, 1.0, self.K + 1)
+        self._key_V: list[np.ndarray | None] = [base.V0] + [None] * self.K
+        self._interval: int = -1
+        self._field: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None  # (w, S, Jk)
+        self.info = dict(base.info, n_substeps=self.K)
+
+    def _build_field(self, k: int) -> None:
+        """Field for interval k: deformation gradients from key-k state to the FINAL target."""
+        b = self.base
+        Vk = self._key_V[k]
+        assert Vk is not None
+        Fg = deformation_gradients(Vk, b.V1, b.F)
+        R, S, _ = polar_decompose(Fg)
+        decomp = winding_decomposition(R, Vk, b.F, b.uv, b.V1, seed_face=b.info["seed_face"],
+                                       face_conf=b.face_conf)
+        GVk = b.G @ Vk
+        m = len(b.F)
+        Jk = GVk.reshape(3, m, 3).transpose(1, 0, 2)
+        self._field = (decomp, S, Jk)
+        self._interval = k
+
+    def _solve(self, k: int, s: float, t_global: float) -> np.ndarray:
+        b = self.base
+        if self._interval != k:
+            self._build_field(k)
+        decomp, S, Jk = self._field
+        m = len(b.F)
+        Rt = winding_rotations(decomp, s)
+        St = (1.0 - s) * np.tile(np.eye(3), (m, 1, 1)) + s * S
+        Ft = Rt @ St
+        M = Jk @ Ft.transpose(0, 2, 1)
+        return b._poisson_solve(M, t_global)
+
+    def _ensure_key(self, k: int) -> None:
+        if self._key_V[k] is not None:
+            return
+        self._ensure_key(k - 1)
+        t_k = self.keys_t[k]
+        t_prev = self.keys_t[k - 1]
+        s = (t_k - t_prev) / max(1.0 - t_prev, 1e-15)
+        self._key_V[k] = self._solve(k - 1, s, t_k)
+        # free old key states beyond the previous one (sequential evaluation)
+        if k >= 2:
+            self._key_V[k - 2] = None if k - 2 != 0 else self._key_V[0]
+
+    def eval_frame(self, t: float) -> np.ndarray:
+        b = self.base
+        if t <= 0.0:
+            return b.V0.copy()
+        if t >= 1.0:
+            return b.V1.copy()
+        k = min(int(np.searchsorted(self.keys_t, t, side="right")) - 1, self.K - 1)
+        self._ensure_key(k)
+        t_k = self.keys_t[k]
+        s = (t - t_k) / max(1.0 - t_k, 1e-15)
+        return self._solve(k, s, t)
+
+
+def build_unwrap_path(
+    V0: np.ndarray,
+    V1: np.ndarray,
+    F: np.ndarray,
+    uv: np.ndarray,
+    anchor_idx: np.ndarray,
+    *,
+    solver_backend: str = "auto",
+    axis_mode: str = "smooth",
+    face_conf: np.ndarray | None = None,
+    junk_weight: float = 0.05,
+    axis_from_conf: bool = False,
+    repo_root=None,
+) -> UnwrapPath:
+    """Precompute everything needed to evaluate frames (factorization reused across frames).
+
+    face_conf (e.g. texture-alpha visibility): confident faces steer the φ unwrap routing
+    AND carry full weight in the Poisson energy; junk faces get `junk_weight`× area so they
+    follow the visible content instead of bending it (the solve is global).
+    axis_from_conf: in 'smooth' axis mode, junk faces are not axis sources (their t_v is
+    untrusted); the confident axis field is harmonically extended into junk instead.
+    """
+    V0 = np.asarray(V0, dtype=np.float64)
+    V1 = np.asarray(V1, dtype=np.float64)
+    F = np.asarray(F, dtype=np.int32)
+    uv = np.asarray(uv, dtype=np.float64)
+
+    Fg = deformation_gradients(V0, V1, F)
+    R, S, inverted = polar_decompose(Fg)
+    # seed: face whose centroid is nearest the anchor strip centroid
+    anchor_c = V0[anchor_idx].mean(0)
+    cent = V0[F].mean(1)
+    seed = int(np.argmin(((cent - anchor_c) ** 2).sum(1)))
+    decomp = winding_decomposition(R, V0, F, uv, V1, seed_face=seed, axis_mode=axis_mode,
+                                   face_conf=face_conf, axis_from_conf=axis_from_conf)
+    # Model-incoherent faces (residual ≈ π): their source→target rotation is a half-turn
+    # away from anything the axis-winding model can express — locally misregistered UV
+    # patches / fold-backs in merged traces (their TRUE transit is a local π spin; on
+    # healthy meshes only isolated slivers). They cannot be animated coherently with the
+    # sheet, so they become PASSENGERS: (1) the φ unwrap re-routes around them so they
+    # corrupt nothing downstream, (2) their Poisson rows get junk weight so neighbors drag
+    # them instead of being crumpled by them. Exactness at t=1 is untouched (the t=1
+    # field equals the exact target gradients for every face).
+    res_norm = np.linalg.norm(decomp["w_res"], axis=1)
+    incoherent = res_norm > 0.9 * np.pi
+    if incoherent.any():
+        conf2 = (~incoherent) if face_conf is None else (face_conf & ~incoherent)
+        if conf2.any():
+            decomp = winding_decomposition(R, V0, F, uv, V1, seed_face=seed,
+                                           axis_mode=axis_mode, face_conf=conf2,
+                                           axis_from_conf=axis_from_conf)
+            res_norm = np.linalg.norm(decomp["w_res"], axis=1)
+            incoherent = res_norm > 0.9 * np.pi
+        # NOTE: 1-ring dilation of this mask over-suppresses: the
+        # full-weight boundary ring anchors patch borders to the sheet; down-weighting
+        # it gives patches a longer free leash (measured SD peak 1.65 -> 2.06).
+    unwrap_info = {k: v for k, v in decomp.items()
+                   if k not in ("phi", "axis", "axis_per_face", "w_res")}
+    unwrap_info["n_incoherent_passengers"] = int(incoherent.sum())
+
+    # Rigid drift removal anchors on the strip's MODEL-STATIONARY subset: faces within
+    # half a turn of φ=0 and model-coherent. Merged traces can have most of their strip
+    # on sub-sheets wound 1-3 full turns deep (their strip faces genuinely ORBIT the
+    # axis mid-transit); a Kabsch over orbiting points swings the whole sheet by up
+    # to ~100° in a frame. On healthy meshes the whole strip
+    # qualifies and the alignment is unchanged.
+    n = len(V0)
+    strip_mask = np.zeros(n, dtype=bool)
+    strip_mask[np.asarray(anchor_idx)] = True
+    fs = strip_mask[F].any(axis=1)
+    stationary = fs & (np.abs(decomp["phi"]) <= np.pi) & (res_norm <= 0.9 * np.pi)
+    align_verts = np.intersect1d(np.unique(F[stationary]), np.asarray(anchor_idx))
+    align_rotation = True
+    if len(align_verts) < max(8, 0.01 * len(anchor_idx)):
+        # No model-stationary strip subset exists (the whole strip is wound k turns deep
+        # — merged multi-depth traces): a rotation Kabsch onto an orbiting strip swings
+        # the entire sheet. Fall back to translation-only drift removal; the solution's
+        # orientation is already fully determined by the gradient field.
+        align_verts = np.asarray(anchor_idx)
+        align_rotation = False
+    unwrap_info["n_align_verts"] = int(len(align_verts))
+    unwrap_info["align_rotation"] = align_rotation
+
+    G = grad_operator(V0, F)
+    A = face_areas(V0, F)
+    w_face = np.ones(len(F))
+    if face_conf is not None:
+        w_face[~face_conf] = junk_weight
+    w_face[incoherent] = junk_weight
+    if (w_face != 1.0).any():
+        A = A * w_face
+    W = sp.diags(np.tile(A, 3))
+    L = (G.T @ W @ G).tocsr()
+
+    GV0 = G @ V0                                   # (3m,3)
+    m = len(F)
+    J0 = GV0.reshape(3, m, 3).transpose(1, 0, 2)   # (m,3,3) rows=world deriv, cols=coords
+
+    # one pin per connected component (debris islets would otherwise leave L singular);
+    # the main component is pinned at the anchor vertex.
+    n = len(V0)
+    adj = sp.csr_matrix(
+        (np.ones(3 * m, dtype=bool),
+         (np.concatenate([F[:, 0], F[:, 1], F[:, 2]]),
+          np.concatenate([F[:, 1], F[:, 2], F[:, 0]]))),
+        shape=(n, n),
+    )
+    n_comp, labels = sp.csgraph.connected_components(adj, directed=False)
+    pins = [int(anchor_idx[0])]
+    main_label = labels[pins[0]]
+    for c in range(n_comp):
+        if c != main_label:
+            pins.append(int(np.argmax(labels == c)))
+    pins = np.array(sorted(pins))
+    keep = np.setdiff1d(np.arange(n), pins)
+    L_red = L[keep][:, keep].tocsr()
+    solver = FactorizedSPD(L_red, backend=solver_backend, repo_root=repo_root)
+
+    info = {
+        "n_inverted_source_faces": int(inverted.sum()),
+        **unwrap_info,
+        "seed_face": seed,
+        "n_components": int(n_comp),
+        "pins": pins.tolist() if len(pins) <= 16 else f"{len(pins)} pins",
+    }
+    return UnwrapPath(
+        V0=V0, V1=V1, F=F, uv=uv, decomp=decomp, S=S, G=G, A=A, J0=J0,
+        solver=solver, L=L, keep=keep, pins=pins,
+        anchor_idx=np.asarray(anchor_idx), info=info, face_conf=face_conf,
+        align_idx=align_verts, align_rotation=align_rotation,
+    )

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/embedding.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/embedding.py
@@ -1,0 +1,263 @@
+"""Target embedding: place the de-normalized flat UV domain as a plane in 3D.
+
+Frame conventions (see docs/UNWRAP-MATH.md):
+- the UV axis best correlated with a consistent 3D direction is the 'along-axis' (scroll
+  axis) direction; the other is the unroll direction.
+- the flat sheet is rigidly placed by Procrustes of its anchor strip onto the same strip's
+  3D position, so the morph 'peels open' from a near-stationary edge.
+- chirality: the embedding must not mirror the texture; checked numerically here (basis
+  determinant against the source surface orientation) and end-to-end by the render oracle.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .denorm import fit_uv_scale
+
+
+def fit_scroll_axis(V: np.ndarray, F: np.ndarray, uv: np.ndarray) -> dict:
+    """Decide which UV axis runs along the scroll axis, by tangent coherence.
+
+    Per face, world tangents (t_u, t_v) = inv([Δuv1; Δuv2]) · [e1; e2]. The along-axis
+    direction has unit tangents that agree globally (coherence ≈ 1); the unroll direction's
+    tangents sweep around the winding and cancel (coherence ≪ 1, →0 over full turns).
+    Area-weighted; faces with degenerate UV are skipped.
+    """
+    V = np.asarray(V, dtype=np.float64)
+    uv = np.asarray(uv, dtype=np.float64)
+    e1 = V[F[:, 1]] - V[F[:, 0]]
+    e2 = V[F[:, 2]] - V[F[:, 0]]
+    d1 = uv[F[:, 1]] - uv[F[:, 0]]
+    d2 = uv[F[:, 2]] - uv[F[:, 0]]
+    det = d1[:, 0] * d2[:, 1] - d1[:, 1] * d2[:, 0]
+    ok = np.abs(det) > 1e-18
+    inv_det = np.where(ok, 1.0 / np.where(ok, det, 1.0), 0.0)
+    # rows of inv([[du1,dv1],[du2,dv2]]) = [[dv2,-dv1],[-du2,du1]]/det
+    t_u = (d2[:, 1, None] * e1 - d1[:, 1, None] * e2) * inv_det[:, None]
+    t_v = (-d2[:, 0, None] * e1 + d1[:, 0, None] * e2) * inv_det[:, None]
+    area = 0.5 * np.linalg.norm(np.cross(e1, e2), axis=1)
+    w = np.where(ok, area, 0.0)
+
+    def coherence(t: np.ndarray) -> tuple[float, np.ndarray]:
+        n = np.linalg.norm(t, axis=1)
+        good = (n > 1e-300) & ok
+        unit = np.zeros_like(t)
+        unit[good] = t[good] / n[good][:, None]
+        mean = (unit * w[:, None]).sum(0) / max(w.sum(), 1e-300)
+        return float(np.linalg.norm(mean)), mean
+
+    coh_u, mean_u = coherence(t_u)
+    coh_v, mean_v = coherence(t_v)
+    axis_uv = "v" if coh_v >= coh_u else "u"
+    mean_dir = mean_v if axis_uv == "v" else mean_u
+    axis_dir = mean_dir / max(np.linalg.norm(mean_dir), 1e-300)
+    return {
+        "axis_uv": axis_uv,
+        "axis_dir": axis_dir,
+        "details": {"u": {"coherence": coh_u}, "v": {"coherence": coh_v}},
+    }
+
+
+def anchor_strip_indices(uv: np.ndarray, unroll_axis: int, frac: float = 0.02) -> tuple[np.ndarray, str]:
+    """Vertices within `frac` of one extreme of the unroll axis.
+
+    Both extremes are candidates; pick the one with smaller 3D spread relative to its UV
+    extent later — here we simply return the low end; build_target_embedding tries both.
+    """
+    q = uv[:, unroll_axis]
+    lo, hi = q.min(), q.max()
+    span = hi - lo
+    low_idx = np.where(q <= lo + frac * span)[0]
+    high_idx = np.where(q >= hi - frac * span)[0]
+    return low_idx, high_idx  # type: ignore[return-value]
+
+
+def _procrustes_to_strip(flat: np.ndarray, V: np.ndarray, idx: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Rigid (R,t), det(R)=+1, minimizing ‖flat[idx]·Rᵀ + t − V[idx]‖."""
+    P = flat[idx]
+    Q = V[idx]
+    cp, cq = P.mean(0), Q.mean(0)
+    H = (P - cp).T @ (Q - cq)
+    U, _, Vt = np.linalg.svd(H)
+    D = np.diag([1.0, 1.0, np.sign(np.linalg.det(Vt.T @ U.T))])
+    R = Vt.T @ D @ U.T
+    t = cq - cp @ R.T
+    return R, t, P @ R.T + t
+
+
+def surface_orientation_sign(V: np.ndarray, F: np.ndarray, uv: np.ndarray) -> float:
+    """Mean sign linking the 3D face normal to the UV winding: >0 means UV winding is CCW
+    when seen from the +normal side (the textured 'recto')."""
+    a2 = (
+        (uv[F[:, 1], 0] - uv[F[:, 0], 0]) * (uv[F[:, 2], 1] - uv[F[:, 0], 1])
+        - (uv[F[:, 2], 0] - uv[F[:, 0], 0]) * (uv[F[:, 1], 1] - uv[F[:, 0], 1])
+    )
+    return float(np.sign(np.median(a2)))
+
+
+def build_target_embedding(
+    V: np.ndarray,
+    F: np.ndarray,
+    uv_norm: np.ndarray,
+    *,
+    anchor_frac: float = 0.02,
+    force_anchor_end: str = "auto",   # 'auto' | 'outer_radial' (rolling-contact kinematics
+                                       # must anchor at the winding's natural free end)
+) -> dict:
+    """Compute the flat target V1 (n,3) + anchor indices + diagnostics.
+
+    Steps: de-normalize UV → flat 2D in voxel units; decide axis mapping; embed flat in 3D
+    with v-axis ∥ scroll axis via Procrustes on the anchor strip (low-u end by default,
+    choose the end that moves least); enforce non-mirroring (chirality) numerically.
+    """
+    V = np.asarray(V, dtype=np.float64)
+    uv = np.asarray(uv_norm, dtype=np.float64)
+
+    fit = fit_uv_scale(V, F, uv)
+    flat2 = np.stack([uv[:, 0] * fit["s_u"], uv[:, 1] * fit["s_v"]], axis=1)
+
+    ax = fit_scroll_axis(V, F, uv)
+    unroll_axis = 0 if ax["axis_uv"] == "v" else 1  # the OTHER uv axis unrolls
+
+    flat3 = np.zeros((len(V), 3))
+    flat3[:, :2] = flat2
+
+    low_idx, high_idx = anchor_strip_indices(uv, unroll_axis, anchor_frac)
+
+    def tangent_plane_placement(idx: np.ndarray):
+        """Place the flat sheet in the surface's tangent plane at the anchor strip:
+        origin = strip centroid, in-plane axes = (strip direction ≈ scroll axis,
+        unroll direction = the strip's own unroll tangent), normal = area-weighted mean
+        surface normal over the strip's faces. The roll then 'peels open' onto its own
+        tangent plane — no tumble, anchor nearly stationary.
+
+        Orientation contract (natural unroll): the in-plane frame must coincide with the
+        surface's local frame at the strip — u_hat along ∂p/∂(unroll uv), a_hat along the
+        strip's axis tangent. Only then is the source→target rotation field a pure winding
+        about the scroll axis, which `winding_decomposition` can represent. A 180° in-plane
+        misplacement is NOT benign: it bakes a constant π rotation about an in-plane axis
+        into every face (residual ‖w_res‖≈π mesh-wide → mid-transit tumble/snap,
+        observed on damaged merge traces). The legacy 'extend away
+        from the roll body' frame is therefore kept ONLY as the anchor-END selection key
+        (its rms blows up when the body-side flip reverses the strip, which preserves the
+        fleet's historical anchor choices); the PLACED frame is always the natural one.
+
+        Returns (rms_selection, R_natural, t_natural, rms_natural, corrected) where
+        `corrected` is True iff the legacy frame differs from the natural frame.
+        """
+        strip_mask = np.zeros(len(V), dtype=bool)
+        strip_mask[idx] = True
+        f_mask = strip_mask[F].any(axis=1)
+        Fa = F[f_mask]
+        e1 = V[Fa[:, 1]] - V[Fa[:, 0]]
+        e2 = V[Fa[:, 2]] - V[Fa[:, 0]]
+        n = np.cross(e1, e2).sum(0)
+        n_hat = n / max(np.linalg.norm(n), 1e-300)
+        # axis direction within the plane: regression of strip positions on their v coord
+        vq = uv[idx, 1 - unroll_axis] - uv[idx, 1 - unroll_axis].mean()
+        d_axis = (V[idx] - V[idx].mean(0)).T @ vq
+        d_axis -= (d_axis @ n_hat) * n_hat
+        a_hat = d_axis / max(np.linalg.norm(d_axis), 1e-300)
+        flat_unroll_col = unroll_axis
+        flat_axis_col = 1 - unroll_axis
+        # u_hat chosen so det(R) = +1 for the actual column layout (mirror would flip text)
+        u_hat = np.cross(a_hat, n_hat) if flat_unroll_col == 0 else np.cross(n_hat, a_hat)
+
+        # natural unroll tangent of the strip: area-weighted ∂p/∂(unroll uv) over strip
+        # faces, projected into the tangent plane (only its sign matters)
+        d1 = uv[Fa[:, 1]] - uv[Fa[:, 0]]
+        d2 = uv[Fa[:, 2]] - uv[Fa[:, 0]]
+        det = d1[:, 0] * d2[:, 1] - d1[:, 1] * d2[:, 0]
+        safe = np.where(np.abs(det) < 1e-18, 1.0, det)
+        if unroll_axis == 0:
+            t_un = (d2[:, 1, None] * e1 - d1[:, 1, None] * e2) / safe[:, None]
+        else:
+            t_un = (-d2[:, 0, None] * e1 + d1[:, 0, None] * e2) / safe[:, None]
+        t_un[np.abs(det) < 1e-18] = 0.0
+        w_area = 0.5 * np.linalg.norm(np.cross(e1, e2), axis=1)
+        tangent = (t_un * w_area[:, None]).sum(0)
+        tangent -= (tangent @ n_hat) * n_hat
+        # natural frame: u_hat must follow the strip's unroll tangent (flip (u,a) together
+        # = in-plane 180°, the only det-preserving freedom). With n_hat/a_hat taken from
+        # the strip itself this is generically already true; the guard protects degenerate
+        # strips.
+        u_nat, a_nat = (-u_hat, -a_hat) if u_hat @ tangent < 0 else (u_hat, a_hat)
+        # legacy frame (selection key only): extend away from the roll body
+        body_dir = V.mean(0) - V[idx].mean(0)
+        u_leg, a_leg = (-u_hat, -a_hat) if u_hat @ body_dir > 0 else (u_hat, a_hat)
+
+        def build(u_h, a_h):
+            R = np.zeros((3, 3))
+            R[:, flat_unroll_col] = u_h   # flat unroll coord → u_hat
+            R[:, flat_axis_col] = a_h     # flat axis coord → a_hat
+            R[:, 2] = n_hat
+            assert np.linalg.det(R) > 0.99, "tangent-plane frame must be a proper rotation"
+            # anchor strip flat coords → its 3D centroid
+            t_vec = V[idx].mean(0) - (flat3[idx] @ R.T).mean(0)
+            placed = flat3[idx] @ R.T + t_vec
+            rms = float(np.sqrt(((placed - V[idx]) ** 2).sum(1).mean()))
+            return rms, R, t_vec
+
+        rms_nat, R_nat, t_nat = build(u_nat, a_nat)
+        corrected = bool(u_leg @ u_nat < 0)
+        rms_sel = build(u_leg, a_leg)[0] if corrected else rms_nat
+        return rms_sel, R_nat, t_nat, rms_nat, corrected
+
+    candidates = []
+    for name, idx in (("low", low_idx), ("high", high_idx)):
+        rms_sel, R, t, rms_nat, corrected = tangent_plane_placement(idx)
+        candidates.append((rms_sel, name, idx, R, t, rms_nat, corrected))
+    if force_anchor_end == "outer_radial":
+        # winding axis from v-tangent coherence; outer end = strip farther from the axis
+        from .dg_interp import face_uv_tangents
+
+        _, t_v = face_uv_tangents(V, F, uv)
+        nv = np.linalg.norm(t_v, axis=1)
+        ok2 = nv > 1e-12
+        axw = (t_v[ok2] / nv[ok2][:, None]).mean(0)
+        axw /= max(np.linalg.norm(axw), 1e-300)
+        c0 = V.mean(0)
+
+        def mean_radial(idx):
+            rel = V[idx] - c0
+            return float(np.linalg.norm(rel - np.outer(rel @ axw, axw), axis=1).mean())
+
+        r_low, r_high = mean_radial(low_idx), mean_radial(high_idx)
+        want = "low" if r_low >= r_high else "high"
+        candidates = [c for c in candidates if c[1] == want]
+    else:
+        candidates.sort(key=lambda c: c[0])
+    rms_sel, anchor_end, anchor_idx, R, t, rms, orientation_corrected = candidates[0]
+
+    V1 = flat3 @ R.T + t
+
+    # chirality: source recto orientation must survive the embedding.
+    # In the flat sheet the normal is R @ ez (constant). UV winding sign s_uv tells which
+    # side of the UV plane is the recto; the embedded plane normal must equal R@ez * s_uv
+    # consistently — numerically: compare mean target face normal to R@ez.
+    src_sign = surface_orientation_sign(V, F, uv)
+    e1 = V1[F[:, 1]] - V1[F[:, 0]]
+    e2 = V1[F[:, 2]] - V1[F[:, 0]]
+    n_t = np.cross(e1, e2).sum(0)
+    n_t /= max(np.linalg.norm(n_t), 1e-300)
+    plane_n = R @ np.array([0.0, 0.0, 1.0])
+    mirror_check = float(np.dot(n_t, plane_n) * src_sign)
+    # mirror_check > 0 ⇔ winding preserved w.r.t. plane normal ⇔ no mirroring
+    # (Procrustes with det=+1 cannot mirror flat3 in its own plane, but the UV map itself
+    #  could be flipped; record it loudly.)
+
+    return {
+        "V1": V1,
+        "anchor_idx": anchor_idx,
+        "anchor_end": anchor_end,
+        "anchor_rms": rms,
+        "anchor_rms_selection": rms_sel,
+        "orientation_corrected": orientation_corrected,
+        "denorm_fit": fit,
+        "axis": {"axis_uv": ax["axis_uv"], "axis_dir": ax["axis_dir"].tolist(),
+                 "coherences": ax["details"]},
+        "unroll_axis_uv": "u" if unroll_axis == 0 else "v",
+        "uv_winding_sign": src_sign,
+        "mirror_check": mirror_check,
+    }

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/operators.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/operators.py
@@ -1,0 +1,84 @@
+"""Differential operators for the Poisson reconstruction.
+
+Primary: libigl wheel (igl.grad). Fallback: scipy-only construction (same row layout).
+Layout contract: G is (3m, n); rows [0:m] are d/dx-ish components in igl's per-face frame —
+we only ever use G together with the matching area weights and per-face target gradients,
+so the internal layout just has to be self-consistent (asserted in tests on a known mesh).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import scipy.sparse as sp
+
+
+def face_areas(V: np.ndarray, F: np.ndarray) -> np.ndarray:
+    e1 = V[F[:, 1]] - V[F[:, 0]]
+    e2 = V[F[:, 2]] - V[F[:, 0]]
+    return 0.5 * np.linalg.norm(np.cross(e1, e2), axis=1)
+
+
+def grad_operator(V: np.ndarray, F: np.ndarray) -> sp.csr_matrix:
+    """Per-face gradient operator (3m × n), igl layout: rows stacked [m dx; m dy; m dz]
+    in WORLD coordinates (igl.grad uses the 3D embedding, giving world-frame gradients)."""
+    try:
+        import igl
+
+        G = igl.grad(np.asarray(V, dtype=np.float64), np.asarray(F, dtype=np.int64))
+        return sp.csr_matrix(G)
+    except Exception:
+        return _grad_scipy(np.asarray(V, dtype=np.float64), np.asarray(F))
+
+
+def _grad_scipy(V: np.ndarray, F: np.ndarray) -> sp.csr_matrix:
+    """World-frame per-face gradient: ∇φ_i are the standard linear FEM hat-gradients.
+
+    For triangle (i,j,k) with area A and unit normal n̂:
+      ∇φ_i = (n̂ × e_jk) / (2A),  e_jk = x_k − x_j   (rotated opposite edge)
+    """
+    m, n = len(F), len(V)
+    i, j, k = F[:, 0], F[:, 1], F[:, 2]
+    e_i = V[k] - V[j]
+    e_j = V[i] - V[k]
+    e_k = V[j] - V[i]
+    nrm = np.cross(V[j] - V[i], V[k] - V[i])
+    dblA = np.linalg.norm(nrm, axis=1)
+    dblA = np.where(dblA < 1e-300, 1e-300, dblA)
+    n_hat = nrm / dblA[:, None]
+    gi = np.cross(n_hat, e_i) / dblA[:, None]
+    gj = np.cross(n_hat, e_j) / dblA[:, None]
+    gk = np.cross(n_hat, e_k) / dblA[:, None]
+
+    rows, cols, vals = [], [], []
+    for d in range(3):  # world axis
+        base = d * m
+        r = np.arange(m) + base
+        for g, idx in ((gi, i), (gj, j), (gk, k)):
+            rows.append(r)
+            cols.append(idx)
+            vals.append(g[:, d])
+    rows = np.concatenate(rows)
+    cols = np.concatenate(cols)
+    vals = np.concatenate(vals)
+    return sp.csr_matrix((vals, (rows, cols)), shape=(3 * m, n))
+
+
+def poisson_operator(V: np.ndarray, F: np.ndarray) -> tuple[sp.csr_matrix, sp.csr_matrix, np.ndarray]:
+    """Return (L, G, area3): L = Gᵀ diag(area⊗3) G (n×n, PSD with 1-dim null space), G (3m×n)."""
+    G = grad_operator(V, F)
+    A = face_areas(np.asarray(V, np.float64), F)
+    W = sp.diags(np.tile(A, 3))
+    L = (G.T @ W @ G).tocsr()
+    return L, G, A
+
+
+def gradient_rhs(G: sp.csr_matrix, A: np.ndarray, target_grads: np.ndarray) -> np.ndarray:
+    """RHS = Gᵀ diag(area⊗3) f for per-face target gradient matrices.
+
+    target_grads: (m, 3, 3) where target_grads[f] @ (per-face source gradient of x) ...
+    Practically we pass f = stacked per-face world gradients of the target coordinates,
+    shaped (3m, 3) matching G's row layout: rows [d*m + f] = d-th world component of ∇(coord)
+    at face f, columns = x,y,z target coordinate functions.
+    """
+    W = np.tile(A, 3)[:, None]
+    return G.T @ (W * target_grads)

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/rolling.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/rolling.py
@@ -1,0 +1,366 @@
+"""Rolling-contact ("carpet") unroll kinematics — self-intersection-free by construction.
+
+At parameter τ the contact line sits at arc c(τ) from the OUTER end of the winding:
+  s ≤ c : the sheet lies flat on the tangent plane (the existing flat target V1),
+  s > c : the sheet keeps its EXACT original rolled geometry, carried by the rigid motion
+          that aligns the source centerline frame at arc c with the flat frame at arc c
+          (rolling without slipping).
+A rigid copy of intersection-free geometry cannot self-intersect; the flat part is planar;
+they meet tangentially at the contact line where a narrow smoothstep band blends the two
+poses (which already agree to first order there).
+
+Endpoints: c(0) ≤ 0 keeps every vertex in the rolled pose with R(0) ≈ I (the flat target is
+anchored on the tangent plane at the outer end, so the identity holds up to warp noise —
+asserted); c(1) = S + w puts every vertex exactly on V1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .dg_interp import face_uv_tangents
+
+
+def _orthonormal_frame(t: np.ndarray, a: np.ndarray) -> np.ndarray:
+    """Columns [t̂, â⊥, n̂] from tangent + approximate axis."""
+    t = t / max(np.linalg.norm(t), 1e-300)
+    a = a - (a @ t) * t
+    a = a / max(np.linalg.norm(a), 1e-300)
+    n = np.cross(t, a)
+    return np.stack([t, a, n], axis=1)
+
+
+@dataclass
+class RollingContactPath:
+    V0: np.ndarray
+    V1: np.ndarray
+    F: np.ndarray
+    s: np.ndarray              # (n,) arc coordinate from the OUTER end, in [0, S]
+    S: float
+    band: float                # max blend band width (arc units)
+    band_vert: np.ndarray      # (n,) per-vertex band (curvature-adaptive)
+    c_pre: float               # lean-in pre-roll arc (identity → entry pose, arc units)
+    grid_c: np.ndarray         # (K,) arc samples
+    R_grid: np.ndarray         # (K,3,3) rigid rotations source→flat at each c
+    p_grid: np.ndarray         # (K,3) source centerline points
+    f_grid: np.ndarray         # (K,3) flat centerline points
+    lift: np.ndarray           # (K,) plane-clearance lift of the rigid body
+    lift_vis: np.ndarray       # (K,) SMOOTH lift driving the flap bridge (<= lift)
+    pad_arc: float             # landing-flap half-width (clearance exemption zone)
+    n_plane: np.ndarray        # (3,) unrolling-plane normal (toward the roll side)
+    info: dict
+
+    def _rigid_at(self, c: float) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+        c_eval = float(np.clip(c, self.grid_c[0], self.grid_c[-1]))
+        k = int(np.clip(np.searchsorted(self.grid_c, c_eval) - 1, 0, len(self.grid_c) - 2))
+        lam = (c_eval - self.grid_c[k]) / max(self.grid_c[k + 1] - self.grid_c[k], 1e-300)
+        # rotations between neighbouring samples are tiny: normalized linear blend suffices
+        R = (1 - lam) * self.R_grid[k] + lam * self.R_grid[k + 1]
+        U, _, Vt = np.linalg.svd(R)
+        R = U @ Vt
+        p = (1 - lam) * self.p_grid[k] + lam * self.p_grid[k + 1]
+        f = (1 - lam) * self.f_grid[k] + lam * self.f_grid[k + 1]
+        lift = (1 - lam) * self.lift[k] + lam * self.lift[k + 1]
+        lift_v = (1 - lam) * self.lift_vis[k] + lam * self.lift_vis[k + 1]
+        return R, p, f, lift, lift_v
+
+    def eval_frame(self, t: float) -> np.ndarray:
+        """ONE continuous motion (a two-phase split meets at a zero-velocity
+        junction and exposes raw-pose jitter as a visible stutter).
+        The rigid field is defined on c ∈ [−c_pre, S+band]: the negative range is the
+        tip-onto-plane lean-in (slerp Identity→entry pose, arc-proportional), smoothed
+        TOGETHER with the contact field; c(t) is one linear map of the eased timeline."""
+        if t <= 0.0:
+            return self.V0.copy()
+        if t >= 1.0:
+            return self.V1.copy()
+        c = self._contact_arc(t)
+        R, p, f, lift, lift_v = self._rigid_at(c)
+        # Clearance lift: the WHOLE rigid roll rides at +lift (zero internal strain); the
+        # settled sheet stays IN the plane beyond the flap. NO long ramp (the 0.2*S ramp
+        # chased the very lift it existed to avoid: deep lobes raise lift -> ramp raises
+        # the sheet -> the sheet overtakes the lifted lobes; and a v-uniform ramp cannot
+        # thread between lobes at different v). Instead a SHORT paper bridge confined to
+        # the landing flap (<= pad_arc, the zone the clearance certificate exempts as
+        # single material BY CONSTRUCTION): the sheet rises to meet the roll's tangent
+        # exactly like real paper coming off a roller — without it the lifted roll reads
+        # as floating above a knife-flat sheet instead of paying out naturally.
+        rolled = (self.V0 - p) @ R.T + (f + lift * self.n_plane)
+        if c <= 0.0:
+            return rolled
+        flat = self.V1
+        if lift_v > 0.0:
+            # the bridge follows the SMOOTH lift: the raw envelope (which the roll
+            # must ride for clearance) keeps spikes, and a spiky bridge jerks the
+            # flap sheet (measured popping ratio 0.45 -> 0.56 with a raw-lift
+            # bridge). lift_vis <= lift and the flap zone is certificate-exempt,
+            # so no clearance guarantee changes.
+            x = np.clip((c - self.s) / max(self.pad_arc, 1e-300), 0.0, 1.0)
+            g = 1.0 - x * x * (3.0 - 2.0 * x)   # 1 at the contact -> 0 at pad_arc behind
+            flat = self.V1 + (lift_v * g)[:, None] * self.n_plane[None, :]
+        beta = np.clip((c - self.s) / np.maximum(self.band_vert, 1e-300), 0.0, 1.0)
+        beta = beta * beta * (3.0 - 2.0 * beta)  # smoothstep
+        return rolled * (1.0 - beta)[:, None] + flat * beta[:, None]
+
+    def _contact_arc(self, t: float) -> float:
+        return t * (self.S + self.band + self.c_pre) - self.c_pre
+
+    def transition_face_mask(self, t: float) -> np.ndarray | None:
+        """Faces currently crossing the contact band: their fast normal swing is the
+        physical takeoff snap, excluded from the temporal-flip count (gate doc)."""
+        if t <= 0.0 or t >= 1.0:
+            return None
+        c = self._contact_arc(t)
+        if c <= 0.0:
+            return None
+        s_f = self.s[self.F].mean(axis=1)
+        # must cover the contact's sweep BETWEEN the two compared frames
+        pad = 2.0 * self.band + 0.02 * self.S
+        return (s_f > c - self.band - pad) & (s_f < c + pad)
+
+
+def build_rolling_path(
+    V0: np.ndarray,
+    V1: np.ndarray,
+    F: np.ndarray,
+    uv: np.ndarray,
+    s_u: float,
+    *,
+    unroll_axis: int = 0,
+    outer_is_low_u: bool | None = None,
+    n_grid: int = 512,
+    band_frac: float = 0.008,
+    smooth_sigma: int = 21,
+) -> RollingContactPath:
+    """Precompute centerline frames + rigid motions for the rolling-contact unroll.
+
+    V1 must be the flat target anchored ON the tangent plane at the OUTER end (the natural
+    free end of the winding); outer_is_low_u is auto-detected from winding radii when None.
+    """
+    V0 = np.asarray(V0, dtype=np.float64)
+    V1 = np.asarray(V1, dtype=np.float64)
+    uv = np.asarray(uv, dtype=np.float64)
+    u = uv[:, unroll_axis]
+
+    # winding axis (mean v-tangent) + radial distances to find the OUTER end
+    t_u, t_v = face_uv_tangents(V0, F, uv)
+    w_face = np.linalg.norm(np.cross(V0[F[:, 1]] - V0[F[:, 0]], V0[F[:, 2]] - V0[F[:, 0]]), axis=1)
+    tvn = np.linalg.norm(t_v, axis=1)
+    good = tvn > 1e-12
+    axis = (t_v[good] / tvn[good][:, None] * w_face[good][:, None]).sum(0)
+    axis /= max(np.linalg.norm(axis), 1e-300)
+    c0 = V0.mean(0)
+    rel = V0 - c0
+    radial = np.linalg.norm(rel - np.outer(rel @ axis, axis), axis=1)
+    if outer_is_low_u is None:
+        lo_band = u <= np.quantile(u, 0.05)
+        hi_band = u >= np.quantile(u, 0.95)
+        outer_is_low_u = bool(radial[lo_band].mean() > radial[hi_band].mean())
+
+    s_uv = (u.max() - u) * s_u if not outer_is_low_u else (u - u.min()) * s_u
+    # Landing order must equal flat-space order. The linear-in-u arc disagrees
+    # with the vertex's TRUE flat position by O(chart warp) — thousands of voxels
+    # on warped tails — so late-landing patches would keep moving rigidly THROUGH
+    # already-settled sheet, and warp-seam faces would span huge Δs (sliver
+    # spikes at the roll top). Define s as the payout
+    # coordinate IN THE FLAT EMBEDDING itself: a vertex flattens exactly when the contact
+    # line sweeps its own landing slot, so 'settled behind contact, rolled ahead' is exact
+    # and roll-vs-sheet interpenetration is impossible by construction. For a clean chart
+    # this equals the UV arc up to a constant.
+    sc = s_uv - s_uv.mean()
+    reg = (V1 - V1.mean(0)).T @ sc            # payout direction: regression of V1 on the arc
+    u_dir = reg / max(np.linalg.norm(reg), 1e-300)
+    s = (V1 - V1.mean(0)) @ u_dir
+    s -= s.min()
+    S = float(s.max())
+    med_edge = float(np.median(np.linalg.norm(V0[F[:, 1]] - V0[F[:, 0]], axis=1)))
+    band = max(band_frac * S, 4.0 * med_edge)
+
+    # centerline frames on a grid of c
+    grid_c = np.linspace(0.0, S, n_grid)
+    half = max(S / n_grid * 1.5, band / 4)
+    # per-vertex tangents for frame construction
+    tu_v = np.zeros_like(V0)
+    tv_v = np.zeros_like(V0)
+    cnt = np.zeros(len(V0))
+    for j in range(3):
+        np.add.at(tu_v, F[:, j], t_u)
+        np.add.at(tv_v, F[:, j], t_v)
+        np.add.at(cnt, F[:, j], 1.0)
+    tu_v /= np.maximum(cnt, 1.0)[:, None]
+    tv_v /= np.maximum(cnt, 1.0)[:, None]
+    # Per-band rigid transform = Kabsch fit of the band's SOURCE vertices onto their OWN
+    # flat targets. No tangent regressions or sign conventions: at c=0 the embedding placed
+    # the anchor strip on its tangent plane, so the band-0 Kabsch is ≈ identity by
+    # construction; at general c it is exactly the rolling-contact alignment (least-squares
+    # tangency of the remaining roll on the plane at the contact line).
+    order = np.argsort(s)
+    s_sorted = s[order]
+    p_grid = np.empty((n_grid, 3))
+    f_grid = np.empty((n_grid, 3))
+    R_grid = np.empty((n_grid, 3, 3))
+    k_min = max(3000, len(V0) // 200)  # bands must span the v-extent (ragged tips!)
+    for k, c in enumerate(grid_c):
+        h = half
+        i0, i1 = np.searchsorted(s_sorted, [c - h, c + h])
+        while (i1 - i0) < k_min and (i0 > 0 or i1 < len(order)):
+            h *= 1.6
+            i0, i1 = np.searchsorted(s_sorted, [c - h, c + h])
+        idx = order[i0:i1] if i1 > i0 else order[max(0, i0 - 8):min(len(order), i0 + 8)]
+        P, Q = V0[idx], V1[idx]
+        cp, cq = P.mean(0), Q.mean(0)
+        H = (P - cp).T @ (Q - cq)
+        U, _, Vt = np.linalg.svd(H)
+        D = np.diag([1.0, 1.0, np.sign(np.linalg.det(Vt.T @ U.T))])
+        R_grid[k] = Vt.T @ D @ U.T
+        p_grid[k] = cp
+        f_grid[k] = cq
+    # smooth along the grid (warp noise); rotations re-projected to SO(3) after averaging.
+    # END-PRESERVING: blend back to the raw Kabsch poses near both grid ends — heavy
+    # smoothing otherwise drags curled-neighbour poses into grid[0] and manufactures a
+    # fake tip angle (w018: 13° real → 24° smoothed), inflating the settle sweep.
+    if smooth_sigma > 0:
+        from scipy.ndimage import gaussian_filter1d
+        # FULL smoothing: end-preservation exposed raw per-band Kabsch jitter exactly
+        # where the sweep starts (visible vibration); the settle phase targets the
+        # smoothed entry pose, so consistency at c=0 is automatic.
+        p_grid[:] = gaussian_filter1d(p_grid, smooth_sigma, axis=0, mode="nearest")
+        f_grid[:] = gaussian_filter1d(f_grid, smooth_sigma, axis=0, mode="nearest")
+        R_sm = gaussian_filter1d(R_grid.reshape(n_grid, 9), smooth_sigma, axis=0,
+                                 mode="nearest").reshape(n_grid, 3, 3)
+        Us, _, Vts = np.linalg.svd(R_sm)
+        det = np.linalg.det(Us @ Vts)
+        Ds = np.ones((n_grid, 3))
+        Ds[:, 2] = det
+        R_grid = (Us * Ds[:, None, :]) @ Vts
+
+    # Curvature-adaptive blend band: chord-shear in the band scales with band×curvature,
+    # so the band narrows where the winding is tight (scroll cores) and keeps its full
+    # width on gentle outer wraps. Curvature from the RAW centerline (pre-smoothing).
+    dp = np.gradient(p_grid, grid_c, axis=0)
+    t_hat = dp / np.maximum(np.linalg.norm(dp, axis=1, keepdims=True), 1e-300)
+    dt = np.gradient(t_hat, grid_c, axis=0)
+    kappa = np.linalg.norm(dt, axis=1)
+    from scipy.ndimage import gaussian_filter1d as _gf1k
+    kappa = _gf1k(kappa, 9, mode="nearest")
+    band_c = np.clip(np.where(kappa > 1e-12, 0.5 / np.maximum(kappa, 1e-12), band),
+                     4.0 * med_edge, band)
+    band_vert = np.interp(s, grid_c, band_c)
+
+    # Plane-clearance barrier (closed form): the rigid roll's only possible collider is
+    # the unrolling plane (the already-flat sheet lies in it). Per grid contact, measure
+    # how far transformed rolled points BEHIND the contact would dig below the plane and
+    # lift the whole rigid body by that clearance along the plane normal. Rigidity (hence
+    # intra-roll intersection-freedom) is untouched; roll-vs-flat penetration becomes
+    # impossible by construction.
+    n_pl = np.cross(V1[F[:, 1]] - V1[F[:, 0]], V1[F[:, 2]] - V1[F[:, 0]]).sum(0)
+    n_pl /= max(np.linalg.norm(n_pl), 1e-300)
+    if (V0.mean(0) - f_grid[0]) @ n_pl < 0:
+        n_pl = -n_pl                       # normal points toward the roll's side
+    u_pl = f_grid[-1] - f_grid[0]
+    u_pl -= (u_pl @ n_pl) * n_pl
+    u_pl /= max(np.linalg.norm(u_pl), 1e-300)  # plane direction of paying-out
+    sub = np.arange(0, len(V0), 2)
+    eps = 0.5 * float(np.median(np.linalg.norm(V0[F[:, 1]] - V0[F[:, 0]], axis=1)))
+    pad_arc = band + 4.0 * med_edge   # landing flap: single material, exempt from clearance
+    lift_req = np.zeros(n_grid)
+    for k in range(n_grid):
+        c = grid_c[k]
+        m_roll = s[sub] > c
+        if not m_roll.any():
+            continue
+        pts = (V0[sub[m_roll]] - p_grid[k]) @ R_grid[k].T + f_grid[k]
+        behind = (pts - f_grid[k]) @ u_pl < 0.0   # over already-paid-out sheet
+        if not behind.any():
+            continue
+        hgt = (pts[behind] - f_grid[0]) @ n_pl
+        lift_req[k] = max(0.0, eps - float(hgt.min()))
+    from scipy.ndimage import gaussian_filter1d as _gf1
+    # smoothing must never UNDERCUT the requirement (it shaved spiky lift needs by
+    # >1000 units and let pre-landing lobes dig through the plane): smooth for the
+    # visual ride, then take the upper envelope with the raw requirement.
+    lift = np.maximum(_gf1(lift_req, 15, mode="nearest"), lift_req)
+    lift[0] = 0.0  # frame-0 pose must stay the exact source pose
+    # the flap bridge follows a spike-free lift (always <= the clearance envelope)
+    lift_vis = np.minimum(_gf1(lift_req, 31, mode="nearest"), lift)
+    lift_vis[0] = 0.0
+    # NO end taper: forcing lift->0 while the multi-turn core is still wound pushes it
+    # INTO the flat sheet -> coincident surfaces z-fight through the cutout = the
+    # 'transparent roll' artifact. The computed lift need decays
+    # naturally as the core shrinks, and endpoint exactness is already guaranteed by the
+    # blend weights (the rolled pose has weight ~0 in the final frames).
+
+    # identity sanity at c=0 (flat target tangent at the outer end)
+    dev0 = float(np.linalg.norm(R_grid[0] - np.eye(3)))
+    info = {
+        "kinematics": "rolling_contact",
+        "outer_is_low_u": bool(outer_is_low_u),
+        "S_arc": S,
+        "band": band,
+        "R0_identity_dev": dev0,
+        "n_grid": n_grid,
+        "lift_max": float(lift.max()),
+        "lift_eps": eps,
+        "pad_arc": pad_arc,
+    }
+    # Lean-in pre-roll: extend the field below c=0 with slerp(Identity → entry pose),
+    # allocated arc-proportionally (c_pre = mean lean-in displacement so speed across
+    # c=0 is matched by construction), then smooth the UNIFIED field — one continuous
+    # motion: no phase junction, no rate step, no exposed raw-pose jitter.
+    from .dg_interp import rotation_exp as _re, rotation_log as _rl
+    w0 = _rl(R_grid[:1])[0]
+    th0 = float(np.linalg.norm(w0))
+    sub2 = np.arange(0, len(V0), 7)
+    T0_pts = (V0[sub2] - p_grid[0]) @ R_grid[0].T + f_grid[0]
+    M_rot = float(np.linalg.norm(T0_pts - V0[sub2], axis=1).mean())
+    c_pre = float(np.clip(M_rot, 1e-6, 0.35 * S))
+    n_pre = max(12, int(round(n_grid * c_pre / max(S, 1e-300))))
+    alpha = np.arange(n_pre) / n_pre
+    R_pre = _re(alpha[:, None] * w0[None, :])
+    p_pre = np.repeat(p_grid[:1], n_pre, axis=0)
+    f_pre = p_grid[0][None, :] + alpha[:, None] * (f_grid[0] - p_grid[0])[None, :]
+    grid_c = np.concatenate([np.linspace(-c_pre, 0.0, n_pre, endpoint=False), grid_c])
+    R_grid = np.concatenate([R_pre, R_grid], axis=0)
+    p_grid = np.concatenate([p_pre, p_grid], axis=0)
+    f_grid = np.concatenate([f_pre, f_grid], axis=0)
+    # (lift stays zero during lean-in: a pre-rise ramp does not address the
+    # junction rate mismatch — that is pacing — and only adds lean-in motion)
+    lift = np.concatenate([np.zeros(n_pre), lift])
+    lift_vis = np.concatenate([np.zeros(n_pre), lift_vis])
+    from scipy.ndimage import gaussian_filter1d as _gf2
+    p_grid = _gf2(p_grid, 5, axis=0, mode="nearest")
+    f_grid = _gf2(f_grid, 5, axis=0, mode="nearest")
+    # the clearance envelope survives the unified re-smooth: lift may only grow
+    lift = np.maximum(_gf2(lift, 5, mode="nearest"), lift)
+    lift_vis = np.minimum(_gf2(lift_vis, 5, mode="nearest"), lift)
+    Rs = _gf2(R_grid.reshape(len(grid_c), 9), 5, axis=0, mode="nearest").reshape(-1, 3, 3)
+    Uu, _, Vv = np.linalg.svd(Rs)
+    dd = np.linalg.det(Uu @ Vv)
+    Dd = np.ones((len(grid_c), 3))
+    Dd[:, 2] = dd
+    R_grid = (Uu * Dd[:, None, :]) @ Vv
+    # frame-0 exactness, TAPERED: the unified re-smooth bleeds the entry pose into
+    # the first samples; stomping only sample 0 back to identity leaves a field STEP
+    # between grid[0] and grid[1] — invisible at small tip angles (w023: 39°) but a
+    # visible morph-start snap at large ones (w011: 120°, disp delta 3.8x median).
+    # Instead compute the sample-0 correction and decay it smoothly over ~2 sigma.
+    w_err = _rl(R_grid[:1])[0]
+    df_err = f_grid[0] - p_grid[0]
+    K_pin = min(12, len(grid_c) - 1)
+    for k in range(K_pin):
+        a = 1.0 - k / K_pin
+        a = a * a * (3.0 - 2.0 * a)
+        R_grid[k] = _re((-a) * w_err[None])[0] @ R_grid[k]
+        f_grid[k] = f_grid[k] - a * df_err
+        lift[k] = (1.0 - a) * lift[k]
+        lift_vis[k] = (1.0 - a) * lift_vis[k]
+    info["tip_angle_deg"] = float(np.degrees(th0))
+    info["c_pre"] = c_pre
+    return RollingContactPath(V0=V0, V1=V1, F=np.asarray(F), s=s, S=S, band=band,
+                              band_vert=band_vert,
+                              c_pre=c_pre,
+                              grid_c=grid_c, R_grid=R_grid, p_grid=p_grid, f_grid=f_grid,
+                              lift=lift, lift_vis=lift_vis, pad_arc=pad_arc, n_plane=n_pl,
+                              info=info)

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/solver.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/solver.py
@@ -1,0 +1,94 @@
+"""Factor-once / solve-many sparse SPD solver with a backend ladder.
+
+Backends (preference order unless pinned): pypardiso, cholmod (if installed), pyamg, scipy-splu.
+The production choice is recorded by scripts/bench_solver.py in reports/solver_bench.json and
+resolved here when backend='auto'.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+
+_LADDER = ["pypardiso", "cholmod", "pyamg", "scipy-splu"]
+
+
+class FactorizedSPD:
+    """factorize(A) once; solve(B) many times. A must be SPD (pin the null space first)."""
+
+    def __init__(self, A: sp.spmatrix, backend: str = "auto", repo_root: Path | None = None) -> None:
+        if backend == "auto":
+            backend = self._resolve_auto(repo_root)
+        backend = backend.replace("_", "-")
+        if backend == "scipy":
+            backend = "scipy-splu"
+        self.backend = backend
+        A = A.tocsr()
+        if backend == "pypardiso":
+            import pypardiso
+
+            self._solver = pypardiso.PyPardisoSolver()
+            self._A = A
+            self._solver.factorize(A)
+        elif backend == "cholmod":
+            from sksparse.cholmod import cholesky
+
+            self._factor = cholesky(A.tocsc())
+        elif backend == "pyamg":
+            import pyamg
+
+            self._ml = pyamg.smoothed_aggregation_solver(A.tocsr())
+            self._A = A
+        elif backend == "scipy-splu":
+            self._lu = spla.splu(A.tocsc())
+        else:
+            raise ValueError(f"unknown backend {backend!r}")
+
+    @staticmethod
+    def _resolve_auto(repo_root: Path | None) -> str:
+        if repo_root is not None:
+            bench = Path(repo_root) / "reports/solver_bench.json"
+            if bench.exists():
+                chosen = json.loads(bench.read_text()).get("chosen")
+                if chosen:
+                    return chosen
+        for name in _LADDER:
+            try:
+                if name == "pypardiso":
+                    import pypardiso  # noqa: F401
+                elif name == "cholmod":
+                    from sksparse.cholmod import cholesky  # noqa: F401
+                elif name == "pyamg":
+                    import pyamg  # noqa: F401
+                return name
+            except ImportError:
+                continue
+        return "scipy-splu"
+
+    def solve(self, B: np.ndarray) -> np.ndarray:
+        B = np.asarray(B, dtype=np.float64)
+        squeeze = B.ndim == 1
+        if squeeze:
+            B = B[:, None]
+        if self.backend == "pypardiso":
+            X = self._solver.solve(self._A, B)
+        elif self.backend == "cholmod":
+            X = self._factor(B)
+        elif self.backend == "pyamg":
+            cols = [self._ml.solve(B[:, j], tol=1e-10, accel="cg") for j in range(B.shape[1])]
+            X = np.stack(cols, axis=1)
+        else:
+            X = self._lu.solve(B)
+        return X[:, 0] if squeeze else X
+
+
+def pin_vertex(L: sp.spmatrix, pinned: int) -> tuple[sp.csr_matrix, np.ndarray]:
+    """Remove row/col `pinned` (Dirichlet). Returns (L_reduced, keep_index_map)."""
+    n = L.shape[0]
+    keep = np.concatenate([np.arange(pinned), np.arange(pinned + 1, n)])
+    L = L.tocsr()
+    return L[keep][:, keep].tocsr(), keep

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/timeline.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/timeline.py
@@ -1,0 +1,19 @@
+"""Animation timeline: frame index → interpolation parameter t with eased morph and holds."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def quintic(s: np.ndarray) -> np.ndarray:
+    return s * s * s * (s * (6.0 * s - 15.0) + 10.0)
+
+
+def timeline_t(n_frames: int = 240, hold_start: int = 20, hold_end: int = 25, easing: str = "quintic") -> np.ndarray:
+    """t per frame: 0 during the start hold, eased 0→1, 1 during the end hold."""
+    morph = n_frames - hold_start - hold_end
+    if morph < 2:
+        raise ValueError("timeline too short for the holds")
+    s = np.linspace(0.0, 1.0, morph)
+    e = quintic(s) if easing == "quintic" else s
+    return np.concatenate([np.zeros(hold_start), e, np.ones(hold_end)])

--- a/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/trim.py
+++ b/foundation/scroll-unwrap-pipeline/src/scrollkit/unwrap/trim.py
@@ -1,0 +1,202 @@
+"""Data-driven junk-tail trim for wrap charts (animation deliverables only).
+
+Segmentation traces can end in low-confidence tails where the UV chart is
+squeezed or warped (e.g. a double-digit denormalization residual concentrated
+in the inner tail). Consequences: per-vertex arcs disagree with flat positions
+by thousands of voxels (material transported through already-settled sheet),
+warp-seam slivers spike at the roll top, and the squeezed chart renders its
+texture content as a compressed, seam-bounded column at the flat sheet's edge
+— a faithful sampling of the input, but a geometrically broken presentation.
+
+Rule: per-u-bin median of the relative isometry residual of the global denorm
+fit; a CONTIGUOUS run of bad bins touching either chart end is junk and its
+faces are dropped (cap per end: max_trim_frac of the u-range). Interior junk is
+never trimmed (it would split the sheet). M1/M2 mesh deliverables stay FULL —
+only the unwrap animation consumes the trimmed mesh, and the trim is recorded
+in metrics.json.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["junk_tail_trim", "enforce_chart_injectivity"]
+
+
+def enforce_chart_injectivity(V: np.ndarray, F: np.ndarray, uv: np.ndarray, *,
+                              r_uv: float = 5e-4, d3_min_frac: float = 0.15) -> dict:
+    """Drop duplicated chart patches: a chart must be injective (one UV point ==
+    one 3D point). Segmentation traces occasionally duplicate a patch (the trace
+    rides the same physical surface twice); both layers carry the SAME texture
+    region, so they render as offset double-exposed text and flicker as the
+    layers cross while landing (typically a few hundred vertices at a trace's
+    inner tail).
+
+    Detection: vertex pairs within r_uv in UV but > d3_min_frac*median_edge apart
+    in 3D. Resolution: per connected component of flagged vertices, keep the
+    layer consistent with the LOCAL CONSENSUS — the median 3D position of
+    unflagged UV-neighbours — and drop faces touching the deviant layer."""
+    from scipy.spatial import cKDTree
+
+    V = np.asarray(V, dtype=np.float64)
+    F = np.asarray(F)
+    uv = np.asarray(uv, dtype=np.float64)
+    e = V[F[:, 1]] - V[F[:, 0]]
+    med_edge = float(np.median(np.linalg.norm(e, axis=1)))
+    d3_min = d3_min_frac * med_edge
+
+    tree = cKDTree(uv)
+    pairs = tree.query_pairs(r=r_uv, output_type="ndarray")
+    info = {"n_pairs_uv": int(len(pairs)), "n_pairs_far": 0, "n_verts_flagged": 0,
+            "n_verts_dropped": 0, "n_faces_dropped": 0, "med_edge": med_edge}
+    if len(pairs) == 0:
+        return {"V": V, "F": F, "uv": uv, "vert_keep": np.ones(len(V), bool), "info": info}
+    d3 = np.linalg.norm(V[pairs[:, 0]] - V[pairs[:, 1]], axis=1)
+    far = pairs[d3 > d3_min]
+    info["n_pairs_far"] = int(len(far))
+    if len(far) == 0:
+        return {"V": V, "F": F, "uv": uv, "vert_keep": np.ones(len(V), bool), "info": info}
+
+    flagged = np.zeros(len(V), bool)
+    flagged[far.ravel()] = True
+    info["n_verts_flagged"] = int(flagged.sum())
+
+    # consensus position per flagged vertex from UNFLAGGED uv-neighbours
+    ball = tree.query_ball_point(uv[flagged], r=3.0 * r_uv)
+    flag_idx = np.flatnonzero(flagged)
+    consensus = np.full((len(flag_idx), 3), np.nan)
+    for k, nb in enumerate(ball):
+        nb = np.asarray(nb)
+        nb = nb[~flagged[nb]]
+        if len(nb) >= 3:
+            consensus[k] = np.median(V[nb], axis=0)
+    dev = np.linalg.norm(V[flag_idx] - consensus, axis=1)
+
+    # connected components of flagged vertices over mesh edges
+    drop = np.zeros(len(V), bool)
+    f_any = flagged[F].any(axis=1)
+    adj: dict[int, list[int]] = {}
+    for tri in F[f_any]:
+        vs = [v for v in tri if flagged[v]]
+        for a in vs:
+            for b in vs:
+                if a != b:
+                    adj.setdefault(int(a), []).append(int(b))
+    seen = set()
+    pos_in_flag = {int(v): i for i, v in enumerate(flag_idx)}
+    for start in flag_idx:
+        start = int(start)
+        if start in seen:
+            continue
+        comp = [start]
+        seen.add(start)
+        stack = [start]
+        while stack:
+            cur = stack.pop()
+            for nxt in adj.get(cur, ()):
+                if nxt not in seen:
+                    seen.add(nxt)
+                    comp.append(nxt)
+                    stack.append(nxt)
+        devs = [dev[pos_in_flag[v]] for v in comp if not np.isnan(dev[pos_in_flag[v]]).any()]
+        med_dev = float(np.median(devs)) if devs else np.inf
+        # a duplicate layer sits far from the local consensus sheet; the genuine
+        # layer IS the consensus (median dev ~ 0)
+        if med_dev > d3_min:
+            for v in comp:
+                drop[v] = True
+    info["n_verts_dropped"] = int(drop.sum())
+    if not drop.any():
+        return {"V": V, "F": F, "uv": uv, "vert_keep": np.ones(len(V), bool), "info": info}
+
+    keep_f = ~drop[F].any(axis=1)
+    info["n_faces_dropped"] = int((~keep_f).sum())
+    F2 = F[keep_f]
+    used = np.zeros(len(V), bool)
+    used[F2] = True
+    remap = -np.ones(len(V), np.int64)
+    remap[used] = np.arange(int(used.sum()))
+    return {"V": V[used], "F": remap[F2], "uv": uv[used], "vert_keep": used, "info": info}
+
+
+def _denorm_fit(V: np.ndarray, F: np.ndarray, uv: np.ndarray) -> tuple[float, float]:
+    P = [V[F[:, 1]] - V[F[:, 0]], V[F[:, 2]] - V[F[:, 1]], V[F[:, 0]] - V[F[:, 2]]]
+    Q = [uv[F[:, 1]] - uv[F[:, 0]], uv[F[:, 2]] - uv[F[:, 1]], uv[F[:, 0]] - uv[F[:, 2]]]
+    d2 = np.concatenate([np.sum(p * p, axis=1) for p in P])
+    du2 = np.concatenate([q[:, 0] ** 2 for q in Q])
+    dv2 = np.concatenate([q[:, 1] ** 2 for q in Q])
+    A = np.stack([du2, dv2], axis=1)
+    coef, *_ = np.linalg.lstsq(A, d2, rcond=None)
+    return float(np.sqrt(max(coef[0], 1e-12))), float(np.sqrt(max(coef[1], 1e-12)))
+
+
+def junk_tail_trim(V: np.ndarray, F: np.ndarray, uv: np.ndarray, *,
+                   n_bins: int = 200, bad_ratio: float = 3.0,
+                   min_bad_bins: int = 2, max_trim_frac: float = 0.10) -> dict:
+    V = np.asarray(V, dtype=np.float64)
+    F = np.asarray(F)
+    uv = np.asarray(uv, dtype=np.float64)
+    s_u, s_v = _denorm_fit(V, F, uv)
+
+    # per-face relative isometry residual (worst edge of the face)
+    res_face = np.zeros(len(F))
+    for a, b in ((0, 1), (1, 2), (2, 0)):
+        e = V[F[:, b]] - V[F[:, a]]
+        q = uv[F[:, b]] - uv[F[:, a]]
+        d2 = np.sum(e * e, axis=1)
+        m2 = (s_u * q[:, 0]) ** 2 + (s_v * q[:, 1]) ** 2
+        r = np.abs(d2 - m2) / np.maximum(d2, 1e-12)
+        res_face = np.maximum(res_face, r)
+
+    cu = uv[F].mean(axis=1)[:, 0]                     # face centroid u
+    u_lo, u_hi = float(cu.min()), float(cu.max())
+    edges = np.linspace(u_lo, u_hi, n_bins + 1)
+    which = np.clip(np.searchsorted(edges, cu) - 1, 0, n_bins - 1)
+    med_bin = np.full(n_bins, np.nan)
+    for b in range(n_bins):
+        m = which == b
+        if m.any():
+            med_bin[b] = np.median(res_face[m])
+    global_med = float(np.median(res_face))
+    thresh = max(bad_ratio * global_med, 0.02)
+    bad = med_bin > thresh                              # NaN bins -> False (empty)
+
+    def tail_len(order: np.ndarray) -> int:
+        n = 0
+        for b in order:
+            if np.isnan(med_bin[b]) or bad[b]:
+                n += 1
+            else:
+                break
+        return n
+
+    cap = int(max_trim_frac * n_bins)
+    lo_n = min(tail_len(np.arange(n_bins)), cap)
+    hi_n = min(tail_len(np.arange(n_bins)[::-1]), cap)
+    if lo_n < min_bad_bins:
+        lo_n = 0
+    if hi_n < min_bad_bins:
+        hi_n = 0
+
+    u_min_keep = edges[lo_n] if lo_n else -np.inf
+    u_max_keep = edges[n_bins - hi_n] if hi_n else np.inf
+    keep_f = (cu >= u_min_keep) & (cu <= u_max_keep)
+    info = {
+        "s_u": s_u, "s_v": s_v,
+        "global_med_residual": global_med, "threshold": thresh,
+        "trim_lo_bins": int(lo_n), "trim_hi_bins": int(hi_n),
+        "u_keep": [float(u_min_keep), float(u_max_keep)],
+        "n_faces_dropped": int((~keep_f).sum()),
+        "frac_faces_dropped": float((~keep_f).mean()),
+    }
+    if not (~keep_f).any():
+        return {"V": V, "F": F, "uv": uv, "vert_keep": np.ones(len(V), bool),
+                "info": info}
+
+    F2 = F[keep_f]
+    used = np.zeros(len(V), bool)
+    used[F2] = True
+    remap = -np.ones(len(V), np.int64)
+    remap[used] = np.arange(int(used.sum()))
+    return {"V": V[used], "F": remap[F2], "uv": uv[used], "vert_keep": used,
+            "info": info}

--- a/foundation/scroll-unwrap-pipeline/tests/conftest.py
+++ b/foundation/scroll-unwrap-pipeline/tests/conftest.py
@@ -1,0 +1,2 @@
+import sys
+sys.path.insert(0, "tests")

--- a/foundation/scroll-unwrap-pipeline/tests/fixtures.py
+++ b/foundation/scroll-unwrap-pipeline/tests/fixtures.py
@@ -1,0 +1,155 @@
+"""Synthetic fixtures: hand-written binary PLY bytes (independent of scrollkit.io writers,
+so reader bugs can't self-confirm) and analytic meshes for unwrap math."""
+
+from __future__ import annotations
+
+import struct
+
+import numpy as np
+
+
+def asymmetric_quad() -> dict:
+    """Two triangles with deliberately asymmetric geometry, normals, and UVs.
+
+    Every value is unique so any silent reorder/merge/flip/transpose changes something
+    detectable. Includes a duplicated *position* (v3 == v0 location) that must NOT merge.
+    """
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [2.0, 0.125, 0.0],
+            [1.75, 3.0, 0.5],
+            [0.0, 0.0, 0.0],  # duplicate position of v0 — merge trap
+        ],
+        dtype=np.float32,
+    )
+    normals = np.array(
+        [
+            [0.0, 0.0, 1.0],
+            [0.1, 0.0, 0.99],
+            [0.0, 0.1, 0.99],
+            [0.0, 0.0, -1.0],  # deliberately different from v0's normal
+        ],
+        dtype=np.float32,
+    )
+    vertex_uv = np.array(
+        [[0.03125, 0.0625], [0.9, 0.11], [0.77, 0.93], [0.13, 0.81]],
+        dtype=np.float32,
+    )
+    faces = np.array([[0, 1, 2], [2, 1, 3]], dtype=np.int32)
+    wedge_uv = vertex_uv[faces]  # consistent wedge==vertex case
+    return dict(vertices=vertices, normals=normals, vertex_uv=vertex_uv, faces=faces, wedge_uv=wedge_uv)
+
+
+def write_binary_ply_wrapstyle(path, vertices, normals, vertex_uv, faces, wedge_uv, texture_file="tex.png") -> None:
+    """Write a Group-A/B-style PLY (vertex: x,y,z,nx,ny,nz,s,t; face: idx list + texcoord list)
+    using raw struct packing — intentionally NOT scrollkit.io."""
+    n, m = len(vertices), len(faces)
+    header = (
+        "ply\nformat binary_little_endian 1.0\n"
+        f"comment TextureFile {texture_file}\n"
+        f"element vertex {n}\n"
+        + "".join(f"property float {p}\n" for p in ["x", "y", "z", "nx", "ny", "nz", "s", "t"])
+        + f"element face {m}\n"
+        "property list uchar int vertex_indices\n"
+        "property list uchar float texcoord\n"
+        "end_header\n"
+    )
+    with open(path, "wb") as f:
+        f.write(header.encode("ascii"))
+        for i in range(n):
+            f.write(struct.pack("<8f", *vertices[i], *normals[i], *vertex_uv[i]))
+        for t in range(m):
+            f.write(struct.pack("<B3i", 3, *[int(x) for x in faces[t]]))
+            f.write(struct.pack("<B6f", 6, *wedge_uv[t].reshape(-1)))
+
+
+def write_binary_ply_scrollstyle(path, vertices, faces, wedge_uv, texnumber=None, texture_files=("tex.png",)) -> None:
+    """Group-C-style PLY (vertex: x,y,z; face: idx + texcoord [+ texnumber])."""
+    n, m = len(vertices), len(faces)
+    header = (
+        "ply\nformat binary_little_endian 1.0\ncomment VCGLIB generated\n"
+        + "".join(f"comment TextureFile {t}\n" for t in texture_files)
+        + f"element vertex {n}\nproperty float x\nproperty float y\nproperty float z\n"
+        f"element face {m}\n"
+        "property list uchar int vertex_indices\n"
+        "property list uchar float texcoord\n"
+        + ("property int texnumber\n" if texnumber is not None else "")
+        + "end_header\n"
+    )
+    with open(path, "wb") as f:
+        f.write(header.encode("ascii"))
+        for i in range(n):
+            f.write(struct.pack("<3f", *vertices[i]))
+        for t in range(m):
+            f.write(struct.pack("<B3i", 3, *[int(x) for x in faces[t]]))
+            f.write(struct.pack("<B6f", 6, *wedge_uv[t].reshape(-1)))
+            if texnumber is not None:
+                f.write(struct.pack("<i", int(texnumber[t])))
+
+
+def spiral_wrap(n_u: int = 512, n_v: int = 13, r_outer: float = 60.0, r_inner: float = 25.0,
+                height: float = 80.0, turns: float = 4.0, inward: bool = True) -> dict:
+    """Archimedean spiral sheet with a near-isometric flattening (u = arc length).
+
+    `inward=True` parameterizes the trace from the OUTER edge winding INWARD with
+    increasing u — like the production meshes whose anchor-strip tangent points toward
+    the roll centroid at both u-extremes (tangent·(centroid−strip) = +r·|dr/dθ| > 0
+    everywhere for an inward trace). This is the geometry that made the legacy
+    'extend away from the body' embedding heuristic rotate the flat target 180° in-plane.
+    """
+    theta = np.linspace(0.0, turns * 2 * np.pi, n_u)
+    r = r_outer + (r_inner - r_outer) * theta / theta[-1]
+    if not inward:
+        r = r[::-1].copy()
+    x = r * np.cos(theta)
+    y = r * np.sin(theta)
+    seg = np.sqrt(np.diff(x) ** 2 + np.diff(y) ** 2)
+    s = np.concatenate([[0.0], np.cumsum(seg)])  # arc length: isometric u
+    v = np.linspace(0.0, height, n_v)
+    P = np.stack([np.repeat(x, n_v), np.repeat(y, n_v), np.tile(v, n_u)], axis=1)
+    flat = np.stack([np.repeat(s, n_v), np.tile(v, n_u)], axis=1)
+    uv_norm = flat / np.array([s[-1], v[-1]])
+    faces = []
+    for i in range(n_u - 1):
+        for j in range(n_v - 1):
+            a = i * n_v + j
+            b = (i + 1) * n_v + j
+            faces.append([a, b, a + 1])
+            faces.append([b, b + 1, a + 1])
+    return dict(
+        vertices=P.astype(np.float64),
+        faces=np.array(faces, dtype=np.int32),
+        uv_norm=uv_norm.astype(np.float64),
+        flat=flat.astype(np.float64),
+        scale_true=(float(s[-1]), float(v[-1])),
+    )
+
+
+def cylinder_wrap(n_u: int = 64, n_v: int = 17, radius: float = 50.0, height: float = 80.0, turns: float = 0.75) -> dict:
+    """Open cylindrical sheet with its exact isometric flattening.
+
+    3D: p(u,v) = (R cos(θ0 + u/R), R sin(θ0 + u/R), v) for u ∈ [0, turns*2πR], v ∈ [0, H].
+    Exact flat coords: (u, v). Normalized UV divides by extents (the texturing convention).
+    """
+    u = np.linspace(0.0, turns * 2 * np.pi * radius, n_u)
+    v = np.linspace(0.0, height, n_v)
+    uu, vv = np.meshgrid(u, v, indexing="ij")
+    theta = uu / radius
+    P = np.stack([radius * np.cos(theta), radius * np.sin(theta), vv], axis=-1).reshape(-1, 3)
+    flat = np.stack([uu, vv], axis=-1).reshape(-1, 2)
+    uv_norm = flat / np.array([u[-1], v[-1]])
+    faces = []
+    for i in range(n_u - 1):
+        for j in range(n_v - 1):
+            a = i * n_v + j
+            b = (i + 1) * n_v + j
+            faces.append([a, b, a + 1])
+            faces.append([b, b + 1, a + 1])
+    return dict(
+        vertices=P.astype(np.float32),
+        faces=np.array(faces, dtype=np.int32),
+        uv_norm=uv_norm.astype(np.float32),
+        flat=flat.astype(np.float32),
+        scale_true=(float(u[-1]), float(v[-1])),
+    )

--- a/foundation/scroll-unwrap-pipeline/tests/test_convention_traps.py
+++ b/foundation/scroll-unwrap-pipeline/tests/test_convention_traps.py
@@ -1,0 +1,88 @@
+"""Convention traps: any silent flip / transpose / merge / reorder must fail loudly here."""
+
+import numpy as np
+
+from fixtures import asymmetric_quad, cylinder_wrap, write_binary_ply_wrapstyle
+from scrollkit.io import MeshData, dedup_wedge_uv, read_obj, read_ply, write_obj
+from scrollkit.unwrap import fit_uv_scale
+
+
+def test_no_vertex_merge_on_duplicate_positions(tmp_path):
+    q = asymmetric_quad()  # v3 duplicates v0's position
+    p = tmp_path / "q.ply"
+    write_binary_ply_wrapstyle(p, q["vertices"], q["normals"], q["vertex_uv"], q["faces"], q["wedge_uv"])
+    m = read_ply(p)
+    assert m.n_vertices == 4, "duplicate-position vertices must NOT merge"
+    o = tmp_path / "q.obj"
+    write_obj(o, m, texture_file="tex.png")
+    r = read_obj(o)
+    assert r.n_vertices == 4
+    assert np.array_equal(r.faces, q["faces"]), "face order/indices must be preserved verbatim"
+
+
+def test_uv_not_flipped_or_transposed(tmp_path):
+    q = asymmetric_quad()
+    m = MeshData(vertices=q["vertices"], faces=q["faces"], normals=q["normals"],
+                 vertex_uv=q["vertex_uv"], wedge_uv=q["wedge_uv"])
+    o = tmp_path / "q.obj"
+    write_obj(o, m, texture_file="tex.png")
+    r = read_obj(o)
+    uv = r.vertex_uv
+    # u of vertex1 is 0.9 (extreme), v of vertex2 is 0.93 (extreme): transpose or 1-v flip would move them
+    assert np.float32(uv[1, 0]) == np.float32(0.9)
+    assert np.float32(uv[2, 1]) == np.float32(0.93)
+    assert not np.allclose(uv[:, 0], q["vertex_uv"][:, 1]), "UV transpose detected"
+    assert not np.allclose(uv[:, 1], 1.0 - q["vertex_uv"][:, 1]), "V-flip detected"
+
+
+def test_winding_preserved(tmp_path):
+    q = asymmetric_quad()
+    m = MeshData(vertices=q["vertices"], faces=q["faces"])
+    o = tmp_path / "w.obj"
+    write_obj(o, m)
+    r = read_obj(o)
+    e0 = m.vertices[m.faces[0, 1]] - m.vertices[m.faces[0, 0]]
+    e1 = m.vertices[m.faces[0, 2]] - m.vertices[m.faces[0, 0]]
+    n_src = np.cross(e0, e1)
+    f0 = r.faces[0]
+    n_out = np.cross(r.vertices[f0[1]] - r.vertices[f0[0]], r.vertices[f0[2]] - r.vertices[f0[0]])
+    assert np.dot(n_src, n_out) > 0, "winding flipped"
+
+
+def test_wedge_dedup_is_bit_exact():
+    a = np.float32(0.5)
+    b = np.nextafter(a, np.float32(1.0))  # 1 ulp away — must remain distinct
+    nz = np.float32(-0.0)                  # -0.0 vs +0.0: equal as values, different bits
+    pz = np.float32(0.0)
+    w = np.array([[[a, a], [b, a], [a, b]],
+                  [[nz, a], [pz, a], [a, a]]], dtype=np.float32)
+    vt, idx = dedup_wedge_uv(w)
+    # unique bit-rows: (a,a) [shared by both faces], (b,a), (a,b), (-0,a), (+0,a)
+    assert vt.shape[0] == 5, f"bit-exact dedup expected 5 unique rows, got {vt.shape[0]}"
+    vt_bits = vt.view(np.uint32)
+    neg_zero_row = np.array([np.array(-0.0, np.float32).view(np.uint32),
+                             np.array(0.5, np.float32).view(np.uint32)], dtype=np.uint32)
+    assert (vt_bits == neg_zero_row).all(axis=1).any(), "-0.0 row must survive dedup distinct from +0.0"
+    rec = vt[idx]
+    assert np.array_equal(rec.view(np.uint32), w.view(np.uint32))
+
+
+def test_denorm_scale_fit_recovers_cylinder_scales():
+    c = cylinder_wrap()
+    fit = fit_uv_scale(c["vertices"], c["faces"], c["uv_norm"])
+    su_true, sv_true = c["scale_true"]
+    # chord-vs-arc error at 64 segments/0.75 turns is ~0.1%; tolerance 1%
+    assert abs(fit["s_u"] - su_true) / su_true < 0.01
+    assert abs(fit["s_v"] - sv_true) / sv_true < 0.01
+    assert fit["rel_residual_rms"] < 0.01
+
+
+def test_denorm_scale_fit_anisotropic():
+    c = cylinder_wrap()
+    uv = c["uv_norm"].copy()
+    # simulate a non-aspect-preserving normalization: stretch v by 3x in normalized space
+    uv[:, 1] /= 3.0
+    fit = fit_uv_scale(c["vertices"], c["faces"], uv)
+    su_true, sv_true = c["scale_true"]
+    assert abs(fit["s_v"] - 3.0 * sv_true) / (3.0 * sv_true) < 0.01
+    assert abs(fit["anisotropy"] - su_true / (3.0 * sv_true)) / (su_true / (3.0 * sv_true)) < 0.02

--- a/foundation/scroll-unwrap-pipeline/tests/test_decimate.py
+++ b/foundation/scroll-unwrap-pipeline/tests/test_decimate.py
@@ -1,0 +1,101 @@
+"""M2 decimation tests on the analytic cylinder fixture.
+
+The cylinder PLY is written with the tests' own raw-struct writer (NOT scrollkit.io),
+so the decimation path is exercised end-to-end from independent bytes.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from fixtures import cylinder_wrap, write_binary_ply_wrapstyle
+
+from scrollkit.decimate import metrics
+from scrollkit.decimate.core import MeshDecimator
+from scrollkit.io import read_obj
+
+
+@pytest.fixture(scope="module")
+def cyl_ply(tmp_path_factory):
+    td = tmp_path_factory.mktemp("cyl")
+    cyl = cylinder_wrap()  # R=50, 0.75 turns, 64x17 grid -> 2016 faces
+    V, F, UV = cyl["vertices"], cyl["faces"], cyl["uv_norm"]
+    normals = np.zeros_like(V)
+    r = np.linalg.norm(V[:, :2], axis=1, keepdims=True)
+    normals[:, :2] = V[:, :2] / r  # exact outward radial normals
+    wedge = UV[F]
+    ply = td / "cyl.ply"
+    write_binary_ply_wrapstyle(ply, V, normals.astype(np.float32), UV, F, wedge, texture_file="tex.png")
+    # real (tiny) texture so the pymeshlab load + copy_texture path runs cleanly
+    img = np.zeros((8, 8, 4), np.uint8)
+    img[..., 0] = 200
+    img[..., 3] = 255
+    Image.fromarray(img).save(td / "tex.png")
+    return {"ply": ply, "cyl": cyl, "wedge": wedge}
+
+
+def test_cylinder_decimation_keep_030(cyl_ply, tmp_path):
+    cyl = cyl_ply["cyl"]
+    radius = 50.0
+    n_faces_in = cyl["faces"].shape[0]
+
+    dec = MeshDecimator(cyl_ply["ply"])  # edge_len_mean computed from arrays
+    att = dec.try_rung(0.30, 1.0)
+
+    # ~30% of faces kept (VCG hits the target closely; allow 25-35%)
+    keep = att["faces_out"] / n_faces_in
+    assert 0.25 <= keep <= 0.35, f"keep_achieved {keep:.3f} not ~0.30"
+
+    W = dec.last["W"]
+    # UV preserved: every output wedge UV within the source UV bbox
+    src_uv = cyl_ply["wedge"].reshape(-1, 2)
+    lo, hi = src_uv.min(axis=0), src_uv.max(axis=0)
+    out_uv = W.reshape(-1, 2)
+    assert (out_uv >= lo - 1e-6).all() and (out_uv <= hi + 1e-6).all(), (
+        f"output UV outside source bbox: [{out_uv.min(0)}, {out_uv.max(0)}] vs [{lo}, {hi}]"
+    )
+    # no flips: source orientation is uniformly positive in UV space
+    areas = metrics.uv_signed_areas(W)
+    assert (areas > 0).all(), f"{(areas <= 0).sum()} non-positive UV triangles after decimation"
+
+    # Hausdorff small vs cylinder radius (two-sided, sampled by pymeshlab)
+    hd = att["hausdorff"]["two_sided_max"]
+    assert hd < 0.05 * radius, f"two-sided Hausdorff {hd:.3f} not small vs radius {radius}"
+
+    # geometry gates as wired for production all hold on the analytic cylinder
+    assert att["pass"], f"gates failed: {att['fail_reasons']}"
+
+    # written OBJ round-trips through the strict reader with identical arrays
+    out = dec.write_outputs(tmp_path, "cyl", "A")
+    re = read_obj(tmp_path / "cyl_decimated.obj")
+    assert re.n_faces == att["faces_out"]
+    assert np.array_equal(re.vertices.view(np.uint32), dec.last["V"].view(np.uint32))
+    re_wedge = re.vertex_uv[re.faces] if re.vertex_uv is not None else re.wedge_uv
+    assert np.array_equal(re_wedge.view(np.uint32), W.view(np.uint32))
+    assert out["uv_obj_mode"] in ("shared", "wedge")
+    assert (tmp_path / "tex.png").exists() and out["texture_sha256"]
+
+
+def test_wedge_to_vertex_uv_exact_detects_seams():
+    # 2 faces sharing vertices 0,2 with identical UVs everywhere -> exact conversion
+    faces = np.array([[0, 1, 2], [0, 2, 3]], np.int32)
+    uv = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], np.float32)
+    wedge = uv[faces]
+    got = metrics.wedge_to_vertex_uv_exact(4, faces, wedge)
+    assert got is not None and np.array_equal(got.view(np.uint32), uv.view(np.uint32))
+    # introduce a seam: vertex 2 carries two distinct UVs -> must refuse
+    wedge2 = wedge.copy()
+    wedge2[1, 1] = [0.5, 0.5]
+    assert metrics.wedge_to_vertex_uv_exact(4, faces, wedge2) is None
+
+
+def test_uv_chart_count_splits():
+    # two triangles sharing a mesh edge but with disagreeing UVs across it = 2 charts
+    faces = np.array([[0, 1, 2], [0, 2, 3]], np.int32)
+    uv = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], np.float32)
+    assert metrics.uv_chart_count(faces, uv[faces]) == 1
+    wedge = uv[faces].copy()
+    wedge[1] += 2.0  # move face 1's chart elsewhere in UV space
+    assert metrics.uv_chart_count(faces, wedge) == 2

--- a/foundation/scroll-unwrap-pipeline/tests/test_ink_bake.py
+++ b/foundation/scroll-unwrap-pipeline/tests/test_ink_bake.py
@@ -1,0 +1,150 @@
+"""M2.5 ink bake — synthetic 64x64 grading checks (see docs/QUALITY-GATES.md).
+
+Asserts on compose_overlay/grade_overlay: alpha untouched, amber tint applied
+where ink is high, base preserved exactly where ink is 0 (beyond glow reach),
+screen glow strictly non-darkening, plus polarity verification and resampling.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from scrollkit.ink.bake import (
+    DEFAULT_PARAMS,
+    block_mean,
+    choose_polarity,
+    compose_overlay,
+    grade_overlay,
+    registration_check,
+    resample_ink,
+    smoothstep,
+)
+
+N = 64
+TINT = np.array(DEFAULT_PARAMS["tint_rgb"], dtype=np.float32)
+
+
+@pytest.fixture()
+def base() -> np.ndarray:
+    """Known RGBA base: random papyrus-ish RGB, alpha with 0 / 200 / 255 values."""
+    rng = np.random.default_rng(7)
+    rgba = np.empty((N, N, 4), np.uint8)
+    rgba[..., :3] = rng.integers(60, 200, (N, N, 3))
+    rgba[..., 3] = 0
+    rgba[4:60, 4:60, 3] = 255
+    rgba[4:8, 4:8, 3] = 200  # mid alpha values must survive verbatim too
+    return rgba
+
+
+@pytest.fixture()
+def ink_blob() -> np.ndarray:
+    """Synthetic ink: zero everywhere, a value-1.0 disc (r=5) centred at (16,16)."""
+    yy, xx = np.mgrid[0:N, 0:N]
+    return ((yy - 16) ** 2 + (xx - 16) ** 2 <= 5**2).astype(np.float32)
+
+
+def test_alpha_untouched(base, ink_blob):
+    out, _ = compose_overlay(base, ink_blob, DEFAULT_PARAMS)
+    assert out.dtype == np.uint8 and out.shape == base.shape
+    assert np.array_equal(out[..., 3], base[..., 3])
+
+
+def test_base_preserved_where_ink_zero(base, ink_blob):
+    """Pixels beyond ink AND beyond gaussian reach (4*sigma truncation) are byte-equal."""
+    out, op = compose_overlay(base, ink_blob, DEFAULT_PARAMS)
+    assert np.array_equal(op == 0, ink_blob < DEFAULT_PARAMS["opacity_lo"])
+    far = np.s_[40:, 40:]  # blob edge at ~21 px + glow radius 12 px << 40
+    assert np.array_equal(out[far][..., :3], base[far][..., :3])
+
+
+def test_tint_applied_where_ink_high(base, ink_blob):
+    p0 = dict(DEFAULT_PARAMS, glow_strength=0.0)
+    out0, op = grade_overlay(base[..., :3], ink_blob, p0)
+    c = (16, 16)
+    # full smoothstep saturation at ink=1.0 -> opacity == scale
+    assert op[c] == pytest.approx(DEFAULT_PARAMS["opacity_scale"])
+    # glow-free output == the lerp formula exactly (incl. round-half-even), everywhere
+    expected = np.clip(
+        np.rint(base[..., :3].astype(np.float32) * (1 - op[..., None]) + TINT * op[..., None]), 0, 255
+    ).astype(np.uint8)
+    assert np.array_equal(out0, expected)
+    # the lerp moves every channel toward the amber tint
+    assert np.all(np.abs(out0[c] - TINT) <= np.abs(base[c][:3].astype(np.float32) - TINT))
+    # full pipeline: screen glow only brightens on top of the lerp
+    out, _ = compose_overlay(base, ink_blob, DEFAULT_PARAMS)
+    assert np.all(out[c][:3].astype(int) >= out0[c].astype(int))
+    # amber channel ordering R > G > B at a saturated ink pixel
+    got = out[c][:3].astype(np.float32)
+    assert got[0] > got[1] > got[2]
+
+
+def test_screen_glow_monotone(base, ink_blob):
+    """screen(out, tint*G) never darkens any channel anywhere, and grows with strength."""
+    p0 = dict(DEFAULT_PARAMS, glow_strength=0.0)
+    p1 = dict(DEFAULT_PARAMS, glow_strength=0.30)
+    p2 = dict(DEFAULT_PARAMS, glow_strength=0.60)
+    out0, _ = grade_overlay(base[..., :3], ink_blob, p0)
+    out1, _ = grade_overlay(base[..., :3], ink_blob, p1)
+    out2, _ = grade_overlay(base[..., :3], ink_blob, p2)
+    assert np.all(out1.astype(int) >= out0.astype(int))
+    assert np.all(out2.astype(int) >= out1.astype(int))
+    assert out1.sum() > out0.sum()  # glow visibly adds light near the blob
+
+
+def test_smoothstep_edges():
+    lo, hi = DEFAULT_PARAMS["opacity_lo"], DEFAULT_PARAMS["opacity_hi"]
+    x = np.array([0.0, lo, (lo + hi) / 2, hi, 1.0], np.float32)
+    s = smoothstep(x, lo, hi)
+    assert s[0] == 0 and s[1] == 0 and s[3] == 1 and s[4] == 1
+    assert 0.49 < s[2] < 0.51  # midpoint of the band -> 0.5: fibers visible through midtones
+
+
+def test_polarity_flip_on_mislabel():
+    """Dark-ink raster labelled 'positive' must be flipped by the sparse-tail check."""
+    rng = np.random.default_rng(1)
+    ink255 = np.full((N, N), 220.0, np.float32) + rng.normal(0, 3, (N, N)).astype(np.float32)
+    ink255[10:14, 10:40] = 40.0  # dark stroke, ~3% of the frame
+    mask = np.ones((N, N), bool)
+    thr_mid = (DEFAULT_PARAMS["opacity_lo"] + DEFAULT_PARAMS["opacity_hi"]) / 2
+    n, info = choose_polarity(ink255, mask, "positive (ink bright)", thr_mid)
+    assert info["flipped_vs_audit"] and info["used"].startswith("inverted") and info["in_band"]
+    assert 0.005 <= info["coverage_used"] <= 0.35
+    assert n[12, 20] > 0.8 and n[40, 40] < 0.2  # ink=high after fix
+    # and a correctly-labelled inverted raster is kept as-is
+    _, info2 = choose_polarity(ink255, mask, "inverted (ink dark)", thr_mid)
+    assert not info2["flipped_vs_audit"] and info2["in_band"]
+
+
+def test_registration_identity_and_flip():
+    # asymmetric mask (top-left block) so the flip variants are distinguishable
+    mask = np.zeros((N, N), bool)
+    mask[:32, :32] = True
+    ink = np.zeros((N, N), np.float32)
+    ink[4:12, 8:24] = 1.0  # ink inside the top-left block
+    kept, reg = registration_check(ink, mask)
+    assert reg["variant_used"] == "identity" and reg["anomaly"] is None
+    assert reg["outside_frac"] == 0.0 and kept is ink
+    # mirrored ink (all on the wrong side) must be caught and decisively flipped back
+    bad = ink[:, ::-1].copy()
+    kept2, reg2 = registration_check(bad, mask)
+    assert reg2["anomaly"] is not None and reg2["anomaly"]["decisive"]
+    assert reg2["variant_used"] == "fliplr" and reg2["outside_frac"] == 0.0
+    assert np.array_equal(kept2, ink)
+
+
+def test_block_mean_and_resample_two_step():
+    rng = np.random.default_rng(2)
+    src = rng.integers(0, 256, (130, 97), np.uint8)
+    ds, crop = block_mean(src, 4)
+    assert ds.shape == (32, 24) and crop == (2, 1)
+    assert ds[0, 0] == pytest.approx(src[:4, :4].mean(), abs=1e-4)
+    # 5x source -> two-step lands on exact target dims, values stay in range
+    big = np.tile(src, (5, 5))[: 64 * 5, : 32 * 5]
+    out, steps = resample_ink(big, (32, 64), two_step=True)
+    assert out.shape == (64, 32) and out.dtype == np.float32
+    assert [s["op"] for s in steps] == ["block_mean", "lanczos"]
+    assert steps[0]["factor"] == 3 and float(out.min()) >= 0.0 and float(out.max()) <= 255.0
+    # constant raster survives the whole chain exactly
+    flat, _ = resample_ink(np.full((300, 200), 130, np.uint8), (40, 60), two_step=True)
+    assert np.allclose(flat, 130.0, atol=0.51)

--- a/foundation/scroll-unwrap-pipeline/tests/test_io_roundtrip.py
+++ b/foundation/scroll-unwrap-pipeline/tests/test_io_roundtrip.py
@@ -1,0 +1,87 @@
+"""Bit-exactness of the strict IO paths."""
+
+import numpy as np
+import pytest
+
+from fixtures import asymmetric_quad, write_binary_ply_scrollstyle, write_binary_ply_wrapstyle
+from scrollkit.io import MeshData, read_obj, read_ply, write_obj
+
+
+def bits(a):
+    return a.view(np.uint32) if a is not None else None
+
+
+def test_ply_reader_wrapstyle(tmp_path):
+    q = asymmetric_quad()
+    p = tmp_path / "quad.ply"
+    write_binary_ply_wrapstyle(p, q["vertices"], q["normals"], q["vertex_uv"], q["faces"], q["wedge_uv"])
+    m = read_ply(p)
+    assert np.array_equal(bits(m.vertices), bits(q["vertices"]))
+    assert np.array_equal(bits(m.normals), bits(q["normals"]))
+    assert np.array_equal(bits(m.vertex_uv), bits(q["vertex_uv"]))
+    assert np.array_equal(m.faces, q["faces"])
+    assert np.array_equal(bits(m.wedge_uv), bits(q["wedge_uv"]))
+    assert m.texture_files == ["tex.png"]
+    assert m.wedge_equals_vertex_uv() is True
+
+
+def test_ply_reader_scrollstyle_texnumber(tmp_path):
+    q = asymmetric_quad()
+    tn = np.array([0, 0], dtype=np.int32)
+    p = tmp_path / "scroll.ply"
+    write_binary_ply_scrollstyle(p, q["vertices"], q["faces"], q["wedge_uv"], texnumber=tn,
+                                 texture_files=("a.png", "missing.png"))
+    m = read_ply(p)
+    assert m.normals is None and m.vertex_uv is None
+    assert np.array_equal(m.face_texnumber, tn)
+    assert m.texture_files == ["a.png", "missing.png"]
+
+
+@pytest.mark.parametrize("with_normals", [True, False])
+def test_obj_roundtrip_shared(tmp_path, with_normals):
+    q = asymmetric_quad()
+    mesh = MeshData(
+        vertices=q["vertices"], faces=q["faces"],
+        normals=q["normals"] if with_normals else None,
+        vertex_uv=q["vertex_uv"], wedge_uv=q["wedge_uv"],
+    )
+    p = tmp_path / "quad.obj"
+    write_obj(p, mesh, texture_file="tex.png", uv_mode="shared")
+    r = read_obj(p)
+    assert np.array_equal(bits(r.vertices), bits(mesh.vertices))
+    assert np.array_equal(r.faces, mesh.faces)
+    assert np.array_equal(bits(r.vertex_uv), bits(mesh.vertex_uv))
+    if with_normals:
+        assert np.array_equal(bits(r.normals), bits(mesh.normals))
+    assert r.texture_files == ["tex.png"]
+
+
+def test_obj_roundtrip_wedge(tmp_path):
+    q = asymmetric_quad()
+    # wedge UVs deliberately NOT equal to any per-vertex assignment: corner-unique values
+    wuv = np.arange(12, dtype=np.float32).reshape(2, 3, 2) / 16.0 + 0.015625
+    mesh = MeshData(vertices=q["vertices"], faces=q["faces"], wedge_uv=wuv)
+    p = tmp_path / "wedge.obj"
+    write_obj(p, mesh, texture_file="tex.png", uv_mode="wedge")
+    r = read_obj(p)
+    assert np.array_equal(bits(r.vertices), bits(mesh.vertices))
+    assert np.array_equal(r.faces, mesh.faces)
+    assert r.wedge_uv is not None
+    assert np.array_equal(bits(r.wedge_uv), bits(wuv))
+
+
+def test_format_round_trips_adversarial_float32(tmp_path):
+    # denormals, near-max, ulp neighbours, negative zero, pi-ish values
+    vals = np.array(
+        [1e-39, -1e-39, 3.4028235e38, -3.4028235e38, 1.0, np.nextafter(np.float32(1.0), np.float32(2.0)),
+         -0.0, 0.0, 3.14159265, 2.7182818, 1e-45, 12345.678],
+        dtype=np.float32,
+    )
+    V = np.repeat(vals, 3)[: (len(vals) // 3) * 9].reshape(-1, 3)
+    mesh = MeshData(vertices=V.astype(np.float32), faces=np.zeros((1, 3), np.int32))
+    p = tmp_path / "adv.obj"
+    write_obj(p, mesh)
+    r = read_obj(p)
+    assert np.array_equal(bits(r.vertices), bits(mesh.vertices)), (
+        "%.9g failed to round-trip float32 bit-exactly"
+    )

--- a/foundation/scroll-unwrap-pipeline/tests/test_render_scene.py
+++ b/foundation/scroll-unwrap-pipeline/tests/test_render_scene.py
@@ -1,0 +1,248 @@
+"""Offscreen (EGL) regression tests pinning scrollkit.render.scene's texture-orientation
+transforms and the SceneRenderer animation path.
+
+The expected corner colors are derived ANALYTICALLY from the audit's normative
+orientation definitions (reports/audit.json: tex_orientation.definitions):
+
+    topleft:            pixel_col = s*(W-1);     pixel_row = t*(H-1)      (row 0 = file top)
+    opengl_bottomleft:  pixel_col = s*(W-1);     pixel_row = (1-t)*(H-1)
+    rot180:             pixel_col = (1-s)*(W-1); pixel_row = (1-t)*(H-1)  (== bottomleft
+                                                                           with u also flipped)
+
+NOT from the implementation — so any regression in the numpy flips chosen for VTK's
+native convention (uv_probe: t=0 samples the BOTTOM array row) fails here.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from fixtures import asymmetric_quad
+
+PALETTE = {
+    "red": (255, 0, 0),
+    "green": (0, 255, 0),
+    "blue": (0, 0, 255),
+    "yellow": (255, 255, 0),
+}
+TEX_W = TEX_H = 32  # quadrant texture dims used by every test
+
+
+def _egl_available() -> bool:
+    try:
+        import scrollkit.render.scene  # noqa: F401  (pins headless EGL env first)
+        import pyvista as pv
+
+        pl = pv.Plotter(off_screen=True, window_size=(32, 32))
+        pl.add_mesh(pv.Sphere())
+        img = pl.screenshot(return_img=True)
+        pl.close()
+        return img is not None and img.size > 0
+    except Exception:
+        return False
+
+
+EGL_OK = _egl_available()
+needs_egl = pytest.mark.skipif(not EGL_OK, reason="EGL offscreen rendering unavailable")
+
+
+# --------------------------------------------------------------------------------------
+# analytic machinery (independent of scrollkit.render internals)
+# --------------------------------------------------------------------------------------
+def make_quadrant_texture(tmp_path):
+    """4-color file image: row 0 = file TOP. TL=red TR=green BL=blue BR=yellow."""
+    img = np.zeros((TEX_H, TEX_W, 3), np.uint8)
+    img[: TEX_H // 2, : TEX_W // 2] = PALETTE["red"]
+    img[: TEX_H // 2, TEX_W // 2 :] = PALETTE["green"]
+    img[TEX_H // 2 :, : TEX_W // 2] = PALETTE["blue"]
+    img[TEX_H // 2 :, TEX_W // 2 :] = PALETTE["yellow"]
+    path = tmp_path / "quadrants.png"
+    Image.fromarray(img).save(path)
+    return path
+
+
+def expected_color(s: float, t: float, orientation: str) -> str:
+    """Which file-image quadrant does (s,t) address under the audit's definition?"""
+    if orientation == "topleft":
+        row, col = t * (TEX_H - 1), s * (TEX_W - 1)
+    elif orientation == "opengl_bottomleft":
+        row, col = (1.0 - t) * (TEX_H - 1), s * (TEX_W - 1)
+    elif orientation == "rot180":
+        row, col = (1.0 - t) * (TEX_H - 1), (1.0 - s) * (TEX_W - 1)
+    else:
+        raise ValueError(orientation)
+    top, left = row < TEX_H / 2, col < TEX_W / 2
+    return {(True, True): "red", (True, False): "green",
+            (False, True): "blue", (False, False): "yellow"}[(top, left)]
+
+
+def classify(px) -> tuple[str, int]:
+    px = np.asarray(px, dtype=np.int64)
+    name, ref = min(PALETTE.items(), key=lambda kv: int(np.abs(np.array(kv[1]) - px).sum()))
+    return name, int(np.abs(np.array(ref) - px).sum())
+
+
+def world_to_pixel(p, cam, size) -> tuple[int, int]:
+    """Project a world point through a parallel camera dict to (row, col) of the
+    screenshot (row 0 = screen top). Pixel k spans NDC [(2k/W)-1, (2(k+1)/W)-1]."""
+    W, H = size
+    pos = np.asarray(cam["position"], float)
+    foc = np.asarray(cam["focal_point"], float)
+    up = np.asarray(cam["up"], float)
+    dop = foc - pos
+    dop /= np.linalg.norm(dop)
+    right = np.cross(dop, up)
+    right /= np.linalg.norm(right)
+    true_up = np.cross(right, dop)
+    ps = float(cam["parallel_scale"])
+    aspect = W / H
+    rel = np.asarray(p, float) - foc
+    x = float(rel @ right) / (ps * aspect)  # NDC in [-1, 1]
+    y = float(rel @ true_up) / ps
+    col = int(round((x + 1.0) * W / 2.0 - 0.5))
+    row = int(round((1.0 - y) * H / 2.0 - 0.5))
+    return row, col
+
+
+# --------------------------------------------------------------------------------------
+# orientation pinning: asymmetric-quad fixture x 4-color texture x 3 conventions
+# --------------------------------------------------------------------------------------
+@needs_egl
+@pytest.mark.parametrize("orientation", ["opengl_bottomleft", "topleft", "rot180"])
+def test_orientation_corner_landing(tmp_path, orientation):
+    from scrollkit.render.scene import render_mesh_arrays
+
+    q = asymmetric_quad()
+    tex = make_quadrant_texture(tmp_path)
+    size = (512, 512)
+
+    # The fixture's two triangles share an identical screen footprint (v3 duplicates
+    # v0's position) and would z-fight — render each triangle separately. Together
+    # their corners cover all four UV quadrants.
+    for tri in range(2):
+        F = q["faces"][tri : tri + 1]
+        ids = F[0]
+        Pw = q["vertices"][ids].astype(np.float64)
+        UV = q["vertex_uv"][ids].astype(np.float64)
+        cen_p, cen_uv = Pw.mean(axis=0), UV.mean(axis=0)
+
+        # face-on parallel camera looking down -z (quad lives near the z=0 plane)
+        lo, hi = Pw[:, :2].min(axis=0), Pw[:, :2].max(axis=0)
+        c = 0.5 * (lo + hi)
+        half = 0.5 * (hi - lo)
+        cam = dict(
+            position=(c[0], c[1], 10.0),
+            focal_point=(c[0], c[1], 0.0),
+            up=(0.0, 1.0, 0.0),
+            parallel_scale=float(max(half)) * 1.2,
+            parallel=True,
+        )
+        img = render_mesh_arrays(
+            q["vertices"], F, q["vertex_uv"], tex, orientation,
+            camera=cam, size=size, background="#000000", lighting="flat",
+        )
+        assert img.shape == (size[1], size[0], 3) and img.dtype == np.uint8
+
+        for k in range(3):
+            # sample pulled 30% toward the centroid: stays inside the triangle (no edge
+            # antialiasing) and inside the corner's UV quadrant (margin >= 0.18 from 0.5)
+            pw = 0.7 * Pw[k] + 0.3 * cen_p
+            s, t = 0.7 * UV[k] + 0.3 * cen_uv
+            exp = expected_color(s, t, orientation)
+            row, col = world_to_pixel(pw, cam, size)
+            patch = img[row - 1 : row + 2, col - 1 : col + 2].reshape(-1, 3).astype(float).mean(axis=0)
+            got, dist = classify(patch)
+            assert dist < 60, f"{orientation} tri{tri} corner{k}: ambiguous pixel {patch.tolist()}"
+            assert got == exp, (
+                f"{orientation} tri{tri} corner{k} (s={s:.3f}, t={t:.3f}): rendered {got} "
+                f"{patch.tolist()}, audit definition demands {exp}"
+            )
+
+
+# --------------------------------------------------------------------------------------
+# wedge corner-split (pure numpy — no GPU needed)
+# --------------------------------------------------------------------------------------
+def test_split_wedge_to_vertex_bit_exact():
+    from scrollkit.io import MeshData
+    from scrollkit.render.scene import split_wedge_to_vertex
+
+    q = asymmetric_quad()
+
+    # wedge == vertex (A/B case): pass-through, no resplit
+    mesh = MeshData(vertices=q["vertices"], faces=q["faces"],
+                    vertex_uv=q["vertex_uv"], wedge_uv=q["wedge_uv"])
+    V, F, uv = split_wedge_to_vertex(mesh)
+    assert V is mesh.vertices and F is mesh.faces and uv is mesh.vertex_uv
+
+    # wedge-only (C case), wedge derived from vertex table: shared corners merge back
+    mesh_c = MeshData(vertices=q["vertices"], faces=q["faces"], wedge_uv=q["wedge_uv"])
+    V, F, uv = split_wedge_to_vertex(mesh_c)
+    assert V.dtype == np.float32 and uv.dtype == np.float32 and F.dtype == np.int32
+    assert V.shape[0] == 4  # 4 unique (vertex, uv) pairs (v0/v3 same position, distinct uv)
+    assert np.array_equal(uv[F].view(np.uint32), q["wedge_uv"].view(np.uint32))
+    assert np.array_equal(V[F].view(np.uint32), q["vertices"][q["faces"]].view(np.uint32))
+
+    # true per-corner divergence: face 1 re-textures its corners -> vertices must split
+    w = q["wedge_uv"].copy()
+    w[1] = np.array([[0.5, 0.5], [0.25, 0.75], [0.125, 0.875]], np.float32)
+    mesh_s = MeshData(vertices=q["vertices"], faces=q["faces"], wedge_uv=w)
+    V, F, uv = split_wedge_to_vertex(mesh_s)
+    assert V.shape[0] == 6  # f0:(v0,v1,v2) + f1:(v2',v1',v3) all unique pairs
+    assert np.array_equal(uv[F].view(np.uint32), w.view(np.uint32))
+    assert np.array_equal(V[F].view(np.uint32), q["vertices"][q["faces"]].view(np.uint32))
+
+
+# --------------------------------------------------------------------------------------
+# auto_camera fit guarantee (pure numpy)
+# --------------------------------------------------------------------------------------
+def test_auto_camera_fits_union_bbox():
+    from scrollkit.render.scene import auto_camera
+
+    rng = np.random.default_rng(7)
+    P = rng.uniform(-3.0, 9.0, size=(5000, 3)) * np.array([4.0, 1.0, 0.25])
+    aspect, margin = 16 / 9, 0.06
+    cam = auto_camera(P, aspect, margin)
+    assert cam["parallel"] is True
+    pos = np.asarray(cam["position"])
+    foc = np.asarray(cam["focal_point"])
+    assert np.allclose(foc, 0.5 * (P.min(0) + P.max(0)))
+    dop = foc - pos
+    dop /= np.linalg.norm(dop)
+    up = np.asarray(cam["up"])
+    right = np.cross(dop, up)
+    right /= np.linalg.norm(right)
+    rel = P - foc
+    hw = np.abs(rel @ right).max()
+    hh = np.abs(rel @ np.cross(right, dop)).max()
+    ps = cam["parallel_scale"]
+    # every point inside the frame with the 6% margin honored
+    assert hh <= ps and hw <= ps * aspect
+    assert ps >= max(hh, hw / aspect) * (1 + margin) - 1e-9
+
+
+# --------------------------------------------------------------------------------------
+# SceneRenderer animation path: in-place point update == fresh render
+# --------------------------------------------------------------------------------------
+@needs_egl
+def test_scene_renderer_update_points(tmp_path):
+    from scrollkit.render.scene import SceneRenderer, render_mesh_arrays
+
+    tex = make_quadrant_texture(tmp_path)
+    V = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], np.float32)
+    F = np.array([[0, 1, 2], [0, 2, 3]], np.int32)
+    uv = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], np.float32)
+    cam = dict(position=(1.5, 0.5, 5.0), focal_point=(1.5, 0.5, 0.0),
+               up=(0.0, 1.0, 0.0), parallel_scale=1.6, parallel=True)
+
+    r = SceneRenderer(V, F, uv, tex, "opengl_bottomleft", camera=cam, size=(256, 256))
+    img0 = r.screenshot()
+    V2 = V + np.array([2.0, 0.0, 0.0], np.float32)
+    r.update_points(V2)
+    img1 = r.screenshot()
+    r.close()
+
+    assert not np.array_equal(img0, img1), "update_points had no visible effect"
+    fresh = render_mesh_arrays(V2, F, uv, tex, "opengl_bottomleft", camera=cam, size=(256, 256))
+    assert np.array_equal(img1, fresh), "in-place point update diverges from fresh render"

--- a/foundation/scroll-unwrap-pipeline/tests/test_unwrap_core.py
+++ b/foundation/scroll-unwrap-pipeline/tests/test_unwrap_core.py
@@ -1,0 +1,199 @@
+"""M3 core math on the analytic cylinder: endpoints exact, transit area-preserving,
+multi-turn branch unwrapping correct."""
+
+import numpy as np
+import pytest
+
+from fixtures import cylinder_wrap, spiral_wrap
+from scrollkit.unwrap.dg_interp import (
+    branch_consistent_logs,
+    build_unwrap_path,
+    deformation_gradients,
+    face_uv_tangents,
+    polar_decompose,
+    rotation_exp,
+    rotation_log,
+    winding_decomposition,
+)
+from scrollkit.unwrap.embedding import build_target_embedding
+from scrollkit.unwrap.operators import face_areas
+from scrollkit.unwrap.timeline import timeline_t
+
+
+def test_rotation_log_exp_roundtrip():
+    rng = np.random.default_rng(7)
+    w = rng.normal(size=(500, 3))
+    w *= (rng.uniform(0.01, np.pi - 0.01, size=500) / np.linalg.norm(w, axis=1))[:, None]
+    R = rotation_exp(w)
+    w2 = rotation_log(R)
+    assert np.allclose(w, w2, atol=1e-9)
+    # near-pi
+    wpi = rng.normal(size=(100, 3))
+    wpi *= ((np.pi - 1e-7) / np.linalg.norm(wpi, axis=1))[:, None]
+    R = rotation_exp(wpi)
+    w2 = rotation_log(R)
+    assert np.allclose(rotation_exp(w2), R, atol=1e-6)
+
+
+def test_polar_handles_reflection():
+    Fm = np.tile(np.eye(3), (2, 1, 1))
+    Fm[1, 2, 2] = -1.0  # reflection
+    R, S, inv = polar_decompose(Fm)
+    assert not inv[0] and inv[1]
+    assert np.allclose(np.linalg.det(R), 1.0)
+    assert np.allclose(R @ S, Fm, atol=1e-12)
+
+
+@pytest.mark.parametrize("turns", [0.75, 2.5])
+def test_branch_unwrapping_multi_turn(turns):
+    c = cylinder_wrap(n_u=int(96 * max(1.0, turns)), n_v=9, turns=turns)
+    emb = build_target_embedding(c["vertices"], c["faces"], c["uv_norm"])
+    Fg = deformation_gradients(c["vertices"].astype(np.float64), emb["V1"], c["faces"])
+    R, S, inv = polar_decompose(Fg)
+    assert inv.sum() == 0
+    w, info = branch_consistent_logs(R, c["faces"], seed_face=0)
+    assert info["n_unreached"] == 0
+    # total unwrapped rotation must reach ~ the full winding angle of the roll
+    expected = turns * 2 * np.pi
+    assert info["max_unwrapped_angle_rad"] > 0.75 * expected, info
+    # and naive (wrapped) logs must NOT exceed pi — proving the unwrap did something real
+    assert np.linalg.norm(rotation_log(R), axis=1).max() <= np.pi + 1e-6
+
+
+def test_cylinder_unroll_endpoints_and_area():
+    c = cylinder_wrap(n_u=128, n_v=13, turns=1.5)
+    V0 = c["vertices"].astype(np.float64)
+    F = c["faces"]
+    emb = build_target_embedding(V0, F, c["uv_norm"])
+    assert emb["mirror_check"] > 0, "embedding must not mirror the texture"
+    # de-norm scales must recover the true UV extents (anisotropy = extent ratio, NOT 1)
+    su_true, sv_true = c["scale_true"]
+    assert abs(emb["denorm_fit"]["s_u"] - su_true) / su_true < 0.01
+    assert abs(emb["denorm_fit"]["s_v"] - sv_true) / sv_true < 0.01
+    assert emb["denorm_fit"]["rel_residual_rms"] < 0.005
+    assert emb["axis"]["axis_uv"] == "v", "cylinder axis runs along v"
+    assert emb["anchor_rms"] < 0.5, "anchor strip must fit near-exactly"
+
+    path = build_unwrap_path(V0, emb["V1"], F, c["uv_norm"].astype(np.float64),
+                             emb["anchor_idx"], solver_backend="scipy-splu")
+    assert path.info["n_unreached"] == 0
+
+    A0 = face_areas(V0, F)
+    A1 = face_areas(emb["V1"], F)
+
+    # endpoints (exact short-circuits)
+    assert np.allclose(path.eval_frame(0.0), V0)
+    assert np.allclose(path.eval_frame(1.0), emb["V1"])
+    # ...and through the actual solve: reconstruction at t≈1 must reproduce the target
+    V_near1 = path.eval_frame(1.0 - 1e-9)
+    span = (V0.max(0) - V0.min(0)).max()
+    assert np.abs(V_near1 - emb["V1"]).max() < 1e-4 * span, (
+        f"Poisson solve at t≈1 deviates from target by {np.abs(V_near1 - emb['V1']).max():.4g}"
+    )
+
+    # transit: areas within tight bounds of the endpoint blend (isometric roll ⇒ ~constant)
+    for t in (0.25, 0.5, 0.75):
+        Vt = path.eval_frame(t)
+        assert np.isfinite(Vt).all()
+        At = face_areas(Vt, F)
+        blend = (1 - t) * A0 + t * A1
+        rel = np.abs(At - blend) / blend
+        assert np.quantile(rel, 0.95) < 0.02, f"t={t}: P95 area deviation {np.quantile(rel, 0.95):.4f}"
+        assert rel.max() < 0.05, f"t={t}: max area deviation {rel.max():.4f}"
+
+    # solved midpoint must differ hugely from linear vertex blend (the morph actually unrolls)
+    lerp_mid = 0.5 * (V0 + emb["V1"])
+    Vmid = path.eval_frame(0.5)
+    assert np.abs(Vmid - lerp_mid).max() > 0.05 * (V0.max(0) - V0.min(0)).max()
+
+
+@pytest.mark.parametrize("inward", [True, False])
+def test_embedding_natural_orientation(inward):
+    """The flat target must sit in the surface's NATURAL frame at the anchor strip.
+
+    An inward-parameterized spiral makes the anchor tangent point toward the roll
+    centroid at both u-extremes; the legacy 'extend away from the body' heuristic then
+    rotated the target 180° in-plane, which (a) reversed the anchor strip along the
+    scroll axis and (b) injected a constant π rotation about an in-plane axis into the
+    source→target map — unrepresentable by the axis-winding model, so ‖w_res‖≈π on most
+    faces and the transit tumbled (observed on several damaged merge traces). The natural
+    placement must hold for BOTH trace directions, and the residual must stay bump-scale.
+    """
+    c = spiral_wrap(inward=inward)
+    V0, F, uvn = c["vertices"], c["faces"], c["uv_norm"]
+    emb = build_target_embedding(V0, F, uvn)
+    assert emb["mirror_check"] > 0
+    if inward:
+        # the legacy frame disagrees with the natural one here — correction must engage
+        assert emb["orientation_corrected"], "legacy body-side frame should differ on inward trace"
+    # anchor strip placed un-reversed: rms ≪ strip extent (~height)
+    assert emb["anchor_rms"] < 2.0, emb["anchor_rms"]
+
+    # source v-tangents must agree with the embedded sheet's v direction (no global flip)
+    t_u, t_v = face_uv_tangents(V0, F, uvn.astype(np.float64))
+    uvc = uvn - uvn.mean(0)
+    V1c = emb["V1"] - emb["V1"].mean(0)
+    v_dir = V1c.T @ uvc[:, 1].astype(np.float64)
+    v_hat = v_dir / np.linalg.norm(v_dir)
+    cos = (t_v / np.linalg.norm(t_v, axis=1, keepdims=True)) @ v_hat
+    assert (cos > 0).mean() > 0.999, "embedded v-axis anti-parallel to source v-tangents"
+
+    # winding decomposition: residual must be bump-scale, no π-residual population
+    Fg = deformation_gradients(V0.astype(np.float64), emb["V1"], F)
+    R, S, inv = polar_decompose(Fg)
+    assert inv.sum() == 0
+    anchor_c = V0[emb["anchor_idx"]].mean(0)
+    cent = V0[F].mean(1)
+    seed = int(np.argmin(((cent - anchor_c) ** 2).sum(1)))
+    d = winding_decomposition(R, V0.astype(np.float64), F, uvn.astype(np.float64),
+                              emb["V1"], seed_face=seed, axis_mode="global")
+    assert d["n_big_residual"] == 0, d
+    assert d["residual_norm_p99"] < 0.3, d
+    assert d["phi_span_turns"] > 0.75 * 4.0, d
+
+
+def test_phi_unwrap_branch_immune_to_junk_moat():
+    """A junk moat with garbage raw φ must not shift the far side onto a wrong 2π branch.
+
+    Regression guard: low-confidence anchor-strip regions can land
+    ±1..3 full turns off, so they secretly orbited the axis mid-transit and the anchor
+    Kabsch tumbled the whole sheet. Junk faces inherit the branch from confident
+    ancestry; their own (untrusted) raw values only contribute mod 2π.
+    """
+    from scrollkit.unwrap.dg_interp import _scalar_graph_unwrap
+
+    c = cylinder_wrap(n_u=160, n_v=7, turns=1.5)
+    F = c["faces"]
+    uvc = c["uv_norm"][F].mean(1)
+    # true smooth field: 1.5 turns across u
+    phi_true = uvc[:, 0] * 1.5 * 2 * np.pi
+    raw = (phi_true + np.pi) % (2 * np.pi) - np.pi
+    # junk moat in the middle of u with GARBAGE raw values
+    moat = (uvc[:, 0] > 0.45) & (uvc[:, 0] < 0.55)
+    rng = np.random.default_rng(3)
+    raw_garbage = raw.copy()
+    raw_garbage[moat] = rng.uniform(-np.pi, np.pi, moat.sum())
+    conf = ~moat
+
+    out, n_unreached = _scalar_graph_unwrap(raw_garbage, F, seed_face=0, conf=conf)
+    assert n_unreached == 0
+    err = out[conf] - phi_true[conf]
+    err -= err[0]  # global offset irrelevant
+    assert np.abs(err).max() < 1e-6, (
+        f"confident faces landed on a wrong branch: max err {np.abs(err).max():.3f} rad"
+    )
+    # junk faces: garbage mod-2π values are expected (raw is noise), but the BRANCH must
+    # follow the confident neighborhood — no junk face may orbit a full turn away
+    err_j = out[moat] - phi_true[moat]
+    assert np.abs(err_j).max() < 2 * np.pi, (
+        f"junk face on a wrong branch: max err {np.abs(err_j).max():.3f} rad"
+    )
+
+
+def test_timeline_shape():
+    t = timeline_t(240, 20, 25)
+    assert len(t) == 240
+    assert (t[:20] == 0).all() and (t[-25:] == 1).all()
+    d = np.diff(t)
+    assert (d >= -1e-12).all()
+    assert d.max() < 0.02  # smooth, no jumps

--- a/foundation/scroll-unwrap-pipeline/uv.lock
+++ b/foundation/scroll-unwrap-pipeline/uv.lock
@@ -1,0 +1,798 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb", size = 293419, upload-time = "2025-07-26T12:01:21.16Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6", size = 273979, upload-time = "2025-07-26T12:01:22.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/a12359b9b2ca3a845e8f7f9ac08bdf776114eb931392fcad91743e2ea17b/contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7", size = 332653, upload-time = "2025-07-26T12:01:24.155Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/897aeebfb475b7748ea67b61e045accdfcf0d971f8a588b67108ed7f5512/contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8", size = 379536, upload-time = "2025-07-26T12:01:25.91Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8a/a8c584b82deb248930ce069e71576fc09bd7174bbd35183b7943fb1064fd/contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea", size = 384397, upload-time = "2025-07-26T12:01:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1", size = 362601, upload-time = "2025-07-26T12:01:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0a/a3fe3be3ee2dceb3e615ebb4df97ae6f3828aa915d3e10549ce016302bd1/contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7", size = 1331288, upload-time = "2025-07-26T12:01:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/acad9bd4e97f13f3e2b18a3977fe1b4a37ecf3d38d815333980c6c72e963/contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411", size = 1403386, upload-time = "2025-07-26T12:01:33.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "cyclopts"
+version = "4.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/b7/2e64e26e7189c2f0f88cea467d068ec968f2fa24628b0ffb93132a0f2b14/cyclopts-4.17.0.tar.gz", hash = "sha256:6b3231f18b404879e978214ef26fa174e8b505bd0f2117290b4135560666004b", size = 181338, upload-time = "2026-06-09T13:41:26.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/26/1614f15b8ea89ee201a2484ea5bede7319a2b07c796c321ffdadd705559e/cyclopts-4.17.0-py3-none-any.whl", hash = "sha256:6ee947c9f3bbe9679b9fa9cea1bb327298db80b302df62d7f1d1bd82726508e0", size = 219147, upload-time = "2026-06-09T13:41:24.97Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02", size = 2881131, upload-time = "2026-05-14T12:03:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/c815bea63117fa63e4e1c01f8a1110d2112fa003f838e6467094ec2432ce/fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0", size = 2426704, upload-time = "2026-05-14T12:03:15.801Z" },
+    { url = "https://files.pythonhosted.org/packages/44/04/0b91d8e916e92ad1fac9e4624760baf0fd5ff2ead614c2f68fb21373f03f/fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af", size = 5044298, upload-time = "2026-05-14T12:03:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8", size = 4999800, upload-time = "2026-05-14T12:03:20.161Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6d/67fe16c48d7ce050979b33f47e0d28a318f02da030602e944c34f7a16ef3/fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b", size = 4982666, upload-time = "2026-05-14T12:03:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/3bbab338c07c71fa56269953845e92c951a61457bbbb0f1022551ea266d9/fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78", size = 5133598, upload-time = "2026-05-14T12:03:25.168Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/aa27c7f98db5b064883dadcc5283947e81e034de42e22a33675878d98b54/fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263", size = 2292575, upload-time = "2026-05-14T12:03:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/87/36/cccb9bc2a6ab63d1b2980374f0dca72ce95ae267c9b4cfe77455bb70d0d4/fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272", size = 2343211, upload-time = "2026-05-14T12:03:30.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "imageio"
+version = "2.37.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "intel-cmplr-lib-ur"
+version = "2026.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "umf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/6d/b981353d0ba8dc6d54510aba97f67ddce3872a693f41841bb77a120f512c/intel_cmplr_lib_ur-2026.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:5fb75293e7f1f8377cda3aac44f4e7c0c1dd38e281fecefa76ca1459382763a4", size = 31565700, upload-time = "2026-04-24T14:10:16.369Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0f/427cee2d63934966338cc58b3782819c196b90407d60c58ea708be78eb50/intel_cmplr_lib_ur-2026.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:db2639ff3b1467edd5f5872a6005564ff4d9685b4fa68f5a4b42230a0d8a1562", size = 1305315, upload-time = "2026-04-24T14:12:08.402Z" },
+]
+
+[[package]]
+name = "intel-openmp"
+version = "2026.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "intel-cmplr-lib-ur" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/52/ad8da758c96299c27ac1f0345979f9202a517c4f18ef6a1e9b7a781d6948/intel_openmp-2026.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:c4605c63840d6dc0188610f9d0dcc5ae6c73c988f98c36c4bd807bcbd0de73bb", size = 57250534, upload-time = "2026-04-24T14:10:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/48/32b1c24d3f1e4f47495d29bda38002384ae03a9ab709b575dda31842c0a4/intel_openmp-2026.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:d1f18c4e1be8426da117252a4fb8e5d72be44807b0251fcea23e2fa7b7d85981", size = 30721954, upload-time = "2026-04-24T14:11:48.06Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d9/405320f8077e8e1c5c4bd6adc45e1e6edf6d727b6da7f2e2533cf58bff71/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588", size = 66388, upload-time = "2026-03-09T13:13:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/795fedf35634f746151ca8839d05681ceb6287fbed6cc1c9bf235f7887c2/kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819", size = 64068, upload-time = "2026-03-09T13:13:25.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f", size = 1477934, upload-time = "2026-03-09T13:13:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf", size = 1278537, upload-time = "2026-03-09T13:13:28.707Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/9b782923aada3fafb1d6b84e13121954515c669b18af0c26e7d21f579855/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d", size = 1296685, upload-time = "2026-03-09T13:13:30.528Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/83241b6634b04fe44e892688d5208332bde130f38e610c0418f9ede47ded/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083", size = 1346024, upload-time = "2026-03-09T13:13:32.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/db/30ed226fb271ae1a6431fc0fe0edffb2efe23cadb01e798caeb9f2ceae8f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6", size = 987241, upload-time = "2026-03-09T13:13:34.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/c314595208e4c9587652d50959ead9e461995389664e490f4dce7ff0f782/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1", size = 2227742, upload-time = "2026-03-09T13:13:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/43/0499cec932d935229b5543d073c2b87c9c22846aab48881e9d8d6e742a2d/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0", size = 2323966, upload-time = "2026-03-09T13:13:38.204Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/79b0d760907965acfd9d61826a3d41f8f093c538f55cd2633d3f0db269f6/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15", size = 1977417, upload-time = "2026-03-09T13:13:39.966Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/01d0537c41cb75a551a438c3c7a80d0c60d60b81f694dac83dd436aec0d0/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314", size = 2491238, upload-time = "2026-03-09T13:13:41.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569, upload-time = "2026-03-09T13:13:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997, upload-time = "2026-03-09T13:13:46.878Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262, upload-time = "2026-03-09T13:15:35.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
+]
+
+[[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
+name = "libigl"
+version = "2.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2d/595f3ba33701b2354723821e38745674ae9b21ec79d18d7757dbe2e893c3/libigl-2.6.2.tar.gz", hash = "sha256:5da0c5d889a66e3e90eefe6b7f0e7239ade6ac94353585f1b5b086bb1372599e", size = 41219283, upload-time = "2026-03-05T17:28:03.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/99/99422c55a722afea4cd25c8d6c2fd5f432be564a12cfa18a2aae7160abff/libigl-2.6.2-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:9b477b584277def1fbf99c05a9ca59c96ad09f6e6572ac58b88ac73c7f3f7ac9", size = 11257225, upload-time = "2026-03-05T17:27:50.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/3c6994d112759d25b00007384651157dabf955c61a62050de4fadea794f2/libigl-2.6.2-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e92dac380ec1f81d87a6f5423b2de228e106f90edb9c14033984210c23b32854", size = 12820764, upload-time = "2026-03-05T17:27:52.08Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/c6/5581e26c72233ebb2a2a6fed2d24fb7c66b4700120b813f51b0555acf0b6/matplotlib-3.10.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0c3c28d9fbcc1fe7a03be236d73430cf6409c41fb2383a7ac52fe932b072cb1", size = 8319908, upload-time = "2026-04-24T00:12:21.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/18/4880dd762e40cd360c1bf06e890c5a97b997e91cb324602b1a19950ad5ce/matplotlib-3.10.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cb28c2bd769aa3e98322c6ab09854cbcc52ab69d2759d681bba3e327b2b320", size = 8216016, upload-time = "2026-04-24T00:12:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/32/91/d024616abdba99e83120e07a20658976f6a343646710760c4a51df126029/matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae20801130378b82d647ff5047c07316295b68dc054ca6b3c13519d0ea624285", size = 8789336, upload-time = "2026-04-24T00:12:26.096Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/04/030a2f61ef2158f5e4c259487a92ac877732499fb33d871585d89e03c42d/matplotlib-3.10.9-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c63ebcd8b4b169eb2f5c200552ae6b8be8999a005b6b507ed76fb8d7d674fe2", size = 9604602, upload-time = "2026-04-24T00:12:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/541e4d09d87bb6b5830fc28b4c887a9a8cf4e1c6cee698a8c05552ae2003/matplotlib-3.10.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d75d11c949914165976c621b2324f9ef162af7ebf4b057ddf95dd1dba7e5edcf", size = 9670966, upload-time = "2026-04-24T00:12:32.131Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a1/4571fc46e7702de8d0c2dc54ad1b2f8e29328dea3ee90831181f7353d93c/matplotlib-3.10.9-cp312-cp312-win_amd64.whl", hash = "sha256:d091f9d758b34aaaaa6331d13574bf01891d903b3dec59bfff458ef7551de5d6", size = 8217462, upload-time = "2026-04-24T00:12:35.226Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d0/2269edb12aa30c13c8bcc9382892e39943ce1d28aab4ec296e0381798e81/matplotlib-3.10.9-cp312-cp312-win_arm64.whl", hash = "sha256:10cc5ce06d10231c36f40e875f3c7e8050362a4ee8f0ee5d29a6b3277d57bb42", size = 8136688, upload-time = "2026-04-24T00:12:37.442Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mkl"
+version = "2026.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "intel-openmp" },
+    { name = "onemkl-license" },
+    { name = "tbb" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/97/06ad1072db8a3c4d1e6237badf660c4c754d2b513264996121c2b666d65d/mkl-2026.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:4a9525ddd671b422fedfc690dd9270beb65c8cbd47044b52d2a4e3f6162c9de6", size = 224036598, upload-time = "2026-04-24T14:12:43.717Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2f/8a77106ef648cc1f04aa27e8b6c50cd82de38d1767801ef29cd75b8026e8/mkl-2026.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:801c9cc748be81d8269bfec2495d02be38560fc7386439c18499ab3f32b06b3e", size = 180805356, upload-time = "2026-04-24T14:08:52.681Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+]
+
+[[package]]
+name = "onemkl-license"
+version = "2026.0.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/fa/7c9af1e1fcea378257958355f7f2b80d6cc50a36ceebec0ad2fa9bd6b538/onemkl_license-2026.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:939058a4f34859863eaa3734b678e880cd1ce5f589458feea118bf2212514341", size = 58936, upload-time = "2026-04-24T14:13:19.607Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8e/fc57a715c626333e2ac8d2444d97ae2b1421fe33628261645668e6b9624b/onemkl_license-2026.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:8106d1177cc473b615e88d2051b4943aeb4c1408d79c8df22ab13ed8660760bb", size = 58961, upload-time = "2026-04-24T14:09:34.005Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "plyfile"
+version = "1.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/35/fe6e7cb8048e4055c7bdeae4287ee4b4e5fd230d9373744f570a6ce2721d/plyfile-1.1.4.tar.gz", hash = "sha256:29daf18c0957a0957c5a77edff7b92acfeff90c9b64ea6c2ab2dd6f44ddc50d6", size = 36162, upload-time = "2026-05-28T21:33:04.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/d0/2e912d5e1fa017e10c196609d008ff5954ddb9d0487de77a5de03141613a/plyfile-1.1.4-py3-none-any.whl", hash = "sha256:69eb9bfa85de9396e516e89d5b87abc8640e78b5dddd9df25926fb33df314edb", size = 36455, upload-time = "2026-05-28T21:33:03.804Z" },
+]
+
+[[package]]
+name = "pooch"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
+]
+
+[[package]]
+name = "pyamg"
+version = "5.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/f1/e7f0466af00dc59b6592f03499a8ca1c839d5265a045d0b010b574f67143/pyamg-5.3.0.tar.gz", hash = "sha256:5323d0f1a4cd999be246a90d580c9e1e9b584b98887f6298d397611087ef860b", size = 4161140, upload-time = "2025-08-24T02:06:10.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/6f/603ade45abb6ef8fdc40884cb246733efe110db2563c54fd19f7dc240832/pyamg-5.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:661f510311fbfa03b8b317ce9cdb6602902321dd936bcc975ee94bfe43eacb72", size = 1852410, upload-time = "2025-08-24T02:05:48.601Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c4/ae346f844d4e08a15b9178707ced39de3f92c4e1b0447d0a9c5ccd24eaac/pyamg-5.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7d38303310e8551ae737898577c6ec69a1ee0fa4baf95f525c86f0071d94260", size = 1763595, upload-time = "2025-08-24T02:05:50.55Z" },
+    { url = "https://files.pythonhosted.org/packages/db/45/1c03a50699d1ce96f5a3f54755c3bdd575e459f8ba2c66eba3365881584c/pyamg-5.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a69c7974b26b1d5cd5bc0e371c565239199e9032b2ceb97190d492cd6498367", size = 1899545, upload-time = "2025-08-24T02:05:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/16/d703720aeaf57eca57867993b57d969ed1bc9675a93c82606663587aa285/pyamg-5.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a6de101435d11645293f83b23c22830c372100d13e6d0bcb8d1abd3e92c88c8", size = 2943354, upload-time = "2025-08-24T02:05:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/79/84/cefaabc44798ba7df2e806f4eb06ea435fe627886b40f312d263aaa7b76f/pyamg-5.3.0-cp312-cp312-win32.whl", hash = "sha256:0561b942b7b8a35700842077a2b6a228510ae8fcc402862bd3f60dc7d2cd75f4", size = 1563969, upload-time = "2025-08-24T02:05:55.662Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8b/ff8c56c1f7a7997c7988c84bc55bc34b336b862531fbf88d3a8c5aa3fe5f/pyamg-5.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:dd832b392314c5d4dbb6464f7ba8d788694d253a51b9809af8ade4886d24565f", size = 1681747, upload-time = "2025-08-24T02:05:57.421Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymeshlab"
+version = "2025.7.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/c1/a8db8ba66b5c51e700ba0eccea2c81f68a3223b775b0afe7b30a3da9a2ec/pymeshlab-2025.7.post1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:693101c1ade7aadbad114878626307bf434fe607de873449fbe6b6b95a30cd01", size = 64995577, upload-time = "2026-01-30T08:40:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/0d/6692ef6d96fa27763899665562c11ee6411eba55b2bddcda6799213dadac/pymeshlab-2025.7.post1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:265503a06968420c8eb6934e3db78ff0767518000d8afd46ef3c976a506cfcf7", size = 54506925, upload-time = "2026-01-30T08:40:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8d/6082aa85f8c918901221d1a7e1e810cb5b56eecbed59a5e688feea92c148/pymeshlab-2025.7.post1-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:d39fbaac1274adbbdf75cd999710d2ba48bd4d9087f34815afbdedb99dd3ded6", size = 65341068, upload-time = "2026-01-30T08:41:02.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4c/b0b1b5ad425acd80abcff4632f0241ca490c52ef9c48013d71f573680a2a/pymeshlab-2025.7.post1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:bc453d89b114671affc747991a939b257d2320b71885b31213190c64081f5c35", size = 106530409, upload-time = "2026-01-30T08:41:05.155Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/66b91d2d77fbb2bf729dfe58692957bad3cea706ecb3fe51fca4b07c0c95/pymeshlab-2025.7.post1-cp312-cp312-win_amd64.whl", hash = "sha256:fc04cb2206e8d0194b2c8f61ea6ef54505bbe3d217e7f1960ee9608464f9bfad", size = 55211790, upload-time = "2026-01-30T08:41:08.339Z" },
+]
+
+[[package]]
+name = "pypardiso"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkl" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/f8/38f3c9983ffc789fa7ddda88cf2ce388a489698ba73edb9e5355a564966e/pypardiso-0.4.7.tar.gz", hash = "sha256:0f307c749ace576d9de5c63ce39af0e850d8f772697260454f3deb0202a7a92d", size = 13851, upload-time = "2025-11-02T23:11:32.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/11/80f3b55f77309b1993e68776778510f46195252b5393b967f67d28dbb6b6/pypardiso-0.4.7-py3-none-any.whl", hash = "sha256:157b2d188d884b4bf2cd90a0cb3efae513b8b6215c29ebb4659e9cc38610c839", size = 10070, upload-time = "2025-11-02T23:11:31.127Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyvista"
+version = "0.48.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cyclopts" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pooch" },
+    { name = "scooby" },
+    { name = "typing-extensions" },
+    { name = "vtk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/11/554ae45f79d45039c733d93acb36a433b71e8c63a79bbf2f414b3685de18/pyvista-0.48.4.tar.gz", hash = "sha256:c639dad1bddff5e366d77371f66f783f6e6a0581446810a66439902222d8db07", size = 2581423, upload-time = "2026-05-18T02:25:51.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/91/696d869e4df2e25a5b201a69ce69a2204d37fad3e90c2b731f7b3f1d7c68/pyvista-0.48.4-py3-none-any.whl", hash = "sha256:a46eda178e10e279afda550c341676a82dcee607c86db74565fa455ac0bd23e2", size = 2629373, upload-time = "2026-05-18T02:25:49.919Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/56/3191bae66b08ccc637ea8120426068bcb361cc323c96404c310886937067/rich_rst-2.0.1.tar.gz", hash = "sha256:cbe236ed0901d1ec8427cc6a50bf0a34353ba28ad014dc24def68bfe7f3b9e68", size = 300570, upload-time = "2026-05-16T00:47:57.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3d/55c17d3ebdf3cd81356002afe5bef9bb8af631db2819785b6eac845b925b/rich_rst-2.0.1-py3-none-any.whl", hash = "sha256:7ee15f345ce25fa02b582c272a6cdbaf0c21243e38061cea273cff659bf3ef61", size = 272922, upload-time = "2026-05-16T00:47:55.508Z" },
+]
+
+[[package]]
+name = "rtree"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/09/7302695875a019514de9a5dd17b8320e7a19d6e7bc8f85dcfb79a4ce2da3/rtree-1.4.1.tar.gz", hash = "sha256:c6b1b3550881e57ebe530cc6cffefc87cd9bf49c30b37b894065a9f810875e46", size = 52425, upload-time = "2025-08-13T19:32:01.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d9/108cd989a4c0954e60b3cdc86fd2826407702b5375f6dfdab2802e5fed98/rtree-1.4.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d672184298527522d4914d8ae53bf76982b86ca420b0acde9298a7a87d81d4a4", size = 468484, upload-time = "2025-08-13T19:31:50.593Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/cf/2710b6fd6b07ea0aef317b29f335790ba6adf06a28ac236078ed9bd8a91d/rtree-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7e48d805e12011c2cf739a29d6a60ae852fb1de9fc84220bbcef67e6e595d7d", size = 436325, upload-time = "2025-08-13T19:31:52.367Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e1/4d075268a46e68db3cac51846eb6a3ab96ed481c585c5a1ad411b3c23aad/rtree-1.4.1-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa8c4496e31e9ad58ff6c7df89abceac7022d906cb64a3e18e4fceae6b77f65", size = 459789, upload-time = "2025-08-13T19:31:53.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/75/e5d44be90525cd28503e7f836d077ae6663ec0687a13ba7810b4114b3668/rtree-1.4.1-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12de4578f1b3381a93a655846900be4e3d5f4cd5e306b8b00aa77c1121dc7e8c", size = 507644, upload-time = "2025-08-13T19:31:55.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/85/b8684f769a142163b52859a38a486493b05bafb4f2fb71d4f945de28ebf9/rtree-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b558edda52eca3e6d1ee629042192c65e6b7f2c150d6d6cd207ce82f85be3967", size = 1454478, upload-time = "2025-08-13T19:31:56.808Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
+]
+
+[[package]]
+name = "scikit-image"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy" },
+    { name = "tifffile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/e8/e13757982264b33a1621628f86b587e9a73a13f5256dad49b19ba7dc9083/scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c", size = 12376452, upload-time = "2025-12-20T17:10:52.796Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/f8dd17d0510f9911f9f17ba301f7455328bf13dae416560126d428de9568/scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37", size = 12061567, upload-time = "2025-12-20T17:10:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/c70120a6880579fb42b91567ad79feb4772f7be72e8d52fec403a3dde0c6/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44", size = 13084214, upload-time = "2025-12-20T17:10:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466", size = 13561683, upload-time = "2025-12-20T17:10:59.49Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/48bdfd92794c5002d664e0910a349d0a1504671ef5ad358150f21643c79a/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932", size = 14112147, upload-time = "2025-12-20T17:11:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/ac71694da92f5def5953ca99f18a10fe98eac2dd0a34079389b70b4d0394/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70", size = 14661625, upload-time = "2025-12-20T17:11:04.528Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4d/a3cc1e96f080e253dad2251bfae7587cf2b7912bcd76fd43fd366ff35a87/scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0", size = 11911059, upload-time = "2025-12-20T17:11:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/d1b8055f584acc937478abf4550d122936f420352422a1a625eef2c605d8/scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8", size = 11348740, upload-time = "2025-12-20T17:11:09.118Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+]
+
+[[package]]
+name = "scooby"
+version = "0.11.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/06/9a8600207fd72a29ee965e9a4c61b750cc3fa106768f14a7b3ee3e36cb61/scooby-0.11.2.tar.gz", hash = "sha256:0575c73636ec4c2587bea1f8a038798ddcb249e02067fae897dac3bf4f4e444d", size = 242928, upload-time = "2026-04-22T23:13:12.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/bc/1173f502f1870e3bae81c148326c5cbcc19ec77df79a9aaf17a59911355c/scooby-0.11.2-py3-none-any.whl", hash = "sha256:f34c36bbee749b2c55816a080521f216d88304e635017e911c12249607d38c49", size = 20142, upload-time = "2026-04-22T23:13:10.705Z" },
+]
+
+[[package]]
+name = "scrollkit"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "libigl" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "plyfile" },
+    { name = "pyamg" },
+    { name = "pymeshlab" },
+    { name = "pypardiso" },
+    { name = "pyvista" },
+    { name = "pyyaml" },
+    { name = "rtree" },
+    { name = "scikit-image" },
+    { name = "scipy" },
+    { name = "tifffile" },
+    { name = "trimesh" },
+    { name = "vtk" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "libigl", specifier = ">=2.6.2" },
+    { name = "matplotlib", specifier = ">=3.9" },
+    { name = "numpy", specifier = ">=2.0" },
+    { name = "pillow", specifier = ">=10.3" },
+    { name = "plyfile", specifier = ">=1.0" },
+    { name = "pyamg", specifier = ">=5.2" },
+    { name = "pymeshlab", specifier = ">=2023.12" },
+    { name = "pypardiso", specifier = ">=0.4.6" },
+    { name = "pyvista", specifier = ">=0.44" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rtree", specifier = ">=1.4.1" },
+    { name = "scikit-image", specifier = ">=0.24" },
+    { name = "scipy", specifier = ">=1.13" },
+    { name = "tifffile", specifier = ">=2024.6.18" },
+    { name = "trimesh", specifier = ">=4.4" },
+    { name = "vtk", specifier = ">=9.5" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.2" }]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tbb"
+version = "2023.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tcmlib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/d2/9a994ce9b18182b04783282eba77e236d23919acf42a886d72fe14fc78a4/tbb-2023.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:482f57656386ea14b96e8da36b3fcc4cd880834ef0f328ba09e8e2e3c639285e", size = 6785156, upload-time = "2026-04-24T14:10:01.59Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f8/dd5e1d9955c91ebd301d855232163750489b20ea5a8c4e40954269493dcc/tbb-2023.0.0-py3-none-win_amd64.whl", hash = "sha256:82d1c2b4b6881d5b4f2e67288ca1c864f54e3cd82c7e428aaf912aa30ab21d01", size = 427718, upload-time = "2026-04-24T14:10:47.885Z" },
+]
+
+[[package]]
+name = "tcmlib"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/24/aa409bb20703acc70cf4d3bc620a55c789639c2995b2667fb44ae7236ec9/tcmlib-1.5.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9d7c01cff35aae9bf5390b620680ebdf10a7d211c22d6488a27a029502e7d0aa", size = 2812669, upload-time = "2026-04-24T14:14:18.557Z" },
+    { url = "https://files.pythonhosted.org/packages/67/6d/9095c93326d0f8a5469ab22480d02795f24c08f1e7f383c73316ff106347/tcmlib-1.5.0-py2.py3-none-win_amd64.whl", hash = "sha256:f7b62787214083d490b39d7650f1e477eeacc875e7f86799feb9aa1fd34460d4", size = 366719, upload-time = "2026-04-24T14:09:45.977Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl", hash = "sha256:0d7382d2769b855b81ce358528e2b40c16d48aa39031746efa81215205332a8d", size = 267108, upload-time = "2026-05-31T23:57:10.597Z" },
+]
+
+[[package]]
+name = "trimesh"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/37/5cb90f04990260d2caceb6093560c6cefafca1ec522c1e43be01ca658244/trimesh-4.12.2.tar.gz", hash = "sha256:c8ca31571ac00b112e4e160e66a2d4c3491df321f056bd33806be0485d1af9d9", size = 842220, upload-time = "2026-05-01T00:57:43.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/98/716a473cfb24750858ddd5d14e6527539dd206583a46408d08eeb2844a75/trimesh-4.12.2-py3-none-any.whl", hash = "sha256:b5b5afa63c5272345f2858f7676bc8c217dc8a89f4fadf6193fe10a81b5ff2aa", size = 741043, upload-time = "2026-05-01T00:57:40.763Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "umf"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tcmlib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/72/2e0182f4e6a727a15d0a8a99a82182a4f5bdec1a4f5767acfd2abdc72070/umf-1.1.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:567152c5ee6b8e16cc56b29a8a9a6b918de1febf89877f71ea2e8247ef39fc32", size = 424455, upload-time = "2026-04-24T14:13:51.436Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/43/d89fee46bed22a461714a8786b833a89bff2f0a5e058b02eed3be842752e/umf-1.1.0-py2.py3-none-win_amd64.whl", hash = "sha256:a8c5ff84901fe6348715b6c1c85de4d195a6c69185d99ce4ebf7449b5d04011c", size = 289901, upload-time = "2026-04-24T14:08:31.647Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "vtk"
+version = "9.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/d3/344f3664586f1f8bb5f7950db73c257439f5c796e0978e7a53e91d0fe2aa/vtk-9.6.2-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:2adcaed1cc4d3411a6b19834d6ed7d480f9ad9252e56546ea9930e66beae84e8", size = 114881278, upload-time = "2026-05-19T04:47:12.045Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b1/754bd95da3d216e852014758c9ad626601482e2e0b1da98fa83adc5fe1b8/vtk-9.6.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d1eb5368039dd6a88e8102bee1db50e6f1e5a12945887ea1025069a99fb8088e", size = 106960169, upload-time = "2026-05-19T04:47:17.187Z" },
+    { url = "https://files.pythonhosted.org/packages/96/f8/b392298c74aa7b88c731a43253ccd50b388bf42a1a29b50fa735c4f22f41/vtk-9.6.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c9f31430d15afbf46c2076cf3e30b4d6136512a5faabee8318552ccea907323", size = 146027355, upload-time = "2026-05-19T04:47:22.412Z" },
+    { url = "https://files.pythonhosted.org/packages/71/35/67a7760852100c98a8fb6f1221e7eb359ad4d0b1b9edd8beea42c79e16c4/vtk-9.6.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:91e1962c93217cf91ca4fe50762dd26dfc22290b74b8b0de77576f93f7c17abb", size = 135789817, upload-time = "2026-05-19T04:47:27.551Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/61/58e162d9cdbf02a3578ef4e68f4003b8cb9f351b7aa409960da3cc383017/vtk-9.6.2-cp312-cp312-win_amd64.whl", hash = "sha256:83b4af00b31395a13acb20e26a42ee097b85e41a0a087be2340d3749cb58250f", size = 81305902, upload-time = "2026-05-19T04:47:32.305Z" },
+]


### PR DESCRIPTION
## What

`foundation/scroll-unwrap-pipeline/` — a production pipeline that takes textured Herculaneum wrap segments (binary PLY + ink predictions in the same UV space) to finished unwrap animations:

- exact PLY->OBJ conversion (bit-equal round-trip gates, SHA-verified textures)
- perceptually-gated UV-preserving decimation (keep-fraction ladder, render-SSIM + Hausdorff gates)
- carbon-black ink-overlay baking (recto-only via two-sided materials)
- self-intersection-free unwrap animation: rolling-contact kinematics with a closed-form plane-clearance barrier, chart sanitation (injectivity enforcement, junk-tail trim), and a per-frame roll-vs-sheet clearance certificate as a hard gate; deformation-gradient fallback ladder with clearance-dominant ranking
- headless EGL alpha-cutout renderer -> 4K masters + 1080p derivatives (plain / ink / reveal variants, 16:9 + 9:16), per-frame textured OBJs (ink as a two-sided thin shell)
- signature-keyed batch staging so artifacts from different code revisions can never silently coexist

## Specs & layout

Binding contracts in `docs/`: MESH-IO, UNWRAP-MATH, RENDER-STYLE, QUALITY-GATES (incl. the vision-review JSON interface for the final gate). `src/scrollkit` (io | decimate | ink | unwrap | metrics | render), stage CLIs + `gate_m0..m5` under `scripts/`, synthetic-fixture tests under `tests/`.

## Checks

- Full pytest suite green in this tree's own environment (`uv sync && uv run pytest`): 38/38 — IO convention traps, analytic-cylinder kinematics, render orientation pinning, ink grading.
- All stage CLIs import and parse args cleanly; gates exit RED correctly on an empty tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)