### PR TITLE
Add vc_straighten + self-calibrating vc_merge_tifxyz gates + VC3D Straighten menu

### DIFF
--- a/volume-cartographer/apps/CMakeLists.txt
+++ b/volume-cartographer/apps/CMakeLists.txt
@@ -120,6 +120,9 @@ target_link_libraries(vc_tifxyz_inp_mask vc_core)
 add_executable(vc_tifxyz_trim src/vc_tifxyz_trim.cpp)
 target_link_libraries(vc_tifxyz_trim vc_core opencv_core opencv_imgcodecs TIFF::TIFF)
 
+add_executable(vc_straighten src/vc_straighten.cpp)
+target_link_libraries(vc_straighten vc_core Boost::program_options opencv_core opencv_imgproc opencv_imgcodecs opencv_flann TIFF::TIFF)
+
 add_executable(vc_cut_windings src/vc_cut_windings.cpp)
 target_link_libraries(vc_cut_windings vc_core opencv_core)
 
@@ -244,6 +247,7 @@ if(VC_USE_PCH)
         vc_merge_tifxyz vc_merge_patch vc_visualize vc_volpkg_convert vc_transform_geom
         vc_gen_normalgrids vc_ngrids vc_tifxyz2rgb vc_rgb2tifxyz vc_thinning
         vc_tifxyz vc_project_tifxyz vc_zarr_to_tiff vc_zarr_recompress
+        vc_straighten
     )
         target_precompile_headers(${_app} REUSE_FROM vc_common_pch)
     endforeach()

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -3588,6 +3588,10 @@ void CWindow::CreateWidgets(void)
             this, [this](const QString& segmentId) {
                 _segmentationCommandHandler->onSlimFlatten(segmentId.toStdString());
             });
+    connect(_surfacePanel.get(), &SurfacePanelController::straightenRequested,
+            this, [this](const QString& segmentId) {
+                _segmentationCommandHandler->onStraighten(segmentId.toStdString());
+            });
     connect(_surfacePanel.get(), &SurfacePanelController::abfFlattenRequested,
             this, [this](const QString& segmentId) {
                 _segmentationCommandHandler->onABFFlatten(segmentId.toStdString());

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -1411,6 +1411,108 @@ private:
     QPointer<QProgressDialog> progress_;
 };
 
+// vc_straighten runs directly on tifxyz dirs (no OBJ round-trip), so this is a
+// single subprocess: stream its stdout into the progress label, then reload
+// the surface list so the new surface appears.
+class StraightenJob : public QObject {
+    Q_OBJECT
+public:
+    StraightenJob(QWidget* parentWidget, SurfacePanelController* surfacePanel,
+                  SegmentationCommandHandler* handler, const QString& straightenExe,
+                  const QString& segDir, const QString& segmentStem,
+                  const QString& outputDir, const QStringList& extraArgs)
+        : QObject(handler)
+        , parentWidget_(parentWidget)
+        , handler_(handler)
+        , surfacePanel_(surfacePanel)
+        , stem_(segmentStem)
+        , outDir_(outputDir)
+        , proc_(new QProcess(this))
+        , progress_(new QProgressDialog(QObject::tr("Straightening..."), QObject::tr("Cancel"), 0, 0, parentWidget))
+    {
+        progress_->setWindowModality(Qt::NonModal);
+        progress_->setMinimumDuration(0);
+        progress_->setRange(0, 0); // indeterminate; vc_straighten emits no PROGRESS
+        progress_->setAttribute(Qt::WA_DeleteOnClose);
+        connect(progress_, &QProgressDialog::canceled, this, &StraightenJob::onCanceled_);
+
+        proc_->setProcessChannelMode(QProcess::MergedChannels);
+        connect(proc_, &QProcess::readyReadStandardOutput, this, &StraightenJob::onStdout_);
+        connect(proc_, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+                this, &StraightenJob::onFinished_);
+        connect(proc_, &QProcess::errorOccurred, this, &StraightenJob::onProcError_);
+
+        QStringList args;
+        args << segDir << outputDir << extraArgs;
+        std::cout << "[straighten] launching: " << straightenExe.toStdString()
+                  << " " << args.join(' ').toStdString() << std::endl;
+        if (handler_) emit handler_->statusMessage(QObject::tr("Running vc_straighten..."), 0);
+        proc_->start(straightenExe, args);
+    }
+
+private slots:
+    void onStdout_() {
+        const QString chunk = QString::fromLocal8Bit(proc_->readAllStandardOutput());
+        const QStringList lines = chunk.split('\n', Qt::SkipEmptyParts);
+        for (const QString& raw : lines) {
+            const QString line = raw.trimmed();
+            if (line.isEmpty()) continue;
+            std::cout << "[straighten] " << line.toStdString() << std::endl;
+            if (progress_) progress_->setLabelText(line);
+            if (handler_) emit handler_->statusMessage(line, 0);
+        }
+    }
+
+    void onCanceled_() {
+        if (proc_ && proc_->state() != QProcess::NotRunning) proc_->kill();
+    }
+
+    void onProcError_(QProcess::ProcessError e) {
+        // A crash is reported through finished(); only the hard start failure
+        // needs handling here.
+        if (e != QProcess::FailedToStart || done_) return;
+        done_ = true;
+        if (handler_) emit handler_->statusMessage(QObject::tr("Straighten failed"), 5000);
+        if (progress_) progress_->close();
+        QMessageBox::critical(parentWidget_, QObject::tr("Straighten Failed"),
+            QObject::tr("Could not launch vc_straighten."));
+        deleteLater();
+    }
+
+    void onFinished_(int code, QProcess::ExitStatus status) {
+        if (done_) return;
+        done_ = true;
+        if (progress_) progress_->close();
+        if (status != QProcess::NormalExit || code != 0) {
+            if (handler_) emit handler_->statusMessage(QObject::tr("Straighten failed"), 5000);
+            QMessageBox::critical(parentWidget_, QObject::tr("Straighten Failed"),
+                QObject::tr("vc_straighten exited with code %1.\nSee the console for details.").arg(code));
+            deleteLater();
+            return;
+        }
+        const QString label = !stem_.isEmpty() ? stem_ : outDir_;
+        if (handler_) emit handler_->statusMessage(QObject::tr("Straighten complete: %1").arg(label), 5000);
+        QMessageBox::information(parentWidget_, QObject::tr("Straighten Complete"),
+            QObject::tr("Straightened surface saved to:\n%1").arg(outDir_));
+        if (surfacePanel_) {
+            QMetaObject::invokeMethod(surfacePanel_.data(),
+                                      &SurfacePanelController::reloadSurfacesFromDisk,
+                                      Qt::QueuedConnection);
+        }
+        deleteLater();
+    }
+
+private:
+    QWidget* parentWidget_ = nullptr;
+    QPointer<SegmentationCommandHandler> handler_;
+    QPointer<SurfacePanelController> surfacePanel_;
+    QString stem_;
+    QString outDir_;
+    QProcess* proc_ = nullptr;
+    QPointer<QProgressDialog> progress_;
+    bool done_ = false;
+};
+
 } // -------------------- end anonymous namespace ------------------------------
 
 // ====================== SegmentationCommandHandler ============================
@@ -1681,6 +1783,54 @@ void SegmentationCommandHandler::onSlimFlatten(const std::string& segmentId)
     if (!std::isfinite(voxelSize) || voxelSize <= 0.0) voxelSize = 0.0;
 
     new SlimJob(_parentWidget, segDir, segmentStem, flatboiExe, this, iters, tol, energy, keepPercent, inpaintHoles, outputDir, voxelSize);
+}
+
+void SegmentationCommandHandler::onStraighten(const std::string& segmentId)
+{
+    auto* surface = requireSurfaceAndRunner(segmentId, false);
+    if (!surface) return;
+    if (_cmdRunner && _cmdRunner->isRunning()) {
+        QMessageBox::warning(_parentWidget, tr("Warning"), tr("A command line tool is already running."));
+        return;
+    }
+
+    const std::filesystem::path segDirFs = surface->path; // tifxyz folder
+    const QString segDir = QString::fromStdString(segDirFs.string());
+    const QString segmentStem = QString::fromStdString(segmentId);
+
+    const QString exe = findVcTool("vc_straighten");
+    if (exe.isEmpty()) {
+        QMessageBox::critical(_parentWidget, tr("Error"),
+            tr("Could not find the 'vc_straighten' executable.\n"
+               "Looked in known locations and PATH.\n\n"
+               "Tip: set an override via VC.ini [tools] vc_straighten, or put "
+               "the binary on PATH."));
+        emit statusMessage(tr("Straighten failed"), 5000);
+        return;
+    }
+
+    const QString defaultOutput = segDir.endsWith("_straightened")
+        ? (segDir + "_v2") : (segDir + "_straightened");
+    StraightenDialog dlg(_parentWidget, defaultOutput);
+    if (dlg.exec() != QDialog::Accepted) {
+        return;
+    }
+    const QString outputDir = dlg.outputPath();
+    if (QFileInfo::exists(outputDir)) {
+        QMessageBox::warning(_parentWidget, tr("Straighten"),
+            tr("Output directory already exists:\n%1\n\nvc_straighten will not "
+               "overwrite it; choose a different name.").arg(outputDir));
+        return;
+    }
+    const QStringList args = dlg.toArgs();
+    std::cout << "[straighten] segment=" << segmentId
+              << " dir=" << segDirFs.string()
+              << " out=" << outputDir.toStdString()
+              << " exe=" << exe.toStdString()
+              << " args=" << args.join(' ').toStdString()
+              << std::endl;
+
+    new StraightenJob(_parentWidget, _surfacePanel, this, exe, segDir, segmentStem, outputDir, args);
 }
 
 void SegmentationCommandHandler::onABFFlatten(const std::string& segmentId)

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.hpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.hpp
@@ -119,6 +119,7 @@ public slots:
     void onRotateSurface(const std::string& segmentId);
     void onAlphaCompRefine(const std::string& segmentId);
     void onSlimFlatten(const std::string& segmentId);
+    void onStraighten(const std::string& segmentId);
     void onABFFlatten(const std::string& segmentId);
     void onExportWidthChunks(const std::string& segmentId);
     void onRasterizeSegments(const QStringList& segmentIds);

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
@@ -821,6 +821,11 @@ void SurfacePanelController::showContextMenu(const QPoint& pos)
         emit slimFlattenRequested(segmentId);
     });
 
+    QAction* straightenAction = contextMenu.addAction(tr("Straighten (vc_straighten)"));
+    connect(straightenAction, &QAction::triggered, this, [this, segmentId]() {
+        emit straightenRequested(segmentId);
+    });
+
     QAction* abfFlattenAction = contextMenu.addAction(tr("ABF++ flatten"));
     connect(abfFlattenAction, &QAction::triggered, this, [this, segmentId]() {
         emit abfFlattenRequested(segmentId);

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.hpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.hpp
@@ -120,6 +120,7 @@ signals:
     void visLasagnaObjRequested(const QString& segmentId);
     void cropBoundsRequested(const QString& segmentId);
     void slimFlattenRequested(const QString& segmentId);
+    void straightenRequested(const QString& segmentId);
     void abfFlattenRequested(const QString& segmentId);
     void recalcAreaRequested(const QStringList& segmentIds);
     void exportTifxyzChunksRequested(const QString& segmentId);

--- a/volume-cartographer/apps/VC3D/ToolDialogs.cpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.cpp
@@ -1613,6 +1613,152 @@ QString SlimFlattenDialog::outputPath() const
     return defaultOutput_;
 }
 
+// ================= StraightenDialog =================
+bool StraightenDialog::s_haveSession = false;
+bool StraightenDialog::s_unbend = true;
+double StraightenDialog::s_unbendSmoothCols = 300.0;
+int StraightenDialog::s_overlapPasses = 2;
+bool StraightenDialog::s_orthogonalize = true;
+bool StraightenDialog::s_trim = true;
+double StraightenDialog::s_trimMaxEdge = 100.0;
+
+StraightenDialog::StraightenDialog(QWidget* parent, const QString& defaultOutputPath)
+    : QDialog(parent)
+    , defaultOutput_(defaultOutputPath)
+{
+    setWindowTitle(tr("Straighten"));
+    auto main = new QVBoxLayout(this);
+    auto form = new QFormLayout();
+    main->addLayout(form);
+
+    cbUnbend_ = new QCheckBox(tr("Unbend (spine-based bend removal)"), this);
+    cbUnbend_->setChecked(s_haveSession ? s_unbend : true);
+    cbUnbend_->setToolTip(tr(
+        "Fit a smooth spine through the band and re-coordinate into "
+        "(arc-length, normal-offset). A local rotation that removes global "
+        "curvature without shearing. Run this before the other stages when "
+        "the flattened band curves in UV (e.g. a free-boundary SLIM result)."));
+    form->addRow(QString(), cbUnbend_);
+
+    spUnbendSmooth_ = new QDoubleSpinBox(this);
+    spUnbendSmooth_->setRange(10.0, 5000.0);
+    spUnbendSmooth_->setDecimals(0);
+    spUnbendSmooth_->setSingleStep(50.0);
+    spUnbendSmooth_->setValue(s_haveSession ? s_unbendSmoothCols : 300.0);
+    spUnbendSmooth_->setToolTip(tr("Spine Gaussian sigma (columns). Larger keeps the unbend gentle/global."));
+    form->addRow(tr("Unbend smoothing:"), spUnbendSmooth_);
+
+    spOverlap_ = new QSpinBox(this);
+    spOverlap_->setRange(0, 10);
+    spOverlap_->setValue(s_haveSession ? s_overlapPasses : 2);
+    spOverlap_->setToolTip(tr(
+        "Cross-wrap row-alignment passes. Each pass pairs grid points with the "
+        "nearest 3D point one winding over and warps v so they share a row; "
+        "each pass re-measures from the 3D geometry. 0 disables."));
+    form->addRow(tr("Overlap-pair passes:"), spOverlap_);
+
+    cbOrtho_ = new QCheckBox(tr("Orthogonalize columns"), this);
+    cbOrtho_->setChecked(s_haveSession ? s_orthogonalize : true);
+    cbOrtho_->setToolTip(tr("Remove residual column shear measured from the surface tangents."));
+    form->addRow(QString(), cbOrtho_);
+
+    cbTrim_ = new QCheckBox(tr("Trim bridge cells"), this);
+    cbTrim_->setChecked(s_haveSession ? s_trim : true);
+    cbTrim_->setToolTip(tr(
+        "Drop cells whose 3D step to a grid neighbor is absurdly long. They are "
+        "few but dominate area-weighted distortion metrics and render as "
+        "mid-air geometry."));
+    form->addRow(QString(), cbTrim_);
+
+    spTrimMaxEdge_ = new QDoubleSpinBox(this);
+    spTrimMaxEdge_->setRange(1.0, 10000.0);
+    spTrimMaxEdge_->setDecimals(0);
+    spTrimMaxEdge_->setSingleStep(10.0);
+    spTrimMaxEdge_->setValue(s_haveSession ? s_trimMaxEdge : 100.0);
+    spTrimMaxEdge_->setToolTip(tr("Max 3D neighbor-step (voxels) before a cell is trimmed. Nominal step is 1/scale (~20 at scale 0.05)."));
+    form->addRow(tr("Trim max edge:"), spTrimMaxEdge_);
+
+    auto outputRow = new QHBoxLayout();
+    edtOutput_ = new QLineEdit(this);
+    edtOutput_->setText(defaultOutput_);
+    edtOutput_->setToolTip(tr("Output tifxyz directory (must not exist). Defaults to <segment>_straightened next to the input."));
+    auto btnBrowse = new QPushButton(tr("Browse..."), this);
+    auto btnReset = new QPushButton(tr("Default"), this);
+    outputRow->addWidget(edtOutput_, /*stretch=*/1);
+    outputRow->addWidget(btnBrowse);
+    outputRow->addWidget(btnReset);
+    form->addRow(tr("Output:"), outputRow);
+
+    auto syncEnabled = [this]() {
+        if (spUnbendSmooth_) spUnbendSmooth_->setEnabled(cbUnbend_->isChecked());
+        if (spTrimMaxEdge_)  spTrimMaxEdge_->setEnabled(cbTrim_->isChecked());
+    };
+    connect(cbUnbend_, &QCheckBox::toggled, this, [syncEnabled]() { syncEnabled(); });
+    connect(cbTrim_,   &QCheckBox::toggled, this, [syncEnabled]() { syncEnabled(); });
+    syncEnabled();
+
+    connect(btnBrowse, &QPushButton::clicked, this, [this]() {
+        const QString start = edtOutput_->text().isEmpty()
+            ? QFileInfo(defaultOutput_).absolutePath()
+            : edtOutput_->text();
+        const QString chosen = QFileDialog::getSaveFileName(
+            this, tr("Choose output tifxyz directory"), start,
+            /*filter=*/QString(), /*selectedFilter=*/nullptr,
+            QFileDialog::DontConfirmOverwrite);
+        if (!chosen.isEmpty()) edtOutput_->setText(chosen);
+    });
+    connect(btnReset, &QPushButton::clicked, this, [this]() {
+        edtOutput_->setText(defaultOutput_);
+    });
+
+    auto btns = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    connect(btns, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(btns, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    main->addWidget(btns);
+
+    connect(btns, &QDialogButtonBox::accepted, this, [this]() {
+        s_haveSession = true;
+        s_unbend = cbUnbend_->isChecked();
+        s_unbendSmoothCols = spUnbendSmooth_->value();
+        s_overlapPasses = spOverlap_->value();
+        s_orthogonalize = cbOrtho_->isChecked();
+        s_trim = cbTrim_->isChecked();
+        s_trimMaxEdge = spTrimMaxEdge_->value();
+    });
+}
+
+QString StraightenDialog::outputPath() const
+{
+    if (edtOutput_) {
+        const QString t = edtOutput_->text().trimmed();
+        if (!t.isEmpty()) return t;
+    }
+    return defaultOutput_;
+}
+
+QStringList StraightenDialog::toArgs() const
+{
+    QStringList a;
+    if (cbUnbend_ && cbUnbend_->isChecked()) {
+        a << QStringLiteral("--unbend");
+        if (spUnbendSmooth_)
+            a << QStringLiteral("--unbend-smooth-cols")
+              << QString::number(spUnbendSmooth_->value(), 'f', 0);
+    }
+    // Always explicit so vc_straighten never falls back to its implicit
+    // "no stage flags = full default pipeline" behavior.
+    a << QStringLiteral("--overlap-pairs")
+      << QString::number(spOverlap_ ? spOverlap_->value() : 2);
+    if (cbOrtho_ && cbOrtho_->isChecked()) a << QStringLiteral("--orthogonalize");
+    if (cbTrim_ && cbTrim_->isChecked()) {
+        a << QStringLiteral("--trim");
+        if (spTrimMaxEdge_)
+            a << QStringLiteral("--trim-max-edge")
+              << QString::number(spTrimMaxEdge_->value(), 'f', 0);
+    }
+    return a;
+}
+
 // ================= VisLasagnaObjDialog =================
 // static session members
 bool VisLasagnaObjDialog::s_haveSession = false;

--- a/volume-cartographer/apps/VC3D/ToolDialogs.hpp
+++ b/volume-cartographer/apps/VC3D/ToolDialogs.hpp
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 #include <QString>
+#include <QStringList>
 #include <QLineEdit>
 #include <QDoubleSpinBox>
 #include <QSpinBox>
@@ -594,6 +595,39 @@ private:
     QComboBox* cbEnergy_{nullptr};
     QDoubleSpinBox* spKeepPercent_{nullptr};
     QCheckBox* cbInpaint_{nullptr};
+    QLineEdit* edtOutput_{nullptr};
+    QString defaultOutput_;
+};
+
+// Runs vc_straighten on a tifxyz surface (tifxyz -> tifxyz, no OBJ round-trip).
+// Exposes the four pipeline stages and the few parameters that matter; the
+// rest use the tool's CLI defaults.
+class StraightenDialog : public QDialog {
+    Q_OBJECT
+public:
+    StraightenDialog(QWidget* parent, const QString& defaultOutputPath);
+
+    QString outputPath() const;
+    // CLI args (without input/output) derived from the dialog state. Always
+    // emits an explicit --overlap-pairs so the tool never falls back to its
+    // implicit "no flags = full pipeline" default.
+    QStringList toArgs() const;
+
+private:
+    static bool s_haveSession;
+    static bool s_unbend;
+    static double s_unbendSmoothCols;
+    static int s_overlapPasses;
+    static bool s_orthogonalize;
+    static bool s_trim;
+    static double s_trimMaxEdge;
+
+    QCheckBox* cbUnbend_{nullptr};
+    QDoubleSpinBox* spUnbendSmooth_{nullptr};
+    QSpinBox* spOverlap_{nullptr};
+    QCheckBox* cbOrtho_{nullptr};
+    QCheckBox* cbTrim_{nullptr};
+    QDoubleSpinBox* spTrimMaxEdge_{nullptr};
     QLineEdit* edtOutput_{nullptr};
     QString defaultOutput_;
 };

--- a/volume-cartographer/apps/src/vc_merge_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_merge_tifxyz.cpp
@@ -362,6 +362,26 @@ struct GMConfig {
     double   ransac_max_thresh{10.0};
     double   ransac_mad_k{3.0};
     uint32_t ransac_seed{0};
+    // Self-calibrating RANSAC gates (default on). A first ungated fit of
+    // every edge yields a per-merge consensus: the median pair-scale and the
+    // median centroid shift across edges. Edges whose ungated model is an
+    // outlier vs that consensus are re-fit under consensus-relative gates.
+    // This rejects two pathologies seen with fused windings — degenerate
+    // near-identity "stacked" placements (shift << consensus) and wild-scale
+    // "diagonal" models (scale far from consensus) — without baking in a
+    // wrap-width or scale constant. It auto-disables for co-located patch
+    // merges, where the consensus shift is itself ~0.
+    bool     ransac_autogate{true};
+    double   ransac_autogate_scale_k{1.8};    // accept scale in
+                                              // [consensus/k, consensus*k]
+    double   ransac_autogate_shift_frac{0.35};// min shift = frac * consensus
+    // Manual gate overrides (cells / unitless scale). Each, when > 0, pins the
+    // corresponding bound and takes precedence over the consensus value. With
+    // autogate off, these are applied directly in a single fit (the prior
+    // behavior). 0 = derive from consensus (autogate on) or disable (off).
+    double   ransac_min_shift{0.0};
+    double   ransac_scale_min{0.0};
+    double   ransac_scale_max{0.0};
     // Per-surface RBF anchor count cap. 0 = no cap (current behavior). When
     // set, surfaces whose union-of-incident-edge anchor count exceeds the cap
     // are spatially decimated by keeping one original anchor per coarse cell
@@ -658,7 +678,9 @@ struct GMRansac {
 GMRansac gmRansacSimilarity(const std::vector<cv::Vec2d>& src,
                             const std::vector<cv::Vec2d>& dst,
                             int iters, double min_t, double max_t,
-                            double mad_k, uint32_t seed)
+                            double mad_k, uint32_t seed,
+                            double min_shift = 0.0,
+                            double scale_min = 0.0, double scale_max = 0.0)
 {
     const int N = (int)src.size();
     GMRansac R; R.inlier.assign(N, 1);
@@ -676,6 +698,10 @@ GMRansac gmRansacSimilarity(const std::vector<cv::Vec2d>& src,
     double mad = gmMedianInPlace(dev) * 1.4826;
     double thresh = std::min(max_t, std::max(min_t, mad_k * mad));
 
+    cv::Vec2d centroid(0, 0);
+    for (int i = 0; i < N; ++i) centroid += src[i];
+    centroid *= 1.0 / N;
+
     std::mt19937 rng(seed);
     std::uniform_int_distribution<int> uni(0, N - 1);
     int best_cnt = -1;
@@ -689,6 +715,14 @@ GMRansac gmRansacSimilarity(const std::vector<cv::Vec2d>& src,
         d2[0] = dst[i]; d2[1] = dst[j];
         cv::Matx23d Mh;
         try { Mh = gmFitSimilarity(s2, d2); } catch (...) { continue; }
+        if (min_shift > 0.0 &&
+            cv::norm(gmApplyAffine(Mh, centroid) - centroid) < min_shift)
+            continue;  // degenerate near-identity (stacked) placement
+        if (scale_max > 0.0) {
+            const double sh = gmSimilarityScale(Mh);
+            if (sh < scale_min || sh > scale_max)
+                continue;  // wild-scale diagonal model
+        }
         int cnt = 0;
         std::vector<uint8_t> inl(N, 0);
         for (int k = 0; k < N; ++k) {
@@ -726,13 +760,29 @@ GMRansac gmRansacSimilarity(const std::vector<cv::Vec2d>& src,
 
 struct GMEdgeRun {
     std::string a, b;
-    std::vector<cv::Vec2d> pA, pB;
+    std::vector<cv::Vec2d> pA, pB;          // RANSAC inliers (consumed downstream)
+    std::vector<cv::Vec2d> pA_all, pB_all;  // full anchor set (transient; kept
+                                            // only until the auto-gate re-fit,
+                                            // then cleared to free memory)
     cv::Matx23d M_pair;
     double sigma_in{1.0};
     double thresh{0.0};
     int n_in{0}, n_total{0};
     int real_overlap_a{-1}, real_overlap_b{-1};
 };
+
+// Centroid shift (cells) a pair model implies on its own anchor set: the mean
+// |M*p - p| over the source anchors. ~0 for a stacked/co-located placement,
+// ~one wrap width for a true winding-advance seam.
+inline double gmCentroidShift(const cv::Matx23d& M,
+                              const std::vector<cv::Vec2d>& src)
+{
+    if (src.empty()) return 0.0;
+    cv::Vec2d c(0, 0);
+    for (const auto& p : src) c += p;
+    c *= 1.0 / src.size();
+    return cv::norm(gmApplyAffine(M, c) - c);
+}
 
 // Joint per-surface AFFINE bundle adjustment: 6 dof per surface (m00, m01, t0,
 // m10, m11, t1), ref pinned to identity. Each anchor pair on edge (a, b)
@@ -1741,10 +1791,21 @@ GMAlignState gmAlignAll(const fs::path& merge_path, GMConfig cfg)
 
     std::cout << "[2/6] per-edge overlap+anchors+RANSAC similarity\n";
     std::vector<GMEdgeRun> edge_runs;
+    std::vector<json> edge_json_pre;   // parallel to edge_runs; finalized below
     edge_runs.reserve(st.cfg.edges.size());
+    edge_json_pre.reserve(st.cfg.edges.size());
     for (const auto& n : st.names)
         st.real_overlap_native[n] = Mat1b::zeros(st.surfs.at(n).H, st.surfs.at(n).W);
     std::vector<GMEdgeSpec> dropped_edges;
+
+    // With autogate on (default), the first per-edge fit is ungated; the
+    // consensus pass below derives gates and re-fits outliers. With autogate
+    // off, the manual gate values are applied directly here (prior behavior).
+    const bool autogate = st.cfg.ransac_autogate;
+    const double fit_min_shift = autogate ? 0.0 : st.cfg.ransac_min_shift;
+    const double fit_scale_min = autogate ? 0.0 : st.cfg.ransac_scale_min;
+    const double fit_scale_max = autogate ? 0.0 : st.cfg.ransac_scale_max;
+
     for (const auto& e : st.cfg.edges) {
         if (!st.surfs.count(e.a) || !st.surfs.count(e.b))
             throw std::runtime_error("global mode: unknown surface in edge "
@@ -1766,7 +1827,8 @@ GMAlignState gmAlignAll(const fs::path& merge_path, GMConfig cfg)
 
             GMRansac R = gmRansacSimilarity(pA, pB,
                 st.cfg.ransac_iters, st.cfg.ransac_min_thresh, st.cfg.ransac_max_thresh,
-                st.cfg.ransac_mad_k, st.cfg.ransac_seed);
+                st.cfg.ransac_mad_k, st.cfg.ransac_seed,
+                fit_min_shift, fit_scale_min, fit_scale_max);
 
             GMEdgeRun er;
             er.a = e.a; er.b = e.b;
@@ -1775,8 +1837,12 @@ GMAlignState gmAlignAll(const fs::path& merge_path, GMConfig cfg)
             er.pA.reserve(R.n_in); er.pB.reserve(R.n_in);
             for (size_t i = 0; i < pA.size(); ++i)
                 if (R.inlier[i]) { er.pA.push_back(pA[i]); er.pB.push_back(pB[i]); }
+            // Keep the full anchor set for a possible consensus re-fit (the
+            // inliers above are biased toward whichever population won this
+            // ungated fit, so a re-fit must start from all anchors).
+            if (autogate) { er.pA_all = std::move(pA); er.pB_all = std::move(pB); }
 
-            // Accumulate real-overlap masks per surface.
+            // Accumulate real-overlap masks per surface (independent of fit).
             if (!pr.realA.empty() && pr.realA.size() == st.real_overlap_native[e.a].size()) {
                 int oA = 0;
                 Mat1b& dst = st.real_overlap_native[e.a];
@@ -1794,25 +1860,7 @@ GMAlignState gmAlignAll(const fs::path& merge_path, GMConfig cfg)
                 er.real_overlap_b = oB;
             }
 
-            const double pair_sc = gmSimilarityScale(er.M_pair);
-            std::cout << "    inliers=" << er.n_in << "/" << er.n_total
-                      << "  (thresh=" << std::fixed << std::setprecision(2) << er.thresh
-                      << ")  pair scale=" << std::fixed << std::setprecision(4) << pair_sc
-                      << "  sigma_in=" << std::fixed << std::setprecision(2) << er.sigma_in
-                      << "  real-overlap A=" << er.real_overlap_a
-                      << " B=" << er.real_overlap_b << "\n";
-            std::cout.unsetf(std::ios::fixed);
-            st.total_inliers += er.n_in;
-
-            json ej = pr.edge_json;
-            ej["ransac_inliers"] = er.n_in;
-            ej["ransac_total"]   = er.n_total;
-            ej["ransac_thresh"]  = er.thresh;
-            ej["ransac_sigma_in"]= er.sigma_in;
-            ej["pair_scale"]     = pair_sc;
-            ej["real_overlap_A"] = er.real_overlap_a;
-            ej["real_overlap_B"] = er.real_overlap_b;
-            st.edges_json.push_back(std::move(ej));
+            edge_json_pre.push_back(std::move(pr.edge_json));
             edge_runs.push_back(std::move(er));
         } catch (const std::exception& ex) {
             std::cout << "    WARN: " << ex.what() << " — dropping edge\n";
@@ -1828,6 +1876,96 @@ GMAlignState gmAlignAll(const fs::path& merge_path, GMConfig cfg)
         kept.reserve(edge_runs.size());
         for (const auto& er : edge_runs) kept.push_back({er.a, er.b});
         gmCheckConnected(st.cfg.surfaces, kept);
+    }
+
+    // [2.5] Self-calibrating gate: derive per-merge consensus from the ungated
+    // fits and re-fit the edges that contradict it. The median is robust to a
+    // minority of bad (stacked / wild) edges, and collapses the gate to a
+    // no-op when the merge genuinely has no advance (co-located patches).
+    if (autogate && !edge_runs.empty()) {
+        std::vector<double> scales, shifts;
+        scales.reserve(edge_runs.size());
+        shifts.reserve(edge_runs.size());
+        for (const auto& er : edge_runs) {
+            scales.push_back(gmSimilarityScale(er.M_pair));
+            shifts.push_back(gmCentroidShift(er.M_pair, er.pA_all));
+        }
+        std::vector<double> sc_s = scales, sh_s = shifts;
+        const double cons_scale = gmMedianInPlace(sc_s);
+        const double cons_shift = gmMedianInPlace(sh_s);
+        const double K = std::max(st.cfg.ransac_autogate_scale_k, 1.0001);
+        const double scale_lo = (st.cfg.ransac_scale_min > 0.0)
+            ? st.cfg.ransac_scale_min : cons_scale / K;
+        const double scale_hi = (st.cfg.ransac_scale_max > 0.0)
+            ? st.cfg.ransac_scale_max : cons_scale * K;
+        const double min_shift = (st.cfg.ransac_min_shift > 0.0)
+            ? st.cfg.ransac_min_shift
+            : cons_shift * st.cfg.ransac_autogate_shift_frac;
+        std::cout << "  auto-gate: consensus scale=" << std::fixed
+                  << std::setprecision(4) << cons_scale
+                  << " shift=" << std::setprecision(1) << cons_shift
+                  << " cells -> accept scale in [" << std::setprecision(3)
+                  << scale_lo << ", " << scale_hi << "], min_shift="
+                  << std::setprecision(1) << min_shift << " cells\n";
+        std::cout.unsetf(std::ios::fixed);
+        for (size_t k = 0; k < edge_runs.size(); ++k) {
+            GMEdgeRun& er = edge_runs[k];
+            const bool bad_scale = scales[k] < scale_lo || scales[k] > scale_hi;
+            const bool bad_shift = (min_shift > 0.0) && (shifts[k] < min_shift);
+            if (!bad_scale && !bad_shift) continue;
+            GMRansac R2 = gmRansacSimilarity(er.pA_all, er.pB_all,
+                st.cfg.ransac_iters, st.cfg.ransac_min_thresh,
+                st.cfg.ransac_max_thresh, st.cfg.ransac_mad_k, st.cfg.ransac_seed,
+                min_shift, scale_lo, scale_hi);
+            std::cout << "    re-fit " << er.a << "<->" << er.b << " (scale "
+                      << std::fixed << std::setprecision(3) << scales[k]
+                      << ", shift " << std::setprecision(1) << shifts[k] << " -> ";
+            if (R2.n_in > 0) {
+                er.M_pair = R2.M; er.sigma_in = R2.sigma_in; er.thresh = R2.thresh;
+                er.n_in = R2.n_in;
+                er.pA.clear(); er.pB.clear();
+                er.pA.reserve(R2.n_in); er.pB.reserve(R2.n_in);
+                for (size_t i = 0; i < er.pA_all.size(); ++i)
+                    if (R2.inlier[i]) { er.pA.push_back(er.pA_all[i]);
+                                        er.pB.push_back(er.pB_all[i]); }
+                std::cout << "scale " << std::setprecision(3)
+                          << gmSimilarityScale(er.M_pair) << ", shift "
+                          << std::setprecision(1)
+                          << gmCentroidShift(er.M_pair, er.pA_all)
+                          << ", inliers " << er.n_in << "/" << er.n_total << ")\n";
+            } else {
+                std::cout << "no hypothesis passed the gate; keeping original)\n";
+            }
+            std::cout.unsetf(std::ios::fixed);
+        }
+    }
+
+    // [2.6] Finalize: free the transient anchor sets, tally inliers, print the
+    // per-edge summary (reflecting any re-fit), and emit edge JSON.
+    for (size_t k = 0; k < edge_runs.size(); ++k) {
+        GMEdgeRun& er = edge_runs[k];
+        er.pA_all.clear(); er.pA_all.shrink_to_fit();
+        er.pB_all.clear(); er.pB_all.shrink_to_fit();
+        const double pair_sc = gmSimilarityScale(er.M_pair);
+        std::cout << "    " << er.a << "<->" << er.b
+                  << ": inliers=" << er.n_in << "/" << er.n_total
+                  << "  (thresh=" << std::fixed << std::setprecision(2) << er.thresh
+                  << ")  pair scale=" << std::setprecision(4) << pair_sc
+                  << "  sigma_in=" << std::setprecision(2) << er.sigma_in
+                  << "  real-overlap A=" << er.real_overlap_a
+                  << " B=" << er.real_overlap_b << "\n";
+        std::cout.unsetf(std::ios::fixed);
+        st.total_inliers += er.n_in;
+
+        json ej = std::move(edge_json_pre[k]);
+        ej["ransac_inliers"] = er.n_in;
+        ej["ransac_total"]   = er.n_total;
+        ej["ransac_thresh"]  = er.thresh;
+        ej["ransac_sigma_in"]= er.sigma_in;
+        ej["pair_scale"]     = pair_sc;
+        ej["real_overlap_A"] = er.real_overlap_a;
+        ej["real_overlap_B"] = er.real_overlap_b;
+        st.edges_json.push_back(std::move(ej));
     }
 
     std::cout << "[3/6] joint affine fit (ref=" << st.ref
@@ -2097,6 +2235,12 @@ int gmBlendAndRasterize(GMAlignState& st, const fs::path& obj2tifxyz,
             {"ransac_max_thresh", cfg.ransac_max_thresh},
             {"ransac_mad_k", cfg.ransac_mad_k},
             {"ransac_seed", cfg.ransac_seed},
+            {"ransac_autogate", cfg.ransac_autogate},
+            {"ransac_autogate_scale_k", cfg.ransac_autogate_scale_k},
+            {"ransac_autogate_shift_frac", cfg.ransac_autogate_shift_frac},
+            {"ransac_min_shift", cfg.ransac_min_shift},
+            {"ransac_scale_min", cfg.ransac_scale_min},
+            {"ransac_scale_max", cfg.ransac_scale_max},
             {"idw_k", kIdwK},
             {"step_size", kStepSize},
             {"anchor_bin_size", kAnchorBinSize},
@@ -2210,6 +2354,34 @@ int main(int argc, char** argv)
          "Per-edge RANSAC MAD multiplier (clamped to [min, max] threshold).")
         ("ransac-seed", po::value<uint32_t>()->default_value(defaults.ransac_seed),
          "Per-edge RANSAC RNG seed (0 = nondeterministic).")
+        ("ransac-autogate", po::value<bool>()->default_value(defaults.ransac_autogate),
+         "Self-calibrating RANSAC gates (default on). Fits every edge ungated, "
+         "takes the median pair-scale and median centroid-shift across edges "
+         "as the per-merge consensus, then re-fits only the edges that "
+         "contradict it (stacked windings, wild-scale models). Adapts to wrap "
+         "width and cross-resolution merges, and disables itself for "
+         "co-located patch merges (consensus shift ~0). Pass "
+         "--ransac-autogate=false for the prior fixed-gate behavior.")
+        ("ransac-autogate-scale-k", po::value<double>()->default_value(defaults.ransac_autogate_scale_k),
+         "Auto-gate scale tolerance: accept hypotheses with scale in "
+         "[consensus/k, consensus*k]. Default 1.8.")
+        ("ransac-autogate-shift-frac", po::value<double>()->default_value(defaults.ransac_autogate_shift_frac),
+         "Auto-gate minimum shift as a fraction of the consensus shift. "
+         "Default 0.35.")
+        ("ransac-min-shift", po::value<double>()->default_value(defaults.ransac_min_shift),
+         "Manual override: reject RANSAC hypotheses whose A->B centroid shift "
+         "is below this many cells. >0 pins the auto-gate minimum shift; with "
+         "--ransac-autogate=false it is applied directly. 0 = derive from "
+         "consensus (default).")
+        ("ransac-scale-min", po::value<double>()->default_value(defaults.ransac_scale_min),
+         "Manual override: lower bound on hypothesis similarity scale. >0 "
+         "pins the auto-gate lower scale bound. 0 = derive from consensus "
+         "(default).")
+        ("ransac-scale-max", po::value<double>()->default_value(defaults.ransac_scale_max),
+         "Manual override: upper bound on hypothesis similarity scale. >0 "
+         "pins the auto-gate upper scale bound. With --ransac-autogate=false, "
+         "the manual scale gate is active only when this is >0. 0 = derive "
+         "from consensus (default).")
         ("anchor-cap", po::value<int>()->default_value(defaults.anchor_cap),
          "Per-surface RBF anchor count cap. If >0 and a surface's union of "
          "incident-edge anchors exceeds this count, spatially decimate them by "
@@ -2251,6 +2423,12 @@ int main(int argc, char** argv)
     cfg.ransac_max_thresh     = vm["ransac-max-thresh"].as<double>();
     cfg.ransac_mad_k          = vm["ransac-mad-k"].as<double>();
     cfg.ransac_seed           = vm["ransac-seed"].as<uint32_t>();
+    cfg.ransac_autogate       = vm["ransac-autogate"].as<bool>();
+    cfg.ransac_autogate_scale_k    = vm["ransac-autogate-scale-k"].as<double>();
+    cfg.ransac_autogate_shift_frac = vm["ransac-autogate-shift-frac"].as<double>();
+    cfg.ransac_min_shift      = vm["ransac-min-shift"].as<double>();
+    cfg.ransac_scale_min      = vm["ransac-scale-min"].as<double>();
+    cfg.ransac_scale_max      = vm["ransac-scale-max"].as<double>();
     cfg.anchor_cap            = vm["anchor-cap"].as<int>();
     {
         const std::string pd = vm["paths-dir"].as<std::string>();

--- a/volume-cartographer/apps/src/vc_merge_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_merge_tifxyz.cpp
@@ -731,6 +731,22 @@ GMRansac gmRansacSimilarity(const std::vector<cv::Vec2d>& src,
         }
         if (cnt > best_cnt) { best_cnt = cnt; best_inl.swap(inl); }
     }
+    // If the shift/scale gate rejected every sampled hypothesis, best_cnt is
+    // still -1. Do NOT fall through to the gather/identity refit below: fitting
+    // the empty inlier set yields identity and then re-selects inliers by
+    // distance alone, silently re-admitting the very near-identity/contact
+    // model the gate was meant to reject. Report no inliers instead, so the
+    // caller keeps the prior model (auto-gate re-fit) or drops the edge. For
+    // ungated calls the gate-continue never fires, so best_cnt >= 0 and this
+    // guard is a no-op.
+    if (best_cnt < 0) {
+        R.M = cv::Matx23d::eye();
+        std::fill(R.inlier.begin(), R.inlier.end(), (uint8_t)0);
+        R.thresh = thresh;
+        R.sigma_in = 1.0;
+        R.n_in = 0;
+        return R;
+    }
     auto gather = [&](std::vector<cv::Vec2d>& sv, std::vector<cv::Vec2d>& dv){
         sv.clear(); dv.clear();
         for (int k = 0; k < N; ++k) if (best_inl[k]) { sv.push_back(src[k]); dv.push_back(dst[k]); }

--- a/volume-cartographer/apps/src/vc_straighten.cpp
+++ b/volume-cartographer/apps/src/vc_straighten.cpp
@@ -1,0 +1,814 @@
+// vc_straighten.cpp
+//
+// Unified tifxyz straightening pipeline. Ports four Python prototypes
+// (straighten_unbend_band, straighten_overlap_pairs,
+// straighten_orthogonalize_columns, trim_stretch_outliers) into one binary
+// with shared load / resample / save infrastructure.
+//
+// Stages, in pipeline order:
+//   unbend        gentle global bend removal: fit a smooth spine through the
+//                 band and re-coordinate into (arc-length, normal-offset). A
+//                 local rotation, so it does not shear; run before the others
+//                 when the band curves in UV.
+//   overlap-pairs cross-wrap row alignment: pair each grid point with the
+//                 nearest 3D point one winding over (its self-overlap), then
+//                 warp v so paired points share a row. May be repeated.
+//   orthogonalize remove residual column shear measured from the surface
+//                 tangents (tau = e_v . e_u / |e_u|^2) via a u-warp.
+//   trim          invalidate "bridge" cells whose 3D step to a grid neighbor
+//                 is absurd (they wreck area-weighted distortion metrics).
+//
+// Default pipeline (no stage flags): unbend, overlap-pairs x2, orthogonalize,
+// trim. Each warp uses a monotone (fold-over-proof) inverse and validity-aware
+// bilinear resampling, matching the Python reference.
+
+#include "vc/core/util/QuadSurface.hpp"
+#include "vc/core/util/Tiff.hpp"
+#include "utils/Json.hpp"
+
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/flann.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace po = boost::program_options;
+namespace fs = std::filesystem;
+using utils::Json;
+
+// ---------------------------------------------------------------------------
+// Grid: a tifxyz surface in memory.
+// ---------------------------------------------------------------------------
+struct Grid {
+    cv::Mat_<cv::Vec3f>  P;       // H x W world points; invalid = (-1,-1,-1)
+    cv::Mat_<uint8_t>    valid;   // H x W; 1 = valid
+    cv::Vec2f            scale{0.05f, 0.05f};
+    int H() const { return P.rows; }
+    int W() const { return P.cols; }
+    long nvalid() const { return cv::countNonZero(valid); }
+};
+
+static bool isInvalid(const cv::Vec3f& p) {
+    return p[0] == -1.0f && p[1] == -1.0f && p[2] == -1.0f;
+}
+
+static Grid loadGrid(const fs::path& dir)
+{
+    auto surf = load_quad_from_tifxyz(dir.string());
+    Grid g;
+    g.P = surf->rawPointsPtr()->clone();
+    g.scale = surf->scale();
+    const int H = g.P.rows, W = g.P.cols;
+    g.valid = cv::Mat_<uint8_t>::zeros(H, W);
+    for (int r = 0; r < H; ++r)
+        for (int c = 0; c < W; ++c)
+            if (!isInvalid(g.P(r, c))) g.valid(r, c) = 1;
+
+    // Honor an explicit mask.tif the same way the Python loader does.
+    const fs::path mp = dir / "mask.tif";
+    if (fs::exists(mp)) {
+        std::vector<cv::Mat> layers;
+        cv::imreadmulti(mp.string(), layers, cv::IMREAD_UNCHANGED);
+        if (!layers.empty() && !layers[0].empty()
+            && layers[0].rows == H && layers[0].cols == W) {
+            cv::Mat m = layers[0];
+            if (m.channels() > 1) { std::vector<cv::Mat> ch; cv::split(m, ch); m = ch[0]; }
+            cv::Mat m8; m.convertTo(m8, CV_8U);
+            for (int r = 0; r < H; ++r)
+                for (int c = 0; c < W; ++c)
+                    if (m8.at<uint8_t>(r, c) < 255) g.valid(r, c) = 0;
+        }
+    }
+    return g;
+}
+
+static void saveGrid(const Grid& g, const fs::path& outdir, const fs::path& srcdir)
+{
+    if (fs::exists(outdir))
+        throw std::runtime_error("output exists: " + outdir.string());
+    fs::create_directories(outdir);
+
+    cv::Mat_<cv::Vec3f> P = g.P.clone();
+    for (int r = 0; r < g.H(); ++r)
+        for (int c = 0; c < g.W(); ++c)
+            if (!g.valid(r, c)) P(r, c) = cv::Vec3f(-1, -1, -1);
+
+    std::vector<cv::Mat> xyz;
+    cv::split(P, xyz);
+    writeTiff(outdir / "x.tif", xyz[0], -1, 0, 0, -1.0f, COMPRESSION_ADOBE_DEFLATE);
+    writeTiff(outdir / "y.tif", xyz[1], -1, 0, 0, -1.0f, COMPRESSION_ADOBE_DEFLATE);
+    writeTiff(outdir / "z.tif", xyz[2], -1, 0, 0, -1.0f, COMPRESSION_ADOBE_DEFLATE);
+    cv::Mat mask(g.H(), g.W(), CV_8U);
+    for (int r = 0; r < g.H(); ++r)
+        for (int c = 0; c < g.W(); ++c)
+            mask.at<uint8_t>(r, c) = g.valid(r, c) ? 255 : 0;
+    writeTiff(outdir / "mask.tif", mask, -1, 0, 0, 0.0f, COMPRESSION_ADOBE_DEFLATE);
+
+    Json meta;
+    const fs::path sm = srcdir / "meta.json";
+    if (fs::exists(sm)) meta = Json::parse_file(sm.string());
+    meta["uuid"] = outdir.filename().string();
+    meta["format"] = "tifxyz";
+    meta["type"] = "seg";
+    if (!meta.contains("scale")) {           // preserve the input's scale array
+        Json arr = Json::array();            // (resampling does not change it)
+        Json a; a = (double)g.scale[0]; arr.push_back(a);
+        Json b; b = (double)g.scale[1]; arr.push_back(b);
+        meta["scale"] = arr;
+    }
+    meta.erase("bbox");
+    std::ofstream out(outdir / "meta.json");
+    out << meta.dump();
+}
+
+// ---------------------------------------------------------------------------
+// Small numeric helpers (numpy/scipy equivalents).
+// ---------------------------------------------------------------------------
+
+// np.interp: piecewise-linear with endpoint clamping; xp strictly ascending.
+static double interp1(const std::vector<double>& xp, const std::vector<double>& fp,
+                      double x)
+{
+    const size_t n = xp.size();
+    if (n == 0) return 0.0;
+    if (x <= xp[0]) return fp[0];
+    if (x >= xp[n - 1]) return fp[n - 1];
+    size_t lo = 0, hi = n - 1;
+    while (hi - lo > 1) { size_t m = (lo + hi) / 2; if (xp[m] <= x) lo = m; else hi = m; }
+    const double t = (x - xp[lo]) / (xp[hi] - xp[lo]);
+    return fp[lo] + t * (fp[hi] - fp[lo]);
+}
+
+// percentile p in [0,100] over a copy of v (numpy 'linear' interpolation).
+static double percentile(std::vector<double> v, double p)
+{
+    if (v.empty()) return 0.0;
+    std::sort(v.begin(), v.end());
+    const double idx = (p / 100.0) * (v.size() - 1);
+    const size_t lo = (size_t)std::floor(idx);
+    const size_t hi = std::min(lo + 1, v.size() - 1);
+    return v[lo] + (idx - lo) * (v[hi] - v[lo]);
+}
+
+// 1-D Gaussian smoothing, BORDER_REPLICATE, truncate=4 (matches scipy
+// gaussian_filter1d mode='nearest').
+static std::vector<double> gaussian1d(const std::vector<double>& a, double sigma)
+{
+    const int n = (int)a.size();
+    if (sigma <= 0 || n == 0) return a;
+    const int rad = (int)std::ceil(4.0 * sigma);
+    std::vector<double> k(2 * rad + 1);
+    double ksum = 0.0;
+    for (int i = -rad; i <= rad; ++i) {
+        k[i + rad] = std::exp(-0.5 * (i * i) / (sigma * sigma));
+        ksum += k[i + rad];
+    }
+    for (double& w : k) w /= ksum;
+    std::vector<double> out(n, 0.0);
+    for (int i = 0; i < n; ++i) {
+        double s = 0.0;
+        for (int j = -rad; j <= rad; ++j) {
+            int idx = i + j;
+            if (idx < 0) idx = 0; else if (idx >= n) idx = n - 1;  // replicate
+            s += k[j + rad] * a[idx];
+        }
+        out[i] = s;
+    }
+    return out;
+}
+
+// np.gradient(A, h, axis): central differences interior, one-sided at edges.
+static cv::Mat_<double> gradientAxis(const cv::Mat_<double>& A, double h, int axis)
+{
+    cv::Mat_<double> G(A.rows, A.cols, 0.0);
+    if (axis == 0) {
+        for (int c = 0; c < A.cols; ++c)
+            for (int r = 0; r < A.rows; ++r) {
+                if (A.rows == 1) { G(r, c) = 0; continue; }
+                if (r == 0)            G(r, c) = (A(1, c) - A(0, c)) / h;
+                else if (r == A.rows-1)G(r, c) = (A(r, c) - A(r-1, c)) / h;
+                else                   G(r, c) = (A(r+1, c) - A(r-1, c)) / (2*h);
+            }
+    } else {
+        for (int r = 0; r < A.rows; ++r)
+            for (int c = 0; c < A.cols; ++c) {
+                if (A.cols == 1) { G(r, c) = 0; continue; }
+                if (c == 0)            G(r, c) = (A(r, 1) - A(r, 0)) / h;
+                else if (c == A.cols-1)G(r, c) = (A(r, c) - A(r, c-1)) / h;
+                else                   G(r, c) = (A(r, c+1) - A(r, c-1)) / (2*h);
+            }
+    }
+    return G;
+}
+
+// Bilinear sampler over a coarse field at bin centers ((i+0.5)*bin), with
+// linear extrapolation past the edge centers (matches RegularGridInterpolator
+// method='linear', fill_value=None).
+struct CoarseField {
+    cv::Mat_<double> S;
+    double binv, binu;
+    double sample(double v, double u) const {
+        const int nbv = S.rows, nbu = S.cols;
+        double fi = v / binv - 0.5, fj = u / binu - 0.5;
+        int i0 = (nbv >= 2) ? std::clamp((int)std::floor(fi), 0, nbv - 2) : 0;
+        int j0 = (nbu >= 2) ? std::clamp((int)std::floor(fj), 0, nbu - 2) : 0;
+        double ti = (nbv >= 2) ? (fi - i0) : 0.0;
+        double tj = (nbu >= 2) ? (fj - j0) : 0.0;
+        int i1 = std::min(i0 + 1, nbv - 1), j1 = std::min(j0 + 1, nbu - 1);
+        double a = S(i0, j0) * (1 - tj) + S(i0, j1) * tj;
+        double b = S(i1, j0) * (1 - tj) + S(i1, j1) * tj;
+        return a * (1 - ti) + b * ti;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Validity-aware resampling + the shared shift-field machinery.
+//
+// Both warp stages reduce to the same operation, one the transpose of the
+// other: bin a per-cell field, fill+smooth it, integrate into a cumulative
+// row shift S(v,u), gauge-fix it, then resample v per column. orthogonalize
+// reaches it by transposing its grid and (negated) field in and out, so this
+// code only ever has to handle the v-warp orientation.
+// ---------------------------------------------------------------------------
+
+// Per-column v-warp: each (r,c) maps to source row fwd(r,c). Builds the
+// monotone (fold-over-proof) inverse per column and blends with the
+// both/only0/only1 rule.
+static Grid resampleRows(const Grid& g, const cv::Mat_<double>& fwd)
+{
+    const int H = g.H(), W = g.W();
+    double fmin = 1e300, fmax = -1e300;
+    for (int r = 0; r < H; ++r)
+        for (int c = 0; c < W; ++c)
+            if (g.valid(r, c)) { fmin = std::min(fmin, fwd(r, c)); fmax = std::max(fmax, fwd(r, c)); }
+    const double offset = -fmin;
+    const int nOut = (int)std::ceil(fmax + offset) + 1;
+
+    Grid o;
+    o.scale = g.scale;
+    o.P = cv::Mat_<cv::Vec3f>(nOut, W, cv::Vec3f(-1, -1, -1));
+    o.valid = cv::Mat_<uint8_t>::zeros(nOut, W);
+
+    long dropped = 0;
+    for (int c = 0; c < W; ++c) {
+        std::vector<double> fk, vk;
+        double run = -1e300;
+        for (int r = 0; r < H; ++r) {
+            const double f = fwd(r, c);
+            if (f >= run) {
+                if (fk.empty() || f - fk.back() > 1e-6) { fk.push_back(f); vk.push_back(r); }
+                run = f;
+            }
+        }
+        dropped += H - (long)fk.size();
+        if (fk.size() < 2) continue;
+        for (int o2 = 0; o2 < nOut; ++o2) {
+            const double tgt = o2 - offset;
+            if (tgt < fk.front() || tgt > fk.back()) continue;
+            const double sc = interp1(fk, vk, tgt);
+            if (sc < 0 || sc > H - 1) continue;
+            const int r0 = (int)std::floor(sc), r1 = std::min(r0 + 1, H - 1);
+            const float t = (float)(sc - r0);
+            const bool m0 = g.valid(r0, c), m1 = g.valid(r1, c);
+            if (!m0 && !m1) continue;
+            o.P(o2, c) = (m0 && m1) ? (1.0f - t) * g.P(r0, c) + t * g.P(r1, c)
+                       : (m0 ? g.P(r0, c) : g.P(r1, c));
+            o.valid(o2, c) = 1;
+        }
+    }
+    std::cout << "  monotone inverse: dropped " << dropped << " fold-over samples ("
+              << (100.0 * dropped / ((double)H * W)) << "%), output "
+              << nOut << "x" << W << " (offset " << offset << ")\n";
+    return o;
+}
+
+static Grid transposeGrid(const Grid& g)
+{
+    Grid t;
+    t.scale = cv::Vec2f(g.scale[1], g.scale[0]);
+    cv::transpose(g.P, t.P);
+    cv::transpose(g.valid, t.valid);
+    return t;
+}
+
+// Fill NaN bins (interp along u within each row, then column means for fully
+// empty rows, then 0) and Gaussian-smooth.
+static void fillAndSmoothCoarse(cv::Mat_<double>& rate, double smooth)
+{
+    const int nbv = rate.rows, nbu = rate.cols;
+    for (int i = 0; i < nbv; ++i) {
+        std::vector<double> gx, gy;
+        for (int j = 0; j < nbu; ++j) if (std::isfinite(rate(i, j))) { gx.push_back(j); gy.push_back(rate(i, j)); }
+        if (!gx.empty() && (int)gx.size() < nbu)
+            for (int j = 0; j < nbu; ++j) if (!std::isfinite(rate(i, j))) rate(i, j) = interp1(gx, gy, j);
+    }
+    std::vector<double> colMean(nbu, 0.0); std::vector<int> colCnt(nbu, 0);
+    for (int i = 0; i < nbv; ++i)
+        for (int j = 0; j < nbu; ++j)
+            if (std::isfinite(rate(i, j))) { colMean[j] += rate(i, j); colCnt[j]++; }
+    for (int j = 0; j < nbu; ++j) colMean[j] = colCnt[j] ? colMean[j] / colCnt[j] : 0.0;
+    for (int i = 0; i < nbv; ++i) {
+        bool anyFinite = false;
+        for (int j = 0; j < nbu; ++j) if (std::isfinite(rate(i, j))) { anyFinite = true; break; }
+        for (int j = 0; j < nbu; ++j)
+            if (!anyFinite) rate(i, j) = colMean[j];
+            else if (!std::isfinite(rate(i, j))) rate(i, j) = 0.0;
+    }
+    cv::GaussianBlur(rate, rate, cv::Size(0, 0), smooth, smooth, cv::BORDER_REPLICATE);
+}
+
+// Coarse per-bin count of valid full-res cells (gauge weights).
+static cv::Mat_<double> coarseValidCount(const Grid& g, int binU, int binV, int nbv, int nbu)
+{
+    cv::Mat_<double> w(nbv, nbu, 0.0);
+    for (int r = 0; r < g.H(); ++r)
+        for (int c = 0; c < g.W(); ++c)
+            if (g.valid(r, c)) w(std::min(r / binV, nbv - 1), std::min(c / binU, nbu - 1)) += 1.0;
+    return w;
+}
+
+// Fill+smooth a binned rate field, integrate along u into a cumulative shift
+// S(v,u), and apply the stretch-neutral gauge (zero the valid-weighted mean
+// dS/dv per row). Returns the gauge-fixed field, ready for sampling.
+static CoarseField buildShiftField(const Grid& g, cv::Mat_<double> rate,
+                                   int binU, int binV, double smooth)
+{
+    fillAndSmoothCoarse(rate, smooth);
+    const int nbv = rate.rows, nbu = rate.cols;
+    cv::Mat_<double> S(nbv, nbu, 0.0);
+    for (int i = 0; i < nbv; ++i) {
+        double acc = 0.0;
+        for (int j = 0; j < nbu; ++j) { acc += rate(i, j) * binU; S(i, j) = acc - 0.5 * rate(i, j) * binU; }
+    }
+    cv::Mat_<double> wValid = coarseValidCount(g, binU, binV, nbv, nbu);
+    cv::Mat_<double> dSdv = gradientAxis(S, binV, 0);
+    std::vector<double> gprime(nbv, 0.0);
+    std::vector<int> goodRows; std::vector<double> gv;
+    for (int i = 0; i < nbv; ++i) {
+        double num = 0, den = 0;
+        for (int j = 0; j < nbu; ++j) { num += dSdv(i, j) * wValid(i, j); den += wValid(i, j); }
+        if (den > 0) { gprime[i] = num / den; goodRows.push_back(i); gv.push_back(gprime[i]); }
+    }
+    std::vector<double> gxd(goodRows.begin(), goodRows.end());
+    for (int i = 0; i < nbv; ++i) {
+        bool isGood = false; for (int gr : goodRows) if (gr == i) { isGood = true; break; }
+        if (!isGood) gprime[i] = interp1(gxd, gv, i);
+    }
+    gprime = gaussian1d(gprime, 1.5);
+    double acc = 0.0;
+    for (int i = 0; i < nbv; ++i) { acc += gprime[i] * binV; for (int j = 0; j < nbu; ++j) S(i, j) -= acc; }
+    return CoarseField{S, (double)binV, (double)binU};
+}
+
+// Forward map v' = v - S(v,u) and resample.
+static Grid applyShiftWarp(const Grid& g, const CoarseField& field)
+{
+    cv::Mat_<double> fwd(g.H(), g.W());
+    for (int r = 0; r < g.H(); ++r)
+        for (int c = 0; c < g.W(); ++c)
+            fwd(r, c) = r - field.sample(r, c);
+    return resampleRows(g, fwd);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: unbend.
+// ---------------------------------------------------------------------------
+static Grid stageUnbend(const Grid& g, double smoothCols, int minValidRows)
+{
+    const int H = g.H(), W = g.W();
+    std::cout << "[unbend] input " << H << "x" << W << ", valid " << g.nvalid() << "\n";
+
+    // Spine: per-column median valid row, interpolated over empty columns.
+    std::vector<double> spine(W, std::nan("")), cols(W);
+    std::iota(cols.begin(), cols.end(), 0.0);
+    std::vector<int> good;
+    for (int c = 0; c < W; ++c) {
+        std::vector<int> rows;
+        for (int r = 0; r < H; ++r) if (g.valid(r, c)) rows.push_back(r);
+        if ((int)rows.size() >= minValidRows) {
+            std::nth_element(rows.begin(), rows.begin() + rows.size() / 2, rows.end());
+            spine[c] = rows[rows.size() / 2];
+            good.push_back(c);
+        }
+    }
+    if ((int)good.size() < W / 10)
+        throw std::runtime_error("unbend: too few populated columns for a spine");
+    std::vector<double> gx, gy;
+    for (int c : good) { gx.push_back(c); gy.push_back(spine[c]); }
+    for (int c = 0; c < W; ++c)
+        if (std::isnan(spine[c])) spine[c] = interp1(gx, gy, c);
+    spine = gaussian1d(spine, smoothCols);
+
+    // Tangent / normal / arc length along the spine.
+    std::vector<double> fp(W), ds(W), s(W), nx(W), ny(W);
+    for (int c = 0; c < W; ++c) {
+        if (W == 1) fp[c] = 0;
+        else if (c == 0)     fp[c] = spine[1] - spine[0];
+        else if (c == W - 1) fp[c] = spine[c] - spine[c - 1];
+        else                 fp[c] = 0.5 * (spine[c + 1] - spine[c - 1]);
+    }
+    for (int c = 0; c < W; ++c) {
+        ds[c] = std::sqrt(1.0 + fp[c] * fp[c]);
+        nx[c] = -fp[c] / ds[c];
+        ny[c] = 1.0 / ds[c];
+    }
+    s[0] = 0.0;
+    for (int c = 1; c < W; ++c) s[c] = s[c - 1] + 0.5 * (ds[c] + ds[c - 1]);
+
+    // t-range used by valid cells (small-angle normal offset estimate).
+    std::vector<double> tEst;
+    tEst.reserve(g.nvalid());
+    for (int r = 0; r < H; ++r)
+        for (int c = 0; c < W; ++c)
+            if (g.valid(r, c)) tEst.push_back((r - spine[c]) / ds[c]);
+    const double tLo = std::floor(percentile(tEst, 0.1)) - 10;
+    const double tHi = std::ceil(percentile(tEst, 99.9)) + 10;
+
+    const int Wout = (int)std::ceil(s[W - 1]) + 1;
+    const int Hout = (int)(tHi - tLo) + 1;
+    std::cout << "  spine arc length " << s[W - 1] << " cols, output "
+              << Hout << "x" << Wout << " (t in [" << tLo << ", " << tHi << "])\n";
+
+    // Per output column: source u(s), spine point, spine normal.
+    std::vector<double> uOfS(Wout), sp(Wout), nxs(Wout), nys(Wout);
+    for (int o = 0; o < Wout; ++o) {
+        uOfS[o] = interp1(s, cols, (double)o);
+        sp[o]  = interp1(cols, spine, uOfS[o]);
+        nxs[o] = interp1(cols, nx, uOfS[o]);
+        nys[o] = interp1(cols, ny, uOfS[o]);
+    }
+
+    Grid out;
+    out.scale = g.scale;
+    out.P = cv::Mat_<cv::Vec3f>(Hout, Wout, cv::Vec3f(-1, -1, -1));
+    out.valid = cv::Mat_<uint8_t>::zeros(Hout, Wout);
+    for (int oy = 0; oy < Hout; ++oy) {
+        const double tv = oy + tLo;
+        for (int ox = 0; ox < Wout; ++ox) {
+            const double srcC = uOfS[ox] + tv * nxs[ox];
+            const double srcR = sp[ox]   + tv * nys[ox];
+            if (srcR < 0 || srcR > H - 1 || srcC < 0 || srcC > W - 1) continue;
+            const int r0 = (int)std::floor(srcR), c0 = (int)std::floor(srcC);
+            const int r1 = std::min(r0 + 1, H - 1), c1 = std::min(c0 + 1, W - 1);
+            if (!g.valid(r0, c0) || !g.valid(r0, c1) ||
+                !g.valid(r1, c0) || !g.valid(r1, c1)) continue;  // fully-valid only
+            const float tr = (float)(srcR - r0), tc = (float)(srcC - c0);
+            const cv::Vec3f a = (1 - tc) * g.P(r0, c0) + tc * g.P(r0, c1);
+            const cv::Vec3f b = (1 - tc) * g.P(r1, c0) + tc * g.P(r1, c1);
+            out.P(oy, ox) = (1 - tr) * a + tr * b;
+            out.valid(oy, ox) = 1;
+        }
+    }
+    std::cout << "  valid " << out.nvalid() << "\n";
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Stage: overlap-pairs.
+// ---------------------------------------------------------------------------
+struct OverlapParams {
+    int    stride = 2;
+    double threshold = 0.0;     // 0 = auto
+    double thresholdFactor = 1.4;
+    int    minDu = 150;
+    int    maxDv = 300;
+    double maxSearch = 120.0;
+    int    k = 32;
+    int    binU = 64, binV = 64;
+    int    minCount = 3;
+    double smoothBins = 1.5;
+    double clipRhoPct = 1.0;
+    unsigned seed = 7;
+};
+
+// Returns the predicted post-warp mean|dv|; if applyWarp, *out holds the result.
+static double stageOverlapPairs(const Grid& g, const OverlapParams& pr,
+                                bool applyWarp, Grid* out)
+{
+    const int H = g.H(), W = g.W();
+    std::cout << "[overlap-pairs] input " << H << "x" << W
+              << ", valid " << g.nvalid() << "\n";
+
+    // Subsample valid cells into a point cloud.
+    std::vector<float> feat;   // N x 3
+    std::vector<double> us, vs;
+    for (int r = 0; r < H; r += pr.stride)
+        for (int c = 0; c < W; c += pr.stride)
+            if (g.valid(r, c)) {
+                const cv::Vec3f& p = g.P(r, c);
+                feat.push_back(p[0]); feat.push_back(p[1]); feat.push_back(p[2]);
+                us.push_back(c); vs.push_back(r);
+            }
+    const int N = (int)us.size();
+    std::cout << "  subsampled points (stride " << pr.stride << "): " << N << "\n";
+    if (N < 1000) throw std::runtime_error("overlap-pairs: too few valid points");
+    cv::Mat features(N, 3, CV_32F, feat.data());
+    cv::flann::Index tree(features, cv::flann::KDTreeIndexParams(4));
+
+    auto knn = [&](const cv::Mat& q, int k, cv::Mat& idx, cv::Mat& d2) {
+        tree.knnSearch(q, idx, d2, k, cv::flann::SearchParams(32));
+    };
+
+    // Spacing estimate: nearest cross-wrap (|du|>=minDu) neighbor distance.
+    {
+        std::mt19937 rng(pr.seed);
+        const int nSample = std::min(30000, N);
+        std::vector<int> sel(N); std::iota(sel.begin(), sel.end(), 0);
+        std::shuffle(sel.begin(), sel.end(), rng);
+        sel.resize(nSample);
+        cv::Mat q(nSample, 3, CV_32F);
+        for (int i = 0; i < nSample; ++i)
+            for (int j = 0; j < 3; ++j) q.at<float>(i, j) = feat[3 * sel[i] + j];
+        cv::Mat idx, d2; knn(q, 64, idx, d2);
+        std::vector<double> nd;
+        const double maxS2 = pr.maxSearch * pr.maxSearch;
+        for (int i = 0; i < nSample; ++i) {
+            double best = 1e300;
+            for (int kk = 0; kk < idx.cols; ++kk) {
+                const int j = idx.at<int>(i, kk);
+                if (j < 0 || j >= N) continue;
+                const double dd2 = d2.at<float>(i, kk);
+                if (dd2 > maxS2) continue;
+                if (std::abs(us[j] - us[sel[i]]) >= pr.minDu)
+                    best = std::min(best, std::sqrt(dd2));
+            }
+            if (best < 1e299) nd.push_back(best);
+        }
+        if (nd.size() < 100)
+            throw std::runtime_error("overlap-pairs: spacing estimate found too few cross-wrap neighbors");
+        const double med = percentile(nd, 50);
+        std::cout << "  cross-wrap nearest distance p25/p50/p75 = "
+                  << percentile(nd, 25) << "/" << med << "/" << percentile(nd, 75)
+                  << " voxels (" << (100.0 * nd.size() / nSample) << "% matched)\n";
+        const_cast<OverlapParams&>(pr).threshold =
+            (pr.threshold > 0) ? pr.threshold : pr.thresholdFactor * med;
+    }
+    const double threshold = pr.threshold;
+    const double thr2 = threshold * threshold;
+    std::cout << "  threshold: " << threshold << " voxels\n";
+
+    // Find one cross-wrap pair per point (nearest rightward neighbor).
+    std::vector<int> pi, pj;
+    {
+        const int chunk = 200000;
+        for (int lo = 0; lo < N; lo += chunk) {
+            const int hi = std::min(lo + chunk, N);
+            cv::Mat q(hi - lo, 3, CV_32F);
+            for (int i = lo; i < hi; ++i)
+                for (int j = 0; j < 3; ++j) q.at<float>(i - lo, j) = feat[3 * i + j];
+            cv::Mat idx, d2; knn(q, pr.k, idx, d2);
+            for (int i = lo; i < hi; ++i) {
+                int bestj = -1; double bestd = 1e300;
+                for (int kk = 0; kk < idx.cols; ++kk) {
+                    const int j = idx.at<int>(i - lo, kk);
+                    if (j < 0 || j >= N) continue;
+                    const double dd2 = d2.at<float>(i - lo, kk);
+                    if (dd2 > thr2) continue;
+                    if (us[j] - us[i] < pr.minDu) continue;
+                    if (std::abs(vs[j] - vs[i]) > pr.maxDv) continue;
+                    if (dd2 < bestd) { bestd = dd2; bestj = j; }
+                }
+                if (bestj >= 0) { pi.push_back(i); pj.push_back(bestj); }
+            }
+        }
+    }
+    const int np = (int)pi.size();
+    if (np < 1000) throw std::runtime_error("overlap-pairs: too few pairs");
+    {
+        std::vector<double> adv, advdu;
+        double sdv = 0;
+        for (int p = 0; p < np; ++p) {
+            double dv = vs[pj[p]] - vs[pi[p]];
+            adv.push_back(std::abs(dv)); sdv += dv;
+            advdu.push_back(us[pj[p]] - us[pi[p]]);
+        }
+        std::cout << "  pairs: " << np << "  wrap width p50=" << percentile(advdu, 50)
+                  << "  dv before: mean=" << sdv / np
+                  << " mean|dv|=" << std::accumulate(adv.begin(), adv.end(), 0.0) / np
+                  << " p95|dv|=" << percentile(adv, 95) << " rows\n";
+    }
+
+    // Rate field rho = dv/du binned at pair midpoints.
+    const int nbu = (int)std::ceil((double)W / pr.binU);
+    const int nbv = (int)std::ceil((double)H / pr.binV);
+    std::vector<double> rho(np), um(np), vm(np);
+    for (int p = 0; p < np; ++p) {
+        rho[p] = (vs[pj[p]] - vs[pi[p]]) / (us[pj[p]] - us[pi[p]]);
+        um[p] = 0.5 * (us[pi[p]] + us[pj[p]]);
+        vm[p] = 0.5 * (vs[pi[p]] + vs[pj[p]]);
+    }
+    const double clo = percentile(rho, pr.clipRhoPct), chi = percentile(rho, 100 - pr.clipRhoPct);
+    cv::Mat_<double> sum(nbv, nbu, 0.0), cnt(nbv, nbu, 0.0);
+    for (int p = 0; p < np; ++p) {
+        const double rc = std::clamp(rho[p], clo, chi);
+        const int bu = std::clamp((int)(um[p] / pr.binU), 0, nbu - 1);
+        const int bv = std::clamp((int)(vm[p] / pr.binV), 0, nbv - 1);
+        sum(bv, bu) += rc; cnt(bv, bu) += 1.0;
+    }
+    cv::Mat_<double> rate(nbv, nbu); rate.setTo(std::nan(""));
+    for (int i = 0; i < nbv; ++i)
+        for (int j = 0; j < nbu; ++j)
+            if (cnt(i, j) >= pr.minCount) rate(i, j) = sum(i, j) / cnt(i, j);
+
+    CoarseField field = buildShiftField(g, rate, pr.binU, pr.binV, pr.smoothBins);
+
+    // Predicted post-warp dv (validation).
+    {
+        double sdv = 0, sadv = 0; std::vector<double> adv;
+        for (int p = 0; p < np; ++p) {
+            const double s1 = field.sample(vs[pi[p]], us[pi[p]]);
+            const double s2 = field.sample(vs[pj[p]], us[pj[p]]);
+            const double d = (vs[pj[p]] - s2) - (vs[pi[p]] - s1);
+            sdv += d; sadv += std::abs(d); adv.push_back(std::abs(d));
+        }
+        std::cout << "  dv after (predicted): mean=" << sdv / np
+                  << " mean|dv|=" << sadv / np
+                  << " p95|dv|=" << percentile(adv, 95) << " rows\n";
+        if (!applyWarp) return sadv / np;
+    }
+
+    *out = applyShiftWarp(g, field);
+    std::cout << "  valid " << out->nvalid() << "\n";
+    return 0.0;
+}
+
+// ---------------------------------------------------------------------------
+// Stage: orthogonalize columns.
+// ---------------------------------------------------------------------------
+struct OrthoParams {
+    int binU = 64, binV = 64, minCount = 50;
+    double smoothBins = 1.5, clipTauPct = 1.0;
+};
+
+// tau = (e_v . e_u)/|e_u|^2 from central-difference tangents; NaN where unavailable.
+static cv::Mat_<double> measureSlant(const Grid& g)
+{
+    const int H = g.H(), W = g.W();
+    cv::Mat_<double> tau(H, W); tau.setTo(std::nan(""));
+    for (int r = 0; r < H; ++r)
+        for (int c = 1; c < W - 1; ++c) {
+            if (r < 1 || r > H - 2) continue;
+            if (!g.valid(r, c + 1) || !g.valid(r, c - 1) ||
+                !g.valid(r + 1, c) || !g.valid(r - 1, c)) continue;
+            const cv::Vec3f eu = 0.5f * (g.P(r, c + 1) - g.P(r, c - 1));
+            const cv::Vec3f ev = 0.5f * (g.P(r + 1, c) - g.P(r - 1, c));
+            const double nu2 = eu.dot(eu);
+            if (nu2 <= 0) continue;
+            tau(r, c) = eu.dot(ev) / nu2;
+        }
+    return tau;
+}
+
+static Grid stageOrthogonalize(const Grid& g, const OrthoParams& pr)
+{
+    const int H = g.H(), W = g.W();
+    std::cout << "[orthogonalize] input " << H << "x" << W << ", valid " << g.nvalid() << "\n";
+    cv::Mat_<double> tau = measureSlant(g);
+    std::vector<double> tv;
+    for (int r = 0; r < H; ++r) for (int c = 0; c < W; ++c) if (std::isfinite(tau(r, c))) tv.push_back(tau(r, c));
+    const double clo = percentile(tv, pr.clipTauPct), chi = percentile(tv, 100 - pr.clipTauPct);
+    {
+        std::vector<double> a; for (double v : tv) a.push_back(std::abs(std::clamp(v, clo, chi)));
+        std::cout << "  slant before: mean|tau|=" << std::accumulate(a.begin(), a.end(), 0.0) / std::max<size_t>(a.size(),1)
+                  << " p95=" << percentile(a, 95) << "\n";
+    }
+
+    const int nbu = (int)std::ceil((double)W / pr.binU);
+    const int nbv = (int)std::ceil((double)H / pr.binV);
+    cv::Mat_<double> sum(nbv, nbu, 0.0), cnt(nbv, nbu, 0.0);
+    for (int r = 0; r < H; ++r)
+        for (int c = 0; c < W; ++c)
+            if (std::isfinite(tau(r, c))) {
+                sum(std::min(r / pr.binV, nbv - 1), std::min(c / pr.binU, nbu - 1)) += std::clamp(tau(r, c), clo, chi);
+                cnt(std::min(r / pr.binV, nbv - 1), std::min(c / pr.binU, nbu - 1)) += 1.0;
+            }
+    cv::Mat_<double> fld(nbv, nbu); fld.setTo(std::nan(""));
+    for (int i = 0; i < nbv; ++i) for (int j = 0; j < nbu; ++j) if (cnt(i, j) >= pr.minCount) fld(i, j) = sum(i, j) / cnt(i, j);
+
+    // The column-shear u-warp is the transpose of the row-shift v-warp. Feed the
+    // transposed grid and the transposed, negated slant field through the shared
+    // shift machinery (negated so the shared v' = v - S yields u' = u + T), then
+    // transpose the result back. Bin sizes swap with the axes.
+    Grid gt = transposeGrid(g);
+    cv::Mat_<double> rt; cv::transpose(fld, rt); rt = -rt;
+    CoarseField field = buildShiftField(gt, rt, pr.binV, pr.binU, pr.smoothBins);
+    Grid out = transposeGrid(applyShiftWarp(gt, field));
+    out.scale = g.scale;
+
+    cv::Mat_<double> tau2 = measureSlant(out);
+    std::vector<double> a2;
+    for (int r = 0; r < out.H(); ++r) for (int c = 0; c < out.W(); ++c) if (std::isfinite(tau2(r, c))) a2.push_back(std::abs(tau2(r, c)));
+    std::cout << "  slant after: mean|tau|=" << std::accumulate(a2.begin(), a2.end(), 0.0) / std::max<size_t>(a2.size(),1)
+              << " p95=" << percentile(a2, 95) << "\n  valid " << out.nvalid() << "\n";
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Stage: trim bridge cells.
+// ---------------------------------------------------------------------------
+static void stageTrim(Grid& g, double maxEdge)
+{
+    const int H = g.H(), W = g.W();
+    cv::Mat_<uint8_t> bad = cv::Mat_<uint8_t>::zeros(H, W);
+    auto dist = [&](int r0, int c0, int r1, int c1) {
+        return cv::norm(g.P(r0, c0) - g.P(r1, c1));
+    };
+    for (int r = 0; r < H; ++r)
+        for (int c = 0; c < W; ++c) {
+            if (!g.valid(r, c)) continue;
+            if (c + 1 < W && g.valid(r, c + 1) && dist(r, c, r, c + 1) > maxEdge) { bad(r, c) = 1; bad(r, c + 1) = 1; }
+            if (r + 1 < H && g.valid(r + 1, c) && dist(r, c, r + 1, c) > maxEdge) { bad(r, c) = 1; bad(r + 1, c) = 1; }
+        }
+    long n = 0;
+    for (int r = 0; r < H; ++r)
+        for (int c = 0; c < W; ++c)
+            if (bad(r, c) && g.valid(r, c)) { g.valid(r, c) = 0; g.P(r, c) = cv::Vec3f(-1, -1, -1); ++n; }
+    std::cout << "[trim] removed " << n << " bridge cells (max-edge " << maxEdge
+              << "); valid " << g.nvalid() << "\n";
+}
+
+// ---------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+    std::string inPath, outPath;
+    OverlapParams op; OrthoParams qp;
+    double unbendSmooth = 300.0; int unbendMinRows = 30;
+    double trimMaxEdge = 100.0;
+    int overlapCount = -1;
+    bool doUnbend = false, doOrtho = false, doTrim = false, analyze = false;
+
+    po::options_description desc("vc_straighten: unified tifxyz straightening");
+    desc.add_options()
+        ("help,h", "show help")
+        ("input", po::value<std::string>(&inPath), "input tifxyz dir")
+        ("output", po::value<std::string>(&outPath), "output tifxyz dir (must not exist)")
+        ("unbend", po::bool_switch(&doUnbend), "run the spine unbend stage")
+        ("overlap-pairs", po::value<int>(&overlapCount), "run N overlap-pair passes")
+        ("orthogonalize", po::bool_switch(&doOrtho), "run the column orthogonalize stage")
+        ("trim", po::bool_switch(&doTrim), "run the bridge-cell trim stage")
+        ("analyze", po::bool_switch(&analyze), "measure cross-wrap dv on the input and exit (no output)")
+        ("unbend-smooth-cols", po::value<double>(&unbendSmooth)->default_value(300.0), "unbend spine Gaussian sigma (cols)")
+        ("unbend-min-rows", po::value<int>(&unbendMinRows)->default_value(30), "min valid rows for a spine column")
+        ("threshold", po::value<double>(&op.threshold)->default_value(0.0), "overlap 3D threshold (0=auto)")
+        ("min-du", po::value<int>(&op.minDu)->default_value(150), "min |du| (cols) for a cross-wrap pair")
+        ("max-dv", po::value<int>(&op.maxDv)->default_value(300), "reject pairs with |dv| above this")
+        ("stride", po::value<int>(&op.stride)->default_value(2), "subsample stride for the KD-tree")
+        ("trim-max-edge", po::value<double>(&trimMaxEdge)->default_value(100.0), "trim cells touching a 3D edge longer than this (voxels)")
+        ("seed", po::value<unsigned>(&op.seed)->default_value(7), "RNG seed for the spacing estimate");
+    po::positional_options_description pos;
+    pos.add("input", 1).add("output", 1);
+    po::variables_map vm;
+    try {
+        po::store(po::command_line_parser(argc, argv).options(desc).positional(pos).run(), vm);
+        po::notify(vm);
+    } catch (const std::exception& e) {
+        std::cerr << "error: " << e.what() << "\n" << desc << "\n";
+        return 1;
+    }
+    if (vm.count("help") || inPath.empty()) { std::cout << desc << "\n"; return vm.count("help") ? 0 : 1; }
+
+    // Default pipeline when no stage flag is given.
+    const bool anyStage = doUnbend || doOrtho || doTrim || overlapCount >= 0 || analyze;
+    if (!anyStage) { doUnbend = true; overlapCount = 2; doOrtho = true; doTrim = true; }
+    if (overlapCount < 0) overlapCount = 0;
+
+    Grid g;
+    try { g = loadGrid(inPath); }
+    catch (const std::exception& e) { std::cerr << "error loading " << inPath << ": " << e.what() << "\n"; return 1; }
+
+    if (analyze) {
+        stageOverlapPairs(g, op, /*applyWarp=*/false, nullptr);
+        return 0;
+    }
+    if (outPath.empty()) { std::cerr << "error: output dir required\n"; return 1; }
+    if (fs::exists(outPath)) { std::cerr << "error: output exists: " << outPath << "\n"; return 1; }
+
+    try {
+        if (doUnbend) g = stageUnbend(g, unbendSmooth, unbendMinRows);
+        for (int p = 0; p < overlapCount; ++p) {
+            std::cout << "--- overlap-pairs pass " << (p + 1) << "/" << overlapCount << " ---\n";
+            OverlapParams pp = op; pp.threshold = (op.threshold > 0 ? op.threshold : 0.0);
+            Grid next; stageOverlapPairs(g, pp, /*applyWarp=*/true, &next); g = std::move(next);
+        }
+        if (doOrtho) g = stageOrthogonalize(g, qp);
+        if (doTrim)  stageTrim(g, trimMaxEdge);
+        saveGrid(g, outPath, inPath);
+    } catch (const std::exception& e) {
+        std::cerr << "error: " << e.what() << "\n";
+        return 2;
+    }
+    std::cout << "wrote: " << outPath << "  (" << g.H() << "x" << g.W()
+              << ", valid=" << g.nvalid() << ")\n";
+    return 0;
+}

--- a/volume-cartographer/apps/src/vc_straighten.cpp
+++ b/volume-cartographer/apps/src/vc_straighten.cpp
@@ -521,7 +521,10 @@ static double stageOverlapPairs(const Grid& g, const OverlapParams& pr,
     };
 
     // Spacing estimate: nearest cross-wrap (|du|>=minDu) neighbor distance.
-    {
+    // Skipped entirely when the user supplies --threshold, so an explicit
+    // override is honored even on sparse surfaces where the random sample
+    // would find too few cross-wrap neighbors to auto-calibrate.
+    if (pr.threshold <= 0.0) {
         std::mt19937 rng(pr.seed);
         const int nSample = std::min(30000, N);
         std::vector<int> sel(N); std::iota(sel.begin(), sel.end(), 0);
@@ -551,8 +554,7 @@ static double stageOverlapPairs(const Grid& g, const OverlapParams& pr,
         std::cout << "  cross-wrap nearest distance p25/p50/p75 = "
                   << percentile(nd, 25) << "/" << med << "/" << percentile(nd, 75)
                   << " voxels (" << (100.0 * nd.size() / nSample) << "% matched)\n";
-        const_cast<OverlapParams&>(pr).threshold =
-            (pr.threshold > 0) ? pr.threshold : pr.thresholdFactor * med;
+        const_cast<OverlapParams&>(pr).threshold = pr.thresholdFactor * med;
     }
     const double threshold = pr.threshold;
     const double thr2 = threshold * threshold;


### PR DESCRIPTION
## Summary

Tooling for straightening flattened tifxyz surfaces, plus a fix for a winding-merge failure mode, developed on P.Herc. 1667. Three pieces:

1. **`vc_merge_tifxyz`: self-calibrating RANSAC gates for fused windings.** When adjacent windings are nearly fused (inter-winding gap below the overlap threshold) and cut at the same seam angle, each edge's anchor set contains two populations — the true end-overlap seam and dense near-identity cross-winding *contact* matches. The contacts can outvote the seam in RANSAC and stack consecutive surfaces on top of each other; once that's gated, an anchor-starved edge can instead latch onto a wild-scale "diagonal" model. A new `--ransac-autogate` (default on) fits every edge ungated, takes the median pair-scale and median centroid-shift across edges as a per-merge consensus, and re-fits only the edges that contradict it under consensus-relative bounds. It bakes in no wrap-width or scale constant, adapts to cross-resolution merges, and disables itself for co-located patch merges. Manual `--ransac-min-shift` / `--ransac-scale-min` / `--ransac-scale-max` remain as overrides; `--ransac-autogate=false` restores the prior behavior.

2. **`vc_straighten`: new unified C++ straightening pipeline.** One binary, four stages selectable via `--unbend` / `--overlap-pairs N` / `--orthogonalize` / `--trim` (default = all four), plus `--analyze` to report cross-wrap mismatch without writing output:
   - **unbend** — fit a smooth spine through a curved band and re-coordinate into (arc-length, normal-offset); a local rotation, distortion-free to first order, for when a flattening (e.g. free-boundary SLIM) leaves the band curved in UV.
   - **overlap-pairs** — pair each grid point with the nearest 3D point one winding over (self-overlap) and warp v so paired points share a row.
   - **orthogonalize** — remove residual column shear measured from the surface tangents (the transpose of the overlap v-warp; the two stages share one shift-field core).
   - **trim** — drop "bridge" cells whose 3D step to a grid neighbor is absurd, which otherwise dominate area-weighted metrics.

3. **VC3D GUI: "Straighten (vc_straighten)" context-menu action.** Right-clicking a surface in the segmentation panel now offers Straighten next to SLIM-flatten / ABF++ flatten, with a dialog for the stages and output path. It runs `vc_straighten` as a background subprocess and reloads the surface list on success.

## Validation (P.Herc. 1667 w011+)

- The autogate merge with **no manual flags** derived gates `[0.538, 1.744]` / min_shift 137.4 and re-fit exactly the five stacked tail edges onto the true seam, producing monotonic placements (w032..w041 advancing +3088 → +6353 cells).
- On a SLIM-flattened "banana", `vc_straighten` takes cross-wrap mean|dv| from 69.5 to ~2.9 rows and matches the reference flatboi stretch metrics (L2 mean 1.086, median 1.145, L∞ 6.50, area 0.106).

## Notes

- `vc_straighten`'s `unbend` parameters were tuned on this one scroll; a second-surface validation would be worth doing before relying on it widely.
- The Python prototypes these tools were ported from are intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
