### PR TITLE
Run persistent cache size scan off the UI thread

### DIFF
--- a/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
+++ b/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
@@ -131,6 +131,7 @@ private:
         std::deque<std::pair<std::chrono::steady_clock::time_point, std::size_t>> remoteDownloadHistory_;
         std::chrono::steady_clock::time_point lastPersistentCacheSizeScan_{};
         std::size_t cachedPersistentCacheBytes_ = 0;
+        bool persistentCacheScanInFlight_ = false;
     };
 
     static ChunkResult resultFromEntryLocked(State& state, const ChunkKey& key, Entry& entry);

--- a/volume-cartographer/core/src/render/ChunkCache.cpp
+++ b/volume-cartographer/core/src/render/ChunkCache.cpp
@@ -51,6 +51,16 @@ utils::ThreadPool& persistentCacheWriterPool()
     return pool;
 }
 
+utils::ThreadPool& persistentCacheScannerPool()
+{
+    // Walking the persistent cache directory to total its on-disk size can
+    // take long enough to stutter a UI thread that polls stats() on a timer.
+    // Run the scan here so stats() never blocks on the filesystem walk, and
+    // keep it off the writer pool so a slow scan does not stall writeback.
+    static utils::ThreadPool pool(1);
+    return pool;
+}
+
 std::string fetchErrorMessage(const ChunkFetchResult& fetch)
 {
     if (!fetch.message.empty())
@@ -250,7 +260,7 @@ ChunkCache::Stats ChunkCache::stats() const
 {
     auto state = state_;
     std::optional<std::filesystem::path> persistentPath;
-    bool scanPersistentCacheBytes = false;
+    bool startScan = false;
     Stats result;
     {
         std::lock_guard lock(state->mutex_);
@@ -269,18 +279,30 @@ ChunkCache::Stats ChunkCache::stats() const
         result.remoteDownloadBytesPerSecond =
             static_cast<double>(recentBytes) /
             std::chrono::duration<double>(kDownloadStatsWindow).count();
+        // Always report the last computed on-disk size. The recursive walk that
+        // refreshes it runs on a background thread (below), so stats() never
+        // blocks its caller (e.g. the UI status-bar timer) on the filesystem.
         result.persistentCacheBytes = state->cachedPersistentCacheBytes_;
         persistentPath = state->options_.persistentCachePath;
-        scanPersistentCacheBytes = persistentPath.has_value() &&
+        const bool scanDue = persistentPath.has_value() &&
             (state->lastPersistentCacheSizeScan_ == std::chrono::steady_clock::time_point{} ||
              now - state->lastPersistentCacheSizeScan_ >= kPersistentCacheSizeScanInterval);
-        if (scanPersistentCacheBytes)
+        if (scanDue && !state->persistentCacheScanInFlight_) {
+            startScan = true;
+            state->persistentCacheScanInFlight_ = true;
             state->lastPersistentCacheSizeScan_ = now;
+        }
     }
-    if (scanPersistentCacheBytes) {
-        result.persistentCacheBytes = persistentCacheBytes(persistentPath);
-        std::lock_guard lock(state->mutex_);
-        state->cachedPersistentCacheBytes_ = result.persistentCacheBytes;
+    if (startScan) {
+        std::weak_ptr<State> weakState = state;
+        persistentCacheScannerPool().enqueue([weakState, persistentPath] {
+            const std::size_t bytes = persistentCacheBytes(persistentPath);
+            if (auto state = weakState.lock()) {
+                std::lock_guard lock(state->mutex_);
+                state->cachedPersistentCacheBytes_ = bytes;
+                state->persistentCacheScanInFlight_ = false;
+            }
+        });
     }
     return result;
 }


### PR DESCRIPTION
## Problem

Panning a streamed (remote) volume in the VC3D GUI hangs briefly **~every 2 seconds, regardless of pan speed** — including the secondary fiber viewer.

## Root cause

`ChunkCache::stats()` recomputes the on-disk persistent cache size on a 2s interval (`kPersistentCacheSizeScanInterval`) by walking the entire cache directory with `recursive_directory_iterator` and `file_size()`-ing every chunk file. `stats()` is polled **on the UI thread** by each viewer's 500ms status-bar timer (`CChunkedVolumeViewer::updateStatusLabel`). For a remote volume — the only case where `persistentCachePath` is set — the disk cache grows as you pan, so that synchronous walk blocks the Qt event loop every 2s. It's wall-clock-driven, hence independent of pan speed, and worsens as the cache grows. Local volumes never set `persistentCachePath`, so they're unaffected.

## Fix

`stats()` now returns the last-computed `cachedPersistentCacheBytes_` immediately and dispatches the directory walk to a dedicated single-thread `persistentCacheScannerPool()` (kept off the writer pool so a slow scan can't stall writeback). A `persistentCacheScanInFlight_` flag prevents overlapping/piled-up scans, and the background task captures a `weak_ptr<State>` so a closed viewer can't cause a use-after-free.

The reported "disk" stat now lags by up to one scan interval, which is cosmetic.

## Testing

- `vc_core` and `VC3D` build cleanly.
- Not yet manually verified in the GUI; the `ChunkCache` unit tests are gated behind `BUILD_TESTING`, which is off in this build config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)