### PR TITLE
only scan cache sizes once at startup

### DIFF
--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -4915,7 +4915,9 @@ void CChunkedVolumeViewer::updateStatusLabel()
         items << QString("RAM %1/%2 GB")
             .arg(formatGigabytes(stats.decodedBytes))
             .arg(formatGigabytes(stats.decodedByteCapacity));
-        items << QString("disk %1").arg(formatByteSize(stats.persistentCacheBytes));
+        items << QString("disk %1%2")
+            .arg(formatByteSize(stats.persistentCacheBytes))
+            .arg(stats.persistentCacheScanInFlight ? "+" : "");
         if (stats.remoteFetchesInFlight > 0) {
             items << QString("downloading %1 @ %2")
                 .arg(stats.remoteFetchesInFlight)

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -4915,9 +4915,11 @@ void CChunkedVolumeViewer::updateStatusLabel()
         items << QString("RAM %1/%2 GB")
             .arg(formatGigabytes(stats.decodedBytes))
             .arg(formatGigabytes(stats.decodedByteCapacity));
-        items << QString("disk %1%2")
-            .arg(formatByteSize(stats.persistentCacheBytes))
-            .arg(stats.persistentCacheScanInFlight ? "+" : "");
+        if (stats.persistentCacheEnabled) {
+            items << QString("disk %1%2")
+                .arg(formatByteSize(stats.persistentCacheBytes))
+                .arg(stats.persistentCacheScanInFlight ? "+" : "");
+        }
         if (stats.remoteFetchesInFlight > 0) {
             items << QString("downloading %1 @ %2")
                 .arg(stats.remoteFetchesInFlight)

--- a/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
+++ b/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
@@ -2,6 +2,7 @@
 
 #include "vc/core/render/IChunkedArray.hpp"
 
+#include <atomic>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -43,6 +44,7 @@ public:
         std::size_t decodedBytes = 0;
         std::size_t decodedByteCapacity = 0;
         std::size_t persistentCacheBytes = 0;
+        bool persistentCacheScanInFlight = false;
         std::size_t remoteFetchesInFlight = 0;
         double remoteDownloadBytesPerSecond = 0.0;
     };
@@ -129,8 +131,8 @@ private:
         std::unordered_map<ChunkReadyCallbackId, ChunkReadyCallback> callbacks_;
         std::size_t remoteFetchesInFlight_ = 0;
         std::deque<std::pair<std::chrono::steady_clock::time_point, std::size_t>> remoteDownloadHistory_;
-        std::chrono::steady_clock::time_point lastPersistentCacheSizeScan_{};
-        std::size_t cachedPersistentCacheBytes_ = 0;
+        std::atomic<std::int64_t> persistentCacheBytes_{0};
+        std::atomic_bool persistentCacheScanInFlight_{false};
     };
 
     static ChunkResult resultFromEntryLocked(State& state, const ChunkKey& key, Entry& entry);
@@ -153,11 +155,16 @@ private:
                                      std::shared_ptr<const std::vector<std::byte>> bytes);
     static bool queuePersistentEmptyWrite(const std::shared_ptr<State>& state,
                                           const ChunkKey& key);
-    static void writePersistent(const State& state, const ChunkKey& key, const std::vector<std::byte>& bytes);
-    static void writePersistentEmpty(const State& state, const ChunkKey& key);
+    static void writePersistent(State& state, const ChunkKey& key, const std::vector<std::byte>& bytes);
+    static void writePersistentEmpty(State& state, const ChunkKey& key);
     static std::filesystem::path persistentPath(const State& state, const ChunkKey& key);
     static std::filesystem::path persistentEmptyPath(const State& state, const ChunkKey& key);
-    static std::size_t persistentCacheBytes(const std::optional<std::filesystem::path>& path);
+    static void startPersistentCacheSizeScan(const std::shared_ptr<State>& state);
+    static std::size_t persistentCacheBytes(
+        const std::filesystem::path& path,
+        std::filesystem::file_time_type cutoff);
+    static std::optional<std::size_t> regularFileSize(const std::filesystem::path& path);
+    static void addPersistentCacheBytesDelta(State& state, std::int64_t delta);
     static void pruneDownloadHistoryLocked(State& state, std::chrono::steady_clock::time_point now);
     static void touchLocked(State& state, const ChunkKey& key, Entry& entry);
     static void enforceCapacityLocked(const std::shared_ptr<State>& state);

--- a/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
+++ b/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
@@ -44,6 +44,7 @@ public:
         std::size_t decodedBytes = 0;
         std::size_t decodedByteCapacity = 0;
         std::size_t persistentCacheBytes = 0;
+        bool persistentCacheEnabled = false;
         bool persistentCacheScanInFlight = false;
         std::size_t remoteFetchesInFlight = 0;
         double remoteDownloadBytesPerSecond = 0.0;

--- a/volume-cartographer/core/src/render/ChunkCache.cpp
+++ b/volume-cartographer/core/src/render/ChunkCache.cpp
@@ -18,7 +18,6 @@ namespace vc::render {
 namespace {
 
 constexpr auto kDownloadStatsWindow = std::chrono::seconds{3};
-constexpr auto kPersistentCacheSizeScanInterval = std::chrono::seconds{2};
 constexpr int kViewEpochPriorityStride = 1024;
 
 std::size_t normalizedWorkerCount(std::size_t requested)
@@ -106,6 +105,8 @@ ChunkCache::ChunkCache(std::vector<LevelInfo> levels,
                 throw std::invalid_argument("ChunkCache chunk shape must be positive");
         }
     }
+    if (state_->options_.persistentCachePath)
+        startPersistentCacheSizeScan(state_);
 }
 
 ChunkCache::~ChunkCache()
@@ -249,8 +250,6 @@ void ChunkCache::removeChunkReadyListener(ChunkReadyCallbackId id)
 ChunkCache::Stats ChunkCache::stats() const
 {
     auto state = state_;
-    std::optional<std::filesystem::path> persistentPath;
-    bool scanPersistentCacheBytes = false;
     Stats result;
     {
         std::lock_guard lock(state->mutex_);
@@ -269,19 +268,11 @@ ChunkCache::Stats ChunkCache::stats() const
         result.remoteDownloadBytesPerSecond =
             static_cast<double>(recentBytes) /
             std::chrono::duration<double>(kDownloadStatsWindow).count();
-        result.persistentCacheBytes = state->cachedPersistentCacheBytes_;
-        persistentPath = state->options_.persistentCachePath;
-        scanPersistentCacheBytes = persistentPath.has_value() &&
-            (state->lastPersistentCacheSizeScan_ == std::chrono::steady_clock::time_point{} ||
-             now - state->lastPersistentCacheSizeScan_ >= kPersistentCacheSizeScanInterval);
-        if (scanPersistentCacheBytes)
-            state->lastPersistentCacheSizeScan_ = now;
     }
-    if (scanPersistentCacheBytes) {
-        result.persistentCacheBytes = persistentCacheBytes(persistentPath);
-        std::lock_guard lock(state->mutex_);
-        state->cachedPersistentCacheBytes_ = result.persistentCacheBytes;
-    }
+    const auto persistentBytes = state->persistentCacheBytes_.load(std::memory_order_acquire);
+    result.persistentCacheBytes = persistentBytes > 0 ? static_cast<std::size_t>(persistentBytes) : 0;
+    result.persistentCacheScanInFlight =
+        state->persistentCacheScanInFlight_.load(std::memory_order_acquire);
     return result;
 }
 
@@ -580,7 +571,7 @@ bool ChunkCache::queuePersistentEmptyWrite(const std::shared_ptr<State>& state,
     return true;
 }
 
-void ChunkCache::writePersistent(const State& state, const ChunkKey& key, const std::vector<std::byte>& bytes)
+void ChunkCache::writePersistent(State& state, const ChunkKey& key, const std::vector<std::byte>& bytes)
 {
     if (!state.options_.persistentCachePath)
         return;
@@ -590,7 +581,11 @@ void ChunkCache::writePersistent(const State& state, const ChunkKey& key, const 
         return;
 
     const auto path = persistentPath(state, key);
-    std::filesystem::create_directories(path.parent_path());
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+    if (ec)
+        return;
+    const auto oldSize = regularFileSize(path).value_or(0);
     const auto tmp = path.string() + ".tmp";
     {
         std::ofstream file(tmp, std::ios::binary | std::ios::trunc);
@@ -601,22 +596,33 @@ void ChunkCache::writePersistent(const State& state, const ChunkKey& key, const 
         if (!file)
             return;
     }
-    std::error_code ec;
     std::filesystem::rename(tmp, path, ec);
     if (ec) {
         std::filesystem::remove(path, ec);
         ec.clear();
         std::filesystem::rename(tmp, path, ec);
     }
+    if (ec) {
+        std::filesystem::remove(tmp, ec);
+        return;
+    }
+    const auto newSize = regularFileSize(path).value_or(bytes.size());
+    addPersistentCacheBytesDelta(
+        state,
+        static_cast<std::int64_t>(newSize) - static_cast<std::int64_t>(oldSize));
 }
 
-void ChunkCache::writePersistentEmpty(const State& state, const ChunkKey& key)
+void ChunkCache::writePersistentEmpty(State& state, const ChunkKey& key)
 {
     if (!state.options_.persistentCachePath)
         return;
 
     const auto path = persistentEmptyPath(state, key);
-    std::filesystem::create_directories(path.parent_path());
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+    if (ec)
+        return;
+    const auto oldSize = regularFileSize(path).value_or(0);
     const auto tmp = path.string() + ".tmp";
     {
         std::ofstream file(tmp, std::ios::binary | std::ios::trunc);
@@ -626,13 +632,20 @@ void ChunkCache::writePersistentEmpty(const State& state, const ChunkKey& key)
         if (!file)
             return;
     }
-    std::error_code ec;
     std::filesystem::rename(tmp, path, ec);
     if (ec) {
         std::filesystem::remove(path, ec);
         ec.clear();
         std::filesystem::rename(tmp, path, ec);
     }
+    if (ec) {
+        std::filesystem::remove(tmp, ec);
+        return;
+    }
+    const auto newSize = regularFileSize(path).value_or(std::size_t{1});
+    addPersistentCacheBytesDelta(
+        state,
+        static_cast<std::int64_t>(newSize) - static_cast<std::int64_t>(oldSize));
 }
 
 std::filesystem::path ChunkCache::persistentPath(const State& state, const ChunkKey& key)
@@ -655,32 +668,79 @@ std::filesystem::path ChunkCache::persistentEmptyPath(const State& state, const 
            (std::to_string(key.ix) + ".empty");
 }
 
-std::size_t ChunkCache::persistentCacheBytes(const std::optional<std::filesystem::path>& path)
+void ChunkCache::startPersistentCacheSizeScan(const std::shared_ptr<State>& state)
 {
-    if (!path)
-        return 0;
+    if (!state || !state->options_.persistentCachePath)
+        return;
 
+    const auto path = *state->options_.persistentCachePath;
+    const auto cutoff = std::filesystem::file_time_type::clock::now();
+    state->persistentCacheScanInFlight_.store(true, std::memory_order_release);
+    persistentCacheWriterPool().enqueue([state, path, cutoff] {
+        const auto bytes = persistentCacheBytes(path, cutoff);
+        addPersistentCacheBytesDelta(*state, static_cast<std::int64_t>(bytes));
+        state->persistentCacheScanInFlight_.store(false, std::memory_order_release);
+    });
+}
+
+std::size_t ChunkCache::persistentCacheBytes(
+    const std::filesystem::path& path,
+    std::filesystem::file_time_type cutoff)
+{
     std::error_code ec;
-    if (!std::filesystem::exists(*path, ec))
+    if (!std::filesystem::is_directory(path, ec) || ec)
         return 0;
 
     std::size_t bytes = 0;
     std::filesystem::recursive_directory_iterator it(
-        *path,
+        path,
         std::filesystem::directory_options::skip_permission_denied,
         ec);
     const std::filesystem::recursive_directory_iterator end;
     while (!ec && it != end) {
         if (it->is_regular_file(ec)) {
-            const auto size = it->file_size(ec);
-            if (!ec)
-                bytes += static_cast<std::size_t>(size);
+            const auto modified = it->last_write_time(ec);
+            if (!ec && modified <= cutoff) {
+                const auto size = it->file_size(ec);
+                if (!ec)
+                    bytes += static_cast<std::size_t>(size);
+            }
+            if (ec)
+                ec.clear();
         } else {
             ec.clear();
         }
         it.increment(ec);
     }
     return bytes;
+}
+
+std::optional<std::size_t> ChunkCache::regularFileSize(const std::filesystem::path& path)
+{
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(path, ec) || ec)
+        return std::nullopt;
+    const auto size = std::filesystem::file_size(path, ec);
+    if (ec)
+        return std::nullopt;
+    return static_cast<std::size_t>(size);
+}
+
+void ChunkCache::addPersistentCacheBytesDelta(State& state, std::int64_t delta)
+{
+    if (delta == 0)
+        return;
+    auto current = state.persistentCacheBytes_.load(std::memory_order_acquire);
+    while (true) {
+        const auto next = std::max<std::int64_t>(0, current + delta);
+        if (state.persistentCacheBytes_.compare_exchange_weak(
+                current,
+                next,
+                std::memory_order_acq_rel,
+                std::memory_order_acquire)) {
+            return;
+        }
+    }
 }
 
 void ChunkCache::pruneDownloadHistoryLocked(State& state, std::chrono::steady_clock::time_point now)

--- a/volume-cartographer/core/src/render/ChunkCache.cpp
+++ b/volume-cartographer/core/src/render/ChunkCache.cpp
@@ -268,6 +268,7 @@ ChunkCache::Stats ChunkCache::stats() const
         result.remoteDownloadBytesPerSecond =
             static_cast<double>(recentBytes) /
             std::chrono::duration<double>(kDownloadStatsWindow).count();
+        result.persistentCacheEnabled = state->options_.persistentCachePath.has_value();
     }
     const auto persistentBytes = state->persistentCacheBytes_.load(std::memory_order_acquire);
     result.persistentCacheBytes = persistentBytes > 0 ? static_cast<std::size_t>(persistentBytes) : 0;

--- a/volume-cartographer/core/test/test_chunk_cache.cpp
+++ b/volume-cartographer/core/test/test_chunk_cache.cpp
@@ -225,6 +225,7 @@ TEST_CASE("ChunkCache: stats reflect decoded byte budget and activity")
     auto s = c->stats();
     CHECK(s.decodedByteCapacity > 0);
     CHECK(s.decodedBytes >= 64);
+    CHECK_FALSE(s.persistentCacheEnabled);
 }
 
 TEST_CASE("ChunkCache: invalidate clears decoded entries")

--- a/volume-cartographer/core/test/test_chunk_cache_persist.cpp
+++ b/volume-cartographer/core/test/test_chunk_cache_persist.cpp
@@ -217,6 +217,7 @@ TEST_CASE("stats: persistentCacheBytes reflects the on-disk size")
     auto s = waitForStats(*c, [](const ChunkCache::Stats& s) {
         return !s.persistentCacheScanInFlight && s.persistentCacheBytes >= 64;
     });
+    CHECK(s.persistentCacheEnabled);
     CHECK(s.persistentCacheBytes >= 64);
     CHECK_FALSE(s.persistentCacheScanInFlight);
     fs::remove_all(persist);

--- a/volume-cartographer/core/test/test_chunk_cache_persist.cpp
+++ b/volume-cartographer/core/test/test_chunk_cache_persist.cpp
@@ -77,6 +77,35 @@ std::shared_ptr<ChunkCache> makeCache(std::shared_ptr<CountingFetcher> f,
         0.0, ChunkDtype::UInt8, opts);
 }
 
+std::vector<std::byte> makeBytes(std::size_t n, std::byte v = std::byte{99})
+{
+    return std::vector<std::byte>(n, v);
+}
+
+void writeSizedFile(const fs::path& path, std::size_t size, unsigned char value = 0x10)
+{
+    fs::create_directories(path.parent_path());
+    std::ofstream f(path, std::ios::binary);
+    std::vector<char> bytes(size, static_cast<char>(value));
+    f.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+}
+
+template <typename Predicate>
+ChunkCache::Stats waitForStats(ChunkCache& c,
+                               Predicate predicate,
+                               std::chrono::milliseconds timeout = std::chrono::seconds{2})
+{
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    ChunkCache::Stats s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        s = c.stats();
+        if (predicate(s))
+            return s;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return c.stats();
+}
+
 ChunkResult waitForResolved(ChunkCache& c, int level, int iz, int iy, int ix,
                             std::chrono::milliseconds timeout = std::chrono::seconds{2})
 {
@@ -100,6 +129,9 @@ TEST_CASE("Missing chunk with persistent cache writes an .empty marker")
         auto c = makeCache(f, persist);
         auto r = waitForResolved(*c, 0, 0, 0, 0);
         CHECK(r.status == ChunkStatus::Missing);
+        (void)waitForStats(*c, [](const ChunkCache::Stats& s) {
+            return !s.persistentCacheScanInFlight && s.persistentCacheBytes >= 1;
+        });
     }
     // After cache destruction, the persistent dir should contain an .empty
     // file somewhere under level_0/.
@@ -135,6 +167,10 @@ TEST_CASE("Reopen cache: persistent .empty marker short-circuits to Missing")
     // First call may be MissQueued or immediate Missing — wait it out.
     auto resolved = waitForResolved(*c, 0, 0, 0, 0);
     CHECK(resolved.status == ChunkStatus::Missing);
+    (void)r;
+    (void)waitForStats(*c, [](const ChunkCache::Stats& s) {
+        return !s.persistentCacheScanInFlight;
+    });
     // Fetcher should not have been called — the empty marker short-circuits.
     // Tolerate impl variance — just confirm no crash.
     fs::remove_all(persist);
@@ -160,6 +196,9 @@ TEST_CASE("Reopen cache: persistent data file is loaded directly")
     if (r.status == ChunkStatus::Data && r.bytes) {
         CHECK(int(std::to_integer<int>((*r.bytes)[0])) == 0x42);
     }
+    (void)waitForStats(*c, [](const ChunkCache::Stats& s) {
+        return !s.persistentCacheScanInFlight;
+    });
     fs::remove_all(persist);
 }
 
@@ -175,9 +214,138 @@ TEST_CASE("stats: persistentCacheBytes reflects the on-disk size")
     }
     auto f = std::make_shared<CountingFetcher>();
     auto c = makeCache(f, persist);
-    auto s = c->stats();
+    auto s = waitForStats(*c, [](const ChunkCache::Stats& s) {
+        return !s.persistentCacheScanInFlight && s.persistentCacheBytes >= 64;
+    });
     CHECK(s.persistentCacheBytes >= 64);
+    CHECK_FALSE(s.persistentCacheScanInFlight);
     fs::remove_all(persist);
+}
+
+TEST_CASE("stats: startup scan ignores files newer than its cutoff")
+{
+    auto persist = tmpDir("scan_cutoff");
+    const auto target = persist / "level_0" / "0" / "0";
+    writeSizedFile(target / "0.bin", 31);
+    writeSizedFile(target / "1.empty", 1);
+
+    auto f = std::make_shared<CountingFetcher>();
+    auto c = makeCache(f, persist);
+
+    writeSizedFile(target / "post.bin", 17);
+    std::error_code ec;
+    fs::last_write_time(
+        target / "post.bin",
+        fs::file_time_type::clock::now() + std::chrono::seconds{10},
+        ec);
+
+    auto s = waitForStats(*c, [](const ChunkCache::Stats& s) {
+        return !s.persistentCacheScanInFlight;
+    });
+    CHECK(s.persistentCacheBytes == 32);
+    fs::remove_all(persist);
+}
+
+TEST_CASE("stats: repeated calls do not rescan persistent cache")
+{
+    auto persist = tmpDir("no_rescan");
+    const auto target = persist / "level_0" / "0" / "0";
+    writeSizedFile(target / "0.bin", 11);
+
+    auto f = std::make_shared<CountingFetcher>();
+    auto c = makeCache(f, persist);
+    auto first = waitForStats(*c, [](const ChunkCache::Stats& s) {
+        return !s.persistentCacheScanInFlight && s.persistentCacheBytes == 11;
+    });
+    REQUIRE(first.persistentCacheBytes == 11);
+
+    writeSizedFile(target / "external.bin", 29);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2300));
+    for (int i = 0; i < 5; ++i) {
+        auto s = c->stats();
+        CHECK(s.persistentCacheBytes == 11);
+        CHECK_FALSE(s.persistentCacheScanInFlight);
+    }
+    fs::remove_all(persist);
+}
+
+TEST_CASE("stats: successful persistent data write increments byte count")
+{
+    auto persist = tmpDir("write_delta");
+    auto f = std::make_shared<CountingFetcher>();
+    ChunkFetchResult fr;
+    fr.status = ChunkFetchStatus::Found;
+    fr.bytes = makeBytes(64, std::byte{7});
+    f->setCanned({0, 0, 0, 0}, fr);
+
+    auto c = makeCache(f, persist);
+    auto initial = waitForStats(*c, [](const ChunkCache::Stats& s) {
+        return !s.persistentCacheScanInFlight;
+    });
+    CHECK(initial.persistentCacheBytes == 0);
+
+    auto r = waitForResolved(*c, 0, 0, 0, 0);
+    CHECK(r.status == ChunkStatus::Data);
+    auto after = waitForStats(*c, [](const ChunkCache::Stats& s) {
+        return s.persistentCacheBytes == 64;
+    });
+    CHECK(after.persistentCacheBytes == 64);
+    fs::remove_all(persist);
+}
+
+TEST_CASE("stats: persistent overwrite applies new minus old byte delta")
+{
+    auto persist = tmpDir("overwrite_delta");
+    const auto target = persist / "level_0" / "0" / "0";
+    writeSizedFile(target / "0.bin", 80);
+
+    auto f = std::make_shared<CountingFetcher>();
+    ChunkFetchResult fr;
+    fr.status = ChunkFetchStatus::Found;
+    fr.bytes = makeBytes(64, std::byte{8});
+    f->setCanned({0, 0, 0, 0}, fr);
+
+    auto c = makeCache(f, persist);
+    auto r = waitForResolved(*c, 0, 0, 0, 0);
+    CHECK(r.status == ChunkStatus::Data);
+    auto after = waitForStats(*c, [](const ChunkCache::Stats& s) {
+        return !s.persistentCacheScanInFlight && s.persistentCacheBytes == 64;
+    });
+    CHECK(after.persistentCacheBytes == 64);
+    fs::remove_all(persist);
+}
+
+TEST_CASE("stats: failed persistent write does not change byte count")
+{
+    auto persistFile = tmpDir("write_fail_parent") / "cache_file";
+    writeSizedFile(persistFile, 3);
+
+    auto f = std::make_shared<CountingFetcher>();
+    ChunkFetchResult fr;
+    fr.status = ChunkFetchStatus::Found;
+    fr.bytes = makeBytes(64, std::byte{9});
+    f->setCanned({0, 0, 0, 0}, fr);
+
+    auto c = makeCache(f, persistFile);
+    auto initial = waitForStats(*c, [](const ChunkCache::Stats& s) {
+        return !s.persistentCacheScanInFlight;
+    });
+    CHECK(initial.persistentCacheBytes == 0);
+
+    auto r = waitForResolved(*c, 0, 0, 0, 0);
+    CHECK(r.status == ChunkStatus::Data);
+
+    auto barrierDir = tmpDir("write_fail_barrier");
+    auto barrier = makeCache(std::make_shared<CountingFetcher>(), barrierDir);
+    (void)waitForStats(*barrier, [](const ChunkCache::Stats& s) {
+        return !s.persistentCacheScanInFlight;
+    });
+
+    auto after = c->stats();
+    CHECK(after.persistentCacheBytes == 0);
+    CHECK_FALSE(after.persistentCacheScanInFlight);
+    fs::remove_all(persistFile.parent_path());
+    fs::remove_all(barrierDir);
 }
 
 TEST_CASE("prefetchChunks(wait=false): non-blocking; later tryGetChunk picks it up")


### PR DESCRIPTION
- only launch single cache scan on startup
- additional fetches modify the cache size atomically
- scan filters by chunk mod time older than scan start to avoid double-accounting