### PR TITLE
vc: fix zarr datatypes for single-byte types

### DIFF
--- a/volume-cartographer/utils/src/zarr.cpp
+++ b/volume-cartographer/utils/src/zarr.cpp
@@ -1280,7 +1280,8 @@ std::string serialize_zarray(const ZarrMetadata& meta) {
 
     // dtype
     s += "  \"dtype\": \"";
-    s += meta.byte_order;
+    // Byte order is not applicable to single-byte dtypes; zarr v2 uses '|'.
+    s += (dtype_size(meta.dtype) == 1) ? '|' : meta.byte_order;
     s += dtype_string_v2(meta.dtype);
     s += "\",\n";
 


### PR DESCRIPTION
Especially, from `<u1` to `|u1`. Single-byte types don't have a byte order