### PR TITLE
docs: refresh active prize count wording

### DIFF
--- a/scrollprize.org/docs/01_get_started.md
+++ b/scrollprize.org/docs/01_get_started.md
@@ -69,7 +69,7 @@ Contestants can also contribute to our two primary subproblems:
 </Admonition>
 
 <Admonition type="info" icon="🖋️" title="Ink Detection">
-* Prizes: 7 x \$60,000 [First Letters and First Title Prizes](prizes#first-letters-and-title-prizes)
+* Prizes: \$60,000 each [First Letters and First Title Prizes](prizes#first-letters-and-title-prizes)
 * Starting point: [Ink detection tutorial](tutorial5)
 </Admonition>
 

--- a/scrollprize.org/src/components/Landing.js
+++ b/scrollprize.org/src/components/Landing.js
@@ -331,7 +331,7 @@ const prizes = [
   // },
   {
     title: "First Letters / First Title Prizes",
-    prizeMoney: "7 x $60,000",
+    prizeMoney: "$60,000 each",
     description:
       "Find the first letters or the title of a scroll",
     requirement: "",


### PR DESCRIPTION
Addresses part of #199.

Issue: https://github.com/ScrollPrize/villa/issues/199
Source checked: https://scrollprize.org/prizes

## Reproduction

The getting started page and landing page still describe the First Letters / First Title prizes as `7 x $60,000`, while the current prizes documentation lists the active First Letters and First Title prizes as `$60,000` each.

## Changes

- Updated the getting started Ink Detection callout to say `$60,000 each`.
- Updated the landing page prize card to say `$60,000 each`.

This keeps the two high-visibility pages aligned with the current prizes page without restating a stale count.

## Scope / Minimality

This is intentionally focused on the reported documentation issue: only the two visible pages that repeated the stale `7 x $60,000` wording are changed. There are no unrelated refactors, rule changes, generated asset updates, or broader copy edits.

## Validation

- Checked the current prizes documentation for the source wording.
- Confirmed the stale `7 x $60,000` text is removed from the edited files.
- Ran `git diff --check` and it passed with no whitespace errors.

## Known Limits / Non-goals

- This does not change the prize rules or prize definitions.
- This does not update generated site assets or unrelated copy.
