### PR TITLE
VC3D: add horizontal flip to the surface rotation transform

### DIFF
--- a/volume-cartographer/apps/VC3D/CMakeLists.txt
+++ b/volume-cartographer/apps/VC3D/CMakeLists.txt
@@ -165,6 +165,7 @@ set(srcs
     overlays/PlaneSlicingOverlayController.hpp
     overlays/SurfaceRotationOverlayController.cpp
     overlays/SurfaceRotationOverlayController.hpp
+    overlays/SurfaceRotationTransform.hpp
     overlays/AtlasOverlayController.cpp
     overlays/AtlasOverlayController.hpp
     overlays/AtlasControlPointsOverlayController.cpp

--- a/volume-cartographer/apps/VC3D/overlays/SurfaceRotationOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/SurfaceRotationOverlayController.cpp
@@ -1,4 +1,5 @@
 #include "SurfaceRotationOverlayController.hpp"
+#include "SurfaceRotationTransform.hpp"
 
 #include "../CState.hpp"
 #include "../volume_viewers/CVolumeViewerView.hpp"
@@ -9,6 +10,7 @@
 #include "vc/core/types/VolumePkg.hpp"
 
 #include <QApplication>
+#include <QCheckBox>
 #include <QDoubleSpinBox>
 #include <QFutureWatcher>
 #include <QGraphicsProxyWidget>
@@ -33,6 +35,8 @@
 namespace
 {
 constexpr const char* kOverlayGroupKey = "surface_transform_rotate";
+constexpr const char* kHorizontalFlipObjectName = "surfaceHorizontalFlipCheckBox";
+constexpr const char* kApplyTransformObjectName = "surfaceTransformApplyButton";
 constexpr double kPi = 3.14159265358979323846;
 
 struct RotationSaveResult {
@@ -43,6 +47,52 @@ struct RotationSaveResult {
 bool hasFileMetadata(const std::shared_ptr<QuadSurface>& surface)
 {
     return surface && !surface->path.empty() && !surface->id.empty();
+}
+
+vc3d::surface_rotation::TransformPersistenceCompatibility surfaceTransformPersistenceCompatibility(
+    const std::shared_ptr<QuadSurface>& surface)
+{
+    if (!surface) {
+        return {};
+    }
+
+    const bool hasComponents =
+        surface->meta.contains("components") && surface->meta["components"].is_array() && surface->meta["components"].size() > 0;
+    return vc3d::surface_rotation::transformPersistenceCompatibility(surface->path, hasComponents);
+}
+
+QString horizontalFlipUnavailableTooltip(const vc3d::surface_rotation::TransformPersistenceCompatibility& compatibility)
+{
+    if (compatibility.hasMultipageMask && compatibility.hasDisconnectedComponents) {
+        return QObject::tr(
+            "Horizontal flip is unavailable because this surface has a multipage mask and "
+            "disconnected component ranges.");
+    }
+    if (compatibility.hasMultipageMask) {
+        return QObject::tr(
+            "Horizontal flip is unavailable because this surface has a multipage "
+            "multilayer_mask.tif sidecar.");
+    }
+    return QObject::tr(
+        "Horizontal flip is unavailable because this surface has disconnected component "
+        "ranges.");
+}
+
+QString transformPersistenceUnavailableTooltip(const vc3d::surface_rotation::TransformPersistenceCompatibility& compatibility)
+{
+    if (compatibility.hasMultipageMask && compatibility.hasDisconnectedComponents) {
+        return QObject::tr(
+            "Apply is unavailable because multipage masks and disconnected component "
+            "ranges cannot yet be transformed safely.");
+    }
+    if (compatibility.hasMultipageMask) {
+        return QObject::tr(
+            "Apply is unavailable because multipage multilayer_mask.tif sidecars cannot "
+            "yet be transformed safely.");
+    }
+    return QObject::tr(
+        "Apply is unavailable because disconnected component ranges cannot yet be "
+        "transformed safely.");
 }
 
 class RotationDial final : public QWidget
@@ -169,7 +219,13 @@ public:
         _spin->setFixedWidth(92);
         controls->addWidget(_spin);
 
+        _horizontalFlip = new QCheckBox(tr("Flip horizontally"), this);
+        _horizontalFlip->setObjectName(QString::fromLatin1(kHorizontalFlipObjectName));
+        _horizontalFlip->setStyleSheet("QCheckBox { color: white; }");
+        controls->addWidget(_horizontalFlip);
+
         auto* apply = new QPushButton(tr("Apply"), this);
+        apply->setObjectName(QString::fromLatin1(kApplyTransformObjectName));
         controls->addWidget(apply);
         layout->addLayout(controls);
 
@@ -194,6 +250,11 @@ public:
                                  angleChanged(value);
                              }
                          });
+        QObject::connect(_horizontalFlip, &QCheckBox::toggled, this, [this](bool enabled) {
+            if (horizontalFlipChanged) {
+                horizontalFlipChanged(enabled);
+            }
+        });
         QObject::connect(apply, &QPushButton::clicked, this, [this]() {
             if (applyRequested) {
                 applyRequested();
@@ -209,6 +270,7 @@ public:
     }
 
     std::function<void(double)> angleChanged;
+    std::function<void(bool)> horizontalFlipChanged;
     std::function<void()> applyRequested;
 
 protected:
@@ -225,6 +287,7 @@ protected:
 private:
     RotationDial* _dial{nullptr};
     QDoubleSpinBox* _spin{nullptr};
+    QCheckBox* _horizontalFlip{nullptr};
 };
 } // namespace
 
@@ -288,6 +351,7 @@ void SurfaceRotationOverlayController::beginRotate()
     cancelRotate();
     _sourceSurface = std::move(source);
     _angleDeg = 0.0;
+    _horizontalFlip = false;
     _rotateActive = true;
     ensureWidgetForTarget();
 }
@@ -296,20 +360,21 @@ void SurfaceRotationOverlayController::cancelRotate()
 {
     // Restore the un-previewed source surface — but only if no save
     // worker is currently mutating it. Publishing _sourceSurface
-    // while applyRotation()'s background rotate() / saveOverwrite()
+    // while applyRotation()'s background transform / saveOverwrite()
     // is running would point surfaceChanged consumers at a cv::Mat
     // the worker is concurrently writing, racing on _points and the
     // ancillary channels. Whatever was previously active (typically
     // the last _previewSurface from a dial drag) stays in place; the
     // worker's finished slot already drops its own setSurface via
     // the stale-completion guard, so the UI never sees the
-    // cancelled-session's post-rotate output either. A user who
-    // wants the on-disk post-rotate state can reopen the segment.
+    // cancelled-session's transformed output either. A user who
+    // wants the on-disk transformed state can reopen the segment.
     if (_rotateActive && _state && _sourceSurface && !_saveInFlight) {
         _state->setSurface("segmentation", _sourceSurface, false, true);
     }
     _rotateActive = false;
     _angleDeg = 0.0;
+    _horizontalFlip = false;
     _sourceSurface.reset();
     _previewSurface.reset();
     // Invalidate any in-flight save worker — the session it was
@@ -446,6 +511,7 @@ void SurfaceRotationOverlayController::ensureWidgetForTarget()
     auto* widget = new RotationWidget();
     widget->setAngle(_angleDeg);
     widget->angleChanged = [this](double angle) { setAngle(angle); };
+    widget->horizontalFlipChanged = [this](bool enabled) { setHorizontalFlip(enabled); };
     widget->applyRequested = [this]() { applyRotation(); };
 
     auto* proxy = new QGraphicsProxyWidget();
@@ -454,6 +520,11 @@ void SurfaceRotationOverlayController::ensureWidgetForTarget()
     viewer->graphicsView()->scene()->addItem(proxy);
     it->proxy = proxy;
     viewer->setOverlayGroup(kOverlayGroupKey, {proxy});
+    const bool flipWasSelected = _horizontalFlip;
+    synchronizeTransformPersistenceCompatibility();
+    if (flipWasSelected && !_horizontalFlip) {
+        updatePreview();
+    }
     positionWidget(*it);
 }
 
@@ -487,6 +558,47 @@ void SurfaceRotationOverlayController::setAngle(double angleDeg)
     updatePreview();
 }
 
+bool SurfaceRotationOverlayController::setHorizontalFlip(bool enabled)
+{
+    const bool previouslySelected = _horizontalFlip;
+    _horizontalFlip = enabled;
+    const bool available = synchronizeTransformPersistenceCompatibility();
+    if (_horizontalFlip != previouslySelected) {
+        updatePreview();
+    }
+    if (enabled && !available) {
+        return false;
+    }
+    return true;
+}
+
+bool SurfaceRotationOverlayController::synchronizeTransformPersistenceCompatibility()
+{
+    const auto compatibility = surfaceTransformPersistenceCompatibility(_sourceSurface);
+    const auto selection = vc3d::surface_rotation::reconcileHorizontalFlipSelection(_horizontalFlip, compatibility);
+    _horizontalFlip = selection.selected;
+
+    const bool available = compatibility.allowed();
+    const QString tooltip = available ? QString{} : horizontalFlipUnavailableTooltip(compatibility);
+    for (const auto& entry : _viewers) {
+        if (!entry.proxy || !entry.proxy->widget()) {
+            continue;
+        }
+        if (auto* checkbox = entry.proxy->widget()->findChild<QCheckBox*>(QString::fromLatin1(kHorizontalFlipObjectName))) {
+            const QSignalBlocker blocker(checkbox);
+            checkbox->setChecked(_horizontalFlip);
+            checkbox->setEnabled(available);
+            checkbox->setToolTip(tooltip);
+        }
+
+        if (auto* apply = entry.proxy->widget()->findChild<QPushButton*>(QString::fromLatin1(kApplyTransformObjectName))) {
+            apply->setEnabled(available);
+            apply->setToolTip(available ? QString{} : transformPersistenceUnavailableTooltip(compatibility));
+        }
+    }
+    return available;
+}
+
 void SurfaceRotationOverlayController::updatePreview()
 {
     if (!_rotateActive || !_state || !_sourceSurface) {
@@ -501,7 +613,9 @@ void SurfaceRotationOverlayController::updatePreview()
         return;
     }
 
-    if (std::abs(_angleDeg) < 0.01) {
+    synchronizeTransformPersistenceCompatibility();
+    const vc3d::surface_rotation::Transform transform{static_cast<float>(_angleDeg), _horizontalFlip};
+    if (transform.isNoOp()) {
         _previewSurface.reset();
         _state->setSurface("segmentation", _sourceSurface, false, true);
         return;
@@ -511,7 +625,7 @@ void SurfaceRotationOverlayController::updatePreview()
     if (!_previewSurface) {
         return;
     }
-    _previewSurface->rotate(static_cast<float>(_angleDeg));
+    transform.applyInMemory(*_previewSurface);
     _state->setSurface("segmentation", _previewSurface, false, true);
 }
 
@@ -530,11 +644,27 @@ void SurfaceRotationOverlayController::applyRotation()
         return;
     }
 
-    // Trivial rotation: no I/O, nothing to do off-thread.
-    if (std::abs(_angleDeg) < 0.01) {
+    const bool flipWasSelected = _horizontalFlip;
+    const bool persistenceAvailable = synchronizeTransformPersistenceCompatibility();
+    if (!persistenceAvailable) {
+        if (flipWasSelected && !_horizontalFlip) {
+            updatePreview();
+        }
+        QMessageBox::warning(
+            nullptr,
+            tr("Surface Transform Unavailable"),
+            transformPersistenceUnavailableTooltip(surfaceTransformPersistenceCompatibility(_sourceSurface)));
+        return;
+    }
+
+    const vc3d::surface_rotation::Transform transform{static_cast<float>(_angleDeg), _horizontalFlip};
+
+    // No transform: no I/O, nothing to do off-thread.
+    if (transform.isNoOp()) {
         _state->setSurface("segmentation", _sourceSurface, false, true);
         _rotateActive = false;
         _angleDeg = 0.0;
+        _horizontalFlip = false;
         _previewSurface.reset();
         _sourceSurface.reset();
         clearWidgets();
@@ -542,24 +672,19 @@ void SurfaceRotationOverlayController::applyRotation()
     }
 
     if (!hasFileMetadata(_sourceSurface)) {
-        QMessageBox::warning(nullptr,
-                             tr("Rotation Failed"),
-                             tr("Failed to save the rotated surface: the selected surface is missing file metadata."));
+        QMessageBox::warning(nullptr, tr("Surface Transform Failed"), tr("Failed to save the transformed surface: the selected surface is missing file metadata."));
         return;
     }
 
     // Clone the source before dispatching the worker. The worker can then
-    // rotate/save without racing the live surface used by the preview, and a
+    // transform/save without racing the live surface used by the preview, and a
     // failed save leaves the in-memory source unchanged.
     auto surface = cloneSurface(_sourceSurface);
     if (!surface) {
-        QMessageBox::warning(nullptr,
-                             tr("Rotation Failed"),
-                             tr("Failed to save the rotated surface: could not copy the selected surface."));
+        QMessageBox::warning(nullptr, tr("Surface Transform Failed"), tr("Failed to save the transformed surface: could not copy the selected surface."));
         return;
     }
 
-    const float angleDeg = static_cast<float>(_angleDeg);
     const int session = ++_saveSessionId;
     _saveInFlight = true;
     QPointer<SurfaceRotationOverlayController> self(this);
@@ -603,12 +728,14 @@ void SurfaceRotationOverlayController::applyRotation()
                     }
                     self->clearWidgets();
                     self->_rotateActive = false;
+                    self->_angleDeg = 0.0;
+                    self->_horizontalFlip = false;
                     self->_previewSurface.reset();
                     self->_sourceSurface.reset();
-                    QMessageBox::warning(nullptr,
-                                         tr("Rotation Failed"),
-                                         tr("Failed to save the rotated surface: %1").arg(
-                                             result.error.isEmpty() ? tr("no surface was written") : result.error));
+                    QMessageBox::warning(
+                        nullptr,
+                        tr("Surface Transform Failed"),
+                        tr("Failed to save the transformed surface: %1").arg(result.error.isEmpty() ? tr("no surface was written") : result.error));
                     return;
                 }
 
@@ -619,19 +746,18 @@ void SurfaceRotationOverlayController::applyRotation()
 
                 self->_rotateActive = false;
                 self->_angleDeg = 0.0;
+                self->_horizontalFlip = false;
                 self->_previewSurface.reset();
                 self->_sourceSurface.reset();
                 self->clearWidgets();
             });
 
-    auto future = QtConcurrent::run([surface, angleDeg]() -> RotationSaveResult {
-        // saveOverwrite() snapshots the on-disk state before
-        // overwriting it. rotate() only mutates _points in memory,
-        // so the on-disk x/y/z.tif are still pre-rotate when the
-        // snapshot is taken — the backup ring captures the
-        // pre-rotation files automatically.
+    auto future = QtConcurrent::run([surface, transform]() -> RotationSaveResult {
+        // applyInMemory() keeps rotation in memory and temporarily hides the
+        // backing path while flipping. saveOverwrite() remains the one
+        // persistence step and can snapshot the pre-transform files first.
         try {
-            surface->rotate(angleDeg);
+            transform.applyInMemory(*surface);
             surface->saveOverwrite();
         } catch (const std::exception& e) {
             return RotationSaveResult{nullptr, QString::fromUtf8(e.what())};

--- a/volume-cartographer/apps/VC3D/overlays/SurfaceRotationOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/SurfaceRotationOverlayController.hpp
@@ -40,6 +40,8 @@ private:
     void clearWidgets();
     void positionWidget(ViewerEntry& entry) const;
     void setAngle(double angleDeg);
+    bool setHorizontalFlip(bool enabled);
+    bool synchronizeTransformPersistenceCompatibility();
     void updatePreview();
     void applyRotation();
     static std::shared_ptr<QuadSurface> cloneSurface(const std::shared_ptr<QuadSurface>& surface);
@@ -53,6 +55,7 @@ private:
 
     bool _rotateActive{false};
     double _angleDeg{0.0};
+    bool _horizontalFlip{false};
     std::shared_ptr<QuadSurface> _sourceSurface;
     std::shared_ptr<QuadSurface> _previewSurface;
 

--- a/volume-cartographer/apps/VC3D/overlays/SurfaceRotationTransform.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/SurfaceRotationTransform.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cmath>
+#include <filesystem>
+#include <utility>
+
+namespace vc3d::surface_rotation
+{
+constexpr float kMinimumAngleDegrees = 0.01f;
+
+struct TransformPersistenceCompatibility {
+    bool hasMultipageMask{false};
+    bool hasDisconnectedComponents{false};
+
+    [[nodiscard]] bool allowed() const { return !hasMultipageMask && !hasDisconnectedComponents; }
+};
+
+[[nodiscard]] inline TransformPersistenceCompatibility transformPersistenceCompatibility(
+    const std::filesystem::path& surfacePath,
+    bool hasDisconnectedComponents)
+{
+    std::error_code ec;
+    const bool hasMultipageMask = !surfacePath.empty() &&
+                                  (std::filesystem::exists(surfacePath / "multilayer_mask.tif", ec) || bool(ec));
+    return {hasMultipageMask, hasDisconnectedComponents};
+}
+
+struct HorizontalFlipSelection {
+    bool selected{false};
+    bool selectionCleared{false};
+};
+
+[[nodiscard]] inline HorizontalFlipSelection reconcileHorizontalFlipSelection(bool selected, const TransformPersistenceCompatibility& compatibility)
+{
+    const bool allowed = compatibility.allowed();
+    return {selected && allowed, selected && !allowed};
+}
+
+struct Transform {
+    float angleDegrees{0.0f};
+    bool flipHorizontally{false};
+
+    [[nodiscard]] bool isNoOp() const { return std::abs(angleDegrees) < kMinimumAngleDegrees && !flipHorizontally; }
+
+    template <typename Surface>
+    void applyInMemory(Surface& surface) const
+    {
+        if (isNoOp()) {
+            return;
+        }
+
+        if (std::abs(angleDegrees) >= kMinimumAngleDegrees) {
+            surface.rotate(angleDegrees);
+        }
+        if (!flipHorizontally) {
+            return;
+        }
+
+        // QuadSurface::flipV() also updates disk-backed sidecar TIFFs when a
+        // path is present. Preview and Apply flip a clone in memory;
+        // persistence remains the caller's single saveOverwrite() step.
+        auto backingPath = std::move(surface.path);
+        surface.path.clear();
+        try {
+            surface.flipV();
+        } catch (...) {
+            surface.path = std::move(backingPath);
+            throw;
+        }
+        surface.path = std::move(backingPath);
+    }
+};
+}  // namespace vc3d::surface_rotation

--- a/volume-cartographer/apps/VC3D/test/CMakeLists.txt
+++ b/volume-cartographer/apps/VC3D/test/CMakeLists.txt
@@ -1,3 +1,22 @@
+find_package(Qt6 REQUIRED COMPONENTS Concurrent Core Test Widgets)
+
+add_executable(test_surface_rotation_transform
+    test_surface_rotation_transform.cpp)
+
+target_include_directories(test_surface_rotation_transform PRIVATE
+    ${PROJECT_SOURCE_DIR}/apps/VC3D)
+
+target_link_libraries(test_surface_rotation_transform PRIVATE
+    Qt6::Core
+    Qt6::Test)
+
+set_target_properties(test_surface_rotation_transform PROPERTIES
+    AUTOMOC ON AUTOUIC OFF AUTORCC OFF)
+
+add_test(NAME surface_rotation_transform COMMAND test_surface_rotation_transform)
+vc_register_test_target(test_surface_rotation_transform)
+vc_register_ctest(surface_rotation_transform test_surface_rotation_transform)
+
 # Standalone unit test for SeedingBatchTracker (apps/VC3D/SeedingBatchTracker.*),
 # the honest run/expand batch-outcome aggregation extracted from SeedingWidget.
 # Deterministic, no process launch, no volume data — safe for the default ctest
@@ -7,8 +26,6 @@
 # so we compile its source straight into the test and link just Qt6::Core (for
 # QString et al.) + Qt6::Test (the QTest harness). No other VC3D code is pulled
 # in, keeping the test fast and self-contained.
-find_package(Qt6 REQUIRED COMPONENTS Concurrent Core Test Widgets)
-
 add_executable(test_unified_browser_dialog
     test_unified_browser_dialog.cpp
     ${PROJECT_SOURCE_DIR}/apps/VC3D/UnifiedBrowserDialog.cpp

--- a/volume-cartographer/apps/VC3D/test/test_surface_rotation_transform.cpp
+++ b/volume-cartographer/apps/VC3D/test/test_surface_rotation_transform.cpp
@@ -1,0 +1,164 @@
+#include "overlays/SurfaceRotationTransform.hpp"
+
+#include <QTemporaryDir>
+#include <QTest>
+
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+struct RecordingSurface {
+    std::filesystem::path path{"source-segment"};
+    std::vector<std::string> operations;
+    bool rotateSawBackingPath{false};
+    bool flipSawBackingPath{false};
+    bool failFlip{false};
+
+    void rotate(float)
+    {
+        operations.emplace_back("rotate");
+        rotateSawBackingPath = rotateSawBackingPath || !path.empty();
+    }
+
+    void flipV()
+    {
+        operations.emplace_back("flipV");
+        flipSawBackingPath = flipSawBackingPath || !path.empty();
+        if (failFlip) {
+            throw std::runtime_error("flip failed");
+        }
+    }
+};
+}  // namespace
+
+class SurfaceRotationTransformTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void rotatesThenFlipsHorizontally()
+    {
+        RecordingSurface surface;
+
+        vc3d::surface_rotation::Transform{37.0f, true}.applyInMemory(surface);
+
+        const std::vector<std::string> expected{"rotate", "flipV"};
+        QVERIFY(surface.operations == expected);
+        QVERIFY(surface.rotateSawBackingPath);
+        QVERIFY(!surface.flipSawBackingPath);
+        QVERIFY(surface.path == std::filesystem::path{"source-segment"});
+    }
+
+    void keepsBackingPathVisibleForRotationOnly()
+    {
+        RecordingSurface surface;
+
+        vc3d::surface_rotation::Transform{37.0f, false}.applyInMemory(surface);
+
+        const std::vector<std::string> expected{"rotate"};
+        QVERIFY(surface.operations == expected);
+        QVERIFY(surface.rotateSawBackingPath);
+        QVERIFY(!surface.flipSawBackingPath);
+        QVERIFY(surface.path == std::filesystem::path{"source-segment"});
+    }
+
+    void supportsHorizontalFlipWithoutRotation()
+    {
+        RecordingSurface surface;
+
+        vc3d::surface_rotation::Transform{0.0f, true}.applyInMemory(surface);
+
+        const std::vector<std::string> expected{"flipV"};
+        QVERIFY(surface.operations == expected);
+        QVERIFY(!surface.flipSawBackingPath);
+        QVERIFY(surface.path == std::filesystem::path{"source-segment"});
+    }
+
+    void skipsNoOpWithoutTouchingTheSurface()
+    {
+        RecordingSurface surface;
+
+        const vc3d::surface_rotation::Transform transform{0.0f, false};
+        QVERIFY(transform.isNoOp());
+        transform.applyInMemory(surface);
+
+        QVERIFY(surface.operations.empty());
+        QVERIFY(!surface.flipSawBackingPath);
+        QVERIFY(surface.path == std::filesystem::path{"source-segment"});
+    }
+
+    void restoresBackingPathWhenTransformThrows()
+    {
+        RecordingSurface surface;
+        surface.failFlip = true;
+
+        bool threw = false;
+        try {
+            vc3d::surface_rotation::Transform{0.0f, true}.applyInMemory(surface);
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+
+        QVERIFY(threw);
+        QVERIFY(!surface.flipSawBackingPath);
+        QVERIFY(surface.path == std::filesystem::path{"source-segment"});
+    }
+
+    void blocksTransformPersistenceForUnsupportedSurfaceFeatures()
+    {
+        const vc3d::surface_rotation::TransformPersistenceCompatibility supported;
+        const vc3d::surface_rotation::TransformPersistenceCompatibility mask{true, false};
+        const vc3d::surface_rotation::TransformPersistenceCompatibility components{false, true};
+        const vc3d::surface_rotation::TransformPersistenceCompatibility both{true, true};
+
+        QVERIFY(supported.allowed());
+        QVERIFY(!mask.allowed());
+        QVERIFY(!components.allowed());
+        QVERIFY(!both.allowed());
+    }
+
+    void detectsPersistenceCompatibilityFromSurfaceFiles()
+    {
+        QTemporaryDir temporaryDirectory;
+        QVERIFY(temporaryDirectory.isValid());
+        const std::filesystem::path root{temporaryDirectory.path().toStdString()};
+
+        const auto supported = vc3d::surface_rotation::transformPersistenceCompatibility(root, false);
+        QVERIFY(supported.allowed());
+
+        std::ofstream(root / "multilayer_mask.tif").put('\0');
+        const auto mask = vc3d::surface_rotation::transformPersistenceCompatibility(root, false);
+        QVERIFY(mask.hasMultipageMask);
+        QVERIFY(!mask.allowed());
+
+        const auto components = vc3d::surface_rotation::transformPersistenceCompatibility(std::filesystem::path{}, true);
+        QVERIFY(components.hasDisconnectedComponents);
+        QVERIFY(!components.allowed());
+    }
+
+    void reconcilesHorizontalFlipSelectionWithCompatibility()
+    {
+        const vc3d::surface_rotation::TransformPersistenceCompatibility supported;
+        const vc3d::surface_rotation::TransformPersistenceCompatibility unsupported{true, false};
+
+        const auto retained = vc3d::surface_rotation::reconcileHorizontalFlipSelection(true, supported);
+        QVERIFY(retained.selected);
+        QVERIFY(!retained.selectionCleared);
+
+        const auto cleared = vc3d::surface_rotation::reconcileHorizontalFlipSelection(true, unsupported);
+        QVERIFY(!cleared.selected);
+        QVERIFY(cleared.selectionCleared);
+
+        const auto alreadyClear = vc3d::surface_rotation::reconcileHorizontalFlipSelection(false, unsupported);
+        QVERIFY(!alreadyClear.selected);
+        QVERIFY(!alreadyClear.selectionCleared);
+    }
+};
+
+QTEST_APPLESS_MAIN(SurfaceRotationTransformTest)
+
+#include "test_surface_rotation_transform.moc"

--- a/volume-cartographer/docs/extending_and_modifying_segmentations.md
+++ b/volume-cartographer/docs/extending_and_modifying_segmentations.md
@@ -2,6 +2,10 @@ Segmentation growth and editing is now supported within the segmentation widget.
 
 This is relatively untested, but (should) work. It's possible to easily create relatively large segmentations rather quickly -- i created this nearly 22cm segmentation in less than 5 minutes. ![grow_example.png](grow_example.png)
 
+**rotate and flip a surface**
+
+Select a segmentation, then open `Actions > Transforms > Rotate`. Adjust the angle and, if needed, enable `Flip horizontally`; the segmentation view previews rotation followed by the horizontal flip. Select `Apply` to write the transformed surface. Rotation preview remains available for surfaces with multipage `multilayer_mask.tif` sidecars or disconnected component ranges, but `Apply` is disabled because those structures cannot yet be transformed safely.
+
 **prerequisites** 
 - you must have computed normal grids in the volpkg directory stored as `/path/to/example.volpkg/normal_grids/`
   - to compute these, run `/path/to/build/bin/vc_compute_normal_grids` , use the help option to see the options (or just enter it without any arguments)


### PR DESCRIPTION
Related to #370

The existing VC3D transform on `main` already provides arbitrary rotation preview and Apply. This follow-up adds horizontal flip to the same `Actions > Transforms > Rotate` workflow.

For ordinary single-page TIFF surfaces, Apply safely persists rotation followed by horizontal flip. For multipage mask inputs or surfaces with non-empty components, Apply is blocked before destructive persistence. Focused tests cover transform order and path restoration, compatibility detection, and selection clearing.

## Real-scroll evidence

Captured with the rebased VC3D binary built from source commit `b5e4fd30f1711ede4ddc0dda78b08e25639a4220`, using the [official Open Data manifest](https://vesuvius-challenge-open-data.s3.us-east-1.amazonaws.com/metadata.json): sample `PHerc0800`, volume `20250521135224`, segment `20251028220955` ([source TIFXYZ](https://vesuvius-challenge-open-data.s3.us-east-1.amazonaws.com/PHerc0800/segments/20251028220955-auto_grown_20251028220955262/mesh/intermediate/tifxyz_original/x.tif)).

| Original | Preview: 37° + horizontal flip | Persisted after Apply |
| --- | --- | --- |
| ![Original real-scroll surface](https://raw.githubusercontent.com/LubuSeb/villa/3f768a14b176ada8987de7d2b8ba780bd95d8e70/volume-cartographer/docs/imgs/surface-transform-real-scroll-before.png) | ![Real-scroll transform preview](https://raw.githubusercontent.com/LubuSeb/villa/3f768a14b176ada8987de7d2b8ba780bd95d8e70/volume-cartographer/docs/imgs/surface-transform-real-scroll-preview.png) | ![Persisted real-scroll transform](https://raw.githubusercontent.com/LubuSeb/villa/3f768a14b176ada8987de7d2b8ba780bd95d8e70/volume-cartographer/docs/imgs/surface-transform-real-scroll-after.png) |

The materialized coordinate files changed on Apply while their provenance file did not:

- `catalog-origin.json`: `f5d24ba3…` → `f5d24ba3…` (unchanged)
- `x.tif`: `faccfaac…` → `9dd25200…`
- `y.tif`: `0477c43c…` → `fb504ba6…`
- `z.tif`: `df09bbae…` → `44c0bdf6…`

## Validation

- Rebased cleanly onto `main` at `93d939acdf0c238a284ba0ce0b746748ddda892f`.
- GCC 15.2.0 release build: all 152 CTest tests passed, including `surface_rotation_transform`.
- Clang 21.1.8 release build succeeded; 151/152 CTest tests passed, including `surface_rotation_transform`. The sole failure was an unrelated `test_zarr_chunk_fetcher` temp-cache cleanup race, reproduced across isolated reruns with different `.tmp` files and subcases.
- `git diff --check` passes.

AI-assisted tooling was used for implementation and validation. No bounty claim is attached to this follow-up.
