### PR TITLE
Make QuadSurface gen safe for parallel rendering

### DIFF
--- a/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
@@ -362,16 +362,8 @@ public:
     // because gen() can be called from concurrent OMP threads.
     mutable std::atomic<bool> _validMaskAllValid{false};
     mutable cv::Mat_<cv::Vec3f> _normalCache;
-    // gen() scratch buffers reused across render ticks. At 1920×1080 each
-    // coords/normals Mat is ~170 MiB of cv::Vec3f; submitRender fires every
-    // 16-33 ms so fresh allocations burn GB/sec through the allocator and
-    // page-fault every frame. cv::warpAffine writes these as dst: OpenCV's
-    // Mat::create reuses the buffer when size+type match the existing alloc,
-    // so these stay at one buffer per surface after steady state is reached.
-    // mutable because gen() is const.
-    mutable cv::Mat_<cv::Vec3f> _genCoordsScratch;
-    mutable cv::Mat_<cv::Vec3f> _genNormalsScratch;
-    mutable cv::Mat_<uint8_t> _genValidScratch;
+    // Guards lazy normal-cache rebuilds while gen() runs on parallel tile workers.
+    mutable std::mutex _normalCacheMutex;
     cv::Vec2f _scale;
 
     void setChannel(const std::string& name, const cv::Mat& channel);

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -264,6 +264,10 @@ void warpNearestConstU8(const cv::Mat_<uint8_t>& src,
                         uint8_t border)
 {
     const int sc = src.cols, sr = src.rows;
+    if (sc <= 0 || sr <= 0) {
+        dst.setTo(border);
+        return;
+    }
     const int dw = dst.cols, dh = dst.rows;
     const float fox = float(ox), foy = float(oy);
     const float fsx = float(sx), fsy = float(sy);
@@ -290,6 +294,10 @@ void warpNearestConstVec3f(const cv::Mat_<cv::Vec3f>& src,
                            const cv::Vec3f& border)
 {
     const int sc = src.cols, sr = src.rows;
+    if (sc <= 0 || sr <= 0) {
+        dst.setTo(border);
+        return;
+    }
     const int dw = dst.cols, dh = dst.rows;
     const float fox = float(ox), foy = float(oy);
     const float fsx = float(sx), fsy = float(sy);
@@ -644,7 +652,10 @@ void QuadSurface::unloadPoints()
     _channels.clear();
     _validMaskCache = cv::Mat_<uint8_t>();
     _validMaskAllValid = false;
-    _normalCache = cv::Mat_<cv::Vec3f>();
+    {
+        std::lock_guard<std::mutex> normalLock(_normalCacheMutex);
+        _normalCache = cv::Mat_<cv::Vec3f>();
+    }
     _needsLoad = true;
     if (DebugLoggingEnabled()) {
         std::fprintf(stderr, "[SURF] unload %s (%zu MB freed)\n", id.c_str(), mb);
@@ -655,7 +666,10 @@ void QuadSurface::unloadCaches()
 {
     _validMaskCache = cv::Mat_<uint8_t>();
     _validMaskAllValid = false;
-    _normalCache = cv::Mat_<cv::Vec3f>();
+    {
+        std::lock_guard<std::mutex> normalLock(_normalCacheMutex);
+        _normalCache = cv::Mat_<cv::Vec3f>();
+    }
     // Release loaded channel pixel data but keep the keys so channel(name)
     // still knows which channels exist on disk and can lazy-reload them.
     for (auto& [_, mat] : _channels) {
@@ -741,7 +755,10 @@ void QuadSurface::invalidateCache()
     _bbox = {{-1, -1, -1}, {-1, -1, -1}};
     _validMaskCache = cv::Mat_<uint8_t>();
     _validMaskAllValid = false;
-    _normalCache = cv::Mat_<cv::Vec3f>();
+    {
+        std::lock_guard<std::mutex> normalLock(_normalCacheMutex);
+        _normalCache = cv::Mat_<cv::Vec3f>();
+    }
 }
 
 void QuadSurface::gen(cv::Mat_<cv::Vec3f>* coords,
@@ -777,8 +794,10 @@ void QuadSurface::gen(cv::Mat_<cv::Vec3f>* coords,
     bool skipValidity = _validMaskAllValid;
 
     // --- warp coords and validity ----------------------------------------
-    cv::Mat_<cv::Vec3f>& coords_big = _genCoordsScratch;
-    cv::Mat_<uint8_t>& valid_big = _genValidScratch;
+    thread_local cv::Mat_<cv::Vec3f> coordsScratch;
+    thread_local cv::Mat_<uint8_t> validScratch;
+    cv::Mat_<cv::Vec3f>& coords_big = coordsScratch;
+    cv::Mat_<uint8_t>& valid_big = validScratch;
 
     if (!_components.empty()) {
         // Multi-component surface: warp each component separately with
@@ -832,44 +851,52 @@ void QuadSurface::gen(cv::Mat_<cv::Vec3f>* coords,
     }
 
     // --- normals: warp cached source-grid normals -------------------
-    cv::Mat_<cv::Vec3f>& normals_big = _genNormalsScratch;
+    thread_local cv::Mat_<cv::Vec3f> normalsScratch;
+    cv::Mat_<cv::Vec3f>& normals_big = normalsScratch;
     if (need_normals) {
         // Build source-grid normal cache once per surface. Subsequent gen()
         // calls (panning, zooming) reuse it. Cleared by unloadCaches() when
         // a different surface becomes active.
-        if (_normalCache.empty() || _normalCache.size() != _points->size()) {
-            _normalCache.create(_points->rows, _points->cols);
-            const cv::Vec3f qn(std::numeric_limits<float>::quiet_NaN(),
-                               std::numeric_limits<float>::quiet_NaN(),
-                               std::numeric_limits<float>::quiet_NaN());
-            const int rows = _points->rows;
-            const int cols = _points->cols;
-            // Border rows/cols: no ±1 neighbors, fill with NaN sentinel.
-            if (rows > 0) {
-                cv::Vec3f* top = _normalCache[0];
-                cv::Vec3f* bot = _normalCache[rows - 1];
-                for (int c = 0; c < cols; c++) { top[c] = qn; bot[c] = qn; }
-            }
-            #pragma omp parallel for schedule(dynamic, 16)
-            for (int r = 1; r < rows - 1; r++) {
-                cv::Vec3f* dst = _normalCache[r];
-                const cv::Vec3f* row = (*_points)[r];
-                dst[0] = qn;
-                dst[cols - 1] = qn;
-                for (int c = 1; c < cols - 1; c++) {
-                    if (row[c][0] == -1.f) {
-                        dst[c] = qn;
-                    } else {
-                        dst[c] = grid_normal_int(*_points, r, c);
+        cv::Mat_<cv::Vec3f> normalCache;
+        {
+            std::lock_guard<std::mutex> normalLock(_normalCacheMutex);
+            if (_normalCache.empty() || _normalCache.size() != _points->size()) {
+                _normalCache.create(_points->rows, _points->cols);
+                const cv::Vec3f qn(std::numeric_limits<float>::quiet_NaN(),
+                                   std::numeric_limits<float>::quiet_NaN(),
+                                   std::numeric_limits<float>::quiet_NaN());
+                const int rows = _points->rows;
+                const int cols = _points->cols;
+                // Border rows/cols: no +/-1 neighbors, fill with NaN sentinel.
+                if (rows > 0) {
+                    cv::Vec3f* top = _normalCache[0];
+                    cv::Vec3f* bot = _normalCache[rows - 1];
+                    for (int c = 0; c < cols; c++) { top[c] = qn; bot[c] = qn; }
+                }
+                #pragma omp parallel for schedule(dynamic, 16)
+                for (int r = 1; r < rows - 1; r++) {
+                    cv::Vec3f* dst = _normalCache[r];
+                    const cv::Vec3f* row = (*_points)[r];
+                    if (cols > 0) {
+                        dst[0] = qn;
+                        dst[cols - 1] = qn;
+                    }
+                    for (int c = 1; c < cols - 1; c++) {
+                        if (row[c][0] == -1.f) {
+                            dst[c] = qn;
+                        } else {
+                            dst[c] = grid_normal_int(*_points, r, c);
+                        }
                     }
                 }
             }
+            normalCache = _normalCache;
         }
         const cv::Vec3f qnVec(std::numeric_limits<float>::quiet_NaN(),
                               std::numeric_limits<float>::quiet_NaN(),
                               std::numeric_limits<float>::quiet_NaN());
         normals_big.create(h + 8, w + 8);
-        warpNearestConstVec3f(_normalCache, normals_big,
+        warpNearestConstVec3f(normalCache, normals_big,
                               ox, oy, sx, sy, qnVec);
     }
 

--- a/volume-cartographer/core/test/test_quadsurface_components.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_components.cpp
@@ -11,6 +11,9 @@
 
 #include <filesystem>
 #include <random>
+#include <atomic>
+#include <thread>
+#include <vector>
 
 namespace fs = std::filesystem;
 
@@ -69,6 +72,38 @@ TEST_CASE("QuadSurface(path,json) with components: gen() uses multi-component wa
     CHECK(coords.rows == 8);
     CHECK(coords.cols == 8);
     fs::remove_all(root);
+}
+
+TEST_CASE("QuadSurface::gen with normals is safe across concurrent tile workers")
+{
+    QuadSurface qs(grid(64, 64), cv::Vec2f(1.f, 1.f));
+    std::atomic<bool> ok{true};
+    std::vector<std::thread> workers;
+
+    for (int t = 0; t < 8; ++t) {
+        workers.emplace_back([&qs, &ok, t]() {
+            try {
+                for (int i = 0; i < 24; ++i) {
+                    cv::Mat_<cv::Vec3f> coords, normals;
+                    qs.gen(&coords, &normals, cv::Size(32, 24),
+                           cv::Vec3f(static_cast<float>(t + i), static_cast<float>(i), 1.0f),
+                           1.0f, cv::Vec3f(0, 0, 0));
+                    if (coords.rows != 24 || coords.cols != 32 ||
+                        normals.rows != 24 || normals.cols != 32) {
+                        ok = false;
+                    }
+                }
+            } catch (...) {
+                ok = false;
+            }
+        });
+    }
+
+    for (auto& worker : workers) {
+        worker.join();
+    }
+
+    CHECK(ok.load());
 }
 
 TEST_CASE("components-meta with degenerate ranges is filtered out")


### PR DESCRIPTION
Fixes #1046.

## Summary

- make `QuadSurface::gen()` safe when `vc_render_tifxyz` calls it from parallel tile workers
- move the large coordinate/validity/normal scratch buffers from shared per-surface members to per-thread scratch buffers
- guard lazy normal-cache rebuilds and snapshot the cache header before warping normals
- add an empty-source guard to the nearest-neighbor warp helpers
- add a concurrent `QuadSurface::gen()` regression test that requests normals from multiple worker threads

## Reproduction / Root Cause

Issue #1046 reports SIGSEGVs in `vc-render-tifxyz` after updating from an April build. The posted stack trace lands in:

```text
QuadSurface::gen -> warpNearestConstVec3f -> orow[dx] = ... srow[sx_i]
```

`vc_render_tifxyz` renders tile columns inside an OpenMP loop, and each tile calls `genTile()`, which calls `QuadSurface::gen()` on the same `QuadSurface`.

The recent optimized `gen()` path reused mutable destination scratch buffers on the surface object:

- `_genCoordsScratch`
- `_genValidScratch`
- `_genNormalsScratch`

Those are written by each `gen()` call, so parallel tile workers could write and resize the same `cv::Mat` storage concurrently. The lazy `_normalCache` build was also unguarded, so first-use normal generation could race.

## Scope / Minimality

This patch is limited to:

- `volume-cartographer/core/include/vc/core/util/QuadSurface.hpp`
- `volume-cartographer/core/src/QuadSurface.cpp`
- `volume-cartographer/core/test/test_quadsurface_components.cpp`

It does not change surface-normal orientation policy, `vc_render_tifxyz` command-line options, renderer output semantics, or scheduling.

## Issue / Artifact Binding

- Issue: https://github.com/ScrollPrize/villa/issues/1046
- Artifact: this pull request from `LubuSeb:codex/villa-1046-threadsafe-gen`
- Prize context: Vesuvius Challenge monthly progress prizes may consider VC/tooling improvements; this PR is the reviewable technical artifact, not a guaranteed award request.

## Validation

Run in the project Docker builder:

```sh
cmake --preset ci-tests-gcc
cmake --build --preset ci-tests-gcc --target vc_render_tifxyz
cmake --build --preset ci-tests-gcc --target test_quadsurface_components
./build/ci-tests-gcc/bin/test_quadsurface_components
cmake --build --preset ci-tests-gcc
ctest --preset ci-tests-gcc --output-on-failure
```

Results:

- `vc_render_tifxyz` built successfully.
- `test_quadsurface_components` passed, including the new concurrent `QuadSurface::gen()` regression.
- Full configured CTest passed: `97/97` tests.
- `git diff --check` passed; only Windows LF-to-CRLF warnings were emitted by Git.

## Known Limits

I did not have the private/large segment dataset that produced the original backtrace, so I validated the failure mode with a focused concurrency regression and the full Dockerized test suite rather than a direct data replay.

This is also a normal GitHub PR contribution. It may be relevant for Vesuvius monthly progress-prize review, but this PR does not claim or guarantee an award.
