### PR TITLE
vc-render-tifxyz: add opt-in normal direction flip

### DIFF
--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -268,12 +268,14 @@ static void genTile(QuadSurface* surf, const cv::Size& size, float render_scale,
 static void prepareBaseAndDirs(const cv::Mat_<cv::Vec3f>& pts, const cv::Mat_<cv::Vec3f>& nrm,
                                 float scale_seg, float ds_scale,
                                 bool hasAffine, const AffineTransform& aff,
+                                bool flipNormals,
                                 cv::Mat_<cv::Vec3f>& base, cv::Mat_<cv::Vec3f>& dirs)
 {
     base = pts.clone(); base *= scale_seg;
     dirs = nrm.clone();
     if (hasAffine) applyAffineTransform(base, dirs, aff);
     normalizeNormals(dirs);
+    if (flipNormals) dirs *= -1.0f;
     base *= ds_scale;
 }
 
@@ -463,6 +465,7 @@ static std::vector<vc::render::ChunkKey> collectPrefetchKeysForRows(
     float dsScale,
     bool hasAffine,
     const AffineTransform& aff,
+    bool flipNormals,
     uint32_t rowStart,
     uint32_t rowEnd,
     uint32_t bandH,
@@ -495,7 +498,7 @@ static std::vector<vc::render::ChunkKey> collectPrefetchKeysForRows(
         genTile(surf, cv::Size(tgtSize.width, int(dy)), renderScale, u0, v0, bandPts, bandNrm);
 
         cv::Mat_<cv::Vec3f> base, dirs;
-        prepareBaseAndDirs(bandPts, bandNrm, scaleSeg, dsScale, hasAffine, aff, base, dirs);
+        prepareBaseAndDirs(bandPts, bandNrm, scaleSeg, dsScale, hasAffine, aff, flipNormals, base, dirs);
 
         auto region = computeChunkRegionForSamples(base, dirs, offsets, ds, level);
         if (region.valid()) {
@@ -579,6 +582,7 @@ static void renderBands(
     const cv::Size& fullSize, const cv::Rect& crop, const cv::Size& tgtSize,
     float renderScale, float scaleSeg, float dsScale,
     bool hasAffine, const AffineTransform& aff,
+    bool flipNormals,
     int numSlices, double sliceStep,
     const std::vector<float>& accumOffsets, AccumType accumType,
     bool isComposite, int compositeStart, int compositeEnd,
@@ -614,7 +618,7 @@ static void renderBands(
         genTile(surf, cv::Size(tgtSize.width, int(dy)), renderScale, u0, v0, bandPts, bandNrm);
 
         cv::Mat_<cv::Vec3f> base, dirs;
-        prepareBaseAndDirs(bandPts, bandNrm, scaleSeg, dsScale, hasAffine, aff, base, dirs);
+        prepareBaseAndDirs(bandPts, bandNrm, scaleSeg, dsScale, hasAffine, aff, flipNormals, base, dirs);
 
         std::vector<cv::Mat> slices;
 
@@ -695,6 +699,7 @@ static void renderTiles(
     const cv::Size& fullSize, const cv::Rect& crop, const cv::Size& tgtSize,
     float renderScale, float scaleSeg, float dsScale,
     bool hasAffine, const AffineTransform& aff,
+    bool flipNormals,
     int numSlices, double sliceStep,
     const std::vector<float>& accumOffsets, AccumType accumType,
     bool isComposite, int compositeStart, int compositeEnd,
@@ -822,7 +827,7 @@ static void renderTiles(
 
             // 2. Prepare base coords and step directions
             cv::Mat_<cv::Vec3f> base, dirs;
-            prepareBaseAndDirs(tilePts, tileNrm, scaleSeg, dsScale, hasAffine, aff, base, dirs);
+            prepareBaseAndDirs(tilePts, tileNrm, scaleSeg, dsScale, hasAffine, aff, flipNormals, base, dirs);
 
             // 3. Sample all slices for this tile (single-threaded)
             std::vector<cv::Mat_<T>> raw;
@@ -1063,6 +1068,7 @@ int main(int argc, char *argv[])
         ("scale-segmentation", po::value<float>()->default_value(1.0), "Scale segmentation")
         ("rotate", po::value<double>()->default_value(0.0), "Rotate output (0/90/180/270)")
         ("flip", po::value<int>()->default_value(-1), "Flip: 0=V, 1=H, 2=Both")
+        ("flip-normals", po::bool_switch()->default_value(false), "Flip generated surface normals before sampling")
         ("zarr-output", po::value<std::string>(), "Output path for .zarr (optional)")
         ("tif-output", po::value<std::string>(), "Output path for per-slice TIFFs (optional)")
         ("quick-tif", po::bool_switch()->default_value(false), "Fast TIF: PACKBITS + zero low nibble")
@@ -1228,6 +1234,7 @@ int main(int argc, char *argv[])
     float scale_seg = parsed["scale-segmentation"].as<float>();
     double rotate_angle = parsed["rotate"].as<double>();
     int flip_axis = parsed["flip"].as<int>();
+    const bool flip_normals = parsed["flip-normals"].as<bool>();
     const bool quickTif = parsed["quick-tif"].as<bool>();
 
     // --- Load affines ---
@@ -1372,6 +1379,7 @@ int main(int argc, char *argv[])
         logPrintf(stdout, "Rotation: %.0f degrees\n", rotate_angle);
     }
     if (flip_axis >= 0) logPrintf(stdout, "Flip: %s\n", flip_axis == 0 ? "V" : flip_axis == 1 ? "H" : "Both");
+    if (flip_normals) logPrintf(stdout, "Normal direction: flipped before sampling\n");
 
     if (wantZarr) {
         if (auto p = std::filesystem::path(zarrOutputArg).parent_path(); !p.empty())
@@ -1621,6 +1629,7 @@ int main(int argc, char *argv[])
                 full_size, crop, tgt_size,
                 float(render_scale), scale_seg, ds_scale,
                 hasAffine, affineTransform,
+                flip_normals,
                 rowStart, rowEnd, kPrefetchBandH,
                 num_slices, slice_step, accumOffsets,
                 isCompositeMode, compositeStart, compositeEnd);
@@ -1641,7 +1650,7 @@ int main(int argc, char *argv[])
                 if (useU16)
                     renderTiles<uint16_t>(surf.get(), chunk_cache, chunk_cache, cacheLevel,
                         full_size, crop, tgt_size, float(render_scale), scale_seg, ds_scale,
-                        hasAffine, affineTransform, num_slices, slice_step,
+                        hasAffine, affineTransform, flip_normals, num_slices, slice_step,
                         accumOffsets, accumType, isCompositeMode, compositeStart, compositeEnd,
                         compositeParams, rotQuad, flip_axis, numParts, partId, cvType,
                         dsOut.get(), chunks0, tilesXSrc, tilesYSrc,
@@ -1651,7 +1660,7 @@ int main(int argc, char *argv[])
                 else
                     renderTiles<uint8_t>(surf.get(), chunk_cache, chunk_cache, cacheLevel,
                         full_size, crop, tgt_size, float(render_scale), scale_seg, ds_scale,
-                        hasAffine, affineTransform, num_slices, slice_step,
+                        hasAffine, affineTransform, flip_normals, num_slices, slice_step,
                         accumOffsets, accumType, isCompositeMode, compositeStart, compositeEnd,
                         compositeParams, rotQuad, flip_axis, numParts, partId, cvType,
                         dsOut.get(), chunks0, tilesXSrc, tilesYSrc,
@@ -1683,13 +1692,13 @@ int main(int argc, char *argv[])
                 if (useU16)
                     renderBands<uint16_t>(surf.get(), chunk_cache, chunk_cache, cacheLevel,
                         full_size, crop, tgt_size, float(render_scale), scale_seg, ds_scale,
-                        hasAffine, affineTransform, num_slices, slice_step,
+                        hasAffine, affineTransform, flip_normals, num_slices, slice_step,
                         accumOffsets, accumType, isCompositeMode, compositeStart, compositeEnd,
                         compositeParams, rotQuad, flip_axis, numParts, partId, cvType, bandH, writerFn);
                 else
                     renderBands<uint8_t>(surf.get(), chunk_cache, chunk_cache, cacheLevel,
                         full_size, crop, tgt_size, float(render_scale), scale_seg, ds_scale,
-                        hasAffine, affineTransform, num_slices, slice_step,
+                        hasAffine, affineTransform, flip_normals, num_slices, slice_step,
                         accumOffsets, accumType, isCompositeMode, compositeStart, compositeEnd,
                         compositeParams, rotQuad, flip_axis, numParts, partId, cvType, bandH, writerFn);
             }


### PR DESCRIPTION
Fixes #1044.

## Summary

- add an opt-in `--flip-normals` flag to `vc_render_tifxyz`
- flip the generated surface-normal sampling direction before applying slice offsets
- pass the same normal-direction setting through both prefetch-region calculation and tiled/banded rendering
- leave existing output behavior unchanged unless the new flag is provided

## Scope / Minimality

This patch is limited to `volume-cartographer/apps/src/vc_render_tifxyz.cpp`.

It does not change the default normal orientation policy, surface generation, affine transform behavior, output post-processing, or tile scheduling. The option is deliberately off by default because issue #1044 discussed making the reversed normal direction available as an optional flag rather than changing defaults globally.

## Reproduction / Context

Issue #1044 reports that readable UV-space text can render with the opposite orientation from what the reporter expects, and asks whether `vc_render_tifxyz` should flip normal direction. The maintainer discussion explicitly allows adding the behavior as an optional flag rather than changing default behavior.

The relevant renderer path generates surface points and normals, normalizes the direction vectors, then samples image data at slice offsets along those normals. Without an opt-in switch, users have to change segment orientation or modify code locally to sample in the opposite direction. This patch exposes that opposite sampling direction as a CLI option while preserving the existing default.

## Issue / Artifact Binding

- Issue: https://github.com/ScrollPrize/villa/issues/1044
- Artifact: this pull request from `LubuSeb:codex/villa-1044-flip-normals`
- Prize context: Vesuvius Challenge monthly progress prizes may consider VC/tooling improvements; this PR is the reviewable technical artifact, not a guaranteed award request.

## Validation

Run in the project Docker builder:

```sh
cmake --preset ci-tests-gcc
cmake --build --preset ci-tests-gcc --target vc_render_tifxyz
./build/ci-tests-gcc/bin/vc_render_tifxyz --help | grep -q -- --flip-normals
cmake --build --preset ci-tests-gcc
ctest --preset ci-tests-gcc --output-on-failure
```

Results:

- `vc_render_tifxyz` built successfully.
- `--flip-normals` is exposed by `vc_render_tifxyz --help`.
- Full configured CTest passed: `97/97` tests.
- `git diff --check` passed; only Windows LF-to-CRLF warnings were emitted by Git.

## Known Limits

I validated the control path, build, CLI exposure, and full Dockerized test suite. I did not have a reviewer-provided segment/volume pair with a known desired flipped-normal rendering, so this PR implements the requested opt-in direction switch without asserting that it should become the default.
