### PR TITLE
docs: update stale FAQ prize timing reference

### DIFF
--- a/scrollprize.org/docs/09_faq.md
+++ b/scrollprize.org/docs/09_faq.md
@@ -59,7 +59,7 @@ Join us to win prizes and be a part of history!
 
 ### What dates do I need to know?
 
-The [2024 prize](2024_prizes) deadlines closed on **December 31, 2024**, and we are now evaluating the submissions and preparing the next stages. [Join the community](get_started#1-join-the-community) to stay tuned!
+Current prize opportunities are listed on the [Open Prizes](prizes) page. The [2024 prize](2024_prizes) deadlines closed on **December 31, 2024** and remain available for historical reference. [Join the community](get_started#1-join-the-community) to stay tuned!
 
 ### What's the historical background of Herculaneum and the scrolls?
 


### PR DESCRIPTION
Addresses part of #199.

Issue: https://github.com/ScrollPrize/villa/issues/199
Source checked: https://scrollprize.org/prizes and `scrollprize.org/docs/34_prizes.md`

## Summary

- Update the FAQ dates answer to point readers to the current Open Prizes page.
- Keep the 2024 prize page linked as historical reference.

## Why

Issue #199 tracks out-of-date documentation on scrollprize.org. The FAQ still says the team is evaluating 2024 submissions and preparing next stages, while the current docs have an active Open Prizes page.

## Scope / Duplicate Check

This is intentionally limited to `scrollprize.org/docs/09_faq.md`.

I did not change the stale `7 x $60,000` prize-count wording because PR #1050 already addresses that part of #199 in `01_get_started.md` and the landing page.

## Verification

- Checked `scrollprize.org/docs/34_prizes.md` for `id: prizes` and the Open Prizes title.
- Ran `git diff --check`.
- Confirmed the stale `preparing the next stages` phrase is removed from `scrollprize.org/docs/09_faq.md`.

## Notes

No historical prize archive pages were changed.