### PR TITLE
docs: fix stale dates, baseline, and archived repo links (#199)

### DIFF
--- a/scrollprize.org/docs/03_tutorial.md
+++ b/scrollprize.org/docs/03_tutorial.md
@@ -93,7 +93,7 @@ The X-ray photos are combined into a 3D scan volume using [tomographic reconstru
   <figcaption className="mt-0">Artistic visualization of constructing a 3D volume; in reality the object rotates as it is scanned.</figcaption>
 </figure>
 
-We store the 3D scan volume as a directory full of .tif files, where each file represents one horizontal cross-section or "slice" of the object, typically starting at the bottom of the scroll or scroll fragment and moving upwards. We call this a .tif image stack. You can view and explore a 3D scan volume of a scroll in your browser right now in [one click](https://dl.ash2txt.org/view/Scroll1), or with a few lines of code ([Python](https://github.com/ScrollPrize/vesuvius), [C](https://github.com/ScrollPrize/vesuvius-c)).
+We store the 3D scan volume as a directory full of .tif files, where each file represents one horizontal cross-section or "slice" of the object, typically starting at the bottom of the scroll or scroll fragment and moving upwards. We call this a .tif image stack. You can view and explore a 3D scan volume of a scroll in your browser right now in [one click](https://dl.ash2txt.org/view/Scroll1), or with a few lines of code ([Python](https://github.com/ScrollPrize/villa/tree/main/vesuvius), [C](https://github.com/ScrollPrize/villa/tree/main/vesuvius-c)).
 
 Remember that each pixel in the image stack actually represents a cube (voxel) of physical space. If your volume has a 10um voxel size, then 100 slices will be 1mm (1000um) of the object.
 

--- a/scrollprize.org/docs/09_faq.md
+++ b/scrollprize.org/docs/09_faq.md
@@ -54,12 +54,12 @@ A few hundred scrolls were excavated that were never opened, and remain rolled u
 Our community is building methods to read these scrolls using micro-CT and an algorithmic pipeline using machine learning and computer vision.
 
 We've awarded \$1,800,500 in prizes and broken through, revealing complete passages of Greek philosophy from the inside of a closed Herculaneum scroll for the first time.
-Now we are continuing - we want to go from reading 5% of one scroll to reading multiple complete scrolls.
+Now we are continuing - having read one scroll from end to end, we want to read the rest of the library.
 Join us to win prizes and be a part of history!
 
 ### What dates do I need to know?
 
-The [2024 prize](2024_prizes) deadlines closed on **December 31, 2024**, and we are now evaluating the submissions and preparing the next stages. [Join the community](get_started#1-join-the-community) to stay tuned!
+Monthly Progress Prizes are awarded on a rolling basis, with deadlines at the end of each month — see the [Prizes page](prizes) for the current cycle. For our latest milestone, see [First scroll read](firstscroll). [Join the community](get_started#1-join-the-community) to stay tuned!
 
 ### What's the historical background of Herculaneum and the scrolls?
 

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -55,7 +55,7 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 ### 🌟 Highlighted
 
-- [vesuvius](https://github.com/scrollprize/vesuvius): Python library for accessing Vesuvius Challenge data. Allows direct access to scroll data without managing download scripts or storing terabytes of CT scans locally.
+- [vesuvius](https://github.com/ScrollPrize/villa/tree/main/vesuvius): Python library for accessing Vesuvius Challenge data. Allows direct access to scroll data without managing download scripts or storing terabytes of CT scans locally.
 
 - [Segment browser](https://github.com/jrudolph/vesuvius-browser) is a web-based tool to browse layers and open source ink detection results of all released segments. By Johannes Rudolph
 


### PR DESCRIPTION
Addresses #199.

This PR corrects high-confidence, verifiable out-of-date information. Scope is deliberately small so it can be reviewed and merged quickly; happy to follow up with further fixes once these land.

**Changes:**

- **09_faq.md** — "What dates do I need to know?" was frozen at "the 2024 prize deadlines closed on December 31, 2024, and we are now evaluating the submissions" (~18 months stale). Updated to point to the current monthly Progress Prize cycle and the latest milestone (First scroll read).
- **09_faq.md** — Updated the "go from reading 5% of one scroll" baseline, since one scroll has now been read end to end.
- **03_tutorial.md** — Repointed the archived `ScrollPrize/vesuvius` and `ScrollPrize/vesuvius-c` library links to the maintained location under `villa/tree/main/` (the old repos are archived and self-redirect there).
- **20_community_projects.md** — Repointed the remaining archived `scrollprize/vesuvius` link to `villa/tree/main/vesuvius`, matching the already-updated `vesuvius-c` link on the line below.

Each change was verified against the live source files and the project's own announcements. Happy to adjust wording on request.

**One thing to flag for maintainers:** while editing 20_community_projects.md I noticed an entry around line 82 referencing pull/999 and pull/997 ("scroll-specific augmentations by pscamillo") that I wasn't able to verify — leaving it untouched, but flagging in case it warrants a look.