### PR TITLE
Make QuadSurface::gen() safe for concurrent rendering

### DIFF
--- a/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/QuadSurface.hpp
@@ -362,16 +362,19 @@ public:
     // because gen() can be called from concurrent OMP threads.
     mutable std::atomic<bool> _validMaskAllValid{false};
     mutable cv::Mat_<cv::Vec3f> _normalCache;
-    // gen() scratch buffers reused across render ticks. At 1920×1080 each
-    // coords/normals Mat is ~170 MiB of cv::Vec3f; submitRender fires every
-    // 16-33 ms so fresh allocations burn GB/sec through the allocator and
-    // page-fault every frame. cv::warpAffine writes these as dst: OpenCV's
-    // Mat::create reuses the buffer when size+type match the existing alloc,
-    // so these stay at one buffer per surface after steady state is reached.
-    // mutable because gen() is const.
-    mutable cv::Mat_<cv::Vec3f> _genCoordsScratch;
-    mutable cv::Mat_<cv::Vec3f> _genNormalsScratch;
-    mutable cv::Mat_<uint8_t> _genValidScratch;
+    // Guards lazy (re)builds and clears of the shared caches above
+    // (_validMaskCache, _validMaskAllValid, _normalCache). gen()/validMask()
+    // can run concurrently on a single surface from the renderer's OMP tile
+    // workers; without this two threads race to build/free the same cv::Mat.
+    // Lock ordering: always _loadMutex -> _cacheMutex, never the reverse.
+    mutable std::mutex _cacheMutex;
+    // gen()'s coords/normals/validity scratch buffers were previously shared
+    // mutable members reused across render ticks to avoid per-frame
+    // reallocation (each ~170 MiB at 1920×1080). That reuse is unsafe under
+    // concurrent gen(): one thread's Mat::create() reallocates the buffer
+    // while another reads it (the vc-render-tifxyz SIGSEGV). They are now
+    // thread_local locals inside gen(), preserving the per-thread allocation
+    // reuse without cross-thread sharing.
     cv::Vec2f _scale;
 
     void setChannel(const std::string& name, const cv::Mat& channel);

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -642,9 +642,12 @@ void QuadSurface::unloadPoints()
     }
     _points.reset();
     _channels.clear();
-    _validMaskCache = cv::Mat_<uint8_t>();
-    _validMaskAllValid = false;
-    _normalCache = cv::Mat_<cv::Vec3f>();
+    {
+        std::lock_guard<std::mutex> cacheLock(_cacheMutex);
+        _validMaskCache = cv::Mat_<uint8_t>();
+        _validMaskAllValid = false;
+        _normalCache = cv::Mat_<cv::Vec3f>();
+    }
     _needsLoad = true;
     if (DebugLoggingEnabled()) {
         std::fprintf(stderr, "[SURF] unload %s (%zu MB freed)\n", id.c_str(), mb);
@@ -653,9 +656,12 @@ void QuadSurface::unloadPoints()
 
 void QuadSurface::unloadCaches()
 {
-    _validMaskCache = cv::Mat_<uint8_t>();
-    _validMaskAllValid = false;
-    _normalCache = cv::Mat_<cv::Vec3f>();
+    {
+        std::lock_guard<std::mutex> cacheLock(_cacheMutex);
+        _validMaskCache = cv::Mat_<uint8_t>();
+        _validMaskAllValid = false;
+        _normalCache = cv::Mat_<cv::Vec3f>();
+    }
     // Release loaded channel pixel data but keep the keys so channel(name)
     // still knows which channels exist on disk and can lazy-reload them.
     for (auto& [_, mat] : _channels) {
@@ -670,6 +676,13 @@ cv::Mat_<uint8_t> QuadSurface::validMask() const
         return cv::Mat_<uint8_t>();
     }
 
+    // All access to _validMaskCache happens under _cacheMutex: gen() can call
+    // validMask() concurrently from OMP tile workers. The cache is published as
+    // a complete Mat below, so holding the lock for the whole accessor avoids
+    // both a duplicate build and a torn read of the Mat header. The returned
+    // header copy (made under the lock) keeps the pixel buffer alive for the
+    // caller after the lock is released.
+    std::lock_guard<std::mutex> cacheLock(_cacheMutex);
     if (!_validMaskCache.empty() &&
         _validMaskCache.rows == _points->rows &&
         _validMaskCache.cols == _points->cols) {
@@ -739,9 +752,12 @@ void QuadSurface::invalidateCache()
     }
 
     _bbox = {{-1, -1, -1}, {-1, -1, -1}};
-    _validMaskCache = cv::Mat_<uint8_t>();
-    _validMaskAllValid = false;
-    _normalCache = cv::Mat_<cv::Vec3f>();
+    {
+        std::lock_guard<std::mutex> cacheLock(_cacheMutex);
+        _validMaskCache = cv::Mat_<uint8_t>();
+        _validMaskAllValid = false;
+        _normalCache = cv::Mat_<cv::Vec3f>();
+    }
 }
 
 void QuadSurface::gen(cv::Mat_<cv::Vec3f>* coords,
@@ -777,8 +793,15 @@ void QuadSurface::gen(cv::Mat_<cv::Vec3f>* coords,
     bool skipValidity = _validMaskAllValid;
 
     // --- warp coords and validity ----------------------------------------
-    cv::Mat_<cv::Vec3f>& coords_big = _genCoordsScratch;
-    cv::Mat_<uint8_t>& valid_big = _genValidScratch;
+    // Thread-local scratch: keeps the per-frame allocation-reuse optimization
+    // (Mat::create reuses the buffer when size+type match) while making gen()
+    // safe to call concurrently on one surface — each OMP worker owns its own
+    // buffers instead of racing on shared members.
+    thread_local cv::Mat_<cv::Vec3f> tl_coordsScratch;
+    thread_local cv::Mat_<cv::Vec3f> tl_normalsScratch;
+    thread_local cv::Mat_<uint8_t> tl_validScratch;
+    cv::Mat_<cv::Vec3f>& coords_big = tl_coordsScratch;
+    cv::Mat_<uint8_t>& valid_big = tl_validScratch;
 
     if (!_components.empty()) {
         // Multi-component surface: warp each component separately with
@@ -832,44 +855,53 @@ void QuadSurface::gen(cv::Mat_<cv::Vec3f>* coords,
     }
 
     // --- normals: warp cached source-grid normals -------------------
-    cv::Mat_<cv::Vec3f>& normals_big = _genNormalsScratch;
+    cv::Mat_<cv::Vec3f>& normals_big = tl_normalsScratch;
     if (need_normals) {
-        // Build source-grid normal cache once per surface. Subsequent gen()
-        // calls (panning, zooming) reuse it. Cleared by unloadCaches() when
-        // a different surface becomes active.
-        if (_normalCache.empty() || _normalCache.size() != _points->size()) {
-            _normalCache.create(_points->rows, _points->cols);
-            const cv::Vec3f qn(std::numeric_limits<float>::quiet_NaN(),
-                               std::numeric_limits<float>::quiet_NaN(),
-                               std::numeric_limits<float>::quiet_NaN());
-            const int rows = _points->rows;
-            const int cols = _points->cols;
-            // Border rows/cols: no ±1 neighbors, fill with NaN sentinel.
-            if (rows > 0) {
-                cv::Vec3f* top = _normalCache[0];
-                cv::Vec3f* bot = _normalCache[rows - 1];
-                for (int c = 0; c < cols; c++) { top[c] = qn; bot[c] = qn; }
-            }
-            #pragma omp parallel for schedule(dynamic, 16)
-            for (int r = 1; r < rows - 1; r++) {
-                cv::Vec3f* dst = _normalCache[r];
-                const cv::Vec3f* row = (*_points)[r];
-                dst[0] = qn;
-                dst[cols - 1] = qn;
-                for (int c = 1; c < cols - 1; c++) {
-                    if (row[c][0] == -1.f) {
-                        dst[c] = qn;
-                    } else {
-                        dst[c] = grid_normal_int(*_points, r, c);
+        // Build the source-grid normal cache once per surface (subsequent gen()
+        // calls for panning/zooming reuse it; cleared by unloadCaches() when a
+        // different surface becomes active). Build *and* snapshot the cache
+        // header under _cacheMutex: concurrent gen() workers must not read
+        // _normalCache while another is still filling it, and create() marks the
+        // Mat non-empty before it is populated. The cheap header snapshot under
+        // the lock lets the expensive warp run lock-free on a stable buffer.
+        cv::Mat_<cv::Vec3f> normalCacheSnapshot;
+        {
+            std::lock_guard<std::mutex> cacheLock(_cacheMutex);
+            if (_normalCache.empty() || _normalCache.size() != _points->size()) {
+                _normalCache.create(_points->rows, _points->cols);
+                const cv::Vec3f qn(std::numeric_limits<float>::quiet_NaN(),
+                                   std::numeric_limits<float>::quiet_NaN(),
+                                   std::numeric_limits<float>::quiet_NaN());
+                const int rows = _points->rows;
+                const int cols = _points->cols;
+                // Border rows/cols: no ±1 neighbors, fill with NaN sentinel.
+                if (rows > 0) {
+                    cv::Vec3f* top = _normalCache[0];
+                    cv::Vec3f* bot = _normalCache[rows - 1];
+                    for (int c = 0; c < cols; c++) { top[c] = qn; bot[c] = qn; }
+                }
+                #pragma omp parallel for schedule(dynamic, 16)
+                for (int r = 1; r < rows - 1; r++) {
+                    cv::Vec3f* dst = _normalCache[r];
+                    const cv::Vec3f* row = (*_points)[r];
+                    dst[0] = qn;
+                    dst[cols - 1] = qn;
+                    for (int c = 1; c < cols - 1; c++) {
+                        if (row[c][0] == -1.f) {
+                            dst[c] = qn;
+                        } else {
+                            dst[c] = grid_normal_int(*_points, r, c);
+                        }
                     }
                 }
             }
+            normalCacheSnapshot = _normalCache;
         }
         const cv::Vec3f qnVec(std::numeric_limits<float>::quiet_NaN(),
                               std::numeric_limits<float>::quiet_NaN(),
                               std::numeric_limits<float>::quiet_NaN());
         normals_big.create(h + 8, w + 8);
-        warpNearestConstVec3f(_normalCache, normals_big,
+        warpNearestConstVec3f(normalCacheSnapshot, normals_big,
                               ox, oy, sx, sy, qnVec);
     }
 
@@ -1258,8 +1290,11 @@ void QuadSurface::invalidateMask()
 {
     // Clear from memory
     _channels.erase("mask");
-    _validMaskCache = cv::Mat_<uint8_t>();
-    _validMaskAllValid = false;
+    {
+        std::lock_guard<std::mutex> cacheLock(_cacheMutex);
+        _validMaskCache = cv::Mat_<uint8_t>();
+        _validMaskAllValid = false;
+    }
 
     // Delete from disk
     if (!path.empty()) {

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -327,6 +327,7 @@ vc_add_test(NAME test_plane_surface)
 vc_add_test(NAME test_compositing)
 
 vc_add_test(NAME test_quadsurface_basics)
+vc_add_test(NAME test_quadsurface_gen_concurrency)
 
 vc_add_test(NAME test_load_json)
 

--- a/volume-cartographer/core/test/test_quadsurface_gen_concurrency.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_gen_concurrency.cpp
@@ -1,0 +1,133 @@
+// Regression test for concurrent QuadSurface::gen().
+//
+// The renderer (vc_render_tifxyz, Render.cpp) calls gen() from OpenMP tile
+// workers on a *single* surface instance. gen() previously wrote into shared
+// mutable scratch members (_genCoordsScratch/_genNormalsScratch/
+// _genValidScratch) and lazily built shared caches (_normalCache,
+// _validMaskCache) without guarding them. Under concurrency one thread's
+// Mat::create() reallocated a buffer another thread was reading -> data race
+// and SIGSEGV (issue #1046 / #1054).
+//
+// This test fails (mismatch or crash) on the unfixed code and passes once the
+// scratch buffers are thread-local and the cache builds are guarded.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "vc/core/util/QuadSurface.hpp"
+
+#include <opencv2/core.hpp>
+
+#include <cmath>
+#include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace {
+
+// A wavy, partly-sparse grid: the z-variation makes normals non-trivial (so the
+// _normalCache path matters) and the -1 sentinels force the validity-mask path
+// (so _validMaskCache / the per-pixel invalidation pass run too).
+cv::Mat_<cv::Vec3f> makeWavyGrid(int rows, int cols)
+{
+    cv::Mat_<cv::Vec3f> m(rows, cols);
+    for (int r = 0; r < rows; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            const float z = 50.f + 6.f * std::sin(0.20f * c) * std::cos(0.17f * r);
+            m(r, c) = cv::Vec3f(static_cast<float>(c), static_cast<float>(r), z);
+        }
+    }
+    // Punch a few invalid cells so validMask() is not all-valid.
+    for (int r = 3; r < rows; r += 11)
+        for (int c = 5; c < cols; c += 13)
+            m(r, c) = cv::Vec3f(-1.f, -1.f, -1.f);
+    return m;
+}
+
+// Element-wise equality with NaN==NaN (invalid pixels are quiet NaN).
+bool vec3fMatsEqual(const cv::Mat_<cv::Vec3f>& a, const cv::Mat_<cv::Vec3f>& b)
+{
+    if (a.size() != b.size()) return false;
+    for (int r = 0; r < a.rows; ++r) {
+        const cv::Vec3f* pa = a[r];
+        const cv::Vec3f* pb = b[r];
+        for (int c = 0; c < a.cols; ++c) {
+            for (int k = 0; k < 3; ++k) {
+                const float x = pa[c][k], y = pb[c][k];
+                const bool bothNan = std::isnan(x) && std::isnan(y);
+                if (!bothNan && x != y) return false;
+            }
+        }
+    }
+    return true;
+}
+
+struct TileParams {
+    cv::Vec3f offset;
+    float scale;
+};
+
+// A spread of pan/zoom requests, mimicking the renderer issuing many gen()
+// calls for different viewport tiles of the same surface.
+std::vector<TileParams> makeTiles(int n)
+{
+    std::vector<TileParams> tiles;
+    tiles.reserve(n);
+    for (int i = 0; i < n; ++i) {
+        const float ox = static_cast<float>((i * 7) % 40);
+        const float oy = static_cast<float>((i * 5) % 32);
+        const float scale = (i % 3 == 0) ? 1.0f : (i % 3 == 1) ? 0.5f : 2.0f;
+        tiles.push_back({cv::Vec3f(ox, oy, 0.f), scale});
+    }
+    return tiles;
+}
+
+} // namespace
+
+TEST_CASE("QuadSurface::gen is consistent under concurrent calls")
+{
+    const int rows = 96, cols = 128;
+    const cv::Size tileSize(80, 64);
+    const auto tiles = makeTiles(64);
+
+    auto pts = makeWavyGrid(rows, cols);
+
+    // --- serial reference (fresh surface, caches cold at start) ----------
+    std::vector<cv::Mat_<cv::Vec3f>> refCoords(tiles.size());
+    std::vector<cv::Mat_<cv::Vec3f>> refNormals(tiles.size());
+    {
+        QuadSurface ref(pts, cv::Vec2f(1.f, 1.f));
+        for (size_t i = 0; i < tiles.size(); ++i) {
+            cv::Mat_<cv::Vec3f> coords, normals;
+            ref.gen(&coords, &normals, tileSize, cv::Vec3f(0, 0, 0),
+                    tiles[i].scale, tiles[i].offset);
+            // gen() returns views into (thread-local) scratch; clone to snapshot
+            // before the buffer is reused by the next call.
+            refCoords[i] = coords.clone();
+            refNormals[i] = normals.clone();
+        }
+    }
+
+    // --- concurrent run on a single shared surface ----------------------
+    QuadSurface shared(pts, cv::Vec2f(1.f, 1.f));
+    std::vector<cv::Mat_<cv::Vec3f>> outCoords(tiles.size());
+    std::vector<cv::Mat_<cv::Vec3f>> outNormals(tiles.size());
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int i = 0; i < static_cast<int>(tiles.size()); ++i) {
+        cv::Mat_<cv::Vec3f> coords, normals;
+        shared.gen(&coords, &normals, tileSize, cv::Vec3f(0, 0, 0),
+                   tiles[i].scale, tiles[i].offset);
+        outCoords[i] = coords.clone();
+        outNormals[i] = normals.clone();
+    }
+
+    int mismatches = 0;
+    for (size_t i = 0; i < tiles.size(); ++i) {
+        if (!vec3fMatsEqual(outCoords[i], refCoords[i])) ++mismatches;
+        if (!vec3fMatsEqual(outNormals[i], refNormals[i])) ++mismatches;
+    }
+    CHECK(mismatches == 0);
+}


### PR DESCRIPTION
## Problem

The renderer (`Render.cpp`, `vc_render_tifxyz`) calls `QuadSurface::gen()` from OpenMP tile workers on a **single** surface instance. `gen()` wrote into shared `mutable` scratch members (`_genCoordsScratch`/`_genNormalsScratch`/`_genValidScratch`) and lazily built shared caches (`_normalCache`, `_validMaskCache`) with no synchronization. Concurrently this corrupts output and can crash — one thread's `cv::Mat::create()` reallocates a buffer another thread is mid-read. This is the `vc-render-tifxyz` SIGSEGV in #1046, and the thread-safety gap tracked in #1054.

Closes #1054. Closes #1046 (same root cause — backtrace points at the `_normalCache` warp in `gen()`; see analysis on that issue).

## Fix

- **Scratch buffers → `thread_local`.** Each worker reuses its own coords/normals/validity buffer across frames, keeping the per-frame allocation-reuse optimization without cross-thread sharing.
- **Lazy caches serialized with a new `_cacheMutex`.** `validMask()` takes the lock for the whole accessor and returns a header copy made under it. `_normalCache` is built **and snapshotted** under the lock; the expensive warp then runs lock-free on the snapshot.
  - The snapshot is the crucial part: plain double-checked locking is **not** enough, because `cv::Mat::create()` marks the Mat non-empty *before* it is filled — so a second thread on the cache-hit path would warp a half-built cache (silent wrong normals, no crash).
  - Every cache-clear site (`unloadPoints`, `unloadCaches`, `invalidateCache`, `invalidateMask`) takes the same lock. Lock ordering is always `_loadMutex -> _cacheMutex`.

**No numeric change:** outputs are bit-identical to the serial path.

## Test

Adds `test_quadsurface_gen_concurrency`: runs many `gen()` calls concurrently on one surface and checks each result matches a serial reference bit-for-bit.

- **Unfixed:** fails 20/20 (corrupted output).
- **Fixed:** passes 40/40 stress runs, and clean under ThreadSanitizer.

ThreadSanitizer note: with `-DVC_ENABLE_TSAN=ON` the only remaining warnings are inside `validMask()`'s internal `#pragma omp parallel for` reduction — a known GCC libgomp false positive (libgomp barriers aren't modeled by TSAN without the archer runtime). Suppress with `race:libgomp.so` / `called_from_lib:libgomp.so`.

```
cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVC_TESTING=ON
cmake --build build --target test_quadsurface_gen_concurrency -j
ctest --test-dir build -R test_quadsurface_gen_concurrency --output-on-failure
```
