### PR TITLE
vc_obj2tifxyz: avoid floating point calculation in rasterization

### DIFF
--- a/volume-cartographer/apps/src/vc_obj2tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_obj2tifxyz.cpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <cmath>
 #include <memory>
+#include <stdexcept>
 
 struct Vertex {
     cv::Vec3f pos;
@@ -271,6 +272,17 @@ public:
             std::cout << "Scale(OBJ units; compensated to raw-pixel spacing): "
                       << measured[0] << ", " << measured[1] << std::endl;
         }
+
+        // rasterizeTriangle evaluates edge functions in int64 on fixed-point
+        // coordinates up to (grid-1)*SUBPIXEL. Keep 2*L^2 below INT64_MAX so the
+        // signed-area computation cannot overflow. The limit (~8.4M px/axis) is
+        // far above any real tifxyz grid; tripping it means the inputs are wrong.
+        const long long max_dim = std::max(grid_size[0], grid_size[1]);
+        if (max_dim * SUBPIXEL >= 2'000'000'000LL) {
+            throw std::runtime_error(
+                "grid dimension too large for exact int64 rasterization: "
+                + std::to_string(max_dim));
+        }
     }
     
     QuadSurface* createQuadSurface(float mesh_units = 1.0f) {
@@ -390,65 +402,79 @@ private:
                 return; // skip faces with missing/invalid UVs
             }
         }
-        // Get triangle vertices and UVs
-        cv::Vec3f v0 = vertices[face.v[0]].pos;
-        cv::Vec3f v1 = vertices[face.v[1]].pos;
-        cv::Vec3f v2 = vertices[face.v[2]].pos;
-        
-        cv::Vec2f uv0 = uvs[face.vt[0]].coord;
-        cv::Vec2f uv1 = uvs[face.vt[1]].coord;
-        cv::Vec2f uv2 = uvs[face.vt[2]].coord;
-        
-        // Transform UVs to grid coordinates
-        // Map from [uv_min, uv_max] to [0, grid_size-1]
-        cv::Vec2f uv_range = uv_max - uv_min;
-        const float rx = std::max(uv_range[0], 1e-12f);
-        const float ry = std::max(uv_range[1], 1e-12f);
-        uv0 = (uv0 - uv_min);
-        uv0[0] = uv0[0] / rx * (grid_size[0] - 1);
-        uv0[1] = uv0[1] / ry * (grid_size[1] - 1);
-        
-        uv1 = (uv1 - uv_min);
-        uv1[0] = uv1[0] / rx * (grid_size[0] - 1);
-        uv1[1] = uv1[1] / ry * (grid_size[1] - 1);
-        
-        uv2 = (uv2 - uv_min);
-        uv2[0] = uv2[0] / rx * (grid_size[0] - 1);
-        uv2[1] = uv2[1] / ry * (grid_size[1] - 1);
-        
-        // Find bounding box in grid coordinates
-        int min_x = std::max(0, static_cast<int>(std::floor(std::min({uv0[0], uv1[0], uv2[0]}))) - 1);
-        int max_x = std::min(grid_size[0] - 1, static_cast<int>(std::ceil(std::max({uv0[0], uv1[0], uv2[0]}))) + 1);
-        int min_y = std::max(0, static_cast<int>(std::floor(std::min({uv0[1], uv1[1], uv2[1]}))) - 1);
-        int max_y = std::min(grid_size[1] - 1, static_cast<int>(std::ceil(std::max({uv0[1], uv1[1], uv2[1]}))) + 1);
-        
-        // Rasterize triangle
+        // Triangle 3D positions (reordered together with the UVs below to
+        // enforce a consistent winding for the fill rule).
+        cv::Vec3f pos[3] = { vertices[face.v[0]].pos,
+                             vertices[face.v[1]].pos,
+                             vertices[face.v[2]].pos };
+        int vidx[3] = { face.v[0], face.v[1], face.v[2] }; // for approval grid_uv lookup
+
+        // Map UVs into grid space in double, then snap each vertex to a
+        // fixed-point sub-pixel grid. Integer edge functions then make the
+        // inclusion test exact (no float rounding, identical on every
+        // architecture); the top-left fill rule assigns each pixel that lands
+        // on a shared edge to exactly one triangle, so a grid-aligned surface
+        // is covered without the periodic gaps a float barycentric test left.
+        const double rx = std::max<double>(uv_max[0] - uv_min[0], 1e-12);
+        const double ry = std::max<double>(uv_max[1] - uv_min[1], 1e-12);
+        long long X[3], Y[3];
+        double gx[3], gy[3];
+        for (int k = 0; k < 3; ++k) {
+            const cv::Vec2f uv = uvs[face.vt[k]].coord;
+            gx[k] = (double(uv[0]) - uv_min[0]) / rx * (grid_size[0] - 1);
+            gy[k] = (double(uv[1]) - uv_min[1]) / ry * (grid_size[1] - 1);
+            X[k] = std::llround(gx[k] * SUBPIXEL);
+            Y[k] = std::llround(gy[k] * SUBPIXEL);
+        }
+
+        // Twice the signed area. Zero -> degenerate (covers nothing).
+        // Normalize to CCW so the top-left rule has a consistent orientation.
+        long long area2 = edgeFn(X[0], Y[0], X[1], Y[1], X[2], Y[2]);
+        if (area2 == 0) {
+            return;
+        }
+        if (area2 < 0) {
+            std::swap(X[1], X[2]); std::swap(Y[1], Y[2]);
+            std::swap(pos[1], pos[2]); std::swap(vidx[1], vidx[2]);
+            area2 = -area2;
+        }
+
+        // Top-left bias per edge: a pixel exactly on an edge (w == 0) is
+        // included only when that edge is top-left. Folding the bias into the
+        // comparison turns the rule into a single (w + bias) >= 0 test.
+        const long long bias0 = isTopLeft(X[2] - X[1], Y[2] - Y[1]) ? 0 : -1; // edge B->C
+        const long long bias1 = isTopLeft(X[0] - X[2], Y[0] - Y[2]) ? 0 : -1; // edge C->A
+        const long long bias2 = isTopLeft(X[1] - X[0], Y[1] - Y[0]) ? 0 : -1; // edge A->B
+
+        // Bounding box on the pixel grid.
+        const int min_x = std::max(0, static_cast<int>(std::floor(std::min({gx[0], gx[1], gx[2]}))));
+        const int max_x = std::min(grid_size[0] - 1, static_cast<int>(std::ceil(std::max({gx[0], gx[1], gx[2]}))));
+        const int min_y = std::max(0, static_cast<int>(std::floor(std::min({gy[0], gy[1], gy[2]}))));
+        const int max_y = std::min(grid_size[1] - 1, static_cast<int>(std::ceil(std::max({gy[0], gy[1], gy[2]}))));
+
+        const double inv_area = 1.0 / static_cast<double>(area2);
         for (int y = min_y; y <= max_y; y++) {
+            const long long Py = static_cast<long long>(y) * SUBPIXEL;
             for (int x = min_x; x <= max_x; x++) {
-                cv::Vec2f p(x, y);
-                
-                // Compute barycentric coordinates
-                cv::Vec3f bary = computeBarycentric(p, uv0, uv1, uv2);
-                
-                // Check if point is inside triangle
-                if (bary[0] >= 0 && bary[1] >= 0 && bary[2] >= 0) {
-                    // Interpolate 3D position
-                    cv::Vec3f pos = bary[0] * v0 + bary[1] * v1 + bary[2] * v2;
-
-                    // Only update if not already set (first triangle wins)
-                    if (points(y, x)[0] == -1) {
-                        points(y, x) = pos;
-
-                        // Same first-wins gate for approval: interpolate the
-                        // original (col,row) with the same weights and sample
-                        // the source mask there.
-                        if (hasApproval()) {
-                            const cv::Vec2f cr = bary[0] * grid_uv[face.v[0]].cr
-                                               + bary[1] * grid_uv[face.v[1]].cr
-                                               + bary[2] * grid_uv[face.v[2]].cr;
-                            out_approval(y, x) = sampleSrcApproval(cr[0], cr[1]);
-                        }
-                    }
+                const long long Px = static_cast<long long>(x) * SUBPIXEL;
+                const long long w0 = edgeFn(X[1], Y[1], X[2], Y[2], Px, Py); // weight of vertex 0
+                const long long w1 = edgeFn(X[2], Y[2], X[0], Y[0], Px, Py); // weight of vertex 1
+                const long long w2 = edgeFn(X[0], Y[0], X[1], Y[1], Px, Py); // weight of vertex 2
+                if ((w0 + bias0) < 0 || (w1 + bias1) < 0 || (w2 + bias2) < 0) {
+                    continue;
+                }
+                if (points(y, x)[0] != -1) {
+                    continue; // first triangle wins
+                }
+                const float b0 = static_cast<float>(w0 * inv_area);
+                const float b1 = static_cast<float>(w1 * inv_area);
+                const float b2 = static_cast<float>(w2 * inv_area);
+                points(y, x) = b0 * pos[0] + b1 * pos[1] + b2 * pos[2];
+                if (hasApproval()) {
+                    const cv::Vec2f cr = b0 * grid_uv[vidx[0]].cr
+                                       + b1 * grid_uv[vidx[1]].cr
+                                       + b2 * grid_uv[vidx[2]].cr;
+                    out_approval(y, x) = sampleSrcApproval(cr[0], cr[1]);
                 }
             }
         }
@@ -468,27 +494,21 @@ private:
         return src_approval.at<cv::Vec3b>(row, col);
     }
 
-    cv::Vec3f computeBarycentric(const cv::Vec2f& p, const cv::Vec2f& a, const cv::Vec2f& b, const cv::Vec2f& c) {
-        cv::Vec2f v0 = c - a;
-        cv::Vec2f v1 = b - a;
-        cv::Vec2f v2 = p - a;
-        
-        float dot00 = v0.dot(v0);
-        float dot01 = v0.dot(v1);
-        float dot02 = v0.dot(v2);
-        float dot11 = v1.dot(v1);
-        float dot12 = v1.dot(v2);
-        
-        const float denom = (dot00 * dot11 - dot01 * dot01);
-        if (std::fabs(denom) < 1e-20f || !std::isfinite(denom)) {
-            // Degenerate triangle in UV space -> mark "outside"
-            return cv::Vec3f(-1.f, -1.f, -1.f);
-        }
-        float invDenom = 1.0f / denom;
-        float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
-        float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
-        
-        return cv::Vec3f(1.0f - u - v, v, u);
+    // Sub-pixel resolution for fixed-point vertex snapping (8 fractional bits).
+    static constexpr long long SUBPIXEL = 256;
+
+    // Twice the signed area of triangle (A, B, P): (B-A) x (P-A). Exact in int64.
+    static long long edgeFn(long long ax, long long ay,
+                            long long bx, long long by,
+                            long long px, long long py) {
+        return (bx - ax) * (py - ay) - (by - ay) * (px - ax);
+    }
+
+    // Top-left edge predicate for the fill rule. Antisymmetric under edge
+    // reversal, so the two triangles sharing an edge make opposite choices and
+    // each on-edge pixel is claimed exactly once.
+    static bool isTopLeft(long long dx, long long dy) {
+        return dy < 0 || (dy == 0 && dx < 0);
     }
 };
 


### PR DESCRIPTION
To avoid rounding issues during tifxyz->obj->tifxyz roundtrips where vertices might fall on exact grid corners. That can happen either in the identity case or for 180 degree rotation.