### PR TITLE
docs: fix stale links to the archived ScrollPrize/vesuvius repo

### DIFF
--- a/scrollprize.org/docs/01_get_started.md
+++ b/scrollprize.org/docs/01_get_started.md
@@ -69,7 +69,7 @@ Contestants can also contribute to our two primary subproblems:
 </Admonition>
 
 <Admonition type="info" icon="🖋️" title="Ink Detection">
-* Prizes: 7 x \$60,000 [First Letters and First Title Prizes](prizes#first-letters-and-title-prizes)
+* Prizes: \$60,000 each for the [First Letters and First Title Prizes](prizes#first-letters-and-title-prizes)
 * Starting point: [Ink detection tutorial](tutorial5)
 </Admonition>
 

--- a/scrollprize.org/docs/03_tutorial.md
+++ b/scrollprize.org/docs/03_tutorial.md
@@ -93,7 +93,7 @@ The X-ray photos are combined into a 3D scan volume using [tomographic reconstru
   <figcaption className="mt-0">Artistic visualization of constructing a 3D volume; in reality the object rotates as it is scanned.</figcaption>
 </figure>
 
-We store the 3D scan volume as a directory full of .tif files, where each file represents one horizontal cross-section or "slice" of the object, typically starting at the bottom of the scroll or scroll fragment and moving upwards. We call this a .tif image stack. You can view and explore a 3D scan volume of a scroll in your browser right now in [one click](https://dl.ash2txt.org/view/Scroll1), or with a few lines of code ([Python](https://github.com/ScrollPrize/vesuvius), [C](https://github.com/ScrollPrize/vesuvius-c)).
+We store the 3D scan volume as a directory full of .tif files, where each file represents one horizontal cross-section or "slice" of the object, typically starting at the bottom of the scroll or scroll fragment and moving upwards. We call this a .tif image stack. You can view and explore a 3D scan volume of a scroll in your browser right now in [one click](https://dl.ash2txt.org/view/Scroll1), or with a few lines of code ([Python](https://github.com/ScrollPrize/villa/tree/main/vesuvius), [C](https://github.com/ScrollPrize/villa/tree/main/vesuvius-c)).
 
 Remember that each pixel in the image stack actually represents a cube (voxel) of physical space. If your volume has a 10um voxel size, then 100 slices will be 1mm (1000um) of the object.
 

--- a/scrollprize.org/docs/06_tutorial_thaumato.md
+++ b/scrollprize.org/docs/06_tutorial_thaumato.md
@@ -44,7 +44,7 @@ For a more technical walkthrough of the pipeline, see this [walkthrough video](h
 For an introduction to one of the core problems in this pipeline where we need your help, check out the [Sheet Stitching Problem Playground](https://github.com/schillij95/graph_problem/tree/main).
 
 Thaumato is one approach but there may be others - for example, volumetric instance segmentation might be useful as an input to later mesh stitching algorithms.
-If interested, check out [this notebook](https://colab.research.google.com/github/ScrollPrize/vesuvius/blob/main/notebooks/example3_cubes_bootstrap.ipynb) providing easy access to volumetric segmentation labels.
+If interested, check out [this notebook](https://colab.research.google.com/github/ScrollPrize/villa/blob/main/vesuvius/src/vesuvius/examples/notebooks/example3_cubes_bootstrap.ipynb) providing easy access to volumetric segmentation labels.
 
 ### Walkthrough
 

--- a/scrollprize.org/docs/07_tutorial5.md
+++ b/scrollprize.org/docs/07_tutorial5.md
@@ -45,7 +45,7 @@ This tutorial gives a high-level overview on ink detection methods.
 Since this tutorial was written, ink detection has successfully recovered text from inside the rolled scrolls.
 The technical principles remain the same as what is described here.
 
-The tutorial can be followed by the more hands-on notebooks [on Kaggle](https://www.kaggle.com/code/jpposma/vesuvius-challenge-ink-detection-tutorial) and [a more recent version on Colab](https://colab.research.google.com/github/ScrollPrize/vesuvius/blob/main/notebooks/example2_ink_detection.ipynb).
+The tutorial can be followed by the more hands-on notebooks [on Kaggle](https://www.kaggle.com/code/jpposma/vesuvius-challenge-ink-detection-tutorial) and [a more recent version on Colab](https://colab.research.google.com/github/ScrollPrize/villa/blob/main/vesuvius/src/vesuvius/examples/notebooks/example2_ink_detection.ipynb).
 
 Ink detection is the task of taking data from a 3D X-ray scan around a papyrus surface, and identifying the locations of the inked parts of the papyrus.
 

--- a/scrollprize.org/docs/29_tutorial4.md
+++ b/scrollprize.org/docs/29_tutorial4.md
@@ -48,7 +48,7 @@ For a more technical walkthrough of the pipeline, see this [walkthrough video](h
 For an introduction to one of the core problems in this pipeline where we need your help, check out the [Sheet Stitching Problem Playground](https://github.com/schillij95/graph_problem/tree/main).
 
 Thaumato is one approach but there may be others - for example, volumetric instance segmentation might be useful as an input to later mesh stitching algorithms.
-If interested, check out [this notebook](https://colab.research.google.com/github/ScrollPrize/vesuvius/blob/main/notebooks/example3_cubes_bootstrap.ipynb) providing easy access to volumetric segmentation labels.
+If interested, check out [this notebook](https://colab.research.google.com/github/ScrollPrize/villa/blob/main/vesuvius/src/vesuvius/examples/notebooks/example3_cubes_bootstrap.ipynb) providing easy access to volumetric segmentation labels.
 
 ### Walkthrough
 

--- a/vesuvius-c/README.md
+++ b/vesuvius-c/README.md
@@ -41,7 +41,7 @@ https://github.com/user-attachments/assets/e4b90221-744a-46d6-a7c2-cc3f1685fd54
 
 The library fetches scroll data from the Vesuvius Challenge [data server](https://dl.ash2txt.org) in the background. Only the necessary volume chunks are requested, and on-disk caching is used to store downloads between program invocations and avoid re-downloading identical files.
 
-For a similar library in Python, see [vesuvius](https://github.com/ScrollPrize/vesuvius).
+For a similar library in Python, see [vesuvius](https://github.com/ScrollPrize/villa/tree/main/vesuvius).
 
 > ⚠️ `vesuvius-c`  is in beta and the interface may change. Please feel free to reach out with development ideas.
 

--- a/vesuvius/README.md
+++ b/vesuvius/README.md
@@ -41,11 +41,11 @@ _this package is in active development_
 ## 📓 Introductory notebooks
 To get started, we recommend these notebooks that jump right in:
 
-1. 📊 [Scroll Data Access](https://colab.research.google.com/github/ScrollPrize/vesuvius/blob/main/notebooks/example1_data_access.ipynb): an introduction to accessing scroll data using a few lines of Python!
+1. 📊 [Scroll Data Access](https://colab.research.google.com/github/ScrollPrize/villa/blob/main/vesuvius/src/vesuvius/examples/notebooks/example1_data_access.ipynb): an introduction to accessing scroll data using a few lines of Python!
 
-2. ✒️ [Ink Detection](https://colab.research.google.com/github/ScrollPrize/vesuvius/blob/main/notebooks/example2_ink_detection.ipynb): load and visualize segments with ink labels, and train models to detect ink in CT.
+2. ✒️ [Ink Detection](https://colab.research.google.com/github/ScrollPrize/villa/blob/main/vesuvius/src/vesuvius/examples/notebooks/example2_ink_detection.ipynb): load and visualize segments with ink labels, and train models to detect ink in CT.
 
-3. 🧩 [Volumetric instance segmentation cubes](https://colab.research.google.com/github/ScrollPrize/vesuvius/blob/main/notebooks/example3_cubes_bootstrap.ipynb): how to access instance-annotated cubes with the `Cube` class, used for volumetric segmentation approaches.
+3. 🧩 [Volumetric instance segmentation cubes](https://colab.research.google.com/github/ScrollPrize/villa/blob/main/vesuvius/src/vesuvius/examples/notebooks/example3_cubes_bootstrap.ipynb): how to access instance-annotated cubes with the `Cube` class, used for volumetric segmentation approaches.
 
 ## `vesuvius` does:
 - **Data retrieval**: Fetches volumetric scroll data, surface volumes of scroll segments, and annotated volumetric instance segmentation labels. Remote repositories and local files are supported.


### PR DESCRIPTION
## Summary
While going through the Get Started flow and tutorials as a newcomer (issue #199), I found several links pointing to the standalone `ScrollPrize/vesuvius` repo, which was archived on 2024-11-21 in favor of `vesuvius/` inside this monorepo. The archived repo still resolves (so the links don't 404), but they point to a frozen 2024 snapshot instead of the actively maintained code/notebooks.

- `scrollprize.org/docs/07_tutorial5.md`, `06_tutorial_thaumato.md`, `29_tutorial4.md`: Colab notebook links updated to `villa/vesuvius/src/vesuvius/examples/notebooks/...`
- `scrollprize.org/docs/03_tutorial.md`, `vesuvius-c/README.md`: plain repo links updated to `villa/tree/main/vesuvius`
- `vesuvius/README.md`: same fix for its own 3 "Introductory notebooks" links
- `scrollprize.org/docs/01_get_started.md`: fixed a stale "7 x \$60,000" figure that no longer matches the current First Letters / First Title prize amounts on the prizes page

## Test plan
- [x] Verified the new notebook paths return HTTP 200 on `raw.githubusercontent.com` against `main`
- [x] Verified current `docs/34_prizes.md` wording to confirm the corrected prize figure