### PR TITLE
Viewer control UI

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -1693,12 +1693,12 @@ CWindow::CWindow(size_t cacheSizeGB, RenderBenchOptions benchOptions) :
         }
     });
 
-    // Slice step size label in status bar
+    // Z-scroll sensitivity label in status bar
     _sliceStepLabel = new QLabel(this);
     _sliceStepLabel->setContentsMargins(4, 0, 4, 0);
-    int initialStepSize = _viewerManager->sliceStepSize();
-    _sliceStepLabel->setText(tr("Step: %1").arg(initialStepSize));
-    _sliceStepLabel->setToolTip(tr("Slice step size: use Shift+G / Shift+H to adjust"));
+    double initialSensitivity = _viewerManager->zScrollSensitivity();
+    _sliceStepLabel->setText(tr("Z sens: %1").arg(initialSensitivity, 0, 'f', 1));
+    _sliceStepLabel->setToolTip(tr("Z-scroll sensitivity: use Shift+G / Shift+H to adjust"));
     statusBar()->addPermanentWidget(_sliceStepLabel);
 
     _pointsOverlay = std::make_unique<PointsOverlayController>(_state->pointCollection(), this);
@@ -6305,7 +6305,6 @@ void CWindow::CreateWidgets(void)
         .claheTileSize = ui.spinClaheTileSize,
         .zoomInButton = ui.btnZoomIn,
         .zoomOutButton = ui.btnZoomOut,
-        .sliceStepSizeSpin = ui.spinSliceStepSize,
         .volumeWindowContainer = ui.volumeWindowContainer,
         .overlayWindowContainer = ui.overlayWindowContainer,
         .intersectionOpacitySpin = ui.spinIntersectionOpacity,
@@ -6318,8 +6317,8 @@ void CWindow::CreateWidgets(void)
             this, &CWindow::onZoomIn);
     connect(_viewerControlsPanel.get(), &ViewerControlsPanel::zoomOutRequested,
             this, &CWindow::onZoomOut);
-    connect(_viewerManager.get(), &ViewerManager::sliceStepSizeChanged,
-            this, &CWindow::onSliceStepSizeChanged);
+    connect(_viewerManager.get(), &ViewerManager::zScrollSensitivityChanged,
+            this, &CWindow::onZScrollSensitivityChanged);
     connect(_viewerControlsPanel.get(), &ViewerControlsPanel::statusMessageRequested,
             this, &CWindow::onShowStatusMessage);
     if (_viewerControlsPanel) {
@@ -6627,18 +6626,14 @@ void CWindow::keyPressEvent(QKeyEvent* event)
         }
     }
 
-    // Shift+G decreases slice step size, Shift+H increases it
+    // Shift+G decreases Z-scroll sensitivity, Shift+H increases it
     if (event->modifiers() == vc3d::keybinds::keypress::SliceStepDecrease.modifiers && _viewerManager) {
         if (event->key() == vc3d::keybinds::keypress::SliceStepDecrease.key) {
-            int currentStep = _viewerManager->sliceStepSize();
-            int newStep = std::max(1, currentStep - 1);
-            _viewerManager->setSliceStepSize(newStep);
+            _viewerManager->setZScrollSensitivity(_viewerManager->zScrollSensitivity() - 0.1);
             event->accept();
             return;
         } else if (event->key() == vc3d::keybinds::keypress::SliceStepIncrease.key) {
-            int currentStep = _viewerManager->sliceStepSize();
-            int newStep = std::min(100, currentStep + 1);
-            _viewerManager->setSliceStepSize(newStep);
+            _viewerManager->setZScrollSensitivity(_viewerManager->zScrollSensitivity() + 0.1);
             event->accept();
             return;
         }
@@ -6851,19 +6846,12 @@ void CWindow::onSegmentationGrowthStatusChanged(bool running)
     }
 }
 
-void CWindow::onSliceStepSizeChanged(int newSize)
+void CWindow::onZScrollSensitivityChanged(double sensitivity)
 {
-    // Update status bar label
+    // Update status bar label. Persistence + viewer refresh happen in
+    // ViewerManager::setZScrollSensitivity (the single source of truth).
     if (_sliceStepLabel) {
-        _sliceStepLabel->setText(tr("Step: %1").arg(newSize));
-    }
-
-    // Save to settings
-    QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
-    settings.setValue(vc3d::settings::viewer::SLICE_STEP_SIZE, newSize);
-
-    if (_viewerControlsPanel) {
-        _viewerControlsPanel->setSliceStepSize(newSize);
+        _sliceStepLabel->setText(tr("Z sens: %1").arg(sensitivity, 0, 'f', 1));
     }
 }
 

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -6479,14 +6479,6 @@ void CWindow::CreateWidgets(void)
         chkAxisOverlays->setChecked(showOverlays);
         connect(chkAxisOverlays, &QCheckBox::toggled, this, &CWindow::onAxisOverlayVisibilityToggled);
     }
-    if (auto* chkPlaneIntersectionLines = ui.chkPlaneIntersectionLines) {
-        bool showPlaneIntersectionLines = settings.value(vc3d::settings::viewer::SHOW_PLANE_INTERSECTION_LINES,
-                                                         vc3d::settings::viewer::SHOW_PLANE_INTERSECTION_LINES_DEFAULT).toBool();
-        QSignalBlocker blocker(chkPlaneIntersectionLines);
-        chkPlaneIntersectionLines->setChecked(showPlaneIntersectionLines);
-        connect(chkPlaneIntersectionLines, &QCheckBox::toggled,
-                this, &CWindow::onPlaneIntersectionLinesToggled);
-    }
     if (auto* spinAxisOverlayOpacity = ui.spinAxisOverlayOpacity) {
         int storedOpacity = settings.value(vc3d::settings::viewer::AXIS_OVERLAY_OPACITY,
                                            spinAxisOverlayOpacity->value()).toInt();
@@ -6522,9 +6514,6 @@ void CWindow::CreateWidgets(void)
         onAxisOverlayVisibilityToggled(chkAxisOverlays->isChecked());
     }
     onMoveOnSurfaceChangedToggled(moveOnSurfaceChangeEnabled());
-    if (auto* chkPlaneIntersectionLines = ui.chkPlaneIntersectionLines) {
-        onPlaneIntersectionLinesToggled(chkPlaneIntersectionLines->isChecked());
-    }
 
 }
 

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -6479,13 +6479,6 @@ void CWindow::CreateWidgets(void)
         chkAxisOverlays->setChecked(showOverlays);
         connect(chkAxisOverlays, &QCheckBox::toggled, this, &CWindow::onAxisOverlayVisibilityToggled);
     }
-    if (auto* chkMoveOnSurfaceChanged = ui.chkMoveOnSurfaceChanged) {
-        bool moveOnSurfaceChanged = settings.value(vc3d::settings::viewer::RESET_VIEW_ON_SURFACE_CHANGE,
-                                                   vc3d::settings::viewer::RESET_VIEW_ON_SURFACE_CHANGE_DEFAULT).toBool();
-        QSignalBlocker blocker(chkMoveOnSurfaceChanged);
-        chkMoveOnSurfaceChanged->setChecked(moveOnSurfaceChanged);
-        connect(chkMoveOnSurfaceChanged, &QCheckBox::toggled, this, &CWindow::onMoveOnSurfaceChangedToggled);
-    }
     if (auto* chkPlaneIntersectionLines = ui.chkPlaneIntersectionLines) {
         bool showPlaneIntersectionLines = settings.value(vc3d::settings::viewer::SHOW_PLANE_INTERSECTION_LINES,
                                                          vc3d::settings::viewer::SHOW_PLANE_INTERSECTION_LINES_DEFAULT).toBool();
@@ -6528,9 +6521,7 @@ void CWindow::CreateWidgets(void)
     if (auto* chkAxisOverlays = ui.chkAxisOverlays) {
         onAxisOverlayVisibilityToggled(chkAxisOverlays->isChecked());
     }
-    if (auto* chkMoveOnSurfaceChanged = ui.chkMoveOnSurfaceChanged) {
-        onMoveOnSurfaceChangedToggled(chkMoveOnSurfaceChanged->isChecked());
-    }
+    onMoveOnSurfaceChangedToggled(moveOnSurfaceChangeEnabled());
     if (auto* chkPlaneIntersectionLines = ui.chkPlaneIntersectionLines) {
         onPlaneIntersectionLinesToggled(chkPlaneIntersectionLines->isChecked());
     }

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -6307,7 +6307,6 @@ void CWindow::CreateWidgets(void)
         .zoomOutButton = ui.btnZoomOut,
         .volumeWindowContainer = ui.volumeWindowContainer,
         .overlayWindowContainer = ui.overlayWindowContainer,
-        .intersectionOpacitySpin = ui.spinIntersectionOpacity,
         .intersectionThicknessSpin = ui.doubleSpinIntersectionThickness,
     };
     _viewerControlsPanel = std::make_unique<ViewerControlsPanel>(viewerControlsUi,
@@ -6479,15 +6478,6 @@ void CWindow::CreateWidgets(void)
         chkAxisOverlays->setChecked(showOverlays);
         connect(chkAxisOverlays, &QCheckBox::toggled, this, &CWindow::onAxisOverlayVisibilityToggled);
     }
-    if (auto* spinAxisOverlayOpacity = ui.spinAxisOverlayOpacity) {
-        int storedOpacity = settings.value(vc3d::settings::viewer::AXIS_OVERLAY_OPACITY,
-                                           spinAxisOverlayOpacity->value()).toInt();
-        storedOpacity = std::clamp(storedOpacity, spinAxisOverlayOpacity->minimum(), spinAxisOverlayOpacity->maximum());
-        QSignalBlocker blocker(spinAxisOverlayOpacity);
-        spinAxisOverlayOpacity->setValue(storedOpacity);
-        connect(spinAxisOverlayOpacity, qOverload<int>(&QSpinBox::valueChanged), this, &CWindow::onAxisOverlayOpacityChanged);
-    }
-
     if (auto* btnResetRot = ui.btnResetAxisRotations) {
         connect(btnResetRot, &QPushButton::clicked, this, &CWindow::onResetAxisAlignedRotations);
     }
@@ -6507,9 +6497,8 @@ void CWindow::CreateWidgets(void)
     if (chkAxisAlignedSlices) {
         onAxisAlignedSlicesToggled(chkAxisAlignedSlices->isChecked());
     }
-    if (auto* spinAxisOverlayOpacity = ui.spinAxisOverlayOpacity) {
-        onAxisOverlayOpacityChanged(spinAxisOverlayOpacity->value());
-    }
+    onAxisOverlayOpacityChanged(settings.value(vc3d::settings::viewer::AXIS_OVERLAY_OPACITY,
+                                               vc3d::settings::viewer::AXIS_OVERLAY_OPACITY_DEFAULT).toInt());
     if (auto* chkAxisOverlays = ui.chkAxisOverlays) {
         onAxisOverlayVisibilityToggled(chkAxisOverlays->isChecked());
     }
@@ -7822,9 +7811,6 @@ void CWindow::onAxisOverlayVisibilityToggled(bool enabled)
     if (_planeSlicingOverlay) {
         _planeSlicingOverlay->setAxisAlignedEnabled(enabled && _axisAlignedSliceController->isEnabled());
     }
-    if (auto* spinAxisOverlayOpacity = ui.spinAxisOverlayOpacity) {
-        spinAxisOverlayOpacity->setEnabled(_axisAlignedSliceController->isEnabled() && enabled);
-    }
     QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
     settings.setValue(vc3d::settings::viewer::SHOW_AXIS_OVERLAYS, enabled ? "1" : "0");
 }
@@ -7841,7 +7827,7 @@ void CWindow::onAxisOverlayOpacityChanged(int value)
 
 void CWindow::onAxisAlignedSlicesToggled(bool enabled)
 {
-    _axisAlignedSliceController->setEnabled(enabled, ui.chkAxisOverlays, ui.spinAxisOverlayOpacity);
+    _axisAlignedSliceController->setEnabled(enabled, ui.chkAxisOverlays);
     QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
     settings.setValue(vc3d::settings::viewer::USE_AXIS_ALIGNED_SLICES, enabled ? "1" : "0");
 }

--- a/volume-cartographer/apps/VC3D/CWindow.hpp
+++ b/volume-cartographer/apps/VC3D/CWindow.hpp
@@ -244,7 +244,7 @@ private slots:
     // unless --record was passed and the recorder isn't already attached).
     void maybeAttachBenchRecorder();
     void onSegmentationGrowthStatusChanged(bool running);
-    void onSliceStepSizeChanged(int newSize);
+    void onZScrollSensitivityChanged(double sensitivity);
     void onSurfaceWillBeDeleted(std::string name, std::shared_ptr<Surface> surf);
     void onConvertPointToAnchor(uint64_t pointId, uint64_t collectionId);
     void onNewFiberRequested();

--- a/volume-cartographer/apps/VC3D/Keybinds.cpp
+++ b/volume-cartographer/apps/VC3D/Keybinds.cpp
@@ -17,7 +17,7 @@ constexpr const char* kSectionSegGrowth = "Segmentation Growth";
 constexpr const char* kSectionPushPull = "Push/Pull";
 constexpr const char* kSectionPointCollection = "Point Collection";
 constexpr const char* kSectionMouseControls = "Mouse Controls";
-constexpr const char* kSectionSliceStep = "Slice Step Size";
+constexpr const char* kSectionSliceStep = "Z-Scroll Sensitivity";
 
 enum class HelpKeyType {
     Shortcut,
@@ -208,7 +208,7 @@ const KeyPressDef RecenterFocus{
 const KeyPressDef SliceStepDecrease{
     "slice_step_decrease",
     kSectionSliceStep,
-    "Decrease slice step size",
+    "Decrease Z-scroll sensitivity",
     Qt::Key_G,
     Qt::ShiftModifier,
     false
@@ -216,7 +216,7 @@ const KeyPressDef SliceStepDecrease{
 const KeyPressDef SliceStepIncrease{
     "slice_step_increase",
     kSectionSliceStep,
-    "Increase slice step size",
+    "Increase Z-scroll sensitivity",
     Qt::Key_H,
     Qt::ShiftModifier,
     false

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -298,14 +298,14 @@ LineAnnotationDialog::LineAnnotationDialog(ViewerManager* viewerManager,
         }
     }
     _sliceStepLabel = new QLabel(this);
-    _sliceStepLabel->setText(tr("Step: %1").arg(_viewerManager ? _viewerManager->sliceStepSize() : 1));
-    _sliceStepLabel->setToolTip(tr("Shift+Scroll step size. Use Shift+G / Shift+H to adjust."));
+    _sliceStepLabel->setText(tr("Z sens: %1").arg(_viewerManager ? _viewerManager->zScrollSensitivity() : 1.0, 0, 'f', 1));
+    _sliceStepLabel->setToolTip(tr("Z-scroll sensitivity. Use Shift+G / Shift+H to adjust."));
     _sliceStepLabel->installEventFilter(this);
     buttonLayout->addWidget(_sliceStepLabel);
     if (_viewerManager) {
-        connect(_viewerManager, &ViewerManager::sliceStepSizeChanged, this, [this](int size) {
+        connect(_viewerManager, &ViewerManager::zScrollSensitivityChanged, this, [this](double sensitivity) {
             if (_sliceStepLabel) {
-                _sliceStepLabel->setText(tr("Step: %1").arg(size));
+                _sliceStepLabel->setText(tr("Z sens: %1").arg(sensitivity, 0, 'f', 1));
             }
         });
     }
@@ -1258,7 +1258,9 @@ bool LineAnnotationDialog::shiftCurrentLinePositionByScrollSteps(int steps)
     if (!_hasGeneratedViews || _generatedViews.linePoints.empty()) {
         return true;
     }
-    const int sliceStepSize = _viewerManager ? _viewerManager->sliceStepSize() : 1;
+    const int sliceStepSize = _viewerManager
+        ? std::max(1, static_cast<int>(std::lround(_viewerManager->zScrollSensitivity())))
+        : 1;
     const double position = vc3d::line_annotation::shiftedLinePosition(
         _currentLinePosition,
         steps,
@@ -1275,7 +1277,9 @@ bool LineAnnotationDialog::shiftCurrentCutPlaneStraightByScrollSteps(int steps)
         return true;
     }
     auto* plane = _generatedViews.currentCutSurface.get();
-    const int sliceStepSize = _viewerManager ? _viewerManager->sliceStepSize() : 1;
+    const int sliceStepSize = _viewerManager
+        ? std::max(1, static_cast<int>(std::lround(_viewerManager->zScrollSensitivity())))
+        : 1;
     const cv::Vec3f origin = plane->origin();
     const cv::Vec3f normal = plane->normal({0.0f, 0.0f, 0.0f});
     const cv::Vec3f shiftedOrigin =
@@ -1836,7 +1840,7 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     QPainterPath controlPath;
     QPainterPath seedPath;
     const double lineRadius =
-        std::max(0.5, static_cast<double>(_viewerManager ? _viewerManager->sliceStepSize() : 1) * 0.5);
+        std::max(0.5, (_viewerManager ? _viewerManager->zScrollSensitivity() : 1.0) * 0.5);
     const double lower = _currentLinePosition - lineRadius;
     const double upper = _currentLinePosition + lineRadius;
     const auto& indices = _generatedControlIndex.sortedControlIndices;
@@ -2198,14 +2202,12 @@ bool LineAnnotationDialog::handleKeyPress(QKeyEvent* event)
     if (_viewerManager &&
         event->modifiers() == vc3d::keybinds::keypress::SliceStepDecrease.modifiers) {
         if (event->key() == vc3d::keybinds::keypress::SliceStepDecrease.key) {
-            const int newStep = std::max(1, _viewerManager->sliceStepSize() - 1);
-            _viewerManager->setSliceStepSize(newStep);
+            _viewerManager->setZScrollSensitivity(_viewerManager->zScrollSensitivity() - 0.1);
             event->accept();
             return true;
         }
         if (event->key() == vc3d::keybinds::keypress::SliceStepIncrease.key) {
-            const int newStep = std::min(100, _viewerManager->sliceStepSize() + 1);
-            _viewerManager->setSliceStepSize(newStep);
+            _viewerManager->setZScrollSensitivity(_viewerManager->zScrollSensitivity() + 0.1);
             event->accept();
             return true;
         }

--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -748,10 +748,14 @@ void MenuActionController::showSettingsDialog()
     const bool resetViewOnSurfaceChange =
         settings.value(vc3d::settings::viewer::RESET_VIEW_ON_SURFACE_CHANGE,
                        vc3d::settings::viewer::RESET_VIEW_ON_SURFACE_CHANGE_DEFAULT).toBool();
+    const bool showPlaneLines =
+        settings.value(vc3d::settings::viewer::SHOW_PLANE_INTERSECTION_LINES,
+                       vc3d::settings::viewer::SHOW_PLANE_INTERSECTION_LINES_DEFAULT).toBool();
     if (_window->_viewerManager) {
-        _window->_viewerManager->forEachBaseViewer([showDirHints](VolumeViewerBase* viewer) {
+        _window->_viewerManager->forEachBaseViewer([showDirHints, showPlaneLines](VolumeViewerBase* viewer) {
             if (viewer) {
                 viewer->setShowDirectionHints(showDirHints);
+                viewer->setPlaneIntersectionLinesVisible(showPlaneLines);
                 // Re-read viewer settings (sensitivities, scalebar voxel size, ...)
                 // so changes made in the dialog take effect immediately.
                 viewer->reloadPerfSettings();

--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -758,10 +758,6 @@ void MenuActionController::showSettingsDialog()
             }
         });
     }
-    if (_window->ui.chkMoveOnSurfaceChanged) {
-        QSignalBlocker blocker(_window->ui.chkMoveOnSurfaceChanged);
-        _window->ui.chkMoveOnSurfaceChanged->setChecked(resetViewOnSurfaceChange);
-    }
     _window->onMoveOnSurfaceChangedToggled(resetViewOnSurfaceChange);
 
     dialog->deleteLater();

--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -756,9 +756,10 @@ void MenuActionController::showSettingsDialog()
             if (viewer) {
                 viewer->setShowDirectionHints(showDirHints);
                 viewer->setPlaneIntersectionLinesVisible(showPlaneLines);
-                // Re-read viewer settings (sensitivities, scalebar voxel size, ...)
-                // so changes made in the dialog take effect immediately.
+                // Re-read viewer settings (sensitivities, interpolation, scalebar voxel
+                // size, ...) so changes made in the dialog take effect immediately.
                 viewer->reloadPerfSettings();
+                viewer->renderVisible(true);
             }
         });
     }

--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -765,6 +765,17 @@ void MenuActionController::showSettingsDialog()
     }
     _window->onMoveOnSurfaceChangedToggled(resetViewOnSurfaceChange);
 
+    if (_window->_viewerManager) {
+        const int intersectionOpacity =
+            settings.value(vc3d::settings::viewer::INTERSECTION_OPACITY,
+                           vc3d::settings::viewer::INTERSECTION_OPACITY_DEFAULT).toInt();
+        _window->_viewerManager->setIntersectionOpacity(
+            std::clamp(static_cast<float>(intersectionOpacity) / 100.0f, 0.0f, 1.0f));
+    }
+    _window->onAxisOverlayOpacityChanged(
+        settings.value(vc3d::settings::viewer::AXIS_OVERLAY_OPACITY,
+                       vc3d::settings::viewer::AXIS_OVERLAY_OPACITY_DEFAULT).toInt());
+
     dialog->deleteLater();
 }
 

--- a/volume-cartographer/apps/VC3D/SettingsDialog.cpp
+++ b/volume-cartographer/apps/VC3D/SettingsDialog.cpp
@@ -36,6 +36,9 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
     chkPlaySoundAfterSegRun->setChecked(settings.value(viewer::PLAY_SOUND_AFTER_SEG_RUN, viewer::PLAY_SOUND_AFTER_SEG_RUN_DEFAULT).toInt() != 0);
     edtUsername->setText(settings.value(viewer::USERNAME, viewer::USERNAME_DEFAULT).toString());
     chkResetViewOnSurfaceChange->setChecked(settings.value(viewer::RESET_VIEW_ON_SURFACE_CHANGE, viewer::RESET_VIEW_ON_SURFACE_CHANGE_DEFAULT).toInt() != 0);
+    if (auto* chk = findChild<QCheckBox*>("chkShowPlaneIntersectionLines")) {
+        chk->setChecked(settings.value(viewer::SHOW_PLANE_INTERSECTION_LINES, viewer::SHOW_PLANE_INTERSECTION_LINES_DEFAULT).toInt() != 0);
+    }
     // Show direction hints (flip_x arrows)
     if (findChild<QCheckBox*>("chkShowDirectionHints")) {
         findChild<QCheckBox*>("chkShowDirectionHints")->setChecked(settings.value(viewer::SHOW_DIRECTION_HINTS, viewer::SHOW_DIRECTION_HINTS_DEFAULT).toInt() != 0);
@@ -130,6 +133,9 @@ void SettingsDialog::accept()
     settings.setValue(viewer::PLAY_SOUND_AFTER_SEG_RUN, chkPlaySoundAfterSegRun->isChecked() ? "1" : "0");
     settings.setValue(viewer::USERNAME, edtUsername->text());
     settings.setValue(viewer::RESET_VIEW_ON_SURFACE_CHANGE, chkResetViewOnSurfaceChange->isChecked() ? "1" : "0");
+    if (auto* chk = findChild<QCheckBox*>("chkShowPlaneIntersectionLines")) {
+        settings.setValue(viewer::SHOW_PLANE_INTERSECTION_LINES, chk->isChecked() ? "1" : "0");
+    }
     if (findChild<QCheckBox*>("chkShowDirectionHints")) {
         settings.setValue(viewer::SHOW_DIRECTION_HINTS, findChild<QCheckBox*>("chkShowDirectionHints")->isChecked() ? "1" : "0");
     }

--- a/volume-cartographer/apps/VC3D/SettingsDialog.cpp
+++ b/volume-cartographer/apps/VC3D/SettingsDialog.cpp
@@ -42,6 +42,12 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
     if (auto* cmb = findChild<QComboBox*>("cmbInterpolation")) {
         cmb->setCurrentIndex(std::clamp(settings.value(perf::INTERPOLATION_METHOD, perf::INTERPOLATION_METHOD_DEFAULT).toInt(), 0, 1));
     }
+    if (auto* spin = findChild<QSpinBox*>("spinIntersectionOpacity")) {
+        spin->setValue(std::clamp(settings.value(viewer::INTERSECTION_OPACITY, viewer::INTERSECTION_OPACITY_DEFAULT).toInt(), 0, 100));
+    }
+    if (auto* spin = findChild<QSpinBox*>("spinAxisOverlayOpacity")) {
+        spin->setValue(std::clamp(settings.value(viewer::AXIS_OVERLAY_OPACITY, viewer::AXIS_OVERLAY_OPACITY_DEFAULT).toInt(), 0, 100));
+    }
     // Show direction hints (flip_x arrows)
     if (findChild<QCheckBox*>("chkShowDirectionHints")) {
         findChild<QCheckBox*>("chkShowDirectionHints")->setChecked(settings.value(viewer::SHOW_DIRECTION_HINTS, viewer::SHOW_DIRECTION_HINTS_DEFAULT).toInt() != 0);
@@ -141,6 +147,12 @@ void SettingsDialog::accept()
     }
     if (auto* cmb = findChild<QComboBox*>("cmbInterpolation")) {
         settings.setValue(perf::INTERPOLATION_METHOD, cmb->currentIndex());
+    }
+    if (auto* spin = findChild<QSpinBox*>("spinIntersectionOpacity")) {
+        settings.setValue(viewer::INTERSECTION_OPACITY, spin->value());
+    }
+    if (auto* spin = findChild<QSpinBox*>("spinAxisOverlayOpacity")) {
+        settings.setValue(viewer::AXIS_OVERLAY_OPACITY, spin->value());
     }
     if (findChild<QCheckBox*>("chkShowDirectionHints")) {
         settings.setValue(viewer::SHOW_DIRECTION_HINTS, findChild<QCheckBox*>("chkShowDirectionHints")->isChecked() ? "1" : "0");

--- a/volume-cartographer/apps/VC3D/SettingsDialog.cpp
+++ b/volume-cartographer/apps/VC3D/SettingsDialog.cpp
@@ -39,6 +39,9 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
     if (auto* chk = findChild<QCheckBox*>("chkShowPlaneIntersectionLines")) {
         chk->setChecked(settings.value(viewer::SHOW_PLANE_INTERSECTION_LINES, viewer::SHOW_PLANE_INTERSECTION_LINES_DEFAULT).toInt() != 0);
     }
+    if (auto* cmb = findChild<QComboBox*>("cmbInterpolation")) {
+        cmb->setCurrentIndex(std::clamp(settings.value(perf::INTERPOLATION_METHOD, perf::INTERPOLATION_METHOD_DEFAULT).toInt(), 0, 1));
+    }
     // Show direction hints (flip_x arrows)
     if (findChild<QCheckBox*>("chkShowDirectionHints")) {
         findChild<QCheckBox*>("chkShowDirectionHints")->setChecked(settings.value(viewer::SHOW_DIRECTION_HINTS, viewer::SHOW_DIRECTION_HINTS_DEFAULT).toInt() != 0);
@@ -135,6 +138,9 @@ void SettingsDialog::accept()
     settings.setValue(viewer::RESET_VIEW_ON_SURFACE_CHANGE, chkResetViewOnSurfaceChange->isChecked() ? "1" : "0");
     if (auto* chk = findChild<QCheckBox*>("chkShowPlaneIntersectionLines")) {
         settings.setValue(viewer::SHOW_PLANE_INTERSECTION_LINES, chk->isChecked() ? "1" : "0");
+    }
+    if (auto* cmb = findChild<QComboBox*>("cmbInterpolation")) {
+        settings.setValue(perf::INTERPOLATION_METHOD, cmb->currentIndex());
     }
     if (findChild<QCheckBox*>("chkShowDirectionHints")) {
         settings.setValue(viewer::SHOW_DIRECTION_HINTS, findChild<QCheckBox*>("chkShowDirectionHints")->isChecked() ? "1" : "0");

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -2021,19 +2021,6 @@
        </property>
       </widget>
      </item>
-     <item row="12" column="0">
-      <widget class="QCheckBox" name="chkPlaneIntersectionLines">
-       <property name="toolTip">
-        <string>Show slice-plane intersection lines in the segmentation surface view</string>
-       </property>
-       <property name="text">
-        <string>Show plane lines on segmentation view</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
     </layout>
    </widget>
    </widget>

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -2021,19 +2021,6 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="0" colspan="4">
-      <widget class="QCheckBox" name="chkMoveOnSurfaceChanged">
-       <property name="toolTip">
-        <string>Move viewers to the selected surface when the active surface changes</string>
-       </property>
-       <property name="text">
-        <string>Move on surface change</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
      <item row="12" column="0">
       <widget class="QCheckBox" name="chkPlaneIntersectionLines">
        <property name="toolTip">

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -1906,32 +1906,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="labelIntersectionOpacity">
-       <property name="text">
-        <string>Intersection opacity</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1" colspan="2">
-      <widget class="QSpinBox" name="spinIntersectionOpacity">
-       <property name="minimum">
-        <number>0</number>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="value">
-        <number>100</number>
-       </property>
-       <property name="suffix">
-        <string>%</string>
-       </property>
-       <property name="toolTip">
-        <string>Adjust opacity of intersection overlays</string>
-       </property>
-     </widget>
-    </item>
      <item row="5" column="0">
       <widget class="QLabel" name="labelIntersectionThickness">
        <property name="text">
@@ -1978,29 +1952,6 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="labelAxisOverlayOpacity">
-       <property name="text">
-        <string>Axis overlay opacity</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1" colspan="2">
-      <widget class="QSpinBox" name="spinAxisOverlayOpacity">
-       <property name="minimum">
-        <number>0</number>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="value">
-        <number>70</number>
-       </property>
-       <property name="suffix">
-        <string>%</string>
        </property>
       </widget>
      </item>

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -2047,29 +2047,6 @@
        </property>
       </widget>
      </item>
-     <item row="13" column="0">
-      <widget class="QLabel" name="labelSliceStepSize">
-       <property name="text">
-        <string>Slice step size</string>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="1" colspan="2">
-      <widget class="QSpinBox" name="spinSliceStepSize">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="value">
-        <number>1</number>
-       </property>
-       <property name="toolTip">
-        <string>Number of slices to pan with Shift+ScrollWheel. Adjust step size with Shift+G and Shift+H.</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </widget>
    </widget>

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -142,7 +142,7 @@ namespace viewer {
     constexpr double DIRECTION_STEP_DEFAULT = 10.0;
     constexpr bool USE_SEG_STEP_FOR_HINTS_DEFAULT = true;
     constexpr int DIRECTION_STEP_POINTS_DEFAULT = 5;
-    constexpr bool RESET_VIEW_ON_SURFACE_CHANGE_DEFAULT = true;
+    constexpr bool RESET_VIEW_ON_SURFACE_CHANGE_DEFAULT = false;
     constexpr bool SHOW_PLANE_INTERSECTION_LINES_DEFAULT = true;
     constexpr bool MIRROR_CURSOR_TO_SEGMENTATION_DEFAULT = false;
     constexpr int MAX_DISPLAYED_RESOLUTION_DEFAULT = 0;

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -234,6 +234,7 @@ namespace perf {
     constexpr int PARALLEL_PROCESSES_DEFAULT = 8;
     constexpr int ITERATION_COUNT_DEFAULT = 1000;
     constexpr int DOWNSCALE_OVERRIDE_DEFAULT = 0;
+    constexpr int INTERPOLATION_METHOD_DEFAULT = 1;  // 0 = Nearest, 1 = Trilinear
     constexpr bool ENABLE_FILE_WATCHING_DEFAULT = true;
     constexpr int RAM_CACHE_SIZE_GB_DEFAULT = 10;
 

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -163,7 +163,7 @@ namespace viewer {
 
     constexpr auto INTERSECTION_MAX_SURFACES = "viewer/intersection_max_surfaces";
 
-    constexpr int INTERSECTION_OPACITY_DEFAULT = 100;
+    constexpr int INTERSECTION_OPACITY_DEFAULT = 70;
     constexpr float INTERSECTION_THICKNESS_DEFAULT = 0.0f;
     constexpr int INTERSECTION_SAMPLING_STRIDE_DEFAULT = 1;
     constexpr int INTERSECTION_MAX_SURFACES_DEFAULT = 0;  // 0 = unlimited
@@ -174,7 +174,7 @@ namespace viewer {
     constexpr auto USE_AXIS_ALIGNED_SLICES = "viewer/use_axis_aligned_slices";
 
     constexpr bool SHOW_AXIS_OVERLAYS_DEFAULT = true;
-    constexpr int AXIS_OVERLAY_OPACITY_DEFAULT = 100;
+    constexpr int AXIS_OVERLAY_OPACITY_DEFAULT = 70;
     constexpr bool USE_AXIS_ALIGNED_SLICES_DEFAULT = true;
 
     // Remote volume chunk cache directory. Resolved through

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -172,12 +172,10 @@ namespace viewer {
     constexpr auto SHOW_AXIS_OVERLAYS = "viewer/show_axis_overlays";
     constexpr auto AXIS_OVERLAY_OPACITY = "viewer/axis_overlay_opacity";
     constexpr auto USE_AXIS_ALIGNED_SLICES = "viewer/use_axis_aligned_slices";
-    constexpr auto SLICE_STEP_SIZE = "viewer/slice_step_size";
 
     constexpr bool SHOW_AXIS_OVERLAYS_DEFAULT = true;
     constexpr int AXIS_OVERLAY_OPACITY_DEFAULT = 100;
     constexpr bool USE_AXIS_ALIGNED_SLICES_DEFAULT = true;
-    constexpr int SLICE_STEP_SIZE_DEFAULT = 1;
 
     // Remote volume chunk cache directory. Resolved through
     // vc3d::remoteCachePath() — see that function for the priority rules.

--- a/volume-cartographer/apps/VC3D/VCSettings.ui
+++ b/volume-cartographer/apps/VC3D/VCSettings.ui
@@ -370,6 +370,27 @@
             </property>
            </widget>
           </item>
+          <item row="12" column="0">
+           <widget class="QLabel" name="labelInterpolation">
+            <property name="text">
+             <string>Interpolation</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1">
+           <widget class="QComboBox" name="cmbInterpolation">
+            <item>
+             <property name="text">
+              <string>Nearest</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Trilinear</string>
+             </property>
+            </item>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/volume-cartographer/apps/VC3D/VCSettings.ui
+++ b/volume-cartographer/apps/VC3D/VCSettings.ui
@@ -318,7 +318,7 @@
              <string>Reset view when switching between surfaces</string>
             </property>
             <property name="checked">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="toolTip">
              <string>When enabled, the view will automatically fit and center on each surface when switching between segments</string>

--- a/volume-cartographer/apps/VC3D/VCSettings.ui
+++ b/volume-cartographer/apps/VC3D/VCSettings.ui
@@ -391,6 +391,55 @@
             </item>
            </widget>
           </item>
+          <item row="13" column="0">
+           <widget class="QLabel" name="labelIntersectionOpacity">
+            <property name="text">
+             <string>Intersection opacity</string>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="1">
+           <widget class="QSpinBox" name="spinIntersectionOpacity">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>70</number>
+            </property>
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="toolTip">
+             <string>Adjust opacity of intersection overlays</string>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="0">
+           <widget class="QLabel" name="labelAxisOverlayOpacity">
+            <property name="text">
+             <string>Axis overlay opacity</string>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="1">
+           <widget class="QSpinBox" name="spinAxisOverlayOpacity">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>70</number>
+            </property>
+            <property name="suffix">
+             <string>%</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/volume-cartographer/apps/VC3D/VCSettings.ui
+++ b/volume-cartographer/apps/VC3D/VCSettings.ui
@@ -357,6 +357,19 @@
             </property>
            </widget>
           </item>
+          <item row="11" column="0" colspan="2">
+           <widget class="QCheckBox" name="chkShowPlaneIntersectionLines">
+            <property name="text">
+             <string>Show plane lines on segmentation view</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Show slice-plane intersection lines in the segmentation surface view</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/volume-cartographer/apps/VC3D/ViewerManager.cpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.cpp
@@ -58,6 +58,10 @@ ViewerManager::ViewerManager(CState* state,
     const float minHigh = std::min(_volumeWindowLow + 1.0f, 255.0f);
     _volumeWindowHigh = std::clamp(storedBaseHigh, minHigh, 255.0f);
 
+    const double storedZScroll = settings.value(viewer::ZSCROLL_SENSITIVITY,
+                                                 viewer::ZSCROLL_SENSITIVITY_DEFAULT).toDouble();
+    _zScrollSensitivity = std::clamp(storedZScroll, 0.1, 100.0);
+
     _surfacePatchSamplingStride = viewer::INTERSECTION_SAMPLING_STRIDE_DEFAULT;
     const float storedThickness = settings.value(viewer::INTERSECTION_THICKNESS, viewer::INTERSECTION_THICKNESS_DEFAULT).toFloat();
     _intersectionThickness = std::max(0.0f, storedThickness);
@@ -981,14 +985,24 @@ void ViewerManager::broadcastLinkedCursor(VolumeViewerBase* source,
     });
 }
 
-void ViewerManager::setSliceStepSize(int size)
+void ViewerManager::setZScrollSensitivity(double sensitivity)
 {
-    const int clampedSize = std::max(1, size);
-    if (_sliceStepSize == clampedSize) {
+    const double clamped = std::clamp(sensitivity, 0.1, 100.0);
+    if (std::abs(_zScrollSensitivity - clamped) < 1e-9) {
         return;
     }
-    _sliceStepSize = clampedSize;
-    emit sliceStepSizeChanged(_sliceStepSize);
+    _zScrollSensitivity = clamped;
+
+    QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
+    settings.setValue(vc3d::settings::viewer::ZSCROLL_SENSITIVITY, _zScrollSensitivity);
+
+    forEachBaseViewer([](VolumeViewerBase* viewer) {
+        if (viewer) {
+            viewer->reloadPerfSettings();
+        }
+    });
+
+    emit zScrollSensitivityChanged(_zScrollSensitivity);
 }
 
 void ViewerManager::forEachBaseViewer(const std::function<void(VolumeViewerBase*)>& fn) const

--- a/volume-cartographer/apps/VC3D/ViewerManager.cpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.cpp
@@ -52,8 +52,16 @@ ViewerManager::ViewerManager(CState* state,
     const float normalized = static_cast<float>(savedOpacityPercent) / 100.0f;
     _intersectionOpacity = std::clamp(normalized, 0.0f, 1.0f);
 
-    const float storedBaseLow = settings.value(viewer::BASE_WINDOW_LOW, viewer::BASE_WINDOW_LOW_DEFAULT).toFloat();
-    const float storedBaseHigh = settings.value(viewer::BASE_WINDOW_HIGH, viewer::BASE_WINDOW_HIGH_DEFAULT).toFloat();
+    float storedBaseLow = settings.value(viewer::BASE_WINDOW_LOW, viewer::BASE_WINDOW_LOW_DEFAULT).toFloat();
+    float storedBaseHigh = settings.value(viewer::BASE_WINDOW_HIGH, viewer::BASE_WINDOW_HIGH_DEFAULT).toFloat();
+    // The window is a fixed 0-255 scale. Values persisted on a different scale (e.g. a
+    // legacy 16-bit build) would otherwise clamp to (255, 255) and slam both slider
+    // handles to the far right. Fall back to defaults if the stored pair is out of range
+    // or collapsed so the control is usable again.
+    if (storedBaseLow < 0.0f || storedBaseHigh > 255.0f || (storedBaseHigh - storedBaseLow) < 1.0f) {
+        storedBaseLow = viewer::BASE_WINDOW_LOW_DEFAULT;
+        storedBaseHigh = viewer::BASE_WINDOW_HIGH_DEFAULT;
+    }
     _volumeWindowLow = std::clamp(storedBaseLow, 0.0f, 255.0f);
     const float minHigh = std::min(_volumeWindowLow + 1.0f, 255.0f);
     _volumeWindowHigh = std::clamp(storedBaseHigh, minHigh, 255.0f);

--- a/volume-cartographer/apps/VC3D/ViewerManager.hpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.hpp
@@ -110,8 +110,8 @@ public:
     void broadcastLinkedCursor(VolumeViewerBase* source,
                                const std::optional<cv::Vec3f>& point);
 
-    void setSliceStepSize(int size);
-    int sliceStepSize() const { return _sliceStepSize; }
+    void setZScrollSensitivity(double sensitivity);
+    double zScrollSensitivity() const { return _zScrollSensitivity; }
 
     void forEachBaseViewer(const std::function<void(VolumeViewerBase*)>& fn) const;
     void setIntersectionThickness(float thickness);
@@ -136,7 +136,7 @@ signals:
     void volumeWindowChanged(float low, float high);
     void overlayVolumeAvailabilityChanged(bool hasOverlay);
     void samplingStrideChanged(int stride);
-    void sliceStepSizeChanged(int size);
+    void zScrollSensitivityChanged(double sensitivity);
 
 private slots:
     void onGlobalTick();
@@ -202,7 +202,7 @@ private:
     float _volumeWindowLow{0.0f};
     float _volumeWindowHigh{255.0f};
     bool _mirrorCursorToSegmentation{false};
-    int _sliceStepSize{1};
+    double _zScrollSensitivity{1.0};
     int _surfacePatchSamplingStride{1};
     std::atomic<bool> _shuttingDown{false};
     int _intersectionMaxSurfaces{0};  // 0 = unlimited

--- a/volume-cartographer/apps/VC3D/viewer_controls/ViewerControlsPanel.cpp
+++ b/volume-cartographer/apps/VC3D/viewer_controls/ViewerControlsPanel.cpp
@@ -245,17 +245,6 @@ void ViewerControlsPanel::setOverlayWindowAvailable(bool available)
     updateOverlayWindowControlsEnabled();
 }
 
-void ViewerControlsPanel::setSliceStepSize(int value)
-{
-    if (!_sliceStepSizeSpin) {
-        return;
-    }
-    QSignalBlocker blocker(_sliceStepSizeSpin);
-    _sliceStepSizeSpin->setValue(std::clamp(value,
-                                            _sliceStepSizeSpin->minimum(),
-                                            _sliceStepSizeSpin->maximum()));
-}
-
 void ViewerControlsPanel::setupViewerControlWiring()
 {
     setupWindowRangeControls();
@@ -268,28 +257,6 @@ void ViewerControlsPanel::setupViewerControlWiring()
         connect(_uiRefs.zoomOutButton, &QPushButton::clicked, this, &ViewerControlsPanel::zoomOutRequested);
     }
 
-    if (auto* spinSliceStep = _uiRefs.sliceStepSizeSpin) {
-        _sliceStepSizeSpin = spinSliceStep;
-        QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
-        int savedStep = settings.value(vc3d::settings::viewer::SLICE_STEP_SIZE,
-                                       vc3d::settings::viewer::SLICE_STEP_SIZE_DEFAULT).toInt();
-        savedStep = std::clamp(savedStep, spinSliceStep->minimum(), spinSliceStep->maximum());
-        {
-            QSignalBlocker blocker(spinSliceStep);
-            spinSliceStep->setValue(savedStep);
-        }
-        if (_viewerManager) {
-            _viewerManager->setSliceStepSize(savedStep);
-        }
-        connect(spinSliceStep, qOverload<int>(&QSpinBox::valueChanged), this, [this](int value) {
-            if (_viewerManager) {
-                _viewerManager->setSliceStepSize(value);
-            }
-            QSettings s(vc3d::settingsFilePath(), QSettings::IniFormat);
-            s.setValue(vc3d::settings::viewer::SLICE_STEP_SIZE, value);
-            emit sliceStepSizeChanged(value);
-        });
-    }
 }
 
 void ViewerControlsPanel::setupWindowRangeControls()

--- a/volume-cartographer/apps/VC3D/viewer_controls/ViewerControlsPanel.cpp
+++ b/volume-cartographer/apps/VC3D/viewer_controls/ViewerControlsPanel.cpp
@@ -338,26 +338,6 @@ void ViewerControlsPanel::setupIntersectionControls()
 {
     QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
 
-    if (auto* spinIntersectionOpacity = _uiRefs.intersectionOpacitySpin) {
-        const int savedOpacity = settings.value(vc3d::settings::viewer::INTERSECTION_OPACITY,
-                                                spinIntersectionOpacity->value()).toInt();
-        const int boundedOpacity = std::clamp(savedOpacity,
-                                              spinIntersectionOpacity->minimum(),
-                                              spinIntersectionOpacity->maximum());
-        spinIntersectionOpacity->setValue(boundedOpacity);
-        connect(spinIntersectionOpacity, QOverload<int>::of(&QSpinBox::valueChanged),
-                this, [this](int value) {
-                    if (!_viewerManager) {
-                        return;
-                    }
-                    const float normalized = std::clamp(static_cast<float>(value) / 100.0f, 0.0f, 1.0f);
-                    _viewerManager->setIntersectionOpacity(normalized);
-                });
-        if (_viewerManager) {
-            _viewerManager->setIntersectionOpacity(spinIntersectionOpacity->value() / 100.0f);
-        }
-    }
-
     if (auto* spinIntersectionThickness = _uiRefs.intersectionThicknessSpin) {
         const double savedThickness = settings.value(vc3d::settings::viewer::INTERSECTION_THICKNESS,
                                                      spinIntersectionThickness->value()).toDouble();

--- a/volume-cartographer/apps/VC3D/viewer_controls/ViewerControlsPanel.hpp
+++ b/volume-cartographer/apps/VC3D/viewer_controls/ViewerControlsPanel.hpp
@@ -139,7 +139,6 @@ public:
         QPushButton* zoomOutButton{nullptr};
         QWidget* volumeWindowContainer{nullptr};
         QWidget* overlayWindowContainer{nullptr};
-        QSpinBox* intersectionOpacitySpin{nullptr};
         QDoubleSpinBox* intersectionThicknessSpin{nullptr};
     };
 

--- a/volume-cartographer/apps/VC3D/viewer_controls/ViewerControlsPanel.hpp
+++ b/volume-cartographer/apps/VC3D/viewer_controls/ViewerControlsPanel.hpp
@@ -137,7 +137,6 @@ public:
 
         QPushButton* zoomInButton{nullptr};
         QPushButton* zoomOutButton{nullptr};
-        QSpinBox* sliceStepSizeSpin{nullptr};
         QWidget* volumeWindowContainer{nullptr};
         QWidget* overlayWindowContainer{nullptr};
         QSpinBox* intersectionOpacitySpin{nullptr};
@@ -153,12 +152,10 @@ public:
     void toggleSegmentationComposite();
     void setViewControlsEnabled(bool enabled);
     void setOverlayWindowAvailable(bool available);
-    void setSliceStepSize(int value);
 
 signals:
     void zoomInRequested();
     void zoomOutRequested();
-    void sliceStepSizeChanged(int value);
     void statusMessageRequested(QString text, int timeoutMs);
 
 private:
@@ -182,7 +179,6 @@ private:
     ViewerTransformsPanel* _transformsPanel{nullptr};
     WindowRangeWidget* _volumeWindowWidget{nullptr};
     WindowRangeWidget* _overlayWindowWidget{nullptr};
-    QSpinBox* _sliceStepSizeSpin{nullptr};
     bool _viewControlsEnabled{true};
     bool _overlayWindowAvailable{false};
 };

--- a/volume-cartographer/apps/VC3D/viewer_controls/panels/ViewerNavigationPanel.cpp
+++ b/volume-cartographer/apps/VC3D/viewer_controls/panels/ViewerNavigationPanel.cpp
@@ -7,6 +7,7 @@
 
 #include <QDoubleSpinBox>
 #include <QSettings>
+#include <QSignalBlocker>
 #include <QVBoxLayout>
 
 ViewerNavigationPanel::ViewerNavigationPanel(ViewerManager* viewerManager, QWidget* parent)
@@ -20,7 +21,35 @@ ViewerNavigationPanel::ViewerNavigationPanel(ViewerManager* viewerManager, QWidg
     using namespace vc3d::settings;
     addSensitivityControl(layout, tr("Pan sensitivity"), viewer::PAN_SENSITIVITY, viewer::PAN_SENSITIVITY_DEFAULT);
     addSensitivityControl(layout, tr("Zoom sensitivity"), viewer::ZOOM_SENSITIVITY, viewer::ZOOM_SENSITIVITY_DEFAULT);
-    addSensitivityControl(layout, tr("Z-scroll sensitivity"), viewer::ZSCROLL_SENSITIVITY, viewer::ZSCROLL_SENSITIVITY_DEFAULT);
+
+    // Z-scroll sensitivity is also driven by the Shift+G / Shift+H keybindings, so it is
+    // routed through ViewerManager (the single source of truth) rather than writing the
+    // setting directly. The spin box both drives and reflects that value.
+    auto* zScrollRow = new LabeledControlRow(tr("Z-scroll sensitivity"), this);
+    _zScrollSpin = new QDoubleSpinBox(zScrollRow);
+    _zScrollSpin->setRange(0.1, 100.0);
+    _zScrollSpin->setSingleStep(0.1);
+    _zScrollSpin->setDecimals(1);
+    _zScrollSpin->setValue(_viewerManager ? _viewerManager->zScrollSensitivity()
+                                          : viewer::ZSCROLL_SENSITIVITY_DEFAULT);
+    zScrollRow->addControl(_zScrollSpin);
+    zScrollRow->addStretch(1);
+    layout->addWidget(zScrollRow);
+
+    connect(_zScrollSpin, &QDoubleSpinBox::valueChanged, this, [this](double value) {
+        if (_viewerManager) {
+            _viewerManager->setZScrollSensitivity(value);
+        }
+    });
+    if (_viewerManager) {
+        connect(_viewerManager, &ViewerManager::zScrollSensitivityChanged, this, [this](double value) {
+            if (!_zScrollSpin) {
+                return;
+            }
+            QSignalBlocker blocker(_zScrollSpin);
+            _zScrollSpin->setValue(value);
+        });
+    }
 }
 
 void ViewerNavigationPanel::addSensitivityControl(QVBoxLayout* layout,

--- a/volume-cartographer/apps/VC3D/viewer_controls/panels/ViewerNavigationPanel.hpp
+++ b/volume-cartographer/apps/VC3D/viewer_controls/panels/ViewerNavigationPanel.hpp
@@ -3,6 +3,7 @@
 #include <QWidget>
 
 class ViewerManager;
+class QDoubleSpinBox;
 
 class ViewerNavigationPanel : public QWidget
 {
@@ -18,4 +19,5 @@ private:
                                double defaultValue);
 
     ViewerManager* _viewerManager{nullptr};
+    QDoubleSpinBox* _zScrollSpin{nullptr};
 };

--- a/volume-cartographer/apps/VC3D/viewer_controls/panels/ViewerViewExtrasPanel.cpp
+++ b/volume-cartographer/apps/VC3D/viewer_controls/panels/ViewerViewExtrasPanel.cpp
@@ -5,7 +5,6 @@
 #include "volume_viewers/VolumeViewerBase.hpp"
 #include "elements/LabeledControlRow.hpp"
 
-#include <QComboBox>
 #include <QSettings>
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -21,28 +20,6 @@ ViewerViewExtrasPanel::ViewerViewExtrasPanel(ViewerManager* viewerManager, QWidg
     layout->setSpacing(8);
 
     QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
-
-    auto* interpRow = new LabeledControlRow(tr("Interpolation"), this);
-    auto* cmbInterp = new QComboBox(interpRow);
-    cmbInterp->addItem(tr("Nearest"));
-    cmbInterp->addItem(tr("Trilinear"));
-    cmbInterp->setCurrentIndex(std::clamp(settings.value(vc3d::settings::perf::INTERPOLATION_METHOD, 1).toInt(), 0, 1));
-    interpRow->addControl(cmbInterp, 1);
-    layout->addWidget(interpRow);
-
-    connect(cmbInterp, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int idx) {
-        QSettings s(vc3d::settingsFilePath(), QSettings::IniFormat);
-        s.setValue(vc3d::settings::perf::INTERPOLATION_METHOD, idx);
-        if (_viewerManager) {
-            _viewerManager->forEachBaseViewer([](VolumeViewerBase* viewer) {
-                if (!viewer) {
-                    return;
-                }
-                viewer->reloadPerfSettings();
-                viewer->renderVisible(true);
-            });
-        }
-    });
 
     auto* maxResolutionRow = new LabeledControlRow(tr("Max displayed resolution"), this);
     auto* maxResolution = new QSpinBox(maxResolutionRow);

--- a/volume-cartographer/apps/VC3D/viewer_controls/panels/ViewerViewExtrasPanel.cpp
+++ b/volume-cartographer/apps/VC3D/viewer_controls/panels/ViewerViewExtrasPanel.cpp
@@ -5,7 +5,6 @@
 #include "volume_viewers/VolumeViewerBase.hpp"
 #include "elements/LabeledControlRow.hpp"
 
-#include <QCheckBox>
 #include <QComboBox>
 #include <QSettings>
 #include <QSpinBox>
@@ -63,28 +62,6 @@ ViewerViewExtrasPanel::ViewerViewExtrasPanel(ViewerManager* viewerManager, QWidg
     connect(maxResolution, QOverload<int>::of(&QSpinBox::valueChanged), this, [this](int value) {
         QSettings s(vc3d::settingsFilePath(), QSettings::IniFormat);
         s.setValue(vc3d::settings::viewer::MAX_DISPLAYED_RESOLUTION, std::clamp(value, 0, 5));
-        if (_viewerManager) {
-            _viewerManager->forEachBaseViewer([](VolumeViewerBase* viewer) {
-                if (!viewer) {
-                    return;
-                }
-                viewer->reloadPerfSettings();
-                viewer->renderVisible(true);
-            });
-        }
-    });
-
-    auto* chkHighlight = new QCheckBox(tr("Highlight downscaled chunks"), this);
-    chkHighlight->setToolTip(
-        tr("Tint pixels sourced from a coarser pyramid level than the current zoom "
-           "target. Green = 1 level coarser; red = 5+ levels coarser. Untinted pixels "
-           "rendered at the requested resolution."));
-    chkHighlight->setChecked(settings.value("viewer_controls/highlight_downscaled", false).toBool());
-    layout->addWidget(chkHighlight);
-
-    connect(chkHighlight, &QCheckBox::toggled, this, [this](bool on) {
-        QSettings s(vc3d::settingsFilePath(), QSettings::IniFormat);
-        s.setValue("viewer_controls/highlight_downscaled", on);
         if (_viewerManager) {
             _viewerManager->forEachBaseViewer([](VolumeViewerBase* viewer) {
                 if (!viewer) {

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -862,7 +862,7 @@ void CChunkedVolumeViewer::reloadPerfSettings()
     _zScrollSensitivity = std::max(0.01f, s.value(viewer::ZSCROLL_SENSITIVITY, viewer::ZSCROLL_SENSITIVITY_DEFAULT).toFloat());
     _voxelSizeOverrideUm = std::max(0.0, s.value(viewer::VOXEL_SIZE_UM, viewer::VOXEL_SIZE_UM_DEFAULT).toDouble());
     updateScalebarScale();   // override may have changed -> refresh the scalebar
-    const int interpIdx = s.value(perf::INTERPOLATION_METHOD, 1).toInt();
+    const int interpIdx = s.value(perf::INTERPOLATION_METHOD, perf::INTERPOLATION_METHOD_DEFAULT).toInt();
     _samplingMethod = static_cast<vc::Sampling>(std::clamp(interpIdx, 0, 1));
     _maxDisplayedResolution = std::clamp(
         s.value(viewer::MAX_DISPLAYED_RESOLUTION, viewer::MAX_DISPLAYED_RESOLUTION_DEFAULT).toInt(),


### PR DESCRIPTION
- remove the slice step size spinbox/logic
- default move on surface change to false, and move the checkbox into settings > view
- default show plane lines on segmentation view to true, and move the checkbox into settings > view
- default interpolation to trilinear, and move the dropdown into settings > view
- remove the highlight downscaled chunks checkbox/logic
- the volume windowing handles dont work, they are both slammed all the way to the right
- intersection opacity and axis overlay opacity defaulted to 70% , setting moved to settings > view