### PR TITLE
Overlay max res prefetch cleanup

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -7216,6 +7216,7 @@ void CWindow::CreateWidgets(void)
             .colormapSelect = ui.overlayColormapSelect,
             .opacitySpin = ui.overlayOpacitySpin,
             .thresholdSpin = ui.overlayThresholdSpin,
+            .maxDisplayedResolutionSpin = ui.overlayMaxDisplayedResolutionSpin,
         };
         _volumeOverlay->setUi(overlayUi);
         if (_viewerControlsPanel) {

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -1300,7 +1300,33 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0" colspan="3">
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelOverlayMaxDisplayedResolution">
+       <property name="text">
+        <string>Max displayed resolution</string>
+       </property>
+       <property name="toolTip">
+        <string>Clamp overlay rendering and chunk fetches so overlay pyramid levels finer than this scale are not requested.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QSpinBox" name="overlayMaxDisplayedResolutionSpin">
+       <property name="toolTip">
+        <string>Clamp overlay rendering and chunk fetches so overlay pyramid levels finer than this scale are not requested.</string>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>5</number>
+       </property>
+       <property name="value">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0" colspan="3">
       <spacer name="verticalSpacerOverlay">
        <property name="orientation">
         <enum>Qt::Vertical</enum>

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -445,6 +445,9 @@ namespace volume_overlay {
     constexpr auto WINDOW_HIGH = "window_high";
     constexpr auto THRESHOLD = "threshold";  // Legacy key
     constexpr auto COLORMAP = "colormap";
+    constexpr auto MAX_DISPLAYED_RESOLUTION = "max_displayed_resolution";
+
+    constexpr int MAX_DISPLAYED_RESOLUTION_DEFAULT = 0;
 }
 
 } // namespace settings

--- a/volume-cartographer/apps/VC3D/ViewerManager.cpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.cpp
@@ -238,6 +238,7 @@ VolumeViewerBase* ViewerManager::initializeChunkedViewer(CChunkedVolumeViewer* c
     baseViewer->setOverlayOpacity(_overlayOpacity);
     baseViewer->setOverlayColormap(_overlayColormapId);
     baseViewer->setOverlayWindow(_overlayWindowLow, _overlayWindowHigh);
+    baseViewer->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
 
     if (_segmentationModule && role != ViewerRole::Annotation) {
         _segmentationModule->attachViewer(baseViewer);
@@ -426,6 +427,14 @@ void ViewerManager::setOverlayWindow(float low, float high)
     forEachBaseViewer([this](VolumeViewerBase* v) { v->setOverlayWindow(_overlayWindowLow, _overlayWindowHigh); });
 
     emit overlayWindowChanged(_overlayWindowLow, _overlayWindowHigh);
+}
+
+void ViewerManager::setOverlayMaxDisplayedResolution(int level)
+{
+    _overlayMaxDisplayedResolution = std::clamp(level, 0, 5);
+    forEachBaseViewer([this](VolumeViewerBase* v) {
+        v->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
+    });
 }
 
 void ViewerManager::setVolumeWindow(float low, float high)

--- a/volume-cartographer/apps/VC3D/ViewerManager.hpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.hpp
@@ -93,6 +93,8 @@ public:
     void setOverlayWindow(float low, float high);
     float overlayWindowLow() const { return _overlayWindowLow; }
     float overlayWindowHigh() const { return _overlayWindowHigh; }
+    void setOverlayMaxDisplayedResolution(int level);
+    int overlayMaxDisplayedResolution() const { return _overlayMaxDisplayedResolution; }
 
     void setVolumeWindow(float low, float high);
     float volumeWindowLow() const { return _volumeWindowLow; }
@@ -202,6 +204,7 @@ private:
     std::string _overlayColormapId;
     float _overlayWindowLow{0.0f};
     float _overlayWindowHigh{255.0f};
+    int _overlayMaxDisplayedResolution{0};
     float _volumeWindowLow{0.0f};
     float _volumeWindowHigh{255.0f};
     bool _mirrorCursorToSegmentation{false};

--- a/volume-cartographer/apps/VC3D/overlays/VolumeOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/VolumeOverlayController.cpp
@@ -111,6 +111,12 @@ void VolumeOverlayController::setUi(const UiRefs& ui)
         _ui.thresholdSpin->setValue(spinValueFromWindow(_overlayWindowLow));
     }
 
+    if (_ui.maxDisplayedResolutionSpin) {
+        _ui.maxDisplayedResolutionSpin->setRange(0, 5);
+        QSignalBlocker blocker(_ui.maxDisplayedResolutionSpin);
+        _ui.maxDisplayedResolutionSpin->setValue(std::clamp(_overlayMaxDisplayedResolution, 0, 5));
+    }
+
     populateColormapOptions();
     refreshVolumeOptions();
     updateUiEnabled();
@@ -133,6 +139,13 @@ void VolumeOverlayController::setVolumePkg(const std::shared_ptr<VolumePkg>& pkg
     setColormap(_overlayColormapName);
     setOpacity(_overlayOpacity);
     setWindowBounds(_overlayWindowLow, _overlayWindowHigh);
+    if (_ui.maxDisplayedResolutionSpin) {
+        const QSignalBlocker blocker(_ui.maxDisplayedResolutionSpin);
+        _ui.maxDisplayedResolutionSpin->setValue(std::clamp(_overlayMaxDisplayedResolution, 0, 5));
+    }
+    if (_viewerManager) {
+        _viewerManager->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
+    }
     updateUiEnabled();
     _suspendPersistence = false;
 }
@@ -169,6 +182,7 @@ void VolumeOverlayController::clearVolumePkg()
     _overlayOpacityBeforeToggle = _overlayOpacity;
     _overlayWindowLow = 0.0f;
     _overlayWindowHigh = 255.0f;
+    _overlayMaxDisplayedResolution = vc3d::settings::volume_overlay::MAX_DISPLAYED_RESOLUTION_DEFAULT;
     if (_ui.opacitySpin) {
         const QSignalBlocker blocker(_ui.opacitySpin);
         _ui.opacitySpin->setValue(percentValueFromOpacity(_overlayOpacity));
@@ -177,11 +191,16 @@ void VolumeOverlayController::clearVolumePkg()
         const QSignalBlocker blocker(_ui.thresholdSpin);
         _ui.thresholdSpin->setValue(spinValueFromWindow(_overlayWindowLow));
     }
+    if (_ui.maxDisplayedResolutionSpin) {
+        const QSignalBlocker blocker(_ui.maxDisplayedResolutionSpin);
+        _ui.maxDisplayedResolutionSpin->setValue(_overlayMaxDisplayedResolution);
+    }
 
     if (_viewerManager) {
         _viewerManager->setOverlayOpacity(_overlayOpacity);
         _viewerManager->setOverlayWindow(_overlayWindowLow, _overlayWindowHigh);
         _viewerManager->setOverlayColormap(std::string());
+        _viewerManager->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
     }
 
     updateUiEnabled();
@@ -354,6 +373,12 @@ void VolumeOverlayController::connectUiSignals()
             _ui.thresholdSpin, qOverload<int>(&QSpinBox::valueChanged),
             this, [this](int value) { handleThresholdChanged(value); }));
     }
+
+    if (_ui.maxDisplayedResolutionSpin) {
+        _connections.push_back(QObject::connect(
+            _ui.maxDisplayedResolutionSpin, qOverload<int>(&QSpinBox::valueChanged),
+            this, [this](int value) { handleMaxDisplayedResolutionChanged(value); }));
+    }
 }
 
 void VolumeOverlayController::disconnectUiSignals()
@@ -439,6 +464,9 @@ void VolumeOverlayController::updateUiEnabled()
     if (_ui.thresholdSpin) {
         _ui.thresholdSpin->setEnabled(hasOverlay);
     }
+    if (_ui.maxDisplayedResolutionSpin) {
+        _ui.maxDisplayedResolutionSpin->setEnabled(hasOverlay);
+    }
     if (_ui.colormapSelect) {
         const bool hasColormaps = _ui.colormapSelect->count() > 0;
         _ui.colormapSelect->setEnabled(hasOverlay && hasColormaps);
@@ -474,6 +502,7 @@ void VolumeOverlayController::loadState()
     _overlayWindowLow = 0.0f;
     _overlayWindowHigh = 255.0f;
     _overlayColormapName.clear();
+    _overlayMaxDisplayedResolution = vc3d::settings::volume_overlay::MAX_DISPLAYED_RESOLUTION_DEFAULT;
 
     if (_volpkgPath.isEmpty()) {
         return;
@@ -522,6 +551,12 @@ void VolumeOverlayController::loadState()
         _overlayColormapName = storedColormap.toStdString();
     }
 
+    _overlayMaxDisplayedResolution = std::clamp(
+        settings.value(volume_overlay::MAX_DISPLAYED_RESOLUTION,
+                       volume_overlay::MAX_DISPLAYED_RESOLUTION_DEFAULT).toInt(),
+        0,
+        5);
+
     settings.endGroup();
     settings.endGroup();
 }
@@ -548,6 +583,7 @@ void VolumeOverlayController::saveState() const
     settings.setValue(volume_overlay::WINDOW_HIGH, _overlayWindowHigh);
     settings.setValue(volume_overlay::THRESHOLD, _overlayWindowLow); // legacy compatibility
     settings.setValue(volume_overlay::COLORMAP, QString::fromStdString(_overlayColormapName));
+    settings.setValue(volume_overlay::MAX_DISPLAYED_RESOLUTION, _overlayMaxDisplayedResolution);
     settings.endGroup();
     settings.endGroup();
 }
@@ -646,6 +682,28 @@ void VolumeOverlayController::setWindowBounds(float low, float high)
 
     if (_viewerManager) {
         _viewerManager->setOverlayWindow(_overlayWindowLow, _overlayWindowHigh);
+    }
+}
+
+void VolumeOverlayController::handleMaxDisplayedResolutionChanged(int value)
+{
+    const int clamped = std::clamp(value, 0, 5);
+    if (_overlayMaxDisplayedResolution == clamped) {
+        return;
+    }
+
+    _overlayMaxDisplayedResolution = clamped;
+    if (_ui.maxDisplayedResolutionSpin && _ui.maxDisplayedResolutionSpin->value() != clamped) {
+        const QSignalBlocker blocker(_ui.maxDisplayedResolutionSpin);
+        _ui.maxDisplayedResolutionSpin->setValue(clamped);
+    }
+
+    if (_viewerManager) {
+        _viewerManager->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
+    }
+
+    if (!_suspendPersistence) {
+        saveState();
     }
 }
 

--- a/volume-cartographer/apps/VC3D/overlays/VolumeOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/VolumeOverlayController.hpp
@@ -26,6 +26,7 @@ public:
         QPointer<QComboBox> colormapSelect;
         QPointer<QSpinBox> opacitySpin;
         QPointer<QSpinBox> thresholdSpin;
+        QPointer<QSpinBox> maxDisplayedResolutionSpin;
     };
 
     explicit VolumeOverlayController(ViewerManager* manager, QObject* parent = nullptr);
@@ -58,6 +59,7 @@ private:
     void handleColormapChanged(int index);
     void handleOpacityChanged(int value);
     void handleThresholdChanged(int value);
+    void handleMaxDisplayedResolutionChanged(int value);
 
     ViewerManager* _viewerManager{nullptr};
     UiRefs _ui;
@@ -72,6 +74,7 @@ private:
     float _overlayOpacityBeforeToggle{0.5f};
     float _overlayWindowLow{0.0f};
     float _overlayWindowHigh{255.0f};
+    int _overlayMaxDisplayedResolution{0};
     bool _overlayVisible{false};
 
     std::vector<QMetaObject::Connection> _connections;

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -1479,6 +1479,20 @@ int CChunkedVolumeViewer::renderStartLevel(bool preferSurfaceResolution) const
     return std::clamp(level, 0, _chunkArray->numLevels() - 1);
 }
 
+int CChunkedVolumeViewer::overlayRenderStartLevel(bool preferSurfaceResolution) const
+{
+    if (!_overlayChunkArray) {
+        return 0;
+    }
+
+    int level = _dsScaleIdx;
+    if (preferSurfaceResolution && level < _overlayChunkArray->numLevels() - 1) {
+        level -= kSurfaceResolutionLevelBias;
+    }
+    level = std::max(level, _overlayMaxDisplayedResolution);
+    return std::clamp(level, 0, _overlayChunkArray->numLevels() - 1);
+}
+
 void CChunkedVolumeViewer::markInteractiveMotion(double)
 {
     // Interactions schedule a normal full-quality render directly (scheduleRender in
@@ -1498,6 +1512,7 @@ void CChunkedVolumeViewer::prefetchPlaneHalo(
     const cv::Vec3f& vxStep,
     const cv::Vec3f& vyStep,
     int startLevel,
+    int overlayStartLevel,
     const vc::render::ChunkedPlaneSampler::Options& options)
 {
     const bool prefetchBase = shouldPrefetchRemoteVolumeHalo(_volume);
@@ -1515,6 +1530,7 @@ void CChunkedVolumeViewer::prefetchPlaneHalo(
     const int expandedW = fbW + 2 * halo;
     std::unordered_set<vc::render::ChunkKey, vc::render::ChunkKeyHash> uniqueKeys;
     auto collect = [&](vc::render::IChunkedArray& array,
+                       int level,
                        const cv::Vec3f& stripOrigin,
                        int stripW,
                        int stripH) {
@@ -1522,18 +1538,18 @@ void CChunkedVolumeViewer::prefetchPlaneHalo(
             return;
         cv::Mat_<uint8_t> stripCoverage(stripH, stripW, uint8_t(0));
         auto keys = vc::render::ChunkedPlaneSampler::collectPlaneDependencies(
-            array, startLevel, stripOrigin, vxStep, vyStep, stripCoverage, options);
+            array, level, stripOrigin, vxStep, vyStep, stripCoverage, options);
         uniqueKeys.insert(keys.begin(), keys.end());
     };
 
     std::vector<vc::render::ChunkKey> keys;
     if (prefetchBase && _chunkArray) {
-        collect(*_chunkArray, origin - vxStep * float(halo) - vyStep * float(halo),
+        collect(*_chunkArray, startLevel, origin - vxStep * float(halo) - vyStep * float(halo),
                 expandedW, halo);
-        collect(*_chunkArray, origin - vxStep * float(halo) + vyStep * float(fbH),
+        collect(*_chunkArray, startLevel, origin - vxStep * float(halo) + vyStep * float(fbH),
                 expandedW, halo);
-        collect(*_chunkArray, origin - vxStep * float(halo), halo, fbH);
-        collect(*_chunkArray, origin + vxStep * float(fbW), halo, fbH);
+        collect(*_chunkArray, startLevel, origin - vxStep * float(halo), halo, fbH);
+        collect(*_chunkArray, startLevel, origin + vxStep * float(fbW), halo, fbH);
 
         keys.reserve(uniqueKeys.size());
         for (const auto& key : uniqueKeys)
@@ -1541,15 +1557,17 @@ void CChunkedVolumeViewer::prefetchPlaneHalo(
         _chunkArray->prefetchChunks(keys, false, kChunkPrefetchPriorityOffset);
     }
 
-    if (!prefetchOverlay || !_overlayChunkArray || _overlayOpacity <= 0.0f)
+    if (!prefetchOverlay || !_overlayChunkArray || _overlayOpacity <= 0.0f ||
+        _overlayChunkArray->numLevels() <= 0)
         return;
+    overlayStartLevel = std::clamp(overlayStartLevel, 0, _overlayChunkArray->numLevels() - 1);
     uniqueKeys.clear();
-    collect(*_overlayChunkArray, origin - vxStep * float(halo) - vyStep * float(halo),
+    collect(*_overlayChunkArray, overlayStartLevel, origin - vxStep * float(halo) - vyStep * float(halo),
             expandedW, halo);
-    collect(*_overlayChunkArray, origin - vxStep * float(halo) + vyStep * float(fbH),
+    collect(*_overlayChunkArray, overlayStartLevel, origin - vxStep * float(halo) + vyStep * float(fbH),
             expandedW, halo);
-    collect(*_overlayChunkArray, origin - vxStep * float(halo), halo, fbH);
-    collect(*_overlayChunkArray, origin + vxStep * float(fbW), halo, fbH);
+    collect(*_overlayChunkArray, overlayStartLevel, origin - vxStep * float(halo), halo, fbH);
+    collect(*_overlayChunkArray, overlayStartLevel, origin + vxStep * float(fbW), halo, fbH);
     keys.clear();
     keys.reserve(uniqueKeys.size());
     for (const auto& key : uniqueKeys)
@@ -1560,6 +1578,7 @@ void CChunkedVolumeViewer::prefetchPlaneHalo(
 void CChunkedVolumeViewer::prefetchPlaneNormalNeighbors(
     PlaneSurface& plane,
     int startLevel,
+    int overlayStartLevel,
     const vc::render::ChunkedPlaneSampler::Options& options)
 {
     const bool prefetchBase = shouldSpeculativelyPrefetchVolume(_volume);
@@ -1642,17 +1661,19 @@ void CChunkedVolumeViewer::prefetchPlaneNormalNeighbors(
         collect(*_chunkArray, startLevel, chunkDistance(*_chunkArray, startLevel));
     }
 
-    if (!prefetchOverlay || !_overlayChunkArray || _overlayOpacity <= 0.0f)
+    if (!prefetchOverlay || !_overlayChunkArray || _overlayOpacity <= 0.0f ||
+        _overlayChunkArray->numLevels() <= 0)
         return;
     if (_overlayChunkArray->numLevels() <= 0)
         return;
-    const int overlayLevel = std::clamp(startLevel, 0, _overlayChunkArray->numLevels() - 1);
+    const int overlayLevel = std::clamp(overlayStartLevel, 0, _overlayChunkArray->numLevels() - 1);
     collect(*_overlayChunkArray, overlayLevel, chunkDistance(*_overlayChunkArray, overlayLevel));
 }
 
 void CChunkedVolumeViewer::prefetchSurfaceHalo(
     Surface& surf,
     int startLevel,
+    int overlayStartLevel,
     const vc::render::ChunkedPlaneSampler::Options& options,
     int fbW,
     int fbH)
@@ -1670,6 +1691,7 @@ void CChunkedVolumeViewer::prefetchSurfaceHalo(
     std::unordered_set<vc::render::ChunkKey, vc::render::ChunkKeyHash> uniqueKeys;
 
     auto collect = [&](vc::render::IChunkedArray& array,
+                       int level,
                        int sceneX,
                        int sceneY,
                        int stripW,
@@ -1687,16 +1709,16 @@ void CChunkedVolumeViewer::prefetchSurfaceHalo(
 
         cv::Mat_<uint8_t> coverage(stripH, stripW, uint8_t(0));
         auto keys = vc::render::ChunkedPlaneSampler::collectCoordsDependencies(
-            array, startLevel, coords, coverage, options);
+            array, level, coords, coverage, options);
         uniqueKeys.insert(keys.begin(), keys.end());
     };
 
     std::vector<vc::render::ChunkKey> keys;
     if (prefetchBase && _chunkArray) {
-        collect(*_chunkArray, -halo, -halo, fbW + 2 * halo, halo);
-        collect(*_chunkArray, -halo, fbH, fbW + 2 * halo, halo);
-        collect(*_chunkArray, -halo, 0, halo, fbH);
-        collect(*_chunkArray, fbW, 0, halo, fbH);
+        collect(*_chunkArray, startLevel, -halo, -halo, fbW + 2 * halo, halo);
+        collect(*_chunkArray, startLevel, -halo, fbH, fbW + 2 * halo, halo);
+        collect(*_chunkArray, startLevel, -halo, 0, halo, fbH);
+        collect(*_chunkArray, startLevel, fbW, 0, halo, fbH);
 
         keys.reserve(uniqueKeys.size());
         for (const auto& key : uniqueKeys)
@@ -1704,13 +1726,15 @@ void CChunkedVolumeViewer::prefetchSurfaceHalo(
         _chunkArray->prefetchChunks(keys, false, kChunkPrefetchPriorityOffset);
     }
 
-    if (!prefetchOverlay || !_overlayChunkArray || _overlayOpacity <= 0.0f)
+    if (!prefetchOverlay || !_overlayChunkArray || _overlayOpacity <= 0.0f ||
+        _overlayChunkArray->numLevels() <= 0)
         return;
+    overlayStartLevel = std::clamp(overlayStartLevel, 0, _overlayChunkArray->numLevels() - 1);
     uniqueKeys.clear();
-    collect(*_overlayChunkArray, -halo, -halo, fbW + 2 * halo, halo);
-    collect(*_overlayChunkArray, -halo, fbH, fbW + 2 * halo, halo);
-    collect(*_overlayChunkArray, -halo, 0, halo, fbH);
-    collect(*_overlayChunkArray, fbW, 0, halo, fbH);
+    collect(*_overlayChunkArray, overlayStartLevel, -halo, -halo, fbW + 2 * halo, halo);
+    collect(*_overlayChunkArray, overlayStartLevel, -halo, fbH, fbW + 2 * halo, halo);
+    collect(*_overlayChunkArray, overlayStartLevel, -halo, 0, halo, fbH);
+    collect(*_overlayChunkArray, overlayStartLevel, fbW, 0, halo, fbH);
     keys.clear();
     keys.reserve(uniqueKeys.size());
     for (const auto& key : uniqueKeys)
@@ -1848,6 +1872,7 @@ struct CChunkedVolumeViewer::RenderContext {
     float zOff = 0.0f;
     cv::Vec3f zOffWorldDir{0, 0, 0};
     int startLevel = 0;
+    int overlayStartLevel = 0;
     vc::Sampling samplingMethod = vc::Sampling::Trilinear;
     CompositeRenderSettings compositeSettings;
     float windowLow = 0.0f;
@@ -1891,10 +1916,10 @@ CChunkedVolumeViewer::RenderResult CChunkedVolumeViewer::renderFrame(RenderConte
     bool phaseGenCached = false;
     QElapsedTimer phaseTimer;
     if (ProfileLoggingEnabled()) {
-        Logger()->info("[vc3d-profile] renderFrame begin reason='{}' caller='{}' serial={} surf='{}' size={}x{} level={} overlay={} composite={} planeComposite={}",
+        Logger()->info("[vc3d-profile] renderFrame begin reason='{}' caller='{}' serial={} surf='{}' size={}x{} level={} overlay_level={} overlay={} composite={} planeComposite={}",
                        ctx.profileReason, ctx.profileCaller, ctx.serial,
                        ctx.surf ? ctx.surf->id : std::string(""),
-                       ctx.fbW, ctx.fbH, ctx.startLevel,
+                       ctx.fbW, ctx.fbH, ctx.startLevel, ctx.overlayStartLevel,
                        bool(ctx.overlayChunkArray && ctx.overlayVolume && ctx.overlayOpacity > 0.0f),
                        ctx.compositeSettings.enabled, ctx.compositeSettings.planeEnabled);
     }
@@ -2083,7 +2108,7 @@ CChunkedVolumeViewer::RenderResult CChunkedVolumeViewer::renderFrame(RenderConte
             overlayCoverage.create(ctx.fbH, ctx.fbW);
             overlayValues.setTo(0);
             overlayCoverage.setTo(0);
-            const int level = std::clamp(ctx.startLevel, 0, ctx.overlayChunkArray->numLevels() - 1);
+            const int level = std::clamp(ctx.overlayStartLevel, 0, ctx.overlayChunkArray->numLevels() - 1);
             vc::render::ChunkedPlaneSampler::samplePlaneFineToCoarse(
                 *ctx.overlayChunkArray, level, origin, vxStep, vyStep,
                 overlayValues, overlayCoverage, options);
@@ -2155,7 +2180,7 @@ CChunkedVolumeViewer::RenderResult CChunkedVolumeViewer::renderFrame(RenderConte
                 overlayCoverage.create(ctx.fbH, ctx.fbW);
                 overlayValues.setTo(0);
                 overlayCoverage.setTo(0);
-                const int level = std::clamp(ctx.startLevel, 0, ctx.overlayChunkArray->numLevels() - 1);
+                const int level = std::clamp(ctx.overlayStartLevel, 0, ctx.overlayChunkArray->numLevels() - 1);
                 vc::render::ChunkedPlaneSampler::sampleCoordsFineToCoarse(
                     *ctx.overlayChunkArray, level, coords, overlayValues, overlayCoverage, options);
             }
@@ -2216,7 +2241,9 @@ std::optional<CChunkedVolumeViewer::PendingRenderJob> CChunkedVolumeViewer::capt
     job.scale = _scale;
     job.zOff = _zOff;
     job.zOffWorldDir = _zOffWorldDir;
-    job.startLevel = renderStartLevel(dynamic_cast<PlaneSurface*>(surf.get()) == nullptr);
+    const bool preferSurfaceResolution = dynamic_cast<PlaneSurface*>(surf.get()) == nullptr;
+    job.startLevel = renderStartLevel(preferSurfaceResolution);
+    job.overlayStartLevel = overlayRenderStartLevel(preferSurfaceResolution);
     job.samplingMethod = _samplingMethod;
     job.compositeSettings = _compositeSettings;
     job.windowLow = _windowLow;
@@ -2257,6 +2284,7 @@ bool CChunkedVolumeViewer::renderJobsEquivalentForDisplay(const PendingRenderJob
            a.zOff == b.zOff &&
            vecEqual(a.zOffWorldDir, b.zOffWorldDir) &&
            a.startLevel == b.startLevel &&
+           a.overlayStartLevel == b.overlayStartLevel &&
            a.samplingMethod == b.samplingMethod &&
            a.compositeSettings == b.compositeSettings &&
            a.windowLow == b.windowLow &&
@@ -2332,6 +2360,7 @@ void CChunkedVolumeViewer::startRenderJob(PendingRenderJob job)
     ctx.zOff = job.zOff;
     ctx.zOffWorldDir = job.zOffWorldDir;
     ctx.startLevel = job.startLevel;
+    ctx.overlayStartLevel = job.overlayStartLevel;
     ctx.samplingMethod = job.samplingMethod;
     ctx.compositeSettings = job.compositeSettings;
     ctx.windowLow = job.windowLow;
@@ -2496,6 +2525,7 @@ void CChunkedVolumeViewer::finishRenderOnMainThread(std::shared_ptr<RenderResult
         const vc::render::ChunkedPlaneSampler::Options options(_samplingMethod, 32);
         if (auto* plane = dynamic_cast<PlaneSurface*>(surf.get())) {
             const int startLevel = renderStartLevel(false);
+            const int overlayStartLevel = overlayRenderStartLevel(false);
             const cv::Vec3f vx = plane->basisX();
             const cv::Vec3f vy = plane->basisY();
             const cv::Vec3f n = plane->normal({0, 0, 0});
@@ -2505,10 +2535,10 @@ void CChunkedVolumeViewer::finishRenderOnMainThread(std::shared_ptr<RenderResult
                                    + vy * (_surfacePtrY - halfH)
                                    + plane->origin()
                                    + n * _zOff;
-            prefetchPlaneHalo(origin, vx / _scale, vy / _scale, startLevel, options);
-            prefetchPlaneNormalNeighbors(*plane, startLevel, options);
+            prefetchPlaneHalo(origin, vx / _scale, vy / _scale, startLevel, overlayStartLevel, options);
+            prefetchPlaneNormalNeighbors(*plane, startLevel, overlayStartLevel, options);
         } else {
-            prefetchSurfaceHalo(*surf, renderStartLevel(true), options,
+            prefetchSurfaceHalo(*surf, renderStartLevel(true), overlayRenderStartLevel(true), options,
                                 _framebuffer.width(), _framebuffer.height());
         }
     }
@@ -2657,6 +2687,21 @@ void CChunkedVolumeViewer::setOverlayWindow(float low, float high)
     _overlayWindowLow = std::clamp(low, 0.0f, 255.0f);
     _overlayWindowHigh = std::clamp(high, _overlayWindowLow + 1.0f, 255.0f);
     submitRender("overlay window changed");
+}
+
+void CChunkedVolumeViewer::setOverlayMaxDisplayedResolution(int level)
+{
+    if (_closing) {
+        return;
+    }
+
+    const int clamped = std::clamp(level, 0, 5);
+    if (_overlayMaxDisplayedResolution == clamped) {
+        return;
+    }
+
+    _overlayMaxDisplayedResolution = clamped;
+    submitRender("overlay max displayed resolution changed");
 }
 
 void CChunkedVolumeViewer::panByF(float dx, float dy)

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -69,10 +69,6 @@ constexpr float kSegmentationResolutionLodZoomBias = 1.0f;
 constexpr int kSurfaceResolutionLevelBias = 1;
 constexpr int kInitialSegmentationSurfaceLevel = 5;
 constexpr float kPanSmoothingAlpha = 0.65f;
-constexpr bool kEnableRemoteVolumePrefetchHalo = false;
-constexpr int kChunkPrefetchHaloPx = 128;
-constexpr int kChunkPrefetchPriorityOffset = 1024;
-constexpr int kNormalPrefetchSampleStridePx = 32;
 constexpr int kSurfaceCellTileSize = 64;
 constexpr std::array<QRgb, 12> kIntersectionPalette = {
     qRgb(255, 120, 120), qRgb(120, 200, 255), qRgb(120, 255, 140),
@@ -166,22 +162,6 @@ std::string normalizedVolumeCacheIdentity(const std::shared_ptr<Volume>& volume)
     if (ec)
         path = volume->path();
     return "local|" + path.string() + "|id=" + volume->id();
-}
-
-bool shouldSpeculativelyPrefetchVolume(const std::shared_ptr<Volume>& volume)
-{
-    // Demand-driven: render workers' tryGetChunk misses queue exactly what the
-    // requested frames need. Speculative visible-set/halo/neighbor warming wasted
-    // bandwidth on chunks that may never be sampled. (Disabled, not deleted, so the
-    // enumeration code path stays compiling.)
-    (void)volume;
-    return false;
-}
-
-bool shouldPrefetchRemoteVolumeHalo(const std::shared_ptr<Volume>& volume)
-{
-    return kEnableRemoteVolumePrefetchHalo &&
-           shouldSpeculativelyPrefetchVolume(volume);
 }
 
 uint32_t alphaBlendArgb(uint32_t base, uint32_t overlay, float alpha)
@@ -457,106 +437,6 @@ std::uint64_t surfaceCellTileKey(int col, int row)
     return surfaceTileKey(tx, ty);
 }
 
-void addChunkBox(std::unordered_set<vc::render::ChunkKey, vc::render::ChunkKeyHash>& keys,
-                 vc::render::IChunkedArray& array,
-                 int level,
-                 const cv::Vec3f& lo0,
-                 const cv::Vec3f& hi0,
-                 vc::Sampling sampling)
-{
-    const auto shape = array.shape(level);
-    const auto chunkShape = array.chunkShape(level);
-    if (shape[0] <= 0 || shape[1] <= 0 || shape[2] <= 0 ||
-        chunkShape[0] <= 0 || chunkShape[1] <= 0 || chunkShape[2] <= 0) {
-        return;
-    }
-
-    const auto transform = array.levelTransform(level);
-    auto toLevel = [&transform](const cv::Vec3f& p) {
-        return cv::Vec3f(
-            float(double(p[0]) * transform.scaleFromLevel0[0] + transform.offsetFromLevel0[0]),
-            float(double(p[1]) * transform.scaleFromLevel0[1] + transform.offsetFromLevel0[1]),
-            float(double(p[2]) * transform.scaleFromLevel0[2] + transform.offsetFromLevel0[2]));
-    };
-    const cv::Vec3f lo = toLevel(lo0);
-    const cv::Vec3f hi = toLevel(hi0);
-    const float pad = sampling == vc::Sampling::Nearest ? 0.5f : 1.0f;
-
-    const int ix0 = std::clamp(int(std::floor(std::min(lo[0], hi[0]) - pad)), 0, shape[2] - 1);
-    const int iy0 = std::clamp(int(std::floor(std::min(lo[1], hi[1]) - pad)), 0, shape[1] - 1);
-    const int iz0 = std::clamp(int(std::floor(std::min(lo[2], hi[2]) - pad)), 0, shape[0] - 1);
-    const int ix1 = std::clamp(int(std::ceil(std::max(lo[0], hi[0]) + pad)), 0, shape[2] - 1);
-    const int iy1 = std::clamp(int(std::ceil(std::max(lo[1], hi[1]) + pad)), 0, shape[1] - 1);
-    const int iz1 = std::clamp(int(std::ceil(std::max(lo[2], hi[2]) + pad)), 0, shape[0] - 1);
-    if (ix1 < ix0 || iy1 < iy0 || iz1 < iz0)
-        return;
-
-    for (int cz = iz0 / chunkShape[0]; cz <= iz1 / chunkShape[0]; ++cz) {
-        for (int cy = iy0 / chunkShape[1]; cy <= iy1 / chunkShape[1]; ++cy) {
-            for (int cx = ix0 / chunkShape[2]; cx <= ix1 / chunkShape[2]; ++cx)
-                keys.insert({level, cz, cy, cx});
-        }
-    }
-}
-
-std::vector<vc::render::ChunkKey> collectSurfaceCellChunkKeys(
-    vc::render::IChunkedArray& array,
-    QuadSurface& surface,
-    const cv::Rect& cellRect,
-    int level,
-    vc::Sampling sampling)
-{
-    std::vector<vc::render::ChunkKey> result;
-    if (level < 0 || level >= array.numLevels())
-        return result;
-
-    const cv::Mat_<cv::Vec3f>* points = surface.rawPointsPtr();
-    if (!points || points->empty() || points->cols < 2 || points->rows < 2)
-        return result;
-
-    const cv::Rect bounds(0, 0, points->cols - 1, points->rows - 1);
-    const cv::Rect rect = cellRect & bounds;
-    if (rect.empty())
-        return result;
-
-    std::unordered_set<vc::render::ChunkKey, vc::render::ChunkKeyHash> keys;
-    keys.reserve(std::size_t(rect.area() / 4 + 16));
-    for (int y = rect.y; y < rect.y + rect.height; ++y) {
-        const cv::Vec3f* row0 = points->ptr<cv::Vec3f>(y);
-        const cv::Vec3f* row1 = points->ptr<cv::Vec3f>(y + 1);
-        for (int x = rect.x; x < rect.x + rect.width; ++x) {
-            const cv::Vec3f p00 = row0[x];
-            const cv::Vec3f p10 = row0[x + 1];
-            const cv::Vec3f p01 = row1[x];
-            const cv::Vec3f p11 = row1[x + 1];
-            if (!validSurfacePoint(p00) || !validSurfacePoint(p10) ||
-                !validSurfacePoint(p01) || !validSurfacePoint(p11)) {
-                continue;
-            }
-            cv::Vec3f lo(std::min({p00[0], p10[0], p01[0], p11[0]}),
-                         std::min({p00[1], p10[1], p01[1], p11[1]}),
-                         std::min({p00[2], p10[2], p01[2], p11[2]}));
-            cv::Vec3f hi(std::max({p00[0], p10[0], p01[0], p11[0]}),
-                         std::max({p00[1], p10[1], p01[1], p11[1]}),
-                         std::max({p00[2], p10[2], p01[2], p11[2]}));
-            addChunkBox(keys, array, level, lo, hi, sampling);
-        }
-    }
-
-    result.reserve(keys.size());
-    for (const auto& key : keys)
-        result.push_back(key);
-    return result;
-}
-
-bool rectContains(const cv::Rect& outer, const cv::Rect& inner)
-{
-    return inner.x >= outer.x &&
-           inner.y >= outer.y &&
-           inner.x + inner.width <= outer.x + outer.width &&
-           inner.y + inner.height <= outer.y + outer.height;
-}
-
 QString formatVec3(const cv::Vec3f& v)
 {
     return QString("(%1, %2, %3)")
@@ -811,8 +691,7 @@ CChunkedVolumeViewer::~CChunkedVolumeViewer()
 void CChunkedVolumeViewer::showEvent(QShowEvent* event)
 {
     QWidget::showEvent(event);
-    // Render whatever went stale while this viewer was hidden (submitRender skipped
-    // renders + prefetch for invisible viewers).
+    // Render whatever went stale while this viewer was hidden.
     if (_renderStaleWhileHidden && !_closing) {
         _renderStaleWhileHidden = false;
         submitRender("shown after hidden");
@@ -1007,7 +886,6 @@ void CChunkedVolumeViewer::OnVolumeChanged(std::shared_ptr<Volume> vol)
         _genSurfaceCache->normals.release();
     }
     _zOffWorldDir = {0, 0, 0};
-    _surfaceChunkPrefetchCache = {};
     if (_cursorCrosshair)
         _cursorCrosshair->hide();
     clearLineAnnotationPlacementMarker();
@@ -1036,7 +914,6 @@ void CChunkedVolumeViewer::invalidateVis()
         return;
     }
     _genCacheDirty = true;
-    _surfaceChunkPrefetchCache = {};
 }
 
 void CChunkedVolumeViewer::invalidateVisRegion(const std::string& name, const cv::Rect& changedCells)
@@ -1047,29 +924,7 @@ void CChunkedVolumeViewer::invalidateVisRegion(const std::string& name, const cv
     }
 
 
-    auto surf = _surfWeak.lock();
-    auto* quad = dynamic_cast<QuadSurface*>(surf.get());
-    if (!quad) {
-        invalidateVis();
-        return;
-    }
-
     _genCacheDirty = true;
-
-    auto& cache = _surfaceChunkPrefetchCache;
-    if (!cache.valid || cache.surface != quad) {
-        return;
-    }
-
-    const int tx0 = changedCells.x / kSurfaceCellTileSize;
-    const int ty0 = changedCells.y / kSurfaceCellTileSize;
-    const int tx1 = (changedCells.x + changedCells.width - 1) / kSurfaceCellTileSize;
-    const int ty1 = (changedCells.y + changedCells.height - 1) / kSurfaceCellTileSize;
-    for (int ty = ty0; ty <= ty1; ++ty) {
-        for (int tx = tx0; tx <= tx1; ++tx) {
-            cache.tileKeys.erase(surfaceTileKey(tx, ty));
-        }
-    }
 }
 
 void CChunkedVolumeViewer::onSurfaceChanged(const std::string& name,
@@ -1130,7 +985,6 @@ void CChunkedVolumeViewer::onSurfaceChanged(const std::string& name,
     }
 
     _genCacheDirty = true;
-    _surfaceChunkPrefetchCache = {};
     _zOffWorldDir = {0, 0, 0};
     invalidateIntersect(name);
     if (!surf) {
@@ -1426,7 +1280,7 @@ void CChunkedVolumeViewer::serviceRenderTick()
         emit overlaysUpdated();
     }
 
-    // Periodic status refresh (background prefetch/download progress).
+    // Periodic status refresh (background download progress).
     if (--_statusRefreshTicks <= 0) {
         _statusRefreshTicks = kStatusRefreshTicks;
         updateStatusLabel();
@@ -1505,360 +1359,6 @@ bool CChunkedVolumeViewer::streamingCompositeUnsupported() const
            _compositeSettings.params.lightingEnabled ||
            _compositeSettings.params.method == "beerLambert" ||
            _compositeSettings.useVolumeGradients;
-}
-
-void CChunkedVolumeViewer::prefetchPlaneHalo(
-    const cv::Vec3f& origin,
-    const cv::Vec3f& vxStep,
-    const cv::Vec3f& vyStep,
-    int startLevel,
-    int overlayStartLevel,
-    const vc::render::ChunkedPlaneSampler::Options& options)
-{
-    const bool prefetchBase = shouldPrefetchRemoteVolumeHalo(_volume);
-    const bool prefetchOverlay = shouldPrefetchRemoteVolumeHalo(_overlayVolume);
-    if (_framebuffer.isNull() ||
-        (!prefetchBase && !prefetchOverlay))
-        return;
-
-    const int fbW = _framebuffer.width();
-    const int fbH = _framebuffer.height();
-    if (fbW <= 0 || fbH <= 0)
-        return;
-
-    const int halo = kChunkPrefetchHaloPx;
-    const int expandedW = fbW + 2 * halo;
-    std::unordered_set<vc::render::ChunkKey, vc::render::ChunkKeyHash> uniqueKeys;
-    auto collect = [&](vc::render::IChunkedArray& array,
-                       int level,
-                       const cv::Vec3f& stripOrigin,
-                       int stripW,
-                       int stripH) {
-        if (stripW <= 0 || stripH <= 0)
-            return;
-        cv::Mat_<uint8_t> stripCoverage(stripH, stripW, uint8_t(0));
-        auto keys = vc::render::ChunkedPlaneSampler::collectPlaneDependencies(
-            array, level, stripOrigin, vxStep, vyStep, stripCoverage, options);
-        uniqueKeys.insert(keys.begin(), keys.end());
-    };
-
-    std::vector<vc::render::ChunkKey> keys;
-    if (prefetchBase && _chunkArray) {
-        collect(*_chunkArray, startLevel, origin - vxStep * float(halo) - vyStep * float(halo),
-                expandedW, halo);
-        collect(*_chunkArray, startLevel, origin - vxStep * float(halo) + vyStep * float(fbH),
-                expandedW, halo);
-        collect(*_chunkArray, startLevel, origin - vxStep * float(halo), halo, fbH);
-        collect(*_chunkArray, startLevel, origin + vxStep * float(fbW), halo, fbH);
-
-        keys.reserve(uniqueKeys.size());
-        for (const auto& key : uniqueKeys)
-            keys.push_back(key);
-        _chunkArray->prefetchChunks(keys, false, kChunkPrefetchPriorityOffset);
-    }
-
-    if (!prefetchOverlay || !_overlayChunkArray || _overlayOpacity <= 0.0f ||
-        _overlayChunkArray->numLevels() <= 0)
-        return;
-    overlayStartLevel = std::clamp(overlayStartLevel, 0, _overlayChunkArray->numLevels() - 1);
-    uniqueKeys.clear();
-    collect(*_overlayChunkArray, overlayStartLevel, origin - vxStep * float(halo) - vyStep * float(halo),
-            expandedW, halo);
-    collect(*_overlayChunkArray, overlayStartLevel, origin - vxStep * float(halo) + vyStep * float(fbH),
-            expandedW, halo);
-    collect(*_overlayChunkArray, overlayStartLevel, origin - vxStep * float(halo), halo, fbH);
-    collect(*_overlayChunkArray, overlayStartLevel, origin + vxStep * float(fbW), halo, fbH);
-    keys.clear();
-    keys.reserve(uniqueKeys.size());
-    for (const auto& key : uniqueKeys)
-        keys.push_back(key);
-    _overlayChunkArray->prefetchChunks(keys, false, kChunkPrefetchPriorityOffset);
-}
-
-void CChunkedVolumeViewer::prefetchPlaneNormalNeighbors(
-    PlaneSurface& plane,
-    int startLevel,
-    int overlayStartLevel,
-    const vc::render::ChunkedPlaneSampler::Options& options)
-{
-    const bool prefetchBase = shouldSpeculativelyPrefetchVolume(_volume);
-    const bool prefetchOverlay = shouldSpeculativelyPrefetchVolume(_overlayVolume);
-    if (_framebuffer.isNull() || (!prefetchBase && !prefetchOverlay))
-        return;
-
-    const int fbW = _framebuffer.width();
-    const int fbH = _framebuffer.height();
-    if (fbW <= 0 || fbH <= 0)
-        return;
-
-    const cv::Vec3f vx = plane.basisX();
-    const cv::Vec3f vy = plane.basisY();
-    cv::Vec3f normal = plane.normal({0, 0, 0});
-    const float normalLen = static_cast<float>(cv::norm(normal));
-    if (normalLen <= 1e-6f)
-        return;
-    normal *= 1.0f / normalLen;
-
-    const float halfW = static_cast<float>(fbW) * 0.5f / _scale;
-    const float halfH = static_cast<float>(fbH) * 0.5f / _scale;
-    const cv::Vec3f origin = vx * (_surfacePtrX - halfW)
-                           + vy * (_surfacePtrY - halfH)
-                           + plane.origin()
-                           + normal * _zOff;
-    const cv::Vec3f vxStep = vx / _scale;
-    const cv::Vec3f vyStep = vy / _scale;
-
-    const int sampleStride = std::max(1, kNormalPrefetchSampleStridePx);
-    const int sampleW = std::max(1, (fbW + sampleStride - 1) / sampleStride + 1);
-    const int sampleH = std::max(1, (fbH + sampleStride - 1) / sampleStride + 1);
-    const cv::Vec3f sampleVxStep = vxStep * float(sampleStride);
-    const cv::Vec3f sampleVyStep = vyStep * float(sampleStride);
-
-    auto chunkDistance = [&](vc::render::IChunkedArray& array, int level) -> float {
-        if (level < 0 || level >= array.numLevels())
-            return 0.0f;
-        const auto chunkZyx = array.chunkShape(level);
-        const std::array<int, 3> chunkXyz{chunkZyx[2], chunkZyx[1], chunkZyx[0]};
-        const auto transform = array.levelTransform(level);
-        int axis = 0;
-        float best = std::abs(normal[0]);
-        for (int i = 1; i < 3; ++i) {
-            const float v = std::abs(normal[i]);
-            if (v > best) {
-                best = v;
-                axis = i;
-            }
-        }
-        const double levelScale = std::abs(transform.scaleFromLevel0[axis]);
-        if (chunkXyz[axis] <= 0 || levelScale <= 1e-12)
-            return 0.0f;
-        return static_cast<float>(double(chunkXyz[axis]) / levelScale);
-    };
-
-    auto collect = [&](vc::render::IChunkedArray& array, int level, float distance) {
-        if (distance <= 0.0f || level < 0 || level >= array.numLevels())
-            return;
-        std::unordered_set<vc::render::ChunkKey, vc::render::ChunkKeyHash> uniqueKeys;
-        cv::Mat_<uint8_t> coverage(sampleH, sampleW, uint8_t(0));
-        for (float dir : {-1.0f, 1.0f}) {
-            auto keys = vc::render::ChunkedPlaneSampler::collectPlaneDependencies(
-                array, level, origin + normal * (dir * distance),
-                sampleVxStep, sampleVyStep, coverage, options);
-            uniqueKeys.insert(keys.begin(), keys.end());
-        }
-
-        if (uniqueKeys.empty())
-            return;
-        std::vector<vc::render::ChunkKey> keys;
-        keys.reserve(uniqueKeys.size());
-        for (const auto& key : uniqueKeys)
-            keys.push_back(key);
-        array.prefetchChunks(keys, false, kChunkPrefetchPriorityOffset);
-    };
-
-    if (prefetchBase && _chunkArray && _chunkArray->numLevels() > 0) {
-        startLevel = std::clamp(startLevel, 0, _chunkArray->numLevels() - 1);
-        collect(*_chunkArray, startLevel, chunkDistance(*_chunkArray, startLevel));
-    }
-
-    if (!prefetchOverlay || !_overlayChunkArray || _overlayOpacity <= 0.0f ||
-        _overlayChunkArray->numLevels() <= 0)
-        return;
-    if (_overlayChunkArray->numLevels() <= 0)
-        return;
-    const int overlayLevel = std::clamp(overlayStartLevel, 0, _overlayChunkArray->numLevels() - 1);
-    collect(*_overlayChunkArray, overlayLevel, chunkDistance(*_overlayChunkArray, overlayLevel));
-}
-
-void CChunkedVolumeViewer::prefetchSurfaceHalo(
-    Surface& surf,
-    int startLevel,
-    int overlayStartLevel,
-    const vc::render::ChunkedPlaneSampler::Options& options,
-    int fbW,
-    int fbH)
-{
-    const bool prefetchBase = shouldPrefetchRemoteVolumeHalo(_volume);
-    const bool prefetchOverlay = shouldPrefetchRemoteVolumeHalo(_overlayVolume);
-    if (fbW <= 0 || fbH <= 0 ||
-        (!prefetchBase && !prefetchOverlay))
-        return;
-
-    const int halo = kChunkPrefetchHaloPx;
-    const cv::Vec3f baseOffset(_surfacePtrX * _scale - float(fbW) * 0.5f,
-                               _surfacePtrY * _scale - float(fbH) * 0.5f,
-                               0.0f);
-    std::unordered_set<vc::render::ChunkKey, vc::render::ChunkKeyHash> uniqueKeys;
-
-    auto collect = [&](vc::render::IChunkedArray& array,
-                       int level,
-                       int sceneX,
-                       int sceneY,
-                       int stripW,
-                       int stripH) {
-        if (stripW <= 0 || stripH <= 0)
-            return;
-
-        cv::Mat_<cv::Vec3f> coords;
-        cv::Mat_<cv::Vec3f> normals;
-        const cv::Vec3f offset = baseOffset + cv::Vec3f(float(sceneX), float(sceneY), 0.0f);
-        surf.gen(&coords, _zOff != 0.0f ? &normals : nullptr,
-                 cv::Size(stripW, stripH), {0, 0, 0}, _scale, offset);
-
-        applyPerPixelNormalOffset(coords, normals, _zOff);
-
-        cv::Mat_<uint8_t> coverage(stripH, stripW, uint8_t(0));
-        auto keys = vc::render::ChunkedPlaneSampler::collectCoordsDependencies(
-            array, level, coords, coverage, options);
-        uniqueKeys.insert(keys.begin(), keys.end());
-    };
-
-    std::vector<vc::render::ChunkKey> keys;
-    if (prefetchBase && _chunkArray) {
-        collect(*_chunkArray, startLevel, -halo, -halo, fbW + 2 * halo, halo);
-        collect(*_chunkArray, startLevel, -halo, fbH, fbW + 2 * halo, halo);
-        collect(*_chunkArray, startLevel, -halo, 0, halo, fbH);
-        collect(*_chunkArray, startLevel, fbW, 0, halo, fbH);
-
-        keys.reserve(uniqueKeys.size());
-        for (const auto& key : uniqueKeys)
-            keys.push_back(key);
-        _chunkArray->prefetchChunks(keys, false, kChunkPrefetchPriorityOffset);
-    }
-
-    if (!prefetchOverlay || !_overlayChunkArray || _overlayOpacity <= 0.0f ||
-        _overlayChunkArray->numLevels() <= 0)
-        return;
-    overlayStartLevel = std::clamp(overlayStartLevel, 0, _overlayChunkArray->numLevels() - 1);
-    uniqueKeys.clear();
-    collect(*_overlayChunkArray, overlayStartLevel, -halo, -halo, fbW + 2 * halo, halo);
-    collect(*_overlayChunkArray, overlayStartLevel, -halo, fbH, fbW + 2 * halo, halo);
-    collect(*_overlayChunkArray, overlayStartLevel, -halo, 0, halo, fbH);
-    collect(*_overlayChunkArray, overlayStartLevel, fbW, 0, halo, fbH);
-    keys.clear();
-    keys.reserve(uniqueKeys.size());
-    for (const auto& key : uniqueKeys)
-        keys.push_back(key);
-    _overlayChunkArray->prefetchChunks(keys, false, kChunkPrefetchPriorityOffset);
-}
-
-void CChunkedVolumeViewer::prefetchVisibleSurfaceChunks(int priorityOffset)
-{
-    if (!shouldSpeculativelyPrefetchVolume(_volume) ||
-        !_chunkArray || _framebuffer.isNull() || _framebuffer.width() <= 0 ||
-        _framebuffer.height() <= 0) {
-        return;
-    }
-
-    auto surf = _surfWeak.lock();
-    auto* quad = dynamic_cast<QuadSurface*>(surf.get());
-    if (!quad) {
-        _surfaceChunkPrefetchCache = {};
-        return;
-    }
-
-    const cv::Mat_<cv::Vec3f>* points = quad->rawPointsPtr();
-    if (!points || points->cols < 2 || points->rows < 2)
-        return;
-
-    const int level = renderStartLevel(true);
-    if (level < 0 || level >= _chunkArray->numLevels())
-        return;
-
-    const float halfW = static_cast<float>(_framebuffer.width()) * 0.5f / std::max(_scale, kMinScale);
-    const float halfH = static_cast<float>(_framebuffer.height()) * 0.5f / std::max(_scale, kMinScale);
-    const cv::Vec2f g0 = quad->ptrToGrid({_surfacePtrX - halfW, _surfacePtrY - halfH, 0.0f});
-    const cv::Vec2f g1 = quad->ptrToGrid({_surfacePtrX + halfW, _surfacePtrY + halfH, 0.0f});
-    const float minX = std::min(g0[0], g1[0]);
-    const float maxX = std::max(g0[0], g1[0]);
-    const float minY = std::min(g0[1], g1[1]);
-    const float maxY = std::max(g0[1], g1[1]);
-
-    cv::Rect visibleCells(
-        int(std::floor(minX)) - 1,
-        int(std::floor(minY)) - 1,
-        std::max(1, int(std::ceil(maxX)) - int(std::floor(minX)) + 3),
-        std::max(1, int(std::ceil(maxY)) - int(std::floor(minY)) + 3));
-    const cv::Rect cellBounds(0, 0, points->cols - 1, points->rows - 1);
-    visibleCells &= cellBounds;
-    if (visibleCells.empty())
-        return;
-
-    const float cellsPerPixelX =
-        float(visibleCells.width) / float(std::max(1, _framebuffer.width()));
-    const float cellsPerPixelY =
-        float(visibleCells.height) / float(std::max(1, _framebuffer.height()));
-    const int padX = std::max(1, int(std::ceil(float(kChunkPrefetchHaloPx) * cellsPerPixelX)) + 2);
-    const int padY = std::max(1, int(std::ceil(float(kChunkPrefetchHaloPx) * cellsPerPixelY)) + 2);
-    cv::Rect paddedCells(
-        visibleCells.x - padX,
-        visibleCells.y - padY,
-        visibleCells.width + padX * 2,
-        visibleCells.height + padY * 2);
-    paddedCells &= cellBounds;
-    if (paddedCells.empty())
-        return;
-
-    auto& cache = _surfaceChunkPrefetchCache;
-    if (!cache.valid || cache.surface != quad || cache.level != level ||
-        cache.sampling != _samplingMethod) {
-        cache = {};
-        cache.surface = quad;
-        cache.level = level;
-        cache.sampling = _samplingMethod;
-    }
-
-    auto collectKeysForCells = [&](const cv::Rect& cells,
-                                   std::unordered_set<vc::render::ChunkKey,
-                                                      vc::render::ChunkKeyHash>& keys) {
-        if (cells.empty())
-            return;
-        const int tx0 = cells.x / kSurfaceCellTileSize;
-        const int ty0 = cells.y / kSurfaceCellTileSize;
-        const int tx1 = (cells.x + cells.width - 1) / kSurfaceCellTileSize;
-        const int ty1 = (cells.y + cells.height - 1) / kSurfaceCellTileSize;
-        for (int ty = ty0; ty <= ty1; ++ty) {
-            for (int tx = tx0; tx <= tx1; ++tx) {
-                const std::uint64_t key = surfaceTileKey(tx, ty);
-                auto it = cache.tileKeys.find(key);
-                if (it == cache.tileKeys.end()) {
-                    cv::Rect tileCells(tx * kSurfaceCellTileSize,
-                                       ty * kSurfaceCellTileSize,
-                                       kSurfaceCellTileSize,
-                                       kSurfaceCellTileSize);
-                    tileCells &= cellBounds;
-                    it = cache.tileKeys.emplace(
-                        key,
-                        collectSurfaceCellChunkKeys(*_chunkArray, *quad, tileCells, level, _samplingMethod)).first;
-                }
-                keys.insert(it->second.begin(), it->second.end());
-            }
-        }
-    };
-
-    std::unordered_set<vc::render::ChunkKey, vc::render::ChunkKeyHash> visibleKeys;
-    std::unordered_set<vc::render::ChunkKey, vc::render::ChunkKeyHash> speculativeKeys;
-    collectKeysForCells(visibleCells, visibleKeys);
-    collectKeysForCells(paddedCells, speculativeKeys);
-    for (const auto& key : visibleKeys)
-        speculativeKeys.erase(key);
-
-    cache.valid = true;
-    cache.prefetchedCellRect = rectContains(cache.prefetchedCellRect, paddedCells)
-        ? cache.prefetchedCellRect
-        : paddedCells;
-
-    std::vector<vc::render::ChunkKey> keys;
-    keys.reserve(visibleKeys.size());
-    for (const auto& key : visibleKeys)
-        keys.push_back(key);
-    _chunkArray->prefetchChunks(keys, false, priorityOffset);
-
-    keys.clear();
-    keys.reserve(speculativeKeys.size());
-    for (const auto& key : speculativeKeys)
-        keys.push_back(key);
-    _chunkArray->prefetchChunks(keys, false, kChunkPrefetchPriorityOffset);
 }
 
 struct CChunkedVolumeViewer::RenderContext {
@@ -2346,8 +1846,6 @@ void CChunkedVolumeViewer::startRenderJob(PendingRenderJob job)
         job.overlayChunkArray->beginViewRequest();
     }
 
-    prefetchVisibleSurfaceChunks();
-
     RenderContext ctx;
     ctx.renderJob = job;
     ctx.serial = ++_renderSerial;
@@ -2430,8 +1928,8 @@ void CChunkedVolumeViewer::submitRender(const char* reason, std::source_location
         _pendingRenderReason = reason ? reason : "";
         _pendingRenderCaller = profileCaller(caller);
     }
-    // Hidden viewer (minimized subwindow / background tab): skip the render AND its
-    // prefetch entirely. Mark stale so showEvent renders it when it becomes visible.
+    // Hidden viewer (minimized subwindow / background tab): skip the render.
+    // Mark stale so showEvent renders it when it becomes visible.
     if (!isVisible()) {
         _renderStaleWhileHidden = true;
         profile.setDetails("action=skip hidden");
@@ -2521,27 +2019,6 @@ void CChunkedVolumeViewer::finishRenderOnMainThread(std::shared_ptr<RenderResult
     _displayedRenderJob = result->renderJob;
     syncCameraTransform();
     scheduleIntersectionRender("stable render finished");
-    if (auto surf = _surfWeak.lock()) {
-        const vc::render::ChunkedPlaneSampler::Options options(_samplingMethod, 32);
-        if (auto* plane = dynamic_cast<PlaneSurface*>(surf.get())) {
-            const int startLevel = renderStartLevel(false);
-            const int overlayStartLevel = overlayRenderStartLevel(false);
-            const cv::Vec3f vx = plane->basisX();
-            const cv::Vec3f vy = plane->basisY();
-            const cv::Vec3f n = plane->normal({0, 0, 0});
-            const float halfW = static_cast<float>(_framebuffer.width()) * 0.5f / _scale;
-            const float halfH = static_cast<float>(_framebuffer.height()) * 0.5f / _scale;
-            const cv::Vec3f origin = vx * (_surfacePtrX - halfW)
-                                   + vy * (_surfacePtrY - halfH)
-                                   + plane->origin()
-                                   + n * _zOff;
-            prefetchPlaneHalo(origin, vx / _scale, vy / _scale, startLevel, overlayStartLevel, options);
-            prefetchPlaneNormalNeighbors(*plane, startLevel, overlayStartLevel, options);
-        } else {
-            prefetchSurfaceHalo(*surf, renderStartLevel(true), overlayRenderStartLevel(true), options,
-                                _framebuffer.width(), _framebuffer.height());
-        }
-    }
     emit overlaysUpdated();
     _view->viewport()->update();
     emit renderFrameCompleted(result->serial, result->renderFrameElapsedMs);
@@ -2714,7 +2191,6 @@ void CChunkedVolumeViewer::panByF(float dx, float dy)
         _surfacePtrX = std::clamp(_surfacePtrX, _contentMinU, _contentMaxU);
         _surfacePtrY = std::clamp(_surfacePtrY, _contentMinV, _contentMaxV);
     }
-    prefetchVisibleSurfaceChunks();
     submitRender("pan");
     refreshSameWrapAnnotationOverlay();
     emit overlaysUpdated();
@@ -2746,7 +2222,6 @@ void CChunkedVolumeViewer::zoomStepsAt(int steps, const QPointF& scenePos)
     recalcPyramidLevel();
     _genCacheDirty = true;
     resizeFramebuffer();
-    prefetchVisibleSurfaceChunks();
     submitRender("zoom");
     refreshSameWrapAnnotationOverlay();
     emit overlaysUpdated();
@@ -2765,7 +2240,6 @@ void CChunkedVolumeViewer::notifyInteractiveViewChange(double motionPx)
 
     markInteractiveMotion(motionPx);
     _genCacheDirty = true;
-    prefetchVisibleSurfaceChunks();
     submitRender("interactive view change");
     emit overlaysUpdated();
 }
@@ -3454,7 +2928,6 @@ void CChunkedVolumeViewer::markSurfaceGeometryChanged()
     }
     ++_surfaceGeometryEpoch;
     _genCacheDirty = true;
-    _surfaceChunkPrefetchCache = {};
 }
 
 void CChunkedVolumeViewer::updateLineAnnotationPlacementMarker(const QPointF& scenePos)

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -437,6 +437,14 @@ std::uint64_t surfaceCellTileKey(int col, int row)
     return surfaceTileKey(tx, ty);
 }
 
+bool rectContains(const cv::Rect& outer, const cv::Rect& inner)
+{
+    return inner.x >= outer.x &&
+           inner.y >= outer.y &&
+           inner.x + inner.width <= outer.x + outer.width &&
+           inner.y + inner.height <= outer.y + outer.height;
+}
+
 QString formatVec3(const cv::Vec3f& v)
 {
     return QString("(%1, %2, %3)")

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -286,23 +286,6 @@ private:
     void updateContentBounds();
     QPointF surfaceToScene(float surfX, float surfY) const;
     cv::Vec2f sceneToSurface(const QPointF& scenePos) const;
-    void prefetchPlaneHalo(const cv::Vec3f& origin,
-                           const cv::Vec3f& vxStep,
-                           const cv::Vec3f& vyStep,
-                           int startLevel,
-                           int overlayStartLevel,
-                           const vc::render::ChunkedPlaneSampler::Options& options);
-    void prefetchPlaneNormalNeighbors(PlaneSurface& plane,
-                                      int startLevel,
-                                      int overlayStartLevel,
-                                      const vc::render::ChunkedPlaneSampler::Options& options);
-    void prefetchSurfaceHalo(Surface& surf,
-                             int startLevel,
-                             int overlayStartLevel,
-                             const vc::render::ChunkedPlaneSampler::Options& options,
-                             int fbW,
-                             int fbH);
-    void prefetchVisibleSurfaceChunks(int priorityOffset = 0);
     struct GeneratedSurfaceCache;
     struct PendingRenderJob {
         std::uint64_t requestId = 0;
@@ -416,16 +399,6 @@ private:
     cv::Mat_<uint8_t> _coverage;
     std::shared_ptr<GeneratedSurfaceCache> _genSurfaceCache;
     bool _genCacheDirty = true;
-
-    struct SurfaceChunkPrefetchCache {
-        Surface* surface = nullptr;
-        int level = -1;
-        vc::Sampling sampling = vc::Sampling::Trilinear;
-        bool valid = false;
-        cv::Rect prefetchedCellRect;
-        std::unordered_map<std::uint64_t, std::vector<vc::render::ChunkKey>> tileKeys;
-    };
-    SurfaceChunkPrefetchCache _surfaceChunkPrefetchCache;
 
     float _surfacePtrX = 0.0f;
     float _surfacePtrY = 0.0f;

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -135,6 +135,7 @@ public:
     void setOverlayColormap(const std::string& colormapId) override;
     void setOverlayThreshold(float threshold) override;
     void setOverlayWindow(float low, float high) override;
+    void setOverlayMaxDisplayedResolution(int level) override;
 
     void setSegmentationEditActive(bool active) override { if (_closing) return; _segmentationEditActive = active; }
     void setSegmentationIntersectionDeferral(bool active) override;
@@ -289,12 +290,15 @@ private:
                            const cv::Vec3f& vxStep,
                            const cv::Vec3f& vyStep,
                            int startLevel,
+                           int overlayStartLevel,
                            const vc::render::ChunkedPlaneSampler::Options& options);
     void prefetchPlaneNormalNeighbors(PlaneSurface& plane,
                                       int startLevel,
+                                      int overlayStartLevel,
                                       const vc::render::ChunkedPlaneSampler::Options& options);
     void prefetchSurfaceHalo(Surface& surf,
                              int startLevel,
+                             int overlayStartLevel,
                              const vc::render::ChunkedPlaneSampler::Options& options,
                              int fbW,
                              int fbH);
@@ -310,6 +314,7 @@ private:
         float zOff = 0.0f;
         cv::Vec3f zOffWorldDir{0, 0, 0};
         int startLevel = 0;
+        int overlayStartLevel = 0;
         vc::Sampling samplingMethod = vc::Sampling::Trilinear;
         CompositeRenderSettings compositeSettings;
         float windowLow = 0.0f;
@@ -350,6 +355,7 @@ private:
     void finishRenderOnMainThread(std::shared_ptr<RenderResult> result);
     void markInteractiveMotion(double motionPx);
     int renderStartLevel(bool preferSurfaceResolution = false) const;
+    int overlayRenderStartLevel(bool preferSurfaceResolution = false) const;
     bool streamingCompositeUnsupported() const;
     std::optional<cv::Vec3f> cursorVolumePosition(const QPointF& scenePos) const;
     void updateCursorCrosshair(const QPointF& scenePos);
@@ -442,6 +448,7 @@ private:
     std::string _overlayColormapId;
     float _overlayWindowLow = 0.0f;
     float _overlayWindowHigh = 255.0f;
+    int _overlayMaxDisplayedResolution = 0;
 
     CompositeRenderSettings _compositeSettings;
     bool _resetViewOnSurfaceChange = true;

--- a/volume-cartographer/apps/VC3D/volume_viewers/VolumeViewerBase.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/VolumeViewerBase.hpp
@@ -127,6 +127,7 @@ public:
     virtual void setOverlayColormap(const std::string& colormapId) = 0;
     virtual void setOverlayThreshold(float threshold) = 0;
     virtual void setOverlayWindow(float low, float high) = 0;
+    virtual void setOverlayMaxDisplayedResolution(int level) = 0;
     virtual void reloadPerfSettings() = 0;
 
     // --- Interaction state ---

--- a/volume-cartographer/core/test/test_segmentation_intersection_invalidation.cpp
+++ b/volume-cartographer/core/test/test_segmentation_intersection_invalidation.cpp
@@ -90,6 +90,7 @@ public:
     void setOverlayColormap(const std::string&) override {}
     void setOverlayThreshold(float) override {}
     void setOverlayWindow(float, float) override {}
+    void setOverlayMaxDisplayedResolution(int) override {}
     void reloadPerfSettings() override {}
 
     uint64_t highlightedPointId() const override { return 0; }

--- a/volume-cartographer/core/test/test_viewer_overlay_surface_primitives.cpp
+++ b/volume-cartographer/core/test/test_viewer_overlay_surface_primitives.cpp
@@ -108,6 +108,7 @@ public:
     void setOverlayColormap(const std::string&) override {}
     void setOverlayThreshold(float) override {}
     void setOverlayWindow(float, float) override {}
+    void setOverlayMaxDisplayedResolution(int) override {}
     void reloadPerfSettings() override {}
 
     uint64_t highlightedPointId() const override { return 0; }


### PR DESCRIPTION
- add overlay max resolution setting independent of primary vol (ink or surf vols are fine at downsample, dont need to waste network speed and disk cache if we dont want to)
- remove already disabled speculative prefetch / halo code