### PR TITLE
scrollprize.org: data browser — PHerc. 1667 scanned at DLS then resca…

### DIFF
--- a/scrollprize.org/src/data/atlasOverlay.json
+++ b/scrollprize.org/src/data/atlasOverlay.json
@@ -256,6 +256,7 @@
         "CC BY-NC 4.0": "all other data"
       },
       "note": "Scroll 4 — the first Herculaneum scroll virtually unwrapped and read in full, end to end, without ever being physically opened. Scanned and read at 2.4µm.",
+      "desc": "PHerc. 1667 is a rolled Herculaneum papyrus from the [Biblioteca Nazionale di Napoli](https://www.bnnonline.it/it/121/officina-dei-papiri-ercolanesi), carbonized during the eruption of Mount Vesuvius in 79 AD. It was first scanned at the [Diamond Light Source](https://www.diamond.ac.uk) in Oxfordshire, UK (2023, at 3.24 µm and 7.91 µm), and later rescanned at 2.4 µm at the [ESRF](https://www.esrf.fr) in Grenoble, France (2025) — the scan from which it was virtually unwrapped and read in full.\n\nIt is similar in size to PHerc. 332 (Scroll 3).",
       "photo": "https://vesuvius-challenge-open-data.s3.amazonaws.com/PHerc1667/photos/PHerc1667_photo.jpg",
       "bucketUrl": "https://vesuvius-challenge-open-data.s3.amazonaws.com/index.html#PHerc1667/",
       "content": {


### PR DESCRIPTION
…nned at ESRF

The About text said only "scanned at the Diamond Light Source", but the scroll was first scanned at DLS (2023, 3.24 µm and 7.91 µm) and later rescanned at 2.4 µm at the ESRF (2025) — the scan from which it was virtually unwrapped and read in full. Overrides the S3 metadata desc via atlasOverlay.json (same mechanism as Scroll 3).