### PR TITLE
docs: update stale information across scrollprize.org (#199)

### DIFF
--- a/scrollprize.org/docs/01_get_started.md
+++ b/scrollprize.org/docs/01_get_started.md
@@ -69,7 +69,7 @@ Contestants can also contribute to our two primary subproblems:
 </Admonition>
 
 <Admonition type="info" icon="🖋️" title="Ink Detection">
-* Prizes: 7 x \$60,000 [First Letters and First Title Prizes](prizes#first-letters-and-title-prizes)
+* Prizes: [First Letters and First Title Prizes](prizes#first-letters-and-title-prizes) (\$60,000 each)
 * Starting point: [Ink detection tutorial](tutorial5)
 </Admonition>
 

--- a/scrollprize.org/docs/09_faq.md
+++ b/scrollprize.org/docs/09_faq.md
@@ -54,12 +54,13 @@ A few hundred scrolls were excavated that were never opened, and remain rolled u
 Our community is building methods to read these scrolls using micro-CT and an algorithmic pipeline using machine learning and computer vision.
 
 We've awarded \$1,800,500 in prizes and broken through, revealing complete passages of Greek philosophy from the inside of a closed Herculaneum scroll for the first time.
-Now we are continuing - we want to go from reading 5% of one scroll to reading multiple complete scrolls.
+In June 2026 we read an entire Herculaneum scroll (PHerc. 1667) from beginning to end for the first time.
+Now we are continuing - we want to go from reading one complete scroll to reading the hundreds that remain sealed.
 Join us to win prizes and be a part of history!
 
 ### What dates do I need to know?
 
-The [2024 prize](2024_prizes) deadlines closed on **December 31, 2024**, and we are now evaluating the submissions and preparing the next stages. [Join the community](get_started#1-join-the-community) to stay tuned!
+The [First Letters and First Title prizes](prizes#first-letters-and-title-prizes) have no fixed deadline - they stay open until won. [Progress Prizes](prizes#progress-prizes) are evaluated monthly; check the [Prizes page](prizes) for the current submission deadline. [Join the community](get_started#1-join-the-community) to stay tuned!
 
 ### What's the historical background of Herculaneum and the scrolls?
 

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -152,10 +152,10 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 - [segmata](https://github.com/sgoutteb/segmata) by Stephane Gouttebroze:
     - Improve the segmentation process by sharpening the layers rendering, this is based on optimizing the layer 32, a further objective is to link this optimization on a inference loop (optimizing on the detected ink instead of only layers)
 
-- [Synthetic instance labels and volume generation](https://lcparker/synthetic-pages) by lcparker
+- [Synthetic instance labels and volume generation](https://github.com/lcparker/synthetic-pages) by lcparker
     - Generate artificial 3D volumes with corresponding instance labels for use in pretraining instance segmentation networks
 
-- [Mask3D for instance segmentation on scroll volumes](https://lcparker/Mask3D) by lcparker
+- [Mask3D for instance segmentation on scroll volumes](https://github.com/lcparker/Mask3D) by lcparker
     - SOTA instance segmentation network, configured to work with scroll volumes
     - [Effects of pretraining on synthetically generated data](https://github.com/lcparker/pretraining-advantage), plus pretrained and finetuned weights for the Mask3D network
 - [Affinity Prediction with Unet](https://discordapp.com/channels/1079907749569237093/1407379961417039953) by Ayush Mishra
@@ -168,24 +168,23 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 #### 🌟 Highlighted
 
-- [Sheet instance annotation of cubes for Deep Learning models](https://dl.ash2txt.org/full-scrolls/Scroll1/PHercParis4.volpkg/seg-volumetric-labels/finished_cubes/) (work in progress)
-    - [More cubes to annotate, help us!](https://dl.ash2txt.org/full-scrolls/Scroll1/PHercParis4.volpkg/seg-volumetric-labels/cubes/)
+- [Sheet instance annotation of cubes for Deep Learning models](https://dl.ash2txt.org/full-scrolls/Scroll1/PHercParis4.volpkg/volumetric-instance-labels/) - includes `instance-labels/` (manually annotated cubes), the recommended `instance-labels-harmonized/` (consistent instance IDs across cube boundaries), and `semantic-labels/`
 
 - [Denoised and contrast enhanced volumes](https://discord.com/channels/1079907749569237093/1249316301273436320), download [here](https://dl.ash2txt.org/full-scrolls/Scroll1/PHercParis4.volpkg/volumes_denoised_ce/), same path pattern for other scrolls.
 
 #### Scroll Surface Predictions
-- [Scroll 1, and 3 Surface Predictions](https://dl.ash2txt.org/community-uploads/bruniss/p2_submission/) by Sean Johnson
-- [Scroll 4 Surface Predictions](https://dl.ash2txt.org/community-uploads/bruniss/Fiber-and-Surface-Models/Predictions/s4/) by Sean Johnson
+- [Scroll 1, and 3 Surface Predictions](https://dl.ash2txt.org/community-uploads/bruniss/scrolls/s1/surfaces/) by Sean Johnson (also see [Scroll 3](https://dl.ash2txt.org/community-uploads/bruniss/scrolls/s3/surfaces/))
+- [Scroll 4 Surface Predictions](https://dl.ash2txt.org/community-uploads/bruniss/scrolls/s4/fiber_surfaces/) by Sean Johnson
 - [Scroll Surface Prediction Repository and Writeup](https://github.com/bruniss/VC-Surface-Models) by Sean Johnson 
 
 #### 📜 Segments
--[Large Autosegmentation of Scroll5](https://dl.ash2txt.org/community-uploads/bruniss/p2_submission/s5_initial_trace/) by Hendrik Schilling and Sean Johnson -- Unsupervised, many switches -- check readme.md
+-[Large Autosegmentation of Scroll5](https://dl.ash2txt.org/community-uploads/bruniss/scrolls/s5/autogens/s5_initial_trace/) by Hendrik Schilling and Sean Johnson -- Unsupervised, many switches -- check readme.md
 
 - [Scroll 2 segments](https://discord.com/channels/1079907749569237093/1079907750265499772/1245553260362858577) by Sean Johnson
 
 - [New segments](https://discord.com/channels/1079907749569237093/1234969334535946303) by Sean Johnson
 
-- [Large segments](http://dl.ash2txt.org/bruniss-uploads/) by Sean Johnson
+- [Large segments](https://dl.ash2txt.org/community-uploads/bruniss/scrolls/) by Sean Johnson (uploads reorganized into per-scroll folders)
 
 - [Rescaled to 7.91um fragment surfaces and labels](https://dl.ash2txt.org/community-uploads/jrudolph/rescaled-fragments/) by Johannes Rudolph
 
@@ -239,7 +238,7 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 #### 🌟 Highlighted
 
 - [3D (volumetric) Ink detection model](https://github.com/ryanchesler/3d-ink-detection) by Ryan Chesler. Ink detection model that works on full scroll data in 3D, without segmentation nor flattening.
-- [Volumetric Ink Detection for Scroll 1, 2, 3, 4](https://dl.ash2txt.org/community-uploads/bruniss/3d%20Ink%20/) by Sean Johnson
+- [Volumetric Ink Detection for Scroll 1, 2, 3, 4](https://dl.ash2txt.org/community-uploads/bruniss/scrolls/) by Sean Johnson (each scroll folder now has its own `3d_ink/` subfolder)
 
 #### ⚙️ Tools
 

--- a/scrollprize.org/docs/34_prizes.md
+++ b/scrollprize.org/docs/34_prizes.md
@@ -116,7 +116,7 @@ We maintain a [public wishlist](https://github.com/ScrollPrize/villa/issues?q=is
 [Improvements to VC3D](https://github.com/ScrollPrize/villa/issues?q=is%3Aissue%20state%3Aopen%20label%3AVC3D) can be also considered for progress prizes!
 Some are additionally labeled as [good first issues](https://github.com/ScrollPrize/villa/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) for newcomers!
 
-Submissions are evaluated monthly, and multiple submissions/awards per month are permitted. The next deadline is 11:59pm Pacific, June 30th, 2026!
+Submissions are evaluated monthly, and multiple submissions/awards per month are permitted. The next deadline is 11:59pm Pacific, July 31st, 2026!
 
 <details>
 <summary>Submission criteria and requirements</summary>


### PR DESCRIPTION
Addresses #199 (identify and update out-of-date documentation on scrollprize.org).

## Changes

- **FAQ**: replaced "reading 5% of one scroll" with a mention of the full read of PHerc. 1667 (Scroll 4, June 2026), and replaced the "What dates do I need to know?" section (which pointed to a 2024 prize deadline that closed 18 months ago) with the current prize structure (First Letters/Title have no fixed deadline, Progress Prizes are monthly).
- **Get Started**: fixed "7 x $60,000" for the ink detection prizes — there are 2 ($60,000 each: First Letters, First Title).
- **Prizes**: the hardcoded Progress Prize monthly deadline ("June 30th, 2026") had already passed; updated to the next month-end.
- **Community Projects**: fixed a handful of broken links, verified individually before changing anything:
  - Two links to `lcparker`'s repos were missing the `github.com` host (confirmed via the GitHub API that `Mask3D` and `synthetic-pages` exist under that account).
  - Several `dl.ash2txt.org/community-uploads/bruniss/...` links pointed to folders that no longer exist; the uploads have been reorganized into a consistent per-scroll layout (`bruniss/scrolls/<scroll>/...`). Each replacement was checked against the live directory listing before being used (e.g. the Scroll 5 autosegmentation link now points to `scrolls/s5/autogens/s5_initial_trace/`, which still contains the same `README.txt` referenced in the original text).
  - `seg-volumetric-labels/...` was replaced with `volumetric-instance-labels/...`, confirmed via that folder's own `README.txt`, which describes it as the direct successor (including the harmonized instance-label set flagged as the "recommended starting point").

## Known remaining issue (not fixed here)

- `volumes_denoised_ce/` under the PHercParis4 volpkg no longer exists and I could not find an obvious successor path in the current directory listing. Left as-is rather than guessing; flagging here for a maintainer who might know where this moved.
- A few other dead links were found but intentionally left untouched because fixing them would require guessing at intent rather than following clear evidence: `github.com/lcparker/pretraining-advantage`, `github.com/lukeboi/scroll-first-letters`, and `github.com/lukeboi/scroll-viewer` (repos no longer exist under those accounts/names).

No code changes, no build/test impact — Markdown/MDX content only.