### PR TITLE
build: try running codeql analyze-deep on builder image

### DIFF
--- a/.github/workflows/vc3d-codeql.yml
+++ b/.github/workflows/vc3d-codeql.yml
@@ -82,6 +82,17 @@ jobs:
     if: github.event_name == 'push'
     needs: [changes]
     runs-on: ubuntu-latest
+    # Run inside the prebuilt VC3D builder image (Ubuntu 26.04 + all build
+    # deps baked in). This is the single source of truth for the toolchain
+    # — the same image the main CI uses — so CodeQL compiles against the
+    # exact LLVM/Flang 21 environment install_build_deps.sh targets. Running
+    # the script bare on the ubuntu-latest (24.04) runner failed because
+    # noble has no flang-21 / libclang-rt-21-dev.
+    container:
+      image: ghcr.io/scrollprize/villa/volume-cartographer:builder-ubuntu-26.04
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 360
     permissions:
       security-events: write
@@ -97,10 +108,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # history-aware queries if needed
-
-      - name: Install build deps
-        if: needs.changes.outputs.vc == 'true'
-        run: sudo bash volume-cartographer/scripts/install_build_deps.sh
 
       - name: Initialize CodeQL
         if: needs.changes.outputs.vc == 'true'


### PR DESCRIPTION
To fix the codeql analysis on main which has been broken since we removed the 24.04 build.