### PR TITLE
build: try to fix codeql by using 26.04 base image instead

### DIFF
--- a/.github/workflows/vc3d-codeql.yml
+++ b/.github/workflows/vc3d-codeql.yml
@@ -81,18 +81,14 @@ jobs:
   analyze_deep:
     if: github.event_name == 'push'
     needs: [changes]
-    runs-on: ubuntu-latest
-    # Run inside the prebuilt VC3D builder image (Ubuntu 26.04 + all build
-    # deps baked in). This is the single source of truth for the toolchain
-    # — the same image the main CI uses — so CodeQL compiles against the
-    # exact LLVM/Flang 21 environment install_build_deps.sh targets. Running
-    # the script bare on the ubuntu-latest (24.04) runner failed because
-    # noble has no flang-21 / libclang-rt-21-dev.
-    container:
-      image: ghcr.io/scrollprize/villa/volume-cartographer:builder-ubuntu-26.04
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    # Pin to Ubuntu 26.04 (resolute) rather than ubuntu-latest (still 24.04).
+    # install_build_deps.sh — the single source of truth for the VC3D
+    # toolchain, shared with the Dockerfile (FROM ubuntu:26.04) — pulls
+    # flang-21 / libclang-rt-21-dev, which only exist in 26.04's default
+    # repos. On noble the deps install failed with "Unable to locate package".
+    # NOTE: ubuntu-26.04 is currently a *preview* runner image; revisit once
+    # ubuntu-latest migrates to 26.04 (GA), at which point this pin can drop.
+    runs-on: ubuntu-26.04
     timeout-minutes: 360
     permissions:
       security-events: write
@@ -108,6 +104,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # history-aware queries if needed
+
+      - name: Install build deps
+        if: needs.changes.outputs.vc == 'true'
+        run: sudo bash volume-cartographer/scripts/install_build_deps.sh
 
       - name: Initialize CodeQL
         if: needs.changes.outputs.vc == 'true'


### PR DESCRIPTION
Our own build container is likely to large to work