### PR TITLE
vc: build linux appimage for single file linunx download

### DIFF
--- a/.github/workflows/vc3d-linux.yml
+++ b/.github/workflows/vc3d-linux.yml
@@ -1,0 +1,156 @@
+name: VC3D Linux AppImage
+run-name: VC3D Linux ${{ github.event_name }} ${{ inputs.request_id || github.sha }}
+
+# Builds VC3D in the Ubuntu 26.04 CI builder image and packages it into a single
+# self-contained AppImage via scripts/Dockerfile.appimage. glibc + the dynamic
+# loader are bundled, so the result runs on distros with an OLDER glibc than the
+# build image; a split-out debug-symbols companion (VC3D-<arch>-debug.tar.zst) is
+# produced alongside. Main, release, and manual runs also smoke-test the AppImage
+# on the plain ubuntu-24.04 runner (glibc 2.39, older than the 26.04 build image)
+# with no build deps installed, so a missing bundle or a too-new glibc reference
+# fails loudly here instead of on a user's machine. Published-release AppImages
+# are attached to the GitHub release.
+
+on:
+  # Keep the workflow check present on PRs, but satisfy it with a lightweight
+  # no-op; vc3d-ci owns the required native Linux compile gate.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'volume-cartographer/**'
+      - '.github/workflows/vc3d-linux.yml'
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit to package (defaults to the selected workflow ref)
+        required: false
+        type: string
+      request_id:
+        description: Optional caller correlation ID
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # A newer main build supersedes an older package build. Never cancel a release
+  # or an explicitly requested build.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
+jobs:
+  pr-noop:
+    name: Build + package (AppImage)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - run: echo "Native compile coverage is provided by the required vc3d-ci Linux job."
+
+  build-linux:
+    name: Build + package (AppImage)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha || github.sha }}
+
+      # The build runs inside the published CI builder image (Ubuntu 26.04 + all
+      # deps); logging in lets `docker build` pull it from ghcr.
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build AppImage
+        working-directory: volume-cartographer
+        run: |
+          DOCKER_BUILDKIT=1 docker build \
+            -o type=local,dest=dist \
+            -f scripts/Dockerfile.appimage \
+            .
+          ls -la dist/
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: VC3D-linux-appimage
+          path: |
+            volume-cartographer/dist/VC3D-*.AppImage
+            volume-cartographer/dist/VC3D-*-debug.tar.zst
+          if-no-files-found: error
+
+      # Prove the AppImage is self-contained AND runs on an older glibc than the
+      # 26.04 build image: run it on the plain ubuntu-24.04 runner (glibc 2.39)
+      # with no build deps installed.
+      - name: Smoke test the AppImage
+        working-directory: volume-cartographer/dist
+        timeout-minutes: 10
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: '1'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xvfb
+          appimage="$(ls VC3D-*.AppImage)"
+          chmod +x "$appimage"
+          echo "runner glibc: $(ldd --version | head -1)"
+
+          # Console CLI tool via the symlink dispatch: loads the vc_core/OpenCV/
+          # Ceres closure against the bundled glibc. No-args prints usage and
+          # exits 1; anything else means a load failure (missing lib / too-new
+          # glibc reference).
+          ln -sf "$appimage" vc_tifxyz_trim
+          set +e; ./vc_tifxyz_trim; rc=$?; set -e
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+            echo "::error::vc_tifxyz_trim failed to start (exit $rc)"; exit 1
+          fi
+          echo "vc_tifxyz_trim OK (exit $rc)"
+
+          # GUI: initialize the real xcb Qt stack under a virtual display. VC3D
+          # has no clean --version/--help exit on Linux, so assert a known
+          # startup marker with no crash-report banner, then let the timeout stop
+          # it.
+          out="$(timeout 40 xvfb-run -a ./"$appimage" </dev/null 2>&1 || true)"
+          echo "$out" | grep -viE '^(Detected locale|Qt depends|If this causes|for more info)' | tail -20
+          if echo "$out" | grep -q "CRASH REPORT"; then
+            echo "::error::VC3D crashed during GUI startup"; exit 1
+          fi
+          if ! echo "$out" | grep -qiE "Axis-aligned slices|chunk cache budget"; then
+            echo "::error::VC3D GUI did not reach expected startup markers"; exit 1
+          fi
+          echo "VC3D GUI init OK"
+
+  release-linux:
+    name: Attach Linux AppImage to release
+    if: github.event_name == 'release'
+    needs: build-linux
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download AppImage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: VC3D-linux-appimage
+          path: release-assets
+
+      - name: Attach AppImage to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            release-assets/VC3D-*.AppImage \
+            release-assets/VC3D-*-debug.tar.zst \
+            --clobber

--- a/volume-cartographer/.dockerignore
+++ b/volume-cartographer/.dockerignore
@@ -6,6 +6,8 @@
 .zenodo.json
 .idea/
 build
+dist
+*.AppImage
 results
 **/build/
 **/CMakeFiles/

--- a/volume-cartographer/.gitignore
+++ b/volume-cartographer/.gitignore
@@ -55,5 +55,9 @@ VC.ini
 
 build/perf.data
 
+# AppImage packaging output (scripts/build_appimage.sh / Dockerfile.appimage)
+dist/
+*.AppImage
+
 # Claude Code runtime
 .claude/

--- a/volume-cartographer/scripts/Dockerfile.appimage
+++ b/volume-cartographer/scripts/Dockerfile.appimage
@@ -20,9 +20,10 @@ FROM ${BUILDER_IMAGE} AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
 # patchelf: rewrites RPATHs during bundling. file/desktop-file-utils: used by
-# linuxdeploy for ELF/desktop validation.
+# linuxdeploy for ELF/desktop validation. zstd: compresses the debug-symbols
+# companion (build_appimage.sh falls back to gzip without it).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends patchelf file desktop-file-utils \
+ && apt-get install -y --no-install-recommends patchelf file desktop-file-utils zstd \
  && rm -rf /var/lib/apt/lists/*
 
 COPY . /src

--- a/volume-cartographer/scripts/Dockerfile.appimage
+++ b/volume-cartographer/scripts/Dockerfile.appimage
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.7
+#
+# Clean-room Linux AppImage build for Volume Cartographer (VC3D).
+#
+# Builds VC3D against the published CI builder image (Ubuntu 26.04 + all deps),
+# then packages the runtime install tree into a single relocatable .AppImage
+# via scripts/build_appimage.sh. glibc + the dynamic loader are bundled, so the
+# result runs on distros with an OLDER glibc than the 26.04 build image.
+#
+# Build (writes dist/VC3D-x86_64.AppImage on the host):
+#   docker build -o type=local,dest=dist -f scripts/Dockerfile.appimage .
+#
+# Against the local dev builder image instead of ghcr:
+#   docker build -o type=local,dest=dist -f scripts/Dockerfile.appimage \
+#     --build-arg BUILDER_IMAGE=vc-builder:dev .
+
+ARG BUILDER_IMAGE=ghcr.io/scrollprize/villa/volume-cartographer:builder-ubuntu-26.04
+
+FROM ${BUILDER_IMAGE} AS build
+ARG DEBIAN_FRONTEND=noninteractive
+
+# patchelf: rewrites RPATHs during bundling. file/desktop-file-utils: used by
+# linuxdeploy for ELF/desktop validation.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends patchelf file desktop-file-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY . /src
+WORKDIR /src
+
+RUN cmake --preset ci-release-gcc \
+ && cmake --build --preset ci-release-gcc
+
+ENV QMAKE=/usr/bin/qmake6
+RUN OUT_DIR=/out BUILD_DIR=/src/build/ci-release-gcc bash scripts/build_appimage.sh
+
+# Export the artifacts via `-o type=local,dest=dist`: the minified .AppImage
+# plus the split-out debug-symbols companion (VC3D-<arch>-debug.tar.zst).
+FROM scratch AS export
+COPY --from=build /out/ /

--- a/volume-cartographer/scripts/appimage/AppRun
+++ b/volume-cartographer/scripts/appimage/AppRun
@@ -7,9 +7,18 @@
 #      not the app, so Qt can't derive the plugin dir from qt.conf — we set
 #      QT_PLUGIN_PATH explicitly. (Harmless in non-bundled mode too.)
 #   2. Dispatch to the right executable. VC3D ships the GUI plus ~35 CLI tools
-#      in one AppImage. Symlink the .AppImage to a tool name
-#      (e.g. `ln -s VC3D-x86_64.AppImage vc_obj2tifxyz`) to run that tool;
-#      otherwise the GUI (VC3D) launches.
+#      in one AppImage, used as a multitool: the first argument selects the tool.
+#        a. subcommand — the first argument names a tool:
+#               ./VC3D-x86_64.AppImage vc_obj2tifxyz in.obj out/
+#               ./VC3D-x86_64.AppImage VC3D            # launch the GUI
+#           Nicer via a short `vc` symlink:
+#               ln -s VC3D-x86_64.AppImage vc && vc vc_obj2tifxyz in.obj out/
+#        b. argv0 — symlink the .AppImage to a tool name and run that symlink:
+#               ln -s VC3D-x86_64.AppImage vc_obj2tifxyz && ./vc_obj2tifxyz ...
+#        c. `list` prints the bundled executables; `help` prints usage.
+#      With no tool selected: a bare desktop/double-click launch (no terminal)
+#      opens the GUI, while an interactive terminal prints usage — so the CLI
+#      feels like a multitool without breaking the desktop entry.
 #   3. If glibc was bundled (scripts/build_appimage.sh, default), launch through
 #      the bundled loader so the host's glibc is never used — this is what lets
 #      the AppImage run on distros older than the build machine. If not bundled,
@@ -21,12 +30,50 @@ LIBDIR="$HERE/usr/lib"
 
 export QT_PLUGIN_PATH="$HERE/usr/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
 
-BIN=VC3D
-if [ -n "${ARGV0:-}" ]; then
-    cand="$(basename "$ARGV0")"
-    if [ "$cand" != "AppRun" ] && [ -x "$HERE/usr/bin/$cand" ]; then
-        BIN="$cand"
-    fi
+invoked="$(basename "${ARGV0:-$0}")"
+
+list_tools() { find "$HERE/usr/bin" -maxdepth 1 -type f -executable -printf '%f\n' | sort; }
+usage() {
+    cat <<EOF
+Volume Cartographer (VC3D) — GUI + command-line toolkit in one AppImage.
+
+Usage:
+  $invoked VC3D [args...]     launch the GUI
+  $invoked <tool> [args...]   run a bundled command-line tool
+  $invoked list               list the bundled tools
+  $invoked help               show this help
+
+Each tool can also be run by symlinking the AppImage to its name, e.g.
+  ln -s $invoked vc_obj2tifxyz && ./vc_obj2tifxyz ...
+EOF
+}
+
+BIN=""
+if [ "$invoked" != "AppRun" ] && [ "$invoked" != "vc" ] && [ -x "$HERE/usr/bin/$invoked" ]; then
+    # (b) argv0 names a bundled tool.
+    BIN="$invoked"
+else
+    case "${1:-}" in
+        list|--list|--list-tools)
+            list_tools; exit 0 ;;
+        help|-h|--help)
+            usage; exit 0 ;;
+        "")
+            # No tool selected. Desktop/double-click (no controlling terminal)
+            # opens the GUI; an interactive terminal gets usage.
+            if [ -t 0 ] || [ -t 1 ]; then usage; exit 0; else BIN=VC3D; fi ;;
+        *)
+            # Any other first argument — including a bare option like
+            # --cache-size — must name a bundled tool. Passing options to the
+            # GUI requires an explicit tool: `<cmd> VC3D --cache-size ...`.
+            if [ -x "$HERE/usr/bin/$1" ]; then
+                # (a) first argument names a bundled tool.
+                BIN="$1"; shift
+            else
+                echo "$invoked: unknown tool '$1' — run '$invoked list', or pass options explicitly, e.g. '$invoked VC3D $*'" >&2
+                exit 2
+            fi ;;
+    esac
 fi
 
 LOADER="$LIBDIR/ld-linux-x86-64.so.2"

--- a/volume-cartographer/scripts/appimage/AppRun
+++ b/volume-cartographer/scripts/appimage/AppRun
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Entry point for the Volume Cartographer AppImage.
+#
+# Responsibilities:
+#   1. Point Qt at the bundled plugins. When the app is launched through the
+#      bundled dynamic loader (glibc-bundle mode), /proc/self/exe is the loader,
+#      not the app, so Qt can't derive the plugin dir from qt.conf — we set
+#      QT_PLUGIN_PATH explicitly. (Harmless in non-bundled mode too.)
+#   2. Dispatch to the right executable. VC3D ships the GUI plus ~35 CLI tools
+#      in one AppImage. Symlink the .AppImage to a tool name
+#      (e.g. `ln -s VC3D-x86_64.AppImage vc_obj2tifxyz`) to run that tool;
+#      otherwise the GUI (VC3D) launches.
+#   3. If glibc was bundled (scripts/build_appimage.sh, default), launch through
+#      the bundled loader so the host's glibc is never used — this is what lets
+#      the AppImage run on distros older than the build machine. If not bundled,
+#      run the binary directly and rely on the host glibc.
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+export APPDIR="$HERE"
+LIBDIR="$HERE/usr/lib"
+
+export QT_PLUGIN_PATH="$HERE/usr/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
+
+BIN=VC3D
+if [ -n "${ARGV0:-}" ]; then
+    cand="$(basename "$ARGV0")"
+    if [ "$cand" != "AppRun" ] && [ -x "$HERE/usr/bin/$cand" ]; then
+        BIN="$cand"
+    fi
+fi
+
+LOADER="$LIBDIR/ld-linux-x86-64.so.2"
+if [ -e "$LOADER" ]; then
+    # glibc-bundle mode: charset modules + resolve NSS/glibc satellites and
+    # dlopened Qt-plugin deps from our own libs.
+    export GCONV_PATH="$LIBDIR/gconv"
+    export LD_LIBRARY_PATH="$LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    exec "$LOADER" --library-path "$LIBDIR" "$HERE/usr/bin/$BIN" "$@"
+else
+    exec "$HERE/usr/bin/$BIN" "$@"
+fi

--- a/volume-cartographer/scripts/appimage/README.md
+++ b/volume-cartographer/scripts/appimage/README.md
@@ -87,6 +87,46 @@ when double-clicked from a desktop (no terminal attached).
 On systems without FUSE, prefix with `APPIMAGE_EXTRACT_AND_RUN=1` or install
 `libfuse2`.
 
+## Prerequisites (what the host must provide)
+
+The AppImage bundles glibc + the loader, Qt, OpenCV, Ceres, and the whole
+`vc_*` closure. It deliberately does **not** bundle the GPU/graphics stack or
+the font libraries (linuxdeploy's excludelist) — those are driver-coupled or
+version-sensitive and are present on every desktop. The host must provide:
+
+- **OpenGL (glvnd + a driver)** — `libGLX.so.0`, `libEGL.so.1`, `libOpenGL.so.0`
+  (Debian/Ubuntu: `libglvnd0 libglx0 libegl1 libopengl0 libgl1`) plus a driver
+  (`libgl1-mesa-dri libglx-mesa0`, or the vendor driver).
+- **X11 client libs** — `libX11.so.6`, `libX11-xcb.so.1`, `libxcb.so.1`,
+  `libICE.so.6`, `libSM.so.6` (`libx11-6 libx11-xcb1 libxcb1 libice6 libsm6`).
+- **Fonts / text shaping** — `libfontconfig.so.1`, `libfreetype.so.6`,
+  `libharfbuzz.so.0` (`libfontconfig1 libfreetype6 libharfbuzz0b`).
+- **Ubiquitous base libs** (already on essentially every system) —
+  `libexpat1 zlib1g libuuid1 libcom-err2 libgmp10 libgpg-error0`.
+
+On any normal Linux **desktop** these are all already installed; the list
+matters only for minimal/headless/container environments.
+
+### CLI tools vs. the GUI
+
+`vc_core` links Qt6::Gui, so every binary (CLI included) needs the libraries
+above to be *present* — but the CLI tools don't open a display and tolerate old
+versions. The GUI additionally needs a running display server (X, or Wayland via
+XWayland/xcb) and a **recent FreeType** (`FT_Get_Paint`, FreeType ≥ 2.11).
+
+Tested (glibc is bundled, so it's never the limit):
+
+| Distro | glibc | FreeType | CLI tools | GUI |
+| --- | --- | --- | --- | --- |
+| Ubuntu 24.04 | 2.39 | 2.13 | ✅ | ✅ |
+| Ubuntu 22.04 | 2.35 | 2.11 | ✅ | ✅ |
+| Ubuntu 20.04 | 2.31 | 2.10 | ✅ | ❌ `undefined symbol: FT_Get_Paint` |
+
+**Effective floor:** CLI → glibc 2.31+ (Ubuntu 20.04+); GUI → FreeType 2.11+
+(Ubuntu 22.04+, Debian 12+, Fedora 36+). Bundling `libfreetype`+`libharfbuzz`
+would lower the GUI floor to match the CLI, at the cost of using host font
+config — left to the host by default here.
+
 ## Size
 
 The Release build carries full DWARF debug info (VC3D alone is ~490 MB

--- a/volume-cartographer/scripts/appimage/README.md
+++ b/volume-cartographer/scripts/appimage/README.md
@@ -1,0 +1,103 @@
+# Linux AppImage packaging
+
+Bundles VC3D (the GUI) plus all ~35 `vc_*` command-line tools into a single
+relocatable `VC3D-x86_64.AppImage`.
+
+**Runs on old distros.** The build image (Ubuntu 26.04) ships a very new glibc
+(2.43). glibc is backward- but not forward-compatible, so a binary built there
+would refuse to start on anything older (`version 'GLIBC_2.43' not found`). To
+avoid that, the packaging **bundles glibc + the dynamic loader** (plus
+`libstdc++`, `gconv` charset modules, and NSS libs) and launches the app through
+the bundled loader, so the host's glibc is never used. The result runs on
+essentially any modern Linux (validated on glibc 2.42; works well below that).
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `../build_appimage.sh` | Core packaging logic (shared source of truth): install the `vc_runtime` component → `linuxdeploy` + `linuxdeploy-plugin-qt` (Qt libs, platform/xcb plugin, all shared-lib deps) → bundle glibc/loader → `appimagetool`. |
+| `../Dockerfile.appimage` | Clean-room reproducible build on the CI builder image. |
+| `VC3D.desktop` | Desktop entry (menu name, icon, categories). |
+| `AppRun` | Entry point. Sets `QT_PLUGIN_PATH`, launches via the bundled loader, and dispatches the GUI or a CLI tool by symlink name (see below). |
+
+The AppImage icon reuses the GUI window icon (`apps/VC3D/logo.png`).
+
+> Note on tooling: `linuxdeploy-plugin-qt` handles the Qt bundle because the Qt
+> platform plugin (`libqxcb.so`) and its X11/xcb dependency tree are `dlopen`ed
+> at runtime — a link-scan bundler (e.g. sharun) misses them. The glibc/loader
+> bundling on top is the same technique sharun uses, applied to that AppDir.
+
+## Build
+
+### Reproducible (Docker, recommended for releases)
+
+Writes `dist/VC3D-x86_64.AppImage` on the host:
+
+```bash
+docker build -o type=local,dest=dist -f scripts/Dockerfile.appimage .
+# against the local dev builder image instead of ghcr:
+docker build -o type=local,dest=dist -f scripts/Dockerfile.appimage \
+  --build-arg BUILDER_IMAGE=vc-builder:dev .
+```
+
+### From an existing local build
+
+Needs a completed build (default preset `ci-release-gcc`) plus `qt6-base-dev`
+(`qmake6`) and `patchelf`:
+
+```bash
+cmake --preset ci-release-gcc
+cmake --build --preset ci-release-gcc
+scripts/build_appimage.sh          # -> dist/VC3D-x86_64.AppImage
+```
+
+Set `BUNDLE_GLIBC=0` to skip glibc bundling (smaller image, but then it only
+runs on hosts whose glibc is at least as new as the build machine's).
+
+## Running
+
+```bash
+./VC3D-x86_64.AppImage             # launches the GUI
+
+# Run any bundled CLI tool by symlinking the AppImage to its name:
+ln -s VC3D-x86_64.AppImage vc_obj2tifxyz
+./vc_obj2tifxyz in.obj out/        # runs the vc_obj2tifxyz binary
+```
+
+On systems without FUSE, prefix with `APPIMAGE_EXTRACT_AND_RUN=1` or install
+`libfuse2`.
+
+## Size
+
+The Release build carries full DWARF debug info (VC3D alone is ~490 MB
+unstripped), so packaging **strips** the binaries and, by default, extracts the
+symbols into a separate companion. Two artifacts result:
+
+| Artifact | Size | Notes |
+| --- | --- | --- |
+| `VC3D-x86_64.AppImage` | **~116 MB** | Minified download. |
+| `VC3D-x86_64-debug.tar.zst` | ~375 MB | Split-out debug symbols, linked to the stripped binaries via `.gnu_debuglink` — keep it around to symbolize crash reports / run under gdb. |
+
+Set `DEBUG_BUNDLE=0` to skip the companion, or `STRIP_FLAGS=` to ship an
+unstripped AppImage instead.
+
+Two size levers are applied by default:
+- **Strip + split debug info.** The Release build carries full DWARF (VC3D alone
+  is ~490 MB unstripped); stripping reclaims it into the companion above.
+- **`EXCLUDE_TOOLS`.** `vc_render_video` and `vc_diffuse_winding` are dropped from
+  the AppImage — they are the only binaries that pull the ~87 MB
+  `opencv_videoio` → ffmpeg codec chain (x265/codec2/aom/SvtAv1/…), and neither
+  is used by any pipeline. They remain in the Docker image. Set `EXCLUDE_TOOLS=`
+  to keep them (adds ~45 MB to the download).
+
+Where the ~116 MB goes (uncompressed AppDir ~354 MB, zstd-squashed): binaries
+are ~25 MB after stripping — the rest is genuinely-used shared libraries. The
+largest are all real dependencies: OpenBLAS (numerics), the OpenCV **GDAL** chain
+(`libopencv_imgcodecs` hard-links `libgdal` for image I/O), ICU (Qt), and Qt
+itself. Compression is already zstd and near its floor (xz is unsupported by the
+bundled mksquashfs and too slow to mount anyway; zstd level 22 saves <1 MB).
+
+The one sizeable lever left needs a build-level change, not a packaging tweak:
+rebuild OpenCV with `-DWITH_GDAL=OFF` → drops the ~56 MB GDAL chain (VC only
+needs tiff/png/jpg, which imgcodecs handles without GDAL). That requires a
+source OpenCV build in the builder image, so it's out of scope here.

--- a/volume-cartographer/scripts/appimage/README.md
+++ b/volume-cartographer/scripts/appimage/README.md
@@ -56,13 +56,33 @@ runs on hosts whose glibc is at least as new as the build machine's).
 
 ## Running
 
-```bash
-./VC3D-x86_64.AppImage             # launches the GUI
+The AppImage is a multitool: the first argument selects the GUI (`VC3D`) or any
+bundled CLI tool.
 
-# Run any bundled CLI tool by symlinking the AppImage to its name:
-ln -s VC3D-x86_64.AppImage vc_obj2tifxyz
-./vc_obj2tifxyz in.obj out/        # runs the vc_obj2tifxyz binary
+```bash
+./VC3D-x86_64.AppImage VC3D                   # launch the GUI
+./VC3D-x86_64.AppImage VC3D --cache-size 20   # GUI with options
+./VC3D-x86_64.AppImage vc_obj2tifxyz in.obj out/   # run a CLI tool
+./VC3D-x86_64.AppImage list                   # list the bundled tools
+./VC3D-x86_64.AppImage help                   # usage
 ```
+
+A short `vc` symlink makes it ergonomic; each tool can also be a symlink of its
+own:
+
+```bash
+ln -s VC3D-x86_64.AppImage vc
+./vc vc_obj2tifxyz in.obj out/
+./vc VC3D                                     # GUI
+
+ln -s VC3D-x86_64.AppImage vc_obj2tifxyz      # named-link dispatch
+./vc_obj2tifxyz in.obj out/
+```
+
+Selection is explicit: a bare option (`./VC3D-x86_64.AppImage --cache-size 20`)
+is rejected — pass it through a tool (`... VC3D --cache-size 20`). Running the
+AppImage with no arguments shows this usage in a terminal, and launches the GUI
+when double-clicked from a desktop (no terminal attached).
 
 On systems without FUSE, prefix with `APPIMAGE_EXTRACT_AND_RUN=1` or install
 `libfuse2`.

--- a/volume-cartographer/scripts/appimage/VC3D.desktop
+++ b/volume-cartographer/scripts/appimage/VC3D.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Volume Cartographer 3D
+GenericName=Volumetric Editor
+Comment=Volumetric processing and segmentation toolkit
+Exec=VC3D
+Icon=VC3D
+Categories=Graphics;Science;Education;
+Terminal=false
+StartupWMClass=VC3D

--- a/volume-cartographer/scripts/build_appimage.sh
+++ b/volume-cartographer/scripts/build_appimage.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# build_appimage.sh — package an already-built VC3D tree into a Linux AppImage.
+#
+# Single source of truth for AppImage packaging, shared by
+# scripts/Dockerfile.appimage (clean-room reproducible build) and by anyone
+# packaging a local build tree.
+#
+# Pipeline:
+#   1. install the vc_runtime component into an AppDir
+#   2. add the desktop entry + icon
+#   3. linuxdeploy + linuxdeploy-plugin-qt: bundle Qt (libs, platform/xcb
+#      plugin, imageformats, ...) and every other shared-lib dependency
+#   4. (default) bundle glibc + the dynamic loader + libstdc++/libgcc + gconv +
+#      NSS, and launch through the bundled loader (see scripts/appimage/AppRun).
+#      This is what lets the AppImage run on distros OLDER than the build box —
+#      glibc is backward- but not forward-compatible, and the build image
+#      (Ubuntu 26.04) ships a very new glibc. Disable with BUNDLE_GLIBC=0.
+#   5. appimagetool: squash the AppDir into VC3D-<arch>.AppImage
+#
+# Prereqs: a completed build (default preset ci-release-gcc), qt6-base-dev
+# (qmake6), and patchelf. Tools (linuxdeploy, the qt plugin, appimagetool) are
+# downloaded on first run and cached under $TOOLS_DIR.
+#
+# Usage:
+#   scripts/build_appimage.sh
+#   BUILD_DIR=build/ci-release-gcc OUT_DIR=dist scripts/build_appimage.sh
+#
+# Env overrides:
+#   BUILD_DIR     CMake build tree to install from (default build/ci-release-gcc)
+#   OUT_DIR       Where the .AppImage is written                (default dist)
+#   APPDIR        Staging AppDir                     (default $BUILD_DIR/AppDir)
+#   TOOLS_DIR     Tool cache                        (default $BUILD_DIR/.appimage-tools)
+#   STRIP_FLAGS   strip mode for VC's own binaries/libs   (default --strip-debug;
+#                 the Release build still carries DWARF — this reclaims ~490MB
+#                 from VC3D alone. --strip-debug keeps .symtab so the crash
+#                 handler can still symbolize; use '--strip-unneeded' for the
+#                 smallest result, or STRIP_FLAGS= to skip.)
+#   DEBUG_BUNDLE  Also emit a VC3D-<arch>-debug.tar.* with the split-out debug
+#                 symbols (linked to the stripped binaries via debuglink, so
+#                 crash reports stay symbolizable). 1/0, default 1. Ignored when
+#                 STRIP_FLAGS is empty.
+#   QMAKE         Path to qmake6                              (default: autodetect)
+#   ARCH          Target architecture                        (default: uname -m)
+#   BUNDLE_GLIBC  Bundle glibc for old-distro support (1/0)   (default 1)
+#   GLIBC_SRCDIR  Where to copy glibc libs from  (default /usr/lib/<arch>-linux-gnu)
+#   EXCLUDE_TOOLS Space-separated executables to drop from the AppImage before
+#                 dependency bundling. Default drops the two video tools
+#                 (vc_render_video, vc_diffuse_winding) — the only things that
+#                 pull the ~87MB opencv_videoio/ffmpeg chain. Set EXCLUDE_TOOLS=
+#                 to keep everything. (Excluded tools remain in the Docker image.)
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/.." && pwd)"
+
+ARCH="${ARCH:-$(uname -m)}"
+BUILD_DIR="${BUILD_DIR:-$repo_root/build/ci-release-gcc}"
+OUT_DIR="${OUT_DIR:-$repo_root/dist}"
+APPDIR="${APPDIR:-$BUILD_DIR/AppDir}"
+TOOLS_DIR="${TOOLS_DIR:-$BUILD_DIR/.appimage-tools}"
+QMAKE="${QMAKE:-$(command -v qmake6 || command -v qmake || true)}"
+BUNDLE_GLIBC="${BUNDLE_GLIBC:-1}"
+GLIBC_SRCDIR="${GLIBC_SRCDIR:-/usr/lib/${ARCH}-linux-gnu}"
+EXCLUDE_TOOLS="${EXCLUDE_TOOLS-vc_render_video vc_diffuse_winding}"
+STRIP_FLAGS="${STRIP_FLAGS---strip-debug}"   # unset (STRIP_FLAGS=) to skip
+DEBUG_BUNDLE="${DEBUG_BUNDLE:-1}"            # also emit VC3D-<arch>-debug.tar.* companion
+
+[ -d "$BUILD_DIR" ] || { echo "error: build dir '$BUILD_DIR' not found — configure & build first" >&2; exit 1; }
+[ -n "$QMAKE" ]     || { echo "error: qmake6 not found — install qt6-base-dev (or set QMAKE=...)" >&2; exit 1; }
+command -v patchelf >/dev/null || { echo "error: patchelf not found (apt install patchelf)" >&2; exit 1; }
+if [ "$BUNDLE_GLIBC" = 1 ] && [ "$ARCH" != x86_64 ]; then
+    echo "error: glibc bundling here only handles x86_64 (set BUNDLE_GLIBC=0)" >&2; exit 1
+fi
+
+# linuxdeploy / appimagetool can't use FUSE in most containers; extract-and-run
+# makes every nested AppImage self-extract.
+export APPIMAGE_EXTRACT_AND_RUN=1
+export QMAKE
+
+echo "==> Staging install tree into $APPDIR"
+rm -rf "$APPDIR"
+cmake --install "$BUILD_DIR" --prefix "$APPDIR/usr" --component vc_runtime
+
+if [ -n "$EXCLUDE_TOOLS" ]; then
+    echo "==> Excluding tools from the AppImage: $EXCLUDE_TOOLS"
+    for t in $EXCLUDE_TOOLS; do
+        rm -fv "$APPDIR/usr/bin/$t"
+    done
+fi
+
+echo "==> Adding desktop entry and icon"
+install -Dm644 "$here/appimage/VC3D.desktop" "$APPDIR/usr/share/applications/VC3D.desktop"
+# The GUI's window icon (apps/VC3D/logo.png, 128x128) doubles as the AppImage
+# icon; its basename must match the desktop file's Icon= key (VC3D).
+install -Dm644 "$repo_root/apps/VC3D/logo.png" \
+    "$APPDIR/usr/share/icons/hicolor/128x128/apps/VC3D.png"
+
+echo "==> Fetching packaging tools into $TOOLS_DIR"
+mkdir -p "$TOOLS_DIR"
+fetch() { # url dest
+    if [ ! -x "$TOOLS_DIR/$2" ]; then
+        curl -fsSL -o "$TOOLS_DIR/$2" "$1"
+        chmod +x "$TOOLS_DIR/$2"
+    fi
+}
+ldbase="https://github.com/linuxdeploy"
+fetch "$ldbase/linuxdeploy/releases/download/continuous/linuxdeploy-$ARCH.AppImage" "linuxdeploy-$ARCH.AppImage"
+fetch "$ldbase/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-$ARCH.AppImage" "linuxdeploy-plugin-qt-$ARCH.AppImage"
+fetch "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$ARCH.AppImage" "appimagetool-$ARCH.AppImage"
+# linuxdeploy discovers plugins named `linuxdeploy-plugin-<name>` on PATH.
+export PATH="$TOOLS_DIR:$PATH"
+
+echo "==> Bundling Qt + shared-lib dependencies (linuxdeploy)"
+"$TOOLS_DIR/linuxdeploy-$ARCH.AppImage" --appdir "$APPDIR" --plugin qt
+
+if [ "$BUNDLE_GLIBC" = 1 ]; then
+    echo "==> Bundling glibc + loader (for old-distro compatibility)"
+    libdir="$APPDIR/usr/lib"
+    loader="$(patchelf --print-interpreter "$APPDIR/usr/bin/VC3D")"
+    cp -Lv "$loader" "$libdir/"
+    # glibc runtime family + libstdc++/libgcc (all excluded by linuxdeploy),
+    # plus the NSS modules glibc dlopens for host/user lookups.
+    for l in libc.so.6 libm.so.6 libmvec.so.1 libdl.so.2 libpthread.so.0 \
+             librt.so.1 libresolv.so.2 libutil.so.1 libanl.so.1 \
+             libBrokenLocale.so.1 libnss_files.so.2 libnss_dns.so.2 \
+             libnss_compat.so.2 libstdc++.so.6 libgcc_s.so.1; do
+        if [ -e "$GLIBC_SRCDIR/$l" ]; then
+            cp -Lv "$GLIBC_SRCDIR/$l" "$libdir/"
+        else
+            echo "   (skip missing $l)"
+        fi
+    done
+    # charset conversion modules (iconv) — glibc loads these from GCONV_PATH.
+    [ -d "$GLIBC_SRCDIR/gconv" ] && cp -a "$GLIBC_SRCDIR/gconv" "$libdir/gconv"
+    # offscreen QPA plugin — lets headless CLI tools / CI init Qt without a display.
+    qpd="$("$QMAKE" -query QT_INSTALL_PLUGINS)"
+    [ -e "$qpd/platforms/libqoffscreen.so" ] && \
+        cp -Lv "$qpd/platforms/libqoffscreen.so" "$APPDIR/usr/plugins/platforms/"
+fi
+
+if [ -n "$STRIP_FLAGS" ]; then
+    before=$(du -sm "$APPDIR" | cut -f1)
+    dbgstage=""
+    if [ "$DEBUG_BUNDLE" = 1 ]; then
+        echo "==> Stripping ($STRIP_FLAGS) + extracting debug symbols into a companion bundle"
+        dbgstage="$BUILD_DIR/.appimage-debug"; rm -rf "$dbgstage"
+    else
+        echo "==> Stripping binaries and libraries ($STRIP_FLAGS)"
+    fi
+    # Everything except the bundled dynamic loader (never strip ld-linux).
+    while IFS= read -r -d '' f; do
+        case "$(basename "$f")" in ld-linux-*) continue ;; esac
+        # Split debug info out to a companion .debug (linked via debuglink) only
+        # for files that actually carry it — skip already-stripped system libs.
+        if [ -n "$dbgstage" ] && readelf -SW "$f" 2>/dev/null | grep -q '\.debug_info'; then
+            rel="${f#"$APPDIR"/}"; dbg="$dbgstage/$rel.debug"
+            mkdir -p "$(dirname "$dbg")"
+            objcopy --only-keep-debug "$f" "$dbg" 2>/dev/null || true
+            strip $STRIP_FLAGS "$f" 2>/dev/null || true
+            objcopy --add-gnu-debuglink="$dbg" "$f" 2>/dev/null || true
+        else
+            strip $STRIP_FLAGS "$f" 2>/dev/null || true
+        fi
+    done < <(find "$APPDIR/usr/bin" "$APPDIR/usr/lib" "$APPDIR/usr/plugins" \
+                  -type f \( -name '*.so*' -o -perm -u+x \) -print0)
+    after=$(du -sm "$APPDIR" | cut -f1)
+    echo "    AppDir: ${before} MB -> ${after} MB"
+
+    if [ -n "$dbgstage" ] && [ -d "$dbgstage" ]; then
+        mkdir -p "$OUT_DIR"
+        if command -v zstd >/dev/null 2>&1; then
+            dbgout="$OUT_DIR/VC3D-$ARCH-debug.tar.zst"; tar -C "$dbgstage" --zstd -cf "$dbgout" .
+        else
+            dbgout="$OUT_DIR/VC3D-$ARCH-debug.tar.gz";  tar -C "$dbgstage" -czf "$dbgout" .
+        fi
+        echo "    Debug bundle: $dbgout ($(du -sh "$dbgout" | cut -f1))"
+    fi
+fi
+
+echo "==> Installing AppRun"
+install -m755 "$here/appimage/AppRun" "$APPDIR/AppRun"
+
+echo "==> Squashing AppImage (appimagetool)"
+mkdir -p "$OUT_DIR"
+out="$OUT_DIR/VC3D-$ARCH.AppImage"
+ARCH="$ARCH" "$TOOLS_DIR/appimagetool-$ARCH.AppImage" "$APPDIR" "$out"
+echo "==> Done: $out"


### PR DESCRIPTION
This builds a linux single file appimage that can be used to launch most of VC's tools from a single binary (this is a resurrection of an old VC AppImage build which I did in 2023). I excluded vc-diffuse-winding and vc-render-video to be able to exclude the video components).

Claude figured out some shenanigans to be able to build on Ubuntu 26.04 and include the glibc, so that the build also works on older Ubuntu, though not sure how reliable that is going to be.

The single binary has a multitool wrapper, so you can run the individual binaries with `<downloaded binary> VC3D` or `<downloaded binary> vc-render-tifxyz`. You can also create symlinks for the individual commands that will be automatically dispatched to the tool.