### PR TITLE
Fix default z_max initialization in vc_calc_surface_metrics

### DIFF
--- a/volume-cartographer/apps/src/vc_calc_surface_metrics.cpp
+++ b/volume-cartographer/apps/src/vc_calc_surface_metrics.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
     if (z_min == -1)
         z_min = (int)surface->bbox().low[2];
     if (z_max == -1)
-        z_min = (int)surface->bbox().high[2];
+        z_max = (int)surface->bbox().high[2];
 
     utils::Json metrics = calc_point_metrics(collection, surface.get(), z_min, z_max);
 


### PR DESCRIPTION
## Summary

When `--z_max` is left at its default value (`-1`), `vc_calc_surface_metrics`
initializes `z_min` twice instead of initializing `z_max`:

```cpp
if (z_min == -1)
    z_min = (int)surface->bbox().low[2];
if (z_max == -1)
    z_min = (int)surface->bbox().high[2];   // should be z_max
```

As a result, `z_max` remains `-1`.

## Effect

With the default CLI behavior (no explicit `--z_min`/`--z_max`), all points are
filtered out because the effective condition becomes:

```
p[2] >= bbox.high[2] && p[2] <= -1
```

which produces an empty metrics object.

Using the same surface (a published PHerc0172 segment) and point collection:

| invocation | result |
|---|---|
| default (no `--z_min`/`--z_max`) | `null` written to output |
| explicit `--z_min 0 --z_max <bbox_high>` | `{"in_surface_frac_valid": 1.0}` |

The only difference between the two runs is providing `--z_max` explicitly.

## Notes

`scripts/evaluation/eval_surface_tracer.py` normally receives `z_range` from its
configuration (`example_config.json` defines it), so this change only affects the
default CLI path and the usage shown in `docs/surface_metrics.md`.

While investigating this I also observed that invoking the tool with `--winding`
after an empty metrics result leads to `json::update()` throwing. I left that out
of this PR to keep the fix focused.