### PR TITLE
spiral: configure setuptools packaging so editable install works

### DIFF
--- a/volume-cartographer/scripts/spiral/pyproject.toml
+++ b/volume-cartographer/scripts/spiral/pyproject.toml
@@ -26,3 +26,10 @@ dependencies = [
     "wandb>=0.28.0",
     "zarr>=3.2.1",
 ]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = []


### PR DESCRIPTION
**Problem:** The install command documented in the [spiral tutorial](https://scrollprize.org/tutorial_spiral) fails on any recent setuptools:

    $ uv pip install -e scripts/spiral
    error: Multiple top-level modules discovered in a flat-layout: ['tracks', 'sample_spiral', 'geom_utils', ...]

**Cause:** `scripts/spiral/pyproject.toml` declares no build backend or package-discovery config, so setuptools' legacy backend refuses the flat layout with 25 top-level modules.

**Fix:** declare the setuptools backend and set `py-modules = []`. The editable install then just registers the declared dependencies — matching how the scripts are actually run (in-place from the directory).

**Tested:** Python 3.14.5 + uv on Linux Mint — the same command fails before the change and succeeds after; all dependencies resolve and import (`kornia`, `zarr`, `pyro`, `kimimaro`, ...).