### PR TITLE
vc_sync: rclone parallel transfers, upload validation, hfsync subcommand

### DIFF
--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -687,7 +687,14 @@ class S3SyncManager:
         ok = self._run_rclone(['copy', self.local_dir, self._rclone_remote()],
                               list(pre_stats))
         if not ok:
-            print("  ⚠️  rclone reported errors during upload; verifying what was transferred")
+            # Don't advance tracking on a partial failure: a same-size stale
+            # remote object would pass the size check below and the file would
+            # then be recorded as in sync, permanently skipping the re-upload.
+            # Leaving tracking unchanged re-schedules every file next sync;
+            # rclone skips the ones that did transfer, so the retry is cheap.
+            print(f"  ❌ rclone reported errors during upload; tracking left "
+                  f"unchanged for all {len(pre_stats)} files, will retry on next sync")
+            return 0
 
         for path, (size, mtime) in pre_stats.items():
             try:
@@ -727,7 +734,12 @@ class S3SyncManager:
         print(f"  Downloading {len(paths)} files ({self.RCLONE_TRANSFERS} parallel transfers)...")
         ok = self._run_rclone(['copy', self._rclone_remote(), self.local_dir], paths)
         if not ok:
-            print("  ⚠️  rclone reported errors during download; verifying what was transferred")
+            # Mirror of the upload case: a same-size stale local file would
+            # pass the size check and be recorded as in sync with the new
+            # remote ETag, permanently skipping the re-download
+            print(f"  ❌ rclone reported errors during download; tracking left "
+                  f"unchanged for all {len(paths)} files, will retry on next sync")
+            return 0
 
         success_count = 0
         with self._get_db() as conn:

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -2,6 +2,12 @@
 """
 AWS S3 Interactive Sync Tool with Conflict Resolution
 
+Transfers run through rclone (parallel, one process per batch) when the rclone
+binary is available, and fall back to serial per-file aws CLI calls otherwise.
+Neither path needs an rclone config file: credentials come from the standard
+AWS credential chain (env vars pasted into the terminal, ~/.aws/credentials,
+or EC2 instance roles).
+
 Automatically ignores:
 - Hidden files and directories (starting with .)
 - Any directory containing 'layers' in its name (e.g., layers/, layers_fullres/, old_layers/)
@@ -15,18 +21,35 @@ Usage:
     python s3_sync.py sync <directory> [--dry-run] [--sync-backups]
     python s3_sync.py update <directory> [--sync-backups]
     python s3_sync.py reset <directory> [--sync-backups]
+    python s3_sync.py hfsync <directory> [--dry-run]
+
+Hugging Face sync (hfsync):
+    Pushes fiber JSONs carrying a given tag to a Hugging Face storage bucket.
+    Opt-in per directory: it only runs where a .hfsync.json exists next to the
+    data (the file is never synced to S3 and should not be committed anywhere):
+
+        {
+          "hf_bucket_path": "hf://buckets/<org>/<bucket>/<path>",
+          "hf_cli": "/path/to/hf",          # optional, defaults to hf on PATH
+          "tag": "reviewed"                 # optional, defaults to "reviewed"
+        }
+
+    Authentication uses the token stored by `hf auth login`; no credentials
+    are read from or written to this script or its config. Upload is additive
+    and skips unchanged files; a remote file is only removed when the same
+    filename exists locally WITHOUT the tag. Files that exist only remotely
+    are never touched.
 """
 
 import os
 import sys
 import json
-import csv
-import tempfile
+import shutil
 import sqlite3
 import argparse
+import tempfile
 import subprocess
-from datetime import datetime, timezone
-from pathlib import Path
+from datetime import datetime
 from enum import Enum
 from contextlib import contextmanager
 
@@ -39,11 +62,6 @@ BACKUP_PATTERNS = [
     '_bak',
     '.bak',
 ]
-
-# Report configuration
-REPORT_S3_BUCKET = "philodemos"
-REPORT_S3_PREFIX = "david/reports"
-
 
 class SyncAction(Enum):
     UPLOAD = "upload"
@@ -60,6 +78,10 @@ def is_backup_file(filename):
 
 
 class S3SyncManager:
+    # Parallel transfer settings for the rclone fast path
+    RCLONE_TRANSFERS = 16
+    RCLONE_CHECKERS = 32
+
     def __init__(self, local_dir, s3_bucket=None, s3_prefix=None,
                  aws_profile=None):
         self.local_dir = os.path.abspath(local_dir)
@@ -83,6 +105,37 @@ class S3SyncManager:
 
         # Initialize database
         self._init_db()
+
+        self.use_rclone = self._detect_rclone()
+
+    def _detect_rclone(self):
+        """Use rclone only if the binary exists AND can read the sync directory.
+
+        Sandboxed installs (e.g. the Ubuntu snap) may lack access to some
+        paths — a snap without the removable-media interface cannot read
+        /media, for instance. Probing the actual sync dir catches that.
+
+        Sets self.rclone_unavailable_reason when returning False.
+        """
+        self.rclone_unavailable_reason = None
+
+        if not shutil.which('rclone'):
+            self.rclone_unavailable_reason = "rclone binary not found on PATH"
+            return False
+
+        result = subprocess.run(
+            ['rclone', 'lsf', self.local_dir, '--max-depth', '1'],
+            capture_output=True, text=True)
+        if result.returncode != 0:
+            detail_lines = (result.stderr or '').strip().splitlines()
+            detail = detail_lines[-1] if detail_lines else "unknown error"
+            self.rclone_unavailable_reason = (
+                f"rclone cannot read {self.local_dir} "
+                f"(sandboxed install? a snap needs its home/removable-media "
+                f"interfaces connected): {detail}")
+            return False
+
+        return True
 
     def _load_config(self):
         """Load configuration from JSON file"""
@@ -225,11 +278,14 @@ class S3SyncManager:
         continuation_token = None
         page_count = 0
 
+        # Trailing slash keeps sibling prefixes (e.g. "<prefix>_old") out of the listing
+        list_prefix = f"{self.s3_prefix}/" if self.s3_prefix else ""
+
         while True:
             cmd = [
                 'aws', 's3api', 'list-objects-v2',
                 '--bucket', self.s3_bucket,
-                '--prefix', self.s3_prefix
+                '--prefix', list_prefix
             ]
 
             if continuation_token:
@@ -248,14 +304,12 @@ class S3SyncManager:
                     print("No files found in S3")
                 break
 
-            prefix_len = len(self.s3_prefix) + 1 if self.s3_prefix else 0
-
             for obj in data['Contents']:
                 # Skip if it's just the prefix itself
-                if obj['Key'] == self.s3_prefix + '/':
+                if obj['Key'] == list_prefix:
                     continue
 
-                relative_path = obj['Key'][prefix_len:]
+                relative_path = obj['Key'][len(list_prefix):]
 
                 # Skip hidden files
                 filename = os.path.basename(relative_path)
@@ -295,219 +349,6 @@ class S3SyncManager:
 
         print(f"Found {len(files)} S3 files")
         return files
-
-    def _get_report_csv_path(self, suffix=""):
-        """Return the S3 URL and filename for the report based on the volume package name"""
-        pkg_name = Path(self.local_dir).resolve().parent.name
-        if pkg_name.endswith(".volpkg"):
-            pkg_name = pkg_name[:-7]
-        filename = f"{pkg_name}{suffix}.csv"
-        return f"s3://{REPORT_S3_BUCKET}/{REPORT_S3_PREFIX}/{filename}", filename
-
-    def _get_segment_name(self, root, meta_data):
-        """Resolve segment name from meta.json contents or directory name"""
-        return meta_data.get('uuid', os.path.basename(root))
-
-    def _get_volume_voxel_size(self):
-        """Find voxel size from volumes/*/meta.json"""
-        volumes_dir = Path(self.local_dir).resolve().parent / "volumes"
-        if not volumes_dir.exists():
-            return None
-
-        for root, dirs, filenames in os.walk(volumes_dir):
-            if 'meta.json' not in filenames:
-                continue
-            meta_path = os.path.join(root, 'meta.json')
-            try:
-                with open(meta_path, 'r') as f:
-                    meta_data = json.load(f)
-                voxel_size = meta_data.get('voxelsize')
-            except (json.JSONDecodeError, OSError):
-                continue
-
-            if isinstance(voxel_size, (list, tuple)) and voxel_size:
-                voxel_size = voxel_size[0]
-
-            try:
-                return float(voxel_size)
-            except (TypeError, ValueError):
-                continue
-
-        return None
-
-    def _count_non_black_pixels(self, image_path):
-        """Count non-black pixels in an image file"""
-        try:
-            from PIL import Image
-        except ImportError:
-            print("  Warning: Pillow is required to read approval.tif files")
-            return None
-
-        try:
-            with Image.open(image_path) as img:
-                data = img.getdata()
-                if img.mode in ("1", "L", "I", "I;16", "F"):
-                    return sum(1 for p in data if p != 0)
-
-                count = 0
-                for p in data:
-                    if isinstance(p, int):
-                        if p != 0:
-                            count += 1
-                    else:
-                        if any(channel != 0 for channel in p[:3]):
-                            count += 1
-                return count
-        except Exception as e:
-            print(f"  Warning: Could not read {image_path}: {e}")
-            return None
-
-    def _collect_segment_areas(self):
-        """Collect segment names and area_cm2 values from meta.json files"""
-        segments = {}
-        for root, dirs, filenames in os.walk(self.local_dir):
-            dirs[:] = [d for d in dirs if not d.startswith('.') and 'layers' not in d.lower() and d != 'backups']
-            if 'meta.json' in filenames:
-                meta_path = os.path.join(root, 'meta.json')
-                try:
-                    with open(meta_path, 'r') as f:
-                        meta_data = json.load(f)
-                    segment_name = self._get_segment_name(root, meta_data)
-                    area_cm2 = meta_data.get('area_cm2', 0.0)
-                    segments[segment_name] = area_cm2
-                except (json.JSONDecodeError, OSError) as e:
-                    print(f"  Warning: Could not read {meta_path}: {e}")
-                    continue
-        return segments
-
-    def _collect_approval_areas(self):
-        """Collect segment names and approval areas from approval.tif files"""
-        voxel_size = self._get_volume_voxel_size()
-        if voxel_size is None:
-            return {}
-        pixel_area = (20 * voxel_size / 10000) ** 2
-
-        segments = {}
-        for root, dirs, filenames in os.walk(self.local_dir):
-            dirs[:] = [d for d in dirs if not d.startswith('.') and 'layers' not in d.lower() and d != 'backups']
-            if 'meta.json' in filenames:
-                meta_path = os.path.join(root, 'meta.json')
-                try:
-                    with open(meta_path, 'r') as f:
-                        meta_data = json.load(f)
-                    segment_name = self._get_segment_name(root, meta_data)
-                except (json.JSONDecodeError, OSError) as e:
-                    print(f"  Warning: Could not read {meta_path}: {e}")
-                    continue
-
-                approval_path = os.path.join(root, 'approval.tif')
-                if os.path.exists(approval_path):
-                    pixel_count = self._count_non_black_pixels(approval_path)
-                    if pixel_count is None:
-                        continue
-                    segments[segment_name] = pixel_count * pixel_area
-                else:
-                    segments[segment_name] = 0.0
-
-        return segments
-
-    def _generate_report(self, current_segments, report_suffix):
-        """Generate or update a CSV report and upload to S3"""
-        s3_csv_path, report_filename = self._get_report_csv_path(report_suffix)
-        current_datetime = datetime.now().strftime("%Y%m%d%H%M%S")
-
-        if not current_segments:
-            return False
-
-        existing_data = {}
-        existing_datetimes = []
-
-        # Try to download existing CSV
-        download_tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
-        download_tmp_path = download_tmp.name
-        download_tmp.close()
-
-        try:
-            cmd = ['aws', 's3', 'cp', s3_csv_path, download_tmp_path]
-            if self.aws_profile:
-                cmd.extend(['--profile', self.aws_profile])
-            subprocess.run(cmd, capture_output=True, text=True, check=True)
-
-            with open(download_tmp_path, 'r', newline='') as f:
-                reader = csv.reader(f)
-                rows = list(reader)
-
-            if rows:
-                existing_datetimes = rows[0][1:] if len(rows[0]) > 1 else []
-                for row in rows[1:]:
-                    if not row:
-                        continue
-                    segment_name = row[0]
-                    values = [float(val) if val else 0.0 for val in row[1:]]
-                    # Pad to header length if necessary
-                    if len(values) < len(existing_datetimes):
-                        values.extend([0.0] * (len(existing_datetimes) - len(values)))
-                    existing_data[segment_name] = values
-
-                pass
-        except subprocess.CalledProcessError:
-            pass
-        except Exception:
-            pass
-        finally:
-            try:
-                os.unlink(download_tmp_path)
-            except OSError:
-                pass
-
-        # Only include segments that currently exist (remove deleted segments)
-        all_segments = set(current_segments.keys())
-        header_row = ["Segment Name"] + existing_datetimes + [current_datetime]
-        csv_rows = [header_row]
-
-        for segment_name in sorted(all_segments):
-            row = [segment_name]
-            previous_values = existing_data.get(segment_name, [0.0] * len(existing_datetimes))
-            if len(previous_values) < len(existing_datetimes):
-                previous_values.extend([0.0] * (len(existing_datetimes) - len(previous_values)))
-            row.extend(previous_values)
-            row.append(current_segments.get(segment_name, 0.0))
-            csv_rows.append(row)
-
-        # Write new CSV
-        upload_tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
-        upload_tmp_path = upload_tmp.name
-        try:
-            with open(upload_tmp_path, 'w', newline='') as f:
-                writer = csv.writer(f)
-                writer.writerows(csv_rows)
-
-            cmd = ['aws', 's3', 'cp', upload_tmp_path, s3_csv_path]
-            if self.aws_profile:
-                cmd.extend(['--profile', self.aws_profile])
-            subprocess.run(cmd, check=True, capture_output=True)
-            return True
-        except subprocess.CalledProcessError as e:
-            return False
-        finally:
-            try:
-                os.unlink(upload_tmp_path)
-            except OSError:
-                pass
-
-    def generate_segment_report(self):
-        """Generate or update the segment area CSV report and upload to S3"""
-        print("\nGenerating reports...")
-        current_segments = self._collect_segment_areas()
-        segment_ok = self._generate_report(current_segments, "")
-
-        approval_segments = self._collect_approval_areas()
-        approval_ok = self._generate_report(approval_segments, "_approval")
-
-        if segment_ok and approval_ok:
-            print("✓ Reports uploaded")
-        else:
-            print("✗ At least one report failed")
 
     def update_files(self, include_backups=False):
         """Update file tracking with current state"""
@@ -666,10 +507,19 @@ class S3SyncManager:
         local_path = os.path.join(self.local_dir, path)
         s3_path = self._get_s3_url(path)
 
+        # Re-stat immediately before upload: interactive prompts can leave a long
+        # window between scan and upload, during which the file may have changed
+        pre_stat = os.stat(local_path)
+
         print(f"  Uploading: {path} → remote")
 
         cmd = ['aws', 's3', 'cp', local_path, s3_path]
         self._run_aws_command(cmd)
+
+        post_stat = os.stat(local_path)
+        if (post_stat.st_size, post_stat.st_mtime) != (pre_stat.st_size, pre_stat.st_mtime):
+            print(f"  ⚠️  {path} changed while it was being uploaded; "
+                  f"the S3 copy may be incomplete and will be re-uploaded on next sync")
 
         print(f"  ✓ Uploaded: {path}")
 
@@ -682,17 +532,18 @@ class S3SyncManager:
         s3_mtime = self._parse_timestamp(data['LastModified'])
         s3_etag = data.get('ETag', '').strip('"')
 
-        # Update database with actual local file info
+        # Track the pre-upload stats: if the file changed during upload, the next
+        # scan will see a local difference and schedule a re-upload
         with self._get_db() as conn:
             conn.execute('''
-                INSERT OR REPLACE INTO files 
+                INSERT OR REPLACE INTO files
                 (path, local_size, local_mtime, s3_size, s3_mtime, s3_etag)
                 VALUES (?, ?, ?, ?, ?, ?)
             ''', (
                 path,
-                local_files[path]['local_size'],
-                local_files[path]['local_mtime'],
-                local_files[path]['local_size'],
+                pre_stat.st_size,
+                pre_stat.st_mtime,
+                pre_stat.st_size,
                 s3_mtime,
                 s3_etag
             ))
@@ -770,6 +621,156 @@ class S3SyncManager:
 
         return True
 
+    def _rclone_remote(self):
+        """On-the-fly rclone remote for the S3 target (no rclone.conf needed).
+
+        env_auth=true uses the standard AWS credential chain, so this works
+        both with credentials pasted into the terminal (env vars) and with
+        EC2 instance roles — same sources as the aws CLI.
+        """
+        return f":s3,provider=AWS,env_auth=true,no_check_bucket=true:{self.s3_bucket}/{self.s3_prefix}"
+
+    def _rclone_env(self):
+        """Environment for rclone subprocesses, mirroring aws CLI credential/region config"""
+        env = os.environ.copy()
+        if self.aws_profile:
+            env['AWS_PROFILE'] = self.aws_profile
+        region = env.get('AWS_REGION') or env.get('AWS_DEFAULT_REGION')
+        if region:
+            env.setdefault('RCLONE_S3_REGION', region)
+        return env
+
+    def _run_rclone(self, args, paths):
+        """Run one rclone command over a --files-from list of relative paths"""
+        # The list file lives inside the sync dir (hidden, so scans skip it):
+        # sandboxed rclone installs (e.g. snap) often cannot read /tmp, but
+        # must be able to read the sync dir for transfers to work at all
+        with tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False,
+                                         dir=self.local_dir, prefix='.s3sync-files-') as f:
+            f.write('\n'.join(paths) + '\n')
+            list_path = f.name
+
+        cmd = ['rclone'] + args + [
+            '--files-from', list_path,
+            '--transfers', str(self.RCLONE_TRANSFERS),
+            '--checkers', str(self.RCLONE_CHECKERS),
+            '--stats-one-line', '--stats', '15s',
+        ]
+
+        try:
+            result = subprocess.run(cmd, env=self._rclone_env())
+            return result.returncode == 0
+        finally:
+            try:
+                os.unlink(list_path)
+            except OSError:
+                pass
+
+    def perform_uploads_batch(self, paths, include_backups=False):
+        """Upload files to S3 in one parallel rclone run and update tracking"""
+        if not paths:
+            return 0
+
+        # Stat immediately before the transfer so mid-upload changes are detectable
+        pre_stats = {}
+        for path in paths:
+            try:
+                stat = os.stat(os.path.join(self.local_dir, path))
+                pre_stats[path] = (stat.st_size, stat.st_mtime)
+            except OSError as e:
+                print(f"  ❌ Cannot read {path}: {e}")
+
+        if not pre_stats:
+            return 0
+
+        print(f"  Uploading {len(pre_stats)} files ({self.RCLONE_TRANSFERS} parallel transfers)...")
+        ok = self._run_rclone(['copy', self.local_dir, self._rclone_remote()],
+                              list(pre_stats))
+        if not ok:
+            print("  ⚠️  rclone reported errors during upload; verifying what was transferred")
+
+        for path, (size, mtime) in pre_stats.items():
+            try:
+                stat = os.stat(os.path.join(self.local_dir, path))
+                if (stat.st_size, stat.st_mtime) != (size, mtime):
+                    print(f"  ⚠️  {path} changed while it was being uploaded; "
+                          f"the S3 copy may be incomplete and will be re-uploaded on next sync")
+            except OSError:
+                print(f"  ⚠️  {path} disappeared during upload")
+
+        # One listing pass for fresh S3 metadata instead of a head-object per file
+        fresh_s3 = self.scan_s3_files(include_backups)
+
+        success_count = 0
+        with self._get_db() as conn:
+            for path, (size, mtime) in pre_stats.items():
+                s3_info = fresh_s3.get(path)
+                if not s3_info or s3_info['s3_size'] != size:
+                    print(f"  ❌ Upload not verified for {path}; will retry on next sync")
+                    continue
+                conn.execute('''
+                    INSERT OR REPLACE INTO files
+                    (path, local_size, local_mtime, s3_size, s3_mtime, s3_etag)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                ''', (path, size, mtime,
+                      s3_info['s3_size'], s3_info['s3_mtime'], s3_info.get('s3_etag')))
+                success_count += 1
+
+        print(f"  ✓ Uploaded {success_count}/{len(paths)} files")
+        return success_count
+
+    def perform_downloads_batch(self, paths, s3_files):
+        """Download files from S3 in one parallel rclone run and update tracking"""
+        if not paths:
+            return 0
+
+        print(f"  Downloading {len(paths)} files ({self.RCLONE_TRANSFERS} parallel transfers)...")
+        ok = self._run_rclone(['copy', self._rclone_remote(), self.local_dir], paths)
+        if not ok:
+            print("  ⚠️  rclone reported errors during download; verifying what was transferred")
+
+        success_count = 0
+        with self._get_db() as conn:
+            for path in paths:
+                local_path = os.path.join(self.local_dir, path)
+                try:
+                    stat = os.stat(local_path)
+                except OSError:
+                    print(f"  ❌ Download not verified for {path}; will retry on next sync")
+                    continue
+                if stat.st_size != s3_files[path]['s3_size']:
+                    print(f"  ❌ Size mismatch for {path}; will retry on next sync")
+                    continue
+                conn.execute('''
+                    INSERT OR REPLACE INTO files
+                    (path, local_size, local_mtime, s3_size, s3_mtime, s3_etag)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                ''', (path, stat.st_size, stat.st_mtime,
+                      s3_files[path]['s3_size'], s3_files[path]['s3_mtime'],
+                      s3_files[path].get('s3_etag')))
+                success_count += 1
+
+        print(f"  ✓ Downloaded {success_count}/{len(paths)} files")
+        return success_count
+
+    def perform_deletes_remote_batch(self, paths):
+        """Delete files from S3 in one rclone run and update tracking"""
+        if not paths:
+            return 0
+
+        print(f"  Deleting {len(paths)} files from S3...")
+        ok = self._run_rclone(['delete', self._rclone_remote()], paths)
+        if not ok:
+            print("  ❌ rclone reported errors during deletion; tracking left unchanged, will retry on next sync")
+            return 0
+
+        with self._get_db() as conn:
+            for path in paths:
+                conn.execute('DELETE FROM files WHERE path = ?', (path,))
+
+        print(f"  ✓ Deleted {len(paths)} files from S3")
+        return len(paths)
+
     def _print_file_preview(self, files, title, max_files=50):
         """Print preview of files to be processed"""
         if not files:
@@ -784,10 +785,34 @@ class S3SyncManager:
         if len(files) > max_files:
             print(f"  ... and {len(files) - max_files} more files")
 
+    def _validate_upload_candidates(self, paths):
+        """Flag zero-byte files and unparseable JSON among upload candidates"""
+        flagged = []
+        for path in paths:
+            local_path = os.path.join(self.local_dir, path)
+            try:
+                if os.path.getsize(local_path) == 0:
+                    flagged.append((path, "zero-byte file"))
+                    continue
+                if path.lower().endswith('.json'):
+                    with open(local_path, 'r') as f:
+                        json.load(f)
+            except json.JSONDecodeError as e:
+                flagged.append((path, f"unparseable JSON ({e.msg} at line {e.lineno})"))
+            except (OSError, UnicodeDecodeError) as e:
+                flagged.append((path, f"unreadable ({e})"))
+        return flagged
+
     def sync(self, dry_run=False, include_backups=False):
         """Perform interactive sync operation"""
         if not include_backups:
             print("Note: Ignoring backups/ directories (use --sync-backups to include them)")
+
+        if self.use_rclone:
+            print("Transfer backend: rclone (parallel transfers)")
+        else:
+            print("Transfer backend: aws CLI (serial)")
+            print(f"⚠️  rclone unavailable, syncs will be slower: {self.rclone_unavailable_reason}")
 
         print("\nAnalyzing changes...")
 
@@ -834,7 +859,14 @@ class S3SyncManager:
         self._print_file_preview(deletes_remote, "Files to Delete from S3")
         self._print_file_preview(conflicts, "Conflicts to Resolve")
 
+        # Flag suspect upload candidates (zero-byte files, unparseable JSON)
+        invalid_uploads = self._validate_upload_candidates([p for p, _ in uploads])
+
         if dry_run:
+            if invalid_uploads:
+                print(f"\n⚠️  {len(invalid_uploads)} upload candidate(s) look invalid:")
+                for path, problem in invalid_uploads:
+                    print(f"  {path}: {problem}")
             print("\n--dry-run mode: No changes will be made")
             return
 
@@ -848,6 +880,32 @@ class S3SyncManager:
             if action != SyncAction.SKIP:
                 resolved_actions.append((path, action))
 
+        # Let the user decide what to do with suspect upload candidates
+        invalid_uploads += self._validate_upload_candidates(
+            [p for p, a in resolved_actions if a == SyncAction.UPLOAD])
+
+        if invalid_uploads:
+            print(f"\n⚠️  {len(invalid_uploads)} upload candidate(s) look invalid:")
+            for path, problem in invalid_uploads:
+                print(f"  {path}: {problem}")
+
+            skip_paths = set()
+            for path, problem in invalid_uploads:
+                while True:
+                    response = input(f"\n{path} ({problem}) — [u]pload anyway, [s]kip? ").strip().lower()
+                    if response == 'u':
+                        break
+                    elif response == 's':
+                        skip_paths.add(path)
+                        break
+                    else:
+                        print("Invalid choice. Please enter 'u' or 's'.")
+
+            if skip_paths:
+                uploads = [(p, r) for p, r in uploads if p not in skip_paths]
+                resolved_actions = [(p, a) for p, a in resolved_actions if p not in skip_paths]
+                print(f"\nSkipping {len(skip_paths)} invalid file(s)")
+
         # Confirm before proceeding
         total_operations = (len(uploads) + len(downloads) + len(deletes_local) +
                             len(deletes_remote) + len(resolved_actions))
@@ -859,27 +917,41 @@ class S3SyncManager:
             print("Sync cancelled.")
             return
 
+        # Merge resolved conflicts into the main action lists
+        for path, action in resolved_actions:
+            if action == SyncAction.UPLOAD:
+                uploads.append((path, "Resolved conflict"))
+            elif action == SyncAction.DOWNLOAD:
+                downloads.append((path, "Resolved conflict"))
+            elif action == SyncAction.DELETE_LOCAL:
+                deletes_local.append((path, "Resolved conflict"))
+            elif action == SyncAction.DELETE_REMOTE:
+                deletes_remote.append((path, "Resolved conflict"))
+
         # Perform operations
         print("\nSyncing...")
         success_count = 0
 
-        # Process uploads
-        for path, reason in uploads:
-            try:
-                self.perform_upload(path, local_files)
-                success_count += 1
-            except Exception as e:
-                print(f"  ❌ Failed to upload {path}: {e}")
+        # Process uploads and downloads
+        if self.use_rclone:
+            success_count += self.perform_uploads_batch([p for p, _ in uploads], include_backups)
+            success_count += self.perform_downloads_batch([p for p, _ in downloads], s3_files)
+        else:
+            for path, reason in uploads:
+                try:
+                    self.perform_upload(path, local_files)
+                    success_count += 1
+                except Exception as e:
+                    print(f"  ❌ Failed to upload {path}: {e}")
 
-        # Process downloads
-        for path, reason in downloads:
-            try:
-                self.perform_download(path, s3_files)
-                success_count += 1
-            except Exception as e:
-                print(f"  ❌ Failed to download {path}: {e}")
+            for path, reason in downloads:
+                try:
+                    self.perform_download(path, s3_files)
+                    success_count += 1
+                except Exception as e:
+                    print(f"  ❌ Failed to download {path}: {e}")
 
-        # Process deletions
+        # Process local deletions (no network involved, always per-file)
         for path, reason in deletes_local:
             try:
                 self.perform_delete_local(path)
@@ -887,27 +959,16 @@ class S3SyncManager:
             except Exception as e:
                 print(f"  ❌ Failed to delete local {path}: {e}")
 
-        for path, reason in deletes_remote:
-            try:
-                self.perform_delete_remote(path)
-                success_count += 1
-            except Exception as e:
-                print(f"  ❌ Failed to delete remote {path}: {e}")
-
-        # Process resolved conflicts
-        for path, action in resolved_actions:
-            try:
-                if action == SyncAction.UPLOAD:
-                    self.perform_upload(path, local_files)
-                elif action == SyncAction.DOWNLOAD:
-                    self.perform_download(path, s3_files)
-                elif action == SyncAction.DELETE_LOCAL:
-                    self.perform_delete_local(path)
-                elif action == SyncAction.DELETE_REMOTE:
+        # Process remote deletions
+        if self.use_rclone:
+            success_count += self.perform_deletes_remote_batch([p for p, _ in deletes_remote])
+        else:
+            for path, reason in deletes_remote:
+                try:
                     self.perform_delete_remote(path)
-                success_count += 1
-            except Exception as e:
-                print(f"  ❌ Failed to process {path}: {e}")
+                    success_count += 1
+                except Exception as e:
+                    print(f"  ❌ Failed to delete remote {path}: {e}")
 
         print(f"\n✓ Sync complete: {success_count}/{total_operations} operations successful")
 
@@ -919,6 +980,12 @@ class S3SyncManager:
 
         if self.aws_profile:
             print(f"AWS Profile: {self.aws_profile}")
+
+        if self.use_rclone:
+            print("Transfer backend: rclone (parallel transfers)")
+        else:
+            print("Transfer backend: aws CLI (serial)")
+            print(f"⚠️  rclone unavailable, syncs will be slower: {self.rclone_unavailable_reason}")
 
         if not include_backups:
             print("Note: Ignoring backups/ directories (use --sync-backups to include them)")
@@ -959,6 +1026,145 @@ class S3SyncManager:
                         print(f"  {path}: {reason}")
 
 
+HFSYNC_CONFIG_NAME = '.hfsync.json'
+
+
+def load_hfsync_config(local_dir):
+    """Load the per-directory Hugging Face sync opt-in config, or None if absent"""
+    config_path = os.path.join(local_dir, HFSYNC_CONFIG_NAME)
+    if not os.path.exists(config_path):
+        return None
+
+    with open(config_path, 'r') as f:
+        config = json.load(f)
+
+    bucket_path = config.get('hf_bucket_path', '')
+    if not bucket_path.startswith('hf://buckets/'):
+        raise ValueError(f"{config_path}: 'hf_bucket_path' must start with hf://buckets/")
+    config['hf_bucket_path'] = bucket_path.rstrip('/')
+
+    hf_cli = shutil.which(config.get('hf_cli') or 'hf')
+    if not hf_cli:
+        raise ValueError(
+            f"{config_path}: hf CLI not found "
+            f"(install huggingface_hub>=1.0 or set 'hf_cli' to the binary's path)")
+    config['hf_cli'] = hf_cli
+
+    config.setdefault('tag', 'reviewed')
+    return config
+
+
+def classify_fibers(local_dir, tag):
+    """Split the directory's fiber JSONs into tagged / untagged / invalid"""
+    tagged, untagged, invalid = [], [], []
+
+    for name in sorted(os.listdir(local_dir)):
+        if name.startswith('.') or not name.endswith('.json'):
+            continue
+        path = os.path.join(local_dir, name)
+        if not os.path.isfile(path):
+            continue
+
+        try:
+            if os.path.getsize(path) == 0:
+                invalid.append((name, "zero-byte file"))
+                continue
+            with open(path, 'r') as f:
+                tags = json.load(f).get('tags', [])
+        except json.JSONDecodeError as e:
+            invalid.append((name, f"unparseable JSON ({e.msg} at line {e.lineno})"))
+            continue
+        except (OSError, UnicodeDecodeError) as e:
+            invalid.append((name, f"unreadable ({e})"))
+            continue
+
+        if tag in tags:
+            tagged.append(name)
+        else:
+            untagged.append(name)
+
+    return tagged, untagged, invalid
+
+
+def hf_sync(local_dir, dry_run=False):
+    """Sync tagged fibers to the Hugging Face bucket configured in .hfsync.json"""
+    local_dir = os.path.abspath(local_dir)
+
+    config = load_hfsync_config(local_dir)
+    if config is None:
+        print(f"Hugging Face sync is not configured for {local_dir}")
+        print(f"To enable it, create {os.path.join(local_dir, HFSYNC_CONFIG_NAME)}:")
+        print('  {')
+        print('    "hf_bucket_path": "hf://buckets/<org>/<bucket>/<path>",')
+        print('    "hf_cli": "/path/to/hf",          (optional, defaults to hf on PATH)')
+        print('    "tag": "reviewed"                 (optional)')
+        print('  }')
+        return
+
+    hf_cli = config['hf_cli']
+    bucket_path = config['hf_bucket_path']
+    tag = config['tag']
+
+    print(f"Hugging Face sync: {local_dir} → {bucket_path}")
+    if dry_run:
+        print("--dry-run mode: No changes will be made")
+
+    tagged, untagged, invalid = classify_fibers(local_dir, tag)
+    print(f"\nLocal fibers: {len(tagged)} tagged '{tag}', "
+          f"{len(untagged)} without the tag, {len(invalid)} invalid")
+    for name, problem in invalid:
+        print(f"  ⚠️  Skipping {name}: {problem}")
+
+    # Upload (additive): stage tagged files with mtimes preserved so
+    # `hf buckets sync` transfers only new or changed ones
+    if tagged:
+        staging = tempfile.mkdtemp(prefix='hfsync-')
+        try:
+            for name in tagged:
+                shutil.copy2(os.path.join(local_dir, name), staging)
+
+            cmd = [hf_cli, 'buckets', 'sync', staging, bucket_path]
+            if dry_run:
+                cmd.append('--dry-run')
+            result = subprocess.run(cmd)
+            if result.returncode != 0:
+                print("❌ hf buckets sync failed; aborting before removals")
+                return
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+
+    # Removals: only filenames that exist locally WITHOUT the tag and are
+    # present remotely. Files that exist only remotely are never touched.
+    result = subprocess.run([hf_cli, 'buckets', 'list', bucket_path, '-R', '-q'],
+                            capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"❌ Could not list {bucket_path}: {(result.stderr or '').strip()}")
+        return
+    remote_names = {line.rsplit('/', 1)[-1]
+                    for line in result.stdout.splitlines() if line.strip()}
+
+    to_remove = [name for name in untagged if name in remote_names]
+    removed = 0
+    for name in to_remove:
+        if dry_run:
+            print(f"  Would remove from HF (no longer tagged '{tag}'): {name}")
+            continue
+        rm = subprocess.run([hf_cli, 'buckets', 'rm', f"{bucket_path}/{name}", '--yes'],
+                            capture_output=True, text=True)
+        if rm.returncode == 0:
+            print(f"  ✓ Removed from HF (no longer tagged '{tag}'): {name}")
+            removed += 1
+        else:
+            print(f"  ❌ Failed to remove {name}: {(rm.stderr or '').strip()}")
+
+    if dry_run:
+        print(f"\n--dry-run: {len(tagged)} upload candidates (unchanged files "
+              f"are skipped, see plan above), {len(to_remove)} would be removed")
+    else:
+        print(f"\n✓ Hugging Face sync complete: {len(tagged)} tagged fibers synced, "
+              f"{removed} removed, {len(invalid)} skipped as invalid")
+
+
 def main():
     parser = argparse.ArgumentParser(description='AWS S3 interactive sync with conflict resolution')
     subparsers = parser.add_subparsers(dest='command', help='Commands')
@@ -991,6 +1197,13 @@ def main():
     reset_parser = subparsers.add_parser('reset', help='Reset sync tracking (mark all as synced)')
     reset_parser.add_argument('directory', help='Local directory')
     reset_parser.add_argument('--sync-backups', action='store_true', help='Include backups/ directories in reset')
+
+    # Hugging Face sync command
+    hfsync_parser = subparsers.add_parser(
+        'hfsync', help='Sync tagged fibers to a Hugging Face bucket (requires .hfsync.json)')
+    hfsync_parser.add_argument('directory', help='Local directory')
+    hfsync_parser.add_argument('--dry-run', action='store_true',
+                               help='Show what would be synced without doing it')
 
     args = parser.parse_args()
 
@@ -1057,6 +1270,10 @@ def main():
         print("\n✓ Initialization complete!")
         print("Use 'status' command to see current sync state")
 
+    elif args.command == 'hfsync':
+        # Independent of the S3 sync configuration; gated only on .hfsync.json
+        hf_sync(args.directory, args.dry_run)
+
     else:
         # Check for existing configuration
         config_file = os.path.join(args.directory, '.s3sync.json')
@@ -1073,8 +1290,6 @@ def main():
 
         elif args.command == 'sync':
             manager.sync(args.dry_run, getattr(args, 'sync_backups', False))
-            if not args.dry_run:
-                manager.generate_segment_report()
 
         elif args.command == 'update':
             manager.update_files(getattr(args, 'sync_backups', False))


### PR DESCRIPTION
## Summary

Speed, safety, and publishing improvements to `scripts/vc_sync.py`:

**Parallel transfers via rclone (with automatic fallback)**
- When the `rclone` binary is available, uploads/downloads/remote-deletes run as one batched rclone process with 16 parallel transfers instead of one serial `aws s3 cp` subprocess per file — minutes → seconds for typical fiber batches.
- No rclone configuration needed on any machine: an on-the-fly remote (`:s3,provider=AWS,env_auth=true:`) uses the same credential chain as the aws CLI (env vars, `~/.aws/credentials`, EC2 instance roles).
- Detection probes that rclone can actually **read the sync directory** — sandboxed installs (e.g. the Ubuntu snap without its `removable-media` interface) fail the probe and the script falls back to the original serial aws CLI path, printing the reason.

**Upload safety**
- Files are re-stat'ed immediately before upload (the interactive prompts can leave a long window after the scan) and checked again after; a file modified mid-upload is flagged and re-uploaded on the next sync. This closes the race that could silently persist truncated uploads.
- Zero-byte files and unparseable JSON among upload candidates are listed with a per-file `[u]pload anyway / [s]kip` prompt before the confirmation gate (shown read-only under `--dry-run`).

**Correctness fix**
- The S3 listing prefix now ends with `/`, so sibling prefixes (e.g. `<prefix>_old`) can no longer bleed into the scan with mangled relative paths.

**New: opt-in `hfsync` subcommand**
- `vc_sync.py hfsync <dir> [--dry-run]` syncs tagged fiber JSONs (default tag: `reviewed`) to a Hugging Face storage bucket.
- Entirely configured by a local `.hfsync.json` next to the data (documented in the module docstring). The script contains no bucket names, tokens, or machine paths; directories without the config file are unaffected. Auth uses the token stored by `hf auth login`.
- Semantics: additive upload (unchanged files skip via size/mtime); a remote file is removed only when the same filename exists locally *without* the tag, so remote-only files can never be deleted.

**Removed**
- The segment-area CSV reporting pipeline (and its hardcoded report bucket), per project decision.

## Test plan

- Batch upload/download/remote-delete exercised against a local stand-in remote: flat fiber layout (20/5/3 files) and nested tifxyz layout (`<segment>/{meta.json,x.tif,y.tif,z.tif}` with 2 MB binaries) — transfers byte-identical, tracking DB keys consistent with the S3 scanner.
- Fallback detection verified for both failure reasons (binary missing; directory unreadable by a sandboxed install).
- Validation flags zero-byte and mid-write-truncated JSON; valid JSON and non-JSON pass.
- `hfsync` verified against a real HF bucket scratch path: dry-run makes no changes, un-tagged files are removed, remote-only files survive; then a production run (25 new uploads, 152 skips, 0 removals).
- Local scan of a real 116-file / 9.5 GB tifxyz `paths` directory confirms filters and nested path handling are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVkXaynVESTt7q8Z8n6LU2