### PR TITLE
volume-cartographer: build VC3D with the MSVC / Visual Studio 2022 to…

### DIFF
--- a/volume-cartographer/.gitignore
+++ b/volume-cartographer/.gitignore
@@ -31,6 +31,10 @@ target/
 *build*/
 deps/
 .cache/
+# Machine-local presets (e.g. Windows MSVC toolchain path); see CMakePresets.json
+CMakeUserPresets.json
+# vcpkg manifest-mode install tree (also created under build/ by the toolchain)
+vcpkg_installed/
 
 # Vim
 tags

--- a/volume-cartographer/CMakeLists.txt
+++ b/volume-cartographer/CMakeLists.txt
@@ -15,6 +15,14 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # OFF locally for PaStiX.)
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build vc_* and FetchContent deps as .so")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+# GCC/MinGW export every symbol from a shared library by default, which is what
+# the vc_* .so/.dll split relies on. MSVC exports nothing unless asked, so a
+# shared lib with no __declspec(dllexport) yields no import .lib and downstream
+# links fail (LNK1181). Auto-generate the export table for every shared target
+# to match the GCC behavior the codebase assumes.
+if(MSVC)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 # Exes default to -fPIE; force -fPIC to match the shared libs' PCH. -no-pie
 # only on exe links (mold/lld reject it on a .so). PE/COFF has no PIC/PIE
 # distinction, so skip both on Windows.
@@ -192,7 +200,14 @@ endif()
 # into host tuning. Windows installers use the general x86-64 baseline so they
 # run on all supported amd64 CPUs; Linux retains the existing x86-64-v3 floor.
 # armv8.2-a avoids SVE so Apple M1-M3 + Qualcomm Oryon work alongside Graviton.
-if(VC_MARCH_NATIVE)
+if(MSVC)
+    # MSVC has no -march/-pipe. It targets the portable x86-64 (SSE2) baseline
+    # by default, matching the Windows floor used on the GCC path below;
+    # VC_MARCH_NATIVE opts into AVX2 host tuning.
+    if(VC_MARCH_NATIVE)
+        add_compile_options(/arch:AVX2)
+    endif()
+elseif(VC_MARCH_NATIVE)
     add_compile_options(-pipe -march=native)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
     if(WIN32)
@@ -206,7 +221,28 @@ else()
     add_compile_options(-pipe)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(MSVC)
+    # MSVC toolchain equivalents of the GCC/Clang setup below:
+    #   /Zi   PDB debug info (moral equivalent of -g3; kept in every config so
+    #         release crash dumps still symbolize)
+    #   /Gy /Gw  function/data-level linking so /OPT:REF,ICF can strip unused
+    #         code (~ -ffunction-sections/-fdata-sections + --gc-sections)
+    #   /bigobj  lift the COFF 32k-section limit (~ -Wa,-mbig-obj)
+    #   /permissive- /Zc:__cplusplus /Zc:preprocessor  standards conformance
+    #   /utf-8   treat sources as UTF-8 (the GCC/Clang default)
+    #   /MP      parallel TU compilation
+    #   /wd4068  ignore the unknown `#pragma omp` (OpenMP is stubbed, see below)
+    set(_dbg "")
+    set(_lto "")
+    set(_link "")
+    add_compile_options(/Zi /Gy /Gw /bigobj /permissive- /Zc:__cplusplus
+                        /Zc:preprocessor /utf-8 /MP /wd4068)
+    add_link_options(/DEBUG /OPT:REF /OPT:ICF)
+    # Windows.h hygiene + the libm-style math constants (M_PI, ...) that
+    # MinGW/GCC expose by default but MSVC gates behind these macros.
+    add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN _USE_MATH_DEFINES
+                            _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(_dbg -g3 -fno-omit-frame-pointer -fasynchronous-unwind-tables -fstandalone-debug)
     set(_lto -flto=thin)
     if(APPLE)
@@ -251,12 +287,17 @@ else()
         endif()
     endif()
 endif()
-add_compile_options(${_dbg} -ffunction-sections -fdata-sections)
+if(MSVC)
+    add_compile_options(${_dbg})
+else()
+    add_compile_options(${_dbg} -ffunction-sections -fdata-sections)
+endif()
 add_link_options(${_link})
 
-if(WIN32)
+if(WIN32 AND NOT MSVC)
     # Several large TUs (Qt-heavy VC3D sources, template-dense core) exceed
-    # the default COFF 32k-section limit; -mbig-obj lifts it.
+    # the default COFF 32k-section limit; -mbig-obj lifts it for the binutils
+    # assembler. (MSVC gets /bigobj in the compiler-family block above.)
     add_compile_options(-Wa,-mbig-obj)
 endif()
 
@@ -319,16 +360,21 @@ endif()
 # Sanitizer/coverage flags applied below, after libs/ — see that block.
 
 # ---- Optimization + LTO -----------------------------------------------------
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_compile_options(-O0)
-elseif(CMAKE_BUILD_TYPE STREQUAL "QuickBuild")
-    add_compile_options(-O1)
-elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-    add_compile_options(-O3)
-elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    add_compile_options(-O2)
-elseif(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-    add_compile_options(-Os)
+# GCC/Clang optimization levels. MSVC takes its optimization from CMake's
+# per-config flags (/O2 for Release/RelWithDebInfo, /Od for Debug), so it is
+# intentionally left out of this block.
+if(NOT MSVC)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(-O0)
+    elseif(CMAKE_BUILD_TYPE STREQUAL "QuickBuild")
+        add_compile_options(-O1)
+    elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+        add_compile_options(-O3)
+    elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        add_compile_options(-O2)
+    elseif(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+        add_compile_options(-Os)
+    endif()
 endif()
 # LTO stays off on Windows: GCC LTO across DLLs interacts badly with PE
 # auto-import/export-all, and link times on the CI runners balloon.
@@ -346,7 +392,12 @@ if(VC_BUILD_PYTHON)
 endif()
 
 # ---- Warnings ---------------------------------------------------------------
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(MSVC)
+    # Highest-volume MSVC-only warnings that GCC/Clang never emit for this
+    # code: narrowing/precision conversions, signed/unsigned compares, and the
+    # CRT "deprecation" of standard/POSIX names. Noise, not bugs.
+    add_compile_options(/wd4244 /wd4267 /wd4305 /wd4018 /wd4146 /wd4996)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     add_compile_options(-Wno-unknown-warning-option)
 else()
     add_compile_options(-Wno-psabi -Wno-ignored-attributes -Wno-narrowing)
@@ -375,7 +426,7 @@ if(VC_WARNINGS AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         -Wno-pre-c++20-compat -Wno-pre-c++23-compat -Wno-pre-c++26-compat
         -Wno-nested-anon-types -Wno-gnu-anonymous-struct
     )
-elseif(VC_WARNINGS)
+elseif(VC_WARNINGS AND NOT MSVC)
     add_compile_options(
         -Wall -Wextra -pedantic
         -Wattributes -Wcast-align -Wcast-qual -Wchar-subscripts -Wcomment
@@ -389,18 +440,25 @@ elseif(VC_WARNINGS)
     )
 endif()
 if(VC_WERROR)
-    add_compile_options(-Werror)
+    if(MSVC)
+        add_compile_options(/WX)
+    else()
+        add_compile_options(-Werror)
+    endif()
 endif()
 
 if(VC_PROFILE_COMPILE)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    if(MSVC)
+        # MSVC has no stable per-TU timing flag; leave compile profiling to the
+        # GCC/Clang builds.
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         add_compile_options(-ftime-trace -ftime-trace-granularity=200)
     else()
         add_compile_options(-ftime-report)
     endif()
 endif()
 
-if(VC_DEAD_CODE_REPORT)
+if(VC_DEAD_CODE_REPORT AND NOT MSVC)
     add_compile_options(
         -Wunused -Wunused-function -Wunused-variable -Wunused-parameter
         -Wunused-value -Wunused-result
@@ -482,7 +540,14 @@ find_package(nlohmann_json REQUIRED)
 find_package(CURL REQUIRED)
 find_package(TIFF REQUIRED)
 find_package(ZLIB REQUIRED)
-find_package(PkgConfig REQUIRED)
+if(MSVC)
+    # On MSVC, zstd/lz4 come from vcpkg CMake configs (below), and the
+    # pkg-config-only consumers (vendored libbacktrace, avahi) are Linux-only,
+    # so pkg-config is optional rather than required.
+    find_package(PkgConfig)
+else()
+    find_package(PkgConfig REQUIRED)
+endif()
 # Blosc1 (libblosc-dev on Debian/Ubuntu; c-blosc on Homebrew). No upstream
 # CMake config is shipped, so locate by header+lib and wrap in an imported
 # target consumers link as Blosc::blosc.
@@ -536,13 +601,31 @@ if(VC_ENABLE_AMGX)
     endif()
     message(STATUS "Using AMGX include=${AMGX_INCLUDE_DIR} library=${AMGX_LIBRARY}")
 endif()
-pkg_check_modules(zstd REQUIRED IMPORTED_TARGET libzstd)
-pkg_check_modules(lz4 REQUIRED IMPORTED_TARGET liblz4)
-if(NOT TARGET zstd::libzstd)
-    add_library(zstd::libzstd ALIAS PkgConfig::zstd)
-endif()
-if(NOT TARGET LZ4::lz4)
-    add_library(LZ4::lz4 ALIAS PkgConfig::lz4)
+if(MSVC)
+    # vcpkg ships CMake configs for these (no .pc/pkg-config on MSVC). Normalize
+    # whatever target each exports to the names the tree consumes: utils links
+    # zstd::libzstd and LZ4::lz4.
+    find_package(zstd CONFIG REQUIRED)
+    find_package(lz4 CONFIG REQUIRED)
+    if(NOT TARGET zstd::libzstd)
+        if(TARGET zstd::libzstd_shared)
+            add_library(zstd::libzstd ALIAS zstd::libzstd_shared)
+        elseif(TARGET zstd::libzstd_static)
+            add_library(zstd::libzstd ALIAS zstd::libzstd_static)
+        endif()
+    endif()
+    if(NOT TARGET LZ4::lz4 AND TARGET lz4::lz4)
+        add_library(LZ4::lz4 ALIAS lz4::lz4)
+    endif()
+else()
+    pkg_check_modules(zstd REQUIRED IMPORTED_TARGET libzstd)
+    pkg_check_modules(lz4 REQUIRED IMPORTED_TARGET liblz4)
+    if(NOT TARGET zstd::libzstd)
+        add_library(zstd::libzstd ALIAS PkgConfig::zstd)
+    endif()
+    if(NOT TARGET LZ4::lz4)
+        add_library(LZ4::lz4 ALIAS PkgConfig::lz4)
+    endif()
 endif()
 if(VC_BUILD_APPS)
     find_package(CGAL REQUIRED)
@@ -562,7 +645,13 @@ if(VC_BUILD_PYTHON)
     find_package(nanobind CONFIG REQUIRED)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR MSVC)
+    # Clang and MSVC both use the no-op OpenMP shim: -fopenmp / -openmp is never
+    # enabled, so every `#pragma omp` is ignored and the omp_*() runtime calls
+    # resolve to the inline stubs in core/openmp_stub/omp.h. These builds run the
+    # parallel regions serially, which is why the ignored `critical`/`atomic`
+    # pragmas remain correct. Only the GCC build links real OpenMP. (MSVC
+    # silences the resulting unknown-pragma C4068 in the compiler-family block.)
     include_directories(${CMAKE_SOURCE_DIR}/core/openmp_stub)
     add_library(openmp_stub INTERFACE)
     add_library(OpenMP::OpenMP_CXX ALIAS openmp_stub)

--- a/volume-cartographer/CMakePresets.json
+++ b/volume-cartographer/CMakePresets.json
@@ -158,6 +158,23 @@
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
     },
     {
+      "name": "windows-msvc",
+      "displayName": "Windows (MSVC + vcpkg, RelWithDebInfo)",
+      "description": "Native Windows build with the Visual Studio 2022 MSVC toolchain and vcpkg-provided dependencies. Requires VCPKG_ROOT to point at a bootstrapped vcpkg checkout; run from a VS x64 developer environment (or VS2022's CMake integration) so cl.exe and Ninja are on PATH. flatboi (PaStiX) is unavailable on Windows and defaults off.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/windows-msvc",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-rel",
+        "VCPKG_HOST_TRIPLET": "x64-windows-rel",
+        "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/triplets",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "VC_TESTING": "OFF"
+      },
+      "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
+    },
+    {
       "name": "macos-homebrew-llvm",
       "displayName": "macOS Homebrew LLVM",
       "description": "Native macOS build using Homebrew LLVM/Clang, lld, and Homebrew binutils. The only Apple-toolchain pieces in the loop are SDKROOT (system headers/frameworks) and libSystem, because there is no Homebrew alternative for those.",
@@ -220,7 +237,8 @@
     { "name": "ci-strict-warnings-clang", "configurePreset": "ci-strict-warnings-clang" },
     { "name": "ci-dead-code-gcc",         "configurePreset": "ci-dead-code-gcc" },
     { "name": "ci-dead-code-clang",       "configurePreset": "ci-dead-code-clang" },
-    { "name": "ci-windows-mingw",         "configurePreset": "ci-windows-mingw" }
+    { "name": "ci-windows-mingw",         "configurePreset": "ci-windows-mingw" },
+    { "name": "windows-msvc",             "configurePreset": "windows-msvc" }
   ],
 
   "testPresets": [

--- a/volume-cartographer/README.md
+++ b/volume-cartographer/README.md
@@ -47,6 +47,27 @@ cmake --build --preset ci-windows-mingw
 cpack --config build/ci-windows-mingw/CPackConfig.cmake
 ```
 
+Alternatively, VC3D builds with the **native MSVC / Visual Studio 2022 toolchain**
+using [vcpkg](https://github.com/microsoft/vcpkg) for dependencies, via the
+`windows-msvc` preset. Bootstrap a vcpkg checkout, then from an *x64 Native Tools
+Command Prompt for VS 2022* (so `cl.exe`/Ninja are on `PATH`):
+
+```bat
+set VCPKG_ROOT=C:\path\to\vcpkg
+cmake --preset windows-msvc
+cmake --build build\windows-msvc
+```
+
+The first configure builds the dependency closure (Qt, OpenCV, Ceres, CGAL, ...)
+from source via vcpkg — this takes a while, but later configures restore it from
+vcpkg's binary cache. The result is `build\windows-msvc\bin\VC3D.exe` with the Qt
+plugins and dependency DLLs deployed alongside it, runnable in place. To work in
+the VS2022 IDE, *Open Folder* on `volume-cartographer/`. Note that the VS
+developer environment forces `VCPKG_ROOT` to the port-less bundled vcpkg, so
+create a `CMakeUserPresets.json` (gitignored) that pins `CMAKE_TOOLCHAIN_FILE` to
+your vcpkg and select the resulting local preset — otherwise VS reconfigures
+against the wrong vcpkg and rebuilds every dependency.
+
 Note: the flatboi SLIM flattening tool (PaStiX-based) is not available on Windows; Docker or WSL still covers that workflow.
 
 #### macOS

--- a/volume-cartographer/apps/VC3D/CMakeLists.txt
+++ b/volume-cartographer/apps/VC3D/CMakeLists.txt
@@ -281,6 +281,45 @@ target_link_libraries(VC3D
     Blosc::blosc
 )
 
+# Build-tree Qt plugin deployment (MSVC/vcpkg). vcpkg copies the Qt DLLs next to
+# the executable but not the plugin tree, so a freshly built VC3D.exe cannot find
+# platforms/qwindows.dll and aborts on startup. Copy the plugin folders next to
+# VC3D.exe after each link so it runs straight from the build directory without a
+# separate windeployqt step. (Packaging/install deployment is handled separately
+# in cmake/WindowsPackaging.cmake.)
+if(WIN32 AND MSVC)
+    set(_vc_qwin_loc "")
+    if(TARGET Qt6::QWindowsIntegrationPlugin)
+        foreach(_cfg IMPORTED_LOCATION_RELEASE IMPORTED_LOCATION_RELWITHDEBINFO
+                     IMPORTED_LOCATION_DEBUG IMPORTED_LOCATION)
+            get_target_property(_vc_qwin_loc Qt6::QWindowsIntegrationPlugin ${_cfg})
+            if(_vc_qwin_loc)
+                break()
+            endif()
+        endforeach()
+    endif()
+    if(_vc_qwin_loc)
+        # _vc_qwin_loc = <qt>/plugins/platforms/qwindows.dll; go up twice.
+        get_filename_component(_vc_qt_plugins "${_vc_qwin_loc}" DIRECTORY)
+        get_filename_component(_vc_qt_plugins "${_vc_qt_plugins}" DIRECTORY)
+        foreach(_pd platforms styles imageformats iconengines tls generic
+                    networkinformation)
+            if(EXISTS "${_vc_qt_plugins}/${_pd}")
+                add_custom_command(TARGET VC3D POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+                        "${_vc_qt_plugins}/${_pd}"
+                        "$<TARGET_FILE_DIR:VC3D>/${_pd}"
+                    COMMENT "Deploying Qt ${_pd} plugins next to VC3D.exe"
+                    VERBATIM)
+            endif()
+        endforeach()
+    else()
+        message(WARNING
+            "Qt platform plugin not located; VC3D.exe may not launch from the "
+            "build tree without a manual windeployqt/plugin copy.")
+    endif()
+endif()
+
 if(VC_USE_PCH)
     # VC3D gets its own PCH = vc_core's common headers + the heavy Qt umbrella
     # headers. Qt stays out of vc_core's shared PCH so the Qt-free CLI apps that

--- a/volume-cartographer/apps/VC3D/VCAppMain.cpp
+++ b/volume-cartographer/apps/VC3D/VCAppMain.cpp
@@ -88,7 +88,9 @@ static bool hasCliFlag(int argc, char* argv[], const char* flag)
     return false;
 }
 
+#if defined(__GNUC__) || defined(__clang__)
 __attribute__((visibility("default")))
+#endif
 auto main(int argc, char* argv[]) -> int
 {
 #ifdef _WIN32

--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -48,7 +48,10 @@ static std::thread g_logFlushThread;
 // Log to file if active, otherwise to the given default stream.
 // When logging to a shared file in multi-part mode, each line is prefixed with the part id.
 static void logPrintf(FILE* defaultStream, const char* fmt, ...)
-    __attribute__((format(printf, 2, 3)));
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((format(printf, 2, 3)))
+#endif
+    ;
 static void logPrintf(FILE* defaultStream, const char* fmt, ...)
 {
     FILE* out = g_logFile ? g_logFile : defaultStream;

--- a/volume-cartographer/core/include/vc/core/render/Colormaps.hpp
+++ b/volume-cartographer/core/include/vc/core/render/Colormaps.hpp
@@ -6,6 +6,13 @@
 #include <string>
 #include <vector>
 
+// __has_builtin isn't provided by every preprocessor (e.g. pre-16.1 MSVC); fall
+// back so the nt_store_u32 __builtin_nontemporal_store check below degrades to
+// the plain store rather than failing to preprocess.
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 namespace vc {
 
 enum class OverlayColormapKind { OpenCv, Tint, DiscreteLut };

--- a/volume-cartographer/core/openmp_stub/omp.h
+++ b/volume-cartographer/core/openmp_stub/omp.h
@@ -70,7 +70,13 @@ static inline int omp_test_nest_lock(omp_nest_lock_t* lock) {
 /* Timing functions */
 static inline double omp_get_wtime(void) {
     struct timespec ts;
+#if defined(_WIN32)
+    /* clock_gettime/CLOCK_MONOTONIC are POSIX and absent on MSVC; the C11
+     * timespec_get is available on both and needs no extra headers. */
+    timespec_get(&ts, TIME_UTC);
+#else
     clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
     return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
 }
 

--- a/volume-cartographer/core/src/CacheCompression.cpp
+++ b/volume-cartographer/core/src/CacheCompression.cpp
@@ -10,6 +10,10 @@
 
 #include <zstd.h>
 
+#if defined(_MSC_VER)
+#include <intrin.h>   // __umulh / _udiv128 for the 128-bit rANS reciprocal math
+#endif
+
 namespace vc {
 
 namespace {
@@ -176,8 +180,12 @@ struct RansEncSym {
 
 inline std::uint64_t ransMulHi(std::uint64_t a, std::uint64_t b)
 {
+#if defined(_MSC_VER)
+    return __umulh(a, b);   // high 64 bits of the 64x64 product
+#else
     return static_cast<std::uint64_t>(
         (static_cast<unsigned __int128>(a) * b) >> 64);
+#endif
 }
 
 // Histogram -> frequencies summing to exactly kRansM, every present symbol
@@ -227,9 +235,18 @@ void ransBuildEncTable(const std::uint32_t freq[256], RansEncSym enc[256])
             std::uint32_t k = 1;
             while ((1u << k) < f) ++k;  // k = ceil(log2 f)
             e.shift = k - 1;
+            // num = 2^(k+63) + (f-1): high 64 bits = 2^(k-1), low 64 bits =
+            // (f-1). The quotient num/f provably fits in 64 bits (f > 2^(k-1)),
+            // so the 128/64 -> 64 division is well-defined on both paths.
+#if defined(_MSC_VER)
+            std::uint64_t ransRcpRem;
+            e.rcp = _udiv128(std::uint64_t{1} << (k - 1),
+                             static_cast<std::uint64_t>(f) - 1, f, &ransRcpRem);
+#else
             const auto num =
                 ((static_cast<unsigned __int128>(1) << (k + 63)) + f - 1);
             e.rcp = static_cast<std::uint64_t>(num / f);
+#endif
             e.bias = cum;
         }
         cum += f;

--- a/volume-cartographer/core/src/QuadSurface.cpp
+++ b/volume-cartographer/core/src/QuadSurface.cpp
@@ -54,6 +54,11 @@
 // Use libtiff for BigTIFF
 #include <tiffio.h>
 
+// GCC/Clang spell the restrict qualifier __restrict__; MSVC only has __restrict.
+#if defined(_MSC_VER)
+#define __restrict__ __restrict
+#endif
+
 namespace {
 
 void replaceFile(const std::filesystem::path& source,

--- a/volume-cartographer/core/src/Slicing.cpp
+++ b/volume-cartographer/core/src/Slicing.cpp
@@ -17,9 +17,19 @@
 #include <omp.h>
 
 #if defined(_MSC_VER)
+#include <cstring>            // std::memcpy for the __builtin_memcpy shim below
 #define VC_FORCE_INLINE __forceinline
+// MSVC has no __builtin_memcpy; std::memcpy lowers to the same inlined move.
+#define __builtin_memcpy std::memcpy
 #else
 #define VC_FORCE_INLINE __attribute__((always_inline)) inline
+#endif
+
+// __has_builtin is a Clang/GCC/modern-MSVC (VS2019 16.1+) feature-test operator,
+// but older or exotic preprocessors don't provide it. Define a fallback so the
+// __builtin_nontemporal_store checks below degrade to the portable store.
+#ifndef __has_builtin
+#define __has_builtin(x) 0
 #endif
 
 namespace {

--- a/volume-cartographer/libs/OpenABF/include/OpenABF/OpenABF.hpp
+++ b/volume-cartographer/libs/OpenABF/include/OpenABF/OpenABF.hpp
@@ -3126,7 +3126,10 @@ static auto icase_compare(const std::string_view a, const std::string_view b)
 static auto trim_left(std::string_view s) -> std::string_view
 {
     const auto& loc = std::locale();
-    const auto* start = std::find_if_not(
+    // NOTE: string_view::iterator is a raw pointer on libstdc++/libc++ but a
+    // class type on MSVC's STL, so deduce the iterator type (const auto), not a
+    // pointer (const auto*), to stay portable.
+    const auto start = std::find_if_not(
         std::begin(s), std::end(s),
         [&loc](auto ch) -> bool { return std::isspace(ch, loc); });
     s.remove_prefix(std::distance(std::begin(s), start));
@@ -3137,7 +3140,7 @@ static auto trim_left(std::string_view s) -> std::string_view
 static auto trim_right(std::string_view s) -> std::string_view
 {
     const auto& loc = std::locale();
-    const auto* start =
+    const auto start =
         std::find_if_not(s.rbegin(), s.rend(), [&loc](auto ch) -> bool {
             return std::isspace(ch, loc);
         }).base();

--- a/volume-cartographer/libs/c3d/CMakeLists.txt
+++ b/volume-cartographer/libs/c3d/CMakeLists.txt
@@ -6,7 +6,16 @@ target_include_directories(c3d PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
-target_compile_features(c3d PRIVATE c_std_23)
+if(MSVC)
+    # CMake has no c_std_23 mapping for MSVC's C frontend; request the latest C
+    # mode directly. Scope it to C sources via a genex so it is not applied to
+    # the (C++) AUTOMOC mocs_compilation.cpp stub, which already gets
+    # /std:c++latest and would otherwise trip D8016 (the two /std flags are
+    # mutually exclusive).
+    target_compile_options(c3d PRIVATE $<$<COMPILE_LANGUAGE:C>:/std:clatest>)
+else()
+    target_compile_features(c3d PRIVATE c_std_23)
+endif()
 
 # The repo-wide policy (AGENTS.md §3.1) is strict IEEE math — no
 # -ffast-math / -Ofast. Keep it here too: c3d is a compression codec,
@@ -14,11 +23,23 @@ target_compile_features(c3d PRIVATE c_std_23)
 # encoded bytes non-reproducible between platforms. The upstream
 # throughput targets were measured with -ffast-math but the reference
 # decoder is fine without it.
-target_compile_options(c3d PRIVATE
-    -fno-math-errno
-    -fno-trapping-math
-    # Upstream vendored code — we don't own the style, silence the noise.
-    -w
-)
+if(MSVC)
+    # /w silences the vendored code's warnings. MSVC keeps its default
+    # (precise) FP model; -fno-math-errno / -fno-trapping-math are GCC/Clang
+    # micro-optimizations, not correctness requirements, so they are dropped.
+    target_compile_options(c3d PRIVATE /w)
+else()
+    target_compile_options(c3d PRIVATE
+        -fno-math-errno
+        -fno-trapping-math
+        # Upstream vendored code — we don't own the style, silence the noise.
+        -w
+    )
+endif()
 
-target_link_libraries(c3d PRIVATE m)
+# libm is a Unix-ism; on MSVC the math routines live in the CRT. (MinGW ships
+# an empty libm, so linking -lm is harmless there — hence NOT MSVC, not
+# NOT WIN32.)
+if(NOT MSVC)
+    target_link_libraries(c3d PRIVATE m)
+endif()

--- a/volume-cartographer/libs/c3d/c3d.c
+++ b/volume-cartographer/libs/c3d/c3d.c
@@ -15,6 +15,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* MSVC lacks the GCC/Clang branch-prediction, prefetch, and alignment builtins
+ * used below. Map them to no-op-equivalent forms (correct results, just without
+ * the optimizer hint). Only defined off the GCC/Clang path. */
+#if !defined(__GNUC__) && !defined(__clang__)
+#  define __builtin_expect(expr, expected)   (expr)
+#  define __builtin_prefetch(...)            ((void)0)
+#  define __builtin_assume_aligned(ptr, ...) (ptr)
+#endif
+
 /* C11 aligned_alloc is missing from the Windows UCRT; _aligned_malloc is the
  * equivalent but its memory must go through _aligned_free (plain free() is
  * undefined on it), so the paired frees route through c3d_aligned_free. */
@@ -27,8 +36,11 @@
 #  define c3d_aligned_free free
 #endif
 
-/* Endianness gate — LE only. */
-#if !defined(__BYTE_ORDER__) || __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+/* Endianness gate — LE only. Windows targets (x86/x64/ARM64) are always
+ * little-endian, but MSVC does not define __BYTE_ORDER__, so exempt _WIN32 from
+ * the predefine-based check rather than tripping the #error. */
+#if !defined(_WIN32) && \
+    (!defined(__BYTE_ORDER__) || __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__)
 #  error "c3d requires a little-endian target"
 #endif
 

--- a/volume-cartographer/triplets/x64-windows-rel.cmake
+++ b/volume-cartographer/triplets/x64-windows-rel.cmake
@@ -1,0 +1,12 @@
+# Release-only variant of the stock x64-windows triplet (dynamic CRT + dynamic
+# libs, matching Qt/OpenCV's requirements). Dropping the debug build of every
+# dependency roughly halves the vcpkg build time and on-disk footprint, which
+# matters a lot for the Qt6 + OpenCV(contrib) + CGAL + Ceres closure.
+#
+# The VC3D app is therefore built as Release/RelWithDebInfo (release CRT, /MD)
+# so it links cleanly against these release-only dependencies. A Debug (/MDd)
+# app build would mismatch the CRT — use RelWithDebInfo for debugging instead.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE release)

--- a/volume-cartographer/utils/src/aws_auth.cpp
+++ b/volume-cartographer/utils/src/aws_auth.cpp
@@ -12,6 +12,12 @@
 #include <string>
 #include <vector>
 
+#if defined(_MSC_VER)
+// MSVC spells the POSIX process-pipe API with a leading underscore.
+#define popen _popen
+#define pclose _pclose
+#endif
+
 namespace utils {
 
 AwsAuth AwsAuth::load(const std::string& profile)
@@ -29,7 +35,14 @@ AwsAuth AwsAuth::load(const std::string& profile)
         std::string cmd = "aws configure export-credentials";
         if (!profileArg.empty())
             cmd += " --profile " + profileArg;
+        // Suppress the tool's stderr. On Windows _popen runs the command via
+        // cmd.exe, whose null device is NUL, not /dev/null; an unresolved
+        // /dev/null redirect target there fails the whole command before it runs.
+#if defined(_WIN32)
+        cmd += " 2>NUL";
+#else
         cmd += " 2>/dev/null";
+#endif
         std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
         if (!pipe) return false;
         std::string output;

--- a/volume-cartographer/vcpkg.json
+++ b/volume-cartographer/vcpkg.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "volume-cartographer",
+  "version": "1.0.0",
+  "description": "VC3D / Volume Cartographer dependency manifest (used for the Windows MSVC build via vcpkg; ignored on Linux/macOS builds that do not use the vcpkg toolchain).",
+  "builtin-baseline": "8e8dfb4ba483886936ded5ca201b500b8d8b0096",
+  "dependencies": [
+    "qtbase",
+    "boost-program-options",
+    "boost-graph",
+    "boost-geometry",
+    {
+      "name": "ceres",
+      "features": [
+        "eigensparse"
+      ]
+    },
+    "eigen3",
+    {
+      "name": "opencv4",
+      "features": [
+        "contrib"
+      ]
+    },
+    "nlohmann-json",
+    "curl",
+    "tiff",
+    "zlib",
+    "blosc",
+    "zstd",
+    "lz4",
+    "cgal"
+  ]
+}


### PR DESCRIPTION
Vesuvius folks asked for Scrollfiesta! integration into VC3D; since I work on Windows with Visual Studio 2022... well, the first step is getting VC3D running with Visual Studio 2022! So here you go.

This patch adds a native MSVC build path along the existing GCC/Clang (Linux), macOS, and MinGW (Windows) paths. It uses vcpkg for resolving all dependencies. VC3D and all vc_* CLI tools compile and link with cl.exe, and VC3D.exe launches from the build tree. Every change is if(MSVC)/#if defined(_MSC_VER) guarded, so the Linux, macOS, and MinGW builds are unchanged.

Build instructions are in README.md. Nothing *should* be touched on the Linux or OSX or MinGW paths.

Build system:
- MSVC equivalents for the GCC/Clang flag set (/bigobj, /Zi /Gy /Gw, /OPT:REF, /permissive- /Zc:__cplusplus, NOMINMAX, _USE_MATH_DEFINES, ...)
- CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS so the shared vc_* libs export like GCC
- zstd/lz4 via vcpkg CMake configs instead of pkg-config
- OpenMP reuses the existing no-op stub (as the Clang path already does)
- windows-msvc preset + release-only x64-windows-rel triplet + vcpkg.json
- POST_BUILD deploy of Qt plugins next to VC3D.exe so it runs in place

Source portability (all guarded):
- __int128 rANS reciprocal math -> __umulh/_udiv128 (CacheCompression)
- __builtin_* shims + endianness gate (c3d.c); C sources use /std:clatest
- __builtin_memcpy (Slicing), __restrict__ -> __restrict (QuadSurface)
- clock_gettime -> timespec_get (openmp stub), popen -> _popen (aws_auth)
- guard unconditional __attribute__ (VCAppMain, vc_render_tifxyz)
- OpenABF trim(): don't assume string_view iterators are raw pointers, which is false on MSVC's STL (portable const auto, not const auto*)

The packaging scripts (cmake/WindowsPackaging.cmake / cpack) is still MSYS2-oriented and left unchanged; only the build and run-from-build-tree path is covered in this patch.