### PR TITLE
scrollprize.org: note footer license is default, not absolute

### DIFF
--- a/scrollprize.org/docusaurus.config.js
+++ b/scrollprize.org/docusaurus.config.js
@@ -290,7 +290,7 @@ const config = {
               ],
             },
           ],
-          copyright: `Copyright © ${new Date().getFullYear()} Vesuvius Challenge · Content licensed CC BY-NC 4.0`,
+          copyright: `Copyright © ${new Date().getFullYear()} Vesuvius Challenge · Content licensed CC BY-NC 4.0 unless otherwise specified`,
         },
         image: '/img/social/opengraph.jpg',
         metadata: [


### PR DESCRIPTION
Some assets (e.g. the EduceLab-Scrolls dataset, per docs/02_data.md) carry their own license terms, so the footer's blanket CC BY-NC 4.0 claim needed a caveat.