### PR TITLE
Add inkdx to community projects (Ink Detection tools)

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -267,6 +267,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 #### ⚙️ Tools
 
+- [inkdx](https://github.com/ash9241/inkdx) by Aishwarya Das. Ink-failure diagnostics: attributes missing ink per tile to scan, surface, or model via causally-gated profile/geometry/prediction metrics; machine-readable JSON + self-contained HTML reports; validated with induced-failure attribution matrices on real scroll data.
+
 - [ScrollMAE](https://github.com/jgcarrasco/ScrollMAE) by Jorge García. Contains the necessary code to pretrain a 3D ResNet on unlabeled data and then finetune it to perform ink detection.
 
 - [Unsupervised Ink Detection with DINO](https://github.com/jgcarrasco/dino-ink-detection) by Jorge García. Contains experiments related to detecting ink without labels, including a Colab notebook.


### PR DESCRIPTION
Adds [inkdx](https://github.com/ash9241/inkdx) (MIT, v0.1.0) to the segments-based Ink Detection tools list.

inkdx addresses 2026 open problem #9 (ink signal detection & diagnostics): given a segment and optionally an ink prediction, it attributes ink-recovery failure per 256px tile to a pipeline stage — scan (raw-voxel noise/CNR/haze), surface (profile-peak offset/prominence, sheet-switch multiplicity, tearing, holes), or model (bimodal commitment vs mid-gray confusion) — via causally-ordered gating, with machine-readable JSON reports (per-tile metrics + located suspect regions with z-score evidence) and self-contained HTML reports.

Validated with induced-failure attribution matrices on real data (noise → 100% scan, 8-voxel mesh offset → 94% surface, undertrained checkpoint → 81% model), plus a phantom test suite with analytic ground truth. A full 1.6-gigapixel segment (w00, PHerc. Paris 4) diagnoses in ~10 min on 8 CPU cores.

Release thread on Discord: https://discord.com/channels/1079907749569237093/1162822236521115720/threads/1528098732728652017

Submitted per the July 2026 Progress Prize form instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)