### PR TITLE
Prevent phantom predictions at inference time (addresses #1114, complements #1156)

### DIFF
--- a/vesuvius/src/vesuvius/data/utils.py
+++ b/vesuvius/src/vesuvius/data/utils.py
@@ -130,6 +130,11 @@ def open_zarr(path: str, mode: str = 'r',
     if verbose:
         print(f"Opening zarr store at {path} with mode={mode}")
     
+    # zarr 3.x raises TypeError when storage_options is provided (even {}) for
+    # non-URI stores such as local paths; only pass it for fsspec URIs.
+    if "://" not in path:
+        storage_options = None
+
     # If we're creating a new array (mode='w') and shape is provided, pass creation parameters
     if mode == 'w' and shape is not None:
         create_kwargs = {}

--- a/vesuvius/src/vesuvius/data/vc_dataset.py
+++ b/vesuvius/src/vesuvius/data/vc_dataset.py
@@ -46,6 +46,7 @@ class VCDataset(Dataset):
             skip_empty_patches: bool = True,  # Whether to skip empty (homogeneous) patches
             anon: bool = False,  # Use anonymous (unsigned) requests for S3 input paths
             read_retries: int = 4,  # Attempts per read, forwarded to Volume
+            return_zero_mask: bool = False,  # Also return per-patch mask of raw==0 voxels (see issue #1114)
             ):
         """
         Dataset for nnUNet inference using the Volume class for data access and preprocessing.
@@ -99,6 +100,7 @@ class VCDataset(Dataset):
         self.return_as_tensor = True # Dataset __getitem__ always returns tensors
         self.skip_empty_patches = skip_empty_patches
         self.anon = anon
+        self.return_zero_mask = return_zero_mask
         self.empty_patches_skipped = 0  # Counter for skipped patches
         self.non_empty_mask = None  # Per-patch bool mask; populated below for infer mode with zarr input
 
@@ -233,6 +235,7 @@ class VCDataset(Dataset):
                 path=use_path,
                 anon=self.anon,
                 read_retries=read_retries,
+                return_zero_mask=self.return_zero_mask,
             )
 
             # Get shape and dtype from the primary resolution level (0)
@@ -577,8 +580,12 @@ class VCDataset(Dataset):
                 # For 3D input (Z, Y, X), we always create a single-channel tensor
                 # The model expects a single channel regardless of how many output classes it produces
                 
-                # Volume returns (Z, Y, X) tensor
-                extracted_tensor = self.volume[z_slice, y_slice, x_slice]
+                # Volume returns (Z, Y, X) tensor, plus a raw==0 mask when enabled
+                extracted_zero_mask = None
+                if self.return_zero_mask:
+                    extracted_tensor, extracted_zero_mask = self.volume[z_slice, y_slice, x_slice]
+                else:
+                    extracted_tensor = self.volume[z_slice, y_slice, x_slice]
                 
                 # Fast check for empty patch - skip if all zeros or all values are the same
                 # This avoids processing empty patches which won't contain any information
@@ -602,9 +609,14 @@ class VCDataset(Dataset):
                 # Use the dtype returned by Volume
                 # ALWAYS use a single channel (1) here since we're coming from Z,Y,X data
                 patch_tensor = torch.zeros((1, pZ, pY, pX), dtype=extracted_tensor.dtype)
-                
+
                 # Copy fetched data into the patch tensor
                 patch_tensor[0, :fetched_z, :fetched_y, :fetched_x] = extracted_tensor
+
+                if self.return_zero_mask:
+                    # Padding regions lie outside the volume -> treat as empty (True)
+                    zero_mask_tensor = torch.ones((1, pZ, pY, pX), dtype=torch.bool)
+                    zero_mask_tensor[0, :fetched_z, :fetched_y, :fetched_x] = extracted_zero_mask
 
             elif len(self.input_shape) == 4: # Input is C, Z, Y, X
                 # Volume returns (C, Z, Y, X) tensor
@@ -621,7 +633,11 @@ class VCDataset(Dataset):
                     print(f"4D input: Extracting {self.num_input_channels} channels from data with {available_channels} channels")
                 
                 # Take exactly what the model expects
-                extracted_tensor = self.volume[:self.num_input_channels, z_slice, y_slice, x_slice]
+                extracted_zero_mask = None
+                if self.return_zero_mask:
+                    extracted_tensor, extracted_zero_mask = self.volume[:self.num_input_channels, z_slice, y_slice, x_slice]
+                else:
+                    extracted_tensor = self.volume[:self.num_input_channels, z_slice, y_slice, x_slice]
                 
                 # Check for empty patch - flag if all values are the same
                 is_empty = False
@@ -655,6 +671,12 @@ class VCDataset(Dataset):
                 
                 # Copy fetched data
                 patch_tensor[:, :fetched_z, :fetched_y, :fetched_x] = extracted_tensor
+
+                if self.return_zero_mask:
+                    # Padding regions lie outside the volume -> treat as empty (True).
+                    # A voxel counts as empty only if ALL input channels are raw 0.
+                    zero_mask_tensor = torch.ones((1, pZ, pY, pX), dtype=torch.bool)
+                    zero_mask_tensor[0, :fetched_z, :fetched_y, :fetched_x] = extracted_zero_mask.all(dim=0)
             else:
                  # Should have been caught in init, but safety check
                  raise RuntimeError(f"Unsupported volume shape encountered in getitem: {self.input_shape}")
@@ -674,12 +696,15 @@ class VCDataset(Dataset):
 
         position_tuple = (int(z), int(y), int(x))
 
-        return {
+        item = {
             "data": patch_tensor, # Key required by nnUNet inference
             "pos": position_tuple, # Pass position for potential stitching later
             "index": idx, # Pass original index
             "is_empty": is_empty # Flag to indicate if patch is empty (to skip model inference)
         }
+        if self.return_zero_mask:
+            item["zero_mask"] = zero_mask_tensor
+        return item
     
     @staticmethod
     def collate_fn(batch):
@@ -691,10 +716,13 @@ class VCDataset(Dataset):
         pos = [item["pos"] for item in batch]
         indices = [item["index"] for item in batch]
         is_empty = [item.get("is_empty", False) for item in batch]
-        
-        return {
+
+        result = {
             "data": data,
             "pos": pos,
             "index": indices,
             "is_empty": is_empty
         }
+        if "zero_mask" in batch[0]:
+            result["zero_mask"] = torch.stack([item["zero_mask"] for item in batch])
+        return result

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -917,7 +917,11 @@ class Volume:
 
         # Zero-mask must be computed on the RAW data: normalization maps raw
         # zeros to a nonzero value (e.g. -mean/std under zscore schemes).
-        zero_mask = (data_slice == 0) if self.return_zero_mask else None
+        # getattr, not self.return_zero_mask: Volume is also built via
+        # __new__ without __init__ (see tests/data/test_volume_retry.py), and
+        # this path must keep working for instances that never set the flag.
+        want_zero_mask = getattr(self, "return_zero_mask", False)
+        zero_mask = (data_slice == 0) if want_zero_mask else None
 
         # --- Preprocessing Steps ---
 
@@ -1064,7 +1068,7 @@ class Volume:
                 print(f"  Error converting NumPy array to PyTorch Tensor: {e}")
                 raise
 
-        if self.return_zero_mask:
+        if want_zero_mask:
             if self.return_as_tensor:
                 zero_mask = torch.from_numpy(np.ascontiguousarray(zero_mask))
             return data_slice, zero_mask

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -161,6 +161,7 @@ class Volume:
                  download_only: bool = False,
                  anon: bool = False,
                  read_retries: int = 4,
+                 return_zero_mask: bool = False,
                  ):
 
         """
@@ -207,6 +208,11 @@ class Volume:
             connections, truncated payloads, 429/5xx — are retried with exponential
             backoff so one hiccup does not abort a long streaming job. Deterministic
             errors are re-raised immediately. Pass 1 to disable retrying.
+        return_zero_mask : bool, default = False
+            If True, __getitem__ returns a tuple (data, zero_mask) where zero_mask
+            marks voxels whose RAW (pre-normalization) value is exactly 0, i.e.
+            regions removed by volume masking. Normalization maps raw zeros to a
+            nonzero value, so the mask must be captured before preprocessing.
         """
 
         # Initialize basic attributes
@@ -221,6 +227,7 @@ class Volume:
         self.verbose = verbose
         self.anon = anon
         self.read_retries = max(1, int(read_retries))
+        self.return_zero_mask = return_zero_mask
         self.inklabel = None  # Initialize inklabel
 
         # --- Input Validation ---
@@ -908,6 +915,10 @@ class Volume:
             print(f"  Error: {e}")
             raise  # Re-raise the exception
 
+        # Zero-mask must be computed on the RAW data: normalization maps raw
+        # zeros to a nonzero value (e.g. -mean/std under zscore schemes).
+        zero_mask = (data_slice == 0) if self.return_zero_mask else None
+
         # --- Preprocessing Steps ---
 
         # 1. Convert to float32 for normalization calculations (if needed)
@@ -1052,6 +1063,11 @@ class Volume:
             except Exception as e:
                 print(f"  Error converting NumPy array to PyTorch Tensor: {e}")
                 raise
+
+        if self.return_zero_mask:
+            if self.return_as_tensor:
+                zero_mask = torch.from_numpy(np.ascontiguousarray(zero_mask))
+            return data_slice, zero_mask
 
         return data_slice
 

--- a/vesuvius/src/vesuvius/models/run/blending.py
+++ b/vesuvius/src/vesuvius/models/run/blending.py
@@ -378,6 +378,23 @@ def generate_gaussian_map(patch_size: tuple, sigma_scale: float = 8.0, dtype=np.
     return gaussian_map_np
 
 
+def normalize_blended_logits(chunk_logits, chunk_weights):
+    """Divide accumulated logit*weight sums by the accumulated weights, in place.
+
+    Voxels with weight 0 had no contributions: chunk_logits is already 0
+    there and `where=...` leaves them untouched. Dividing by the exact
+    weight (no epsilon) preserves the weighted average at every covered
+    voxel. A denominator epsilon pulls logits toward 0 wherever the total
+    weight is not far above it: a lone outer-corner Gaussian contribution
+    at a volume edge weighs ~exp(-24) regardless of patch size, which a
+    1e-8 epsilon shrinks by ~265x - enough to read as p ~ 0.5 downstream
+    no matter what the model predicted (see the #1173 review).
+    """
+    weights_b = chunk_weights[np.newaxis, :, :, :]
+    np.divide(chunk_logits, weights_b, out=chunk_logits, where=weights_b > 0)
+    return chunk_logits
+
+
 # --- Worker Process State ---
 _worker_state = {}
 
@@ -408,7 +425,7 @@ def _init_worker(part_files, output_path, gaussian_map, patch_size, num_classes,
     })
 
 
-def process_chunk(chunk_info, chunk_patches, epsilon=1e-8):
+def process_chunk(chunk_info, chunk_patches):
     """
     Process a single chunk using worker-cached zarr stores.
 
@@ -418,7 +435,6 @@ def process_chunk(chunk_info, chunk_patches, epsilon=1e-8):
         chunk_info: Dictionary with chunk boundaries
         chunk_patches: Dict {part_id: [(patch_idx, z, y, x), ...]} precomputed
                        for this chunk (non-empty, intersecting patches only)
-        epsilon: Small value for numerical stability
     """
     part_files = _worker_state['part_files']
     gaussian_map = _worker_state['gaussian_map']
@@ -520,11 +536,7 @@ def process_chunk(chunk_info, chunk_patches, epsilon=1e-8):
             slice(x_start, x_end)
         )
 
-        # Divide in place: voxels with weight==0 had no contributions so
-        # chunk_logits is already 0 there, and `where=...` leaves them untouched.
-        weights_b = chunk_weights[np.newaxis, :, :, :]
-        np.divide(chunk_logits, weights_b + epsilon,
-                  out=chunk_logits, where=weights_b > 0)
+        normalize_blended_logits(chunk_logits, chunk_weights)
 
         finalize_config = _worker_state.get('finalize_config')
         if finalize_config is not None:

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -233,6 +233,49 @@ def _resolve_model_path(model_path: str, cache_dir: str, verbose: bool = False) 
     return target
 
 
+# Activations with classification semantics, where "background" is well
+# defined for empty-input masking. Heads with any other activation (e.g.
+# 'none' on continuous targets such as surface_frame, or checkpoints whose
+# target config was lost) are skipped: forcing +/-20 logits there would
+# corrupt valid regression output instead of encoding background.
+MASKABLE_ACTIVATIONS = ('sigmoid', 'softmax')
+
+
+def apply_empty_input_mask(output_batch, zero_mask, is_multi_task=False,
+                           target_info=None, num_classes=None):
+    """Force background logits where the raw input volume is 0 (issue #1114).
+
+    +/-20 matches the logit saturation convention in finalize_outputs:
+    a single channel is treated as a sigmoid foreground logit (strongly
+    negative -> background), multiple channels as softmax classes with
+    class 0 the background (driven up, others down).
+
+    When per-target configs are available (train.py checkpoints), only
+    targets whose activation is in MASKABLE_ACTIVATIONS are masked and
+    continuous/regression heads are left untouched. Without target configs
+    (nnUNet or external ResNet loaders) the output is a segmentation or
+    classification head by construction, so channel count alone selects
+    the convention.
+    """
+    if is_multi_task and target_info:
+        for _, info in target_info.items():
+            if info.get('activation') not in MASKABLE_ACTIVATIONS:
+                continue
+            s = info['start_channel']
+            e = info.get('end_channel', s + 1)
+            if e - s > 1:
+                output_batch[:, s:s + 1].masked_fill_(zero_mask, 20.0)
+                output_batch[:, s + 1:e].masked_fill_(zero_mask, -20.0)
+            else:
+                output_batch[:, s:e].masked_fill_(zero_mask, -20.0)
+    elif num_classes == 1:
+        output_batch.masked_fill_(zero_mask, -20.0)
+    else:
+        output_batch[:, 0:1].masked_fill_(zero_mask, 20.0)
+        output_batch[:, 1:].masked_fill_(zero_mask, -20.0)
+    return output_batch
+
+
 class Inferer():
     def __init__(self,
                  model_path: str = None,
@@ -255,7 +298,7 @@ class Inferer():
                  writer_workers: int = None,
                  verbose: bool = False,
                  skip_empty_patches: bool = True,  # Skip empty/homogeneous patches
-                 mask_empty_input: bool = True,  # Suppress logits where raw input volume is 0 (issue #1114)
+                 mask_empty_input: bool = False,  # Opt-in: suppress logits where raw input volume is 0 (issue #1114)
                  # params to get passed to Volume 
                  scroll_id: [str, int] = None,
                  segment_id: [str, int] = None,
@@ -467,7 +510,8 @@ class Inferer():
                 self.target_info[target_name] = {
                     'out_channels': target_channels,
                     'start_channel': self.num_classes,
-                    'end_channel': self.num_classes + target_channels
+                    'end_channel': self.num_classes + target_channels,
+                    'activation': target_config.get('activation')
                 }
                 self.num_classes += target_channels
             if self.verbose:
@@ -511,7 +555,10 @@ class Inferer():
                             self.target_info[target_name] = {
                                 'out_channels': target_channels,
                                 'start_channel': self.num_classes,
-                                'end_channel': self.num_classes + target_channels
+                                'end_channel': self.num_classes + target_channels,
+                                # No config available: activation (and therefore
+                                # background semantics) unknown for this target.
+                                'activation': None
                             }
                             self.num_classes += target_channels
                         if self.verbose:
@@ -524,7 +571,16 @@ class Inferer():
                             print(f"Inferred number of output classes via dummy inference: {self.num_classes}")
             except Exception as e:
                 raise RuntimeError(f"Warning: Could not automatically determine number of classes via dummy inference: {e}. \nEnsure your model is loaded correctly and check the expected input shape")
-            
+
+        # Empty-input masking only applies to heads with classification
+        # semantics; tell the user up front which targets will be skipped.
+        if self.mask_empty_input and self.is_multi_task and self.target_info:
+            skipped = [name for name, info in self.target_info.items()
+                       if info.get('activation') not in MASKABLE_ACTIVATIONS]
+            if skipped:
+                print(f"mask_empty_input: skipping non-classification target(s) {skipped} "
+                      f"(no background class; only sigmoid/softmax heads are masked)")
+
         return model
     
     def _load_train_py_model(self, checkpoint_path):
@@ -635,7 +691,8 @@ class Inferer():
                 self.target_info[target_name] = {
                     'out_channels': target_channels,
                     'start_channel': num_classes,
-                    'end_channel': num_classes + target_channels
+                    'end_channel': num_classes + target_channels,
+                    'activation': target_config.get('activation')
                 }
                 num_classes += target_channels
             
@@ -1059,29 +1116,20 @@ class Inferer():
                     # removed by volume masking). Prevents phantom surface voxels at
                     # mask boundaries -- see ScrollPrize/villa#1114. Overlapping
                     # patches read identical raw voxels, so masking is consistent
-                    # across patches and survives gaussian blending. +/-20 matches
-                    # the logit saturation convention used in finalize_outputs.
+                    # across patches, and blend normalization preserves the
+                    # weighted average at covered voxels (see
+                    # blending.normalize_blended_logits), so saturated logits
+                    # survive blending. The finalize-stage support mask proposed
+                    # in #1156 remains the post-blend invariant and the repair
+                    # path for already-published artifacts.
                     if self.mask_empty_input and isinstance(batch_data, dict) and 'zero_mask' in batch_data:
                         zero_mask = to_device(batch_data['zero_mask'])  # (B, 1, Z, Y, X) bool
-                        if self.is_multi_task and getattr(self, 'target_info', None):
-                            # Per-target, matching finalize_outputs semantics:
-                            # single channel -> sigmoid (negative logit = background);
-                            # multi channel -> class 0 is background (drive it up).
-                            for _, info in self.target_info.items():
-                                s = info['start_channel']
-                                e = info.get('end_channel', s + 1)
-                                if e - s > 1:
-                                    output_batch[:, s:s + 1].masked_fill_(zero_mask, 20.0)
-                                    output_batch[:, s + 1:e].masked_fill_(zero_mask, -20.0)
-                                else:
-                                    output_batch[:, s:e].masked_fill_(zero_mask, -20.0)
-                        elif self.num_classes == 1:
-                            # Sigmoid: strongly negative logit -> p ~ 0
-                            output_batch.masked_fill_(zero_mask, -20.0)
-                        else:
-                            # Single-task softmax: drive background (class 0) up, others down
-                            output_batch[:, 0:1].masked_fill_(zero_mask, 20.0)
-                            output_batch[:, 1:].masked_fill_(zero_mask, -20.0)
+                        apply_empty_input_mask(
+                            output_batch, zero_mask,
+                            is_multi_task=self.is_multi_task,
+                            target_info=getattr(self, 'target_info', None),
+                            num_classes=self.num_classes
+                        )
                         del zero_mask
 
                     output_np = self._finalize_output_batch(output_batch)
@@ -1208,11 +1256,13 @@ def build_parser():
     parser.add_argument('--no_skip_empty_patches', dest='skip_empty_patches', action='store_false',
                       help='Process all patches, even if they appear empty')
     parser.set_defaults(skip_empty_patches=True)
-    parser.add_argument('--no_mask_empty_input', dest='mask_empty_input', action='store_false',
-                      help='Disable suppression of predictions where the raw input volume is 0. '
-                           'By default such voxels (regions removed by volume masking) are forced '
-                           'to background to prevent phantom predictions (see issue #1114).')
-    parser.set_defaults(mask_empty_input=True)
+    parser.add_argument('--mask_empty_input', dest='mask_empty_input', action='store_true',
+                      help='Suppress predictions where the raw input volume is 0 (regions removed '
+                           'by volume masking) to prevent phantom predictions at mask boundaries '
+                           '(see issue #1114). Opt-in. Only classification heads (sigmoid/softmax '
+                           'activation) are masked; continuous-valued heads (activation "none") '
+                           'are skipped.')
+    parser.set_defaults(mask_empty_input=False)
     
     # Add arguments for Zarr compression
     parser.add_argument('--zarr_compressor', type=str, default='zstd',

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -255,6 +255,7 @@ class Inferer():
                  writer_workers: int = None,
                  verbose: bool = False,
                  skip_empty_patches: bool = True,  # Skip empty/homogeneous patches
+                 mask_empty_input: bool = True,  # Suppress logits where raw input volume is 0 (issue #1114)
                  # params to get passed to Volume 
                  scroll_id: [str, int] = None,
                  segment_id: [str, int] = None,
@@ -293,6 +294,7 @@ class Inferer():
         self.num_dataloader_workers = num_dataloader_workers
         self.writer_workers = writer_workers
         self.skip_empty_patches = skip_empty_patches
+        self.mask_empty_input = mask_empty_input
         self.scroll_id = scroll_id
         self.segment_id = segment_id
         self.energy = energy
@@ -731,6 +733,7 @@ class Inferer():
             verbose=self.verbose,
             mode='infer',
             skip_empty_patches=self.skip_empty_patches,
+            return_zero_mask=self.mask_empty_input,
             scroll_id=self.scroll_id,
             segment_id=self.segment_id,
             energy=self.energy,
@@ -1052,6 +1055,35 @@ class Inferer():
                         if self.verbose:
                             print("Batch contains only empty patches, skipping model inference")
 
+                    # Suppress predictions where the raw input volume is 0 (regions
+                    # removed by volume masking). Prevents phantom surface voxels at
+                    # mask boundaries -- see ScrollPrize/villa#1114. Overlapping
+                    # patches read identical raw voxels, so masking is consistent
+                    # across patches and survives gaussian blending. +/-20 matches
+                    # the logit saturation convention used in finalize_outputs.
+                    if self.mask_empty_input and isinstance(batch_data, dict) and 'zero_mask' in batch_data:
+                        zero_mask = to_device(batch_data['zero_mask'])  # (B, 1, Z, Y, X) bool
+                        if self.is_multi_task and getattr(self, 'target_info', None):
+                            # Per-target, matching finalize_outputs semantics:
+                            # single channel -> sigmoid (negative logit = background);
+                            # multi channel -> class 0 is background (drive it up).
+                            for _, info in self.target_info.items():
+                                s = info['start_channel']
+                                e = info.get('end_channel', s + 1)
+                                if e - s > 1:
+                                    output_batch[:, s:s + 1].masked_fill_(zero_mask, 20.0)
+                                    output_batch[:, s + 1:e].masked_fill_(zero_mask, -20.0)
+                                else:
+                                    output_batch[:, s:e].masked_fill_(zero_mask, -20.0)
+                        elif self.num_classes == 1:
+                            # Sigmoid: strongly negative logit -> p ~ 0
+                            output_batch.masked_fill_(zero_mask, -20.0)
+                        else:
+                            # Single-task softmax: drive background (class 0) up, others down
+                            output_batch[:, 0:1].masked_fill_(zero_mask, 20.0)
+                            output_batch[:, 1:].masked_fill_(zero_mask, -20.0)
+                        del zero_mask
+
                     output_np = self._finalize_output_batch(output_batch)
                     current_batch_size = output_np.shape[0]
 
@@ -1176,6 +1208,11 @@ def build_parser():
     parser.add_argument('--no_skip_empty_patches', dest='skip_empty_patches', action='store_false',
                       help='Process all patches, even if they appear empty')
     parser.set_defaults(skip_empty_patches=True)
+    parser.add_argument('--no_mask_empty_input', dest='mask_empty_input', action='store_false',
+                      help='Disable suppression of predictions where the raw input volume is 0. '
+                           'By default such voxels (regions removed by volume masking) are forced '
+                           'to background to prevent phantom predictions (see issue #1114).')
+    parser.set_defaults(mask_empty_input=True)
     
     # Add arguments for Zarr compression
     parser.add_argument('--zarr_compressor', type=str, default='zstd',
@@ -1271,6 +1308,7 @@ def main():
         writer_workers=args.writer_workers,
         verbose=args.verbose,
         skip_empty_patches=args.skip_empty_patches,  # Skip empty patches flag
+        mask_empty_input=args.mask_empty_input,  # Suppress phantom preds where raw input is 0 (issue #1114)
         # Pass Volume-specific parameters to VCDataset
         scroll_id=scroll_id,
         segment_id=segment_id,

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -241,6 +241,13 @@ def _resolve_model_path(model_path: str, cache_dir: str, verbose: bool = False) 
 MASKABLE_ACTIVATIONS = ('sigmoid', 'softmax')
 
 
+def _is_maskable_activation(activation):
+    """True when a target's configured activation implies classification
+    semantics. Case-insensitive, matching how activation strings are treated
+    elsewhere in villa (e.g. utils/plotting.py); None/unknown is not maskable."""
+    return isinstance(activation, str) and activation.lower() in MASKABLE_ACTIVATIONS
+
+
 def apply_empty_input_mask(output_batch, zero_mask, is_multi_task=False,
                            target_info=None, num_classes=None):
     """Force background logits where the raw input volume is 0 (issue #1114).
@@ -251,15 +258,15 @@ def apply_empty_input_mask(output_batch, zero_mask, is_multi_task=False,
     class 0 the background (driven up, others down).
 
     When per-target configs are available (train.py checkpoints), only
-    targets whose activation is in MASKABLE_ACTIVATIONS are masked and
-    continuous/regression heads are left untouched. Without target configs
+    targets whose activation matches MASKABLE_ACTIVATIONS (case-insensitive)
+    are masked and continuous/regression heads are left untouched. Without target configs
     (nnUNet or external ResNet loaders) the output is a segmentation or
     classification head by construction, so channel count alone selects
     the convention.
     """
     if is_multi_task and target_info:
         for _, info in target_info.items():
-            if info.get('activation') not in MASKABLE_ACTIVATIONS:
+            if not _is_maskable_activation(info.get('activation')):
                 continue
             s = info['start_channel']
             e = info.get('end_channel', s + 1)
@@ -576,10 +583,13 @@ class Inferer():
         # semantics; tell the user up front which targets will be skipped.
         if self.mask_empty_input and self.is_multi_task and self.target_info:
             skipped = [name for name, info in self.target_info.items()
-                       if info.get('activation') not in MASKABLE_ACTIVATIONS]
+                       if not _is_maskable_activation(info.get('activation'))]
             if skipped:
                 print(f"mask_empty_input: skipping non-classification target(s) {skipped} "
                       f"(no background class; only sigmoid/softmax heads are masked)")
+                if len(skipped) == len(self.target_info):
+                    print("mask_empty_input: no maskable targets found - "
+                          "masking will have no effect for this model")
 
         return model
     

--- a/vesuvius/tests/models/run/test_blending_normalization.py
+++ b/vesuvius/tests/models/run/test_blending_normalization.py
@@ -1,0 +1,99 @@
+"""Tests for the gaussian blend normalization (#1173 review).
+
+The blend step accumulates sum(logit * w) and sum(w) per voxel, then
+normalizes. Dividing by (sum(w) + epsilon) instead of sum(w) pulled
+logits toward 0 wherever the accumulated weight was not far above the
+epsilon: at a voxel covered by a single outer-corner Gaussian
+contribution (weight ~exp(-24)), a saturated -20 logit came out as
+~-0.075 (sigmoid ~0.48), above low probability thresholds - and genuine
+model logits were flattened the same way. The normalization must
+preserve the weighted average at every covered voxel and leave
+uncovered voxels untouched; the `where=weights > 0` guard already
+protects the division, so no epsilon is needed.
+"""
+
+import math
+
+import numpy as np
+
+from vesuvius.models.run.blending import generate_gaussian_map, normalize_blended_logits
+
+# Probability threshold used by the affected surface-prediction runs;
+# finalize_outputs converts it to a logit cutoff: sigmoid(x) > T <=> x > log(T/(1-T)).
+THRESHOLD = 0.2
+LOGIT_CUTOFF = math.log(THRESHOLD / (1.0 - THRESHOLD))
+
+LEGACY_EPSILON = 1e-8
+SATURATION = 20.0
+
+
+def _corner_weight():
+    gmap = generate_gaussian_map((128, 128, 128))[0]
+    return float(gmap[0, 0, 0])
+
+
+def test_corner_weight_is_in_the_legacy_pathological_regime():
+    """Documents the #1173 review finding against the legacy formula."""
+    w = _corner_weight()
+    # The outer corner weighs ~exp(-24), far below the legacy epsilon.
+    assert 0.0 < w < LEGACY_EPSILON
+
+    # sum(logit*w) / (sum(w) + eps) diluted -20 above the threshold cutoff,
+    # i.e. a masked-background voxel read as foreground at threshold 0.2.
+    diluted = (-SATURATION * w) / (w + LEGACY_EPSILON)
+    assert diluted > LOGIT_CUTOFF
+    assert 0.4 < 1.0 / (1.0 + math.exp(-diluted)) < 0.5
+
+
+def test_normalization_preserves_saturation_at_corner_weight():
+    w = _corner_weight()
+    logits = np.full((1, 1, 1, 1), -SATURATION * w, dtype=np.float32)
+    weights = np.full((1, 1, 1), w, dtype=np.float32)
+
+    normalize_blended_logits(logits, weights)
+
+    assert np.isclose(logits[0, 0, 0, 0], -SATURATION, rtol=1e-5)
+    assert logits[0, 0, 0, 0] < LOGIT_CUTOFF
+
+
+def test_normalization_is_exact_for_multiple_contributions():
+    """A weighted average of identical logits is that logit, at any weight."""
+    w = _corner_weight()
+    total_w = np.float32(w) + np.float32(2.0 * w) + np.float32(0.5 * w)
+    logits = np.full((2, 1, 1, 1), -SATURATION * total_w, dtype=np.float32)
+    weights = np.full((1, 1, 1), total_w, dtype=np.float32)
+
+    normalize_blended_logits(logits, weights)
+
+    assert np.allclose(logits, -SATURATION, rtol=1e-5)
+
+
+def test_normalization_leaves_uncovered_voxels_untouched():
+    logits = np.zeros((2, 2, 2, 2), dtype=np.float32)
+    weights = np.zeros((2, 2, 2), dtype=np.float32)
+    weights[0, 0, 0] = 0.5
+    logits[:, 0, 0, 0] = 3.0 * 0.5
+
+    normalize_blended_logits(logits, weights)
+
+    # The covered voxel is the weighted average; uncovered voxels stay 0.
+    assert np.allclose(logits[:, 0, 0, 0], 3.0)
+    uncovered = np.ones((2, 2, 2), dtype=bool)
+    uncovered[0, 0, 0] = False
+    assert (logits[:, uncovered] == 0.0).all()
+
+
+def test_normalization_matches_legacy_for_typical_weights():
+    """For ordinary interior weights the epsilon removal is a ~1e-8
+    relative change: results agree with the legacy formula to float32
+    precision."""
+    rng = np.random.default_rng(0)
+    weights = rng.uniform(0.5, 4.0, size=(3, 3, 3)).astype(np.float32)
+    raw = rng.normal(0.0, 5.0, size=(2, 3, 3, 3)).astype(np.float32)
+    logits = raw * weights[np.newaxis]
+    legacy = logits / (weights[np.newaxis] + LEGACY_EPSILON)
+
+    normalize_blended_logits(logits, weights)
+
+    assert np.allclose(logits, raw, rtol=1e-5)
+    assert np.allclose(logits, legacy, rtol=1e-5)

--- a/vesuvius/tests/models/run/test_blending_normalization.py
+++ b/vesuvius/tests/models/run/test_blending_normalization.py
@@ -44,6 +44,13 @@ def test_corner_weight_is_in_the_legacy_pathological_regime():
     assert diluted > LOGIT_CUTOFF
     assert 0.4 < 1.0 / (1.0 + math.exp(-diluted)) < 0.5
 
+    # Two-channel convention: +20/-20 diluted to ~+0.075/-0.075, so the
+    # foreground softmax read ~0.462 - also above the 0.2 threshold.
+    fg = (-SATURATION * w) / (w + LEGACY_EPSILON)
+    bg = (+SATURATION * w) / (w + LEGACY_EPSILON)
+    assert (fg - bg) > LOGIT_CUTOFF
+    assert 0.4 < 1.0 / (1.0 + math.exp(-(fg - bg))) < 0.5
+
 
 def test_normalization_preserves_saturation_at_corner_weight():
     w = _corner_weight()
@@ -54,6 +61,23 @@ def test_normalization_preserves_saturation_at_corner_weight():
 
     assert np.isclose(logits[0, 0, 0, 0], -SATURATION, rtol=1e-5)
     assert logits[0, 0, 0, 0] < LOGIT_CUTOFF
+
+
+def test_normalization_preserves_softmax_pair_at_corner_weight():
+    """The two-channel +20/-20 background/foreground pair also survives at the
+    corner weight: the foreground softmax stays decisively below threshold."""
+    w = _corner_weight()
+    logits = np.zeros((2, 1, 1, 1), dtype=np.float32)
+    logits[0, 0, 0, 0] = +SATURATION * w
+    logits[1, 0, 0, 0] = -SATURATION * w
+    weights = np.full((1, 1, 1), w, dtype=np.float32)
+
+    normalize_blended_logits(logits, weights)
+
+    assert np.isclose(logits[0, 0, 0, 0], +SATURATION, rtol=1e-5)
+    assert np.isclose(logits[1, 0, 0, 0], -SATURATION, rtol=1e-5)
+    # p_fg > T <=> logit_fg - logit_bg > cutoff; -40 is decisively below.
+    assert (logits[1, 0, 0, 0] - logits[0, 0, 0, 0]) < LOGIT_CUTOFF
 
 
 def test_normalization_is_exact_for_multiple_contributions():

--- a/vesuvius/tests/models/run/test_mask_empty_input.py
+++ b/vesuvius/tests/models/run/test_mask_empty_input.py
@@ -10,9 +10,11 @@ covered in test_blending_normalization.py.
 
 import inspect
 import math
+import sys
 
 import torch
 
+from vesuvius.models.run import inference
 from vesuvius.models.run.inference import (
     Inferer,
     MASKABLE_ACTIVATIONS,
@@ -31,6 +33,45 @@ SATURATION = 20.0
 def test_mask_empty_input_is_opt_in():
     sig = inspect.signature(Inferer.__init__)
     assert sig.parameters["mask_empty_input"].default is False
+
+
+def test_main_forwards_mask_empty_input(monkeypatch, tmp_path):
+    """The CLI flag must actually reach Inferer, and default to off without it
+    (mirrors test_main_accepts_input_anon in test_inference_legacy_checkpoint)."""
+    captured = {}
+    logits_path = tmp_path / "logits_part_0.zarr"
+    coords_path = tmp_path / "coordinates_part_0.zarr"
+    logits_path.mkdir()
+    coords_path.mkdir()
+
+    class FakeInferer:
+        skip_empty_patches = False
+        dataset = None
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def infer(self):
+            return str(logits_path), str(coords_path)
+
+    monkeypatch.setattr(inference, "Inferer", FakeInferer)
+    base_argv = [
+        "vesuvius.predict",
+        "--model_path", str(tmp_path / "model.pth"),
+        "--input_dir", str(tmp_path / "in.zarr"),
+        "--output_dir", str(tmp_path / "out"),
+        "--max_patches", "1",
+        "--device", "cpu",
+    ]
+
+    monkeypatch.setattr(sys, "argv", base_argv + ["--mask_empty_input"])
+    assert inference.main() == 0
+    assert captured["mask_empty_input"] is True
+
+    captured.clear()
+    monkeypatch.setattr(sys, "argv", list(base_argv))
+    assert inference.main() == 0
+    assert captured["mask_empty_input"] is False
 
 
 def _make_target_info(specs):
@@ -127,6 +168,23 @@ def test_single_task_conventions_without_target_info():
     apply_empty_input_mask(output, zero_mask, num_classes=3)
     assert (output[:, 0] == SATURATION).all()
     assert (output[:, 1:] == -SATURATION).all()
+
+
+def test_activation_matching_is_case_insensitive():
+    """Cased activation strings appear in configs and are lowercased elsewhere
+    in villa (cf. utils/plotting.py); the masking gate must tolerate them."""
+    torch.manual_seed(3)
+    output = torch.randn(2, 3, 4, 4, 4)
+    zero_mask = torch.ones(2, 1, 4, 4, 4, dtype=torch.bool)
+    target_info = _make_target_info([("ink", 1, "Sigmoid"), ("damage", 2, "SOFTMAX")])
+
+    apply_empty_input_mask(
+        output, zero_mask, is_multi_task=True, target_info=target_info, num_classes=3
+    )
+
+    assert (output[:, 0] == -SATURATION).all()
+    assert (output[:, 1] == SATURATION).all()
+    assert (output[:, 2] == -SATURATION).all()
 
 
 def test_maskable_activations_are_classification_only():

--- a/vesuvius/tests/models/run/test_mask_empty_input.py
+++ b/vesuvius/tests/models/run/test_mask_empty_input.py
@@ -1,0 +1,133 @@
+"""Tests for empty-input masking of inference outputs (issue #1114).
+
+Covers the head-semantics edge case raised in the #1173 review: only
+sigmoid/softmax (classification) heads have a background class to force,
+so continuous heads (activation "none", e.g. the 9-channel surface_frame
+target) and targets whose activation is unknown must pass through
+unmasked. The blend-normalization edge case from the same review is
+covered in test_blending_normalization.py.
+"""
+
+import inspect
+import math
+
+import torch
+
+from vesuvius.models.run.inference import (
+    Inferer,
+    MASKABLE_ACTIVATIONS,
+    apply_empty_input_mask,
+)
+
+# Probability threshold used by the affected surface-prediction runs.
+# finalize_outputs converts it to a logit cutoff: sigmoid(x) > T <=> x > log(T/(1-T)),
+# and for 2-class softmax: p_fg > T <=> logit_fg - logit_bg > log(T/(1-T)).
+THRESHOLD = 0.2
+LOGIT_CUTOFF = math.log(THRESHOLD / (1.0 - THRESHOLD))
+
+SATURATION = 20.0
+
+
+def test_mask_empty_input_is_opt_in():
+    sig = inspect.signature(Inferer.__init__)
+    assert sig.parameters["mask_empty_input"].default is False
+
+
+def _make_target_info(specs):
+    """Build a target_info dict from (name, out_channels, activation) tuples."""
+    info = {}
+    start = 0
+    for name, channels, activation in specs:
+        info[name] = {
+            "out_channels": channels,
+            "start_channel": start,
+            "end_channel": start + channels,
+            "activation": activation,
+        }
+        start += channels
+    return info
+
+
+def test_continuous_head_is_not_masked():
+    """A surface_frame style head (activation "none") passes through unchanged."""
+    torch.manual_seed(0)
+    output = torch.randn(2, 9, 4, 4, 4)
+    original = output.clone()
+    zero_mask = torch.ones(2, 1, 4, 4, 4, dtype=torch.bool)
+
+    target_info = _make_target_info([("surface_frame", 9, "none")])
+    apply_empty_input_mask(
+        output, zero_mask, is_multi_task=True, target_info=target_info, num_classes=9
+    )
+
+    assert torch.equal(output, original)
+
+
+def test_unknown_activation_is_not_masked():
+    """Targets whose config was lost (activation None) are skipped, not guessed."""
+    torch.manual_seed(1)
+    output = torch.randn(2, 2, 4, 4, 4)
+    original = output.clone()
+    zero_mask = torch.ones(2, 1, 4, 4, 4, dtype=torch.bool)
+
+    target_info = _make_target_info([("mystery", 2, None)])
+    apply_empty_input_mask(
+        output, zero_mask, is_multi_task=True, target_info=target_info, num_classes=2
+    )
+
+    assert torch.equal(output, original)
+
+
+def test_mixed_targets_mask_only_classification_heads():
+    """Multi-task: sigmoid/softmax heads are masked, the continuous head is not."""
+    torch.manual_seed(2)
+    specs = [("ink", 1, "sigmoid"), ("frame", 9, "none"), ("damage", 2, "softmax")]
+    target_info = _make_target_info(specs)
+    num_classes = 12
+
+    output = torch.randn(2, num_classes, 4, 4, 4)
+    original = output.clone()
+    zero_mask = torch.zeros(2, 1, 4, 4, 4, dtype=torch.bool)
+    zero_mask[:, :, :2] = True
+    masked = zero_mask[:, 0]
+
+    apply_empty_input_mask(
+        output, zero_mask, is_multi_task=True, target_info=target_info,
+        num_classes=num_classes,
+    )
+
+    # ink (sigmoid, channel 0): masked voxels forced to -20
+    assert (output[:, 0][masked] == -SATURATION).all()
+    # frame (continuous, channels 1:10): untouched everywhere
+    assert torch.equal(output[:, 1:10], original[:, 1:10])
+    # damage (softmax, channels 10:12): background up, foreground down
+    assert (output[:, 10][masked] == SATURATION).all()
+    assert (output[:, 11][masked] == -SATURATION).all()
+    # Unmasked voxels untouched for all targets
+    unmasked = ~masked
+    assert torch.equal(output[:, :, 2:], original[:, :, 2:])
+    assert (output[:, 0][unmasked] == original[:, 0][unmasked]).all()
+
+    # The masked logits decide background under finalize_outputs semantics.
+    assert (output[:, 0][masked] < LOGIT_CUTOFF).all()
+    assert ((output[:, 11] - output[:, 10])[masked] < LOGIT_CUTOFF).all()
+
+
+def test_single_task_conventions_without_target_info():
+    """Without target configs (nnUNet/ResNet loaders) channel count decides."""
+    zero_mask = torch.ones(2, 1, 4, 4, 4, dtype=torch.bool)
+
+    # Single channel: sigmoid convention, strongly negative logit.
+    output = torch.randn(2, 1, 4, 4, 4)
+    apply_empty_input_mask(output, zero_mask, num_classes=1)
+    assert (output == -SATURATION).all()
+
+    # Multi channel: softmax convention, class 0 is background.
+    output = torch.randn(2, 3, 4, 4, 4)
+    apply_empty_input_mask(output, zero_mask, num_classes=3)
+    assert (output[:, 0] == SATURATION).all()
+    assert (output[:, 1:] == -SATURATION).all()
+
+
+def test_maskable_activations_are_classification_only():
+    assert set(MASKABLE_ACTIVATIONS) == {"sigmoid", "softmax"}

--- a/vesuvius/tests/models/run/test_zero_mask_datapath.py
+++ b/vesuvius/tests/models/run/test_zero_mask_datapath.py
@@ -1,0 +1,104 @@
+"""Tests for how the raw==0 zero mask is produced and transported for
+empty-input masking (issue #1114): Volume computes it on RAW data before
+normalization, VCDataset attaches it per patch (padding regions True,
+multi-channel voxels masked only when all channels are 0), and collate_fn
+stacks it across the batch.
+"""
+
+import numpy as np
+import torch
+import zarr
+
+from vesuvius.data.vc_dataset import VCDataset
+from vesuvius.data.volume import Volume
+
+
+def _write_zarr(path, arr):
+    z = zarr.open(str(path), mode="w", shape=arr.shape, chunks=arr.shape, dtype=arr.dtype)
+    z[:] = arr
+    return arr
+
+
+def test_volume_zero_mask_computed_on_raw_values(tmp_path):
+    """The mask must mark raw==0 voxels even though normalization maps them to
+    a nonzero value - a post-normalization input==0 check would miss them."""
+    rng = np.random.default_rng(0)
+    raw = rng.integers(50, 200, size=(16, 16, 16), dtype=np.uint8)
+    raw[:4] = 0
+    _write_zarr(tmp_path / "vol.zarr", raw)
+
+    volume = Volume(
+        type="zarr",
+        path=str(tmp_path / "vol.zarr"),
+        normalization_scheme="instance_zscore",
+        return_as_tensor=True,
+        return_zero_mask=True,
+    )
+    data, mask = volume[:, :, :]
+
+    np.testing.assert_array_equal(mask.numpy(), raw == 0)
+    assert (np.abs(data.numpy()[raw == 0]) > 1e-6).all()
+
+
+def test_vcdataset_patch_mask_and_collate(tmp_path):
+    """Per-patch masks match raw==0 at the patch position; a fully-zero patch
+    is flagged empty with an all-True mask; collate stacks mixed patches."""
+    rng = np.random.default_rng(1)
+    raw = rng.integers(50, 200, size=(32, 32, 64), dtype=np.uint8)
+    raw[:, :, :32] = 0  # first patch fully zero
+    raw[5:8, 5:8, 40:44] = 0  # small zero pocket inside the second patch
+    _write_zarr(tmp_path / "vol.zarr", raw)
+
+    ds = VCDataset(
+        input_path=str(tmp_path / "vol.zarr"),
+        patch_size=(32, 32, 32),
+        step_size=1.0,
+        normalization_scheme="instance_zscore",
+        mode="infer",
+        skip_empty_patches=True,
+        return_zero_mask=True,
+        verbose=False,
+    )
+    assert len(ds) == 2
+
+    items = {ds[i]["pos"]: ds[i] for i in range(len(ds))}
+    empty_item = items[(0, 0, 0)]
+    data_item = items[(0, 0, 32)]
+
+    assert empty_item["is_empty"] is True
+    assert bool(empty_item["zero_mask"].all())
+
+    assert data_item["is_empty"] is False
+    expected = raw[:, :, 32:64] == 0
+    np.testing.assert_array_equal(data_item["zero_mask"][0].numpy(), expected)
+
+    batch = VCDataset.collate_fn([empty_item, data_item])
+    assert tuple(batch["zero_mask"].shape) == (2, 1, 32, 32, 32)
+    assert batch["zero_mask"].dtype == torch.bool
+    assert bool(batch["zero_mask"][0].all())
+    np.testing.assert_array_equal(batch["zero_mask"][1, 0].numpy(), expected)
+
+
+def test_vcdataset_multichannel_mask_requires_all_channels_zero(tmp_path):
+    """4D input: a voxel is masked only when ALL input channels read raw 0."""
+    raw = np.full((2, 8, 8, 8), 100, dtype=np.uint8)
+    raw[:, 0] = 0  # both channels zero at z=0 -> masked
+    raw[0, 1] = 0  # only channel 0 zero at z=1 -> not masked
+    _write_zarr(tmp_path / "vol4d.zarr", raw)
+
+    ds = VCDataset(
+        input_path=str(tmp_path / "vol4d.zarr"),
+        patch_size=(8, 8, 8),
+        step_size=1.0,
+        normalization_scheme="instance_zscore",
+        mode="infer",
+        skip_empty_patches=False,
+        return_zero_mask=True,
+        verbose=False,
+    )
+    assert len(ds) == 1
+
+    zero_mask = ds[0]["zero_mask"]
+    assert tuple(zero_mask.shape) == (1, 8, 8, 8)
+    assert bool(zero_mask[0, 0].all())
+    assert not bool(zero_mask[0, 1:].any())


### PR DESCRIPTION
Addresses #1114. Complementary to #1156.

**How this relates to #1156**: that PR masks the *finalized* outputs against CT support, which repairs artifacts after the fact and covers already-published zarrs. This PR adds the prevention layer @jrudolph suggested in the issue: mask the logits right after inference, where the input patch is still in memory - so phantoms never enter the blending/finalize path in the first place, at essentially zero extra I/O. The two are not competing; a pipeline ideally wants both (prevent at source, verify/repair at finalize).

On the note in #1156 that logit masking is insufficient (equal logits give p = 0.5, which is positive at a 0.2 threshold): that holds for *zeroed* logits, but not for saturated ones. Masked voxels here are forced to saturated background logits (+/-20, the same convention `finalize_outputs` already uses): sigmoid(-20) is ~2e-9, and for 2-class outputs bg/fg get +20/-20 so `logit[1] - logit[0] = -40`, far below any threshold cutoff. This is unit-tested against the exact threshold semantics in `finalize_outputs` for both sigmoid and 2-class softmax.

The review below surfaced a genuine gap in that argument: the blending normalization added a 1e-8 epsilon to the denominator, which diluted any logit - saturated or genuine - toward 0 (p ~ 0.5) at voxels whose total Gaussian weight sits near or below the epsilon, e.g. a lone outer-corner patch contribution at a volume edge (weight ~exp(-24)). The epsilon predates the `where=weights > 0` guard that already protects the division, so it is now removed: the blended value is the exact weighted average at every covered voxel and saturation does survive blending. Regression tests pin the corner case; #1156's finalize-stage mask remains the post-blend guarantee and the repair path for already-published artifacts.

**Changes**

- `Volume`: new opt-in `return_zero_mask` - returns `(data, mask)` with the mask computed on the **raw** data, before normalization (zscore maps raw zeros to a nonzero value, so the check can't happen later).
- `VCDataset`: passes the per-patch mask through `__getitem__` / `collate_fn`.
- `blending`: normalization now preserves the weighted average at covered voxels (`normalize_blended_logits`); the former denominator epsilon diluted low-weight voxels toward p ~ 0.5, saturated or not.
- `Inferer`: masked voxels forced to saturated background logits, handled per-target for multi-task models - only classification heads (sigmoid/softmax activation); continuous targets such as the 9-channel `surface_frame` (activation `none`) are skipped, with a notice at model load. Overlapping patches read identical raw voxels, so masking is consistent across patches. Opt-in via `--mask_empty_input` (off by default).

There is also a small separate commit fixing `open_zarr` for local paths under zarr 3.x (`storage_options` may not be passed for non-URI stores, even as `{}`). If #1156's `utils.py` change already covers this, happy to drop that commit.

**Validation**

Reproduced the numbers from the issue on the published m7 predictions, streamed from the open bucket:

| z | positives | phantom fraction (mine) | issue |
|---|---|---|---|
| 2000 | 2,259,758 | 0.681 | 0.681 |
| 4224 | 2,379,932 | 0.672 | 0.672 |
| 6000 | 2,110,813 | 0.646 | 0.646 |

Chunk-wise `pred[vol==0]=0` on the z=2000 slab leaves exactly 720,960 positives = 2,259,758 - 1,538,798 phantoms, i.e. the mask removes precisely the phantom set and nothing else. The data path is unit-tested against a synthetic volume (mask == raw==0 through normalization/patching/collate). What I could not run locally is a full end-to-end inference with a real checkpoint (no GPU here) - happy to iterate if anything shows up there.

Committed tests: `tests/models/run/test_blending_normalization.py` (corner-weight preservation, zero-coverage passthrough, agreement with the legacy formula at typical weights) and `tests/models/run/test_mask_empty_input.py` (activation gating, masking conventions, opt-in default).

For scale context: I measured the same halo across all 36 samples with published m7 surface predictions - every one is affected, and 16.9% of all stored prediction chunks are certain phantoms (details: https://github.com/Schurkai/vesuvius-phantom-audit). That is why source-level prevention seemed worth having in addition to the finalize-stage repair.
