### PR TITLE
community_projects: add Volume chunk cache + chunk-size study, and a readability gate

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -70,6 +70,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [llfio-chunkloader](https://github.com/climbmax123/LLFIOCunkloadingTestingAndBenching): A method to access data in chunks of (x,y,z) that is much faster and more compute-efficient than Zarr. (Written in C++ but it is possible to integrate in Python).
 
+- [Volume read cache + chunk-size study](https://github.com/ScrollPrize/villa/pull/1177) by Prasad Khake. Fixes zarr-3 breakage in the Python `vesuvius` `Volume` (multiscale reads raised `TypeError` under the pinned zarr) and adds an opt-in LRU chunk cache — repeated reads of a region are served from memory (~300× faster, byte-identical, off by default) instead of re-fetched, restoring the caching lost when zarr 3 removed `LRUStoreCache`. Includes a measured chunk-size × access-pattern study: read amplification (bytes fetched vs. requested) swings from 1.3× to 176× depending on chunk geometry and access pattern (random patches / z-slices / sequential tracing), giving a basis for choosing chunk shape per workload rather than by opinion.
+
 - [preprocessed-data](https://github.com/usc-caisplusplus/scroll-data-preprocessing): Data preprocessing code and a fully processed version of the dataset in .zarr format to allow for faster training of ink detection models. 
 
 ## Segmentation

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -236,6 +236,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [Scroll Slab Viewer](https://github.com/Paul-G2/ScrollSlabViewer) by Paul Geiger. A 3D viewer tailored for the [Kaggle Surface Detection challenge](https://www.kaggle.com/competitions/vesuvius-challenge-surface-detection).
 
+- [Readability gate](https://github.com/robertlangdonn/vesuvius-readability-gate) by Prasad Khake. A CPU-only readability-risk diagnostic for rendered surfaces: it scores per-column "depth occupancy" over the ink model's 62-layer render window — a surface that isolates one papyrus sheet lights a small localized slice (readable), while one that can't (oblique geometry, or packed/gap-less laminae) saturates through depth (speckle). Predicts whether a candidate surface is worth running ink inference on before spending GPU. Validated on public data (a readable PHerc1667 sheet at median occupancy 0.35 vs unreadable PHerc1203 auto-grown surfaces at 0.97) with a same-scroll geometry-sensitivity control.
+
 ## Ink Detection
 
 ### 🏆 3D Ink Detection


### PR DESCRIPTION
Two community-project listings under existing sections of `20_community_projects.md`:

**Data access** — [Volume read cache + chunk-size study](https://github.com/ScrollPrize/villa/pull/1177): fixes zarr-3 multiscale breakage in the Python `vesuvius` `Volume` and restores an opt-in LRU chunk cache (~300× faster repeat reads, byte-identical), plus a measured chunk-size × access-pattern study (read amplification 1.3×–176×).

**Segmentation** — [Readability gate](https://github.com/robertlangdonn/vesuvius-readability-gate): a CPU-only readability-risk diagnostic that scores depth occupancy over the ink model's 62-layer render window to predict whether a candidate surface can yield legible ink *before* spending inference GPU. Validated on public data (readable PHerc1667 0.35 vs unreadable PHerc1203 0.97) with a same-scroll geometry control.

Both link to public, reproducible work. Happy to split into two PRs if preferred.