### PR TITLE
fix(scrollprize): protect federated auth configuration

### DIFF
--- a/.github/workflows/progress-prizes-google.yml
+++ b/.github/workflows/progress-prizes-google.yml
@@ -150,50 +150,17 @@ jobs:
         with:
           node-version: 24
 
-      - name: Validate protected environment configuration
+      - name: Register protected Google configuration masks
         shell: bash
         env:
-          GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ vars.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ vars.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
-          PROGRESS_PRIZE_DRIVE_ID: ${{ vars.PROGRESS_PRIZE_DRIVE_ID }}
-          PROGRESS_PRIZE_FOLDER_ID: ${{ vars.PROGRESS_PRIZE_FOLDER_ID }}
-          PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ vars.PROGRESS_PRIZE_SOURCE_FORM_ID }}
-          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ vars.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
-          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ vars.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
-          AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
-          OPERATION: ${{ inputs.operation }}
-        run: |
-          set -euo pipefail
-          for name in \
-            GOOGLE_WORKLOAD_IDENTITY_PROVIDER \
-            GOOGLE_SERVICE_ACCOUNT_EMAIL \
-            PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \
-            PROGRESS_PRIZE_DRIVE_ID \
-            PROGRESS_PRIZE_FOLDER_ID \
-            PROGRESS_PRIZE_SOURCE_FORM_ID \
-            PROGRESS_PRIZE_EDITOR_GROUP_EMAIL
-          do
-            test -n "${!name}" || { echo "Missing protected Environment variable: $name" >&2; exit 1; }
-          done
-          if test "$AUTOMATION_ENVIRONMENT" = staging -a "$OPERATION" = cleanup; then
-            test -n "$PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" || {
-              echo "Missing protected Environment variable: PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" >&2
-              exit 1
-            }
-          fi
-
-      - name: Mask protected Google identifiers
-        shell: bash
-        env:
-          GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ vars.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ vars.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
-          PROGRESS_PRIZE_DRIVE_ID: ${{ vars.PROGRESS_PRIZE_DRIVE_ID }}
-          PROGRESS_PRIZE_FOLDER_ID: ${{ vars.PROGRESS_PRIZE_FOLDER_ID }}
-          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ vars.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
-          PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ vars.PROGRESS_PRIZE_SOURCE_FORM_ID }}
-          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ vars.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+          GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          PROGRESS_PRIZE_DRIVE_ID: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          PROGRESS_PRIZE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
+          PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
         run: |
           set -euo pipefail
           for name in \
@@ -209,21 +176,54 @@ jobs:
             value="${!name}"
             test -z "$value" && continue
             case "$value" in
-              *$'\r'*|*$'\n'*) echo "Protected Environment variable has an invalid value." >&2; exit 1 ;;
+              *$'\r'*|*$'\n'*) echo "Protected Environment secret has an invalid value." >&2; exit 1 ;;
             esac
             printf '::add-mask::%s\n' "$value"
           done
+
+      - name: Validate protected environment configuration
+        shell: bash
+        env:
+          GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          PROGRESS_PRIZE_DRIVE_ID: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          PROGRESS_PRIZE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
+          AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
+          OPERATION: ${{ inputs.operation }}
+        run: |
+          set -euo pipefail
+          for name in \
+            GOOGLE_WORKLOAD_IDENTITY_PROVIDER \
+            GOOGLE_SERVICE_ACCOUNT_EMAIL \
+            PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \
+            PROGRESS_PRIZE_DRIVE_ID \
+            PROGRESS_PRIZE_FOLDER_ID \
+            PROGRESS_PRIZE_SOURCE_FORM_ID \
+            PROGRESS_PRIZE_EDITOR_GROUP_EMAIL
+          do
+            test -n "${!name}" || { echo "Missing protected Environment secret: $name" >&2; exit 1; }
+          done
+          if test "$AUTOMATION_ENVIRONMENT" = staging -a "$OPERATION" = cleanup; then
+            test -n "$PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" || {
+              echo "Missing protected Environment secret: PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" >&2
+              exit 1
+            }
+          fi
 
       - name: Authenticate read-only validation without a credential file
         if: inputs.operation == 'validate' || inputs.operation == 'verify' || inputs['dry-run']
         id: auth-read
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
-          workload_identity_provider: ${{ vars.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
           token_format: access_token
           access_token_lifetime: 900s
-          access_token_scopes: >-
+          access_token_scopes: |-
             https://www.googleapis.com/auth/forms.body.readonly
             https://www.googleapis.com/auth/drive.readonly
           create_credentials_file: false
@@ -234,11 +234,11 @@ jobs:
         id: auth-write
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
-          workload_identity_provider: ${{ vars.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
           token_format: access_token
           access_token_lifetime: 900s
-          access_token_scopes: >-
+          access_token_scopes: |-
             https://www.googleapis.com/auth/forms.body
             https://www.googleapis.com/auth/drive
           create_credentials_file: false
@@ -281,15 +281,15 @@ jobs:
           GOOGLE_ACCESS_TOKEN: ${{ steps['auth-read'].outputs.access_token || steps['auth-write'].outputs.access_token }}
           PROGRESS_PRIZE_ENVIRONMENT: ${{ inputs.environment }}
           PROGRESS_PRIZE_EVENT_NAME: ${{ github.event_name }}
-          PROGRESS_PRIZE_DRIVE_ID: ${{ vars.PROGRESS_PRIZE_DRIVE_ID }}
-          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ vars.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
-          PROGRESS_PRIZE_FOLDER_ID: ${{ vars.PROGRESS_PRIZE_FOLDER_ID }}
-          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ vars.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
-          PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ vars.PROGRESS_PRIZE_SOURCE_FORM_ID }}
-          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ vars.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
-          PROGRESS_PRIZE_SERVICE_ACCOUNT_EMAIL: ${{ vars.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs.environment == 'staging' && vars.GOOGLE_SERVICE_ACCOUNT_EMAIL || '' }}
-          PROGRESS_PRIZE_STAGING_FOLDER_ID: ${{ inputs.environment == 'staging' && vars.PROGRESS_PRIZE_FOLDER_ID || '' }}
+          PROGRESS_PRIZE_DRIVE_ID: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          PROGRESS_PRIZE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
+          PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+          PROGRESS_PRIZE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs.environment == 'staging' && secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL || '' }}
+          PROGRESS_PRIZE_STAGING_FOLDER_ID: ${{ inputs.environment == 'staging' && secrets.PROGRESS_PRIZE_FOLDER_ID || '' }}
           PROGRESS_PRIZE_BRANCH: ${{ inputs.branch }}
           PROGRESS_PRIZE_TARGET_BRANCH: ${{ inputs['target-branch'] }}
           PROGRESS_PRIZE_DEFAULT_TARGET_BRANCH: main

--- a/.github/workflows/progress-prizes-vercel-preview.yml
+++ b/.github/workflows/progress-prizes-vercel-preview.yml
@@ -43,12 +43,12 @@ jobs:
       - name: Mask the protected Vercel project identifier
         shell: bash
         env:
-          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           set -euo pipefail
           test -n "$VERCEL_PROJECT_ID"
           case "$VERCEL_PROJECT_ID" in
-            *$'\r'*|*$'\n'*) echo "Preview Environment variable has an invalid value." >&2; exit 1 ;;
+            *$'\r'*|*$'\n'*) echo "Preview Environment secret has an invalid value." >&2; exit 1 ;;
           esac
           printf '::add-mask::%s\n' "$VERCEL_PROJECT_ID"
 
@@ -57,7 +57,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_PATH: ${{ github.event_path }}
-          EXPECTED_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          EXPECTED_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -47,12 +47,14 @@ The workflows invoke:
 node scrollprize.org/scripts/progress-prizes/automation-cli.mjs COMMAND ...
 ```
 
-Private identifiers are read only from the protected Environment variables
-below. Operation JSON is kept in `$RUNNER_TEMP`, never uploaded, and only a
-canonical `forms.gle` or `docs.google.com/forms/d/e/.../viewform` URL may cross
-the authenticated job boundary. Because GitHub variables are not masked
-automatically, the workflows validate and register every protected Google and
-Vercel identifier with `add-mask` before an action or verifier can log it.
+Private identifiers are read only from protected Environment secrets below.
+They are configuration values rather than Google credentials, but secrets are
+required because GitHub does not automatically redact Environment variables
+from public Actions logs. Operation JSON is kept in `$RUNNER_TEMP`, never
+uploaded, and only a canonical `forms.gle` or
+`docs.google.com/forms/d/e/.../viewform` URL may cross the authenticated job
+boundary. The workflows also register every protected identifier with
+`add-mask` before validation as defense in depth.
 
 ## GitHub Environments
 
@@ -64,7 +66,7 @@ require a month-end wait.
 
 ### `progress-prizes-staging`
 
-Protected Environment variables:
+Protected Environment secrets:
 
 - `GOOGLE_WORKLOAD_IDENTITY_PROVIDER`
 - `GOOGLE_SERVICE_ACCOUNT_EMAIL`
@@ -108,7 +110,7 @@ on each managed staging form.
 
 ### `progress-prizes-production`
 
-Protected Environment variables:
+Protected Environment secrets:
 
 - `GOOGLE_WORKLOAD_IDENTITY_PROVIDER`
 - `GOOGLE_SERVICE_ACCOUNT_EMAIL`
@@ -152,23 +154,22 @@ renamed. At activation it is closed first and receives only the private recovery
 state marker. The August copy is created in the production Shared Drive and is
 cryptographically bound to that exact source ID. After its activation, managed
 `appProperties` discovery always selects the prior managed target, so the
-fallback variable does not need a monthly edit and is ignored for later cycles.
+fallback secret does not need a monthly edit and is ignored for later cycles.
 
 ### `progress-prizes-preview`
 
-Protected Environment variable:
+Protected Environment secret:
 
 - `VERCEL_PROJECT_ID`
-
-Environment secret:
 
 - `VERCEL_AUTOMATION_BYPASS_SECRET`
 
 The bypass value is needed because the current Vercel previews are protected by
 SSO. It is sent only after the verifier has accepted an HTTPS `*.vercel.app`
-origin for the configured project; redirects are never followed. This is the
-only long-lived GitHub secret required by these workflows, and it is a Vercel
-preview secret—not a Google credential.
+origin for the configured project; redirects are never followed. This bypass
+value is the only secret here that grants access outside GitHub. The Google
+Environment secrets contain identifiers and ACL configuration only—not a key,
+refresh token, or other reusable credential.
 
 ## Google WIF setup
 
@@ -295,7 +296,7 @@ managed source in any later cycle fails instead of reusing July:
    write the private recovery marker.
 6. After the August form is active and verified, the owner may remove both
    direct service-account ACLs from July. Later cycles resolve only managed forms
-   in the production Shared Drive, even if the stale fallback variable remains.
+   in the production Shared Drive, even if the stale fallback secret remains.
 
 If Workspace policy refuses direct sharing to a service-account principal, move
 the source into the production Shared Drive or redesign the identity boundary.

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -55,12 +55,41 @@ test('Google OIDC exists only in the guarded reusable workflow and authenticated
   assert.match(google, /create_credentials_file: false/);
   assert.match(google, /export_environment_variables: false/);
   assert.match(google, /printf '::add-mask::%s\\n' \"\$value\"/);
+  const maskStep = google.indexOf('- name: Register protected Google configuration masks');
+  const validationStep = google.indexOf('- name: Validate protected environment configuration');
+  assert.ok(maskStep >= 0 && maskStep < validationStep, 'mask registration must precede validation');
+  assert.doesNotMatch(
+    google,
+    /\$\{\{\s*vars(?:\.|\[)/,
+    'protected Google configuration must use auto-masked Environment secrets, never variables',
+  );
+  for (const name of [
+    'GOOGLE_WORKLOAD_IDENTITY_PROVIDER',
+    'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+    'PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL',
+    'PROGRESS_PRIZE_DRIVE_ID',
+    'PROGRESS_PRIZE_FOLDER_ID',
+    'PROGRESS_PRIZE_ARCHIVE_FOLDER_ID',
+    'PROGRESS_PRIZE_SOURCE_FORM_ID',
+    'PROGRESS_PRIZE_EDITOR_GROUP_EMAIL',
+  ]) {
+    assert.match(google, new RegExp(`secrets\\.${name}\\b`), `${name} must be an Environment secret`);
+  }
   assert.ok(
-    [...google.matchAll(/PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: \$\{\{ vars\.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \}\}/g)].length >= 3,
+    [...google.matchAll(/PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: \$\{\{ secrets\.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \}\}/g)].length >= 3,
     'the private Drive administrator must be validated, masked, and passed to the CLI',
   );
   assert.match(google, /GOOGLE_SERVICE_ACCOUNT_EMAIL \\\n            PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \\\n            PROGRESS_PRIZE_DRIVE_ID/);
   assert.match(google, /access_token_lifetime: 900s/);
+  assert.doesNotMatch(google, /access_token_scopes: >-/);
+  assert.match(
+    google,
+    /access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\.readonly/,
+  );
+  assert.match(
+    google,
+    /access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\n/,
+  );
   assert.match(google, /Authenticate read-only validation/);
   assert.match(
     google,
@@ -75,6 +104,7 @@ test('Google OIDC exists only in the guarded reusable workflow and authenticated
   assert.match(google, /TARGET_CYCLE: \$\{\{ inputs\['target-cycle'\] \}\}/);
   for (const runBlock of google.matchAll(/^ {8}run: \|\n((?:(?: {10}.*)?\n)*)/gm)) {
     assert.doesNotMatch(runBlock[1], /\$\{\{ inputs\['target-cycle'\] \}\}/);
+    assert.doesNotMatch(runBlock[1], /\$\{\{\s*(?:secrets|vars)(?:\.|\[)/);
   }
   assert.match(google, /ref: refs\/heads\/main/);
   assert.match(google, /automation-cli\.mjs/);
@@ -145,6 +175,12 @@ test('Vercel verification runs trusted default-branch code and requires GitHub a
   assert.match(vercel, /payload\.git\?\.ref/);
   assert.match(vercel, /progress-prizes\/vercel-preview/);
   assert.match(vercel, /VERCEL_AUTOMATION_BYPASS_SECRET/);
+  assert.doesNotMatch(vercel, /\$\{\{\s*vars\.VERCEL_PROJECT_ID\s*\}\}/);
+  assert.equal(
+    [...vercel.matchAll(/\$\{\{\s*secrets\.VERCEL_PROJECT_ID\s*\}\}/g)].length,
+    2,
+    'the Vercel project identifier must be auto-masked at both uses',
+  );
   assert.match(vercel, /printf '::add-mask::%s\\n' \"\$VERCEL_PROJECT_ID\"/);
   assert.match(vercel, /!process\.env\.VERCEL_AUTOMATION_BYPASS_SECRET/);
   assert.match(vercel, /redirect: 'error'/);


### PR DESCRIPTION
Fix the first live rehearsal failure before any Google API mutation.

- stores private Google configuration and the Vercel project identifier as protected Environment secrets so GitHub masks them before step startup
- registers defense-in-depth masks before validation
- sends OAuth scopes as a newline-separated list accepted by google-github-actions/auth
- adds workflow contract regressions and updates setup documentation

Verification: full repository tests, 160 Progress Prize tests, YAML parsing, actionlint, Node syntax checks, and git diff --check all pass. The failed rehearsal run containing pre-mask diagnostics was deleted.