### PR TITLE
fix(scrollprize): resolve environment secrets in reusable job

### DIFF
--- a/.github/workflows/progress-prizes-google.yml
+++ b/.github/workflows/progress-prizes-google.yml
@@ -59,6 +59,31 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      GOOGLE_WORKLOAD_IDENTITY_PROVIDER:
+        description: Resolved only from the selected protected Environment
+        required: false
+      GOOGLE_SERVICE_ACCOUNT_EMAIL:
+        description: Resolved only from the selected protected Environment
+        required: false
+      PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL:
+        description: Resolved only from the selected protected Environment
+        required: false
+      PROGRESS_PRIZE_DRIVE_ID:
+        description: Resolved only from the selected protected Environment
+        required: false
+      PROGRESS_PRIZE_FOLDER_ID:
+        description: Resolved only from the selected protected Environment
+        required: false
+      PROGRESS_PRIZE_ARCHIVE_FOLDER_ID:
+        description: Resolved only from the selected protected Environment
+        required: false
+      PROGRESS_PRIZE_SOURCE_FORM_ID:
+        description: Resolved only from the selected protected Environment
+        required: false
+      PROGRESS_PRIZE_EDITOR_GROUP_EMAIL:
+        description: Resolved only from the selected protected Environment
+        required: false
     outputs:
       responder-uri:
         description: Intentionally public canonical responder URL

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -55,6 +55,9 @@ uploaded, and only a canonical `forms.gle` or
 `docs.google.com/forms/d/e/.../viewform` URL may cross the authenticated job
 boundary. The workflows also register every protected identifier with
 `add-mask` before validation as defense in depth.
+The reusable Google workflow declares these secret names as optional solely so
+GitHub can resolve the job's selected Environment. Callers never pass or
+inherit them, and the job-level Environment value is authoritative.
 
 ## GitHub Environments
 

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -63,7 +63,7 @@ test('Google OIDC exists only in the guarded reusable workflow and authenticated
     /\$\{\{\s*vars(?:\.|\[)/,
     'protected Google configuration must use auto-masked Environment secrets, never variables',
   );
-  for (const name of [
+  const protectedGoogleSecretNames = [
     'GOOGLE_WORKLOAD_IDENTITY_PROVIDER',
     'GOOGLE_SERVICE_ACCOUNT_EMAIL',
     'PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL',
@@ -72,7 +72,19 @@ test('Google OIDC exists only in the guarded reusable workflow and authenticated
     'PROGRESS_PRIZE_ARCHIVE_FOLDER_ID',
     'PROGRESS_PRIZE_SOURCE_FORM_ID',
     'PROGRESS_PRIZE_EDITOR_GROUP_EMAIL',
-  ]) {
+  ];
+  const declarationBlock = google.slice(
+    google.indexOf('    secrets:\n'),
+    google.indexOf('    outputs:\n'),
+  );
+  const declaredEnvironmentSecrets = [
+    ...declarationBlock.matchAll(
+      /^      ([A-Z][A-Z0-9_]+):\n        description: .*\n        required: false$/gm,
+    ),
+  ].map((match) => match[1]);
+  assert.deepEqual(declaredEnvironmentSecrets, protectedGoogleSecretNames);
+  assert.doesNotMatch(declarationBlock, /required: true/);
+  for (const name of protectedGoogleSecretNames) {
     assert.match(google, new RegExp(`secrets\\.${name}\\b`), `${name} must be an Environment secret`);
   }
   assert.ok(
@@ -134,6 +146,11 @@ test('rehearsal controls are fixed to staging and its ephemeral branches', async
   const rehearsal = await workflow('progress-prizes-rehearsal.yml');
   assert.match(rehearsal, /^on:\n  workflow_dispatch:/m);
   assert.doesNotMatch(rehearsal, /schedule:|pull_request/);
+  assert.doesNotMatch(
+    rehearsal,
+    /^ {4}secrets:/m,
+    'callers must not pass or override the Google job Environment secrets',
+  );
   assert.match(rehearsal, /codex\/progress-prize-smoke-20260720/);
   assert.match(rehearsal, /codex\/progress-prize-smoke-base-20260720/);
   assert.match(rehearsal, /fault: after-copy/);


### PR DESCRIPTION
The protected Google job selected the correct Environment, but GitHub returned empty secret contexts because the reusable workflow did not declare their names.

This change declares the eight Environment secret names as optional workflow-call secrets. Callers still pass no secrets, so the selected job Environment remains authoritative and cannot be overridden. Contract tests enforce both properties.

Verification: 173/173 full tests, 160/160 Progress Prize tests, YAML parsing, actionlint, Node syntax checks, and git diff --check.