### PR TITLE
fix(scrollprize): bind Google jobs to literal environments

### DIFF
--- a/.github/actions/progress-prizes-google/action.yml
+++ b/.github/actions/progress-prizes-google/action.yml
@@ -1,0 +1,399 @@
+name: Progress Prize Google operation
+description: Run one guarded Progress Prize Google Forms operation from a trusted checkout
+
+inputs:
+  operation:
+    description: validate, bootstrap, prepare, activate, verify, or cleanup
+    required: true
+  environment:
+    description: staging or production
+    required: true
+  source-cycle:
+    description: Source cycle in YYYY-MM form
+    required: false
+    default: ""
+  target-cycle:
+    description: Target cycle in YYYY-MM form
+    required: false
+    default: ""
+  simulated-now:
+    description: Staging workflow_dispatch clock only
+    required: false
+    default: ""
+  fault:
+    description: Staging workflow_dispatch fault point only
+    required: false
+    default: ""
+  expect-fault:
+    description: Require the named staging fault to occur
+    required: false
+    default: "false"
+  dry-run:
+    description: Ask a supported operation to make no mutation
+    required: false
+    default: "false"
+  verify-mode:
+    description: prepared, active, or cleaned
+    required: false
+    default: prepared
+  branch:
+    description: Runtime branch asserted by the automation core
+    required: true
+  target-branch:
+    description: PR base asserted by the automation core
+    required: true
+  head-sha:
+    description: Exact tested commit used by activation
+    required: false
+    default: ""
+  workload-identity-provider:
+    description: Protected Environment WIF provider identifier
+    required: true
+  service-account-email:
+    description: Protected Environment service account identifier
+    required: true
+  drive-admin-email:
+    description: Protected Environment break-glass administrator identity
+    required: true
+  drive-id:
+    description: Protected Environment Shared Drive identifier
+    required: true
+  folder-id:
+    description: Protected Environment active folder identifier
+    required: true
+  archive-folder-id:
+    description: Protected staging archive folder identifier
+    required: false
+    default: ""
+  source-form-id:
+    description: Protected initial source form identifier
+    required: true
+  editor-group-email:
+    description: Protected Environment editor group identity
+    required: true
+
+outputs:
+  responder-uri:
+    description: Intentionally public canonical responder URL
+    value: ${{ steps.result.outputs['responder-uri'] }}
+
+runs:
+  using: composite
+  steps:
+    - name: Reject unsafe controls before authentication
+      shell: bash
+      env:
+        REPOSITORY: ${{ github.repository }}
+        REPOSITORY_ID: ${{ github.repository_id }}
+        REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+        REF: ${{ github.ref }}
+        AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
+        EVENT_NAME: ${{ github.event_name }}
+        OPERATION: ${{ inputs.operation }}
+        SIMULATED_NOW: ${{ inputs['simulated-now'] }}
+        FAULT: ${{ inputs.fault }}
+        EXPECT_FAULT: ${{ inputs['expect-fault'] }}
+        DRY_RUN: ${{ inputs['dry-run'] }}
+        BRANCH: ${{ inputs.branch }}
+        TARGET_BRANCH: ${{ inputs['target-branch'] }}
+        SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+        TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+        HEAD_SHA: ${{ inputs['head-sha'] }}
+      run: |
+        set -euo pipefail
+        test "$REPOSITORY" = ScrollPrize/villa
+        test "$REPOSITORY_ID" = 890972577
+        test "$REPOSITORY_OWNER_ID" = 121906140
+        test "$REF" = refs/heads/main
+        test "$EVENT_NAME" = workflow_dispatch -o "$EVENT_NAME" = schedule
+        case "$OPERATION" in
+          validate|bootstrap|prepare|activate|verify|cleanup) ;;
+          *) exit 1 ;;
+        esac
+        case "$EXPECT_FAULT" in true|false) ;; *) exit 1 ;; esac
+        case "$DRY_RUN" in true|false) ;; *) exit 1 ;; esac
+        if test -n "$SOURCE_CYCLE"; then [[ "$SOURCE_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; fi
+        if test -n "$TARGET_CYCLE"; then [[ "$TARGET_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; fi
+        case "$OPERATION" in
+          validate|bootstrap) test -n "$SOURCE_CYCLE" ;;
+          prepare|activate|verify|cleanup) test -n "$TARGET_CYCLE" ;;
+        esac
+        if test "$OPERATION" = activate; then [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; fi
+        if test -n "$HEAD_SHA"; then [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; fi
+        if test "$AUTOMATION_ENVIRONMENT" = production; then
+          test "$OPERATION" != bootstrap
+          test "$OPERATION" != cleanup
+          test -z "$SIMULATED_NOW"
+          test -z "$FAULT"
+          test "$EXPECT_FAULT" = false
+          test "$TARGET_BRANCH" = main
+          test "$BRANCH" = main -o "$BRANCH" = "codex/progress-prize-$TARGET_CYCLE"
+        else
+          test "$AUTOMATION_ENVIRONMENT" = staging
+          test "$EVENT_NAME" = workflow_dispatch
+          test "$BRANCH" = codex/progress-prize-smoke-20260720
+          test "$TARGET_BRANCH" = codex/progress-prize-smoke-base-20260720
+          if test -n "$FAULT"; then
+            case "$FAULT" in
+              after-copy|after-close-source) ;;
+              *) exit 1 ;;
+            esac
+          fi
+        fi
+        if test "$EXPECT_FAULT" = true; then
+          test -n "$FAULT"
+          test "$AUTOMATION_ENVIRONMENT" = staging
+        fi
+
+    - name: Set up Node.js
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
+
+    - name: Register protected Google configuration masks
+      shell: bash
+      env:
+        GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ inputs['workload-identity-provider'] }}
+        GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ inputs['service-account-email'] }}
+        PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ inputs['drive-admin-email'] }}
+        PROGRESS_PRIZE_DRIVE_ID: ${{ inputs['drive-id'] }}
+        PROGRESS_PRIZE_FOLDER_ID: ${{ inputs['folder-id'] }}
+        PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ inputs['archive-folder-id'] }}
+        PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ inputs['source-form-id'] }}
+        PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ inputs['editor-group-email'] }}
+      run: |
+        set -euo pipefail
+        for name in \
+          GOOGLE_WORKLOAD_IDENTITY_PROVIDER \
+          GOOGLE_SERVICE_ACCOUNT_EMAIL \
+          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \
+          PROGRESS_PRIZE_DRIVE_ID \
+          PROGRESS_PRIZE_FOLDER_ID \
+          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID \
+          PROGRESS_PRIZE_SOURCE_FORM_ID \
+          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL
+        do
+          value="${!name}"
+          test -z "$value" && continue
+          case "$value" in
+            *$'\r'*|*$'\n'*) echo "Protected Environment secret has an invalid value." >&2; exit 1 ;;
+          esac
+          printf '::add-mask::%s\n' "$value"
+        done
+
+    - name: Validate protected environment configuration
+      shell: bash
+      env:
+        GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ inputs['workload-identity-provider'] }}
+        GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ inputs['service-account-email'] }}
+        PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ inputs['drive-admin-email'] }}
+        PROGRESS_PRIZE_DRIVE_ID: ${{ inputs['drive-id'] }}
+        PROGRESS_PRIZE_FOLDER_ID: ${{ inputs['folder-id'] }}
+        PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ inputs['source-form-id'] }}
+        PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ inputs['editor-group-email'] }}
+        PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ inputs['archive-folder-id'] }}
+        AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
+        OPERATION: ${{ inputs.operation }}
+      run: |
+        set -euo pipefail
+        for name in \
+          GOOGLE_WORKLOAD_IDENTITY_PROVIDER \
+          GOOGLE_SERVICE_ACCOUNT_EMAIL \
+          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \
+          PROGRESS_PRIZE_DRIVE_ID \
+          PROGRESS_PRIZE_FOLDER_ID \
+          PROGRESS_PRIZE_SOURCE_FORM_ID \
+          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL
+        do
+          test -n "${!name}" || { echo "Missing protected Environment secret: $name" >&2; exit 1; }
+        done
+        if test "$AUTOMATION_ENVIRONMENT" = staging -a "$OPERATION" = cleanup; then
+          test -n "$PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" || {
+            echo "Missing protected Environment secret: PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" >&2
+            exit 1
+          }
+        fi
+
+    - name: Authenticate read-only validation without a credential file
+      if: inputs.operation == 'validate' || inputs.operation == 'verify' || inputs['dry-run'] == 'true'
+      id: auth-read
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      with:
+        workload_identity_provider: ${{ inputs['workload-identity-provider'] }}
+        service_account: ${{ inputs['service-account-email'] }}
+        token_format: access_token
+        access_token_lifetime: 1200s
+        access_token_scopes: |-
+          https://www.googleapis.com/auth/forms.body.readonly
+          https://www.googleapis.com/auth/drive.readonly
+        create_credentials_file: false
+        export_environment_variables: false
+
+    - name: Authenticate mutating operations without a credential file
+      if: inputs.operation != 'validate' && inputs.operation != 'verify' && inputs['dry-run'] != 'true'
+      id: auth-write
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      with:
+        workload_identity_provider: ${{ inputs['workload-identity-provider'] }}
+        service_account: ${{ inputs['service-account-email'] }}
+        token_format: access_token
+        access_token_lifetime: 1200s
+        access_token_scopes: |-
+          https://www.googleapis.com/auth/forms.body
+          https://www.googleapis.com/auth/drive
+        create_credentials_file: false
+        export_environment_variables: false
+
+    - name: Fetch the managed page at the exact gated commit
+      if: inputs.operation == 'activate' || (inputs.operation == 'verify' && inputs['head-sha'] != '')
+      shell: bash
+      env:
+        HEAD_SHA: ${{ inputs['head-sha'] }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        node --input-type=module <<'NODE'
+        import { writeFile } from 'node:fs/promises';
+
+        const sha = process.env.HEAD_SHA ?? '';
+        if (!/^[a-f0-9]{40}$/i.test(sha)) throw new Error('The operation requires an exact commit SHA.');
+        const url = new URL('https://api.github.com/repos/ScrollPrize/villa/contents/scrollprize.org/docs/34_prizes.md');
+        url.searchParams.set('ref', sha);
+        const response = await fetch(url, {
+          redirect: 'error',
+          headers: {
+            accept: 'application/vnd.github.raw+json',
+            authorization: `Bearer ${process.env.GH_TOKEN}`,
+            'user-agent': 'progress-prize-rollover',
+            'x-github-api-version': '2022-11-28',
+          },
+        });
+        if (response.status !== 200) throw new Error('Could not read the managed page at the activation commit.');
+        const body = await response.text();
+        if (Buffer.byteLength(body, 'utf8') > 1024 * 1024) throw new Error('Managed page response is too large.');
+        await writeFile(`${process.env.RUNNER_TEMP}/progress-prizes-page.md`, body, { mode: 0o600 });
+        NODE
+
+    - name: Run Google operation
+      id: operation
+      shell: bash
+      env:
+        GOOGLE_ACCESS_TOKEN: ${{ steps['auth-read'].outputs.access_token || steps['auth-write'].outputs.access_token }}
+        PROGRESS_PRIZE_ENVIRONMENT: ${{ inputs.environment }}
+        PROGRESS_PRIZE_EVENT_NAME: ${{ github.event_name }}
+        PROGRESS_PRIZE_DRIVE_ID: ${{ inputs['drive-id'] }}
+        PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ inputs['drive-admin-email'] }}
+        PROGRESS_PRIZE_FOLDER_ID: ${{ inputs['folder-id'] }}
+        PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ inputs['archive-folder-id'] }}
+        PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ inputs['source-form-id'] }}
+        PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ inputs['editor-group-email'] }}
+        PROGRESS_PRIZE_SERVICE_ACCOUNT_EMAIL: ${{ inputs['service-account-email'] }}
+        PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs.environment == 'staging' && inputs['service-account-email'] || '' }}
+        PROGRESS_PRIZE_STAGING_FOLDER_ID: ${{ inputs.environment == 'staging' && inputs['folder-id'] || '' }}
+        PROGRESS_PRIZE_BRANCH: ${{ inputs.branch }}
+        PROGRESS_PRIZE_TARGET_BRANCH: ${{ inputs['target-branch'] }}
+        PROGRESS_PRIZE_DEFAULT_TARGET_BRANCH: main
+        PROGRESS_PRIZE_SMOKE_BRANCH_PREFIX: codex/progress-prize-smoke-
+        PROGRESS_PRIZE_SMOKE_DATE: ${{ inputs.environment == 'staging' && '2026-07-20' || '' }}
+        PROGRESS_PRIZE_VERIFIED_SHA: ${{ inputs['head-sha'] }}
+        PROGRESS_PRIZE_HEAD_SHA: ${{ inputs['head-sha'] }}
+        OPERATION: ${{ inputs.operation }}
+        SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+        TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+        SIMULATED_NOW: ${{ inputs['simulated-now'] }}
+        FAULT: ${{ inputs.fault }}
+        EXPECT_FAULT: ${{ inputs['expect-fault'] }}
+        DRY_RUN: ${{ inputs['dry-run'] }}
+        VERIFY_MODE: ${{ inputs['verify-mode'] }}
+      run: |
+        set -euo pipefail
+        arguments=("$OPERATION" --environment "$PROGRESS_PRIZE_ENVIRONMENT" --event-name "$PROGRESS_PRIZE_EVENT_NAME")
+        test -z "$SOURCE_CYCLE" || arguments+=(--source-cycle "$SOURCE_CYCLE")
+        test -z "$TARGET_CYCLE" || arguments+=(--target-cycle "$TARGET_CYCLE")
+        test -z "$SIMULATED_NOW" || arguments+=(--simulated-now "$SIMULATED_NOW")
+        test -z "$FAULT" || arguments+=(--fault "$FAULT")
+        test "$DRY_RUN" = false || arguments+=(--dry-run)
+        if test "$OPERATION" = verify; then arguments+=(--mode "$VERIFY_MODE"); fi
+        if test -f "$RUNNER_TEMP/progress-prizes-page.md"; then
+          arguments+=(--page-path "$RUNNER_TEMP/progress-prizes-page.md")
+        fi
+
+        set +e
+        node scrollprize.org/scripts/progress-prizes/automation-cli.mjs "${arguments[@]}" \
+          >"$RUNNER_TEMP/progress-prizes-result.json" \
+          2>"$RUNNER_TEMP/progress-prizes-error.txt"
+        operation_status=$?
+        set -e
+
+        if test "$EXPECT_FAULT" = true; then
+          if test "$operation_status" -ne 0; then
+            grep -Fq "Injected staging rollover failure at $FAULT" "$RUNNER_TEMP/progress-prizes-error.txt"
+          else
+            FAULT="$FAULT" node --input-type=module <<'NODE'
+            import { readFile } from 'node:fs/promises';
+
+            const result = JSON.parse(await readFile(
+              `${process.env.RUNNER_TEMP}/progress-prizes-result.json`,
+              'utf8',
+            ));
+            const passedCopyFault = process.env.FAULT === 'after-copy'
+              && result.action === 'prepare'
+              && result.status === 'prepared'
+              && result.created === false
+              && result.resumed === true;
+            const passedCloseFault = process.env.FAULT === 'after-close-source'
+              && result.action === 'activate'
+              && result.status === 'active';
+            if (!passedCopyFault && !passedCloseFault) {
+              throw new Error('Expected staging fault neither occurred nor had already been recovered.');
+            }
+            NODE
+          fi
+          : >"$RUNNER_TEMP/progress-prizes-error.txt"
+          printf '{"status":"expected-fault"}\n' >"$RUNNER_TEMP/progress-prizes-result.json"
+        elif test "$operation_status" -ne 0; then
+          echo "The redacted Progress Prize operation failed; inspect the job summary." >&2
+          exit "$operation_status"
+        fi
+
+    - name: Export only the public responder URL
+      id: result
+      shell: bash
+      env:
+        RESULT_PATH: ${{ runner.temp }}/progress-prizes-result.json
+      run: |
+        set -euo pipefail
+        node --input-type=module <<'NODE'
+        import { appendFile, readFile } from 'node:fs/promises';
+
+        const result = JSON.parse(await readFile(process.env.RESULT_PATH, 'utf8'));
+        const value = result.responderUri ?? result.publicResponderUri ?? '';
+        if (value !== '') {
+          const url = new URL(value);
+          const short = url.origin === 'https://forms.gle';
+          const canonical = url.origin === 'https://docs.google.com'
+            && url.pathname.startsWith('/forms/d/e/')
+            && url.pathname.endsWith('/viewform');
+          if ((!short && !canonical) || url.username || url.password || url.search || url.hash || /[\r\n]/.test(value)) {
+            throw new Error('Operation did not return a canonical public responder URL.');
+          }
+        }
+        await appendFile(process.env.GITHUB_OUTPUT, `responder-uri=${value}\n`);
+        NODE
+
+    - name: Write redacted audit summary
+      if: always()
+      shell: bash
+      env:
+        OPERATION: ${{ inputs.operation }}
+        AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
+        OPERATION_OUTCOME: ${{ steps.operation.outcome }}
+      run: |
+        {
+          echo "### Progress Prize Google operation"
+          echo
+          echo "- Environment: \`$AUTOMATION_ENVIRONMENT\`"
+          echo "- Operation: \`$OPERATION\`"
+          echo "- Outcome: \`$OPERATION_OUTCOME\`"
+          echo "- Private Google identifiers and ACL identities are intentionally omitted."
+        } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/progress-prizes-google.yml
+++ b/.github/workflows/progress-prizes-google.yml
@@ -59,79 +59,52 @@ on:
         required: false
         type: string
         default: ""
-    secrets:
-      GOOGLE_WORKLOAD_IDENTITY_PROVIDER:
-        description: Resolved only from the selected protected Environment
-        required: false
-      GOOGLE_SERVICE_ACCOUNT_EMAIL:
-        description: Resolved only from the selected protected Environment
-        required: false
-      PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL:
-        description: Resolved only from the selected protected Environment
-        required: false
-      PROGRESS_PRIZE_DRIVE_ID:
-        description: Resolved only from the selected protected Environment
-        required: false
-      PROGRESS_PRIZE_FOLDER_ID:
-        description: Resolved only from the selected protected Environment
-        required: false
-      PROGRESS_PRIZE_ARCHIVE_FOLDER_ID:
-        description: Resolved only from the selected protected Environment
-        required: false
-      PROGRESS_PRIZE_SOURCE_FORM_ID:
-        description: Resolved only from the selected protected Environment
-        required: false
-      PROGRESS_PRIZE_EDITOR_GROUP_EMAIL:
-        description: Resolved only from the selected protected Environment
-        required: false
     outputs:
       responder-uri:
         description: Intentionally public canonical responder URL
-        value: ${{ jobs.google.outputs['responder-uri'] }}
+        value: ${{ jobs.select-result.outputs['responder-uri'] }}
 
 permissions: {}
 
 jobs:
-  google:
-    name: ${{ inputs.environment }} ${{ inputs.operation }}
-    if: >-
-      github.repository == 'ScrollPrize/villa' &&
-      github.repository_id == '890972577' &&
-      github.repository_owner_id == '121906140' &&
-      github.ref == 'refs/heads/main' &&
-      (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
-      (inputs.environment == 'staging' || inputs.environment == 'production') &&
-      contains(fromJSON('["validate","bootstrap","prepare","activate","verify","cleanup"]'), inputs.operation)
+  preflight:
+    name: Reject unsafe Google routing
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    environment: ${{ inputs.environment == 'staging' && 'progress-prizes-staging' || 'progress-prizes-production' }}
-    permissions:
-      contents: read
-      id-token: write
-    outputs:
-      responder-uri: ${{ steps.result.outputs['responder-uri'] }}
+    timeout-minutes: 5
+    permissions: {}
     steps:
-      - name: Reject unsafe controls before authentication
+      - name: Validate immutable context and controls
         shell: bash
         env:
-          AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_ID: ${{ github.repository_id }}
+          REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+          REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
+          AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
           OPERATION: ${{ inputs.operation }}
+          SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
           SIMULATED_NOW: ${{ inputs['simulated-now'] }}
           FAULT: ${{ inputs.fault }}
           EXPECT_FAULT: ${{ inputs['expect-fault'] }}
+          DRY_RUN: ${{ inputs['dry-run'] }}
           BRANCH: ${{ inputs.branch }}
           TARGET_BRANCH: ${{ inputs['target-branch'] }}
-          SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
-          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
           HEAD_SHA: ${{ inputs['head-sha'] }}
         run: |
           set -euo pipefail
+          test "$REPOSITORY" = ScrollPrize/villa
+          test "$REPOSITORY_ID" = 890972577
+          test "$REPOSITORY_OWNER_ID" = 121906140
+          test "$REF" = refs/heads/main
+          [[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ]]
           test "$EVENT_NAME" = workflow_dispatch -o "$EVENT_NAME" = schedule
-          case "$OPERATION" in
-            validate|bootstrap|prepare|activate|verify|cleanup) ;;
-            *) exit 1 ;;
-          esac
+          case "$AUTOMATION_ENVIRONMENT" in staging|production) ;; *) exit 1 ;; esac
+          case "$OPERATION" in validate|bootstrap|prepare|activate|verify|cleanup) ;; *) exit 1 ;; esac
+          case "$EXPECT_FAULT" in true|false) ;; *) exit 1 ;; esac
+          case "$DRY_RUN" in true|false) ;; *) exit 1 ;; esac
           if test -n "$SOURCE_CYCLE"; then [[ "$SOURCE_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; fi
           if test -n "$TARGET_CYCLE"; then [[ "$TARGET_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; fi
           case "$OPERATION" in
@@ -141,6 +114,8 @@ jobs:
           if test "$OPERATION" = activate; then [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; fi
           if test -n "$HEAD_SHA"; then [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; fi
           if test "$AUTOMATION_ENVIRONMENT" = production; then
+            test "$OPERATION" != bootstrap
+            test "$OPERATION" != cleanup
             test -z "$SIMULATED_NOW"
             test -z "$FAULT"
             test "$EXPECT_FAULT" = false
@@ -151,10 +126,7 @@ jobs:
             test "$BRANCH" = codex/progress-prize-smoke-20260720
             test "$TARGET_BRANCH" = codex/progress-prize-smoke-base-20260720
             if test -n "$FAULT"; then
-              case "$FAULT" in
-                after-copy|after-close-source) ;;
-                *) exit 1 ;;
-              esac
+              case "$FAULT" in after-copy|after-close-source) ;; *) exit 1 ;; esac
             fi
           fi
           if test "$EXPECT_FAULT" = true; then
@@ -162,263 +134,138 @@ jobs:
             test "$AUTOMATION_ENVIRONMENT" = staging
           fi
 
-      - name: Check out trusted automation code
+  production:
+    name: production ${{ inputs.operation }}
+    needs: preflight
+    if: inputs.environment == 'production'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-production
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      responder-uri: ${{ steps.google.outputs['responder-uri'] }}
+    steps:
+      - name: Check out the exact approved workflow commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: refs/heads/main
+          ref: ${{ github.sha }}
           persist-credentials: false
           clean: true
           fetch-depth: 1
-
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Run production Google operation
+        id: google
+        uses: ./.github/actions/progress-prizes-google
         with:
-          node-version: 24
+          operation: ${{ inputs.operation }}
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          simulated-now: ${{ inputs['simulated-now'] }}
+          fault: ${{ inputs.fault }}
+          expect-fault: ${{ inputs['expect-fault'] }}
+          dry-run: ${{ inputs['dry-run'] }}
+          verify-mode: ${{ inputs['verify-mode'] }}
+          branch: ${{ inputs.branch }}
+          target-branch: ${{ inputs['target-branch'] }}
+          head-sha: ${{ inputs['head-sha'] }}
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
 
-      - name: Register protected Google configuration masks
-        shell: bash
-        env:
-          GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
-          PROGRESS_PRIZE_DRIVE_ID: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
-          PROGRESS_PRIZE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
-          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
-          PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
-          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
-        run: |
-          set -euo pipefail
-          for name in \
-            GOOGLE_WORKLOAD_IDENTITY_PROVIDER \
-            GOOGLE_SERVICE_ACCOUNT_EMAIL \
-            PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \
-            PROGRESS_PRIZE_DRIVE_ID \
-            PROGRESS_PRIZE_FOLDER_ID \
-            PROGRESS_PRIZE_ARCHIVE_FOLDER_ID \
-            PROGRESS_PRIZE_SOURCE_FORM_ID \
-            PROGRESS_PRIZE_EDITOR_GROUP_EMAIL
-          do
-            value="${!name}"
-            test -z "$value" && continue
-            case "$value" in
-              *$'\r'*|*$'\n'*) echo "Protected Environment secret has an invalid value." >&2; exit 1 ;;
-            esac
-            printf '::add-mask::%s\n' "$value"
-          done
-
-      - name: Validate protected environment configuration
-        shell: bash
-        env:
-          GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
-          PROGRESS_PRIZE_DRIVE_ID: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
-          PROGRESS_PRIZE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
-          PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
-          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
-          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
-          AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
-          OPERATION: ${{ inputs.operation }}
-        run: |
-          set -euo pipefail
-          for name in \
-            GOOGLE_WORKLOAD_IDENTITY_PROVIDER \
-            GOOGLE_SERVICE_ACCOUNT_EMAIL \
-            PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \
-            PROGRESS_PRIZE_DRIVE_ID \
-            PROGRESS_PRIZE_FOLDER_ID \
-            PROGRESS_PRIZE_SOURCE_FORM_ID \
-            PROGRESS_PRIZE_EDITOR_GROUP_EMAIL
-          do
-            test -n "${!name}" || { echo "Missing protected Environment secret: $name" >&2; exit 1; }
-          done
-          if test "$AUTOMATION_ENVIRONMENT" = staging -a "$OPERATION" = cleanup; then
-            test -n "$PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" || {
-              echo "Missing protected Environment secret: PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" >&2
-              exit 1
-            }
-          fi
-
-      - name: Authenticate read-only validation without a credential file
-        if: inputs.operation == 'validate' || inputs.operation == 'verify' || inputs['dry-run']
-        id: auth-read
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+  staging:
+    name: staging ${{ inputs.operation }}
+    needs: preflight
+    if: inputs.environment == 'staging'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-staging
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      responder-uri: ${{ steps.google.outputs['responder-uri'] }}
+    steps:
+      - name: Check out the exact approved workflow commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          token_format: access_token
-          access_token_lifetime: 900s
-          access_token_scopes: |-
-            https://www.googleapis.com/auth/forms.body.readonly
-            https://www.googleapis.com/auth/drive.readonly
-          create_credentials_file: false
-          export_environment_variables: false
-
-      - name: Authenticate mutating operations without a credential file
-        if: inputs.operation != 'validate' && inputs.operation != 'verify' && !inputs['dry-run']
-        id: auth-write
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Run staging Google operation
+        id: google
+        uses: ./.github/actions/progress-prizes-google
         with:
-          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          token_format: access_token
-          access_token_lifetime: 900s
-          access_token_scopes: |-
-            https://www.googleapis.com/auth/forms.body
-            https://www.googleapis.com/auth/drive
-          create_credentials_file: false
-          export_environment_variables: false
+          operation: ${{ inputs.operation }}
+          environment: staging
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          simulated-now: ${{ inputs['simulated-now'] }}
+          fault: ${{ inputs.fault }}
+          expect-fault: ${{ inputs['expect-fault'] }}
+          dry-run: ${{ inputs['dry-run'] }}
+          verify-mode: ${{ inputs['verify-mode'] }}
+          branch: ${{ inputs.branch }}
+          target-branch: ${{ inputs['target-branch'] }}
+          head-sha: ${{ inputs['head-sha'] }}
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
 
-      - name: Fetch the managed page at the exact gated commit
-        if: inputs.operation == 'activate' || (inputs.operation == 'verify' && inputs['head-sha'] != '')
-        shell: bash
-        env:
-          HEAD_SHA: ${{ inputs['head-sha'] }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          node --input-type=module <<'NODE'
-          import { writeFile } from 'node:fs/promises';
-
-          const sha = process.env.HEAD_SHA ?? '';
-          if (!/^[a-f0-9]{40}$/i.test(sha)) throw new Error('The operation requires an exact commit SHA.');
-          const url = new URL('https://api.github.com/repos/ScrollPrize/villa/contents/scrollprize.org/docs/34_prizes.md');
-          url.searchParams.set('ref', sha);
-          const response = await fetch(url, {
-            redirect: 'error',
-            headers: {
-              accept: 'application/vnd.github.raw+json',
-              authorization: `Bearer ${process.env.GH_TOKEN}`,
-              'user-agent': 'progress-prize-rollover',
-              'x-github-api-version': '2022-11-28',
-            },
-          });
-          if (response.status !== 200) throw new Error('Could not read the managed page at the activation commit.');
-          const body = await response.text();
-          if (Buffer.byteLength(body, 'utf8') > 1024 * 1024) throw new Error('Managed page response is too large.');
-          await writeFile(`${process.env.RUNNER_TEMP}/progress-prizes-page.md`, body, { mode: 0o600 });
-          NODE
-
-      - name: Run Google operation
-        id: operation
-        shell: bash
-        env:
-          GOOGLE_ACCESS_TOKEN: ${{ steps['auth-read'].outputs.access_token || steps['auth-write'].outputs.access_token }}
-          PROGRESS_PRIZE_ENVIRONMENT: ${{ inputs.environment }}
-          PROGRESS_PRIZE_EVENT_NAME: ${{ github.event_name }}
-          PROGRESS_PRIZE_DRIVE_ID: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
-          PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
-          PROGRESS_PRIZE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
-          PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
-          PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
-          PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
-          PROGRESS_PRIZE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs.environment == 'staging' && secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL || '' }}
-          PROGRESS_PRIZE_STAGING_FOLDER_ID: ${{ inputs.environment == 'staging' && secrets.PROGRESS_PRIZE_FOLDER_ID || '' }}
-          PROGRESS_PRIZE_BRANCH: ${{ inputs.branch }}
-          PROGRESS_PRIZE_TARGET_BRANCH: ${{ inputs['target-branch'] }}
-          PROGRESS_PRIZE_DEFAULT_TARGET_BRANCH: main
-          PROGRESS_PRIZE_SMOKE_BRANCH_PREFIX: codex/progress-prize-smoke-
-          PROGRESS_PRIZE_SMOKE_DATE: ${{ inputs.environment == 'staging' && '2026-07-20' || '' }}
-          PROGRESS_PRIZE_VERIFIED_SHA: ${{ inputs['head-sha'] }}
-          PROGRESS_PRIZE_HEAD_SHA: ${{ inputs['head-sha'] }}
-          OPERATION: ${{ inputs.operation }}
-          SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
-          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
-          SIMULATED_NOW: ${{ inputs['simulated-now'] }}
-          FAULT: ${{ inputs.fault }}
-          EXPECT_FAULT: ${{ inputs['expect-fault'] }}
-          DRY_RUN: ${{ inputs['dry-run'] }}
-          VERIFY_MODE: ${{ inputs['verify-mode'] }}
-        run: |
-          set -euo pipefail
-          arguments=("$OPERATION" --environment "$PROGRESS_PRIZE_ENVIRONMENT" --event-name "$PROGRESS_PRIZE_EVENT_NAME")
-          test -z "$SOURCE_CYCLE" || arguments+=(--source-cycle "$SOURCE_CYCLE")
-          test -z "$TARGET_CYCLE" || arguments+=(--target-cycle "$TARGET_CYCLE")
-          test -z "$SIMULATED_NOW" || arguments+=(--simulated-now "$SIMULATED_NOW")
-          test -z "$FAULT" || arguments+=(--fault "$FAULT")
-          test "$DRY_RUN" = false || arguments+=(--dry-run)
-          if test "$OPERATION" = verify; then arguments+=(--mode "$VERIFY_MODE"); fi
-          if test -f "$RUNNER_TEMP/progress-prizes-page.md"; then
-            arguments+=(--page-path "$RUNNER_TEMP/progress-prizes-page.md")
-          fi
-
-          set +e
-          node scrollprize.org/scripts/progress-prizes/automation-cli.mjs "${arguments[@]}" \
-            >"$RUNNER_TEMP/progress-prizes-result.json" \
-            2>"$RUNNER_TEMP/progress-prizes-error.txt"
-          operation_status=$?
-          set -e
-
-          if test "$EXPECT_FAULT" = true; then
-            if test "$operation_status" -ne 0; then
-              grep -Fq "Injected staging rollover failure at $FAULT" "$RUNNER_TEMP/progress-prizes-error.txt"
-            else
-              FAULT="$FAULT" node --input-type=module <<'NODE'
-              import { readFile } from 'node:fs/promises';
-
-              const result = JSON.parse(await readFile(
-                `${process.env.RUNNER_TEMP}/progress-prizes-result.json`,
-                'utf8',
-              ));
-              const passedCopyFault = process.env.FAULT === 'after-copy'
-                && result.action === 'prepare'
-                && result.status === 'prepared'
-                && result.created === false
-                && result.resumed === true;
-              const passedCloseFault = process.env.FAULT === 'after-close-source'
-                && result.action === 'activate'
-                && result.status === 'active';
-              if (!passedCopyFault && !passedCloseFault) {
-                throw new Error('Expected staging fault neither occurred nor had already been recovered.');
-              }
-              NODE
-            fi
-            : >"$RUNNER_TEMP/progress-prizes-error.txt"
-            printf '{"status":"expected-fault"}\n' >"$RUNNER_TEMP/progress-prizes-result.json"
-          elif test "$operation_status" -ne 0; then
-            echo "The redacted Progress Prize operation failed; inspect the job summary." >&2
-            exit "$operation_status"
-          fi
-
-      - name: Export only the public responder URL
+  select-result:
+    name: Export selected public result
+    needs:
+      - preflight
+      - production
+      - staging
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      responder-uri: ${{ steps.result.outputs['responder-uri'] }}
+    steps:
+      - name: Require exactly one successful protected job
         id: result
         shell: bash
         env:
-          RESULT_PATH: ${{ runner.temp }}/progress-prizes-result.json
+          AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+          PRODUCTION_RESULT: ${{ needs.production.result }}
+          STAGING_RESULT: ${{ needs.staging.result }}
+          PRODUCTION_URI: ${{ needs.production.outputs['responder-uri'] }}
+          STAGING_URI: ${{ needs.staging.outputs['responder-uri'] }}
         run: |
           set -euo pipefail
-          node --input-type=module <<'NODE'
-          import { appendFile, readFile } from 'node:fs/promises';
-
-          const result = JSON.parse(await readFile(process.env.RESULT_PATH, 'utf8'));
-          const value = result.responderUri ?? result.publicResponderUri ?? '';
-          if (value !== '') {
-            const url = new URL(value);
-            const short = url.origin === 'https://forms.gle';
-            const canonical = url.origin === 'https://docs.google.com'
-              && url.pathname.startsWith('/forms/d/e/')
-              && url.pathname.endsWith('/viewform');
-            if ((!short && !canonical) || url.username || url.password || url.search || url.hash || /[\r\n]/.test(value)) {
-              throw new Error('Operation did not return a canonical public responder URL.');
-            }
-          }
-          await appendFile(process.env.GITHUB_OUTPUT, `responder-uri=${value}\n`);
-          NODE
-
-      - name: Write redacted audit summary
-        if: always()
-        shell: bash
-        env:
-          OPERATION: ${{ inputs.operation }}
-          AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
-          OPERATION_OUTCOME: ${{ steps.operation.outcome }}
-        run: |
-          {
-            echo "### Progress Prize Google operation"
-            echo
-            echo "- Environment: \`$AUTOMATION_ENVIRONMENT\`"
-            echo "- Operation: \`$OPERATION\`"
-            echo "- Outcome: \`$OPERATION_OUTCOME\`"
-            echo "- Private Google identifiers and ACL identities are intentionally omitted."
-          } >>"$GITHUB_STEP_SUMMARY"
+          test "$PREFLIGHT_RESULT" = success
+          case "$AUTOMATION_ENVIRONMENT" in
+            production)
+              test "$PRODUCTION_RESULT" = success
+              test "$STAGING_RESULT" = skipped
+              selected_uri="$PRODUCTION_URI"
+              ;;
+            staging)
+              test "$STAGING_RESULT" = success
+              test "$PRODUCTION_RESULT" = skipped
+              selected_uri="$STAGING_URI"
+              ;;
+            *) exit 1 ;;
+          esac
+          case "$selected_uri" in *$'\r'*|*$'\n'*) exit 1 ;; esac
+          case "$selected_uri" in
+            ""|https://forms.gle/*|https://docs.google.com/forms/d/e/*/viewform) ;;
+            *) exit 1 ;;
+          esac
+          printf 'responder-uri=%s\n' "$selected_uri" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/progress-prizes-pr-safety.yml
+++ b/.github/workflows/progress-prizes-pr-safety.yml
@@ -3,6 +3,7 @@ name: Progress Prize public safety
 on:
   pull_request:
     paths:
+      - .github/actions/progress-prizes-google/**
       - .github/progress-prizes*
       - .github/workflows/progress-prizes-*.yml
       - .github/workflows/progress-prizes-*.yaml

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -20,10 +20,14 @@ repository secret, file, log, cache, or artifact.
 
 ## Workflow map
 
-- `progress-prizes-google.yml` is the only Google-authenticated reusable job. It
-  accepts only `workflow_dispatch` or `schedule`, checks the immutable repository
-  and owner IDs, checks out trusted `main`, and exports only the intentionally
-  public `responder-uri`.
+- `progress-prizes-google.yml` is the only Google-authenticated reusable
+  workflow. A no-secret preflight rejects unsafe routing, then exactly one of two
+  jobs with literal `progress-prizes-staging` or `progress-prizes-production`
+  Environment bindings checks out the exact approved workflow commit. It exports
+  only the intentionally public `responder-uri`.
+- `.github/actions/progress-prizes-google/action.yml` is the shared local action
+  used by both literal Environment jobs. It validates controls again, exchanges
+  OIDC without a credential file, and runs the dependency-free CLI.
 - `progress-prizes-rehearsal.yml` is the July 20 staging rehearsal. Its fixed
   branches are `codex/progress-prize-smoke-20260720` and
   `codex/progress-prize-smoke-base-20260720`.
@@ -55,9 +59,12 @@ uploaded, and only a canonical `forms.gle` or
 `docs.google.com/forms/d/e/.../viewform` URL may cross the authenticated job
 boundary. The workflows also register every protected identifier with
 `add-mask` before validation as defense in depth.
-The reusable Google workflow declares these secret names as optional solely so
-GitHub can resolve the job's selected Environment. Callers never pass or
-inherit them, and the job-level Environment value is authoritative.
+Callers never pass or inherit these secrets. The reusable workflow uses two
+literal Environment jobs because the July rehearsal proved that GitHub created
+the correct deployment but did not hydrate secrets for an expression-selected
+Environment in a called workflow. Both jobs invoke the same local action, and
+the exact trigger commit—not a mutable branch tip—is the executable code that
+receives the approved secrets.
 
 ## GitHub Environments
 

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -26,14 +26,33 @@ async function workflow(name) {
   return readFile(resolve(repositoryRoot, '.github/workflows', name), 'utf8');
 }
 
+async function googleAction() {
+  return readFile(
+    resolve(repositoryRoot, '.github/actions/progress-prizes-google/action.yml'),
+    'utf8',
+  );
+}
+
+function jobBlock(source, name) {
+  const marker = `  ${name}:\n`;
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${name} job`);
+  const following = source.slice(start + marker.length);
+  const next = following.search(/^  [a-z][a-z0-9-]*:\n/m);
+  return source.slice(start, next === -1 ? source.length : start + marker.length + next);
+}
+
 test('every third-party action is pinned to an approved immutable commit', async () => {
   const approved = new Set([
     'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0',
     'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020',
     'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093',
   ]);
-  for (const name of workflowNames) {
-    const source = await workflow(name);
+  const sources = await Promise.all([
+    ...workflowNames.map(async (name) => [name, await workflow(name)]),
+    ['progress-prizes-google/action.yml', await googleAction()],
+  ]);
+  for (const [name, source] of sources) {
     for (const match of source.matchAll(/^\s*uses:\s*([^\s#]+).*$/gm)) {
       const action = match[1];
       if (action.startsWith('./')) continue;
@@ -43,103 +62,172 @@ test('every third-party action is pinned to an approved immutable commit', async
   }
 });
 
-test('Google OIDC exists only in the guarded reusable workflow and authenticated callers', async () => {
+test('Google OIDC uses two literal protected Environment jobs and one secret-free composite', async () => {
   const google = await workflow('progress-prizes-google.yml');
+  const action = await googleAction();
   assert.match(google, /^on:\n  workflow_call:/m);
   assert.doesNotMatch(google, /pull_request(?:_target)?:/);
-  assert.match(google, /github\.repository_id == '890972577'/);
-  assert.match(google, /github\.repository_owner_id == '121906140'/);
-  assert.match(google, /github\.ref == 'refs\/heads\/main'/);
-  assert.match(google, /github\.event_name == 'workflow_dispatch' \|\| github\.event_name == 'schedule'/);
-  assert.match(google, /contents: read\n      id-token: write/);
-  assert.match(google, /create_credentials_file: false/);
-  assert.match(google, /export_environment_variables: false/);
-  assert.match(google, /printf '::add-mask::%s\\n' \"\$value\"/);
-  const maskStep = google.indexOf('- name: Register protected Google configuration masks');
-  const validationStep = google.indexOf('- name: Validate protected environment configuration');
-  assert.ok(maskStep >= 0 && maskStep < validationStep, 'mask registration must precede validation');
-  assert.doesNotMatch(
-    google,
-    /\$\{\{\s*vars(?:\.|\[)/,
-    'protected Google configuration must use auto-masked Environment secrets, never variables',
-  );
-  const protectedGoogleSecretNames = [
-    'GOOGLE_WORKLOAD_IDENTITY_PROVIDER',
-    'GOOGLE_SERVICE_ACCOUNT_EMAIL',
-    'PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL',
-    'PROGRESS_PRIZE_DRIVE_ID',
-    'PROGRESS_PRIZE_FOLDER_ID',
-    'PROGRESS_PRIZE_ARCHIVE_FOLDER_ID',
-    'PROGRESS_PRIZE_SOURCE_FORM_ID',
-    'PROGRESS_PRIZE_EDITOR_GROUP_EMAIL',
-  ];
-  const declarationBlock = google.slice(
-    google.indexOf('    secrets:\n'),
-    google.indexOf('    outputs:\n'),
-  );
-  const declaredEnvironmentSecrets = [
-    ...declarationBlock.matchAll(
-      /^      ([A-Z][A-Z0-9_]+):\n        description: .*\n        required: false$/gm,
-    ),
-  ].map((match) => match[1]);
-  assert.deepEqual(declaredEnvironmentSecrets, protectedGoogleSecretNames);
-  assert.doesNotMatch(declarationBlock, /required: true/);
-  for (const name of protectedGoogleSecretNames) {
-    assert.match(google, new RegExp(`secrets\\.${name}\\b`), `${name} must be an Environment secret`);
+  assert.doesNotMatch(google, /^    secrets:/m, 'Environment secrets must not be caller inputs');
+  assert.doesNotMatch(google, /environment:\s*\$\{\{/);
+
+  const production = jobBlock(google, 'production');
+  const staging = jobBlock(google, 'staging');
+  for (const [name, protectedJob] of [['production', production], ['staging', staging]]) {
+    assert.match(protectedJob, new RegExp(`if: inputs\\.environment == '${name}'`));
+    assert.match(protectedJob, new RegExp(`environment: progress-prizes-${name}`));
+    assert.match(protectedJob, /contents: read\n      id-token: write/);
+    assert.match(protectedJob, /ref: \$\{\{ github\.sha \}\}/);
+    assert.match(protectedJob, /uses: \.\/\.github\/actions\/progress-prizes-google/);
+    assert.match(protectedJob, new RegExp(`^          environment: ${name}$`, 'm'));
+    assert.match(
+      protectedJob,
+      /responder-uri: \$\{\{ steps\.google\.outputs\['responder-uri'\] \}\}/,
+    );
   }
-  assert.ok(
-    [...google.matchAll(/PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: \$\{\{ secrets\.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \}\}/g)].length >= 3,
-    'the private Drive administrator must be validated, masked, and passed to the CLI',
+  assert.equal(
+    [...google.matchAll(/ref: \$\{\{ github\.sha \}\}/g)].length,
+    2,
+    'both protected jobs must check out the exact approved workflow commit',
   );
-  assert.match(google, /GOOGLE_SERVICE_ACCOUNT_EMAIL \\\n            PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \\\n            PROGRESS_PRIZE_DRIVE_ID/);
-  assert.match(google, /access_token_lifetime: 900s/);
-  assert.doesNotMatch(google, /access_token_scopes: >-/);
+
+  const secretMappings = new Map([
+    ['workload-identity-provider', 'GOOGLE_WORKLOAD_IDENTITY_PROVIDER'],
+    ['service-account-email', 'GOOGLE_SERVICE_ACCOUNT_EMAIL'],
+    ['drive-admin-email', 'PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL'],
+    ['drive-id', 'PROGRESS_PRIZE_DRIVE_ID'],
+    ['folder-id', 'PROGRESS_PRIZE_FOLDER_ID'],
+    ['archive-folder-id', 'PROGRESS_PRIZE_ARCHIVE_FOLDER_ID'],
+    ['source-form-id', 'PROGRESS_PRIZE_SOURCE_FORM_ID'],
+    ['editor-group-email', 'PROGRESS_PRIZE_EDITOR_GROUP_EMAIL'],
+  ]);
+  for (const [input, secret] of secretMappings) {
+    const mapping = `          ${input}: \${{ secrets.${secret} }}`;
+    assert.equal(
+      google.split(mapping).length - 1,
+      2,
+      `${secret} must be mapped once in each literal Environment job`,
+    );
+    if (input === 'archive-folder-id') {
+      assert.match(
+        action,
+        /^  archive-folder-id:\n(?:    .*\n)*?    required: false\n    default: ""$/m,
+      );
+    } else {
+      assert.match(
+        action,
+        new RegExp(`^  ${input}:\\n(?:    .*\\n)*?    required: true$`, 'm'),
+      );
+    }
+  }
+  assert.doesNotMatch(
+    action,
+    /\$\{\{\s*(?:secrets|vars)(?:\.|\[)/,
+    'the composite must receive protected values only through explicit inputs',
+  );
+  assert.doesNotMatch(google, /google-github-actions\/auth/);
+  assert.equal([...action.matchAll(/google-github-actions\/auth@/g)].length, 2);
+  assert.match(action, /create_credentials_file: false/);
+  assert.match(action, /export_environment_variables: false/);
+  assert.match(action, /printf '::add-mask::%s\\n' "\$value"/);
+  const maskStep = action.indexOf('- name: Register protected Google configuration masks');
+  const validationStep = action.indexOf('- name: Validate protected environment configuration');
+  assert.ok(maskStep >= 0 && maskStep < validationStep, 'mask registration must precede validation');
+  assert.equal([...action.matchAll(/access_token_lifetime: 1200s/g)].length, 2);
+  assert.doesNotMatch(action, /access_token_scopes: >-/);
   assert.match(
-    google,
+    action,
     /access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\.readonly/,
   );
   assert.match(
-    google,
+    action,
     /access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\n/,
   );
-  assert.match(google, /Authenticate read-only validation/);
-  assert.match(
-    google,
-    /inputs\.operation == 'validate' \|\| inputs\.operation == 'verify' \|\| inputs\['dry-run'\]/,
-  );
-  assert.match(google, /https:\/\/www\.googleapis\.com\/auth\/forms\.body\.readonly/);
-  assert.match(google, /https:\/\/www\.googleapis\.com\/auth\/drive\.readonly/);
-  assert.match(google, /Authenticate mutating operations/);
-  assert.match(google, /https:\/\/www\.googleapis\.com\/auth\/forms\.body\n/);
-  assert.match(google, /https:\/\/www\.googleapis\.com\/auth\/drive\n/);
-  assert.doesNotMatch(google, /drive\.file/);
-  assert.match(google, /TARGET_CYCLE: \$\{\{ inputs\['target-cycle'\] \}\}/);
-  for (const runBlock of google.matchAll(/^ {8}run: \|\n((?:(?: {10}.*)?\n)*)/gm)) {
-    assert.doesNotMatch(runBlock[1], /\$\{\{ inputs\['target-cycle'\] \}\}/);
-    assert.doesNotMatch(runBlock[1], /\$\{\{\s*(?:secrets|vars)(?:\.|\[)/);
-  }
-  assert.match(google, /ref: refs\/heads\/main/);
-  assert.match(google, /automation-cli\.mjs/);
-  assert.doesNotMatch(google, /credentials_json|service_account_key|private_key/i);
+  assert.doesNotMatch(action, /drive\.file/);
+  assert.match(action, /automation-cli\.mjs/);
+  assert.doesNotMatch(`${google}\n${action}`, /credentials_json|service_account_key|private_key/i);
 
   const publicSafety = await workflow('progress-prizes-pr-safety.yml');
+  assert.match(publicSafety, /\.github\/actions\/progress-prizes-google\/\*\*/);
   assert.doesNotMatch(publicSafety, /id-token|google-github-actions|GOOGLE_/);
   assert.doesNotMatch(publicSafety, /secrets\./);
   assert.doesNotMatch(publicSafety, /pull_request_target/);
 });
 
-test('the authenticated reusable exposes no private Google output', async () => {
+test('Google preflight and result selector fail closed around one protected job', async () => {
   const google = await workflow('progress-prizes-google.yml');
+  const action = await googleAction();
+  const preflight = jobBlock(google, 'preflight');
+  const selector = jobBlock(google, 'select-result');
+
+  assert.match(preflight, /name: Reject unsafe Google routing/);
+  assert.match(preflight, /permissions: \{\}/);
+  assert.match(preflight, /WORKFLOW_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(preflight, /test "\$REPOSITORY" = ScrollPrize\/villa/);
+  assert.match(preflight, /test "\$REPOSITORY_ID" = 890972577/);
+  assert.match(preflight, /test "\$REPOSITORY_OWNER_ID" = 121906140/);
+  assert.match(preflight, /test "\$REF" = refs\/heads\/main/);
+  assert.match(preflight, /\[\[ "\$WORKFLOW_SHA" =~ \^\[a-f0-9\]\{40\}\$ \]\]/);
+  assert.match(preflight, /case "\$AUTOMATION_ENVIRONMENT" in staging\|production/);
+  assert.match(preflight, /test "\$OPERATION" != bootstrap/);
+  assert.match(action, /test "\$OPERATION" != bootstrap/);
+
+  assert.match(selector, /needs:\n      - preflight\n      - production\n      - staging/);
+  assert.match(selector, /if: always\(\)/);
+  assert.match(selector, /permissions: \{\}/);
+  assert.match(selector, /test "\$PREFLIGHT_RESULT" = success/);
+  assert.match(selector, /test "\$PRODUCTION_RESULT" = success/);
+  assert.match(selector, /test "\$STAGING_RESULT" = skipped/);
+  assert.match(selector, /test "\$STAGING_RESULT" = success/);
+  assert.match(selector, /test "\$PRODUCTION_RESULT" = skipped/);
+  assert.match(selector, /https:\/\/docs\.google\.com\/forms\/d\/e\/\*\/viewform/);
+
   const workflowOutputs = google.slice(
     google.indexOf('    outputs:\n'),
     google.indexOf('\n\npermissions:'),
   );
-  const outputNames = [...workflowOutputs.matchAll(/^      ([a-z][a-z-]+):\n        description:/gm)]
+  const workflowOutputNames = [
+    ...workflowOutputs.matchAll(/^      ([a-z][a-z-]+):\n        description:/gm),
+  ].map((match) => match[1]);
+  assert.deepEqual(workflowOutputNames, ['responder-uri']);
+  assert.match(
+    google,
+    /value: \$\{\{ jobs\.select-result\.outputs\['responder-uri'\] \}\}/,
+  );
+
+  const actionOutputs = action.slice(
+    action.indexOf('outputs:\n'),
+    action.indexOf('\nruns:'),
+  );
+  const actionOutputNames = [...actionOutputs.matchAll(/^  ([a-z][a-z-]+):\n/gm)]
     .map((match) => match[1]);
-  assert.deepEqual(outputNames, ['responder-uri']);
-  assert.match(google, /Export only the public responder URL/);
-  assert.match(google, /Private Google identifiers and ACL identities are intentionally omitted/);
-  assert.doesNotMatch(google, /GITHUB_OUTPUT.*(?:form-id|folder-id|drive-id|editor)/i);
+  assert.deepEqual(actionOutputNames, ['responder-uri']);
+  assert.match(selector, /printf 'responder-uri=%s\\n' "\$selected_uri" >>"\$GITHUB_OUTPUT"/);
+  assert.doesNotMatch(
+    `${google}\n${action}`,
+    /GITHUB_OUTPUT.*(?:form-id|folder-id|drive-id|editor)/i,
+  );
+});
+
+test('composite boolean inputs stay strings across authentication and fault handling', async () => {
+  const google = await workflow('progress-prizes-google.yml');
+  const action = await googleAction();
+  for (const input of ['expect-fault', 'dry-run']) {
+    assert.match(
+      action,
+      new RegExp(`^  ${input}:\\n(?:    .*\\n)*?    default: "false"$`, 'm'),
+    );
+    const forwarding = `          ${input}: \${{ inputs['${input}'] }}`;
+    assert.equal(
+      google.split(forwarding).length - 1,
+      2,
+      `${input} must be passed to both protected jobs`,
+    );
+  }
+  assert.match(action, /inputs\['dry-run'\] == 'true'/);
+  assert.match(action, /inputs\['dry-run'\] != 'true'/);
+  assert.match(action, /case "\$EXPECT_FAULT" in true\|false/);
+  assert.match(action, /case "\$DRY_RUN" in true\|false/);
+  assert.match(action, /test "\$DRY_RUN" = false \|\| arguments\+=\(--dry-run\)/);
 });
 
 test('rehearsal controls are fixed to staging and its ephemeral branches', async () => {
@@ -175,9 +263,12 @@ test('rehearsal controls are fixed to staging and its ephemeral branches', async
   assert.match(pagePr, /test \"\$base_sha\" = \"\$\(git rev-parse refs\/remotes\/origin\/main\^\{commit\}\)\"/);
 
   const google = await workflow('progress-prizes-google.yml');
-  assert.match(google, /passedCopyFault/);
-  assert.match(google, /result\.created === false/);
-  assert.match(google, /result\.resumed === true/);
+  const action = await googleAction();
+  assert.doesNotMatch(google, /passedCopyFault|passedCloseFault/);
+  assert.match(action, /passedCopyFault/);
+  assert.match(action, /passedCloseFault/);
+  assert.match(action, /result\.created === false/);
+  assert.match(action, /result\.resumed === true/);
 });
 
 test('Vercel verification runs trusted default-branch code and requires GitHub association', async () => {


### PR DESCRIPTION
## Summary

- split the reusable Google operation into literal staging and production Environment jobs
- move shared authenticated logic into a secret-isolated local composite action
- add no-secret preflight and fail-closed public-result selection
- execute the exact approved workflow commit and reject production bootstrap before OIDC
- expand public PR safety and workflow-contract coverage

This fixes the observed reusable-workflow behavior where an expression-selected Environment created the deployment but did not hydrate its Environment secrets. No Google identifier or reusable credential is committed.

## Verification

- `npm test` (174 passing)
- `npm run test:progress-prizes` (161 passing)
- focused workflow contract tests (8 passing)
- YAML parse, actionlint, Node syntax, `git diff --check`
- exact staged-tree replay
- private-value scan against staged files and diff

The next step after merge is a read-only production validation, followed by the isolated staging rehearsal.