### PR TITLE
fix(scrollprize): expose bounded redacted diagnostics

### DIFF
--- a/.github/actions/progress-prizes-google/action.yml
+++ b/.github/actions/progress-prizes-google/action.yml
@@ -353,7 +353,8 @@ runs:
           : >"$RUNNER_TEMP/progress-prizes-error.txt"
           printf '{"status":"expected-fault"}\n' >"$RUNNER_TEMP/progress-prizes-result.json"
         elif test "$operation_status" -ne 0; then
-          echo "The redacted Progress Prize operation failed; inspect the job summary." >&2
+          node scrollprize.org/scripts/progress-prizes/error-diagnostic-cli.mjs \
+            "$RUNNER_TEMP/progress-prizes-error.txt"
           exit "$operation_status"
         fi
 

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { appendFile, readFile, writeFile } from 'node:fs/promises';
+import { Buffer } from 'node:buffer';
 import { resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -25,6 +26,9 @@ const DEFAULT_PAGE_PATH = resolve(
 );
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const GIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
+const AUTOMATION_ERROR_INPUT_MAX_UNITS = 4_096;
+const AUTOMATION_ERROR_MAX_BYTES = 600;
+export const AUTOMATION_ERROR_FALLBACK = 'progress-prizes: Automation failed without a safe diagnostic';
 const OUTPUT_STATUSES = new Set([
   'active',
   'archived',
@@ -245,6 +249,65 @@ function privateValues(env) {
   return PRIVATE_ENV_NAMES.map((name) => optionalEnv(env, name)).filter(Boolean);
 }
 
+/**
+ * Produce one bounded log line without retaining private Google configuration,
+ * ACL identities, URLs, opaque identifiers, or control characters.
+ */
+export function formatAutomationError(error, { env = process.env } = {}) {
+  try {
+    if (!(error instanceof Error) || typeof error.message !== 'string') {
+      return AUTOMATION_ERROR_FALLBACK;
+    }
+    const oversized = error.message.length > AUTOMATION_ERROR_INPUT_MAX_UNITS;
+    let message = error.message.slice(0, AUTOMATION_ERROR_INPUT_MAX_UNITS);
+    if (oversized) message = `${message.replace(/\S+$/u, '')} [TRUNCATED]`;
+
+    const redacted = redactForLog(message, { secrets: privateValues(env) })
+      .replace(/https?:\/\/\S+/giu, '[REDACTED_URL]')
+      .replace(/\S*@\S*/gu, '[REDACTED_EMAIL]')
+      .replace(/(?:[A-Za-z0-9_-]{16,}|\d{10,})/g, '[REDACTED]')
+      .replace(/::/g, ': :')
+      .replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]+/gu, ' ')
+      .replace(/[^\x20-\x7e]/g, '?')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (redacted === '') return AUTOMATION_ERROR_FALLBACK;
+
+    const value = `progress-prizes: ${redacted}`;
+    if (Buffer.byteLength(value, 'utf8') <= AUTOMATION_ERROR_MAX_BYTES) return value;
+    let low = 0;
+    let high = value.length;
+    while (low < high) {
+      const middle = Math.ceil((low + high) / 2);
+      if (Buffer.byteLength(value.slice(0, middle), 'utf8') <= AUTOMATION_ERROR_MAX_BYTES) {
+        low = middle;
+      } else {
+        high = middle - 1;
+      }
+    }
+    return value.slice(0, low);
+  } catch {
+    return AUTOMATION_ERROR_FALLBACK;
+  }
+}
+
+/** Accept and independently re-sanitize one bounded ASCII diagnostic line. */
+export function safeAutomationDiagnostic(value, { env = process.env } = {}) {
+  try {
+    if (!Buffer.isBuffer(value) || value.length < 2 || value.length > 601) {
+      return AUTOMATION_ERROR_FALLBACK;
+    }
+    const decoded = value.toString('utf8');
+    if (!Buffer.from(decoded, 'utf8').equals(value)) return AUTOMATION_ERROR_FALLBACK;
+    const match = decoded.match(/^(progress-prizes: [\x20-\x7e]{1,583})\n$/);
+    if (!match) return AUTOMATION_ERROR_FALLBACK;
+    const message = match[1].slice('progress-prizes: '.length);
+    return formatAutomationError(new Error(message), { env });
+  } catch {
+    return AUTOMATION_ERROR_FALLBACK;
+  }
+}
+
 function assertSourceCycleMatchesTarget(options, targetCycle) {
   const expected = previousCycle(targetCycle);
   if (options['source-cycle'] !== undefined) {
@@ -455,7 +518,7 @@ async function main() {
   try {
     await runAutomationCli(process.argv.slice(2));
   } catch (error) {
-    process.stderr.write(`progress-prizes: ${error.message}\n`);
+    process.stderr.write(`${formatAutomationError(error)}\n`);
     process.exitCode = 1;
   }
 }

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
@@ -1,12 +1,18 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { Buffer } from 'node:buffer';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 import {
   ResponderUrlResolutionError,
+  AUTOMATION_ERROR_FALLBACK,
   createExactShaActivationGate,
   createFilePageFacade,
+  formatAutomationError,
   resolveGoogleResponderUri,
   runAutomationCli,
+  safeAutomationDiagnostic,
 } from './automation-cli.mjs';
 import { runCli } from './cli.mjs';
 import { PROGRESS_PRIZE_MARKERS } from './markdown.mjs';
@@ -131,6 +137,98 @@ test('short URL resolution rejects unsafe redirect targets with a fixed log-safe
       return true;
     },
   );
+});
+
+test('automation failure diagnostics are single-line, bounded, and fully redacted', () => {
+  const unknownOpaqueId = '1UnknownGoogleOpaqueIdentifier9876543210';
+  const unconfiguredEmail = 'private-user@localhost';
+  const diagnostic = formatAutomationError(new Error([
+    'Google API request failed',
+    PRIVATE.token,
+    PRIVATE.form,
+    PRIVATE.folder,
+    PRIVATE.account,
+    `https://docs.google.com/forms/d/${unknownOpaqueId}/edit`,
+    unknownOpaqueId,
+    unconfiguredEmail,
+    '\n\u0085\u2028::warning title=unsafe::injected',
+    'multibyte-\u00e9\u00e9\u00e9\u00e9',
+    'x'.repeat(10_000),
+  ].join(' ')), { env: stagingEnv() });
+
+  assert.match(diagnostic, /^progress-prizes: /);
+  assert.ok(Buffer.byteLength(diagnostic, 'utf8') <= 600);
+  assert.doesNotMatch(diagnostic, /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u);
+  assert.doesNotMatch(diagnostic, /https?:\/\//);
+  assert.doesNotMatch(diagnostic, /::/);
+  assert.equal(diagnostic.includes(unconfiguredEmail), false);
+  assert.equal(diagnostic.includes(unknownOpaqueId), false);
+  for (const privateValue of Object.values(PRIVATE)) {
+    assert.equal(diagnostic.includes(privateValue), false);
+  }
+  assert.equal(safeAutomationDiagnostic(Buffer.from(`${diagnostic}\n`)), diagnostic);
+  assert.equal(
+    safeAutomationDiagnostic(Buffer.from(`${diagnostic}\nsecond line\n`)),
+    AUTOMATION_ERROR_FALLBACK,
+  );
+  assert.equal(
+    safeAutomationDiagnostic(Buffer.alloc(602, 0x61)),
+    AUTOMATION_ERROR_FALLBACK,
+  );
+  assert.equal(
+    safeAutomationDiagnostic(Buffer.from([0xff, 0x0a])),
+    AUTOMATION_ERROR_FALLBACK,
+  );
+
+  const forgedOpaqueId = '-UnknownGoogleOpaqueIdentifier9876543210-';
+  const forged = safeAutomationDiagnostic(Buffer.from([
+    'progress-prizes:',
+    PRIVATE.token,
+    PRIVATE.account,
+    `https://docs.google.com/forms/d/${forgedOpaqueId}/edit`,
+    forgedOpaqueId,
+    'private-user@localhost',
+    '::warning title=unsafe::injected',
+  ].join(' ') + '\n'), { env: stagingEnv() });
+  assert.match(forged, /^progress-prizes: /);
+  assert.doesNotMatch(forged, /https?:\/\/|::|@/);
+  assert.equal(forged.includes(PRIVATE.token), false);
+  assert.equal(forged.includes(forgedOpaqueId), false);
+});
+
+test('automation failure formatter fails closed for hostile errors and environments', () => {
+  const hostileError = new Proxy(new Error('private-message'), {
+    get(target, property, receiver) {
+      if (property === 'message') throw new Error('hostile getter');
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  assert.equal(
+    formatAutomationError(hostileError, { env: stagingEnv() }),
+    'progress-prizes: Automation failed without a safe diagnostic',
+  );
+  assert.equal(
+    formatAutomationError(new Error('private-message'), {
+      env: new Proxy({}, { get() { throw new Error('hostile environment'); } }),
+    }),
+    'progress-prizes: Automation failed without a safe diagnostic',
+  );
+  const multibyte = formatAutomationError(new Error('\u20ac'.repeat(1_000)), { env: stagingEnv() });
+  assert.ok(Buffer.byteLength(multibyte, 'utf8') <= 600);
+});
+
+test('automation CLI subprocess emits only one bounded redacted diagnostic line', () => {
+  const unknownOpaqueId = '1UnknownGoogleOpaqueIdentifier9876543210';
+  const cli = fileURLToPath(new URL('./automation-cli.mjs', import.meta.url));
+  const child = spawnSync(process.execPath, [cli, 'prepare', `--${unknownOpaqueId}`], {
+    encoding: 'utf8',
+    env: { ...process.env, ...stagingEnv() },
+  });
+  assert.equal(child.status, 1);
+  assert.equal(child.stdout, '');
+  assert.match(child.stderr, /^progress-prizes: [^\r\n]+\n$/);
+  assert.ok(Buffer.byteLength(child.stderr.trimEnd(), 'utf8') <= 600);
+  assert.equal(child.stderr.includes(unknownOpaqueId), false);
 });
 
 test('file page facade keeps file IO local and resolves canonical URLs without fetch', async () => {

--- a/scrollprize.org/scripts/progress-prizes/error-diagnostic-cli.mjs
+++ b/scrollprize.org/scripts/progress-prizes/error-diagnostic-cli.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { Buffer } from 'node:buffer';
+import { constants } from 'node:fs';
+import { lstat, open } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  AUTOMATION_ERROR_FALLBACK,
+  safeAutomationDiagnostic,
+} from './automation-cli.mjs';
+
+function sameFileIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameFileVersion(left, right) {
+  return sameFileIdentity(left, right)
+    && left.size === right.size
+    && left.mtimeNs === right.mtimeNs
+    && left.ctimeNs === right.ctimeNs;
+}
+
+export async function readBoundedDiagnostic(
+  file,
+  runnerTemp,
+  { openFile = open } = {},
+) {
+  try {
+    if (typeof file !== 'string' || typeof runnerTemp !== 'string' || runnerTemp === '') {
+      return AUTOMATION_ERROR_FALLBACK;
+    }
+    const expected = resolve(runnerTemp, 'progress-prizes-error.txt');
+    if (resolve(file) !== expected) return AUTOMATION_ERROR_FALLBACK;
+    const pathStat = await lstat(expected, { bigint: true });
+    if (!pathStat.isFile() || pathStat.size < 2n || pathStat.size > 601n) {
+      return AUTOMATION_ERROR_FALLBACK;
+    }
+
+    const handle = await openFile(expected, constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+      const openedStat = await handle.stat({ bigint: true });
+      if (!openedStat.isFile() || !sameFileVersion(pathStat, openedStat)) {
+        return AUTOMATION_ERROR_FALLBACK;
+      }
+      const bytes = Buffer.alloc(Number(openedStat.size));
+      let offset = 0;
+      while (offset < bytes.length) {
+        const { bytesRead } = await handle.read(bytes, offset, bytes.length - offset, offset);
+        if (bytesRead === 0) break;
+        offset += bytesRead;
+      }
+      const finalStat = await handle.stat({ bigint: true });
+      if (offset !== bytes.length || !sameFileVersion(openedStat, finalStat)) {
+        return AUTOMATION_ERROR_FALLBACK;
+      }
+      return safeAutomationDiagnostic(bytes);
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return AUTOMATION_ERROR_FALLBACK;
+  }
+}
+
+async function main() {
+  const diagnostic = await readBoundedDiagnostic(process.argv[2], process.env.RUNNER_TEMP);
+  process.stderr.write(`${diagnostic}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scrollprize.org/scripts/progress-prizes/error-diagnostic-cli.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/error-diagnostic-cli.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, open, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { AUTOMATION_ERROR_FALLBACK } from './automation-cli.mjs';
+import { readBoundedDiagnostic } from './error-diagnostic-cli.mjs';
+
+const cli = fileURLToPath(new URL('./error-diagnostic-cli.mjs', import.meta.url));
+
+function runDiagnostic(file, runnerTemp) {
+  return spawnSync(process.execPath, [cli, file], {
+    encoding: 'utf8',
+    env: { ...process.env, RUNNER_TEMP: runnerTemp },
+  });
+}
+
+test('diagnostic reader emits one validated line and rejects every unsafe file shape', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'progress-prize-diagnostic-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const file = join(directory, 'progress-prizes-error.txt');
+  const safe = 'progress-prizes: Google API request failed (drive.files.get): HTTP 403';
+
+  await writeFile(file, `${safe}\n`, 'utf8');
+  let child = runDiagnostic(file, directory);
+  assert.equal(child.status, 0);
+  assert.equal(child.stdout, '');
+  assert.equal(child.stderr, `${safe}\n`);
+
+  for (const unsafe of [
+    `progress-prizes: ${'private'.repeat(1_000)}\n`,
+    `${safe}\nprivate-second-line\n`,
+    `${safe}\r\n`,
+    'not-progress-prizes: private\n',
+  ]) {
+    await writeFile(file, unsafe, 'utf8');
+    child = runDiagnostic(file, directory);
+    assert.equal(child.status, 0);
+    assert.equal(child.stdout, '');
+    assert.equal(child.stderr, `${AUTOMATION_ERROR_FALLBACK}\n`);
+    assert.equal(child.stderr.includes('private-second-line'), false);
+  }
+
+  const outside = join(directory, 'outside.txt');
+  await writeFile(outside, `${safe}\n`, 'utf8');
+  child = runDiagnostic(outside, directory);
+  assert.equal(child.stderr, `${AUTOMATION_ERROR_FALLBACK}\n`);
+});
+
+test('diagnostic reader rejects same-size replacement and symlink races', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'progress-prize-diagnostic-race-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const file = join(directory, 'progress-prizes-error.txt');
+  const replacement = join(directory, 'replacement.txt');
+  const outside = join(directory, 'outside.txt');
+  const originalLine = `progress-prizes: ${'A'.repeat(32)}\n`;
+  const replacementLine = `progress-prizes: ${'B'.repeat(32)}\n`;
+
+  await writeFile(file, originalLine, 'utf8');
+  await writeFile(replacement, replacementLine, 'utf8');
+  let replaced = false;
+  const replacedDiagnostic = await readBoundedDiagnostic(file, directory, {
+    openFile: async (path, flags) => {
+      if (!replaced) {
+        replaced = true;
+        await rename(replacement, path);
+      }
+      return open(path, flags);
+    },
+  });
+  assert.equal(replacedDiagnostic, AUTOMATION_ERROR_FALLBACK);
+
+  await writeFile(file, originalLine, 'utf8');
+  await writeFile(outside, replacementLine, 'utf8');
+  let linked = false;
+  const linkedDiagnostic = await readBoundedDiagnostic(file, directory, {
+    openFile: async (path, flags) => {
+      if (!linked) {
+        linked = true;
+        await rm(path);
+        await symlink(outside, path);
+      }
+      return open(path, flags);
+    },
+  });
+  assert.equal(linkedDiagnostic, AUTOMATION_ERROR_FALLBACK);
+});

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -242,6 +242,13 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
   );
   assert.doesNotMatch(action, /drive\.file/);
   assert.match(action, /automation-cli\.mjs/);
+  assert.match(action, /error-diagnostic-cli\.mjs/);
+  assert.doesNotMatch(action, /(?:cat|head|tail|read|wc) .*progress-prizes-error/);
+  assert.equal([...action.matchAll(/grep .*progress-prizes-error/g)].length, 1);
+  assert.match(
+    action,
+    /grep -Fq "Injected staging rollover failure at \$FAULT" "\$RUNNER_TEMP\/progress-prizes-error\.txt"/,
+  );
   assert.doesNotMatch(`${rehearsal}\n${action}`, /credentials_json|service_account_key|private_key/i);
 
   const publicSafety = await workflow('progress-prizes-pr-safety.yml');


### PR DESCRIPTION
## What changed

- emit one bounded, independently redacted diagnostic when a Google rollover operation fails
- reject oversized, multiline, invalid UTF-8, wrong-path, replaced, or symlinked diagnostic files
- prevent raw error-file readers in the composite action contract
- add adversarial formatter, subprocess, file-race, and workflow tests

## Why

The staging rehearsal authenticated successfully but its generic failure message hid the safe API/preflight reason. This preserves the no-secret boundary while making the next rehearsal failure actionable.

## Validation

- `npm test` (180 tests)
- `npm run test:progress-prizes` (167 tests)
- targeted diagnostic/workflow suite (25 tests)
- actionlint on all four Progress Prize workflows
- YAML and Node syntax checks
- `git diff --check`
- local scan of all configured private Google values: zero matches in the six committed files and zero formatter/second-stage leaks