### PR TITLE
fix(scrollprize): support copy-only staging viewers

### DIFF
--- a/.github/actions/progress-prizes-google/action.yml
+++ b/.github/actions/progress-prizes-google/action.yml
@@ -52,6 +52,10 @@ inputs:
   service-account-email:
     description: Protected Environment service account identifier
     required: true
+  staging-service-account-email:
+    description: Protected staging identity used by production ACL validation
+    required: false
+    default: ""
   drive-admin-email:
     description: Protected Environment break-glass administrator identity
     required: true
@@ -155,6 +159,7 @@ runs:
       env:
         GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ inputs['workload-identity-provider'] }}
         GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ inputs['service-account-email'] }}
+        PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs['staging-service-account-email'] }}
         PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ inputs['drive-admin-email'] }}
         PROGRESS_PRIZE_DRIVE_ID: ${{ inputs['drive-id'] }}
         PROGRESS_PRIZE_FOLDER_ID: ${{ inputs['folder-id'] }}
@@ -166,6 +171,7 @@ runs:
         for name in \
           GOOGLE_WORKLOAD_IDENTITY_PROVIDER \
           GOOGLE_SERVICE_ACCOUNT_EMAIL \
+          PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \
           PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \
           PROGRESS_PRIZE_DRIVE_ID \
           PROGRESS_PRIZE_FOLDER_ID \
@@ -186,6 +192,7 @@ runs:
       env:
         GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ inputs['workload-identity-provider'] }}
         GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ inputs['service-account-email'] }}
+        PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs['staging-service-account-email'] }}
         PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ inputs['drive-admin-email'] }}
         PROGRESS_PRIZE_DRIVE_ID: ${{ inputs['drive-id'] }}
         PROGRESS_PRIZE_FOLDER_ID: ${{ inputs['folder-id'] }}
@@ -194,6 +201,7 @@ runs:
         PROGRESS_PRIZE_ARCHIVE_FOLDER_ID: ${{ inputs['archive-folder-id'] }}
         AUTOMATION_ENVIRONMENT: ${{ inputs.environment }}
         OPERATION: ${{ inputs.operation }}
+        SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
       run: |
         set -euo pipefail
         for name in \
@@ -210,6 +218,15 @@ runs:
         if test "$AUTOMATION_ENVIRONMENT" = staging -a "$OPERATION" = cleanup; then
           test -n "$PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" || {
             echo "Missing protected Environment secret: PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" >&2
+            exit 1
+          }
+        fi
+        if test "$AUTOMATION_ENVIRONMENT" = production \
+          && test "$OPERATION" = validate \
+          && test "$SOURCE_CYCLE" = 2026-07
+        then
+          test -n "$PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL" || {
+            echo "Missing protected Environment secret: PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL" >&2
             exit 1
           }
         fi
@@ -288,7 +305,7 @@ runs:
         PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ inputs['source-form-id'] }}
         PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ inputs['editor-group-email'] }}
         PROGRESS_PRIZE_SERVICE_ACCOUNT_EMAIL: ${{ inputs['service-account-email'] }}
-        PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs.environment == 'staging' && inputs['service-account-email'] || '' }}
+        PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs.environment == 'staging' && inputs['service-account-email'] || inputs['staging-service-account-email'] }}
         PROGRESS_PRIZE_STAGING_FOLDER_ID: ${{ inputs.environment == 'staging' && inputs['folder-id'] || '' }}
         PROGRESS_PRIZE_BRANCH: ${{ inputs.branch }}
         PROGRESS_PRIZE_TARGET_BRANCH: ${{ inputs['target-branch'] }}

--- a/.github/workflows/progress-prizes-rehearsal.yml
+++ b/.github/workflows/progress-prizes-rehearsal.yml
@@ -166,6 +166,7 @@ jobs:
           target-branch: main
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
@@ -40,6 +40,7 @@ function productionEnv(overrides = {}) {
     PROGRESS_PRIZE_DRIVE_ID: 'private-production-drive-id',
     PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: 'production-break-glass@private.example',
     PROGRESS_PRIZE_SERVICE_ACCOUNT_EMAIL: 'production-bot@private.example',
+    PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: PRIVATE.account,
     PROGRESS_PRIZE_SOURCE_FORM_ID: PRIVATE.form,
     PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: 'production-editors@private.example',
     PROGRESS_PRIZE_BRANCH: 'codex/progress-prize-2026-08',
@@ -473,6 +474,7 @@ test('top-level CLI keeps page validate compatibility and routes source-cycle va
   });
   assert.equal(capture.method, 'validate');
   assert.equal(capture.input.sourceFormId, PRIVATE.form);
+  assert.equal(capture.dependencies.runtime.stagingServiceAccountEmail, PRIVATE.account);
 });
 
 test('bootstrap, verify, and cleanup commands map to the corresponding service operations', async () => {

--- a/scrollprize.org/scripts/progress-prizes/rollover.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.mjs
@@ -60,6 +60,12 @@ const ALLOWED_VERIFY_MODES = new Set(['prepared', 'active', 'cleaned']);
 const GOOGLE_FORM_MIME_TYPE = 'application/vnd.google-apps.form';
 const GOOGLE_FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
 const INITIAL_EXPLICIT_SOURCE_CYCLE = '2026-07';
+const ANONYMOUS_PUBLISHED_RESPONDER_PERMISSION = Object.freeze({
+  type: 'anyone',
+  role: 'reader',
+  allowFileDiscovery: false,
+  view: 'published',
+});
 const SOURCE_ORIGINS = Object.freeze({
   MANAGED: 'managed',
   EXPLICIT_SHARED_DRIVE: 'explicit-shared-drive',
@@ -615,6 +621,28 @@ function assertDirectAutomationPermission(permissions, runtime, expectedRole) {
   }
 }
 
+function assertSingleBootstrapReaderPermission(permissions, runtime) {
+  if (runtime.stagingServiceAccountEmail === undefined) {
+    throw new Error('Production validation requires the configured staging automation identity');
+  }
+  const nonPublishedReaders = permissions.filter((permission) => (
+    permission?.deleted !== true
+    && permission?.pendingOwner !== true
+    && permission?.role === 'reader'
+    && permission?.view !== 'published'
+  ));
+  const bootstrapReaders = nonPublishedReaders.filter((permission) => (
+    permission.type === 'user'
+    && !isInheritedPermission(permission)
+    && !hasValue(permission.expirationTime)
+    && isGoogleServiceAccountIdentity(permission)
+    && isAutomationIdentity(permission, runtime.stagingServiceAccountEmail)
+  ));
+  if (nonPublishedReaders.length !== 1 || bootstrapReaders.length !== 1) {
+    throw new Error('The production form must have exactly one direct copy-only automation reader');
+  }
+}
+
 async function ensurePermissions(google, fileId, expected, options) {
   let current = await google.getAllPermissions({ fileId });
   const currentKeys = new Set(effectiveComparablePermissions(current).map(permissionIdentityKey));
@@ -734,7 +762,10 @@ function assertSourceCapabilities(file, required = ['canCopy', 'canEdit', 'canSh
 
 function assertReadCopyOnlyCapabilities(file) {
   assertSourceCapabilities(file, ['canCopy']);
-  if (file?.capabilities?.canEdit === true || file?.capabilities?.canShare === true) {
+  if (
+    file?.capabilities?.canEdit !== false
+    || file?.capabilities?.canShare !== false
+  ) {
     throw new Error('The staging identity has forbidden edit or share access to production');
   }
 }
@@ -1028,15 +1059,23 @@ export function createRolloverService({
     );
   }
 
-  async function loadSnapshot(file) {
-    const [form, currentFile, permissions] = await Promise.all([
+  async function loadReadableSnapshot(file) {
+    const [form, currentFile] = await Promise.all([
       google.getForm({ formId: file.id }),
       google.getFile({ fileId: file.id }),
-      google.getAllPermissions({ fileId: file.id }),
     ]);
     assertNoLinkedSheet(form);
     publishState(form);
     assertPublicResponderUri(form.responderUri);
+    return { form, file: currentFile };
+  }
+
+  async function loadSnapshot(file) {
+    const [readable, permissions] = await Promise.all([
+      loadReadableSnapshot(file),
+      google.getAllPermissions({ fileId: file.id }),
+    ]);
+    const { form, file: currentFile } = readable;
     return { form, file: currentFile, permissions };
   }
 
@@ -1102,6 +1141,9 @@ export function createRolloverService({
       requireShare: true,
     });
     assertRequiredSourcePermissions(snapshot.permissions, collaboratorPermissions);
+    if (source.origin === SOURCE_ORIGINS.EXPLICIT_MY_DRIVE) {
+      assertSingleBootstrapReaderPermission(snapshot.permissions, runtime);
+    }
     expectedTargetPermissions(
       snapshot.permissions,
       collaboratorPermissions,
@@ -1155,12 +1197,12 @@ export function createRolloverService({
     ) {
       throw new Error('Staging bootstrap requires the initial explicit My Drive source');
     }
-    const liveSnapshot = await loadSnapshot(liveFile);
-    // The staging identity deliberately has read/copy-only access to production.
-    // It must never need edit or share capability on the active live form.
+    // Google permits detailed My Drive ACL reads only to writers/owners. The
+    // separately approved production validation checks that ACL; this staging
+    // identity must remain a Viewer and validates only its effective read/copy
+    // capabilities plus the source content and publishing state.
+    const liveSnapshot = await loadReadableSnapshot(liveFile);
     assertReadCopyOnlyCapabilities(liveSnapshot.file);
-    assertDirectAutomationPermission(liveSnapshot.permissions, runtime, 'reader');
-    assertRequiredSourcePermissions(liveSnapshot.permissions);
     assertTitle(liveSnapshot.form, liveSnapshot.file, cycleTitle(sourceCycle));
     assertExpectedPublishing(liveSnapshot.form, {
       isPublished: true,
@@ -1259,10 +1301,10 @@ export function createRolloverService({
       ...titled,
     };
     const expectedPermissions = expectedTargetPermissions(
-      liveSnapshot.permissions,
+      [ANONYMOUS_PUBLISHED_RESPONDER_PERMISSION],
       collaboratorPermissions,
       false,
-      SOURCE_ORIGINS.EXPLICIT_MY_DRIVE,
+      SOURCE_ORIGINS.MANAGED,
     );
     stagedSnapshot.permissions = await ensurePermissions(
       google,
@@ -1284,7 +1326,7 @@ export function createRolloverService({
       isAcceptingResponses: stagedState === ROLLOVER_FILE_STATES.ACTIVE,
     });
 
-    const liveAfter = await loadSnapshot(liveFile);
+    const liveAfter = await loadReadableSnapshot(liveFile);
     if (
       JSON.stringify(formStructure(liveSnapshot.form)) !== JSON.stringify(formStructure(liveAfter.form))
       || liveSnapshot.form.info?.title !== liveAfter.form.info?.title

--- a/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
@@ -658,6 +658,76 @@ test('production preflight verifies the published reader and configured editor g
     }),
     /unexpected non-public published responder permission/,
   );
+
+  for (const mutate of [
+    (permissions) => permissions.filter(
+      ({ emailAddress }) => emailAddress !== STAGING_SERVICE_ACCOUNT,
+    ),
+    (permissions) => [...permissions, {
+      id: 'unexpected-human-reader',
+      type: 'user',
+      role: 'reader',
+      emailAddress: 'unexpected-reader@example.org',
+    }],
+    (permissions) => permissions.map((permission) => (
+      permission.emailAddress === STAGING_SERVICE_ACCOUNT
+        ? { ...permission, expirationTime: '2027-01-01T00:00:00Z' }
+        : permission
+    )),
+    (permissions) => permissions.map((permission) => (
+      permission.emailAddress === STAGING_SERVICE_ACCOUNT
+        ? { ...permission, role: 'commenter' }
+        : permission
+    )),
+    (permissions) => permissions.map((permission) => (
+      permission.emailAddress === STAGING_SERVICE_ACCOUNT
+        ? { ...permission, permissionDetails: [{ inherited: true }] }
+        : permission
+    )),
+    (permissions) => [...permissions, {
+      id: 'duplicate-automation-reader',
+      type: 'user',
+      role: 'reader',
+      emailAddress: 'duplicate-reader@private-project.iam.gserviceaccount.com',
+    }],
+    (permissions) => permissions.map((permission) => (
+      permission.emailAddress === STAGING_SERVICE_ACCOUNT
+        ? {
+          ...permission,
+          emailAddress: 'replacement-reader@private-project.iam.gserviceaccount.com',
+        }
+        : permission
+    )),
+  ]) {
+    const invalidBootstrapReaderGoogle = grantProductionSourceAccess(new FakeGoogle());
+    invalidBootstrapReaderGoogle.permissions.set(
+      LIVE_FORM_ID,
+      mutate(invalidBootstrapReaderGoogle.permissions.get(LIVE_FORM_ID)),
+    );
+    await assert.rejects(
+      service({
+        google: invalidBootstrapReaderGoogle,
+        runtime: productionRuntime(),
+      }).rollover.validate({
+        sourceFormId: LIVE_FORM_ID,
+        sourceCycle: '2026-07',
+        collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+      }),
+      /exactly one direct copy-only automation reader/,
+    );
+  }
+
+  await assert.rejects(
+    service({
+      google: grantProductionSourceAccess(new FakeGoogle()),
+      runtime: productionRuntime({ stagingServiceAccountEmail: undefined }),
+    }).rollover.validate({
+      sourceFormId: LIVE_FORM_ID,
+      sourceCycle: '2026-07',
+      collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+    }),
+    /requires the configured staging automation identity/,
+  );
 });
 
 test('destination folder preflight blocks both dry-run and real copies', async () => {
@@ -1027,21 +1097,57 @@ test('bootstrap copies the live form into staging, limits ACLs, and never mutate
     (fileId === LIVE_FORM_ID || formId === LIVE_FORM_ID)
     && ['updateFile', 'createPermission', 'deletePermission', 'updateFormTitle', 'setPublishState'].includes(method));
   assert.deepEqual(liveMutations, []);
+  assert.equal(
+    context.google.calls.some(
+      ({ method, fileId }) => method === 'getAllPermissions' && fileId === LIVE_FORM_ID,
+    ),
+    false,
+  );
+});
+
+test('bootstrap does not require a staging Viewer to enumerate the production ACL', async () => {
+  const context = service();
+  context.google.files.get(LIVE_FORM_ID).capabilities.canEdit = false;
+  context.google.files.get(LIVE_FORM_ID).capabilities.canShare = false;
+  const originalGetAllPermissions = context.google.getAllPermissions.bind(context.google);
+  let livePermissionReads = 0;
+  context.google.getAllPermissions = async (input) => {
+    if (input.fileId === LIVE_FORM_ID) {
+      livePermissionReads += 1;
+      throw new Error('A Viewer cannot enumerate the production ACL');
+    }
+    return originalGetAllPermissions(input);
+  };
+
+  const result = await context.rollover.bootstrapStagingSource({
+    sourceFormId: LIVE_FORM_ID,
+    sourceCycle: '2026-07',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+  });
+
+  assert.equal(result.status, 'active');
+  assert.equal(livePermissionReads, 0);
 });
 
 test('bootstrap rejects an overprivileged staging identity before copying production', async () => {
   for (const capability of ['canEdit', 'canShare']) {
-    const context = service();
-    context.google.files.get(LIVE_FORM_ID).capabilities[capability] = true;
-    await assert.rejects(
-      context.rollover.bootstrapStagingSource({
-        sourceFormId: LIVE_FORM_ID,
-        sourceCycle: '2026-07',
-        collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
-      }),
-      /forbidden edit or share access/,
-    );
-    assert.equal(context.google.calls.some(({ method }) => method === 'copyFile'), false);
+    for (const invalidValue of [true, null, 'false', undefined]) {
+      const context = service();
+      if (invalidValue === undefined) {
+        delete context.google.files.get(LIVE_FORM_ID).capabilities[capability];
+      } else {
+        context.google.files.get(LIVE_FORM_ID).capabilities[capability] = invalidValue;
+      }
+      await assert.rejects(
+        context.rollover.bootstrapStagingSource({
+          sourceFormId: LIVE_FORM_ID,
+          sourceCycle: '2026-07',
+          collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+        }),
+        /forbidden edit or share access/,
+      );
+      assert.equal(context.google.calls.some(({ method }) => method === 'copyFile'), false);
+    }
   }
 });
 

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -203,6 +203,22 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
     [...rehearsal.matchAll(/environment: progress-prizes-staging/g)].length,
     googleJobNames.length - 1,
   );
+  const productionValidationJob = jobBlock(rehearsal, 'validate-production');
+  assert.match(
+    productionValidationJob,
+    /^          staging-service-account-email: \$\{\{ secrets\.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \}\}$/m,
+  );
+  assert.equal(
+    [...rehearsal.matchAll(/secrets\.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL/g)].length,
+    1,
+    'only protected production validation may receive the staging identity',
+  );
+  for (const name of googleJobNames.filter((name) => name !== 'validate-production')) {
+    assert.doesNotMatch(
+      jobBlock(rehearsal, name),
+      /staging-service-account-email|PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL/,
+    );
+  }
 
   for (const name of jobNames(rehearsal).filter((name) => !googleJobNames.includes(name))) {
     const ordinaryJob = jobBlock(rehearsal, name);
@@ -217,6 +233,23 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
       assert.match(action, new RegExp(`^  ${input}:\\n(?:    .*\\n)*?    required: true$`, 'm'));
     }
   }
+  assert.match(
+    action,
+    /^  staging-service-account-email:\n(?:    .*\n)*?    required: false\n    default: ""$/m,
+  );
+  assert.match(
+    action,
+    /PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL:\s+\$\{\{ inputs\['staging-service-account-email'\] \}\}/,
+  );
+  assert.match(
+    action,
+    /PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \\\n\s+PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL/,
+    'the staging identity must be masked before protected configuration validation',
+  );
+  assert.match(
+    action,
+    /inputs\.environment == 'staging' && inputs\['service-account-email'\] \|\| inputs\['staging-service-account-email'\]/,
+  );
   assert.doesNotMatch(
     action,
     /\$\{\{\s*(?:secrets|vars)(?:\.|\[)/,
@@ -229,7 +262,17 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
   assert.match(action, /printf '::add-mask::%s\\n' "\$value"/);
   const maskStep = action.indexOf('- name: Register protected Google configuration masks');
   const validationStep = action.indexOf('- name: Validate protected environment configuration');
+  const readAuthStep = action.indexOf('- name: Authenticate read-only validation');
   assert.ok(maskStep >= 0 && maskStep < validationStep, 'mask registration must precede validation');
+  assert.ok(
+    validationStep < readAuthStep,
+    'protected configuration must be validated before requesting an OIDC token',
+  );
+  assert.match(
+    action,
+    /if test "\$AUTOMATION_ENVIRONMENT" = production \\\n\s+&& test "\$OPERATION" = validate \\\n\s+&& test "\$SOURCE_CYCLE" = 2026-07\n\s+then\n\s+test -n "\$PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL"/,
+    'initial production validation must require the exact staging identity before authentication',
+  );
   assert.equal([...action.matchAll(/access_token_lifetime: 1200s/g)].length, 2);
   assert.doesNotMatch(action, /access_token_scopes: >-/);
   assert.match(


### PR DESCRIPTION
## What changed

- Keep the staging automation identity at Drive Viewer privilege while bootstrapping the rehearsal source.
- Perform the exact direct, non-expiring staging-reader ACL check in the protected production read-only validation job.
- Stop requesting the live My Drive ACL from staging, then reconstruct the staging copy ACL from the fixed public responder permission and protected staging editor group.
- Fail closed when copy/edit/share capabilities are absent, ambiguous, or overprivileged.
- Add workflow contracts for masking, pre-auth validation, exact identity propagation, and secret scoping.

## Root cause

Google Drive allows a Viewer to copy a form but does not allow that Viewer to enumerate detailed permissions. The rehearsal therefore failed at `drive.permissions.list` before any copy was made.

## Security

The cross-environment identity is stored only as a protected production Environment secret, is masked before validation, and is never forwarded to staging, PR, Vercel, or ordinary jobs. Authentication remains keyless OIDC/WIF with read-only scopes for production validation. No private identifier is committed.

## Validation

- `npm test` — 181 passed
- `npm run test:progress-prizes` — 168 passed
- targeted rollover/CLI/workflow contracts — 113 passed
- `actionlint` on all Progress Prize workflows
- YAML, Bash, and Node syntax checks
- `git diff --check`
- private-value scan: 10 protected values checked across 6 files, 0 matches
- independent security and test reviews: no blockers