### PR TITLE
fix(scrollprize): handle unpublished form defaults

### DIFF
--- a/scrollprize.org/scripts/progress-prizes/rollover.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.mjs
@@ -289,15 +289,40 @@ function managedTitle(runtime, clock, role, cycle) {
 }
 
 function publishState(form) {
-  const state = form?.publishSettings?.publishState;
-  if (
-    state === null
-    || typeof state !== 'object'
-    || typeof state.isPublished !== 'boolean'
-    || typeof state.isAcceptingResponses !== 'boolean'
-  ) {
+  const settings = form?.publishSettings;
+  if (settings === undefined) {
     throw new Error('Form does not expose modern publishSettings; migrate it before rollover');
   }
+  if (
+    settings === null
+    || typeof settings !== 'object'
+    || Array.isArray(settings)
+  ) {
+    throw new Error('Form exposes malformed modern publishSettings');
+  }
+  // Forms uses protobuf JSON. A modern unpublished form can expose an empty
+  // publishSettings message, and false scalar fields can be omitted. Only the
+  // absence of publishSettings itself identifies a legacy form.
+  const encodedState = settings.publishState;
+  if (
+    encodedState !== undefined
+    && (
+      encodedState === null
+      || typeof encodedState !== 'object'
+      || Array.isArray(encodedState)
+    )
+  ) {
+    throw new Error('Form exposes malformed modern publishSettings');
+  }
+  for (const field of ['isPublished', 'isAcceptingResponses']) {
+    if (encodedState?.[field] !== undefined && typeof encodedState[field] !== 'boolean') {
+      throw new Error('Form exposes malformed modern publishSettings');
+    }
+  }
+  const state = {
+    isPublished: encodedState?.isPublished ?? false,
+    isAcceptingResponses: encodedState?.isAcceptingResponses ?? false,
+  };
   if (!state.isPublished && state.isAcceptingResponses) {
     throw new Error('Form reports an invalid publishing state');
   }

--- a/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
@@ -496,6 +496,24 @@ test('validate safely stops for linked Sheets and legacy publish settings', asyn
     legacy.rollover.validate({ sourceFormId: LIVE_FORM_ID, sourceCycle: '2026-07' }),
     /modern publishSettings/,
   );
+
+  const unpublishedModernGoogle = grantProductionSourceAccess(new FakeGoogle());
+  unpublishedModernGoogle.forms.get(LIVE_FORM_ID).publishSettings = {};
+  await assert.rejects(
+    service({
+      google: unpublishedModernGoogle,
+      runtime: productionRuntime(),
+    }).rollover.validate({
+      sourceFormId: LIVE_FORM_ID,
+      sourceCycle: '2026-07',
+      collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+    }),
+    /not in the expected live publishing state/,
+  );
+  assert.equal(
+    unpublishedModernGoogle.calls.some(({ method }) => method === 'setPublishState'),
+    false,
+  );
 });
 
 test('production accepts only its explicit My Drive bootstrap source with copy and edit access', async () => {
@@ -1127,6 +1145,183 @@ test('bootstrap does not require a staging Viewer to enumerate the production AC
 
   assert.equal(result.status, 'active');
   assert.equal(livePermissionReads, 0);
+});
+
+test('bootstrap initializes omitted modern publish-state defaults on exactly one copy', async (t) => {
+  for (const scenario of [
+    {
+      name: 'optional publishState omitted',
+      publishSettings: {},
+      expectedAcceptingWrites: [false, true],
+    },
+    {
+      name: 'false scalar fields omitted',
+      publishSettings: { publishState: {} },
+      expectedAcceptingWrites: [false, true],
+    },
+    {
+      name: 'false accepting-responses field omitted',
+      publishSettings: { publishState: { isPublished: true } },
+      expectedAcceptingWrites: [true],
+    },
+  ]) {
+    await t.test(scenario.name, async () => {
+      const context = service();
+      const originalCopyFile = context.google.copyFile.bind(context.google);
+      context.google.copyFile = async (input) => {
+        const copied = await originalCopyFile(input);
+        context.google.forms.get(copied.id).publishSettings = clone(scenario.publishSettings);
+        return copied;
+      };
+
+      const result = await context.rollover.bootstrapStagingSource({
+        sourceFormId: LIVE_FORM_ID,
+        sourceCycle: '2026-07',
+        collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+      });
+      const stagedSource = context.google.managed(ROLLOVER_FILE_ROLES.SOURCE, '2026-07')[0];
+      const publishWrites = context.google.calls.filter(
+        ({ method, formId }) => method === 'setPublishState' && formId === stagedSource.id,
+      );
+
+      assert.equal(result.status, 'active');
+      assert.equal(result.created, true);
+      assert.deepEqual(
+        publishWrites.map(({ isAcceptingResponses }) => isAcceptingResponses),
+        scenario.expectedAcceptingWrites,
+      );
+      assert.equal(
+        context.google.calls.filter(({ method, appProperties }) =>
+          method === 'copyFile' && appProperties?.role === ROLLOVER_FILE_ROLES.SOURCE).length,
+        1,
+      );
+      assert.deepEqual(context.google.forms.get(stagedSource.id).publishSettings.publishState, {
+        isPublished: true,
+        isAcceptingResponses: true,
+      });
+    });
+  }
+});
+
+test('bootstrap resumes one marked copy with omitted modern publish-state defaults', async () => {
+  const context = service();
+  const stagedSource = await context.google.copyFile({
+    fileId: LIVE_FORM_ID,
+    name: '[SMOKE SOURCE 2026-07-20] July 2026 Progress Prizes',
+    parentId: 'private-staging-folder',
+    appProperties: {
+      managedBy: ROLLOVER_MANAGED_BY,
+      schemaVersion: '1',
+      environment: 'staging',
+      role: ROLLOVER_FILE_ROLES.SOURCE,
+      cycle: '2026-07',
+      state: ROLLOVER_FILE_STATES.COPIED,
+    },
+  });
+  context.google.forms.get(stagedSource.id).publishSettings = {};
+
+  const result = await context.rollover.bootstrapStagingSource({
+    sourceFormId: LIVE_FORM_ID,
+    sourceCycle: '2026-07',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+  });
+  const publishWrites = context.google.calls.filter(
+    ({ method, formId }) => method === 'setPublishState' && formId === stagedSource.id,
+  );
+
+  assert.equal(result.status, 'active');
+  assert.equal(result.created, false);
+  assert.equal(result.resumed, true);
+  assert.deepEqual(
+    publishWrites.map(({ isAcceptingResponses }) => isAcceptingResponses),
+    [false, true],
+  );
+  assert.equal(
+    context.google.calls.filter(({ method, appProperties }) =>
+      method === 'copyFile' && appProperties?.role === ROLLOVER_FILE_ROLES.SOURCE).length,
+    1,
+  );
+  assert.equal(
+    context.google.files.get(stagedSource.id).appProperties.state,
+    ROLLOVER_FILE_STATES.ACTIVE,
+  );
+});
+
+test('bootstrap rejects absent or malformed copied publish settings before reconciliation', async (t) => {
+  for (const scenario of [
+    {
+      name: 'legacy settings absent',
+      publishSettings: undefined,
+      expected: /modern publishSettings/,
+    },
+    {
+      name: 'publishSettings is null',
+      publishSettings: null,
+      expected: /malformed modern publishSettings/,
+    },
+    {
+      name: 'publishSettings is not an object',
+      publishSettings: 'invalid',
+      expected: /malformed modern publishSettings/,
+    },
+    {
+      name: 'publishSettings is an array',
+      publishSettings: [],
+      expected: /malformed modern publishSettings/,
+    },
+    {
+      name: 'publishState is null',
+      publishSettings: { publishState: null },
+      expected: /malformed modern publishSettings/,
+    },
+    {
+      name: 'published flag is not boolean',
+      publishSettings: { publishState: { isPublished: 'false' } },
+      expected: /malformed modern publishSettings/,
+    },
+    {
+      name: 'accepting flag is not boolean',
+      publishSettings: { publishState: { isAcceptingResponses: 'false' } },
+      expected: /malformed modern publishSettings/,
+    },
+    {
+      name: 'accepting while unpublished',
+      publishSettings: { publishState: { isAcceptingResponses: true } },
+      expected: /invalid publishing state/,
+    },
+  ]) {
+    await t.test(scenario.name, async () => {
+      const context = service();
+      const originalCopyFile = context.google.copyFile.bind(context.google);
+      context.google.copyFile = async (input) => {
+        const copied = await originalCopyFile(input);
+        if (scenario.publishSettings === undefined) {
+          delete context.google.forms.get(copied.id).publishSettings;
+        } else {
+          context.google.forms.get(copied.id).publishSettings = clone(scenario.publishSettings);
+        }
+        return copied;
+      };
+
+      await assert.rejects(
+        context.rollover.bootstrapStagingSource({
+          sourceFormId: LIVE_FORM_ID,
+          sourceCycle: '2026-07',
+          collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+        }),
+        scenario.expected,
+      );
+      const stagedSource = context.google.managed(ROLLOVER_FILE_ROLES.SOURCE, '2026-07')[0];
+      assert.ok(stagedSource);
+      assert.equal(stagedSource.appProperties.state, ROLLOVER_FILE_STATES.COPIED);
+      assert.equal(
+        context.google.calls.some(({ method, fileId, formId }) =>
+          (fileId === stagedSource.id || formId === stagedSource.id)
+          && ['updateFile', 'createPermission', 'updateFormTitle', 'setPublishState'].includes(method)),
+        false,
+      );
+    });
+  }
 });
 
 test('bootstrap rejects an overprivileged staging identity before copying production', async () => {


### PR DESCRIPTION
## What changed

- Treat an exposed but empty `publishSettings` message as a modern unpublished form.
- Normalize omitted protobuf boolean fields to their safe `false` defaults.
- Continue to hard-fail when the outer `publishSettings` field is absent (legacy form), malformed, or reports the impossible unpublished-but-accepting combination.
- Add direct recovery coverage for an existing cycle-marked `COPIED` staging form, proving the next run resumes it and does not create a second copy.

## Root cause

Modern Forms publishing state is represented with protobuf JSON. Google documents `publishState` as optional, and default-valued `false` scalar fields can be omitted. The staging copy was therefore rejected even though the omitted values represented the safest unpublished/closed state.

References:

- https://developers.google.com/workspace/forms/api/reference/rest/v1/forms
- https://developers.google.com/workspace/forms/api/guides/publish-form#check_if_a_form_is_a_legacy_form
- https://protobuf.dev/programming-guides/json/#presence-and-default-values

## Security and recovery

Missing values are normalized only toward `false`; publication is still an explicit verified write. Production validation remains read-only. Truly absent or malformed publishing metadata fails closed before ACL, title, or publish reconciliation. The existing copy is rediscovered by its environment/cycle `appProperties` marker and resumed.

## Validation

- `npm test` — 195 passed
- `npm run test:progress-prizes` — 182 passed
- rollover suite — 104 passed
- Node syntax and `actionlint`
- `git diff --check`
- private-value scan: 10 protected values checked across 2 files, 0 matches
- independent implementation and documentation reviews: no blockers