### PR TITLE
fix(scrollprize): trust current preview metadata

### DIFF
--- a/.github/progress-prizes-github.mjs
+++ b/.github/progress-prizes-github.mjs
@@ -15,12 +15,13 @@ const API = 'https://api.github.com';
 const SMOKE_HEAD = 'codex/progress-prize-smoke-20260720';
 const SMOKE_BASE = 'codex/progress-prize-smoke-base-20260720';
 const PREVIEW_CONTEXT = 'progress-prizes/vercel-preview';
-const PREVIEW_WORKFLOW_NAME = 'Progress Prize Vercel preview gate';
+const PREVIEW_DESCRIPTION = 'Exact Progress Prize preview verified';
 const PREVIEW_WORKFLOW_PATH = '.github/workflows/progress-prizes-vercel-preview.yml';
 const TEST_CHECK = 'Public no-secret tests';
 const SUCCESSFUL_CONCLUSIONS = new Set(['success', 'neutral', 'skipped']);
 const REPOSITORY_ID = 890972577;
 const OWNER_ID = 121906140;
+const GITHUB_ACTIONS_BOT_ID = 41898282;
 const PAGE_PATH = 'scrollprize.org/docs/34_prizes.md';
 
 function previewRunId(status) {
@@ -33,7 +34,16 @@ function isTrustedPreviewStatus(status) {
   return status?.context === PREVIEW_CONTEXT
     && status.state === 'success'
     && status.creator?.login === 'github-actions[bot]'
+    && status.creator?.id === GITHUB_ACTIONS_BOT_ID
+    && status.creator?.type === 'Bot'
+    && status.description === PREVIEW_DESCRIPTION
     && previewRunId(status) !== undefined;
+}
+
+function latestPreviewStatus(statuses) {
+  return Array.isArray(statuses)
+    ? statuses.find((status) => status.context === PREVIEW_CONTEXT)
+    : undefined;
 }
 
 function fail(message) {
@@ -156,10 +166,11 @@ export function assertSinglePageCommit(commit, { headSha, baseSha } = {}) {
 export function isTrustedPreviewRun({ status, run, expectedSha } = {}) {
   const sha = assertSha(expectedSha);
   const runId = previewRunId(status);
+  const expectedRunName = `Progress Prize Vercel preview ${sha}`;
   return isTrustedPreviewStatus(status)
     && String(run?.id ?? '') === runId
     && run?.html_url === status.target_url
-    && run?.name === PREVIEW_WORKFLOW_NAME
+    && run?.name === expectedRunName
     && run?.path === PREVIEW_WORKFLOW_PATH
     && run?.event === 'repository_dispatch'
     && run?.actor?.login === 'vercel[bot]'
@@ -173,7 +184,7 @@ export function isTrustedPreviewRun({ status, run, expectedSha } = {}) {
     && run?.head_branch === 'main'
     && run?.status === 'completed'
     && run?.conclusion === 'success'
-    && run?.display_title === `Progress Prize Vercel preview ${sha}`;
+    && run?.display_title === expectedRunName;
 }
 
 async function github(path, { method = 'GET', body, token = process.env.GITHUB_TOKEN } = {}) {
@@ -321,7 +332,7 @@ async function readPreviewRun(status, expectedSha) {
 }
 
 export function gateSnapshot({ statuses, checks, previewRun, expectedSha }) {
-  const preview = statuses?.statuses?.find((status) => status.context === PREVIEW_CONTEXT);
+  const preview = latestPreviewStatus(statuses);
   const runs = checks?.check_runs;
   const publicTest = Array.isArray(runs) && runs.find((run) => run.name === TEST_CHECK);
   const allFinishedSuccessfully = Array.isArray(runs)
@@ -364,7 +375,7 @@ async function gate(options) {
     });
     if (sha !== expectedSha) fail('Pull request head changed after preparation.');
     const [statuses, checks] = await Promise.all([
-      github(`/repos/${OWNER}/${REPO}/commits/${sha}/status`),
+      github(`/repos/${OWNER}/${REPO}/commits/${sha}/statuses?per_page=100`),
       github(`/repos/${OWNER}/${REPO}/commits/${sha}/check-runs?per_page=100`),
       verifyPageDelta({
         head,
@@ -375,7 +386,7 @@ async function gate(options) {
         targetCycle,
       }),
     ]);
-    const preview = statuses?.statuses?.find((status) => status.context === PREVIEW_CONTEXT);
+    const preview = latestPreviewStatus(statuses);
     const previewRun = await readPreviewRun(preview, expectedSha);
     if (gateSnapshot({ statuses, checks, previewRun, expectedSha }).ready) {
       if (process.env.GITHUB_OUTPUT) {
@@ -404,14 +415,14 @@ async function waitPreview(options) {
   while (true) {
     const [ref, statuses, page] = await Promise.all([
       github(`/repos/${OWNER}/${REPO}/git/ref/heads/${encodeURIComponent(branch)}`),
-      github(`/repos/${OWNER}/${REPO}/commits/${sha}/status`),
+      github(`/repos/${OWNER}/${REPO}/commits/${sha}/statuses?per_page=100`),
       readPageAt(sha),
     ]);
     if (ref?.object?.type !== 'commit' || ref.object.sha !== sha) {
       fail('Fixed smoke base changed while waiting for its preview.');
     }
     if (page.cycle !== cycle) fail('Post-merge smoke base has the wrong page cycle.');
-    const preview = statuses?.statuses?.find((status) => status.context === PREVIEW_CONTEXT);
+    const preview = latestPreviewStatus(statuses);
     const previewRun = await readPreviewRun(preview, sha);
     if (previewRun) return { headSha: sha };
     if (Date.now() >= deadline) fail('Timed out waiting for the post-merge smoke preview.');

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -426,6 +426,17 @@ test('Vercel verification runs trusted default-branch code and requires GitHub a
   assert.doesNotMatch(vercel, /checkout.*(?:HEAD_SHA|deployment|pull_request)/i);
 });
 
+test('preview gates use creator-bearing newest-first commit status history', async () => {
+  const helper = await readFile(
+    resolve(repositoryRoot, '.github/progress-prizes-github.mjs'),
+    'utf8',
+  );
+  const historyEndpoint = 'github(`/repos/${OWNER}/${REPO}/commits/${sha}/statuses?per_page=100`)';
+  const combinedEndpoint = 'github(`/repos/${OWNER}/${REPO}/commits/${sha}/status`)';
+  assert.equal(helper.split(historyEndpoint).length - 1, 2);
+  assert.equal(helper.includes(combinedEndpoint), false);
+});
+
 test('trusted branch and exact-check gate helpers reject ambiguous automation state', () => {
   assert.deepEqual(
     assertAutomationBranch(
@@ -439,18 +450,17 @@ test('trusted branch and exact-check gate helpers reject ambiguous automation st
 
   const expectedSha = 'a'.repeat(40);
   const baseSha = 'b'.repeat(40);
-  const statuses = {
-    statuses: [{
-      context: 'progress-prizes/vercel-preview',
-      state: 'success',
-      creator: { login: 'github-actions[bot]' },
-      target_url: 'https://github.com/ScrollPrize/villa/actions/runs/12345',
-    }],
-  };
+  const statuses = [{
+    context: 'progress-prizes/vercel-preview',
+    state: 'success',
+    description: 'Exact Progress Prize preview verified',
+    creator: { login: 'github-actions[bot]', id: 41898282, type: 'Bot' },
+    target_url: 'https://github.com/ScrollPrize/villa/actions/runs/12345',
+  }];
   const previewRun = {
     id: 12345,
-    html_url: statuses.statuses[0].target_url,
-    name: 'Progress Prize Vercel preview gate',
+    html_url: statuses[0].target_url,
+    name: `Progress Prize Vercel preview ${expectedSha}`,
     path: '.github/workflows/progress-prizes-vercel-preview.yml',
     event: 'repository_dispatch',
     actor: { login: 'vercel[bot]', type: 'Bot' },
@@ -483,8 +493,20 @@ test('trusted branch and exact-check gate helpers reject ambiguous automation st
       },
     ],
   };
-  assert.equal(isTrustedPreviewRun({ status: statuses.statuses[0], run: previewRun, expectedSha }), true);
+  assert.equal(isTrustedPreviewRun({ status: statuses[0], run: previewRun, expectedSha }), true);
   assert.equal(gateSnapshot({ statuses, checks: successfulChecks, previewRun, expectedSha }).ready, true);
+  assert.equal(gateSnapshot({
+    statuses: { statuses },
+    checks: successfulChecks,
+    previewRun,
+    expectedSha,
+  }).ready, false, 'the obsolete combined-status response shape must fail closed');
+  assert.equal(gateSnapshot({
+    statuses: [{ context: 'unrelated', state: 'failure' }, statuses[0]],
+    checks: successfulChecks,
+    previewRun,
+    expectedSha,
+  }).ready, true, 'the first matching context is the newest preview status');
   assert.equal(gateSnapshot({
     statuses,
     checks: { total_count: 1, check_runs: successfulChecks.check_runs.slice(1) },
@@ -510,19 +532,42 @@ test('trusted branch and exact-check gate helpers reject ambiguous automation st
     expectedSha,
   }).ready, false);
   assert.equal(gateSnapshot({
-    statuses: {
-      statuses: [{
-        ...statuses.statuses[0],
-        creator: { login: 'spoofed-user' },
-      }],
-    },
+    statuses: [{
+      ...statuses[0],
+      creator: { login: 'spoofed-user' },
+    }, statuses[0]],
     checks: successfulChecks,
     previewRun,
     expectedSha,
-  }).ready, false);
+  }).ready, false, 'an older trusted success must not override the newest matching status');
+  assert.equal(gateSnapshot({
+    statuses: [{ ...statuses[0], state: 'pending' }, statuses[0]],
+    checks: successfulChecks,
+    previewRun,
+    expectedSha,
+  }).ready, false, 'an older success must not override a newer pending status');
+  assert.equal(gateSnapshot({
+    statuses: [statuses[0], { ...statuses[0], state: 'failure' }],
+    checks: successfulChecks,
+    previewRun,
+    expectedSha,
+  }).ready, true, 'a newer trusted success supersedes older statuses');
+
+  for (const status of [
+    { ...statuses[0], context: 'untrusted/context' },
+    { ...statuses[0], state: 'failure' },
+    { ...statuses[0], description: 'Looks plausible but is not exact' },
+    { ...statuses[0], creator: undefined },
+    { ...statuses[0], creator: null },
+    { ...statuses[0], creator: { ...statuses[0].creator, login: 'spoofed-user' } },
+    { ...statuses[0], creator: { ...statuses[0].creator, id: 1 } },
+    { ...statuses[0], creator: { ...statuses[0].creator, type: 'User' } },
+  ]) {
+    assert.equal(isTrustedPreviewRun({ status, run: previewRun, expectedSha }), false);
+  }
 
   for (const [field, value] of [
-    ['name', 'Untrusted workflow'],
+    ['name', `Progress Prize Vercel preview ${baseSha}`],
     ['path', '.github/workflows/untrusted.yml'],
     ['event', 'workflow_dispatch'],
     ['head_branch', 'feature/untrusted'],
@@ -531,23 +576,33 @@ test('trusted branch and exact-check gate helpers reject ambiguous automation st
     ['display_title', `Progress Prize Vercel preview ${baseSha}`],
   ]) {
     assert.equal(isTrustedPreviewRun({
-      status: statuses.statuses[0],
+      status: statuses[0],
       run: { ...previewRun, [field]: value },
       expectedSha,
     }), false);
   }
   assert.equal(isTrustedPreviewRun({
-    status: statuses.statuses[0],
+    status: statuses[0],
     run: { ...previewRun, actor: { login: 'attacker', type: 'User' } },
     expectedSha,
   }), false);
   assert.equal(isTrustedPreviewRun({
-    status: statuses.statuses[0],
+    status: statuses[0],
+    run: { ...previewRun, actor: { login: 'vercel[bot]', type: 'User' } },
+    expectedSha,
+  }), false);
+  assert.equal(isTrustedPreviewRun({
+    status: statuses[0],
     run: { ...previewRun, triggering_actor: { login: 'human', type: 'User' } },
     expectedSha,
   }), false);
   assert.equal(isTrustedPreviewRun({
-    status: statuses.statuses[0],
+    status: statuses[0],
+    run: { ...previewRun, triggering_actor: { login: 'vercel[bot]', type: 'User' } },
+    expectedSha,
+  }), false);
+  assert.equal(isTrustedPreviewRun({
+    status: statuses[0],
     run: {
       ...previewRun,
       repository: { ...previewRun.repository, id: 1 },
@@ -555,7 +610,7 @@ test('trusted branch and exact-check gate helpers reject ambiguous automation st
     expectedSha,
   }), false);
   assert.equal(isTrustedPreviewRun({
-    status: statuses.statuses[0],
+    status: statuses[0],
     run: {
       ...previewRun,
       repository: {
@@ -566,12 +621,34 @@ test('trusted branch and exact-check gate helpers reject ambiguous automation st
     expectedSha,
   }), false);
   assert.equal(isTrustedPreviewRun({
-    status: statuses.statuses[0],
+    status: statuses[0],
     run: { ...previewRun, head_repository: { id: 1 } },
     expectedSha,
   }), false);
   assert.equal(isTrustedPreviewRun({
-    status: { ...statuses.statuses[0], target_url: 'https://github.com/ScrollPrize/villa/actions/runs/999' },
+    status: statuses[0],
+    run: { ...previewRun, id: 999 },
+    expectedSha,
+  }), false);
+  assert.equal(isTrustedPreviewRun({
+    status: statuses[0],
+    run: { ...previewRun, html_url: 'https://github.com/ScrollPrize/villa/actions/runs/999' },
+    expectedSha,
+  }), false);
+  for (const target_url of [
+    'https://github.com/ScrollPrize/villa/actions/runs/12345/',
+    'https://github.com/ScrollPrize/villa/actions/runs/12345?trusted=false',
+    'https://github.com/ScrollPrize/villa/actions/runs/12345#spoofed',
+    'https://github.com/attacker/villa/actions/runs/12345',
+  ]) {
+    assert.equal(isTrustedPreviewRun({
+      status: { ...statuses[0], target_url },
+      run: previewRun,
+      expectedSha,
+    }), false);
+  }
+  assert.equal(isTrustedPreviewRun({
+    status: { ...statuses[0], target_url: 'https://github.com/ScrollPrize/villa/actions/runs/999' },
     run: previewRun,
     expectedSha,
   }), false);


### PR DESCRIPTION
Fix the Progress Prize rehearsal gate for GitHub's current REST metadata without weakening provenance. The gate now reads newest-first creator-bearing commit statuses, requires the immutable GitHub Actions bot identity and exact success description, and binds both workflow run name fields to the exact preview SHA.\n\nVerified locally: 196 full tests, 10 focused workflow-contract tests, Node syntax, git diff checks, private-value scan 0/10, independent security review approved.