### PR TITLE
fix(scrollprize): retry exact PR metadata binding

### DIFF
--- a/.github/progress-prizes-github.mjs
+++ b/.github/progress-prizes-github.mjs
@@ -90,26 +90,36 @@ export function assertAutomationBranch(head, base) {
   fail('Head/base pair is outside the Progress Prize automation allowlist.');
 }
 
+function assertPullAssociation(pull, { head, base } = {}) {
+  assertAutomationBranch(head, base);
+  if (
+    pull?.state !== 'open'
+    || pull.head?.ref !== head
+    || pull.base?.ref !== base
+    || pull.head?.repo?.id !== REPOSITORY_ID
+    || pull.base?.repo?.id !== REPOSITORY_ID
+    || pull.head?.repo?.full_name !== `${OWNER}/${REPO}`
+    || pull.base?.repo?.full_name !== `${OWNER}/${REPO}`
+  ) {
+    fail('Automation pull request association failed.');
+  }
+  return pull;
+}
+
+function pullShasMatch(pull, { headSha, baseSha }) {
+  return pull?.head?.sha === headSha && pull?.base?.sha === baseSha;
+}
+
 export function assertPullBinding(pull, {
   head,
   base,
   headSha,
   baseSha,
 } = {}) {
-  assertAutomationBranch(head, base);
+  assertPullAssociation(pull, { head, base });
   assertSha(headSha);
   assertSha(baseSha);
-  if (
-    pull?.state !== 'open'
-    || pull.head?.ref !== head
-    || pull.base?.ref !== base
-    || pull.head?.sha !== headSha
-    || pull.base?.sha !== baseSha
-    || pull.head?.repo?.id !== REPOSITORY_ID
-    || pull.base?.repo?.id !== REPOSITORY_ID
-    || pull.head?.repo?.full_name !== `${OWNER}/${REPO}`
-    || pull.base?.repo?.full_name !== `${OWNER}/${REPO}`
-  ) {
+  if (!pullShasMatch(pull, { headSha, baseSha })) {
     fail('Automation pull request is not bound to the expected immutable refs.');
   }
   return pull;
@@ -205,6 +215,37 @@ async function github(path, { method = 'GET', body, token = process.env.GITHUB_T
   return response.status === 204 ? undefined : response.json();
 }
 
+export async function waitForPullBinding({
+  number,
+  head,
+  base,
+  headSha,
+  baseSha,
+} = {}, {
+  attempts = 12,
+  delayMs = 5_000,
+  readPull = (pullNumber) => github(`/repos/${OWNER}/${REPO}/pulls/${pullNumber}`),
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+} = {}) {
+  if (!Number.isInteger(number) || number < 1) fail('Invalid pull request number.');
+  assertAutomationBranch(head, base);
+  assertSha(headSha);
+  assertSha(baseSha);
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > 12) {
+    fail('Invalid pull request convergence attempts.');
+  }
+  if (!Number.isInteger(delayMs) || delayMs < 0 || delayMs > 5_000) {
+    fail('Invalid pull request convergence delay.');
+  }
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const pull = await readPull(number);
+    assertPullAssociation(pull, { head, base });
+    if (pullShasMatch(pull, { headSha, baseSha })) return pull;
+    if (attempt < attempts) await sleep(delayMs);
+  }
+  fail('Automation pull request immutable refs did not converge.');
+}
+
 async function findPull(head, base) {
   assertAutomationBranch(head, base);
   const pulls = await github(
@@ -212,17 +253,7 @@ async function findPull(head, base) {
   );
   if (!Array.isArray(pulls) || pulls.length !== 1) fail('Expected exactly one open automation pull request.');
   const pull = pulls[0];
-  if (
-    pull.head?.ref !== head
-    || pull.base?.ref !== base
-    || pull.head?.repo?.id !== REPOSITORY_ID
-    || pull.base?.repo?.id !== REPOSITORY_ID
-    || pull.head?.repo?.full_name !== `${OWNER}/${REPO}`
-    || pull.base?.repo?.full_name !== `${OWNER}/${REPO}`
-  ) {
-    fail('Automation pull request association failed.');
-  }
-  return pull;
+  return assertPullAssociation(pull, { head, base });
 }
 
 async function activationState(options) {
@@ -450,8 +481,9 @@ async function ensurePull(options) {
     responderUri,
   });
   const pulls = await github(
-    `/repos/${OWNER}/${REPO}/pulls?state=open&head=${encodeURIComponent(`${OWNER}:${head}`)}&base=${encodeURIComponent(base)}&per_page=10`,
+    `/repos/${OWNER}/${REPO}/pulls?state=open&head=${encodeURIComponent(`${OWNER}:${head}`)}&per_page=10`,
   );
+  if (!Array.isArray(pulls)) fail('Automation pull request listing failed.');
   let pull;
   if (pulls.length === 0) {
     pull = await github(`/repos/${OWNER}/${REPO}/pulls`, {
@@ -465,13 +497,18 @@ async function ensurePull(options) {
       },
     });
   } else if (pulls.length === 1) {
-    pull = pulls[0];
+    pull = assertPullAssociation(pulls[0], { head, base });
   } else {
-    fail('Multiple automation pull requests match the fixed head/base pair.');
+    fail('Multiple open pull requests use the fixed automation head.');
   }
   if (!Number.isInteger(pull?.number) || pull.number < 1) fail('Pull request creation failed.');
-  pull = await github(`/repos/${OWNER}/${REPO}/pulls/${pull.number}`);
-  assertPullBinding(pull, { head, base, headSha, baseSha });
+  pull = await waitForPullBinding({
+    number: pull.number,
+    head,
+    base,
+    headSha,
+    baseSha,
+  });
   await verifyPageDelta({
     head,
     base,

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -12,6 +12,7 @@ import {
   assertSinglePageCommit,
   gateSnapshot,
   isTrustedPreviewRun,
+  waitForPullBinding,
 } from '../../../.github/progress-prizes-github.mjs';
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
@@ -437,6 +438,20 @@ test('preview gates use creator-bearing newest-first commit status history', asy
   assert.equal(helper.includes(combinedEndpoint), false);
 });
 
+test('PR preparation discovers by immutable head and waits for exact SHA convergence', async () => {
+  const helper = await readFile(
+    resolve(repositoryRoot, '.github/progress-prizes-github.mjs'),
+    'utf8',
+  );
+  const start = helper.indexOf('async function ensurePull(options)');
+  const end = helper.indexOf('async function merge(options)', start);
+  assert.ok(start >= 0 && end > start);
+  const ensurePull = helper.slice(start, end);
+  assert.match(ensurePull, /pulls\?state=open&head=/);
+  assert.doesNotMatch(ensurePull, /&base=/);
+  assert.match(ensurePull, /waitForPullBinding/);
+});
+
 test('trusted branch and exact-check gate helpers reject ambiguous automation state', () => {
   assert.deepEqual(
     assertAutomationBranch(
@@ -714,4 +729,90 @@ test('the GitHub helper binds the PR and exact deterministic page-only commit', 
     ...commit,
     files: [...commit.files, { filename: '.github/workflows/untrusted.yml', status: 'added' }],
   }, { headSha, baseSha }), /one page-only commit/);
+});
+
+test('PR binding retry tolerates only bounded stale SHAs', async () => {
+  const head = 'codex/progress-prize-smoke-20260720';
+  const base = 'codex/progress-prize-smoke-base-20260720';
+  const headSha = 'a'.repeat(40);
+  const baseSha = 'b'.repeat(40);
+  const exactPull = {
+    number: 1194,
+    state: 'open',
+    head: {
+      ref: head,
+      sha: headSha,
+      repo: { id: 890972577, full_name: 'ScrollPrize/villa' },
+    },
+    base: {
+      ref: base,
+      sha: baseSha,
+      repo: { id: 890972577, full_name: 'ScrollPrize/villa' },
+    },
+  };
+  const stalePull = {
+    ...exactPull,
+    head: { ...exactPull.head, sha: 'c'.repeat(40) },
+    base: { ...exactPull.base, sha: 'd'.repeat(40) },
+  };
+  const responses = [stalePull, stalePull, exactPull];
+  const sleeps = [];
+  const result = await waitForPullBinding({
+    number: exactPull.number,
+    head,
+    base,
+    headSha,
+    baseSha,
+  }, {
+    attempts: 3,
+    delayMs: 7,
+    readPull: async () => responses.shift(),
+    sleep: async (milliseconds) => sleeps.push(milliseconds),
+  });
+  assert.equal(result, exactPull);
+  assert.deepEqual(sleeps, [7, 7]);
+
+  let unsafeReads = 0;
+  let unsafeSleeps = 0;
+  await assert.rejects(
+    waitForPullBinding({
+      number: exactPull.number,
+      head,
+      base,
+      headSha,
+      baseSha,
+    }, {
+      attempts: 3,
+      delayMs: 0,
+      readPull: async () => {
+        unsafeReads += 1;
+        return { ...stalePull, base: { ...stalePull.base, ref: 'main' } };
+      },
+      sleep: async () => { unsafeSleeps += 1; },
+    }),
+    /association failed/,
+  );
+  assert.equal(unsafeReads, 1);
+  assert.equal(unsafeSleeps, 0);
+
+  let staleReads = 0;
+  await assert.rejects(
+    waitForPullBinding({
+      number: exactPull.number,
+      head,
+      base,
+      headSha,
+      baseSha,
+    }, {
+      attempts: 2,
+      delayMs: 0,
+      readPull: async () => {
+        staleReads += 1;
+        return stalePull;
+      },
+      sleep: async () => {},
+    }),
+    /immutable refs did not converge/,
+  );
+  assert.equal(staleReads, 2);
 });


### PR DESCRIPTION
Handle GitHub's short PR-metadata lag after the lease-protected smoke-head update. Discovery is bound to the fixed automation head and fails on ambiguity; polling is bounded to 12 reads and retries only stale head/base SHAs while revalidating the exact open PR refs and immutable repository identity on every response. Deterministic page verification still runs before and after convergence.\n\nVerified: 198 full tests, 12 focused contract tests, Node and diff checks, protected-value scan 0/10, independent security review approved.