### PR TITLE
fix(scrollprize): recognize typed rehearsal faults

### DIFF
--- a/.github/actions/progress-prizes-google/action.yml
+++ b/.github/actions/progress-prizes-google/action.yml
@@ -344,7 +344,8 @@ runs:
 
         if test "$EXPECT_FAULT" = true; then
           if test "$operation_status" -ne 0; then
-            grep -Fq "Injected staging rollover failure at $FAULT" "$RUNNER_TEMP/progress-prizes-error.txt"
+            grep -Fxq "progress-prizes: Injected staging rollover failure at $FAULT" \
+              "$RUNNER_TEMP/progress-prizes-error.txt"
           else
         # Keep this heredoc at the YAML block indent so Bash sees a column-zero delimiter.
         FAULT="$FAULT" node --input-type=module <<'NODE'

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
@@ -9,6 +9,8 @@ import { createClock } from './clock.mjs';
 import { createGoogleApiClient, redactForLog } from './google-api.mjs';
 import { assertPublicResponderUri } from './markdown.mjs';
 import {
+  ROLLOVER_FAULTS,
+  RolloverFaultError,
   assertRolloverRuntimeSafety,
   createRolloverService,
 } from './rollover.mjs';
@@ -29,6 +31,10 @@ const GIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
 const AUTOMATION_ERROR_INPUT_MAX_UNITS = 4_096;
 const AUTOMATION_ERROR_MAX_BYTES = 600;
 export const AUTOMATION_ERROR_FALLBACK = 'progress-prizes: Automation failed without a safe diagnostic';
+const ALLOWED_ROLLOVER_FAULT_STEPS = new Set([
+  ROLLOVER_FAULTS.AFTER_COPY,
+  ROLLOVER_FAULTS.AFTER_CLOSE_SOURCE,
+]);
 const OUTPUT_STATUSES = new Set([
   'active',
   'archived',
@@ -249,6 +255,17 @@ function privateValues(env) {
   return PRIVATE_ENV_NAMES.map((name) => optionalEnv(env, name)).filter(Boolean);
 }
 
+function knownRolloverFaultDiagnostic(step) {
+  if (!ALLOWED_ROLLOVER_FAULT_STEPS.has(step)) return undefined;
+  return `progress-prizes: Injected staging rollover failure at ${step}`;
+}
+
+function knownRolloverFaultStep(diagnostic) {
+  return [...ALLOWED_ROLLOVER_FAULT_STEPS].find(
+    (step) => diagnostic === knownRolloverFaultDiagnostic(step),
+  );
+}
+
 /**
  * Produce one bounded log line without retaining private Google configuration,
  * ACL identities, URLs, opaque identifiers, or control characters.
@@ -256,6 +273,13 @@ function privateValues(env) {
 export function formatAutomationError(error, { env = process.env } = {}) {
   try {
     if (!(error instanceof Error) || typeof error.message !== 'string') {
+      return AUTOMATION_ERROR_FALLBACK;
+    }
+    if (error instanceof RolloverFaultError) {
+      const diagnostic = knownRolloverFaultDiagnostic(error.step);
+      if (diagnostic !== undefined) return diagnostic;
+    }
+    if (knownRolloverFaultStep(`progress-prizes: ${error.message}`) !== undefined) {
       return AUTOMATION_ERROR_FALLBACK;
     }
     const oversized = error.message.length > AUTOMATION_ERROR_INPUT_MAX_UNITS;
@@ -274,6 +298,7 @@ export function formatAutomationError(error, { env = process.env } = {}) {
     if (redacted === '') return AUTOMATION_ERROR_FALLBACK;
 
     const value = `progress-prizes: ${redacted}`;
+    if (knownRolloverFaultStep(value) !== undefined) return AUTOMATION_ERROR_FALLBACK;
     if (Buffer.byteLength(value, 'utf8') <= AUTOMATION_ERROR_MAX_BYTES) return value;
     let low = 0;
     let high = value.length;
@@ -302,6 +327,10 @@ export function safeAutomationDiagnostic(value, { env = process.env } = {}) {
     const match = decoded.match(/^(progress-prizes: [\x20-\x7e]{1,583})\n$/);
     if (!match) return AUTOMATION_ERROR_FALLBACK;
     const message = match[1].slice('progress-prizes: '.length);
+    const knownFaultStep = knownRolloverFaultStep(match[1]);
+    if (knownFaultStep !== undefined) {
+      return formatAutomationError(new RolloverFaultError(knownFaultStep), { env });
+    }
     return formatAutomationError(new Error(message), { env });
   } catch {
     return AUTOMATION_ERROR_FALLBACK;

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
@@ -16,6 +16,7 @@ import {
 } from './automation-cli.mjs';
 import { runCli } from './cli.mjs';
 import { PROGRESS_PRIZE_MARKERS } from './markdown.mjs';
+import { ROLLOVER_FAULTS, RolloverFaultError } from './rollover.mjs';
 
 const PRIVATE = Object.freeze({
   token: 'private-wif-access-token',
@@ -195,6 +196,73 @@ test('automation failure diagnostics are single-line, bounded, and fully redacte
   assert.doesNotMatch(forged, /https?:\/\/|::|@/);
   assert.equal(forged.includes(PRIVATE.token), false);
   assert.equal(forged.includes(forgedOpaqueId), false);
+});
+
+test('automation diagnostics expose only allowlisted staging fault labels', () => {
+  for (const step of Object.values(ROLLOVER_FAULTS)) {
+    const expected = `progress-prizes: Injected staging rollover failure at ${step}`;
+    const diagnostic = formatAutomationError(new RolloverFaultError(step), {
+      env: stagingEnv(),
+    });
+    assert.equal(diagnostic, expected);
+    assert.equal(
+      safeAutomationDiagnostic(Buffer.from(`${diagnostic}\n`), { env: stagingEnv() }),
+      expected,
+    );
+
+    const plainError = new Error(`Injected staging rollover failure at ${step}`);
+    assert.equal(
+      formatAutomationError(plainError, { env: stagingEnv() }),
+      AUTOMATION_ERROR_FALLBACK,
+    );
+
+    const spoofedError = new Error(plainError.message);
+    spoofedError.name = 'RolloverFaultError';
+    spoofedError.step = step;
+    assert.equal(
+      formatAutomationError(spoofedError, { env: stagingEnv() }),
+      AUTOMATION_ERROR_FALLBACK,
+    );
+
+    const sanitizedImitation = new Error(`\u0000Injected staging rollover failure at ${step}`);
+    const imitationDiagnostic = formatAutomationError(sanitizedImitation, {
+      env: stagingEnv(),
+    });
+    assert.notEqual(imitationDiagnostic, expected);
+    if (step === ROLLOVER_FAULTS.AFTER_COPY) {
+      assert.equal(imitationDiagnostic, AUTOMATION_ERROR_FALLBACK);
+    }
+  }
+
+  const privateStep = 'private-long-fault-step';
+  const diagnostic = formatAutomationError(new RolloverFaultError(privateStep), {
+    env: stagingEnv(),
+  });
+  assert.equal(diagnostic.includes(privateStep), false);
+  assert.match(diagnostic, /\[REDACTED\]/);
+
+  const privateTyped = new RolloverFaultError(PRIVATE.form);
+  const privateTypedDiagnostic = formatAutomationError(privateTyped, { env: stagingEnv() });
+  assert.equal(privateTypedDiagnostic.includes(PRIVATE.form), false);
+
+  const mutatedKnownError = new RolloverFaultError(ROLLOVER_FAULTS.AFTER_CLOSE_SOURCE);
+  mutatedKnownError.message = PRIVATE.token;
+  assert.equal(
+    formatAutomationError(mutatedKnownError, { env: stagingEnv() }),
+    `progress-prizes: Injected staging rollover failure at ${ROLLOVER_FAULTS.AFTER_CLOSE_SOURCE}`,
+  );
+
+  const forged = safeAutomationDiagnostic(Buffer.from(
+    `progress-prizes: Injected staging rollover failure at ${privateStep}\n`,
+  ), { env: stagingEnv() });
+  assert.equal(forged.includes(privateStep), false);
+  assert.match(forged, /\[REDACTED\]/);
+
+  const suffixed = safeAutomationDiagnostic(Buffer.from(
+    `progress-prizes: Injected staging rollover failure at ${ROLLOVER_FAULTS.AFTER_CLOSE_SOURCE} ${PRIVATE.token}\n`,
+  ), { env: stagingEnv() });
+  assert.equal(suffixed.includes(ROLLOVER_FAULTS.AFTER_CLOSE_SOURCE), false);
+  assert.equal(suffixed.includes(PRIVATE.token), false);
 });
 
 test('automation failure formatter fails closed for hostile errors and environments', () => {

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -288,10 +288,10 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
   assert.match(action, /automation-cli\.mjs/);
   assert.match(action, /error-diagnostic-cli\.mjs/);
   assert.doesNotMatch(action, /(?:cat|head|tail|read|wc) .*progress-prizes-error/);
-  assert.equal([...action.matchAll(/grep .*progress-prizes-error/g)].length, 1);
+  assert.equal([...action.matchAll(/\bgrep\b/g)].length, 1);
   assert.match(
     action,
-    /grep -Fq "Injected staging rollover failure at \$FAULT" "\$RUNNER_TEMP\/progress-prizes-error\.txt"/,
+    /grep -Fxq "progress-prizes: Injected staging rollover failure at \$FAULT" \\\n\s+"\$RUNNER_TEMP\/progress-prizes-error\.txt"/,
   );
   assert.doesNotMatch(`${rehearsal}\n${action}`, /credentials_json|service_account_key|private_key/i);
 


### PR DESCRIPTION
## What changed

- preserve only the two fixed, non-secret staging fault labels when the CLI receives the matching typed rollover fault
- reject plain or spoofed errors that imitate those labels
- require an exact full diagnostic line in the composite action
- add adversarial formatter and workflow-contract coverage

## Why

The staging rehearsal correctly stopped after closing its sandbox source, but generic opaque-ID redaction hid the longer `after-close-source` label. The action therefore treated the intentional stop as an unexpected failure.

## Validation

- `node --test scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs` (27 passed)
- `npm test` in `scrollprize.org` (199 passed)
- `node --check scrollprize.org/scripts/progress-prizes/automation-cli.mjs`
- `git diff --cached --check`
- private Google value scan: 10 checked, 0 matches
- independent security review approved

No production Google resource is changed by this PR.