### PR TITLE
fix(scrollprize): recover staged activation rehearsals

### DIFF
--- a/.github/actions/progress-prizes-google/action.yml
+++ b/.github/actions/progress-prizes-google/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Ask a supported operation to make no mutation
     required: false
     default: "false"
+  allow-activation-rewind:
+    description: Explicit staging-only bootstrap recovery from the close-fault checkpoint
+    required: false
+    default: "false"
   verify-mode:
     description: prepared, active, or cleaned
     required: false
@@ -53,7 +57,11 @@ inputs:
     description: Protected Environment service account identifier
     required: true
   staging-service-account-email:
-    description: Protected staging identity used by production ACL validation
+    description: Independently protected staging identity and production ACL expectation
+    required: false
+    default: ""
+  staging-folder-id:
+    description: Independently protected staging active-folder identifier
     required: false
     default: ""
   drive-admin-email:
@@ -98,6 +106,7 @@ runs:
         FAULT: ${{ inputs.fault }}
         EXPECT_FAULT: ${{ inputs['expect-fault'] }}
         DRY_RUN: ${{ inputs['dry-run'] }}
+        ALLOW_ACTIVATION_REWIND: ${{ inputs['allow-activation-rewind'] }}
         BRANCH: ${{ inputs.branch }}
         TARGET_BRANCH: ${{ inputs['target-branch'] }}
         SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
@@ -116,20 +125,33 @@ runs:
         esac
         case "$EXPECT_FAULT" in true|false) ;; *) exit 1 ;; esac
         case "$DRY_RUN" in true|false) ;; *) exit 1 ;; esac
+        case "$ALLOW_ACTIVATION_REWIND" in true|false) ;; *) exit 1 ;; esac
         if test -n "$SOURCE_CYCLE"; then [[ "$SOURCE_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; fi
         if test -n "$TARGET_CYCLE"; then [[ "$TARGET_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; fi
         case "$OPERATION" in
           validate|bootstrap) test -n "$SOURCE_CYCLE" ;;
           prepare|activate|verify|cleanup) test -n "$TARGET_CYCLE" ;;
         esac
+        if test "$OPERATION" = bootstrap; then test "$SOURCE_CYCLE" = 2026-07; fi
         if test "$OPERATION" = activate; then [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; fi
         if test -n "$HEAD_SHA"; then [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; fi
+        if test "$OPERATION" = bootstrap && test -n "$TARGET_CYCLE"; then
+          test "$ALLOW_ACTIVATION_REWIND" = true
+        fi
+        if test "$ALLOW_ACTIVATION_REWIND" = true; then
+          test "$AUTOMATION_ENVIRONMENT" = staging
+          test "$EVENT_NAME" = workflow_dispatch
+          test "$OPERATION" = bootstrap
+          test "$SOURCE_CYCLE" = 2026-07
+          test "$TARGET_CYCLE" = 2026-08
+        fi
         if test "$AUTOMATION_ENVIRONMENT" = production; then
           test "$OPERATION" != bootstrap
           test "$OPERATION" != cleanup
           test -z "$SIMULATED_NOW"
           test -z "$FAULT"
           test "$EXPECT_FAULT" = false
+          test "$ALLOW_ACTIVATION_REWIND" = false
           test "$TARGET_BRANCH" = main
           test "$BRANCH" = main -o "$BRANCH" = "codex/progress-prize-$TARGET_CYCLE"
         else
@@ -160,6 +182,7 @@ runs:
         GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ inputs['workload-identity-provider'] }}
         GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ inputs['service-account-email'] }}
         PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs['staging-service-account-email'] }}
+        PROGRESS_PRIZE_STAGING_FOLDER_ID: ${{ inputs['staging-folder-id'] }}
         PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ inputs['drive-admin-email'] }}
         PROGRESS_PRIZE_DRIVE_ID: ${{ inputs['drive-id'] }}
         PROGRESS_PRIZE_FOLDER_ID: ${{ inputs['folder-id'] }}
@@ -172,6 +195,7 @@ runs:
           GOOGLE_WORKLOAD_IDENTITY_PROVIDER \
           GOOGLE_SERVICE_ACCOUNT_EMAIL \
           PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \
+          PROGRESS_PRIZE_STAGING_FOLDER_ID \
           PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL \
           PROGRESS_PRIZE_DRIVE_ID \
           PROGRESS_PRIZE_FOLDER_ID \
@@ -193,6 +217,7 @@ runs:
         GOOGLE_WORKLOAD_IDENTITY_PROVIDER: ${{ inputs['workload-identity-provider'] }}
         GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ inputs['service-account-email'] }}
         PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs['staging-service-account-email'] }}
+        PROGRESS_PRIZE_STAGING_FOLDER_ID: ${{ inputs['staging-folder-id'] }}
         PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL: ${{ inputs['drive-admin-email'] }}
         PROGRESS_PRIZE_DRIVE_ID: ${{ inputs['drive-id'] }}
         PROGRESS_PRIZE_FOLDER_ID: ${{ inputs['folder-id'] }}
@@ -220,6 +245,19 @@ runs:
             echo "Missing protected Environment secret: PROGRESS_PRIZE_ARCHIVE_FOLDER_ID" >&2
             exit 1
           }
+        fi
+        if test "$AUTOMATION_ENVIRONMENT" = staging; then
+          for name in \
+            PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \
+            PROGRESS_PRIZE_STAGING_FOLDER_ID
+          do
+            test -n "${!name}" || {
+              echo "Missing protected Environment secret: $name" >&2
+              exit 1
+            }
+          done
+          test "$GOOGLE_SERVICE_ACCOUNT_EMAIL" = "$PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL"
+          test "$PROGRESS_PRIZE_FOLDER_ID" = "$PROGRESS_PRIZE_STAGING_FOLDER_ID"
         fi
         if test "$AUTOMATION_ENVIRONMENT" = production \
           && test "$OPERATION" = validate \
@@ -305,8 +343,8 @@ runs:
         PROGRESS_PRIZE_SOURCE_FORM_ID: ${{ inputs['source-form-id'] }}
         PROGRESS_PRIZE_EDITOR_GROUP_EMAIL: ${{ inputs['editor-group-email'] }}
         PROGRESS_PRIZE_SERVICE_ACCOUNT_EMAIL: ${{ inputs['service-account-email'] }}
-        PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs.environment == 'staging' && inputs['service-account-email'] || inputs['staging-service-account-email'] }}
-        PROGRESS_PRIZE_STAGING_FOLDER_ID: ${{ inputs.environment == 'staging' && inputs['folder-id'] || '' }}
+        PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL: ${{ inputs['staging-service-account-email'] }}
+        PROGRESS_PRIZE_STAGING_FOLDER_ID: ${{ inputs['staging-folder-id'] }}
         PROGRESS_PRIZE_BRANCH: ${{ inputs.branch }}
         PROGRESS_PRIZE_TARGET_BRANCH: ${{ inputs['target-branch'] }}
         PROGRESS_PRIZE_DEFAULT_TARGET_BRANCH: main
@@ -321,6 +359,7 @@ runs:
         FAULT: ${{ inputs.fault }}
         EXPECT_FAULT: ${{ inputs['expect-fault'] }}
         DRY_RUN: ${{ inputs['dry-run'] }}
+        ALLOW_ACTIVATION_REWIND: ${{ inputs['allow-activation-rewind'] }}
         VERIFY_MODE: ${{ inputs['verify-mode'] }}
       run: |
         set -euo pipefail
@@ -330,6 +369,7 @@ runs:
         test -z "$SIMULATED_NOW" || arguments+=(--simulated-now "$SIMULATED_NOW")
         test -z "$FAULT" || arguments+=(--fault "$FAULT")
         test "$DRY_RUN" = false || arguments+=(--dry-run)
+        test "$ALLOW_ACTIVATION_REWIND" = false || arguments+=(--allow-activation-rewind)
         if test "$OPERATION" = verify; then arguments+=(--mode "$VERIFY_MODE"); fi
         if test -f "$RUNNER_TEMP/progress-prizes-page.md"; then
           arguments+=(--page-path "$RUNNER_TEMP/progress-prizes-page.md")

--- a/.github/workflows/progress-prizes-rehearsal.yml
+++ b/.github/workflows/progress-prizes-rehearsal.yml
@@ -92,6 +92,8 @@ jobs:
 
           const source = parseCycle(process.env.SOURCE_CYCLE);
           const target = parseCycle(process.env.TARGET_CYCLE);
+          assert.equal(process.env.SOURCE_CYCLE, '2026-07');
+          assert.equal(process.env.TARGET_CYCLE, '2026-08');
           const expectedTarget = source.month === 12
             ? { year: source.year + 1, month: 1 }
             : { year: source.year, month: source.month + 1 };
@@ -204,14 +206,18 @@ jobs:
           operation: bootstrap
           environment: staging
           source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ (inputs.operation == 'full-rehearsal' || inputs.operation == 'activation-fault-recovery') && inputs['target-cycle'] || '' }}
+          allow-activation-rewind: ${{ inputs.operation == 'full-rehearsal' || inputs.operation == 'activation-fault-recovery' }}
           simulated-now: ${{ inputs['preparation-now'] }}
           branch: codex/progress-prize-smoke-20260720
           target-branch: codex/progress-prize-smoke-base-20260720
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -253,9 +259,11 @@ jobs:
           target-branch: codex/progress-prize-smoke-base-20260720
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -295,9 +303,11 @@ jobs:
           target-branch: codex/progress-prize-smoke-base-20260720
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -357,9 +367,11 @@ jobs:
           head-sha: ${{ needs.prepare-page.outputs['head-sha'] }}
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -447,9 +459,11 @@ jobs:
           head-sha: ${{ needs.activation-gate.outputs['head-sha'] }}
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -489,9 +503,11 @@ jobs:
           head-sha: ${{ needs.activation-gate.outputs['head-sha'] }}
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -532,9 +548,11 @@ jobs:
           head-sha: ${{ needs.activation-gate.outputs['head-sha'] }}
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -652,9 +670,11 @@ jobs:
           head-sha: ${{ needs.activation-gate.outputs['head-sha'] }}
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -693,9 +713,11 @@ jobs:
           target-branch: codex/progress-prize-smoke-base-20260720
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -733,9 +755,11 @@ jobs:
           target-branch: codex/progress-prize-smoke-base-20260720
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -772,9 +796,11 @@ jobs:
           target-branch: codex/progress-prize-smoke-base-20260720
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
@@ -812,9 +838,11 @@ jobs:
           target-branch: codex/progress-prize-smoke-base-20260720
           workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
           drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
           drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
           folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
           archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -78,10 +78,14 @@ Protected Environment secrets:
 
 - `GOOGLE_WORKLOAD_IDENTITY_PROVIDER`
 - `GOOGLE_SERVICE_ACCOUNT_EMAIL`
+- `PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL` (an independently configured
+  copy of the expected staging service-account identity)
 - `PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL` (one private human kept as the inherited
   break-glass Shared Drive Manager)
 - `PROGRESS_PRIZE_DRIVE_ID` (the staging Shared Drive)
 - `PROGRESS_PRIZE_FOLDER_ID` (the staging active folder)
+- `PROGRESS_PRIZE_STAGING_FOLDER_ID` (an independently configured copy of the
+  expected staging active-folder ID)
 - `PROGRESS_PRIZE_ARCHIVE_FOLDER_ID` (the staging archive folder)
 - `PROGRESS_PRIZE_SOURCE_FORM_ID` (the initial owner-My-Drive form's private file ID)
 - `PROGRESS_PRIZE_EDITOR_GROUP_EMAIL` (the staging-only group containing the
@@ -122,6 +126,8 @@ Protected Environment secrets:
 
 - `GOOGLE_WORKLOAD_IDENTITY_PROVIDER`
 - `GOOGLE_SERVICE_ACCOUNT_EMAIL`
+- `PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL` (the staging reader identity
+  expected on the initial live form during read-only validation)
 - `PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL` (one private human kept as the inherited
   break-glass Shared Drive Manager)
 - `PROGRESS_PRIZE_DRIVE_ID` (the destination/managed production Shared Drive)
@@ -154,8 +160,10 @@ explicitly on every managed form. Every active permission role is inspected:
 any other Google service account—including a reader or owner—fails closed, as
 do inherited editors, domains, additional Managers, or Content managers.
 
-No archive folder is supplied to production, and the workflow deliberately
-supplies empty staging-identity values in production mode.
+No archive or staging folder is supplied to production. Production mutation
+jobs receive no staging identity; the initial July read-only validation is the
+only exception, because it verifies the expected staging reader on the live
+form without granting the production identity access to staging.
 `PROGRESS_PRIZE_SOURCE_FORM_ID` is a one-time, explicit fallback. The July form
 never receives managed environment/role/cycle markers and is never moved or
 renamed. At activation it is closed first and receives only the private recovery

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
@@ -14,7 +14,7 @@ import {
   assertRolloverRuntimeSafety,
   createRolloverService,
 } from './rollover.mjs';
-import { parseCycle, previousCycle } from './dates.mjs';
+import { nextCycle, parseCycle, previousCycle } from './dates.mjs';
 import {
   GOOGLE_CLI_USAGE,
   GOOGLE_COMMANDS,
@@ -361,6 +361,32 @@ function assertAutomationOptions(command, options) {
   if (options.fault !== undefined && !['bootstrap', 'prepare', 'activate'].includes(command)) {
     throw new Error('--fault is accepted only by bootstrap, prepare, and activate');
   }
+  if (command === 'bootstrap') {
+    const sourceCycle = requireOption(options, 'source-cycle');
+    parseCycle(sourceCycle);
+    if (sourceCycle !== '2026-07') {
+      throw new Error('Staging bootstrap is restricted to the initial 2026-07 source cycle');
+    }
+  }
+  if (options['allow-activation-rewind'] === true && command !== 'bootstrap') {
+    throw new Error('--allow-activation-rewind is accepted only by bootstrap');
+  }
+  if (options['allow-activation-rewind'] === true) {
+    const sourceCycle = requireOption(options, 'source-cycle');
+    const targetCycle = requireOption(options, 'target-cycle');
+    parseCycle(sourceCycle);
+    parseCycle(targetCycle);
+    if (nextCycle(sourceCycle) !== targetCycle) {
+      throw new Error('Activation rewind target cycle must immediately follow the source cycle');
+    }
+  }
+  if (
+    command === 'bootstrap'
+    && options['target-cycle'] !== undefined
+    && options['allow-activation-rewind'] !== true
+  ) {
+    throw new Error('--target-cycle requires --allow-activation-rewind for bootstrap');
+  }
   for (const shaOption of ['head-sha', 'verified-sha']) {
     if (options[shaOption] !== undefined && command !== 'activate') {
       throw new Error(`--${shaOption} is accepted only by activate`);
@@ -449,7 +475,10 @@ export async function runAutomationCli(argv, {
   // This validation deliberately precedes token access, Google client creation,
   // responder URL resolution, and every filesystem/network call.
   const runtime = buildRuntime(options, env);
-  assertRolloverRuntimeSafety(runtime, { faultInjection: options.fault });
+  assertRolloverRuntimeSafety(runtime, {
+    faultInjection: options.fault,
+    allowActivationRewind: options['allow-activation-rewind'] === true,
+  });
   const clock = createClock({
     environment: runtime.environment,
     eventName: runtime.eventName,
@@ -495,12 +524,21 @@ export async function runAutomationCli(argv, {
   } else if (command === 'bootstrap') {
     const sourceCycle = requireOption(options, 'source-cycle');
     parseCycle(sourceCycle);
+    const allowActivationRewind = options['allow-activation-rewind'] === true;
+    let targetCycle;
+    if (allowActivationRewind) {
+      targetCycle = requireOption(options, 'target-cycle');
+      parseCycle(targetCycle);
+      assertSourceCycleMatchesTarget(options, targetCycle);
+    }
     result = await rollover.bootstrapStagingSource({
       sourceFormId: requiredEnv(env, AUTOMATION_ENV.SOURCE_FORM_ID),
       sourceCycle,
+      targetCycle,
       collaboratorPermissions: collaborators,
       dryRun: options['dry-run'] === true,
       faultInjection: options.fault,
+      allowActivationRewind,
     });
   } else {
     const targetCycle = requireOption(options, 'target-cycle');

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
@@ -342,6 +342,134 @@ test('production-only guards reject staging controls before token access, client
       }),
       /alternate target branch/,
     ],
+    [
+      [
+        'bootstrap',
+        '--source-cycle', '2026-07',
+        '--target-cycle', '2026-08',
+        '--allow-activation-rewind',
+      ],
+      productionEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /activation rewind is forbidden in production/,
+    ],
+  ]) {
+    let clientCalls = 0;
+    let fileCalls = 0;
+    let fetchCalls = 0;
+    await assert.rejects(
+      runAutomationCli(argv, {
+        env,
+        googleFactory: () => { clientCalls += 1; return {}; },
+        read: async () => { fileCalls += 1; return ''; },
+        write: async () => { fileCalls += 1; },
+        fetchImpl: async () => { fetchCalls += 1; return new Response(); },
+        output: () => {},
+      }),
+      expected,
+    );
+    assert.equal(clientCalls, 0);
+    assert.equal(fileCalls, 0);
+    assert.equal(fetchCalls, 0);
+  }
+});
+
+test('activation rewind controls fail closed before token access, client creation, file IO, or network', async () => {
+  for (const [argv, env, expected] of [
+    [
+      ['prepare', '--target-cycle', '2026-08', '--allow-activation-rewind'],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /accepted only by bootstrap/,
+    ],
+    [
+      ['bootstrap', '--source-cycle', '2026-07', '--allow-activation-rewind'],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /Missing required option --target-cycle/,
+    ],
+    [
+      ['bootstrap', '--target-cycle', '2026-08', '--allow-activation-rewind'],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /Missing required option --source-cycle/,
+    ],
+    [
+      [
+        'bootstrap',
+        '--source-cycle', '2026-07',
+        '--target-cycle', '2026-09',
+        '--allow-activation-rewind',
+      ],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /must immediately follow the source cycle/,
+    ],
+    [
+      [
+        'bootstrap',
+        '--source-cycle', '2026-08',
+        '--target-cycle', '2026-09',
+        '--allow-activation-rewind',
+      ],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /restricted to the initial 2026-07 source cycle/,
+    ],
+    [
+      [
+        'bootstrap',
+        '--source-cycle', '2026-07',
+        '--target-cycle', '2026-08',
+        '--allow-activation-rewind',
+      ],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined, GITHUB_EVENT_NAME: 'schedule' }),
+      /manually dispatched staging run/,
+    ],
+    [
+      [
+        'bootstrap',
+        '--source-cycle', '2026-07',
+        '--target-cycle', '2026-08',
+        '--allow-activation-rewind',
+      ],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined, PROGRESS_PRIZE_SERVICE_ACCOUNT_EMAIL: 'wrong@example.org' }),
+      /staging service account/,
+    ],
+    [
+      [
+        'bootstrap',
+        '--source-cycle', '2026-07',
+        '--target-cycle', '2026-08',
+        '--allow-activation-rewind',
+      ],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined, PROGRESS_PRIZE_FOLDER_ID: 'wrong-folder' }),
+      /staging folder/,
+    ],
+    [
+      [
+        'bootstrap',
+        '--source-cycle', '2026-07',
+        '--target-cycle', '2026-08',
+        '--allow-activation-rewind',
+      ],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined, PROGRESS_PRIZE_BRANCH: 'feature/not-smoke' }),
+      /smoke branch prefix/,
+    ],
+    [
+      [
+        'bootstrap',
+        '--source-cycle', '2026-07',
+        '--target-cycle', '2026-08',
+        '--allow-activation-rewind=true',
+      ],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /does not accept a value/,
+    ],
+    [
+      [
+        'bootstrap',
+        '--source-cycle', '2026-07',
+        '--target-cycle', '2026-08',
+        '--allow-activation-rewind', 'false',
+      ],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /Unexpected positional argument/,
+    ],
   ]) {
     let clientCalls = 0;
     let fileCalls = 0;
@@ -576,4 +704,27 @@ test('bootstrap, verify, and cleanup commands map to the corresponding service o
     assert.equal(capture.method, method);
     if (expectedMode !== undefined) assert.equal(capture.input.mode, expectedMode);
   }
+});
+
+test('bootstrap routes the explicit staging activation rewind and consecutive target cycle', async () => {
+  const capture = {};
+  await runAutomationCli([
+    'bootstrap',
+    '--source-cycle', '2026-07',
+    '--target-cycle', '2026-08',
+    '--allow-activation-rewind',
+  ], {
+    env: stagingEnv(),
+    googleFactory: () => ({}),
+    rolloverFactory: fakeRolloverFactory({
+      capture,
+      result: { status: 'active', cycle: '2026-07' },
+    }),
+    output: () => {},
+  });
+  assert.equal(capture.method, 'bootstrapStagingSource');
+  assert.equal(capture.input.sourceCycle, '2026-07');
+  assert.equal(capture.input.targetCycle, '2026-08');
+  assert.equal(capture.input.allowActivationRewind, true);
+  assert.equal(capture.dependencies.runtime.environment, 'staging');
 });

--- a/scrollprize.org/scripts/progress-prizes/cli-args.mjs
+++ b/scrollprize.org/scripts/progress-prizes/cli-args.mjs
@@ -1,4 +1,4 @@
-const BOOLEAN_OPTIONS = new Set(['dry-run', 'google', 'help']);
+const BOOLEAN_OPTIONS = new Set(['allow-activation-rewind', 'dry-run', 'google', 'help']);
 const VALUE_OPTIONS = new Set([
   'environment',
   'event-name',
@@ -107,6 +107,7 @@ Clock options:
 export const GOOGLE_CLI_USAGE = `Google automation (private values are environment variables only):
   node automation-cli.mjs validate --source-cycle YYYY-MM [--page-path PATH]
   node automation-cli.mjs bootstrap --source-cycle YYYY-MM [--dry-run] [staging controls]
+    [--allow-activation-rewind --target-cycle YYYY-MM]
   node automation-cli.mjs prepare --target-cycle YYYY-MM [--source-cycle YYYY-MM] [--dry-run]
   node automation-cli.mjs activate --target-cycle YYYY-MM [--source-cycle YYYY-MM] [--fault STEP]
   node automation-cli.mjs verify --target-cycle YYYY-MM [--source-cycle YYYY-MM] \\
@@ -120,6 +121,7 @@ Public controls:
   --preparation-days N               Defaults to 7
   --simulated-now ISO_TIMESTAMP      Staging workflow_dispatch only
   --fault after-copy|after-close-source
+  --allow-activation-rewind          Explicit staging bootstrap recovery only
   --head-sha SHA --verified-sha SHA  Exact preview-verified activation commit
   --dry-run                          Bootstrap and prepare only
 `;

--- a/scrollprize.org/scripts/progress-prizes/rollover.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.mjs
@@ -7,6 +7,7 @@ import {
   assertPublicResponderUri,
   assertStagingOnlyControl,
   getCycleDeadline,
+  nextCycle,
   parseCycle,
   parseProgressPrizeMarkdown,
   planRollover,
@@ -32,6 +33,7 @@ export const ROLLOVER_FILE_STATES = Object.freeze({
   COPIED: 'copied',
   PREPARED: 'prepared',
   ACTIVATING: 'activating',
+  REWINDING: 'rewinding',
   ACTIVE: 'active',
   CLOSED: 'closed',
   ARCHIVED: 'archived',
@@ -174,10 +176,17 @@ function assertStagingIdentity(runtime) {
  * Identifiers are compared but deliberately omitted from every error message so
  * that a failed public workflow cannot disclose private Workspace configuration.
  */
-export function assertRolloverRuntimeSafety(runtimeInput, { faultInjection } = {}) {
+export function assertRolloverRuntimeSafety(runtimeInput, {
+  faultInjection,
+  allowActivationRewind = false,
+} = {}) {
   const runtime = normalizeRuntime(runtimeInput);
   const hasSimulatedTime = hasValue(runtime.simulatedNow);
   const hasFault = hasValue(faultInjection);
+
+  if (typeof allowActivationRewind !== 'boolean') {
+    throw new TypeError('allowActivationRewind must be a boolean');
+  }
 
   assertStagingOnlyControl({
     environment: runtime.environment,
@@ -190,6 +199,12 @@ export function assertRolloverRuntimeSafety(runtimeInput, { faultInjection } = {
     eventName: runtime.eventName,
     controlName: 'fault injection',
     enabled: hasFault,
+  });
+  assertStagingOnlyControl({
+    environment: runtime.environment,
+    eventName: runtime.eventName,
+    controlName: 'activation rewind',
+    enabled: allowActivationRewind,
   });
 
   if (hasFault && !Object.values(ROLLOVER_FAULTS).includes(faultInjection)) {
@@ -211,7 +226,7 @@ export function assertRolloverRuntimeSafety(runtimeInput, { faultInjection } = {
     }
   }
 
-  if (hasSimulatedTime || hasFault) {
+  if (hasSimulatedTime || hasFault || allowActivationRewind) {
     assertStagingIdentity(runtime);
   }
 
@@ -1104,8 +1119,25 @@ export function createRolloverService({
     return { form, file: currentFile, permissions };
   }
 
-  async function markFile(file, state, extra = {}) {
+  async function markFile(file, state, extra = {}, { expectedAppProperties } = {}) {
+    // The workflow's static concurrency group is the mutation lock. Refetching
+    // here additionally rejects a state changed since the last full snapshot
+    // before issuing the metadata patch.
     const current = await google.getFile({ fileId: file.id });
+    if (expectedAppProperties !== undefined) {
+      if (
+        expectedAppProperties === null
+        || typeof expectedAppProperties !== 'object'
+        || Array.isArray(expectedAppProperties)
+      ) {
+        throw new TypeError('expectedAppProperties must be an object');
+      }
+      if (Object.entries(expectedAppProperties).some(
+        ([key, value]) => current.appProperties?.[key] !== value,
+      )) {
+        throw new Error('Managed file changed before its rollover state transition');
+      }
+    }
     const appProperties = {
       ...(current.appProperties ?? {}),
       ...extra,
@@ -1194,16 +1226,274 @@ export function createRolloverService({
     });
   }
 
+  function bootstrapRewindTransition(sourceSnapshot, targetSnapshot, {
+    sourceCycle,
+    targetCycle,
+  }) {
+    const sourceState = sourceSnapshot.file.appProperties?.state;
+    const targetState = targetSnapshot.file.appProperties?.state;
+    const sourceOpen = publishingMatches(sourceSnapshot.form, {
+      isPublished: true,
+      isAcceptingResponses: true,
+    });
+    const sourceClosed = publishingMatches(sourceSnapshot.form, {
+      isPublished: true,
+      isAcceptingResponses: false,
+    });
+    const targetClosed = publishingMatches(targetSnapshot.form, {
+      isPublished: true,
+      isAcceptingResponses: false,
+    });
+    const sourceRewindBound = sourceSnapshot.file.appProperties?.rewindTargetCycle
+      === targetCycle;
+    const targetRewindBound = targetSnapshot.file.appProperties?.rewindSourceCycle
+      === sourceCycle;
+
+    if (
+      sourceState === ROLLOVER_FILE_STATES.CLOSED
+      && sourceClosed
+      && targetState === ROLLOVER_FILE_STATES.ACTIVATING
+      && targetClosed
+    ) return 'closed-activating';
+    if (
+      sourceState === ROLLOVER_FILE_STATES.CLOSED
+      && sourceClosed
+      && targetState === ROLLOVER_FILE_STATES.REWINDING
+      && targetClosed
+      && targetRewindBound
+    ) return 'target-rewinding';
+    if (
+      sourceState === ROLLOVER_FILE_STATES.ACTIVE
+      && sourceClosed
+      && targetState === ROLLOVER_FILE_STATES.REWINDING
+      && targetClosed
+      && sourceRewindBound
+      && targetRewindBound
+    ) return 'source-armed';
+    if (
+      sourceState === ROLLOVER_FILE_STATES.ACTIVE
+      && sourceClosed
+      && targetState === ROLLOVER_FILE_STATES.PREPARED
+      && targetClosed
+      && sourceRewindBound
+      && targetRewindBound
+    ) return 'target-prepared';
+    if (
+      sourceState === ROLLOVER_FILE_STATES.ACTIVE
+      && sourceOpen
+      && targetState === ROLLOVER_FILE_STATES.PREPARED
+      && targetClosed
+      && sourceRewindBound
+      && targetRewindBound
+    ) return 'rewound';
+    throw new Error('Managed staging forms are not in an allowed activation rewind state');
+  }
+
+  async function loadBootstrapRewindPair({
+    sourceFile,
+    liveSnapshot,
+    sourceCycle,
+    targetCycle,
+    collaboratorPermissions,
+    expectedSourcePermissions,
+  }) {
+    const targetFile = await requireManagedFile(ROLLOVER_FILE_ROLES.TARGET, targetCycle);
+    const [sourceSnapshot, targetSnapshot] = await Promise.all([
+      loadSnapshot(sourceFile),
+      loadSnapshot(targetFile),
+    ]);
+    assertManagedFile(
+      sourceSnapshot.file,
+      runtime,
+      ROLLOVER_FILE_ROLES.SOURCE,
+      sourceCycle,
+    );
+    assertManagedFile(
+      targetSnapshot.file,
+      runtime,
+      ROLLOVER_FILE_ROLES.TARGET,
+      targetCycle,
+    );
+    assertSourceCapabilities(sourceSnapshot.file);
+    assertSourceCapabilities(targetSnapshot.file);
+    assertSameStructure(liveSnapshot.form, sourceSnapshot.form);
+    assertSameStructure(sourceSnapshot.form, targetSnapshot.form);
+    assertTitle(
+      sourceSnapshot.form,
+      sourceSnapshot.file,
+      managedTitle(runtime, clock, ROLLOVER_FILE_ROLES.SOURCE, sourceCycle),
+    );
+    assertTitle(
+      targetSnapshot.form,
+      targetSnapshot.file,
+      managedTitle(runtime, clock, ROLLOVER_FILE_ROLES.TARGET, targetCycle),
+    );
+    assertPermissionsMatch(expectedSourcePermissions, sourceSnapshot.permissions, { runtime });
+    assertPermissionsMatch(
+      expectedTargetPermissions(
+        sourceSnapshot.permissions,
+        collaboratorPermissions,
+        true,
+        SOURCE_ORIGINS.MANAGED,
+      ),
+      targetSnapshot.permissions,
+      { runtime },
+    );
+    assertSourceFingerprint(targetSnapshot.file, sourceSnapshot.file, runtime, sourceCycle);
+    if (
+      sourceSnapshot.file.appProperties?.targetCycle !== targetCycle
+      || targetSnapshot.file.appProperties?.sourceCycle !== sourceCycle
+    ) {
+      throw new Error('Managed staging activation rewind cycle binding does not match');
+    }
+    return Object.freeze({
+      sourceSnapshot,
+      targetSnapshot,
+      transition: bootstrapRewindTransition(sourceSnapshot, targetSnapshot, {
+        sourceCycle,
+        targetCycle,
+      }),
+    });
+  }
+
+  async function rewindStagingActivation({
+    sourceFile,
+    liveSnapshot,
+    sourceCycle,
+    targetCycle,
+    collaboratorPermissions,
+    expectedSourcePermissions,
+    dryRun,
+  }) {
+    const loadPair = () => loadBootstrapRewindPair({
+      sourceFile,
+      liveSnapshot,
+      sourceCycle,
+      targetCycle,
+      collaboratorPermissions,
+      expectedSourcePermissions,
+    });
+    async function restoreClosedSourceAfterValidationFailure() {
+      try {
+        const sourceForm = await google.getForm({ formId: sourceFile.id });
+        const currentPublishing = publishState(sourceForm);
+        if (!currentPublishing.isAcceptingResponses) return;
+
+        const currentFile = await google.getFile({ fileId: sourceFile.id });
+        assertManagedFile(
+          currentFile,
+          runtime,
+          ROLLOVER_FILE_ROLES.SOURCE,
+          sourceCycle,
+        );
+        const currentState = currentFile.appProperties?.state;
+        const isCloseCheckpoint = currentState === ROLLOVER_FILE_STATES.CLOSED;
+        const isRewindCheckpoint = currentState === ROLLOVER_FILE_STATES.ACTIVE
+          && currentFile.appProperties?.rewindTargetCycle === targetCycle;
+        if (!isCloseCheckpoint && !isRewindCheckpoint) {
+          throw new Error('Source is not bound to this activation rewind');
+        }
+        await ensurePublishState(google, sourceForm, {
+          isPublished: currentPublishing.isPublished,
+          isAcceptingResponses: false,
+        });
+      } catch {
+        throw new Error('Managed staging activation rewind could not restore a closed source');
+      }
+    }
+
+    let pair;
+    try {
+      pair = await loadPair();
+    } catch (error) {
+      if (!dryRun) await restoreClosedSourceAfterValidationFailure();
+      throw error;
+    }
+    if (dryRun || pair.transition === 'rewound') return pair;
+
+    if (pair.transition === 'closed-activating') {
+      await markFile(pair.targetSnapshot.file, ROLLOVER_FILE_STATES.REWINDING, {
+        sourceCycle,
+        rewindSourceCycle: sourceCycle,
+      }, {
+        expectedAppProperties: {
+          state: ROLLOVER_FILE_STATES.ACTIVATING,
+          sourceCycle,
+        },
+      });
+      pair = await loadPair();
+    }
+    if (pair.transition === 'target-rewinding') {
+      // Arm the source marker while the form is still closed. This makes a
+      // failed marker write retryable without ever exposing two open forms.
+      await markFile(pair.sourceSnapshot.file, ROLLOVER_FILE_STATES.ACTIVE, {
+        sourceCycle,
+        targetCycle,
+        rewindTargetCycle: targetCycle,
+      }, {
+        expectedAppProperties: {
+          state: ROLLOVER_FILE_STATES.CLOSED,
+          targetCycle,
+        },
+      });
+      pair = await loadPair();
+    }
+    if (pair.transition === 'source-armed') {
+      await markFile(pair.targetSnapshot.file, ROLLOVER_FILE_STATES.PREPARED, {
+        sourceCycle,
+        rewindSourceCycle: sourceCycle,
+      }, {
+        expectedAppProperties: {
+          state: ROLLOVER_FILE_STATES.REWINDING,
+          sourceCycle,
+          rewindSourceCycle: sourceCycle,
+        },
+      });
+      pair = await loadPair();
+    }
+    if (pair.transition === 'target-prepared') {
+      // Reload immediately before opening, then reload again afterward. If the
+      // closed target or any binding drifts across that boundary, close the
+      // source again before surfacing the failure.
+      pair = await loadPair();
+      try {
+        await ensurePublishState(google, pair.sourceSnapshot.form, {
+          isPublished: true,
+          isAcceptingResponses: true,
+        });
+        pair = await loadPair();
+        if (pair.transition !== 'rewound') {
+          throw new Error('Managed staging activation rewind did not reach its final state');
+        }
+      } catch (error) {
+        await restoreClosedSourceAfterValidationFailure();
+        throw error;
+      }
+    }
+    if (pair.transition !== 'rewound') {
+      throw new Error('Managed staging activation rewind stopped at an unsupported checkpoint');
+    }
+    return pair;
+  }
+
   async function bootstrapStagingSource({
     sourceFormId,
     sourceCycle,
+    targetCycle,
     collaboratorPermissions = [],
     dryRun = false,
     faultInjection,
+    allowActivationRewind = false,
   } = {}) {
-    assertRolloverRuntimeSafety(runtime, { faultInjection });
+    assertRolloverRuntimeSafety(runtime, { faultInjection, allowActivationRewind });
     assertStagingIdentity(runtime);
     parseCycle(sourceCycle);
+    if (allowActivationRewind) {
+      parseCycle(targetCycle);
+      if (targetCycle !== nextCycle(sourceCycle)) {
+        throw new Error('Activation rewind target cycle must immediately follow the source cycle');
+      }
+    }
     if (sourceCycle !== INITIAL_EXPLICIT_SOURCE_CYCLE) {
       throw new Error('Staging bootstrap is restricted to the initial explicit source cycle');
     }
@@ -1288,7 +1578,7 @@ export function createRolloverService({
       }
     }
 
-    if (dryRun) {
+    if (dryRun && !allowActivationRewind) {
       if (stagedFile !== undefined) {
         const permissions = await google.getAllPermissions({ fileId: stagedFile.id });
         assertSharedDriveManagerPermissions(permissions, runtime);
@@ -1304,7 +1594,7 @@ export function createRolloverService({
       });
     }
 
-    if (stagedFile.appProperties?.state === ROLLOVER_FILE_STATES.COPIED) {
+    if (!dryRun && stagedFile.appProperties?.state === ROLLOVER_FILE_STATES.COPIED) {
       const recoveryForm = await google.getForm({ formId: stagedFile.id });
       await ensurePublishState(google, recoveryForm, {
         isPublished: true,
@@ -1320,36 +1610,69 @@ export function createRolloverService({
     );
     assertSourceCapabilities(stagedSnapshot.file);
     const title = managedTitle(runtime, clock, ROLLOVER_FILE_ROLES.SOURCE, sourceCycle);
-    const titled = await updateTitles(stagedSnapshot.file, stagedSnapshot.form, title);
-    stagedSnapshot = {
-      ...stagedSnapshot,
-      ...titled,
-    };
     const expectedPermissions = expectedTargetPermissions(
       [ANONYMOUS_PUBLISHED_RESPONDER_PERMISSION],
       collaboratorPermissions,
       false,
       SOURCE_ORIGINS.MANAGED,
     );
-    stagedSnapshot.permissions = await ensurePermissions(
-      google,
-      stagedSnapshot.file.id,
-      expectedPermissions,
-      { runtime },
-    );
-    assertSameStructure(liveSnapshot.form, stagedSnapshot.form);
-    assertTitle(stagedSnapshot.form, stagedSnapshot.file, title);
     const stagedState = stagedSnapshot.file.appProperties?.state;
-    if (
-      stagedState !== ROLLOVER_FILE_STATES.COPIED
-      && stagedState !== ROLLOVER_FILE_STATES.ACTIVE
-    ) {
-      throw new Error('Managed staging source is not in a bootstrap recovery state');
+    const sourceHasRewindBinding = stagedState === ROLLOVER_FILE_STATES.ACTIVE
+      && stagedSnapshot.file.appProperties?.rewindTargetCycle === targetCycle;
+    const needsActivationRewind = allowActivationRewind
+      && (stagedState === ROLLOVER_FILE_STATES.CLOSED || sourceHasRewindBinding);
+    let rewound = false;
+    if (needsActivationRewind) {
+      const pair = await rewindStagingActivation({
+        sourceFile: stagedSnapshot.file,
+        liveSnapshot,
+        sourceCycle,
+        targetCycle,
+        collaboratorPermissions,
+        expectedSourcePermissions: expectedPermissions,
+        dryRun,
+      });
+      stagedSnapshot = pair.sourceSnapshot;
+      rewound = !dryRun;
+    } else if (dryRun) {
+      assertSharedDriveManagerPermissions(stagedSnapshot.permissions, runtime);
+      assertNoInheritedOrAdministrativeFormCollaborators(stagedSnapshot.permissions, runtime);
+    } else {
+      const titled = await updateTitles(stagedSnapshot.file, stagedSnapshot.form, title);
+      stagedSnapshot = {
+        ...stagedSnapshot,
+        ...titled,
+      };
+      stagedSnapshot.permissions = await ensurePermissions(
+        google,
+        stagedSnapshot.file.id,
+        expectedPermissions,
+        { runtime },
+      );
+      assertSameStructure(liveSnapshot.form, stagedSnapshot.form);
+      assertTitle(stagedSnapshot.form, stagedSnapshot.file, title);
+      if (
+        stagedState !== ROLLOVER_FILE_STATES.COPIED
+        && stagedState !== ROLLOVER_FILE_STATES.ACTIVE
+      ) {
+        throw new Error('Managed staging source is not in a bootstrap recovery state');
+      }
+      assertExpectedPublishing(stagedSnapshot.form, {
+        isPublished: true,
+        isAcceptingResponses: stagedState === ROLLOVER_FILE_STATES.ACTIVE,
+      });
     }
-    assertExpectedPublishing(stagedSnapshot.form, {
-      isPublished: true,
-      isAcceptingResponses: stagedState === ROLLOVER_FILE_STATES.ACTIVE,
-    });
+
+    if (dryRun) {
+      return Object.freeze({
+        action: 'bootstrap',
+        status: 'planned',
+        cycle: sourceCycle,
+        title,
+        created: false,
+        resumed: true,
+      });
+    }
 
     const liveAfter = await loadReadableSnapshot(liveFile);
     if (
@@ -1361,17 +1684,19 @@ export function createRolloverService({
       throw new Error('Production source changed during staging bootstrap');
     }
 
-    stagedSnapshot.form = await ensurePublishState(google, stagedSnapshot.form, {
-      isPublished: true,
-      isAcceptingResponses: true,
-    });
-    assertExpectedPublishing(stagedSnapshot.form, {
-      isPublished: true,
-      isAcceptingResponses: true,
-    });
-    await markFile(stagedSnapshot.file, ROLLOVER_FILE_STATES.ACTIVE, {
-      sourceCycle,
-    });
+    if (!rewound) {
+      stagedSnapshot.form = await ensurePublishState(google, stagedSnapshot.form, {
+        isPublished: true,
+        isAcceptingResponses: true,
+      });
+      assertExpectedPublishing(stagedSnapshot.form, {
+        isPublished: true,
+        isAcceptingResponses: true,
+      });
+      await markFile(stagedSnapshot.file, ROLLOVER_FILE_STATES.ACTIVE, {
+        sourceCycle,
+      });
+    }
 
     return Object.freeze({
       action: 'bootstrap',

--- a/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
@@ -443,6 +443,34 @@ async function bootstrapAndPrepare(context) {
   });
 }
 
+async function closedActivationCheckpoint() {
+  const google = new FakeGoogle();
+  const page = new MemoryPage();
+  await bootstrapAndPrepare(service({ google, page }));
+  const activation = service({
+    google,
+    page,
+    clock: fixedClock('2026-08-01T07:00:01Z'),
+    runtime: stagingRuntime({ simulatedNow: '2026-08-01T07:00:01Z' }),
+  });
+  await assert.rejects(
+    activation.rollover.activate({
+      targetCycle: '2026-08',
+      faultInjection: ROLLOVER_FAULTS.AFTER_CLOSE_SOURCE,
+    }),
+    (error) => error instanceof RolloverFaultError
+      && error.step === ROLLOVER_FAULTS.AFTER_CLOSE_SOURCE,
+  );
+  page.content = pageMarkdown();
+  return {
+    google,
+    page,
+    source: google.managed(ROLLOVER_FILE_ROLES.SOURCE, '2026-07')[0],
+    target: google.managed(ROLLOVER_FILE_ROLES.TARGET, '2026-08')[0],
+    bootstrap: service({ google, page }).rollover,
+  };
+}
+
 test('validate performs a read-only production preflight and resolves the public short URL', async () => {
   const google = grantProductionSourceAccess(new FakeGoogle());
   const context = service({
@@ -2369,6 +2397,458 @@ test('activate recovers after closing the source, opens the target once, and is 
   assert.equal((await active.rollover.verify({ targetCycle: '2026-08', mode: 'active' })).status, 'valid');
 });
 
+test('explicit staging bootstrap rewinds only the exact close-fault checkpoint', async () => {
+  const context = await closedActivationCheckpoint();
+  const copiesBefore = context.google.calls.filter(({ method }) => method === 'copyFile').length;
+
+  const rewound = await context.bootstrap.bootstrapStagingSource({
+    sourceFormId: LIVE_FORM_ID,
+    sourceCycle: '2026-07',
+    targetCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+    allowActivationRewind: true,
+  });
+
+  assert.equal(rewound.status, 'active');
+  assert.equal(rewound.created, false);
+  assert.equal(rewound.resumed, true);
+  assert.equal(context.source.appProperties.state, ROLLOVER_FILE_STATES.ACTIVE);
+  assert.equal(context.target.appProperties.state, ROLLOVER_FILE_STATES.PREPARED);
+  assert.equal(context.source.appProperties.rewindTargetCycle, '2026-08');
+  assert.equal(context.target.appProperties.rewindSourceCycle, '2026-07');
+  assert.deepEqual(context.google.forms.get(context.source.id).publishSettings.publishState, {
+    isPublished: true,
+    isAcceptingResponses: true,
+  });
+  assert.deepEqual(context.google.forms.get(context.target.id).publishSettings.publishState, {
+    isPublished: true,
+    isAcceptingResponses: false,
+  });
+  assert.equal(
+    context.google.calls.filter(({ method }) => method === 'copyFile').length,
+    copiesBefore,
+  );
+
+  const mutationStart = context.google.calls.length;
+  assert.equal((await context.bootstrap.bootstrapStagingSource({
+    sourceFormId: LIVE_FORM_ID,
+    sourceCycle: '2026-07',
+    targetCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+    allowActivationRewind: true,
+  })).status, 'active');
+  assert.deepEqual(
+    context.google.calls.slice(mutationStart).filter(({ method }) => [
+      'copyFile',
+      'createPermission',
+      'setPublishState',
+      'updateFile',
+      'updateFormTitle',
+    ].includes(method)),
+    [],
+  );
+
+  const prepared = await context.bootstrap.prepare({
+    targetCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+    faultInjection: ROLLOVER_FAULTS.AFTER_COPY,
+  });
+  assert.equal(prepared.status, 'prepared');
+  assert.equal(prepared.created, false);
+  assert.equal(prepared.resumed, true);
+});
+
+test('activation rewind is explicit, dry-run safe, and rejects completed or drifted targets', async (t) => {
+  await t.test('explicit control is required', async () => {
+    const context = await closedActivationCheckpoint();
+    const sourceOpenWritesBefore = context.google.calls.filter(
+      ({ method, formId, isAcceptingResponses }) => method === 'setPublishState'
+        && formId === context.source.id
+        && isAcceptingResponses === true,
+    ).length;
+    await assert.rejects(
+      context.bootstrap.bootstrapStagingSource({
+        sourceFormId: LIVE_FORM_ID,
+        sourceCycle: '2026-07',
+        collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+      }),
+      /not in a bootstrap recovery state/,
+    );
+    assert.equal(
+      context.google.calls.filter(
+        ({ method, formId, isAcceptingResponses }) => method === 'setPublishState'
+          && formId === context.source.id
+          && isAcceptingResponses === true,
+      ).length,
+      sourceOpenWritesBefore,
+    );
+  });
+
+  await t.test('dry run validates without mutation', async () => {
+    const context = await closedActivationCheckpoint();
+    const mutationStart = context.google.calls.length;
+    const result = await context.bootstrap.bootstrapStagingSource({
+      sourceFormId: LIVE_FORM_ID,
+      sourceCycle: '2026-07',
+      targetCycle: '2026-08',
+      collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+      allowActivationRewind: true,
+      dryRun: true,
+    });
+    assert.equal(result.status, 'planned');
+    assert.deepEqual(
+      context.google.calls.slice(mutationStart).filter(({ method }) => [
+        'copyFile',
+        'createPermission',
+        'setPublishState',
+        'updateFile',
+        'updateFormTitle',
+      ].includes(method)),
+      [],
+    );
+    assert.equal(context.source.appProperties.state, ROLLOVER_FILE_STATES.CLOSED);
+    assert.equal(context.target.appProperties.state, ROLLOVER_FILE_STATES.ACTIVATING);
+  });
+
+  await t.test('dry run never closes an open COPIED checkpoint', async () => {
+    const google = new FakeGoogle();
+    const page = new MemoryPage();
+    const bootstrap = service({ google, page });
+    await assert.rejects(
+      bootstrap.rollover.bootstrapStagingSource({
+        sourceFormId: LIVE_FORM_ID,
+        sourceCycle: '2026-07',
+        collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+        faultInjection: ROLLOVER_FAULTS.AFTER_COPY,
+      }),
+      /after-copy/,
+    );
+    const source = google.managed(ROLLOVER_FILE_ROLES.SOURCE, '2026-07')[0];
+    google.forms.get(source.id).publishSettings.publishState.isAcceptingResponses = true;
+    const mutationStart = google.calls.length;
+    const result = await bootstrap.rollover.bootstrapStagingSource({
+      sourceFormId: LIVE_FORM_ID,
+      sourceCycle: '2026-07',
+      targetCycle: '2026-08',
+      collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+      allowActivationRewind: true,
+      dryRun: true,
+    });
+    assert.equal(result.status, 'planned');
+    assert.equal(
+      google.calls.slice(mutationStart).some(({ method }) => [
+        'copyFile',
+        'createPermission',
+        'setPublishState',
+        'updateFile',
+        'updateFormTitle',
+      ].includes(method)),
+      false,
+    );
+    assert.equal(
+      google.forms.get(source.id).publishSettings.publishState.isAcceptingResponses,
+      true,
+    );
+    assert.equal(source.appProperties.state, ROLLOVER_FILE_STATES.COPIED);
+  });
+
+  await t.test('dry run never repairs an invalid reopened checkpoint', async () => {
+    const context = await closedActivationCheckpoint();
+    Object.assign(context.source.appProperties, {
+      state: ROLLOVER_FILE_STATES.ACTIVE,
+      targetCycle: '2026-08',
+      rewindTargetCycle: '2026-08',
+    });
+    Object.assign(context.target.appProperties, {
+      state: ROLLOVER_FILE_STATES.PREPARED,
+      sourceCycle: '2026-07',
+      rewindSourceCycle: '2026-07',
+    });
+    context.google.forms.get(context.source.id)
+      .publishSettings.publishState.isAcceptingResponses = true;
+    context.google.forms.get(context.target.id)
+      .publishSettings.publishState.isAcceptingResponses = true;
+    const mutationStart = context.google.calls.length;
+    await assert.rejects(
+      context.bootstrap.bootstrapStagingSource({
+        sourceFormId: LIVE_FORM_ID,
+        sourceCycle: '2026-07',
+        targetCycle: '2026-08',
+        collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+        allowActivationRewind: true,
+        dryRun: true,
+      }),
+      /not in an allowed activation rewind state/,
+    );
+    assert.equal(
+      context.google.calls.slice(mutationStart).some(({ method }) => [
+        'copyFile',
+        'createPermission',
+        'setPublishState',
+        'updateFile',
+        'updateFormTitle',
+      ].includes(method)),
+      false,
+    );
+    assert.equal(
+      context.google.forms.get(context.source.id).publishSettings.publishState
+        .isAcceptingResponses,
+      true,
+    );
+  });
+
+  await t.test('completed activation cannot be rewound', async () => {
+    const context = await closedActivationCheckpoint();
+    context.page.content = pageMarkdown(
+      '2026-08',
+      context.google.forms.get(context.target.id).responderUri,
+    );
+    const active = service({
+      google: context.google,
+      page: context.page,
+      clock: fixedClock('2026-08-01T07:00:01Z'),
+      runtime: stagingRuntime({ simulatedNow: '2026-08-01T07:00:01Z' }),
+    });
+    await active.rollover.activate({ targetCycle: '2026-08' });
+    context.page.content = pageMarkdown();
+    const mutationStart = context.google.calls.length;
+    await assert.rejects(
+      context.bootstrap.bootstrapStagingSource({
+        sourceFormId: LIVE_FORM_ID,
+        sourceCycle: '2026-07',
+        targetCycle: '2026-08',
+        collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+        allowActivationRewind: true,
+      }),
+      /not in an allowed activation rewind state/,
+    );
+    assert.equal(
+      context.google.calls.slice(mutationStart).some(
+        ({ method, formId, isAcceptingResponses }) => method === 'setPublishState'
+          && formId === context.source.id
+          && isAcceptingResponses === true,
+      ),
+      false,
+    );
+    assert.equal(context.source.appProperties.state, ROLLOVER_FILE_STATES.CLOSED);
+    assert.equal(context.target.appProperties.state, ROLLOVER_FILE_STATES.ACTIVE);
+  });
+
+  await t.test('source fingerprint drift fails before reopening', async () => {
+    const context = await closedActivationCheckpoint();
+    context.target.appProperties.sourceFingerprint = 'drifted-source-fingerprint';
+    const mutationStart = context.google.calls.length;
+    await assert.rejects(
+      context.bootstrap.bootstrapStagingSource({
+        sourceFormId: LIVE_FORM_ID,
+        sourceCycle: '2026-07',
+        targetCycle: '2026-08',
+        collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+        allowActivationRewind: true,
+      }),
+      /not bound to the resolved source form/,
+    );
+    assert.equal(
+      context.google.calls.slice(mutationStart).some(
+        ({ method, formId, isAcceptingResponses }) => method === 'setPublishState'
+          && formId === context.source.id
+          && isAcceptingResponses === true,
+      ),
+      false,
+    );
+  });
+});
+
+test('activation rewind resumes every mutation checkpoint without another copy', async (t) => {
+  const scenarios = [
+    { name: 'target REWINDING marker', method: 'updateFile', role: 'target', state: 'rewinding' },
+    { name: 'source ACTIVE marker', method: 'updateFile', role: 'source', state: 'active' },
+    { name: 'target PREPARED marker', method: 'updateFile', role: 'target', state: 'prepared' },
+    { name: 'source reopen', method: 'setPublishState', role: 'source' },
+  ];
+
+  for (const scenario of scenarios) {
+    await t.test(scenario.name, async () => {
+      const context = await closedActivationCheckpoint();
+      const copiesBefore = context.google.calls.filter(({ method }) => method === 'copyFile').length;
+      let failOnce = true;
+      if (scenario.method === 'updateFile') {
+        const updateFile = context.google.updateFile.bind(context.google);
+        context.google.updateFile = async (input) => {
+          const expectedId = scenario.role === 'source' ? context.source.id : context.target.id;
+          if (
+            failOnce
+            && input.fileId === expectedId
+            && input.appProperties?.state === scenario.state
+          ) {
+            failOnce = false;
+            throw new Error(`injected ${scenario.name} failure`);
+          }
+          return updateFile(input);
+        };
+      } else {
+        const setPublishState = context.google.setPublishState.bind(context.google);
+        context.google.setPublishState = async (input) => {
+          if (
+            failOnce
+            && input.formId === context.source.id
+            && input.isAcceptingResponses === true
+          ) {
+            failOnce = false;
+            throw new Error('injected source reopen failure');
+          }
+          return setPublishState(input);
+        };
+      }
+
+      const options = {
+        sourceFormId: LIVE_FORM_ID,
+        sourceCycle: '2026-07',
+        targetCycle: '2026-08',
+        collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+        allowActivationRewind: true,
+      };
+      await assert.rejects(
+        context.bootstrap.bootstrapStagingSource(options),
+        /injected .* failure/,
+      );
+      assert.equal((await context.bootstrap.bootstrapStagingSource(options)).status, 'active');
+      assert.equal(context.source.appProperties.state, ROLLOVER_FILE_STATES.ACTIVE);
+      assert.equal(context.target.appProperties.state, ROLLOVER_FILE_STATES.PREPARED);
+      assert.equal(
+        context.google.calls.filter(({ method }) => method === 'copyFile').length,
+        copiesBefore,
+      );
+    });
+  }
+});
+
+test('activation rewind revalidates the target after a hard stop following source reopen', async () => {
+  const context = await closedActivationCheckpoint();
+  Object.assign(context.source.appProperties, {
+    state: ROLLOVER_FILE_STATES.ACTIVE,
+    targetCycle: '2026-08',
+    rewindTargetCycle: '2026-08',
+  });
+  Object.assign(context.target.appProperties, {
+    state: ROLLOVER_FILE_STATES.PREPARED,
+    sourceCycle: '2026-07',
+    rewindSourceCycle: '2026-07',
+  });
+  context.google.forms.get(context.source.id)
+    .publishSettings.publishState.isAcceptingResponses = true;
+
+  const options = {
+    sourceFormId: LIVE_FORM_ID,
+    sourceCycle: '2026-07',
+    targetCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+    allowActivationRewind: true,
+  };
+  const mutationStart = context.google.calls.length;
+  assert.equal((await context.bootstrap.bootstrapStagingSource(options)).status, 'active');
+  assert.equal(
+    context.google.calls.slice(mutationStart).some(({ method }) => [
+      'copyFile',
+      'createPermission',
+      'setPublishState',
+      'updateFile',
+      'updateFormTitle',
+    ].includes(method)),
+    false,
+  );
+
+  context.google.forms.get(context.target.id)
+    .publishSettings.publishState.isAcceptingResponses = true;
+  await assert.rejects(
+    context.bootstrap.bootstrapStagingSource(options),
+    /not in an allowed activation rewind state/,
+  );
+  assert.equal(
+    context.google.forms.get(context.source.id).publishSettings.publishState.isAcceptingResponses,
+    false,
+  );
+  context.google.forms.get(context.target.id)
+    .publishSettings.publishState.isAcceptingResponses = false;
+  assert.equal((await context.bootstrap.bootstrapStagingSource(options)).status, 'active');
+});
+
+test('activation rewind re-closes the source when the target races open', async () => {
+  const context = await closedActivationCheckpoint();
+  const setPublishState = context.google.setPublishState.bind(context.google);
+  let raceOnce = true;
+  context.google.setPublishState = async (input) => {
+    const result = await setPublishState(input);
+    if (
+      raceOnce
+      && input.formId === context.source.id
+      && input.isAcceptingResponses === true
+    ) {
+      raceOnce = false;
+      context.google.forms.get(context.target.id)
+        .publishSettings.publishState.isAcceptingResponses = true;
+    }
+    return result;
+  };
+
+  const options = {
+    sourceFormId: LIVE_FORM_ID,
+    sourceCycle: '2026-07',
+    targetCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+    allowActivationRewind: true,
+  };
+  await assert.rejects(
+    context.bootstrap.bootstrapStagingSource(options),
+    /not in an allowed activation rewind state/,
+  );
+  assert.equal(
+    context.google.forms.get(context.source.id).publishSettings.publishState.isAcceptingResponses,
+    false,
+  );
+  context.google.forms.get(context.target.id)
+    .publishSettings.publishState.isAcceptingResponses = false;
+  assert.equal((await context.bootstrap.bootstrapStagingSource(options)).status, 'active');
+});
+
+test('activation rewind refuses to overwrite a freshly changed target state', async () => {
+  const context = await closedActivationCheckpoint();
+  const getFile = context.google.getFile.bind(context.google);
+  let targetReads = 0;
+  context.google.getFile = async (input) => {
+    if (input.fileId === context.target.id) {
+      targetReads += 1;
+      if (targetReads === 2) {
+        context.target.appProperties.state = ROLLOVER_FILE_STATES.ACTIVE;
+        context.google.forms.get(context.target.id)
+          .publishSettings.publishState.isAcceptingResponses = true;
+      }
+    }
+    return getFile(input);
+  };
+
+  await assert.rejects(
+    context.bootstrap.bootstrapStagingSource({
+      sourceFormId: LIVE_FORM_ID,
+      sourceCycle: '2026-07',
+      targetCycle: '2026-08',
+      collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+      allowActivationRewind: true,
+    }),
+    /changed before its rollover state transition/,
+  );
+  assert.equal(context.target.appProperties.state, ROLLOVER_FILE_STATES.ACTIVE);
+  assert.equal(context.source.appProperties.state, ROLLOVER_FILE_STATES.CLOSED);
+  assert.equal(
+    context.google.calls.some(
+      ({ method, fileId, appProperties }) => method === 'updateFile'
+        && fileId === context.target.id
+        && appProperties?.state === ROLLOVER_FILE_STATES.REWINDING,
+    ),
+    false,
+  );
+});
+
 test('activate rejects publishing drift and resumes an explicitly marked target activation', async () => {
   const manualGoogle = new FakeGoogle();
   const manualPage = new MemoryPage();
@@ -2577,6 +3057,18 @@ test('production safety rejects simulated time, faults, alternate bases, and sta
     /fault injection is forbidden in production/,
   );
   assert.throws(
+    () => assertRolloverRuntimeSafety(productionRuntime({ eventName: 'workflow_dispatch' }), {
+      allowActivationRewind: true,
+    }),
+    /activation rewind is forbidden in production/,
+  );
+  assert.throws(
+    () => assertRolloverRuntimeSafety(productionRuntime(), {
+      allowActivationRewind: 'true',
+    }),
+    /must be a boolean/,
+  );
+  assert.throws(
     () => assertRolloverRuntimeSafety(productionRuntime({ targetBranch: 'test-base' })),
     /alternate target branch/,
   );
@@ -2629,19 +3121,22 @@ test('break-glass administrator cannot also be the explicit editor collaborator'
   assert.equal(google.calls.length, 0);
 });
 
-test('fault injection also requires the staging account, folder, dispatch event, and smoke branch', () => {
+test('staging-only controls require the staging account, folder, dispatch event, and smoke branch', () => {
   for (const [override, expected] of [
     [{ eventName: 'schedule', simulatedNow: undefined }, /manually dispatched staging run/],
     [{ serviceAccountEmail: 'wrong@example.org' }, /staging service account/],
     [{ folderId: 'wrong-folder' }, /staging folder/],
     [{ branch: 'feature/not-a-smoke-run' }, /smoke branch prefix/],
   ]) {
-    assert.throws(
-      () => assertRolloverRuntimeSafety(stagingRuntime(override), {
-        faultInjection: ROLLOVER_FAULTS.AFTER_COPY,
-      }),
-      expected,
-    );
+    for (const controls of [
+      { faultInjection: ROLLOVER_FAULTS.AFTER_COPY },
+      { allowActivationRewind: true },
+    ]) {
+      assert.throws(
+        () => assertRolloverRuntimeSafety(stagingRuntime(override), controls),
+        expected,
+      );
+    }
   }
 });
 

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -151,6 +151,10 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
     'Google-secret jobs must not be reintroduced behind workflow_call',
   );
   assert.match(rehearsal, /^on:\n  workflow_dispatch:/m);
+  assert.match(
+    rehearsal,
+    /^concurrency:\n  group: progress-prizes-staging-rehearsal\n  cancel-in-progress: false$/m,
+  );
   assert.doesNotMatch(rehearsal, /workflow_call:|pull_request(?:_target)?:/);
   assert.doesNotMatch(rehearsal, /uses: \.\/\.github\/workflows\/progress-prizes-google\.yml/);
   assert.doesNotMatch(rehearsal, /secrets:\s*inherit/);
@@ -211,15 +215,25 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
   );
   assert.equal(
     [...rehearsal.matchAll(/secrets\.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL/g)].length,
-    1,
-    'only protected production validation may receive the staging identity',
+    googleJobNames.length,
+    'every Google job must receive an independently protected staging identity',
   );
+  assert.doesNotMatch(productionValidationJob, /staging-folder-id|PROGRESS_PRIZE_STAGING_FOLDER_ID/);
   for (const name of googleJobNames.filter((name) => name !== 'validate-production')) {
-    assert.doesNotMatch(
-      jobBlock(rehearsal, name),
-      /staging-service-account-email|PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL/,
+    const stagingJob = jobBlock(rehearsal, name);
+    assert.match(
+      stagingJob,
+      /^          staging-service-account-email: \$\{\{ secrets\.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \}\}$/m,
+    );
+    assert.match(
+      stagingJob,
+      /^          staging-folder-id: \$\{\{ secrets\.PROGRESS_PRIZE_STAGING_FOLDER_ID \}\}$/m,
     );
   }
+  assert.equal(
+    [...rehearsal.matchAll(/secrets\.PROGRESS_PRIZE_STAGING_FOLDER_ID/g)].length,
+    googleJobNames.length - 1,
+  );
 
   for (const name of jobNames(rehearsal).filter((name) => !googleJobNames.includes(name))) {
     const ordinaryJob = jobBlock(rehearsal, name);
@@ -240,16 +254,25 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
   );
   assert.match(
     action,
+    /^  staging-folder-id:\n(?:    .*\n)*?    required: false\n    default: ""$/m,
+  );
+  assert.match(
+    action,
     /PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL:\s+\$\{\{ inputs\['staging-service-account-email'\] \}\}/,
   );
   assert.match(
     action,
-    /PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \\\n\s+PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL/,
-    'the staging identity must be masked before protected configuration validation',
+    /PROGRESS_PRIZE_STAGING_FOLDER_ID:\s+\$\{\{ inputs\['staging-folder-id'\] \}\}/,
   );
   assert.match(
     action,
-    /inputs\.environment == 'staging' && inputs\['service-account-email'\] \|\| inputs\['staging-service-account-email'\]/,
+    /PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \\\n\s+PROGRESS_PRIZE_STAGING_FOLDER_ID \\\n\s+PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL/,
+    'the independent staging identity and folder must be masked before validation',
+  );
+  assert.doesNotMatch(
+    action,
+    /inputs\.environment == 'staging' && inputs\['(?:service-account-email|folder-id)'\]/,
+    'the expected staging identity and folder must not be derived from operational inputs',
   );
   assert.doesNotMatch(
     action,
@@ -273,6 +296,14 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
     action,
     /if test "\$AUTOMATION_ENVIRONMENT" = production \\\n\s+&& test "\$OPERATION" = validate \\\n\s+&& test "\$SOURCE_CYCLE" = 2026-07\n\s+then\n\s+test -n "\$PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL"/,
     'initial production validation must require the exact staging identity before authentication',
+  );
+  assert.match(
+    action,
+    /test "\$GOOGLE_SERVICE_ACCOUNT_EMAIL" = "\$PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL"/,
+  );
+  assert.match(
+    action,
+    /test "\$PROGRESS_PRIZE_FOLDER_ID" = "\$PROGRESS_PRIZE_STAGING_FOLDER_ID"/,
   );
   assert.equal([...action.matchAll(/access_token_lifetime: 1200s/g)].length, 2);
   assert.doesNotMatch(action, /access_token_scopes: >-/);
@@ -319,6 +350,8 @@ test('secret-free preflight and composite guards reject unsafe controls before O
   assert.match(preflight, /allowedOperations\.has\(process\.env\.OPERATION/);
   assert.match(preflight, /SOURCE_CYCLE/);
   assert.match(preflight, /TARGET_CYCLE/);
+  assert.match(preflight, /assert\.equal\(process\.env\.SOURCE_CYCLE, '2026-07'\)/);
+  assert.match(preflight, /assert\.equal\(process\.env\.TARGET_CYCLE, '2026-08'\)/);
   assert.match(preflight, /PREPARATION_NOW/);
   assert.match(preflight, /ACTIVATION_NOW/);
   assert.match(jobBlock(rehearsal, 'validate-production'), /needs: preflight/);
@@ -330,6 +363,13 @@ test('secret-free preflight and composite guards reject unsafe controls before O
   assert.match(action, /test "\$REF" = refs\/heads\/main/);
   assert.match(action, /test "\$OPERATION" != bootstrap/);
   assert.match(action, /test "\$OPERATION" != cleanup/);
+  assert.match(action, /test "\$SOURCE_CYCLE" = 2026-07/);
+  assert.match(
+    action,
+    /test "\$OPERATION" = bootstrap && test -n "\$TARGET_CYCLE"/,
+  );
+  assert.match(action, /test "\$ALLOW_ACTIVATION_REWIND" = true/);
+  assert.match(action, /test "\$TARGET_CYCLE" = 2026-08/);
 
   const actionOutputs = action.slice(action.indexOf('outputs:\n'), action.indexOf('\nruns:'));
   const actionOutputNames = [...actionOutputs.matchAll(/^  ([a-z][a-z-]+):\n/gm)]
@@ -343,7 +383,7 @@ test('secret-free preflight and composite guards reject unsafe controls before O
 
 test('composite boolean inputs stay strings across authentication and fault handling', async () => {
   const action = await googleAction();
-  for (const input of ['expect-fault', 'dry-run']) {
+  for (const input of ['expect-fault', 'dry-run', 'allow-activation-rewind']) {
     assert.match(
       action,
       new RegExp(`^  ${input}:\\n(?:    .*\\n)*?    default: "false"$`, 'm'),
@@ -353,7 +393,70 @@ test('composite boolean inputs stay strings across authentication and fault hand
   assert.match(action, /inputs\['dry-run'\] != 'true'/);
   assert.match(action, /case "\$EXPECT_FAULT" in true\|false/);
   assert.match(action, /case "\$DRY_RUN" in true\|false/);
+  assert.match(action, /case "\$ALLOW_ACTIVATION_REWIND" in true\|false/);
   assert.match(action, /test "\$DRY_RUN" = false \|\| arguments\+=\(--dry-run\)/);
+  assert.match(
+    action,
+    /test "\$ALLOW_ACTIVATION_REWIND" = false \|\| arguments\+=\(--allow-activation-rewind\)/,
+  );
+});
+
+test('composite pre-auth guard executes the activation rewind matrix before OIDC', async () => {
+  const action = await googleAction();
+  const guard = literalRunScripts(action)[0]?.source;
+  assert.equal(typeof guard, 'string');
+  const valid = {
+    REPOSITORY: 'ScrollPrize/villa',
+    REPOSITORY_ID: '890972577',
+    REPOSITORY_OWNER_ID: '121906140',
+    REF: 'refs/heads/main',
+    AUTOMATION_ENVIRONMENT: 'staging',
+    EVENT_NAME: 'workflow_dispatch',
+    OPERATION: 'bootstrap',
+    SIMULATED_NOW: '',
+    FAULT: '',
+    EXPECT_FAULT: 'false',
+    DRY_RUN: 'false',
+    ALLOW_ACTIVATION_REWIND: 'true',
+    BRANCH: 'codex/progress-prize-smoke-20260720',
+    TARGET_BRANCH: 'codex/progress-prize-smoke-base-20260720',
+    SOURCE_CYCLE: '2026-07',
+    TARGET_CYCLE: '2026-08',
+    HEAD_SHA: '',
+  };
+  const run = (override = {}) => spawnSync('bash', ['--noprofile', '--norc'], {
+    input: guard,
+    encoding: 'utf8',
+    env: { ...valid, ...override },
+  });
+
+  assert.equal(run().status, 0);
+  for (const override of [
+    { ALLOW_ACTIVATION_REWIND: 'TRUE' },
+    { ALLOW_ACTIVATION_REWIND: '1' },
+    { ALLOW_ACTIVATION_REWIND: '' },
+    { ALLOW_ACTIVATION_REWIND: 'false' },
+    { TARGET_CYCLE: '' },
+    { TARGET_CYCLE: '2026-09' },
+    { SOURCE_CYCLE: '2026-12', TARGET_CYCLE: '2027-01' },
+    { OPERATION: 'prepare' },
+    { EVENT_NAME: 'schedule' },
+    { BRANCH: 'feature/not-smoke' },
+    { TARGET_BRANCH: 'main' },
+    {
+      AUTOMATION_ENVIRONMENT: 'production',
+      BRANCH: 'main',
+      TARGET_BRANCH: 'main',
+    },
+    {
+      AUTOMATION_ENVIRONMENT: 'production',
+      EVENT_NAME: 'schedule',
+      BRANCH: 'main',
+      TARGET_BRANCH: 'main',
+    },
+  ]) {
+    assert.notEqual(run(override).status, 0, JSON.stringify(override));
+  }
 });
 
 test('rehearsal controls are fixed to staging and its ephemeral branches', async () => {
@@ -378,6 +481,22 @@ test('rehearsal controls are fixed to staging and its ephemeral branches', async
   assert.match(rehearsal, /actions: read\n      contents: read\n      statuses: read/);
   assert.match(rehearsal, /--base-sha \"\$EXPECTED_BASE_SHA\"/);
   assert.match(rehearsal, /--source-cycle \"\$SOURCE_CYCLE\"/);
+
+  const bootstrap = jobBlock(rehearsal, 'bootstrap-staging');
+  assert.equal([...rehearsal.matchAll(/allow-activation-rewind:/g)].length, 1);
+  assert.match(bootstrap, /^          operation: bootstrap$/m);
+  assert.match(bootstrap, /^          environment: staging$/m);
+  assert.match(
+    bootstrap,
+    /^          allow-activation-rewind: \$\{\{ inputs\.operation == 'full-rehearsal' \|\| inputs\.operation == 'activation-fault-recovery' \}\}$/m,
+  );
+  assert.match(
+    bootstrap,
+    /^          target-cycle: \$\{\{ \(inputs\.operation == 'full-rehearsal' \|\| inputs\.operation == 'activation-fault-recovery'\) && inputs\['target-cycle'\] \|\| '' \}\}$/m,
+  );
+  for (const name of googleJobNames.filter((name) => name !== 'bootstrap-staging')) {
+    assert.doesNotMatch(jobBlock(rehearsal, name), /allow-activation-rewind/);
+  }
 
   const pagePr = await workflow('progress-prizes-page-pr.yml');
   assert.match(pagePr, /--force-with-lease=\"refs\/heads\/\$HEAD_BRANCH:\$REMOTE_HEAD_SHA\"/);


### PR DESCRIPTION
## Summary

- add a staging-only recovery path for an activation rehearsal interrupted after the source form was closed
- require explicit July/August smoke-cycle, environment, identity, folder, event, and branch guards before Google authentication
- preserve dry-run immutability and validate both managed forms before reopening the source
- add unit and workflow-contract coverage for recovery checkpoints and protected staging inputs

## Validation

- `npm test` in `scrollprize.org` (218 passed)
- Node syntax checks for the progress-prize scripts
- workflow/action YAML parse and contract tests
- `git diff --check`
- staged scan against all locally held private Google values (0 matches)
- independent security and correctness review

This PR contains no Google credentials, internal IDs, ACL identities, or tokens. It does not modify the live production form.