### PR TITLE
ci(scrollprize): add guarded progress prize rollover

### DIFF
--- a/.github/actions/progress-prizes-google/action.yml
+++ b/.github/actions/progress-prizes-google/action.yml
@@ -50,6 +50,14 @@ inputs:
     description: Exact tested commit used by activation
     required: false
     default: ""
+  base-sha:
+    description: Exact trusted main commit leased by production activation
+    required: false
+    default: ""
+  github-token:
+    description: Ephemeral GitHub token used only for the production activation lease
+    required: false
+    default: ""
   workload-identity-provider:
     description: Protected Environment WIF provider identifier
     required: true
@@ -107,18 +115,20 @@ runs:
         EXPECT_FAULT: ${{ inputs['expect-fault'] }}
         DRY_RUN: ${{ inputs['dry-run'] }}
         ALLOW_ACTIVATION_REWIND: ${{ inputs['allow-activation-rewind'] }}
+        VERIFY_MODE: ${{ inputs['verify-mode'] }}
         BRANCH: ${{ inputs.branch }}
         TARGET_BRANCH: ${{ inputs['target-branch'] }}
         SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
         TARGET_CYCLE: ${{ inputs['target-cycle'] }}
         HEAD_SHA: ${{ inputs['head-sha'] }}
+        BASE_SHA: ${{ inputs['base-sha'] }}
       run: |
         set -euo pipefail
         test "$REPOSITORY" = ScrollPrize/villa
         test "$REPOSITORY_ID" = 890972577
         test "$REPOSITORY_OWNER_ID" = 121906140
         test "$REF" = refs/heads/main
-        test "$EVENT_NAME" = workflow_dispatch -o "$EVENT_NAME" = schedule
+        test "$EVENT_NAME" = workflow_dispatch
         case "$OPERATION" in
           validate|bootstrap|prepare|activate|verify|cleanup) ;;
           *) exit 1 ;;
@@ -126,15 +136,26 @@ runs:
         case "$EXPECT_FAULT" in true|false) ;; *) exit 1 ;; esac
         case "$DRY_RUN" in true|false) ;; *) exit 1 ;; esac
         case "$ALLOW_ACTIVATION_REWIND" in true|false) ;; *) exit 1 ;; esac
-        if test -n "$SOURCE_CYCLE"; then [[ "$SOURCE_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; fi
-        if test -n "$TARGET_CYCLE"; then [[ "$TARGET_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]; fi
+        case "$VERIFY_MODE" in prepared|active|cleaned) ;; *) exit 1 ;; esac
+        if test "$DRY_RUN" = true; then
+          case "$OPERATION" in bootstrap|prepare) ;; *) exit 1 ;; esac
+        fi
+        if test -n "$SOURCE_CYCLE"; then
+          [[ "$SOURCE_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]] || exit 1
+        fi
+        if test -n "$TARGET_CYCLE"; then
+          [[ "$TARGET_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]] || exit 1
+        fi
         case "$OPERATION" in
           validate|bootstrap) test -n "$SOURCE_CYCLE" ;;
           prepare|activate|verify|cleanup) test -n "$TARGET_CYCLE" ;;
         esac
-        if test "$OPERATION" = bootstrap; then test "$SOURCE_CYCLE" = 2026-07; fi
-        if test "$OPERATION" = activate; then [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; fi
-        if test -n "$HEAD_SHA"; then [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]]; fi
+        if test "$OPERATION" = bootstrap; then test "$SOURCE_CYCLE" = 2026-07 || exit 1; fi
+        if test "$OPERATION" = activate; then
+          [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]] || exit 1
+        fi
+        if test -n "$HEAD_SHA"; then [[ "$HEAD_SHA" =~ ^[a-fA-F0-9]{40}$ ]] || exit 1; fi
+        if test -n "$BASE_SHA"; then [[ "$BASE_SHA" =~ ^[a-fA-F0-9]{40}$ ]] || exit 1; fi
         if test "$OPERATION" = bootstrap && test -n "$TARGET_CYCLE"; then
           test "$ALLOW_ACTIVATION_REWIND" = true
         fi
@@ -154,11 +175,18 @@ runs:
           test "$ALLOW_ACTIVATION_REWIND" = false
           test "$TARGET_BRANCH" = main
           test "$BRANCH" = main -o "$BRANCH" = "codex/progress-prize-$TARGET_CYCLE"
+          if test "$OPERATION" = activate; then
+            [[ "$BASE_SHA" =~ ^[a-fA-F0-9]{40}$ ]] || exit 1
+            test "$BRANCH" = "codex/progress-prize-$TARGET_CYCLE" || exit 1
+          else
+            test -z "$BASE_SHA"
+          fi
         else
           test "$AUTOMATION_ENVIRONMENT" = staging
           test "$EVENT_NAME" = workflow_dispatch
           test "$BRANCH" = codex/progress-prize-smoke-20260720
           test "$TARGET_BRANCH" = codex/progress-prize-smoke-base-20260720
+          test -z "$BASE_SHA"
           if test -n "$FAULT"; then
             case "$FAULT" in
               after-copy|after-close-source) ;;
@@ -246,6 +274,7 @@ runs:
             exit 1
           }
         fi
+
         if test "$AUTOMATION_ENVIRONMENT" = staging; then
           for name in \
             PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \
@@ -268,6 +297,26 @@ runs:
             exit 1
           }
         fi
+
+    - name: Wait for the real production cutoff without a Google token
+      if: inputs.environment == 'production' && inputs.operation == 'activate'
+      shell: bash
+      env:
+        SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+      run: |
+        set -euo pipefail
+        node --input-type=module <<'NODE'
+        import { getCycleDeadline } from './scrollprize.org/scripts/progress-prizes/dates.mjs';
+
+        const cutoff = getCycleDeadline(process.env.SOURCE_CYCLE).cutoffAt;
+        const waitMilliseconds = cutoff.getTime() - Date.now();
+        if (waitMilliseconds > 60 * 60 * 1000) {
+          throw new Error('Production activation was started outside its bounded cutoff window.');
+        }
+        if (waitMilliseconds > 0) {
+          await new Promise((resolve) => setTimeout(resolve, waitMilliseconds));
+        }
+        NODE
 
     - name: Authenticate read-only validation without a credential file
       if: inputs.operation == 'validate' || inputs.operation == 'verify' || inputs['dry-run'] == 'true'
@@ -333,6 +382,7 @@ runs:
       id: operation
       shell: bash
       env:
+        GITHUB_TOKEN: ${{ inputs.environment == 'production' && inputs.operation == 'activate' && inputs['github-token'] || '' }}
         GOOGLE_ACCESS_TOKEN: ${{ steps['auth-read'].outputs.access_token || steps['auth-write'].outputs.access_token }}
         PROGRESS_PRIZE_ENVIRONMENT: ${{ inputs.environment }}
         PROGRESS_PRIZE_EVENT_NAME: ${{ github.event_name }}
@@ -352,6 +402,10 @@ runs:
         PROGRESS_PRIZE_SMOKE_DATE: ${{ inputs.environment == 'staging' && '2026-07-20' || '' }}
         PROGRESS_PRIZE_VERIFIED_SHA: ${{ inputs['head-sha'] }}
         PROGRESS_PRIZE_HEAD_SHA: ${{ inputs['head-sha'] }}
+        GATED_HEAD_SHA: ${{ inputs['head-sha'] }}
+        GATED_BASE_SHA: ${{ inputs['base-sha'] }}
+        HEAD_BRANCH: ${{ inputs.branch }}
+        BASE_BRANCH: ${{ inputs['target-branch'] }}
         OPERATION: ${{ inputs.operation }}
         SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
         TARGET_CYCLE: ${{ inputs['target-cycle'] }}
@@ -369,10 +423,30 @@ runs:
         test -z "$SIMULATED_NOW" || arguments+=(--simulated-now "$SIMULATED_NOW")
         test -z "$FAULT" || arguments+=(--fault "$FAULT")
         test "$DRY_RUN" = false || arguments+=(--dry-run)
+        if test "$PROGRESS_PRIZE_ENVIRONMENT" = production \
+          -a "$OPERATION" = prepare \
+          -a "$DRY_RUN" = true
+        then
+          # A production dry-run is an immediate, read-only rehearsal. Extending
+          # only its planning window exercises the real form/folder/ACL preflight
+          # on any day of the source month without weakening the seven-day writer.
+          arguments+=(--preparation-days 31)
+        fi
         test "$ALLOW_ACTIVATION_REWIND" = false || arguments+=(--allow-activation-rewind)
         if test "$OPERATION" = verify; then arguments+=(--mode "$VERIFY_MODE"); fi
         if test -f "$RUNNER_TEMP/progress-prizes-page.md"; then
           arguments+=(--page-path "$RUNNER_TEMP/progress-prizes-page.md")
+        fi
+
+        if test "$PROGRESS_PRIZE_ENVIRONMENT" = production -a "$OPERATION" = activate; then
+          node .github/progress-prizes-github.mjs gate \
+            --head "$HEAD_BRANCH" \
+            --base "$BASE_BRANCH" \
+            --base-sha "$GATED_BASE_SHA" \
+            --source-cycle "$SOURCE_CYCLE" \
+            --cycle "$TARGET_CYCLE" \
+            --sha "$GATED_HEAD_SHA" \
+            --timeout-seconds 0
         fi
 
         set +e
@@ -414,6 +488,25 @@ runs:
           node scrollprize.org/scripts/progress-prizes/error-diagnostic-cli.mjs \
             "$RUNNER_TEMP/progress-prizes-error.txt"
           exit "$operation_status"
+        fi
+
+        if test "$OPERATION" = activate -a "$EXPECT_FAULT" = false; then
+          node --input-type=module <<'NODE'
+        import { readFile } from 'node:fs/promises';
+
+        const result = JSON.parse(await readFile(
+          `${process.env.RUNNER_TEMP}/progress-prizes-result.json`,
+          'utf8',
+        ));
+        if (
+          result.action !== 'activate'
+          || result.status !== 'active'
+          || result.sourceAcceptingResponses !== false
+          || result.targetAcceptingResponses !== true
+        ) {
+          throw new Error('Activation did not reach the verified active state.');
+        }
+        NODE
         fi
 
     - name: Export only the public responder URL

--- a/.github/progress-prizes-github.mjs
+++ b/.github/progress-prizes-github.mjs
@@ -173,6 +173,22 @@ export function assertSinglePageCommit(commit, { headSha, baseSha } = {}) {
   return commit;
 }
 
+export function activationCommitNeedsRefresh(commit, { headSha, baseSha } = {}) {
+  assertSha(headSha);
+  assertSha(baseSha);
+  if (
+    commit?.sha !== headSha
+    || commit.parents?.length !== 1
+    || commit.files?.length !== 1
+    || commit.files[0]?.filename !== PAGE_PATH
+    || commit.files[0]?.status !== 'modified'
+  ) {
+    fail('Only a page-only commit with a stale parent may be refreshed.');
+  }
+  const parentSha = assertSha(commit.parents[0]?.sha ?? '');
+  return parentSha !== baseSha;
+}
+
 export function isTrustedPreviewRun({ status, run, expectedSha } = {}) {
   const sha = assertSha(expectedSha);
   const runId = previewRunId(status);
@@ -256,42 +272,74 @@ async function findPull(head, base) {
   return assertPullAssociation(pull, { head, base });
 }
 
-async function activationState(options) {
-  const head = required(options, 'head');
-  const base = required(options, 'base');
-  const cycle = assertCycle(required(options, 'cycle'));
+export async function resolveProductionActivationState({
+  head,
+  base,
+  cycle,
+  expectedBaseSha,
+} = {}, {
+  listPulls = () => github(
+    `/repos/${OWNER}/${REPO}/pulls?state=open&head=${encodeURIComponent(`${OWNER}:${head}`)}&base=${encodeURIComponent(base)}&per_page=10`,
+  ),
+  readCommit = (sha) => github(`/repos/${OWNER}/${REPO}/commits/${sha}`),
+  readMainRef = () => github(`/repos/${OWNER}/${REPO}/git/ref/heads/main`),
+  readPage = (sha) => readPageAt(sha),
+} = {}) {
+  if (typeof head !== 'string' || head === '') fail('Missing production activation head.');
+  if (typeof base !== 'string' || base === '') fail('Missing production activation base.');
+  const targetCycle = assertCycle(cycle);
+  const trustedBaseSha = assertSha(expectedBaseSha);
   const contract = assertAutomationBranch(head, base);
   if (contract.kind !== 'production') fail('Activation-state recovery is production-only.');
-  const pulls = await github(
-    `/repos/${OWNER}/${REPO}/pulls?state=open&head=${encodeURIComponent(`${OWNER}:${head}`)}&base=${encodeURIComponent(base)}&per_page=10`,
-  );
+  const pulls = await listPulls();
   if (!Array.isArray(pulls) || pulls.length > 1) fail('Production activation PR state is ambiguous.');
   let state;
   let sha;
   let baseSha;
   let number = '';
+  let refreshRequired = false;
   if (pulls.length === 1) {
     const pull = pulls[0];
     sha = assertSha(pull.head?.sha ?? '');
     baseSha = assertSha(pull.base?.sha ?? '');
+    if (baseSha !== trustedBaseSha) fail('Production main moved after the workflow was dispatched.');
     assertPullBinding(pull, { head, base, headSha: sha, baseSha });
+    const commit = await readCommit(sha);
+    refreshRequired = activationCommitNeedsRefresh(commit, { headSha: sha, baseSha });
     state = 'pending';
     number = String(pull.number);
   } else {
-    const ref = await github(`/repos/${OWNER}/${REPO}/git/ref/heads/main`);
+    const ref = await readMainRef();
     sha = assertSha(ref?.object?.sha ?? '');
+    if (sha !== trustedBaseSha) fail('Production main moved after the workflow was dispatched.');
     baseSha = sha;
-    const page = await readPageAt(sha);
-    if (page.cycle !== cycle) fail('Neither a pending PR nor a completed production cycle exists.');
+    const page = await readPage(sha);
+    if (page.cycle !== targetCycle) fail('Neither a pending PR nor a completed production cycle exists.');
     state = 'completed';
   }
+  return {
+    state,
+    headSha: sha,
+    baseSha,
+    pullNumber: number,
+    refreshRequired,
+  };
+}
+
+async function activationState(options) {
+  const result = await resolveProductionActivationState({
+    head: required(options, 'head'),
+    base: required(options, 'base'),
+    cycle: required(options, 'cycle'),
+    expectedBaseSha: required(options, 'expected-base-sha'),
+  });
   if (process.env.GITHUB_OUTPUT) {
     await appendFile(
       process.env.GITHUB_OUTPUT,
-      `state=${state}\nhead-sha=${sha}\nbase-sha=${baseSha}\npr-number=${number}\n`,
+      `state=${result.state}\nhead-sha=${result.headSha}\nbase-sha=${result.baseSha}\npr-number=${result.pullNumber}\nrefresh-required=${result.refreshRequired}\n`,
     );
   }
-  return { state, headSha: sha, baseSha, pullNumber: number };
+  return result;
 }
 
 async function readPageMarkdownAt(sha) {

--- a/.github/workflows/progress-prizes-production.yml
+++ b/.github/workflows/progress-prizes-production.yml
@@ -1,0 +1,860 @@
+name: Progress Prize production rollover
+run-name: >-
+  Progress Prize production ${{ inputs.operation }}
+  ${{ inputs['source-cycle'] }} to ${{ inputs['target-cycle'] }}
+  request ${{ inputs['request-id'] || 'manual' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Safe production operation
+        required: true
+        type: choice
+        default: validate
+        options:
+          - validate
+          - dry-run
+          - prepare
+          - activate
+          - verify
+      source-cycle:
+        description: Source cycle (YYYY-MM)
+        required: true
+        type: string
+        default: "2026-07"
+      target-cycle:
+        description: Consecutive target cycle (YYYY-MM)
+        required: true
+        type: string
+        default: "2026-08"
+      verify-mode:
+        description: Verification state
+        required: true
+        type: choice
+        default: prepared
+        options:
+          - prepared
+          - active
+      request-id:
+        description: Trusted schedule run ID; leave empty for manual dispatch
+        required: false
+        type: string
+        default: ""
+
+permissions: {}
+
+concurrency:
+  group: progress-prizes-production
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Validate public production controls
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Reject invalid trigger context and controls
+        env:
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_ID: ${{ github.repository_id }}
+          REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+          REF: ${{ github.ref }}
+          HEAD_SHA: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          OPERATION: ${{ inputs.operation }}
+          SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+          VERIFY_MODE: ${{ inputs['verify-mode'] }}
+          REQUEST_ID: ${{ inputs['request-id'] }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+
+          assert.equal(process.env.REPOSITORY, 'ScrollPrize/villa');
+          assert.equal(process.env.REPOSITORY_ID, '890972577');
+          assert.equal(process.env.REPOSITORY_OWNER_ID, '121906140');
+          assert.equal(process.env.REF, 'refs/heads/main');
+          assert.match(process.env.HEAD_SHA ?? '', /^[a-f0-9]{40}$/);
+          assert.equal(process.env.EVENT_NAME, 'workflow_dispatch');
+          assert.equal(
+            new Set(['validate', 'dry-run', 'prepare', 'activate', 'verify'])
+              .has(process.env.OPERATION ?? ''),
+            true,
+          );
+          assert.equal(new Set(['prepared', 'active']).has(process.env.VERIFY_MODE ?? ''), true);
+          assert.match(process.env.SOURCE_CYCLE ?? '', /^\d{4}-(?:0[1-9]|1[0-2])$/);
+          assert.match(process.env.TARGET_CYCLE ?? '', /^\d{4}-(?:0[1-9]|1[0-2])$/);
+
+          const [sourceYear, sourceMonth] = process.env.SOURCE_CYCLE.split('-').map(Number);
+          const target = sourceMonth === 12
+            ? `${sourceYear + 1}-01`
+            : `${sourceYear}-${String(sourceMonth + 1).padStart(2, '0')}`;
+          assert.equal(process.env.TARGET_CYCLE, target);
+          if (process.env.REQUEST_ID !== '') assert.match(process.env.REQUEST_ID, /^[1-9]\d*$/);
+          NODE
+
+  validate:
+    if: inputs.operation == 'validate'
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-production
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      responder-uri: ${{ steps.google.outputs['responder-uri'] }}
+    steps:
+      - name: Check out the exact trusted trigger commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Validate production Google Form
+        id: google
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: validate
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          branch: main
+          target-branch: main
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ inputs['source-cycle'] == '2026-07' && secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL || '' }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+
+  dry-run:
+    if: inputs.operation == 'dry-run'
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the exact trusted trigger commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Dry-run production preparation
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: prepare
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          dry-run: "true"
+          branch: main
+          target-branch: main
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+      - name: Summarize the public no-mutation proposal
+        env:
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { appendFile } from 'node:fs/promises';
+          import { getCycleDeadline } from './scrollprize.org/scripts/progress-prizes/dates.mjs';
+
+          const deadline = getCycleDeadline(process.env.TARGET_CYCLE);
+          const title = `${deadline.monthName} ${deadline.year} Progress Prizes`;
+          await appendFile(
+            process.env.GITHUB_STEP_SUMMARY,
+            [
+              '### Production dry-run proposal',
+              '',
+              `- Form title: \`${title}\``,
+              `- Public deadline: \`${deadline.label}\``,
+              '- Google mutation: `disabled`',
+              '- Website mutation: `disabled`',
+              '',
+            ].join('\n'),
+          );
+          NODE
+
+  prepare-google:
+    if: inputs.operation == 'prepare'
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-production
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      responder-uri: ${{ steps.google.outputs['responder-uri'] }}
+    steps:
+      - name: Check out the exact trusted trigger commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Prepare the next production Google Form
+        id: google
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: prepare
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          branch: main
+          target-branch: main
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+
+  prepare-page:
+    if: >-
+      inputs.operation == 'prepare' &&
+      needs.prepare-google.outputs['responder-uri'] != ''
+    needs: prepare-google
+    uses: ./.github/workflows/progress-prizes-page-pr.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      environment: production
+      source-cycle: ${{ inputs['source-cycle'] }}
+      target-cycle: ${{ inputs['target-cycle'] }}
+      responder-uri: ${{ needs.prepare-google.outputs['responder-uri'] }}
+      head-branch: codex/progress-prize-${{ inputs['target-cycle'] }}
+      base-branch: main
+
+  activation-state:
+    name: Resolve pending or completed activation
+    if: inputs.operation == 'activate'
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      state: ${{ steps.state.outputs.state }}
+      head-sha: ${{ steps.state.outputs['head-sha'] }}
+      base-sha: ${{ steps.state.outputs['base-sha'] }}
+      pr-number: ${{ steps.state.outputs['pr-number'] }}
+      refresh-required: ${{ steps.state.outputs['refresh-required'] }}
+    steps:
+      - name: Check out exact trusted state code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Resolve trusted GitHub activation state
+        id: state
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: codex/progress-prize-${{ inputs['target-cycle'] }}
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+          TRIGGER_SHA: ${{ github.sha }}
+        run: >-
+          node .github/progress-prizes-github.mjs activation-state
+          --head "$HEAD_BRANCH"
+          --base main
+          --cycle "$TARGET_CYCLE"
+          --expected-base-sha "$TRIGGER_SHA"
+
+  activation-page-state:
+    name: Recover the intentionally public prepared page state
+    if: >-
+      inputs.operation == 'activate' &&
+      needs.activation-state.outputs.state == 'pending' &&
+      needs.activation-state.outputs['refresh-required'] == 'true'
+    needs: activation-state
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      responder-uri: ${{ steps.page.outputs['responder-uri'] }}
+    steps:
+      - name: Check out exact trusted parser code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Read only managed public fields from the pending commit
+        id: page
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.activation-state.outputs['head-sha'] }}
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { appendFile } from 'node:fs/promises';
+          import { parseProgressPrizeMarkdown } from './scrollprize.org/scripts/progress-prizes/markdown.mjs';
+
+          const sha = process.env.HEAD_SHA ?? '';
+          if (!/^[a-f0-9]{40}$/.test(sha)) throw new Error('Recovery requires an exact commit SHA.');
+          const url = new URL('https://api.github.com/repos/ScrollPrize/villa/contents/scrollprize.org/docs/34_prizes.md');
+          url.searchParams.set('ref', sha);
+          const response = await fetch(url, {
+            redirect: 'error',
+            headers: {
+              accept: 'application/vnd.github.raw+json',
+              authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+              'user-agent': 'progress-prize-page-recovery',
+              'x-github-api-version': '2022-11-28',
+            },
+          });
+          if (response.status !== 200) throw new Error('Could not read the pending managed page.');
+          const body = await response.text();
+          if (Buffer.byteLength(body, 'utf8') > 1024 * 1024) throw new Error('Managed page response is too large.');
+          const page = parseProgressPrizeMarkdown(body);
+          if (page.cycle !== process.env.TARGET_CYCLE) {
+            throw new Error('Pending page cycle does not match the requested recovery cycle.');
+          }
+          await appendFile(process.env.GITHUB_OUTPUT, `responder-uri=${page.responderUri}\n`);
+          NODE
+
+  refresh-page:
+    name: Rebuild a stale prepared page on the exact current main
+    if: >-
+      inputs.operation == 'activate' &&
+      needs.activation-state.outputs.state == 'pending' &&
+      needs.activation-state.outputs['refresh-required'] == 'true'
+    needs:
+      - activation-state
+      - activation-page-state
+    uses: ./.github/workflows/progress-prizes-page-pr.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      environment: production
+      source-cycle: ${{ inputs['source-cycle'] }}
+      target-cycle: ${{ inputs['target-cycle'] }}
+      responder-uri: ${{ needs.activation-page-state.outputs['responder-uri'] }}
+      head-branch: codex/progress-prize-${{ inputs['target-cycle'] }}
+      base-branch: main
+
+  activation-binding:
+    name: Freeze the prepared activation commit
+    if: >-
+      always() &&
+      needs.activation-state.result == 'success' &&
+      needs.activation-state.outputs.state == 'pending' &&
+      (needs.refresh-page.result == 'success' || needs.refresh-page.result == 'skipped')
+    needs:
+      - activation-state
+      - refresh-page
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      head-sha: ${{ steps.binding.outputs['head-sha'] }}
+      base-sha: ${{ steps.binding.outputs['base-sha'] }}
+      pr-number: ${{ steps.binding.outputs['pr-number'] }}
+    steps:
+      - name: Select and validate the exact pending tuple
+        id: binding
+        env:
+          REFRESH_REQUIRED: ${{ needs.activation-state.outputs['refresh-required'] }}
+          STATE_HEAD_SHA: ${{ needs.activation-state.outputs['head-sha'] }}
+          STATE_BASE_SHA: ${{ needs.activation-state.outputs['base-sha'] }}
+          STATE_PR_NUMBER: ${{ needs.activation-state.outputs['pr-number'] }}
+          REFRESH_HEAD_SHA: ${{ needs.refresh-page.outputs['head-sha'] }}
+          REFRESH_BASE_SHA: ${{ needs.refresh-page.outputs['base-sha'] }}
+          REFRESH_PR_NUMBER: ${{ needs.refresh-page.outputs['pr-number'] }}
+          TRIGGER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if test "$REFRESH_REQUIRED" = true; then
+            head_sha="$REFRESH_HEAD_SHA"
+            base_sha="$REFRESH_BASE_SHA"
+            pr_number="$REFRESH_PR_NUMBER"
+          else
+            test "$REFRESH_REQUIRED" = false
+            head_sha="$STATE_HEAD_SHA"
+            base_sha="$STATE_BASE_SHA"
+            pr_number="$STATE_PR_NUMBER"
+          fi
+          [[ "$head_sha" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$base_sha" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
+          test "$base_sha" = "$TRIGGER_SHA"
+          printf 'head-sha=%s\nbase-sha=%s\npr-number=%s\n' \
+            "$head_sha" "$base_sha" "$pr_number" >>"$GITHUB_OUTPUT"
+
+  activation-gate:
+    name: Gate the exact production PR and preview
+    if: inputs.operation == 'activate' && needs.activation-state.outputs.state == 'pending'
+    needs:
+      - activation-state
+      - activation-binding
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
+      statuses: read
+    outputs:
+      head-sha: ${{ steps.gate.outputs['head-sha'] }}
+      base-sha: ${{ steps.gate.outputs['base-sha'] }}
+      pr-number: ${{ steps.gate.outputs['pr-number'] }}
+    steps:
+      - name: Check out exact trusted gate code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Wait for the immutable code checks and Vercel preview
+        id: gate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: codex/progress-prize-${{ inputs['target-cycle'] }}
+          HEAD_SHA: ${{ needs.activation-binding.outputs['head-sha'] }}
+          BASE_SHA: ${{ needs.activation-binding.outputs['base-sha'] }}
+          SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+        run: >-
+          node .github/progress-prizes-github.mjs gate
+          --head "$HEAD_BRANCH"
+          --base main
+          --base-sha "$BASE_SHA"
+          --source-cycle "$SOURCE_CYCLE"
+          --cycle "$TARGET_CYCLE"
+          --sha "$HEAD_SHA"
+          --timeout-seconds 1800
+      - name: Open approval only inside the bounded cutoff window
+        env:
+          SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { getCycleDeadline } from './scrollprize.org/scripts/progress-prizes/dates.mjs';
+
+          const waitMilliseconds = getCycleDeadline(process.env.SOURCE_CYCLE).cutoffAt.getTime()
+            - Date.now();
+          if (waitMilliseconds > 60 * 60 * 1000) {
+            throw new Error('Production approval was requested outside its bounded cutoff window.');
+          }
+          NODE
+
+  activation-approval:
+    name: Approve the real production cutoff
+    if: inputs.operation == 'activate' && needs.activation-state.outputs.state == 'pending'
+    needs:
+      - activation-state
+      - activation-gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    environment: progress-prizes-production-activation
+    permissions: {}
+    steps:
+      - name: Bind approval to the exact gated run
+        env:
+          HEAD_SHA: ${{ needs.activation-gate.outputs['head-sha'] }}
+          BASE_SHA: ${{ needs.activation-gate.outputs['base-sha'] }}
+          TRIGGER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$HEAD_SHA" =~ ^[a-f0-9]{40}$ ]]
+          test "$BASE_SHA" = "$TRIGGER_SHA"
+
+  activate-production:
+    name: Lease and activate production
+    if: inputs.operation == 'activate' && needs.activation-state.outputs.state == 'pending'
+    needs:
+      - activation-state
+      - activation-gate
+      - activation-approval
+    runs-on: ubuntu-24.04
+    timeout-minutes: 70
+    environment: progress-prizes-production
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      id-token: write
+      pull-requests: read
+      statuses: read
+    outputs:
+      responder-uri: ${{ steps.google.outputs['responder-uri'] }}
+      head-sha: ${{ needs.activation-gate.outputs['head-sha'] }}
+      base-sha: ${{ needs.activation-gate.outputs['base-sha'] }}
+      pr-number: ${{ needs.activation-gate.outputs['pr-number'] }}
+    steps:
+      - name: Check out the exact trusted trigger commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Activate only the exact gated production transition
+        id: google
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: activate
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          branch: codex/progress-prize-${{ inputs['target-cycle'] }}
+          target-branch: main
+          head-sha: ${{ needs.activation-gate.outputs['head-sha'] }}
+          base-sha: ${{ needs.activation-gate.outputs['base-sha'] }}
+          github-token: ${{ github.token }}
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+
+  merge:
+    name: Ready and merge the activated page
+    if: inputs.operation == 'activate' && needs.activation-state.outputs.state == 'pending'
+    needs:
+      - activation-state
+      - activate-production
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out exact trusted merge code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Merge only the activated immutable tuple
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: codex/progress-prize-${{ inputs['target-cycle'] }}
+          HEAD_SHA: ${{ needs.activate-production.outputs['head-sha'] }}
+          BASE_SHA: ${{ needs.activate-production.outputs['base-sha'] }}
+          PR_NUMBER: ${{ needs.activate-production.outputs['pr-number'] }}
+          SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+        run: >-
+          node .github/progress-prizes-github.mjs merge
+          --head "$HEAD_BRANCH"
+          --base main
+          --sha "$HEAD_SHA"
+          --base-sha "$BASE_SHA"
+          --pr-number "$PR_NUMBER"
+          --source-cycle "$SOURCE_CYCLE"
+          --cycle "$TARGET_CYCLE"
+
+  verify-completed-activation:
+    if: inputs.operation == 'activate' && needs.activation-state.outputs.state == 'completed'
+    needs:
+      - preflight
+      - activation-state
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the exact trusted trigger commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Verify the already completed production activation
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: verify
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          verify-mode: active
+          branch: main
+          target-branch: main
+          head-sha: ${{ needs.activation-state.outputs['head-sha'] }}
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+
+  verify-prepared-state:
+    name: Resolve the pending page for prepared verification
+    if: inputs.operation == 'verify' && inputs['verify-mode'] == 'prepared'
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      head-branch: ${{ steps.binding.outputs['head-branch'] }}
+      head-sha: ${{ steps.state.outputs['head-sha'] }}
+    steps:
+      - name: Check out exact trusted state code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Resolve exactly one pending rollover pull request
+        id: state
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: codex/progress-prize-${{ inputs['target-cycle'] }}
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+          TRIGGER_SHA: ${{ github.sha }}
+        run: >-
+          node .github/progress-prizes-github.mjs activation-state
+          --head "$HEAD_BRANCH"
+          --base main
+          --cycle "$TARGET_CYCLE"
+          --expected-base-sha "$TRIGGER_SHA"
+      - name: Require pending prepared state
+        if: steps.state.outputs.state != 'pending'
+        run: |
+          echo "Prepared verification requires exactly one pending rollover pull request." >&2
+          exit 1
+      - name: Reject a prepared page that requires reconstruction
+        if: steps.state.outputs['refresh-required'] != 'false'
+        run: |
+          echo "Prepared verification requires an exact page-only commit on current main." >&2
+          exit 1
+      - name: Export the fixed automation branch
+        id: binding
+        env:
+          HEAD_BRANCH: codex/progress-prize-${{ inputs['target-cycle'] }}
+        run: printf 'head-branch=%s\n' "$HEAD_BRANCH" >>"$GITHUB_OUTPUT"
+
+  verify-prepared:
+    if: inputs.operation == 'verify' && inputs['verify-mode'] == 'prepared'
+    needs:
+      - preflight
+      - verify-prepared-state
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the exact trusted trigger commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Verify the exact prepared production form and page
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: verify
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          verify-mode: prepared
+          branch: ${{ needs.verify-prepared-state.outputs['head-branch'] }}
+          target-branch: main
+          head-sha: ${{ needs.verify-prepared-state.outputs['head-sha'] }}
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+
+  verify-active:
+    if: inputs.operation == 'verify' && inputs['verify-mode'] == 'active'
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the exact trusted trigger commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Verify active production Google and page state
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: verify
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          verify-mode: active
+          branch: main
+          target-branch: main
+          head-sha: ${{ github.sha }}
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+
+  report-scheduled-failure:
+    name: Report a redacted scheduled production failure
+    if: >-
+      always() &&
+      inputs['request-id'] != '' &&
+      (needs.preflight.result == 'failure' ||
+       needs.validate.result == 'failure' ||
+       needs.dry-run.result == 'failure' ||
+       needs.prepare-google.result == 'failure' ||
+       needs.prepare-page.result == 'failure' ||
+       needs.activation-state.result == 'failure' ||
+       needs.activation-page-state.result == 'failure' ||
+       needs.refresh-page.result == 'failure' ||
+       needs.activation-binding.result == 'failure' ||
+       needs.activation-gate.result == 'failure' ||
+       needs.activation-approval.result == 'failure' ||
+       needs.activate-production.result == 'failure' ||
+       needs.merge.result == 'failure' ||
+       needs.verify-completed-activation.result == 'failure' ||
+       needs.verify-prepared-state.result == 'failure' ||
+       needs.verify-prepared.result == 'failure' ||
+       needs.verify-active.result == 'failure')
+    needs:
+      - preflight
+      - validate
+      - dry-run
+      - prepare-google
+      - prepare-page
+      - activation-state
+      - activation-page-state
+      - refresh-page
+      - activation-binding
+      - activation-gate
+      - activation-approval
+      - activate-production
+      - merge
+      - verify-completed-activation
+      - verify-prepared-state
+      - verify-prepared
+      - verify-active
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Create or reuse the fixed automation issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const title = '[automation] Progress Prize rollover needs attention';
+          const notice = [
+            'A scheduled Progress Prize rollover did not complete.',
+            '',
+            `Review the redacted [Actions run](${process.env.RUN_URL}).`,
+            '',
+            'Google identifiers, ACL identities, and operation output are intentionally omitted.',
+          ].join('\n');
+
+          async function github(path, method = 'GET', body) {
+            const response = await fetch(`https://api.github.com${path}`, {
+              method,
+              redirect: 'error',
+              headers: {
+                accept: 'application/vnd.github+json',
+                authorization: `Bearer ${process.env.GH_TOKEN}`,
+                'content-type': 'application/json',
+                'user-agent': 'progress-prize-production-reporter',
+                'x-github-api-version': '2022-11-28',
+              },
+              body: body === undefined ? undefined : JSON.stringify(body),
+            });
+            if (!response.ok) throw new Error('Redacted issue reporting failed.');
+            return response.status === 204 ? undefined : response.json();
+          }
+
+          const query = new URLSearchParams({
+            q: `repo:ScrollPrize/villa is:issue is:open in:title "${title}"`,
+            per_page: '100',
+          });
+          const search = await github(`/search/issues?${query}`);
+          if (!Number.isInteger(search?.total_count) || search.total_count > 100) {
+            throw new Error('Redacted issue reporting search is ambiguous.');
+          }
+          const existing = search.items.filter(
+            (issue) => !issue.pull_request && issue.title === title,
+          );
+          if (existing.length > 1) throw new Error('Redacted issue reporting is ambiguous.');
+          if (existing.length === 1) {
+            await github(
+              `/repos/ScrollPrize/villa/issues/${existing[0].number}/comments`,
+              'POST',
+              { body: notice },
+            );
+          } else {
+            await github('/repos/ScrollPrize/villa/issues', 'POST', { title, body: notice });
+          }
+          NODE

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -34,9 +34,10 @@ repository secret, file, log, cache, or artifact.
 - `progress-prizes-vercel-preview.yml` runs trusted default-branch verifier code
   on a Vercel `repository_dispatch`. It never checks out or executes deployed
   branch code.
-- Milestone 4 adds `progress-prizes-production.yml` only after the complete
-  staging rehearsal passes. It provides guarded `validate`, `dry-run`, `prepare`,
-  `activate`, and `verify` operations.
+- `progress-prizes-production.yml` provides guarded `validate`, `dry-run`,
+  `prepare`, `activate`, and `verify` operations after the complete staging
+  rehearsal has passed. Every authenticated job is literal in that top-level
+  workflow and calls the same local action exercised by staging.
 - Milestone 5 adds `progress-prizes-schedule.yml` only after production
   `validate` and `dry-run` pass. Reaching `main` is what enables its Pacific-time
   schedules.
@@ -59,18 +60,23 @@ Google-secret-consuming jobs are never placed behind `workflow_call`, and no
 workflow uses `secrets: inherit`. Live July validation runs showed that GitHub
 created and approved the correct deployment but still evaluated every protected
 Environment secret as empty inside a called workflow, both with expression-based
-and literal Environment names. Each top-level dispatch or schedule workflow
-therefore binds its Google jobs directly to a literal protected Environment and
-invokes the same local action. The exact trigger commit—not a mutable branch
-tip—is the executable code that receives the approved secrets.
+and literal Environment names. Each top-level workflow that authenticates to
+Google therefore binds its Google jobs directly to a literal protected
+Environment and invokes the same local action. The separate scheduler
+authenticates only to GitHub and dispatches the production workflow. The exact
+trigger commit—not a mutable branch tip—is the executable code that receives
+the approved secrets.
 
 ## GitHub Environments
 
-Create these environments before merging the workflows. Restrict all three to
+Create these environments before merging the workflows. Restrict all four to
 the protected `main` branch. Require an authorized Vesuvius Challenge reviewer
-on `progress-prizes-production`; this is the human gate before production Google
-access, including the real July 31 activation. Staging and preview should not
-require a month-end wait.
+only on `progress-prizes-production-activation`; this is the human gate for the
+real close/open transition. The approval job receives no Google configuration,
+OIDC permission, or repository write permission. Staging, preview, and
+`progress-prizes-production` itself must not require a reviewer, so a queued
+daily preparation cannot hold the production concurrency lock and block the
+cutoff or its recovery run.
 
 ### `progress-prizes-staging`
 
@@ -161,9 +167,11 @@ any other Google service account—including a reader or owner—fails closed, a
 do inherited editors, domains, additional Managers, or Content managers.
 
 No archive or staging folder is supplied to production. Production mutation
-jobs receive no staging identity; the initial July read-only validation is the
-only exception, because it verifies the expected staging reader on the live
-form without granting the production identity access to staging.
+jobs receive no staging identity. The initial July read-only validation is the
+only exception: the workflow conditionally supplies the expected staging reader
+identity for that source cycle, so it can verify the live form without granting
+the production identity access to staging. Later validation cycles receive an
+empty staging-identity input.
 `PROGRESS_PRIZE_SOURCE_FORM_ID` is a one-time, explicit fallback. The July form
 never receives managed environment/role/cycle markers and is never moved or
 renamed. At activation it is closed first and receives only the private recovery
@@ -171,6 +179,16 @@ state marker. The August copy is created in the production Shared Drive and is
 cryptographically bound to that exact source ID. After its activation, managed
 `appProperties` discovery always selects the prior managed target, so the
 fallback secret does not need a monthly edit and is ignored for later cycles.
+
+### `progress-prizes-production-activation`
+
+This Environment contains no secrets or variables. Require one authorized
+Vesuvius Challenge reviewer, disallow self-review if the organization supports
+it, and restrict deployment branches to protected `main`. The workflow first
+freezes and verifies the exact Progress Prize PR, public test, and Vercel
+preview; then this Environment records the human approval. The following
+Google job rechecks the immutable lease immediately before mutation, so a PR or
+`main` change while approval is pending fails closed.
 
 ### `progress-prizes-preview`
 
@@ -219,11 +237,25 @@ attribute.workflow_ref == 'ScrollPrize/villa/.github/workflows/progress-prizes-r
 assertion.workflow_sha == assertion.sha
 ```
 
-For the rehearsal, use the same immutable repository, owner, ref, event, and
-top-level workflow checks for production, but set the Environment to
-`progress-prizes-production`. Milestone 4 replaces the rehearsal workflow ref
-with the exact production workflow ref; milestone 5 adds the exact schedule
-workflow ref and permits `schedule` only for that workflow.
+Use this separate condition blueprint for the production provider after the
+production workflow reaches protected `main`:
+
+```text
+attribute.repository == 'ScrollPrize/villa' &&
+attribute.repository_id == '890972577' &&
+attribute.repository_owner_id == '121906140' &&
+attribute.ref == 'refs/heads/main' &&
+attribute.event_name == 'workflow_dispatch' &&
+attribute.environment == 'progress-prizes-production' &&
+attribute.workflow_ref == 'ScrollPrize/villa/.github/workflows/progress-prizes-production.yml@refs/heads/main' &&
+assertion.workflow_sha == assertion.sha
+```
+
+The schedule milestone does not receive Google configuration or OIDC. It
+computes the Pacific window and dispatches this exact production workflow with
+`GITHUB_TOKEN`; GitHub documents `workflow_dispatch` as an event that is allowed
+to create a new run from `GITHUB_TOKEN`. The production WIF condition therefore
+does not need to permit the schedule workflow path or a `schedule` event.
 
 Bind only that provider principal to its matching service account with
 `roles/iam.workloadIdentityUser`. Use the numeric Google project number when
@@ -269,10 +301,12 @@ Before rehearsal, an administrator must:
    automation PR with the exact head SHA/ref and allowed base, or the exact
    current SHA of the fixed smoke base after merge.
 
-As observed on July 20, 2026, the repository still lacked the three Progress
-Prize Environments, `main` branch protection, and the Actions PR setting; Vercel
-previews redirected to SSO. Those are external blockers, not values that can be
-safely filled in by repository code.
+The July 20 setup created the staging, production, and preview Environments,
+enabled an active `Protect main` ruleset, and verified an exact Vercel preview
+through its protected bypass secret. The separate secret-free production
+activation Environment is added with the guarded production milestone. These
+controls remain administrator-managed external configuration; their private
+values never belong in repository code.
 
 ## Initial My Drive cycle
 
@@ -359,10 +393,49 @@ Individual rehearsal segments are available for recovery. They remain fixed to
 the same staging identities, folder, clock rules, and smoke branches; the core
 also rejects fault injection unless every staging condition is true.
 
-After the full rehearsal passes, add and merge the guarded production workflow,
-then dispatch production `dry-run` and `validate`. Add
+The full rehearsal passed through verified cleanup before the production
+workflow was added. Merge the guarded production workflow, update the
+production WIF condition to its exact path, then dispatch production `validate`
+and `dry-run`. Add
 `progress-prizes-schedule.yml` only at the final schedule milestone: once it
 reaches `main`, GitHub enables the Pacific daily schedules.
+
+## Production operations and recovery
+
+Use **Progress Prize production rollover** on `main`. For July to August, keep
+`source-cycle=2026-07` and `target-cycle=2026-08`; later targets must always be
+the immediately following month. Leave `request-id` empty for every manual run.
+
+- `validate` performs the read-only live-form, capability, publishing, response,
+  ACL, copy, and linked-Sheet preflight. It never writes Google or GitHub state.
+- `dry-run` is deliberately useful before the normal seven-day preparation
+  window. It uses the real clock and the same preparation preflight, but extends
+  only the read-only planning window to 31 days. It creates no copy, changes no
+  ACL or publishing state, writes no website branch, and records only the
+  proposed public title and deadline in the run summary. Real `prepare` remains
+  fixed to seven days.
+- `prepare` is safe to dispatch repeatedly. It succeeds without opening a page
+  PR outside the seven-day window. Inside the window it resumes the one managed
+  target for the cycle, keeps it published but closed, and reconstructs the one
+  marker-only draft page PR.
+- `verify` with `prepared` requires that exact page-only PR on current `main`;
+  `active` requires the completed website and Google close/open state.
+- `activate` should be dispatched near 23:40 Pacific on the final day. The exact
+  PR tests and Vercel preview pass first. Approval is offered only when the real
+  cutoff is at most one hour away (or has passed), through the secret-free
+  `progress-prizes-production-activation` Environment. The job waits without a
+  Google token, authenticates at cutoff, reacquires a zero-wait GitHub lease,
+  closes the source, opens and reload-verifies the target, then merges only the
+  activated commit.
+
+If preparation, activation, or merge stops, rerun the same operation and cycle.
+Managed Drive markers make Google copy and close/open recovery idempotent. A
+rerun after a completed merge performs read-only active verification. If `main`
+moved before mutation, activation reconstructs and rechecks a stale-parent page
+commit; any multi-file, merge, wrong-path, or query-bearing change fails closed.
+Never use simulated time, fault controls, alternate branches, or staging folders
+for production; those inputs are absent and the shared action rejects them
+before authentication.
 
 ## Local verification
 

--- a/scrollprize.org/scripts/progress-prizes/index.mjs
+++ b/scrollprize.org/scripts/progress-prizes/index.mjs
@@ -26,6 +26,7 @@ export {
 
 export {
   PROGRESS_PRIZE_MARKERS,
+  assertCanonicalPublicResponderUri,
   assertPublicResponderUri,
   parseProgressPrizeMarkdown,
   updateProgressPrizeMarkdown,

--- a/scrollprize.org/scripts/progress-prizes/markdown.mjs
+++ b/scrollprize.org/scripts/progress-prizes/markdown.mjs
@@ -119,12 +119,21 @@ export function assertPublicResponderUri(responderUri) {
   return url.toString();
 }
 
+export function assertCanonicalPublicResponderUri(responderUri) {
+  const normalized = assertPublicResponderUri(responderUri);
+  const url = new URL(normalized);
+  if (url.search !== '') {
+    throw new TypeError('responderUri must not contain query parameters');
+  }
+  return normalized;
+}
+
 function parseFormLine(line) {
   const match = /^\[Submission Form\]\((https:\/\/[^\s)]+)\)$/.exec(line);
   if (!match) {
     throw new Error('Managed form line has an unexpected format');
   }
-  return assertPublicResponderUri(match[1]);
+  return assertCanonicalPublicResponderUri(match[1]);
 }
 
 export function parseProgressPrizeMarkdown(markdown) {
@@ -176,7 +185,7 @@ export function updateProgressPrizeMarkdown(markdown, {
 } = {}) {
   const current = parseProgressPrizeMarkdown(markdown);
   const targetDeadline = getCycleDeadline(targetCycle);
-  const normalizedResponderUri = assertPublicResponderUri(responderUri);
+  const normalizedResponderUri = assertCanonicalPublicResponderUri(responderUri);
   const next = Object.freeze({
     cycle: targetCycle,
     deadline: targetDeadline,

--- a/scrollprize.org/scripts/progress-prizes/production-workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/production-workflow-contract.test.mjs
@@ -1,0 +1,347 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const googleJobs = [
+  'validate',
+  'dry-run',
+  'prepare-google',
+  'activate-production',
+  'verify-completed-activation',
+  'verify-prepared',
+  'verify-active',
+];
+const githubOnlyJobs = [
+  'preflight',
+  'prepare-page',
+  'activation-state',
+  'activation-page-state',
+  'refresh-page',
+  'activation-binding',
+  'activation-gate',
+  'activation-approval',
+  'merge',
+  'verify-prepared-state',
+  'report-scheduled-failure',
+];
+const protectedMappings = new Map([
+  ['workload-identity-provider', 'GOOGLE_WORKLOAD_IDENTITY_PROVIDER'],
+  ['service-account-email', 'GOOGLE_SERVICE_ACCOUNT_EMAIL'],
+  ['drive-admin-email', 'PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL'],
+  ['drive-id', 'PROGRESS_PRIZE_DRIVE_ID'],
+  ['folder-id', 'PROGRESS_PRIZE_FOLDER_ID'],
+  ['source-form-id', 'PROGRESS_PRIZE_SOURCE_FORM_ID'],
+  ['editor-group-email', 'PROGRESS_PRIZE_EDITOR_GROUP_EMAIL'],
+]);
+
+async function productionWorkflow() {
+  return readFile(
+    resolve(repositoryRoot, '.github/workflows/progress-prizes-production.yml'),
+    'utf8',
+  );
+}
+
+async function googleAction() {
+  return readFile(
+    resolve(repositoryRoot, '.github/actions/progress-prizes-google/action.yml'),
+    'utf8',
+  );
+}
+
+function jobBlock(source, name) {
+  const startMarker = `  ${name}:\n`;
+  const start = source.indexOf(startMarker);
+  assert.notEqual(start, -1, `missing ${name} job`);
+  const remainder = source.slice(start + startMarker.length);
+  const next = remainder.search(/^  [a-z0-9-]+:\n/m);
+  return next === -1
+    ? source.slice(start)
+    : source.slice(start, start + startMarker.length + next);
+}
+
+function jobNames(source) {
+  const jobs = source.slice(source.indexOf('\njobs:\n') + '\njobs:\n'.length);
+  return [...jobs.matchAll(/^  ([a-z][a-z0-9-]*):\n/gm)].map((match) => match[1]);
+}
+
+function literalRunScripts(source) {
+  const lines = source.split('\n');
+  const scripts = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const run = lines[index].match(/^(\s*)run:\s*\|[-+]?\s*$/);
+    if (!run) continue;
+    let firstContent = index + 1;
+    while (firstContent < lines.length && lines[firstContent].trim() === '') firstContent += 1;
+    const contentIndent = lines[firstContent]?.match(/^ */)?.[0].length ?? 0;
+    assert.ok(contentIndent > run[1].length, `run block at line ${index + 1} has no body`);
+    const body = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const line = lines[cursor];
+      const indentation = line.match(/^ */)?.[0].length ?? 0;
+      if (line.trim() !== '' && indentation < contentIndent) break;
+      body.push(line.trim() === '' ? '' : line.slice(contentIndent));
+    }
+    scripts.push(`${body.join('\n')}\n`);
+  }
+  return scripts;
+}
+
+test('production accepts only a secret-free manual dispatch contract', async () => {
+  const source = await productionWorkflow();
+  const inputSection = source.slice(0, source.indexOf('\npermissions:'));
+  const preflight = jobBlock(source, 'preflight');
+
+  assert.match(source, /^on:\n  workflow_dispatch:/m);
+  assert.doesNotMatch(source, /workflow_call:|pull_request(?:_target)?:/);
+  assert.doesNotMatch(inputSection, /^  (?:schedule|repository_dispatch):/m);
+  assert.doesNotMatch(inputSection, /^\s+(?:simulated-now|fault|base-branch|head-sha):/m);
+  assert.match(source, /^concurrency:\n  group: progress-prizes-production\n  cancel-in-progress: false$/m);
+  assert.match(preflight, /permissions: \{\}/);
+  assert.doesNotMatch(preflight, /environment:|id-token|secrets\./);
+  assert.match(preflight, /assert\.equal\(process\.env\.REPOSITORY, 'ScrollPrize\/villa'\)/);
+  assert.match(preflight, /assert\.equal\(process\.env\.REPOSITORY_ID, '890972577'\)/);
+  assert.match(preflight, /assert\.equal\(process\.env\.REPOSITORY_OWNER_ID, '121906140'\)/);
+  assert.match(preflight, /assert\.equal\(process\.env\.REF, 'refs\/heads\/main'\)/);
+  assert.match(preflight, /assert\.equal\(process\.env\.EVENT_NAME, 'workflow_dispatch'\)/);
+  assert.match(preflight, /process\.env\.TARGET_CYCLE, target/);
+  assert.match(preflight, /\^\[1-9\]\\d\*\$/);
+  assert.deepEqual(
+    new Set(jobNames(source)),
+    new Set([...googleJobs, ...githubOnlyJobs]),
+    'every production job must be assigned to the Google or secret-free control plane',
+  );
+});
+
+test('production preflight executes a strict valid and invalid control matrix', async () => {
+  const source = await productionWorkflow();
+  const [guard] = literalRunScripts(jobBlock(source, 'preflight'));
+  assert.ok(guard);
+  const valid = {
+    REPOSITORY: 'ScrollPrize/villa',
+    REPOSITORY_ID: '890972577',
+    REPOSITORY_OWNER_ID: '121906140',
+    REF: 'refs/heads/main',
+    HEAD_SHA: 'a'.repeat(40),
+    EVENT_NAME: 'workflow_dispatch',
+    OPERATION: 'activate',
+    SOURCE_CYCLE: '2026-07',
+    TARGET_CYCLE: '2026-08',
+    VERIFY_MODE: 'prepared',
+    REQUEST_ID: '',
+  };
+  const execute = (overrides = {}) => spawnSync('bash', ['--noprofile', '--norc', '-c', guard], {
+    env: { ...process.env, ...valid, ...overrides },
+    encoding: 'utf8',
+  });
+  assert.equal(execute().status, 0);
+  for (const overrides of [
+    { REPOSITORY_ID: '1' },
+    { REF: 'refs/heads/feature' },
+    { EVENT_NAME: 'schedule' },
+    { OPERATION: 'cleanup' },
+    { TARGET_CYCLE: '2026-09' },
+    { REQUEST_ID: 'untrusted' },
+  ]) {
+    assert.notEqual(execute(overrides).status, 0, JSON.stringify(overrides));
+  }
+});
+
+test('every production Google job is literal, exact-SHA, and explicitly secret mapped', async () => {
+  const source = await productionWorkflow();
+
+  assert.doesNotMatch(source, /progress-prizes-google\.yml|secrets:\s*inherit/);
+  assert.doesNotMatch(source, /environment:\s*\$\{\{/);
+  for (const name of googleJobs) {
+    const job = jobBlock(source, name);
+    assert.match(job, /runs-on: ubuntu-24\.04/);
+    assert.match(job, /environment: progress-prizes-production/);
+    assert.match(job, /contents: read/);
+    assert.match(job, /id-token: write/);
+    assert.match(job, /ref: \$\{\{ github\.sha \}\}/);
+    assert.match(job, /persist-credentials: false/);
+    assert.match(job, /uses: \.\/\.github\/actions\/progress-prizes-google/);
+    assert.match(job, /^          environment: production$/m);
+    for (const [input, secret] of protectedMappings) {
+      assert.match(
+        job,
+        new RegExp(`^          ${input}: \\$\\{\\{ secrets\\.${secret} \\}\\}$`, 'm'),
+      );
+    }
+    assert.doesNotMatch(job, /staging-folder-id|archive-folder-id/);
+  }
+
+  const validation = jobBlock(source, 'validate');
+  assert.match(
+    validation,
+    /^          staging-service-account-email: \$\{\{ inputs\['source-cycle'\] == '2026-07' && secrets\.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \|\| '' \}\}$/m,
+  );
+  for (const name of googleJobs.filter((name) => name !== 'validate')) {
+    assert.doesNotMatch(jobBlock(source, name), /staging-service-account-email/);
+  }
+});
+
+test('production dry-run immediately exercises a read-only public proposal', async () => {
+  const production = await productionWorkflow();
+  const action = await googleAction();
+  const dryRun = jobBlock(production, 'dry-run');
+
+  assert.match(dryRun, /^          operation: prepare$/m);
+  assert.match(dryRun, /^          dry-run: "true"$/m);
+  assert.match(dryRun, /Summarize the public no-mutation proposal/);
+  assert.match(dryRun, /getCycleDeadline\(process\.env\.TARGET_CYCLE\)/);
+  assert.match(dryRun, /Google mutation: `disabled`/);
+  assert.match(dryRun, /Website mutation: `disabled`/);
+  assert.match(
+    action,
+    /PROGRESS_PRIZE_ENVIRONMENT" = production \\\n\s+-a "\$OPERATION" = prepare \\\n\s+-a "\$DRY_RUN" = true/,
+  );
+  assert.match(action, /arguments\+=\(--preparation-days 31\)/);
+  assert.match(
+    action,
+    /if: inputs\.operation == 'validate' \|\| inputs\.operation == 'verify' \|\| inputs\['dry-run'\] == 'true'/,
+  );
+});
+
+test('normal preparation no-ops safely outside the seven-day window', async () => {
+  const production = await productionWorkflow();
+  const google = jobBlock(production, 'prepare-google');
+  const page = jobBlock(production, 'prepare-page');
+
+  assert.doesNotMatch(google, /preparation-days/);
+  assert.match(
+    page,
+    /inputs\.operation == 'prepare' &&\n\s+needs\.prepare-google\.outputs\['responder-uri'\] != ''/,
+  );
+  assert.match(page, /responder-uri: \$\{\{ needs\.prepare-google\.outputs\['responder-uri'\] \}\}/);
+  assert.match(page, /head-branch: codex\/progress-prize-\$\{\{ inputs\['target-cycle'\] \}\}/);
+  assert.match(page, /base-branch: main/);
+});
+
+test('GitHub control-plane jobs have no Google identity or OIDC', async () => {
+  const source = await productionWorkflow();
+  for (const name of githubOnlyJobs) {
+    const job = jobBlock(source, name);
+    assert.doesNotMatch(job, /id-token:\s*write/);
+    assert.doesNotMatch(job, /secrets\.(?:GOOGLE_|PROGRESS_PRIZE_)/);
+    assert.doesNotMatch(job, /google-github-actions\/auth|GOOGLE_ACCESS_TOKEN/);
+  }
+
+  const approval = jobBlock(source, 'activation-approval');
+  assert.match(approval, /environment: progress-prizes-production-activation/);
+  assert.match(approval, /permissions: \{\}/);
+  const reporter = jobBlock(source, 'report-scheduled-failure');
+  assert.match(reporter, /permissions:\n      issues: write/);
+  assert.match(reporter, /\/search\/issues\?\$\{query\}/);
+  assert.match(reporter, /search\.total_count > 100/);
+  assert.match(reporter, /Google identifiers, ACL identities, and operation output are intentionally omitted/);
+});
+
+test('every privileged checkout executes the immutable trigger code', async () => {
+  const source = await productionWorkflow();
+  for (const name of [
+    ...googleJobs,
+    'activation-state',
+    'activation-page-state',
+    'activation-gate',
+    'merge',
+    'verify-prepared-state',
+  ]) {
+    const job = jobBlock(source, name);
+    assert.match(job, /uses: actions\/checkout@[a-f0-9]{40}/);
+    assert.match(job, /ref: \$\{\{ github\.sha \}\}/);
+    assert.doesNotMatch(job, /ref: (?:refs\/heads\/main|main)/);
+  }
+});
+
+test('activation gates, approves, waits, authenticates, leases, verifies, then merges', async () => {
+  const production = await productionWorkflow();
+  const action = await googleAction();
+  const gate = jobBlock(production, 'activation-gate');
+  const approval = jobBlock(production, 'activation-approval');
+  const activation = jobBlock(production, 'activate-production');
+  const merge = jobBlock(production, 'merge');
+
+  assert.match(gate, /needs:\n      - activation-state\n      - activation-binding/);
+  assert.match(gate, /progress-prizes-github\.mjs gate/);
+  assert.match(gate, /--timeout-seconds 1800/);
+  assert.match(gate, /Open approval only inside the bounded cutoff window/);
+  assert.match(gate, /waitMilliseconds > 60 \* 60 \* 1000/);
+  assert.match(approval, /needs:\n      - activation-state\n      - activation-gate/);
+  assert.match(activation, /needs:\n      - activation-state\n      - activation-gate\n      - activation-approval/);
+  assert.match(activation, /base-sha: \$\{\{ needs\.activation-gate\.outputs\['base-sha'\] \}\}/);
+  assert.match(activation, /github-token: \$\{\{ github\.token \}\}/);
+
+  const wait = action.indexOf('Wait for the real production cutoff without a Google token');
+  const auth = action.indexOf('Authenticate mutating operations without a credential file');
+  const zeroLease = action.indexOf('--timeout-seconds 0');
+  const mutation = action.indexOf('automation-cli.mjs "${arguments[@]}"');
+  assert.ok(wait !== -1 && wait < auth && auth < zeroLease && zeroLease < mutation);
+  assert.match(action, /waitMilliseconds > 60 \* 60 \* 1000/);
+  assert.match(action, /GATED_BASE_SHA: \$\{\{ inputs\['base-sha'\] \}\}/);
+  assert.match(action, /result\.sourceAcceptingResponses !== false/);
+  assert.match(action, /result\.targetAcceptingResponses !== true/);
+
+  assert.match(merge, /needs:\n      - activation-state\n      - activate-production/);
+  assert.match(merge, /HEAD_SHA: \$\{\{ needs\.activate-production\.outputs\['head-sha'\] \}\}/);
+  assert.match(merge, /BASE_SHA: \$\{\{ needs\.activate-production\.outputs\['base-sha'\] \}\}/);
+  assert.match(merge, /PR_NUMBER: \$\{\{ needs\.activate-production\.outputs\['pr-number'\] \}\}/);
+  assert.match(merge, /--sha "\$HEAD_SHA"/);
+  assert.match(merge, /--base-sha "\$BASE_SHA"/);
+});
+
+test('activation reuses an exact prepared commit and refreshes only stale parents', async () => {
+  const production = await productionWorkflow();
+  const state = jobBlock(production, 'activation-state');
+  const page = jobBlock(production, 'activation-page-state');
+  const refresh = jobBlock(production, 'refresh-page');
+  const binding = jobBlock(production, 'activation-binding');
+  const completed = jobBlock(production, 'verify-completed-activation');
+
+  assert.match(state, /refresh-required: \$\{\{ steps\.state\.outputs\['refresh-required'\] \}\}/);
+  assert.match(state, /--expected-base-sha "\$TRIGGER_SHA"/);
+  assert.match(page, /outputs\['refresh-required'\] == 'true'/);
+  assert.match(page, /parseProgressPrizeMarkdown/);
+  assert.match(refresh, /outputs\['refresh-required'\] == 'true'/);
+  assert.match(refresh, /progress-prizes-page-pr\.yml/);
+  assert.match(binding, /if test "\$REFRESH_REQUIRED" = true/);
+  assert.match(binding, /test "\$base_sha" = "\$TRIGGER_SHA"/);
+  assert.match(completed, /outputs\.state == 'completed'/);
+  assert.match(completed, /operation: verify/);
+  assert.match(completed, /verify-mode: active/);
+});
+
+test('prepared verification binds the pending page while active verification binds main', async () => {
+  const production = await productionWorkflow();
+  const resolver = jobBlock(production, 'verify-prepared-state');
+  const prepared = jobBlock(production, 'verify-prepared');
+  const active = jobBlock(production, 'verify-active');
+
+  assert.match(resolver, /progress-prizes-github\.mjs activation-state/);
+  assert.match(resolver, /--expected-base-sha "\$TRIGGER_SHA"/);
+  assert.match(resolver, /steps\.state\.outputs\.state != 'pending'/);
+  assert.match(resolver, /steps\.state\.outputs\['refresh-required'\] != 'false'/);
+  assert.match(prepared, /needs:\n      - preflight\n      - verify-prepared-state/);
+  assert.match(prepared, /branch: \$\{\{ needs\.verify-prepared-state\.outputs\['head-branch'\] \}\}/);
+  assert.match(prepared, /head-sha: \$\{\{ needs\.verify-prepared-state\.outputs\['head-sha'\] \}\}/);
+  assert.match(active, /branch: main/);
+  assert.match(active, /head-sha: \$\{\{ github\.sha \}\}/);
+});
+
+test('documentation pins production WIF to only the exact top-level dispatch workflow', async () => {
+  const readme = await readFile(
+    resolve(repositoryRoot, 'scrollprize.org/scripts/progress-prizes/README.md'),
+    'utf8',
+  );
+  assert.match(
+    readme,
+    /attribute\.workflow_ref == 'ScrollPrize\/villa\/\.github\/workflows\/progress-prizes-production\.yml@refs\/heads\/main'/,
+  );
+  assert.match(readme, /attribute\.event_name == 'workflow_dispatch'/);
+  assert.match(readme, /attribute\.environment == 'progress-prizes-production'/);
+  assert.match(readme, /assertion\.workflow_sha == assertion\.sha/);
+  assert.match(readme, /schedule milestone does not receive Google configuration or OIDC/);
+});

--- a/scrollprize.org/scripts/progress-prizes/test/markdown.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/test/markdown.test.mjs
@@ -6,6 +6,7 @@ import { dirname, resolve } from 'node:path';
 
 import {
   PROGRESS_PRIZE_MARKERS,
+  assertCanonicalPublicResponderUri,
   assertPublicResponderUri,
   parseProgressPrizeMarkdown,
   updateProgressPrizeMarkdown,
@@ -142,6 +143,15 @@ test('parser rejects noncanonical or non-month-end deadlines', () => {
 test('only public responder URLs are accepted', () => {
   assert.equal(assertPublicResponderUri(oldUri), oldUri);
   assert.equal(assertPublicResponderUri(`${newUri}?usp=sf_link`), `${newUri}?usp=sf_link`);
+  assert.equal(assertCanonicalPublicResponderUri(newUri), newUri);
+  assert.throws(
+    () => assertCanonicalPublicResponderUri(`${newUri}?entry.123=prefilled`),
+    /query parameters/,
+  );
+  assert.throws(
+    () => parseProgressPrizeMarkdown(fixture({ uri: `${newUri}?entry.123=prefilled` })),
+    /query parameters/,
+  );
   for (const uri of [
     'http://forms.gle/OldForm',
     'https://docs.google.com/forms/d/e/EditorForm/edit',

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -6,12 +6,14 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  activationCommitNeedsRefresh,
   assertAutomationBranch,
   assertDeterministicPageDelta,
   assertPullBinding,
   assertSinglePageCommit,
   gateSnapshot,
   isTrustedPreviewRun,
+  resolveProductionActivationState,
   waitForPullBinding,
 } from '../../../.github/progress-prizes-github.mjs';
 
@@ -19,6 +21,7 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../.
 const workflowNames = [
   'progress-prizes-page-pr.yml',
   'progress-prizes-pr-safety.yml',
+  'progress-prizes-production.yml',
   'progress-prizes-rehearsal.yml',
   'progress-prizes-vercel-preview.yml',
 ];
@@ -418,11 +421,13 @@ test('composite pre-auth guard executes the activation rewind matrix before OIDC
     EXPECT_FAULT: 'false',
     DRY_RUN: 'false',
     ALLOW_ACTIVATION_REWIND: 'true',
+    VERIFY_MODE: 'prepared',
     BRANCH: 'codex/progress-prize-smoke-20260720',
     TARGET_BRANCH: 'codex/progress-prize-smoke-base-20260720',
     SOURCE_CYCLE: '2026-07',
     TARGET_CYCLE: '2026-08',
     HEAD_SHA: '',
+    BASE_SHA: '',
   };
   const run = (override = {}) => spawnSync('bash', ['--noprofile', '--norc'], {
     input: guard,
@@ -454,6 +459,52 @@ test('composite pre-auth guard executes the activation rewind matrix before OIDC
       BRANCH: 'main',
       TARGET_BRANCH: 'main',
     },
+  ]) {
+    assert.notEqual(run(override).status, 0, JSON.stringify(override));
+  }
+});
+
+test('composite production activation guard requires an exact immutable base lease', async () => {
+  const action = await googleAction();
+  const guard = literalRunScripts(action)[0]?.source;
+  const valid = {
+    REPOSITORY: 'ScrollPrize/villa',
+    REPOSITORY_ID: '890972577',
+    REPOSITORY_OWNER_ID: '121906140',
+    REF: 'refs/heads/main',
+    AUTOMATION_ENVIRONMENT: 'production',
+    EVENT_NAME: 'workflow_dispatch',
+    OPERATION: 'activate',
+    SIMULATED_NOW: '',
+    FAULT: '',
+    EXPECT_FAULT: 'false',
+    DRY_RUN: 'false',
+    ALLOW_ACTIVATION_REWIND: 'false',
+    VERIFY_MODE: 'prepared',
+    BRANCH: 'codex/progress-prize-2026-08',
+    TARGET_BRANCH: 'main',
+    SOURCE_CYCLE: '2026-07',
+    TARGET_CYCLE: '2026-08',
+    HEAD_SHA: 'a'.repeat(40),
+    BASE_SHA: 'b'.repeat(40),
+  };
+  const run = (override = {}) => spawnSync('bash', ['--noprofile', '--norc'], {
+    input: guard,
+    encoding: 'utf8',
+    env: { ...valid, ...override },
+  });
+
+  assert.equal(run().status, 0);
+  for (const override of [
+    { BASE_SHA: '' },
+    { BASE_SHA: 'not-a-sha' },
+    { EVENT_NAME: 'schedule' },
+    { BRANCH: 'main' },
+    { TARGET_BRANCH: 'release' },
+    { SIMULATED_NOW: '2026-08-01T07:01:00.000Z' },
+    { FAULT: 'after-close-source' },
+    { DRY_RUN: 'true' },
+    { VERIFY_MODE: 'invalid' },
   ]) {
     assert.notEqual(run(override).status, 0, JSON.stringify(override));
   }
@@ -844,10 +895,123 @@ test('the GitHub helper binds the PR and exact deterministic page-only commit', 
     files: [{ filename: 'scrollprize.org/docs/34_prizes.md', status: 'modified' }],
   };
   assert.equal(assertSinglePageCommit(commit, { headSha, baseSha }), commit);
+  assert.equal(activationCommitNeedsRefresh(commit, { headSha, baseSha }), false);
   assert.throws(() => assertSinglePageCommit({
     ...commit,
     files: [...commit.files, { filename: '.github/workflows/untrusted.yml', status: 'added' }],
   }, { headSha, baseSha }), /one page-only commit/);
+  assert.equal(activationCommitNeedsRefresh({
+    ...commit,
+    parents: [{ sha: 'c'.repeat(40) }],
+  }, { headSha, baseSha }), true);
+  assert.throws(() => activationCommitNeedsRefresh({
+    ...commit,
+    files: [...commit.files, { filename: '.github/workflows/untrusted.yml', status: 'added' }],
+  }, { headSha, baseSha }), /Only a page-only commit/);
+  assert.throws(() => activationCommitNeedsRefresh({
+    ...commit,
+    parents: [{ sha: baseSha }, { sha: 'c'.repeat(40) }],
+  }, { headSha, baseSha }), /Only a page-only commit/);
+});
+
+test('production activation-state recovery distinguishes exact, stale, and completed state', async () => {
+  const head = 'codex/progress-prize-2026-08';
+  const base = 'main';
+  const headSha = 'a'.repeat(40);
+  const baseSha = 'b'.repeat(40);
+  const staleSha = 'c'.repeat(40);
+  const pull = {
+    number: 42,
+    state: 'open',
+    head: {
+      ref: head,
+      sha: headSha,
+      repo: { id: 890972577, full_name: 'ScrollPrize/villa' },
+    },
+    base: {
+      ref: base,
+      sha: baseSha,
+      repo: { id: 890972577, full_name: 'ScrollPrize/villa' },
+    },
+  };
+  const exactCommit = {
+    sha: headSha,
+    parents: [{ sha: baseSha }],
+    files: [{ filename: 'scrollprize.org/docs/34_prizes.md', status: 'modified' }],
+  };
+  const options = { head, base, cycle: '2026-08', expectedBaseSha: baseSha };
+
+  const pending = await resolveProductionActivationState(options, {
+    listPulls: async () => [pull],
+    readCommit: async () => exactCommit,
+  });
+  assert.deepEqual(pending, {
+    state: 'pending',
+    headSha,
+    baseSha,
+    pullNumber: '42',
+    refreshRequired: false,
+  });
+
+  const stale = await resolveProductionActivationState(options, {
+    listPulls: async () => [pull],
+    readCommit: async () => ({ ...exactCommit, parents: [{ sha: staleSha }] }),
+  });
+  assert.equal(stale.refreshRequired, true);
+
+  const completed = await resolveProductionActivationState(options, {
+    listPulls: async () => [],
+    readMainRef: async () => ({ object: { sha: baseSha } }),
+    readPage: async () => ({ cycle: '2026-08' }),
+  });
+  assert.deepEqual(completed, {
+    state: 'completed',
+    headSha: baseSha,
+    baseSha,
+    pullNumber: '',
+    refreshRequired: false,
+  });
+});
+
+test('production activation-state recovery fails closed on ambiguous or drifting state', async () => {
+  const head = 'codex/progress-prize-2026-08';
+  const base = 'main';
+  const headSha = 'a'.repeat(40);
+  const baseSha = 'b'.repeat(40);
+  const pull = {
+    number: 42,
+    state: 'open',
+    head: {
+      ref: head,
+      sha: headSha,
+      repo: { id: 890972577, full_name: 'ScrollPrize/villa' },
+    },
+    base: {
+      ref: base,
+      sha: baseSha,
+      repo: { id: 890972577, full_name: 'ScrollPrize/villa' },
+    },
+  };
+  const options = { head, base, cycle: '2026-08', expectedBaseSha: baseSha };
+
+  await assert.rejects(
+    resolveProductionActivationState(options, { listPulls: async () => [pull, pull] }),
+    /ambiguous/,
+  );
+  await assert.rejects(
+    resolveProductionActivationState(options, {
+      listPulls: async () => [{ ...pull, base: { ...pull.base, sha: 'c'.repeat(40) } }],
+    }),
+    /main moved/,
+  );
+  await assert.rejects(
+    resolveProductionActivationState(options, {
+      listPulls: async () => [],
+      readMainRef: async () => ({ object: { sha: baseSha } }),
+      readPage: async () => ({ cycle: '2026-07' }),
+    }),
+    /Neither a pending PR nor a completed production cycle exists/,
+  );
 });
 
 test('PR binding retry tolerates only bounded stale SHAs', async () => {


### PR DESCRIPTION
Adds the top-level, workflow_dispatch-only production Progress Prize rollover after the complete staging rehearsal passed. Google jobs bind directly to the literal protected Environment and exchange short-lived OIDC tokens only from exact main code. Activation requires the exact page-only PR, public tests, Vercel preview, bounded cutoff window, secret-free reviewer approval, a post-approval zero-time lease, verified close/open state, and an exact-head merge.\n\nAlso adds immediate read-only production dry-run support, safe outside-window preparation no-op behavior, canonical responder URL enforcement, idempotent pending/completed recovery, redacted failure reporting, operator documentation, and executable workflow contracts.\n\nVerification: 232 tests passed; actionlint v1.7.12 passed; YAML, Bash, Node syntax, git diff checks, and independent security/workflow audits passed. Exact scan against all 10 protected local Google values found zero matches. No schedule is included in this milestone.