### PR TITLE
ci(scrollprize): schedule monthly progress prize rollovers

### DIFF
--- a/.github/progress-prizes-schedule.mjs
+++ b/.github/progress-prizes-schedule.mjs
@@ -1,0 +1,725 @@
+#!/usr/bin/env node
+
+import { appendFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const OWNER = 'ScrollPrize';
+const REPOSITORY = 'villa';
+const REPOSITORY_ID = 890972577;
+const API_ORIGIN = 'https://api.github.com';
+const WEB_ORIGIN = 'https://github.com';
+const MAIN_REF = 'main';
+const PRODUCTION_WORKFLOW = 'progress-prizes-production.yml';
+const PRODUCTION_WORKFLOW_PATH = `.github/workflows/${PRODUCTION_WORKFLOW}`;
+const PAGE_PATH = 'scrollprize.org/docs/34_prizes.md';
+const API_VERSION = '2022-11-28';
+const SAFE_FAILURE = 'Progress Prize scheduler GitHub coordination failed safely.';
+
+export const MAX_GITHUB_RESPONSE_BYTES = 256 * 1024;
+export const NONTERMINAL_RUN_STATUSES = Object.freeze([
+  'requested',
+  'queued',
+  'pending',
+  'waiting',
+  'in_progress',
+]);
+
+const NONTERMINAL_STATUS_SET = new Set(NONTERMINAL_RUN_STATUSES);
+const RUN_STATUS_SET = new Set([...NONTERMINAL_RUN_STATUSES, 'completed']);
+const OPERATIONS = new Set(['dry-run', 'prepare', 'activate']);
+const DEDUPE_REASONS = new Set([
+  'production-idle',
+  'production-run-nonterminal',
+  'prepare-required',
+  'prepare-exact',
+  'prepare-refresh',
+]);
+const DISPATCH_REASONS = new Set([
+  'production-dispatched',
+  'production-run-nonterminal',
+]);
+
+function failClosed() {
+  throw new Error(SAFE_FAILURE);
+}
+
+function isPlainObject(value) {
+  return value !== null
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && (Object.getPrototypeOf(value) === Object.prototype
+      || Object.getPrototypeOf(value) === null);
+}
+
+function assertPlainObject(value) {
+  if (!isPlainObject(value)) failClosed();
+  return value;
+}
+
+function assertPositiveInteger(value) {
+  if (!Number.isSafeInteger(value) || value < 1) failClosed();
+  return value;
+}
+
+function assertSha(value) {
+  if (typeof value !== 'string' || !/^[a-f0-9]{40}$/.test(value)) failClosed();
+  return value;
+}
+
+function assertOperation(value) {
+  if (typeof value !== 'string' || !OPERATIONS.has(value)) failClosed();
+  return value;
+}
+
+function parseCycle(value) {
+  if (typeof value !== 'string') failClosed();
+  const match = /^([1-9]\d{3})-(0[1-9]|1[0-2])$/.exec(value);
+  if (!match) failClosed();
+  return { value, year: Number(match[1]), month: Number(match[2]) };
+}
+
+function assertConsecutiveCycles(sourceCycle, targetCycle) {
+  const source = parseCycle(sourceCycle);
+  const target = parseCycle(targetCycle);
+  const nextYear = source.month === 12 ? source.year + 1 : source.year;
+  const nextMonth = source.month === 12 ? 1 : source.month + 1;
+  if (
+    nextYear > 9999
+    || target.year !== nextYear
+    || target.month !== nextMonth
+  ) {
+    failClosed();
+  }
+  return Object.freeze({ sourceCycle: source.value, targetCycle: target.value });
+}
+
+function assertRequestId(value) {
+  if (typeof value === 'number' && (!Number.isSafeInteger(value) || value < 1)) failClosed();
+  const text = typeof value === 'number' ? String(value) : value;
+  if (
+    typeof text !== 'string'
+    || !/^[1-9]\d*$/.test(text)
+    || text.length > 20
+    || BigInt(text) > 18_446_744_073_709_551_615n
+  ) {
+    failClosed();
+  }
+  return text;
+}
+
+function assertToken(token) {
+  if (
+    typeof token !== 'string'
+    || token.length < 1
+    || token.length > 16_384
+    || /[\r\n]/.test(token)
+  ) {
+    failClosed();
+  }
+  return token;
+}
+
+function assertRepository(value) {
+  const repository = assertPlainObject(value);
+  if (
+    repository.id !== REPOSITORY_ID
+    || repository.full_name !== `${OWNER}/${REPOSITORY}`
+  ) {
+    failClosed();
+  }
+  return repository;
+}
+
+function workflowRunApiUrl(id) {
+  return `${API_ORIGIN}/repos/${OWNER}/${REPOSITORY}/actions/runs/${id}`;
+}
+
+function workflowRunHtmlUrl(id) {
+  return `${WEB_ORIGIN}/${OWNER}/${REPOSITORY}/actions/runs/${id}`;
+}
+
+function pullApiUrl(number) {
+  return `${API_ORIGIN}/repos/${OWNER}/${REPOSITORY}/pulls/${number}`;
+}
+
+function pullHtmlUrl(number) {
+  return `${WEB_ORIGIN}/${OWNER}/${REPOSITORY}/pull/${number}`;
+}
+
+function assertWorkflowRun(run, expectedStatus) {
+  const value = assertPlainObject(run);
+  const id = assertPositiveInteger(value.id);
+  if (
+    !RUN_STATUS_SET.has(value.status)
+    || (expectedStatus !== undefined && value.status !== expectedStatus)
+    || value.event !== 'workflow_dispatch'
+    || value.head_branch !== MAIN_REF
+    || value.path !== PRODUCTION_WORKFLOW_PATH
+    || value.url !== workflowRunApiUrl(id)
+    || value.html_url !== workflowRunHtmlUrl(id)
+  ) {
+    failClosed();
+  }
+  assertSha(value.head_sha);
+  assertRepository(value.repository);
+  assertRepository(value.head_repository);
+  return Object.freeze({
+    runId: id,
+    runUrl: value.html_url,
+    status: value.status,
+  });
+}
+
+async function readBoundedText(response) {
+  let reader;
+  try {
+    if (
+      response?.redirected !== false
+      || typeof response.headers?.get !== 'function'
+      || typeof response.body?.getReader !== 'function'
+    ) {
+      failClosed();
+    }
+    const contentLength = response.headers.get('content-length');
+    if (contentLength !== null) {
+      if (!/^\d+$/.test(contentLength)) failClosed();
+      const length = Number(contentLength);
+      if (!Number.isSafeInteger(length) || length > MAX_GITHUB_RESPONSE_BYTES) failClosed();
+    }
+    reader = response.body.getReader();
+  } catch {
+    failClosed();
+  }
+
+  const decoder = new TextDecoder();
+  let byteLength = 0;
+  let result = '';
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!(value instanceof Uint8Array)) failClosed();
+      byteLength += value.byteLength;
+      if (byteLength > MAX_GITHUB_RESPONSE_BYTES) {
+        await reader.cancel();
+        failClosed();
+      }
+      result += decoder.decode(value, { stream: true });
+    }
+    result += decoder.decode();
+  } catch {
+    failClosed();
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      failClosed();
+    }
+  }
+  return result;
+}
+
+async function readBoundedJson(response) {
+  const text = await readBoundedText(response);
+  try {
+    return JSON.parse(text);
+  } catch {
+    failClosed();
+  }
+}
+
+async function githubJson(path, {
+  token,
+  fetchImpl = globalThis.fetch,
+  method = 'GET',
+  body,
+  expectedStatus = 200,
+} = {}) {
+  const credential = assertToken(token);
+  if (typeof fetchImpl !== 'function') failClosed();
+  if (typeof path !== 'string' || !path.startsWith('/repos/ScrollPrize/villa/')) failClosed();
+
+  let response;
+  try {
+    response = await fetchImpl(`${API_ORIGIN}${path}`, {
+      method,
+      redirect: 'error',
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${credential}`,
+        'content-type': 'application/json',
+        'user-agent': 'progress-prize-trusted-scheduler',
+        'x-github-api-version': API_VERSION,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  } catch {
+    failClosed();
+  }
+
+  try {
+    if (response?.status !== expectedStatus || response.redirected !== false) failClosed();
+    return await readBoundedJson(response);
+  } catch {
+    failClosed();
+  }
+}
+
+function workflowRunsPath(status) {
+  const query = new URLSearchParams({
+    branch: MAIN_REF,
+    event: 'workflow_dispatch',
+    status,
+    per_page: '100',
+  });
+  return `/repos/${OWNER}/${REPOSITORY}/actions/workflows/${PRODUCTION_WORKFLOW}/runs?${query}`;
+}
+
+function recentWorkflowRunsPath() {
+  const query = new URLSearchParams({
+    branch: MAIN_REF,
+    event: 'workflow_dispatch',
+    per_page: '10',
+  });
+  return `/repos/${OWNER}/${REPOSITORY}/actions/workflows/${PRODUCTION_WORKFLOW}/runs?${query}`;
+}
+
+function assertWorkflowRunsPage(body, expectedStatus) {
+  const value = assertPlainObject(body);
+  if (
+    !Number.isSafeInteger(value.total_count)
+    || value.total_count < 0
+    || value.total_count > 100
+    || !Array.isArray(value.workflow_runs)
+    || value.workflow_runs.length !== value.total_count
+  ) {
+    failClosed();
+  }
+  const ids = new Set();
+  return value.workflow_runs.map((run) => {
+    const inspected = assertWorkflowRun(run, expectedStatus);
+    if (ids.has(inspected.runId)) failClosed();
+    ids.add(inspected.runId);
+    return inspected;
+  });
+}
+
+function assertRecentWorkflowRunsPage(body) {
+  const value = assertPlainObject(body);
+  if (
+    !Number.isSafeInteger(value.total_count)
+    || value.total_count < 0
+    || !Array.isArray(value.workflow_runs)
+    || value.workflow_runs.length !== Math.min(value.total_count, 10)
+  ) {
+    failClosed();
+  }
+  const ids = new Set();
+  return value.workflow_runs.map((run) => {
+    const inspected = assertWorkflowRun(run);
+    if (ids.has(inspected.runId)) failClosed();
+    ids.add(inspected.runId);
+    return inspected;
+  });
+}
+
+export async function inspectProductionWorkflowRuns({
+  token,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const pages = await Promise.all(NONTERMINAL_RUN_STATUSES.map(async (status) => {
+    const body = await githubJson(workflowRunsPath(status), { token, fetchImpl });
+    return assertWorkflowRunsPage(body, status);
+  }));
+
+  // A single final snapshot closes the crossing-state gap between the filtered
+  // requests (for example, requested -> queued while those pages are read).
+  const recentBody = await githubJson(recentWorkflowRunsPath(), { token, fetchImpl });
+  const recentRuns = assertRecentWorkflowRunsPage(recentBody);
+
+  for (let index = 0; index < pages.length; index += 1) {
+    const run = pages[index][0];
+    if (run) {
+      return Object.freeze({
+        dispatch: false,
+        reason: 'production-run-nonterminal',
+        blockingStatus: NONTERMINAL_RUN_STATUSES[index],
+        blockingRunId: run.runId,
+        blockingRunUrl: run.runUrl,
+      });
+    }
+  }
+  const recentBlocker = recentRuns.find((run) => NONTERMINAL_STATUS_SET.has(run.status));
+  if (recentBlocker) {
+    return Object.freeze({
+      dispatch: false,
+      reason: 'production-run-nonterminal',
+      blockingStatus: recentBlocker.status,
+      blockingRunId: recentBlocker.runId,
+      blockingRunUrl: recentBlocker.runUrl,
+    });
+  }
+  return Object.freeze({ dispatch: true, reason: 'production-idle' });
+}
+
+function assertMainRef(body) {
+  const value = assertPlainObject(body);
+  const object = assertPlainObject(value.object);
+  const sha = assertSha(object.sha);
+  if (
+    value.ref !== 'refs/heads/main'
+    || object.type !== 'commit'
+    || object.url !== `${API_ORIGIN}/repos/${OWNER}/${REPOSITORY}/git/commits/${sha}`
+  ) {
+    failClosed();
+  }
+  return sha;
+}
+
+function automationBranch(targetCycle) {
+  const target = parseCycle(targetCycle);
+  return `codex/progress-prize-${target.value}`;
+}
+
+function assertPull(pull, { branch }) {
+  const value = assertPlainObject(pull);
+  const number = assertPositiveInteger(value.number);
+  assertPositiveInteger(value.id);
+  const head = assertPlainObject(value.head);
+  const base = assertPlainObject(value.base);
+  const headSha = assertSha(head.sha);
+  const baseSha = assertSha(base.sha);
+  if (
+    value.state !== 'open'
+    || value.url !== pullApiUrl(number)
+    || value.html_url !== pullHtmlUrl(number)
+    || head.ref !== branch
+    || base.ref !== MAIN_REF
+  ) {
+    failClosed();
+  }
+  assertRepository(head.repo);
+  assertRepository(base.repo);
+  return Object.freeze({
+    number,
+    url: value.html_url,
+    headSha,
+    baseSha,
+  });
+}
+
+function assertPageOnlyCommit(commit, { headSha }) {
+  const value = assertPlainObject(commit);
+  if (
+    value.sha !== headSha
+    || value.url !== `${API_ORIGIN}/repos/${OWNER}/${REPOSITORY}/commits/${headSha}`
+    || !Array.isArray(value.parents)
+    || value.parents.length !== 1
+    || !Array.isArray(value.files)
+    || value.files.length !== 1
+    || value.files[0]?.filename !== PAGE_PATH
+    || value.files[0]?.status !== 'modified'
+  ) {
+    failClosed();
+  }
+  return assertSha(value.parents[0]?.sha);
+}
+
+export async function inspectProductionPrepare({
+  targetCycle,
+  token,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const branch = automationBranch(targetCycle);
+  const query = new URLSearchParams({
+    state: 'open',
+    head: `${OWNER}:${branch}`,
+    base: MAIN_REF,
+    per_page: '2',
+  });
+  const pulls = await githubJson(
+    `/repos/${OWNER}/${REPOSITORY}/pulls?${query}`,
+    { token, fetchImpl },
+  );
+  if (!Array.isArray(pulls) || pulls.length > 1) failClosed();
+  if (pulls.length === 0) {
+    return Object.freeze({ dispatch: true, reason: 'prepare-required' });
+  }
+
+  const pull = assertPull(pulls[0], { branch });
+  const commitBody = await githubJson(
+    `/repos/${OWNER}/${REPOSITORY}/commits/${pull.headSha}?per_page=2`,
+    { token, fetchImpl },
+  );
+  const parentSha = assertPageOnlyCommit(commitBody, { headSha: pull.headSha });
+  // Read main last so the skip decision is based on the freshest ref observed by
+  // this helper, rather than on a ref read before the pull and commit requests.
+  const mainBody = await githubJson(
+    `/repos/${OWNER}/${REPOSITORY}/git/ref/heads/${MAIN_REF}`,
+    { token, fetchImpl },
+  );
+  const mainSha = assertMainRef(mainBody);
+  if (parentSha !== mainSha || pull.baseSha !== mainSha) {
+    return Object.freeze({
+      dispatch: true,
+      reason: 'prepare-refresh',
+      pullNumber: pull.number,
+      pullUrl: pull.url,
+    });
+  }
+  return Object.freeze({
+    dispatch: false,
+    reason: 'prepare-exact',
+    pullNumber: pull.number,
+    pullUrl: pull.url,
+  });
+}
+
+export async function dedupeProductionDispatch({
+  operation,
+  targetCycle,
+  token,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const selectedOperation = assertOperation(operation);
+  parseCycle(targetCycle);
+  const runState = await inspectProductionWorkflowRuns({ token, fetchImpl });
+  if (!runState.dispatch || selectedOperation !== 'prepare') return runState;
+  return inspectProductionPrepare({ targetCycle, token, fetchImpl });
+}
+
+export function buildProductionDispatch({
+  operation,
+  sourceCycle,
+  targetCycle,
+  requestId,
+} = {}) {
+  const selectedOperation = assertOperation(operation);
+  const cycles = assertConsecutiveCycles(sourceCycle, targetCycle);
+  const numericRequestId = assertRequestId(requestId);
+  return Object.freeze({
+    ref: MAIN_REF,
+    inputs: Object.freeze({
+      operation: selectedOperation,
+      'source-cycle': cycles.sourceCycle,
+      'target-cycle': cycles.targetCycle,
+      'verify-mode': 'prepared',
+      'request-id': numericRequestId,
+    }),
+    return_run_details: true,
+  });
+}
+
+export async function dispatchProductionWorkflow({
+  operation,
+  sourceCycle,
+  targetCycle,
+  requestId,
+  token,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const dispatch = buildProductionDispatch({
+    operation,
+    sourceCycle,
+    targetCycle,
+    requestId,
+  });
+  const runState = await inspectProductionWorkflowRuns({ token, fetchImpl });
+  if (!runState.dispatch) {
+    return Object.freeze({
+      dispatched: false,
+      reason: runState.reason,
+      blockingStatus: runState.blockingStatus,
+      blockingRunId: runState.blockingRunId,
+      blockingRunUrl: runState.blockingRunUrl,
+    });
+  }
+  const body = await githubJson(
+    `/repos/${OWNER}/${REPOSITORY}/actions/workflows/${PRODUCTION_WORKFLOW}/dispatches`,
+    {
+      token,
+      fetchImpl,
+      method: 'POST',
+      body: dispatch,
+      expectedStatus: 200,
+    },
+  );
+  const value = assertPlainObject(body);
+  const runId = assertPositiveInteger(value.workflow_run_id);
+  const apiUrl = workflowRunApiUrl(runId);
+  const htmlUrl = workflowRunHtmlUrl(runId);
+  if (value.run_url !== apiUrl || value.html_url !== htmlUrl) failClosed();
+  return Object.freeze({
+    dispatched: true,
+    reason: 'production-dispatched',
+    runId,
+    apiUrl,
+    htmlUrl,
+  });
+}
+
+function parseArgs(argv) {
+  if (!Array.isArray(argv) || argv.length < 1) failClosed();
+  const [command, ...tokens] = argv;
+  if (command !== 'dedupe' && command !== 'dispatch') failClosed();
+  if (tokens.length % 2 !== 0) failClosed();
+  const options = Object.create(null);
+  for (let index = 0; index < tokens.length; index += 2) {
+    const name = tokens[index];
+    const value = tokens[index + 1];
+    if (
+      typeof name !== 'string'
+      || !/^--[a-z][a-z0-9-]*$/.test(name)
+      || typeof value !== 'string'
+      || value.length === 0
+      || value.startsWith('--')
+    ) {
+      failClosed();
+    }
+    const key = name.slice(2);
+    if (Object.hasOwn(options, key)) failClosed();
+    options[key] = value;
+  }
+  const allowed = command === 'dedupe'
+    ? new Set(['operation', 'target-cycle'])
+    : new Set(['operation', 'source-cycle', 'target-cycle', 'request-id']);
+  if (Object.keys(options).some((key) => !allowed.has(key))) failClosed();
+  if (Object.keys(options).length !== allowed.size) failClosed();
+  for (const name of allowed) {
+    if (!Object.hasOwn(options, name)) failClosed();
+  }
+  return { command, options };
+}
+
+function assertPublicOutputValue(value) {
+  const text = String(value);
+  if (!/^[A-Za-z0-9:/._-]+$/.test(text) || /[\r\n]/.test(text)) failClosed();
+  return text;
+}
+
+function outputEntries(command, result) {
+  if (command === 'dedupe') {
+    if (
+      typeof result?.dispatch !== 'boolean'
+      || !DEDUPE_REASONS.has(result.reason)
+    ) {
+      failClosed();
+    }
+    const entries = [
+      ['dispatch', result.dispatch ? 'true' : 'false'],
+      ['dedupe-reason', result.reason],
+    ];
+    if (result.blockingStatus !== undefined) {
+      if (!NONTERMINAL_STATUS_SET.has(result.blockingStatus)) failClosed();
+      entries.push(['blocking-status', result.blockingStatus]);
+    }
+    if (result.blockingRunId !== undefined) entries.push(['blocking-run-id', result.blockingRunId]);
+    if (result.blockingRunUrl !== undefined) entries.push(['blocking-run-url', result.blockingRunUrl]);
+    if (result.pullNumber !== undefined) entries.push(['pull-number', result.pullNumber]);
+    if (result.pullUrl !== undefined) entries.push(['pull-url', result.pullUrl]);
+    return entries;
+  }
+  if (
+    typeof result?.dispatched !== 'boolean'
+    || !DISPATCH_REASONS.has(result.reason)
+    || result.dispatched !== (result.reason === 'production-dispatched')
+  ) {
+    failClosed();
+  }
+  const entries = [
+    ['dispatched', result.dispatched ? 'true' : 'false'],
+    ['dispatch-reason', result.reason],
+  ];
+  if (result.dispatched) {
+    const runId = assertPositiveInteger(result.runId);
+    if (
+      result.apiUrl !== workflowRunApiUrl(runId)
+      || result.htmlUrl !== workflowRunHtmlUrl(runId)
+    ) {
+      failClosed();
+    }
+    entries.push(
+      ['child-run-id', runId],
+      ['child-run-api-url', result.apiUrl],
+      ['child-run-html-url', result.htmlUrl],
+    );
+  } else {
+    if (!NONTERMINAL_STATUS_SET.has(result.blockingStatus)) failClosed();
+    const runId = assertPositiveInteger(result.blockingRunId);
+    if (result.blockingRunUrl !== workflowRunHtmlUrl(runId)) failClosed();
+    entries.push(
+      ['blocking-status', result.blockingStatus],
+      ['blocking-run-id', runId],
+      ['blocking-run-url', result.blockingRunUrl],
+    );
+  }
+  return entries;
+}
+
+async function appendPublicOutputs(command, result, {
+  outputPath,
+  appendFileImpl = appendFile,
+} = {}) {
+  if (
+    typeof outputPath !== 'string'
+    || outputPath.length < 1
+    || outputPath.length > 4096
+    || /[\0\r\n]/.test(outputPath)
+    || typeof appendFileImpl !== 'function'
+  ) {
+    failClosed();
+  }
+  const content = `${outputEntries(command, result)
+    .map(([key, value]) => `${key}=${assertPublicOutputValue(value)}`)
+    .join('\n')}\n`;
+  try {
+    await appendFileImpl(outputPath, content, 'utf8');
+  } catch {
+    failClosed();
+  }
+}
+
+export async function runSchedulerCli(argv, {
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  appendFileImpl = appendFile,
+} = {}) {
+  const { command, options } = parseArgs(argv);
+  const token = env?.GITHUB_TOKEN;
+  let result;
+  if (command === 'dedupe') {
+    result = await dedupeProductionDispatch({
+      operation: options.operation,
+      targetCycle: options['target-cycle'],
+      token,
+      fetchImpl,
+    });
+  } else {
+    result = await dispatchProductionWorkflow({
+      operation: options.operation,
+      sourceCycle: options['source-cycle'],
+      targetCycle: options['target-cycle'],
+      requestId: options['request-id'],
+      token,
+      fetchImpl,
+    });
+  }
+  await appendPublicOutputs(command, result, {
+    outputPath: env?.GITHUB_OUTPUT,
+    appendFileImpl,
+  });
+  return result;
+}
+
+async function main() {
+  try {
+    await runSchedulerCli(process.argv.slice(2));
+  } catch {
+    process.stderr.write(`${SAFE_FAILURE}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/.github/workflows/progress-prizes-production.yml
+++ b/.github/workflows/progress-prizes-production.yml
@@ -47,6 +47,7 @@ permissions: {}
 concurrency:
   group: progress-prizes-production
   cancel-in-progress: false
+  queue: max
 
 jobs:
   preflight:
@@ -762,6 +763,12 @@ jobs:
     name: Report a redacted scheduled production failure
     if: >-
       always() &&
+      github.repository == 'ScrollPrize/villa' &&
+      github.repository_id == '890972577' &&
+      github.repository_owner_id == '121906140' &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'ScrollPrize/villa/.github/workflows/progress-prizes-production.yml@refs/heads/main' &&
+      github.workflow_sha == github.sha &&
       inputs['request-id'] != '' &&
       (needs.preflight.result == 'failure' ||
        needs.validate.result == 'failure' ||

--- a/.github/workflows/progress-prizes-schedule.yml
+++ b/.github/workflows/progress-prizes-schedule.yml
@@ -1,0 +1,374 @@
+name: Progress Prize production schedule
+run-name: Progress Prize scheduler ${{ github.event_name }} run ${{ github.run_id }}
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * *"
+      timezone: America/Los_Angeles
+    - cron: "40 23 28-31 * *"
+      timezone: America/Los_Angeles
+    - cron: "17 0 1 * *"
+      timezone: America/Los_Angeles
+    - cron: "47 6 1 * *"
+      timezone: America/Los_Angeles
+
+permissions: {}
+
+concurrency:
+  group: progress-prizes-schedule
+  cancel-in-progress: false
+  queue: max
+
+jobs:
+  preflight:
+    name: Validate the secret-free scheduler context
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Reject untrusted triggers and refs
+        env:
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_ID: ${{ github.repository_id }}
+          REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+          REF: ${{ github.ref }}
+          HEAD_SHA: ${{ github.sha }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE_EXPRESSION: ${{ github.event.schedule || '' }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+
+          const allowedSchedules = new Set([
+            '17 6 * * *',
+            '40 23 28-31 * *',
+            '17 0 1 * *',
+            '47 6 1 * *',
+          ]);
+          assert.equal(process.env.REPOSITORY, 'ScrollPrize/villa');
+          assert.equal(process.env.REPOSITORY_ID, '890972577');
+          assert.equal(process.env.REPOSITORY_OWNER_ID, '121906140');
+          assert.equal(process.env.REF, 'refs/heads/main');
+          assert.match(process.env.HEAD_SHA ?? '', /^[a-f0-9]{40}$/);
+          assert.equal(process.env.WORKFLOW_SHA, process.env.HEAD_SHA);
+          assert.equal(
+            process.env.WORKFLOW_REF,
+            'ScrollPrize/villa/.github/workflows/progress-prizes-schedule.yml@refs/heads/main',
+          );
+          assert.match(process.env.RUN_ID ?? '', /^[1-9]\d*$/);
+          if (process.env.EVENT_NAME === 'schedule') {
+            assert.equal(allowedSchedules.has(process.env.SCHEDULE_EXPRESSION ?? ''), true);
+          } else {
+            assert.equal(process.env.EVENT_NAME, 'workflow_dispatch');
+            assert.equal(process.env.SCHEDULE_EXPRESSION, '');
+          }
+          NODE
+
+  plan:
+    name: Plan from the real Pacific clock
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      operation: ${{ steps.plan.outputs.operation }}
+      source-cycle: ${{ steps.plan.outputs['source-cycle'] }}
+      target-cycle: ${{ steps.plan.outputs['target-cycle'] }}
+      reason: ${{ steps.plan.outputs.reason }}
+    steps:
+      - name: Check out the exact trusted scheduler commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Validate context and select one operation
+        id: plan
+        env:
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_ID: ${{ github.repository_id }}
+          REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+          REF: ${{ github.ref }}
+          HEAD_SHA: ${{ github.sha }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE_EXPRESSION: ${{ github.event.schedule || '' }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          import { appendFile } from 'node:fs/promises';
+          import {
+            PROGRESS_PRIZE_SCHEDULES,
+            SCHEDULE_OPERATIONS,
+            planScheduleDispatch,
+          } from './scrollprize.org/scripts/progress-prizes/schedule.mjs';
+
+          assert.equal(process.env.REPOSITORY, 'ScrollPrize/villa');
+          assert.equal(process.env.REPOSITORY_ID, '890972577');
+          assert.equal(process.env.REPOSITORY_OWNER_ID, '121906140');
+          assert.equal(process.env.REF, 'refs/heads/main');
+          assert.match(process.env.HEAD_SHA ?? '', /^[a-f0-9]{40}$/);
+          assert.equal(process.env.WORKFLOW_SHA, process.env.HEAD_SHA);
+          assert.equal(
+            process.env.WORKFLOW_REF,
+            'ScrollPrize/villa/.github/workflows/progress-prizes-schedule.yml@refs/heads/main',
+          );
+          assert.equal(
+            new Set(['schedule', 'workflow_dispatch']).has(process.env.EVENT_NAME ?? ''),
+            true,
+          );
+
+          const scheduledCron = process.env.SCHEDULE_EXPRESSION || undefined;
+          if (process.env.EVENT_NAME === 'schedule') {
+            assert.equal(new Set(Object.values(PROGRESS_PRIZE_SCHEDULES)).has(scheduledCron), true);
+          } else {
+            assert.equal(scheduledCron, undefined);
+          }
+
+          const plan = planScheduleDispatch({
+            now: new Date(),
+            eventName: process.env.EVENT_NAME,
+            scheduledCron,
+          });
+          assert.equal(new Set(Object.values(SCHEDULE_OPERATIONS)).has(plan.operation), true);
+          assert.match(plan.sourceCycle, /^\d{4}-(?:0[1-9]|1[0-2])$/);
+          assert.match(plan.targetCycle, /^\d{4}-(?:0[1-9]|1[0-2])$/);
+          assert.match(plan.reason, /^[a-z0-9-]+$/);
+
+          await appendFile(
+            process.env.GITHUB_OUTPUT,
+            [
+              `operation=${plan.operation}`,
+              `source-cycle=${plan.sourceCycle}`,
+              `target-cycle=${plan.targetCycle}`,
+              `reason=${plan.reason}`,
+              '',
+            ].join('\n'),
+          );
+          await appendFile(
+            process.env.GITHUB_STEP_SUMMARY,
+            [
+              '### Progress Prize schedule decision',
+              '',
+              `- Operation: \`${plan.operation}\``,
+              `- Source cycle: \`${plan.sourceCycle}\``,
+              `- Target cycle: \`${plan.targetCycle}\``,
+              `- Reason: \`${plan.reason}\``,
+              `- Observed at: \`${plan.observedAt.toISOString()}\``,
+              '- Clock: `real America/Los_Angeles time`',
+              '',
+            ].join('\n'),
+          );
+          NODE
+
+  dedupe:
+    name: Refuse stale or duplicate production work
+    if: needs.plan.outputs.operation != 'none'
+    needs: plan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    outputs:
+      should-dispatch: ${{ steps.dedupe.outputs.dispatch }}
+      reason: ${{ steps.dedupe.outputs['dedupe-reason'] }}
+    steps:
+      - name: Check out the exact trusted coordination code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Inspect only the exact production workflow and page PR
+        id: dedupe
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPERATION: ${{ needs.plan.outputs.operation }}
+          TARGET_CYCLE: ${{ needs.plan.outputs['target-cycle'] }}
+        run: >-
+          node .github/progress-prizes-schedule.mjs dedupe
+          --operation "$OPERATION"
+          --target-cycle "$TARGET_CYCLE"
+      - name: Summarize the public deduplication decision
+        env:
+          DEDUPE_REASON: ${{ steps.dedupe.outputs['dedupe-reason'] }}
+          SHOULD_DISPATCH: ${{ steps.dedupe.outputs.dispatch }}
+        run: |
+          set -euo pipefail
+          [[ "$DEDUPE_REASON" =~ ^[a-z0-9-]+$ ]]
+          [[ "$SHOULD_DISPATCH" == true || "$SHOULD_DISPATCH" == false ]]
+          printf '%s\n' \
+            '### Production dispatch deduplication' \
+            '' \
+            "- Dispatch: \`$SHOULD_DISPATCH\`" \
+            "- Reason: \`$DEDUPE_REASON\`" \
+            '' >>"$GITHUB_STEP_SUMMARY"
+
+  dispatch:
+    name: Dispatch the guarded production workflow
+    if: needs.dedupe.outputs['should-dispatch'] == 'true'
+    needs:
+      - plan
+      - dedupe
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Check out the exact trusted dispatch code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Dispatch an exact real-clock operation
+        id: child
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPERATION: ${{ needs.plan.outputs.operation }}
+          SOURCE_CYCLE: ${{ needs.plan.outputs['source-cycle'] }}
+          TARGET_CYCLE: ${{ needs.plan.outputs['target-cycle'] }}
+          REQUEST_ID: ${{ github.run_id }}
+        run: >-
+          node .github/progress-prizes-schedule.mjs dispatch
+          --operation "$OPERATION"
+          --source-cycle "$SOURCE_CYCLE"
+          --target-cycle "$TARGET_CYCLE"
+          --request-id "$REQUEST_ID"
+      - name: Record the exact public child run
+        if: steps.child.outputs.dispatched == 'true'
+        env:
+          CHILD_RUN_ID: ${{ steps.child.outputs['child-run-id'] }}
+          CHILD_RUN_URL: ${{ steps.child.outputs['child-run-html-url'] }}
+        run: |
+          set -euo pipefail
+          [[ "$CHILD_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          test "$CHILD_RUN_URL" = \
+            "https://github.com/ScrollPrize/villa/actions/runs/$CHILD_RUN_ID"
+          printf '%s\n' \
+            '### Guarded production dispatch' \
+            '' \
+            "- Child run: [$CHILD_RUN_ID]($CHILD_RUN_URL)" \
+            '' >>"$GITHUB_STEP_SUMMARY"
+      - name: Record a race-safe duplicate suppression
+        if: steps.child.outputs.dispatched == 'false'
+        env:
+          DISPATCH_REASON: ${{ steps.child.outputs['dispatch-reason'] }}
+          BLOCKING_STATUS: ${{ steps.child.outputs['blocking-status'] }}
+        run: |
+          set -euo pipefail
+          test "$DISPATCH_REASON" = production-run-nonterminal
+          [[ "$BLOCKING_STATUS" =~ ^(requested|queued|pending|waiting|in_progress)$ ]]
+          printf '%s\n' \
+            '### Guarded production dispatch' \
+            '' \
+            '- Child dispatch: `suppressed`' \
+            "- Reason: \`$DISPATCH_REASON\`" \
+            "- Blocking state: \`$BLOCKING_STATUS\`" \
+            '' >>"$GITHUB_STEP_SUMMARY"
+
+  report-failure:
+    name: Report a redacted scheduler failure
+    if: >-
+      always() &&
+      github.repository == 'ScrollPrize/villa' &&
+      github.repository_id == '890972577' &&
+      github.repository_owner_id == '121906140' &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'ScrollPrize/villa/.github/workflows/progress-prizes-schedule.yml@refs/heads/main' &&
+      github.workflow_sha == github.sha &&
+      (needs.preflight.result == 'failure' ||
+       needs.plan.result == 'failure' ||
+       needs.dedupe.result == 'failure' ||
+       needs.dispatch.result == 'failure')
+    needs:
+      - preflight
+      - plan
+      - dedupe
+      - dispatch
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Create or reuse the fixed automation issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const title = '[automation] Progress Prize rollover needs attention';
+          const notice = [
+            'The secret-free Progress Prize scheduler did not complete.',
+            '',
+            `Review the redacted [Actions run](${process.env.RUN_URL}).`,
+            '',
+            'Google identifiers, ACL identities, and operation output are intentionally omitted.',
+          ].join('\n');
+
+          async function github(path, method = 'GET', body) {
+            const response = await fetch(`https://api.github.com${path}`, {
+              method,
+              redirect: 'error',
+              headers: {
+                accept: 'application/vnd.github+json',
+                authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                'content-type': 'application/json',
+                'user-agent': 'progress-prize-schedule-reporter',
+                'x-github-api-version': '2022-11-28',
+              },
+              body: body === undefined ? undefined : JSON.stringify(body),
+            });
+            if (!response.ok) throw new Error('Redacted scheduler issue reporting failed.');
+            return response.status === 204 ? undefined : response.json();
+          }
+
+          const query = new URLSearchParams({
+            q: `repo:ScrollPrize/villa is:issue is:open in:title "${title}"`,
+            per_page: '100',
+          });
+          const search = await github(`/search/issues?${query}`);
+          if (!Number.isInteger(search?.total_count) || search.total_count > 100) {
+            throw new Error('Redacted scheduler issue search is ambiguous.');
+          }
+          const existing = search.items.filter(
+            (issue) => !issue.pull_request && issue.title === title,
+          );
+          if (existing.length > 1) throw new Error('Redacted scheduler issue search is ambiguous.');
+          if (existing.length === 1) {
+            await github(
+              `/repos/ScrollPrize/villa/issues/${existing[0].number}/comments`,
+              'POST',
+              { body: notice },
+            );
+          } else {
+            await github('/repos/ScrollPrize/villa/issues', 'POST', { title, body: notice });
+          }
+          NODE

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -38,9 +38,10 @@ repository secret, file, log, cache, or artifact.
   `prepare`, `activate`, and `verify` operations after the complete staging
   rehearsal has passed. Every authenticated job is literal in that top-level
   workflow and calls the same local action exercised by staging.
-- Milestone 5 adds `progress-prizes-schedule.yml` only after production
-  `validate` and `dry-run` pass. Reaching `main` is what enables its Pacific-time
-  schedules.
+- `progress-prizes-schedule.yml` is the secret-free scheduler added only after
+  production `validate` and `dry-run` passed. Reaching `main` enables its
+  Pacific-time schedules; a manual dispatch is permanently restricted to a
+  read-only production dry-run.
 
 The workflows invoke:
 
@@ -394,11 +395,11 @@ the same staging identities, folder, clock rules, and smoke branches; the core
 also rejects fault injection unless every staging condition is true.
 
 The full rehearsal passed through verified cleanup before the production
-workflow was added. Merge the guarded production workflow, update the
-production WIF condition to its exact path, then dispatch production `validate`
-and `dry-run`. Add
-`progress-prizes-schedule.yml` only at the final schedule milestone: once it
-reaches `main`, GitHub enables the Pacific daily schedules.
+workflow was added. The guarded workflow was then merged, the production WIF
+condition was restricted to its exact path, and production `validate` and
+`dry-run` both passed on July 21, 2026. The scheduler is the final milestone:
+GitHub enables its Pacific schedules only after that reviewed file reaches
+`main`.
 
 ## Production operations and recovery
 
@@ -437,6 +438,43 @@ Never use simulated time, fault controls, alternate branches, or staging folders
 for production; those inputs are absent and the shared action rejects them
 before authentication.
 
+## Automated schedule and immediate smoke
+
+The scheduler owns no Google or Vercel configuration, protected Environment,
+OIDC permission, reusable credential, or repository secret. It runs only trusted
+code from the exact `main` commit, derives cycles from the real
+`America/Los_Angeles` clock, and uses the repository `GITHUB_TOKEN` solely to
+dispatch `progress-prizes-production.yml` on `main`. The dispatch response is
+bound to the exact child run ID and public Actions URL.
+
+- `06:17` Pacific is the daily preparation probe. It no-ops before the exact
+  seven-day window and after cutoff. Once an exact page-only draft PR already
+  sits directly above current `main`, it skips repeated preparation instead of
+  force-pushing a new commit and restarting checks.
+- `23:40` Pacific on candidate final days dispatches activation only when the
+  observed date is the actual last calendar day. The production workflow—not
+  the scheduler—runs tests and the Vercel gate, requests human approval, waits
+  for cutoff without a Google token, then authenticates.
+- `00:17` and `06:47` Pacific on the first day are independent recovery probes.
+  Delayed final-day events retain the previous source cycle through that first
+  day, while every day-two event no-ops. If an exact production run is already
+  nonterminal, the scheduler does not enqueue a stale duplicate.
+
+Production and scheduler concurrency groups never cancel an in-progress run and
+use GitHub's queued concurrency mode so a manual race cannot silently replace a
+pending cutoff run. The scheduler itself never sleeps. GitHub may delay or drop
+a scheduled event, and public-repository schedules can be disabled after 60 days
+without repository activity, so the production workflow keeps its manual
+`prepare` and `activate` recovery path.
+
+Immediately after the scheduler reaches `main`, manually dispatch **Progress
+Prize production schedule** once. Manual scheduler runs have no inputs and can
+only dispatch the real-clock production `dry-run`; they cannot prepare, close,
+open, share, publish, merge, or update the website. Verify that the scheduler's
+recorded child run is the exact successful read-only production run. Scheduled
+preparation must remain reviewer-free; the reviewer gate belongs only to the
+secret-free `progress-prizes-production-activation` Environment.
+
 ## Local verification
 
 No package installation is required for the automation tests:
@@ -451,11 +489,19 @@ Lint only the new workflows with actionlint (the repository has unrelated legacy
 workflow findings):
 
 ```bash
-actionlint ../.github/workflows/progress-prizes-*.yml
+actionlint \
+  -ignore 'unexpected key "queue" for "concurrency" section' \
+  ../.github/workflows/progress-prizes-*.yml
 ```
+
+The narrow ignore is for actionlint 1.7.12, released before GitHub added the
+valid `concurrency.queue: max` syntax in May 2026. It suppresses only that known
+schema-lag diagnostic; every other workflow finding remains fatal. Remove the
+ignore once a released actionlint understands queued concurrency.
 
 The rehearsal-foundation contract test checks immutable action pins, OIDC
 isolation, repository IDs, staging-only controls, exact-commit Vercel
 association, and trusted GitHub check provenance. The gated production and
-schedule milestones have separate contract tests so those files cannot be
-committed early merely to satisfy a foundation test.
+scheduler have separate executable contract tests for the clock boundaries,
+minimal permissions, deduplication, fixed dispatch endpoint, child-run binding,
+redacted failures, and absence of Google configuration.

--- a/scrollprize.org/scripts/progress-prizes/production-workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/production-workflow-contract.test.mjs
@@ -99,7 +99,10 @@ test('production accepts only a secret-free manual dispatch contract', async () 
   assert.doesNotMatch(source, /workflow_call:|pull_request(?:_target)?:/);
   assert.doesNotMatch(inputSection, /^  (?:schedule|repository_dispatch):/m);
   assert.doesNotMatch(inputSection, /^\s+(?:simulated-now|fault|base-branch|head-sha):/m);
-  assert.match(source, /^concurrency:\n  group: progress-prizes-production\n  cancel-in-progress: false$/m);
+  assert.match(
+    source,
+    /^concurrency:\n  group: progress-prizes-production\n  cancel-in-progress: false\n  queue: max$/m,
+  );
   assert.match(preflight, /permissions: \{\}/);
   assert.doesNotMatch(preflight, /environment:|id-token|secrets\./);
   assert.match(preflight, /assert\.equal\(process\.env\.REPOSITORY, 'ScrollPrize\/villa'\)/);

--- a/scrollprize.org/scripts/progress-prizes/schedule-github.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule-github.test.mjs
@@ -1,0 +1,718 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  MAX_GITHUB_RESPONSE_BYTES,
+  NONTERMINAL_RUN_STATUSES,
+  buildProductionDispatch,
+  dedupeProductionDispatch,
+  dispatchProductionWorkflow,
+  inspectProductionPrepare,
+  inspectProductionWorkflowRuns,
+  runSchedulerCli,
+} from '../../../.github/progress-prizes-schedule.mjs';
+
+const API = 'https://api.github.com';
+const WEB = 'https://github.com';
+const OWNER = 'ScrollPrize';
+const REPO = 'villa';
+const REPOSITORY_ID = 890972577;
+const TOKEN = 'github_pat_private_test_value';
+const SAFE_FAILURE = 'Progress Prize scheduler GitHub coordination failed safely.';
+const MAIN_SHA = 'a'.repeat(40);
+const STALE_SHA = 'b'.repeat(40);
+const HEAD_SHA = 'c'.repeat(40);
+const TARGET_CYCLE = '2026-08';
+const BRANCH = `codex/progress-prize-${TARGET_CYCLE}`;
+const WORKFLOW_RUNS_PATH = '/repos/ScrollPrize/villa/actions/workflows/progress-prizes-production.yml/runs';
+
+function repository() {
+  return { id: REPOSITORY_ID, full_name: `${OWNER}/${REPO}` };
+}
+
+function jsonResponse(body, { status = 200, headers = {} } = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+function workflowRun(status, id = 1234) {
+  return {
+    id,
+    status,
+    event: 'workflow_dispatch',
+    head_branch: 'main',
+    head_sha: 'd'.repeat(40),
+    path: '.github/workflows/progress-prizes-production.yml',
+    url: `${API}/repos/${OWNER}/${REPO}/actions/runs/${id}`,
+    html_url: `${WEB}/${OWNER}/${REPO}/actions/runs/${id}`,
+    repository: repository(),
+    head_repository: repository(),
+  };
+}
+
+function assertTrustedRequest(url, options, { method = 'GET' } = {}) {
+  assert.equal(options.method, method);
+  assert.equal(options.redirect, 'error');
+  assert.equal(options.headers.accept, 'application/vnd.github+json');
+  assert.equal(options.headers.authorization, `Bearer ${TOKEN}`);
+  assert.equal(options.headers['content-type'], 'application/json');
+  assert.equal(options.headers['user-agent'], 'progress-prize-trusted-scheduler');
+  assert.equal(options.headers['x-github-api-version'], '2022-11-28');
+  return new URL(url);
+}
+
+function runsResponse(parsed, { runsByStatus = {}, recentRuns = [] } = {}) {
+  assert.equal(parsed.pathname, WORKFLOW_RUNS_PATH);
+  assert.equal(parsed.searchParams.get('branch'), 'main');
+  assert.equal(parsed.searchParams.get('event'), 'workflow_dispatch');
+  const status = parsed.searchParams.get('status');
+  if (status === null) {
+    assert.equal(parsed.searchParams.get('per_page'), '10');
+    return jsonResponse({ total_count: recentRuns.length, workflow_runs: recentRuns });
+  }
+  assert.equal(parsed.searchParams.get('per_page'), '100');
+  assert.equal(NONTERMINAL_RUN_STATUSES.includes(status), true);
+  const runs = runsByStatus[status] ?? [];
+  return jsonResponse({ total_count: runs.length, workflow_runs: runs });
+}
+
+function runListFetch(runsByStatus = {}, { recentRuns = [] } = {}) {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    const parsed = assertTrustedRequest(url, options);
+    const status = parsed.searchParams.get('status');
+    calls.push(status ?? 'recent');
+    return runsResponse(parsed, { runsByStatus, recentRuns });
+  };
+  return { fetchImpl, calls };
+}
+
+function mainRefBody() {
+  return {
+    ref: 'refs/heads/main',
+    object: {
+      type: 'commit',
+      sha: MAIN_SHA,
+      url: `${API}/repos/${OWNER}/${REPO}/git/commits/${MAIN_SHA}`,
+    },
+  };
+}
+
+function pull(number = 42) {
+  return {
+    id: 9876 + number,
+    number,
+    state: 'open',
+    url: `${API}/repos/${OWNER}/${REPO}/pulls/${number}`,
+    html_url: `${WEB}/${OWNER}/${REPO}/pull/${number}`,
+    head: {
+      ref: BRANCH,
+      sha: HEAD_SHA,
+      repo: repository(),
+    },
+    base: {
+      ref: 'main',
+      sha: MAIN_SHA,
+      repo: repository(),
+    },
+  };
+}
+
+function pageOnlyCommit(parentSha = MAIN_SHA) {
+  return {
+    sha: HEAD_SHA,
+    url: `${API}/repos/${OWNER}/${REPO}/commits/${HEAD_SHA}`,
+    parents: [{ sha: parentSha }],
+    files: [{
+      filename: 'scrollprize.org/docs/34_prizes.md',
+      status: 'modified',
+    }],
+  };
+}
+
+function productionStateFetch({
+  pulls = [pull()],
+  commit = pageOnlyCommit(),
+} = {}) {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    const parsed = assertTrustedRequest(url, options);
+    calls.push(parsed.href);
+    if (parsed.pathname === WORKFLOW_RUNS_PATH) {
+      return runsResponse(parsed);
+    }
+    if (parsed.pathname === `/repos/${OWNER}/${REPO}/git/ref/heads/main`) {
+      return jsonResponse(mainRefBody());
+    }
+    if (parsed.pathname === `/repos/${OWNER}/${REPO}/pulls`) {
+      assert.equal(parsed.searchParams.get('state'), 'open');
+      assert.equal(parsed.searchParams.get('head'), `${OWNER}:${BRANCH}`);
+      assert.equal(parsed.searchParams.get('base'), 'main');
+      assert.equal(parsed.searchParams.get('per_page'), '2');
+      return jsonResponse(pulls);
+    }
+    if (parsed.pathname === `/repos/${OWNER}/${REPO}/commits/${HEAD_SHA}`) {
+      assert.equal(parsed.searchParams.get('per_page'), '2');
+      return jsonResponse(commit);
+    }
+    assert.fail(`Unexpected mocked request: ${parsed.href}`);
+  };
+  return { fetchImpl, calls };
+}
+
+async function thrownError(promise) {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  assert.fail('Expected operation to fail closed.');
+}
+
+test('every nonterminal production state suppresses dispatch', async (t) => {
+  for (const [index, status] of NONTERMINAL_RUN_STATUSES.entries()) {
+    await t.test(status, async () => {
+      const run = workflowRun(status, 1200 + index);
+      const { fetchImpl, calls } = runListFetch({ [status]: [run] });
+      const result = await inspectProductionWorkflowRuns({ token: TOKEN, fetchImpl });
+      assert.deepEqual(result, {
+        dispatch: false,
+        reason: 'production-run-nonterminal',
+        blockingStatus: status,
+        blockingRunId: run.id,
+        blockingRunUrl: run.html_url,
+      });
+      assert.deepEqual(new Set(calls), new Set([...NONTERMINAL_RUN_STATUSES, 'recent']));
+    });
+  }
+});
+
+test('production run fixture binds the API path without an @ref suffix to main', async () => {
+  const run = workflowRun('in_progress', 29857030793);
+  assert.equal(run.path, '.github/workflows/progress-prizes-production.yml');
+  assert.equal(run.head_branch, 'main');
+  const { fetchImpl } = runListFetch({ in_progress: [run] });
+  const result = await inspectProductionWorkflowRuns({ token: TOKEN, fetchImpl });
+  assert.equal(result.dispatch, false);
+  assert.equal(result.blockingRunId, 29857030793);
+});
+
+test('an exact empty scan of every nonterminal state allows dispatch', async () => {
+  const { fetchImpl, calls } = runListFetch();
+  assert.deepEqual(
+    await inspectProductionWorkflowRuns({ token: TOKEN, fetchImpl }),
+    { dispatch: true, reason: 'production-idle' },
+  );
+  assert.deepEqual(new Set(calls), new Set([...NONTERMINAL_RUN_STATUSES, 'recent']));
+});
+
+test('a final recent-run snapshot catches requested to queued scan crossings', async () => {
+  const blocker = workflowRun('queued', 2026072101);
+  let phase = 'requested';
+  const fetchImpl = async (url, options) => {
+    const parsed = assertTrustedRequest(url, options);
+    const status = parsed.searchParams.get('status');
+    if (status === 'requested') {
+      await new Promise((resolve) => setImmediate(resolve));
+      phase = 'queued';
+      return runsResponse(parsed);
+    }
+    if (status === 'queued') {
+      assert.equal(phase, 'requested');
+      return runsResponse(parsed);
+    }
+    if (status === null) {
+      assert.equal(phase, 'queued');
+      return runsResponse(parsed, { recentRuns: [blocker] });
+    }
+    return runsResponse(parsed);
+  };
+
+  assert.deepEqual(
+    await inspectProductionWorkflowRuns({ token: TOKEN, fetchImpl }),
+    {
+      dispatch: false,
+      reason: 'production-run-nonterminal',
+      blockingStatus: 'queued',
+      blockingRunId: blocker.id,
+      blockingRunUrl: blocker.html_url,
+    },
+  );
+});
+
+test('recent snapshot validates terminal run identity while allowing an idle result', async () => {
+  const completed = workflowRun('completed', 2026072102);
+  const { fetchImpl } = runListFetch({}, { recentRuns: [completed] });
+  assert.deepEqual(
+    await inspectProductionWorkflowRuns({ token: TOKEN, fetchImpl }),
+    { dispatch: true, reason: 'production-idle' },
+  );
+
+  completed.path = '.github/workflows/a-different-workflow.yml';
+  const malformed = runListFetch({}, { recentRuns: [completed] });
+  await assert.rejects(
+    inspectProductionWorkflowRuns({ token: TOKEN, fetchImpl: malformed.fetchImpl }),
+    { message: SAFE_FAILURE },
+  );
+});
+
+test('run inspection fails closed for malformed, mismatched, and oversized pages', async (t) => {
+  const cases = [
+    {
+      name: 'malformed JSON',
+      response: () => new Response(`{"private":"${TOKEN}"`, { status: 200 }),
+    },
+    {
+      name: 'oversized JSON',
+      response: () => new Response('x'.repeat(MAX_GITHUB_RESPONSE_BYTES + 1), { status: 200 }),
+    },
+    {
+      name: 'oversized count',
+      response: () => jsonResponse({ total_count: 101, workflow_runs: [] }),
+    },
+    {
+      name: 'status mismatch',
+      response: () => jsonResponse({
+        total_count: 1,
+        workflow_runs: [workflowRun('queued')],
+      }),
+    },
+    {
+      name: 'repository mismatch',
+      response: () => {
+        const run = workflowRun('requested');
+        run.repository.id += 1;
+        return jsonResponse({ total_count: 1, workflow_runs: [run] });
+      },
+    },
+  ];
+
+  for (const item of cases) {
+    await t.test(item.name, async () => {
+      const fetchImpl = async (url, options) => {
+        const parsed = assertTrustedRequest(url, options);
+        const status = parsed.searchParams.get('status');
+        if (status === 'requested') return item.response();
+        return jsonResponse({ total_count: 0, workflow_runs: [] });
+      };
+      const error = await thrownError(inspectProductionWorkflowRuns({ token: TOKEN, fetchImpl }));
+      assert.equal(error.message, SAFE_FAILURE);
+      assert.equal(error.message.includes(TOKEN), false);
+    });
+  }
+});
+
+test('prepare skips only one exact page-only PR directly above current main', async () => {
+  const { fetchImpl } = productionStateFetch();
+  assert.deepEqual(
+    await dedupeProductionDispatch({
+      operation: 'prepare',
+      targetCycle: TARGET_CYCLE,
+      token: TOKEN,
+      fetchImpl,
+    }),
+    {
+      dispatch: false,
+      reason: 'prepare-exact',
+      pullNumber: 42,
+      pullUrl: `${WEB}/${OWNER}/${REPO}/pull/42`,
+    },
+  );
+});
+
+test('prepare dispatches when its fixed PR does not exist', async () => {
+  const { fetchImpl } = productionStateFetch({ pulls: [] });
+  assert.deepEqual(
+    await inspectProductionPrepare({
+      targetCycle: TARGET_CYCLE,
+      token: TOKEN,
+      fetchImpl,
+    }),
+    { dispatch: true, reason: 'prepare-required' },
+  );
+});
+
+test('a stale page-only PR is refreshed rather than skipped', async () => {
+  const { fetchImpl } = productionStateFetch({ commit: pageOnlyCommit(STALE_SHA) });
+  assert.deepEqual(
+    await inspectProductionPrepare({
+      targetCycle: TARGET_CYCLE,
+      token: TOKEN,
+      fetchImpl,
+    }),
+    {
+      dispatch: true,
+      reason: 'prepare-refresh',
+      pullNumber: 42,
+      pullUrl: `${WEB}/${OWNER}/${REPO}/pull/42`,
+    },
+  );
+});
+
+test('a PR whose reported base is not current main is refreshed rather than skipped', async () => {
+  const mismatchedPull = pull();
+  mismatchedPull.base.sha = STALE_SHA;
+  const { fetchImpl } = productionStateFetch({ pulls: [mismatchedPull] });
+  assert.deepEqual(
+    await inspectProductionPrepare({
+      targetCycle: TARGET_CYCLE,
+      token: TOKEN,
+      fetchImpl,
+    }),
+    {
+      dispatch: true,
+      reason: 'prepare-refresh',
+      pullNumber: 42,
+      pullUrl: `${WEB}/${OWNER}/${REPO}/pull/42`,
+    },
+  );
+});
+
+test('ambiguous and malformed automation PR state fails closed', async (t) => {
+  await t.test('two matching PRs', async () => {
+    const { fetchImpl } = productionStateFetch({ pulls: [pull(42), pull(43)] });
+    await assert.rejects(
+      inspectProductionPrepare({ targetCycle: TARGET_CYCLE, token: TOKEN, fetchImpl }),
+      { message: SAFE_FAILURE },
+    );
+  });
+
+  await t.test('non-page-only commit', async () => {
+    const commit = pageOnlyCommit();
+    commit.files.push({ filename: 'README.md', status: 'modified' });
+    const { fetchImpl } = productionStateFetch({ commit });
+    await assert.rejects(
+      inspectProductionPrepare({ targetCycle: TARGET_CYCLE, token: TOKEN, fetchImpl }),
+      { message: SAFE_FAILURE },
+    );
+  });
+
+  await t.test('wrong fixed branch association', async () => {
+    const wrongPull = pull();
+    wrongPull.head.ref = 'codex/not-the-fixed-branch';
+    const { fetchImpl } = productionStateFetch({ pulls: [wrongPull] });
+    await assert.rejects(
+      inspectProductionPrepare({ targetCycle: TARGET_CYCLE, token: TOKEN, fetchImpl }),
+      { message: SAFE_FAILURE },
+    );
+  });
+});
+
+test('dispatch body is fixed, consecutive, prepared, and numeric', () => {
+  assert.deepEqual(
+    buildProductionDispatch({
+      operation: 'activate',
+      sourceCycle: '2026-12',
+      targetCycle: '2027-01',
+      requestId: 123456,
+    }),
+    {
+      ref: 'main',
+      inputs: {
+        operation: 'activate',
+        'source-cycle': '2026-12',
+        'target-cycle': '2027-01',
+        'verify-mode': 'prepared',
+        'request-id': '123456',
+      },
+      return_run_details: true,
+    },
+  );
+
+  assert.equal(
+    buildProductionDispatch({
+      operation: 'prepare',
+      sourceCycle: '2026-07',
+      targetCycle: '2026-08',
+      requestId: '9007199254740993',
+    }).inputs['request-id'],
+    '9007199254740993',
+  );
+
+  for (const input of [
+    { operation: 'none', sourceCycle: '2026-07', targetCycle: '2026-08', requestId: '1' },
+    { operation: 'prepare', sourceCycle: '2026-07', targetCycle: '2026-09', requestId: '1' },
+    { operation: 'prepare', sourceCycle: '2026-07', targetCycle: '2026-08', requestId: '01' },
+    { operation: 'prepare', sourceCycle: '2026-07', targetCycle: '2026-08', requestId: 'not-numeric' },
+  ]) {
+    assert.throws(() => buildProductionDispatch(input), { message: SAFE_FAILURE });
+  }
+});
+
+test('dispatch posts only the fixed production request and validates exact child URLs', async () => {
+  const childId = 7654321;
+  let calls = 0;
+  const fetchImpl = async (url, options) => {
+    calls += 1;
+    const parsed = new URL(url);
+    if (parsed.pathname === WORKFLOW_RUNS_PATH) {
+      assertTrustedRequest(url, options);
+      return runsResponse(parsed);
+    }
+    assertTrustedRequest(url, options, { method: 'POST' });
+    assert.equal(
+      parsed.pathname,
+      '/repos/ScrollPrize/villa/actions/workflows/progress-prizes-production.yml/dispatches',
+    );
+    assert.deepEqual(JSON.parse(options.body), {
+      ref: 'main',
+      inputs: {
+        operation: 'dry-run',
+        'source-cycle': '2026-07',
+        'target-cycle': '2026-08',
+        'verify-mode': 'prepared',
+        'request-id': '9988',
+      },
+      return_run_details: true,
+    });
+    return jsonResponse({
+      workflow_run_id: childId,
+      run_url: `${API}/repos/${OWNER}/${REPO}/actions/runs/${childId}`,
+      html_url: `${WEB}/${OWNER}/${REPO}/actions/runs/${childId}`,
+    });
+  };
+
+  assert.deepEqual(
+    await dispatchProductionWorkflow({
+      operation: 'dry-run',
+      sourceCycle: '2026-07',
+      targetCycle: '2026-08',
+      requestId: '9988',
+      token: TOKEN,
+      fetchImpl,
+    }),
+    {
+      dispatched: true,
+      reason: 'production-dispatched',
+      runId: childId,
+      apiUrl: `${API}/repos/${OWNER}/${REPO}/actions/runs/${childId}`,
+      htmlUrl: `${WEB}/${OWNER}/${REPO}/actions/runs/${childId}`,
+    },
+  );
+  assert.equal(calls, NONTERMINAL_RUN_STATUSES.length + 2);
+});
+
+test('dispatch rejects non-200, redirect, malformed URLs, and oversized bodies generically', async (t) => {
+  const childId = 77;
+  const bodies = [
+    {
+      name: 'non-200',
+      response: () => jsonResponse({ private: TOKEN }, { status: 403 }),
+    },
+    {
+      name: 'redirect',
+      response: () => new Response(null, { status: 302, headers: { location: 'https://example.test/' } }),
+    },
+    {
+      name: 'wrong child URL',
+      response: () => jsonResponse({
+        workflow_run_id: childId,
+        run_url: `${API}/repos/attacker/repository/actions/runs/${childId}`,
+        html_url: `${WEB}/${OWNER}/${REPO}/actions/runs/${childId}`,
+      }),
+    },
+    {
+      name: 'non-positive child ID',
+      response: () => jsonResponse({ workflow_run_id: 0, run_url: '', html_url: '' }),
+    },
+    {
+      name: 'oversized response',
+      response: () => new Response('x'.repeat(MAX_GITHUB_RESPONSE_BYTES + 1), { status: 200 }),
+    },
+  ];
+
+  for (const item of bodies) {
+    await t.test(item.name, async () => {
+      const fetchImpl = async (url, options) => {
+        const parsed = new URL(url);
+        if (parsed.pathname === WORKFLOW_RUNS_PATH) {
+          assertTrustedRequest(url, options);
+          return runsResponse(parsed);
+        }
+        assertTrustedRequest(url, options, { method: 'POST' });
+        return item.response();
+      };
+      const error = await thrownError(dispatchProductionWorkflow({
+        operation: 'prepare',
+        sourceCycle: '2026-07',
+        targetCycle: '2026-08',
+        requestId: '123',
+        token: TOKEN,
+        fetchImpl,
+      }));
+      assert.equal(error.message, SAFE_FAILURE);
+      assert.equal(error.message.includes(TOKEN), false);
+    });
+  }
+});
+
+test('dedupe CLI writes only public enums and run identifiers to GITHUB_OUTPUT', async () => {
+  const blocker = workflowRun('waiting', 20260720);
+  const { fetchImpl } = runListFetch({ waiting: [blocker] });
+  let appended;
+  const result = await runSchedulerCli([
+    'dedupe',
+    '--operation', 'activate',
+    '--target-cycle', TARGET_CYCLE,
+  ], {
+    env: { GITHUB_TOKEN: TOKEN, GITHUB_OUTPUT: '/tmp/github-output' },
+    fetchImpl,
+    appendFileImpl: async (path, content, encoding) => {
+      appended = { path, content, encoding };
+    },
+  });
+  assert.equal(result.dispatch, false);
+  assert.deepEqual(appended, {
+    path: '/tmp/github-output',
+    content: [
+      'dispatch=false',
+      'dedupe-reason=production-run-nonterminal',
+      'blocking-status=waiting',
+      'blocking-run-id=20260720',
+      `blocking-run-url=${WEB}/${OWNER}/${REPO}/actions/runs/20260720`,
+      '',
+    ].join('\n'),
+    encoding: 'utf8',
+  });
+  assert.equal(appended.content.includes(TOKEN), false);
+});
+
+test('dispatch CLI suppresses a run that appears after an idle dedupe without POSTing', async () => {
+  const blocker = workflowRun('queued', 2026072199);
+  let phase = 'dedupe';
+  let posted = false;
+  const fetchImpl = async (url, options) => {
+    const parsed = new URL(url);
+    if (parsed.pathname !== WORKFLOW_RUNS_PATH) {
+      posted = true;
+      assert.fail('A production dispatch must not be posted while another run is nonterminal.');
+    }
+    assertTrustedRequest(url, options);
+    if (phase === 'dedupe') return runsResponse(parsed);
+    const status = parsed.searchParams.get('status');
+    return runsResponse(parsed, {
+      runsByStatus: status === 'queued' ? { queued: [blocker] } : {},
+      recentRuns: status === null ? [blocker] : [],
+    });
+  };
+
+  let dedupeOutput = '';
+  const dedupe = await runSchedulerCli([
+    'dedupe',
+    '--operation', 'activate',
+    '--target-cycle', TARGET_CYCLE,
+  ], {
+    env: { GITHUB_TOKEN: TOKEN, GITHUB_OUTPUT: '/tmp/dedupe-output' },
+    fetchImpl,
+    appendFileImpl: async (_path, content) => {
+      dedupeOutput = content;
+    },
+  });
+  assert.deepEqual(dedupe, { dispatch: true, reason: 'production-idle' });
+  assert.equal(dedupeOutput, 'dispatch=true\ndedupe-reason=production-idle\n');
+
+  phase = 'dispatch';
+  let dispatchOutput = '';
+  const dispatch = await runSchedulerCli([
+    'dispatch',
+    '--operation', 'activate',
+    '--source-cycle', '2026-07',
+    '--target-cycle', TARGET_CYCLE,
+    '--request-id', '20260721',
+  ], {
+    env: { GITHUB_TOKEN: TOKEN, GITHUB_OUTPUT: '/tmp/dispatch-output' },
+    fetchImpl,
+    appendFileImpl: async (_path, content) => {
+      dispatchOutput = content;
+    },
+  });
+  assert.deepEqual(dispatch, {
+    dispatched: false,
+    reason: 'production-run-nonterminal',
+    blockingStatus: 'queued',
+    blockingRunId: blocker.id,
+    blockingRunUrl: blocker.html_url,
+  });
+  assert.equal(dispatchOutput, [
+    'dispatched=false',
+    'dispatch-reason=production-run-nonterminal',
+    'blocking-status=queued',
+    `blocking-run-id=${blocker.id}`,
+    `blocking-run-url=${blocker.html_url}`,
+    '',
+  ].join('\n'));
+  assert.equal(posted, false);
+  assert.equal(dispatchOutput.includes(TOKEN), false);
+});
+
+test('dispatch CLI exposes only the positive child ID and exact public URLs', async () => {
+  const childId = 20260801;
+  const fetchImpl = async (url, options) => {
+    const parsed = new URL(url);
+    if (parsed.pathname === WORKFLOW_RUNS_PATH) {
+      assertTrustedRequest(url, options);
+      return runsResponse(parsed);
+    }
+    assertTrustedRequest(url, options, { method: 'POST' });
+    return jsonResponse({
+      workflow_run_id: childId,
+      run_url: `${API}/repos/${OWNER}/${REPO}/actions/runs/${childId}`,
+      html_url: `${WEB}/${OWNER}/${REPO}/actions/runs/${childId}`,
+    });
+  };
+  let output = '';
+  await runSchedulerCli([
+    'dispatch',
+    '--operation', 'activate',
+    '--source-cycle', '2026-07',
+    '--target-cycle', TARGET_CYCLE,
+    '--request-id', '445566',
+  ], {
+    env: { GITHUB_TOKEN: TOKEN, GITHUB_OUTPUT: '/tmp/github-output' },
+    fetchImpl,
+    appendFileImpl: async (_path, content) => {
+      output = content;
+    },
+  });
+  assert.equal(output, [
+    'dispatched=true',
+    'dispatch-reason=production-dispatched',
+    'child-run-id=20260801',
+    `child-run-api-url=${API}/repos/${OWNER}/${REPO}/actions/runs/20260801`,
+    `child-run-html-url=${WEB}/${OWNER}/${REPO}/actions/runs/20260801`,
+    '',
+  ].join('\n'));
+  assert.equal(output.includes(TOKEN), false);
+});
+
+test('CLI failure neither writes outputs nor exposes token or response body', async () => {
+  const privateBody = `private-response-${TOKEN}`;
+  let appendCalled = false;
+  const error = await thrownError(runSchedulerCli([
+    'dispatch',
+    '--operation', 'prepare',
+    '--source-cycle', '2026-07',
+    '--target-cycle', TARGET_CYCLE,
+    '--request-id', '42',
+  ], {
+    env: { GITHUB_TOKEN: TOKEN, GITHUB_OUTPUT: '/tmp/github-output' },
+    fetchImpl: async (url, options) => {
+      const parsed = new URL(url);
+      if (parsed.pathname === WORKFLOW_RUNS_PATH) {
+        assertTrustedRequest(url, options);
+        return runsResponse(parsed);
+      }
+      assertTrustedRequest(url, options, { method: 'POST' });
+      return new Response(privateBody, { status: 500 });
+    },
+    appendFileImpl: async () => {
+      appendCalled = true;
+    },
+  }));
+  assert.equal(error.message, SAFE_FAILURE);
+  assert.equal(error.message.includes(TOKEN), false);
+  assert.equal(error.message.includes(privateBody), false);
+  assert.equal(appendCalled, false);
+});

--- a/scrollprize.org/scripts/progress-prizes/schedule-workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule-workflow-contract.test.mjs
@@ -1,0 +1,300 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const schedulePath = resolve(
+  repositoryRoot,
+  '.github/workflows/progress-prizes-schedule.yml',
+);
+const productionPath = resolve(
+  repositoryRoot,
+  '.github/workflows/progress-prizes-production.yml',
+);
+const helperPath = resolve(repositoryRoot, '.github/progress-prizes-schedule.mjs');
+
+async function source(path) {
+  return readFile(path, 'utf8');
+}
+
+function jobBlock(workflow, name) {
+  const marker = `  ${name}:\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${name} job`);
+  const remainder = workflow.slice(start + marker.length);
+  const next = remainder.search(/^  [a-z][a-z0-9-]*:\n/m);
+  return next === -1
+    ? workflow.slice(start)
+    : workflow.slice(start, start + marker.length + next);
+}
+
+function jobNames(workflow) {
+  const jobs = workflow.slice(workflow.indexOf('\njobs:\n') + '\njobs:\n'.length);
+  return [...jobs.matchAll(/^  ([a-z][a-z0-9-]*):\n/gm)].map((match) => match[1]);
+}
+
+function literalRunScripts(workflow) {
+  const lines = workflow.split('\n');
+  const scripts = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const run = lines[index].match(/^(\s*)run:\s*\|[-+]?\s*$/);
+    if (!run) continue;
+    let firstContent = index + 1;
+    while (firstContent < lines.length && lines[firstContent].trim() === '') firstContent += 1;
+    const contentIndent = lines[firstContent]?.match(/^ */)?.[0].length ?? 0;
+    assert.ok(contentIndent > run[1].length);
+    const body = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const line = lines[cursor];
+      const indentation = line.match(/^ */)?.[0].length ?? 0;
+      if (line.trim() !== '' && indentation < contentIndent) break;
+      body.push(line.trim() === '' ? '' : line.slice(contentIndent));
+    }
+    scripts.push(`${body.join('\n')}\n`);
+  }
+  return scripts;
+}
+
+test('scheduler exposes only a real-clock manual smoke and four Pacific schedules', async () => {
+  const workflow = await source(schedulePath);
+  const triggers = workflow.slice(0, workflow.indexOf('\npermissions:'));
+  const expectedCrons = [
+    '17 6 * * *',
+    '40 23 28-31 * *',
+    '17 0 1 * *',
+    '47 6 1 * *',
+  ];
+
+  assert.match(triggers, /^on:\n  workflow_dispatch:\n  schedule:/m);
+  assert.doesNotMatch(
+    triggers,
+    /^  (?:pull_request|pull_request_target|push|workflow_call|workflow_run|repository_dispatch):/m,
+  );
+  assert.doesNotMatch(triggers, /^    inputs:/m);
+  assert.deepEqual(
+    [...triggers.matchAll(/^    - cron: "([^"]+)"$/gm)].map((match) => match[1]),
+    expectedCrons,
+  );
+  assert.equal(
+    [...triggers.matchAll(/^      timezone: America\/Los_Angeles$/gm)].length,
+    expectedCrons.length,
+  );
+  for (const cron of expectedCrons) {
+    assert.notEqual(Number(cron.split(' ')[0]), 0, `${cron} must avoid minute zero`);
+  }
+});
+
+test('scheduler jobs keep GitHub write authority isolated from planning and Google', async () => {
+  const workflow = await source(schedulePath);
+  assert.match(workflow, /^permissions: \{\}$/m);
+  assert.match(
+    workflow,
+    /^concurrency:\n  group: progress-prizes-schedule\n  cancel-in-progress: false\n  queue: max$/m,
+  );
+  assert.deepEqual(
+    new Set(jobNames(workflow)),
+    new Set(['preflight', 'plan', 'dedupe', 'dispatch', 'report-failure']),
+  );
+
+  const preflight = jobBlock(workflow, 'preflight');
+  const plan = jobBlock(workflow, 'plan');
+  const dedupe = jobBlock(workflow, 'dedupe');
+  const dispatch = jobBlock(workflow, 'dispatch');
+  const reporter = jobBlock(workflow, 'report-failure');
+  assert.match(preflight, /permissions: \{\}/);
+  assert.doesNotMatch(preflight, /uses:/);
+  assert.match(plan, /permissions:\n      contents: read/);
+  assert.match(dedupe, /permissions:\n      actions: read\n      contents: read\n      pull-requests: read/);
+  assert.match(dispatch, /permissions:\n      actions: write\n      contents: read/);
+  assert.match(reporter, /permissions:\n      issues: write/);
+  assert.equal([...workflow.matchAll(/actions: write/g)].length, 1);
+  assert.equal([...workflow.matchAll(/issues: write/g)].length, 1);
+
+  assert.doesNotMatch(workflow, /id-token:|environment:|secrets\.|vars\./);
+  assert.doesNotMatch(
+    workflow,
+    /GOOGLE_(?:ACCESS_TOKEN|WORKLOAD_IDENTITY_PROVIDER|SERVICE_ACCOUNT)|PROGRESS_PRIZE_(?:DRIVE|FOLDER|SOURCE_FORM|EDITOR_GROUP)|VERCEL_/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /google-github-actions\/auth|actions\/(?:cache|upload-artifact|download-artifact)|secrets:\s*inherit/,
+  );
+  assert.doesNotMatch(workflow, /uses: \.\/\.github\/workflows\/progress-prizes-production\.yml/);
+});
+
+test('every scheduler checkout and third-party action is immutable', async () => {
+  const workflow = await source(schedulePath);
+  const approved = new Set([
+    'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0',
+    'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020',
+  ]);
+  for (const match of workflow.matchAll(/^\s*uses:\s*([^\s#]+).*$/gm)) {
+    assert.ok(approved.has(match[1]), match[1]);
+    assert.match(match[1], /@[a-f0-9]{40}$/);
+  }
+  const checkoutCount = [...workflow.matchAll(/uses: actions\/checkout@/g)].length;
+  assert.equal(checkoutCount, 3);
+  assert.equal([...workflow.matchAll(/ref: \$\{\{ github\.sha \}\}/g)].length, checkoutCount);
+  assert.equal([...workflow.matchAll(/persist-credentials: false/g)].length, checkoutCount);
+  assert.doesNotMatch(workflow, /ref: (?:main|refs\/heads\/main)$/m);
+});
+
+test('secret-free preflight executes an exact valid and invalid context matrix', async () => {
+  const workflow = await source(schedulePath);
+  const [guard] = literalRunScripts(jobBlock(workflow, 'preflight'));
+  assert.ok(guard);
+  const valid = {
+    REPOSITORY: 'ScrollPrize/villa',
+    REPOSITORY_ID: '890972577',
+    REPOSITORY_OWNER_ID: '121906140',
+    REF: 'refs/heads/main',
+    HEAD_SHA: 'a'.repeat(40),
+    WORKFLOW_REF: 'ScrollPrize/villa/.github/workflows/progress-prizes-schedule.yml@refs/heads/main',
+    WORKFLOW_SHA: 'a'.repeat(40),
+    EVENT_NAME: 'workflow_dispatch',
+    SCHEDULE_EXPRESSION: '',
+    RUN_ID: '12345',
+  };
+  const execute = (overrides = {}) => spawnSync(
+    'bash',
+    ['--noprofile', '--norc', '-c', guard],
+    { cwd: repositoryRoot, env: { ...process.env, ...valid, ...overrides }, encoding: 'utf8' },
+  );
+  assert.equal(execute().status, 0);
+  assert.equal(execute({
+    EVENT_NAME: 'schedule',
+    SCHEDULE_EXPRESSION: '17 6 * * *',
+  }).status, 0);
+  for (const overrides of [
+    { REPOSITORY_ID: '1' },
+    { REPOSITORY_OWNER_ID: '1' },
+    { REF: 'refs/heads/feature' },
+    { WORKFLOW_REF: 'ScrollPrize/villa/.github/workflows/other.yml@refs/heads/main' },
+    { WORKFLOW_SHA: 'b'.repeat(40) },
+    { EVENT_NAME: 'pull_request' },
+    { EVENT_NAME: 'schedule', SCHEDULE_EXPRESSION: '0 0 * * *' },
+    { EVENT_NAME: 'workflow_dispatch', SCHEDULE_EXPRESSION: '17 6 * * *' },
+    { RUN_ID: 'not-numeric' },
+  ]) {
+    assert.notEqual(execute(overrides).status, 0, JSON.stringify(overrides));
+  }
+  assert.doesNotMatch(guard, /ACTOR|actor/);
+});
+
+test('workflow wiring makes manual scheduler dispatch read-only dry-run only', async () => {
+  const workflow = await source(schedulePath);
+  const planJob = jobBlock(workflow, 'plan');
+  const [planScript] = literalRunScripts(planJob);
+  const temporary = await mkdtemp(join(tmpdir(), 'progress-prize-schedule-contract-'));
+  try {
+    const outputPath = join(temporary, 'output');
+    const summaryPath = join(temporary, 'summary');
+    const result = spawnSync('bash', ['--noprofile', '--norc', '-c', planScript], {
+      cwd: repositoryRoot,
+      env: {
+        ...process.env,
+        REPOSITORY: 'ScrollPrize/villa',
+        REPOSITORY_ID: '890972577',
+        REPOSITORY_OWNER_ID: '121906140',
+        REF: 'refs/heads/main',
+        HEAD_SHA: 'a'.repeat(40),
+        WORKFLOW_REF: 'ScrollPrize/villa/.github/workflows/progress-prizes-schedule.yml@refs/heads/main',
+        WORKFLOW_SHA: 'a'.repeat(40),
+        EVENT_NAME: 'workflow_dispatch',
+        SCHEDULE_EXPRESSION: '',
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_STEP_SUMMARY: summaryPath,
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const output = await readFile(outputPath, 'utf8');
+    assert.match(output, /^operation=dry-run$/m);
+    assert.doesNotMatch(output, /^operation=(?:prepare|activate)$/m);
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+});
+
+test('dedupe and dispatch use only the tested fixed helper contract', async () => {
+  const workflow = await source(schedulePath);
+  const helper = await source(helperPath);
+  const dedupe = jobBlock(workflow, 'dedupe');
+  const dispatch = jobBlock(workflow, 'dispatch');
+
+  assert.match(dedupe, /progress-prizes-schedule\.mjs dedupe/);
+  assert.match(dedupe, /--operation "\$OPERATION"/);
+  assert.match(dedupe, /--target-cycle "\$TARGET_CYCLE"/);
+  assert.match(dispatch, /needs\.dedupe\.outputs\['should-dispatch'\] == 'true'/);
+  assert.match(dispatch, /progress-prizes-schedule\.mjs dispatch/);
+  assert.match(dispatch, /--request-id "\$REQUEST_ID"/);
+  assert.match(dispatch, /REQUEST_ID: \$\{\{ github\.run_id \}\}/);
+  assert.match(dispatch, /if: steps\.child\.outputs\.dispatched == 'true'/);
+  assert.match(dispatch, /if: steps\.child\.outputs\.dispatched == 'false'/);
+  assert.match(dispatch, /production-run-nonterminal/);
+
+  assert.match(
+    helper,
+    /\/actions\/workflows\/\$\{PRODUCTION_WORKFLOW\}\/dispatches/,
+  );
+  assert.match(helper, /const PRODUCTION_WORKFLOW = 'progress-prizes-production\.yml'/);
+  assert.match(helper, /ref: MAIN_REF/);
+  assert.match(helper, /return_run_details: true/);
+  assert.match(helper, /expectedStatus: 200/);
+  assert.match(helper, /redirect: 'error'/);
+  assert.match(helper, /MAX_GITHUB_RESPONSE_BYTES = 256 \* 1024/);
+  assert.match(helper, /new Set\(\['dry-run', 'prepare', 'activate'\]\)/);
+  assert.match(helper, /'requested'[\s\S]*'queued'[\s\S]*'pending'[\s\S]*'waiting'[\s\S]*'in_progress'/);
+  assert.match(
+    helper,
+    /export async function dispatchProductionWorkflow[\s\S]*const runState = await inspectProductionWorkflowRuns[\s\S]*if \(!runState\.dispatch\)[\s\S]*githubJson\(/,
+  );
+  assert.doesNotMatch(
+    helper,
+    /actions\/(?:runs\/[^'"`]*\/(?:cancel|rerun|approve)|workflows\/[^'"`]*\/(?:enable|disable))/,
+  );
+});
+
+test('scheduler never waits or exposes simulated and staging controls', async () => {
+  const workflow = await source(schedulePath);
+  assert.doesNotMatch(workflow, /\bsleep\b|setTimeout|simulated-now|SIMULATED_NOW|fault-injection|after-copy|after-close-source/);
+  assert.doesNotMatch(workflow, /staging-folder|archive-folder|smoke-branch/);
+});
+
+test('redacted reporting is main-bound and cannot expose operation responses', async () => {
+  const workflow = await source(schedulePath);
+  const reporter = jobBlock(workflow, 'report-failure');
+  assert.match(reporter, /github\.ref == 'refs\/heads\/main'/);
+  assert.match(reporter, /github\.workflow_sha == github\.sha/);
+  assert.match(reporter, /issues: write/);
+  assert.match(reporter, /Google identifiers, ACL identities, and operation output are intentionally omitted/);
+  assert.doesNotMatch(reporter, /needs\.plan\.outputs|steps\.child\.outputs|response\.text/);
+});
+
+test('production remains dispatch-only, queued, and WIF-isolated from scheduler', async () => {
+  const production = await source(productionPath);
+  const readme = await source(resolve(
+    repositoryRoot,
+    'scrollprize.org/scripts/progress-prizes/README.md',
+  ));
+  const triggers = production.slice(0, production.indexOf('\npermissions:'));
+  assert.match(triggers, /^on:\n  workflow_dispatch:/m);
+  assert.doesNotMatch(triggers, /^  (?:schedule|workflow_call|repository_dispatch|pull_request):/m);
+  assert.match(
+    production,
+    /^concurrency:\n  group: progress-prizes-production\n  cancel-in-progress: false\n  queue: max$/m,
+  );
+  assert.match(
+    readme,
+    /attribute\.workflow_ref == 'ScrollPrize\/villa\/\.github\/workflows\/progress-prizes-production\.yml@refs\/heads\/main'/,
+  );
+  assert.match(readme, /attribute\.event_name == 'workflow_dispatch'/);
+  assert.doesNotMatch(
+    readme,
+    /attribute\.workflow_ref == 'ScrollPrize\/villa\/\.github\/workflows\/progress-prizes-schedule\.yml/,
+  );
+});

--- a/scrollprize.org/scripts/progress-prizes/schedule.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule.mjs
@@ -1,0 +1,346 @@
+import { parseInstant } from './clock.mjs';
+import {
+  PACIFIC_TIME_ZONE,
+  daysInMonth,
+  formatCycle,
+  getCycleDeadline,
+  getPacificParts,
+  nextCycle,
+  pacificDateTimeToInstant,
+  previousCycle,
+  subtractPacificCalendarDays,
+} from './dates.mjs';
+
+export const SCHEDULE_CRONS = Object.freeze({
+  PREPARE: '17 6 * * *',
+  PRE_CUTOFF: '40 23 28-31 * *',
+  EARLY_RECOVERY: '17 0 1 * *',
+  LATE_RECOVERY: '47 6 1 * *',
+});
+
+// Workflow-facing alias kept explicit so the public control contract reads as
+// Progress Prize-specific at the dispatch boundary.
+export const PROGRESS_PRIZE_SCHEDULES = SCHEDULE_CRONS;
+
+export const SCHEDULE_OPERATIONS = Object.freeze({
+  NONE: 'none',
+  DRY_RUN: 'dry-run',
+  PREPARE: 'prepare',
+  ACTIVATE: 'activate',
+});
+
+export const SCHEDULE_REASONS = Object.freeze({
+  OUTSIDE_WINDOW: 'outside-window',
+  WRONG_SLOT: 'wrong-schedule-slot',
+  SLOT_NOT_DUE: 'schedule-slot-not-due',
+  MANUAL_DRY_RUN: 'manual-dry-run',
+  PREPARATION: 'preparation-window',
+  PRE_CUTOFF: 'pre-cutoff',
+  EARLY_RECOVERY: 'early-recovery',
+  LATE_RECOVERY: 'late-recovery',
+});
+
+const ALLOWED_EVENTS = new Set(['schedule', 'workflow_dispatch']);
+const ALLOWED_CRONS = new Set(Object.values(SCHEDULE_CRONS));
+const ACTIVATION_CRONS = new Set([
+  SCHEDULE_CRONS.PRE_CUTOFF,
+  SCHEDULE_CRONS.EARLY_RECOVERY,
+  SCHEDULE_CRONS.LATE_RECOVERY,
+]);
+const PREPARATION_DAYS = 7;
+
+function calendarDate({ year, month, day }) {
+  return Object.freeze({ year, month, day });
+}
+
+function previousCalendarDate(parts) {
+  const date = new Date(0);
+  date.setUTCFullYear(parts.year, parts.month - 1, parts.day);
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return calendarDate({
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+  });
+}
+
+function isFirstDay(parts) {
+  return parts.day === 1;
+}
+
+function isLastDay(parts) {
+  return parts.day === daysInMonth(parts.year, parts.month);
+}
+
+function cronWallTime(cron) {
+  if (cron === SCHEDULE_CRONS.PREPARE) return Object.freeze({ hour: 6, minute: 17 });
+  if (cron === SCHEDULE_CRONS.PRE_CUTOFF) return Object.freeze({ hour: 23, minute: 40 });
+  if (cron === SCHEDULE_CRONS.EARLY_RECOVERY) return Object.freeze({ hour: 0, minute: 17 });
+  if (cron === SCHEDULE_CRONS.LATE_RECOVERY) return Object.freeze({ hour: 6, minute: 47 });
+  throw new TypeError('scheduledCron is outside the Progress Prize schedule allowlist');
+}
+
+function scheduledOriginDate(observedAt, local, cron) {
+  const { hour, minute } = cronWallTime(cron);
+  const scheduledToday = pacificDateTimeToInstant({
+    year: local.year,
+    month: local.month,
+    day: local.day,
+    hour,
+    minute,
+  });
+  return observedAt >= scheduledToday
+    ? calendarDate(local)
+    : previousCalendarDate(local);
+}
+
+function assertTrigger({ eventName, scheduledCron }) {
+  if (!ALLOWED_EVENTS.has(eventName)) {
+    throw new TypeError('eventName must be schedule or workflow_dispatch');
+  }
+  if (eventName === 'schedule') {
+    if (typeof scheduledCron !== 'string' || !ALLOWED_CRONS.has(scheduledCron)) {
+      throw new TypeError('scheduledCron is outside the Progress Prize schedule allowlist');
+    }
+    return scheduledCron;
+  }
+  if (scheduledCron !== undefined && scheduledCron !== null && scheduledCron !== '') {
+    throw new Error('workflow_dispatch must not claim a scheduled cron slot');
+  }
+  return '';
+}
+
+function noDispatch({
+  eventName,
+  scheduledCron,
+  observedAt,
+  reason,
+  sourceCycle,
+  targetCycle,
+}) {
+  return Object.freeze({
+    dispatch: false,
+    operation: SCHEDULE_OPERATIONS.NONE,
+    reason,
+    eventName,
+    scheduledCron,
+    timeZone: PACIFIC_TIME_ZONE,
+    observedAt,
+    sourceCycle,
+    targetCycle,
+    preparationOpensAt: null,
+    activationAt: null,
+  });
+}
+
+function dispatchPlan({
+  operation,
+  reason,
+  eventName,
+  scheduledCron,
+  observedAt,
+  sourceCycle,
+  targetCycle,
+  preparationOpensAt,
+  activationAt,
+}) {
+  return Object.freeze({
+    dispatch: true,
+    operation,
+    reason,
+    eventName,
+    scheduledCron,
+    timeZone: PACIFIC_TIME_ZONE,
+    observedAt,
+    sourceCycle,
+    targetCycle,
+    preparationOpensAt,
+    activationAt,
+  });
+}
+
+function classifyObservedTime(observedAt, local) {
+  const localCycle = formatCycle(local.year, local.month);
+
+  // The whole first Pacific calendar day is reserved for bounded activation
+  // recovery. A run delayed into day two must never select the previous cycle.
+  if (isFirstDay(local)) {
+    const sourceCycle = previousCycle(localCycle);
+    const activationAt = getCycleDeadline(sourceCycle).cutoffAt;
+    const lateRecoveryAt = pacificDateTimeToInstant({
+      year: local.year,
+      month: local.month,
+      day: 1,
+      hour: 6,
+      minute: 47,
+    });
+    return {
+      operation: SCHEDULE_OPERATIONS.ACTIVATE,
+      reason: observedAt < lateRecoveryAt
+        ? SCHEDULE_REASONS.EARLY_RECOVERY
+        : SCHEDULE_REASONS.LATE_RECOVERY,
+      sourceCycle,
+      targetCycle: localCycle,
+      preparationOpensAt: subtractPacificCalendarDays(activationAt, PREPARATION_DAYS),
+      activationAt,
+    };
+  }
+
+  const sourceCycle = localCycle;
+  const targetCycle = nextCycle(sourceCycle);
+  const sourceDeadline = getCycleDeadline(sourceCycle);
+  const preparationOpensAt = subtractPacificCalendarDays(
+    sourceDeadline.cutoffAt,
+    PREPARATION_DAYS,
+  );
+  const preCutoffAt = pacificDateTimeToInstant({
+    year: sourceDeadline.year,
+    month: sourceDeadline.month,
+    day: sourceDeadline.day,
+    hour: 23,
+    minute: 40,
+  });
+
+  if (observedAt >= preCutoffAt && observedAt < sourceDeadline.cutoffAt) {
+    return {
+      operation: SCHEDULE_OPERATIONS.ACTIVATE,
+      reason: SCHEDULE_REASONS.PRE_CUTOFF,
+      sourceCycle,
+      targetCycle,
+      preparationOpensAt,
+      activationAt: sourceDeadline.cutoffAt,
+    };
+  }
+  if (observedAt >= preparationOpensAt && observedAt < preCutoffAt) {
+    return {
+      operation: SCHEDULE_OPERATIONS.PREPARE,
+      reason: SCHEDULE_REASONS.PREPARATION,
+      sourceCycle,
+      targetCycle,
+      preparationOpensAt,
+      activationAt: sourceDeadline.cutoffAt,
+    };
+  }
+  return undefined;
+}
+
+function scheduledActivationIsDue({ scheduledCron, observedAt, local }) {
+  if (scheduledCron === SCHEDULE_CRONS.PRE_CUTOFF) {
+    // The pre-cutoff cron cannot originate on day one (its day-of-month field
+    // is 28-31), so every first-day observation is a delayed final-day event,
+    // even after the 23:40 wall-clock time has passed again.
+    return isLastDay(local)
+      || (isFirstDay(local) && isLastDay(previousCalendarDate(local)));
+  }
+  const origin = scheduledOriginDate(observedAt, local, scheduledCron);
+  return isFirstDay(origin) && isFirstDay(local);
+}
+
+/**
+ * Select at most one secret-free production dispatch from the real observed
+ * instant and its trusted GitHub trigger context.
+ *
+ * Schedule slots are intentionally not interchangeable: only the daily 06:17
+ * slot can prepare. The three activation slots may recover a delayed final-day
+ * run during the first Pacific day, but never during day two.
+ */
+export function planScheduleDispatch({
+  now = new Date(),
+  eventName,
+  scheduledCron,
+} = {}) {
+  const observedAt = parseInstant(now, 'now');
+  const trustedCron = assertTrigger({ eventName, scheduledCron });
+  const local = getPacificParts(observedAt);
+  const currentPacificCycle = formatCycle(local.year, local.month);
+
+  // A manual scheduler run is a smoke test of the dispatch chain, never an
+  // authority to prepare or activate. It derives the current Pacific source
+  // month and asks the production workflow for its independently guarded,
+  // read-only dry-run.
+  if (eventName === 'workflow_dispatch') {
+    const sourceCycle = currentPacificCycle;
+    const targetCycle = nextCycle(sourceCycle);
+    const activationAt = getCycleDeadline(sourceCycle).cutoffAt;
+    return dispatchPlan({
+      operation: SCHEDULE_OPERATIONS.DRY_RUN,
+      reason: SCHEDULE_REASONS.MANUAL_DRY_RUN,
+      eventName,
+      scheduledCron: trustedCron,
+      observedAt,
+      sourceCycle,
+      targetCycle,
+      preparationOpensAt: subtractPacificCalendarDays(activationAt, PREPARATION_DAYS),
+      activationAt,
+    });
+  }
+
+  const classified = classifyObservedTime(observedAt, local);
+
+  if (classified === undefined) {
+    return noDispatch({
+      eventName,
+      scheduledCron: trustedCron,
+      observedAt,
+      reason: SCHEDULE_REASONS.OUTSIDE_WINDOW,
+      sourceCycle: currentPacificCycle,
+      targetCycle: nextCycle(currentPacificCycle),
+    });
+  }
+
+  if (eventName === 'schedule') {
+    if (classified.operation === SCHEDULE_OPERATIONS.PREPARE) {
+      if (trustedCron !== SCHEDULE_CRONS.PREPARE) {
+        return noDispatch({
+          eventName,
+          scheduledCron: trustedCron,
+          observedAt,
+          reason: SCHEDULE_REASONS.WRONG_SLOT,
+          sourceCycle: classified.sourceCycle,
+          targetCycle: classified.targetCycle,
+        });
+      }
+    } else if (
+      !ACTIVATION_CRONS.has(trustedCron)
+      || !scheduledActivationIsDue({ scheduledCron: trustedCron, observedAt, local })
+    ) {
+      return noDispatch({
+        eventName,
+        scheduledCron: trustedCron,
+        observedAt,
+        reason: ACTIVATION_CRONS.has(trustedCron)
+          ? SCHEDULE_REASONS.SLOT_NOT_DUE
+          : SCHEDULE_REASONS.WRONG_SLOT,
+        sourceCycle: classified.sourceCycle,
+        targetCycle: classified.targetCycle,
+      });
+    }
+  }
+
+  return dispatchPlan({
+    ...classified,
+    eventName,
+    scheduledCron: trustedCron,
+    observedAt,
+  });
+}
+
+export function serializeScheduleDispatch(plan) {
+  if (plan === null || typeof plan !== 'object') {
+    throw new TypeError('plan must be a schedule dispatch plan');
+  }
+  return Object.freeze({
+    dispatch: plan.dispatch,
+    operation: plan.operation,
+    reason: plan.reason,
+    eventName: plan.eventName,
+    scheduledCron: plan.scheduledCron,
+    timeZone: plan.timeZone,
+    observedAt: plan.observedAt.toISOString(),
+    sourceCycle: plan.sourceCycle,
+    targetCycle: plan.targetCycle,
+    preparationOpensAt: plan.preparationOpensAt?.toISOString() ?? '',
+    activationAt: plan.activationAt?.toISOString() ?? '',
+  });
+}

--- a/scrollprize.org/scripts/progress-prizes/schedule.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule.test.mjs
@@ -1,0 +1,262 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PROGRESS_PRIZE_SCHEDULES,
+  SCHEDULE_CRONS,
+  SCHEDULE_OPERATIONS,
+  SCHEDULE_REASONS,
+  planScheduleDispatch,
+  serializeScheduleDispatch,
+} from './schedule.mjs';
+
+function plan(now, scheduledCron, eventName = 'schedule') {
+  return planScheduleDispatch({ now, eventName, scheduledCron });
+}
+
+test('schedule constants use the four exact Pacific cron slots', () => {
+  assert.deepEqual(SCHEDULE_CRONS, {
+    PREPARE: '17 6 * * *',
+    PRE_CUTOFF: '40 23 28-31 * *',
+    EARLY_RECOVERY: '17 0 1 * *',
+    LATE_RECOVERY: '47 6 1 * *',
+  });
+  assert.equal(PROGRESS_PRIZE_SCHEDULES, SCHEDULE_CRONS);
+});
+
+test('only the preparation slot dispatches during the seven-day window', () => {
+  const preparation = plan('2026-07-28T13:17:00Z', SCHEDULE_CRONS.PREPARE);
+  assert.equal(preparation.dispatch, true);
+  assert.equal(preparation.operation, SCHEDULE_OPERATIONS.PREPARE);
+  assert.equal(preparation.reason, SCHEDULE_REASONS.PREPARATION);
+  assert.equal(preparation.sourceCycle, '2026-07');
+  assert.equal(preparation.targetCycle, '2026-08');
+
+  const candidateActivation = plan(
+    '2026-07-29T06:40:00Z',
+    SCHEDULE_CRONS.PRE_CUTOFF,
+  );
+  assert.equal(candidateActivation.dispatch, false);
+  assert.equal(candidateActivation.operation, SCHEDULE_OPERATIONS.NONE);
+  assert.equal(candidateActivation.reason, SCHEDULE_REASONS.WRONG_SLOT);
+
+  for (const cron of [SCHEDULE_CRONS.EARLY_RECOVERY, SCHEDULE_CRONS.LATE_RECOVERY]) {
+    const wrongSlot = plan('2026-07-28T13:17:00Z', cron);
+    assert.equal(wrongSlot.dispatch, false);
+    assert.equal(wrongSlot.reason, SCHEDULE_REASONS.WRONG_SLOT);
+  }
+});
+
+test('scheduled planning has exact seven-day preparation boundaries', () => {
+  const before = planScheduleDispatch({
+    now: '2026-07-25T06:59:59.999Z',
+    eventName: 'schedule',
+    scheduledCron: SCHEDULE_CRONS.PREPARE,
+  });
+  assert.equal(before.dispatch, false);
+  assert.equal(before.reason, SCHEDULE_REASONS.OUTSIDE_WINDOW);
+
+  const opens = planScheduleDispatch({
+    now: '2026-07-25T07:00:00Z',
+    eventName: 'schedule',
+    scheduledCron: SCHEDULE_CRONS.PREPARE,
+  });
+  assert.equal(opens.operation, SCHEDULE_OPERATIONS.PREPARE);
+  assert.equal(opens.preparationOpensAt.toISOString(), '2026-07-25T07:00:00.000Z');
+  assert.equal(opens.activationAt.toISOString(), '2026-08-01T07:00:00.000Z');
+
+  const lastPreparationInstant = planScheduleDispatch({
+    now: '2026-08-01T06:39:59.999Z',
+    eventName: 'schedule',
+    scheduledCron: SCHEDULE_CRONS.PREPARE,
+  });
+  assert.equal(lastPreparationInstant.operation, SCHEDULE_OPERATIONS.PREPARE);
+});
+
+test('preparation boundaries follow Pacific calendar days in PST and leap February', () => {
+  const november = plan('2026-11-24T14:17:00Z', SCHEDULE_CRONS.PREPARE);
+  assert.equal(november.operation, SCHEDULE_OPERATIONS.PREPARE);
+  assert.equal(november.sourceCycle, '2026-11');
+  assert.equal(november.targetCycle, '2026-12');
+  assert.equal(november.preparationOpensAt.toISOString(), '2026-11-24T08:00:00.000Z');
+
+  const ordinaryFebruary = plan('2027-02-22T14:17:00Z', SCHEDULE_CRONS.PREPARE);
+  assert.equal(ordinaryFebruary.operation, SCHEDULE_OPERATIONS.PREPARE);
+  assert.equal(ordinaryFebruary.preparationOpensAt.toISOString(), '2027-02-22T08:00:00.000Z');
+
+  const leapBefore = plan('2028-02-22T14:17:00Z', SCHEDULE_CRONS.PREPARE);
+  assert.equal(leapBefore.operation, SCHEDULE_OPERATIONS.NONE);
+  const leapOpens = plan('2028-02-23T14:17:00Z', SCHEDULE_CRONS.PREPARE);
+  assert.equal(leapOpens.operation, SCHEDULE_OPERATIONS.PREPARE);
+  assert.equal(leapOpens.preparationOpensAt.toISOString(), '2028-02-23T08:00:00.000Z');
+});
+
+test('the final-day 23:40 slot dispatches before both PDT and PST cutoffs', () => {
+  const pdt = plan('2026-08-01T06:40:00Z', SCHEDULE_CRONS.PRE_CUTOFF);
+  assert.equal(pdt.operation, SCHEDULE_OPERATIONS.ACTIVATE);
+  assert.equal(pdt.reason, SCHEDULE_REASONS.PRE_CUTOFF);
+  assert.equal(pdt.sourceCycle, '2026-07');
+  assert.equal(pdt.targetCycle, '2026-08');
+  assert.equal(pdt.activationAt.toISOString(), '2026-08-01T07:00:00.000Z');
+
+  const pst = plan('2027-01-01T07:40:00Z', SCHEDULE_CRONS.PRE_CUTOFF);
+  assert.equal(pst.operation, SCHEDULE_OPERATIONS.ACTIVATE);
+  assert.equal(pst.reason, SCHEDULE_REASONS.PRE_CUTOFF);
+  assert.equal(pst.sourceCycle, '2026-12');
+  assert.equal(pst.targetCycle, '2027-01');
+  assert.equal(pst.activationAt.toISOString(), '2027-01-01T08:00:00.000Z');
+});
+
+test('candidate pre-cutoff dates validate the actual last Pacific day', () => {
+  const july28 = plan('2026-07-29T06:40:00Z', SCHEDULE_CRONS.PRE_CUTOFF);
+  assert.equal(july28.dispatch, false);
+
+  const april30 = plan('2027-05-01T06:40:00Z', SCHEDULE_CRONS.PRE_CUTOFF);
+  assert.equal(april30.dispatch, true);
+  assert.equal(april30.sourceCycle, '2027-04');
+  assert.equal(april30.targetCycle, '2027-05');
+});
+
+test('leap February uses February 29 while non-leap February uses February 28', () => {
+  const leapCandidate = plan('2028-02-29T07:40:00Z', SCHEDULE_CRONS.PRE_CUTOFF);
+  assert.equal(leapCandidate.dispatch, false);
+
+  const leapLastDay = plan('2028-03-01T07:40:00Z', SCHEDULE_CRONS.PRE_CUTOFF);
+  assert.equal(leapLastDay.dispatch, true);
+  assert.equal(leapLastDay.sourceCycle, '2028-02');
+  assert.equal(leapLastDay.targetCycle, '2028-03');
+  assert.equal(leapLastDay.activationAt.toISOString(), '2028-03-01T08:00:00.000Z');
+
+  const ordinaryLastDay = plan('2027-03-01T07:40:00Z', SCHEDULE_CRONS.PRE_CUTOFF);
+  assert.equal(ordinaryLastDay.dispatch, true);
+  assert.equal(ordinaryLastDay.sourceCycle, '2027-02');
+  assert.equal(ordinaryLastDay.targetCycle, '2027-03');
+});
+
+test('first-day recovery slots dispatch at 00:17 and 06:47 Pacific', () => {
+  const early = plan('2026-08-01T07:17:00Z', SCHEDULE_CRONS.EARLY_RECOVERY);
+  assert.equal(early.operation, SCHEDULE_OPERATIONS.ACTIVATE);
+  assert.equal(early.reason, SCHEDULE_REASONS.EARLY_RECOVERY);
+  assert.equal(early.sourceCycle, '2026-07');
+  assert.equal(early.targetCycle, '2026-08');
+
+  const late = plan('2026-08-01T13:47:00Z', SCHEDULE_CRONS.LATE_RECOVERY);
+  assert.equal(late.operation, SCHEDULE_OPERATIONS.ACTIVATE);
+  assert.equal(late.reason, SCHEDULE_REASONS.LATE_RECOVERY);
+  assert.equal(late.sourceCycle, '2026-07');
+  assert.equal(late.targetCycle, '2026-08');
+});
+
+test('delayed activation events recover by their actual first-day Pacific window', () => {
+  const delayedPreCutoff = plan('2026-08-01T07:43:00Z', SCHEDULE_CRONS.PRE_CUTOFF);
+  assert.equal(delayedPreCutoff.operation, SCHEDULE_OPERATIONS.ACTIVATE);
+  assert.equal(delayedPreCutoff.reason, SCHEDULE_REASONS.EARLY_RECOVERY);
+
+  const earlyDelayedPastLateSlot = plan(
+    '2026-08-01T16:05:00Z',
+    SCHEDULE_CRONS.EARLY_RECOVERY,
+  );
+  assert.equal(earlyDelayedPastLateSlot.operation, SCHEDULE_OPERATIONS.ACTIVATE);
+  assert.equal(earlyDelayedPastLateSlot.reason, SCHEDULE_REASONS.LATE_RECOVERY);
+
+  const lateDelayedToEvening = plan(
+    '2026-08-02T05:59:59Z',
+    SCHEDULE_CRONS.LATE_RECOVERY,
+  );
+  assert.equal(lateDelayedToEvening.operation, SCHEDULE_OPERATIONS.ACTIVATE);
+  assert.equal(lateDelayedToEvening.reason, SCHEDULE_REASONS.LATE_RECOVERY);
+
+  const preCutoffDelayedToEndOfFirstDay = plan(
+    '2026-08-02T06:59:59Z',
+    SCHEDULE_CRONS.PRE_CUTOFF,
+  );
+  assert.equal(preCutoffDelayedToEndOfFirstDay.operation, SCHEDULE_OPERATIONS.ACTIVATE);
+  assert.equal(preCutoffDelayedToEndOfFirstDay.sourceCycle, '2026-07');
+});
+
+test('day-two delays always no-op instead of selecting a stale cycle', () => {
+  for (const cron of [
+    SCHEDULE_CRONS.PRE_CUTOFF,
+    SCHEDULE_CRONS.EARLY_RECOVERY,
+    SCHEDULE_CRONS.LATE_RECOVERY,
+  ]) {
+    const dayTwo = plan('2026-08-02T07:17:00Z', cron);
+    assert.equal(dayTwo.dispatch, false, cron);
+    assert.equal(dayTwo.operation, SCHEDULE_OPERATIONS.NONE, cron);
+    assert.equal(dayTwo.reason, SCHEDULE_REASONS.OUTSIDE_WINDOW, cron);
+    assert.equal(dayTwo.sourceCycle, '2026-08');
+    assert.equal(dayTwo.targetCycle, '2026-09');
+  }
+});
+
+test('manual dispatch is always a real-clock dry-run with consecutive Pacific cycles', () => {
+  const preparation = planScheduleDispatch({
+    now: '2026-07-28T13:17:00Z',
+    eventName: 'workflow_dispatch',
+  });
+  assert.equal(preparation.dispatch, true);
+  assert.equal(preparation.operation, SCHEDULE_OPERATIONS.DRY_RUN);
+  assert.equal(preparation.reason, SCHEDULE_REASONS.MANUAL_DRY_RUN);
+  assert.equal(preparation.sourceCycle, '2026-07');
+  assert.equal(preparation.targetCycle, '2026-08');
+
+  const activation = planScheduleDispatch({
+    now: '2026-08-01T20:00:00Z',
+    eventName: 'workflow_dispatch',
+  });
+  assert.equal(activation.operation, SCHEDULE_OPERATIONS.DRY_RUN);
+  assert.equal(activation.reason, SCHEDULE_REASONS.MANUAL_DRY_RUN);
+  assert.equal(activation.sourceCycle, '2026-08');
+  assert.equal(activation.targetCycle, '2026-09');
+
+  const noOp = planScheduleDispatch({
+    now: '2026-08-02T20:00:00Z',
+    eventName: 'workflow_dispatch',
+  });
+  assert.equal(noOp.operation, SCHEDULE_OPERATIONS.DRY_RUN);
+  assert.equal(noOp.sourceCycle, '2026-08');
+  assert.equal(noOp.targetCycle, '2026-09');
+});
+
+test('unknown trigger contexts and cron claims fail closed', () => {
+  assert.throws(
+    () => planScheduleDispatch({ now: '2026-07-28T13:17:00Z', eventName: 'pull_request' }),
+    /eventName/,
+  );
+  assert.throws(
+    () => plan('2026-07-28T13:17:00Z', '0 0 * * *'),
+    /allowlist/,
+  );
+  assert.throws(
+    () => planScheduleDispatch({
+      now: '2026-07-28T13:17:00Z',
+      eventName: 'workflow_dispatch',
+      scheduledCron: SCHEDULE_CRONS.PREPARE,
+    }),
+    /must not claim/,
+  );
+  assert.throws(
+    () => planScheduleDispatch({ now: '2026-07-28T13:17:00', eventName: 'workflow_dispatch' }),
+    /explicit offset/,
+  );
+});
+
+test('serialized plans expose only stable public control fields', () => {
+  const serialized = serializeScheduleDispatch(plan(
+    '2026-08-01T06:40:00Z',
+    SCHEDULE_CRONS.PRE_CUTOFF,
+  ));
+  assert.deepEqual(serialized, {
+    dispatch: true,
+    operation: 'activate',
+    reason: 'pre-cutoff',
+    eventName: 'schedule',
+    scheduledCron: '40 23 28-31 * *',
+    timeZone: 'America/Los_Angeles',
+    observedAt: '2026-08-01T06:40:00.000Z',
+    sourceCycle: '2026-07',
+    targetCycle: '2026-08',
+    preparationOpensAt: '2026-07-25T07:00:00.000Z',
+    activationAt: '2026-08-01T07:00:00.000Z',
+  });
+});

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -23,6 +23,7 @@ const workflowNames = [
   'progress-prizes-pr-safety.yml',
   'progress-prizes-production.yml',
   'progress-prizes-rehearsal.yml',
+  'progress-prizes-schedule.yml',
   'progress-prizes-vercel-preview.yml',
 ];
 const googleJobNames = [


### PR DESCRIPTION
## Summary

- add a real-clock, Pacific-time scheduler for preparation and activation recovery
- keep manual scheduler dispatch read-only and production Google access isolated in the existing guarded workflow
- deduplicate production runs and prepared page-only PRs before dispatch
- retain required human approval only for production activation
- document the recovery and public-repository security model

## Verification

- `npm test`: 290 passed, 0 failed
- Node syntax checks passed
- workflow lint passed with the exact documented schema-lag exception for GitHub `concurrency.queue`
- `git diff --check` passed
- staged-content scan: all 10 protected Google values, email literals, and key markers had zero matches
- independent security audit: no actionable findings

## Deployment

This PR does not modify the live July form. After checks pass, the merged scheduler will first be manually dispatched in dry-run-only mode; real activation remains protected by the `progress-prizes-production-activation` reviewer gate.