### PR TITLE
spiral: clamp bilinear atlas lookups inside the addressed patch

### DIFF
--- a/volume-cartographer/scripts/spiral/fit_spiral.py
+++ b/volume-cartographer/scripts/spiral/fit_spiral.py
@@ -664,6 +664,7 @@ class PatchGpuAtlas:
             self.widths,
             patch_idx_per_sample,
             ijs,
+            heights=self.heights,
         )
 
     def append_patches(self, patches_by_id):

--- a/volume-cartographer/scripts/spiral/geom_utils.py
+++ b/volume-cartographer/scripts/spiral/geom_utils.py
@@ -42,15 +42,30 @@ def expm_2x2(L):
 
 
 @maybe_compile
-def bilinear_atlas_lookup(zyxs_flat, offsets, widths, patch_indices, ijs):
-    """Bilinearly sample packed patch grids at fractional ``(i, j)`` coordinates."""
+def bilinear_atlas_lookup(zyxs_flat, offsets, widths, patch_indices, ijs, heights=None):
+    """Bilinearly sample packed patch grids at fractional ``(i, j)`` coordinates.
+
+    When ``heights`` is given, the four bilinear corners are clamped inside the
+    addressed patch. Callers relying on "floor(ij) lies on a valid quad" should
+    pass it: jitters drawn as float64 in [0, 1) and cast to float32 can round
+    to exactly 1.0, which pushes a sample one cell past the last valid quad
+    row/column - the corner gather then silently reads the next patch's first
+    row (or trips a device-side assert on the atlas's last patch).
+    """
     base = offsets[patch_indices]
     width = widths[patch_indices]
     ijs = ijs.to(torch.float32)
     i0 = ijs[..., 0].floor().to(torch.int64)
     j0 = ijs[..., 1].floor().to(torch.int64)
-    di = (ijs[..., 0] - i0.to(torch.float32)).unsqueeze(-1)
-    dj = (ijs[..., 1] - j0.to(torch.float32)).unsqueeze(-1)
+    if heights is not None:
+        height = heights[patch_indices]
+        i0 = torch.minimum(i0.clamp(min=0), height - 2)
+        j0 = torch.minimum(j0.clamp(min=0), width - 2)
+        di = (ijs[..., 0] - i0.to(torch.float32)).unsqueeze(-1).clamp(0., 1.)
+        dj = (ijs[..., 1] - j0.to(torch.float32)).unsqueeze(-1).clamp(0., 1.)
+    else:
+        di = (ijs[..., 0] - i0.to(torch.float32)).unsqueeze(-1)
+        dj = (ijs[..., 1] - j0.to(torch.float32)).unsqueeze(-1)
 
     flat_tl = base + i0 * width + j0
     tl = zyxs_flat[flat_tl]

--- a/volume-cartographer/scripts/spiral/tests/test_speedup_equivalence.py
+++ b/volume-cartographer/scripts/spiral/tests/test_speedup_equivalence.py
@@ -538,5 +538,46 @@ class TritonGapExpanderTests(unittest.TestCase):
         self._run_case('inverse', 0.37)
 
 
+class BilinearAtlasLookupClampTest(unittest.TestCase):
+    """Edge samples must stay inside their patch (float32-rounded jitter can
+    reach exactly 1.0 and floor one cell past the last valid quad row/col)."""
+
+    def _make_atlas(self):
+        # two patches with distinct, recognisable values
+        a = torch.arange(4 * 5 * 3, dtype=torch.float32).reshape(4, 5, 3)
+        b = 1000. + torch.arange(3 * 4 * 3, dtype=torch.float32).reshape(3, 4, 3)
+        zyxs_flat = torch.cat([a.reshape(-1, 3), b.reshape(-1, 3)], dim=0)
+        offsets = torch.tensor([0, 20, 32], dtype=torch.int64)
+        widths = torch.tensor([5, 4], dtype=torch.int64)
+        heights = torch.tensor([4, 3], dtype=torch.int64)
+        return a, b, zyxs_flat, offsets, widths, heights
+
+    def test_edge_sample_stays_in_patch(self):
+        from geom_utils import bilinear_atlas_lookup
+        a, b, zyxs_flat, offsets, widths, heights = self._make_atlas()
+        # i lands exactly on the last row of patch 0 (jitter rounded to 1.0)
+        ij = torch.tensor([[3.0, 2.5]], dtype=torch.float32)
+        idx = torch.tensor([0], dtype=torch.int64)
+        out = bilinear_atlas_lookup(zyxs_flat, offsets, widths, idx, ij,
+                                    heights=heights)
+        # clamped to the (2, 2)-(3, 3) quad at di=1: row 3 interpolated at j=2.5
+        expected = (a[3, 2] + a[3, 3]) / 2
+        torch.testing.assert_close(out[0], expected)
+        # without the clamp the same sample reads into patch 1's first row
+        leaked = bilinear_atlas_lookup(zyxs_flat, offsets, widths, idx, ij)
+        self.assertGreater(float(leaked.max()), 999.)
+
+    def test_last_patch_edge_does_not_index_oob(self):
+        from geom_utils import bilinear_atlas_lookup
+        _a, _b, zyxs_flat, offsets, widths, heights = self._make_atlas()
+        ij = torch.tensor([[2.0, 3.0]], dtype=torch.float32)  # last row+col
+        idx = torch.tensor([1], dtype=torch.int64)
+        out = bilinear_atlas_lookup(zyxs_flat, offsets, widths, idx, ij,
+                                    heights=heights)
+        self.assertTrue(bool(torch.isfinite(out).all()))
+        with self.assertRaises(IndexError):
+            bilinear_atlas_lookup(zyxs_flat, offsets, widths, idx, ij)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Bug

`_sample_patch_tracks` draws per-strip jitters as float64 in `[0, 1)` and casts them to float32 (`losses.py`, `rand(N).astype(np.float32)`). Values within `2^-25` of 1.0 round to **exactly 1.0**, so a sample lands one full cell past the last valid quad row/column of its patch. `bilinear_atlas_lookup` then builds corner indices without bounds checks:

- on a multi-patch atlas, `flat_bl = base + i0 * width + j0` walks into the **next patch's first row** — a silent wrong-patch read that corrupts the interpolated value;
- on the atlas's **last** patch it walks off the flat buffer — CUDA device-side assert (`index out of bounds` in an IndexKernel) that kills the run.

The event is rare (~3e-8 per draw) so large runs mostly see occasional silent corruption. With a single small verified patch it is a hard, deterministic crash: seed 1 reproduces it at step 1217 (twice in our runs); a `CUDA_LAUNCH_BLOCKING=1` traceback lands on the corner gather in `PatchGpuAtlas.lookup`.

We hit this while running `fit_spiral.py` on PHerc1218 with a single synthesized seed patch (context: https://github.com/IyanDopico/vesuvius-sheet-tools — first spiral-fit input pack for that scroll).

## Fix

`bilinear_atlas_lookup` gains an optional `heights` argument. When provided, the four bilinear corners are clamped inside the addressed patch (`i0 <= H-2`, `j0 <= W-2`, `di`/`dj` clamped to `[0, 1]`), which turns the rounding edge case into a correct last-quad interpolation. `PatchGpuAtlas.lookup` passes its `heights`; callers that omit the argument keep the previous behavior, so nothing else changes.

## Test

`BilinearAtlasLookupClampTest` (in `tests/test_speedup_equivalence.py`) builds a tiny two-patch atlas and covers both failure modes on CPU:
- an edge sample on patch 0 that, unclamped, reads patch 1's values — clamped, it returns the correct last-row interpolation;
- the same sample on the last patch, which raises `IndexError` unclamped and returns finite values clamped.

## Validation

The same clamp, applied as a runtime patch, took our PHerc1218 fit from a deterministic crash at step 1217 to a clean 30,000-step run end-to-end (97.8%/98.4% constraint satisfaction on relative-/same-winding point collections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
