### PR TITLE
VC3D: cross-fiber link workflow in the Line Annotation GUI

### DIFF
--- a/volume-cartographer/apps/VC3D/CFiberWidget.cpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.cpp
@@ -37,6 +37,7 @@ namespace {
 enum FiberColumn {
     kNameColumn = 0,
     kDirectionColumn,
+    kLinkColumn,
     kLengthColumn,
     kControlPointsColumn,
     kLinePointsColumn,
@@ -328,6 +329,7 @@ void CFiberWidget::setupUi()
     _model->setHorizontalHeaderLabels({
         tr("name"),
         tr("dir"),
+        tr("link"),
         tr("len"),
         tr("cps"),
         tr("pts"),
@@ -353,6 +355,7 @@ void CFiberWidget::setupUi()
     _treeView->header()->setSortIndicator(_sortColumn, _sortOrder);
     _treeView->setColumnWidth(kNameColumn, 220);
     _treeView->setColumnWidth(kDirectionColumn, 42);
+    _treeView->setColumnWidth(kLinkColumn, 42);
     _treeView->setColumnWidth(kLengthColumn, 72);
     _treeView->setColumnWidth(kControlPointsColumn, 48);
     _treeView->setColumnWidth(kLinePointsColumn, 48);
@@ -654,6 +657,7 @@ void CFiberWidget::rebuildModel()
     _model->setHorizontalHeaderLabels({
         tr("name"),
         tr("dir"),
+        tr("link"),
         tr("len"),
         tr("cps"),
         tr("pts"),
@@ -669,6 +673,9 @@ void CFiberWidget::rebuildModel()
         QList<QStandardItem*> row{
             readOnlyItem(displayNameForFiber(fiber)),
             readOnlyItem(directionForFiber(fiber)),
+            readOnlyItem(fiber.linkedFiberCount > 0
+                             ? QString::number(fiber.linkedFiberCount)
+                             : QString()),
             readOnlyItem(formatDouble(fiber.lengthVx, 1)),
             readOnlyItem(QString::number(fiber.controlPointCount)),
             readOnlyItem(QString::number(fiber.linePointCount)),
@@ -687,6 +694,7 @@ void CFiberWidget::rebuildModel()
             QList<QStandardItem*> childRow{
                 readOnlyItem(spanName),
                 readOnlyItem(directionForFiber(fiber)),
+                readOnlyItem(QString()),
                 readOnlyItem(formatDouble(span.lengthVx, 1)),
                 readOnlyItem(QString::number(span.controlPointCount)),
                 readOnlyItem(QString::number(span.linePointCount)),
@@ -815,6 +823,10 @@ void CFiberWidget::sortFibers()
             less = compareText(a, b);
             break;
         }
+        case kLinkColumn:
+            different = lhs.linkedFiberCount != rhs.linkedFiberCount;
+            less = compareNumber(lhs.linkedFiberCount, rhs.linkedFiberCount);
+            break;
         case kLengthColumn:
             different = lhs.lengthVx != rhs.lengthVx;
             less = compareNumber(lhs.lengthVx, rhs.lengthVx);

--- a/volume-cartographer/apps/VC3D/CFiberWidget.hpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.hpp
@@ -59,6 +59,7 @@ public:
         std::string automaticHvTag;
         std::string manualHvTag;
         std::vector<std::string> tags;
+        int linkedFiberCount = 0;
     };
 
     explicit CFiberWidget(QWidget* parent = nullptr);

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -7474,6 +7474,7 @@ void CWindow::CreateWidgets(void)
                     fiber.automaticHvTag,
                     fiber.manualHvTag,
                     fiber.tags,
+                    fiber.linkedFiberCount,
                 });
             }
             if (_fiberWidget) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -7135,6 +7135,9 @@ LineAnnotationController::OptimizationTaskResult LineAnnotationController::runOp
 
 void LineAnnotationController::loadFibersForCurrentPackage()
 {
+    // Runtime fiber ids are reassigned per package load; a surviving candidate
+    // could silently point at an unrelated fiber with the same id.
+    _linkCandidate.reset();
     _fibers.clear();
     _fiberAlignmentMetrics.clear();
     _pendingFiberAlignmentMetrics.clear();

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -2028,6 +2028,36 @@ bool LineAnnotationController::launchSession(LineAnnotationController::SourceKin
                 openFiberAtControlPoint(branchFiberId, branchControlPointIndex);
             });
     connect(dialog,
+            &LineAnnotationDialog::generatedControlPointLinkCandidateRequested,
+            this,
+            [this](const std::string& name, size_t controlPointIndex, cv::Vec3f volumePoint) {
+                handleGeneratedControlPointLinkCandidate(name, controlPointIndex, volumePoint);
+            });
+    connect(dialog,
+            &LineAnnotationDialog::generatedControlPointLinkWithCandidateRequested,
+            this,
+            [this](const std::string& name, size_t controlPointIndex, cv::Vec3f volumePoint) {
+                handleGeneratedControlPointLinkWithCandidate(name, controlPointIndex, volumePoint);
+            });
+    connect(dialog,
+            &LineAnnotationDialog::generatedNearbyAnnotationOpenRequested,
+            this,
+            [this](uint64_t fiberId, cv::Vec3f volumePoint) {
+                handleGeneratedOpenNearbyAnnotation(fiberId, volumePoint);
+            });
+    connect(dialog,
+            &LineAnnotationDialog::generatedControlPointUnlinkRequested,
+            this,
+            [this](const std::string& name,
+                   size_t controlPointIndex,
+                   uint64_t branchFiberId,
+                   int branchControlPointIndex) {
+                handleGeneratedControlPointUnlink(name,
+                                                  controlPointIndex,
+                                                  branchFiberId,
+                                                  branchControlPointIndex);
+            });
+    connect(dialog,
             &LineAnnotationDialog::generatedPredSnapPointRequested,
             this,
             [this](const std::string& name, cv::Vec3f volumePoint) {
@@ -2381,6 +2411,12 @@ void LineAnnotationController::deleteFibers(std::vector<uint64_t> fiberIds)
     }
     if (deletedIds.empty()) {
         return;
+    }
+
+    if (_linkCandidate && std::binary_search(deletedIds.begin(),
+                                             deletedIds.end(),
+                                             _linkCandidate->fiberId)) {
+        _linkCandidate.reset();
     }
 
     _fibers.erase(std::remove_if(_fibers.begin(),
@@ -4041,7 +4077,7 @@ void LineAnnotationController::rebuildIntersectionInspection()
                             vc3d::line_annotation::GeneratedViews views;
                             views.linePoints = generatedLinePoints(linePoints);
                             views.lineUpVectors = lineUpVectors;
-                            views.controlPoints = generatedControlMarkers(session->controlPoints, session->branches);
+                            views.controlPoints = controlMarkersForSession(*session);
                             views.branchLinePoints = generatedBranchLinePointsForSession(*session);
                             views.branchLinks = generatedBranchLinkMarkers(session->branches);
                             views.predSnapPoints =
@@ -4164,7 +4200,7 @@ void LineAnnotationController::rebuildIntersectionInspection()
                     vc3d::line_annotation::GeneratedViews views;
                     views.linePoints = generatedLinePoints(linePoints);
                     views.lineUpVectors = lineUpVectors;
-                    views.controlPoints = generatedControlMarkers(session->controlPoints, session->branches);
+                    views.controlPoints = controlMarkersForSession(*session);
                     views.branchLinePoints = generatedBranchLinePointsForSession(*session);
                     views.branchLinks = generatedBranchLinkMarkers(session->branches);
                     views.predSnapPoints =
@@ -4506,6 +4542,54 @@ void LineAnnotationController::closeFiberWindowForSurface(const std::string& sur
     }
 }
 
+std::vector<vc3d::line_annotation::GeneratedOverlay::ControlPointMarker>
+LineAnnotationController::controlMarkersForSession(const LineAnnotationSession& session) const
+{
+    auto markers = generatedControlMarkers(session.controlPoints, session.branches);
+    if (_linkCandidate && _linkCandidate->fiberId != 0 &&
+        session.fiberId == _linkCandidate->fiberId) {
+        for (size_t i = 0; i < session.controlPoints.size() && i < markers.size(); ++i) {
+            if (pointsApproximatelyEqual(session.controlPoints[i].volumePoint,
+                                         _linkCandidate->position)) {
+                markers[i].isLinkCandidate = true;
+                break;
+            }
+        }
+    }
+    return markers;
+}
+
+std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker>
+LineAnnotationController::markLinkCandidateFiberIntersections(
+    std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker> markers) const
+{
+    const uint64_t candidateFiberId =
+        _linkCandidate ? _linkCandidate->fiberId : uint64_t{0};
+    for (auto& marker : markers) {
+        marker.isLinkCandidateFiber =
+            candidateFiberId != 0 && marker.fiberId == candidateFiberId;
+    }
+    return markers;
+}
+
+vc3d::line_annotation::GeneratedLinkCandidateMenuState
+LineAnnotationController::linkCandidateMenuState(const LineAnnotationSession& session) const
+{
+    vc3d::line_annotation::GeneratedLinkCandidateMenuState state;
+    if (!_linkCandidate || _linkCandidate->fiberId == 0) {
+        return state;
+    }
+    if (session.fiberId != 0 && session.fiberId == _linkCandidate->fiberId) {
+        state.enabled = false;
+        state.label = tr("Link with candidate (same fiber)");
+    } else {
+        state.enabled = true;
+        state.label = tr("Link with candidate (Fiber %1)")
+                          .arg(static_cast<qulonglong>(_linkCandidate->fiberId));
+    }
+    return state;
+}
+
 bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolumeViewer* viewer,
                                                                     const QPointF& scenePoint,
                                                                     const QPoint& globalPos)
@@ -4529,7 +4613,8 @@ bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolu
             viewer->surfName(),
             viewer,
             scenePoint,
-            globalPos);
+            globalPos,
+            linkCandidateMenuState(*pane->session));
     } else if (_intersectionInspection) {
         const auto contextIt =
             _intersectionInspection->generatedSurfaceContexts.find(viewer->surfName());
@@ -4557,12 +4642,15 @@ bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolu
         options.viewer = viewer;
         options.scenePoint = scenePoint;
         options.globalPos = globalPos;
-        options.controlPoints = generatedControlMarkers(pane->session->controlPoints, pane->session->branches);
+        options.controlPoints = controlMarkersForSession(*pane->session);
         options.linePointCount = pane->session->optimizedLine.points.empty()
             ? pane->session->controlPoints.size()
             : pane->session->optimizedLine.points.size();
         options.linePosition = linePosition;
         options.stripViewer = context.strip;
+        const auto candidateState = linkCandidateMenuState(*pane->session);
+        options.linkWithCandidateEnabled = candidateState.enabled;
+        options.linkWithCandidateLabel = candidateState.label;
         if (auto* plane = dynamic_cast<PlaneSurface*>(viewer->currentSurface())) {
             options.branchLinkDirection = plane->normal({0.0f, 0.0f, 0.0f});
         }
@@ -4583,6 +4671,29 @@ bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolu
                                               linkedControlPoint,
                                               openAfterCreate,
                                               linkDirection);
+        };
+        options.designateLinkCandidate = [this, surfaceName = viewer->surfName()](
+                                             size_t controlPointIndex,
+                                             cv::Vec3f volumePoint) {
+            handleGeneratedControlPointLinkCandidate(surfaceName,
+                                                     controlPointIndex,
+                                                     volumePoint);
+        };
+        options.linkWithCandidate = [this, surfaceName = viewer->surfName()](
+                                        size_t controlPointIndex,
+                                        cv::Vec3f volumePoint) {
+            handleGeneratedControlPointLinkWithCandidate(surfaceName,
+                                                         controlPointIndex,
+                                                         volumePoint);
+        };
+        options.unlinkBranch = [this, surfaceName = viewer->surfName()](
+                                   size_t controlPointIndex,
+                                   uint64_t branchFiberId,
+                                   int branchControlPointIndex) {
+            handleGeneratedControlPointUnlink(surfaceName,
+                                              controlPointIndex,
+                                              branchFiberId,
+                                              branchControlPointIndex);
         };
         result = vc3d::line_annotation::showGeneratedControlPointContextMenu(options);
     }
@@ -4950,6 +5061,38 @@ void LineAnnotationController::invalidateFiberAlignmentMetrics(uint64_t fiberId,
 
 std::vector<LineAnnotationController::FiberSummary> LineAnnotationController::fiberSummaries() const
 {
+    // Connected-component sizes over the branch-link graph (union-find), so the
+    // panel can show how many fibers are chained together through links.
+    std::unordered_map<uint64_t, size_t> indexById;
+    indexById.reserve(_fibers.size());
+    for (size_t i = 0; i < _fibers.size(); ++i) {
+        indexById.emplace(_fibers[i].id, i);
+    }
+    std::vector<size_t> componentParent(_fibers.size());
+    for (size_t i = 0; i < componentParent.size(); ++i) {
+        componentParent[i] = i;
+    }
+    const auto findRoot = [&componentParent](size_t index) {
+        while (componentParent[index] != index) {
+            componentParent[index] = componentParent[componentParent[index]];
+            index = componentParent[index];
+        }
+        return index;
+    };
+    for (size_t i = 0; i < _fibers.size(); ++i) {
+        for (const auto& branch : _fibers[i].branches) {
+            const auto targetIt = indexById.find(branch.branchFiberId);
+            if (targetIt == indexById.end()) {
+                continue;
+            }
+            componentParent[findRoot(i)] = findRoot(targetIt->second);
+        }
+    }
+    std::unordered_map<size_t, int> componentSizes;
+    for (size_t i = 0; i < _fibers.size(); ++i) {
+        ++componentSizes[findRoot(i)];
+    }
+
     std::vector<FiberSummary> summaries;
     summaries.reserve(_fibers.size());
     for (const auto& fiber : _fibers) {
@@ -4967,6 +5110,7 @@ std::vector<LineAnnotationController::FiberSummary> LineAnnotationController::fi
             summary.alignment = cachedAlignmentForSpan(fiber.id, span.spanIndex);
             spanSummaries.push_back(std::move(summary));
         }
+        const int componentSize = componentSizes[findRoot(indexById.at(fiber.id))];
         summaries.push_back(FiberSummary{
             fiber.id,
             fiber.fileName,
@@ -4983,6 +5127,7 @@ std::vector<LineAnnotationController::FiberSummary> LineAnnotationController::fi
             vc3d::line_annotation::fiberHvTagToString(fiber.hvClassification.automaticTag),
             fiber.manualHvTag,
             fiber.tags,
+            componentSize >= 2 ? componentSize : 0,
         });
     }
     std::sort(summaries.begin(), summaries.end(), [](const FiberSummary& a, const FiberSummary& b) {
@@ -5254,7 +5399,7 @@ void LineAnnotationController::handleGeneratedControlPoint(const std::string& su
         syncLinkedBranchMetadataAfterFiberModification(session);
         if (pane->dialog) {
             pane->dialog->setGeneratedBranchOverlayData(
-                generatedControlMarkers(session.controlPoints, session.branches),
+                controlMarkersForSession(session),
                 generatedBranchLinePointsForSession(session),
                 generatedBranchLinkMarkers(session.branches));
             pane->dialog->setGeneratedPredSnapPoints(
@@ -5461,7 +5606,7 @@ void LineAnnotationController::handleGeneratedControlPointBranch(const std::stri
             parentSession.branches.end());
         if (pane->dialog) {
             pane->dialog->setGeneratedBranchOverlayData(
-                generatedControlMarkers(parentSession.controlPoints, parentSession.branches),
+                controlMarkersForSession(parentSession),
                 generatedBranchLinePointsForSession(parentSession),
                 generatedBranchLinkMarkers(parentSession.branches),
                 true);
@@ -5475,8 +5620,7 @@ void LineAnnotationController::handleGeneratedControlPointBranch(const std::stri
     invalidateFiberAlignmentMetrics(parentFiberId, true);
     emitFiberSummaries();
     if (pane->dialog) {
-        auto controlMarkers =
-            generatedControlMarkers(parentSession.controlPoints, parentSession.branches);
+        auto controlMarkers = controlMarkersForSession(parentSession);
         auto branchLinePoints = generatedBranchLinePointsForSession(parentSession);
         auto branchLinks = generatedBranchLinkMarkers(parentSession.branches);
         pane->dialog->setGeneratedBranchOverlayData(
@@ -5490,6 +5634,346 @@ void LineAnnotationController::handleGeneratedControlPointBranch(const std::stri
         return;
     }
     refreshBranchLineViews(parentFiberId);
+}
+
+void LineAnnotationController::handleGeneratedControlPointLinkCandidate(
+    const std::string& surfaceName,
+    size_t controlPointIndex,
+    cv::Vec3f volumePoint)
+{
+    (void)volumePoint;
+    auto* pane = paneForSurface(surfaceName);
+    if (!pane || !pane->session) {
+        return;
+    }
+    auto& session = *pane->session;
+    if (controlPointIndex >= session.controlPoints.size()) {
+        return;
+    }
+    const cv::Vec3d candidatePosition = session.controlPoints[controlPointIndex].volumePoint;
+    if (!finitePoint(candidatePosition)) {
+        showError(tr("Could not determine a finite position for the link candidate."));
+        return;
+    }
+    ensureSessionFiberIdentity(session);
+    if (session.fiberId == 0) {
+        session.fiberId = nextFiberId();
+    }
+
+    LinkCandidate candidate;
+    candidate.fiberId = session.fiberId;
+    candidate.fiberFileName = session.fiberFileName;
+    candidate.position = candidatePosition;
+    const auto storedIndexMap = storedIndexMapForSessionControls(session.controlPoints);
+    if (controlPointIndex < storedIndexMap.size()) {
+        candidate.storedControlPointIndexHint = storedIndexMap[controlPointIndex];
+    }
+    _linkCandidate = candidate;
+
+    if (pane->dialog) {
+        pane->dialog->setGeneratedBranchOverlayData(
+            controlMarkersForSession(session),
+            generatedBranchLinePointsForSession(session),
+            generatedBranchLinkMarkers(session.branches),
+            false);
+    }
+}
+
+void LineAnnotationController::handleGeneratedOpenNearbyAnnotation(uint64_t fiberId,
+                                                                   cv::Vec3f volumePoint)
+{
+    if (fiberId == 0) {
+        return;
+    }
+    const auto fiberIt = std::find_if(_fibers.begin(),
+                                      _fibers.end(),
+                                      [fiberId](const StoredFiber& fiber) {
+                                          return fiber.id == fiberId;
+                                      });
+    if (fiberIt == _fibers.end()) {
+        showError(tr("Could not find fiber %1 for the nearby annotation.")
+                      .arg(static_cast<qulonglong>(fiberId)));
+        return;
+    }
+    if (fiberIt->linePoints.empty() || !finitePoint(toVec3d(volumePoint))) {
+        openFiber(fiberId);
+        return;
+    }
+    const size_t linePointIndex =
+        vc3d::fiber_slice::nearestLinePointIndex(fiberIt->linePoints, toVec3d(volumePoint));
+    openFiberAtLinePointIndex(fiberId, static_cast<int>(linePointIndex));
+}
+
+void LineAnnotationController::handleGeneratedControlPointLinkWithCandidate(
+    const std::string& surfaceName,
+    size_t controlPointIndex,
+    cv::Vec3f volumePoint)
+{
+    (void)volumePoint;
+    auto* pane = paneForSurface(surfaceName);
+    if (!pane || !pane->session) {
+        return;
+    }
+    auto& session = *pane->session;
+    if (session.taskState == LineAnnotationSession::TaskState::Running) {
+        showError(tr("Line optimization is already running."));
+        return;
+    }
+    if (controlPointIndex >= session.controlPoints.size()) {
+        return;
+    }
+    if (!_linkCandidate || _linkCandidate->fiberId == 0) {
+        showError(tr("No link candidate is designated."));
+        return;
+    }
+
+    ensureSessionFiberIdentity(session);
+    if (session.fiberId == 0) {
+        session.fiberId = nextFiberId();
+    }
+    if (session.fiberId == _linkCandidate->fiberId) {
+        showError(tr("The link candidate is on this fiber; designate a candidate on a "
+                     "different fiber."));
+        return;
+    }
+
+    const LinkCandidate candidate = *_linkCandidate;
+    const auto findFarFiber = [this, &candidate]() {
+        return std::find_if(_fibers.begin(),
+                            _fibers.end(),
+                            [&candidate](const StoredFiber& fiber) {
+                                return fiber.id == candidate.fiberId;
+                            });
+    };
+    auto farIt = findFarFiber();
+    if (farIt == _fibers.end()) {
+        _linkCandidate.reset();
+        showError(tr("The link candidate's fiber no longer exists."));
+        return;
+    }
+    const auto farControlIndex = matchingStoredControlPointIndex(
+        farIt->controlPoints,
+        candidate.storedControlPointIndexHint,
+        candidate.position);
+    if (!farControlIndex) {
+        _linkCandidate.reset();
+        showError(tr("The link candidate control point no longer exists."));
+        return;
+    }
+    const cv::Vec3d farPoint = farIt->controlPoints[static_cast<size_t>(*farControlIndex)];
+    const cv::Vec3d localPoint = session.controlPoints[controlPointIndex].volumePoint;
+    if (!finitePoint(localPoint) || !finitePoint(farPoint)) {
+        showError(tr("Could not determine finite endpoints for the link."));
+        return;
+    }
+    const cv::Vec3d fallbackDirection = normalizedOrZero(farPoint - localPoint);
+    const cv::Vec3d localDirection = endpointTangentFromLinePoints(
+        linePointPositions(session.optimizedLine),
+        localPoint,
+        fallbackDirection);
+    const cv::Vec3d farDirection = endpointTangentFromLinePoints(
+        farIt->linePoints,
+        farPoint,
+        -fallbackDirection);
+    if (!finiteDirection(localDirection) || !finiteDirection(farDirection)) {
+        showError(tr("Could not determine finite link directions between the control points."));
+        return;
+    }
+
+    FiberBranchRef localRef;
+    localRef.controlPointIndex = static_cast<int>(controlPointIndex);
+    localRef.branchFiberId = farIt->id;
+    localRef.branchControlPointIndex = *farControlIndex;
+    localRef.branchFileName = farIt->fileName;
+    localRef.controlPointDirection = localDirection;
+    localRef.branchControlPointDirection = farDirection;
+    localRef.controlPointPosition = localPoint;
+    localRef.branchControlPointPosition = farPoint;
+
+    const auto duplicateLocal = std::find_if(
+        session.branches.begin(),
+        session.branches.end(),
+        [&localRef](const FiberBranchRef& branch) {
+            return branch.branchFiberId == localRef.branchFiberId &&
+                   branch.controlPointIndex == localRef.controlPointIndex &&
+                   branch.branchControlPointIndex == localRef.branchControlPointIndex;
+        });
+    if (duplicateLocal != session.branches.end()) {
+        showError(tr("These control points are already linked."));
+        return;
+    }
+    session.branches.push_back(localRef);
+
+    const uint64_t localFiberId = session.fiberId;
+    const uint64_t farFiberId = farIt->id;
+    try {
+        StoredFiber localFiber = storedFiberFromSession(session);
+        const auto storedLocalBranch = std::find_if(
+            localFiber.branches.begin(),
+            localFiber.branches.end(),
+            [farFiberId, &localPoint, &farPoint](const FiberBranchRef& branch) {
+                return branch.branchFiberId == farFiberId &&
+                       pointsApproximatelyEqual(branch.controlPointPosition, localPoint) &&
+                       pointsApproximatelyEqual(branch.branchControlPointPosition, farPoint);
+            });
+        if (storedLocalBranch == localFiber.branches.end()) {
+            throw std::runtime_error("link entry missing after serialization");
+        }
+
+        FiberBranchRef reciprocal;
+        reciprocal.controlPointIndex = storedLocalBranch->branchControlPointIndex;
+        reciprocal.branchFiberId = localFiber.id;
+        reciprocal.branchControlPointIndex = storedLocalBranch->controlPointIndex;
+        reciprocal.branchFileName = localFiber.fileName;
+        reciprocal.controlPointDirection = storedLocalBranch->branchControlPointDirection;
+        reciprocal.branchControlPointDirection = storedLocalBranch->controlPointDirection;
+        reciprocal.controlPointPosition = storedLocalBranch->branchControlPointPosition;
+        reciprocal.branchControlPointPosition = storedLocalBranch->controlPointPosition;
+
+        // storedFiberFromSession runs the branch metadata sync hook, which may
+        // touch _fibers; re-find the far fiber before mutating it.
+        farIt = findFarFiber();
+        if (farIt == _fibers.end()) {
+            throw std::runtime_error("linked fiber disappeared while saving");
+        }
+        const auto duplicateFar = std::find_if(
+            farIt->branches.begin(),
+            farIt->branches.end(),
+            [&reciprocal](const FiberBranchRef& branch) {
+                return branch.branchFiberId == reciprocal.branchFiberId &&
+                       branch.controlPointIndex == reciprocal.controlPointIndex &&
+                       branch.branchControlPointIndex == reciprocal.branchControlPointIndex;
+            });
+        if (duplicateFar == farIt->branches.end()) {
+            farIt->branches.push_back(reciprocal);
+        }
+        const StoredFiber farFiber = *farIt;
+        scheduleFiberPairSave(localFiber, farFiber);
+
+        auto localIt = std::find_if(
+            _fibers.begin(),
+            _fibers.end(),
+            [&localFiber](const StoredFiber& existing) {
+                return (!localFiber.fileName.empty() &&
+                        existing.fileName == localFiber.fileName) ||
+                       existing.id == localFiber.id;
+            });
+        if (localIt == _fibers.end()) {
+            _fibers.push_back(std::move(localFiber));
+        } else {
+            *localIt = std::move(localFiber);
+        }
+    } catch (const std::exception& ex) {
+        session.branches.erase(
+            std::remove_if(session.branches.begin(),
+                           session.branches.end(),
+                           [&localRef](const FiberBranchRef& branch) {
+                               return branch.branchFiberId == localRef.branchFiberId &&
+                                      branch.controlPointIndex == localRef.controlPointIndex &&
+                                      branch.branchControlPointIndex ==
+                                          localRef.branchControlPointIndex;
+                           }),
+            session.branches.end());
+        if (pane->dialog) {
+            pane->dialog->setGeneratedBranchOverlayData(
+                controlMarkersForSession(session),
+                generatedBranchLinePointsForSession(session),
+                generatedBranchLinkMarkers(session.branches),
+                true);
+        }
+        showError(tr("Could not save linked fibers: %1")
+                      .arg(QString::fromStdString(ex.what())));
+        return;
+    }
+
+    _linkCandidate.reset();
+    session.fiberMetricsMatchStoredFiber = true;
+    invalidateFiberAlignmentMetrics(localFiberId, true);
+    invalidateFiberAlignmentMetrics(farFiberId, true);
+    emitFiberSummaries();
+    if (pane->dialog) {
+        pane->dialog->setGeneratedBranchOverlayData(
+            controlMarkersForSession(session),
+            generatedBranchLinePointsForSession(session),
+            generatedBranchLinkMarkers(session.branches),
+            true);
+    }
+    refreshBranchLineViews(localFiberId);
+}
+
+void LineAnnotationController::handleGeneratedControlPointUnlink(
+    const std::string& surfaceName,
+    size_t controlPointIndex,
+    uint64_t branchFiberId,
+    int branchControlPointIndex)
+{
+    auto* pane = paneForSurface(surfaceName);
+    if (!pane || !pane->session) {
+        return;
+    }
+    auto& session = *pane->session;
+    if (session.taskState == LineAnnotationSession::TaskState::Running) {
+        showError(tr("Line optimization is already running."));
+        return;
+    }
+    if (controlPointIndex >= session.controlPoints.size() || branchFiberId == 0) {
+        return;
+    }
+
+    const std::vector<FiberBranchRef> previousBranches = session.branches;
+    session.branches.erase(
+        std::remove_if(session.branches.begin(),
+                       session.branches.end(),
+                       [&](const FiberBranchRef& branch) {
+                           return branch.controlPointIndex ==
+                                      static_cast<int>(controlPointIndex) &&
+                                  branch.branchFiberId == branchFiberId &&
+                                  (branchControlPointIndex < 0 ||
+                                   branch.branchControlPointIndex ==
+                                       branchControlPointIndex);
+                       }),
+        session.branches.end());
+    if (session.branches.size() == previousBranches.size()) {
+        showError(tr("Could not find the link to remove."));
+        return;
+    }
+
+    const BranchMetadataSyncResult branchSync =
+        syncLinkedBranchMetadataAfterFiberModification(session, nullptr, &previousBranches);
+    scheduleBranchMetadataSaves(branchSync.affectedFiberIds, session.fiberId);
+
+    try {
+        StoredFiber localFiber = storedFiberFromSession(session);
+        scheduleFiberSave(localFiber);
+        auto localIt = std::find_if(
+            _fibers.begin(),
+            _fibers.end(),
+            [&localFiber](const StoredFiber& existing) {
+                return (!localFiber.fileName.empty() &&
+                        existing.fileName == localFiber.fileName) ||
+                       existing.id == localFiber.id;
+            });
+        if (localIt == _fibers.end()) {
+            _fibers.push_back(std::move(localFiber));
+        } else {
+            *localIt = std::move(localFiber);
+        }
+        session.fiberMetricsMatchStoredFiber = true;
+    } catch (const std::exception& ex) {
+        showError(tr("Could not save fiber after unlinking: %1")
+                      .arg(QString::fromStdString(ex.what())));
+    }
+
+    emitFiberSummaries();
+    if (pane->dialog) {
+        pane->dialog->setGeneratedBranchOverlayData(
+            controlMarkersForSession(session),
+            generatedBranchLinePointsForSession(session),
+            generatedBranchLinkMarkers(session.branches),
+            true);
+    }
+    refreshBranchLineViews(session.fiberId);
+    refreshBranchLineViews(branchFiberId);
 }
 
 void LineAnnotationController::handleGeneratedPredSnapPoint(const std::string& surfaceName,
@@ -5677,7 +6161,7 @@ void LineAnnotationController::handleGeneratedControlPointDelete(const std::stri
 
     if (pane->dialog) {
         pane->dialog->setGeneratedBranchOverlayData(
-            generatedControlMarkers(session.controlPoints, session.branches),
+            controlMarkersForSession(session),
             generatedBranchLinePointsForSession(session),
             generatedBranchLinkMarkers(session.branches));
         pane->dialog->setGeneratedPredSnapPoints(
@@ -6271,7 +6755,7 @@ bool LineAnnotationController::materializeGeneratedViews(LineAnnotationSession& 
     generatedViews.seedLineIndex = static_cast<int>(session.optimizedLine.points.size() / 2);
     generatedViews.initialCurrentCutFollowsStripMouse =
         !session.disableInitialGeneratedHoverFollow;
-    generatedViews.controlPoints = generatedControlMarkers(session.controlPoints, session.branches);
+    generatedViews.controlPoints = controlMarkersForSession(session);
     for (const auto& marker : generatedViews.controlPoints) {
         if (marker.isSeed && std::isfinite(marker.linePosition)) {
             generatedViews.seedLineIndex = static_cast<int>(std::llround(marker.linePosition));
@@ -7182,7 +7666,7 @@ void LineAnnotationController::refreshBranchLineViews(uint64_t changedFiberId)
             continue;
         }
         pane.dialog->setGeneratedBranchOverlayData(
-            generatedControlMarkers(pane.session->controlPoints, pane.session->branches),
+            controlMarkersForSession(*pane.session),
             generatedBranchLinePointsForSession(*pane.session),
             generatedBranchLinkMarkers(pane.session->branches));
     }
@@ -7336,7 +7820,8 @@ void LineAnnotationController::handleGeneratedSideStripIntersectionQuery(
         _lastSideStripIntersectionKey != 0 &&
         request.cacheKey == _lastSideStripIntersectionKey &&
         request.surfaceName == _lastSideStripIntersectionSurfaceName) {
-        pane->dialog->setGeneratedFiberIntersectionMarkers(_lastSideStripIntersectionMarkers);
+        pane->dialog->setGeneratedFiberIntersectionMarkers(
+            markLinkCandidateFiberIntersections(_lastSideStripIntersectionMarkers));
         pane->dialog->setGeneratedSideStripIntersectionResult(
             _lastSideStripIntersectionMarkers.size());
         return;
@@ -7370,9 +7855,10 @@ void LineAnnotationController::handleGeneratedSideStripIntersectionQuery(
                 1,
                 previewHardwareThreads > 1 ? (previewHardwareThreads + 1) / 2 : 1);
         previewOptions.branchLinks = request.branchLinks;
-        const auto previewMarkers = sideStripMarkersFromIntersections(
+        auto previewMarkers = sideStripMarkersFromIntersections(
             previewIndex.sideStripIntersections(previewOptions));
-        pane->dialog->setGeneratedFiberIntersectionMarkers(previewMarkers);
+        pane->dialog->setGeneratedFiberIntersectionMarkers(
+            markLinkCandidateFiberIntersections(std::move(previewMarkers)));
     }
 
     if (_sideStripIntersectionRunning) {
@@ -7725,7 +8211,8 @@ void LineAnnotationController::applyPartialSideStripIntersectionMarkers(
         return;
     }
     if (auto* pane = paneForSurface(surfaceName); pane && pane->dialog) {
-        pane->dialog->setGeneratedFiberIntersectionMarkers(std::move(markers));
+        pane->dialog->setGeneratedFiberIntersectionMarkers(
+            markLinkCandidateFiberIntersections(std::move(markers)));
     }
 }
 
@@ -7745,7 +8232,8 @@ void LineAnnotationController::finishSideStripIntersectionQuery(
                 _lastSideStripIntersectionKey = result.cacheKey;
                 _lastSideStripIntersectionSurfaceName = result.surfaceName;
                 _lastSideStripIntersectionMarkers = result.markers;
-                pane->dialog->setGeneratedFiberIntersectionMarkers(std::move(result.markers));
+                pane->dialog->setGeneratedFiberIntersectionMarkers(
+                    markLinkCandidateFiberIntersections(std::move(result.markers)));
                 if (!hasPendingRequest) {
                     pane->dialog->setGeneratedSideStripIntersectionResult(markerCount);
                 }

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -96,6 +96,9 @@ public:
         std::string automaticHvTag;
         std::string manualHvTag;
         std::vector<std::string> tags;
+        // Number of fibers in this fiber's branch-link connected component
+        // (including itself); 0 when the fiber has no links.
+        int linkedFiberCount = 0;
     };
 
     struct FiberSnapshotWithPath {
@@ -366,6 +369,24 @@ private:
     void handleGeneratedPredSnapPoint(const std::string& surfaceName,
                                       cv::Vec3f volumePoint);
     void handleGeneratedSideStripIntersectionQuery(const std::string& surfaceName);
+    void handleGeneratedControlPointLinkCandidate(const std::string& surfaceName,
+                                                  size_t controlPointIndex,
+                                                  cv::Vec3f volumePoint);
+    void handleGeneratedControlPointLinkWithCandidate(const std::string& surfaceName,
+                                                      size_t controlPointIndex,
+                                                      cv::Vec3f volumePoint);
+    void handleGeneratedOpenNearbyAnnotation(uint64_t fiberId, cv::Vec3f volumePoint);
+    void handleGeneratedControlPointUnlink(const std::string& surfaceName,
+                                           size_t controlPointIndex,
+                                           uint64_t branchFiberId,
+                                           int branchControlPointIndex);
+    [[nodiscard]] std::vector<vc3d::line_annotation::GeneratedOverlay::ControlPointMarker>
+        controlMarkersForSession(const LineAnnotationSession& session) const;
+    [[nodiscard]] vc3d::line_annotation::GeneratedLinkCandidateMenuState
+        linkCandidateMenuState(const LineAnnotationSession& session) const;
+    [[nodiscard]] std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker>
+        markLinkCandidateFiberIntersections(
+            std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker> markers) const;
     bool ensureDatasetForSession(LineAnnotationSession& session);
     bool needsFinalOptimization(const LineAnnotationSession& session) const;
     bool finalizeSessionOptimizationSynchronously(LineAnnotationSession& session,
@@ -598,4 +619,15 @@ private:
     std::optional<std::filesystem::path> _currentAtlasDir;
     DatasetPicker _datasetPicker;
     OptimizationTaskFactory _optimizationTaskFactory;
+
+    // Transient (in-memory only) staging state for linking two existing control
+    // points across fibers. Position is the primary key; the stored index is a
+    // hint re-resolved at link time because indices are remapped on save.
+    struct LinkCandidate {
+        uint64_t fiberId = 0;
+        std::string fiberFileName;
+        cv::Vec3d position{0.0, 0.0, 0.0};
+        int storedControlPointIndexHint = -1;
+    };
+    std::optional<LinkCandidate> _linkCandidate;
 };

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -589,6 +589,7 @@ void LineAnnotationDialog::setGeneratedFiberIntersectionMarkers(
     }
     _generatedViews.fiberIntersections = std::move(markers);
     rebuildGeneratedStaticStripOverlays();
+    rebuildGeneratedDynamicOverlays();
 }
 
 void LineAnnotationDialog::setGeneratedSideStripIntersectionBusy(bool busy)
@@ -1307,10 +1308,12 @@ bool LineAnnotationDialog::setGeneratedLineViews(
 }
 
 LineAnnotationDialog::GeneratedControlPointContextResult
-LineAnnotationDialog::showGeneratedControlPointContextMenu(const std::string& surfaceName,
-                                                           CChunkedVolumeViewer* viewer,
-                                                           const QPointF& scenePoint,
-                                                           const QPoint& globalPos)
+LineAnnotationDialog::showGeneratedControlPointContextMenu(
+    const std::string& surfaceName,
+    CChunkedVolumeViewer* viewer,
+    const QPointF& scenePoint,
+    const QPoint& globalPos,
+    const vc3d::line_annotation::GeneratedLinkCandidateMenuState& linkCandidateState)
 {
     if (!viewer || !_hasGeneratedViews || _generatedViews.controlPoints.empty() ||
         _generatedViews.linePoints.empty()) {
@@ -1348,9 +1351,12 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(const std::string& su
     options.scenePoint = scenePoint;
     options.globalPos = globalPos;
     options.controlPoints = _generatedViews.controlPoints;
+    options.fiberIntersections = _generatedViews.fiberIntersections;
     options.linePointCount = _generatedViews.linePoints.size();
     options.linePosition = linePosition;
     options.stripViewer = stripViewer;
+    options.linkWithCandidateEnabled = linkCandidateState.enabled;
+    options.linkWithCandidateLabel = linkCandidateState.label;
     options.branchLinkDirection = branchLinkDirectionForViewer(viewer, linePosition);
     options.deleteControlPoint = [this, surfaceName](double selectedLinePosition,
                                                      cv::Vec3f selectedPoint) {
@@ -1370,6 +1376,29 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(const std::string& su
     };
     options.openBranch = [this](uint64_t branchFiberId, int branchControlPointIndex) {
         emit generatedControlPointBranchOpenRequested(branchFiberId, branchControlPointIndex);
+    };
+    options.designateLinkCandidate = [this, surfaceName](size_t controlPointIndex,
+                                                         cv::Vec3f volumePoint) {
+        emit generatedControlPointLinkCandidateRequested(surfaceName,
+                                                         controlPointIndex,
+                                                         volumePoint);
+    };
+    options.linkWithCandidate = [this, surfaceName](size_t controlPointIndex,
+                                                    cv::Vec3f volumePoint) {
+        emit generatedControlPointLinkWithCandidateRequested(surfaceName,
+                                                             controlPointIndex,
+                                                             volumePoint);
+    };
+    options.openNearbyAnnotation = [this](uint64_t fiberId, cv::Vec3f volumePoint) {
+        emit generatedNearbyAnnotationOpenRequested(fiberId, volumePoint);
+    };
+    options.unlinkBranch = [this, surfaceName](size_t controlPointIndex,
+                                               uint64_t branchFiberId,
+                                               int branchControlPointIndex) {
+        emit generatedControlPointUnlinkRequested(surfaceName,
+                                                  controlPointIndex,
+                                                  branchFiberId,
+                                                  branchControlPointIndex);
     };
     return vc3d::line_annotation::showGeneratedControlPointContextMenu(options);
 }
@@ -2262,7 +2291,13 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     if (_fastCurrentCutOverlayItems.viewer != viewer ||
         !_fastCurrentCutOverlayItems.centerPoint ||
         !_fastCurrentCutOverlayItems.controlPoints ||
-        !_fastCurrentCutOverlayItems.seedPoints) {
+        !_fastCurrentCutOverlayItems.seedPoints ||
+        !_fastCurrentCutOverlayItems.linkCandidatePoints ||
+        !_fastCurrentCutOverlayItems.branchControlPoints ||
+        !_fastCurrentCutOverlayItems.fiberIntersections ||
+        !_fastCurrentCutOverlayItems.linkCandidateFiberIntersections ||
+        !_fastCurrentCutOverlayItems.branchLinkFiberIntersections ||
+        !_fastCurrentCutOverlayItems.fiberIntersectionConnectors) {
         viewer->clearOverlayGroup(kGeneratedDynamicCurrentCutOverlayKey);
         _fastCurrentCutOverlayItems = {};
         _fastCurrentCutOverlayItems.viewer = viewer;
@@ -2289,10 +2324,66 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         _fastCurrentCutOverlayItems.seedPoints->setBrush(controlBrush);
         _fastCurrentCutOverlayItems.seedPoints->setZValue(161.0);
 
+        QPen linkCandidatePen(QColor(60, 235, 120, 245));
+        linkCandidatePen.setWidthF(2.0);
+        QBrush linkCandidateBrush(QColor(60, 235, 120, 175));
+        _fastCurrentCutOverlayItems.linkCandidatePoints = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.linkCandidatePoints->setPen(linkCandidatePen);
+        _fastCurrentCutOverlayItems.linkCandidatePoints->setBrush(linkCandidateBrush);
+        _fastCurrentCutOverlayItems.linkCandidatePoints->setZValue(163.0);
+
+        QPen branchControlPen(QColor(210, 95, 255, 245));
+        branchControlPen.setWidthF(2.0);
+        QBrush branchControlBrush(QColor(210, 95, 255, 175));
+        _fastCurrentCutOverlayItems.branchControlPoints = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.branchControlPoints->setPen(branchControlPen);
+        _fastCurrentCutOverlayItems.branchControlPoints->setBrush(branchControlBrush);
+        _fastCurrentCutOverlayItems.branchControlPoints->setZValue(162.0);
+
+        QPen fiberIntersectionPen(QColor(255, 245, 75, 245));
+        fiberIntersectionPen.setWidthF(1.25);
+        fiberIntersectionPen.setCapStyle(Qt::FlatCap);
+        _fastCurrentCutOverlayItems.fiberIntersections = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.fiberIntersections->setPen(fiberIntersectionPen);
+        _fastCurrentCutOverlayItems.fiberIntersections->setBrush(Qt::NoBrush);
+        _fastCurrentCutOverlayItems.fiberIntersections->setZValue(168.0);
+
+        QPen linkCandidateFiberIntersectionPen(QColor(60, 235, 120, 245));
+        linkCandidateFiberIntersectionPen.setWidthF(1.75);
+        linkCandidateFiberIntersectionPen.setCapStyle(Qt::FlatCap);
+        _fastCurrentCutOverlayItems.linkCandidateFiberIntersections = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.linkCandidateFiberIntersections->setPen(
+            linkCandidateFiberIntersectionPen);
+        _fastCurrentCutOverlayItems.linkCandidateFiberIntersections->setBrush(Qt::NoBrush);
+        _fastCurrentCutOverlayItems.linkCandidateFiberIntersections->setZValue(168.5);
+
+        QPen branchLinkFiberIntersectionPen(QColor(210, 95, 255, 245));
+        branchLinkFiberIntersectionPen.setWidthF(1.75);
+        branchLinkFiberIntersectionPen.setCapStyle(Qt::FlatCap);
+        _fastCurrentCutOverlayItems.branchLinkFiberIntersections = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setPen(
+            branchLinkFiberIntersectionPen);
+        _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setBrush(Qt::NoBrush);
+        _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setZValue(168.25);
+
+        QPen fiberIntersectionConnectorPen(QColor(255, 60, 180, 225));
+        fiberIntersectionConnectorPen.setWidthF(1.4);
+        _fastCurrentCutOverlayItems.fiberIntersectionConnectors = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.fiberIntersectionConnectors->setPen(
+            fiberIntersectionConnectorPen);
+        _fastCurrentCutOverlayItems.fiberIntersectionConnectors->setBrush(Qt::NoBrush);
+        _fastCurrentCutOverlayItems.fiberIntersectionConnectors->setZValue(164.0);
+
         viewer->setOverlayGroup(kGeneratedDynamicCurrentCutOverlayKey,
                                 {_fastCurrentCutOverlayItems.centerPoint,
                                  _fastCurrentCutOverlayItems.controlPoints,
-                                 _fastCurrentCutOverlayItems.seedPoints});
+                                 _fastCurrentCutOverlayItems.seedPoints,
+                                 _fastCurrentCutOverlayItems.linkCandidatePoints,
+                                 _fastCurrentCutOverlayItems.branchControlPoints,
+                                 _fastCurrentCutOverlayItems.fiberIntersections,
+                                 _fastCurrentCutOverlayItems.linkCandidateFiberIntersections,
+                                 _fastCurrentCutOverlayItems.branchLinkFiberIntersections,
+                                 _fastCurrentCutOverlayItems.fiberIntersectionConnectors});
     }
 
     QPointF centerScenePoint;
@@ -2309,6 +2400,8 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
 
     QPainterPath controlPath;
     QPainterPath seedPath;
+    QPainterPath linkCandidatePath;
+    QPainterPath branchControlPath;
     const double lineRadius =
         std::max(0.5, (_viewerManager ? _viewerManager->zScrollSensitivity() : 1.0) * 0.5);
     const double lower = _currentLinePosition - lineRadius;
@@ -2343,7 +2436,12 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         if (!std::isfinite(scenePoint.x()) || !std::isfinite(scenePoint.y())) {
             continue;
         }
-        if (control.isSeed) {
+        if (control.isLinkCandidate) {
+            linkCandidatePath.addEllipse(scenePoint, control.isSeed ? 11.0 : 10.0,
+                                         control.isSeed ? 11.0 : 10.0);
+        } else if (control.hasBranches) {
+            branchControlPath.addEllipse(scenePoint, 12.0, 12.0);
+        } else if (control.isSeed) {
             seedPath.addEllipse(scenePoint, 11.0, 11.0);
         } else {
             controlPath.addEllipse(scenePoint, 10.0, 10.0);
@@ -2351,6 +2449,57 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     }
     _fastCurrentCutOverlayItems.controlPoints->setPath(controlPath);
     _fastCurrentCutOverlayItems.seedPoints->setPath(seedPath);
+    _fastCurrentCutOverlayItems.linkCandidatePoints->setPath(linkCandidatePath);
+    _fastCurrentCutOverlayItems.branchControlPoints->setPath(branchControlPath);
+
+    QPainterPath fiberIntersectionPath;
+    QPainterPath linkCandidateFiberIntersectionPath;
+    QPainterPath branchLinkFiberIntersectionPath;
+    QPainterPath fiberIntersectionConnectorPath;
+    auto* currentCutPlane = _generatedViews.currentCutSurface.get();
+    const std::optional<float> intersectionThreshold =
+        (currentCutPlane && !_generatedViews.fiberIntersections.empty())
+            ? vc3d::line_annotation::generatedCrossSliceControlPointDistanceThreshold(viewer)
+            : std::nullopt;
+    if (intersectionThreshold) {
+        constexpr qreal kIntersectionArm = 7.5;
+        for (const auto& intersection : _generatedViews.fiberIntersections) {
+            if (!finitePoint(intersection.point)) {
+                continue;
+            }
+            const float distance = currentCutPlane->pointDist(intersection.point);
+            if (!std::isfinite(distance) || std::abs(distance) > *intersectionThreshold) {
+                continue;
+            }
+            const QPointF scenePoint = viewer->volumeToScene(intersection.point);
+            if (!std::isfinite(scenePoint.x()) || !std::isfinite(scenePoint.y())) {
+                continue;
+            }
+            if (intersection.connectorStart && finitePoint(*intersection.connectorStart)) {
+                const QPointF connectorScene =
+                    viewer->volumeToScene(*intersection.connectorStart);
+                if (std::isfinite(connectorScene.x()) && std::isfinite(connectorScene.y())) {
+                    fiberIntersectionConnectorPath.moveTo(connectorScene);
+                    fiberIntersectionConnectorPath.lineTo(scenePoint);
+                }
+            }
+            QPainterPath& path = intersection.isLinkCandidateFiber
+                ? linkCandidateFiberIntersectionPath
+                : (intersection.projectedBranchLink ? branchLinkFiberIntersectionPath
+                                                    : fiberIntersectionPath);
+            path.moveTo(scenePoint + QPointF(-kIntersectionArm, -kIntersectionArm));
+            path.lineTo(scenePoint + QPointF(kIntersectionArm, kIntersectionArm));
+            path.moveTo(scenePoint + QPointF(-kIntersectionArm, kIntersectionArm));
+            path.lineTo(scenePoint + QPointF(kIntersectionArm, -kIntersectionArm));
+        }
+    }
+    _fastCurrentCutOverlayItems.fiberIntersections->setPath(fiberIntersectionPath);
+    _fastCurrentCutOverlayItems.linkCandidateFiberIntersections->setPath(
+        linkCandidateFiberIntersectionPath);
+    _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setPath(
+        branchLinkFiberIntersectionPath);
+    _fastCurrentCutOverlayItems.fiberIntersectionConnectors->setPath(
+        fiberIntersectionConnectorPath);
 }
 
 void LineAnnotationDialog::rebuildGeneratedDynamicOverlays(bool updateCurrentCutOverlay,

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -1351,7 +1351,30 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(
     options.scenePoint = scenePoint;
     options.globalPos = globalPos;
     options.controlPoints = _generatedViews.controlPoints;
-    options.fiberIntersections = _generatedViews.fiberIntersections;
+    // On the cut viewers only plane-filtered X markers are drawn; restrict the
+    // hit-test candidates the same way so the menu never targets an invisible
+    // off-plane marker that happens to project near the click.
+    PlaneSurface* cutPlane = nullptr;
+    if (viewer == _currentCutViewer) {
+        cutPlane = _generatedViews.currentCutSurface.get();
+    } else if (viewer == _sideCutViewer) {
+        cutPlane = _generatedViews.sideCutSurface.get();
+    }
+    if (!cutPlane) {
+        options.fiberIntersections = _generatedViews.fiberIntersections;
+    } else if (const std::optional<float> intersectionThreshold =
+                   vc3d::line_annotation::generatedCrossSliceControlPointDistanceThreshold(
+                       viewer)) {
+        for (const auto& intersection : _generatedViews.fiberIntersections) {
+            if (!finitePoint(intersection.point)) {
+                continue;
+            }
+            const float distance = cutPlane->pointDist(intersection.point);
+            if (std::isfinite(distance) && std::abs(distance) <= *intersectionThreshold) {
+                options.fiberIntersections.push_back(intersection);
+            }
+        }
+    }
     options.linePointCount = _generatedViews.linePoints.size();
     options.linePosition = linePosition;
     options.stripViewer = stripViewer;

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -84,6 +84,12 @@ public:
         QGraphicsPathItem* centerPoint = nullptr;
         QGraphicsPathItem* controlPoints = nullptr;
         QGraphicsPathItem* seedPoints = nullptr;
+        QGraphicsPathItem* linkCandidatePoints = nullptr;
+        QGraphicsPathItem* branchControlPoints = nullptr;
+        QGraphicsPathItem* fiberIntersections = nullptr;
+        QGraphicsPathItem* linkCandidateFiberIntersections = nullptr;
+        QGraphicsPathItem* branchLinkFiberIntersections = nullptr;
+        QGraphicsPathItem* fiberIntersectionConnectors = nullptr;
     };
 
     using GeneratedOverlay = vc3d::line_annotation::GeneratedOverlay;
@@ -109,7 +115,8 @@ public:
         const std::string& surfaceName,
         CChunkedVolumeViewer* viewer,
         const QPointF& scenePoint,
-        const QPoint& globalPos);
+        const QPoint& globalPos,
+        const vc3d::line_annotation::GeneratedLinkCandidateMenuState& linkCandidateState = {});
     const std::vector<Pane>& panes() const { return _panes; }
     InitialDirectionMode initialDirectionMode() const;
     ReoptimizationMode reoptimizationMode() const;
@@ -158,6 +165,17 @@ signals:
                                               cv::Vec3f linkDirection);
     void generatedControlPointBranchOpenRequested(uint64_t branchFiberId,
                                                    int branchControlPointIndex);
+    void generatedControlPointLinkCandidateRequested(const std::string& surfaceName,
+                                                     size_t controlPointIndex,
+                                                     cv::Vec3f volumePoint);
+    void generatedControlPointLinkWithCandidateRequested(const std::string& surfaceName,
+                                                         size_t controlPointIndex,
+                                                         cv::Vec3f volumePoint);
+    void generatedNearbyAnnotationOpenRequested(uint64_t fiberId, cv::Vec3f volumePoint);
+    void generatedControlPointUnlinkRequested(const std::string& surfaceName,
+                                              size_t controlPointIndex,
+                                              uint64_t branchFiberId,
+                                              int branchControlPointIndex);
     void generatedPredSnapPointRequested(const std::string& surfaceName,
                                          cv::Vec3f volumePoint);
     void generatedSideStripIntersectionQueryRequested(const std::string& surfaceName);

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
@@ -236,8 +236,16 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
     branchControlPointStyle.penWidth = 2.0;
     branchControlPointStyle.z = 162.0;
 
+    ViewerOverlayControllerBase::OverlayStyle linkCandidateControlPointStyle = branchControlPointStyle;
+    linkCandidateControlPointStyle.penColor = QColor(60, 235, 120, 245);
+    linkCandidateControlPointStyle.brushColor = QColor(60, 235, 120, 175);
+    linkCandidateControlPointStyle.z = 163.0;
+
     auto controlStyleForMarker = [&](const GeneratedOverlay::ControlPointMarker& control)
         -> const ViewerOverlayControllerBase::OverlayStyle& {
+        if (control.isLinkCandidate) {
+            return linkCandidateControlPointStyle;
+        }
         if (control.hasBranches) {
             return branchControlPointStyle;
         }
@@ -287,6 +295,18 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
     fiberIntersectionStyle.penCap = Qt::FlatCap;
     fiberIntersectionStyle.z = 168.0;
 
+    ViewerOverlayControllerBase::OverlayStyle linkCandidateFiberIntersectionStyle =
+        fiberIntersectionStyle;
+    linkCandidateFiberIntersectionStyle.penColor = QColor(60, 235, 120, 245);
+    linkCandidateFiberIntersectionStyle.penWidth = 1.75;
+    linkCandidateFiberIntersectionStyle.z = 168.5;
+
+    ViewerOverlayControllerBase::OverlayStyle branchLinkFiberIntersectionStyle =
+        fiberIntersectionStyle;
+    branchLinkFiberIntersectionStyle.penColor = QColor(210, 95, 255, 245);
+    branchLinkFiberIntersectionStyle.penWidth = 1.75;
+    branchLinkFiberIntersectionStyle.z = 168.25;
+
     auto addVolumePointMarker = [&](const cv::Vec3f& point,
                                     qreal radius,
                                     const ViewerOverlayControllerBase::OverlayStyle& style) {
@@ -298,7 +318,9 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
             radius,
             style});
     };
-    auto addFiberIntersectionMarker = [&](const QPointF& scenePoint) {
+    auto addFiberIntersectionMarker =
+        [&](const QPointF& scenePoint,
+            const ViewerOverlayControllerBase::OverlayStyle& style) {
         if (!finiteScenePoint(scenePoint)) {
             return;
         }
@@ -307,12 +329,12 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
             {scenePoint + QPointF(-kIntersectionArm, -kIntersectionArm),
              scenePoint + QPointF(kIntersectionArm, kIntersectionArm)},
             false,
-            fiberIntersectionStyle});
+            style});
         primitives.push_back(ViewerOverlayControllerBase::LineStripPrimitive{
             {scenePoint + QPointF(-kIntersectionArm, kIntersectionArm),
              scenePoint + QPointF(kIntersectionArm, -kIntersectionArm)},
             false,
-            fiberIntersectionStyle});
+            style});
     };
 
     std::vector<std::pair<QPointF, double>> sceneLine;
@@ -485,7 +507,7 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
                 {localScene, visibleScene},
                 false,
                 style});
-            addFiberIntersectionMarker(visibleScene);
+            addFiberIntersectionMarker(visibleScene, fiberIntersectionStyle);
         }
     }
 
@@ -504,7 +526,12 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
                     branchLinkStyle});
             }
         }
-        addFiberIntersectionMarker(scenePoint);
+        addFiberIntersectionMarker(scenePoint,
+                                   intersection.isLinkCandidateFiber
+                                       ? linkCandidateFiberIntersectionStyle
+                                       : (intersection.projectedBranchLink
+                                              ? branchLinkFiberIntersectionStyle
+                                              : fiberIntersectionStyle));
     }
 
     if (!overlay.useSurfaceCenterLine) {
@@ -638,6 +665,30 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
     }
     const auto& selectedControl = options.controlPoints[selectedIndex];
 
+    // Nearest fiber-intersection "X" marker to the click, within a scene-space
+    // threshold matched to the drawn glyph (arm length 7.5 scene units).
+    constexpr double kFiberIntersectionHitThreshold = 12.0;
+    const GeneratedOverlay::FiberIntersectionMarker* nearbyIntersection = nullptr;
+    double bestIntersectionDistanceSq =
+        kFiberIntersectionHitThreshold * kFiberIntersectionHitThreshold;
+    for (const auto& intersection : options.fiberIntersections) {
+        if (intersection.fiberId == 0 ||
+            intersection.projectedBranchLink ||
+            !finiteGeneratedPoint(intersection.point)) {
+            continue;
+        }
+        const QPointF intersectionScene = options.viewer->volumeToScene(intersection.point);
+        if (!finiteScenePoint(intersectionScene)) {
+            continue;
+        }
+        const QPointF delta = intersectionScene - options.scenePoint;
+        const double distanceSq = delta.x() * delta.x() + delta.y() * delta.y();
+        if (distanceSq < bestIntersectionDistanceSq) {
+            bestIntersectionDistanceSq = distanceSq;
+            nearbyIntersection = &intersection;
+        }
+    }
+
     clearGeneratedControlPointContextPreview(options.viewer, options.surfaceName);
     if (finiteScenePoint(options.scenePoint) && finiteScenePoint(targetScene)) {
         ViewerOverlayControllerBase::OverlayStyle previewStyle;
@@ -682,6 +733,26 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
             openBranchActions.push_back({action, branch});
         }
     }
+    std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>> unlinkActions;
+    if (options.unlinkBranch && !selectedControl.branchLinks.empty()) {
+        if (selectedControl.branchLinks.size() == 1) {
+            const auto& branch = selectedControl.branchLinks.front();
+            QAction* action = menu.addAction(
+                QWidget::tr("Unlink from Fiber %1 / CP %2")
+                    .arg(static_cast<qulonglong>(branch.fiberId))
+                    .arg(branch.controlPointIndex));
+            unlinkActions.push_back({action, branch});
+        } else {
+            QMenu* unlinkMenu = menu.addMenu(QWidget::tr("Unlink"));
+            for (const auto& branch : selectedControl.branchLinks) {
+                QAction* action = unlinkMenu->addAction(
+                    QWidget::tr("Fiber %1 / CP %2")
+                        .arg(static_cast<qulonglong>(branch.fiberId))
+                        .arg(branch.controlPointIndex));
+                unlinkActions.push_back({action, branch});
+            }
+        }
+    }
     const bool canSampleClickedVolume =
         options.viewer->sampleSceneVolume(options.scenePoint).has_value();
     QAction* newLineAnnotationAction =
@@ -701,6 +772,26 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
             selectedControlIndex != std::numeric_limits<size_t>::max() &&
             canSampleClickedVolume);
     }
+    QAction* designateLinkCandidateAction = nullptr;
+    if (options.designateLinkCandidate) {
+        designateLinkCandidateAction =
+            menu.addAction(QWidget::tr("Designate as link candidate"));
+        designateLinkCandidateAction->setEnabled(
+            selectedControlIndex != std::numeric_limits<size_t>::max());
+    }
+    QAction* linkWithCandidateAction = nullptr;
+    if (options.linkWithCandidate && !options.linkWithCandidateLabel.isEmpty()) {
+        linkWithCandidateAction = menu.addAction(options.linkWithCandidateLabel);
+        linkWithCandidateAction->setEnabled(
+            options.linkWithCandidateEnabled &&
+            selectedControlIndex != std::numeric_limits<size_t>::max());
+    }
+    QAction* openNearbyAnnotationAction = nullptr;
+    if (options.openNearbyAnnotation && nearbyIntersection) {
+        openNearbyAnnotationAction = menu.addAction(
+            QWidget::tr("Go to nearby annotation (Fiber %1)")
+                .arg(static_cast<qulonglong>(nearbyIntersection->fiberId)));
+    }
     QAction* selected = menu.exec(options.globalPos);
     clearGeneratedControlPointContextPreview(options.viewer, options.surfaceName);
 
@@ -713,6 +804,12 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
     for (const auto& [action, branch] : openBranchActions) {
         if (selected == action && action->isEnabled()) {
             options.openBranch(branch.fiberId, branch.controlPointIndex);
+            return GeneratedControlPointContextResult::Handled;
+        }
+    }
+    for (const auto& [action, branch] : unlinkActions) {
+        if (selected == action) {
+            options.unlinkBranch(selectedControlIndex, branch.fiberId, branch.controlPointIndex);
             return GeneratedControlPointContextResult::Handled;
         }
     }
@@ -743,6 +840,22 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
                           clickedVolumePoint->position,
                           true,
                           options.branchLinkDirection);
+        return GeneratedControlPointContextResult::Handled;
+    }
+    if (designateLinkCandidateAction &&
+        selected == designateLinkCandidateAction &&
+        designateLinkCandidateAction->isEnabled()) {
+        options.designateLinkCandidate(selectedControlIndex, selectedControl.point);
+        return GeneratedControlPointContextResult::Handled;
+    }
+    if (linkWithCandidateAction &&
+        selected == linkWithCandidateAction &&
+        linkWithCandidateAction->isEnabled()) {
+        options.linkWithCandidate(selectedControlIndex, selectedControl.point);
+        return GeneratedControlPointContextResult::Handled;
+    }
+    if (openNearbyAnnotationAction && selected == openNearbyAnnotationAction) {
+        options.openNearbyAnnotation(nearbyIntersection->fiberId, nearbyIntersection->point);
         return GeneratedControlPointContextResult::Handled;
     }
     return GeneratedControlPointContextResult::Handled;

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
@@ -51,6 +51,7 @@ struct GeneratedOverlay {
         size_t controlIndex = std::numeric_limits<size_t>::max();
         bool isSeed = false;
         bool hasBranches = false;
+        bool isLinkCandidate = false;
         std::vector<uint64_t> branchIds;
         std::vector<BranchLink> branchLinks;
     };
@@ -96,6 +97,7 @@ struct GeneratedOverlay {
         double arclength = std::numeric_limits<double>::quiet_NaN();
         double distance = std::numeric_limits<double>::quiet_NaN();
         bool projectedBranchLink = false;
+        bool isLinkCandidateFiber = false;
         std::optional<cv::Vec3f> connectorStart;
     };
 
@@ -897,8 +899,23 @@ inline GeneratedOverlay makeGeneratedCrossSliceOverlay(
             }
         }
     }
+
+    for (const auto& intersection : views.fiberIntersections) {
+        if (!finiteGeneratedPoint(intersection.point)) {
+            continue;
+        }
+        const float distance = pointDistance(intersection.point);
+        if (std::isfinite(distance) && std::abs(distance) <= *controlDistanceThreshold) {
+            overlay.fiberIntersections.push_back(intersection);
+        }
+    }
     return overlay;
 }
+
+struct GeneratedLinkCandidateMenuState {
+    bool enabled = false;
+    QString label;
+};
 
 struct GeneratedControlPointContextMenuOptions {
     QWidget* parent = nullptr;
@@ -907,15 +924,22 @@ struct GeneratedControlPointContextMenuOptions {
     QPointF scenePoint;
     QPoint globalPos;
     std::vector<GeneratedOverlay::ControlPointMarker> controlPoints;
+    std::vector<GeneratedOverlay::FiberIntersectionMarker> fiberIntersections;
     size_t linePointCount = 0;
     double linePosition = std::numeric_limits<double>::quiet_NaN();
     bool stripViewer = false;
+    bool linkWithCandidateEnabled = false;
+    QString linkWithCandidateLabel;
     cv::Vec3f branchLinkDirection{std::numeric_limits<float>::quiet_NaN(),
                                   std::numeric_limits<float>::quiet_NaN(),
                                   std::numeric_limits<float>::quiet_NaN()};
     std::function<void(double, cv::Vec3f)> deleteControlPoint;
     std::function<void(size_t, cv::Vec3f, bool, cv::Vec3f)> addBranch;
     std::function<void(uint64_t, int)> openBranch;
+    std::function<void(size_t, uint64_t, int)> unlinkBranch;
+    std::function<void(size_t, cv::Vec3f)> designateLinkCandidate;
+    std::function<void(size_t, cv::Vec3f)> linkWithCandidate;
+    std::function<void(uint64_t, cv::Vec3f)> openNearbyAnnotation;
 };
 
 QPointF generatedStripLinePositionToScene(CChunkedVolumeViewer* viewer,

--- a/volume-cartographer/core/test/test_fiber_widget.cpp
+++ b/volume-cartographer/core/test/test_fiber_widget.cpp
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
         metrics.horizontalAdvance(QStringLiteral("kb_..._000002")));
     require(adaptedName.endsWith(QStringLiteral("_000002")),
             "Fiber name elision should preserve the sequence suffix");
-    require(treeView->model()->columnCount() == 8, "Fiber tree should expose eight columns");
+    require(treeView->model()->columnCount() == 9, "Fiber tree should expose nine columns");
     require(treeView->header()->sectionResizeMode(0) == QHeaderView::Interactive,
             "Fiber tree header should allow changing column widths");
     require(treeView->model()->index(1, 0).data().toString() ==
@@ -117,9 +117,9 @@ int main(int argc, char** argv)
             "Fiber tree row should not show the runtime fiber ID");
     require(treeView->model()->rowCount(treeView->model()->index(1, 0)) == 2,
             "Fiber tree row did not expose span children");
-    require(treeView->model()->index(1, 5).data().toString() == QStringLiteral("review"),
+    require(treeView->model()->index(1, 6).data().toString() == QStringLiteral("review"),
             "Fiber tree tags column did not show fiber tags");
-    require(treeView->model()->index(1, 6).data().toString() == QStringLiteral("-"),
+    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("-"),
             "Metrics should be hidden before Calc metrics is enabled");
     require(widget.orderedFiberIds() == std::vector<uint64_t>({1, 2, 3}),
             "Initial fiber order should match the sorted list order");
@@ -215,10 +215,10 @@ int main(int argc, char** argv)
     require(model != nullptr, "Fiber tree should use a standard item model");
     QMetaObject::invokeMethod(treeView->header(),
                               "sectionClicked",
-                              Q_ARG(int, 2));
+                              Q_ARG(int, 3));
     QMetaObject::invokeMethod(treeView->header(),
                               "sectionClicked",
-                              Q_ARG(int, 2));
+                              Q_ARG(int, 3));
     require(widget.orderedFiberIds() == std::vector<uint64_t>({3, 2, 1}),
             "Fiber order should track the current sorted list order");
     QStandardItem* secondItemBeforeMetrics = model->item(1, 0);
@@ -228,21 +228,21 @@ int main(int argc, char** argv)
             "Calc metrics request should use the current fiber list order");
     require(model->item(1, 0) == secondItemBeforeMetrics,
             "Toggling Calc metrics should update cells without rebuilding the fiber rows");
-    require(treeView->model()->index(1, 6).data().toString() == QStringLiteral("25.0"),
+    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("25.0"),
             "Mean alignment error metric was not displayed");
-    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("50.0"),
+    require(treeView->model()->index(1, 8).data().toString() == QStringLiteral("50.0"),
             "Max alignment error metric was not displayed");
-    require(treeView->model()->index(1, 7).data(Qt::BackgroundRole).isValid(),
+    require(treeView->model()->index(1, 8).data(Qt::BackgroundRole).isValid(),
             "Fiber row with max alignment error > 45 deg was not highlighted");
     const QModelIndex secondParent = treeView->model()->index(1, 0);
-    require(treeView->model()->index(1, 7, secondParent).data().toString() == QStringLiteral("52.0"),
+    require(treeView->model()->index(1, 8, secondParent).data().toString() == QStringLiteral("52.0"),
             "Span max alignment error metric was not displayed");
-    require(treeView->model()->index(1, 7, secondParent).data(Qt::BackgroundRole).isValid(),
+    require(treeView->model()->index(1, 8, secondParent).data(Qt::BackgroundRole).isValid(),
             "Span row with max alignment error > 45 deg was not highlighted");
     widget.setAlignmentMetricsPending(true);
     require(model->item(1, 0) == secondItemBeforeMetrics,
             "Marking metrics pending should update cells without rebuilding the fiber rows");
-    require(treeView->model()->index(1, 6).data().toString() == QStringLiteral("..."),
+    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("..."),
             "Pending metric state should be displayed in-place");
     widget.updateAlignmentMetrics(
         2,
@@ -250,18 +250,18 @@ int main(int argc, char** argv)
         {makeMetric(9.0, 21.0, 27), makeMetric(32.0, 53.0, 33)});
     require(model->item(1, 0) == secondItemBeforeMetrics,
             "Live metric update should update cells without rebuilding the fiber rows");
-    require(treeView->model()->index(1, 6).data().toString() == QStringLiteral("26.0"),
+    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("26.0"),
             "Live fiber mean alignment metric was not displayed");
-    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("51.0"),
+    require(treeView->model()->index(1, 8).data().toString() == QStringLiteral("51.0"),
             "Live fiber max alignment metric was not displayed");
-    require(treeView->model()->index(1, 7, secondParent).data().toString() == QStringLiteral("53.0"),
+    require(treeView->model()->index(1, 8, secondParent).data().toString() == QStringLiteral("53.0"),
             "Live span alignment metric was not displayed");
     QMetaObject::invokeMethod(treeView->header(),
                               "sectionClicked",
-                              Q_ARG(int, 2));
+                              Q_ARG(int, 3));
     QMetaObject::invokeMethod(treeView->header(),
                               "sectionClicked",
-                              Q_ARG(int, 2));
+                              Q_ARG(int, 3));
     require(treeView->model()->index(0, 0).data().toString() ==
                 QStringLiteral("zz_20260605T184821587_000003"),
             "Sorting by length descending should reorder only top-level fibers");


### PR DESCRIPTION
## Summary

Adds a workflow for linking **existing** control points across fibers in the Line Annotation GUI (previously links could only be created by spawning a new fiber from a control point), plus supporting visualization and panel changes.

### Link-candidate workflow (Ctrl+right-click context menu)
- **Designate as link candidate** — marks a control point as the pending link target (renders green in all viewers). Only one candidate exists at a time; it is transient (in-memory) and cleared automatically after linking or when its fiber is deleted.
- **Go to nearby annotation** — Ctrl+right-click a fiber-intersection "X" marker to switch the workspace to that fiber, positioned at the intersection (reuses the existing open-fiber flow; current fiber is finalized/saved).
- **Link with candidate** — creates the same reciprocal `FiberBranchRef` pair as existing branch links: both control points turn purple, both fibers' JSONs are saved, and "Go to linked annotation" works from both sides. Disabled when the candidate is on the current fiber.
- **Unlink from Fiber N / CP m** — removes a specific link from both fibers (submenu when a control point has multiple links), using the existing branch-metadata sync hook for reciprocal cleanup.

### Visualization
- Fiber-intersection X markers now also appear in the current-cut and side-cut viewers (previously strip-only), filtered by distance to the cut plane.
- While working in another fiber, the candidate's fiber shows as **green** X's; branch-linked X's render **purple** with their red connector line in all three viewers; linked (purple) control points now render correctly in the fast current-cut overlay path.

### Fibers panel
- New sortable **link** column (between *dir* and *len*) showing the size of each fiber's branch-link connected component — e.g. a chain A–B–C–D–E shows **5** on all five rows; blank when unlinked. Computed via union-find over the branch graph on each summary refresh.

## Test plan
- Builds clean (`ninja VC3D`).
- Manual: designate → green CP in strips/side cut/current cut; re-designate replaces; X navigation switches fiber near the intersection; link → purple CPs + purple X + red connector in all viewers, JSONs contain complete `branches` entries and reload without validation warnings; unlink reverts styling and splits the panel's link counts; same-fiber link disabled; stale candidate (deleted CP/fiber) shows an error and clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dv6qftzVoyCq3LQipYtb6P