### PR TITLE
Lasagna flatten opt

### DIFF
--- a/lasagna/configs/flatten_fast_nofilter.json
+++ b/lasagna/configs/flatten_fast_nofilter.json
@@ -1,7 +1,8 @@
 {
 	"args": {
 		"model-init": "flatten",
-	    "flatten_solver": "forward"
+		"flatten_solver": "forward",
+		"flatten_initial_inversion": false
 	},
 	"base": {
 		"flatten_sdir": 1.0,
@@ -17,6 +18,8 @@
 			"params": ["map_flatten_ms"],
 			"min_scaledown": 0,
 			"args": {
+				"compile_flatten": true,
+				"flatten_diagnostics": false,
 				"flatten_support": true,
 				"flatten_support_radius": 1,
 				"flatten_orient_min_det": 0.0,
@@ -36,6 +39,8 @@
 			"params": ["map_flatten_ms"],
 			"min_scaledown": 0,
 			"args": {
+				"compile_flatten": true,
+				"flatten_diagnostics": false,
 				"flatten_support": true,
 				"flatten_support_radius": 1,
 				"flatten_orient_min_det": 0.0,
@@ -55,6 +60,8 @@
 			"params": ["map_flatten_ms"],
 			"min_scaledown": 0,
 			"args": {
+				"compile_flatten": true,
+				"flatten_diagnostics": false,
 				"flatten_support": true,
 				"flatten_support_radius": 1,
 				"flatten_orient_min_det": 0.0,

--- a/lasagna/configs/flatten_fast_nofilter.json
+++ b/lasagna/configs/flatten_fast_nofilter.json
@@ -20,6 +20,7 @@
 			"args": {
 				"compile_flatten": true,
 				"flatten_diagnostics": false,
+				"fused_flatten_adam_clamp": true,
 				"flatten_support": true,
 				"flatten_support_radius": 1,
 				"flatten_orient_min_det": 0.0,
@@ -41,6 +42,7 @@
 			"args": {
 				"compile_flatten": true,
 				"flatten_diagnostics": false,
+				"fused_flatten_adam_clamp": true,
 				"flatten_support": true,
 				"flatten_support_radius": 1,
 				"flatten_orient_min_det": 0.0,
@@ -62,6 +64,7 @@
 			"args": {
 				"compile_flatten": true,
 				"flatten_diagnostics": false,
+				"fused_flatten_adam_clamp": true,
 				"flatten_support": true,
 				"flatten_support_radius": 1,
 				"flatten_orient_min_det": 0.0,

--- a/lasagna/configs/flatten_fast_nofilter.json
+++ b/lasagna/configs/flatten_fast_nofilter.json
@@ -19,6 +19,7 @@
 			"min_scaledown": 0,
 			"args": {
 				"compile_flatten": true,
+				"compile_flatten_combined": true,
 				"flatten_diagnostics": false,
 				"fused_flatten_adam_clamp": true,
 				"flatten_support": true,
@@ -41,6 +42,7 @@
 			"min_scaledown": 0,
 			"args": {
 				"compile_flatten": true,
+				"compile_flatten_combined": true,
 				"flatten_diagnostics": false,
 				"fused_flatten_adam_clamp": true,
 				"flatten_support": true,
@@ -63,6 +65,7 @@
 			"min_scaledown": 0,
 			"args": {
 				"compile_flatten": true,
+				"compile_flatten_combined": true,
 				"flatten_diagnostics": false,
 				"fused_flatten_adam_clamp": true,
 				"flatten_support": true,

--- a/lasagna/fit.py
+++ b/lasagna/fit.py
@@ -1266,6 +1266,16 @@ def _export_flatten_result(
 	fit2tifxyz._print_area(area)
 
 
+def _initial_flatten_state(
+	mdl: model.Model3D,
+	*,
+	invert_forward: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+	if mdl.flatten_direction == "forward" and not invert_forward:
+		return mdl._flatten_forward_current()
+	return mdl._flatten_sample_current()
+
+
 def _run_flatten_mode(
 	*,
 	cfg: dict,
@@ -1314,6 +1324,7 @@ def _run_flatten_mode(
 	filter_source_angles = _truthy_config_bool(flatten_args.get("flatten_filter_source_angles", True))
 	filter_angle_deg = float(flatten_args.get("flatten_filter_angle_deg", 90.0))
 	filter_radius = int(flatten_args.get("flatten_filter_radius", 2))
+	initial_inversion = _truthy_config_bool(flatten_args.get("flatten_initial_inversion", True))
 	mdl = model.Model3D.from_flatten_tifxyz_crop(
 		xyz,
 		valid,
@@ -1366,9 +1377,16 @@ def _run_flatten_mode(
 			print(f"PROGRESS {step} {total} {loss:.6f}", flush=True)
 
 	with torch.no_grad():
-		map_yx, xyz0, point_mask, quad_mask = mdl._flatten_sample_current()
+		map_yx, xyz0, point_mask, quad_mask = _initial_flatten_state(
+			mdl,
+			invert_forward=initial_inversion,
+		)
+		if flatten_direction == "forward" and not initial_inversion:
+			initial_label = "initial forward flatten (inversion skipped)"
+		else:
+			initial_label = "initial flatten"
 		print(
-			f"initial flatten: map_shape={tuple(map_yx.shape)} "
+			f"{initial_label}: map_shape={tuple(map_yx.shape)} "
 			f"point_valid={int(point_mask.sum())}/{point_mask.numel()} "
 			f"quad_valid={int(quad_mask.sum())}/{quad_mask.numel()}",
 			flush=True,

--- a/lasagna/flatten_clamped_adam.py
+++ b/lasagna/flatten_clamped_adam.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+
+import torch
+
+
+class FlattenClampedAdam(torch.optim.Adam):
+	"""Adam with the flatten UV-vector update cap applied before the parameter write."""
+
+	def __init__(
+		self,
+		params: Iterable[torch.Tensor] | Iterable[dict],
+		*,
+		base_step: float,
+		lr: float = 1.0e-3,
+		betas: tuple[float, float] = (0.9, 0.999),
+		eps: float = 1.0e-8,
+	) -> None:
+		super().__init__(
+			params,
+			lr=lr,
+			betas=betas,
+			eps=eps,
+			weight_decay=0.0,
+			amsgrad=False,
+			foreach=False,
+			maximize=False,
+			capturable=False,
+			differentiable=False,
+			fused=False,
+		)
+		self.base_step = float(base_step)
+		self._triton_disabled_reason: str | None = None
+		self.last_backend = "none"
+
+	@staticmethod
+	def _init_state(state: dict, param: torch.Tensor) -> None:
+		if state:
+			return
+		state["step"] = torch.tensor(0.0, dtype=torch.float32)
+		state["exp_avg"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+		state["exp_avg_sq"] = torch.zeros_like(param, memory_format=torch.preserve_format)
+
+	@staticmethod
+	def _torch_step(
+		param: torch.Tensor,
+		grad: torch.Tensor,
+		exp_avg: torch.Tensor,
+		exp_avg_sq: torch.Tensor,
+		*,
+		beta1: float,
+		beta2: float,
+		step_size: float,
+		bias_correction2_sqrt: float,
+		eps: float,
+		max_step: float,
+	) -> None:
+		exp_avg.lerp_(grad, 1.0 - beta1)
+		exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1.0 - beta2)
+		denom = exp_avg_sq.sqrt().div_(bias_correction2_sqrt).add_(eps)
+		update = exp_avg.div(denom).mul_(-step_size)
+		candidate = param + update
+		delta = candidate - param
+		if update.ndim >= 1 and int(update.shape[0]) == 2:
+			norm = torch.linalg.vector_norm(delta, dim=0, keepdim=True)
+			scale = (float(max_step) / norm.clamp_min(1.0e-12)).clamp_max_(1.0)
+			param.add_(delta * scale)
+		else:
+			param.add_(delta.clamp_(min=-float(max_step), max=float(max_step)))
+
+	def _try_triton_step(self, *args, **kwargs) -> bool:
+		param = args[0]
+		if param.device.type != "cuda" or self._triton_disabled_reason is not None:
+			return False
+		try:
+			from flatten_clamped_adam_triton import clamped_adam_step
+
+			clamped_adam_step(*args, **kwargs)
+		except Exception as exc:
+			self._triton_disabled_reason = f"{type(exc).__name__}: {exc}"
+			print(
+				f"[flatten_clamped_adam] Triton disabled after failure: {self._triton_disabled_reason}",
+				flush=True,
+			)
+			return False
+		return True
+
+	@torch.no_grad()
+	def step(self, closure=None):
+		loss = None
+		if closure is not None:
+			with torch.enable_grad():
+				loss = closure()
+
+		used_triton = False
+		used_torch = False
+		for group in self.param_groups:
+			beta1, beta2 = (float(group["betas"][0]), float(group["betas"][1]))
+			lr = float(group["lr"])
+			eps = float(group["eps"])
+			scale_i = int(group.get("_flatten_scale_i", 0))
+			max_step = self.base_step * (2.0 ** scale_i)
+			if max_step <= 0.0:
+				raise ValueError("FlattenClampedAdam base_step must be positive")
+			if (
+				float(group.get("weight_decay", 0.0)) != 0.0
+				or bool(group.get("amsgrad", False))
+				or bool(group.get("maximize", False))
+				or bool(group.get("capturable", False))
+				or bool(group.get("differentiable", False))
+			):
+				raise ValueError("FlattenClampedAdam supports standard Adam without weight decay or AMSGrad")
+
+			for param in group["params"]:
+				grad = param.grad
+				if grad is None:
+					continue
+				if grad.is_sparse:
+					raise RuntimeError("FlattenClampedAdam does not support sparse gradients")
+				state = self.state[param]
+				self._init_state(state, param)
+				state["step"].add_(1.0)
+				step = float(state["step"].item())
+				bias_correction1 = 1.0 - beta1 ** step
+				bias_correction2_sqrt = math.sqrt(1.0 - beta2 ** step)
+				kwargs = {
+					"beta1": beta1,
+					"beta2": beta2,
+					"step_size": lr / bias_correction1,
+					"bias_correction2_sqrt": bias_correction2_sqrt,
+					"eps": eps,
+					"max_step": max_step,
+				}
+				args = (param, grad, state["exp_avg"], state["exp_avg_sq"])
+				if self._try_triton_step(*args, **kwargs):
+					used_triton = True
+				else:
+					self._torch_step(*args, **kwargs)
+					used_torch = True
+		self.last_backend = "triton" if used_triton and not used_torch else "torch"
+		return loss

--- a/lasagna/flatten_clamped_adam_triton.py
+++ b/lasagna/flatten_clamped_adam_triton.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _clamped_adam_kernel(
+	param,
+	grad,
+	exp_avg,
+	exp_avg_sq,
+	n_vectors,
+	beta1,
+	one_minus_beta1,
+	beta2,
+	one_minus_beta2,
+	step_size,
+	inv_bias_correction2_sqrt,
+	eps,
+	max_step,
+	BLOCK_SIZE: tl.constexpr,
+):
+	off = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+	mask = off < n_vectors
+	off_other = off + n_vectors
+
+	g0 = tl.load(grad + off, mask=mask)
+	g1 = tl.load(grad + off_other, mask=mask)
+	m0_old = tl.load(exp_avg + off, mask=mask)
+	m1_old = tl.load(exp_avg + off_other, mask=mask)
+	v0_old = tl.load(exp_avg_sq + off, mask=mask)
+	v1_old = tl.load(exp_avg_sq + off_other, mask=mask)
+
+	# Match Adam's lerp first-moment update and mul/addcmul second moment.
+	m0 = m0_old + (g0 - m0_old) * one_minus_beta1
+	m1 = m1_old + (g1 - m1_old) * one_minus_beta1
+	v0 = beta2 * v0_old + one_minus_beta2 * g0 * g0
+	v1 = beta2 * v1_old + one_minus_beta2 * g1 * g1
+
+	denom0 = tl.sqrt(v0) * inv_bias_correction2_sqrt + eps
+	denom1 = tl.sqrt(v1) * inv_bias_correction2_sqrt + eps
+	update0 = -step_size * m0 / denom0
+	update1 = -step_size * m1 / denom1
+	p0 = tl.load(param + off, mask=mask)
+	p1 = tl.load(param + off_other, mask=mask)
+	# Reproduce the reference path's float32 parameter write followed by
+	# delta=p_after-p_before before calculating the vector cap.
+	candidate0 = p0 + update0
+	candidate1 = p1 + update1
+	delta0 = candidate0 - p0
+	delta1 = candidate1 - p1
+	delta_norm = tl.sqrt(delta0 * delta0 + delta1 * delta1)
+	update_scale = tl.minimum(1.0, max_step / tl.maximum(delta_norm, 1.0e-12))
+	tl.store(param + off, p0 + delta0 * update_scale, mask=mask)
+	tl.store(param + off_other, p1 + delta1 * update_scale, mask=mask)
+	tl.store(exp_avg + off, m0, mask=mask)
+	tl.store(exp_avg + off_other, m1, mask=mask)
+	tl.store(exp_avg_sq + off, v0, mask=mask)
+	tl.store(exp_avg_sq + off_other, v1, mask=mask)
+
+
+def clamped_adam_step(
+	param: torch.Tensor,
+	grad: torch.Tensor,
+	exp_avg: torch.Tensor,
+	exp_avg_sq: torch.Tensor,
+	*,
+	beta1: float,
+	beta2: float,
+	step_size: float,
+	bias_correction2_sqrt: float,
+	eps: float,
+	max_step: float,
+) -> None:
+	if param.device.type != "cuda":
+		raise ValueError("Triton clamped Adam requires CUDA tensors")
+	if param.dtype != torch.float32:
+		raise ValueError(f"Triton clamped Adam requires float32 parameters, got {param.dtype}")
+	if not all(t.is_contiguous() for t in (param, grad, exp_avg, exp_avg_sq)):
+		raise ValueError("Triton clamped Adam requires contiguous tensors")
+	if not (param.shape == grad.shape == exp_avg.shape == exp_avg_sq.shape):
+		raise ValueError("Triton clamped Adam tensor shapes must match")
+	if param.ndim < 1 or int(param.shape[0]) != 2:
+		raise ValueError(f"Triton clamped Adam requires leading UV dimension 2, got {tuple(param.shape)}")
+
+	n_vectors = int(param.numel()) // 2
+	if n_vectors <= 0:
+		return
+	block_size = 256
+	grid = (triton.cdiv(n_vectors, block_size),)
+	_clamped_adam_kernel[grid](
+		param,
+		grad,
+		exp_avg,
+		exp_avg_sq,
+		n_vectors,
+		float(beta1),
+		1.0 - float(beta1),
+		float(beta2),
+		1.0 - float(beta2),
+		float(step_size),
+		1.0 / float(bias_correction2_sqrt),
+		float(eps),
+		float(max_step),
+		BLOCK_SIZE=block_size,
+		num_warps=4,
+	)

--- a/lasagna/model.py
+++ b/lasagna/model.py
@@ -300,6 +300,9 @@ class FitResult3D:
 	flatten_source_xyz: torch.Tensor | None = None       # (Hs, Ws, 3) frozen source surface
 	flatten_source_valid: torch.Tensor | None = None     # (Hs, Ws) bool frozen source vertices
 	flatten_source_cell_valid: torch.Tensor | None = None  # (Hs-1, Ws-1) bool frozen source quads
+	flatten_source_metric: torch.Tensor | None = None    # (Hs-1, Ws-1, 3) frozen g00,g01,g11
+	flatten_identity_y: torch.Tensor | None = None       # (Hmap,) frozen canonical row coordinates
+	flatten_identity_x: torch.Tensor | None = None       # (Wmap,) frozen canonical column coordinates
 	# Per ext surface: (mask, offset, ext_P, ext_N, full_h, full_w)
 	# ext_P/ext_N = ext corner pos/normal (detached), full_h/full_w = model grid position (row+u, col+v)
 	# Shapes: (D, H_ext, W_ext, ...). Model quad corners are re-gathered from xyz_lr in the loss.
@@ -453,6 +456,21 @@ class Model3D(nn.Module):
 		self.register_buffer("flatten_target_step", torch.tensor(float(mesh_step), device=device, dtype=torch.float32))
 		self.register_buffer("flatten_avg_offset_mask", torch.empty(0, 0, device=device, dtype=torch.bool))
 		self.register_buffer("flatten_initial_avg_offset", torch.zeros(2, device=device, dtype=torch.float32))
+		self.register_buffer(
+			"flatten_source_metric",
+			torch.empty(0, 0, 3, device=device, dtype=torch.float32),
+			persistent=False,
+		)
+		self.register_buffer(
+			"flatten_identity_y",
+			torch.empty(0, device=device, dtype=torch.float32),
+			persistent=False,
+		)
+		self.register_buffer(
+			"flatten_identity_x",
+			torch.empty(0, device=device, dtype=torch.float32),
+			persistent=False,
+		)
 		self.flatten_source_filter_stats: dict[str, float] = {}
 
 		# Amplitude and bias for data matching (deferred but needed for FitResult3D)
@@ -2848,6 +2866,26 @@ class Model3D(nn.Module):
 		return torch.zeros(2, device=map_yx.device, dtype=map_yx.dtype)
 
 	@staticmethod
+	def _flatten_source_metric(xyz: torch.Tensor) -> torch.Tensor:
+		"""Precompute the fixed first fundamental form for each source quad."""
+		if xyz.ndim != 3 or int(xyz.shape[-1]) != 3:
+			raise ValueError(f"flatten source xyz must have shape (H,W,3), got {tuple(xyz.shape)}")
+		p00 = xyz[:-1, :-1]
+		p10 = xyz[1:, :-1]
+		p01 = xyz[:-1, 1:]
+		p11 = xyz[1:, 1:]
+		xy = 0.5 * ((p10 - p00) + (p11 - p01))
+		xx = 0.5 * ((p01 - p00) + (p11 - p10))
+		return torch.stack(
+			(
+				(xy * xy).sum(dim=-1),
+				(xy * xx).sum(dim=-1),
+				(xx * xx).sum(dim=-1),
+			),
+			dim=-1,
+		).contiguous()
+
+	@staticmethod
 	def _source_cell_valid(valid: torch.Tensor) -> torch.Tensor:
 		if int(valid.shape[0]) < 2 or int(valid.shape[1]) < 2:
 			return torch.zeros(max(0, int(valid.shape[0]) - 1), max(0, int(valid.shape[1]) - 1),
@@ -3308,6 +3346,8 @@ class Model3D(nn.Module):
 		self.bias = nn.Parameter(torch.zeros(1, 1, map_h, map_w, device=device, dtype=torch.float32), requires_grad=False)
 		self.flatten_source_xyz = xyz_dev
 		self.flatten_source_valid = valid_dev
+		self.flatten_identity_y = torch.arange(map_h, device=device, dtype=torch.float32)
+		self.flatten_identity_x = torch.arange(map_w, device=device, dtype=torch.float32)
 		source_cell_valid = self._source_cell_valid(valid_dev)
 		if bool(flatten_filter_source_angles):
 			source_cell_valid, filter_stats = self._filter_source_cells_by_angle(
@@ -3329,6 +3369,11 @@ class Model3D(nn.Module):
 				"cell_valid_after": float(source_cell_valid.to(dtype=torch.float32).sum().detach().cpu()),
 			}
 		self.flatten_source_cell_valid = source_cell_valid
+		self.flatten_source_metric = (
+			self._flatten_source_metric(xyz_dev).detach()
+			if direction == "forward"
+			else torch.empty(0, 0, 3, device=device, dtype=torch.float32)
+		)
 		self.flatten_target_step = self._measured_flatten_target_step(
 			xyz_dev,
 			valid_dev,
@@ -3433,13 +3478,8 @@ class Model3D(nn.Module):
 		torch.Tensor,
 	]:
 		map_yx = self.flatten_map()
-		xyz = torch.where(
-			self.flatten_source_valid.unsqueeze(-1),
-			self.flatten_source_xyz,
-			torch.zeros_like(self.flatten_source_xyz),
-		)
 		quad_mask = self.flatten_source_cell_valid.unsqueeze(0)
-		return map_yx, xyz.unsqueeze(0), self.flatten_source_valid, quad_mask
+		return map_yx, self.flatten_source_xyz.unsqueeze(0), self.flatten_source_valid, quad_mask
 
 	def _flatten_sample_current(self) -> tuple[
 		torch.Tensor,
@@ -4140,6 +4180,9 @@ class Model3D(nn.Module):
 			flatten_source_xyz=self.flatten_source_xyz if self.flatten_enabled else None,
 			flatten_source_valid=self.flatten_source_valid if self.flatten_enabled else None,
 			flatten_source_cell_valid=self.flatten_source_cell_valid if self.flatten_enabled else None,
+			flatten_source_metric=self.flatten_source_metric if self.flatten_enabled else None,
+			flatten_identity_y=self.flatten_identity_y if self.flatten_enabled else None,
+			flatten_identity_x=self.flatten_identity_x if self.flatten_enabled else None,
 		)
 
 	def opt_params(self) -> dict[str, list[nn.Parameter]]:
@@ -4242,6 +4285,9 @@ class Model3D(nn.Module):
 		st.pop("flatten_target_step", None)
 		st.pop("flatten_avg_offset_mask", None)
 		st.pop("flatten_initial_avg_offset", None)
+		st.pop("flatten_source_metric", None)
+		st.pop("flatten_identity_y", None)
+		st.pop("flatten_identity_x", None)
 		st.pop("flatten_map_flat", None)
 		st.pop("flatten_point_mask", None)
 		incompat = super().load_state_dict(st, strict=bool(strict))

--- a/lasagna/opt_loss_flatten.py
+++ b/lasagna/opt_loss_flatten.py
@@ -18,6 +18,7 @@ _compile_fullgraph = False
 _compile_key: tuple[bool, str | None, str | None, bool, bool] | None = None
 _compiled_forward_sdir_core = None
 _compiled_orient_core = None
+_compiled_combined_core = None
 _compile_disabled_reason: str | None = None
 
 
@@ -49,13 +50,15 @@ def configure_compile(
 ) -> None:
 	"""Configure opt-in torch.compile use for the expensive flatten loss kernels."""
 	global _compile_flatten, _compile_backend, _compile_mode, _compile_dynamic, _compile_fullgraph
-	global _compile_key, _compiled_forward_sdir_core, _compiled_orient_core, _compile_disabled_reason
+	global _compile_key, _compiled_forward_sdir_core, _compiled_orient_core, _compiled_combined_core
+	global _compile_disabled_reason
 	backend = str(backend).strip() if backend is not None and str(backend).strip() else None
 	mode = str(mode).strip() if mode is not None and str(mode).strip() else None
 	key = (bool(enabled), backend, mode, bool(dynamic), bool(fullgraph))
 	if key != _compile_key:
 		_compiled_forward_sdir_core = None
 		_compiled_orient_core = None
+		_compiled_combined_core = None
 		_compile_disabled_reason = None
 		_compile_key = key
 	_compile_flatten = bool(enabled)
@@ -78,14 +81,22 @@ def _compile_kwargs() -> dict[str, object]:
 
 
 def _compiled_flatten_core(which: str, eager_fn):
-	global _compiled_forward_sdir_core, _compiled_orient_core, _compile_disabled_reason
+	global _compiled_forward_sdir_core, _compiled_orient_core, _compiled_combined_core
+	global _compile_disabled_reason
 	if not _compile_flatten or _compile_disabled_reason is not None:
 		return eager_fn
 	if not hasattr(torch, "compile"):
 		_compile_disabled_reason = "torch.compile is unavailable"
 		print(f"[opt_loss_flatten] compile_flatten disabled: {_compile_disabled_reason}", flush=True)
 		return eager_fn
-	compiled = _compiled_forward_sdir_core if which == "forward_sdir" else _compiled_orient_core
+	if which == "forward_sdir":
+		compiled = _compiled_forward_sdir_core
+	elif which == "orient":
+		compiled = _compiled_orient_core
+	elif which == "combined":
+		compiled = _compiled_combined_core
+	else:
+		raise ValueError(f"unknown flatten compile core {which!r}")
 	if compiled is None:
 		try:
 			compiled = torch.compile(eager_fn, **_compile_kwargs())
@@ -95,8 +106,10 @@ def _compiled_flatten_core(which: str, eager_fn):
 			return eager_fn
 		if which == "forward_sdir":
 			_compiled_forward_sdir_core = compiled
-		else:
+		elif which == "orient":
 			_compiled_orient_core = compiled
+		else:
+			_compiled_combined_core = compiled
 	return compiled
 
 
@@ -157,29 +170,40 @@ def _forward_source_fields(
 	return uv, xyz, vertex_valid.to(dtype=torch.bool), cell_valid.to(dtype=torch.bool)
 
 
+def _identity_vectors(
+	res: fit_model.FitResult3D,
+	map_yx: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+	identity_y = res.flatten_identity_y
+	identity_x = res.flatten_identity_x
+	if identity_y is None or int(identity_y.numel()) != int(map_yx.shape[0]):
+		identity_y = torch.arange(int(map_yx.shape[0]), device=map_yx.device, dtype=map_yx.dtype)
+	else:
+		identity_y = identity_y.to(device=map_yx.device, dtype=map_yx.dtype)
+	if identity_x is None or int(identity_x.numel()) != int(map_yx.shape[1]):
+		identity_x = torch.arange(int(map_yx.shape[1]), device=map_yx.device, dtype=map_yx.dtype)
+	else:
+		identity_x = identity_x.to(device=map_yx.device, dtype=map_yx.dtype)
+	return identity_y, identity_x
+
+
 def _flatten_forward_sdir_core(
 	uv: torch.Tensor,
-	xyz: torch.Tensor,
+	source_metric: torch.Tensor,
 	cell_valid: torch.Tensor,
 	domain_step: torch.Tensor,
 	eps: float,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-	p00 = xyz[:-1, :-1]
-	p10 = xyz[1:, :-1]
-	p01 = xyz[:-1, 1:]
-	p11 = xyz[1:, 1:]
 	u00 = uv[:-1, :-1]
 	u10 = uv[1:, :-1]
 	u01 = uv[:-1, 1:]
 	u11 = uv[1:, 1:]
-	Xy = 0.5 * ((p10 - p00) + (p11 - p01))
-	Xx = 0.5 * ((p01 - p00) + (p11 - p10))
 	Uy = 0.5 * ((u10 - u00) + (u11 - u01))
 	Ux = 0.5 * ((u01 - u00) + (u11 - u10))
 
-	g00 = (Xy * Xy).sum(dim=-1)
-	g01 = (Xy * Xx).sum(dim=-1)
-	g11 = (Xx * Xx).sum(dim=-1)
+	g00 = source_metric[..., 0]
+	g01 = source_metric[..., 1]
+	g11 = source_metric[..., 2]
 	c00 = (Uy * Uy).sum(dim=-1)
 	c01 = (Uy * Ux).sum(dim=-1)
 	c11 = (Ux * Ux).sum(dim=-1)
@@ -212,6 +236,167 @@ def _flatten_forward_sdir_core(
 	return loss, lm, mask, valid
 
 
+def _flatten_forward_combined_core(
+	uv: torch.Tensor,
+	source_metric: torch.Tensor,
+	vertex_valid: torch.Tensor,
+	cell_valid: torch.Tensor,
+	domain_step: torch.Tensor,
+	avg_mask: torch.Tensor,
+	avg_target: torch.Tensor,
+	identity_y: torch.Tensor,
+	identity_x: torch.Tensor,
+	weights: torch.Tensor,
+	eps: float,
+	orient_min_det: float,
+) -> torch.Tensor:
+	"""Combined diagnostics-free forward flatten objective.
+
+	The source metric and identity vectors are immutable model buffers. UV cell
+	derivatives and determinants are shared by symmetric Dirichlet and orientation.
+	"""
+	m00 = uv[:-1, :-1]
+	m10 = uv[1:, :-1]
+	m01 = uv[:-1, 1:]
+	m11 = uv[1:, 1:]
+	uy = 0.5 * ((m10 - m00) + (m11 - m01))
+	ux = 0.5 * ((m01 - m00) + (m11 - m10))
+	c00 = (uy * uy).sum(dim=-1)
+	c01 = (uy * ux).sum(dim=-1)
+	c11 = (ux * ux).sum(dim=-1)
+	det_c = c00 * c11 - c01 * c01
+	det_uv = uy[..., 0] * ux[..., 1] - uy[..., 1] * ux[..., 0]
+
+	g00 = source_metric[..., 0]
+	g01 = source_metric[..., 1]
+	g11 = source_metric[..., 2]
+	det_g = g00 * g11 - g01 * g01
+	inv_g00 = g11 / det_g.clamp_min(eps)
+	inv_g01 = -g01 / det_g.clamp_min(eps)
+	inv_g11 = g00 / det_g.clamp_min(eps)
+	inv_c00 = c11 / det_c.clamp_min(eps)
+	inv_c01 = -c01 / det_c.clamp_min(eps)
+	inv_c11 = c00 / det_c.clamp_min(eps)
+	domain_step2 = domain_step * domain_step
+	tr_j = domain_step2 * (c00 * inv_g00 + 2.0 * c01 * inv_g01 + c11 * inv_g11)
+	tr_inv = (g00 * inv_c00 + 2.0 * g01 * inv_c01 + g11 * inv_c11) / domain_step2
+	sdir_lm = torch.nan_to_num(tr_j + tr_inv - 4.0, nan=0.0, posinf=1.0e12, neginf=0.0)
+	sdir_valid = (
+		cell_valid
+		& torch.isfinite(sdir_lm)
+		& torch.isfinite(det_g)
+		& torch.isfinite(det_c)
+		& (det_g > eps)
+		& (det_c > eps)
+		& torch.isfinite(det_uv)
+		& (det_uv > eps)
+	)
+	sdir_mask = sdir_valid.to(dtype=uv.dtype)
+	sdir_weight = sdir_mask.sum()
+	sdir_sum = (sdir_lm * sdir_mask).sum()
+	sdir_loss = torch.where(
+		sdir_weight > 0,
+		sdir_sum / sdir_weight.clamp_min(1.0),
+		sdir_sum * 0.0,
+	)
+
+	dy0 = uv[1:, :, 0] - uv[:-1, :, 0] - 1.0
+	dy1 = uv[1:, :, 1] - uv[:-1, :, 1]
+	dy_lm = dy0 * dy0 + dy1 * dy1
+	dy_valid = torch.isfinite(dy_lm) & vertex_valid[1:, :] & vertex_valid[:-1, :]
+	dy_mask = dy_valid.to(dtype=uv.dtype)
+	dy_safe = torch.nan_to_num(dy_lm, nan=0.0, posinf=1.0e12, neginf=0.0)
+	dx0 = uv[:, 1:, 0] - uv[:, :-1, 0]
+	dx1 = uv[:, 1:, 1] - uv[:, :-1, 1] - 1.0
+	dx_lm = dx0 * dx0 + dx1 * dx1
+	dx_valid = torch.isfinite(dx_lm) & vertex_valid[:, 1:] & vertex_valid[:, :-1]
+	dx_mask = dx_valid.to(dtype=uv.dtype)
+	dx_safe = torch.nan_to_num(dx_lm, nan=0.0, posinf=1.0e12, neginf=0.0)
+	map_step_sum = (dy_safe * dy_mask).sum() + (dx_safe * dx_mask).sum()
+	map_step_weight = dy_mask.sum() + dx_mask.sum()
+	map_step_loss = torch.where(
+		map_step_weight > 0,
+		map_step_sum / map_step_weight.clamp_min(1.0),
+		map_step_sum * 0.0,
+	)
+
+	avg_mask_f = avg_mask.to(dtype=uv.dtype)
+	avg_weight = avg_mask_f.sum()
+	offset_y = uv[..., 0] - identity_y.reshape(-1, 1)
+	offset_x = uv[..., 1] - identity_x.reshape(1, -1)
+	avg_candidate = torch.stack(
+		((offset_y * avg_mask_f).sum(), (offset_x * avg_mask_f).sum()),
+	) / avg_weight.clamp_min(1.0)
+	avg_diff_candidate = avg_candidate - avg_target
+	avg_diff = torch.where(avg_weight > 0, avg_diff_candidate, torch.zeros_like(avg_diff_candidate))
+	avg_loss = (avg_diff * avg_diff).sum()
+
+	orient_lm = torch.nan_to_num(
+		torch.relu(orient_min_det - det_uv) ** 2,
+		nan=0.0,
+		posinf=1.0e12,
+		neginf=0.0,
+	)
+	orient_active = cell_valid & torch.isfinite(det_uv) & (det_uv < orient_min_det)
+	orient_loss = (orient_lm * orient_active.to(dtype=uv.dtype)).sum()
+
+	return (
+		weights[0] * sdir_loss
+		+ weights[1] * map_step_loss
+		+ weights[2] * avg_loss
+		+ weights[3] * orient_loss
+	)
+
+
+def flatten_combined_loss(
+	*,
+	res: fit_model.FitResult3D,
+	weights: torch.Tensor,
+) -> torch.Tensor:
+	"""Evaluate all four forward flatten terms in one compiled autograd graph."""
+	if not _is_forward(res):
+		raise RuntimeError("combined flatten loss currently requires the forward solver")
+	uv, xyz, vertex_valid, cell_valid = _forward_source_fields(res)
+	if int(uv.shape[0]) < 2 or int(uv.shape[1]) < 2:
+		raise RuntimeError("combined flatten loss requires a map of at least 2x2")
+	metric = res.flatten_source_metric
+	if metric is None or int(metric.numel()) == 0:
+		metric = fit_model.Model3D._flatten_source_metric(xyz)
+	metric = metric.to(device=uv.device, dtype=uv.dtype)
+	if tuple(metric.shape) != (int(uv.shape[0]) - 1, int(uv.shape[1]) - 1, 3):
+		raise RuntimeError(f"flatten source metric shape {tuple(metric.shape)} does not match map {tuple(uv.shape)}")
+	avg_mask = res.flatten_avg_offset_mask
+	avg_target = res.flatten_initial_avg_offset
+	if avg_mask is None or avg_target is None:
+		raise RuntimeError("combined flatten loss requires average-offset mask and target")
+	if tuple(avg_mask.shape) != tuple(uv.shape[:2]):
+		raise RuntimeError("combined flatten average-offset mask shape does not match map")
+	identity_y, identity_x = _identity_vectors(res, uv)
+	if int(weights.numel()) != 4:
+		raise ValueError(f"combined flatten weights must have four values, got {tuple(weights.shape)}")
+	domain_step = (
+		uv.new_tensor(float(res.params.mesh_step))
+		if res.flatten_target_step is None
+		else res.flatten_target_step.to(device=uv.device, dtype=uv.dtype)
+	).clamp_min(1.0e-12)
+	return _run_compiled_flatten_core(
+		"combined",
+		_flatten_forward_combined_core,
+		uv,
+		metric,
+		vertex_valid.to(device=uv.device, dtype=torch.bool),
+		cell_valid.to(device=uv.device, dtype=torch.bool),
+		domain_step,
+		avg_mask.to(device=uv.device, dtype=torch.bool),
+		avg_target.to(device=uv.device, dtype=uv.dtype).reshape(2),
+		identity_y,
+		identity_x,
+		weights.to(device=uv.device, dtype=uv.dtype).reshape(4),
+		float(_sdir_eps),
+		float(_orient_min_det),
+	)
+
+
 def _flatten_forward_sdir_loss(
 	*,
 	res: fit_model.FitResult3D,
@@ -228,12 +413,18 @@ def _flatten_forward_sdir_loss(
 	else:
 		domain_step = res.flatten_target_step.to(device=uv.device, dtype=uv.dtype)
 	domain_step = domain_step.clamp_min(1.0e-12)
+	metric = res.flatten_source_metric
+	if metric is None or int(metric.numel()) == 0:
+		metric = fit_model.Model3D._flatten_source_metric(xyz)
+	metric = metric.to(device=uv.device, dtype=uv.dtype)
+	if tuple(metric.shape) != (int(uv.shape[0]) - 1, int(uv.shape[1]) - 1, 3):
+		raise RuntimeError(f"flatten source metric shape {tuple(metric.shape)} does not match map {tuple(uv.shape)}")
 	eps = float(_sdir_eps)
 	loss, lm, mask, valid = _run_compiled_flatten_core(
 		"forward_sdir",
 		_flatten_forward_sdir_core,
 		uv,
-		xyz,
+		metric,
 		cell_valid,
 		domain_step,
 		eps,
@@ -421,23 +612,22 @@ def flatten_avg_offset_loss(
 	if target.numel() != 2:
 		raise RuntimeError(f"flatten_initial_avg_offset must have 2 values, got {tuple(target.shape)}")
 
-	identity = fit_model.Model3D._identity_flatten_map(
-		h=int(map_yx.shape[0]),
-		w=int(map_yx.shape[1]),
-		device=map_yx.device,
-		dtype=map_yx.dtype,
-	)
+	identity_y, identity_x = _identity_vectors(res, map_yx)
 	mask_f = mask.to(device=map_yx.device, dtype=map_yx.dtype)
 	weight = mask_f.sum()
 	target_t = target.to(device=map_yx.device, dtype=map_yx.dtype).reshape(2)
-	weighted_offset = ((map_yx - identity) * mask_f.unsqueeze(-1)).sum(dim=(0, 1))
+	offset_y = map_yx[..., 0] - identity_y.reshape(-1, 1)
+	offset_x = map_yx[..., 1] - identity_x.reshape(1, -1)
+	weighted_offset = torch.stack(
+		((offset_y * mask_f).sum(), (offset_x * mask_f).sum()),
+	)
 	avg_candidate = weighted_offset / weight.clamp_min(1.0)
 	diff_candidate = avg_candidate - target_t
 	diff = torch.where(weight > 0, diff_candidate, torch.zeros_like(diff_candidate))
 	loss = (diff * diff).sum()
 	if _diagnostics_enabled:
 		lm = torch.nan_to_num(
-			((map_yx - identity) - target_t.reshape(1, 1, 2)).square().sum(dim=-1),
+			(offset_y - target_t[0]).square() + (offset_x - target_t[1]).square(),
 			nan=0.0,
 			posinf=1.0e12,
 			neginf=0.0,

--- a/lasagna/opt_loss_flatten.py
+++ b/lasagna/opt_loss_flatten.py
@@ -7,24 +7,124 @@ import model as fit_model
 
 _sdir_eps = 1.0e-8
 _orient_min_det = 0.0
+_diagnostics_enabled = True
 _last_stats: dict[str, float] = {}
 _prev_point_mask: torch.Tensor | None = None
+_compile_flatten = False
+_compile_backend: str | None = None
+_compile_mode: str | None = None
+_compile_dynamic = False
+_compile_fullgraph = False
+_compile_key: tuple[bool, str | None, str | None, bool, bool] | None = None
+_compiled_forward_sdir_core = None
+_compiled_orient_core = None
+_compile_disabled_reason: str | None = None
 
 
 def configure(
 	*,
 	sdir_eps: float | None = None,
 	orient_min_det: float | None = None,
+	diagnostics: bool = True,
 	reset_history: bool = True,
 ) -> None:
-	global _sdir_eps, _orient_min_det, _last_stats, _prev_point_mask
+	global _sdir_eps, _orient_min_det, _diagnostics_enabled, _last_stats, _prev_point_mask
 	if sdir_eps is not None:
 		_sdir_eps = max(1.0e-12, float(sdir_eps))
 	if orient_min_det is not None:
 		_orient_min_det = float(orient_min_det)
-	if reset_history:
+	_diagnostics_enabled = bool(diagnostics)
+	if reset_history or not _diagnostics_enabled:
 		_last_stats = {}
 		_prev_point_mask = None
+
+
+def configure_compile(
+	*,
+	enabled: bool = False,
+	backend: str | None = None,
+	mode: str | None = None,
+	dynamic: bool = False,
+	fullgraph: bool = False,
+) -> None:
+	"""Configure opt-in torch.compile use for the expensive flatten loss kernels."""
+	global _compile_flatten, _compile_backend, _compile_mode, _compile_dynamic, _compile_fullgraph
+	global _compile_key, _compiled_forward_sdir_core, _compiled_orient_core, _compile_disabled_reason
+	backend = str(backend).strip() if backend is not None and str(backend).strip() else None
+	mode = str(mode).strip() if mode is not None and str(mode).strip() else None
+	key = (bool(enabled), backend, mode, bool(dynamic), bool(fullgraph))
+	if key != _compile_key:
+		_compiled_forward_sdir_core = None
+		_compiled_orient_core = None
+		_compile_disabled_reason = None
+		_compile_key = key
+	_compile_flatten = bool(enabled)
+	_compile_backend = backend
+	_compile_mode = mode
+	_compile_dynamic = bool(dynamic)
+	_compile_fullgraph = bool(fullgraph)
+
+
+def _compile_kwargs() -> dict[str, object]:
+	kwargs: dict[str, object] = {
+		"dynamic": _compile_dynamic,
+		"fullgraph": _compile_fullgraph,
+	}
+	if _compile_backend is not None:
+		kwargs["backend"] = _compile_backend
+	if _compile_mode is not None:
+		kwargs["mode"] = _compile_mode
+	return kwargs
+
+
+def _compiled_flatten_core(which: str, eager_fn):
+	global _compiled_forward_sdir_core, _compiled_orient_core, _compile_disabled_reason
+	if not _compile_flatten or _compile_disabled_reason is not None:
+		return eager_fn
+	if not hasattr(torch, "compile"):
+		_compile_disabled_reason = "torch.compile is unavailable"
+		print(f"[opt_loss_flatten] compile_flatten disabled: {_compile_disabled_reason}", flush=True)
+		return eager_fn
+	compiled = _compiled_forward_sdir_core if which == "forward_sdir" else _compiled_orient_core
+	if compiled is None:
+		try:
+			compiled = torch.compile(eager_fn, **_compile_kwargs())
+		except Exception as exc:
+			_compile_disabled_reason = f"{type(exc).__name__}: {exc}"
+			print(f"[opt_loss_flatten] compile_flatten disabled: {_compile_disabled_reason}", flush=True)
+			return eager_fn
+		if which == "forward_sdir":
+			_compiled_forward_sdir_core = compiled
+		else:
+			_compiled_orient_core = compiled
+	return compiled
+
+
+def _run_compiled_flatten_core(which: str, eager_fn, *args):
+	global _compile_disabled_reason
+	fn = _compiled_flatten_core(which, eager_fn)
+	if fn is eager_fn:
+		return fn(*args)
+	try:
+		return fn(*args)
+	except Exception as exc:
+		_compile_disabled_reason = f"{type(exc).__name__}: {exc}"
+		print(f"[opt_loss_flatten] compile_flatten disabled after failure: {_compile_disabled_reason}", flush=True)
+		return eager_fn(*args)
+
+
+def _diagnostic_maps(
+	lm: torch.Tensor,
+	mask: torch.Tensor,
+	*,
+	leading_dims: int = 2,
+) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
+	if not _diagnostics_enabled:
+		return (), ()
+	for _ in range(leading_dims):
+		lm = lm.unsqueeze(0)
+		mask = mask.unsqueeze(0)
+	return (lm,), (mask,)
 
 
 def last_stats() -> dict[str, float]:
@@ -57,21 +157,13 @@ def _forward_source_fields(
 	return uv, xyz, vertex_valid.to(dtype=torch.bool), cell_valid.to(dtype=torch.bool)
 
 
-def _flatten_forward_sdir_loss(
-	*,
-	res: fit_model.FitResult3D,
-) -> tuple[torch.Tensor, tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
-	global _last_stats, _prev_point_mask
-	uv, xyz, vertex_valid, cell_valid = _forward_source_fields(res)
-	if int(uv.shape[0]) < 2 or int(uv.shape[1]) < 2:
-		zero = uv.sum() * 0.0
-		return zero, (zero.reshape(1, 1, 1, 1),), (zero.reshape(1, 1, 1, 1),)
-	if res.flatten_target_step is None:
-		domain_step = torch.tensor(float(res.params.mesh_step), device=uv.device, dtype=uv.dtype)
-	else:
-		domain_step = res.flatten_target_step.to(device=uv.device, dtype=uv.dtype)
-	domain_step = domain_step.clamp_min(1.0e-12)
-
+def _flatten_forward_sdir_core(
+	uv: torch.Tensor,
+	xyz: torch.Tensor,
+	cell_valid: torch.Tensor,
+	domain_step: torch.Tensor,
+	eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
 	p00 = xyz[:-1, :-1]
 	p10 = xyz[1:, :-1]
 	p01 = xyz[:-1, 1:]
@@ -93,7 +185,6 @@ def _flatten_forward_sdir_loss(
 	c11 = (Ux * Ux).sum(dim=-1)
 	det_g = g00 * g11 - g01 * g01
 	det_c = c00 * c11 - c01 * c01
-	eps = float(_sdir_eps)
 	inv_g00 = g11 / det_g.clamp_min(eps)
 	inv_g01 = -g01 / det_g.clamp_min(eps)
 	inv_g11 = g00 / det_g.clamp_min(eps)
@@ -116,22 +207,51 @@ def _flatten_forward_sdir_loss(
 	)
 	mask = valid.to(dtype=uv.dtype)
 	wsum = mask.sum()
-	if bool((wsum > 0).detach().cpu()):
-		loss = (lm * mask).sum() / wsum
-	else:
-		loss = (lm * 0.0).sum()
+	weighted = (lm * mask).sum()
+	loss = torch.where(wsum > 0, weighted / wsum.clamp_min(1.0), weighted * 0.0)
+	return loss, lm, mask, valid
 
-	with torch.no_grad():
-		_last_stats = {
-			"flatten_point_valid": float(vertex_valid.float().mean().detach().cpu()),
-			"flatten_quad_valid": float(valid.float().mean().detach().cpu()) if valid.numel() else 0.0,
-			"flatten_tgt_step": float(domain_step.detach().cpu()),
-			"flatten_valid_to_invalid": 0.0,
-			"flatten_invalid_to_valid": 0.0,
-			"flatten_sdir_no_new": float(loss.detach().cpu()),
-		}
-		_prev_point_mask = None
-	return loss, (lm.unsqueeze(0).unsqueeze(1),), (mask.unsqueeze(0).unsqueeze(1),)
+
+def _flatten_forward_sdir_loss(
+	*,
+	res: fit_model.FitResult3D,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
+	global _last_stats, _prev_point_mask
+	uv, xyz, vertex_valid, cell_valid = _forward_source_fields(res)
+	if int(uv.shape[0]) < 2 or int(uv.shape[1]) < 2:
+		zero = uv.sum() * 0.0
+		if _diagnostics_enabled:
+			return zero, (zero.reshape(1, 1, 1, 1),), (zero.reshape(1, 1, 1, 1),)
+		return zero, (), ()
+	if res.flatten_target_step is None:
+		domain_step = torch.tensor(float(res.params.mesh_step), device=uv.device, dtype=uv.dtype)
+	else:
+		domain_step = res.flatten_target_step.to(device=uv.device, dtype=uv.dtype)
+	domain_step = domain_step.clamp_min(1.0e-12)
+	eps = float(_sdir_eps)
+	loss, lm, mask, valid = _run_compiled_flatten_core(
+		"forward_sdir",
+		_flatten_forward_sdir_core,
+		uv,
+		xyz,
+		cell_valid,
+		domain_step,
+		eps,
+	)
+
+	if _diagnostics_enabled:
+		with torch.no_grad():
+			_last_stats = {
+				"flatten_point_valid": float(vertex_valid.float().mean().detach().cpu()),
+				"flatten_quad_valid": float(valid.float().mean().detach().cpu()) if valid.numel() else 0.0,
+				"flatten_tgt_step": float(domain_step.detach().cpu()),
+				"flatten_valid_to_invalid": 0.0,
+				"flatten_invalid_to_valid": 0.0,
+				"flatten_sdir_no_new": float(loss.detach().cpu()),
+			}
+			_prev_point_mask = None
+	lms, masks = _diagnostic_maps(lm, mask)
+	return loss, lms, masks
 
 
 def flatten_sdir_loss(
@@ -156,7 +276,9 @@ def flatten_sdir_loss(
 		raise RuntimeError(f"flatten_xyz must have shape (1,H,W,3), got {tuple(xyz.shape)}")
 	if int(xyz.shape[1]) < 2 or int(xyz.shape[2]) < 2:
 		zero = xyz.sum() * 0.0
-		return zero, (zero.reshape(1, 1, 1, 1),), (zero.reshape(1, 1, 1, 1),)
+		if _diagnostics_enabled:
+			return zero, (zero.reshape(1, 1, 1, 1),), (zero.reshape(1, 1, 1, 1),)
+		return zero, (), ()
 
 	p00 = xyz[:, :-1, :-1]
 	p10 = xyz[:, 1:, :-1]
@@ -179,49 +301,49 @@ def flatten_sdir_loss(
 	lm = torch.nan_to_num(tr_g + tr_inv - 4.0, nan=0.0, posinf=1.0e12, neginf=0.0)
 	mask = quad_mask.to(device=lm.device, dtype=lm.dtype)
 	wsum = mask.sum()
-	if bool((wsum > 0).detach().cpu()):
-		loss = (lm * mask).sum() / wsum
-	else:
-		loss = (lm * 0.0).sum()
+	weighted = (lm * mask).sum()
+	loss = torch.where(wsum > 0, weighted / wsum.clamp_min(1.0), weighted * 0.0)
 
-	with torch.no_grad():
-		pm = point_mask.to(dtype=torch.bool)
-		qm = quad_mask.to(dtype=torch.bool)
-		prev_pm = _prev_point_mask
-		if prev_pm is None or tuple(prev_pm.shape) != tuple(pm.shape):
-			valid_to_invalid = torch.zeros_like(pm)
-			invalid_to_valid = torch.zeros_like(pm)
-			no_new_loss = loss.detach()
-		else:
-			prev_pm = prev_pm.to(device=pm.device, dtype=torch.bool)
-			valid_to_invalid = prev_pm & ~pm
-			invalid_to_valid = ~prev_pm & pm
-			stable_pm = pm & prev_pm
-			if int(stable_pm.shape[0]) > 1 and int(stable_pm.shape[1]) > 1:
-				stable_qm = (
-					stable_pm[:-1, :-1] &
-					stable_pm[1:, :-1] &
-					stable_pm[:-1, 1:] &
-					stable_pm[1:, 1:]
-				).unsqueeze(0) & qm
-			else:
-				stable_qm = torch.zeros_like(qm)
-			stable_mask = stable_qm.to(device=lm.device, dtype=lm.dtype)
-			stable_wsum = stable_mask.sum()
-			if bool((stable_wsum > 0).detach().cpu()):
-				no_new_loss = (lm * stable_mask).sum() / stable_wsum
-			else:
+	if _diagnostics_enabled:
+		with torch.no_grad():
+			pm = point_mask.to(dtype=torch.bool)
+			qm = quad_mask.to(dtype=torch.bool)
+			prev_pm = _prev_point_mask
+			if prev_pm is None or tuple(prev_pm.shape) != tuple(pm.shape):
+				valid_to_invalid = torch.zeros_like(pm)
+				invalid_to_valid = torch.zeros_like(pm)
 				no_new_loss = loss.detach()
-		_last_stats = {
-			"flatten_point_valid": float(pm.float().mean().detach().cpu()),
-			"flatten_quad_valid": float(qm.float().mean().detach().cpu()) if qm.numel() else 0.0,
-			"flatten_tgt_step": float(domain_step.detach().cpu()),
-			"flatten_valid_to_invalid": float(valid_to_invalid.float().mean().detach().cpu()),
-			"flatten_invalid_to_valid": float(invalid_to_valid.float().mean().detach().cpu()),
-			"flatten_sdir_no_new": float(no_new_loss.detach().cpu()),
-		}
-		_prev_point_mask = pm.detach().clone()
-	return loss, (lm.unsqueeze(1),), (mask.unsqueeze(1),)
+			else:
+				prev_pm = prev_pm.to(device=pm.device, dtype=torch.bool)
+				valid_to_invalid = prev_pm & ~pm
+				invalid_to_valid = ~prev_pm & pm
+				stable_pm = pm & prev_pm
+				if int(stable_pm.shape[0]) > 1 and int(stable_pm.shape[1]) > 1:
+					stable_qm = (
+						stable_pm[:-1, :-1] &
+						stable_pm[1:, :-1] &
+						stable_pm[:-1, 1:] &
+						stable_pm[1:, 1:]
+					).unsqueeze(0) & qm
+				else:
+					stable_qm = torch.zeros_like(qm)
+				stable_mask = stable_qm.to(device=lm.device, dtype=lm.dtype)
+				stable_wsum = stable_mask.sum()
+				if bool((stable_wsum > 0).detach().cpu()):
+					no_new_loss = (lm * stable_mask).sum() / stable_wsum
+				else:
+					no_new_loss = loss.detach()
+			_last_stats = {
+				"flatten_point_valid": float(pm.float().mean().detach().cpu()),
+				"flatten_quad_valid": float(qm.float().mean().detach().cpu()) if qm.numel() else 0.0,
+				"flatten_tgt_step": float(domain_step.detach().cpu()),
+				"flatten_valid_to_invalid": float(valid_to_invalid.float().mean().detach().cpu()),
+				"flatten_invalid_to_valid": float(invalid_to_valid.float().mean().detach().cpu()),
+				"flatten_sdir_no_new": float(no_new_loss.detach().cpu()),
+			}
+			_prev_point_mask = pm.detach().clone()
+	lms, masks = _diagnostic_maps(lm, mask, leading_dims=1)
+	return loss, lms, masks
 
 
 def flatten_map_step_loss(
@@ -247,9 +369,11 @@ def flatten_map_step_loss(
 		if valid_mask is not None:
 			mask = mask & valid_mask.to(device=lm.device, dtype=torch.bool)
 		mask_f = mask.to(dtype=lm.dtype)
-		maps.append(torch.nan_to_num(lm, nan=0.0, posinf=1.0e12, neginf=0.0).unsqueeze(0).unsqueeze(1))
-		masks.append(mask_f.unsqueeze(0).unsqueeze(1))
-		sum_loss = sum_loss + (maps[-1].squeeze(0).squeeze(0) * mask_f).sum()
+		lm_safe = torch.nan_to_num(lm, nan=0.0, posinf=1.0e12, neginf=0.0)
+		if _diagnostics_enabled:
+			maps.append(lm_safe.unsqueeze(0).unsqueeze(1))
+			masks.append(mask_f.unsqueeze(0).unsqueeze(1))
+		sum_loss = sum_loss + (lm_safe * mask_f).sum()
 		sum_weight = sum_weight + mask_f.sum()
 
 	source_valid = None
@@ -271,10 +395,8 @@ def flatten_map_step_loss(
 		valid_edge = None if source_valid is None else (source_valid[:, 1:] & source_valid[:, :-1])
 		_accumulate((dx * dx).sum(dim=-1), valid_edge)
 
-	if bool((sum_weight > 0).detach().cpu()):
-		loss = sum_loss / sum_weight
-	else:
-		loss = map_yx.sum() * 0.0
+	loss = torch.where(sum_weight > 0, sum_loss / sum_weight.clamp_min(1.0), sum_loss * 0.0)
+	if _diagnostics_enabled and not maps:
 		zero = loss.reshape(1, 1, 1, 1)
 		maps = [zero]
 		masks = [zero]
@@ -307,26 +429,46 @@ def flatten_avg_offset_loss(
 	)
 	mask_f = mask.to(device=map_yx.device, dtype=map_yx.dtype)
 	weight = mask_f.sum()
-	if bool((weight > 0).detach().cpu()):
-		avg_offset = ((map_yx - identity) * mask_f.unsqueeze(-1)).sum(dim=(0, 1)) / weight
-		diff = avg_offset - target.to(device=map_yx.device, dtype=map_yx.dtype).reshape(2)
-		loss = (diff * diff).sum()
-	else:
-		avg_offset = map_yx.sum(dim=(0, 1)) * 0.0
-		diff = avg_offset
-		loss = map_yx.sum() * 0.0
-	lm = torch.nan_to_num(
-		((map_yx - identity) - target.to(device=map_yx.device, dtype=map_yx.dtype).reshape(1, 1, 2)).square().sum(dim=-1),
-		nan=0.0,
-		posinf=1.0e12,
-		neginf=0.0,
-	)
-	with torch.no_grad():
-		_last_stats = {
-			**_last_stats,
-			"flatten_avg_offset_norm": float(torch.linalg.vector_norm(diff).detach().cpu()),
-		}
-	return loss, (lm.unsqueeze(0).unsqueeze(1),), (mask_f.unsqueeze(0).unsqueeze(1),)
+	target_t = target.to(device=map_yx.device, dtype=map_yx.dtype).reshape(2)
+	weighted_offset = ((map_yx - identity) * mask_f.unsqueeze(-1)).sum(dim=(0, 1))
+	avg_candidate = weighted_offset / weight.clamp_min(1.0)
+	diff_candidate = avg_candidate - target_t
+	diff = torch.where(weight > 0, diff_candidate, torch.zeros_like(diff_candidate))
+	loss = (diff * diff).sum()
+	if _diagnostics_enabled:
+		lm = torch.nan_to_num(
+			((map_yx - identity) - target_t.reshape(1, 1, 2)).square().sum(dim=-1),
+			nan=0.0,
+			posinf=1.0e12,
+			neginf=0.0,
+		)
+		with torch.no_grad():
+			_last_stats = {
+				**_last_stats,
+				"flatten_avg_offset_norm": float(torch.linalg.vector_norm(diff).detach().cpu()),
+			}
+		return loss, (lm.unsqueeze(0).unsqueeze(1),), (mask_f.unsqueeze(0).unsqueeze(1),)
+	return loss, (), ()
+
+
+def _flatten_orient_core(
+	map_yx: torch.Tensor,
+	valid_cells: torch.Tensor,
+	min_det_value: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+	m00 = map_yx[:-1, :-1]
+	m10 = map_yx[1:, :-1]
+	m01 = map_yx[:-1, 1:]
+	m11 = map_yx[1:, 1:]
+	dy = 0.5 * ((m10 - m00) + (m11 - m01))
+	dx = 0.5 * ((m01 - m00) + (m11 - m10))
+	det = dy[..., 0] * dx[..., 1] - dy[..., 1] * dx[..., 0]
+	min_det = torch.tensor(min_det_value, device=map_yx.device, dtype=map_yx.dtype)
+	lm = torch.nan_to_num(torch.relu(min_det - det) ** 2, nan=0.0, posinf=1.0e12, neginf=0.0)
+	active = valid_cells & torch.isfinite(det) & (det < min_det)
+	mask = active.to(dtype=lm.dtype)
+	loss = (lm * mask).sum()
+	return loss, lm, mask, det
 
 
 def flatten_orient_loss(
@@ -344,45 +486,45 @@ def flatten_orient_loss(
 	H, W = int(map_yx.shape[0]), int(map_yx.shape[1])
 	if H < 2 or W < 2:
 		zero = map_yx.sum() * 0.0
-		return zero, (zero.reshape(1, 1, 1, 1),), (zero.reshape(1, 1, 1, 1),)
+		if _diagnostics_enabled:
+			return zero, (zero.reshape(1, 1, 1, 1),), (zero.reshape(1, 1, 1, 1),)
+		return zero, (), ()
 
-	m00 = map_yx[:-1, :-1]
-	m10 = map_yx[1:, :-1]
-	m01 = map_yx[:-1, 1:]
-	m11 = map_yx[1:, 1:]
-	dy = 0.5 * ((m10 - m00) + (m11 - m01))
-	dx = 0.5 * ((m01 - m00) + (m11 - m10))
-	det = dy[..., 0] * dx[..., 1] - dy[..., 1] * dx[..., 0]
-	min_det = torch.tensor(float(_orient_min_det), device=map_yx.device, dtype=map_yx.dtype)
-	lm = torch.nan_to_num(torch.relu(min_det - det) ** 2, nan=0.0, posinf=1.0e12, neginf=0.0)
-	valid_cells = torch.ones_like(det, dtype=torch.bool)
+	valid_cells = torch.ones((H - 1, W - 1), device=map_yx.device, dtype=torch.bool)
 	if _is_forward(res):
 		if res.flatten_source_cell_valid is None:
 			raise RuntimeError("forward flatten_orient requires flatten_source_cell_valid")
 		valid_cells = res.flatten_source_cell_valid.to(device=map_yx.device, dtype=torch.bool)
-		if tuple(valid_cells.shape) != tuple(det.shape):
+		if tuple(valid_cells.shape) != (H - 1, W - 1):
 			raise RuntimeError("forward flatten source cell mask shape does not match orient determinant")
-	active = valid_cells & torch.isfinite(det) & (det < min_det)
-	mask = active.to(dtype=lm.dtype)
-	loss = (lm * mask).sum()
+	loss, lm, mask, det = _run_compiled_flatten_core(
+		"orient",
+		_flatten_orient_core,
+		map_yx,
+		valid_cells,
+		float(_orient_min_det),
+	)
 
-	with torch.no_grad():
-		valid_det = det[valid_cells & torch.isfinite(det)]
-		if valid_det.numel():
-			fold_frac = float((valid_det <= 0.0).float().mean().detach().cpu())
-			lowdet_frac = float((valid_det < min_det).float().mean().detach().cpu())
-			min_det_val = float(valid_det.min().detach().cpu())
-			mean_det_val = float(valid_det.mean().detach().cpu())
-		else:
-			fold_frac = 0.0
-			lowdet_frac = 0.0
-			min_det_val = 0.0
-			mean_det_val = 0.0
-		_last_stats = {
-			**_last_stats,
-			"flatten_orient_fold_frac": fold_frac,
-			"flatten_orient_lowdet_frac": lowdet_frac,
-			"flatten_orient_min_det": min_det_val,
-			"flatten_orient_mean_det": mean_det_val,
-		}
-	return loss, (lm.unsqueeze(0).unsqueeze(1),), (mask.unsqueeze(0).unsqueeze(1),)
+	if _diagnostics_enabled:
+		with torch.no_grad():
+			min_det = torch.tensor(float(_orient_min_det), device=map_yx.device, dtype=map_yx.dtype)
+			valid_det = det[valid_cells & torch.isfinite(det)]
+			if valid_det.numel():
+				fold_frac = float((valid_det <= 0.0).float().mean().detach().cpu())
+				lowdet_frac = float((valid_det < min_det).float().mean().detach().cpu())
+				min_det_val = float(valid_det.min().detach().cpu())
+				mean_det_val = float(valid_det.mean().detach().cpu())
+			else:
+				fold_frac = 0.0
+				lowdet_frac = 0.0
+				min_det_val = 0.0
+				mean_det_val = 0.0
+			_last_stats = {
+				**_last_stats,
+				"flatten_orient_fold_frac": fold_frac,
+				"flatten_orient_lowdet_frac": lowdet_frac,
+				"flatten_orient_min_det": min_det_val,
+				"flatten_orient_mean_det": mean_det_val,
+			}
+	lms, masks = _diagnostic_maps(lm, mask)
+	return loss, lms, masks

--- a/lasagna/optimizer.py
+++ b/lasagna/optimizer.py
@@ -2252,10 +2252,56 @@ def optimize(
 			flush=True,
 		)
 
+		_flatten_diagnostics = _truthy(os.environ.get(
+			"LASAGNA_FLATTEN_DIAGNOSTICS",
+			stage_args.get("flatten_diagnostics", True),
+		))
 		opt_loss_flatten.configure(
 			sdir_eps=float(stage_args.get("flatten_sdir_eps", 1.0e-8)),
 			orient_min_det=float(stage_args.get("flatten_orient_min_det", 0.0)),
+			diagnostics=_flatten_diagnostics,
 		)
+		_compile_flatten = _truthy(os.environ.get(
+			"LASAGNA_COMPILE_FLATTEN",
+			stage_args.get("compile_flatten", False),
+		))
+		_compile_flatten_backend = os.environ.get(
+			"LASAGNA_COMPILE_FLATTEN_BACKEND",
+			stage_args.get("compile_flatten_backend", None),
+		)
+		_compile_flatten_mode = os.environ.get(
+			"LASAGNA_COMPILE_FLATTEN_MODE",
+			stage_args.get("compile_flatten_mode", None),
+		)
+		_compile_flatten_dynamic = _truthy(os.environ.get(
+			"LASAGNA_COMPILE_FLATTEN_DYNAMIC",
+			stage_args.get("compile_flatten_dynamic", False),
+		))
+		_compile_flatten_fullgraph = _truthy(os.environ.get(
+			"LASAGNA_COMPILE_FLATTEN_FULLGRAPH",
+			stage_args.get("compile_flatten_fullgraph", False),
+		))
+		opt_loss_flatten.configure_compile(
+			enabled=_compile_flatten,
+			backend=_compile_flatten_backend,
+			mode=_compile_flatten_mode,
+			dynamic=_compile_flatten_dynamic,
+			fullgraph=_compile_flatten_fullgraph,
+		)
+		if not _flatten_diagnostics and "map_flatten_ms" in opt_cfg.params:
+			print(f"[optimizer] {label}: flatten_diagnostics=0", flush=True)
+		if _compile_flatten and "map_flatten_ms" in opt_cfg.params:
+			_details = []
+			if _compile_flatten_backend:
+				_details.append(f"backend={_compile_flatten_backend}")
+			if _compile_flatten_mode:
+				_details.append(f"mode={_compile_flatten_mode}")
+			if _compile_flatten_dynamic:
+				_details.append("dynamic=1")
+			if _compile_flatten_fullgraph:
+				_details.append("fullgraph=1")
+			_detail_str = " " + " ".join(_details) if _details else ""
+			print(f"[optimizer] {label}: compile_flatten=1{_detail_str}", flush=True)
 		_compile_cyl_normal_raw = os.environ.get(
 			"LASAGNA_COMPILE_CYL_NORMAL",
 			stage_args.get("compile_cyl_normal", False),
@@ -3218,7 +3264,10 @@ def optimize(
 				else:
 					lv, lms, masks = result
 					w = _need_term(name, eff_)
-					tv[name] = float(lv.detach().cpu())
+					is_flatten_term = name in (
+						"flatten_sdir", "flatten_map_step", "flatten_avg_offset", "flatten_orient")
+					if _flatten_diagnostics or not is_flatten_term:
+						tv[name] = float(lv.detach().cpu())
 					if name == "pred_dt":
 						tv.update(opt_loss_pred_dt.flow_gate_last_stats())
 					if name == "cyl_outside":
@@ -3227,7 +3276,7 @@ def optimize(
 						tv.update(opt_loss_snap_surf.last_stats())
 					if name == "atlas_line":
 						tv.update(opt_loss_atlas_line.last_stats())
-					if name in ("flatten_sdir", "flatten_avg_offset", "flatten_orient"):
+					if _flatten_diagnostics and name in ("flatten_sdir", "flatten_avg_offset", "flatten_orient"):
 						tv.update(opt_loss_flatten.last_stats())
 					total = total + w * lv
 			display_loss: float | None = None

--- a/lasagna/optimizer.py
+++ b/lasagna/optimizer.py
@@ -29,6 +29,7 @@ import opt_loss_atlas_line
 from snap_surf import map_global as snap_surf_map_global
 from progress_table import format_progress_value, print_progress_legend
 import opt_loss_flatten
+from flatten_clamped_adam import FlattenClampedAdam
 
 
 def _debug_cuda_sync(label: str) -> None:
@@ -2088,6 +2089,10 @@ def optimize(
 			if "map_flatten_ms" in opt_cfg.params and bool(getattr(model, "flatten_enabled", False))
 			else 0.0
 		)
+		fused_flatten_adam_clamp = _truthy(os.environ.get(
+			"LASAGNA_FUSED_FLATTEN_ADAM_CLAMP",
+			stage_args.get("fused_flatten_adam_clamp", False),
+		))
 		if opt_timing_enabled and not is_cyl_shelling_stage:
 			print(
 				f"[optimizer] {label}: opt timing enabled interval={opt_timing_interval} "
@@ -2387,7 +2392,10 @@ def optimize(
 					for pi, p in enumerate(group):
 						if pi < k0:
 							continue
-						param_groups_.append({"params": [p], "lr": _lr_scalespace(lr=settings.lr, scale_i=pi)})
+						param_group = {"params": [p], "lr": _lr_scalespace(lr=settings.lr, scale_i=pi)}
+						if name == "map_flatten_ms":
+							param_group["_flatten_scale_i"] = pi
+						param_groups_.append(param_group)
 				elif name == "cyl_params" and bool(getattr(model, "cyl_shell_mode", False)):
 					scale_count = 0
 					if hasattr(model, "cyl_param_scale_count"):
@@ -2406,16 +2414,35 @@ def optimize(
 						param_groups_.append({"params": [p], "lr": lr_last})
 			return all_params_, param_groups_
 
+		def _make_optimizer(
+			param_groups_: list[dict],
+			opt_settings: OptSettings | None = None,
+		) -> torch.optim.Optimizer:
+			settings = opt_settings if opt_settings is not None else opt_cfg
+			if (
+				fused_flatten_adam_clamp
+				and flatten_max_update > 0.0
+				and settings.params == ["map_flatten_ms"]
+			):
+				return FlattenClampedAdam(param_groups_, base_step=flatten_max_update)
+			return torch.optim.Adam(param_groups_)
+
 		_t = _stage_start(f"{label}.build_optimizer")
 		all_params, param_groups = _make_param_groups()
 		if not param_groups:
 			return data
-		opt = torch.optim.Adam(param_groups)
+		opt = _make_optimizer(param_groups)
 		_capture_optimizer_target_lrs(opt)
 		if flatten_max_update > 0.0 and not is_cyl_shelling_stage:
 			print(
 				f"[optimizer] {label}: flatten_max_update={flatten_max_update:g} "
 				f"(per-scale cap doubles at each coarser level)",
+				flush=True,
+			)
+		if isinstance(opt, FlattenClampedAdam) and not is_cyl_shelling_stage:
+			print(
+				f"[optimizer] {label}: fused_flatten_adam_clamp=1 "
+				f"(Triton CUDA with PyTorch fallback)",
 				flush=True,
 			)
 		_stage_done(f"{label}.build_optimizer", _t)
@@ -2440,7 +2467,7 @@ def optimize(
 				all_params, param_groups = _make_param_groups()
 				if not param_groups:
 					return data
-				opt = torch.optim.Adam(param_groups)
+				opt = _make_optimizer(param_groups)
 				_capture_optimizer_target_lrs(opt)
 		_stage_done(f"{label}.winding_offset_autocrop", _t)
 
@@ -3461,7 +3488,7 @@ def optimize(
 				all_params, param_groups = _make_param_groups(pass_settings)
 				if not param_groups:
 					raise RuntimeError(f"{shell_label}: no cylinder parameters available to optimize")
-				opt = torch.optim.Adam(param_groups)
+				opt = _make_optimizer(param_groups, pass_settings)
 				_capture_optimizer_target_lrs(opt)
 				resample_count = 0
 				resampled_this_pass = False
@@ -4165,7 +4192,11 @@ def optimize(
 			_t_part = time.perf_counter()
 			_flatten_update_before = None
 			_flatten_update_params = all_params.get("flatten_map_ms", [])
-			if flatten_max_update > 0.0 and _flatten_update_params:
+			if (
+				flatten_max_update > 0.0
+				and _flatten_update_params
+				and not isinstance(opt, FlattenClampedAdam)
+			):
 				_flatten_update_before = [p.detach().clone() for p in _flatten_update_params]
 			_apply_optimizer_lr_warmup(opt, step1=step + 1, warmup_steps=lr_warmup_steps)
 			_log_cuda_memory(f"{label}.{step + 1}.opt_step.before")

--- a/lasagna/optimizer.py
+++ b/lasagna/optimizer.py
@@ -2286,6 +2286,10 @@ def optimize(
 			"LASAGNA_COMPILE_FLATTEN_FULLGRAPH",
 			stage_args.get("compile_flatten_fullgraph", False),
 		))
+		_compile_flatten_combined = _truthy(os.environ.get(
+			"LASAGNA_COMPILE_FLATTEN_COMBINED",
+			stage_args.get("compile_flatten_combined", True),
+		))
 		opt_loss_flatten.configure_compile(
 			enabled=_compile_flatten,
 			backend=_compile_flatten_backend,
@@ -2305,8 +2309,35 @@ def optimize(
 				_details.append("dynamic=1")
 			if _compile_flatten_fullgraph:
 				_details.append("fullgraph=1")
+			if (
+				_compile_flatten_combined
+				and not _flatten_diagnostics
+				and str(getattr(model, "flatten_direction", "inverse")) == "forward"
+			):
+				_details.append("combined=1")
 			_detail_str = " " + " ".join(_details) if _details else ""
 			print(f"[optimizer] {label}: compile_flatten=1{_detail_str}", flush=True)
+		_flatten_combined_names = (
+			"flatten_sdir",
+			"flatten_map_step",
+			"flatten_avg_offset",
+			"flatten_orient",
+		)
+		_flatten_combined_weights = None
+		if (
+			_compile_flatten
+			and _compile_flatten_combined
+			and not _flatten_diagnostics
+			and "map_flatten_ms" in opt_cfg.params
+			and str(getattr(model, "flatten_direction", "inverse")) == "forward"
+		):
+			_flatten_weight_values = tuple(_need_term(name, stage_eff) for name in _flatten_combined_names)
+			if all(weight != 0.0 for weight in _flatten_weight_values):
+				_flatten_combined_weights = torch.tensor(
+					_flatten_weight_values,
+					device=next(model.parameters()).device,
+					dtype=torch.float32,
+				)
 		_compile_cyl_normal_raw = os.environ.get(
 			"LASAGNA_COMPILE_CYL_NORMAL",
 			stage_args.get("compile_cyl_normal", False),
@@ -3231,7 +3262,38 @@ def optimize(
 			if stage_uses_cyl_loss:
 				opt_loss_cyl.reset_candidate_terms()
 			D = res_.xyz_lr.shape[0]
+			if _flatten_combined_weights is not None:
+				for name in _flatten_combined_names:
+					t = terms[name]
+					missing = _missing_loss_fields(
+						name=name,
+						required=t.get("needs", Needs()),
+						res_=res_,
+					)
+					if missing:
+						raise RuntimeError(
+							f"{profile_label or label}: active combined flatten loss missing "
+							f"artifact(s) for '{name}': {', '.join(missing)}"
+						)
+				loss_label = f"{profile_label or label}.flatten_combined"
+				_log_cuda_memory(f"{loss_label}.before")
+				_t_loss = _stage_start(loss_label) if profile_label is not None else None
+				_t_loss_wall = time.perf_counter() if timing is not None else None
+				combined_loss = opt_loss_flatten.flatten_combined_loss(
+					res=res_,
+					weights=_flatten_combined_weights,
+				)
+				_debug_cuda_sync(loss_label)
+				_log_cuda_memory(f"{loss_label}.after_raw")
+				if timing is not None and _t_loss_wall is not None:
+					timing.sync()
+					timing.add("loss:flatten_combined", time.perf_counter() - _t_loss_wall)
+				if _t_loss is not None:
+					_stage_done(loss_label, _t_loss)
+				total = total + combined_loss
 			for name, t in terms.items():
+				if _flatten_combined_weights is not None and name in _flatten_combined_names:
+					continue
 				min_d = t.get("min_depth", 1)
 				if D < min_d:
 					continue

--- a/lasagna/tests/test_opt_loss_flatten.py
+++ b/lasagna/tests/test_opt_loss_flatten.py
@@ -18,6 +18,7 @@ if ROOT not in sys.path:
 
 import fit
 import fit2tifxyz
+from flatten_clamped_adam import FlattenClampedAdam
 import model as fit_model
 import opt_loss_flatten
 import optimizer
@@ -277,6 +278,7 @@ class FlattenLossTest(unittest.TestCase):
 		for stage in cfg["stages"]:
 			self.assertFalse(stage["args"]["flatten_diagnostics"])
 			self.assertTrue(stage["args"]["compile_flatten"])
+			self.assertTrue(stage["args"]["fused_flatten_adam_clamp"])
 
 	def test_bilinear_validity_rejects_cells_with_any_invalid_corner(self) -> None:
 		xyz = _flat_grid(4, 4)
@@ -452,6 +454,60 @@ class FlattenLossTest(unittest.TestCase):
 
 		self.assertLessEqual(float(torch.linalg.vector_norm((params[0] - before[0]).detach(), dim=0).max()), 0.10001)
 		self.assertLessEqual(float(torch.linalg.vector_norm((params[1] - before[1]).detach(), dim=0).max()), 0.20001)
+
+	def _assert_fused_clamped_adam_matches_reference(self, device: torch.device) -> None:
+		torch.manual_seed(7)
+		base_step = 0.005
+		reference_params = [
+			torch.nn.Parameter(torch.randn(2, 1, 17, 19, device=device)),
+			torch.nn.Parameter(torch.randn(2, 1, 9, 10, device=device)),
+		]
+		fused_params = [torch.nn.Parameter(p.detach().clone()) for p in reference_params]
+		reference = torch.optim.Adam([
+			{"params": [p], "lr": 0.01, "_flatten_scale_i": scale_i}
+			for scale_i, p in enumerate(reference_params)
+		])
+		fused = FlattenClampedAdam([
+			{"params": [p], "lr": 0.01, "_flatten_scale_i": scale_i}
+			for scale_i, p in enumerate(fused_params)
+		], base_step=base_step)
+
+		for _step in range(8):
+			grads = [torch.randn_like(p) for p in reference_params]
+			for p, grad in zip(reference_params, grads, strict=True):
+				p.grad = grad
+			for p, grad in zip(fused_params, grads, strict=True):
+				p.grad = grad.clone()
+			reference_before = [p.detach().clone() for p in reference_params]
+			fused_before = [p.detach().clone() for p in fused_params]
+			reference.step()
+			optimizer._clamp_flatten_map_ms_update(
+				reference_params,
+				reference_before,
+				base_step=base_step,
+			)
+			fused.step()
+
+			for scale_i, (p, before) in enumerate(zip(fused_params, fused_before, strict=True)):
+				max_norm = torch.linalg.vector_norm((p - before).detach(), dim=0).max()
+				self.assertLessEqual(float(max_norm), base_step * (2.0 ** scale_i) + 1.0e-6)
+
+		for reference_param, fused_param in zip(reference_params, fused_params, strict=True):
+			self.assertTrue(torch.allclose(reference_param, fused_param, rtol=1.0e-6, atol=5.0e-7))
+			for state_name in ("exp_avg", "exp_avg_sq", "step"):
+				self.assertTrue(torch.allclose(
+					reference.state[reference_param][state_name],
+					fused.state[fused_param][state_name],
+					rtol=1.0e-6,
+					atol=1.0e-7,
+				))
+
+	def test_fused_clamped_adam_matches_reference_on_cpu(self) -> None:
+		self._assert_fused_clamped_adam_matches_reference(torch.device("cpu"))
+
+	@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for the Triton fused optimizer test")
+	def test_fused_clamped_adam_matches_reference_on_cuda(self) -> None:
+		self._assert_fused_clamped_adam_matches_reference(torch.device("cuda"))
 
 	def test_orient_regularizer_allows_positive_area_stretch(self) -> None:
 		opt_loss_flatten.configure(orient_min_det=0.0, reset_history=True)

--- a/lasagna/tests/test_opt_loss_flatten.py
+++ b/lasagna/tests/test_opt_loss_flatten.py
@@ -6,6 +6,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import torch
 import tifffile
@@ -252,6 +253,31 @@ class FlattenLossTest(unittest.TestCase):
 		self.assertAlmostEqual(float(map_yx[-1, -1, 0]), 11.0, places=6)
 		self.assertAlmostEqual(float(map_yx[-1, -1, 1]), 22.0, places=6)
 
+	def test_initial_forward_inversion_can_be_skipped(self) -> None:
+		mdl = _make_flatten_model(_flat_grid(5, 7), mesh_step=1, flatten_direction="forward")
+		with mock.patch.object(
+			fit_model.Model3D,
+			"_flatten_invert_forward_uv_map",
+			side_effect=AssertionError("initial inversion should be skipped"),
+		):
+			map_yx, xyz, point_mask, quad_mask = fit._initial_flatten_state(
+				mdl,
+				invert_forward=False,
+			)
+
+		self.assertEqual(tuple(map_yx.shape), (5, 7, 2))
+		self.assertEqual(tuple(xyz.shape), (1, 5, 7, 3))
+		self.assertEqual(tuple(point_mask.shape), (5, 7))
+		self.assertEqual(tuple(quad_mask.shape), (1, 4, 6))
+
+	def test_fast_flatten_config_enables_opt_in_speed_flags(self) -> None:
+		cfg = json.loads((Path(ROOT) / "configs" / "flatten_fast_nofilter.json").read_text(encoding="utf-8"))
+
+		self.assertFalse(cfg["args"]["flatten_initial_inversion"])
+		for stage in cfg["stages"]:
+			self.assertFalse(stage["args"]["flatten_diagnostics"])
+			self.assertTrue(stage["args"]["compile_flatten"])
+
 	def test_bilinear_validity_rejects_cells_with_any_invalid_corner(self) -> None:
 		xyz = _flat_grid(4, 4)
 		valid = torch.ones(4, 4, dtype=torch.bool)
@@ -309,6 +335,54 @@ class FlattenLossTest(unittest.TestCase):
 		self.assertAlmostEqual(float(res.flatten_target_step.detach()), 3.0, places=5)
 		self.assertLess(float(loss.detach()), 1.0e-6)
 		self.assertGreater(int(res.flatten_quad_mask.sum()), 0)
+
+	def test_flatten_diagnostics_can_be_disabled(self) -> None:
+		opt_loss_flatten.configure(diagnostics=False, reset_history=True)
+		try:
+			mdl = _make_flatten_model(_flat_grid(6, 6), mesh_step=1, flatten_direction="forward")
+			res = mdl(fit._dummy_flatten_data(), needs=fit_model.ModelForwardNeeds(flatten=True))
+			for loss_fn in (
+				opt_loss_flatten.flatten_sdir_loss,
+				opt_loss_flatten.flatten_map_step_loss,
+				opt_loss_flatten.flatten_avg_offset_loss,
+				opt_loss_flatten.flatten_orient_loss,
+			):
+				loss, maps, masks = loss_fn(res=res)
+				self.assertTrue(bool(torch.isfinite(loss)))
+				self.assertEqual(maps, ())
+				self.assertEqual(masks, ())
+			self.assertEqual(opt_loss_flatten.last_stats(), {})
+		finally:
+			opt_loss_flatten.configure(diagnostics=True, reset_history=True)
+
+	def test_compiled_forward_flatten_kernels_match_eager_loss_and_gradients(self) -> None:
+		def _evaluate(*, compiled: bool) -> tuple[torch.Tensor, list[torch.Tensor]]:
+			opt_loss_flatten.configure(orient_min_det=1.1, diagnostics=False, reset_history=True)
+			opt_loss_flatten.configure_compile(enabled=compiled, backend="eager")
+			mdl = _make_flatten_model(_flat_grid(7, 7), mesh_step=1, flatten_direction="forward")
+			map_yx = mdl.flatten_map().detach().clone()
+			map_yx[..., 1] = map_yx[..., 1] * 1.1
+			_set_flatten_map(mdl, map_yx)
+			res = mdl(fit._dummy_flatten_data(), needs=fit_model.ModelForwardNeeds(flatten=True))
+			sdir, _maps, _masks = opt_loss_flatten.flatten_sdir_loss(res=res)
+			orient, _maps, _masks = opt_loss_flatten.flatten_orient_loss(res=res)
+			total = sdir + orient
+			total.backward()
+			grads = [p.grad.detach().clone() for p in mdl.flatten_map_ms if p.grad is not None]
+			return total.detach(), grads
+
+		try:
+			eager_loss, eager_grads = _evaluate(compiled=False)
+			compiled_loss, compiled_grads = _evaluate(compiled=True)
+			self.assertIsNotNone(opt_loss_flatten._compiled_forward_sdir_core)
+			self.assertIsNotNone(opt_loss_flatten._compiled_orient_core)
+			self.assertTrue(torch.allclose(compiled_loss, eager_loss, rtol=1.0e-6, atol=1.0e-6))
+			self.assertEqual(len(compiled_grads), len(eager_grads))
+			for compiled_grad, eager_grad in zip(compiled_grads, eager_grads, strict=True):
+				self.assertTrue(torch.allclose(compiled_grad, eager_grad, rtol=1.0e-5, atol=1.0e-6))
+		finally:
+			opt_loss_flatten.configure(diagnostics=True, orient_min_det=0.0, reset_history=True)
+			opt_loss_flatten.configure_compile(enabled=False)
 
 	def test_flatten_target_step_is_measured_not_mesh_step(self) -> None:
 		mdl = _make_flatten_model(_flat_grid(5, 5, sx=3.0, sy=3.0), mesh_step=20)

--- a/lasagna/tests/test_opt_loss_flatten.py
+++ b/lasagna/tests/test_opt_loss_flatten.py
@@ -35,6 +35,7 @@ def _make_flatten_model(
 	xyz: torch.Tensor,
 	valid: torch.Tensor | None = None,
 	*,
+	device: torch.device | None = None,
 	mesh_step: int = 1,
 	flatten_filter_source_angles: bool = False,
 	flatten_filter_angle_deg: float = 90.0,
@@ -46,7 +47,7 @@ def _make_flatten_model(
 	return fit_model.Model3D.from_flatten_tifxyz_crop(
 		xyz,
 		valid,
-		device=torch.device("cpu"),
+		device=torch.device("cpu") if device is None else device,
 		mesh_step=mesh_step,
 		winding_step=1,
 		subsample_mesh=1,
@@ -278,6 +279,7 @@ class FlattenLossTest(unittest.TestCase):
 		for stage in cfg["stages"]:
 			self.assertFalse(stage["args"]["flatten_diagnostics"])
 			self.assertTrue(stage["args"]["compile_flatten"])
+			self.assertTrue(stage["args"]["compile_flatten_combined"])
 			self.assertTrue(stage["args"]["fused_flatten_adam_clamp"])
 
 	def test_bilinear_validity_rejects_cells_with_any_invalid_corner(self) -> None:
@@ -382,6 +384,126 @@ class FlattenLossTest(unittest.TestCase):
 			self.assertEqual(len(compiled_grads), len(eager_grads))
 			for compiled_grad, eager_grad in zip(compiled_grads, eager_grads, strict=True):
 				self.assertTrue(torch.allclose(compiled_grad, eager_grad, rtol=1.0e-5, atol=1.0e-6))
+		finally:
+			opt_loss_flatten.configure(diagnostics=True, orient_min_det=0.0, reset_history=True)
+			opt_loss_flatten.configure_compile(enabled=False)
+
+	def test_forward_flatten_static_caches_match_source_and_identity(self) -> None:
+		mdl = _make_flatten_model(
+			_flat_grid(7, 9, sx=2.0, sy=3.0),
+			mesh_step=5,
+			flatten_direction="forward",
+		)
+
+		expected_metric = fit_model.Model3D._flatten_source_metric(mdl.flatten_source_xyz)
+		self.assertTrue(torch.equal(mdl.flatten_source_metric, expected_metric))
+		self.assertTrue(torch.equal(mdl.flatten_identity_y, torch.arange(7, dtype=torch.float32)))
+		self.assertTrue(torch.equal(mdl.flatten_identity_x, torch.arange(9, dtype=torch.float32)))
+		self.assertNotIn("flatten_source_metric", mdl.state_dict())
+		self.assertNotIn("flatten_identity_y", mdl.state_dict())
+		self.assertNotIn("flatten_identity_x", mdl.state_dict())
+
+	def _assert_combined_forward_flatten_loss_matches_individual_losses_and_gradients(
+		self,
+		*,
+		device: torch.device,
+		backend: str | None,
+	) -> None:
+		weights = torch.tensor([1.0, 0.1, 1.0, 10.0], device=device, dtype=torch.float32)
+
+		def _evaluate(*, combined: bool) -> tuple[torch.Tensor, list[torch.Tensor]]:
+			opt_loss_flatten.configure(orient_min_det=1.1, diagnostics=False, reset_history=True)
+			opt_loss_flatten.configure_compile(enabled=combined, backend=backend)
+			mdl = _make_flatten_model(
+				_flat_grid(8, 9),
+				device=device,
+				mesh_step=1,
+				flatten_direction="forward",
+			)
+			map_yx = mdl.flatten_map().detach().clone()
+			map_yx[..., 0] += 0.03 * torch.sin(map_yx[..., 1])
+			map_yx[..., 1] *= 1.07
+			_set_flatten_map(mdl, map_yx)
+			res = mdl(fit._dummy_flatten_data(), needs=fit_model.ModelForwardNeeds(flatten=True))
+			if combined:
+				total = opt_loss_flatten.flatten_combined_loss(res=res, weights=weights)
+			else:
+				losses = (
+					opt_loss_flatten.flatten_sdir_loss(res=res)[0],
+					opt_loss_flatten.flatten_map_step_loss(res=res)[0],
+					opt_loss_flatten.flatten_avg_offset_loss(res=res)[0],
+					opt_loss_flatten.flatten_orient_loss(res=res)[0],
+				)
+				total = sum(weight * loss for weight, loss in zip(weights, losses, strict=True))
+			total.backward()
+			return total.detach(), [p.grad.detach().clone() for p in mdl.flatten_map_ms]
+
+		try:
+			eager_loss, eager_grads = _evaluate(combined=False)
+			combined_loss, combined_grads = _evaluate(combined=True)
+			self.assertIsNotNone(opt_loss_flatten._compiled_combined_core)
+			self.assertTrue(torch.allclose(combined_loss, eager_loss, rtol=1.0e-6, atol=1.0e-6))
+			self.assertEqual(len(combined_grads), len(eager_grads))
+			for combined_grad, eager_grad in zip(combined_grads, eager_grads, strict=True):
+				self.assertTrue(torch.allclose(combined_grad, eager_grad, rtol=1.0e-5, atol=1.0e-6))
+		finally:
+			opt_loss_flatten.configure(diagnostics=True, orient_min_det=0.0, reset_history=True)
+			opt_loss_flatten.configure_compile(enabled=False)
+
+	def test_combined_forward_flatten_loss_matches_individual_losses_and_gradients(self) -> None:
+		self._assert_combined_forward_flatten_loss_matches_individual_losses_and_gradients(
+			device=torch.device("cpu"),
+			backend="eager",
+		)
+
+	@unittest.skipUnless(torch.cuda.is_available(), "CUDA is not available")
+	def test_combined_forward_flatten_loss_matches_individual_losses_and_gradients_on_cuda(self) -> None:
+		self._assert_combined_forward_flatten_loss_matches_individual_losses_and_gradients(
+			device=torch.device("cuda"),
+			backend=None,
+		)
+
+	def test_optimizer_dispatches_complete_forward_objective_to_combined_loss(self) -> None:
+		mdl = _make_flatten_model(_flat_grid(6, 7), mesh_step=1, flatten_direction="forward")
+		stages = optimizer.load_stages_cfg({
+			"args": {"model-init": "flatten"},
+			"base": {
+				"flatten_sdir": 1.0,
+				"flatten_map_step": 0.1,
+				"flatten_avg_offset": 1.0,
+				"flatten_orient": 10.0,
+			},
+			"stages": [{
+				"name": "flatten",
+				"steps": 1,
+				"lr": 0.0,
+				"params": ["map_flatten_ms"],
+				"args": {
+					"compile_flatten": True,
+					"compile_flatten_backend": "eager",
+					"compile_flatten_combined": True,
+					"flatten_diagnostics": False,
+					"flatten_max_update": 0.0,
+					"status_interval": 0,
+				},
+			}],
+		})
+
+		try:
+			with mock.patch.object(
+				opt_loss_flatten,
+				"flatten_combined_loss",
+				wraps=opt_loss_flatten.flatten_combined_loss,
+			) as combined:
+				optimizer.optimize(
+					model=mdl,
+					data=fit._dummy_flatten_data(),
+					stages=stages,
+					snapshot_interval=0,
+					snapshot_fn=lambda **_kw: None,
+					progress_fn=lambda **_kw: None,
+				)
+			self.assertGreaterEqual(combined.call_count, 2)
 		finally:
 			opt_loss_flatten.configure(diagnostics=True, orient_min_det=0.0, reset_history=True)
 			opt_loss_flatten.configure_compile(enabled=False)


### PR DESCRIPTION
- added a 'diagnostics' flag so we could skip a ton of `.item()` and other things causing syncs
- moved all the flattening losses into a single torch compiled function 
- fused the adam clone > clamp if before:after is too big > clone back ,  rewritten as a single kernel 
