### PR TITLE
docs(community_projects): add scroll-data-audit (open-data integrity auditor)

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -71,6 +71,7 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 - [llfio-chunkloader](https://github.com/climbmax123/LLFIOCunkloadingTestingAndBenching): A method to access data in chunks of (x,y,z) that is much faster and more compute-efficient than Zarr. (Written in C++ but it is possible to integrate in Python).
 
 - [preprocessed-data](https://github.com/usc-caisplusplus/scroll-data-preprocessing): Data preprocessing code and a fully processed version of the dataset in .zarr format to allow for faster training of ink detection models. 
+- [scroll-data-audit](https://github.com/Bullo27/scroll-data-audit) by Matteo Bulloni. Integrity auditor for the open-data: reconciles the catalog (`metadata.json`) against the actual Zarr arrays, filenames and scan metadata, and verifies multiscale pyramid value-correctness. Reported a Scroll 5 (PHerc0172) catalog shape error ([#1211](https://github.com/ScrollPrize/villa/issues/1211)) and certified the rest of the open-data consistent.
 
 ## Segmentation
 


### PR DESCRIPTION
Adds **scroll-data-audit** to the community projects list under _Data access/visualization → 🛠️ Tools_.

[scroll-data-audit](https://github.com/Bullo27/scroll-data-audit) is a small, dependency-light integrity auditor for the open-data (`vesuvius-challenge-open-data`). It reconciles the canonical catalog (`metadata.json`) against the actual Zarr arrays, filenames and scan metadata, and verifies multiscale pyramid value-correctness — anonymous public-data access only, unit-tested, CI-ready (non-zero exit on any HIGH finding).

Running it over the whole catalog surfaced one real, self-contradicting error — the Scroll 5 (PHerc0172) catalog shape reported in #1211 — and certified the rest of the open-data consistent (all other 63 in-bucket volumes match on shape/dtype/pixel-size/energy/multiscale structure; all 320 sampled pyramid level-transitions match the canonical `2×2×2 mean→round` downsample exactly).

Single-line docs addition.

_Disclosure: the tool and this PR were produced by an AI agent (Claude Code, Opus 4.8) working under the direction of @matteobulloni_73362 (GitHub @Bullo27), who verified the findings against the live public data._

🤖 Generated with [Claude Code](https://claude.com/claude-code)