### PR TITLE
fix(VC3D): remote-aware volume path for SeedingWidget Run/Expand (#1188)

### DIFF
--- a/volume-cartographer/apps/VC3D/SeedingWidget.cpp
+++ b/volume-cartographer/apps/VC3D/SeedingWidget.cpp
@@ -1183,7 +1183,10 @@ void SeedingWidget::onRunSegmentationClicked()
         return;
     }
 
-    std::filesystem::path volumePath = currentVolume->path();
+    // Remote-aware: use the volume's command locator so streaming-only volumes
+    // (no local mirror, e.g. Open Data catalog samples) pass a usable volume
+    // argument to vc_grow_seg_from_seed instead of an empty path (issue #1188).
+    const QString volumeArg = QString::fromStdString(currentVolume->commandLocator());
     QString workingDir = QString::fromStdString(pathsDir.parent_path().string());
 
     // Update UI
@@ -1270,7 +1273,7 @@ void SeedingWidget::onRunSegmentationClicked()
             previewParts << QString("OMP_NUM_THREADS=%1").arg(ompThreads);
         }
         previewParts << executablePath
-                     << QString("\"%1\"").arg(QString::fromStdString(volumePath.string()))
+                     << QString("\"%1\"").arg(volumeArg)
                      << QString("\"%1\"").arg(QString::fromStdString(pathsDir.string()))
                      << QString("\"%1\"").arg(QString::fromStdString(seedJsonPath.string()))
                      << QString::number(point.p[0])
@@ -1280,7 +1283,7 @@ void SeedingWidget::onRunSegmentationClicked()
         std::cout << "Starting job " << pointIndex << ": " << previewParts.join(' ').toStdString() << std::endl;
         
         const QStringList toolArgs = QStringList()
-                      << QString::fromStdString(volumePath.string())
+                      << volumeArg
                       << QString::fromStdString(pathsDir.string())
                       << QString::fromStdString(seedJsonPath.string())
                       << QString::number(point.p[0])
@@ -2170,7 +2173,10 @@ void SeedingWidget::onExpandSeedsClicked()
         return;
     }
 
-    std::filesystem::path volumePath = currentVolume->path();
+    // Remote-aware: use the volume's command locator so streaming-only volumes
+    // (no local mirror, e.g. Open Data catalog samples) pass a usable volume
+    // argument to vc_grow_seg_from_seed instead of an empty path (issue #1188).
+    const QString volumeArg = QString::fromStdString(currentVolume->commandLocator());
     QString workingDir = QString::fromStdString(pathsDir.parent_path().string());
 
     // Update UI
@@ -2257,14 +2263,14 @@ void SeedingWidget::onExpandSeedsClicked()
             previewParts << QString("OMP_NUM_THREADS=%1").arg(ompThreads);
         }
         previewParts << executablePath
-                     << QString("\"%1\"").arg(QString::fromStdString(volumePath.string()))
+                     << QString("\"%1\"").arg(volumeArg)
                      << QString("\"%1\"").arg(QString::fromStdString(pathsDir.string()))
                      << QString("\"%1\"").arg(QString::fromStdString(expandJsonPath.string()));
 
         std::cout << "Starting expansion job " << iterationIndex << ": " << previewParts.join(' ').toStdString() << std::endl;
         
         const QStringList toolArgs = QStringList()
-                      << QString::fromStdString(volumePath.string())
+                      << volumeArg
                       << QString::fromStdString(pathsDir.string())
                       << QString::fromStdString(expandJsonPath.string());
 #if defined(Q_OS_LINUX)

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -113,10 +113,9 @@ static QString commandPathForVolume(const std::shared_ptr<Volume>& volume)
     if (!volume) {
         return QString();
     }
-    if (volume->isRemote()) {
-        return QString::fromStdString(volume->remoteLocator());
-    }
-    return QString::fromStdString(volume->path().string());
+    // Remote-aware volume reference; Volume::commandLocator() keeps the
+    // remote-locator vs. local-path choice in a single place.
+    return QString::fromStdString(volume->commandLocator());
 }
 
 static QString findExecutable(

--- a/volume-cartographer/core/include/vc/core/types/Volume.hpp
+++ b/volume-cartographer/core/include/vc/core/types/Volume.hpp
@@ -103,6 +103,21 @@ public:
     [[nodiscard]] std::filesystem::path remotePersistentCachePath() const;
     [[nodiscard]] std::filesystem::path path() const noexcept { return path_; }
 
+    /**
+     * @brief Locator to pass to external command-line tools (e.g.
+     * @c vc_grow_seg_from_seed ) as the volume argument.
+     *
+     * Remote/streaming-only volumes have no local filesystem path, so path()
+     * is empty for them; a caller that forwards path() straight to a child
+     * process hands it an empty argument and the tool fails immediately. This
+     * returns the remote locator for remote volumes and the local path
+     * otherwise, so the spawned tool always receives a usable reference.
+     */
+    [[nodiscard]] std::string commandLocator() const
+    {
+        return isRemote_ ? remoteLocator_ : path_.string();
+    }
+
     [[nodiscard]] int sliceWidth() const noexcept;
     [[nodiscard]] int sliceHeight() const noexcept;
     [[nodiscard]] int numSlices() const noexcept;


### PR DESCRIPTION
## Summary

`SeedingWidget`'s **Run Segmentation** and **Expand Seeds** actions passed `currentVolume->path()` straight to `vc_grow_seg_from_seed` as the volume argument. For a fully-remote / streaming-only volume (no local zarr mirror — e.g. an Open Data catalog sample attached via `catalog.open_sample`), `Volume::path()` is **empty**, so the spawned child received an **empty** volume argument and failed immediately. This hit both the interactive slots and their headless bridge twins (`runSegmentationHeadless()` / `runExpandSeedsHeadless()`), as diagnosed in #1188.

## Fix

- Add `Volume::commandLocator()` — returns `remoteLocator()` for remote volumes and `path().string()` otherwise, i.e. the reference a command-line tool should receive for either volume kind, resolved in one place.
- Route both `SeedingWidget` call sites (`onRunSegmentationClicked` / `onExpandSeedsClicked`, which back the headless RPCs) through it.
- `SegmentationCommandHandler::commandPathForVolume()` — the existing, remote-correct helper this mirrors, and the reason `segmentation.grow_patch_from_seed` already handles remote volumes — now delegates to the same method, so the remote-vs-local choice has a single implementation (per the issue's "share/extract the existing helper" suggestion).

```
Volume::commandLocator()  ->  isRemote_ ? remoteLocator_ : path_.string()
```

30 insertions / 10 deletions across 3 files.

## Not changed — flagging a related latent site

`SeedingWidget::onNeuralTraceClicked()` (`SeedingWidget.cpp` ~L2469) has the same `currentVolume->path()` pattern, feeding `--volume_zarr` to the external `trace.py`. It would hit the identical empty-path failure on remote volumes, but the correct fix depends on whether `trace.py` accepts a remote/streaming locator for `--volume_zarr` (a different tool from `vc_grow_seg_from_seed`), which I can't verify here — so I left it untouched rather than silently hand it a URL it may not support. Happy to switch it to `commandLocator()` too if the neural tracer takes remote input.

## Verification

- `Volume::commandLocator()`'s logic is unit-compiled in isolation (`-std=c++20 -Wall -Wextra`, clean) with asserts over the local-path, remote-locator and empty-`path_` remote cases — the last being exactly this bug (`path()` empty, locator non-empty).
- **Built in-tree against the full toolchain** (Qt6 / OpenCV / Ceres / CGAL, gcc 13, Ninja, Release): `vc_core` (which includes the modified `Volume.hpp`) plus **both** changed VC3D translation units — `SeedingWidget.cpp` and `SegmentationCommandHandler.cpp` — compile cleanly, no warnings on the changed files. Since `commandLocator()` is an inline header method and `commandPathForVolume` is a file-local static, a clean compile of these callers is the complete check for this change (no separate symbols to link).
- CI remains the authoritative full-repo build.

## AI disclosure

Written by **Claude** (Anthropic Claude Code, Opus 4.8) working autonomously under the direction of **@matteobulloni_73362** (GitHub @Bullo27), who is submitting it. Disclosed per the challenge's AI-assistance guidance.

Fixes #1188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)