### PR TITLE
VC3D: pending/approved review states for cross-fiber links

### DIFF
--- a/volume-cartographer/apps/VC3D/CFiberWidget.cpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.cpp
@@ -38,6 +38,7 @@ enum FiberColumn {
     kNameColumn = 0,
     kDirectionColumn,
     kLinkColumn,
+    kPendingColumn,
     kLengthColumn,
     kControlPointsColumn,
     kLinePointsColumn,
@@ -330,6 +331,7 @@ void CFiberWidget::setupUi()
         tr("name"),
         tr("dir"),
         tr("link"),
+        tr("pending"),
         tr("len"),
         tr("cps"),
         tr("pts"),
@@ -356,6 +358,7 @@ void CFiberWidget::setupUi()
     _treeView->setColumnWidth(kNameColumn, 220);
     _treeView->setColumnWidth(kDirectionColumn, 42);
     _treeView->setColumnWidth(kLinkColumn, 42);
+    _treeView->setColumnWidth(kPendingColumn, 56);
     _treeView->setColumnWidth(kLengthColumn, 72);
     _treeView->setColumnWidth(kControlPointsColumn, 48);
     _treeView->setColumnWidth(kLinePointsColumn, 48);
@@ -658,6 +661,7 @@ void CFiberWidget::rebuildModel()
         tr("name"),
         tr("dir"),
         tr("link"),
+        tr("pending"),
         tr("len"),
         tr("cps"),
         tr("pts"),
@@ -675,6 +679,9 @@ void CFiberWidget::rebuildModel()
             readOnlyItem(directionForFiber(fiber)),
             readOnlyItem(fiber.linkedFiberCount > 0
                              ? QString::number(fiber.linkedFiberCount)
+                             : QString()),
+            readOnlyItem(fiber.pendingLinkCount > 0
+                             ? QString::number(fiber.pendingLinkCount)
                              : QString()),
             readOnlyItem(formatDouble(fiber.lengthVx, 1)),
             readOnlyItem(QString::number(fiber.controlPointCount)),
@@ -694,6 +701,7 @@ void CFiberWidget::rebuildModel()
             QList<QStandardItem*> childRow{
                 readOnlyItem(spanName),
                 readOnlyItem(directionForFiber(fiber)),
+                readOnlyItem(QString()),
                 readOnlyItem(QString()),
                 readOnlyItem(formatDouble(span.lengthVx, 1)),
                 readOnlyItem(QString::number(span.controlPointCount)),
@@ -826,6 +834,10 @@ void CFiberWidget::sortFibers()
         case kLinkColumn:
             different = lhs.linkedFiberCount != rhs.linkedFiberCount;
             less = compareNumber(lhs.linkedFiberCount, rhs.linkedFiberCount);
+            break;
+        case kPendingColumn:
+            different = lhs.pendingLinkCount != rhs.pendingLinkCount;
+            less = compareNumber(lhs.pendingLinkCount, rhs.pendingLinkCount);
             break;
         case kLengthColumn:
             different = lhs.lengthVx != rhs.lengthVx;

--- a/volume-cartographer/apps/VC3D/CFiberWidget.hpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.hpp
@@ -60,6 +60,7 @@ public:
         std::string manualHvTag;
         std::vector<std::string> tags;
         int linkedFiberCount = 0;
+        int pendingLinkCount = 0;
     };
 
     explicit CFiberWidget(QWidget* parent = nullptr);

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -7475,6 +7475,7 @@ void CWindow::CreateWidgets(void)
                     fiber.manualHvTag,
                     fiber.tags,
                     fiber.linkedFiberCount,
+                    fiber.pendingLinkCount,
                 });
             }
             if (_fiberWidget) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -1198,6 +1198,7 @@ generatedControlMarkers(
     struct BranchLinkTarget {
         uint64_t fiberId = 0;
         int controlPointIndex = -1;
+        bool pending = false;
     };
     std::unordered_map<size_t, std::vector<BranchLinkTarget>> branchesByControl;
     branchesByControl.reserve(branches.size());
@@ -1218,7 +1219,11 @@ generatedControlMarkers(
                        target.controlPointIndex == branch.branchControlPointIndex;
             });
         if (duplicate == targets.end()) {
-            targets.push_back({branch.branchFiberId, branch.branchControlPointIndex});
+            targets.push_back({branch.branchFiberId,
+                               branch.branchControlPointIndex,
+                               branch.pending});
+        } else {
+            duplicate->pending = duplicate->pending || branch.pending;
         }
     }
 
@@ -1242,7 +1247,9 @@ generatedControlMarkers(
                       });
             for (const auto& target : it->second) {
                 marker.branchIds.push_back(target.fiberId);
-                marker.branchLinks.push_back({target.fiberId, target.controlPointIndex});
+                marker.branchLinks.push_back(
+                    {target.fiberId, target.controlPointIndex, target.pending});
+                marker.hasPendingLinks = marker.hasPendingLinks || target.pending;
             }
             marker.branchIds.erase(std::unique(marker.branchIds.begin(), marker.branchIds.end()),
                                    marker.branchIds.end());
@@ -2056,6 +2063,20 @@ bool LineAnnotationController::launchSession(LineAnnotationController::SourceKin
                                                   controlPointIndex,
                                                   branchFiberId,
                                                   branchControlPointIndex);
+            });
+    connect(dialog,
+            &LineAnnotationDialog::generatedControlPointLinkPendingChangeRequested,
+            this,
+            [this](const std::string& name,
+                   size_t controlPointIndex,
+                   uint64_t branchFiberId,
+                   int branchControlPointIndex,
+                   bool pending) {
+                handleGeneratedControlPointSetLinkPending(name,
+                                                          controlPointIndex,
+                                                          branchFiberId,
+                                                          branchControlPointIndex,
+                                                          pending);
             });
     connect(dialog,
             &LineAnnotationDialog::generatedPredSnapPointRequested,
@@ -4561,13 +4582,28 @@ LineAnnotationController::controlMarkersForSession(const LineAnnotationSession& 
 
 std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker>
 LineAnnotationController::markLinkCandidateFiberIntersections(
-    std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker> markers) const
+    std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker> markers,
+    const std::vector<FiberBranchRef>& branches) const
 {
     const uint64_t candidateFiberId =
         _linkCandidate ? _linkCandidate->fiberId : uint64_t{0};
     for (auto& marker : markers) {
         marker.isLinkCandidateFiber =
             candidateFiberId != 0 && marker.fiberId == candidateFiberId;
+        marker.pendingBranchLink = false;
+        if (!marker.projectedBranchLink || !marker.connectorStart) {
+            continue;
+        }
+        for (const auto& branch : branches) {
+            // connectorStart carries the local endpoint position through a
+            // double->float round trip; match with a coarse tolerance.
+            if (branch.pending && branch.branchFiberId == marker.fiberId &&
+                cv::norm(toVec3f(branch.controlPointPosition) -
+                         *marker.connectorStart) <= 1.0e-3) {
+                marker.pendingBranchLink = true;
+                break;
+            }
+        }
     }
     return markers;
 }
@@ -4694,6 +4730,17 @@ bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolu
                                               controlPointIndex,
                                               branchFiberId,
                                               branchControlPointIndex);
+        };
+        options.setBranchLinkPending = [this, surfaceName = viewer->surfName()](
+                                           size_t controlPointIndex,
+                                           uint64_t branchFiberId,
+                                           int branchControlPointIndex,
+                                           bool pending) {
+            handleGeneratedControlPointSetLinkPending(surfaceName,
+                                                      controlPointIndex,
+                                                      branchFiberId,
+                                                      branchControlPointIndex,
+                                                      pending);
         };
         result = vc3d::line_annotation::showGeneratedControlPointContextMenu(options);
     }
@@ -5111,6 +5158,10 @@ std::vector<LineAnnotationController::FiberSummary> LineAnnotationController::fi
             spanSummaries.push_back(std::move(summary));
         }
         const int componentSize = componentSizes[findRoot(indexById.at(fiber.id))];
+        const int pendingLinkCount = static_cast<int>(
+            std::count_if(fiber.branches.begin(),
+                          fiber.branches.end(),
+                          [](const FiberBranchRef& branch) { return branch.pending; }));
         summaries.push_back(FiberSummary{
             fiber.id,
             fiber.fileName,
@@ -5128,6 +5179,7 @@ std::vector<LineAnnotationController::FiberSummary> LineAnnotationController::fi
             fiber.manualHvTag,
             fiber.tags,
             componentSize >= 2 ? componentSize : 0,
+            pendingLinkCount,
         });
     }
     std::sort(summaries.begin(), summaries.end(), [](const FiberSummary& a, const FiberSummary& b) {
@@ -5535,6 +5587,7 @@ void LineAnnotationController::handleGeneratedControlPointBranch(const std::stri
     parentToLinked.branchControlPointDirection = linkedInitialDirection;
     parentToLinked.controlPointPosition = branchPoint;
     parentToLinked.branchControlPointPosition = linkedPoint;
+    parentToLinked.pending = true;
 
     const auto duplicateParentLink = std::find_if(
         parentSession.branches.begin(),
@@ -5557,6 +5610,7 @@ void LineAnnotationController::handleGeneratedControlPointBranch(const std::stri
     linkedToParent.branchControlPointDirection = parentEndpointDirection;
     linkedToParent.controlPointPosition = linkedPoint;
     linkedToParent.branchControlPointPosition = branchPoint;
+    linkedToParent.pending = true;
     linkedSeedRecord->branches.push_back(linkedToParent);
     linkedSeedRecord->showLinkedLineOverlays = false;
     linkedSeedRecord->surfaceName = "linked_fiber_create_only";
@@ -5789,6 +5843,7 @@ void LineAnnotationController::handleGeneratedControlPointLinkWithCandidate(
     localRef.branchControlPointDirection = farDirection;
     localRef.controlPointPosition = localPoint;
     localRef.branchControlPointPosition = farPoint;
+    localRef.pending = true;
 
     const auto duplicateLocal = std::find_if(
         session.branches.begin(),
@@ -5829,6 +5884,7 @@ void LineAnnotationController::handleGeneratedControlPointLinkWithCandidate(
         reciprocal.branchControlPointDirection = storedLocalBranch->controlPointDirection;
         reciprocal.controlPointPosition = storedLocalBranch->branchControlPointPosition;
         reciprocal.branchControlPointPosition = storedLocalBranch->controlPointPosition;
+        reciprocal.pending = storedLocalBranch->pending;
 
         // storedFiberFromSession runs the branch metadata sync hook, which may
         // touch _fibers; re-find the far fiber before mutating it.
@@ -5961,6 +6017,123 @@ void LineAnnotationController::handleGeneratedControlPointUnlink(
         session.fiberMetricsMatchStoredFiber = true;
     } catch (const std::exception& ex) {
         showError(tr("Could not save fiber after unlinking: %1")
+                      .arg(QString::fromStdString(ex.what())));
+    }
+
+    emitFiberSummaries();
+    if (pane->dialog) {
+        pane->dialog->setGeneratedBranchOverlayData(
+            controlMarkersForSession(session),
+            generatedBranchLinePointsForSession(session),
+            generatedBranchLinkMarkers(session.branches),
+            true);
+    }
+    refreshBranchLineViews(session.fiberId);
+    refreshBranchLineViews(branchFiberId);
+}
+
+void LineAnnotationController::handleGeneratedControlPointSetLinkPending(
+    const std::string& surfaceName,
+    size_t controlPointIndex,
+    uint64_t branchFiberId,
+    int branchControlPointIndex,
+    bool pending)
+{
+    auto* pane = paneForSurface(surfaceName);
+    if (!pane || !pane->session) {
+        return;
+    }
+    auto& session = *pane->session;
+    if (session.taskState == LineAnnotationSession::TaskState::Running) {
+        showError(tr("Line optimization is already running."));
+        return;
+    }
+    if (controlPointIndex >= session.controlPoints.size() || branchFiberId == 0) {
+        return;
+    }
+
+    std::vector<FiberBranchRef> updatedBranches;
+    for (auto& branch : session.branches) {
+        if (branch.controlPointIndex == static_cast<int>(controlPointIndex) &&
+            branch.branchFiberId == branchFiberId &&
+            (branchControlPointIndex < 0 ||
+             branch.branchControlPointIndex == branchControlPointIndex)) {
+            branch.pending = pending;
+            updatedBranches.push_back(branch);
+        }
+    }
+    if (updatedBranches.empty()) {
+        showError(tr("Could not find the link to update."));
+        return;
+    }
+
+    // Flip the reciprocal refs in the linked fiber, whether it is open in a
+    // pane or only loaded from storage. If it is neither, only the local side
+    // is updated/saved (same semantics as unlinking).
+    std::vector<uint64_t> affectedFiberIds;
+    auto updateReciprocals = [&session, pending](std::vector<FiberBranchRef>& targetBranches,
+                                                 const FiberBranchRef& updatedBranch) {
+        bool changed = false;
+        for (auto& candidate : targetBranches) {
+            const bool pointsToSession =
+                candidate.branchFiberId == session.fiberId ||
+                (!session.fiberFileName.empty() &&
+                 candidate.branchFileName == session.fiberFileName);
+            const bool sameLocalEndpoint =
+                candidate.branchControlPointIndex == updatedBranch.controlPointIndex ||
+                pointsApproximatelyEqual(candidate.branchControlPointPosition,
+                                         updatedBranch.controlPointPosition);
+            if (pointsToSession &&
+                candidate.controlPointIndex == updatedBranch.branchControlPointIndex &&
+                sameLocalEndpoint) {
+                candidate.pending = pending;
+                changed = true;
+            }
+        }
+        return changed;
+    };
+    for (const auto& updatedBranch : updatedBranches) {
+        for (const auto& otherPane : _panes) {
+            if (!otherPane.session ||
+                !branchReferencesFiber(updatedBranch,
+                                       otherPane.session->fiberId,
+                                       otherPane.session->fiberFileName)) {
+                continue;
+            }
+            if (updateReciprocals(otherPane.session->branches, updatedBranch)) {
+                addUniqueFiberId(affectedFiberIds, otherPane.session->fiberId);
+            }
+        }
+        for (auto& fiber : _fibers) {
+            if (!branchReferencesFiber(updatedBranch, fiber.id, fiber.fileName)) {
+                continue;
+            }
+            if (updateReciprocals(fiber.branches, updatedBranch)) {
+                addUniqueFiberId(affectedFiberIds, fiber.id);
+            }
+        }
+    }
+    scheduleBranchMetadataSaves(affectedFiberIds, session.fiberId);
+
+    try {
+        StoredFiber localFiber = storedFiberFromSession(session);
+        scheduleFiberSave(localFiber);
+        auto localIt = std::find_if(
+            _fibers.begin(),
+            _fibers.end(),
+            [&localFiber](const StoredFiber& existing) {
+                return (!localFiber.fileName.empty() &&
+                        existing.fileName == localFiber.fileName) ||
+                       existing.id == localFiber.id;
+            });
+        if (localIt == _fibers.end()) {
+            _fibers.push_back(std::move(localFiber));
+        } else {
+            *localIt = std::move(localFiber);
+        }
+        session.fiberMetricsMatchStoredFiber = true;
+    } catch (const std::exception& ex) {
+        showError(tr("Could not save fiber after updating the link: %1")
                       .arg(QString::fromStdString(ex.what())));
     }
 
@@ -7824,7 +7997,8 @@ void LineAnnotationController::handleGeneratedSideStripIntersectionQuery(
         request.cacheKey == _lastSideStripIntersectionKey &&
         request.surfaceName == _lastSideStripIntersectionSurfaceName) {
         pane->dialog->setGeneratedFiberIntersectionMarkers(
-            markLinkCandidateFiberIntersections(_lastSideStripIntersectionMarkers));
+            markLinkCandidateFiberIntersections(_lastSideStripIntersectionMarkers,
+                                                pane->session->branches));
         pane->dialog->setGeneratedSideStripIntersectionResult(
             _lastSideStripIntersectionMarkers.size());
         return;
@@ -7861,7 +8035,8 @@ void LineAnnotationController::handleGeneratedSideStripIntersectionQuery(
         auto previewMarkers = sideStripMarkersFromIntersections(
             previewIndex.sideStripIntersections(previewOptions));
         pane->dialog->setGeneratedFiberIntersectionMarkers(
-            markLinkCandidateFiberIntersections(std::move(previewMarkers)));
+            markLinkCandidateFiberIntersections(std::move(previewMarkers),
+                                                pane->session->branches));
     }
 
     if (_sideStripIntersectionRunning) {
@@ -8215,7 +8390,10 @@ void LineAnnotationController::applyPartialSideStripIntersectionMarkers(
     }
     if (auto* pane = paneForSurface(surfaceName); pane && pane->dialog) {
         pane->dialog->setGeneratedFiberIntersectionMarkers(
-            markLinkCandidateFiberIntersections(std::move(markers)));
+            markLinkCandidateFiberIntersections(
+                std::move(markers),
+                pane->session ? pane->session->branches
+                              : std::vector<FiberBranchRef>{}));
     }
 }
 
@@ -8236,7 +8414,10 @@ void LineAnnotationController::finishSideStripIntersectionQuery(
                 _lastSideStripIntersectionSurfaceName = result.surfaceName;
                 _lastSideStripIntersectionMarkers = result.markers;
                 pane->dialog->setGeneratedFiberIntersectionMarkers(
-                    markLinkCandidateFiberIntersections(std::move(result.markers)));
+                    markLinkCandidateFiberIntersections(
+                        std::move(result.markers),
+                        pane->session ? pane->session->branches
+                                      : std::vector<FiberBranchRef>{}));
                 if (!hasPendingRequest) {
                     pane->dialog->setGeneratedSideStripIntersectionResult(markerCount);
                 }
@@ -9354,6 +9535,9 @@ nlohmann::json LineAnnotationController::fiberSaveSnapshotToJson(
             throw std::runtime_error("Branch link is missing branch_file");
         }
         branchJson["branch_file"] = branchFileName;
+        if (branch.pending) {
+            branchJson["pending"] = true;
+        }
         root["branches"].push_back(std::move(branchJson));
     }
     root["control_points"] = nlohmann::json::array();
@@ -9517,6 +9701,7 @@ void LineAnnotationController::canonicalizeFiberSaveSnapshots(
             reciprocal->branchControlPointPosition = branch.controlPointPosition;
             reciprocal->controlPointDirection = branch.branchControlPointDirection;
             reciprocal->branchControlPointDirection = branch.controlPointDirection;
+            reciprocal->pending = branch.pending;
         }
     }
 }
@@ -9889,6 +10074,7 @@ std::optional<LineAnnotationController::StoredFiber> LineAnnotationController::l
                         pointFromJson(branchJson.at("control_point_position"));
                     branch.branchControlPointPosition =
                         pointFromJson(branchJson.at("branch_control_point_position"));
+                    branch.pending = branchJson.value("pending", false);
                     if (branch.controlPointIndex < 0 ||
                         static_cast<size_t>(branch.controlPointIndex) >=
                             fiber.controlPoints.size()) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -787,6 +787,18 @@ bool branchReferencesFiber(const LineAnnotationController::FiberBranchRef& branc
     return !fileName.empty() && branch.branchFileName == fileName;
 }
 
+bool controlPointHasBranchLink(
+    const std::vector<LineAnnotationController::FiberBranchRef>& branches,
+    size_t controlPointIndex)
+{
+    return std::any_of(
+        branches.begin(),
+        branches.end(),
+        [controlPointIndex](const LineAnnotationController::FiberBranchRef& branch) {
+            return branch.controlPointIndex == static_cast<int>(controlPointIndex);
+        });
+}
+
 bool branchLinkedEndpointMatches(
     const LineAnnotationController::FiberBranchRef& lhs,
     const LineAnnotationController::FiberBranchRef& rhs)
@@ -5536,6 +5548,10 @@ void LineAnnotationController::handleGeneratedControlPointBranch(const std::stri
     if (controlPointIndex >= parentSession.controlPoints.size()) {
         return;
     }
+    if (controlPointHasBranchLink(parentSession.branches, controlPointIndex)) {
+        showError(tr("This control point is already linked; unlink it first."));
+        return;
+    }
     if (openAfterCreate && !ensureDatasetForSession(parentSession)) {
         return;
     }
@@ -5704,6 +5720,10 @@ void LineAnnotationController::handleGeneratedControlPointLinkCandidate(
     if (controlPointIndex >= session.controlPoints.size()) {
         return;
     }
+    if (controlPointHasBranchLink(session.branches, controlPointIndex)) {
+        showError(tr("This control point is already linked; unlink it first."));
+        return;
+    }
     const cv::Vec3d candidatePosition = session.controlPoints[controlPointIndex].volumePoint;
     if (!finitePoint(candidatePosition)) {
         showError(tr("Could not determine a finite position for the link candidate."));
@@ -5776,6 +5796,10 @@ void LineAnnotationController::handleGeneratedControlPointLinkWithCandidate(
     if (controlPointIndex >= session.controlPoints.size()) {
         return;
     }
+    if (controlPointHasBranchLink(session.branches, controlPointIndex)) {
+        showError(tr("This control point is already linked; unlink it first."));
+        return;
+    }
     if (!_linkCandidate || _linkCandidate->fiberId == 0) {
         showError(tr("No link candidate is designated."));
         return;
@@ -5812,6 +5836,11 @@ void LineAnnotationController::handleGeneratedControlPointLinkWithCandidate(
     if (!farControlIndex) {
         _linkCandidate.reset();
         showError(tr("The link candidate control point no longer exists."));
+        return;
+    }
+    if (controlPointHasBranchLink(farIt->branches,
+                                  static_cast<size_t>(*farControlIndex))) {
+        showError(tr("The link candidate is already linked; unlink it first."));
         return;
     }
     const cv::Vec3d farPoint = farIt->controlPoints[static_cast<size_t>(*farControlIndex)];

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -99,6 +99,8 @@ public:
         // Number of fibers in this fiber's branch-link connected component
         // (including itself); 0 when the fiber has no links.
         int linkedFiberCount = 0;
+        // Number of branch links on this fiber still awaiting review approval.
+        int pendingLinkCount = 0;
     };
 
     struct FiberSnapshotWithPath {
@@ -124,6 +126,8 @@ public:
         cv::Vec3d branchControlPointDirection{0.0, 0.0, 0.0};
         cv::Vec3d controlPointPosition{0.0, 0.0, 0.0};
         cv::Vec3d branchControlPointPosition{0.0, 0.0, 0.0};
+        // Link awaits reviewer approval; kept in sync on both reciprocal refs.
+        bool pending = false;
     };
 
     using DatasetPicker =
@@ -380,13 +384,19 @@ private:
                                            size_t controlPointIndex,
                                            uint64_t branchFiberId,
                                            int branchControlPointIndex);
+    void handleGeneratedControlPointSetLinkPending(const std::string& surfaceName,
+                                                   size_t controlPointIndex,
+                                                   uint64_t branchFiberId,
+                                                   int branchControlPointIndex,
+                                                   bool pending);
     [[nodiscard]] std::vector<vc3d::line_annotation::GeneratedOverlay::ControlPointMarker>
         controlMarkersForSession(const LineAnnotationSession& session) const;
     [[nodiscard]] vc3d::line_annotation::GeneratedLinkCandidateMenuState
         linkCandidateMenuState(const LineAnnotationSession& session) const;
     [[nodiscard]] std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker>
         markLinkCandidateFiberIntersections(
-            std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker> markers) const;
+            std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker> markers,
+            const std::vector<FiberBranchRef>& branches) const;
     bool ensureDatasetForSession(LineAnnotationSession& session);
     bool needsFinalOptimization(const LineAnnotationSession& session) const;
     bool finalizeSessionOptimizationSynchronously(LineAnnotationSession& session,

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -1423,6 +1423,16 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(
                                                   branchFiberId,
                                                   branchControlPointIndex);
     };
+    options.setBranchLinkPending = [this, surfaceName](size_t controlPointIndex,
+                                                       uint64_t branchFiberId,
+                                                       int branchControlPointIndex,
+                                                       bool pending) {
+        emit generatedControlPointLinkPendingChangeRequested(surfaceName,
+                                                             controlPointIndex,
+                                                             branchFiberId,
+                                                             branchControlPointIndex,
+                                                             pending);
+    };
     return vc3d::line_annotation::showGeneratedControlPointContextMenu(options);
 }
 
@@ -2317,9 +2327,11 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         !_fastCurrentCutOverlayItems.seedPoints ||
         !_fastCurrentCutOverlayItems.linkCandidatePoints ||
         !_fastCurrentCutOverlayItems.branchControlPoints ||
+        !_fastCurrentCutOverlayItems.pendingBranchControlPoints ||
         !_fastCurrentCutOverlayItems.fiberIntersections ||
         !_fastCurrentCutOverlayItems.linkCandidateFiberIntersections ||
         !_fastCurrentCutOverlayItems.branchLinkFiberIntersections ||
+        !_fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections ||
         !_fastCurrentCutOverlayItems.fiberIntersectionConnectors) {
         viewer->clearOverlayGroup(kGeneratedDynamicCurrentCutOverlayKey);
         _fastCurrentCutOverlayItems = {};
@@ -2363,6 +2375,15 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         _fastCurrentCutOverlayItems.branchControlPoints->setBrush(branchControlBrush);
         _fastCurrentCutOverlayItems.branchControlPoints->setZValue(162.0);
 
+        QPen pendingBranchControlPen(QColor(80, 150, 255, 245));
+        pendingBranchControlPen.setWidthF(2.0);
+        QBrush pendingBranchControlBrush(QColor(80, 150, 255, 175));
+        _fastCurrentCutOverlayItems.pendingBranchControlPoints = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.pendingBranchControlPoints->setPen(pendingBranchControlPen);
+        _fastCurrentCutOverlayItems.pendingBranchControlPoints->setBrush(
+            pendingBranchControlBrush);
+        _fastCurrentCutOverlayItems.pendingBranchControlPoints->setZValue(162.5);
+
         QPen fiberIntersectionPen(QColor(255, 245, 75, 245));
         fiberIntersectionPen.setWidthF(1.25);
         fiberIntersectionPen.setCapStyle(Qt::FlatCap);
@@ -2389,6 +2410,16 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setBrush(Qt::NoBrush);
         _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setZValue(168.25);
 
+        QPen pendingBranchLinkFiberIntersectionPen(QColor(80, 150, 255, 245));
+        pendingBranchLinkFiberIntersectionPen.setWidthF(1.75);
+        pendingBranchLinkFiberIntersectionPen.setCapStyle(Qt::FlatCap);
+        _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections =
+            new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections->setPen(
+            pendingBranchLinkFiberIntersectionPen);
+        _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections->setBrush(Qt::NoBrush);
+        _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections->setZValue(168.3);
+
         QPen fiberIntersectionConnectorPen(QColor(255, 60, 180, 225));
         fiberIntersectionConnectorPen.setWidthF(1.4);
         _fastCurrentCutOverlayItems.fiberIntersectionConnectors = new QGraphicsPathItem();
@@ -2403,9 +2434,11 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
                                  _fastCurrentCutOverlayItems.seedPoints,
                                  _fastCurrentCutOverlayItems.linkCandidatePoints,
                                  _fastCurrentCutOverlayItems.branchControlPoints,
+                                 _fastCurrentCutOverlayItems.pendingBranchControlPoints,
                                  _fastCurrentCutOverlayItems.fiberIntersections,
                                  _fastCurrentCutOverlayItems.linkCandidateFiberIntersections,
                                  _fastCurrentCutOverlayItems.branchLinkFiberIntersections,
+                                 _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections,
                                  _fastCurrentCutOverlayItems.fiberIntersectionConnectors});
     }
 
@@ -2425,6 +2458,7 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     QPainterPath seedPath;
     QPainterPath linkCandidatePath;
     QPainterPath branchControlPath;
+    QPainterPath pendingBranchControlPath;
     const double lineRadius =
         std::max(0.5, (_viewerManager ? _viewerManager->zScrollSensitivity() : 1.0) * 0.5);
     const double lower = _currentLinePosition - lineRadius;
@@ -2462,6 +2496,8 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         if (control.isLinkCandidate) {
             linkCandidatePath.addEllipse(scenePoint, control.isSeed ? 11.0 : 10.0,
                                          control.isSeed ? 11.0 : 10.0);
+        } else if (control.hasPendingLinks) {
+            pendingBranchControlPath.addEllipse(scenePoint, 12.0, 12.0);
         } else if (control.hasBranches) {
             branchControlPath.addEllipse(scenePoint, 12.0, 12.0);
         } else if (control.isSeed) {
@@ -2474,10 +2510,12 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     _fastCurrentCutOverlayItems.seedPoints->setPath(seedPath);
     _fastCurrentCutOverlayItems.linkCandidatePoints->setPath(linkCandidatePath);
     _fastCurrentCutOverlayItems.branchControlPoints->setPath(branchControlPath);
+    _fastCurrentCutOverlayItems.pendingBranchControlPoints->setPath(pendingBranchControlPath);
 
     QPainterPath fiberIntersectionPath;
     QPainterPath linkCandidateFiberIntersectionPath;
     QPainterPath branchLinkFiberIntersectionPath;
+    QPainterPath pendingBranchLinkFiberIntersectionPath;
     QPainterPath fiberIntersectionConnectorPath;
     auto* currentCutPlane = _generatedViews.currentCutSurface.get();
     const std::optional<float> intersectionThreshold =
@@ -2508,8 +2546,11 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
             }
             QPainterPath& path = intersection.isLinkCandidateFiber
                 ? linkCandidateFiberIntersectionPath
-                : (intersection.projectedBranchLink ? branchLinkFiberIntersectionPath
-                                                    : fiberIntersectionPath);
+                : (intersection.projectedBranchLink
+                       ? (intersection.pendingBranchLink
+                              ? pendingBranchLinkFiberIntersectionPath
+                              : branchLinkFiberIntersectionPath)
+                       : fiberIntersectionPath);
             path.moveTo(scenePoint + QPointF(-kIntersectionArm, -kIntersectionArm));
             path.lineTo(scenePoint + QPointF(kIntersectionArm, kIntersectionArm));
             path.moveTo(scenePoint + QPointF(-kIntersectionArm, kIntersectionArm));
@@ -2521,6 +2562,8 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         linkCandidateFiberIntersectionPath);
     _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setPath(
         branchLinkFiberIntersectionPath);
+    _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections->setPath(
+        pendingBranchLinkFiberIntersectionPath);
     _fastCurrentCutOverlayItems.fiberIntersectionConnectors->setPath(
         fiberIntersectionConnectorPath);
 }

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -86,9 +86,11 @@ public:
         QGraphicsPathItem* seedPoints = nullptr;
         QGraphicsPathItem* linkCandidatePoints = nullptr;
         QGraphicsPathItem* branchControlPoints = nullptr;
+        QGraphicsPathItem* pendingBranchControlPoints = nullptr;
         QGraphicsPathItem* fiberIntersections = nullptr;
         QGraphicsPathItem* linkCandidateFiberIntersections = nullptr;
         QGraphicsPathItem* branchLinkFiberIntersections = nullptr;
+        QGraphicsPathItem* pendingBranchLinkFiberIntersections = nullptr;
         QGraphicsPathItem* fiberIntersectionConnectors = nullptr;
     };
 
@@ -176,6 +178,11 @@ signals:
                                               size_t controlPointIndex,
                                               uint64_t branchFiberId,
                                               int branchControlPointIndex);
+    void generatedControlPointLinkPendingChangeRequested(const std::string& surfaceName,
+                                                         size_t controlPointIndex,
+                                                         uint64_t branchFiberId,
+                                                         int branchControlPointIndex,
+                                                         bool pending);
     void generatedPredSnapPointRequested(const std::string& surfaceName,
                                          cv::Vec3f volumePoint);
     void generatedSideStripIntersectionQueryRequested(const std::string& surfaceName);

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
@@ -741,7 +741,8 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
         designateLinkCandidateAction =
             menu.addAction(QWidget::tr("Designate as link candidate"));
         designateLinkCandidateAction->setEnabled(
-            selectedControlIndex != std::numeric_limits<size_t>::max());
+            selectedControlIndex != std::numeric_limits<size_t>::max() &&
+            !selectedControl.hasBranches);
     }
     std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>> openBranchActions;
     if (!selectedControl.branchLinks.empty()) {
@@ -829,14 +830,16 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
             QWidget::tr("New linked line annotation from control point"));
         newLinkedLineAnnotationAction->setEnabled(
             selectedControlIndex != std::numeric_limits<size_t>::max() &&
-            canSampleClickedVolume);
+            canSampleClickedVolume &&
+            !selectedControl.hasBranches);
     }
     QAction* linkWithCandidateAction = nullptr;
     if (options.linkWithCandidate && !options.linkWithCandidateLabel.isEmpty()) {
         linkWithCandidateAction = menu.addAction(options.linkWithCandidateLabel);
         linkWithCandidateAction->setEnabled(
             options.linkWithCandidateEnabled &&
-            selectedControlIndex != std::numeric_limits<size_t>::max());
+            selectedControlIndex != std::numeric_limits<size_t>::max() &&
+            !selectedControl.hasBranches);
     }
     QAction* openNearbyAnnotationAction = nullptr;
     if (options.openNearbyAnnotation && nearbyIntersection) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
@@ -236,6 +236,11 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
     branchControlPointStyle.penWidth = 2.0;
     branchControlPointStyle.z = 162.0;
 
+    ViewerOverlayControllerBase::OverlayStyle pendingBranchControlPointStyle = branchControlPointStyle;
+    pendingBranchControlPointStyle.penColor = QColor(80, 150, 255, 245);
+    pendingBranchControlPointStyle.brushColor = QColor(80, 150, 255, 175);
+    pendingBranchControlPointStyle.z = 162.5;
+
     ViewerOverlayControllerBase::OverlayStyle linkCandidateControlPointStyle = branchControlPointStyle;
     linkCandidateControlPointStyle.penColor = QColor(60, 235, 120, 245);
     linkCandidateControlPointStyle.brushColor = QColor(60, 235, 120, 175);
@@ -245,6 +250,9 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
         -> const ViewerOverlayControllerBase::OverlayStyle& {
         if (control.isLinkCandidate) {
             return linkCandidateControlPointStyle;
+        }
+        if (control.hasPendingLinks) {
+            return pendingBranchControlPointStyle;
         }
         if (control.hasBranches) {
             return branchControlPointStyle;
@@ -306,6 +314,11 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
     branchLinkFiberIntersectionStyle.penColor = QColor(210, 95, 255, 245);
     branchLinkFiberIntersectionStyle.penWidth = 1.75;
     branchLinkFiberIntersectionStyle.z = 168.25;
+
+    ViewerOverlayControllerBase::OverlayStyle pendingBranchLinkFiberIntersectionStyle =
+        branchLinkFiberIntersectionStyle;
+    pendingBranchLinkFiberIntersectionStyle.penColor = QColor(80, 150, 255, 245);
+    pendingBranchLinkFiberIntersectionStyle.z = 168.3;
 
     auto addVolumePointMarker = [&](const cv::Vec3f& point,
                                     qreal radius,
@@ -530,7 +543,9 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
                                    intersection.isLinkCandidateFiber
                                        ? linkCandidateFiberIntersectionStyle
                                        : (intersection.projectedBranchLink
-                                              ? branchLinkFiberIntersectionStyle
+                                              ? (intersection.pendingBranchLink
+                                                     ? pendingBranchLinkFiberIntersectionStyle
+                                                     : branchLinkFiberIntersectionStyle)
                                               : fiberIntersectionStyle));
     }
 
@@ -721,6 +736,13 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
     QMenu menu(options.parent);
     QAction* deleteAction = menu.addAction(QWidget::tr("Delete control point"));
     deleteAction->setEnabled(options.controlPoints.size() > 1);
+    QAction* designateLinkCandidateAction = nullptr;
+    if (options.designateLinkCandidate) {
+        designateLinkCandidateAction =
+            menu.addAction(QWidget::tr("Designate as link candidate"));
+        designateLinkCandidateAction->setEnabled(
+            selectedControlIndex != std::numeric_limits<size_t>::max());
+    }
     std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>> openBranchActions;
     if (!selectedControl.branchLinks.empty()) {
         QMenu* branchMenu = menu.addMenu(QWidget::tr("Go to linked annotation"));
@@ -753,31 +775,61 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
             }
         }
     }
+    std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>> approveActions;
+    std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>> markPendingActions;
+    if (options.setBranchLinkPending && !selectedControl.branchLinks.empty()) {
+        auto addPendingChangeActions =
+            [&menu](std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>>& actions,
+                    const std::vector<GeneratedOverlay::ControlPointMarker::BranchLink>& links,
+                    const QString& singleFormat,
+                    const QString& submenuTitle) {
+                if (links.empty()) {
+                    return;
+                }
+                if (links.size() == 1) {
+                    const auto& branch = links.front();
+                    QAction* action = menu.addAction(
+                        singleFormat
+                            .arg(static_cast<qulonglong>(branch.fiberId))
+                            .arg(branch.controlPointIndex));
+                    actions.push_back({action, branch});
+                } else {
+                    QMenu* submenu = menu.addMenu(submenuTitle);
+                    for (const auto& branch : links) {
+                        QAction* action = submenu->addAction(
+                            QWidget::tr("Fiber %1 / CP %2")
+                                .arg(static_cast<qulonglong>(branch.fiberId))
+                                .arg(branch.controlPointIndex));
+                        actions.push_back({action, branch});
+                    }
+                }
+            };
+        std::vector<GeneratedOverlay::ControlPointMarker::BranchLink> pendingLinks;
+        std::vector<GeneratedOverlay::ControlPointMarker::BranchLink> approvedLinks;
+        for (const auto& branch : selectedControl.branchLinks) {
+            (branch.pending ? pendingLinks : approvedLinks).push_back(branch);
+        }
+        addPendingChangeActions(approveActions,
+                                pendingLinks,
+                                QWidget::tr("Approve link to Fiber %1 / CP %2"),
+                                QWidget::tr("Approve link"));
+        addPendingChangeActions(markPendingActions,
+                                approvedLinks,
+                                QWidget::tr("Mark link as pending (Fiber %1 / CP %2)"),
+                                QWidget::tr("Mark link as pending"));
+    }
     const bool canSampleClickedVolume =
         options.viewer->sampleSceneVolume(options.scenePoint).has_value();
     QAction* newLineAnnotationAction =
         menu.addAction(QWidget::tr("New line annotation"));
     newLineAnnotationAction->setEnabled(canSampleClickedVolume);
     QAction* newLinkedLineAnnotationAction = nullptr;
-    QAction* openNewLineAnnotationAction = nullptr;
     if (options.addBranch) {
         newLinkedLineAnnotationAction = menu.addAction(
             QWidget::tr("New linked line annotation from control point"));
         newLinkedLineAnnotationAction->setEnabled(
             selectedControlIndex != std::numeric_limits<size_t>::max() &&
             canSampleClickedVolume);
-        openNewLineAnnotationAction = menu.addAction(
-            QWidget::tr("Open new linked line annotation from control point"));
-        openNewLineAnnotationAction->setEnabled(
-            selectedControlIndex != std::numeric_limits<size_t>::max() &&
-            canSampleClickedVolume);
-    }
-    QAction* designateLinkCandidateAction = nullptr;
-    if (options.designateLinkCandidate) {
-        designateLinkCandidateAction =
-            menu.addAction(QWidget::tr("Designate as link candidate"));
-        designateLinkCandidateAction->setEnabled(
-            selectedControlIndex != std::numeric_limits<size_t>::max());
     }
     QAction* linkWithCandidateAction = nullptr;
     if (options.linkWithCandidate && !options.linkWithCandidateLabel.isEmpty()) {
@@ -813,6 +865,20 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
             return GeneratedControlPointContextResult::Handled;
         }
     }
+    for (const auto& [action, branch] : approveActions) {
+        if (selected == action) {
+            options.setBranchLinkPending(
+                selectedControlIndex, branch.fiberId, branch.controlPointIndex, false);
+            return GeneratedControlPointContextResult::Handled;
+        }
+    }
+    for (const auto& [action, branch] : markPendingActions) {
+        if (selected == action) {
+            options.setBranchLinkPending(
+                selectedControlIndex, branch.fiberId, branch.controlPointIndex, true);
+            return GeneratedControlPointContextResult::Handled;
+        }
+    }
     if (selected == newLineAnnotationAction && newLineAnnotationAction->isEnabled()) {
         return GeneratedControlPointContextResult::NewLineAnnotationRequested;
     }
@@ -826,19 +892,6 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
         options.addBranch(selectedControlIndex,
                           clickedVolumePoint->position,
                           false,
-                          options.branchLinkDirection);
-        return GeneratedControlPointContextResult::Handled;
-    }
-    if (openNewLineAnnotationAction &&
-        selected == openNewLineAnnotationAction &&
-        openNewLineAnnotationAction->isEnabled()) {
-        const auto clickedVolumePoint = options.viewer->sampleSceneVolume(options.scenePoint);
-        if (!clickedVolumePoint) {
-            return GeneratedControlPointContextResult::Handled;
-        }
-        options.addBranch(selectedControlIndex,
-                          clickedVolumePoint->position,
-                          true,
                           options.branchLinkDirection);
         return GeneratedControlPointContextResult::Handled;
     }

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
@@ -46,11 +46,13 @@ struct GeneratedOverlay {
         struct BranchLink {
             uint64_t fiberId = 0;
             int controlPointIndex = -1;
+            bool pending = false;
         };
 
         size_t controlIndex = std::numeric_limits<size_t>::max();
         bool isSeed = false;
         bool hasBranches = false;
+        bool hasPendingLinks = false;
         bool isLinkCandidate = false;
         std::vector<uint64_t> branchIds;
         std::vector<BranchLink> branchLinks;
@@ -97,6 +99,7 @@ struct GeneratedOverlay {
         double arclength = std::numeric_limits<double>::quiet_NaN();
         double distance = std::numeric_limits<double>::quiet_NaN();
         bool projectedBranchLink = false;
+        bool pendingBranchLink = false;
         bool isLinkCandidateFiber = false;
         std::optional<cv::Vec3f> connectorStart;
     };
@@ -937,6 +940,8 @@ struct GeneratedControlPointContextMenuOptions {
     std::function<void(size_t, cv::Vec3f, bool, cv::Vec3f)> addBranch;
     std::function<void(uint64_t, int)> openBranch;
     std::function<void(size_t, uint64_t, int)> unlinkBranch;
+    // (controlIndex, linkedFiberId, linkedControlPointIndex, newPendingState)
+    std::function<void(size_t, uint64_t, int, bool)> setBranchLinkPending;
     std::function<void(size_t, cv::Vec3f)> designateLinkCandidate;
     std::function<void(size_t, cv::Vec3f)> linkWithCandidate;
     std::function<void(uint64_t, cv::Vec3f)> openNearbyAnnotation;

--- a/volume-cartographer/core/test/test_fiber_widget.cpp
+++ b/volume-cartographer/core/test/test_fiber_widget.cpp
@@ -88,6 +88,8 @@ int main(int argc, char** argv)
     first.spans.push_back({0, 0, 1, 2, 20, 12.0, makeMetric(8.0, 12.0, 38)});
     auto second = makeFiber(2, "kb_20260605T184821587_000002.json", 3, 30, 24.0, {"review"});
     second.alignment = makeMetric(25.0, 50.0, 58);
+    second.linkedFiberCount = 2;
+    second.pendingLinkCount = 1;
     second.spans.push_back({0, 0, 1, 2, 14, 11.0, makeMetric(7.0, 20.0, 26)});
     second.spans.push_back({1, 1, 2, 2, 17, 13.0, makeMetric(31.0, 52.0, 32)});
     auto third = makeFiber(3, "zz_20260605T184821587_000003.json", 4, 40, 36.0);
@@ -105,7 +107,7 @@ int main(int argc, char** argv)
         metrics.horizontalAdvance(QStringLiteral("kb_..._000002")));
     require(adaptedName.endsWith(QStringLiteral("_000002")),
             "Fiber name elision should preserve the sequence suffix");
-    require(treeView->model()->columnCount() == 9, "Fiber tree should expose nine columns");
+    require(treeView->model()->columnCount() == 10, "Fiber tree should expose ten columns");
     require(treeView->header()->sectionResizeMode(0) == QHeaderView::Interactive,
             "Fiber tree header should allow changing column widths");
     require(treeView->model()->index(1, 0).data().toString() ==
@@ -117,9 +119,15 @@ int main(int argc, char** argv)
             "Fiber tree row should not show the runtime fiber ID");
     require(treeView->model()->rowCount(treeView->model()->index(1, 0)) == 2,
             "Fiber tree row did not expose span children");
-    require(treeView->model()->index(1, 6).data().toString() == QStringLiteral("review"),
+    require(treeView->model()->index(1, 2).data().toString() == QStringLiteral("2"),
+            "Fiber tree link column did not show the linked fiber count");
+    require(treeView->model()->index(1, 3).data().toString() == QStringLiteral("1"),
+            "Fiber tree pending column did not show the pending link count");
+    require(treeView->model()->index(0, 3).data().toString().isEmpty(),
+            "Fiber tree pending column should be blank when no links are pending");
+    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("review"),
             "Fiber tree tags column did not show fiber tags");
-    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("-"),
+    require(treeView->model()->index(1, 8).data().toString() == QStringLiteral("-"),
             "Metrics should be hidden before Calc metrics is enabled");
     require(widget.orderedFiberIds() == std::vector<uint64_t>({1, 2, 3}),
             "Initial fiber order should match the sorted list order");
@@ -215,10 +223,10 @@ int main(int argc, char** argv)
     require(model != nullptr, "Fiber tree should use a standard item model");
     QMetaObject::invokeMethod(treeView->header(),
                               "sectionClicked",
-                              Q_ARG(int, 3));
+                              Q_ARG(int, 4));
     QMetaObject::invokeMethod(treeView->header(),
                               "sectionClicked",
-                              Q_ARG(int, 3));
+                              Q_ARG(int, 4));
     require(widget.orderedFiberIds() == std::vector<uint64_t>({3, 2, 1}),
             "Fiber order should track the current sorted list order");
     QStandardItem* secondItemBeforeMetrics = model->item(1, 0);
@@ -228,21 +236,21 @@ int main(int argc, char** argv)
             "Calc metrics request should use the current fiber list order");
     require(model->item(1, 0) == secondItemBeforeMetrics,
             "Toggling Calc metrics should update cells without rebuilding the fiber rows");
-    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("25.0"),
+    require(treeView->model()->index(1, 8).data().toString() == QStringLiteral("25.0"),
             "Mean alignment error metric was not displayed");
-    require(treeView->model()->index(1, 8).data().toString() == QStringLiteral("50.0"),
+    require(treeView->model()->index(1, 9).data().toString() == QStringLiteral("50.0"),
             "Max alignment error metric was not displayed");
-    require(treeView->model()->index(1, 8).data(Qt::BackgroundRole).isValid(),
+    require(treeView->model()->index(1, 9).data(Qt::BackgroundRole).isValid(),
             "Fiber row with max alignment error > 45 deg was not highlighted");
     const QModelIndex secondParent = treeView->model()->index(1, 0);
-    require(treeView->model()->index(1, 8, secondParent).data().toString() == QStringLiteral("52.0"),
+    require(treeView->model()->index(1, 9, secondParent).data().toString() == QStringLiteral("52.0"),
             "Span max alignment error metric was not displayed");
-    require(treeView->model()->index(1, 8, secondParent).data(Qt::BackgroundRole).isValid(),
+    require(treeView->model()->index(1, 9, secondParent).data(Qt::BackgroundRole).isValid(),
             "Span row with max alignment error > 45 deg was not highlighted");
     widget.setAlignmentMetricsPending(true);
     require(model->item(1, 0) == secondItemBeforeMetrics,
             "Marking metrics pending should update cells without rebuilding the fiber rows");
-    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("..."),
+    require(treeView->model()->index(1, 8).data().toString() == QStringLiteral("..."),
             "Pending metric state should be displayed in-place");
     widget.updateAlignmentMetrics(
         2,
@@ -250,18 +258,18 @@ int main(int argc, char** argv)
         {makeMetric(9.0, 21.0, 27), makeMetric(32.0, 53.0, 33)});
     require(model->item(1, 0) == secondItemBeforeMetrics,
             "Live metric update should update cells without rebuilding the fiber rows");
-    require(treeView->model()->index(1, 7).data().toString() == QStringLiteral("26.0"),
+    require(treeView->model()->index(1, 8).data().toString() == QStringLiteral("26.0"),
             "Live fiber mean alignment metric was not displayed");
-    require(treeView->model()->index(1, 8).data().toString() == QStringLiteral("51.0"),
+    require(treeView->model()->index(1, 9).data().toString() == QStringLiteral("51.0"),
             "Live fiber max alignment metric was not displayed");
-    require(treeView->model()->index(1, 8, secondParent).data().toString() == QStringLiteral("53.0"),
+    require(treeView->model()->index(1, 9, secondParent).data().toString() == QStringLiteral("53.0"),
             "Live span alignment metric was not displayed");
     QMetaObject::invokeMethod(treeView->header(),
                               "sectionClicked",
-                              Q_ARG(int, 3));
+                              Q_ARG(int, 4));
     QMetaObject::invokeMethod(treeView->header(),
                               "sectionClicked",
-                              Q_ARG(int, 3));
+                              Q_ARG(int, 4));
     require(treeView->model()->index(0, 0).data().toString() ==
                 QStringLiteral("zz_20260605T184821587_000003"),
             "Sorting by length descending should reorder only top-level fibers");


### PR DESCRIPTION
## Summary

Follow-up to #1208. Adds a review workflow for cross-fiber links so linkages can be double-checked by another user.

### Pending link state
- Every newly created link now starts **pending** — both via **Link with candidate** and via **New linked line annotation from control point**. Pending links behave like normal links but render **blue**; **purple** now means approved.
- Blue is used everywhere purple was: control points and fiber-intersection X markers, in all three viewers including the fast current-cut overlay path. The red connector line is unchanged. A control point with both pending and approved links renders blue (pending wins), and candidate green still takes precedence.

### Review actions (Ctrl+right-click)
- **Approve link** on a pending link converts it to approved (purple). **Mark link as pending** on an approved link flags it back for re-review (blue). Both become a submenu with one "Fiber N / CP m" entry per link when several apply, mirroring the existing Unlink pattern.
- Both actions flip the flag on the reciprocal ref in the linked fiber (open pane or stored, with the same position-fallback matching Unlink uses) and save both fibers' JSONs through the existing branch-metadata save path.

### Persistence
- Serialized as an optional `"pending": true` key per `branches[]` entry, written only when true and mirrored on both sides. Existing JSONs without the key load as approved — fully backwards compatible. Save-time canonicalization also propagates the flag across reciprocal pairs so mismatched sides can't persist.

### Fibers panel
- New sortable **pending** column between *link* and *len* showing the number of pending links directly attached to each fiber; blank when none. The *link* column still counts all links (pending + approved) via the existing union-find.

### Menu cleanup
- Removed the redundant **Open new linked line annotation from control point** entry (create + navigate covers it).
- Moved **Designate as link candidate** up between **Delete control point** and **Go to linked annotation**.

## Test plan
- Builds clean (`ninja VC3D`).
- `test_fiber_widget` updated for the ten-column layout plus new link/pending cell assertions; passes along with `test_line_annotation_generated_views` (43 cases) and `test_line_annotation_context_menu`.
- Manual: link via candidate → blue CPs/X + red connector in strip/side/current-cut, `"pending": true` in both JSONs; spawn linked fiber → parent link blue; Approve → purple both sides, key removed from both JSONs; Mark as pending → back to blue; panel pending counts track state, sortable, blank at zero; restart persists state; legacy fibers load purple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dv6qftzVoyCq3LQipYtb6P