### PR TITLE
VC3D: create New Project on disk and blank viewers on volume close

### DIFF
--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -1542,10 +1542,55 @@ void MenuActionController::materializeCurrentOpenDataSegmentFolder()
 void MenuActionController::newProject()
 {
     if (!_window) return;
+
+    QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
+    // Default new projects into the per-user .VC3D folder (same root the
+    // autosave uses, so home resolution matches across platforms).
+    QString defaultDir;
+    const auto autosaveFile = VolumePkg::autosaveFile();
+    if (!autosaveFile.empty()) {
+        defaultDir = QString::fromStdString(autosaveFile.parent_path().string());
+        QDir().mkpath(defaultDir);
+    }
+    if (defaultDir.isEmpty()) {
+        defaultDir = settings.value(vc3d::settings::project::DEFAULT_PATH).toString();
+    }
+    const QString defaultBase = QStringLiteral("untitled");
+    const QString defaultName = defaultBase + QStringLiteral(".volpkg.json");
+
+    QFileDialog dlg(_window, QObject::tr("New Project"), defaultDir,
+                    QObject::tr("Project (*.volpkg.json)"));
+    dlg.setAcceptMode(QFileDialog::AcceptSave);
+    dlg.setFileMode(QFileDialog::AnyFile);
+    // The non-native dialog is required to reach the filename line edit below.
+    dlg.setOption(QFileDialog::DontUseNativeDialog, true);
+    dlg.selectFile(defaultName);
+    // Qt pre-selects everything before the last dot ("untitled.volpkg"), so
+    // typing would eat the ".volpkg" part; narrow the selection to the base name.
+    QTimer::singleShot(0, &dlg, [&dlg, &defaultBase] {
+        if (auto* edit = dlg.findChild<QLineEdit*>(QStringLiteral("fileNameEdit"))) {
+            edit->setSelection(0, static_cast<int>(defaultBase.size()));
+        }
+    });
+    if (dlg.exec() != QDialog::Accepted || dlg.selectedFiles().isEmpty()) return;
+    QString file = dlg.selectedFiles().first();
+    if (!file.endsWith(".volpkg.json", Qt::CaseInsensitive)) file += ".volpkg.json";
+
     auto pkg = VolumePkg::newEmpty();
-    pkg->saveAutosave();
-    _window->_state->setVpkg(pkg);
-    _window->refreshCurrentVolumePackageUi(QString(), true);
+    QString base = QFileInfo(file).fileName();
+    base.chop(QStringLiteral(".volpkg.json").size());
+    // setName before save(): while the package has no path it only touches the
+    // autosave, and save() then writes the full JSON including the name.
+    pkg->setName(base.toStdString());
+    try {
+        pkg->save(std::filesystem::path(file.toStdString()));
+    } catch (const std::exception& e) {
+        QMessageBox::warning(_window, QObject::tr("New Project failed"), QString::fromUtf8(e.what()));
+        return;
+    }
+    settings.setValue(vc3d::settings::project::DEFAULT_PATH, QFileInfo(file).absolutePath());
+
+    openVolpkgAt(file);
 }
 
 void MenuActionController::saveProjectAs()

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -923,6 +923,11 @@ void CChunkedVolumeViewer::OnVolumeChanged(std::shared_ptr<Volume> vol)
 
     _volume = std::move(vol);
     rebuildChunkArray();
+    if (!_volume) {
+        // No volume means submitRender() below will skip; drop the previous
+        // volume's framebuffer so the view goes blank instead of showing it.
+        clearDisplayedFramebuffer();
+    }
     ensureDefaultSurface();
     if (_volume && isAxisAlignedView() && !hadVolume) {
         const int n = _chunkArray ? _chunkArray->numLevels()
@@ -1128,8 +1133,19 @@ void CChunkedVolumeViewer::onVolumeClosing()
     }
     _chunkArray.reset();
     _volume.reset();
+    clearDisplayedFramebuffer();
     invalidateIntersect();
     onSurfaceChanged(_surfName, nullptr);
+}
+
+void CChunkedVolumeViewer::clearDisplayedFramebuffer()
+{
+    _framebuffer = QImage();
+    _displayedRenderJob.reset();
+    _lastRenderResult.reset();
+    if (_view && _view->viewport()) {
+        _view->viewport()->update();
+    }
 }
 
 void CChunkedVolumeViewer::onPOIChanged(const std::string& name, POI* poi)

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -283,6 +283,7 @@ private:
         std::source_location caller = std::source_location::current());
     void updateStatusLabel();
     void rebuildChunkArray();
+    void clearDisplayedFramebuffer();
     void syncCameraTransform();
     void requestDirectPaint();
     void resizeFramebuffer();


### PR DESCRIPTION
## Problem

File → New Project swapped an in-memory, pathless `VolumePkg` into `CState` with no teardown or UI refresh:

- Surfaces, points, and POIs from the previous project leaked into the new one, and an active segmentation editing session was left running against surfaces about to be replaced (the use-after-free pattern the `CloseVolume` comment warns about).
- The header label and widget states never updated.
- The project existed only in memory — silently discarded unless the user remembered Save Project As, and its autosave record was immediately overwritten.
- Volume views kept displaying the previous project's imagery after the switch.

## Changes

**New Project flow** (`MenuActionController::newProject`):
- Prompts for the `.volpkg.json` name/location up front. The dialog pre-fills an editable `untitled.volpkg.json` with only the `untitled` part selected (so typing doesn't eat the suffix), defaults to the per-user `.VC3D` folder (same home resolution as the autosave, created on demand), and falls back to the last-used project directory.
- Writes the empty project to disk, named after the chosen file, before switching to it. A `.volpkg.json` suffix is appended if missing; save errors warn and abort. Cancel is a true no-op.
- Opens the new file through the existing `openVolpkgAt()` path, reusing `CloseVolume()` teardown, `OpenVolume()` (version check, UI refresh, recent-projects list, file watcher), and `UpdateView()` — no new teardown code.

Since every project now has a real path from creation and all attach/detach mutations already self-persist via `persistProjectState()`, there is no unsaved-project state left to lose.

**Stale volume views** (`CChunkedVolumeViewer`):
- `submitRender()` skips when there is no volume, so after `OnVolumeChanged(nullptr)` the old framebuffer stayed on screen indefinitely. Viewers now clear the displayed framebuffer and repaint blank when their volume is cleared or closing (`clearDisplayedFramebuffer()` called from `OnVolumeChanged` and `onVolumeClosing`).

## Testing

- `VC3D` builds clean; `test_volume_pkg` (28) and `test_volume_pkg_full` (9) pass, covering the empty `newEmpty()` → `save()` → `load()` round-trip the flow relies on.
- Manually verified in the GUI: dialog prefill/selection behavior, project file created and reopened, attach volume persists to the JSON, switching projects blanks the viewers, cancel leaves the current project untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)