### PR TITLE
VC3D: fiber overlay control-point navigation and linked-set coloring

### DIFF
--- a/volume-cartographer/apps/VC3D/CFiberWidget.cpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.cpp
@@ -304,6 +304,16 @@ void CFiberWidget::setupUi()
     connect(_showFibersCheckBox, &QCheckBox::toggled,
             this, &CFiberWidget::showFibersToggled);
 
+    _showLinkedCheckBox = new QCheckBox(tr("Show linked"), mainWidget);
+    _showLinkedCheckBox->setObjectName(QStringLiteral("fiberShowLinkedCheckBox"));
+    _showLinkedCheckBox->setEnabled(false);
+    _showLinkedCheckBox->setToolTip(
+        tr("Color linked fibers as one group and mark linked control points "
+           "(blue = pending, purple = approved)."));
+    fiberDisplayLayout->addWidget(_showLinkedCheckBox);
+    connect(_showLinkedCheckBox, &QCheckBox::toggled,
+            this, &CFiberWidget::showLinkedToggled);
+
     auto* viewDistanceLabel = new QLabel(tr("View distance:"), mainWidget);
     fiberDisplayLayout->addWidget(viewDistanceLabel);
     _fiberViewDistanceSpinBox = new QDoubleSpinBox(mainWidget);
@@ -456,6 +466,7 @@ void CFiberWidget::setupUi()
 void CFiberWidget::setShowFibersAvailable(bool available)
 {
     _showFibersCheckBox->setEnabled(available);
+    _showLinkedCheckBox->setEnabled(available);
     if (!available) {
         setShowFibersChecked(false);
     }
@@ -470,6 +481,17 @@ void CFiberWidget::setShowFibersChecked(bool checked)
 bool CFiberWidget::showFibersChecked() const
 {
     return _showFibersCheckBox->isChecked();
+}
+
+void CFiberWidget::setShowLinkedChecked(bool checked)
+{
+    const QSignalBlocker blocker(_showLinkedCheckBox);
+    _showLinkedCheckBox->setChecked(checked);
+}
+
+bool CFiberWidget::showLinkedChecked() const
+{
+    return _showLinkedCheckBox->isChecked();
 }
 
 void CFiberWidget::setFiberViewDistance(double distance)

--- a/volume-cartographer/apps/VC3D/CFiberWidget.hpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.hpp
@@ -87,6 +87,8 @@ public:
     void setShowFibersAvailable(bool available);
     void setShowFibersChecked(bool checked);
     [[nodiscard]] bool showFibersChecked() const;
+    void setShowLinkedChecked(bool checked);
+    [[nodiscard]] bool showLinkedChecked() const;
     void setFiberViewDistance(double distance);
     [[nodiscard]] double fiberViewDistance() const;
 
@@ -106,6 +108,7 @@ signals:
     void exportFibersRequested();
     void metricsCalculationRequested(std::vector<uint64_t> orderedFiberIds);
     void showFibersToggled(bool checked);
+    void showLinkedToggled(bool checked);
     void fiberViewDistanceChanged(double distance);
 
 private slots:
@@ -155,6 +158,7 @@ private:
 
     QCheckBox* _calcMetricsCheckBox;
     QCheckBox* _showFibersCheckBox;
+    QCheckBox* _showLinkedCheckBox;
     QDoubleSpinBox* _fiberViewDistanceSpinBox;
     QTreeView* _treeView;
     QStandardItemModel* _model;

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -3484,6 +3484,33 @@ void CWindow::configureChunkedViewerConnections(CChunkedVolumeViewer* viewer)
 
                         QMenu menu(this);
 
+                        if (_fiberOverlay && _lineAnnotationController) {
+                            if (const auto hit = _fiberOverlay->hitTestControlPoint(
+                                    viewer, scenePoint, 12.0);
+                                hit && hit->fiberId != 0) {
+                                const uint64_t fiberId = hit->fiberId;
+                                const int controlIndex = hit->controlPointIndex;
+                                QAction* gotoControlPointAction = menu.addAction(
+                                    tr("Go to control point %1 in %2")
+                                        .arg(controlIndex)
+                                        .arg(_lineAnnotationController->fiberDisplayName(fiberId)));
+                                connect(gotoControlPointAction, &QAction::triggered, this,
+                                        [this, fiberId, controlIndex]() {
+                                            if (_fiberWidget) {
+                                                _fiberWidget->selectFiber(fiberId);
+                                            }
+                                            if (_fiberSliceWidget) {
+                                                _fiberSliceWidget->selectFiber(fiberId);
+                                            }
+                                            if (_lineAnnotationController) {
+                                                _lineAnnotationController->openFiberAtControlPoint(
+                                                    fiberId, controlIndex);
+                                            }
+                                        });
+                                menu.addSeparator();
+                            }
+                        }
+
                         QAction* newLineAnnotationAction = menu.addAction(tr("New line annotation"));
                         newLineAnnotationAction->setEnabled(
                             _lineAnnotationController &&
@@ -7381,6 +7408,14 @@ void CWindow::CreateWidgets(void)
             _fiberSliceWidget->setShowFibersChecked(checked);
         }
     };
+    auto syncShowLinkedChecks = [this](bool checked) {
+        if (_fiberWidget) {
+            _fiberWidget->setShowLinkedChecked(checked);
+        }
+        if (_fiberSliceWidget) {
+            _fiberSliceWidget->setShowLinkedChecked(checked);
+        }
+    };
     auto syncFiberViewDistances = [this](double distance) {
         if (_fiberWidget) {
             _fiberWidget->setFiberViewDistance(distance);
@@ -7398,6 +7433,12 @@ void CWindow::CreateWidgets(void)
         }
         syncShowFiberChecks(visible);
     };
+    auto setFiberOverlayShowLinked = [this, syncShowLinkedChecks](bool checked) {
+        if (_fiberOverlay) {
+            _fiberOverlay->setShowLinked(checked);
+        }
+        syncShowLinkedChecks(checked);
+    };
     auto setFiberViewDistance = [this, syncFiberViewDistances](double distance) {
         if (_fiberOverlay) {
             _fiberOverlay->setViewDistance(distance);
@@ -7410,16 +7451,21 @@ void CWindow::CreateWidgets(void)
     if (_fiberWidget) {
         connect(_fiberWidget, &CFiberWidget::showFibersToggled,
                 this, setFiberOverlayVisible);
+        connect(_fiberWidget, &CFiberWidget::showLinkedToggled,
+                this, setFiberOverlayShowLinked);
         connect(_fiberWidget, &CFiberWidget::fiberViewDistanceChanged,
                 this, setFiberViewDistance);
     }
     if (_fiberSliceWidget) {
         connect(_fiberSliceWidget, &CFiberWidget::showFibersToggled,
                 this, setFiberOverlayVisible);
+        connect(_fiberSliceWidget, &CFiberWidget::showLinkedToggled,
+                this, setFiberOverlayShowLinked);
         connect(_fiberSliceWidget, &CFiberWidget::fiberViewDistanceChanged,
                 this, setFiberViewDistance);
     }
     setFiberViewDistance(_fiberWidget->fiberViewDistance());
+    setFiberOverlayShowLinked(_fiberWidget->showLinkedChecked());
 
     if (_lineAnnotationController) {
         auto toFiberWidgetAlignment =
@@ -7487,6 +7533,14 @@ void CWindow::CreateWidgets(void)
                 _fiberSliceWidget->setKnownTags(_lineAnnotationController->knownFiberTags());
             }
 
+            const auto linkInfos = _lineAnnotationController->fiberLinkOverlayInfos();
+            std::unordered_map<uint64_t, const LineAnnotationController::FiberLinkOverlayInfo*>
+                linkInfoById;
+            linkInfoById.reserve(linkInfos.size());
+            for (const auto& info : linkInfos) {
+                linkInfoById.emplace(info.fiberId, &info);
+            }
+
             std::vector<FiberOverlayController::Chain> chains;
             for (const auto& snapshot : _lineAnnotationController->fiberSnapshots()) {
                 if (snapshot.controlPoints.empty()) {
@@ -7499,6 +7553,16 @@ void CWindow::CreateWidgets(void)
                     chain.points.emplace_back(static_cast<float>(point[0]),
                                               static_cast<float>(point[1]),
                                               static_cast<float>(point[2]));
+                }
+                if (const auto it = linkInfoById.find(snapshot.id); it != linkInfoById.end()) {
+                    chain.colorId = it->second->linkGroupId;
+                    chain.pointLinkStates.assign(chain.points.size(), 0);
+                    for (const auto& [cpIndex, pending] : it->second->linkedControlPoints) {
+                        if (cpIndex >= 0 &&
+                            cpIndex < static_cast<int>(chain.pointLinkStates.size())) {
+                            chain.pointLinkStates[cpIndex] = pending ? 1 : 2;
+                        }
+                    }
                 }
                 chains.push_back(std::move(chain));
             }

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -5200,6 +5200,90 @@ std::vector<LineAnnotationController::FiberSummary> LineAnnotationController::fi
     return summaries;
 }
 
+std::vector<LineAnnotationController::FiberLinkOverlayInfo>
+LineAnnotationController::fiberLinkOverlayInfos() const
+{
+    // Union-find mirrors fiberSummaries(): all branches, pending included,
+    // unknown targets skipped.
+    std::unordered_map<uint64_t, size_t> indexById;
+    indexById.reserve(_fibers.size());
+    for (size_t i = 0; i < _fibers.size(); ++i) {
+        indexById.emplace(_fibers[i].id, i);
+    }
+    std::vector<size_t> parent(_fibers.size());
+    for (size_t i = 0; i < parent.size(); ++i) {
+        parent[i] = i;
+    }
+    const auto findRoot = [&parent](size_t index) {
+        while (parent[index] != index) {
+            parent[index] = parent[parent[index]];
+            index = parent[index];
+        }
+        return index;
+    };
+    for (size_t i = 0; i < _fibers.size(); ++i) {
+        for (const auto& branch : _fibers[i].branches) {
+            const auto targetIt = indexById.find(branch.branchFiberId);
+            if (targetIt == indexById.end()) {
+                continue;
+            }
+            parent[findRoot(i)] = findRoot(targetIt->second);
+        }
+    }
+    std::unordered_map<size_t, uint64_t> minIdByRoot;
+    for (size_t i = 0; i < _fibers.size(); ++i) {
+        auto [it, inserted] = minIdByRoot.emplace(findRoot(i), _fibers[i].id);
+        if (!inserted) {
+            it->second = std::min(it->second, _fibers[i].id);
+        }
+    }
+
+    std::vector<FiberLinkOverlayInfo> infos;
+    for (size_t i = 0; i < _fibers.size(); ++i) {
+        const StoredFiber& fiber = _fibers[i];
+        // Pending wins per control point, matching the annotation GUI's
+        // marker precedence.
+        std::map<int, bool> pendingByControlPoint;
+        for (const auto& branch : fiber.branches) {
+            if (indexById.find(branch.branchFiberId) == indexById.end()) {
+                continue;
+            }
+            if (branch.controlPointIndex < 0 ||
+                branch.controlPointIndex >=
+                    static_cast<int>(fiber.controlPoints.size())) {
+                continue;
+            }
+            auto [it, inserted] =
+                pendingByControlPoint.emplace(branch.controlPointIndex, branch.pending);
+            if (!inserted) {
+                it->second = it->second || branch.pending;
+            }
+        }
+        if (pendingByControlPoint.empty()) {
+            continue;
+        }
+        FiberLinkOverlayInfo info;
+        info.fiberId = fiber.id;
+        info.linkGroupId = minIdByRoot.at(findRoot(i));
+        info.linkedControlPoints.assign(pendingByControlPoint.begin(),
+                                        pendingByControlPoint.end());
+        infos.push_back(std::move(info));
+    }
+    return infos;
+}
+
+QString LineAnnotationController::fiberDisplayName(uint64_t fiberId) const
+{
+    for (const StoredFiber& fiber : _fibers) {
+        if (fiber.id == fiberId) {
+            const QString stem =
+                vc3d::displayStemForFiberFile(QString::fromStdString(fiber.fileName));
+            return stem.isEmpty() ? tr("unnamed") : stem;
+        }
+    }
+    return tr("unnamed");
+}
+
 std::vector<std::string> LineAnnotationController::knownFiberTags() const
 {
     return _knownFiberTags;

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -130,6 +131,19 @@ public:
         bool pending = false;
     };
 
+    // Per-fiber data for the fiber overlay's "Show linked" mode. Only fibers
+    // with at least one valid cross-fiber link are returned. linkGroupId is
+    // the smallest fiber id in the fiber's connected component over all
+    // branch links, pending included — same union-find semantics as
+    // fiberSummaries().
+    struct FiberLinkOverlayInfo {
+        uint64_t fiberId = 0;
+        uint64_t linkGroupId = 0;
+        // (local control point index, pending); one entry per linked control
+        // point, pending winning when a point carries both link states.
+        std::vector<std::pair<int, bool>> linkedControlPoints;
+    };
+
     using DatasetPicker =
         std::function<std::optional<std::string>(QWidget*, const std::filesystem::path&)>;
     using VolumeSelectorFactory = std::function<QWidget*(QWidget*)>;
@@ -184,6 +198,9 @@ public:
                                               const QPointF& scenePoint,
                                               const QPoint& globalPos);
     [[nodiscard]] std::vector<FiberSummary> fiberSummaries() const;
+    [[nodiscard]] std::vector<FiberLinkOverlayInfo> fiberLinkOverlayInfos() const;
+    // Display name as shown in the fiber panel (file stem, "unnamed" fallback).
+    [[nodiscard]] QString fiberDisplayName(uint64_t fiberId) const;
     [[nodiscard]] std::vector<std::string> knownFiberTags() const;
     [[nodiscard]] std::vector<vc::atlas::FiberPolyline> fiberSnapshots() const;
     [[nodiscard]] std::vector<vc::atlas::FiberPolyline> fiberSnapshotsFromStorage() const;

--- a/volume-cartographer/apps/VC3D/overlays/FiberOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/FiberOverlayController.cpp
@@ -198,6 +198,16 @@ void FiberOverlayController::setVisible(bool visible)
     refreshAll();
 }
 
+void FiberOverlayController::setShowLinked(bool show)
+{
+    if (_showLinked == show) {
+        return;
+    }
+    _showLinked = show;
+    // Only colors and link markers change; projections stay valid.
+    refreshAll();
+}
+
 ViewerOverlayControllerBase::PointChainStyle
 FiberOverlayController::fiberStyle(const QColor& color, float distanceTolerance)
 {
@@ -224,6 +234,38 @@ bool FiberOverlayController::isOverlayEnabledFor(VolumeViewerBase* viewer) const
     return viewer && _visible && !_chains.empty();
 }
 
+std::optional<FiberOverlayController::ControlPointHit>
+FiberOverlayController::hitTestControlPoint(VolumeViewerBase* viewer,
+                                            const QPointF& scenePoint,
+                                            qreal maxDistancePx) const
+{
+    if (!isOverlayEnabledFor(viewer)) {
+        return std::nullopt;
+    }
+
+    std::optional<ControlPointHit> best;
+    qreal bestDistanceSq = maxDistancePx * maxDistancePx;
+    std::vector<float> opacities;
+    for (const Chain& chain : _chains) {
+        const FilteredPoints filtered =
+            projectedPointChain(viewer, chain.points, _viewDistance, &opacities);
+        for (std::size_t i = 0; i < filtered.scenePoints.size(); ++i) {
+            if (i < opacities.size() && opacities[i] <= 0.0f) {
+                // Boundary projection: line vertex only, no dot drawn.
+                continue;
+            }
+            const QPointF delta = filtered.scenePoints[i] - scenePoint;
+            const qreal distanceSq = delta.x() * delta.x() + delta.y() * delta.y();
+            if (distanceSq < bestDistanceSq && i < filtered.sourceIndices.size()) {
+                bestDistanceSq = distanceSq;
+                best = ControlPointHit{chain.id,
+                                       static_cast<int>(filtered.sourceIndices[i])};
+            }
+        }
+    }
+    return best;
+}
+
 void FiberOverlayController::collectPrimitives(VolumeViewerBase* viewer,
                                                OverlayBuilder& builder)
 {
@@ -232,8 +274,52 @@ void FiberOverlayController::collectPrimitives(VolumeViewerBase* viewer,
     }
 
     for (std::size_t index = 0; index < _chains.size(); ++index) {
-        const PointChainStyle style = fiberStyle(fiberColor(_chains[index].id), _viewDistance);
-        renderPointChain(viewer, builder, _chains[index].points, style);
+        const Chain& chain = _chains[index];
+        const uint64_t colorId =
+            (_showLinked && chain.colorId != 0) ? chain.colorId : chain.id;
+        const PointChainStyle style = fiberStyle(fiberColor(colorId), _viewDistance);
+        renderPointChain(viewer, builder, chain.points, style);
+    }
+
+    if (!_showLinked) {
+        return;
+    }
+
+    // Linked-control-point rings, appended after every chain's primitives so
+    // they paint last (FiberBatchItem draws commands in insertion order).
+    // Colors match the Line Annotation GUI's branch control-point markers.
+    std::vector<float> opacities;
+    for (const Chain& chain : _chains) {
+        if (chain.pointLinkStates.empty()) {
+            continue;
+        }
+        const FilteredPoints filtered =
+            projectedPointChain(viewer, chain.points, _viewDistance, &opacities);
+        for (std::size_t i = 0; i < filtered.scenePoints.size(); ++i) {
+            const float opacity = i < opacities.size() ? opacities[i] : 1.0f;
+            if (opacity <= 0.0f || i >= filtered.sourceIndices.size()) {
+                continue;
+            }
+            const std::size_t source = filtered.sourceIndices[i];
+            if (source >= chain.pointLinkStates.size()) {
+                continue;
+            }
+            const uint8_t state = chain.pointLinkStates[source];
+            if (state == 0) {
+                continue;
+            }
+            const bool pending = state == 1;
+            OverlayStyle style;
+            style.penColor = pending ? QColor(80, 150, 255, 245)
+                                     : QColor(210, 95, 255, 245);
+            style.brushColor = pending ? QColor(80, 150, 255, 175)
+                                       : QColor(210, 95, 255, 175);
+            style.penColor.setAlphaF(style.penColor.alphaF() * opacity);
+            style.brushColor.setAlphaF(style.brushColor.alphaF() * opacity);
+            style.penWidth = 2.0;
+            style.z = 95.0;
+            builder.addPoint(filtered.scenePoints[i], 6.25, style);
+        }
     }
 }
 

--- a/volume-cartographer/apps/VC3D/overlays/FiberOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/FiberOverlayController.hpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 class FiberOverlayController final : public ViewerOverlayControllerBase
@@ -14,6 +15,10 @@ public:
     struct Chain {
         uint64_t id = 0;
         std::vector<cv::Vec3f> points;
+        // Color-group representative when "show linked" is active; 0 = use id.
+        uint64_t colorId = 0;
+        // Parallel to points (may be empty): 0 none, 1 pending link, 2 approved.
+        std::vector<uint8_t> pointLinkStates;
     };
 
     explicit FiberOverlayController(QObject* parent = nullptr);
@@ -22,9 +27,23 @@ public:
     void setChains(std::vector<Chain> chains);
     void setVisible(bool visible);
     void setViewDistance(double distance);
+    void setShowLinked(bool show);
+    [[nodiscard]] bool showLinked() const { return _showLinked; }
     [[nodiscard]] bool isVisible() const { return _visible; }
     [[nodiscard]] bool hasChains() const { return !_chains.empty(); }
     [[nodiscard]] double viewDistance() const { return _viewDistance; }
+
+    struct ControlPointHit {
+        uint64_t fiberId = 0;
+        int controlPointIndex = -1;
+    };
+    // Nearest rendered fiber control point within maxDistancePx scene units
+    // of scenePoint, or nullopt. Matches exactly what renderPointChain draws:
+    // the overlay must be visible and the point must have opacity > 0.
+    [[nodiscard]] std::optional<ControlPointHit> hitTestControlPoint(
+        VolumeViewerBase* viewer,
+        const QPointF& scenePoint,
+        qreal maxDistancePx) const;
 
     static QColor fiberColor(uint64_t fiberId);
     static PointChainStyle fiberStyle(const QColor& color, float distanceTolerance);
@@ -42,5 +61,6 @@ private:
     std::vector<Chain> _chains;
     std::unique_ptr<PersistentItems> _persistentItems;
     bool _visible{false};
+    bool _showLinked{false};
     float _viewDistance{10.0f};
 };

--- a/volume-cartographer/apps/VC3D/overlays/ViewerOverlayControllerBase.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/ViewerOverlayControllerBase.hpp
@@ -369,6 +369,13 @@ protected:
     // chain storage is replaced or mutated.
     void clearPointChainProjectionCache();
 
+    // Projects a chain onto the viewer's surface with per-point opacity;
+    // cached — see clearPointChainProjectionCache().
+    FilteredPoints projectedPointChain(VolumeViewerBase* viewer,
+                                       const std::vector<cv::Vec3f>& points,
+                                       float tolerance,
+                                       std::vector<float>* opacities) const;
+
     // The default implementation materializes primitives as QGraphicsItems.
     // High-volume overlays may override this to retain their graphics items
     // across refreshes while continuing to use the common primitive builder.
@@ -410,10 +417,6 @@ private:
         std::vector<float> opacities;
     };
 
-    FilteredPoints projectedPointChain(VolumeViewerBase* viewer,
-                                       const std::vector<cv::Vec3f>& points,
-                                       float tolerance,
-                                       std::vector<float>* opacities) const;
     void clearPointChainProjectionCache(VolumeViewerBase* viewer);
 
     struct ViewerEntry {


### PR DESCRIPTION
Two additions to the fiber overlay drawn on the flattened segment view and the XY/XZ/YZ slice viewers ("Show fibers" in the fiber panel).

## Jump from a rendered control point to the Line Annotation GUI

Fiber control points drawn by the overlay were display-only — no way to tell which fiber a dot belongs to or open it for editing.

- Ctrl+right-click on a control point now offers **"Go to control point N in \<fiber\>"** at the top of the existing viewer context menu (the annotation-session control-point menu keeps precedence).
- Hit-testing goes through a new `FiberOverlayController::hitTestControlPoint` that reuses the overlay's cached surface projections, so a point is clickable exactly when its dot is rendered (Show fibers on, within view distance, opacity > 0). 12 px scene radius, matching the existing fiber-intersection marker threshold.
- The action selects the fiber row in both fiber panels and opens the Line Annotation workspace focused on that control point via the existing `LineAnnotationController::openFiberAtControlPoint` (same pattern as the atlas-search "Show in line annotation" action). Control point index in the label is 0-based, consistent with the "CP N" readouts elsewhere.
- Supporting change: `ViewerOverlayControllerBase::projectedPointChain` moved from private to protected so the subclass can share the projection cache.

## "Show linked" checkbox — linked-set coloring

Every fiber renders in its own color, so cross-fiber-linked sets (#1208/#1214) are invisible on the overlay.

- New **"Show linked"** checkbox next to "Show fibers" (synced across the fiber and fiber-slice panels).
- When on, every fiber in a linked set (connected component over branch links, pending included — same union-find semantics as `fiberSummaries()`) draws in one color: `fiberColor(smallest fiber id in the set)`. Unlinked fibers keep their individual colors. Once everything is linked, the whole overlay converges to a single color.
- Linked control points get highlight rings in the Line Annotation GUI's marker colors: **blue = pending, purple = approved** (pending wins when a point carries both, matching the GUI's precedence). Rings fade with view distance like the dots.
- Link create/approve/remove already emits `fibersChanged`, so grouping and ring states refresh live.
- With the checkbox off, rendering is byte-identical to before. Link data is exposed through a new self-contained `fiberLinkOverlayInfos()` accessor; `fiberSummaries()` and the Spiral overlay's per-fiber colors are untouched.

## Testing

- Manually tested both features in VC3D: context-menu jump from flattened and slice viewers lands on the right control point; group colors and pending/approved rings track link edits live; toggles sync between panels; rendering with both features off is unchanged.
- `test_viewer_overlay_surface_primitives` passes (only external `Chain` construction site; new fields are trailing with defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)