### PR TITLE
Fiber annotation sync-conflict hardening: content-aware vc_sync + 3-way merge, non-destructive VC3D loading

### DIFF
--- a/volume-cartographer/apps/VC3D/CFiberWidget.cpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.cpp
@@ -720,11 +720,9 @@ void CFiberWidget::rebuildModel()
         };
         applyRowMetadata(row, fiber.id, false, fiber.alignment, showMetrics);
         if (fiber.quarantinedLinkCount > 0) {
-            const QString quarantineTip =
+            row[kLinkColumn]->setToolTip(
                 tr("%1 quarantined link(s): kept on disk, disabled this session")
-                    .arg(fiber.quarantinedLinkCount);
-            row[kLinkColumn]->setToolTip(quarantineTip);
-            row[kPendingColumn]->setToolTip(quarantineTip);
+                    .arg(fiber.quarantinedLinkCount));
         }
 
         QStandardItem* root = row[kNameColumn];

--- a/volume-cartographer/apps/VC3D/CFiberWidget.cpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.cpp
@@ -696,12 +696,17 @@ void CFiberWidget::rebuildModel()
     }
 
     for (const auto& fiber : _fibers) {
+        QString linkText = fiber.linkedFiberCount > 0
+            ? QString::number(fiber.linkedFiberCount)
+            : QString();
+        if (fiber.quarantinedLinkCount > 0) {
+            linkText += QStringLiteral(" (!%1)").arg(fiber.quarantinedLinkCount);
+            linkText = linkText.trimmed();
+        }
         QList<QStandardItem*> row{
             readOnlyItem(displayNameForFiber(fiber)),
             readOnlyItem(directionForFiber(fiber)),
-            readOnlyItem(fiber.linkedFiberCount > 0
-                             ? QString::number(fiber.linkedFiberCount)
-                             : QString()),
+            readOnlyItem(linkText),
             readOnlyItem(fiber.pendingLinkCount > 0
                              ? QString::number(fiber.pendingLinkCount)
                              : QString()),
@@ -713,6 +718,13 @@ void CFiberWidget::rebuildModel()
             readOnlyItem(formatMaxMetric(fiber.alignment, showMetrics)),
         };
         applyRowMetadata(row, fiber.id, false, fiber.alignment, showMetrics);
+        if (fiber.quarantinedLinkCount > 0) {
+            const QString quarantineTip =
+                tr("%1 quarantined link(s): kept on disk, disabled this session")
+                    .arg(fiber.quarantinedLinkCount);
+            row[kLinkColumn]->setToolTip(quarantineTip);
+            row[kPendingColumn]->setToolTip(quarantineTip);
+        }
 
         QStandardItem* root = row[kNameColumn];
         for (const auto& span : fiber.spans) {

--- a/volume-cartographer/apps/VC3D/CFiberWidget.cpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.cpp
@@ -696,13 +696,14 @@ void CFiberWidget::rebuildModel()
     }
 
     for (const auto& fiber : _fibers) {
-        QString linkText = fiber.linkedFiberCount > 0
-            ? QString::number(fiber.linkedFiberCount)
-            : QString();
-        if (fiber.quarantinedLinkCount > 0) {
-            linkText += QStringLiteral(" (!%1)").arg(fiber.quarantinedLinkCount);
-            linkText = linkText.trimmed();
+        QStringList linkParts;
+        if (fiber.linkedFiberCount > 0) {
+            linkParts << QString::number(fiber.linkedFiberCount);
         }
+        if (fiber.quarantinedLinkCount > 0) {
+            linkParts << QStringLiteral("(!%1)").arg(fiber.quarantinedLinkCount);
+        }
+        const QString linkText = linkParts.join(QLatin1Char(' '));
         QList<QStandardItem*> row{
             readOnlyItem(displayNameForFiber(fiber)),
             readOnlyItem(directionForFiber(fiber)),

--- a/volume-cartographer/apps/VC3D/CFiberWidget.hpp
+++ b/volume-cartographer/apps/VC3D/CFiberWidget.hpp
@@ -61,6 +61,8 @@ public:
         std::vector<std::string> tags;
         int linkedFiberCount = 0;
         int pendingLinkCount = 0;
+        // Links kept on disk but disabled this session (shown as "(!N)").
+        int quarantinedLinkCount = 0;
     };
 
     explicit CFiberWidget(QWidget* parent = nullptr);

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -7655,6 +7655,7 @@ void CWindow::CreateWidgets(void)
                     fiber.tags,
                     fiber.linkedFiberCount,
                     fiber.pendingLinkCount,
+                    fiber.quarantinedLinkCount,
                 });
             }
             if (_fiberWidget) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -9863,10 +9863,19 @@ nlohmann::json LineAnnotationController::fiberSaveSnapshotToJson(
     for (const auto& branch : serialized.branches) {
         if (branch.linkState == LinkState::Quarantined) {
             // Quarantined links are written back exactly as loaded — they
-            // failed resolution, not serialization, and dropping them here
-            // would be the data loss the quarantine exists to prevent. Note
-            // the check runs before every validity test below (a missing
-            // target fiber leaves branchFiberId == 0, for instance).
+            // failed resolution, not serialization, and dropping or
+            // altering them here would be the data loss the quarantine
+            // exists to prevent. The original JSON is used verbatim:
+            // loading and resolution normalize directions, sanitize
+            // branch_file, and remap branch_fiber_id to a runtime id, none
+            // of which may leak into the file. Note the check runs before
+            // every validity test below.
+            if (!branch.sourceJson.is_null() && !branch.sourceJson.empty()) {
+                root["branches"].push_back(branch.sourceJson);
+                continue;
+            }
+            // Fallback (should not happen: quarantine is only assigned to
+            // loaded branches, which carry their source JSON).
             nlohmann::json quarantinedJson = {
                 {"control_point_index", branch.controlPointIndex},
                 {"branch_fiber_id", branch.branchFiberId},
@@ -10506,6 +10515,9 @@ std::optional<LineAnnotationController::StoredFiber> LineAnnotationController::l
                         normalizedOrZero(branch.controlPointDirection);
                     branch.branchControlPointDirection =
                         normalizedOrZero(branch.branchControlPointDirection);
+                    // Retained so a later quarantine can serialize the entry
+                    // exactly as it appeared on disk.
+                    branch.sourceJson = branchJson;
                     fiber.branches.push_back(std::move(branch));
                 } catch (const std::exception& ex) {
                     preserveUnparsed(branchJson, ex.what());

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -791,6 +791,23 @@ bool branchReferencesFiber(const LineAnnotationController::FiberBranchRef& branc
     return !fileName.empty() && branch.branchFileName == fileName;
 }
 
+// Quarantined links stay on disk but are excluded from the link graph,
+// sessions, and link editing until repaired or re-resolved.
+bool branchLinkActive(const LineAnnotationController::FiberBranchRef& branch)
+{
+    return branch.linkState != LineAnnotationController::LinkState::Quarantined;
+}
+
+std::vector<LineAnnotationController::FiberBranchRef> activeBranchLinks(
+    const std::vector<LineAnnotationController::FiberBranchRef>& branches)
+{
+    std::vector<LineAnnotationController::FiberBranchRef> active;
+    active.reserve(branches.size());
+    std::copy_if(branches.begin(), branches.end(), std::back_inserter(active),
+                 branchLinkActive);
+    return active;
+}
+
 bool controlPointHasBranchLink(
     const std::vector<LineAnnotationController::FiberBranchRef>& branches,
     size_t controlPointIndex)
@@ -2230,7 +2247,10 @@ void LineAnnotationController::openFiberWithControlPoint(uint64_t fiberId,
     session->fiberFileName = it->fileName;
     session->fiberManualHvTag = it->manualHvTag;
     session->fiberTags = it->tags;
-    session->branches = it->branches;
+    // Quarantined links stay out of live sessions (and thus link editing,
+    // side-strip queries, and reciprocal metadata sync); they are preserved
+    // on save by makeStoredFiberSessionSnapshot.
+    session->branches = activeBranchLinks(it->branches);
     session->disableInitialGeneratedHoverFollow =
         controlPointIndex.has_value() || linePointIndex.has_value() ||
         spanControlIndices.has_value();
@@ -5332,6 +5352,9 @@ std::vector<LineAnnotationController::FiberSummary> LineAnnotationController::fi
     };
     for (size_t i = 0; i < _fibers.size(); ++i) {
         for (const auto& branch : _fibers[i].branches) {
+            if (!branchLinkActive(branch)) {
+                continue;
+            }
             const auto targetIt = indexById.find(branch.branchFiberId);
             if (targetIt == indexById.end()) {
                 continue;
@@ -5365,7 +5388,16 @@ std::vector<LineAnnotationController::FiberSummary> LineAnnotationController::fi
         const int pendingLinkCount = static_cast<int>(
             std::count_if(fiber.branches.begin(),
                           fiber.branches.end(),
-                          [](const FiberBranchRef& branch) { return branch.pending; }));
+                          [](const FiberBranchRef& branch) {
+                              return branchLinkActive(branch) && branch.pending;
+                          }));
+        const int quarantinedLinkCount = static_cast<int>(
+            std::count_if(fiber.branches.begin(),
+                          fiber.branches.end(),
+                          [](const FiberBranchRef& branch) {
+                              return !branchLinkActive(branch);
+                          }) +
+            fiber.unparsedBranchJson.size());
         summaries.push_back(FiberSummary{
             fiber.id,
             fiber.fileName,
@@ -5384,6 +5416,7 @@ std::vector<LineAnnotationController::FiberSummary> LineAnnotationController::fi
             fiber.tags,
             componentSize >= 2 ? componentSize : 0,
             pendingLinkCount,
+            quarantinedLinkCount,
         });
     }
     std::sort(summaries.begin(), summaries.end(), [](const FiberSummary& a, const FiberSummary& b) {
@@ -5415,6 +5448,9 @@ LineAnnotationController::fiberLinkOverlayInfos() const
     };
     for (size_t i = 0; i < _fibers.size(); ++i) {
         for (const auto& branch : _fibers[i].branches) {
+            if (!branchLinkActive(branch)) {
+                continue;
+            }
             const auto targetIt = indexById.find(branch.branchFiberId);
             if (targetIt == indexById.end()) {
                 continue;
@@ -5437,6 +5473,9 @@ LineAnnotationController::fiberLinkOverlayInfos() const
         // marker precedence.
         std::map<int, bool> pendingByControlPoint;
         for (const auto& branch : fiber.branches) {
+            if (!branchLinkActive(branch)) {
+                continue;
+            }
             if (indexById.find(branch.branchFiberId) == indexById.end()) {
                 continue;
             }
@@ -7688,30 +7727,9 @@ void LineAnnotationController::loadFibersForCurrentPackage()
                   });
     };
 
-    auto loadStrictFibers = [&]() {
-        std::vector<StoredFiber> strictFibers;
-        std::vector<std::string> strictErrors;
-        for (const auto& path : fiberFiles) {
-            try {
-                if (auto fiber = loadFiberFile(path)) {
-                    strictFibers.push_back(std::move(*fiber));
-                }
-            } catch (const std::exception& ex) {
-                strictErrors.push_back(
-                    fiberErrorName(path.filename().string()) + ": " + ex.what());
-            }
-        }
-        sortLoadedFibers(strictFibers);
-        (void)validateLoadedFiberLinks(strictFibers, strictErrors);
-        return std::pair<std::vector<StoredFiber>, std::vector<std::string>>{
-            std::move(strictFibers),
-            std::move(strictErrors)};
-    };
-
     std::vector<StoredFiber> loadedFibers;
     std::vector<std::string> fatalLoadErrors;
-    std::vector<std::string> branchLoadErrors;
-    std::unordered_set<std::string> fibersWithRemovedBranchEntries;
+    std::vector<std::string> quarantineNotes;
     for (const auto& path : fiberFiles) {
         try {
             std::ifstream in(path);
@@ -7719,14 +7737,7 @@ void LineAnnotationController::loadFibersForCurrentPackage()
                 throw std::runtime_error("Failed to open fiber file");
             }
             const nlohmann::json root = nlohmann::json::parse(in);
-            std::vector<std::string> branchErrors;
-            if (auto fiber = loadFiberJson(root, path, &branchErrors)) {
-                if (!branchErrors.empty()) {
-                    fibersWithRemovedBranchEntries.insert(fiber->fileName);
-                    branchLoadErrors.insert(branchLoadErrors.end(),
-                                            branchErrors.begin(),
-                                            branchErrors.end());
-                }
+            if (auto fiber = loadFiberJson(root, path, &quarantineNotes)) {
                 loadedFibers.push_back(std::move(*fiber));
             }
         } catch (const std::exception& ex) {
@@ -7755,97 +7766,67 @@ void LineAnnotationController::loadFibersForCurrentPackage()
         }
     }
 
-    const auto branchLinkIssues = collectLoadedFiberBranchIssues(loadedFibers);
-    std::vector<std::string> branchErrors = branchLoadErrors;
-    branchErrors.reserve(branchErrors.size() + branchLinkIssues.size());
-    for (const auto& issue : branchLinkIssues) {
-        if (issue.fiberIndex >= loadedFibers.size()) {
-            continue;
-        }
-        branchErrors.push_back(fiberErrorName(loadedFibers[issue.fiberIndex].fileName) +
-                               ": " + issue.reason);
-    }
+    // Repair what can be resolved by position, quarantine the rest. Loading
+    // never writes to disk: repaired metadata persists on the next
+    // legitimate save, quarantined entries only via the explicit repair
+    // action below.
+    resolveLoadedFiberLinks(loadedFibers, quarantineNotes);
 
-    if (!branchErrors.empty()) {
+    bool repairRequested = false;
+    if (!quarantineNotes.empty()) {
         QString details;
-        const size_t shown = std::min<size_t>(branchErrors.size(), 8);
+        const size_t shown = std::min<size_t>(quarantineNotes.size(), 8);
         for (size_t i = 0; i < shown; ++i) {
             if (!details.isEmpty()) {
                 details += QStringLiteral("\n");
             }
-            details += QString::fromStdString(branchErrors[i]);
+            details += QString::fromStdString(quarantineNotes[i]);
         }
-        if (branchErrors.size() > shown) {
-            details += tr("\n... %1 more branch/link error(s)")
-                           .arg(static_cast<int>(branchErrors.size() - shown));
+        if (quarantineNotes.size() > shown) {
+            details += tr("\n... %1 more quarantined link(s)")
+                           .arg(static_cast<int>(quarantineNotes.size() - shown));
         }
 
-        bool repairRequested = false;
         if (_errorDialogsSuppressed) {
-            // Without dialogs, take the conservative "keep files unchanged"
-            // path and log the details.
-            Logger()->warn("Line Annotation (suppressed dialog): broken fiber "
-                           "branch links, keeping files unchanged:\n{}",
+            // Without dialogs (agent-driven sessions), keep the conservative
+            // default: quarantined links stay on disk, disabled this session.
+            Logger()->warn("Line Annotation (suppressed dialog): {} branch "
+                           "link(s) quarantined, kept on disk but disabled:\n{}",
+                           quarantineNotes.size(),
                            details.toStdString());
         } else {
             QMessageBox prompt(_parentWidget.data());
-            prompt.setIcon(QMessageBox::Warning);
-            prompt.setWindowTitle(tr("Broken branch links"));
-            prompt.setText(tr("Some saved fiber branch links are obsolete or inconsistent."));
+            prompt.setIcon(QMessageBox::Information);
+            prompt.setWindowTitle(tr("Quarantined branch links"));
+            prompt.setText(tr("%1 branch link entrie(s) could not be resolved and were "
+                              "quarantined. They are kept on disk but disabled in "
+                              "this session.")
+                               .arg(static_cast<int>(quarantineNotes.size())));
             prompt.setInformativeText(details);
+            auto* keepButton = prompt.addButton(tr("Keep quarantined"),
+                                                QMessageBox::RejectRole);
             auto* repairButton = prompt.addButton(
-                tr("Remove broken branch links and reload"),
+                tr("Repair now (rewrites affected files)"),
                 QMessageBox::AcceptRole);
-            prompt.addButton(tr("Keep files unchanged"), QMessageBox::RejectRole);
-            prompt.setDefaultButton(qobject_cast<QPushButton*>(repairButton));
+            prompt.setDefaultButton(qobject_cast<QPushButton*>(keepButton));
             prompt.exec();
-            repairRequested = (prompt.clickedButton() == repairButton);
+            repairRequested = prompt.clickedButton() == repairButton;
         }
-
-        if (repairRequested) {
-            std::vector<std::string> repairErrors;
-            if (repairLoadedFiberBranchLinks(loadedFibers,
-                                             fibersWithRemovedBranchEntries,
-                                             branchLinkIssues,
-                                             repairErrors)) {
-                loadFibersForCurrentPackage();
-                return;
-            }
-            for (const auto& error : repairErrors) {
-                Logger()->warn("{}", error);
-            }
-            showError(tr("Could not repair broken branch links:\n%1")
-                          .arg(QString::fromStdString(
-                              repairErrors.empty() ? std::string{"unknown error"}
-                                                   : repairErrors.front())));
-        }
-
-        auto strict = loadStrictFibers();
-        loadedFibers = std::move(strict.first);
-        fatalLoadErrors = std::move(strict.second);
     }
 
     std::vector<std::string> loadErrors = std::move(fatalLoadErrors);
-    if (branchErrors.empty()) {
-        (void)validateLoadedFiberLinks(loadedFibers, loadErrors);
-    }
 
     for (auto& fiber : loadedFibers) {
         addKnownFiberTags(fiber.tags);
-        if (fiber.needsSave) {
-            try {
-                fiber.needsSave = false;
-                saveFiberNow(fiber);
-            } catch (const std::exception& ex) {
-                fiber.needsSave = true;
-                Logger()->warn("Could not update VC3D fiber metadata {}: {}",
-                               fiberPath(fiber).string(),
-                               ex.what());
-            }
-        }
     }
 
     _fibers = std::move(loadedFibers);
+
+    if (repairRequested) {
+        // Flows through the guarded save pipeline, so a concurrent external
+        // change still prompts instead of being clobbered.
+        repairQuarantinedFiberLinks();
+    }
     if (!loadErrors.empty()) {
         for (const auto& error : loadErrors) {
             Logger()->warn("{}", error);
@@ -9513,7 +9494,7 @@ LineAnnotationController::makeIntersectionLineSession(
     session->fiberFileName = fiber.fileName;
     session->fiberManualHvTag = fiber.manualHvTag;
     session->fiberTags = fiber.tags;
-    session->branches = fiber.branches;
+    session->branches = activeBranchLinks(fiber.branches);
     session->focusedLinePosition = std::clamp(
         focusLinePosition,
         0.0,
@@ -9698,6 +9679,17 @@ LineAnnotationController::makeStoredFiberSessionSnapshot(LineAnnotationSession& 
         }
     }
 
+    if (existingIt != _fibers.end()) {
+        // Sessions carry only active links; re-attach quarantined branches
+        // and unparsed entries so a legitimate save cannot drop them.
+        for (const auto& branch : existingIt->branches) {
+            if (!branchLinkActive(branch)) {
+                fiber.branches.push_back(branch);
+            }
+        }
+        fiber.unparsedBranchJson = existingIt->unparsedBranchJson;
+    }
+
     fiber.hvClassification = vc3d::line_annotation::classifyFiberHv(fiber.controlPoints);
     fiber.manualHvTag = session.fiberManualHvTag;
     fiber.tags = session.fiberTags;
@@ -9869,6 +9861,30 @@ nlohmann::json LineAnnotationController::fiberSaveSnapshotToJson(
     };
     root["branches"] = nlohmann::json::array();
     for (const auto& branch : serialized.branches) {
+        if (branch.linkState == LinkState::Quarantined) {
+            // Quarantined links are written back exactly as loaded — they
+            // failed resolution, not serialization, and dropping them here
+            // would be the data loss the quarantine exists to prevent. Note
+            // the check runs before every validity test below (a missing
+            // target fiber leaves branchFiberId == 0, for instance).
+            nlohmann::json quarantinedJson = {
+                {"control_point_index", branch.controlPointIndex},
+                {"branch_fiber_id", branch.branchFiberId},
+                {"branch_control_point_index", branch.branchControlPointIndex},
+                {"control_point_direction", pointToJson(branch.controlPointDirection)},
+                {"branch_control_point_direction",
+                 pointToJson(branch.branchControlPointDirection)},
+                {"control_point_position", pointToJson(branch.controlPointPosition)},
+                {"branch_control_point_position",
+                 pointToJson(branch.branchControlPointPosition)},
+                {"branch_file", branch.branchFileName},
+            };
+            if (branch.pending) {
+                quarantinedJson["pending"] = true;
+            }
+            root["branches"].push_back(std::move(quarantinedJson));
+            continue;
+        }
         if (branch.controlPointIndex < 0 || branch.branchFiberId == 0) {
             continue;
         }
@@ -9904,6 +9920,11 @@ nlohmann::json LineAnnotationController::fiberSaveSnapshotToJson(
             branchJson["pending"] = true;
         }
         root["branches"].push_back(std::move(branchJson));
+    }
+    // Structurally unparseable entries survive load->save round trips
+    // verbatim; only the explicit repair action removes them.
+    for (const auto& unparsed : serialized.unparsedBranchJson) {
+        root["branches"].push_back(unparsed);
     }
     root["control_points"] = nlohmann::json::array();
     root["line_points"] = nlohmann::json::array();
@@ -9979,6 +10000,9 @@ void LineAnnotationController::canonicalizeFiberSaveSnapshots(
 
     for (auto& snapshot : snapshots) {
         for (auto& branch : snapshot.fiber.branches) {
+            if (!branchLinkActive(branch)) {
+                continue;  // written back verbatim, never canonicalized
+            }
             if (auto localIndex = matchingStoredControlPointIndex(
                     snapshot.fiber.controlPoints,
                     branch.controlPointIndex,
@@ -10019,6 +10043,9 @@ void LineAnnotationController::canonicalizeFiberSaveSnapshots(
 
     for (auto& snapshot : snapshots) {
         for (auto& branch : snapshot.fiber.branches) {
+            if (!branchLinkActive(branch)) {
+                continue;
+            }
             if (branch.controlPointIndex < 0 ||
                 branch.branchControlPointIndex < 0 ||
                 static_cast<size_t>(branch.controlPointIndex) >=
@@ -10035,7 +10062,8 @@ void LineAnnotationController::canonicalizeFiberSaveSnapshots(
                 target->fiber.branches.begin(),
                 target->fiber.branches.end(),
                 [&snapshot, &branch](const FiberBranchRef& candidate) {
-                    return branchReferencesFiber(candidate,
+                    return branchLinkActive(candidate) &&
+                           branchReferencesFiber(candidate,
                                                  snapshot.fiber.id,
                                                  snapshot.fiber.fileName) &&
                            (candidate.controlPointIndex ==
@@ -10095,6 +10123,9 @@ void LineAnnotationController::validateFiberSaveSnapshots(
 
     for (const auto& snapshot : snapshots) {
         for (const auto& branch : snapshot.fiber.branches) {
+            if (!branchLinkActive(branch)) {
+                continue;  // preserved verbatim; validation would reject it
+            }
             const auto localIndex = matchingStoredControlPointIndex(
                 snapshot.fiber.controlPoints,
                 branch.controlPointIndex,
@@ -10122,7 +10153,8 @@ void LineAnnotationController::validateFiberSaveSnapshots(
                 target->fiber.branches.begin(),
                 target->fiber.branches.end(),
                 [&snapshot, &branch](const FiberBranchRef& candidate) {
-                    return branchReferencesFiber(candidate,
+                    return branchLinkActive(candidate) &&
+                           branchReferencesFiber(candidate,
                                                  snapshot.fiber.id,
                                                  snapshot.fiber.fileName) &&
                            candidate.controlPointIndex == branch.branchControlPointIndex &&
@@ -10406,51 +10438,47 @@ std::optional<LineAnnotationController::StoredFiber> LineAnnotationController::l
     }
 
     if (root.contains("branches")) {
-        auto recordBranchError = [&](const std::string& reason) {
+        // Tolerant parsing: structurally unusable entries are preserved
+        // verbatim in unparsedBranchJson (and re-emitted on save) instead of
+        // being dropped — loading must never lose data. Semantic problems
+        // (stale indices, drifted positions/directions) are NOT checked
+        // here; resolveLoadedFiberLinks() repairs or quarantines them.
+        auto preserveUnparsed = [&](const nlohmann::json& branchJson,
+                                    const std::string& reason) {
+            fiber.unparsedBranchJson.push_back(branchJson);
             if (branchErrors) {
                 branchErrors->push_back(fiberErrorName(fiber.fileName) + ": " + reason);
-                return true;
             }
-            throw std::runtime_error(reason);
         };
         const auto& branches = root.at("branches");
         if (!branches.is_array()) {
-            if (recordBranchError("branches must be an array")) {
-                fiber.needsSave = true;
-            }
+            preserveUnparsed(branches, "branches must be an array");
         } else {
             for (const auto& branchJson : branches) {
                 try {
                     if (!branchJson.is_object()) {
-                        if (recordBranchError("branch entries must be objects")) {
-                            fiber.needsSave = true;
-                            continue;
-                        }
+                        preserveUnparsed(branchJson, "branch entries must be objects");
+                        continue;
                     }
                     if (branchJson.contains("link_direction")) {
-                        if (recordBranchError("obsolete branch metadata: link_direction")) {
-                            fiber.needsSave = true;
-                            continue;
-                        }
+                        preserveUnparsed(branchJson,
+                                         "obsolete branch metadata: link_direction");
+                        continue;
                     }
-                    FiberBranchRef branch;
                     if (!branchJson.contains("control_point_index") ||
                         !branchJson.contains("branch_control_point_index") ||
                         !branchJson.contains("control_point_direction") ||
                         !branchJson.contains("branch_control_point_direction") ||
                         !branchJson.contains("control_point_position") ||
                         !branchJson.contains("branch_control_point_position")) {
-                        if (recordBranchError("invalid branch metadata")) {
-                            fiber.needsSave = true;
-                            continue;
-                        }
+                        preserveUnparsed(branchJson, "invalid branch metadata");
+                        continue;
                     }
                     if (!branchJson.contains("branch_file")) {
-                        if (recordBranchError("missing branch_file")) {
-                            fiber.needsSave = true;
-                            continue;
-                        }
+                        preserveUnparsed(branchJson, "missing branch_file");
+                        continue;
                     }
+                    FiberBranchRef branch;
                     branch.controlPointIndex =
                         branchJson.at("control_point_index").get<int>();
                     branch.branchFiberId =
@@ -10470,40 +10498,9 @@ std::optional<LineAnnotationController::StoredFiber> LineAnnotationController::l
                     branch.branchControlPointPosition =
                         pointFromJson(branchJson.at("branch_control_point_position"));
                     branch.pending = branchJson.value("pending", false);
-                    if (branch.controlPointIndex < 0 ||
-                        static_cast<size_t>(branch.controlPointIndex) >=
-                            fiber.controlPoints.size()) {
-                        if (recordBranchError("local CP index out of range")) {
-                            fiber.needsSave = true;
-                            continue;
-                        }
-                    }
-                    if (branch.branchControlPointIndex < 0) {
-                        if (recordBranchError("linked CP index out of range")) {
-                            fiber.needsSave = true;
-                            continue;
-                        }
-                    }
                     if (branch.branchFileName.empty()) {
-                        if (recordBranchError("missing branch_file")) {
-                            fiber.needsSave = true;
-                            continue;
-                        }
-                    }
-                    if (!finiteDirection(branch.controlPointDirection) ||
-                        !finiteDirection(branch.branchControlPointDirection)) {
-                        if (recordBranchError("invalid branch directions")) {
-                            fiber.needsSave = true;
-                            continue;
-                        }
-                    }
-                    if (!pointsApproximatelyEqual(
-                            fiber.controlPoints[static_cast<size_t>(branch.controlPointIndex)],
-                            branch.controlPointPosition)) {
-                        if (recordBranchError("local CP position mismatch")) {
-                            fiber.needsSave = true;
-                            continue;
-                        }
+                        preserveUnparsed(branchJson, "missing branch_file");
+                        continue;
                     }
                     branch.controlPointDirection =
                         normalizedOrZero(branch.controlPointDirection);
@@ -10511,10 +10508,7 @@ std::optional<LineAnnotationController::StoredFiber> LineAnnotationController::l
                         normalizedOrZero(branch.branchControlPointDirection);
                     fiber.branches.push_back(std::move(branch));
                 } catch (const std::exception& ex) {
-                    if (recordBranchError(ex.what())) {
-                        fiber.needsSave = true;
-                        continue;
-                    }
+                    preserveUnparsed(branchJson, ex.what());
                 }
             }
         }
@@ -10572,11 +10566,10 @@ std::optional<LineAnnotationController::StoredFiber> LineAnnotationController::l
     return loadFiberJson(root, path);
 }
 
-std::vector<LineAnnotationController::BranchLinkValidationIssue>
-LineAnnotationController::collectLoadedFiberBranchIssues(
-    const std::vector<StoredFiber>& fibers) const
+void LineAnnotationController::resolveLoadedFiberLinks(
+    std::vector<StoredFiber>& fibers,
+    std::vector<std::string>& quarantineNotes) const
 {
-    std::vector<BranchLinkValidationIssue> issues;
     std::unordered_map<std::string, size_t> indexByFileName;
     indexByFileName.reserve(fibers.size());
     for (size_t i = 0; i < fibers.size(); ++i) {
@@ -10585,214 +10578,154 @@ LineAnnotationController::collectLoadedFiberBranchIssues(
         }
     }
 
-    for (size_t fiberIndex = 0; fiberIndex < fibers.size(); ++fiberIndex) {
-        const StoredFiber& fiber = fibers[fiberIndex];
-        for (size_t branchIndex = 0; branchIndex < fiber.branches.size(); ++branchIndex) {
-            const FiberBranchRef& branch = fiber.branches[branchIndex];
-            auto addIssue = [&](const std::string& reason) {
-                issues.push_back({fiberIndex, branchIndex, reason});
-            };
+    auto quarantine = [&quarantineNotes](const StoredFiber& fiber,
+                                         FiberBranchRef& branch,
+                                         const std::string& reason) {
+        branch.linkState = LinkState::Quarantined;
+        branch.quarantineReason = reason;
+        quarantineNotes.push_back(fiberErrorName(fiber.fileName) + ": " + reason);
+    };
 
-            if (branch.controlPointIndex < 0 ||
-                static_cast<size_t>(branch.controlPointIndex) >= fiber.controlPoints.size()) {
-                addIssue("local CP index out of range");
+    // Phase 1: per-branch endpoint resolution, position-first. Both sides
+    // are canonicalized before phase 2 checks reciprocity, so a stale index
+    // on one side cannot hide the reciprocal entry on the other. Everything
+    // here mutates in-memory state only; repaired fibers are flagged
+    // needsSave and persist on their next legitimate save.
+    for (auto& fiber : fibers) {
+        for (auto& branch : fiber.branches) {
+            const auto localIndex = matchingStoredControlPointIndex(
+                fiber.controlPoints,
+                branch.controlPointIndex,
+                branch.controlPointPosition);
+            if (!localIndex) {
+                quarantine(fiber, branch, "local control point not found by position");
                 continue;
             }
-            if (!pointsApproximatelyEqual(
-                    fiber.controlPoints[static_cast<size_t>(branch.controlPointIndex)],
-                    branch.controlPointPosition)) {
-                addIssue("local CP position mismatch");
-                continue;
+            if (*localIndex != branch.controlPointIndex) {
+                branch.controlPointIndex = *localIndex;
+                branch.linkState = LinkState::Repaired;
+                fiber.needsSave = true;
             }
-            if (!finiteDirection(branch.controlPointDirection) ||
-                !finiteDirection(branch.branchControlPointDirection)) {
-                addIssue("invalid branch directions");
-                continue;
-            }
-            if (fiber.linePoints.size() >= 2) {
-                const cv::Vec3d expectedLocal =
-                    endpointTangentFromLinePoints(fiber.linePoints,
-                                                  branch.controlPointPosition);
-                if (!branchDirectionsCompatible(branch.controlPointDirection,
-                                                expectedLocal)) {
-                    addIssue("branch endpoint direction mismatch");
-                    continue;
-                }
-            }
-            if (branch.branchFileName.empty()) {
-                addIssue("missing branch_file");
-                continue;
-            }
-            const auto targetIndex = indexByFileName.find(branch.branchFileName);
-            if (targetIndex == indexByFileName.end()) {
-                addIssue("missing linked fiber");
-                continue;
-            }
-            const StoredFiber& target = fibers[targetIndex->second];
-            if (branch.branchControlPointIndex < 0 ||
-                static_cast<size_t>(branch.branchControlPointIndex) >=
-                    target.controlPoints.size()) {
-                addIssue("linked CP index out of range");
-                continue;
-            }
-            if (!pointsApproximatelyEqual(
-                    target.controlPoints[static_cast<size_t>(branch.branchControlPointIndex)],
-                    branch.branchControlPointPosition)) {
-                addIssue("linked CP position mismatch");
-                continue;
-            }
-            if (target.linePoints.size() >= 2) {
-                const cv::Vec3d expectedLinked =
-                    endpointTangentFromLinePoints(target.linePoints,
-                                                  branch.branchControlPointPosition);
-                if (!branchDirectionsCompatible(branch.branchControlPointDirection,
-                                                expectedLinked)) {
-                    addIssue("branch endpoint direction mismatch");
-                    continue;
-                }
-            }
+            branch.controlPointPosition =
+                fiber.controlPoints[static_cast<size_t>(*localIndex)];
 
-            const auto reciprocal = std::find_if(
+            // Directions always follow the current line tangent: drift from
+            // a re-optimized line is expected, never fatal.
+            const cv::Vec3d refreshedLocal = endpointTangentFromLinePoints(
+                fiber.linePoints, branch.controlPointPosition,
+                branch.controlPointDirection);
+            if (!finiteDirection(refreshedLocal)) {
+                quarantine(fiber, branch, "cannot derive local endpoint direction");
+                continue;
+            }
+            if (!branchDirectionsCompatible(branch.controlPointDirection,
+                                            refreshedLocal)) {
+                branch.linkState = LinkState::Repaired;
+                fiber.needsSave = true;
+            }
+            branch.controlPointDirection = refreshedLocal;
+
+            const auto targetIt = indexByFileName.find(branch.branchFileName);
+            if (targetIt == indexByFileName.end()) {
+                quarantine(fiber, branch,
+                           "missing linked fiber " + branch.branchFileName);
+                continue;
+            }
+            const StoredFiber& target = fibers[targetIt->second];
+            const auto linkedIndex = matchingStoredControlPointIndex(
+                target.controlPoints,
+                branch.branchControlPointIndex,
+                branch.branchControlPointPosition);
+            if (!linkedIndex) {
+                quarantine(fiber, branch, "linked control point not found by position");
+                continue;
+            }
+            if (*linkedIndex != branch.branchControlPointIndex) {
+                branch.branchControlPointIndex = *linkedIndex;
+                branch.linkState = LinkState::Repaired;
+                fiber.needsSave = true;
+            }
+            branch.branchControlPointPosition =
+                target.controlPoints[static_cast<size_t>(*linkedIndex)];
+
+            const cv::Vec3d refreshedLinked = endpointTangentFromLinePoints(
+                target.linePoints, branch.branchControlPointPosition,
+                branch.branchControlPointDirection);
+            if (!finiteDirection(refreshedLinked)) {
+                quarantine(fiber, branch, "cannot derive linked endpoint direction");
+                continue;
+            }
+            if (!branchDirectionsCompatible(branch.branchControlPointDirection,
+                                            refreshedLinked)) {
+                branch.linkState = LinkState::Repaired;
+                fiber.needsSave = true;
+            }
+            branch.branchControlPointDirection = refreshedLinked;
+        }
+    }
+
+    // Phase 2: reciprocal existence, matched on swapped positions only —
+    // phase 1 already canonicalized indices and directions on both sides.
+    // Quarantining a branch never touches other branches or fibers: there
+    // is deliberately no cascade here.
+    for (auto& fiber : fibers) {
+        for (auto& branch : fiber.branches) {
+            if (branch.linkState == LinkState::Quarantined) {
+                continue;
+            }
+            const auto targetIt = indexByFileName.find(branch.branchFileName);
+            if (targetIt == indexByFileName.end()) {
+                continue;  // quarantined in phase 1
+            }
+            const StoredFiber& target = fibers[targetIt->second];
+            const bool hasReciprocal = std::any_of(
                 target.branches.begin(),
                 target.branches.end(),
                 [&fiber, &branch](const FiberBranchRef& candidate) {
-                    return candidate.branchFileName == fiber.fileName &&
-                           candidate.controlPointIndex == branch.branchControlPointIndex &&
-                           candidate.branchControlPointIndex == branch.controlPointIndex &&
+                    return candidate.linkState != LinkState::Quarantined &&
+                           candidate.branchFileName == fiber.fileName &&
                            pointsApproximatelyEqual(candidate.controlPointPosition,
                                                     branch.branchControlPointPosition) &&
                            pointsApproximatelyEqual(candidate.branchControlPointPosition,
-                                                    branch.controlPointPosition) &&
-                           branchDirectionsCompatible(candidate.controlPointDirection,
-                                                      branch.branchControlPointDirection) &&
-                           branchDirectionsCompatible(candidate.branchControlPointDirection,
-                                                      branch.controlPointDirection);
+                                                    branch.controlPointPosition);
                 });
-            if (reciprocal == target.branches.end()) {
-                addIssue("missing reciprocal branch");
+            if (!hasReciprocal) {
+                quarantine(fiber, branch,
+                           "missing reciprocal branch in " + branch.branchFileName);
             }
         }
     }
-    return issues;
 }
 
-bool LineAnnotationController::repairLoadedFiberBranchLinks(
-    std::vector<StoredFiber>& fibers,
-    const std::unordered_set<std::string>& fibersWithRemovedBranchEntries,
-    const std::vector<BranchLinkValidationIssue>& initialIssues,
-    std::vector<std::string>& errors) const
+void LineAnnotationController::repairQuarantinedFiberLinks()
 {
-    std::unordered_set<std::string> changedFiles = fibersWithRemovedBranchEntries;
-
-    auto removeIssues = [&](const std::vector<BranchLinkValidationIssue>& issues) {
-        std::unordered_map<size_t, std::vector<size_t>> branchIndicesByFiber;
-        for (const auto& issue : issues) {
-            if (issue.fiberIndex >= fibers.size()) {
-                continue;
-            }
-            if (issue.branchIndex >= fibers[issue.fiberIndex].branches.size()) {
-                continue;
-            }
-            branchIndicesByFiber[issue.fiberIndex].push_back(issue.branchIndex);
-        }
-
-        bool changed = false;
-        for (auto& [fiberIndex, branchIndices] : branchIndicesByFiber) {
-            auto& fiber = fibers[fiberIndex];
-            std::sort(branchIndices.begin(), branchIndices.end());
-            branchIndices.erase(std::unique(branchIndices.begin(), branchIndices.end()),
-                                branchIndices.end());
-            for (auto it = branchIndices.rbegin(); it != branchIndices.rend(); ++it) {
-                if (*it >= fiber.branches.size()) {
-                    continue;
-                }
-                fiber.branches.erase(fiber.branches.begin() +
-                                     static_cast<std::ptrdiff_t>(*it));
-                fiber.needsSave = true;
-                changedFiles.insert(fiber.fileName);
-                changed = true;
-            }
-        }
-        return changed;
-    };
-
-    (void)removeIssues(initialIssues);
-    for (;;) {
-        const auto issues = collectLoadedFiberBranchIssues(fibers);
-        if (issues.empty()) {
-            break;
-        }
-        if (!removeIssues(issues)) {
-            break;
+    std::vector<uint64_t> affectedFiberIds;
+    for (auto& fiber : _fibers) {
+        const size_t removedBranches = std::erase_if(
+            fiber.branches,
+            [](const FiberBranchRef& branch) {
+                return branch.linkState == LinkState::Quarantined;
+            });
+        const size_t removedUnparsed = fiber.unparsedBranchJson.size();
+        fiber.unparsedBranchJson.clear();
+        if (removedBranches + removedUnparsed > 0) {
+            affectedFiberIds.push_back(fiber.id);
         }
     }
 
-    for (auto& fiber : fibers) {
-        if (changedFiles.find(fiber.fileName) == changedFiles.end() && !fiber.needsSave) {
-            continue;
-        }
-        try {
-            fiber.needsSave = false;
-            saveFiberNow(fiber);
-        } catch (const std::exception& ex) {
-            fiber.needsSave = true;
-            errors.push_back(fiberErrorName(fiber.fileName) + ": " + ex.what());
+    for (uint64_t fiberId : affectedFiberIds) {
+        const auto it = std::find_if(_fibers.begin(), _fibers.end(),
+                                     [fiberId](const StoredFiber& fiber) {
+                                         return fiber.id == fiberId;
+                                     });
+        if (it != _fibers.end()) {
+            scheduleFiberSave(*it);
         }
     }
 
-    return errors.empty();
-}
-
-bool LineAnnotationController::validateLoadedFiberLinks(std::vector<StoredFiber>& fibers,
-                                                        std::vector<std::string>& errors) const
-{
-    bool removedInvalidFibers = false;
-    for (;;) {
-        const auto issues = collectLoadedFiberBranchIssues(fibers);
-        if (issues.empty()) {
-            break;
-        }
-
-        std::unordered_set<std::string> invalidFiles;
-        for (const auto& issue : issues) {
-            if (issue.fiberIndex >= fibers.size()) {
-                continue;
-            }
-            const auto& fiber = fibers[issue.fiberIndex];
-            invalidFiles.insert(fiber.fileName);
-            errors.push_back(fiberErrorName(fiber.fileName) + ": " + issue.reason);
-        }
-        if (invalidFiles.empty()) {
-            break;
-        }
-        removedInvalidFibers = true;
-        fibers.erase(std::remove_if(fibers.begin(),
-                                    fibers.end(),
-                                    [&invalidFiles](const StoredFiber& fiber) {
-                                        return invalidFiles.find(fiber.fileName) !=
-                                               invalidFiles.end();
-                                    }),
-                     fibers.end());
+    if (!affectedFiberIds.empty()) {
+        emitFiberSummaries();
     }
-
-    std::unordered_map<std::string, uint64_t> fiberIdByFileName;
-    fiberIdByFileName.reserve(fibers.size());
-    uint64_t runtimeId = 1;
-    for (auto& fiber : fibers) {
-        fiber.id = runtimeId++;
-        if (!fiber.fileName.empty()) {
-            fiberIdByFileName[fiber.fileName] = fiber.id;
-        }
-    }
-    for (auto& fiber : fibers) {
-        for (auto& branch : fiber.branches) {
-            if (auto it = fiberIdByFileName.find(branch.branchFileName);
-                it != fiberIdByFileName.end()) {
-                branch.branchFiberId = it->second;
-            }
-        }
-    }
-    return !removedInvalidFibers;
 }
 
 std::string LineAnnotationController::uniqueImportedFiberFileName(

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -7798,7 +7798,7 @@ void LineAnnotationController::loadFibersForCurrentPackage()
             QMessageBox prompt(_parentWidget.data());
             prompt.setIcon(QMessageBox::Information);
             prompt.setWindowTitle(tr("Quarantined branch links"));
-            prompt.setText(tr("%1 branch link entrie(s) could not be resolved and were "
+            prompt.setText(tr("%1 branch link(s) could not be resolved and were "
                               "quarantined. They are kept on disk but disabled in "
                               "this session.")
                                .arg(static_cast<int>(quarantineNotes.size())));
@@ -9682,8 +9682,28 @@ LineAnnotationController::makeStoredFiberSessionSnapshot(LineAnnotationSession& 
     if (existingIt != _fibers.end()) {
         // Sessions carry only active links; re-attach quarantined branches
         // and unparsed entries so a legitimate save cannot drop them.
+        // Exception: when the session holds an active link to the same
+        // endpoints (the user re-created a link they saw quarantined), the
+        // new link supersedes the stale entry — writing both would come
+        // back as duplicate active links once the quarantined copy's
+        // reciprocal resolves again.
         for (const auto& branch : existingIt->branches) {
-            if (!branchLinkActive(branch)) {
+            if (branchLinkActive(branch)) {
+                continue;
+            }
+            const bool supersededByActive = std::any_of(
+                fiber.branches.begin(),
+                fiber.branches.end(),
+                [&branch](const FiberBranchRef& active) {
+                    return branchLinkActive(active) &&
+                           active.branchFileName == branch.branchFileName &&
+                           pointsApproximatelyEqual(active.controlPointPosition,
+                                                    branch.controlPointPosition) &&
+                           pointsApproximatelyEqual(
+                               active.branchControlPointPosition,
+                               branch.branchControlPointPosition);
+                });
+            if (!supersededByActive) {
                 fiber.branches.push_back(branch);
             }
         }
@@ -10711,7 +10731,7 @@ void LineAnnotationController::resolveLoadedFiberLinks(
 
 void LineAnnotationController::repairQuarantinedFiberLinks()
 {
-    std::vector<uint64_t> affectedFiberIds;
+    bool anyRemoved = false;
     for (auto& fiber : _fibers) {
         const size_t removedBranches = std::erase_if(
             fiber.branches,
@@ -10721,21 +10741,12 @@ void LineAnnotationController::repairQuarantinedFiberLinks()
         const size_t removedUnparsed = fiber.unparsedBranchJson.size();
         fiber.unparsedBranchJson.clear();
         if (removedBranches + removedUnparsed > 0) {
-            affectedFiberIds.push_back(fiber.id);
+            scheduleFiberSave(fiber);
+            anyRemoved = true;
         }
     }
 
-    for (uint64_t fiberId : affectedFiberIds) {
-        const auto it = std::find_if(_fibers.begin(), _fibers.end(),
-                                     [fiberId](const StoredFiber& fiber) {
-                                         return fiber.id == fiberId;
-                                     });
-        if (it != _fibers.end()) {
-            scheduleFiberSave(*it);
-        }
-    }
-
-    if (!affectedFiberIds.empty()) {
+    if (anyRemoved) {
         emitFiberSummaries();
     }
 }

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -6428,6 +6428,9 @@ void LineAnnotationController::handleGeneratedControlPointSetLinkPending(
                                                  const FiberBranchRef& updatedBranch) {
         bool changed = false;
         for (auto& candidate : targetBranches) {
+            if (!branchLinkActive(candidate)) {
+                continue;  // quarantined links are excluded from link editing
+            }
             const bool pointsToSession =
                 candidate.branchFiberId == session.fiberId ||
                 (!session.fiberFileName.empty() &&
@@ -7823,8 +7826,10 @@ void LineAnnotationController::loadFibersForCurrentPackage()
     _fibers = std::move(loadedFibers);
 
     if (repairRequested) {
-        // Flows through the guarded save pipeline, so a concurrent external
-        // change still prompts instead of being clobbered.
+        // Explicit user action: rewrites the affected files. Note the save
+        // pipeline has NO staleness guard (deliberately deferred), so a
+        // repair racing an external sync write follows last-writer-wins;
+        // vc_sync's conflict copies are the safety net for that case.
         repairQuarantinedFiberLinks();
     }
     if (!loadErrors.empty()) {
@@ -9112,6 +9117,12 @@ std::vector<uint64_t> LineAnnotationController::syncBranchEndpointPositions(
                                 const cv::Vec3d& targetPoint,
                                 const cv::Vec3d& sourcePoint) {
         for (auto& reciprocal : targetBranches) {
+            if (!branchLinkActive(reciprocal)) {
+                // Quarantined entries are excluded from link editing; they
+                // serialize from sourceJson verbatim, so mutating them here
+                // would only desynchronize the in-memory copy.
+                continue;
+            }
             const bool pointsToSession =
                 reciprocal.branchFiberId == session.fiberId ||
                 (!session.fiberFileName.empty() &&
@@ -10481,6 +10492,10 @@ std::optional<LineAnnotationController::StoredFiber> LineAnnotationController::l
         };
         const auto& branches = root.at("branches");
         if (!branches.is_array()) {
+            // The value is preserved but the shape changes: a non-array
+            // "branches" round-trips to an array containing that value
+            // (save always emits an array). Content survives; the original
+            // malformed shape does not.
             preserveUnparsed(branches, "branches must be an array");
         } else {
             for (const auto& branchJson : branches) {
@@ -10621,8 +10636,8 @@ void LineAnnotationController::resolveLoadedFiberLinks(
     // Phase 1: per-branch endpoint resolution, position-first. Both sides
     // are canonicalized before phase 2 checks reciprocity, so a stale index
     // on one side cannot hide the reciprocal entry on the other. Everything
-    // here mutates in-memory state only; repaired fibers are flagged
-    // needsSave and persist on their next legitimate save.
+    // here mutates in-memory state only (marked LinkState::Repaired);
+    // repairs persist whenever the fiber is next legitimately saved.
     for (auto& fiber : fibers) {
         for (auto& branch : fiber.branches) {
             const auto localIndex = matchingStoredControlPointIndex(
@@ -10636,7 +10651,6 @@ void LineAnnotationController::resolveLoadedFiberLinks(
             if (*localIndex != branch.controlPointIndex) {
                 branch.controlPointIndex = *localIndex;
                 branch.linkState = LinkState::Repaired;
-                fiber.needsSave = true;
             }
             branch.controlPointPosition =
                 fiber.controlPoints[static_cast<size_t>(*localIndex)];
@@ -10653,7 +10667,6 @@ void LineAnnotationController::resolveLoadedFiberLinks(
             if (!branchDirectionsCompatible(branch.controlPointDirection,
                                             refreshedLocal)) {
                 branch.linkState = LinkState::Repaired;
-                fiber.needsSave = true;
             }
             branch.controlPointDirection = refreshedLocal;
 
@@ -10675,7 +10688,6 @@ void LineAnnotationController::resolveLoadedFiberLinks(
             if (*linkedIndex != branch.branchControlPointIndex) {
                 branch.branchControlPointIndex = *linkedIndex;
                 branch.linkState = LinkState::Repaired;
-                fiber.needsSave = true;
             }
             branch.branchControlPointPosition =
                 target.controlPoints[static_cast<size_t>(*linkedIndex)];
@@ -10690,7 +10702,6 @@ void LineAnnotationController::resolveLoadedFiberLinks(
             if (!branchDirectionsCompatible(branch.branchControlPointDirection,
                                             refreshedLinked)) {
                 branch.linkState = LinkState::Repaired;
-                fiber.needsSave = true;
             }
             branch.branchControlPointDirection = refreshedLinked;
         }
@@ -10698,8 +10709,11 @@ void LineAnnotationController::resolveLoadedFiberLinks(
 
     // Phase 2: reciprocal existence, matched on swapped positions only —
     // phase 1 already canonicalized indices and directions on both sides.
-    // Quarantining a branch never touches other branches or fibers: there
-    // is deliberately no cascade here.
+    // Quarantining is bounded to the link pair: excluding quarantined
+    // candidates below means the reciprocal half of a broken pair
+    // quarantines too (so a one-sided problem is flagged on both fibers,
+    // and appears as two notes in the dialog), but it never propagates
+    // further — no whole-fiber removal, no chain reaction across links.
     for (auto& fiber : fibers) {
         for (auto& branch : fiber.branches) {
             if (branch.linkState == LinkState::Quarantined) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -331,8 +331,10 @@ private:
         vc3d::line_annotation::FiberHvClassification hvClassification;
         std::string manualHvTag;
         std::vector<std::string> tags;
-        // In-memory metadata refresh pending; written on the next legitimate
-        // save of this fiber. Loading never acts on this by itself.
+        // Vestigial marker: set where in-memory metadata drifted from disk
+        // (e.g. position-repaired links), but nothing consumes it anymore —
+        // the load-time save loop it used to drive was removed so that
+        // loading never writes. Kept as documentation of repair state.
         bool needsSave = false;
         // Branch JSON entries that failed structural parsing; preserved
         // verbatim and re-emitted on save so a load can never drop data.

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -142,6 +142,12 @@ public:
         bool pending = false;
         LinkState linkState = LinkState::Ok;
         std::string quarantineReason;
+        // The exact JSON this branch was parsed from (empty for branches
+        // created in-session). Quarantined links are serialized from this
+        // verbatim so loading + saving cannot normalize directions,
+        // sanitize branch_file, leak runtime branch_fiber_id values, or
+        // drop fields VC3D does not understand.
+        nlohmann::json sourceJson;
     };
 
     // Per-fiber data for the fiber overlay's "Show linked" mode. Only fibers

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -103,6 +103,9 @@ public:
         int linkedFiberCount = 0;
         // Number of branch links on this fiber still awaiting review approval.
         int pendingLinkCount = 0;
+        // Branch links kept on disk but disabled this session (unresolvable
+        // endpoints/reciprocals or unparseable entries).
+        int quarantinedLinkCount = 0;
     };
 
     struct FiberSnapshotWithPath {
@@ -119,6 +122,13 @@ public:
     // saved-fiber control-point ordering. Any live mutation of control points or
     // branches must go through the private session paths that call
     // syncLinkedBranchMetadataAfterFiberModification().
+    // In-memory resolution state of a loaded branch link; never serialized.
+    // Repaired: an endpoint was re-resolved by position (stale index or
+    // direction from an external edit) and awaits the next legitimate save.
+    // Quarantined: an endpoint or the reciprocal entry could not be resolved;
+    // the link is kept verbatim on disk but excluded from link features.
+    enum class LinkState { Ok, Repaired, Quarantined };
+
     struct FiberBranchRef {
         int controlPointIndex = -1;
         uint64_t branchFiberId = 0;
@@ -130,6 +140,8 @@ public:
         cv::Vec3d branchControlPointPosition{0.0, 0.0, 0.0};
         // Link awaits reviewer approval; kept in sync on both reciprocal refs.
         bool pending = false;
+        LinkState linkState = LinkState::Ok;
+        std::string quarantineReason;
     };
 
     // Per-fiber data for the fiber overlay's "Show linked" mode. Only fibers
@@ -313,7 +325,12 @@ private:
         vc3d::line_annotation::FiberHvClassification hvClassification;
         std::string manualHvTag;
         std::vector<std::string> tags;
+        // In-memory metadata refresh pending; written on the next legitimate
+        // save of this fiber. Loading never acts on this by itself.
         bool needsSave = false;
+        // Branch JSON entries that failed structural parsing; preserved
+        // verbatim and re-emitted on save so a load can never drop data.
+        std::vector<nlohmann::json> unparsedBranchJson;
     };
 
     struct StoredFiberSessionSnapshot {
@@ -334,12 +351,6 @@ private:
         std::vector<FiberSaveSnapshot> snapshots;
         bool showErrors = true;
         std::vector<std::shared_ptr<FiberSaveBatchTracker>> batches;
-    };
-
-    struct BranchLinkValidationIssue {
-        size_t fiberIndex = 0;
-        size_t branchIndex = 0;
-        std::string reason;
     };
 
     struct FiberSaveTaskResult {
@@ -490,8 +501,13 @@ private:
                                                              int activeStart = -1,
                                                              int activeEnd = -1) const;
     void loadFibersForCurrentPackage();
-    [[nodiscard]] bool validateLoadedFiberLinks(std::vector<StoredFiber>& fibers,
-                                                std::vector<std::string>& errors) const;
+    // Position-first repair/quarantine of loaded branch links; never touches
+    // disk. Quarantine reasons are appended to quarantineNotes.
+    void resolveLoadedFiberLinks(std::vector<StoredFiber>& fibers,
+                                 std::vector<std::string>& quarantineNotes) const;
+    // Explicit user action: erase quarantined/unparsed branch entries from
+    // the loaded fibers and rewrite the affected files.
+    void repairQuarantinedFiberLinks();
     void emitFiberSummaries();
     void addKnownFiberTags(const std::vector<std::string>& tags);
     [[nodiscard]] std::filesystem::path fibersRootDir() const;
@@ -591,13 +607,6 @@ private:
                                                            const std::filesystem::path& path,
                                                            std::vector<std::string>* branchErrors = nullptr) const;
     [[nodiscard]] std::optional<StoredFiber> loadFiberFile(const std::filesystem::path& path) const;
-    [[nodiscard]] std::vector<BranchLinkValidationIssue> collectLoadedFiberBranchIssues(
-        const std::vector<StoredFiber>& fibers) const;
-    [[nodiscard]] bool repairLoadedFiberBranchLinks(
-        std::vector<StoredFiber>& fibers,
-        const std::unordered_set<std::string>& fibersWithRemovedBranchEntries,
-        const std::vector<BranchLinkValidationIssue>& initialIssues,
-        std::vector<std::string>& errors) const;
     [[nodiscard]] std::string uniqueImportedFiberFileName(const StoredFiber& fiber,
                                                           std::unordered_set<std::string>& reserved,
                                                           uint64_t& nextSequence) const;

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -332,9 +332,10 @@ private:
         std::string manualHvTag;
         std::vector<std::string> tags;
         // Vestigial marker: set where in-memory metadata drifted from disk
-        // (e.g. position-repaired links), but nothing consumes it anymore —
-        // the load-time save loop it used to drive was removed so that
-        // loading never writes. Kept as documentation of repair state.
+        // (e.g. a recomputed hv classification), but nothing consumes it
+        // anymore — the load-time save loop it used to drive was removed so
+        // that loading never writes. Link repairs are tracked separately by
+        // FiberBranchRef::linkState (Repaired).
         bool needsSave = false;
         // Branch JSON entries that failed structural parsing; preserved
         // verbatim and re-emitted on save so a load can never drop data.

--- a/volume-cartographer/scripts/fiber_merge.py
+++ b/volume-cartographer/scripts/fiber_merge.py
@@ -331,10 +331,11 @@ def merge_tags(base_doc, local_doc, remote_doc):
     return merged
 
 
-def merge_line_points(local_doc, remote_doc, regions, anchor_positions):
+def merge_line_points(base_doc, local_doc, remote_doc, regions, anchor_positions):
     """Piecewise line splice. Returns (line_points, note) — note is None on
-    the clean paths and a human-readable reason when falling back to the
-    local line (caller adds the reoptimize tag)."""
+    the clean paths and a self-contained explanation whenever one side's
+    line data could not be carried (the caller adds the reoptimize tag)."""
+    base_line = base_doc.get('line_points', [])
     local_line = local_doc.get('line_points', [])
     remote_line = remote_doc.get('line_points', [])
     owners = [region['owner'] for region in regions]
@@ -342,9 +343,23 @@ def merge_line_points(local_doc, remote_doc, regions, anchor_positions):
     local_owns = 'local' in owners or 'both' in owners
 
     if not remote_owns:
-        return list(local_line), None
+        chosen = list(local_line)
+        # A side can re-optimize its line WITHOUT moving control points;
+        # region ownership cannot see that. Never drop it silently.
+        if (not _seq_eq(remote_line, base_line) and
+                not _seq_eq(remote_line, chosen)):
+            return chosen, ("remote re-optimized the line without moving "
+                            "control points; kept the local line and tagged "
+                            "for reoptimization")
+        return chosen, None
     if not local_owns:
-        return list(remote_line), None
+        chosen = list(remote_line)
+        if (not _seq_eq(local_line, base_line) and
+                not _seq_eq(local_line, chosen)):
+            return chosen, ("local re-optimized the line without moving "
+                            "control points; kept the remote line and tagged "
+                            "for reoptimization")
+        return chosen, None
 
     def anchor_match_tol2(line):
         # An anchor control point must actually lie ON the polyline (lines
@@ -379,7 +394,8 @@ def merge_line_points(local_doc, remote_doc, regions, anchor_positions):
     remote_idx = anchor_line_indices(remote_line)
     if local_idx is None or remote_idx is None:
         return (list(local_line),
-                "line splice failed (anchors not on both polylines)")
+                "line splice failed (anchors not on both polylines); kept "
+                "the local line and tagged for reoptimization")
 
     merged = []
     for k, region in enumerate(regions):
@@ -389,7 +405,9 @@ def merge_line_points(local_doc, remote_doc, regions, anchor_positions):
         lo = 0 if k == 0 else idx[k - 1]
         hi = len(line) if k == len(regions) - 1 else idx[k]
         if hi < lo:
-            return list(local_line), "line splice failed (crossed segments)"
+            return (list(local_line),
+                    "line splice failed (crossed segments); kept the local "
+                    "line and tagged for reoptimization")
         merged.extend(line[lo:hi])
     return merged, None
 
@@ -451,8 +469,9 @@ def merge_fibers(base, local, remote):
         base, local, remote, merged_cps, prefer_local)
     merged_branches = merged_branches + opaque_branches
     if opaque_branches:
+        noun = 'entry' if len(opaque_branches) == 1 else 'entries'
         branch_notes.append(f"{len(opaque_branches)} unparseable branch "
-                            "entrie(s) carried through unchanged")
+                            f"{noun} carried through unchanged")
 
     anchor_positions = []
     for k, region in enumerate(regions[:-1]):
@@ -461,7 +480,7 @@ def merge_fibers(base, local, remote):
 
     geometry_merged = any(region['owner'] in ('local', 'remote', 'both')
                           for region in regions)
-    line_points, line_note = merge_line_points(local, remote, regions,
+    line_points, line_note = merge_line_points(base, local, remote, regions,
                                                anchor_positions)
 
     merged = copy.deepcopy(newer)
@@ -476,7 +495,7 @@ def merge_fibers(base, local, remote):
 
     notes = list(branch_notes)
     if line_note:
-        notes.append(line_note + "; kept local line, tagged for reoptimization")
+        notes.append(line_note)
 
     stats = dict(branch_stats)
     stats['cp_regions_local'] = sum(1 for r in regions if r['owner'] == 'local')

--- a/volume-cartographer/scripts/fiber_merge.py
+++ b/volume-cartographer/scripts/fiber_merge.py
@@ -1,0 +1,426 @@
+"""Three-way merge for VC3D fiber annotation JSON files.
+
+Pure functions over parsed JSON dicts — no I/O, no S3 knowledge. vc_sync
+imports this to auto-resolve conflicts where both machines changed a fiber
+file since their last common synced version (the "base").
+
+Merge semantics per section:
+
+- control_points: classic diff3. Each side's point list is aligned to the
+  base by position (1e-6 tolerance, LCS). Base points matched in BOTH
+  alignments are anchors; between consecutive anchors, a region changed on
+  only one side takes that side's points, identical changes collapse, and
+  a region changed differently on both sides is a conflict (this subsumes
+  delete-vs-modify and both-extending-the-same-end).
+- branches (cross-fiber links): set semantics keyed by
+  (branch_file, local position, linked position). Additions from either
+  side survive; a link present in base and untouched on one side but gone
+  from the other was deleted; a link modified on one side and deleted on
+  the other is kept (an approval must never be silently discarded);
+  pending=False wins over pending=True for the same link. Local
+  control_point_index is re-resolved against the merged points.
+- line_points: derived data (the optimizer fits them to the volume inside
+  VC3D, which this module cannot run). If only one side changed geometry,
+  its line is taken wholesale; if both changed disjoint regions, the line
+  is spliced piecewise at anchor control points; if splicing fails the
+  local line is kept and a "needs_reoptimization" tag is added so VC3D can
+  re-fit later.
+- tags: base-aware set merge. Other scalars follow the side with the newer
+  generation; generation becomes max(local, remote) + 1.
+
+A merge either succeeds cleanly or reports conflicts; it never guesses on
+overlapping edits. Callers keep pre-merge copies of every input.
+"""
+
+import copy
+import math
+
+POS_TOL = 1.0e-6
+
+# Keys this module computes; everything else passes through from the
+# newer-generation side.
+_MANAGED_KEYS = ('control_points', 'line_points', 'branches', 'tags', 'generation')
+
+REOPTIMIZE_TAG = 'needs_reoptimization'
+
+
+def is_fiber_doc(doc):
+    return (isinstance(doc, dict) and
+            doc.get('type') == 'vc3d_fiber' and
+            isinstance(doc.get('control_points'), list) and
+            isinstance(doc.get('line_points'), list))
+
+
+def pos_eq(a, b, tol=POS_TOL):
+    try:
+        return (len(a) == 3 and len(b) == 3 and
+                all(math.isfinite(x) and math.isfinite(y) and abs(x - y) <= tol
+                    for x, y in zip(a, b)))
+    except TypeError:
+        return False
+
+
+def qpos(p):
+    """Quantized position usable as a dict key (matches POS_TOL scale)."""
+    return tuple(round(float(x), 6) for x in p)
+
+
+def _seq_eq(a, b):
+    return len(a) == len(b) and all(pos_eq(x, y) for x, y in zip(a, b))
+
+
+def _dist2(a, b):
+    return sum((float(x) - float(y)) ** 2 for x, y in zip(a, b))
+
+
+def _lcs_matches(base, side):
+    """Longest common subsequence of positions; returns [(base_i, side_j)]."""
+    n, m = len(base), len(side)
+    dp = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in range(n - 1, -1, -1):
+        row = dp[i]
+        below = dp[i + 1]
+        for j in range(m - 1, -1, -1):
+            if pos_eq(base[i], side[j]):
+                row[j] = below[j + 1] + 1
+            else:
+                row[j] = below[j] if below[j] >= row[j + 1] else row[j + 1]
+    matches = []
+    i = j = 0
+    while i < n and j < m:
+        if pos_eq(base[i], side[j]):
+            matches.append((i, j))
+            i += 1
+            j += 1
+        elif dp[i + 1][j] >= dp[i][j + 1]:
+            i += 1
+        else:
+            j += 1
+    return matches
+
+
+def merge_control_points(base, local, remote):
+    """Diff3 over point sequences.
+
+    Returns (merged, regions, conflicts). regions is one entry per
+    inter-anchor gap: {'owner': none|local|remote|both|conflict,
+    'local': (lo, hi), 'remote': (lo, hi)} with half-open side index
+    ranges (exclusive of the surrounding anchors).
+    """
+    match_local = _lcs_matches(base, local)
+    match_remote = _lcs_matches(base, remote)
+    map_local = dict(match_local)
+    map_remote = dict(match_remote)
+    anchors = [bi for bi, _ in match_local if bi in map_remote]
+
+    bounds = ([(-1, -1, -1)] +
+              [(a, map_local[a], map_remote[a]) for a in anchors] +
+              [(len(base), len(local), len(remote))])
+
+    merged = []
+    regions = []
+    conflicts = []
+    for k in range(len(bounds) - 1):
+        b0, l0, r0 = bounds[k]
+        b1, l1, r1 = bounds[k + 1]
+        base_seg = base[b0 + 1:b1]
+        local_seg = local[l0 + 1:l1]
+        remote_seg = remote[r0 + 1:r1]
+        local_changed = not _seq_eq(local_seg, base_seg)
+        remote_changed = not _seq_eq(remote_seg, base_seg)
+
+        if local_changed and remote_changed:
+            if _seq_eq(local_seg, remote_seg):
+                owner, seg = 'both', local_seg
+            else:
+                owner, seg = 'conflict', base_seg
+                conflicts.append(
+                    "control_points: both sides changed base points "
+                    f"{b0 + 1}..{max(b0 + 1, b1 - 1)} differently "
+                    f"(local {len(local_seg)} pts, remote {len(remote_seg)} pts)")
+        elif local_changed:
+            owner, seg = 'local', local_seg
+        elif remote_changed:
+            owner, seg = 'remote', remote_seg
+        else:
+            owner, seg = 'none', base_seg
+
+        merged.extend(seg)
+        regions.append({'owner': owner,
+                        'local': (l0 + 1, l1),
+                        'remote': (r0 + 1, r1)})
+        if b1 < len(base):
+            # Anchor point itself: all three agree within tolerance.
+            merged.append(local[l1])
+
+    return merged, regions, conflicts
+
+
+def _branch_key(branch):
+    return (branch.get('branch_file', ''),
+            qpos(branch.get('control_point_position', (0, 0, 0))),
+            qpos(branch.get('branch_control_point_position', (0, 0, 0))))
+
+
+def _branches_of(doc):
+    branches = doc.get('branches', [])
+    return branches if isinstance(branches, list) else []
+
+
+def _branch_signature(branch):
+    """What counts as a meaningful edit to a link (indices and directions
+    are derived/re-resolved elsewhere; pending is the review state)."""
+    return (bool(branch.get('pending', False)),
+            _branch_key(branch))
+
+
+def merge_branches(base_doc, local_doc, remote_doc, merged_cps, prefer_local):
+    base_by_key = {}
+    for branch in _branches_of(base_doc):
+        if isinstance(branch, dict):
+            base_by_key[_branch_key(branch)] = branch
+    local_entries = [b for b in _branches_of(local_doc) if isinstance(b, dict)]
+    remote_entries = [b for b in _branches_of(remote_doc) if isinstance(b, dict)]
+    local_by_key = {_branch_key(b): b for b in local_entries}
+    remote_by_key = {_branch_key(b): b for b in remote_entries}
+
+    ordered_keys = [_branch_key(b) for b in local_entries]
+    ordered_keys += [_branch_key(b) for b in remote_entries
+                     if _branch_key(b) not in local_by_key]
+
+    merged = []
+    notes = []
+    stats = {'links_kept': 0, 'links_added_local': 0, 'links_added_remote': 0,
+             'links_deleted': 0, 'links_approved': 0}
+    seen = set()
+    for key in ordered_keys:
+        if key in seen:
+            continue
+        seen.add(key)
+        in_local = key in local_by_key
+        in_remote = key in remote_by_key
+        in_base = key in base_by_key
+
+        if in_local and in_remote:
+            local_entry = local_by_key[key]
+            remote_entry = remote_by_key[key]
+            local_pending = bool(local_entry.get('pending', False))
+            remote_pending = bool(remote_entry.get('pending', False))
+            if local_pending != remote_pending:
+                # Approval (pending -> absent/False) always wins.
+                chosen = remote_entry if local_pending else local_entry
+                stats['links_approved'] += 1
+            else:
+                chosen = local_entry if prefer_local else remote_entry
+            merged.append(copy.deepcopy(chosen))
+            stats['links_kept'] += 1
+            continue
+
+        side_entry = local_by_key.get(key) or remote_by_key.get(key)
+        side_name = 'local' if in_local else 'remote'
+        if not in_base:
+            merged.append(copy.deepcopy(side_entry))
+            stats['links_added_%s' % side_name] += 1
+            continue
+        # Present in base, gone from the other side: deletion unless this
+        # side meaningfully modified it (approving a link beats deleting it).
+        if _branch_signature(side_entry) == _branch_signature(base_by_key[key]):
+            stats['links_deleted'] += 1
+            notes.append(f"link to {key[0]} deleted on "
+                         f"{'remote' if in_local else 'local'}")
+            continue
+        merged.append(copy.deepcopy(side_entry))
+        notes.append(f"kept link to {key[0]} modified on {side_name} "
+                     "but deleted on the other side")
+        stats['links_kept'] += 1
+
+    # Local anchor indices may have shifted; re-resolve them against the
+    # merged control points. (VC3D's loader also resolves by position, so
+    # this is belt-and-braces plus a guard for anchors deleted by a
+    # winning geometry hunk.)
+    surviving = []
+    for branch in merged:
+        position = branch.get('control_point_position')
+        index = None
+        best = POS_TOL * POS_TOL
+        for i, cp in enumerate(merged_cps):
+            d2 = _dist2(cp, position)
+            if d2 <= best:
+                best = d2
+                index = i
+        if index is None:
+            notes.append(f"dropped link to {branch.get('branch_file', '?')}: "
+                         "its control point was removed by the merged geometry")
+            stats['links_deleted'] += 1
+            continue
+        branch['control_point_index'] = index
+        surviving.append(branch)
+    return surviving, notes, stats
+
+
+def merge_tags(base_doc, local_doc, remote_doc):
+    base = list(base_doc.get('tags', []) or [])
+    local = list(local_doc.get('tags', []) or [])
+    remote = list(remote_doc.get('tags', []) or [])
+    base_set, local_set, remote_set = set(base), set(local), set(remote)
+
+    def keep(tag):
+        return ((tag in local_set and tag in remote_set) or
+                (tag in local_set and tag not in base_set) or
+                (tag in remote_set and tag not in base_set))
+
+    merged = [t for t in base if keep(t)]
+    merged += [t for t in local if keep(t) and t not in merged]
+    merged += [t for t in remote if keep(t) and t not in merged]
+    return merged
+
+
+def merge_line_points(local_doc, remote_doc, regions, anchor_positions):
+    """Piecewise line splice. Returns (line_points, note) — note is None on
+    the clean paths and a human-readable reason when falling back to the
+    local line (caller adds the reoptimize tag)."""
+    local_line = local_doc.get('line_points', [])
+    remote_line = remote_doc.get('line_points', [])
+    owners = [region['owner'] for region in regions]
+    remote_owns = 'remote' in owners
+    local_owns = 'local' in owners or 'both' in owners
+
+    if not remote_owns:
+        return list(local_line), None
+    if not local_owns:
+        return list(remote_line), None
+
+    def anchor_line_indices(line):
+        indices = []
+        start = 0
+        for position in anchor_positions:
+            best_index = None
+            best_d2 = math.inf
+            for i in range(start, len(line)):
+                d2 = _dist2(line[i], position)
+                if d2 < best_d2:
+                    best_d2 = d2
+                    best_index = i
+            if best_index is None:
+                return None
+            indices.append(best_index)
+            start = best_index + 1
+        return indices
+
+    local_idx = anchor_line_indices(local_line)
+    remote_idx = anchor_line_indices(remote_line)
+    if local_idx is None or remote_idx is None:
+        return list(local_line), "line splice failed (non-monotone anchors)"
+
+    merged = []
+    for k, region in enumerate(regions):
+        owner = region['owner']
+        line = remote_line if owner == 'remote' else local_line
+        idx = remote_idx if owner == 'remote' else local_idx
+        lo = 0 if k == 0 else idx[k - 1]
+        hi = len(line) if k == len(regions) - 1 else idx[k]
+        if hi < lo:
+            return list(local_line), "line splice failed (crossed segments)"
+        merged.extend(line[lo:hi])
+    return merged, None
+
+
+def merge_fibers(base, local, remote):
+    """Three-way merge. Returns
+    {'ok': bool, 'merged': dict|None, 'conflicts': [str], 'notes': [str],
+     'stats': {...}}."""
+    result = {'ok': False, 'merged': None, 'conflicts': [], 'notes': [],
+              'stats': {}}
+
+    for name, doc in (('base', base), ('local', local), ('remote', remote)):
+        if not is_fiber_doc(doc):
+            result['conflicts'].append(f"{name} version is not a vc3d_fiber document")
+            return result
+    for field in ('type', 'version', 'filename'):
+        values = {str(doc.get(field)) for doc in (base, local, remote)}
+        if len(values) > 1:
+            result['conflicts'].append(
+                f"'{field}' differs between versions: {sorted(values)}")
+            return result
+
+    # Short circuits: only one side truly changed, or both converged.
+    if local == remote or remote == base:
+        result.update(ok=True, merged=copy.deepcopy(local),
+                      notes=(["remote side unchanged; kept local"]
+                             if remote == base and local != remote else
+                             ["both sides identical"]))
+        return result
+    if local == base:
+        result.update(ok=True, merged=copy.deepcopy(remote),
+                      notes=["local side unchanged; took remote"])
+        return result
+
+    merged_cps, regions, cp_conflicts = merge_control_points(
+        base['control_points'], local['control_points'],
+        remote['control_points'])
+    if cp_conflicts:
+        result['conflicts'] = cp_conflicts
+        return result
+
+    generation_local = int(local.get('generation', 1) or 1)
+    generation_remote = int(remote.get('generation', 1) or 1)
+    prefer_local = generation_local >= generation_remote
+    newer = local if prefer_local else remote
+
+    merged_branches, branch_notes, branch_stats = merge_branches(
+        base, local, remote, merged_cps, prefer_local)
+
+    anchor_positions = []
+    for k, region in enumerate(regions[:-1]):
+        # The anchor after region k is the point at local index region[k]['local'][1]
+        anchor_positions.append(local['control_points'][region['local'][1]])
+
+    geometry_merged = any(region['owner'] in ('local', 'remote', 'both')
+                          for region in regions)
+    line_points, line_note = merge_line_points(local, remote, regions,
+                                               anchor_positions)
+
+    merged = copy.deepcopy(newer)
+    merged['control_points'] = [list(p) for p in merged_cps]
+    merged['line_points'] = [list(p) for p in line_points]
+    merged['branches'] = merged_branches
+    merged['tags'] = merge_tags(base, local, remote)
+    merged['generation'] = max(generation_local, generation_remote) + 1
+    if geometry_merged or line_note:
+        if REOPTIMIZE_TAG not in merged['tags']:
+            merged['tags'].append(REOPTIMIZE_TAG)
+
+    notes = list(branch_notes)
+    if line_note:
+        notes.append(line_note + "; kept local line, tagged for reoptimization")
+
+    stats = dict(branch_stats)
+    stats['cp_regions_local'] = sum(1 for r in regions if r['owner'] == 'local')
+    stats['cp_regions_remote'] = sum(1 for r in regions if r['owner'] == 'remote')
+    stats['geometry_merged'] = geometry_merged
+
+    result.update(ok=True, merged=merged, notes=notes, stats=stats)
+    return result
+
+
+def summarize(result):
+    if not result['ok']:
+        return 'conflict: ' + '; '.join(result['conflicts'])
+    stats = result.get('stats', {})
+    if not stats:
+        return '; '.join(result.get('notes', [])) or 'merged'
+    parts = []
+    if stats.get('cp_regions_local') or stats.get('cp_regions_remote'):
+        parts.append("control points: %d local + %d remote region(s)" %
+                     (stats.get('cp_regions_local', 0),
+                      stats.get('cp_regions_remote', 0)))
+    added = stats.get('links_added_local', 0) + stats.get('links_added_remote', 0)
+    if added:
+        parts.append(f"links +{added}")
+    if stats.get('links_deleted'):
+        parts.append(f"links -{stats['links_deleted']}")
+    if stats.get('links_approved'):
+        parts.append(f"{stats['links_approved']} link approval(s) applied")
+    if stats.get('geometry_merged'):
+        parts.append("geometry merged (tagged for reoptimization)")
+    return ', '.join(parts) if parts else 'merged (metadata only)'

--- a/volume-cartographer/scripts/fiber_merge.py
+++ b/volume-cartographer/scripts/fiber_merge.py
@@ -297,11 +297,17 @@ def merge_branches(base_doc, local_doc, remote_doc, merged_cps, prefer_local):
     surviving = []
     for branch in merged:
         position = branch.get('control_point_position')
+        # Candidacy uses pos_eq — the same per-axis predicate as every other
+        # position comparison. (A pure Euclidean² <= POS_TOL² bound is up to
+        # 3x stricter than pos_eq and dropped links whose anchor pos_eq-
+        # matched a merged point.) Nearest pos_eq match wins.
         index = None
-        best = POS_TOL * POS_TOL
+        best = math.inf
         for i, cp in enumerate(merged_cps):
+            if not pos_eq(cp, position):
+                continue
             d2 = _dist2(cp, position)
-            if d2 <= best:
+            if d2 < best:
                 best = d2
                 index = i
         if index is None:

--- a/volume-cartographer/scripts/fiber_merge.py
+++ b/volume-cartographer/scripts/fiber_merge.py
@@ -33,6 +33,7 @@ overlapping edits. Callers keep pre-merge copies of every input.
 """
 
 import copy
+import json
 import math
 
 POS_TOL = 1.0e-6
@@ -58,11 +59,6 @@ def pos_eq(a, b, tol=POS_TOL):
                     for x, y in zip(a, b)))
     except TypeError:
         return False
-
-
-def qpos(p):
-    """Quantized position usable as a dict key (matches POS_TOL scale)."""
-    return tuple(round(float(x), 6) for x in p)
 
 
 def _seq_eq(a, b):
@@ -156,83 +152,143 @@ def merge_control_points(base, local, remote):
     return merged, regions, conflicts
 
 
-def _branch_key(branch):
-    return (branch.get('branch_file', ''),
-            qpos(branch.get('control_point_position', (0, 0, 0))),
-            qpos(branch.get('branch_control_point_position', (0, 0, 0))))
-
-
 def _branches_of(doc):
     branches = doc.get('branches', [])
     return branches if isinstance(branches, list) else []
 
 
-def _branch_signature(branch):
-    """What counts as a meaningful edit to a link (indices and directions
-    are derived/re-resolved elsewhere; pending is the review state)."""
-    return (bool(branch.get('pending', False)),
-            _branch_key(branch))
+def _valid_vec3(value):
+    try:
+        return (len(value) == 3 and
+                all(isinstance(x, (int, float)) and math.isfinite(x)
+                    for x in value))
+    except TypeError:
+        return False
+
+
+def _structured_branch(branch):
+    """A branch entry this module understands well enough to merge."""
+    return (isinstance(branch, dict) and
+            isinstance(branch.get('branch_file'), str) and
+            _valid_vec3(branch.get('control_point_position')) and
+            _valid_vec3(branch.get('branch_control_point_position')))
+
+
+def split_branches(doc):
+    """(structured, opaque) partition of a document's branch entries.
+
+    Opaque entries (non-objects, missing or malformed fields) are data
+    this module cannot interpret; they are preserved as-is and merged
+    only by whole-value comparison — never silently dropped."""
+    structured = []
+    opaque = []
+    for branch in _branches_of(doc):
+        (structured if _structured_branch(branch) else opaque).append(branch)
+    return structured, opaque
+
+
+def _canon_opaque(entries):
+    return sorted(json.dumps(entry, sort_keys=True) for entry in entries)
+
+
+def merge_opaque_branches(base_opaque, local_opaque, remote_opaque):
+    """Whole-value base-aware merge of uninterpretable branch entries.
+    Returns (merged_entries, conflict_message_or_None)."""
+    if _canon_opaque(local_opaque) == _canon_opaque(remote_opaque):
+        return copy.deepcopy(local_opaque), None
+    if _canon_opaque(local_opaque) == _canon_opaque(base_opaque):
+        return copy.deepcopy(remote_opaque), None
+    if _canon_opaque(remote_opaque) == _canon_opaque(base_opaque):
+        return copy.deepcopy(local_opaque), None
+    return [], ("branches: structurally unparseable entries differ between "
+                "local and remote; refusing to merge them")
+
+
+def _same_link(a, b):
+    """Tolerant link identity: same target file and both endpoint positions
+    within POS_TOL — the same geometric predicate used for control-point
+    alignment. (Rounded-coordinate keys would split positions that sit on
+    opposite sides of a rounding bucket despite being within tolerance.)"""
+    return (a.get('branch_file') == b.get('branch_file') and
+            pos_eq(a.get('control_point_position'),
+                   b.get('control_point_position')) and
+            pos_eq(a.get('branch_control_point_position'),
+                   b.get('branch_control_point_position')))
+
+
+def _find_link(entries, branch, used):
+    for i, entry in enumerate(entries):
+        if i not in used and _same_link(entry, branch):
+            return i
+    return None
+
+
+def _link_modified(entry, base_entry):
+    """The review state is the meaningful mutable field on a link; indices
+    and directions are derived and re-resolved elsewhere."""
+    return (bool(entry.get('pending', False)) !=
+            bool(base_entry.get('pending', False)))
 
 
 def merge_branches(base_doc, local_doc, remote_doc, merged_cps, prefer_local):
-    base_by_key = {}
-    for branch in _branches_of(base_doc):
-        if isinstance(branch, dict):
-            base_by_key[_branch_key(branch)] = branch
-    local_entries = [b for b in _branches_of(local_doc) if isinstance(b, dict)]
-    remote_entries = [b for b in _branches_of(remote_doc) if isinstance(b, dict)]
-    local_by_key = {_branch_key(b): b for b in local_entries}
-    remote_by_key = {_branch_key(b): b for b in remote_entries}
-
-    ordered_keys = [_branch_key(b) for b in local_entries]
-    ordered_keys += [_branch_key(b) for b in remote_entries
-                     if _branch_key(b) not in local_by_key]
+    base_entries, _ = split_branches(base_doc)
+    local_entries, _ = split_branches(local_doc)
+    remote_entries, _ = split_branches(remote_doc)
 
     merged = []
     notes = []
     stats = {'links_kept': 0, 'links_added_local': 0, 'links_added_remote': 0,
              'links_deleted': 0, 'links_approved': 0}
-    seen = set()
-    for key in ordered_keys:
-        if key in seen:
-            continue
-        seen.add(key)
-        in_local = key in local_by_key
-        in_remote = key in remote_by_key
-        in_base = key in base_by_key
+    used_remote = set()
+    used_base = set()
 
-        if in_local and in_remote:
-            local_entry = local_by_key[key]
-            remote_entry = remote_by_key[key]
-            local_pending = bool(local_entry.get('pending', False))
-            remote_pending = bool(remote_entry.get('pending', False))
-            if local_pending != remote_pending:
-                # Approval (pending -> absent/False) always wins.
-                chosen = remote_entry if local_pending else local_entry
-                stats['links_approved'] += 1
-            else:
-                chosen = local_entry if prefer_local else remote_entry
-            merged.append(copy.deepcopy(chosen))
-            stats['links_kept'] += 1
-            continue
+    def base_match(branch):
+        index = _find_link(base_entries, branch, used_base)
+        if index is None:
+            return None
+        used_base.add(index)
+        return base_entries[index]
 
-        side_entry = local_by_key.get(key) or remote_by_key.get(key)
-        side_name = 'local' if in_local else 'remote'
-        if not in_base:
-            merged.append(copy.deepcopy(side_entry))
+    def merge_one_sided(entry, side_name):
+        base_entry = base_match(entry)
+        if base_entry is None:
+            merged.append(copy.deepcopy(entry))
             stats['links_added_%s' % side_name] += 1
-            continue
+            return
         # Present in base, gone from the other side: deletion unless this
         # side meaningfully modified it (approving a link beats deleting it).
-        if _branch_signature(side_entry) == _branch_signature(base_by_key[key]):
+        if not _link_modified(entry, base_entry):
             stats['links_deleted'] += 1
-            notes.append(f"link to {key[0]} deleted on "
-                         f"{'remote' if in_local else 'local'}")
-            continue
-        merged.append(copy.deepcopy(side_entry))
-        notes.append(f"kept link to {key[0]} modified on {side_name} "
-                     "but deleted on the other side")
+            notes.append(f"link to {entry.get('branch_file', '?')} deleted on "
+                         f"{'remote' if side_name == 'local' else 'local'}")
+            return
+        merged.append(copy.deepcopy(entry))
+        notes.append(f"kept link to {entry.get('branch_file', '?')} modified "
+                     f"on {side_name} but deleted on the other side")
         stats['links_kept'] += 1
+
+    for local_entry in local_entries:
+        remote_index = _find_link(remote_entries, local_entry, used_remote)
+        if remote_index is None:
+            merge_one_sided(local_entry, 'local')
+            continue
+        used_remote.add(remote_index)
+        base_match(local_entry)  # consume the base entry, if any
+        remote_entry = remote_entries[remote_index]
+        local_pending = bool(local_entry.get('pending', False))
+        remote_pending = bool(remote_entry.get('pending', False))
+        if local_pending != remote_pending:
+            # Approval (pending -> absent/False) always wins.
+            chosen = remote_entry if local_pending else local_entry
+            stats['links_approved'] += 1
+        else:
+            chosen = local_entry if prefer_local else remote_entry
+        merged.append(copy.deepcopy(chosen))
+        stats['links_kept'] += 1
+
+    for i, remote_entry in enumerate(remote_entries):
+        if i not in used_remote:
+            merge_one_sided(remote_entry, 'remote')
 
     # Local anchor indices may have shifted; re-resolve them against the
     # merged control points. (VC3D's loader also resolves by position, so
@@ -290,7 +346,19 @@ def merge_line_points(local_doc, remote_doc, regions, anchor_positions):
     if not local_owns:
         return list(remote_line), None
 
+    def anchor_match_tol2(line):
+        # An anchor control point must actually lie ON the polyline (lines
+        # pass through their control points); allow up to twice the median
+        # sample spacing. Without this bound, two unrelated polylines would
+        # be considered splicable via arbitrarily distant "matches".
+        spacings = sorted(_dist2(a, b) for a, b in zip(line[:-1], line[1:]))
+        if not spacings:
+            return 1.0e-6
+        median_d2 = spacings[len(spacings) // 2]
+        return max(4.0 * median_d2, 1.0e-6)  # (2 x spacing)^2
+
     def anchor_line_indices(line):
+        tol2 = anchor_match_tol2(line)
         indices = []
         start = 0
         for position in anchor_positions:
@@ -301,7 +369,7 @@ def merge_line_points(local_doc, remote_doc, regions, anchor_positions):
                 if d2 < best_d2:
                     best_d2 = d2
                     best_index = i
-            if best_index is None:
+            if best_index is None or best_d2 > tol2:
                 return None
             indices.append(best_index)
             start = best_index + 1
@@ -310,7 +378,8 @@ def merge_line_points(local_doc, remote_doc, regions, anchor_positions):
     local_idx = anchor_line_indices(local_line)
     remote_idx = anchor_line_indices(remote_line)
     if local_idx is None or remote_idx is None:
-        return list(local_line), "line splice failed (non-monotone anchors)"
+        return (list(local_line),
+                "line splice failed (anchors not on both polylines)")
 
     merged = []
     for k, region in enumerate(regions):
@@ -362,6 +431,17 @@ def merge_fibers(base, local, remote):
         result['conflicts'] = cp_conflicts
         return result
 
+    # Branch entries this module cannot interpret are preserved by
+    # whole-value comparison; a clean merge must never discard input.
+    _, base_opaque = split_branches(base)
+    _, local_opaque = split_branches(local)
+    _, remote_opaque = split_branches(remote)
+    opaque_branches, opaque_conflict = merge_opaque_branches(
+        base_opaque, local_opaque, remote_opaque)
+    if opaque_conflict:
+        result['conflicts'] = [opaque_conflict]
+        return result
+
     generation_local = int(local.get('generation', 1) or 1)
     generation_remote = int(remote.get('generation', 1) or 1)
     prefer_local = generation_local >= generation_remote
@@ -369,6 +449,10 @@ def merge_fibers(base, local, remote):
 
     merged_branches, branch_notes, branch_stats = merge_branches(
         base, local, remote, merged_cps, prefer_local)
+    merged_branches = merged_branches + opaque_branches
+    if opaque_branches:
+        branch_notes.append(f"{len(opaque_branches)} unparseable branch "
+                            "entrie(s) carried through unchanged")
 
     anchor_positions = []
     for k, region in enumerate(regions[:-1]):

--- a/volume-cartographer/scripts/tests/test_fiber_merge.py
+++ b/volume-cartographer/scripts/tests/test_fiber_merge.py
@@ -138,11 +138,8 @@ def test_adjacent_cp_edits_without_anchor_conflict():
     local_cps[3] = cp(3, dz=5.0)
     remote_cps = copy.deepcopy(BASE_CPS)
     remote_cps[4] = cp(4, dz=-5.0)
-    # CP3 and CP4 are adjacent: no unchanged anchor separates the edits...
-    # but diff3 segmentation places them in separate regions because CP4 is
-    # still an anchor for local and CP3 for remote? No: an anchor must be
-    # unchanged on BOTH sides. CP3 changed locally, CP4 remotely, so the
-    # region between anchors CP2 and CP5 contains both edits -> conflict.
+    # An anchor must be unchanged on BOTH sides, so the region between the
+    # anchors CP2 and CP5 contains both edits -> conflict.
     result = merge_fibers(base, make_fiber(local_cps), make_fiber(remote_cps))
     assert not result['ok']
 
@@ -395,6 +392,21 @@ def test_link_identity_is_tolerance_based_not_rounding_based():
     branches = result['merged']['branches']
     assert len(branches) == 1
     assert branches[0]['pending'] is False  # approval won
+
+
+def test_line_only_reoptimization_is_never_dropped_silently():
+    """A side can re-optimize line_points without moving any control point;
+    region ownership cannot see that, but it must not vanish untagged."""
+    base = make_fiber(BASE_CPS)
+    local = make_fiber(BASE_CPS, tags=['meta-edit'], generation=2)
+    remote = make_fiber(BASE_CPS, generation=2)
+    remote['line_points'] = [[p[0], p[1] + 0.5, p[2]]
+                             for p in remote['line_points']]
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert result['merged']['line_points'] == local['line_points']
+    assert any('re-optimized the line' in n for n in result['notes'])
+    assert REOPTIMIZE_TAG in result['merged']['tags']
 
 
 def test_splice_rejected_when_anchors_not_on_both_lines():

--- a/volume-cartographer/scripts/tests/test_fiber_merge.py
+++ b/volume-cartographer/scripts/tests/test_fiber_merge.py
@@ -394,6 +394,26 @@ def test_link_identity_is_tolerance_based_not_rounding_based():
     assert branches[0]['pending'] is False  # approval won
 
 
+def test_link_survives_jittered_geometry_within_tolerance():
+    """Re-resolving link anchors must use the same per-axis pos_eq predicate
+    as everything else. A pure Euclidean^2 <= POS_TOL^2 bound was up to 3x
+    stricter and silently dropped a valid link when one side's geometry
+    carried sub-tolerance jitter on every axis."""
+    jitter = [[p[0] + 8e-7, p[1] + 8e-7, p[2] + 8e-7] for p in BASE_CPS]
+    base = make_fiber(BASE_CPS)
+    local = make_fiber(jitter, tags=['touched'], generation=2)  # "unchanged"
+    remote = make_fiber(BASE_CPS,
+                        branches=[link('kb_a.json', BASE_CPS[2], OTHER, 2)],
+                        generation=2)
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    branches = result['merged']['branches']
+    assert len(branches) == 1, result['notes']
+    assert fiber_merge.pos_eq(
+        result['merged']['control_points'][branches[0]['control_point_index']],
+        branches[0]['control_point_position'])
+
+
 def test_line_only_reoptimization_is_never_dropped_silently():
     """A side can re-optimize line_points without moving any control point;
     region ownership cannot see that, but it must not vanish untagged."""

--- a/volume-cartographer/scripts/tests/test_fiber_merge.py
+++ b/volume-cartographer/scripts/tests/test_fiber_merge.py
@@ -1,0 +1,334 @@
+"""Unit tests for fiber_merge — pure JSON in/out, no I/O."""
+import copy
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import fiber_merge
+from fiber_merge import merge_fibers, REOPTIMIZE_TAG
+
+
+def cp(i, dz=0.0):
+    """A control point on a simple line, spaced 10 apart."""
+    return [100.0 + 10.0 * i, 200.0, 300.0 + dz]
+
+
+def line_for(cps, samples_per_span=4):
+    """A dense polyline passing through the control points."""
+    line = []
+    for a, b in zip(cps[:-1], cps[1:]):
+        for s in range(samples_per_span):
+            t = s / samples_per_span
+            line.append([a[k] + t * (b[k] - a[k]) for k in range(3)])
+    line.append(list(cps[-1]))
+    return line
+
+
+def make_fiber(cps, branches=None, tags=None, generation=1,
+               filename='dj_x_000001.json'):
+    return {
+        'type': 'vc3d_fiber',
+        'version': 1,
+        'filename': filename,
+        'username': 'dj',
+        'generation': generation,
+        'control_points': [list(p) for p in cps],
+        'line_points': line_for(cps),
+        'branches': copy.deepcopy(branches or []),
+        'tags': list(tags or []),
+    }
+
+
+def link(target, local_pos, remote_pos, local_index, remote_index=0,
+         pending=True):
+    return {
+        'control_point_index': local_index,
+        'branch_fiber_id': 7,
+        'branch_control_point_index': remote_index,
+        'branch_file': target,
+        'control_point_direction': [1.0, 0.0, 0.0],
+        'branch_control_point_direction': [0.0, 1.0, 0.0],
+        'control_point_position': list(local_pos),
+        'branch_control_point_position': list(remote_pos),
+        'pending': pending,
+    }
+
+
+BASE_CPS = [cp(i) for i in range(8)]
+OTHER = [999.0, 999.0, 999.0]
+
+
+def test_link_union_incident_fixture():
+    """The real incident: one side adds L2, the other adds L3; base has L1.
+    Every link must survive with correct indices."""
+    l1 = link('kb_a.json', BASE_CPS[2], OTHER, 2)
+    base = make_fiber(BASE_CPS, branches=[l1])
+    local = make_fiber(BASE_CPS, branches=[l1, link('kb_b.json', BASE_CPS[4], OTHER, 4)],
+                       generation=3)
+    remote = make_fiber(BASE_CPS, branches=[l1, link('kb_c.json', BASE_CPS[6], OTHER, 6)],
+                        generation=2)
+
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    targets = sorted(b['branch_file'] for b in result['merged']['branches'])
+    assert targets == ['kb_a.json', 'kb_b.json', 'kb_c.json']
+    by_target = {b['branch_file']: b for b in result['merged']['branches']}
+    assert by_target['kb_b.json']['control_point_index'] == 4
+    assert by_target['kb_c.json']['control_point_index'] == 6
+    assert result['merged']['generation'] == 4
+
+
+def test_disjoint_cp_edits_merge():
+    base = make_fiber(BASE_CPS)
+    local_cps = copy.deepcopy(BASE_CPS)
+    local_cps[1] = cp(1, dz=5.0)          # local moves CP 1
+    remote_cps = copy.deepcopy(BASE_CPS)
+    remote_cps[6] = cp(6, dz=-5.0)        # remote moves CP 6
+    local = make_fiber(local_cps, generation=2)
+    remote = make_fiber(remote_cps, generation=2)
+
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    merged = result['merged']['control_points']
+    assert merged[1] == cp(1, dz=5.0)
+    assert merged[6] == cp(6, dz=-5.0)
+    assert len(merged) == 8
+    assert result['stats']['geometry_merged']
+    assert REOPTIMIZE_TAG in result['merged']['tags']
+
+
+def test_cp_insertion_shifts_indices_and_links_follow():
+    base = make_fiber(BASE_CPS, branches=[link('kb_a.json', BASE_CPS[6], OTHER, 6)])
+    # local inserts a point between 1 and 2 -> link anchor shifts to index 7
+    local_cps = BASE_CPS[:2] + [[105.0, 205.0, 300.0]] + BASE_CPS[2:]
+    local = make_fiber(local_cps,
+                       branches=[link('kb_a.json', BASE_CPS[6], OTHER, 7)],
+                       generation=2)
+    remote = make_fiber(BASE_CPS,
+                        branches=[link('kb_a.json', BASE_CPS[6], OTHER, 6),
+                                  link('kb_d.json', BASE_CPS[3], OTHER, 3)],
+                        generation=2)
+
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    merged = result['merged']
+    assert len(merged['control_points']) == 9
+    by_target = {b['branch_file']: b for b in merged['branches']}
+    assert by_target['kb_a.json']['control_point_index'] == 7
+    assert by_target['kb_d.json']['control_point_index'] == 4
+
+
+def test_overlapping_cp_edits_conflict():
+    base = make_fiber(BASE_CPS)
+    local_cps = copy.deepcopy(BASE_CPS)
+    local_cps[3] = cp(3, dz=5.0)
+    remote_cps = copy.deepcopy(BASE_CPS)
+    remote_cps[3] = cp(3, dz=-5.0)
+    result = merge_fibers(base, make_fiber(local_cps), make_fiber(remote_cps))
+    assert not result['ok']
+    assert any('control_points' in c for c in result['conflicts'])
+
+
+def test_adjacent_cp_edits_without_anchor_conflict():
+    base = make_fiber(BASE_CPS)
+    local_cps = copy.deepcopy(BASE_CPS)
+    local_cps[3] = cp(3, dz=5.0)
+    remote_cps = copy.deepcopy(BASE_CPS)
+    remote_cps[4] = cp(4, dz=-5.0)
+    # CP3 and CP4 are adjacent: no unchanged anchor separates the edits...
+    # but diff3 segmentation places them in separate regions because CP4 is
+    # still an anchor for local and CP3 for remote? No: an anchor must be
+    # unchanged on BOTH sides. CP3 changed locally, CP4 remotely, so the
+    # region between anchors CP2 and CP5 contains both edits -> conflict.
+    result = merge_fibers(base, make_fiber(local_cps), make_fiber(remote_cps))
+    assert not result['ok']
+
+
+def test_delete_vs_modify_conflicts():
+    base = make_fiber(BASE_CPS)
+    local_cps = BASE_CPS[:3] + BASE_CPS[4:]          # local deletes CP 3
+    remote_cps = copy.deepcopy(BASE_CPS)
+    remote_cps[3] = cp(3, dz=5.0)                    # remote moves CP 3
+    result = merge_fibers(base, make_fiber(local_cps), make_fiber(remote_cps))
+    assert not result['ok']
+
+
+def test_deletion_on_one_side_merges():
+    base = make_fiber(BASE_CPS)
+    local_cps = BASE_CPS[:3] + BASE_CPS[4:]          # local deletes CP 3
+    result = merge_fibers(base, make_fiber(local_cps, generation=2),
+                          make_fiber(BASE_CPS, generation=2))
+    assert result['ok']
+    assert len(result['merged']['control_points']) == 7
+
+
+def test_both_extend_same_end_conflicts():
+    base = make_fiber(BASE_CPS)
+    local = make_fiber(BASE_CPS + [cp(8)])
+    remote = make_fiber(BASE_CPS + [cp(9)])
+    result = merge_fibers(base, local, remote)
+    assert not result['ok']
+
+
+def test_extend_opposite_ends_merges():
+    base = make_fiber(BASE_CPS)
+    local = make_fiber([cp(-1)] + BASE_CPS, generation=2)
+    remote = make_fiber(BASE_CPS + [cp(8)], generation=2)
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    merged = result['merged']['control_points']
+    assert merged[0] == cp(-1)
+    assert merged[-1] == cp(8)
+    assert len(merged) == 10
+
+
+def test_pending_false_wins():
+    pending_link = link('kb_a.json', BASE_CPS[2], OTHER, 2, pending=True)
+    approved_link = link('kb_a.json', BASE_CPS[2], OTHER, 2, pending=False)
+    base = make_fiber(BASE_CPS, branches=[pending_link])
+    local = make_fiber(BASE_CPS, branches=[pending_link], generation=5)
+    remote = make_fiber(BASE_CPS, branches=[approved_link], generation=2)
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert result['merged']['branches'][0]['pending'] is False
+    assert result['stats']['links_approved'] == 1
+
+
+def test_base_aware_deletion():
+    l1 = link('kb_a.json', BASE_CPS[2], OTHER, 2)
+    base = make_fiber(BASE_CPS, branches=[l1])
+    local = make_fiber(BASE_CPS, branches=[l1])          # untouched
+    remote = make_fiber(BASE_CPS, branches=[])           # deleted it
+    result = merge_fibers(base, make_fiber_with_marker(local), remote)
+    assert result['ok']
+    assert result['merged']['branches'] == []
+    assert result['stats']['links_deleted'] == 1
+
+
+def make_fiber_with_marker(fiber):
+    """Make a doc differ from base somewhere harmless so the local==base
+    short-circuit doesn't bypass the branch merge under test."""
+    fiber = copy.deepcopy(fiber)
+    fiber['tags'] = fiber.get('tags', []) + ['marker']
+    return fiber
+
+
+def test_modify_beats_delete():
+    pending_link = link('kb_a.json', BASE_CPS[2], OTHER, 2, pending=True)
+    approved_link = link('kb_a.json', BASE_CPS[2], OTHER, 2, pending=False)
+    base = make_fiber(BASE_CPS, branches=[pending_link])
+    local = make_fiber(BASE_CPS, branches=[approved_link])   # approved it
+    remote = make_fiber(BASE_CPS, branches=[])               # deleted it
+    result = merge_fibers(base, local, make_fiber_with_marker(remote))
+    assert result['ok']
+    assert len(result['merged']['branches']) == 1
+    assert result['merged']['branches'][0]['pending'] is False
+
+
+def test_tags_base_aware_merge():
+    base = make_fiber(BASE_CPS, tags=['old', 'shared'])
+    local = make_fiber(BASE_CPS, tags=['shared', 'from-local'])      # dropped 'old'
+    remote = make_fiber(BASE_CPS, tags=['old', 'shared', 'from-remote'])
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    tags = result['merged']['tags']
+    assert 'shared' in tags
+    assert 'from-local' in tags
+    assert 'from-remote' in tags
+    assert 'old' not in tags  # local removed it, remote left it untouched
+
+
+def test_scalars_follow_newer_generation():
+    base = make_fiber(BASE_CPS)
+    local = make_fiber(BASE_CPS, tags=['a'], generation=2)
+    remote = make_fiber(BASE_CPS, tags=['b'], generation=6)
+    remote['username'] = 'kb'
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert result['merged']['username'] == 'kb'
+    assert result['merged']['generation'] == 7
+
+
+def test_short_circuit_local_unchanged():
+    base = make_fiber(BASE_CPS)
+    remote = make_fiber(BASE_CPS, tags=['new'], generation=4)
+    result = merge_fibers(base, copy.deepcopy(base), remote)
+    assert result['ok']
+    assert result['merged'] == remote
+
+
+def test_noop_stability():
+    base = make_fiber(BASE_CPS)
+    result = merge_fibers(base, copy.deepcopy(base), copy.deepcopy(base))
+    assert result['ok']
+    assert result['merged'] == base
+
+
+def test_tolerance_bounds():
+    jittered = [[p[0] + 1e-9, p[1], p[2]] for p in BASE_CPS]
+    moved = [[p[0] + 1e-3, p[1], p[2]] for p in BASE_CPS]
+    assert fiber_merge.pos_eq(BASE_CPS[0], jittered[0])
+    assert not fiber_merge.pos_eq(BASE_CPS[0], moved[0])
+    # jitter-only side counts as unchanged geometry
+    base = make_fiber(BASE_CPS)
+    local = make_fiber(jittered, tags=['touched'])
+    remote = make_fiber(BASE_CPS, tags=['other'])
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert not result['stats'].get('geometry_merged', False)
+
+
+def test_line_points_taken_from_geometry_owner():
+    base = make_fiber(BASE_CPS)
+    remote_cps = copy.deepcopy(BASE_CPS)
+    remote_cps[6] = cp(6, dz=-5.0)
+    local = make_fiber(BASE_CPS, tags=['meta-only'], generation=2)
+    remote = make_fiber(remote_cps, generation=2)
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert result['merged']['line_points'] == remote['line_points']
+
+
+def test_line_splice_between_owners():
+    base = make_fiber(BASE_CPS)
+    local_cps = copy.deepcopy(BASE_CPS)
+    local_cps[1] = cp(1, dz=5.0)
+    remote_cps = copy.deepcopy(BASE_CPS)
+    remote_cps[6] = cp(6, dz=-5.0)
+    local = make_fiber(local_cps, generation=2)
+    remote = make_fiber(remote_cps, generation=2)
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    line = result['merged']['line_points']
+    assert len(line) > 0
+    # Early line follows local's moved CP1, late line follows remote's CP6
+    def nearest_d2(line, p):
+        return min(sum((a - b) ** 2 for a, b in zip(q, p)) for q in line)
+    assert nearest_d2(line, cp(1, dz=5.0)) < 1.0
+    assert nearest_d2(line, cp(6, dz=-5.0)) < 1.0
+    assert REOPTIMIZE_TAG in result['merged']['tags']
+
+
+def test_filename_mismatch_is_conflict():
+    base = make_fiber(BASE_CPS)
+    local = make_fiber(BASE_CPS, tags=['a'])
+    remote = make_fiber(BASE_CPS, tags=['b'], filename='other.json')
+    result = merge_fibers(base, local, remote)
+    assert not result['ok']
+
+
+def test_link_anchor_removed_by_merged_geometry_dropped_with_note():
+    base = make_fiber(BASE_CPS)
+    # local deletes CP 3; remote links at CP 3 (positions identical to base)
+    local_cps = BASE_CPS[:3] + BASE_CPS[4:]
+    local = make_fiber(local_cps, generation=2)
+    remote = make_fiber(BASE_CPS,
+                        branches=[link('kb_a.json', BASE_CPS[3], OTHER, 3)],
+                        generation=2)
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert result['merged']['branches'] == []
+    assert any('removed by the merged geometry' in n for n in result['notes'])

--- a/volume-cartographer/scripts/tests/test_fiber_merge.py
+++ b/volume-cartographer/scripts/tests/test_fiber_merge.py
@@ -332,3 +332,85 @@ def test_link_anchor_removed_by_merged_geometry_dropped_with_note():
     assert result['ok']
     assert result['merged']['branches'] == []
     assert any('removed by the merged geometry' in n for n in result['notes'])
+
+
+# --- review findings (PR #1223) ---
+
+
+def test_opaque_branch_entries_survive_merge():
+    """Structurally unparseable entries must never vanish from a clean
+    merge (they'd be data loss the C++ loader deliberately preserves)."""
+    opaque = 'unparseable-link'
+    base = make_fiber(BASE_CPS, branches=[opaque])
+    local = make_fiber(BASE_CPS, branches=[opaque], tags=['from-local'])
+    remote = make_fiber(BASE_CPS, branches=[opaque], tags=['from-remote'])
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert result['merged']['branches'] == [opaque]
+
+
+def test_divergent_opaque_entries_conflict():
+    base = make_fiber(BASE_CPS, branches=['legacy-a'])
+    local = make_fiber(BASE_CPS, branches=['legacy-b'], tags=['x'])
+    remote = make_fiber(BASE_CPS, branches=['legacy-c'], tags=['y'])
+    result = merge_fibers(base, local, remote)
+    assert not result['ok']
+    assert any('unparseable' in c for c in result['conflicts'])
+
+
+def test_opaque_entry_deleted_on_one_side_merges():
+    base = make_fiber(BASE_CPS, branches=['legacy-a'])
+    local = make_fiber(BASE_CPS, branches=[], tags=['x'])       # deleted it
+    remote = make_fiber(BASE_CPS, branches=['legacy-a'], tags=['y'])
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert result['merged']['branches'] == []
+
+
+def test_malformed_dict_branch_is_opaque_not_a_crash():
+    """A dict entry with missing/non-vector positions must not reach the
+    geometric code paths (previously an uncaught TypeError)."""
+    broken = {'branch_file': 'kb_a.json', 'control_point_position': 'oops'}
+    base = make_fiber(BASE_CPS, branches=[broken])
+    local = make_fiber(BASE_CPS, branches=[broken], tags=['from-local'])
+    remote = make_fiber(BASE_CPS, branches=[broken], tags=['from-remote'])
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert result['merged']['branches'] == [broken]
+
+
+def test_link_identity_is_tolerance_based_not_rounding_based():
+    """Positions within POS_TOL but on opposite sides of a rounding bucket
+    must still be the SAME link (previously produced a duplicate)."""
+    pos_a = [100.0000004, 200.0, 300.0]
+    pos_b = [100.0000013, 200.0, 300.0]  # within 1e-6 of pos_a
+    cps = [pos_a] + [cp(i) for i in range(1, 4)]
+    approved = link('kb_a.json', pos_a, OTHER, 0, pending=False)
+    jittered_pending = link('kb_a.json', pos_b, OTHER, 0, pending=True)
+    base = make_fiber(cps)
+    local = make_fiber(cps, branches=[approved], generation=2)
+    remote = make_fiber(cps, branches=[jittered_pending], generation=2)
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    branches = result['merged']['branches']
+    assert len(branches) == 1
+    assert branches[0]['pending'] is False  # approval won
+
+
+def test_splice_rejected_when_anchors_not_on_both_lines():
+    """Anchors must actually lie on both polylines; unrelated lines fall
+    back to the local line + reoptimization tag instead of a fake splice."""
+    base = make_fiber(BASE_CPS)
+    local_cps = copy.deepcopy(BASE_CPS)
+    local_cps[1] = cp(1, dz=5.0)          # local owns a region
+    remote_cps = copy.deepcopy(BASE_CPS)
+    remote_cps[6] = cp(6, dz=-5.0)        # remote owns a region
+    local = make_fiber(local_cps, generation=2)
+    remote = make_fiber(remote_cps, generation=2)
+    # Remote's line is unrelated garbage far from every anchor
+    remote['line_points'] = [[-900.0 - i, -900.0, -900.0] for i in range(40)]
+    result = merge_fibers(base, local, remote)
+    assert result['ok']
+    assert result['merged']['line_points'] == local['line_points']
+    assert any('splice failed' in n for n in result['notes'])
+    assert REOPTIMIZE_TAG in result['merged']['tags']

--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -470,6 +470,49 @@ class TestAutoMerge:
         assert len(stashed) == 3  # local + remote + base
         assert any('-base' in name for name in stashed)
 
+    def test_same_basename_conflicts_do_not_collide(self, manager, monkeypatch):
+        """Two conflicting files sharing a basename in different directories
+        must get independent pending/remote temp files; flattening to the
+        basename cross-contaminated their merged content."""
+        plans = {}
+        for pkg, tag in (('pkgA', 'from-a'), ('pkgB', 'from-b')):
+            base = self.fiber([0, 0, 0, 0])
+            local = self.fiber([0, 0, 0, 0], generation=2)
+            local['tags'] = [tag + '-local']
+            remote = self.fiber([0, 0, 0, 0], generation=2)
+            remote['tags'] = [tag + '-remote']
+            path = f'{pkg}/fibers/f.json'
+            local_path = write_local(manager, path, json.dumps(local))
+            shadow = manager._shadow_path(path)
+            os.makedirs(os.path.dirname(shadow), exist_ok=True)
+            with open(shadow, 'w') as f:
+                json.dump(base, f)
+            info = local_info(manager, path)
+            track_row(manager, path, 10, 0.0, 10, 'a' * 32,
+                      manager._file_md5(shadow))
+
+            def fake_fetch(p, remote_doc=remote):
+                tmp = manager._merge_tmp_path(p, '.remote')
+                with open(tmp, 'w') as f:
+                    json.dump(remote_doc, f)
+                return remote_doc, tmp
+
+            monkeypatch.setattr(manager, '_fetch_remote_json', fake_fetch)
+            plan = manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32))
+            assert isinstance(plan, dict)
+            plans[path] = (local_path, plan)
+
+        pending_paths = [plan['pending'] for _, plan in plans.values()]
+        assert len(set(pending_paths)) == 2  # no shared temp file
+
+        manager._apply_pending_merges(
+            [(path, plan) for path, (_, plan) in plans.items()])
+        for path, (local_path, _) in plans.items():
+            merged = json.load(open(local_path))
+            marker = 'from-a' if 'pkgA' in path else 'from-b'
+            assert any(marker in t for t in merged['tags']), \
+                f"{path} received another file's merged content"
+
     def test_no_base_means_no_merge(self, manager, monkeypatch):
         local = self.fiber([0, 0, 0, 0], generation=2)
         path = 'fibers/f.json'

--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -1,0 +1,432 @@
+"""Tests for vc_sync content hashing, shadow bases, and conflict analysis.
+
+Pure-local: a temp directory stands in for the sync dir and tracked rows are
+written straight into the SQLite DB. No S3 or network access.
+"""
+import json
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import vc_sync
+from vc_sync import S3SyncManager, SyncAction
+
+
+@pytest.fixture
+def manager(tmp_path):
+    """A manager over a temp dir with config pre-seeded (no S3 contact)."""
+    config = {
+        's3_bucket': 'test-bucket',
+        's3_prefix': 'test/prefix',
+        'aws_profile': None,
+        'last_updated': '2026-01-01T00:00:00',
+    }
+    (tmp_path / '.s3sync.json').write_text(json.dumps(config))
+    return S3SyncManager(str(tmp_path))
+
+
+def write_local(manager, relpath, content):
+    path = os.path.join(manager.local_dir, relpath)
+    os.makedirs(os.path.dirname(path) or manager.local_dir, exist_ok=True)
+    with open(path, 'w') as f:
+        f.write(content)
+    return path
+
+
+def track_row(manager, path, local_size, local_mtime, s3_size, s3_etag,
+              local_md5=None):
+    with sqlite3.connect(manager.db_file) as conn:
+        conn.execute(
+            'INSERT OR REPLACE INTO files '
+            '(path, local_size, local_mtime, s3_size, s3_mtime, s3_etag, local_md5) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?)',
+            (path, local_size, local_mtime, s3_size, 0.0, s3_etag, local_md5))
+
+
+def local_info(manager, relpath):
+    path = os.path.join(manager.local_dir, relpath)
+    stat = os.stat(path)
+    info = {'path': relpath, 'local_size': stat.st_size,
+            'local_mtime': stat.st_mtime, 'is_backup': False}
+    if manager._should_hash(relpath, stat.st_size):
+        info['local_md5'] = manager._file_md5(path)
+    return info
+
+
+def s3_info(size, etag):
+    return {'path': 'x', 's3_size': size, 's3_mtime': 0.0,
+            's3_etag': etag, 'is_backup': False}
+
+
+class TestHashPolicy:
+    def test_json_small_is_hashed(self):
+        assert S3SyncManager._should_hash('fibers/proj/f1.json', 1024)
+
+    def test_json_case_insensitive(self):
+        assert S3SyncManager._should_hash('a/B.JSON', 10)
+
+    def test_large_json_not_hashed(self):
+        assert not S3SyncManager._should_hash('big.json', vc_sync.HASH_MAX_BYTES + 1)
+
+    def test_non_json_not_hashed(self):
+        assert not S3SyncManager._should_hash('volumes/chunk.zarr', 100)
+        assert not S3SyncManager._should_hash('img.tif', 100)
+
+    def test_none_size_not_hashed(self):
+        assert not S3SyncManager._should_hash('a.json', None)
+
+
+class TestEtagIsMd5:
+    def test_plain_md5(self):
+        assert S3SyncManager._etag_is_md5('d41d8cd98f00b204e9800998ecf8427e')
+
+    def test_multipart_rejected(self):
+        assert not S3SyncManager._etag_is_md5('abc123-4')
+
+    def test_empty_rejected(self):
+        assert not S3SyncManager._etag_is_md5('')
+        assert not S3SyncManager._etag_is_md5(None)
+
+
+class TestIgnoreRules:
+    def test_shadow_and_conflict_dirs_are_ignored(self):
+        # Load-bearing: the tool's own dirs must never sync
+        assert S3SyncManager._is_ignored(
+            f'{vc_sync.BASE_DIR_NAME}/fibers/f1.json')
+        assert S3SyncManager._is_ignored(
+            f'{vc_sync.CONFLICT_DIR_NAME}/fibers/f1.conflict-x-local.json')
+
+    def test_normal_fiber_file_not_ignored(self):
+        assert not S3SyncManager._is_ignored('fibers/proj/kb_001.json')
+
+
+class TestDbMigration:
+    def test_local_md5_column_added(self, manager):
+        with sqlite3.connect(manager.db_file) as conn:
+            cols = {row[1] for row in conn.execute('PRAGMA table_info(files)')}
+        assert 'local_md5' in cols
+
+    def test_migration_idempotent(self, manager):
+        manager._init_db()
+        manager._init_db()
+
+
+class TestAnalyzeChanges:
+    MD5_A = None  # filled per-test from real files
+
+    def test_touch_only_is_not_a_change(self, manager):
+        """mtime moved, content identical -> in sync (no false conflict)."""
+        write_local(manager, 'f.json', '{"a": 1}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], info['local_md5'])
+        # Tracked with same md5 but an mtime far in the past
+        track_row(manager, 'f.json', info['local_size'], info['local_mtime'] - 9999,
+                  info['local_size'], info['local_md5'], info['local_md5'])
+        actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        assert actions['f.json'][0] == SyncAction.SKIP
+
+    def test_mtime_preserving_edit_detected(self, manager):
+        """Content changed but size+mtime identical -> still an upload."""
+        write_local(manager, 'f.json', '{"a": 2}')
+        info = local_info(manager, 'f.json')
+        old_md5 = '0' * 32
+        remote = s3_info(info['local_size'], old_md5)
+        track_row(manager, 'f.json', info['local_size'], info['local_mtime'],
+                  info['local_size'], old_md5, old_md5)
+        actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        assert actions['f.json'][0] == SyncAction.UPLOAD
+
+    def test_both_changed_is_conflict(self, manager):
+        write_local(manager, 'f.json', '{"a": 3}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'] + 5, '1' * 32)
+        track_row(manager, 'f.json', 999, 0.0, 888, '2' * 32, '3' * 32)
+        actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        assert actions['f.json'][0] == SyncAction.CONFLICT
+
+    def test_both_changed_but_converged_skips(self, manager):
+        write_local(manager, 'f.json', '{"a": 4}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], info['local_md5'])
+        track_row(manager, 'f.json', 999, 0.0, 888, '2' * 32, '3' * 32)
+        actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        assert actions['f.json'][0] == SyncAction.SKIP
+        assert 'converged' in actions['f.json'][1].lower()
+
+    def test_converged_with_record_updates_tracking_and_shadow(self, manager):
+        write_local(manager, 'f.json', '{"a": 4}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], info['local_md5'])
+        track_row(manager, 'f.json', 999, 0.0, 888, '2' * 32, '3' * 32)
+        manager.analyze_changes({'f.json': info}, {'f.json': remote}, record=True)
+        with sqlite3.connect(manager.db_file) as conn:
+            row = conn.execute(
+                'SELECT local_md5, s3_etag FROM files WHERE path = ?',
+                ('f.json',)).fetchone()
+        assert row[0] == info['local_md5']
+        assert row[1] == info['local_md5']
+        assert os.path.exists(manager._shadow_path('f.json'))
+
+    def test_untracked_same_size_different_content_is_conflict(self, manager):
+        write_local(manager, 'f.json', '{"a": 5}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], 'f' * 32)  # same size, other bytes
+        actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        assert actions['f.json'][0] == SyncAction.CONFLICT
+
+    def test_untracked_same_size_same_content_skips(self, manager):
+        write_local(manager, 'f.json', '{"a": 6}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], info['local_md5'])
+        actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        assert actions['f.json'][0] == SyncAction.SKIP
+
+    def test_untracked_multipart_etag_keeps_size_heuristic(self, manager):
+        """Non-MD5 etags cannot prove divergence -> keep today's SKIP."""
+        write_local(manager, 'f.json', '{"a": 7}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], 'abc123-4')
+        actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        assert actions['f.json'][0] == SyncAction.SKIP
+
+    def test_md5_backfill_with_record(self, manager):
+        """Row predating hashing gets its md5 adopted when stats match."""
+        write_local(manager, 'f.json', '{"a": 8}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], info['local_md5'])
+        track_row(manager, 'f.json', info['local_size'], info['local_mtime'],
+                  info['local_size'], info['local_md5'], None)
+        manager.analyze_changes({'f.json': info}, {'f.json': remote}, record=True)
+        with sqlite3.connect(manager.db_file) as conn:
+            row = conn.execute('SELECT local_md5 FROM files WHERE path = ?',
+                               ('f.json',)).fetchone()
+        assert row[0] == info['local_md5']
+
+    def test_no_record_leaves_db_untouched(self, manager):
+        write_local(manager, 'f.json', '{"a": 9}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], info['local_md5'])
+        track_row(manager, 'f.json', info['local_size'], info['local_mtime'],
+                  info['local_size'], info['local_md5'], None)
+        manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        with sqlite3.connect(manager.db_file) as conn:
+            row = conn.execute('SELECT local_md5 FROM files WHERE path = ?',
+                               ('f.json',)).fetchone()
+        assert row[0] is None
+
+    def test_non_json_behavior_unchanged(self, manager):
+        """Large/non-json files keep pure size/mtime semantics."""
+        write_local(manager, 'vol.tif', 'not-really-a-tif')
+        path = os.path.join(manager.local_dir, 'vol.tif')
+        stat = os.stat(path)
+        info = {'path': 'vol.tif', 'local_size': stat.st_size,
+                'local_mtime': stat.st_mtime, 'is_backup': False}
+        remote = s3_info(stat.st_size, 'whatever-etag')
+        track_row(manager, 'vol.tif', stat.st_size, stat.st_mtime,
+                  stat.st_size, 'whatever-etag')
+        actions = manager.analyze_changes({'vol.tif': info}, {'vol.tif': remote})
+        assert actions['vol.tif'][0] == SyncAction.SKIP
+
+
+class TestShadow:
+    def test_update_and_remove(self, manager):
+        write_local(manager, 'fibers/f.json', '{"x": 1}')
+        manager._update_shadow('fibers/f.json')
+        shadow = manager._shadow_path('fibers/f.json')
+        assert os.path.exists(shadow)
+        assert open(shadow).read() == '{"x": 1}'
+        manager._remove_shadow('fibers/f.json')
+        assert not os.path.exists(shadow)
+        # empty shadow subdir cleaned up too
+        assert not os.path.exists(os.path.dirname(shadow))
+
+    def test_non_hashable_files_get_no_shadow(self, manager):
+        write_local(manager, 'vol.tif', 'data')
+        manager._update_shadow('vol.tif')
+        assert not os.path.exists(manager._shadow_path('vol.tif'))
+
+    def test_shadow_not_scanned(self, manager):
+        write_local(manager, 'fibers/f.json', '{"x": 1}')
+        manager._update_shadow('fibers/f.json')
+        files = manager.scan_local_files()
+        assert all(not p.startswith(vc_sync.BASE_DIR_NAME) for p in files)
+
+
+class TestConflictStash:
+    def test_stash_local_copy(self, manager):
+        write_local(manager, 'fibers/f.json', '{"mine": true}')
+        dst = manager._stash_conflict_copy('fibers/f.json', 'local')
+        assert dst and os.path.exists(dst)
+        assert open(dst).read() == '{"mine": true}'
+        assert vc_sync.CONFLICT_DIR_NAME in dst
+        assert '-local' in os.path.basename(dst)
+        assert dst.endswith('.json')
+
+    def test_stash_dir_not_scanned(self, manager):
+        write_local(manager, 'fibers/f.json', '{"mine": true}')
+        manager._stash_conflict_copy('fibers/f.json', 'local')
+        files = manager.scan_local_files()
+        assert all(vc_sync.CONFLICT_DIR_NAME not in p for p in files)
+
+    def test_divergent_download_target_stashed(self, manager):
+        write_local(manager, 'fibers/f.json', '{"edited": "locally"}')
+        info = local_info(manager, 'fibers/f.json')
+        # Tracked md5 differs from current content
+        track_row(manager, 'fibers/f.json', info['local_size'], 0.0,
+                  10, 'e' * 32, 'a' * 32)
+        manager._stash_divergent_download_targets(
+            ['fibers/f.json'], {'fibers/f.json': info})
+        stash_root = os.path.join(manager.local_dir, vc_sync.CONFLICT_DIR_NAME)
+        stashed = [f for _, _, fs in os.walk(stash_root) for f in fs]
+        assert len(stashed) == 1
+
+    def test_clean_download_target_not_stashed(self, manager):
+        write_local(manager, 'fibers/f.json', '{"clean": true}')
+        info = local_info(manager, 'fibers/f.json')
+        track_row(manager, 'fibers/f.json', info['local_size'], 0.0,
+                  10, 'e' * 32, info['local_md5'])
+        manager._stash_divergent_download_targets(
+            ['fibers/f.json'], {'fibers/f.json': info})
+        assert not os.path.exists(
+            os.path.join(manager.local_dir, vc_sync.CONFLICT_DIR_NAME))
+
+
+class TestAutoMerge:
+    """_attempt_auto_merge with a stubbed remote fetch — no S3."""
+
+    @staticmethod
+    def fiber(cps_z, branches=None, generation=1):
+        cps = [[100.0 + 10.0 * i, 200.0, 300.0 + z] for i, z in enumerate(cps_z)]
+        return {
+            'type': 'vc3d_fiber', 'version': 1, 'filename': 'f.json',
+            'generation': generation,
+            'control_points': cps,
+            'line_points': cps,  # coarse but valid for the merge
+            'branches': branches or [], 'tags': [],
+        }
+
+    @staticmethod
+    def link(target, anchor_cp):
+        return {
+            'control_point_index': 0, 'branch_fiber_id': 1,
+            'branch_control_point_index': 0, 'branch_file': target,
+            'control_point_direction': [1.0, 0.0, 0.0],
+            'branch_control_point_direction': [0.0, 1.0, 0.0],
+            'control_point_position': list(anchor_cp),
+            'branch_control_point_position': [9.0, 9.0, 9.0],
+            'pending': True,
+        }
+
+    def setup_scenario(self, manager, monkeypatch, base, local, remote):
+        path = 'fibers/f.json'
+        local_path = write_local(manager, path, json.dumps(local))
+        # Shadow holds the base; tracked local_md5 records the base content
+        # (the local file has diverged from it since the last sync).
+        shadow = manager._shadow_path(path)
+        os.makedirs(os.path.dirname(shadow), exist_ok=True)
+        with open(shadow, 'w') as f:
+            json.dump(base, f)
+        base_md5 = manager._file_md5(shadow)
+        info = local_info(manager, path)
+        track_row(manager, path, 10, 0.0, 10, 'a' * 32, base_md5)
+
+        def fake_fetch(p):
+            tmp = manager._merge_tmp_path(p, '.remote')
+            with open(tmp, 'w') as f:
+                json.dump(remote, f)
+            return remote, tmp
+
+        monkeypatch.setattr(manager, '_fetch_remote_json', fake_fetch)
+        return path, local_path, info
+
+    def test_clean_merge_written_and_stashed(self, manager, monkeypatch):
+        base = self.fiber([0, 0, 0, 0])
+        local = self.fiber([0, 0, 0, 0], generation=2)
+        local['branches'] = [self.link('kb_b.json', local['control_points'][1])]
+        remote = self.fiber([0, 0, 0, 0], generation=2)
+        remote['branches'] = [self.link('kb_c.json', remote['control_points'][2])]
+        path, local_path, info = self.setup_scenario(
+            manager, monkeypatch, base, local, remote)
+
+        outcome = manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32))
+
+        assert outcome == 'merged'
+        merged = json.load(open(local_path))
+        targets = sorted(b['branch_file'] for b in merged['branches'])
+        assert targets == ['kb_b.json', 'kb_c.json']
+        assert merged['generation'] == 3
+        stash_root = os.path.join(manager.local_dir, vc_sync.CONFLICT_DIR_NAME)
+        stashed = [f for _, _, fs_ in os.walk(stash_root) for f in fs_]
+        assert len(stashed) == 2  # local + remote pre-merge copies
+
+    def test_dry_run_probes_without_writing(self, manager, monkeypatch):
+        base = self.fiber([0, 0, 0, 0])
+        local = self.fiber([0, 0, 0, 0], generation=2)
+        local['tags'] = ['from-local']
+        remote = self.fiber([0, 0, 0, 0], generation=2)
+        remote['tags'] = ['from-remote']
+        path, local_path, info = self.setup_scenario(
+            manager, monkeypatch, base, local, remote)
+        before = open(local_path).read()
+
+        outcome = manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32),
+                                              dry_run=True)
+
+        assert outcome and outcome.startswith('would auto-merge')
+        assert open(local_path).read() == before
+        stash_root = os.path.join(manager.local_dir, vc_sync.CONFLICT_DIR_NAME)
+        stashed = [f for _, _, fs_ in os.walk(stash_root) for f in fs_]
+        assert stashed == []  # probing writes nothing
+
+    def test_conflicting_merge_stashes_all_three(self, manager, monkeypatch):
+        base = self.fiber([0, 0, 0, 0])
+        local = self.fiber([0, 5, 0, 0], generation=2)   # both move CP1
+        remote = self.fiber([0, -5, 0, 0], generation=2)
+        path, local_path, info = self.setup_scenario(
+            manager, monkeypatch, base, local, remote)
+        before = open(local_path).read()
+
+        outcome = manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32))
+
+        assert outcome is None
+        assert open(local_path).read() == before
+        stash_root = os.path.join(manager.local_dir, vc_sync.CONFLICT_DIR_NAME)
+        stashed = sorted(f for _, _, fs_ in os.walk(stash_root) for f in fs_)
+        assert len(stashed) == 3  # local + remote + base
+        assert any('-base' in name for name in stashed)
+
+    def test_no_base_means_no_merge(self, manager, monkeypatch):
+        local = self.fiber([0, 0, 0, 0], generation=2)
+        path = 'fibers/f.json'
+        write_local(manager, path, json.dumps(local))
+        info = local_info(manager, path)
+        track_row(manager, path, 10, 0.0, 10, 'not-an-md5-etag-4', 'c' * 32)
+        monkeypatch.setattr(manager, '_fetch_remote_json',
+                            lambda p: (self.fiber([0, 0, 0, 1]), None))
+
+        assert manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32)) is None
+
+
+class TestRecordUntrackedSynced:
+    def test_same_size_divergent_content_not_healed(self, manager):
+        write_local(manager, 'f.json', '{"a": 1}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], 'd' * 32)  # same size, other bytes
+        manager._record_untracked_synced({'f.json': info}, {'f.json': remote})
+        with sqlite3.connect(manager.db_file) as conn:
+            rows = conn.execute('SELECT COUNT(*) FROM files').fetchone()[0]
+        assert rows == 0
+
+    def test_verified_pair_healed_with_shadow(self, manager):
+        write_local(manager, 'f.json', '{"a": 1}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], info['local_md5'])
+        manager._record_untracked_synced({'f.json': info}, {'f.json': remote})
+        with sqlite3.connect(manager.db_file) as conn:
+            row = conn.execute('SELECT local_md5 FROM files').fetchone()
+        assert row[0] == info['local_md5']
+        assert os.path.exists(manager._shadow_path('f.json'))

--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -525,6 +525,47 @@ class TestAutoMerge:
         assert manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32)) is None
 
 
+class TestSeedTrackedShadows:
+    """The 'update' upgrade path: tracked-but-unhashed files get md5 + shadow
+    when verifiably in sync (previously only untracked files were seeded)."""
+
+    def test_tracked_row_without_md5_gets_seeded(self, manager):
+        write_local(manager, 'fibers/f.json', '{"a": 1}')
+        info = local_info(manager, 'fibers/f.json')
+        remote = s3_info(info['local_size'], info['local_md5'])
+        # Pre-upgrade row: stats match, no md5
+        track_row(manager, 'fibers/f.json', info['local_size'],
+                  info['local_mtime'], info['local_size'], info['local_md5'])
+        manager._seed_tracked_shadows({'fibers/f.json': info},
+                                      {'fibers/f.json': remote})
+        with sqlite3.connect(manager.db_file) as conn:
+            row = conn.execute('SELECT local_md5 FROM files').fetchone()
+        assert row[0] == info['local_md5']
+        assert os.path.exists(manager._shadow_path('fibers/f.json'))
+
+    def test_locally_changed_file_not_seeded(self, manager):
+        write_local(manager, 'fibers/f.json', '{"a": 2}')
+        info = local_info(manager, 'fibers/f.json')
+        remote = s3_info(info['local_size'], info['local_md5'])
+        # Tracked stats differ from the current file: pending local change
+        track_row(manager, 'fibers/f.json', info['local_size'] + 5, 0.0,
+                  info['local_size'], info['local_md5'])
+        manager._seed_tracked_shadows({'fibers/f.json': info},
+                                      {'fibers/f.json': remote})
+        assert not os.path.exists(manager._shadow_path('fibers/f.json'))
+
+    def test_unverifiable_remote_not_seeded(self, manager, monkeypatch):
+        write_local(manager, 'fibers/f.json', '{"a": 3}')
+        info = local_info(manager, 'fibers/f.json')
+        remote = s3_info(info['local_size'], 'abc123-4')  # opaque etag
+        track_row(manager, 'fibers/f.json', info['local_size'],
+                  info['local_mtime'], info['local_size'], 'abc123-4')
+        monkeypatch.setattr(manager, '_remote_md5', lambda p: None)
+        manager._seed_tracked_shadows({'fibers/f.json': info},
+                                      {'fibers/f.json': remote})
+        assert not os.path.exists(manager._shadow_path('fibers/f.json'))
+
+
 class TestRecordUntrackedSynced:
     def test_same_size_divergent_content_not_healed(self, manager, monkeypatch):
         write_local(manager, 'f.json', '{"a": 1}')

--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -171,10 +171,14 @@ class TestAnalyzeChanges:
         assert row[1] == info['local_md5']
         assert os.path.exists(manager._shadow_path('f.json'))
 
-    def test_untracked_same_size_different_content_is_conflict(self, manager):
+    def test_untracked_same_size_different_content_is_conflict(self, manager,
+                                                               monkeypatch):
         write_local(manager, 'f.json', '{"a": 5}')
         info = local_info(manager, 'f.json')
         remote = s3_info(info['local_size'], 'f' * 32)  # same size, other bytes
+        # The mismatching ETag alone is not proof (could be SSE-KMS); the
+        # remote content settles it.
+        monkeypatch.setattr(manager, '_remote_md5', lambda p: 'f' * 32)
         actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
         assert actions['f.json'][0] == SyncAction.CONFLICT
 
@@ -185,13 +189,43 @@ class TestAnalyzeChanges:
         actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
         assert actions['f.json'][0] == SyncAction.SKIP
 
-    def test_untracked_multipart_etag_keeps_size_heuristic(self, manager):
-        """Non-MD5 etags cannot prove divergence -> keep today's SKIP."""
+    def test_untracked_opaque_etag_resolved_by_remote_hash(self, manager,
+                                                           monkeypatch):
+        """A multipart/KMS ETag proves nothing: the remote content is hashed
+        to decide, instead of silently assuming in-sync."""
         write_local(manager, 'f.json', '{"a": 7}')
         info = local_info(manager, 'f.json')
         remote = s3_info(info['local_size'], 'abc123-4')
+
+        monkeypatch.setattr(manager, '_remote_md5', lambda p: info['local_md5'])
         actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
         assert actions['f.json'][0] == SyncAction.SKIP
+
+        monkeypatch.setattr(manager, '_remote_md5', lambda p: '9' * 32)
+        actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        assert actions['f.json'][0] == SyncAction.CONFLICT
+
+    def test_untracked_unverifiable_content_is_conflict(self, manager,
+                                                        monkeypatch):
+        """If the remote cannot be fetched for hashing, 'unknown' surfaces
+        as a conflict rather than becoming a false baseline."""
+        write_local(manager, 'f.json', '{"a": 7}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], 'abc123-4')
+        monkeypatch.setattr(manager, '_remote_md5', lambda p: None)
+        actions = manager.analyze_changes({'f.json': info}, {'f.json': remote})
+        assert actions['f.json'][0] == SyncAction.CONFLICT
+
+    def test_untracked_non_hashed_file_keeps_size_heuristic(self, manager):
+        """Files outside the hash scope keep the historical size heuristic."""
+        write_local(manager, 'vol2.tif', 'eight ch')
+        path = os.path.join(manager.local_dir, 'vol2.tif')
+        stat = os.stat(path)
+        info = {'path': 'vol2.tif', 'local_size': stat.st_size,
+                'local_mtime': stat.st_mtime, 'is_backup': False}
+        remote = s3_info(stat.st_size, 'abc123-4')
+        actions = manager.analyze_changes({'vol2.tif': info}, {'vol2.tif': remote})
+        assert actions['vol2.tif'][0] == SyncAction.SKIP
 
     def test_md5_backfill_with_record(self, manager):
         """Row predating hashing gets its md5 adopted when stats match."""
@@ -343,7 +377,9 @@ class TestAutoMerge:
         monkeypatch.setattr(manager, '_fetch_remote_json', fake_fetch)
         return path, local_path, info
 
-    def test_clean_merge_written_and_stashed(self, manager, monkeypatch):
+    def test_clean_merge_deferred_until_applied(self, manager, monkeypatch):
+        """Planning never touches the local file; _apply_pending_merges (run
+        after user confirmation) performs the swap and the stashing."""
         base = self.fiber([0, 0, 0, 0])
         local = self.fiber([0, 0, 0, 0], generation=2)
         local['branches'] = [self.link('kb_b.json', local['control_points'][1])]
@@ -351,17 +387,52 @@ class TestAutoMerge:
         remote['branches'] = [self.link('kb_c.json', remote['control_points'][2])]
         path, local_path, info = self.setup_scenario(
             manager, monkeypatch, base, local, remote)
+        before = open(local_path).read()
 
-        outcome = manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32))
+        plan = manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32))
 
-        assert outcome == 'merged'
+        assert isinstance(plan, dict) and os.path.exists(plan['pending'])
+        assert open(local_path).read() == before  # untouched until confirmed
+        stash_root = os.path.join(manager.local_dir, vc_sync.CONFLICT_DIR_NAME)
+
+        def stashes():
+            # Actual conflict copies only — not the .tmp planning scratch
+            return [f for _, _, fs_ in os.walk(stash_root)
+                    for f in fs_ if '.conflict-' in f]
+
+        assert stashes() == []
+
+        manager._apply_pending_merges([(path, plan)])
+
         merged = json.load(open(local_path))
         targets = sorted(b['branch_file'] for b in merged['branches'])
         assert targets == ['kb_b.json', 'kb_c.json']
         assert merged['generation'] == 3
+        assert len(stashes()) == 2  # local + remote pre-merge copies
+        assert not os.path.exists(plan['pending'])
+        assert not os.path.exists(plan['remote_tmp'])
+
+    def test_cancelled_merge_discarded_without_touching_local(self, manager,
+                                                              monkeypatch):
+        base = self.fiber([0, 0, 0, 0])
+        local = self.fiber([0, 0, 0, 0], generation=2)
+        local['tags'] = ['from-local']
+        remote = self.fiber([0, 0, 0, 0], generation=2)
+        remote['tags'] = ['from-remote']
+        path, local_path, info = self.setup_scenario(
+            manager, monkeypatch, base, local, remote)
+        before = open(local_path).read()
+
+        plan = manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32))
+        assert isinstance(plan, dict)
+        manager._discard_pending_merges([(path, plan)])
+
+        assert open(local_path).read() == before
+        assert not os.path.exists(plan['pending'])
+        assert not os.path.exists(plan['remote_tmp'])
         stash_root = os.path.join(manager.local_dir, vc_sync.CONFLICT_DIR_NAME)
-        stashed = [f for _, _, fs_ in os.walk(stash_root) for f in fs_]
-        assert len(stashed) == 2  # local + remote pre-merge copies
+        assert [f for _, _, fs_ in os.walk(stash_root)
+                for f in fs_ if '.conflict-' in f] == []
 
     def test_dry_run_probes_without_writing(self, manager, monkeypatch):
         base = self.fiber([0, 0, 0, 0])
@@ -412,14 +483,38 @@ class TestAutoMerge:
 
 
 class TestRecordUntrackedSynced:
-    def test_same_size_divergent_content_not_healed(self, manager):
+    def test_same_size_divergent_content_not_healed(self, manager, monkeypatch):
         write_local(manager, 'f.json', '{"a": 1}')
         info = local_info(manager, 'f.json')
         remote = s3_info(info['local_size'], 'd' * 32)  # same size, other bytes
+        monkeypatch.setattr(manager, '_remote_md5', lambda p: 'd' * 32)
         manager._record_untracked_synced({'f.json': info}, {'f.json': remote})
         with sqlite3.connect(manager.db_file) as conn:
             rows = conn.execute('SELECT COUNT(*) FROM files').fetchone()[0]
         assert rows == 0
+
+    def test_unverifiable_pair_not_healed(self, manager, monkeypatch):
+        """No content proof (opaque etag, remote unreachable) -> stays
+        untracked instead of becoming a false baseline."""
+        write_local(manager, 'f.json', '{"a": 1}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], 'abc123-4')
+        monkeypatch.setattr(manager, '_remote_md5', lambda p: None)
+        manager._record_untracked_synced({'f.json': info}, {'f.json': remote})
+        with sqlite3.connect(manager.db_file) as conn:
+            rows = conn.execute('SELECT COUNT(*) FROM files').fetchone()[0]
+        assert rows == 0
+
+    def test_opaque_etag_healed_via_remote_hash(self, manager, monkeypatch):
+        write_local(manager, 'f.json', '{"a": 1}')
+        info = local_info(manager, 'f.json')
+        remote = s3_info(info['local_size'], 'abc123-4')
+        monkeypatch.setattr(manager, '_remote_md5', lambda p: info['local_md5'])
+        manager._record_untracked_synced({'f.json': info}, {'f.json': remote})
+        with sqlite3.connect(manager.db_file) as conn:
+            rows = conn.execute('SELECT COUNT(*) FROM files').fetchone()[0]
+        assert rows == 1
+        assert os.path.exists(manager._shadow_path('f.json'))
 
     def test_verified_pair_healed_with_shadow(self, manager):
         write_local(manager, 'f.json', '{"a": 1}')

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -380,6 +380,7 @@ class S3SyncManager:
         whose ETag cannot prove equality."""
         if path in self._remote_md5_cache:
             return self._remote_md5_cache[path]
+        print(f"  Fetching remote copy of {path} to verify content...")
         tmp = self._merge_tmp_path(path, '.hashcheck')
         md5 = None
         try:
@@ -480,9 +481,13 @@ class S3SyncManager:
     # --- fiber-aware three-way merge (see fiber_merge.py) ---
 
     def _merge_tmp_path(self, path, suffix):
-        tmp_dir = os.path.join(self.local_dir, CONFLICT_DIR_NAME, '.tmp')
-        os.makedirs(tmp_dir, exist_ok=True)
-        return os.path.join(tmp_dir, os.path.basename(path) + suffix)
+        # Mirror the relative path (like _shadow_path) — flattening to the
+        # basename would let two same-named files in different directories
+        # overwrite each other's pending merge data mid-run.
+        tmp = os.path.join(self.local_dir, CONFLICT_DIR_NAME, '.tmp',
+                           path + suffix)
+        os.makedirs(os.path.dirname(tmp), exist_ok=True)
+        return tmp
 
     def _load_base(self, path, tracked):
         """Return the parsed last-synced (base) version of a file, or None.
@@ -1613,7 +1618,8 @@ class S3SyncManager:
                 for path, problem in invalid_uploads:
                     print(f"  {path}: {problem}")
             if conflicts and auto_merge and fiber_merge is not None:
-                print("\nMerge preview for conflicts:")
+                print("\nMerge preview for conflicts (fetches remote copies "
+                      "to test-merge; local files are not touched):")
                 for path, reason in conflicts:
                     probe = self._attempt_auto_merge(path,
                                                      local_files.get(path),

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -58,12 +58,21 @@ import json
 import shlex
 import shutil
 import sqlite3
+import hashlib
 import argparse
 import tempfile
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from contextlib import contextmanager
+
+# Optional fiber-aware three-way merge (fiber_merge.py next to this script).
+# Everything else works without it; annotation conflicts just stay manual.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import fiber_merge
+except ImportError:
+    fiber_merge = None
 
 
 # Backup file patterns - these files are only uploaded, never downloaded or deleted
@@ -74,6 +83,17 @@ BACKUP_PATTERNS = [
     '_bak',
     '.bak',
 ]
+
+# Content hashing is restricted to annotation-sized JSON files: volumes and
+# other bulk data keep the cheap size/mtime heuristics.
+HASH_SUFFIXES = ('.json',)
+HASH_MAX_BYTES = 16 * 1024 * 1024
+
+# Tool-owned directories inside the sync dir. Both are dot-prefixed, which
+# _is_ignored and the scan_local_files dir pruning already exclude from
+# syncing — that exclusion is a load-bearing dependency.
+BASE_DIR_NAME = '.s3sync-base'          # last-synced copies (3-way merge base)
+CONFLICT_DIR_NAME = '.s3sync-conflicts'  # versions preserved before overwrite
 
 class SyncAction(Enum):
     UPLOAD = "upload"
@@ -211,6 +231,14 @@ class S3SyncManager:
         # path is the PRIMARY KEY and therefore already indexed; drop the
         # redundant secondary index older versions of this script created
         conn.execute('DROP INDEX IF EXISTS idx_path')
+
+        # Lazy migration: databases created before content hashing lack the
+        # local_md5 column. Rows keep NULL until the file next syncs or a
+        # scan backfills them in analyze_changes.
+        columns = {row[1] for row in conn.execute('PRAGMA table_info(files)')}
+        if 'local_md5' not in columns:
+            conn.execute('ALTER TABLE files ADD COLUMN local_md5 TEXT')
+
         conn.commit()
         conn.close()
 
@@ -240,14 +268,15 @@ class S3SyncManager:
         """
         conn.execute('''
             INSERT OR REPLACE INTO files
-            (path, local_size, local_mtime, s3_size, s3_mtime, s3_etag)
-            VALUES (?, ?, ?, ?, ?, ?)
+            (path, local_size, local_mtime, s3_size, s3_mtime, s3_etag, local_md5)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
         ''', (path,
               local_info['local_size'] if local_info else None,
               local_info['local_mtime'] if local_info else None,
               s3_info['s3_size'] if s3_info else None,
               s3_info['s3_mtime'] if s3_info else None,
-              s3_info.get('s3_etag') if s3_info else None))
+              s3_info.get('s3_etag') if s3_info else None,
+              local_info.get('local_md5') if local_info else None))
 
     def _run_aws_command(self, cmd):
         """Run AWS CLI command with optional profile and better error handling"""
@@ -315,6 +344,263 @@ class S3SyncManager:
 
         return False
 
+    @staticmethod
+    def _should_hash(relative_path, size):
+        """Content-hash policy: annotation-sized JSON files only."""
+        if size is None or size > HASH_MAX_BYTES:
+            return False
+        return relative_path.lower().endswith(HASH_SUFFIXES)
+
+    @staticmethod
+    def _file_md5(filepath):
+        digest = hashlib.md5()
+        with open(filepath, 'rb') as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b''):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @staticmethod
+    def _etag_is_md5(etag):
+        """True when an S3 ETag is a plain MD5 (single-part, non-KMS upload)."""
+        return bool(etag) and '-' not in etag
+
+    # --- shadow copies: the file content as of the last successful sync ---
+    # These are the base versions for three-way merging of divergent
+    # annotation files. Scope matches _should_hash.
+
+    def _shadow_path(self, path):
+        return os.path.join(self.local_dir, BASE_DIR_NAME, path)
+
+    def _update_shadow(self, path):
+        """Record the current local file as the last-synced (base) version."""
+        src = os.path.join(self.local_dir, path)
+        try:
+            stat = os.stat(src)
+        except OSError:
+            return
+        if not self._should_hash(path, stat.st_size):
+            return
+        dst = self._shadow_path(path)
+        try:
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            tmp = dst + '.tmp'
+            shutil.copy2(src, tmp)
+            os.replace(tmp, dst)
+        except OSError as e:
+            print(f"  ⚠️  Could not update merge base for {path}: {e}")
+
+    def _remove_shadow(self, path):
+        dst = self._shadow_path(path)
+        try:
+            os.remove(dst)
+        except OSError:
+            return
+        shadow_root = os.path.join(self.local_dir, BASE_DIR_NAME)
+        dirpath = os.path.dirname(dst)
+        while dirpath != shadow_root and dirpath.startswith(shadow_root + os.sep):
+            try:
+                os.rmdir(dirpath)
+            except OSError:
+                break
+            dirpath = os.path.dirname(dirpath)
+
+    # --- conflict copies: versions preserved before they would be lost ---
+
+    def _stash_conflict_copy(self, path, side, source=None):
+        """Preserve a version of `path` that is about to be overwritten.
+
+        side is 'local', 'remote', or 'base'. source is a filepath to copy;
+        None with side='remote' fetches the current S3 object. Stashing must
+        never block the sync itself, so failures only warn.
+        """
+        stamp = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+        stem, ext = os.path.splitext(os.path.basename(path))
+        dst = os.path.join(self.local_dir, CONFLICT_DIR_NAME,
+                           os.path.dirname(path),
+                           f"{stem}.conflict-{stamp}-{side}{ext}")
+        try:
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if source is None and side == 'remote':
+                self._run_aws_command(['aws', 's3', 'cp', self._get_s3_url(path), dst])
+            else:
+                shutil.copy2(source or os.path.join(self.local_dir, path), dst)
+        except Exception as e:
+            print(f"  ⚠️  Could not save {side} conflict copy for {path}: {e}")
+            return None
+        print(f"  Saved {side} conflict copy: {os.path.relpath(dst, self.local_dir)}")
+        return dst
+
+    def _stash_divergent_download_targets(self, download_paths, local_files):
+        """Stash local copies a download would overwrite when their content
+        diverges from the tracked synced state (or was never tracked)."""
+        if not download_paths:
+            return
+        with self._get_db() as conn:
+            cursor = conn.execute('SELECT path, local_md5 FROM files')
+            tracked_md5 = {row['path']: row['local_md5'] for row in cursor}
+        for path in download_paths:
+            local_info = local_files.get(path)
+            current_md5 = local_info.get('local_md5') if local_info else None
+            if not current_md5:
+                continue  # no local file, or not a hashed file
+            if tracked_md5.get(path) != current_md5:
+                self._stash_conflict_copy(path, 'local')
+
+    # --- fiber-aware three-way merge (see fiber_merge.py) ---
+
+    def _merge_tmp_path(self, path, suffix):
+        tmp_dir = os.path.join(self.local_dir, CONFLICT_DIR_NAME, '.tmp')
+        os.makedirs(tmp_dir, exist_ok=True)
+        return os.path.join(tmp_dir, os.path.basename(path) + suffix)
+
+    def _load_base(self, path, tracked):
+        """Return the parsed last-synced (base) version of a file, or None.
+
+        Prefers the local shadow copy, verified against the tracked md5 it
+        was recorded with; falls back to fetching the exact version from S3
+        version history by the tracked ETag."""
+        shadow = self._shadow_path(path)
+        tracked_md5 = tracked.get('local_md5')
+        if tracked_md5 and os.path.exists(shadow):
+            try:
+                if self._file_md5(shadow) == tracked_md5:
+                    with open(shadow) as f:
+                        return json.load(f)
+            except (OSError, json.JSONDecodeError):
+                pass
+        etag = tracked.get('s3_etag')
+        if etag and self._etag_is_md5(etag):
+            return self._fetch_base_from_history(path, etag)
+        return None
+
+    def _fetch_base_from_history(self, path, etag):
+        """Fetch the object version whose ETag matches the tracked baseline
+        from the (versioned) bucket. Returns parsed JSON or None."""
+        key = f"{self.s3_prefix}/{path}"
+        try:
+            result = self._run_aws_command(['aws', 's3api', 'list-object-versions',
+                                            '--bucket', self.s3_bucket,
+                                            '--prefix', key])
+            data = json.loads(result.stdout or '{}')
+        except Exception:
+            return None
+        version_id = None
+        for version in data.get('Versions', []):
+            if (version.get('Key') == key and
+                    version.get('ETag', '').strip('"') == etag):
+                version_id = version.get('VersionId')
+                break
+        if not version_id:
+            return None
+        tmp = self._merge_tmp_path(path, '.base')
+        try:
+            self._run_aws_command(['aws', 's3api', 'get-object',
+                                   '--bucket', self.s3_bucket,
+                                   '--key', key,
+                                   '--version-id', version_id,
+                                   tmp])
+            with open(tmp) as f:
+                return json.load(f)
+        except Exception:
+            return None
+        finally:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+
+    def _fetch_remote_json(self, path):
+        """Fetch the current remote object. Returns (parsed_json, temp_path)
+        — the caller stashes/removes temp_path — or (None, None)."""
+        tmp = self._merge_tmp_path(path, '.remote')
+        try:
+            self._run_aws_command(['aws', 's3', 'cp', self._get_s3_url(path), tmp])
+            with open(tmp) as f:
+                return json.load(f), tmp
+        except Exception:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+            return None, None
+
+    def _attempt_auto_merge(self, path, local_info, s3_info, dry_run=False):
+        """Try a fiber-aware three-way merge for a conflicting file.
+
+        Returns 'merged' after writing a clean merge to the local file (the
+        caller uploads it), a preview string in dry-run mode, or None when
+        the file is not eligible, no base is available, or the merge has
+        genuine conflicts (pre-merge copies are stashed in that case and
+        the caller falls back to the interactive prompt).
+        """
+        if fiber_merge is None or not local_info or not s3_info:
+            return None
+        if not self._should_hash(path, local_info.get('local_size')):
+            return None
+        local_path = os.path.join(self.local_dir, path)
+        try:
+            with open(local_path) as f:
+                local_doc = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not fiber_merge.is_fiber_doc(local_doc):
+            return None
+
+        with self._get_db() as conn:
+            row = conn.execute('SELECT * FROM files WHERE path = ?',
+                               (path,)).fetchone()
+        tracked = dict(row) if row else {}
+        base_doc = self._load_base(path, tracked)
+        if base_doc is None or not fiber_merge.is_fiber_doc(base_doc):
+            if not dry_run:
+                print(f"  (no merge base available for {path})")
+            return None
+
+        remote_doc, remote_tmp = self._fetch_remote_json(path)
+        if remote_doc is None or not fiber_merge.is_fiber_doc(remote_doc):
+            if remote_tmp:
+                try:
+                    os.remove(remote_tmp)
+                except OSError:
+                    pass
+            return None
+
+        try:
+            result = fiber_merge.merge_fibers(base_doc, local_doc, remote_doc)
+            summary = fiber_merge.summarize(result)
+            if dry_run:
+                return f"would auto-merge ({summary})" if result['ok'] else None
+
+            if not result['ok']:
+                print(f"  ✗ cannot auto-merge {path}:")
+                for conflict in result['conflicts']:
+                    print(f"      {conflict}")
+                # Preserve all three versions for a later manual 3-way merge
+                self._stash_conflict_copy(path, 'local')
+                self._stash_conflict_copy(path, 'remote', source=remote_tmp)
+                shadow = self._shadow_path(path)
+                if os.path.exists(shadow):
+                    self._stash_conflict_copy(path, 'base', source=shadow)
+                return None
+
+            self._stash_conflict_copy(path, 'local')
+            self._stash_conflict_copy(path, 'remote', source=remote_tmp)
+            tmp = local_path + '.merge-tmp'
+            with open(tmp, 'w') as f:
+                json.dump(result['merged'], f, indent=2)
+                f.write('\n')
+            os.replace(tmp, local_path)
+            print(f"  ✓ auto-merged {path}: {summary}")
+            for note in result['notes']:
+                print(f"      note: {note}")
+            return 'merged'
+        finally:
+            if remote_tmp:
+                try:
+                    os.remove(remote_tmp)
+                except OSError:
+                    pass
+
     def scan_local_files(self, include_backups=False):
         """Scan local directory for files"""
         print(f"Scanning local directory: {self.local_dir}")
@@ -335,12 +621,18 @@ class S3SyncManager:
                     continue
 
                 stat = os.stat(filepath)
-                files[relative_path] = {
+                info = {
                     'path': relative_path,
                     'local_size': stat.st_size,
                     'local_mtime': stat.st_mtime,
                     'is_backup': is_backup_file(filename)
                 }
+                if self._should_hash(relative_path, stat.st_size):
+                    try:
+                        info['local_md5'] = self._file_md5(filepath)
+                    except OSError:
+                        pass
+                files[relative_path] = info
 
         print(f"Found {len(files)} local files")
         return files
@@ -432,6 +724,9 @@ class S3SyncManager:
             for path in stale:
                 conn.execute('DELETE FROM files WHERE path = ?', (path,))
 
+        for path in stale:
+            self._remove_shadow(path)
+
         if stale:
             print(f"Pruned {len(stale)} tracking entries for files that no longer exist anywhere")
         return len(stale)
@@ -470,13 +765,34 @@ class S3SyncManager:
             for path in current_paths:
                 self._track_file(conn, path, local_files.get(path), s3_files.get(path))
 
+        # Reset stamps "in sync" even for files that differ, so a shadow copy
+        # is only trustworthy as a merge base where content is verified equal;
+        # anywhere else it would poison future 3-way merges.
+        for path in current_paths:
+            local_info = local_files.get(path)
+            s3_info = s3_files.get(path)
+            md5 = local_info.get('local_md5') if local_info else None
+            etag = (s3_info.get('s3_etag') or '') if s3_info else ''
+            if md5 and self._etag_is_md5(etag) and md5 == etag:
+                self._update_shadow(path)
+            else:
+                self._remove_shadow(path)
+
         self._prune_stale_tracking(current_paths, include_backups)
 
         print("File tracking reset")
 
-    def analyze_changes(self, local_files, s3_files):
-        """Analyze what needs to be synced and detect conflicts"""
+    def analyze_changes(self, local_files, s3_files, record=False):
+        """Analyze what needs to be synced and detect conflicts.
+
+        With record=True (sync, not dry-run), verified ground truth
+        discovered during analysis is written back to tracking: MD5 backfills
+        for rows predating content hashing, and re-tracking of files whose
+        local and remote content converged independently.
+        """
         actions = {}
+        md5_backfills = []   # (md5, path) for rows predating content hashing
+        converged = []       # paths where both sides changed to identical content
 
         with self._get_db() as conn:
             # Get all tracked files
@@ -530,17 +846,42 @@ class S3SyncManager:
 
             # File exists in both places
             elif local_info and s3_info:
+                current_md5 = local_info.get('local_md5')
+                s3_etag = s3_info.get('s3_etag') or ''
                 if tracked_info:
                     # We have tracking history
-                    local_changed = (tracked_info.get('local_size') != local_info['local_size'] or
-                                     (tracked_info.get('local_mtime') and
-                                      abs(tracked_info['local_mtime'] - local_info['local_mtime']) > 1))
+                    stat_changed = (tracked_info.get('local_size') != local_info['local_size'] or
+                                    (tracked_info.get('local_mtime') and
+                                     abs(tracked_info['local_mtime'] - local_info['local_mtime']) > 1))
+
+                    tracked_md5 = tracked_info.get('local_md5')
+                    if current_md5 and tracked_md5:
+                        # Content is authoritative for hashed files: a
+                        # touch/re-save with identical bytes is not a change,
+                        # and a size+mtime-preserving edit is.
+                        local_changed = current_md5 != tracked_md5
+                    else:
+                        local_changed = stat_changed
+                        if current_md5 and not tracked_md5 and not stat_changed:
+                            # Row predates content hashing and the stats say
+                            # the file is unchanged since last sync: adopt the
+                            # current content as the tracked content.
+                            md5_backfills.append((current_md5, path))
 
                     s3_changed = (tracked_info.get('s3_size') != s3_info['s3_size'] or
                                   tracked_info.get('s3_etag') != s3_info['s3_etag'])
 
                     if local_changed and s3_changed:
-                        actions[path] = (SyncAction.CONFLICT, "Both local and S3 modified since last sync")
+                        if (current_md5 and self._etag_is_md5(s3_etag) and
+                                current_md5 == s3_etag):
+                            # Both sides changed but ended up with identical
+                            # content (e.g. both machines synced a third copy)
+                            actions[path] = (SyncAction.SKIP,
+                                             "Both sides converged to identical content")
+                            converged.append(path)
+                        else:
+                            actions[path] = (SyncAction.CONFLICT,
+                                             "Both local and S3 modified since last sync")
                     elif local_changed:
                         actions[path] = (SyncAction.UPLOAD, "Local file modified")
                     elif s3_changed:
@@ -551,12 +892,28 @@ class S3SyncManager:
                     # No tracking history
                     if local_info['local_size'] != s3_info['s3_size']:
                         actions[path] = (SyncAction.CONFLICT, "Files differ (no sync history)")
+                    elif (current_md5 and self._etag_is_md5(s3_etag) and
+                          current_md5 != s3_etag):
+                        # Same size but different bytes: without this check a
+                        # divergent same-size file is silently declared synced
+                        actions[path] = (SyncAction.CONFLICT,
+                                         "Same size but different content (no sync history)")
                     else:
                         actions[path] = (SyncAction.SKIP, "Files appear to be in sync")
 
             # File deleted from both
             elif path in tracked_files and not local_info and not s3_info:
                 actions[path] = (SyncAction.SKIP, "File deleted from both")
+
+        if record and (md5_backfills or converged):
+            with self._get_db() as conn:
+                if md5_backfills:
+                    conn.executemany('UPDATE files SET local_md5 = ? WHERE path = ?',
+                                     md5_backfills)
+                for path in converged:
+                    self._track_file(conn, path, local_files[path], s3_files[path])
+            for path in converged:
+                self._update_shadow(path)
 
         return actions
 
@@ -574,13 +931,31 @@ class S3SyncManager:
             # Backup-pattern files are excluded: they are upload-only, and
             # analyze_changes deliberately re-uploads them when untracked
             # (even on a size match). The upload itself records tracking.
+            # Hashable files must additionally match content (md5 vs a
+            # plain-MD5 ETag) — a same-size divergent file is a conflict,
+            # not an in-sync pair.
+            def content_compatible(path):
+                md5 = local_files[path].get('local_md5')
+                etag = s3_files[path].get('s3_etag') or ''
+                if md5 and self._etag_is_md5(etag):
+                    return md5 == etag
+                return True
+
             healed = [path for path in local_files.keys() & s3_files.keys()
                       if path not in tracked and
                       not local_files[path].get('is_backup') and
-                      local_files[path]['local_size'] == s3_files[path]['s3_size']]
+                      local_files[path]['local_size'] == s3_files[path]['s3_size'] and
+                      content_compatible(path)]
 
             for path in healed:
                 self._track_file(conn, path, local_files[path], s3_files[path])
+
+        for path in healed:
+            md5 = local_files[path].get('local_md5')
+            etag = s3_files[path].get('s3_etag') or ''
+            if md5 and self._etag_is_md5(etag) and md5 == etag:
+                # Content-verified identical: safe to adopt as a merge base
+                self._update_shadow(path)
 
         if healed:
             print(f"Recorded {len(healed)} in-sync file(s) that had no tracking history")
@@ -602,6 +977,17 @@ class S3SyncManager:
             response = prompt_choice(
                 "\nChoose: [l]ocal → remote, [r]emote → local, [s]kip? ",
                 ('l', 'r', 's'))
+
+            # Preserve whichever version is about to be discarded
+            if response == 'r':
+                self._stash_conflict_copy(path, 'local')
+            elif response == 'l':
+                if self._should_hash(path, s3_info['s3_size']):
+                    self._stash_conflict_copy(path, 'remote')
+                else:
+                    print("  (previous remote version remains available "
+                          "through S3 bucket versioning)")
+
             return {'l': SyncAction.UPLOAD,
                     'r': SyncAction.DOWNLOAD}.get(response, SyncAction.SKIP)
 
@@ -642,11 +1028,25 @@ class S3SyncManager:
 
         # Track the pre-upload stats: if the file changed during upload, the next
         # scan will see a local difference and schedule a re-upload
+        local_info = {'local_size': pre_stat.st_size,
+                      'local_mtime': pre_stat.st_mtime}
+        content_verified = False
+        if self._should_hash(path, pre_stat.st_size) and \
+                self._etag_is_md5(s3_info['s3_etag']):
+            local_md5 = self._file_md5(local_path)
+            if local_md5 == s3_info['s3_etag']:
+                local_info['local_md5'] = local_md5
+                content_verified = True
+            else:
+                print(f"  ⚠️  Content verification failed for {path} "
+                      f"(changed during upload?); will retry on next sync")
+                return False
+
         with self._get_db() as conn:
-            self._track_file(conn, path,
-                             {'local_size': pre_stat.st_size,
-                              'local_mtime': pre_stat.st_mtime},
-                             s3_info)
+            self._track_file(conn, path, local_info, s3_info)
+
+        if content_verified:
+            self._update_shadow(path)
 
         return True
 
@@ -667,11 +1067,20 @@ class S3SyncManager:
 
         # Update database with the downloaded file's actual stats
         stat = os.stat(local_path)
+        local_info = {'local_size': stat.st_size, 'local_mtime': stat.st_mtime}
+        s3_etag = s3_files[path].get('s3_etag') or ''
+        if self._should_hash(path, stat.st_size):
+            local_md5 = self._file_md5(local_path)
+            if self._etag_is_md5(s3_etag) and local_md5 != s3_etag:
+                print(f"  ❌ Content verification failed for {path}; "
+                      f"will retry on next sync")
+                return False
+            local_info['local_md5'] = local_md5
+
         with self._get_db() as conn:
-            self._track_file(conn, path,
-                             {'local_size': stat.st_size,
-                              'local_mtime': stat.st_mtime},
-                             s3_files[path])
+            self._track_file(conn, path, local_info, s3_files[path])
+
+        self._update_shadow(path)
 
         return True
 
@@ -689,6 +1098,7 @@ class S3SyncManager:
         # Remove from database
         with self._get_db() as conn:
             conn.execute('DELETE FROM files WHERE path = ?', (path,))
+        self._remove_shadow(path)
 
         return True
 
@@ -706,6 +1116,7 @@ class S3SyncManager:
         # Remove from database
         with self._get_db() as conn:
             conn.execute('DELETE FROM files WHERE path = ?', (path,))
+        self._remove_shadow(path)
 
         return True
 
@@ -911,16 +1322,31 @@ class S3SyncManager:
         fresh_s3 = self._fetch_s3_info(list(pre_stats), include_backups)
 
         success_count = 0
+        shadow_updates = []
         with self._get_db() as conn:
             for path, (size, mtime) in pre_stats.items():
                 s3_info = fresh_s3.get(path)
                 if not s3_info or s3_info['s3_size'] != size:
                     print(f"  ❌ Upload not verified for {path}; will retry on next sync")
                     continue
-                self._track_file(conn, path,
-                                 {'local_size': size, 'local_mtime': mtime},
-                                 s3_info)
+                local_info = {'local_size': size, 'local_mtime': mtime}
+                s3_etag = s3_info.get('s3_etag') or ''
+                if self._should_hash(path, size) and self._etag_is_md5(s3_etag):
+                    try:
+                        local_md5 = self._file_md5(os.path.join(self.local_dir, path))
+                    except OSError:
+                        local_md5 = None
+                    if local_md5 != s3_etag:
+                        print(f"  ❌ Content verification failed for {path} "
+                              f"(changed during upload?); will retry on next sync")
+                        continue
+                    local_info['local_md5'] = local_md5
+                    shadow_updates.append(path)
+                self._track_file(conn, path, local_info, s3_info)
                 success_count += 1
+
+        for path in shadow_updates:
+            self._update_shadow(path)
 
         print(f"  ✓ Uploaded {success_count}/{len(paths)} files")
         return success_count
@@ -941,6 +1367,7 @@ class S3SyncManager:
             return 0
 
         success_count = 0
+        shadow_updates = []
         with self._get_db() as conn:
             for path in paths:
                 local_path = os.path.join(self.local_dir, path)
@@ -952,11 +1379,26 @@ class S3SyncManager:
                 if stat.st_size != s3_files[path]['s3_size']:
                     print(f"  ❌ Size mismatch for {path}; will retry on next sync")
                     continue
-                self._track_file(conn, path,
-                                 {'local_size': stat.st_size,
-                                  'local_mtime': stat.st_mtime},
-                                 s3_files[path])
+                local_info = {'local_size': stat.st_size,
+                              'local_mtime': stat.st_mtime}
+                if self._should_hash(path, stat.st_size):
+                    try:
+                        local_md5 = self._file_md5(local_path)
+                    except OSError:
+                        local_md5 = None
+                    s3_etag = s3_files[path].get('s3_etag') or ''
+                    if local_md5 is None or (self._etag_is_md5(s3_etag) and
+                                             local_md5 != s3_etag):
+                        print(f"  ❌ Content verification failed for {path}; "
+                              f"will retry on next sync")
+                        continue
+                    local_info['local_md5'] = local_md5
+                    shadow_updates.append(path)
+                self._track_file(conn, path, local_info, s3_files[path])
                 success_count += 1
+
+        for path in shadow_updates:
+            self._update_shadow(path)
 
         print(f"  ✓ Downloaded {success_count}/{len(paths)} files")
         return success_count
@@ -979,13 +1421,18 @@ class S3SyncManager:
         fresh_s3 = self._fetch_s3_info(paths, include_backups)
 
         success_count = 0
+        deleted_paths = []
         with self._get_db() as conn:
             for path in paths:
                 if path in fresh_s3:
                     print(f"  ❌ {path} is still present on S3; will retry on next sync")
                     continue
                 conn.execute('DELETE FROM files WHERE path = ?', (path,))
+                deleted_paths.append(path)
                 success_count += 1
+
+        for path in deleted_paths:
+            self._remove_shadow(path)
 
         print(f"  ✓ Deleted {success_count}/{len(paths)} files from S3")
         return success_count
@@ -1033,7 +1480,7 @@ class S3SyncManager:
                 flagged.append((path, f"unreadable ({e})"))
         return flagged
 
-    def sync(self, dry_run=False, include_backups=False):
+    def sync(self, dry_run=False, include_backups=False, auto_merge=True):
         """Perform interactive sync operation"""
         if not include_backups:
             print("Note: Ignoring backups/ directories (use --sync-backups to include them)")
@@ -1049,7 +1496,7 @@ class S3SyncManager:
         local_files = self.scan_local_files(include_backups)
         s3_files = self.scan_s3_files(include_backups)
 
-        actions = self.analyze_changes(local_files, s3_files)
+        actions = self.analyze_changes(local_files, s3_files, record=not dry_run)
 
         # Self-heal tracking so a future local deletion of these files is
         # proposed as a remote delete rather than a re-download
@@ -1094,20 +1541,40 @@ class S3SyncManager:
                 print(f"\n⚠️  {len(invalid_uploads)} upload candidate(s) look invalid:")
                 for path, problem in invalid_uploads:
                     print(f"  {path}: {problem}")
+            if conflicts and auto_merge and fiber_merge is not None:
+                print("\nMerge preview for conflicts:")
+                for path, reason in conflicts:
+                    probe = self._attempt_auto_merge(path,
+                                                     local_files.get(path),
+                                                     s3_files.get(path),
+                                                     dry_run=True)
+                    print(f"  {path}: {probe or 'manual resolution required'}")
             self._print_sync_summary(uploads, downloads, deletes_local, deletes_remote,
                                      "Conflicts", len(conflicts))
             print("\n--dry-run mode: No changes will be made")
             return
 
-        # Process conflicts first
+        # Process conflicts first: auto-merge what we safely can, prompt for
+        # the rest
         resolved_actions = []
+        merged_count = 0
         for path, reason in conflicts:
             local_info = local_files.get(path)
             s3_info = s3_files.get(path)
 
+            if auto_merge and self._attempt_auto_merge(
+                    path, local_info, s3_info) == 'merged':
+                uploads.append((path, "Auto-merged local + remote changes"))
+                merged_count += 1
+                continue
+
             action = self.resolve_conflict(path, reason, local_info, s3_info)
             if action != SyncAction.SKIP:
                 resolved_actions.append((path, action))
+
+        if merged_count:
+            print(f"\n✓ Auto-merged {merged_count} conflicting file(s); "
+                  f"merged versions will be uploaded")
 
         # Let the user decide what to do with suspect upload candidates
         invalid_uploads += self._validate_upload_candidates(
@@ -1145,7 +1612,8 @@ class S3SyncManager:
         # The summary sits right next to the confirmation prompt: with a long
         # file list above, this is what makes the decision readable
         self._print_sync_summary(uploads, downloads, deletes_local, deletes_remote,
-                                 "Conflicts skipped", len(conflicts) - len(resolved_actions))
+                                 "Conflicts skipped",
+                                 len(conflicts) - len(resolved_actions) - merged_count)
 
         total_operations = (len(uploads) + len(downloads) +
                             len(deletes_local) + len(deletes_remote))
@@ -1158,6 +1626,14 @@ class S3SyncManager:
         # Perform operations
         print("\nSyncing...")
         success_count = 0
+
+        # Last line of defense before downloads overwrite local files: stash
+        # any local copy whose content diverges from its tracked state (or
+        # was never tracked). Conflict resolutions above stashed already —
+        # those arrive here with reason "Resolved conflict".
+        self._stash_divergent_download_targets(
+            [p for p, reason in downloads if reason != "Resolved conflict"],
+            local_files)
 
         # Process uploads and downloads
         if self.use_rclone:
@@ -1240,6 +1716,16 @@ class S3SyncManager:
         print(f"  Files to delete (S3): {action_counts.get(SyncAction.DELETE_REMOTE, 0)}")
         print(f"  Files to delete (local): {action_counts.get(SyncAction.DELETE_LOCAL, 0)}")
         print(f"  Conflicts:           {action_counts.get(SyncAction.CONFLICT, 0)}")
+        if action_counts.get(SyncAction.CONFLICT) and fiber_merge is not None:
+            # Cheap offline check: a conflict is a merge candidate when it is
+            # a hashed annotation file with a local merge base. Whether the
+            # merge actually succeeds is only known at sync time.
+            candidates = sum(
+                1 for path, (action, _) in actions.items()
+                if action == SyncAction.CONFLICT and
+                local_files.get(path, {}).get('local_md5') and
+                os.path.exists(self._shadow_path(path)))
+            print(f"    of which auto-merge candidates: {candidates}")
         print(f"  In sync:             {action_counts.get(SyncAction.SKIP, 0)}")
 
         if verbose:
@@ -1414,6 +1900,9 @@ def main():
     sync_parser.add_argument('directory', help='Local directory')
     sync_parser.add_argument('--dry-run', action='store_true', help='Show what would be synced without doing it')
     sync_parser.add_argument('--sync-backups', action='store_true', help='Include backups/ directories in sync')
+    sync_parser.add_argument('--no-auto-merge', action='store_true',
+                             help='Disable the fiber-aware three-way merge for '
+                                  'conflicting annotation files')
 
     # Update command
     update_parser = subparsers.add_parser(
@@ -1486,7 +1975,8 @@ def main():
             manager.show_status(args.verbose, args.sync_backups)
 
         elif args.command == 'sync':
-            manager.sync(args.dry_run, args.sync_backups)
+            manager.sync(args.dry_run, args.sync_backups,
+                         auto_merge=not args.no_auto_merge)
 
         elif args.command == 'update':
             manager.refresh_tracking(args.sync_backups)
@@ -1494,6 +1984,8 @@ def main():
         elif args.command == 'reset':
             print("Resetting sync tracking...")
             print("This will mark ALL current files as synced, discarding any pending differences.")
+            print("Files that currently differ between local and S3 will also lose their "
+                  "merge base until the next successful sync.")
             if not args.sync_backups:
                 print("Note: Excluding backups/ directories (use --sync-backups to include them)")
 

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -389,10 +389,7 @@ class S3SyncManager:
         except Exception:
             md5 = None
         finally:
-            try:
-                os.remove(tmp)
-            except OSError:
-                pass
+            self._remove_merge_tmp(tmp)
         self._remote_md5_cache[path] = md5
         return md5
 
@@ -489,6 +486,26 @@ class S3SyncManager:
         os.makedirs(os.path.dirname(tmp), exist_ok=True)
         return tmp
 
+    def _remove_merge_tmp(self, tmp):
+        """Remove a merge temp file and prune the now-empty mirrored
+        directories beneath .tmp/ so status/dry-run leave no residue."""
+        if not tmp:
+            return
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        tmp_root = os.path.join(self.local_dir, CONFLICT_DIR_NAME, '.tmp')
+        dirpath = os.path.dirname(tmp)
+        while dirpath.startswith(tmp_root + os.sep) or dirpath == tmp_root:
+            try:
+                os.rmdir(dirpath)
+            except OSError:
+                break
+            if dirpath == tmp_root:
+                break
+            dirpath = os.path.dirname(dirpath)
+
     def _load_base(self, path, tracked):
         """Return the parsed last-synced (base) version of a file, or None.
 
@@ -540,10 +557,7 @@ class S3SyncManager:
         except Exception:
             return None
         finally:
-            try:
-                os.remove(tmp)
-            except OSError:
-                pass
+            self._remove_merge_tmp(tmp)
 
     def _fetch_remote_json(self, path):
         """Fetch the current remote object. Returns (parsed_json, temp_path)
@@ -554,10 +568,7 @@ class S3SyncManager:
             with open(tmp) as f:
                 return json.load(f), tmp
         except Exception:
-            try:
-                os.remove(tmp)
-            except OSError:
-                pass
+            self._remove_merge_tmp(tmp)
             return None, None
 
     def _attempt_auto_merge(self, path, local_info, s3_info, dry_run=False):
@@ -643,11 +654,8 @@ class S3SyncManager:
             return {'pending': pending, 'remote_tmp': remote_tmp,
                     'summary': summary}
         finally:
-            if remote_tmp and not keep_remote_tmp:
-                try:
-                    os.remove(remote_tmp)
-                except OSError:
-                    pass
+            if not keep_remote_tmp:
+                self._remove_merge_tmp(remote_tmp)
 
     def _apply_pending_merges(self, pending_merges):
         """Apply confirmed merges: stash the versions being replaced, then
@@ -658,21 +666,12 @@ class S3SyncManager:
                 self._stash_conflict_copy(path, 'remote', source=plan['remote_tmp'])
             os.replace(plan['pending'], os.path.join(self.local_dir, path))
             print(f"  ✓ applied auto-merge: {path}")
-            if plan['remote_tmp']:
-                try:
-                    os.remove(plan['remote_tmp'])
-                except OSError:
-                    pass
+            self._remove_merge_tmp(plan['remote_tmp'])
 
-    @staticmethod
-    def _discard_pending_merges(pending_merges):
+    def _discard_pending_merges(self, pending_merges):
         for _, plan in pending_merges:
-            for temp in (plan['pending'], plan['remote_tmp']):
-                if temp:
-                    try:
-                        os.remove(temp)
-                    except OSError:
-                        pass
+            self._remove_merge_tmp(plan['pending'])
+            self._remove_merge_tmp(plan['remote_tmp'])
 
     def scan_local_files(self, include_backups=False):
         """Scan local directory for files"""
@@ -817,9 +816,70 @@ class S3SyncManager:
         s3_files = self.scan_s3_files(include_backups)
 
         self._record_untracked_synced(local_files, s3_files)
+        self._seed_tracked_shadows(local_files, s3_files)
         self._prune_stale_tracking(set(local_files) | set(s3_files), include_backups)
 
         print("File tracking refreshed")
+
+    def _seed_tracked_shadows(self, local_files, s3_files):
+        """Backfill md5 tracking and shadow merge bases for already-tracked,
+        verifiably in-sync annotation files.
+
+        This is the upgrade path: rows created before content hashing have
+        no md5 and no shadow, and _record_untracked_synced deliberately
+        skips tracked paths — without this, such files would have no merge
+        base until their next real transfer.
+        """
+        with self._get_db() as conn:
+            cursor = conn.execute('SELECT * FROM files')
+            tracked_rows = {row['path']: dict(row) for row in cursor}
+
+        seeded = 0
+        md5_updates = []
+        for path, tracked in tracked_rows.items():
+            local_info = local_files.get(path)
+            s3_info = s3_files.get(path)
+            if not local_info or not s3_info:
+                continue
+            current_md5 = local_info.get('local_md5')
+            if not current_md5:
+                continue  # not hash-scoped
+            if tracked.get('local_md5') and os.path.exists(self._shadow_path(path)):
+                continue  # already seeded
+
+            # Only seed files with no pending change on either side: the
+            # local file must match its tracked state and the remote object
+            # its tracked ETag/size, and both contents must verifiably agree.
+            local_unchanged = (
+                (tracked.get('local_md5') == current_md5) or
+                (not tracked.get('local_md5') and
+                 tracked.get('local_size') == local_info['local_size'] and
+                 tracked.get('local_mtime') is not None and
+                 abs(tracked['local_mtime'] - local_info['local_mtime']) <= 1))
+            remote_unchanged = (
+                tracked.get('s3_size') == s3_info['s3_size'] and
+                tracked.get('s3_etag') == s3_info.get('s3_etag'))
+            if not (local_unchanged and remote_unchanged):
+                continue
+
+            etag = s3_info.get('s3_etag') or ''
+            if self._etag_is_md5(etag) and current_md5 == etag:
+                verified = True
+            else:
+                verified = self._remote_md5(path) == current_md5
+            if not verified:
+                continue
+
+            md5_updates.append((current_md5, path))
+            self._update_shadow(path)
+            seeded += 1
+
+        if md5_updates:
+            with self._get_db() as conn:
+                conn.executemany('UPDATE files SET local_md5 = ? WHERE path = ?',
+                                 md5_updates)
+        if seeded:
+            print(f"Seeded merge bases for {seeded} tracked in-sync file(s)")
 
     def reset_tracking(self, include_backups=False):
         """Stamp the current local and S3 state as the synced baseline.

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -162,6 +162,10 @@ class S3SyncManager:
 
         self.use_rclone = self._detect_rclone()
 
+        # Per-run cache of remote content hashes (path -> md5 or None),
+        # used when an ETag cannot prove content equality.
+        self._remote_md5_cache = {}
+
     def _detect_rclone(self):
         """Use rclone only if the binary exists AND can read the sync directory.
 
@@ -361,8 +365,35 @@ class S3SyncManager:
 
     @staticmethod
     def _etag_is_md5(etag):
-        """True when an S3 ETag is a plain MD5 (single-part, non-KMS upload)."""
+        """True when an S3 ETag has plain-MD5 shape (single-part upload).
+
+        Shape alone is not proof of content MD5 (SSE-KMS/SSE-C ETags are
+        also 32-hex but opaque), so callers may use a matching ETag as
+        POSITIVE evidence of equality only — never a mismatch as proof of
+        difference."""
         return bool(etag) and '-' not in etag
+
+    def _remote_md5(self, path):
+        """Definitive remote content hash: download the object to a temp
+        file and hash it. Cached per run; returns None when the fetch
+        fails. Only used for hash-scoped (annotation-sized JSON) files
+        whose ETag cannot prove equality."""
+        if path in self._remote_md5_cache:
+            return self._remote_md5_cache[path]
+        tmp = self._merge_tmp_path(path, '.hashcheck')
+        md5 = None
+        try:
+            self._run_aws_command(['aws', 's3', 'cp', self._get_s3_url(path), tmp])
+            md5 = self._file_md5(tmp)
+        except Exception:
+            md5 = None
+        finally:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+        self._remote_md5_cache[path] = md5
+        return md5
 
     # --- shadow copies: the file content as of the last successful sync ---
     # These are the base versions for three-way merging of divergent
@@ -527,11 +558,15 @@ class S3SyncManager:
     def _attempt_auto_merge(self, path, local_info, s3_info, dry_run=False):
         """Try a fiber-aware three-way merge for a conflicting file.
 
-        Returns 'merged' after writing a clean merge to the local file (the
-        caller uploads it), a preview string in dry-run mode, or None when
-        the file is not eligible, no base is available, or the merge has
-        genuine conflicts (pre-merge copies are stashed in that case and
-        the caller falls back to the interactive prompt).
+        The local file is NEVER modified here: a clean merge is written to
+        a pending temp file and returned as
+        {'pending': ..., 'remote_tmp': ..., 'summary': ...} for the caller
+        to apply with _apply_pending_merges() AFTER the user confirms the
+        sync (or discard with _discard_pending_merges() on cancellation).
+        Returns a preview string in dry-run mode, or None when the file is
+        not eligible, no base is available, or the merge has genuine
+        conflicts (all three versions are stashed in that case and the
+        caller falls back to the interactive prompt).
         """
         if fiber_merge is None or not local_info or not s3_info:
             return None
@@ -565,8 +600,15 @@ class S3SyncManager:
                     pass
             return None
 
+        keep_remote_tmp = False
         try:
-            result = fiber_merge.merge_fibers(base_doc, local_doc, remote_doc)
+            # A merger bug on malformed input must degrade to manual
+            # resolution, never abort the whole sync.
+            try:
+                result = fiber_merge.merge_fibers(base_doc, local_doc, remote_doc)
+            except Exception as ex:
+                print(f"  ⚠️  merge failed for {path} ({ex}); manual resolution")
+                return None
             summary = fiber_merge.summarize(result)
             if dry_run:
                 return f"would auto-merge ({summary})" if result['ok'] else None
@@ -583,23 +625,49 @@ class S3SyncManager:
                     self._stash_conflict_copy(path, 'base', source=shadow)
                 return None
 
-            self._stash_conflict_copy(path, 'local')
-            self._stash_conflict_copy(path, 'remote', source=remote_tmp)
-            tmp = local_path + '.merge-tmp'
-            with open(tmp, 'w') as f:
+            # Plan only: the local file is untouched until the user confirms
+            pending = self._merge_tmp_path(path, '.merged')
+            with open(pending, 'w') as f:
                 json.dump(result['merged'], f, indent=2)
                 f.write('\n')
-            os.replace(tmp, local_path)
-            print(f"  ✓ auto-merged {path}: {summary}")
+            print(f"  ✓ will auto-merge {path}: {summary}")
             for note in result['notes']:
                 print(f"      note: {note}")
-            return 'merged'
+            print("      (applied after you confirm the sync)")
+            keep_remote_tmp = True
+            return {'pending': pending, 'remote_tmp': remote_tmp,
+                    'summary': summary}
         finally:
-            if remote_tmp:
+            if remote_tmp and not keep_remote_tmp:
                 try:
                     os.remove(remote_tmp)
                 except OSError:
                     pass
+
+    def _apply_pending_merges(self, pending_merges):
+        """Apply confirmed merges: stash the versions being replaced, then
+        atomically swap the merged result into place."""
+        for path, plan in pending_merges:
+            self._stash_conflict_copy(path, 'local')
+            if plan['remote_tmp']:
+                self._stash_conflict_copy(path, 'remote', source=plan['remote_tmp'])
+            os.replace(plan['pending'], os.path.join(self.local_dir, path))
+            print(f"  ✓ applied auto-merge: {path}")
+            if plan['remote_tmp']:
+                try:
+                    os.remove(plan['remote_tmp'])
+                except OSError:
+                    pass
+
+    @staticmethod
+    def _discard_pending_merges(pending_merges):
+        for _, plan in pending_merges:
+            for temp in (plan['pending'], plan['remote_tmp']):
+                if temp:
+                    try:
+                        os.remove(temp)
+                    except OSError:
+                        pass
 
     def scan_local_files(self, include_backups=False):
         """Scan local directory for files"""
@@ -892,14 +960,26 @@ class S3SyncManager:
                     # No tracking history
                     if local_info['local_size'] != s3_info['s3_size']:
                         actions[path] = (SyncAction.CONFLICT, "Files differ (no sync history)")
-                    elif (current_md5 and self._etag_is_md5(s3_etag) and
-                          current_md5 != s3_etag):
-                        # Same size but different bytes: without this check a
-                        # divergent same-size file is silently declared synced
-                        actions[path] = (SyncAction.CONFLICT,
-                                         "Same size but different content (no sync history)")
-                    else:
+                    elif not current_md5:
                         actions[path] = (SyncAction.SKIP, "Files appear to be in sync")
+                    elif self._etag_is_md5(s3_etag) and current_md5 == s3_etag:
+                        actions[path] = (SyncAction.SKIP,
+                                         "Files verified identical (no sync history)")
+                    else:
+                        # The ETag cannot prove equality (mismatch, or an
+                        # opaque multipart/KMS ETag). For annotation files,
+                        # "unknown" must not silently become "in sync":
+                        # settle it by hashing the actual remote content.
+                        remote_md5 = self._remote_md5(path)
+                        if remote_md5 == current_md5:
+                            actions[path] = (SyncAction.SKIP,
+                                             "Files verified identical (no sync history)")
+                        elif remote_md5 is None:
+                            actions[path] = (SyncAction.CONFLICT,
+                                             "Content could not be verified (no sync history)")
+                        else:
+                            actions[path] = (SyncAction.CONFLICT,
+                                             "Same size but different content (no sync history)")
 
             # File deleted from both
             elif path in tracked_files and not local_info and not s3_info:
@@ -931,29 +1011,30 @@ class S3SyncManager:
             # Backup-pattern files are excluded: they are upload-only, and
             # analyze_changes deliberately re-uploads them when untracked
             # (even on a size match). The upload itself records tracking.
-            # Hashable files must additionally match content (md5 vs a
-            # plain-MD5 ETag) — a same-size divergent file is a conflict,
-            # not an in-sync pair.
-            def content_compatible(path):
+            # Hashable files must additionally be verified identical — by a
+            # matching plain-MD5 ETag, or by hashing the remote content
+            # when the ETag proves nothing. Unverified pairs stay untracked
+            # rather than becoming a false baseline.
+            def content_verified(path):
                 md5 = local_files[path].get('local_md5')
+                if not md5:
+                    return True  # not hash-scoped: size heuristic as before
                 etag = s3_files[path].get('s3_etag') or ''
-                if md5 and self._etag_is_md5(etag):
-                    return md5 == etag
-                return True
+                if self._etag_is_md5(etag) and md5 == etag:
+                    return True
+                return self._remote_md5(path) == md5
 
             healed = [path for path in local_files.keys() & s3_files.keys()
                       if path not in tracked and
                       not local_files[path].get('is_backup') and
                       local_files[path]['local_size'] == s3_files[path]['s3_size'] and
-                      content_compatible(path)]
+                      content_verified(path)]
 
             for path in healed:
                 self._track_file(conn, path, local_files[path], s3_files[path])
 
         for path in healed:
-            md5 = local_files[path].get('local_md5')
-            etag = s3_files[path].get('s3_etag') or ''
-            if md5 and self._etag_is_md5(etag) and md5 == etag:
+            if local_files[path].get('local_md5'):
                 # Content-verified identical: safe to adopt as a merge base
                 self._update_shadow(path)
 
@@ -1027,25 +1108,21 @@ class S3SyncManager:
         }
 
         # Track the pre-upload stats: if the file changed during upload, the next
-        # scan will see a local difference and schedule a re-upload
+        # scan will see a local difference and schedule a re-upload.
+        # The ETag is only positive evidence of content (SSE-KMS ETags are
+        # opaque); a mismatch is never treated as a failed transfer — the
+        # CLI already checksums the transfer itself.
         local_info = {'local_size': pre_stat.st_size,
                       'local_mtime': pre_stat.st_mtime}
-        content_verified = False
-        if self._should_hash(path, pre_stat.st_size) and \
-                self._etag_is_md5(s3_info['s3_etag']):
-            local_md5 = self._file_md5(local_path)
-            if local_md5 == s3_info['s3_etag']:
-                local_info['local_md5'] = local_md5
-                content_verified = True
-            else:
-                print(f"  ⚠️  Content verification failed for {path} "
-                      f"(changed during upload?); will retry on next sync")
-                return False
+        stable = (post_stat.st_size, post_stat.st_mtime) == \
+                 (pre_stat.st_size, pre_stat.st_mtime)
+        if self._should_hash(path, pre_stat.st_size) and stable:
+            local_info['local_md5'] = self._file_md5(local_path)
 
         with self._get_db() as conn:
             self._track_file(conn, path, local_info, s3_info)
 
-        if content_verified:
+        if 'local_md5' in local_info:
             self._update_shadow(path)
 
         return True
@@ -1065,17 +1142,14 @@ class S3SyncManager:
 
         print(f"  ✓ Downloaded: {path}")
 
-        # Update database with the downloaded file's actual stats
+        # Update database with the downloaded file's actual stats. The file
+        # just written IS the synced content (the CLI checksums transfers),
+        # so its own hash is the tracking/base truth; the ETag is not
+        # consulted (it is opaque for SSE-KMS objects).
         stat = os.stat(local_path)
         local_info = {'local_size': stat.st_size, 'local_mtime': stat.st_mtime}
-        s3_etag = s3_files[path].get('s3_etag') or ''
         if self._should_hash(path, stat.st_size):
-            local_md5 = self._file_md5(local_path)
-            if self._etag_is_md5(s3_etag) and local_md5 != s3_etag:
-                print(f"  ❌ Content verification failed for {path}; "
-                      f"will retry on next sync")
-                return False
-            local_info['local_md5'] = local_md5
+            local_info['local_md5'] = self._file_md5(local_path)
 
         with self._get_db() as conn:
             self._track_file(conn, path, local_info, s3_files[path])
@@ -1330,18 +1404,20 @@ class S3SyncManager:
                     print(f"  ❌ Upload not verified for {path}; will retry on next sync")
                     continue
                 local_info = {'local_size': size, 'local_mtime': mtime}
-                s3_etag = s3_info.get('s3_etag') or ''
-                if self._should_hash(path, size) and self._etag_is_md5(s3_etag):
+                if self._should_hash(path, size):
+                    # Record the content hash only when the file was stable
+                    # through the upload, so the tracked hash matches what
+                    # actually reached S3. ETags are not consulted (opaque
+                    # under SSE-KMS); the CLI checksums the transfer.
                     try:
-                        local_md5 = self._file_md5(os.path.join(self.local_dir, path))
+                        stat = os.stat(os.path.join(self.local_dir, path))
+                        stable = (stat.st_size, stat.st_mtime) == (size, mtime)
+                        if stable:
+                            local_info['local_md5'] = self._file_md5(
+                                os.path.join(self.local_dir, path))
+                            shadow_updates.append(path)
                     except OSError:
-                        local_md5 = None
-                    if local_md5 != s3_etag:
-                        print(f"  ❌ Content verification failed for {path} "
-                              f"(changed during upload?); will retry on next sync")
-                        continue
-                    local_info['local_md5'] = local_md5
-                    shadow_updates.append(path)
+                        pass
                 self._track_file(conn, path, local_info, s3_info)
                 success_count += 1
 
@@ -1382,18 +1458,13 @@ class S3SyncManager:
                 local_info = {'local_size': stat.st_size,
                               'local_mtime': stat.st_mtime}
                 if self._should_hash(path, stat.st_size):
+                    # The downloaded bytes are the synced content; hash them
+                    # for tracking/base truth. ETags are not consulted.
                     try:
-                        local_md5 = self._file_md5(local_path)
+                        local_info['local_md5'] = self._file_md5(local_path)
+                        shadow_updates.append(path)
                     except OSError:
-                        local_md5 = None
-                    s3_etag = s3_files[path].get('s3_etag') or ''
-                    if local_md5 is None or (self._etag_is_md5(s3_etag) and
-                                             local_md5 != s3_etag):
-                        print(f"  ❌ Content verification failed for {path}; "
-                              f"will retry on next sync")
-                        continue
-                    local_info['local_md5'] = local_md5
-                    shadow_updates.append(path)
+                        pass
                 self._track_file(conn, path, local_info, s3_files[path])
                 success_count += 1
 
@@ -1554,27 +1625,29 @@ class S3SyncManager:
             print("\n--dry-run mode: No changes will be made")
             return
 
-        # Process conflicts first: auto-merge what we safely can, prompt for
-        # the rest
+        # Process conflicts first: plan auto-merges for what we safely can,
+        # prompt for the rest. Merges are only applied after confirmation.
         resolved_actions = []
-        merged_count = 0
+        pending_merges = []
         for path, reason in conflicts:
             local_info = local_files.get(path)
             s3_info = s3_files.get(path)
 
-            if auto_merge and self._attempt_auto_merge(
-                    path, local_info, s3_info) == 'merged':
-                uploads.append((path, "Auto-merged local + remote changes"))
-                merged_count += 1
-                continue
+            if auto_merge:
+                plan = self._attempt_auto_merge(path, local_info, s3_info)
+                if isinstance(plan, dict):
+                    pending_merges.append((path, plan))
+                    uploads.append((path, "Auto-merged local + remote changes"))
+                    continue
 
             action = self.resolve_conflict(path, reason, local_info, s3_info)
             if action != SyncAction.SKIP:
                 resolved_actions.append((path, action))
 
+        merged_count = len(pending_merges)
         if merged_count:
-            print(f"\n✓ Auto-merged {merged_count} conflicting file(s); "
-                  f"merged versions will be uploaded")
+            print(f"\n✓ {merged_count} conflicting file(s) will be auto-merged "
+                  f"and uploaded after confirmation")
 
         # Let the user decide what to do with suspect upload candidates
         invalid_uploads += self._validate_upload_candidates(
@@ -1620,12 +1693,17 @@ class S3SyncManager:
 
         print(f"\n{total_operations} operations will be performed.")
         if not confirm("Continue? [y/N]: "):
-            print("Sync cancelled.")
+            self._discard_pending_merges(pending_merges)
+            print("Sync cancelled. No files were modified.")
             return
 
         # Perform operations
         print("\nSyncing...")
         success_count = 0
+
+        # Confirmed: swap the planned merge results into place (stashing the
+        # pre-merge local and remote versions first)
+        self._apply_pending_merges(pending_merges)
 
         # Last line of defense before downloads overwrite local files: stash
         # any local copy whose content diverges from its tracked state (or


### PR DESCRIPTION
Multiple annotators now link fibers across machines and locations, and a last-writer-wins sync recently clobbered a fiber file (`kb_..._000141.json`): a divergent copy overwrote the newer one, erasing reciprocal link entries and shifting control-point indices. VC3D's loader then amplified the damage — parse-time checks silently deleted branches (and rewrote files on mere load), and the strict validator removed whole fibers, cascading until 7 fibers vanished from the session.

This PR attacks both halves: make the sync detect and resolve divergence instead of silently overwriting, and make VC3D loading degrade gracefully instead of destroying data. Two commits, independently reviewable.

## Commit 1 — vc_sync: detection, safety copies, fiber-aware 3-way merge

All scoped to `*.json` under 16 MB (`_should_hash`); volumes and other bulk data keep the existing size/mtime behavior byte-for-byte.

**Content-aware change detection**
- `.s3sync.db` gains a `local_md5` column (lazy `ALTER TABLE`; old DBs upgrade in place, backfill happens opportunistically).
- Touch/re-save with identical bytes is no longer a change; an mtime-preserving edit is; both-changed-but-identical converges to SKIP; and **untracked same-size divergent files now CONFLICT** instead of being silently declared in sync (one of the silent-clobber paths behind the incident).
- Transfer verification upgraded from size-only to md5-vs-ETag where the ETag is a plain MD5 (multipart/SSE-KMS ETags safely degrade to today's checks).

**Nothing is ever silently lost**
- `.s3sync-base/` keeps each annotation file's last-synced content — the merge base. Seeded by every verified transfer (run `update` once while in sync to backfill); `reset` deletes bases it can't verify so they can't poison merges.
- `.s3sync-conflicts/` receives timestamped copies before any overwrite of divergent content: the losing side of an interactive resolution, a divergent local file before a download, and every pre-merge input. Both dirs are dot-prefixed, which the existing ignore rules already exclude from syncing (locked in by tests).

**Three-way merge (`fiber_merge.py`, pure functions, no I/O)**
Auto-applied in the sync conflicts loop when both sides changed a `vc3d_fiber` file:
- `control_points`: diff3 with **position-based alignment** against the base — index shifts from insertions/deletions are invisible; regions edited on one side merge; only the same points edited differently on both sides conflict.
- `branches[]` (cross-fiber links): set semantics — additions from both sides survive (the incident case), base-aware deletions, approvals beat both pending and deletion.
- `line_points`: taken from the geometry-owning side, or spliced at anchor control points; if splicing isn't safe, the local line is kept and tagged `needs_reoptimization` for VC3D to re-fit (the optimizer needs the volume and can't run here).
- `tags` merge base-aware; `generation = max + 1`.
- Base comes from the shadow copy (md5-verified) or, for conflicts predating the shadow dir, from **S3 version history** by the tracked ETag.
- Clean merges upload through the normal path; genuine conflicts stash local+remote+base and fall back to the existing `[l]/[r]/[s]` prompt — the merge never guesses.
- `sync --dry-run` prints a per-conflict merge preview; `--no-auto-merge` disables; `status` counts merge candidates; a missing `fiber_merge.py` degrades gracefully to manual conflicts.

## Commit 2 — VC3D: non-destructive fiber loading

- `loadFiberJson` preserves structurally unparseable branch entries verbatim (re-emitted on save) — loading can never drop data — and no longer does semantic checks.
- New `resolveLoadedFiberLinks` (replaces `collectLoadedFiberBranchIssues` / `validateLoadedFiberLinks` / load-path repair): re-resolves link endpoints **by stored position** (an index shifted by an external edit heals silently, using the same `matchingStoredControlPointIndex` logic the live-edit paths already use), refreshes endpoint directions from current line tangents (re-optimization drift is not an error), and checks reciprocity by position. Unresolvable links are **quarantined**: kept on disk exactly as loaded, excluded from the link graph/sessions/link editing, shown as `(!N)` in the fiber panel's Link column. No cascade; loading performs **zero writes**.
- The "Broken branch links" repair-or-strict prompt becomes an informational "Quarantined branch links" dialog; its explicit **Repair now** button is the only path that removes quarantined entries (honors the Agent Bridge `_errorDialogsSuppressed` mode by defaulting to keep-quarantined).
- Save paths re-attach quarantined branches and unparsed entries so a legitimate save can't drop what the loader preserved.

Replayed against the incident: the index shifts self-heal silently and exactly one genuinely-broken link gets flagged — instead of 7 fibers disappearing and files being rewritten on load.

## Testing

- `pytest scripts/tests/` — **57 passed**: 21 merge-algorithm tests (incl. the incident as a fixture: base {L1}, local +L2, remote +L3 → all three survive with re-resolved indices; overlap/delete-vs-modify/same-end-extension conflicts; pending→approved precedence; splice paths; tolerance bounds) + analyze_changes hash matrix, shadow/stash behavior, and `_attempt_auto_merge` integration with a stubbed remote.
- C++ suite: **113/113 pass** after rebasing onto the Agent Bridge changes; VC3D builds clean.
- Manually verified earlier on the real PHercParis4 fiber set that the loader repairs the incident files by position with no dialog and no disk writes.

Deliberately **not** in this PR (designed, documented for later): the in-app save-time staleness guard — a stale open VC3D session can still overwrite a synced file; the sync-side conflict copies are the safety net for that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)