### PR TITLE
vc3d-agent-bridge-mcp: add segment attachment and fix overlay synchronization

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -2724,12 +2724,6 @@ CWindow::CWindow(size_t cacheSizeGB, RenderBenchOptions benchOptions) :
                     showStatusBarMessage(message, timeout);
                 }
             });
-    connect(_state, &CState::volumeChanged, _volumeOverlay.get(),
-            [this](const std::shared_ptr<Volume>&, const std::string&) {
-                if (_volumeOverlay && activeWorkspaceViewerManager() == _viewerManager.get()) {
-                    _volumeOverlay->refreshForCurrentVolume();
-                }
-            });
     _viewerManager->setVolumeOverlay(_volumeOverlay.get());
 
     if (_statusDockPanelHost) {

--- a/volume-cartographer/apps/VC3D/ViewerManager.cpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.cpp
@@ -225,6 +225,10 @@ ViewerManager::ViewerManager(CState* state,
 
     if (_state) {
         connect(_state,
+                &CState::volumeChanged,
+                this,
+                &ViewerManager::currentVolumeChanged);
+        connect(_state,
                 &CState::surfaceChanged,
                 this,
                 &ViewerManager::handleSurfaceChanged);

--- a/volume-cartographer/apps/VC3D/ViewerManager.hpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.hpp
@@ -229,6 +229,7 @@ public:
 signals:
     void baseViewerCreated(VolumeViewerBase* viewer);
     void baseViewerClosing(VolumeViewerBase* viewer);
+    void currentVolumeChanged();
     // Emitted whenever the user explicitly places the focus (Ctrl+click,
     // focus-on-cursor key, point activation, ...).
     void focusCenteredByUser(const cv::Vec3f& position);

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
@@ -34,6 +34,7 @@
 #include "vc/core/types/Segmentation.hpp"
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/types/VolumePkg.hpp"
+#include "vc/core/util/Logging.hpp"
 #include "vc/ui/VCCollection.hpp"
 
 QJsonObject AgentBridgeServer::handlePing(const QJsonValue&)
@@ -349,13 +350,10 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
     for (const QJsonValue& tag : tagValues)
         tags.push_back(tag.toString().toStdString());
 
-    bool attached = false;
+    VolumePkg::AttachSegmentsResult attachResult;
     try {
-        attached = vpkg->attachSegmentsEntry(
-                       normalizedLocation, std::move(tags), select) ==
-                   VolumePkg::AttachSegmentsResult::Attached;
-        if (reloadSurfaces)
-            _window->refreshCurrentVolumePackageUi(QString(), true);
+        attachResult = vpkg->attachSegmentsEntry(
+            normalizedLocation, std::move(tags), select);
     } catch (const std::exception& error) {
         throw AgentBridgeError{
             -32005,
@@ -364,6 +362,23 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
         };
     }
 
+    if (reloadSurfaces) {
+        try {
+            _window->refreshCurrentVolumePackageUi(QString(), true);
+        } catch (const std::exception& error) {
+            Logger()->warn(
+                "Segment attachment committed, but the VC3D UI could not "
+                "refresh: {}",
+                error.what());
+        } catch (...) {
+            Logger()->warn(
+                "Segment attachment committed, but the VC3D UI could not "
+                "refresh");
+        }
+    }
+
+    const bool attached =
+        attachResult == VolumePkg::AttachSegmentsResult::Attached;
     return resultFor(attached, persistedLocation);
 }
 

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
@@ -225,6 +225,106 @@ QJsonObject AgentBridgeServer::handleStateGet(const QJsonValue&)
 }
 
 
+QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
+{
+    namespace fs = std::filesystem;
+
+    CState* state = _window ? _window->_state : nullptr;
+    std::shared_ptr<VolumePkg> vpkg = state ? state->vpkg() : nullptr;
+    if (!state || !state->hasVpkg() || !vpkg)
+        throw AgentBridgeError{-32000, "No volume package loaded", {}};
+
+    const QJsonObject p = params.toObject();
+    const QString location = p.value("location").toString();
+    if (location.trimmed().isEmpty()) {
+        throw AgentBridgeError{
+            -32602,
+            "location must not be blank",
+            QJsonObject{{"param", "location"}},
+        };
+    }
+
+    const std::string input = location.toStdString();
+    if (vc::project::isLocationRemote(input)) {
+        throw AgentBridgeError{
+            -32007,
+            "Invalid segments location",
+            QJsonObject{
+                {"kind", "segment"},
+                {"detail", "remote segment locations are not supported"},
+            },
+        };
+    }
+
+    const fs::path localPath =
+        vc::project::resolveLocalPath(input).lexically_normal();
+    if (!localPath.is_absolute()) {
+        throw AgentBridgeError{
+            -32602,
+            "segment path must be absolute",
+            QJsonObject{{"param", "location"}},
+        };
+    }
+    const std::string normalizedLocation = localPath.string();
+
+    const std::string validationError = vc::project::validateLocation(
+        vc::project::Category::Segments, normalizedLocation);
+    if (!validationError.empty()) {
+        throw AgentBridgeError{
+            -32007,
+            "Invalid segments location",
+            QJsonObject{
+                {"kind", "segment"},
+                {"detail", QString::fromStdString(validationError)},
+            },
+        };
+    }
+
+    auto resultFor = [&](bool attached, const std::string& persistedLocation) {
+        return QJsonObject{
+            {"attached", attached},
+            {"alreadyAttached", !attached},
+            {"location", QString::fromStdString(persistedLocation)},
+            {"projectPath", QString::fromStdString(vpkg->path().string())},
+        };
+    };
+
+    if (const auto existing = vpkg->matchingSegmentsEntry(normalizedLocation))
+        return resultFor(false, existing->location);
+
+    std::vector<std::string> tags;
+    const QJsonArray tagValues = p.value("tags").toArray();
+    tags.reserve(tagValues.size());
+    for (const QJsonValue& tag : tagValues)
+        tags.push_back(tag.toString().toStdString());
+
+    try {
+        if (!vpkg->addSegmentsEntry(normalizedLocation, std::move(tags))) {
+            if (const auto existing =
+                    vpkg->matchingSegmentsEntry(normalizedLocation)) {
+                return resultFor(false, existing->location);
+            }
+            throw AgentBridgeError{
+                -32010,
+                "Could not attach segments",
+                QJsonObject{},
+            };
+        }
+        _window->refreshCurrentVolumePackageUi(QString(), true);
+    } catch (const AgentBridgeError&) {
+        throw;
+    } catch (const std::exception& error) {
+        throw AgentBridgeError{
+            -32005,
+            "Could not attach segments",
+            QJsonObject{{"detail", QString::fromUtf8(error.what())}},
+        };
+    }
+
+    return resultFor(true, normalizedLocation);
+}
+
+
 QJsonObject AgentBridgeServer::handleSegmentsList(const QJsonValue& params)
 {
     CState* state = _window ? _window->_state : nullptr;

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
@@ -310,22 +310,26 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
         vpkg->matchingSegmentsEntry(normalizedLocation);
     const std::string persistedLocation =
         existing ? existing->location : normalizedLocation;
-    if (!existing) {
-        const std::string sourceName = localPath.filename().string();
-        for (const auto& entry : vpkg->segmentEntries()) {
-            const fs::path entryPath = vc::project::resolveLocalPath(
-                entry.location, vpkg->path().parent_path()).lexically_normal();
-            if (entryPath.filename() == localPath.filename()) {
-                throw AgentBridgeError{
-                    -32010,
-                    "A segment source with the same directory name is already attached",
-                    QJsonObject{
-                        {"sourceName", QString::fromStdString(sourceName)},
-                        {"existingLocation",
-                         QString::fromStdString(entry.location)},
-                    },
-                };
+    const std::string sourceName = localPath.filename().string();
+    auto sourceNameConflictError =
+        [&](const vc::project::Entry* conflict) {
+            QJsonObject data{
+                {"sourceName", QString::fromStdString(sourceName)},
+            };
+            if (conflict) {
+                data["existingLocation"] =
+                    QString::fromStdString(conflict->location);
             }
+            return AgentBridgeError{
+                -32010,
+                "A segment source with the same directory name is already attached",
+                data,
+            };
+        };
+    if (!existing) {
+        if (const auto conflict =
+                vpkg->matchingSegmentsEntryByDirectoryName(sourceName)) {
+            throw sourceNameConflictError(&*conflict);
         }
     }
 
@@ -360,6 +364,10 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
             "Could not attach segments",
             QJsonObject{{"detail", QString::fromUtf8(error.what())}},
         };
+    }
+    if (attachResult ==
+        VolumePkg::AttachSegmentsResult::SourceNameConflict) {
+        throw sourceNameConflictError(nullptr);
     }
 
     if (reloadSurfaces) {

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
@@ -256,8 +256,10 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
         };
     }
 
-    const fs::path localPath =
+    fs::path localPath =
         vc::project::resolveLocalPath(input).lexically_normal();
+    while (localPath.has_relative_path() && localPath.filename().empty())
+        localPath = localPath.parent_path();
     if (!localPath.is_absolute()) {
         throw AgentBridgeError{
             -32602,

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
@@ -280,17 +280,66 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
         };
     }
 
+    const bool select = p.value("select").toBool(true);
+    auto sourceIsSelected = [&](const std::string& persistedLocation) {
+        const fs::path selected =
+            vpkg->outputSegmentsPath().lexically_normal();
+        const fs::path source = vc::project::resolveLocalPath(
+            persistedLocation, vpkg->path().parent_path()).lexically_normal();
+        if (selected.empty())
+            return false;
+        std::error_code ec;
+        if (fs::equivalent(selected, source, ec))
+            return true;
+        return selected == source;
+    };
     auto resultFor = [&](bool attached, const std::string& persistedLocation) {
         return QJsonObject{
             {"attached", attached},
             {"alreadyAttached", !attached},
             {"location", QString::fromStdString(persistedLocation)},
             {"projectPath", QString::fromStdString(vpkg->path().string())},
+            {"selected", sourceIsSelected(persistedLocation)},
         };
     };
 
-    if (const auto existing = vpkg->matchingSegmentsEntry(normalizedLocation))
-        return resultFor(false, existing->location);
+    const auto existing =
+        vpkg->matchingSegmentsEntry(normalizedLocation);
+    const std::string persistedLocation =
+        existing ? existing->location : normalizedLocation;
+    if (!existing) {
+        const std::string sourceName = localPath.filename().string();
+        for (const auto& entry : vpkg->segmentEntries()) {
+            const fs::path entryPath = vc::project::resolveLocalPath(
+                entry.location, vpkg->path().parent_path()).lexically_normal();
+            if (entryPath.filename() == localPath.filename()) {
+                throw AgentBridgeError{
+                    -32010,
+                    "A segment source with the same directory name is already attached",
+                    QJsonObject{
+                        {"sourceName", QString::fromStdString(sourceName)},
+                        {"existingLocation",
+                         QString::fromStdString(entry.location)},
+                    },
+                };
+            }
+        }
+    }
+
+    const bool selectionChanged =
+        select && !sourceIsSelected(persistedLocation);
+    const bool reloadSurfaces = !existing || selectionChanged;
+    if (reloadSurfaces && _window->_segmentationWidget &&
+        _window->_segmentationWidget->isEditingEnabled()) {
+        throw AgentBridgeError{
+            -32004,
+            "Cannot attach segments while editing",
+            QJsonObject{
+                {"detail",
+                 "disable segmentation editing before changing segment sources"},
+            },
+        };
+    }
 
     std::vector<std::string> tags;
     const QJsonArray tagValues = p.value("tags").toArray();
@@ -298,21 +347,13 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
     for (const QJsonValue& tag : tagValues)
         tags.push_back(tag.toString().toStdString());
 
+    bool attached = false;
     try {
-        if (!vpkg->addSegmentsEntry(normalizedLocation, std::move(tags))) {
-            if (const auto existing =
-                    vpkg->matchingSegmentsEntry(normalizedLocation)) {
-                return resultFor(false, existing->location);
-            }
-            throw AgentBridgeError{
-                -32010,
-                "Could not attach segments",
-                QJsonObject{},
-            };
-        }
-        _window->refreshCurrentVolumePackageUi(QString(), true);
-    } catch (const AgentBridgeError&) {
-        throw;
+        attached = vpkg->attachSegmentsEntry(
+                       normalizedLocation, std::move(tags), select) ==
+                   VolumePkg::AttachSegmentsResult::Attached;
+        if (reloadSurfaces)
+            _window->refreshCurrentVolumePackageUi(QString(), true);
     } catch (const std::exception& error) {
         throw AgentBridgeError{
             -32005,
@@ -321,7 +362,7 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
         };
     }
 
-    return resultFor(true, normalizedLocation);
+    return resultFor(attached, persistedLocation);
 }
 
 

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
@@ -311,25 +311,18 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
     const std::string persistedLocation =
         existing ? existing->location : normalizedLocation;
     const std::string sourceName = localPath.filename().string();
-    auto sourceNameConflictError =
-        [&](const vc::project::Entry* conflict) {
-            QJsonObject data{
-                {"sourceName", QString::fromStdString(sourceName)},
-            };
-            if (conflict) {
-                data["existingLocation"] =
-                    QString::fromStdString(conflict->location);
-            }
-            return AgentBridgeError{
-                -32010,
-                "A segment source with the same directory name is already attached",
-                data,
-            };
-        };
     if (!existing) {
         if (const auto conflict =
                 vpkg->matchingSegmentsEntryByDirectoryName(sourceName)) {
-            throw sourceNameConflictError(&*conflict);
+            throw AgentBridgeError{
+                -32010,
+                "A segment source with the same directory name is already attached",
+                QJsonObject{
+                    {"sourceName", QString::fromStdString(sourceName)},
+                    {"existingLocation",
+                     QString::fromStdString(conflict->location)},
+                },
+            };
         }
     }
 
@@ -365,11 +358,6 @@ QJsonObject AgentBridgeServer::handleSegmentsAttach(const QJsonValue& params)
             QJsonObject{{"detail", QString::fromUtf8(error.what())}},
         };
     }
-    if (attachResult ==
-        VolumePkg::AttachSegmentsResult::SourceNameConflict) {
-        throw sourceNameConflictError(nullptr);
-    }
-
     if (reloadSurfaces) {
         try {
             _window->refreshCurrentVolumePackageUi(QString(), true);

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_viewer.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_viewer.cpp
@@ -20,6 +20,7 @@
 #include "SurfacePanelController.hpp"
 #include "VCSettings.hpp"
 #include "ViewerManager.hpp"
+#include "overlays/VolumeOverlayController.hpp"
 #include "volume_viewers/CChunkedVolumeViewer.hpp"
 #include "volume_viewers/VolumeViewerBase.hpp"
 
@@ -28,7 +29,7 @@
 #include "vc/core/util/Compositing.hpp"
 
 // ---------------------------------------------------------------------------
-// ViewerManager-backed overlay controls and per-viewer intersection sets.
+// Overlay controls and per-viewer intersection sets.
 // ---------------------------------------------------------------------------
 
 namespace {
@@ -44,23 +45,36 @@ ViewerManager* requireViewerManager(ViewerManager* mgr)
     return mgr;
 }
 
-QJsonObject overlaySettingsJson(ViewerManager* mgr)
+VolumeOverlayController* requireVolumeOverlay(
+    VolumeOverlayController* overlay)
+{
+    if (!overlay) {
+        QJsonObject data;
+        data["detail"] = "volume overlay controller is not available";
+        throw AgentBridgeError{
+            -32010, "Volume overlay unavailable", data};
+    }
+    return overlay;
+}
+
+QJsonObject overlaySettingsJson(
+    const VolumeOverlayController::State& state)
 {
     QJsonObject o;
-    o["volumeId"] = QString::fromStdString(mgr->overlayVolumeId());
-    o["colormap"] = QString::fromStdString(mgr->overlayColormap());
-    o["opacity"] = mgr->overlayOpacity();
-    o["threshold"] = mgr->overlayThreshold();
-    o["windowLow"] = mgr->overlayWindowLow();
-    o["windowHigh"] = mgr->overlayWindowHigh();
-    o["maxDisplayedResolution"] = mgr->overlayMaxDisplayedResolution();
+    o["volumeId"] = QString::fromStdString(state.volumeId);
+    o["colormap"] = QString::fromStdString(state.colormap);
+    o["opacity"] = state.opacity;
+    o["threshold"] = state.window.low;
+    o["windowLow"] = state.window.low;
+    o["windowHigh"] = state.window.high;
+    o["maxDisplayedResolution"] = state.maxDisplayedResolution;
 
-    const OverlayCompositeSettings& c = mgr->overlayComposite();
     QJsonObject composite;
-    composite["enabled"] = c.enabled;
-    composite["method"] = QString::fromStdString(c.method);
-    composite["layersFront"] = c.layersFront;
-    composite["layersBehind"] = c.layersBehind;
+    composite["enabled"] = state.composite.enabled;
+    composite["method"] =
+        QString::fromStdString(state.composite.method);
+    composite["layersFront"] = state.composite.layersFront;
+    composite["layersBehind"] = state.composite.layersBehind;
     o["composite"] = composite;
     return o;
 }
@@ -70,14 +84,16 @@ QJsonObject overlaySettingsJson(ViewerManager* mgr)
 
 QJsonObject AgentBridgeServer::handleViewerGetOverlay(const QJsonValue&)
 {
-    ViewerManager* mgr = requireViewerManager(_window ? _window->_viewerManager.get() : nullptr);
-    return overlaySettingsJson(mgr);
+    auto* overlay = requireVolumeOverlay(
+        _window ? _window->_volumeOverlay.get() : nullptr);
+    return overlaySettingsJson(overlay->state());
 }
 
 
 QJsonObject AgentBridgeServer::handleViewerSetOverlay(const QJsonValue& params)
 {
-    ViewerManager* mgr = requireViewerManager(_window ? _window->_viewerManager.get() : nullptr);
+    auto* overlay = requireVolumeOverlay(
+        _window ? _window->_volumeOverlay.get() : nullptr);
     const QJsonObject p = params.toObject();
 
     // Mechanical input validation has already run from the method descriptor.
@@ -92,22 +108,6 @@ QJsonObject AgentBridgeServer::handleViewerSetOverlay(const QJsonValue& params)
     const QString volumeId = hasVolumeId ? p.value("volumeId").toString() : QString();
     const bool clearVolume = clear || (hasVolumeId && volumeId.isEmpty());
     const bool setVolume = !clearVolume && hasVolumeId;
-    // Resolve the overlay Volume shared_ptr up front so the -32007 unknown-volume
-    // check happens in this validation phase, before any setter runs.
-    std::shared_ptr<Volume> overlayVolume;
-    if (setVolume) {
-        CState* state = _window->_state;
-        std::shared_ptr<VolumePkg> vpkg = state ? state->vpkg() : nullptr;
-        if (!state || !state->hasVpkg() || !vpkg)
-            throw AgentBridgeError{-32000, "No volume package loaded", {}};
-        overlayVolume = vpkg->volume(volumeId.toStdString());
-        if (!overlayVolume) {
-            QJsonObject data;
-            data["kind"] = "volume";
-            data["id"] = volumeId;
-            throw AgentBridgeError{-32007, QStringLiteral("Unknown volume id: %1").arg(volumeId), data};
-        }
-    }
 
     const bool hasColormap = p.contains("colormap");
     const QString colormap =
@@ -141,7 +141,7 @@ QJsonObject AgentBridgeServer::handleViewerSetOverlay(const QJsonValue& params)
 
         // Merge over current settings so a caller can tweak one sub-key without
         // restating the rest (a read, so it stays in the validation phase).
-        composite = mgr->overlayComposite();
+        composite = overlay->state().composite;
         if (object.contains("enabled"))
             composite.enabled = object.value("enabled").toBool();
         if (object.contains("method"))
@@ -152,45 +152,64 @@ QJsonObject AgentBridgeServer::handleViewerSetOverlay(const QJsonValue& params)
             composite.layersBehind = object.value("layersBehind").toInt();
     }
 
-    // Apply only after every semantic precondition has passed.
-    if (clearVolume) {
-        mgr->setOverlayVolume(nullptr, "");
-    } else if (setVolume) {
-        // ViewerManager re-validates the coordinate space against the base
-        // volume and may silently null a mismatched selection; the echoed
-        // overlayVolumeId reflects whatever actually stuck.
-        mgr->setOverlayVolume(overlayVolume, volumeId.toStdString());
-    }
+    VolumeOverlayController::Update update;
+    if (clearVolume)
+        update.volumeId = std::string{};
+    else if (setVolume)
+        update.volumeId = volumeId.toStdString();
     if (hasColormap)
-        mgr->setOverlayColormap(colormap.toStdString());
+        update.colormap = colormap.toStdString();
     if (hasOpacity)
-        mgr->setOverlayOpacity(opacity);
+        update.opacity = opacity;
     if (hasThreshold)
-        mgr->setOverlayThreshold(threshold);
-    if (hasWindow)
-        mgr->setOverlayWindow(windowLow, windowHigh);
+        update.threshold = threshold;
+    if (hasWindow) {
+        update.window = VolumeOverlayController::Window{
+            .low = windowLow,
+            .high = windowHigh,
+        };
+    }
     if (hasMaxRes)
-        mgr->setOverlayMaxDisplayedResolution(maxRes);
+        update.maxDisplayedResolution = maxRes;
     if (hasComposite)
-        mgr->setOverlayComposite(composite);
+        update.composite = composite;
 
-    // Echo the resulting full overlay settings (unknown keys are ignored).
-    return overlaySettingsJson(mgr);
+    const auto applyResult = overlay->apply(update);
+    if (applyResult ==
+        VolumeOverlayController::ApplyResult::NoVolumePackage) {
+        throw AgentBridgeError{
+            -32000, "No volume package loaded", {}};
+    }
+    if (applyResult ==
+        VolumeOverlayController::ApplyResult::UnknownVolume) {
+        QJsonObject data;
+        data["kind"] = "volume";
+        data["id"] = volumeId;
+        throw AgentBridgeError{
+            -32007,
+            QStringLiteral("Unknown volume id: %1").arg(volumeId),
+            data,
+        };
+    }
+
+    return overlaySettingsJson(overlay->state());
 }
 
 
 QJsonObject AgentBridgeServer::handleViewerListOverlayVolumes(const QJsonValue&)
 {
-    ViewerManager* mgr = requireViewerManager(_window ? _window->_viewerManager.get() : nullptr);
+    auto* overlay = requireVolumeOverlay(
+        _window ? _window->_volumeOverlay.get() : nullptr);
     CState* state = _window->_state;
     std::shared_ptr<VolumePkg> vpkg = state ? state->vpkg() : nullptr;
     if (!state || !state->hasVpkg() || !vpkg)
         throw AgentBridgeError{-32000, "No volume package loaded", {}};
 
-    // Not filtered by coordinate-space compatibility: setOverlayVolume()
-    // re-validates and silently nulls a mismatched pick, so listing every
+    // Not filtered by coordinate-space compatibility: the overlay controller
+    // re-validates and clears a mismatched pick, so listing every
     // volume lets the agent see (and diagnose) that rejection itself.
-    const std::string currentId = state->currentVolumeId();
+    const auto overlayState = overlay->state();
+    const std::string& currentId = overlayState.currentVolumeId;
     QJsonArray volumes;
     for (const auto& id : vpkg->volumeIDs()) {
         QJsonObject v;
@@ -201,7 +220,8 @@ QJsonObject AgentBridgeServer::handleViewerListOverlayVolumes(const QJsonValue&)
 
     QJsonObject result;
     result["volumes"] = volumes;
-    result["overlayVolumeId"] = QString::fromStdString(mgr->overlayVolumeId());
+    result["overlayVolumeId"] =
+        QString::fromStdString(overlayState.volumeId);
     return result;
 }
 
@@ -270,7 +290,12 @@ QJsonObject AgentBridgeServer::viewerRenderSettingsJson() const
     QJsonObject o;
     o["intersectionOpacity"] = mgr->intersectionOpacity();
     o["intersectionThickness"] = mgr->intersectionThickness();
-    o["overlayOpacity"] = mgr->overlayOpacity();
+    if (_window->_volumeOverlay) {
+        o["overlayOpacity"] =
+            _window->_volumeOverlay->state().opacity;
+    } else {
+        o["overlayOpacity"] = mgr->overlayOpacity();
+    }
     o["intersectionMaxSurfaces"] = mgr->intersectionMaxSurfaces();
     // ViewerManager-backed, so meaningful with zero viewers instantiated too.
     QJsonObject volumeWindow;
@@ -367,6 +392,10 @@ QJsonObject AgentBridgeServer::handleViewerSetRenderSettings(const QJsonValue& p
         const double v = p.value("overlayOpacity").toDouble();
         overlayOpacity = static_cast<float>(std::clamp(v, 0.0, 1.0));
     }
+    VolumeOverlayController* volumeOverlay = hasOverlayOpacity
+        ? requireVolumeOverlay(
+              _window ? _window->_volumeOverlay.get() : nullptr)
+        : nullptr;
 
     const bool hasIntersectionMaxSurfaces = p.contains("intersectionMaxSurfaces");
     int intersectionMaxSurfaces = 0;
@@ -442,8 +471,11 @@ QJsonObject AgentBridgeServer::handleViewerSetRenderSettings(const QJsonValue& p
         mgr->setIntersectionOpacity(intersectionOpacity);
     if (hasIntersectionThickness)
         mgr->setIntersectionThickness(intersectionThickness);
-    if (hasOverlayOpacity)
-        mgr->setOverlayOpacity(overlayOpacity);
+    if (volumeOverlay) {
+        VolumeOverlayController::Update update;
+        update.opacity = overlayOpacity;
+        volumeOverlay->apply(update);
+    }
     if (hasIntersectionMaxSurfaces)
         mgr->setIntersectionMaxSurfaces(intersectionMaxSurfaces);
     if (hasHighlightedSurfaceIds) {

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_session.cpp
@@ -81,8 +81,9 @@ void AgentBridgeServer::registerSessionHandlers()
                 Params::optionalArray(
                     QStringLiteral("tags"),
                     AgentBridgeParamType::String),
+                Params::optionalBoolean(QStringLiteral("select"), true),
             },
-            .errors = {-32602, -32000, -32007, -32005, -32010},
+            .errors = {-32602, -32000, -32004, -32007, -32005, -32010},
             .mcp = mcp(QStringLiteral("vc3d_attach_segments")),
         },
         [this](const QJsonValue& p) { return handleSegmentsAttach(p); });

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_session.cpp
@@ -75,6 +75,20 @@ void AgentBridgeServer::registerSessionHandlers()
 
     registerMethod(
         {
+            .name = QStringLiteral("segments.attach"),
+            .params = {
+                Params::requiredString(QStringLiteral("location")),
+                Params::optionalArray(
+                    QStringLiteral("tags"),
+                    AgentBridgeParamType::String),
+            },
+            .errors = {-32602, -32000, -32007, -32005, -32010},
+            .mcp = mcp(QStringLiteral("vc3d_attach_segments")),
+        },
+        [this](const QJsonValue& p) { return handleSegmentsAttach(p); });
+
+    registerMethod(
+        {
             .name = QStringLiteral("segments.list"),
             .params = {
                 Params::optionalBoolean(QStringLiteral("onlyLoaded"), false),

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeServer.hpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeServer.hpp
@@ -128,6 +128,7 @@ private:
     QJsonObject handlePing(const QJsonValue& params);
     QJsonObject handleRpcDescribe(const QJsonValue& params);
     QJsonObject handleStateGet(const QJsonValue& params);
+    QJsonObject handleSegmentsAttach(const QJsonValue& params);
     QJsonObject handleSegmentsList(const QJsonValue& params);
     QJsonObject handleSegmentsActivate(const QJsonValue& params);
     QJsonObject handleSegmentsFetch(const QJsonValue& params);

--- a/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
+++ b/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
@@ -288,8 +288,8 @@ dialog.
   the same validation, persistence, and UI refresh as the GUI and is
   idempotent by normalized location. It selects the attached segment source by
   default; `select: false` preserves the current source. A source whose
-  directory name is already used by another attachment is rejected because
-  the VC3D source picker identifies entries by that name.
+  directory name is already used case-insensitively by another attachment is
+  rejected because the VC3D source picker identifies entries by that name.
 - `segments.list` reports package segments, whether they are loaded, and the
   active segment.
 - `segments.fetch` materializes an Open Data placeholder. Already-materialized

--- a/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
+++ b/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
@@ -283,6 +283,10 @@ dialog.
 
 ### Segments and review state
 
+- `segments.attach` adds one absolute local tifxyz path to the open package.
+  The path may identify a segment or a directory of segments. Attachment uses
+  the same validation, persistence, and UI refresh as the GUI and is
+  idempotent by normalized location.
 - `segments.list` reports package segments, whether they are loaded, and the
   active segment.
 - `segments.fetch` materializes an Open Data placeholder. Already-materialized
@@ -403,6 +407,7 @@ is the sole bridge method without an MCP tool.
 | `vc3d_add_point_collection` | `points.add_collection` |
 | `vc3d_append_segment_mask` | `segment.append_mask` | Append a volume-image layer to a segment's mask. Blocks until the render completes (130 s client timeout); requires a current volume. |
 | `vc3d_apply_anchor_offset` | `points.apply_anchor_offset` |
+| `vc3d_attach_segments` | `segments.attach` | Attach a local tifxyz segment, or a folder containing tifxyz segments, to the open volume package. |
 | `vc3d_attach_volume` | `volume.attach` | Attach one local zarr volume or remote `.zarr` URL to the open project without changing the current primary volume. Returns a `volume` job; compose with `vc3d_list_overlay_volumes` and `vc3d_set_overlay` to display it. |
 | `vc3d_atlas_open_result` | `atlas.open_result` |
 | `vc3d_atlas_open` | `atlas.open` |

--- a/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
+++ b/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
@@ -451,7 +451,7 @@ is the sole bridge method without an MCP tool.
 | `vc3d_flatten_straighten` | `flatten.straighten` |
 | `vc3d_generate_segment_mask` | `segment.generate_mask` | Render a segment's binary mask. Blocks until the render completes (130 s client timeout); no job to poll. |
 | `vc3d_get_cursor_point` | `canvas.get_cursor_volume_point` | Resolve a viewer scene position (or the current cursor) to a 3D volume point + surface normal. |
-| `vc3d_get_overlay` | `viewer.get_overlay` | Read the current overlay-volume settings. |
+| `vc3d_get_overlay` | `viewer.get_overlay` | Read the active workspace's overlay-volume settings, shared with the GUI controls. |
 | `vc3d_get_render_settings` | `viewer.get_render_settings` | Read the shared viewer render/overlay settings (intersection lines, overlay opacity, surface normals, direction hints, highlighted surfaces). |
 | `vc3d_get_state` | `state.get` | Snapshot of VC3D: open volume package, current volume, active segment, viewers (ids/names), editing mode, running job. Call this first. |
 | `vc3d_grow_patch_from_seed` | `segmentation.grow_patch_from_seed` | Create a brand-new segment by growing a patch from a 3D seed point (headless GrowPatch). Async: returns a jobId and outputDir. |
@@ -466,7 +466,7 @@ is the sole bridge method without an MCP tool.
 | `vc3d_lasagna_service_status` | `lasagna.service_status` |
 | `vc3d_lasagna_start_optimization` | `lasagna.start_optimization` |
 | `vc3d_list_catalog_samples` | `catalog.list_samples` | List samples available to open from the Open Data catalog; use this for discovery when no volume package is loaded. |
-| `vc3d_list_overlay_volumes` | `viewer.list_overlay_volumes` | List every volume id in the open package, for picking an overlay volume. |
+| `vc3d_list_overlay_volumes` | `viewer.list_overlay_volumes` | List every volume id in the open package and the active workspace's selection. |
 | `vc3d_list_points` | `points.list` | List point collections and their points. |
 | `vc3d_list_segments` | `segments.list` | List segments in the open volume package with loaded/active flags. |
 | `vc3d_list_attached_volumes` | `volume.list` | List volume ids already attached to the open package; this does not discover catalog data available to open. |
@@ -511,7 +511,7 @@ is the sole bridge method without an MCP tool.
 | `vc3d_set_auto_fill_mode` | `points.set_auto_fill_mode` |
 | `vc3d_set_axis_aligned_slices` | `viewer.set_axis_aligned_slices` | Enable/disable axis-aligned slice mode (checkbox equivalent) — prerequisite for `viewer.rotate`. |
 | `vc3d_set_intersects` | `viewer.set_intersects` | Set which surfaces' intersection lines a viewer draws. |
-| `vc3d_set_overlay` | `viewer.set_overlay` | Update the overlay-volume settings (volume, colormap, opacity, threshold, window, resolution cap, composite); any subset. |
+| `vc3d_set_overlay` | `viewer.set_overlay` | Update the active workspace and GUI overlay controls together (volume, colormap, opacity, threshold, window, resolution cap, composite); any subset. |
 | `vc3d_set_point_collection_color` | `points.set_collection_color` |
 | `vc3d_set_point_collection_metadata` | `points.set_collection_metadata` |
 | `vc3d_set_point_collection_tag` | `points.set_collection_tag` |

--- a/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
+++ b/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
@@ -286,7 +286,10 @@ dialog.
 - `segments.attach` adds one absolute local tifxyz path to the open package.
   The path may identify a segment or a directory of segments. Attachment uses
   the same validation, persistence, and UI refresh as the GUI and is
-  idempotent by normalized location.
+  idempotent by normalized location. It selects the attached segment source by
+  default; `select: false` preserves the current source. A source whose
+  directory name is already used by another attachment is rejected because
+  the VC3D source picker identifies entries by that name.
 - `segments.list` reports package segments, whether they are loaded, and the
   active segment.
 - `segments.fetch` materializes an Open Data placeholder. Already-materialized

--- a/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
+++ b/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
@@ -2938,6 +2938,7 @@
       "errors": [
         -32602,
         -32000,
+        -32004,
         -32007,
         -32005,
         -32010
@@ -2949,6 +2950,10 @@
         "properties": {
           "location": {
             "type": "string"
+          },
+          "select": {
+            "default": true,
+            "type": "boolean"
           },
           "tags": {
             "items": {

--- a/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
+++ b/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
@@ -2934,6 +2934,35 @@
         "type": "object"
       }
     },
+    "segments.attach": {
+      "errors": [
+        -32602,
+        -32000,
+        -32007,
+        -32005,
+        -32010
+      ],
+      "mcp": {
+        "tool": "vc3d_attach_segments"
+      },
+      "params": {
+        "properties": {
+          "location": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "location"
+        ],
+        "type": "object"
+      }
+    },
     "segments.delete": {
       "errors": [
         -32602,

--- a/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
+++ b/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
@@ -1033,7 +1033,7 @@ def check_segments_attach(
                     f"{type(error).__name__}: {error}",
                 )
 
-    conflicting = root / "other" / source.name
+    conflicting = root / "other" / source.name.upper()
     create_test_segment(
         conflicting / "conflicting-segment", "conflicting-segment")
     before = json.loads(volpkg.read_text())
@@ -1052,7 +1052,9 @@ def check_segments_attach(
         after = json.loads(volpkg.read_text())
         results.record(
             "segments_attach_source_name_conflict",
-            error.code == -32010 and after == before,
+            error.code == -32010
+            and error.data.get("sourceName") == source.name.upper()
+            and after == before,
             f"returned code={error.code} project_unchanged={after == before}",
         )
     except Exception as error:  # noqa: BLE001

--- a/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
+++ b/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
@@ -117,6 +117,17 @@ def create_test_volume(volume: Path, volume_id: str) -> Path:
     return volume
 
 
+def create_test_segment(segment: Path, segment_id: str) -> Path:
+    segment.mkdir(parents=True)
+    (segment / "meta.json").write_text(json.dumps({
+        "type": "seg",
+        "uuid": segment_id,
+        "name": segment_id,
+        "format": "tifxyz",
+    }))
+    return segment
+
+
 def create_test_project(root: Path) -> Path:
     create_test_volume(root / "volumes" / "vol1", "vol1")
 
@@ -246,10 +257,10 @@ def check_rpc_describe(
         coverage = description.get("coverage", {})
         complete = (
             description.get("undocumented") == []
-            and coverage.get("described") == 118
-            and coverage.get("registered") == 118
+            and coverage.get("described") == 119
+            and coverage.get("registered") == 119
             and coverage.get("complete") is True
-            and len(snapshot["methods"]) == 118
+            and len(snapshot["methods"]) == 119
         )
         rendered = json.dumps(snapshot, indent=2, sort_keys=True) + "\n"
         if update_snapshot:
@@ -763,6 +774,120 @@ def check_volume_attach(
     results.record("volume_attach_absolute_path", ok, detail)
 
 
+def check_segments_attach(
+    client: BridgeClient,
+    results: Results,
+    root: Path,
+    volpkg: Path,
+) -> None:
+    source = root / "user-segments"
+    create_test_segment(source / "smoke-segment", "smoke-segment")
+
+    try:
+        result, _ = client.call(
+            "segments.attach",
+            {
+                "location": str(source),
+                "tags": ["source:smoke", "status:working"],
+            },
+            timeout=10.0,
+        )
+        listed, _ = client.call("segments.list", {}, timeout=10.0)
+        document = json.loads(volpkg.read_text())
+        matching = [
+            entry
+            for entry in document.get("segments", [])
+            if isinstance(entry, dict) and entry.get("location") == str(source)
+        ]
+        ids = {segment.get("id") for segment in listed.get("segments", [])}
+        valid = (
+            result == {
+                "attached": True,
+                "alreadyAttached": False,
+                "location": str(source),
+                "projectPath": str(volpkg),
+            }
+            and "smoke-segment" in ids
+            and matching == [{
+                "location": str(source),
+                "tags": ["source:smoke", "status:working"],
+            }]
+        )
+        results.record(
+            "segments_attach_local_source",
+            valid,
+            f"result={result} ids={sorted(value for value in ids if value)}",
+        )
+    except Exception as error:  # noqa: BLE001
+        results.record(
+            "segments_attach_local_source",
+            False,
+            f"{type(error).__name__}: {error}",
+        )
+        return
+
+    try:
+        retry, _ = client.call(
+            "segments.attach",
+            {"location": str(source) + os.sep},
+            timeout=10.0,
+        )
+        document = json.loads(volpkg.read_text())
+        matching = [
+            entry
+            for entry in document.get("segments", [])
+            if isinstance(entry, dict) and entry.get("location") == str(source)
+        ]
+        results.record(
+            "segments_attach_idempotent",
+            retry.get("attached") is False
+            and retry.get("alreadyAttached") is True
+            and matching == [{
+                "location": str(source),
+                "tags": ["source:smoke", "status:working"],
+            }],
+            f"result={retry}",
+        )
+    except Exception as error:  # noqa: BLE001
+        results.record(
+            "segments_attach_idempotent",
+            False,
+            f"{type(error).__name__}: {error}",
+        )
+
+    ok, detail = expect_param_error(
+        client,
+        "segments.attach",
+        {"location": "relative/segments"},
+        "location",
+    )
+    results.record("segments_attach_absolute_path", ok, detail)
+
+    try:
+        client.call(
+            "segments.attach",
+            {"location": str(root / "missing-segments")},
+            timeout=10.0,
+        )
+        results.record(
+            "segments_attach_invalid_layout",
+            False,
+            "expected an error, got a result",
+        )
+    except BridgeError as error:
+        results.record(
+            "segments_attach_invalid_layout",
+            error.code == -32007,
+            f"returned code={error.code}",
+        )
+    except Exception as error:  # noqa: BLE001
+        results.record(
+            "segments_attach_invalid_layout",
+            False,
+            f"unexpected {type(error).__name__}: {error}",
+        )
+
+
 def check_c4(client: BridgeClient, results: Results, volpkg: str,
              broken_fiber_volpkg: str) -> None:
     # Liveness / dispatch sanity.
@@ -1137,6 +1262,7 @@ def main() -> int:
             check_canvas_normalization(client, results)
 
             check_volume_attach(client, results, tmp_path, volpkg)
+            check_segments_attach(client, results, tmp_path, volpkg)
             check_c4(client, results, str(volpkg), str(broken_volpkg))
             check_project_create(client, results, tmp_path)
             check_c2_oversized(sock_path, results)

--- a/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
+++ b/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
@@ -791,9 +791,9 @@ def check_segments_attach(
     )
 
     try:
-        client.call(
+        initial_result, _ = client.call(
             "segments.attach",
-            {"location": str(initial)},
+            {"location": str(initial) + os.sep},
             timeout=10.0,
         )
         result, _ = client.call(
@@ -806,6 +806,10 @@ def check_segments_attach(
         )
         listed, _ = client.call("segments.list", {}, timeout=10.0)
         document = json.loads(volpkg.read_text())
+        initial_locations = {
+            entry.get("location") if isinstance(entry, dict) else entry
+            for entry in document.get("segments", [])
+        }
         matching = [
             entry
             for entry in document.get("segments", [])
@@ -813,7 +817,9 @@ def check_segments_attach(
         ]
         ids = {segment.get("id") for segment in listed.get("segments", [])}
         valid = (
-            result == {
+            initial_result.get("location") == str(initial)
+            and str(initial) in initial_locations
+            and result == {
                 "attached": True,
                 "alreadyAttached": False,
                 "location": str(source),
@@ -829,6 +835,7 @@ def check_segments_attach(
         results.record(
             "segments_attach_local_source",
             valid,
+            f"initial={initial_result} initial_locations={initial_locations} "
             f"result={result} ids={sorted(value for value in ids if value)}",
         )
     except Exception as error:  # noqa: BLE001

--- a/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
+++ b/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
@@ -938,6 +938,46 @@ def check_segments_attach(
             f"{type(error).__name__}: {error}",
         )
 
+    try:
+        client.call(
+            "volume.open",
+            {"path": str(volpkg)},
+            timeout=10.0,
+        )
+        reopened, _ = client.call("segments.list", {}, timeout=10.0)
+        retry, _ = client.call(
+            "segments.attach",
+            {"location": str(source)},
+            timeout=10.0,
+        )
+        document = json.loads(volpkg.read_text())
+        matching = [
+            entry
+            for entry in document.get("segments", [])
+            if isinstance(entry, dict) and entry.get("location") == str(source)
+        ]
+        ids = {
+            segment.get("id")
+            for segment in reopened.get("segments", [])
+        }
+        results.record(
+            "segments_attach_reopen",
+            segment_id in ids
+            and retry.get("alreadyAttached") is True
+            and retry.get("selected") is True
+            and matching == [{
+                "location": str(source),
+                "tags": ["source:smoke", "status:working"],
+            }],
+            f"ids={sorted(value for value in ids if value)} retry={retry}",
+        )
+    except Exception as error:  # noqa: BLE001
+        results.record(
+            "segments_attach_reopen",
+            False,
+            f"{type(error).__name__}: {error}",
+        )
+
     editing_enabled = False
     try:
         client.call(

--- a/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
+++ b/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
@@ -391,6 +391,16 @@ def check_viewer_normalization(client: BridgeClient, results: Results) -> None:
         )
         expect(overlay, "windowLow", 10)
         expect(overlay, "windowHigh", 11)
+
+        overlay, _ = client.call(
+            "viewer.set_overlay",
+            {"colormap": ""},
+            timeout=10.0,
+        )
+        expect(overlay, "colormap", "")
+        overlay, _ = client.call(
+            "viewer.get_overlay", {}, timeout=10.0)
+        expect(overlay, "colormap", "")
     except Exception as error:  # noqa: BLE001
         failures.append(f"{type(error).__name__}: {error}")
 
@@ -635,6 +645,29 @@ def check_volume_attach(
             {"volumeId": "vol2", "opacity": 0.4},
             timeout=10.0,
         )
+        overlay_read, _ = client.call(
+            "viewer.get_overlay", {}, timeout=10.0)
+        selected, _ = client.call(
+            "viewer.list_overlay_volumes", {}, timeout=10.0)
+        render_result, _ = client.call(
+            "viewer.set_render_settings",
+            {"overlayOpacity": 0.35},
+            timeout=10.0,
+        )
+        overlay_after_render, _ = client.call(
+            "viewer.get_overlay", {}, timeout=10.0)
+        results.record(
+            "viewer_overlay_controller_sync",
+            overlay_read.get("volumeId") == "vol2"
+            and selected.get("overlayVolumeId") == "vol2"
+            and abs(render_result.get("overlayOpacity", -1) - 0.35) < 1e-6
+            and overlay_after_render.get("volumeId") == "vol2"
+            and abs(overlay_after_render.get("opacity", -1) - 0.35) < 1e-6,
+            f"set={overlay_result} get={overlay_read} "
+            f"list_id={selected.get('overlayVolumeId')} "
+            f"render_opacity={render_result.get('overlayOpacity')} "
+            f"overlay_opacity={overlay_after_render.get('opacity')}",
+        )
         document = json.loads(volpkg.read_text())
         entries = document.get("volumes", [])
         attached_entry = next(
@@ -678,6 +711,35 @@ def check_volume_attach(
             f"{type(error).__name__}: {error}",
         )
         return
+
+    try:
+        expected_overlay, _ = client.call(
+            "viewer.set_overlay",
+            {
+                "colormap": "",
+                "opacity": 0.35,
+                "window": {"low": 17, "high": 201},
+            },
+            timeout=10.0,
+        )
+        client.call(
+            "volume.open",
+            {"path": str(volpkg)},
+            timeout=10.0,
+        )
+        restored_overlay, _ = client.call(
+            "viewer.get_overlay", {}, timeout=10.0)
+        results.record(
+            "viewer_overlay_reopen",
+            restored_overlay == expected_overlay,
+            f"expected={expected_overlay} restored={restored_overlay}",
+        )
+    except Exception as error:  # noqa: BLE001
+        results.record(
+            "viewer_overlay_reopen",
+            False,
+            f"{type(error).__name__}: {error}",
+        )
 
     try:
         retry, _ = client.call(
@@ -1031,6 +1093,8 @@ def check_c4(client: BridgeClient, results: Results, volpkg: str,
     results.record("c4_volume_path_number", ok, detail)
 
     try:
+        overlay_before_error, _ = client.call(
+            "viewer.get_overlay", {}, timeout=10.0)
         client.call(
             "viewer.set_overlay",
             {"volumeId": "__missing__"},
@@ -1042,10 +1106,14 @@ def check_c4(client: BridgeClient, results: Results, volpkg: str,
             "expected -32007, got a result",
         )
     except BridgeError as error:
+        overlay_after_error, _ = client.call(
+            "viewer.get_overlay", {}, timeout=10.0)
         results.record(
             "viewer_overlay_unknown_volume",
-            error.code == -32007,
-            f"returned code={error.code}",
+            error.code == -32007
+            and overlay_after_error == overlay_before_error,
+            f"returned code={error.code} "
+            f"state_unchanged={overlay_after_error == overlay_before_error}",
         )
     except Exception as error:  # noqa: BLE001
         results.record(

--- a/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
+++ b/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import socket
 import sys
 import tempfile
@@ -780,10 +781,21 @@ def check_segments_attach(
     root: Path,
     volpkg: Path,
 ) -> None:
+    initial = root / "initial-segments"
+    create_test_segment(initial / "initial-segment", "initial-segment")
     source = root / "user-segments"
-    create_test_segment(source / "smoke-segment", "smoke-segment")
+    segment_id = "20241113080880"
+    shutil.copytree(
+        REPO_ROOT / "core" / "test" / "data" / "segments" / segment_id,
+        source / segment_id,
+    )
 
     try:
+        client.call(
+            "segments.attach",
+            {"location": str(initial)},
+            timeout=10.0,
+        )
         result, _ = client.call(
             "segments.attach",
             {
@@ -806,8 +818,9 @@ def check_segments_attach(
                 "alreadyAttached": False,
                 "location": str(source),
                 "projectPath": str(volpkg),
+                "selected": True,
             }
-            and "smoke-segment" in ids
+            and segment_id in ids
             and matching == [{
                 "location": str(source),
                 "tags": ["source:smoke", "status:working"],
@@ -842,6 +855,7 @@ def check_segments_attach(
             "segments_attach_idempotent",
             retry.get("attached") is False
             and retry.get("alreadyAttached") is True
+            and retry.get("selected") is True
             and matching == [{
                 "location": str(source),
                 "tags": ["source:smoke", "status:working"],
@@ -853,6 +867,90 @@ def check_segments_attach(
             "segments_attach_idempotent",
             False,
             f"{type(error).__name__}: {error}",
+        )
+
+    editing_enabled = False
+    try:
+        client.call(
+            "segments.activate",
+            {"segmentId": segment_id},
+            timeout=10.0,
+        )
+        client.call(
+            "segmentation.enable_editing",
+            {"enabled": True},
+            timeout=10.0,
+        )
+        editing_enabled = True
+        blocked = root / "blocked-segments"
+        create_test_segment(blocked / "blocked-segment", "blocked-segment")
+        before = json.loads(volpkg.read_text())
+        try:
+            client.call(
+                "segments.attach",
+                {"location": str(blocked), "select": False},
+                timeout=10.0,
+            )
+            results.record(
+                "segments_attach_editing_guard",
+                False,
+                "expected an error, got a result",
+            )
+        except BridgeError as error:
+            after = json.loads(volpkg.read_text())
+            results.record(
+                "segments_attach_editing_guard",
+                error.code == -32004 and after == before,
+                f"returned code={error.code} project_unchanged={after == before}",
+            )
+    except Exception as error:  # noqa: BLE001
+        results.record(
+            "segments_attach_editing_guard",
+            False,
+            f"{type(error).__name__}: {error}",
+        )
+    finally:
+        if editing_enabled:
+            try:
+                client.call(
+                    "segmentation.enable_editing",
+                    {"enabled": False},
+                    timeout=10.0,
+                )
+            except Exception as error:  # noqa: BLE001
+                results.record(
+                    "segments_attach_editing_cleanup",
+                    False,
+                    f"{type(error).__name__}: {error}",
+                )
+
+    conflicting = root / "other" / source.name
+    create_test_segment(
+        conflicting / "conflicting-segment", "conflicting-segment")
+    before = json.loads(volpkg.read_text())
+    try:
+        client.call(
+            "segments.attach",
+            {"location": str(conflicting)},
+            timeout=10.0,
+        )
+        results.record(
+            "segments_attach_source_name_conflict",
+            False,
+            "expected an error, got a result",
+        )
+    except BridgeError as error:
+        after = json.loads(volpkg.read_text())
+        results.record(
+            "segments_attach_source_name_conflict",
+            error.code == -32010 and after == before,
+            f"returned code={error.code} project_unchanged={after == before}",
+        )
+    except Exception as error:  # noqa: BLE001
+        results.record(
+            "segments_attach_source_name_conflict",
+            False,
+            f"unexpected {type(error).__name__}: {error}",
         )
 
     ok, detail = expect_param_error(

--- a/volume-cartographer/apps/VC3D/overlays/VolumeOverlayController.cpp
+++ b/volume-cartographer/apps/VC3D/overlays/VolumeOverlayController.cpp
@@ -15,6 +15,7 @@
 #include <QFileInfo>
 #include <QSettings>
 #include <QSignalBlocker>
+#include <QScopedValueRollback>
 #include <QSpinBox>
 #include <QVariant>
 
@@ -118,6 +119,13 @@ vc::Sampling samplingMethodFromName(const QString& name)
         : vc::Sampling::Nearest;
 }
 
+std::string defaultOverlayColormap()
+{
+    const auto& entries = volume_viewer_cmaps::entries(
+        volume_viewer_cmaps::EntryScope::OverlayCompatible);
+    return entries.empty() ? std::string{} : entries.front().id;
+}
+
 std::string coordinateSpaceTag(const VolumePkg& pkg, const std::string& volumeId)
 {
     constexpr std::string_view prefix = "vc-open-data-coordinate-space:";
@@ -143,6 +151,71 @@ VolumeOverlayController::VolumeOverlayController(ViewerManager* manager, QObject
     : QObject(parent)
     , _viewerManager(manager)
 {
+    if (_viewerManager) {
+        _volumeChangedConnection = connect(
+            _viewerManager,
+            &ViewerManager::currentVolumeChanged,
+            this,
+            &VolumeOverlayController::refreshForCurrentVolume);
+    }
+}
+
+VolumeOverlayController::State VolumeOverlayController::state() const
+{
+    return {
+        .currentVolumeId = _viewerManager
+            ? _viewerManager->currentVolumeId()
+            : std::string{},
+        .volumeId = _overlayVolumeId,
+        .colormap = _overlayColormapName,
+        .opacity = _overlayOpacity,
+        .window = {
+            .low = _overlayWindowLow,
+            .high = _overlayWindowHigh,
+        },
+        .maxDisplayedResolution = _overlayMaxDisplayedResolution,
+        .composite = currentCompositeSettings(),
+    };
+}
+
+VolumeOverlayController::ApplyResult
+VolumeOverlayController::apply(const Update& update)
+{
+    if (update.volumeId && !update.volumeId->empty()) {
+        if (!_volumePkg) {
+            return ApplyResult::NoVolumePackage;
+        }
+        try {
+            if (!_volumePkg->volume(*update.volumeId)) {
+                return ApplyResult::UnknownVolume;
+            }
+        } catch (const std::out_of_range&) {
+            return ApplyResult::UnknownVolume;
+        }
+    }
+
+    const bool wasSuspended = _suspendPersistence;
+    {
+        const QScopedValueRollback<bool> suspendPersistence(
+            _suspendPersistence, true);
+        if (update.volumeId)
+            setVolumeId(*update.volumeId);
+        if (update.colormap)
+            setColormap(*update.colormap);
+        if (update.opacity)
+            setOpacity(*update.opacity);
+        if (update.threshold)
+            setThreshold(*update.threshold);
+        if (update.window)
+            setWindowBounds(update.window->low, update.window->high);
+        if (update.maxDisplayedResolution)
+            setMaxDisplayedResolution(*update.maxDisplayedResolution);
+        if (update.composite)
+            setComposite(*update.composite);
+    }
+    if (!wasSuspended)
+        saveState();
+    return ApplyResult::Applied;
 }
 
 void VolumeOverlayController::setViewerManager(ViewerManager* manager)
@@ -150,6 +223,7 @@ void VolumeOverlayController::setViewerManager(ViewerManager* manager)
     if (_viewerManager == manager) {
         return;
     }
+    QObject::disconnect(_volumeChangedConnection);
     if (_viewerManager) {
         _viewerManager->setVolumeOverlay(nullptr);
     }
@@ -160,41 +234,34 @@ void VolumeOverlayController::setViewerManager(ViewerManager* manager)
         return;
     }
 
+    _volumeChangedConnection = connect(
+        _viewerManager,
+        &ViewerManager::currentVolumeChanged,
+        this,
+        &VolumeOverlayController::refreshForCurrentVolume);
+
+    // Overlay settings are stored per project, so each workspace receives the
+    // same controller state when it becomes active.
+    const std::string previousVolumeId = _overlayVolumeId;
     const bool wasSuspended = _suspendPersistence;
-    _suspendPersistence = true;
-    _overlayVolume = _viewerManager->overlayVolume();
-    _overlayVolumeId = _viewerManager->overlayVolumeId();
-    _overlayOpacity = _viewerManager->overlayOpacity();
-    _overlayOpacityBeforeToggle = _overlayOpacity;
-    _overlayColormapName = _viewerManager->overlayColormap();
-    _overlaySamplingMethod = _viewerManager->overlaySamplingMethod();
-    _overlayWindowLow = _viewerManager->overlayWindowLow();
-    _overlayWindowHigh = _viewerManager->overlayWindowHigh();
-    _overlayMaxDisplayedResolution = _viewerManager->overlayMaxDisplayedResolution();
-    const auto& composite = _viewerManager->overlayComposite();
-    _compositeEnabled = composite.enabled;
-    _compositeMethod = composite.method;
-    _compositeLayersFront = composite.layersFront;
-    _compositeLayersBehind = composite.layersBehind;
-    _overlayVisible = hasOverlaySelection() && _overlayOpacity > 0.0f;
-
-    _viewerManager->setVolumeOverlay(this);
-    refreshVolumeOptions();
-    populateColormapOptions();
-    applyOverlayVolume();
-    setOpacity(_overlayOpacity);
-    setSamplingMethod(_overlaySamplingMethod);
-    setWindowBounds(_overlayWindowLow, _overlayWindowHigh);
-    if (_ui.maxDisplayedResolutionSpin) {
-        const QSignalBlocker blocker(_ui.maxDisplayedResolutionSpin);
-        _ui.maxDisplayedResolutionSpin->setValue(_overlayMaxDisplayedResolution);
+    {
+        const QScopedValueRollback<bool> suspendPersistence(
+            _suspendPersistence, true);
+        refreshVolumeOptions();
+        populateColormapOptions();
+        applyOverlayVolume();
+        setColormap(_overlayColormapName);
+        setOpacity(_overlayOpacity);
+        setSamplingMethod(_overlaySamplingMethod);
+        setWindowBounds(_overlayWindowLow, _overlayWindowHigh);
+        setMaxDisplayedResolution(_overlayMaxDisplayedResolution);
+        setComposite(currentCompositeSettings());
+        _viewerManager->setVolumeOverlay(this);
+        updateUiEnabled();
     }
-
-    _viewerManager->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
-    syncCompositeUi();
-    pushCompositeToManager();
-    updateUiEnabled();
-    _suspendPersistence = wasSuspended;
+    if (!wasSuspended && _overlayVolumeId != previousVolumeId) {
+        saveState();
+    }
 }
 
 void VolumeOverlayController::setUi(const UiRefs& ui)
@@ -257,8 +324,10 @@ void VolumeOverlayController::setVolumePkg(const std::shared_ptr<VolumePkg>& pkg
     _volumePkg = pkg;
     _volpkgPath = normalizedVolpkgPath(path);
     _overlayVolume.reset();
+    _overlayVolumeIdBeforeToggle.clear();
 
-    _suspendPersistence = true;
+    const QScopedValueRollback<bool> suspendPersistence(
+        _suspendPersistence, true);
     loadState();
     refreshVolumeOptions();
     populateColormapOptions();
@@ -267,33 +336,23 @@ void VolumeOverlayController::setVolumePkg(const std::shared_ptr<VolumePkg>& pkg
     setOpacity(_overlayOpacity);
     setSamplingMethod(_overlaySamplingMethod);
     setWindowBounds(_overlayWindowLow, _overlayWindowHigh);
-    if (_ui.maxDisplayedResolutionSpin) {
-        const QSignalBlocker blocker(_ui.maxDisplayedResolutionSpin);
-        _ui.maxDisplayedResolutionSpin->setValue(std::clamp(_overlayMaxDisplayedResolution, 0, 5));
-    }
-    if (_viewerManager) {
-        _viewerManager->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
-    }
-    syncCompositeUi();
-    pushCompositeToManager();
+    setMaxDisplayedResolution(_overlayMaxDisplayedResolution);
+    setComposite(currentCompositeSettings());
     updateUiEnabled();
-    _suspendPersistence = false;
 }
 
 void VolumeOverlayController::clearVolumePkg()
 {
     saveState();
 
-    _suspendPersistence = true;
+    const QScopedValueRollback<bool> suspendPersistence(
+        _suspendPersistence, true);
     _volumePkg.reset();
     _volpkgPath.clear();
     _overlayVolume.reset();
     _overlayVolumeId.clear();
+    _overlayVolumeIdBeforeToggle.clear();
     _overlayVisible = false;
-
-    if (_viewerManager) {
-        _viewerManager->setOverlayVolume(nullptr, _overlayVolumeId);
-    }
 
     if (_ui.volumeSelect) {
         const QSignalBlocker blocker(_ui.volumeSelect);
@@ -308,6 +367,8 @@ void VolumeOverlayController::clearVolumePkg()
         _ui.colormapSelect->clear();
     }
 
+    setVolumeId({});
+    setColormap({});
     _overlayOpacity = 0.5f;
     _overlayOpacityBeforeToggle = _overlayOpacity;
     _overlayWindowLow = 0.0f;
@@ -318,31 +379,12 @@ void VolumeOverlayController::clearVolumePkg()
     _compositeMethod = vc3d::settings::volume_overlay::COMPOSITE_METHOD_DEFAULT;
     _compositeLayersFront = vc3d::settings::volume_overlay::COMPOSITE_LAYERS_FRONT_DEFAULT;
     _compositeLayersBehind = vc3d::settings::volume_overlay::COMPOSITE_LAYERS_BEHIND_DEFAULT;
-    syncCompositeUi();
-    if (_ui.opacitySpin) {
-        const QSignalBlocker blocker(_ui.opacitySpin);
-        _ui.opacitySpin->setValue(percentValueFromOpacity(_overlayOpacity));
-    }
-    if (_ui.thresholdSpin) {
-        const QSignalBlocker blocker(_ui.thresholdSpin);
-        _ui.thresholdSpin->setValue(spinValueFromWindow(_overlayWindowLow));
-    }
-    if (_ui.maxDisplayedResolutionSpin) {
-        const QSignalBlocker blocker(_ui.maxDisplayedResolutionSpin);
-        _ui.maxDisplayedResolutionSpin->setValue(_overlayMaxDisplayedResolution);
-    }
+    setOpacity(_overlayOpacity);
+    setWindowBounds(_overlayWindowLow, _overlayWindowHigh);
+    setMaxDisplayedResolution(_overlayMaxDisplayedResolution);
     setSamplingMethod(_overlaySamplingMethod);
-
-    if (_viewerManager) {
-        _viewerManager->setOverlayOpacity(_overlayOpacity);
-        _viewerManager->setOverlayWindow(_overlayWindowLow, _overlayWindowHigh);
-        _viewerManager->setOverlayColormap(std::string());
-        _viewerManager->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
-        _viewerManager->setOverlayComposite(currentCompositeSettings());
-    }
-
+    setComposite(currentCompositeSettings());
     updateUiEnabled();
-    _suspendPersistence = false;
 }
 
 void VolumeOverlayController::refreshVolumeOptions()
@@ -391,9 +433,13 @@ void VolumeOverlayController::refreshVolumeOptions()
 
 void VolumeOverlayController::refreshForCurrentVolume()
 {
+    const std::string previousVolumeId = _overlayVolumeId;
     refreshVolumeOptions();
     applyOverlayVolume();
     updateUiEnabled();
+    if (_overlayVolumeId != previousVolumeId && !_suspendPersistence) {
+        saveState();
+    }
 }
 
 void VolumeOverlayController::toggleVisibility()
@@ -579,23 +625,25 @@ void VolumeOverlayController::populateColormapOptions()
         volume_viewer_cmaps::EntryScope::OverlayCompatible);
     const QSignalBlocker blocker(_ui.colormapSelect);
     _ui.colormapSelect->clear();
+    _ui.colormapSelect->addItem(tr("Grayscale"), QVariant(QString()));
 
     int indexToSelect = 0;
-    if (_overlayColormapName.empty() && !entries.empty()) {
-        _overlayColormapName = entries.front().id;
-    }
+    bool found = _overlayColormapName.empty();
 
-    for (int i = 0; i < static_cast<int>(entries.size()); ++i) {
-        const auto& entry = entries.at(i);
+    for (const auto& entry : entries) {
+        const int row = _ui.colormapSelect->count();
         _ui.colormapSelect->addItem(entry.label, QVariant(QString::fromStdString(entry.id)));
         if (entry.id == _overlayColormapName) {
-            indexToSelect = i;
+            indexToSelect = row;
+            found = true;
         }
     }
 
-    if (_ui.colormapSelect->count() > 0) {
-        _ui.colormapSelect->setCurrentIndex(indexToSelect);
+    if (!found && !entries.empty()) {
+        _overlayColormapName = entries.front().id;
+        indexToSelect = 1;
     }
+    _ui.colormapSelect->setCurrentIndex(indexToSelect);
 
     if (_viewerManager) {
         _viewerManager->setOverlayColormap(_overlayColormapName);
@@ -712,7 +760,7 @@ void VolumeOverlayController::loadState()
     _overlayOpacityBeforeToggle = _overlayOpacity;
     _overlayWindowLow = 0.0f;
     _overlayWindowHigh = 255.0f;
-    _overlayColormapName.clear();
+    _overlayColormapName = defaultOverlayColormap();
     _overlaySamplingMethod = vc::Sampling::Nearest;
     _overlayMaxDisplayedResolution = vc3d::settings::volume_overlay::MAX_DISPLAYED_RESOLUTION_DEFAULT;
     _compositeEnabled = vc3d::settings::volume_overlay::COMPOSITE_ENABLED_DEFAULT;
@@ -762,9 +810,9 @@ void VolumeOverlayController::loadState()
         _overlayWindowHigh = std::min(255.0f, _overlayWindowLow + 1.0f);
     }
 
-    const QString storedColormap = settings.value(volume_overlay::COLORMAP).toString();
-    if (!storedColormap.isEmpty()) {
-        _overlayColormapName = storedColormap.toStdString();
+    if (settings.contains(volume_overlay::COLORMAP)) {
+        _overlayColormapName =
+            settings.value(volume_overlay::COLORMAP).toString().toStdString();
     }
 
     _overlaySamplingMethod = samplingMethodFromName(
@@ -832,32 +880,31 @@ void VolumeOverlayController::saveState() const
     settings.endGroup();
 }
 
-void VolumeOverlayController::setColormap(const std::string& id)
+void VolumeOverlayController::setVolumeId(const std::string& id)
 {
-    std::string newId = id;
+    _overlayVolumeId = id;
 
-    if (newId.empty()) {
-        if (_ui.colormapSelect && _ui.colormapSelect->count() > 0) {
-            const QVariant data = _ui.colormapSelect->itemData(_ui.colormapSelect->currentIndex());
-            if (data.isValid()) {
-                newId = data.toString().toStdString();
-            }
-        }
-
-        if (newId.empty()) {
-            const auto& entries = volume_viewer_cmaps::entries();
-            if (!entries.empty()) {
-                newId = entries.front().id;
-            }
-        }
+    if (_ui.volumeSelect) {
+        const QSignalBlocker blocker(_ui.volumeSelect);
+        const int index = id.empty()
+            ? 0
+            : _ui.volumeSelect->findData(
+                  QString::fromStdString(id));
+        _ui.volumeSelect->setCurrentIndex(std::max(index, 0));
     }
 
-    _overlayColormapName = newId;
+    applyOverlayVolume();
+    updateUiEnabled();
+}
+
+void VolumeOverlayController::setColormap(const std::string& id)
+{
+    _overlayColormapName = id;
 
     if (_ui.colormapSelect) {
         const QSignalBlocker blocker(_ui.colormapSelect);
         const QString target = QString::fromStdString(_overlayColormapName);
-        int index = _ui.colormapSelect->findData(target);
+        const int index = _ui.colormapSelect->findData(target);
         if (index >= 0) {
             _ui.colormapSelect->setCurrentIndex(index);
         } else if (_ui.colormapSelect->count() > 0) {
@@ -865,8 +912,6 @@ void VolumeOverlayController::setColormap(const std::string& id)
             const QVariant data = _ui.colormapSelect->currentData();
             if (data.isValid()) {
                 _overlayColormapName = data.toString().toStdString();
-            } else {
-                _overlayColormapName.clear();
             }
         }
     }
@@ -929,11 +974,6 @@ void VolumeOverlayController::setWindowBounds(float low, float high)
         clampedHigh = std::min(255.0f, clampedLow + 1.0f);
     }
 
-    if (std::abs(clampedLow - _overlayWindowLow) < 1e-6f &&
-        std::abs(clampedHigh - _overlayWindowHigh) < 1e-6f) {
-        return;
-    }
-
     _overlayWindowLow = clampedLow;
     _overlayWindowHigh = clampedHigh;
 
@@ -945,6 +985,32 @@ void VolumeOverlayController::setWindowBounds(float low, float high)
     if (_viewerManager) {
         _viewerManager->setOverlayWindow(_overlayWindowLow, _overlayWindowHigh);
     }
+}
+
+void VolumeOverlayController::setMaxDisplayedResolution(int value)
+{
+    _overlayMaxDisplayedResolution = std::clamp(value, 0, 5);
+    if (_ui.maxDisplayedResolutionSpin) {
+        const QSignalBlocker blocker(_ui.maxDisplayedResolutionSpin);
+        _ui.maxDisplayedResolutionSpin->setValue(
+            _overlayMaxDisplayedResolution);
+    }
+    if (_viewerManager) {
+        _viewerManager->setOverlayMaxDisplayedResolution(
+            _overlayMaxDisplayedResolution);
+    }
+}
+
+void VolumeOverlayController::setComposite(
+    const OverlayCompositeSettings& settings)
+{
+    _compositeEnabled = settings.enabled;
+    _compositeMethod = sanitizedCompositeMethod(settings.method);
+    _compositeLayersFront = std::clamp(settings.layersFront, 0, 64);
+    _compositeLayersBehind = std::clamp(settings.layersBehind, 0, 64);
+    syncCompositeUi();
+    pushCompositeToManager();
+    updateUiEnabled();
 }
 
 OverlayCompositeSettings VolumeOverlayController::currentCompositeSettings() const
@@ -994,13 +1060,11 @@ void VolumeOverlayController::handleCompositeEnabledChanged(bool enabled)
         return;
     }
 
-    _compositeEnabled = enabled;
-    pushCompositeToManager();
-    updateUiEnabled();
-
-    if (!_suspendPersistence) {
-        saveState();
-    }
+    auto settings = currentCompositeSettings();
+    settings.enabled = enabled;
+    Update update;
+    update.composite = settings;
+    apply(update);
 }
 
 void VolumeOverlayController::handleCompositeMethodChanged(int index)
@@ -1019,12 +1083,11 @@ void VolumeOverlayController::handleCompositeMethodChanged(int index)
         return;
     }
 
-    _compositeMethod = method;
-    pushCompositeToManager();
-
-    if (!_suspendPersistence) {
-        saveState();
-    }
+    auto settings = currentCompositeSettings();
+    settings.method = method;
+    Update update;
+    update.composite = settings;
+    apply(update);
 }
 
 void VolumeOverlayController::handleCompositeLayersFrontChanged(int value)
@@ -1034,12 +1097,11 @@ void VolumeOverlayController::handleCompositeLayersFrontChanged(int value)
         return;
     }
 
-    _compositeLayersFront = clamped;
-    pushCompositeToManager();
-
-    if (!_suspendPersistence) {
-        saveState();
-    }
+    auto settings = currentCompositeSettings();
+    settings.layersFront = clamped;
+    Update update;
+    update.composite = settings;
+    apply(update);
 }
 
 void VolumeOverlayController::handleCompositeLayersBehindChanged(int value)
@@ -1049,12 +1111,11 @@ void VolumeOverlayController::handleCompositeLayersBehindChanged(int value)
         return;
     }
 
-    _compositeLayersBehind = clamped;
-    pushCompositeToManager();
-
-    if (!_suspendPersistence) {
-        saveState();
-    }
+    auto settings = currentCompositeSettings();
+    settings.layersBehind = clamped;
+    Update update;
+    update.composite = settings;
+    apply(update);
 }
 
 void VolumeOverlayController::handleMaxDisplayedResolutionChanged(int value)
@@ -1064,19 +1125,9 @@ void VolumeOverlayController::handleMaxDisplayedResolutionChanged(int value)
         return;
     }
 
-    _overlayMaxDisplayedResolution = clamped;
-    if (_ui.maxDisplayedResolutionSpin && _ui.maxDisplayedResolutionSpin->value() != clamped) {
-        const QSignalBlocker blocker(_ui.maxDisplayedResolutionSpin);
-        _ui.maxDisplayedResolutionSpin->setValue(clamped);
-    }
-
-    if (_viewerManager) {
-        _viewerManager->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
-    }
-
-    if (!_suspendPersistence) {
-        saveState();
-    }
+    Update update;
+    update.maxDisplayedResolution = clamped;
+    apply(update);
 }
 
 void VolumeOverlayController::handleVolumeComboChanged(int index)
@@ -1097,13 +1148,9 @@ void VolumeOverlayController::handleVolumeComboChanged(int index)
         return;
     }
 
-    _overlayVolumeId = std::move(newId);
-    applyOverlayVolume();
-    updateUiEnabled();
-
-    if (!_suspendPersistence) {
-        saveState();
-    }
+    Update update;
+    update.volumeId = std::move(newId);
+    apply(update);
 }
 
 void VolumeOverlayController::handleColormapChanged(int index)
@@ -1120,19 +1167,16 @@ void VolumeOverlayController::handleColormapChanged(int index)
         }
     }
 
-    setColormap(newId);
-
-    if (!_suspendPersistence) {
-        saveState();
-    }
+    Update update;
+    update.colormap = std::move(newId);
+    apply(update);
 }
 
 void VolumeOverlayController::handleOpacityChanged(int value)
 {
-    setOpacity(normalizedOpacityFromPercent(value));
-    if (!_suspendPersistence) {
-        saveState();
-    }
+    Update update;
+    update.opacity = normalizedOpacityFromPercent(value);
+    apply(update);
 }
 
 void VolumeOverlayController::handleSamplingMethodChanged(int index)
@@ -1150,8 +1194,7 @@ void VolumeOverlayController::handleSamplingMethodChanged(int index)
 
 void VolumeOverlayController::handleThresholdChanged(int value)
 {
-    setThreshold(windowValueFromSpin(value));
-    if (!_suspendPersistence) {
-        saveState();
-    }
+    Update update;
+    update.threshold = windowValueFromSpin(value);
+    apply(update);
 }

--- a/volume-cartographer/apps/VC3D/overlays/VolumeOverlayController.hpp
+++ b/volume-cartographer/apps/VC3D/overlays/VolumeOverlayController.hpp
@@ -6,10 +6,12 @@
 #include <QPointer>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "vc/core/types/Sampling.hpp"
+#include "vc/core/util/Compositing.hpp"
 
 class ViewerManager;
 class VolumePkg;
@@ -18,7 +20,6 @@ class QCheckBox;
 class QComboBox;
 class QSpinBox;
 class QString;
-struct OverlayCompositeSettings;
 
 class VolumeOverlayController : public QObject
 {
@@ -38,8 +39,42 @@ public:
         QPointer<QSpinBox> compositeLayersBehindSpin;
     };
 
+    struct Window {
+        float low{0.0f};
+        float high{255.0f};
+    };
+
+    struct State {
+        std::string currentVolumeId;
+        std::string volumeId;
+        std::string colormap;
+        float opacity{0.5f};
+        Window window;
+        int maxDisplayedResolution{0};
+        OverlayCompositeSettings composite;
+    };
+
+    struct Update {
+        // A present empty id clears the selection; nullopt leaves it unchanged.
+        std::optional<std::string> volumeId;
+        std::optional<std::string> colormap;
+        std::optional<float> opacity;
+        std::optional<float> threshold;
+        std::optional<Window> window;
+        std::optional<int> maxDisplayedResolution;
+        std::optional<OverlayCompositeSettings> composite;
+    };
+
+    enum class ApplyResult {
+        Applied,
+        NoVolumePackage,
+        UnknownVolume,
+    };
+
     explicit VolumeOverlayController(ViewerManager* manager, QObject* parent = nullptr);
 
+    State state() const;
+    ApplyResult apply(const Update& update);
     void setViewerManager(ViewerManager* manager);
     void setUi(const UiRefs& ui);
     void setVolumePkg(const std::shared_ptr<VolumePkg>& pkg, const QString& path);
@@ -61,11 +96,14 @@ private:
     void updateUiEnabled();
     void loadState();
     void saveState() const;
+    void setVolumeId(const std::string& id);
     void setColormap(const std::string& id);
     void setSamplingMethod(vc::Sampling method);
     void setOpacity(float value);
     void setThreshold(float value);
     void setWindowBounds(float low, float high);
+    void setMaxDisplayedResolution(int value);
+    void setComposite(const OverlayCompositeSettings& settings);
     OverlayCompositeSettings currentCompositeSettings() const;
     void syncCompositeUi();
     void pushCompositeToManager();
@@ -102,6 +140,7 @@ private:
     int _compositeLayersBehind{0};
     bool _overlayVisible{false};
 
+    QMetaObject::Connection _volumeChangedConnection;
     std::vector<QMetaObject::Connection> _connections;
     bool _suspendPersistence{false};
 };

--- a/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
+++ b/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
@@ -85,6 +85,8 @@ public:
     [[nodiscard]] const std::vector<vc::project::Entry>& lasagnaDatasetEntries() const;
     [[nodiscard]] std::optional<vc::project::Entry>
     matchingVolumeEntry(const std::string& location) const;
+    [[nodiscard]] std::optional<vc::project::Entry>
+    matchingSegmentsEntry(const std::string& location) const;
 
     bool addVolumeEntry(const std::string& location, std::vector<std::string> tags = {});
     // Persist an already-loaded volume and its tags as one project mutation.

--- a/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
+++ b/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
@@ -53,6 +53,7 @@ public:
     enum class AttachSegmentsResult {
         Attached,
         AlreadyAttached,
+        SourceNameConflict,
     };
 
     static std::shared_ptr<VolumePkg> newEmpty();
@@ -91,6 +92,9 @@ public:
     matchingVolumeEntry(const std::string& location) const;
     [[nodiscard]] std::optional<vc::project::Entry>
     matchingSegmentsEntry(const std::string& location) const;
+    [[nodiscard]] std::optional<vc::project::Entry>
+    matchingSegmentsEntryByDirectoryName(
+        const std::string& directoryName) const;
 
     bool addVolumeEntry(const std::string& location, std::vector<std::string> tags = {});
     // Persist an already-loaded volume and its tags as one project mutation.

--- a/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
+++ b/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
@@ -53,7 +53,6 @@ public:
     enum class AttachSegmentsResult {
         Attached,
         AlreadyAttached,
-        SourceNameConflict,
     };
 
     static std::shared_ptr<VolumePkg> newEmpty();

--- a/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
+++ b/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
@@ -50,6 +50,10 @@ public:
         AlreadyAttached,
         VolumeIdConflict,
     };
+    enum class AttachSegmentsResult {
+        Attached,
+        AlreadyAttached,
+    };
 
     static std::shared_ptr<VolumePkg> newEmpty();
     static std::shared_ptr<VolumePkg> newEmpty(
@@ -115,6 +119,10 @@ public:
                                const std::string& newLocation);
     bool relocateNormalGridEntry(const std::string& oldLocation,
                                  const std::string& newLocation);
+    AttachSegmentsResult attachSegmentsEntry(
+        const std::string& location,
+        std::vector<std::string> tags,
+        bool select);
     bool addSegmentsEntry(const std::string& location, std::vector<std::string> tags = {});
     bool addNormalGridEntry(const std::string& location, std::vector<std::string> tags = {});
     bool addLasagnaDatasetEntry(const std::string& location,

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -920,11 +920,6 @@ VolumePkg::AttachSegmentsResult VolumePkg::attachSegmentsEntry(
 
     const auto existing = matchingSegmentsEntry(location);
     const bool insertEntry = !existing;
-    if (insertEntry &&
-        matchingSegmentsEntryByDirectoryName(
-            normalizedPathName(location))) {
-        return AttachSegmentsResult::SourceNameConflict;
-    }
     const std::string persistedLocation =
         existing ? existing->location : location;
     const vc::project::Entry target{persistedLocation, {}};
@@ -2061,30 +2056,32 @@ void VolumePkg::setSegmentationDirectory(const std::string& dirName)
 
 void VolumePkg::refreshSegmentations()
 {
-    decltype(loadedSegmentations_) previousLoadedSegmentations;
-    decltype(segmentationsByLocation_) previousSegmentationsByLocation;
     std::string previousActiveSegmentsLocation;
     decltype(segmentationTagsByID_) previousSegmentationTags;
     auto previousOutputSegments = outputSegments_;
-
-    {
-        std::lock_guard<std::mutex> lk(segmentsMutex_);
-        previousLoadedSegmentations = loadedSegmentations_;
-        previousSegmentationsByLocation = segmentationsByLocation_;
-        previousActiveSegmentsLocation = activeSegmentsLocation_;
-        previousSegmentationTags = segmentationTagsByID_;
-
-        // Retain the outgoing directory's segmentations so switching back to
-        // it reuses them (and their loaded surfaces) without hitting disk.
-        if (!activeSegmentsLocation_.empty()) {
-            segmentationsByLocation_[activeSegmentsLocation_] = loadedSegmentations_;
-        }
-        activeSegmentsLocation_.clear();
-        loadedSegmentations_.clear();
-        segmentationTagsByID_.clear();
-    }
+    decltype(loadedSegmentations_) previousUnscopedSegmentations;
+    bool stateCleared = false;
 
     try {
+        {
+            std::lock_guard<std::mutex> lk(segmentsMutex_);
+            previousActiveSegmentsLocation = activeSegmentsLocation_;
+            previousSegmentationTags = segmentationTagsByID_;
+
+            // Retain the outgoing directory's segmentations so switching back
+            // reuses their loaded surfaces without hitting disk.
+            if (!activeSegmentsLocation_.empty()) {
+                segmentationsByLocation_[activeSegmentsLocation_] =
+                    loadedSegmentations_;
+            } else {
+                previousUnscopedSegmentations = loadedSegmentations_;
+            }
+            activeSegmentsLocation_.clear();
+            loadedSegmentations_.clear();
+            segmentationTagsByID_.clear();
+            stateCleared = true;
+        }
+
         const vc::project::Entry* selectedSegments = nullptr;
         if (outputSegments_) {
             selectedSegments = findSegmentsEntryByLocation(
@@ -2113,14 +2110,23 @@ void VolumePkg::refreshSegmentations()
                 loadedSegmentations_;
         }
     } catch (...) {
-        std::lock_guard<std::mutex> lk(segmentsMutex_);
-        loadedSegmentations_ = std::move(previousLoadedSegmentations);
-        segmentationsByLocation_ =
-            std::move(previousSegmentationsByLocation);
-        activeSegmentsLocation_ =
-            std::move(previousActiveSegmentsLocation);
-        segmentationTagsByID_ = std::move(previousSegmentationTags);
-        outputSegments_ = std::move(previousOutputSegments);
+        if (stateCleared) {
+            std::lock_guard<std::mutex> lk(segmentsMutex_);
+            if (previousActiveSegmentsLocation.empty()) {
+                loadedSegmentations_ =
+                    std::move(previousUnscopedSegmentations);
+            } else if (const auto previous =
+                           segmentationsByLocation_.find(
+                               previousActiveSegmentsLocation);
+                       previous != segmentationsByLocation_.end()) {
+                loadedSegmentations_ = previous->second;
+            }
+            activeSegmentsLocation_ =
+                std::move(previousActiveSegmentsLocation);
+            segmentationTagsByID_ =
+                std::move(previousSegmentationTags);
+            outputSegments_ = std::move(previousOutputSegments);
+        }
         throw;
     }
 }

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -948,8 +948,20 @@ VolumePkg::AttachSegmentsResult VolumePkg::attachSegmentsEntry(
         }
         throw;
     }
-    if (!opts_.deferResolution)
-        refreshSegmentations();
+    if (!opts_.deferResolution) {
+        try {
+            refreshSegmentations();
+        } catch (const std::exception& error) {
+            Logger()->warn(
+                "Attached segment source '{}', but could not refresh it: {}",
+                persistedLocation,
+                error.what());
+        } catch (...) {
+            Logger()->warn(
+                "Attached segment source '{}', but could not refresh it",
+                persistedLocation);
+        }
+    }
 
     return insertEntry ? AttachSegmentsResult::Attached
                        : AttachSegmentsResult::AlreadyAttached;
@@ -2033,8 +2045,19 @@ void VolumePkg::setSegmentationDirectory(const std::string& dirName)
 
 void VolumePkg::refreshSegmentations()
 {
+    decltype(loadedSegmentations_) previousLoadedSegmentations;
+    decltype(segmentationsByLocation_) previousSegmentationsByLocation;
+    std::string previousActiveSegmentsLocation;
+    decltype(segmentationTagsByID_) previousSegmentationTags;
+    auto previousOutputSegments = outputSegments_;
+
     {
         std::lock_guard<std::mutex> lk(segmentsMutex_);
+        previousLoadedSegmentations = loadedSegmentations_;
+        previousSegmentationsByLocation = segmentationsByLocation_;
+        previousActiveSegmentsLocation = activeSegmentsLocation_;
+        previousSegmentationTags = segmentationTagsByID_;
+
         // Retain the outgoing directory's segmentations so switching back to
         // it reuses them (and their loaded surfaces) without hitting disk.
         if (!activeSegmentsLocation_.empty()) {
@@ -2045,27 +2068,44 @@ void VolumePkg::refreshSegmentations()
         segmentationTagsByID_.clear();
     }
 
-    const vc::project::Entry* selectedSegments = nullptr;
-    if (outputSegments_) {
-        selectedSegments = findSegmentsEntryByLocation(segments_, *outputSegments_, path_.parent_path());
-    }
-    if (!selectedSegments && loadFirstSegmentationDir_ && !loadFirstSegmentationDir_->empty()) {
-        selectedSegments = findSegmentsEntryByDirectoryName(
-            segments_, *loadFirstSegmentationDir_, path_.parent_path());
-        if (!selectedSegments) {
-            Logger()->warn("Requested load-first segmentation directory '{}' not available; using the selected segmentation directory.",
-                           *loadFirstSegmentationDir_);
+    try {
+        const vc::project::Entry* selectedSegments = nullptr;
+        if (outputSegments_) {
+            selectedSegments = findSegmentsEntryByLocation(
+                segments_, *outputSegments_, path_.parent_path());
         }
-    }
-    if (!selectedSegments) {
-        selectedSegments = firstLocalSegmentsEntry(segments_);
-    }
-    if (selectedSegments) {
-        outputSegments_ = selectedSegments->location;
-        resolveSegmentsEntry(*selectedSegments);
+        if (!selectedSegments && loadFirstSegmentationDir_ &&
+            !loadFirstSegmentationDir_->empty()) {
+            selectedSegments = findSegmentsEntryByDirectoryName(
+                segments_, *loadFirstSegmentationDir_, path_.parent_path());
+            if (!selectedSegments) {
+                Logger()->warn(
+                    "Requested load-first segmentation directory '{}' not "
+                    "available; using the selected segmentation directory.",
+                    *loadFirstSegmentationDir_);
+            }
+        }
+        if (!selectedSegments) {
+            selectedSegments = firstLocalSegmentsEntry(segments_);
+        }
+        if (selectedSegments) {
+            outputSegments_ = selectedSegments->location;
+            resolveSegmentsEntry(*selectedSegments);
+            std::lock_guard<std::mutex> lk(segmentsMutex_);
+            activeSegmentsLocation_ = selectedSegments->location;
+            segmentationsByLocation_[activeSegmentsLocation_] =
+                loadedSegmentations_;
+        }
+    } catch (...) {
         std::lock_guard<std::mutex> lk(segmentsMutex_);
-        activeSegmentsLocation_ = selectedSegments->location;
-        segmentationsByLocation_[activeSegmentsLocation_] = loadedSegmentations_;
+        loadedSegmentations_ = std::move(previousLoadedSegmentations);
+        segmentationsByLocation_ =
+            std::move(previousSegmentationsByLocation);
+        activeSegmentsLocation_ =
+            std::move(previousActiveSegmentsLocation);
+        segmentationTagsByID_ = std::move(previousSegmentationTags);
+        outputSegments_ = std::move(previousOutputSegments);
+        throw;
     }
 }
 

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -326,7 +326,12 @@ bool sameLocalSegmentsLocation(const vc::project::Entry& entry,
     if (vc::project::isLocationRemote(entry.location) || vc::project::isLocationRemote(location)) {
         return false;
     }
-    return normalizedLocalPath(entry.location, base) == normalizedLocalPath(location, base);
+    const auto entryPath = normalizedLocalPath(entry.location, base);
+    const auto requestedPath = normalizedLocalPath(location, base);
+    std::error_code ec;
+    if (fs::equivalent(entryPath, requestedPath, ec))
+        return true;
+    return entryPath == requestedPath;
 }
 
 bool matchesSegmentsDirectoryName(const vc::project::Entry& entry,
@@ -896,18 +901,68 @@ bool VolumePkg::mergeVolumeEntryTags(const std::string& location, const std::vec
     return false;
 }
 
-bool VolumePkg::addSegmentsEntry(const std::string& location, std::vector<std::string> tags)
+VolumePkg::AttachSegmentsResult VolumePkg::attachSegmentsEntry(
+    const std::string& location,
+    std::vector<std::string> tags,
+    bool select)
 {
-    if (location.empty()) return false;
-    if (matchingSegmentsEntry(location)) return false;
-    segments_.push_back({location, std::move(tags)});
-    if (!outputSegments_) {
-        outputSegments_ = location;
+    if (location.empty())
+        return AttachSegmentsResult::AlreadyAttached;
+
+    const auto existing = matchingSegmentsEntry(location);
+    const bool insertEntry = !existing;
+    const std::string persistedLocation =
+        existing ? existing->location : location;
+    const vc::project::Entry target{persistedLocation, {}};
+    const bool changeSelection =
+        (select || !outputSegments_) &&
+        (!outputSegments_ ||
+         !sameLocalSegmentsLocation(
+             target, *outputSegments_, path_.parent_path()));
+    if (!insertEntry && !changeSelection)
+        return AttachSegmentsResult::AlreadyAttached;
+
+    const auto previousOutputSegments = outputSegments_;
+    if (insertEntry)
+        segments_.push_back({persistedLocation, std::move(tags)});
+    if (changeSelection)
+        outputSegments_ = persistedLocation;
+
+    try {
+        persistProjectState();
+    } catch (...) {
+        if (insertEntry)
+            segments_.pop_back();
+        outputSegments_ = previousOutputSegments;
+        if (automaticPersistence_) {
+            try {
+                saveAutosave();
+            } catch (const std::exception& error) {
+                Logger()->warn(
+                    "Could not restore the volume-package autosave after a "
+                    "segment attachment failure: {}",
+                    error.what());
+            } catch (...) {
+                Logger()->warn(
+                    "Could not restore the volume-package autosave after a "
+                    "segment attachment failure");
+            }
+        }
+        throw;
     }
     if (!opts_.deferResolution)
         refreshSegmentations();
-    persistProjectState();
-    return true;
+
+    return insertEntry ? AttachSegmentsResult::Attached
+                       : AttachSegmentsResult::AlreadyAttached;
+}
+
+bool VolumePkg::addSegmentsEntry(
+    const std::string& location,
+    std::vector<std::string> tags)
+{
+    return attachSegmentsEntry(location, std::move(tags), false) ==
+           AttachSegmentsResult::Attached;
 }
 
 bool VolumePkg::reconcileSegmentsEntryTags(

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -625,6 +625,16 @@ VolumePkg::matchingVolumeEntry(const std::string& location) const
         : std::optional<vc::project::Entry>(*entry);
 }
 
+std::optional<vc::project::Entry>
+VolumePkg::matchingSegmentsEntry(const std::string& location) const
+{
+    const auto* entry =
+        findSegmentsEntryByLocation(segments_, location, path_.parent_path());
+    return entry
+        ? std::optional<vc::project::Entry>(*entry)
+        : std::nullopt;
+}
+
 bool VolumePkg::addVolumeEntry(const std::string& location, std::vector<std::string> tags)
 {
     if (location.empty()) return false;
@@ -889,7 +899,7 @@ bool VolumePkg::mergeVolumeEntryTags(const std::string& location, const std::vec
 bool VolumePkg::addSegmentsEntry(const std::string& location, std::vector<std::string> tags)
 {
     if (location.empty()) return false;
-    for (const auto& e : segments_) if (e.location == location) return false;
+    if (matchingSegmentsEntry(location)) return false;
     segments_.push_back({location, std::move(tags)});
     if (!outputSegments_) {
         outputSegments_ = location;

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -638,6 +638,17 @@ VolumePkg::matchingSegmentsEntry(const std::string& location) const
         : std::nullopt;
 }
 
+std::optional<vc::project::Entry>
+VolumePkg::matchingSegmentsEntryByDirectoryName(
+    const std::string& directoryName) const
+{
+    const auto* entry = findSegmentsEntryByDirectoryName(
+        segments_, directoryName, path_.parent_path());
+    return entry
+        ? std::optional<vc::project::Entry>(*entry)
+        : std::nullopt;
+}
+
 bool VolumePkg::addVolumeEntry(const std::string& location, std::vector<std::string> tags)
 {
     if (location.empty()) return false;
@@ -909,6 +920,11 @@ VolumePkg::AttachSegmentsResult VolumePkg::attachSegmentsEntry(
 
     const auto existing = matchingSegmentsEntry(location);
     const bool insertEntry = !existing;
+    if (insertEntry &&
+        matchingSegmentsEntryByDirectoryName(
+            normalizedPathName(location))) {
+        return AttachSegmentsResult::SourceNameConflict;
+    }
     const std::string persistedLocation =
         existing ? existing->location : location;
     const vc::project::Entry target{persistedLocation, {}};

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -294,28 +294,24 @@ bool anyImmediateSubdir(const fs::path& dir, bool (*test)(const fs::path&))
     return false;
 }
 
-std::string trimTrailingSeparators(std::string value)
+fs::path withoutTrailingSeparators(fs::path path)
 {
-    while (value.size() > 1 && (value.back() == '/' || value.back() == '\\')) {
-        value.pop_back();
-    }
-    return value;
+    while (path.has_relative_path() && path.filename().empty())
+        path = path.parent_path();
+    return path;
 }
 
 fs::path normalizedLocalPath(const std::string& location, const fs::path& base)
 {
-    return vc::project::resolveLocalPath(trimTrailingSeparators(location), base).lexically_normal();
+    const fs::path path = withoutTrailingSeparators(fs::path(location));
+    return vc::project::resolveLocalPath(path.string(), base).lexically_normal();
 }
 
 std::string normalizedPathName(std::string value)
 {
-    value = trimTrailingSeparators(std::move(value));
-    fs::path path(value);
-    std::string name = path.filename().string();
-    if (name.empty() && path.has_parent_path()) {
-        name = path.parent_path().filename().string();
-    }
-    return name;
+    return withoutTrailingSeparators(fs::path(std::move(value)))
+        .filename()
+        .string();
 }
 
 bool sameLocalSegmentsLocation(const vc::project::Entry& entry,
@@ -339,13 +335,15 @@ bool matchesSegmentsDirectoryName(const vc::project::Entry& entry,
                                   const fs::path& base)
 {
     if (vc::project::isLocationRemote(entry.location)) return false;
-    const auto requested = asciiLower(trimTrailingSeparators(dirName));
+    const auto requested = asciiLower(
+        withoutTrailingSeparators(fs::path(dirName)).string());
     const auto requestedName = asciiLower(normalizedPathName(dirName));
     const auto entryPath = normalizedLocalPath(entry.location, base);
     return asciiLower(entryPath.filename().string()) == requested
         || (!requestedName.empty() && asciiLower(entryPath.filename().string()) == requestedName)
         || asciiLower(entryPath.string()) == requested
-        || asciiLower(trimTrailingSeparators(entry.location)) == requested;
+        || asciiLower(withoutTrailingSeparators(
+                          fs::path(entry.location)).string()) == requested;
 }
 
 const vc::project::Entry* findSegmentsEntryByLocation(const std::vector<vc::project::Entry>& entries,

--- a/volume-cartographer/core/test/test_volume_pkg.cpp
+++ b/volume-cartographer/core/test/test_volume_pkg.cpp
@@ -281,6 +281,12 @@ TEST_CASE("VolumePkg: segment entries match normalized local paths")
         CHECK_FALSE(p->addSegmentsEntry((d / "segments-alias").string()));
     }
 
+#ifndef _WIN32
+    fs::create_directories(d / "segments\\");
+    CHECK_FALSE(p->matchingSegmentsEntry((d / "segments\\").string()));
+    CHECK(p->addSegmentsEntry((d / "segments\\").string()));
+#endif
+
     fs::remove_all(d);
 }
 

--- a/volume-cartographer/core/test/test_volume_pkg.cpp
+++ b/volume-cartographer/core/test/test_volume_pkg.cpp
@@ -290,6 +290,31 @@ TEST_CASE("VolumePkg: segment entries match normalized local paths")
     fs::remove_all(d);
 }
 
+TEST_CASE("VolumePkg: segment directory names are case-insensitive")
+{
+    auto d = tmpDir("segment_source_name");
+    fs::create_directories(d / "one" / "User-Segments");
+    fs::create_directories(d / "two" / "user-segments");
+
+    auto p = VolumePkg::newEmpty();
+    p->save(d / "project.volpkg.json");
+    REQUIRE(p->addSegmentsEntry(
+        (d / "one" / "User-Segments").string()));
+
+    const auto matching =
+        p->matchingSegmentsEntryByDirectoryName("user-segments");
+    REQUIRE(matching);
+    CHECK(matching->location ==
+          (d / "one" / "User-Segments").string());
+    CHECK(
+        p->attachSegmentsEntry(
+            (d / "two" / "user-segments").string(), {}, false) ==
+        VolumePkg::AttachSegmentsResult::SourceNameConflict);
+    CHECK(p->segmentEntries().size() == 1);
+
+    fs::remove_all(d);
+}
+
 TEST_CASE("VolumePkg: segment attachment rolls back after a write failure")
 {
     auto d = tmpDir("segment_attach_rollback");

--- a/volume-cartographer/core/test/test_volume_pkg.cpp
+++ b/volume-cartographer/core/test/test_volume_pkg.cpp
@@ -273,6 +273,50 @@ TEST_CASE("VolumePkg: segment entries match normalized local paths")
     CHECK_FALSE(p->addSegmentsEntry((d / "segments").string()));
     CHECK(p->segmentEntries().size() == 1);
 
+    std::error_code symlinkError;
+    fs::create_directory_symlink(
+        d / "segments", d / "segments-alias", symlinkError);
+    if (!symlinkError) {
+        CHECK(p->matchingSegmentsEntry((d / "segments-alias").string()));
+        CHECK_FALSE(p->addSegmentsEntry((d / "segments-alias").string()));
+    }
+
+    fs::remove_all(d);
+}
+
+TEST_CASE("VolumePkg: segment attachment rolls back after a write failure")
+{
+    auto d = tmpDir("segment_attach_rollback");
+    auto makeSegment = [](const fs::path& path, const std::string& id) {
+        fs::create_directories(path);
+        std::ofstream meta(path / "meta.json");
+        meta << R"({"type":"seg","uuid":")" << id
+             << R"(","format":"tifxyz"})";
+    };
+    makeSegment(d / "initial", "initial");
+    makeSegment(d / "new", "new");
+
+    const auto project = d / "project.volpkg.json";
+    auto p = VolumePkg::newEmpty();
+    p->save(project);
+    REQUIRE(p->addSegmentsEntry((d / "initial").string()));
+    fs::remove(project);
+    fs::create_directory(project);
+
+    CHECK_THROWS(p->attachSegmentsEntry(
+        (d / "new").string(), {"source:test"}, true));
+    REQUIRE(p->segmentEntries().size() == 1);
+    CHECK(p->segmentEntries().front().location == (d / "initial").string());
+    CHECK(p->outputSegmentsPath() == d / "initial");
+    CHECK(p->segmentationIDs() == std::vector<std::string>{"initial"});
+
+    vc::project::LoadOptions deferred;
+    deferred.deferResolution = true;
+    auto autosave = VolumePkg::load(VolumePkg::autosaveFile(), deferred);
+    REQUIRE(autosave->segmentEntries().size() == 1);
+    CHECK(autosave->segmentEntries().front().location ==
+          (d / "initial").string());
+
     fs::remove_all(d);
 }
 

--- a/volume-cartographer/core/test/test_volume_pkg.cpp
+++ b/volume-cartographer/core/test/test_volume_pkg.cpp
@@ -290,11 +290,10 @@ TEST_CASE("VolumePkg: segment entries match normalized local paths")
     fs::remove_all(d);
 }
 
-TEST_CASE("VolumePkg: segment directory names are case-insensitive")
+TEST_CASE("VolumePkg: segment directory-name lookup is case-insensitive")
 {
     auto d = tmpDir("segment_source_name");
     fs::create_directories(d / "one" / "User-Segments");
-    fs::create_directories(d / "two" / "user-segments");
 
     auto p = VolumePkg::newEmpty();
     p->save(d / "project.volpkg.json");
@@ -306,11 +305,6 @@ TEST_CASE("VolumePkg: segment directory names are case-insensitive")
     REQUIRE(matching);
     CHECK(matching->location ==
           (d / "one" / "User-Segments").string());
-    CHECK(
-        p->attachSegmentsEntry(
-            (d / "two" / "user-segments").string(), {}, false) ==
-        VolumePkg::AttachSegmentsResult::SourceNameConflict);
-    CHECK(p->segmentEntries().size() == 1);
 
     fs::remove_all(d);
 }

--- a/volume-cartographer/core/test/test_volume_pkg.cpp
+++ b/volume-cartographer/core/test/test_volume_pkg.cpp
@@ -257,6 +257,25 @@ TEST_CASE("VolumePkg: addSegmentsEntry sets outputSegments on first add")
     CHECK_FALSE(p->addSegmentsEntry(""));
 }
 
+TEST_CASE("VolumePkg: segment entries match normalized local paths")
+{
+    auto d = tmpDir("segment_entry_identity");
+    fs::create_directories(d / "segments");
+
+    auto p = VolumePkg::newEmpty();
+    p->save(d / "project.volpkg.json");
+    REQUIRE(p->addSegmentsEntry("segments", {"source:test"}));
+
+    const auto matching = p->matchingSegmentsEntry((d / "segments").string() + "/");
+    REQUIRE(matching);
+    CHECK(matching->location == "segments");
+    CHECK(matching->tags == std::vector<std::string>{"source:test"});
+    CHECK_FALSE(p->addSegmentsEntry((d / "segments").string()));
+    CHECK(p->segmentEntries().size() == 1);
+
+    fs::remove_all(d);
+}
+
 TEST_CASE("VolumePkg: segment discovery skips transient cache directories")
 {
     auto d = tmpDir("seg_transients");

--- a/volume-cartographer/tools/vc3d-mcp/tests/support/agent_bridge.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/support/agent_bridge.py
@@ -247,6 +247,17 @@ class FakeAgentBridgeServer:
                     error={"code": -32007, "message": "Segment not found",
                            "data": {"kind": "segment", "id": seg}},
                 )
+        elif method == "segments.attach":
+            await self._reply(
+                writer,
+                req_id,
+                result={
+                    "attached": True,
+                    "alreadyAttached": False,
+                    "location": params.get("location"),
+                    "projectPath": "/tmp/project.volpkg.json",
+                },
+            )
         elif method == "viewer.rotate":
             plane = params.get("plane")
             norm = {"xz": "seg xz", "yz": "seg yz",

--- a/volume-cartographer/tools/vc3d-mcp/tests/support/agent_bridge.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/support/agent_bridge.py
@@ -256,6 +256,7 @@ class FakeAgentBridgeServer:
                     "alreadyAttached": False,
                     "location": params.get("location"),
                     "projectPath": "/tmp/project.volpkg.json",
+                    "selected": params.get("select", True),
                 },
             )
         elif method == "viewer.rotate":

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_bridge.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_bridge.py
@@ -262,7 +262,7 @@ class ToolLayerTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result["attached"])
         self.assertEqual(
             self.fake_server.received_requests[-1]["params"],
-            {"location": "/tmp/my-segments"},
+            {"location": "/tmp/my-segments", "select": True},
         )
 
     async def test_vc3d_attach_segments_forwards_tags(self) -> None:
@@ -275,7 +275,19 @@ class ToolLayerTest(unittest.IsolatedAsyncioTestCase):
             {
                 "location": "/tmp/my-segments",
                 "tags": ["source:manual", "status:working"],
+                "select": True,
             },
+        )
+
+    async def test_vc3d_attach_segments_can_preserve_current_source(self) -> None:
+        result = await vc3d_attach_segments(
+            "/tmp/my-segments",
+            select=False,
+        )
+        self.assertFalse(result["selected"])
+        self.assertEqual(
+            self.fake_server.received_requests[-1]["params"],
+            {"location": "/tmp/my-segments", "select": False},
         )
 
     async def test_vc3d_activate_segment_plain_success(self) -> None:

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_bridge.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_bridge.py
@@ -50,6 +50,7 @@ from vc3d_mcp.tools.session import (
 )
 from vc3d_mcp.tools.segmentation import (
     vc3d_activate_segment,
+    vc3d_attach_segments,
     vc3d_delete_segment,
     vc3d_fetch_segment,
     vc3d_grow_segment,
@@ -255,6 +256,27 @@ class ToolLayerTest(unittest.IsolatedAsyncioTestCase):
         result = await vc3d_fetch_segment("seg-ph", wait=False)
         self.assertEqual(result["jobId"], "job-3")
         self.assertNotIn("state", result)
+
+    async def test_vc3d_attach_segments_strips_absent_tags(self) -> None:
+        result = await vc3d_attach_segments("/tmp/my-segments")
+        self.assertTrue(result["attached"])
+        self.assertEqual(
+            self.fake_server.received_requests[-1]["params"],
+            {"location": "/tmp/my-segments"},
+        )
+
+    async def test_vc3d_attach_segments_forwards_tags(self) -> None:
+        await vc3d_attach_segments(
+            "/tmp/my-segments",
+            tags=["source:manual", "status:working"],
+        )
+        self.assertEqual(
+            self.fake_server.received_requests[-1]["params"],
+            {
+                "location": "/tmp/my-segments",
+                "tags": ["source:manual", "status:working"],
+            },
+        )
 
     async def test_vc3d_activate_segment_plain_success(self) -> None:
         result = await vc3d_activate_segment("seg-ready")

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_contract.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_contract.py
@@ -12,7 +12,7 @@ from vc3d_mcp import tools as _tools  # noqa: F401 - registers the MCP tools
 VC_ROOT = Path(__file__).resolve().parents[3]
 SPEC_PATH = VC_ROOT / "apps/VC3D/agent_bridge/SPEC.md"
 DESCRIPTION_PATH = VC_ROOT / "apps/VC3D/agent_bridge/rpc_description.json"
-EXPECTED_RPC_METHODS = 118
+EXPECTED_RPC_METHODS = 119
 MCP_ONLY_TOOLS = {"vc3d_wait_job"}
 
 

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_progress.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_progress.py
@@ -403,7 +403,7 @@ class ToolSchemaTest(unittest.IsolatedAsyncioTestCase):
     """Official-SDK schema assertions over the whole registered tool surface."""
 
     # Assert the exact registered count so schema drift (added/removed tools) is caught.
-    EXPECTED_TOOL_COUNT = 118
+    EXPECTED_TOOL_COUNT = 119
 
     async def test_tool_surface_and_schemas(self) -> None:
         tools = await core.mcp.list_tools()

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/segmentation.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/segmentation.py
@@ -17,6 +17,30 @@ class Point3D(TypedDict):
 
 
 @mcp.tool()
+async def vc3d_attach_segments(
+    location: str,
+    tags: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """Attach a local tifxyz segment, or a folder containing tifxyz segments,
+    to the open volume package.
+
+    location must be an absolute path on the filesystem where VC3D runs. In a
+    containerized setup, use a path mounted into the VC3D container rather than
+    a host-only path. The directory may be one tifxyz segment with meta.json,
+    or a parent whose immediate subdirectories are tifxyz segments.
+
+    tags are stored on a newly attached project entry. Retrying the same
+    location is an idempotent success and keeps the existing entry and tags.
+    Use vc3d_list_segments afterward to discover the attached segment ids, then
+    vc3d_activate_segment to select one.
+    """
+    return await _call(
+        "segments.attach",
+        _strip_none({"location": location, "tags": tags}),
+    )
+
+
+@mcp.tool()
 async def vc3d_list_segments(only_loaded: bool = False) -> dict[str, Any]:
     """List segments in the open volume package with loaded/active flags."""
     return await _call("segments.list", {"onlyLoaded": only_loaded})

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/segmentation.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/segmentation.py
@@ -20,6 +20,7 @@ class Point3D(TypedDict):
 async def vc3d_attach_segments(
     location: str,
     tags: Optional[list[str]] = None,
+    select: bool = True,
 ) -> dict[str, Any]:
     """Attach a local tifxyz segment, or a folder containing tifxyz segments,
     to the open volume package.
@@ -27,16 +28,19 @@ async def vc3d_attach_segments(
     location must be an absolute path on the filesystem where VC3D runs. In a
     containerized setup, use a path mounted into the VC3D container rather than
     a host-only path. The directory may be one tifxyz segment with meta.json,
-    or a parent whose immediate subdirectories are tifxyz segments.
+    or a parent whose immediate subdirectories are tifxyz segments. Its
+    directory name must be unique among the project's segment sources because
+    the VC3D source picker identifies them by that name.
 
-    tags are stored on a newly attached project entry. Retrying the same
-    location is an idempotent success and keeps the existing entry and tags.
-    Use vc3d_list_segments afterward to discover the attached segment ids, then
-    vc3d_activate_segment to select one.
+    tags are stored on a newly attached project entry. select defaults to true,
+    making this source the current segment directory so vc3d_list_segments can
+    discover its ids; pass select=false to register it without switching away
+    from the current source. Retrying the same location is an idempotent success
+    and keeps the existing entry and tags.
     """
     return await _call(
         "segments.attach",
-        _strip_none({"location": location, "tags": tags}),
+        _strip_none({"location": location, "tags": tags, "select": select}),
     )
 
 

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/segmentation.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/segmentation.py
@@ -29,8 +29,9 @@ async def vc3d_attach_segments(
     containerized setup, use a path mounted into the VC3D container rather than
     a host-only path. The directory may be one tifxyz segment with meta.json,
     or a parent whose immediate subdirectories are tifxyz segments. Its
-    directory name must be unique among the project's segment sources because
-    the VC3D source picker identifies them by that name.
+    directory name must be unique, case-insensitively, among the project's
+    segment sources because the VC3D source picker identifies them by that
+    name.
 
     tags are stored on a newly attached project entry. select defaults to true,
     making this source the current segment directory so vc3d_list_segments can

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/viewer.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/viewer.py
@@ -292,11 +292,12 @@ async def vc3d_set_render_settings(
 
 @mcp.tool()
 async def vc3d_get_overlay() -> dict[str, Any]:
-    """Read the current overlay-volume settings (the semi-transparent second
-    volume rendered on top of the base volume).
+    """Read the active workspace's overlay-volume settings (the
+    semi-transparent second volume rendered on top of the base volume). These
+    are the same settings shown in VC3D's Overlay Volume controls.
 
     Returns {"volumeId" (str, "" when no overlay is set), "colormap" (str, ""
-    when unset), "opacity" (0..1), "threshold" (0..255), "windowLow"/
+    for grayscale), "opacity" (0..1), "threshold" (0..255), "windowLow"/
     "windowHigh" (0..255), "maxDisplayedResolution" (int 0..5),
     "composite": {"enabled" (bool), "method" ("max"|"mean"|"min"),
     "layersFront"/"layersBehind" (int 0..64)}}."""
@@ -323,7 +324,7 @@ async def vc3d_set_overlay(
     clear=True. Unknown id raises -32007.
     clear: True clears the overlay volume (equivalent to volume_id="").
     colormap: colormap id, one of "fire", "viridis", "magma", "red", "green",
-    "blue", "cyan", "magenta", "glasbey_black0"; empty string clears it.
+    "blue", "cyan", "magenta", "glasbey_black0"; empty string uses grayscale.
     An unrecognized id raises -32602 rather than being silently ignored.
     opacity: overlay opacity, clamped 0..1.
     threshold: overlay display threshold, clamped 0..255.
@@ -334,9 +335,10 @@ async def vc3d_set_overlay(
     An unrecognized method raises -32602.
 
     Returns the full resulting overlay settings object (same shape as
-    vc3d_get_overlay). Note: ViewerManager re-validates the overlay volume's
-    coordinate space against the base volume and may silently reject a
-    mismatched volume_id -- check the echoed "volumeId" to confirm it stuck.
+    vc3d_get_overlay). The active workspace and its Overlay Volume controls
+    update together. VC3D re-validates the overlay volume's coordinate space
+    against the base volume and may silently reject a mismatched volume_id --
+    check the echoed "volumeId" to confirm it stuck.
     """
     return await _call(
         "viewer.set_overlay",
@@ -358,9 +360,9 @@ async def vc3d_set_overlay(
 @mcp.tool()
 async def vc3d_list_overlay_volumes() -> dict[str, Any]:
     """List every volume id in the open package, for picking an overlay
-    volume via vc3d_set_overlay. Not filtered by coordinate-space
-    compatibility with the base volume -- vc3d_set_overlay re-validates and
-    may silently reject a mismatched pick.
+    volume in the active workspace via vc3d_set_overlay. Not filtered by
+    coordinate-space compatibility with the base volume --
+    vc3d_set_overlay re-validates and may silently reject a mismatched pick.
 
     Returns {"volumes": [{"id", "current" (bool, true for the base volume)}],
     "overlayVolumeId" (str, "" when no overlay is set)}."""


### PR DESCRIPTION
- adds MCP support for attaching local tifxyz segment sources
- makes segment attachment persistent, idempotent, and safe to retry
- rejects ambiguous segment source names before changing the project
- keeps overlay state synchronized with the rendered view and overlay controls
- restores overlay state when reopening a project
- adds focused core, MCP, and offscreen integration coverage

The overlay state could previously diverge between the bridge, controller, and active workspace. Segment attachment was also missing from the MCP surface. These changes keep the shared VC3D operations authoritative and leave bridge-specific validation in the bridge.

Verified with 163 host tests, 3 focused CTests, and the offscreen VC3D smoke suite (119 descriptors and 462 probes).
