### PR TITLE
fix(core): discover remote voxel size at native resolution (fixes #1226)

### DIFF
--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -1396,8 +1396,13 @@ std::shared_ptr<Volume> Volume::NewFromUrl(
 
     std::optional<double> nativeRemoteVoxelSize;
     try {
+        // The samplePixelSize fallback is the only voxel-size source for the
+        // public Open Data volumes (their metadata.json carries it solely as
+        // scan.tomo.acquisition.detector.samplePixelSize). Gating it on a
+        // base-scale selector left native-resolution remote volumes with
+        // voxelsize 0, so area computations downstream collapsed to zero.
         if (auto remoteMeta = loadRemoteVolumeMetadata(
-                remoteUrl, auth, spec.baseScaleLevel > 0)) {
+                remoteUrl, auth, /*discoverPublicSamplePixelSize=*/true)) {
             if (remoteMeta->contains("voxelsize") &&
                 (*remoteMeta)["voxelsize"].is_number()) {
                 const double value = (*remoteMeta)["voxelsize"].get_double();

--- a/volume-cartographer/core/test/test_volume_live_s3.cpp
+++ b/volume-cartographer/core/test/test_volume_live_s3.cpp
@@ -19,16 +19,24 @@ constexpr const char* kVolumeUrl =
     "s3://vesuvius-challenge-open-data/PHerc0172/volumes/"
     "20241024131838-7.910um-53keV-masked.zarr";
 
+// kVolumeUrl above is a legacy export: its meta.json carries a top-level
+// "voxelsize". Most of the bucket now ships the newer metadata.json form, where
+// the size is only under scan.tomo.acquisition.detector.samplePixelSize -- the
+// case that regressed in #1226. 45.532 um, per the volume's own name.
+constexpr const char* kNestedVoxelSizeVolumeUrl =
+    "s3://vesuvius-challenge-open-data/PHercParis4/volumes/"
+    "20260310173927-45.532um-11.0m-110keV-masked.zarr";
+
 bool requireNetwork()
 {
     const char* env = std::getenv("VC_TEST_REQUIRE_NETWORK");
     return env && env[0] && env[0] != '0';
 }
 
-std::shared_ptr<Volume> openOrSkip()
+std::shared_ptr<Volume> openUrlOrSkip(const char* url)
 {
     try {
-        return Volume::NewFromUrl(kVolumeUrl);
+        return Volume::NewFromUrl(url);
     } catch (const std::exception& e) {
         if (requireNetwork()) FAIL("Volume::NewFromUrl failed: " << e.what());
         MESSAGE("Skipping (network unavailable?): " << e.what());
@@ -36,7 +44,20 @@ std::shared_ptr<Volume> openOrSkip()
     }
 }
 
+std::shared_ptr<Volume> openOrSkip() { return openUrlOrSkip(kVolumeUrl); }
+
 } // namespace
+
+TEST_CASE("Volume::NewFromUrl: voxel size from nested acquisition metadata")
+{
+    auto v = openUrlOrSkip(kNestedVoxelSizeVolumeUrl);
+    if (!v) return;
+    CHECK(v->isRemote());
+    CHECK(v->baseScaleLevel() == 0);
+    // Without the samplePixelSize fallback this is 0, and every downstream
+    // area computation collapses with it.
+    CHECK(v->voxelSize() == doctest::Approx(45.532).epsilon(0.0001));
+}
 
 TEST_CASE("Volume::NewFromUrl: opens the PHerc 0172 zarr")
 {


### PR DESCRIPTION
Fixes #1226.

## The bug

`vc_grow_seg_from_seed` on a remote volume at **native resolution** runs the full trace and then silently throws the result away — no output directory, exit 0.

`Volume::NewFromUrl` gated the `scan.tomo.acquisition.detector.samplePixelSize` fallback on `spec.baseScaleLevel > 0`. For the public Open Data volumes that fallback is the *only* reachable voxel-size source: their `metadata.json` has no `voxelsize`, and nothing that the earlier key lookup (`voxelsize` / `voxel_size_um` / `voxelSizeUm` / `pixel_size_um` / `pixelSizeUm` / `resolution_um`, at top level or under `scan` / `volume` / `properties` / `metadata`) can find. The value lives only at `scan.tomo.acquisition.detector.samplePixelSize`.

So at base scale 0 — the default — `metadata_["voxelsize"]` stayed at its `double{}` initialiser. Downstream, `area_cm2` came out 0 and the `min_area_cm` check (default 0.3) dropped the finished segment.

Adding `#vc-base-scale=1` to the same URL made it work, which is what isolated the gate.

Local volumes were never affected — they carry `voxelsize` in their own `meta.json`, so `Volume::New` never needs the fallback.

## The change

Whether to discover the sample pixel size is independent of whether a base scale was requested, and `loadRemoteVolumeMetadata` has exactly one caller, so it is now enabled unconditionally. Six lines, five of them comment.

Behaviour for `baseScaleLevel > 0` is unchanged (it already passed `true`).

## Verification

Run against the live Open Data bucket, `PHercParis4/volumes/20260310173927-45.532um-11.0m-110keV-masked.zarr`, same seed, `seed.json` with no `voxelsize` key:

| | before | after |
|---|---|---|
| base scale 0 (default) | `voxelsize: 0` → 0.00 cm² → **0 segments** | `voxelsize: 45.532` → **147.63 cm² → 1 segment** |
| `#vc-base-scale=1` | `voxelsize: 91.064` → 1 segment | unchanged → 1 segment |

Two independent checks that 45.532 µm is the right value:

- it matches the volume's own name, `...-45.532um-...` (0.045532 mm × 1000);
- the two paths now agree on physical area for the same region — 147.63 cm² at level 0 vs 140.96 cm² at level 1, ~5% apart. A wrong voxel size would surface here as a 4× discrepancy.

Built and run locally on Ubuntu 24.04 (gcc, Qt6, Ninja/Release): `vc_core` and `vc_grow_seg_from_seed` compile and link clean, no new warnings, and the end-to-end runs above are from that binary. A repro script is in the issue.

I did not add a unit test: the affected path needs a live HTTP fetch of a volume's `metadata.json`, and I could not find an existing offline fixture for remote volume metadata to hang one off. Happy to add one if you'd like — a pointer to the pattern you'd prefer would help.

---

Investigation, patch and this description were done with Claude Code (Opus 5), verified by running rather than by reading alone. Reported separately as #1226 in case you'd rather fix it differently — the issue also notes a much smaller, related metadata point I deliberately left out of this diff to keep it focused.