### PR TITLE
fix(VC3D): pass voxel size to vc_render_tifxyz for remote volumes

### DIFF
--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -2055,11 +2055,17 @@ void SegmentationCommandHandler::onRenderSegment(const std::string& segmentId)
     // Interactive renders always start from the TIFF-stack default.
     _cmdRunner->setRenderOutputFormat(CommandLineToolRunner::RenderOutputFormat::TifStack);
     _cmdRunner->setRenderParams(static_cast<float>(dlg.scale()), dlg.groupIdx(), dlg.numSlices());
+    // Remote volumes have no local meta.json for vc_render_tifxyz's
+    // readVolumeVoxelSize() to read, so the size has to come from here or the
+    // render falls back to "no metadata found" and writes TIFFs with no
+    // resolution tag at all. setRenderVoxelSize() already ignores a
+    // non-positive value, so this stays inert when the size is unknown.
     _cmdRunner->setRenderVoxelSize(
         renderVolume ? renderVolume->voxelSize() : 0.0,
         renderVolume &&
             (renderVolume->baseScaleLevel() > 0 ||
-             renderVolume->hasExplicitVoxelSizeOverride()));
+             renderVolume->hasExplicitVoxelSizeOverride() ||
+             renderVolume->isRemote()));
     _cmdRunner->setNextOmpThreads(dlg.ompThreads());
     _cmdRunner->setVolumePath(dlg.volumePath());
     const bool useRemoteVolume = dlg.volumePath() == volumePath && !remoteVolumeUrl.isEmpty();


### PR DESCRIPTION
Renders of remote (Open Data) volumes come out with wrong physical scale, because VC3D never forwards the volume's voxel size to `vc_render_tifxyz`.

## Why

`vc_render_tifxyz` recovers the voxel size from the volume's local `meta.json` (`readVolumeVoxelSize`). A streaming-only remote volume has no local `meta.json`, so it falls back to:

```
Voxel size: 1.0 (no metadata found; override with --voxel-size)
```

VC3D holds the right value, but only forwarded it when the volume was rebased or explicitly overridden:

```cpp
renderVolume->baseScaleLevel() > 0 || renderVolume->hasExplicitVoxelSizeOverride()
```

A native-resolution remote volume — the default when you open an Open Data sample — matches neither.

## What it costs

Not just missing scale, but confidently wrong scale. Same segment, same remote volume, with and without `--voxel-size 45.532`:

**OME-Zarr (`--zarr-output`), `.zattrs`:**

| | axes units | level-0 scale |
|---|---|---|
| without | `nanometer` | `[1.0, 1.0, 1.0]` |
| with | `micrometer` | `[45.532, 45.532, 45.532]` |

The unpatched output declares **1 nm voxels for 45.532 µm data** — off by a factor of 45,532, asserted to anything downstream that reads the multiscale metadata.

**TIFF (`--tif-output`):**

| | XResolution | ResolutionUnit |
|---|---|---|
| without | absent | absent |
| with | 9139805/16384 ≈ 557.86 DPI | inch |

(25400 µm/inch ÷ 45.532 = 557.85.)

## The change

Add `isRemote()` to the condition. `setRenderVoxelSize()` already discards a non-positive value, so this stays inert whenever the size is unknown and cannot regress a render that works today.

## Relationship to #1226 / #1227

Separate defect, but the pair is needed for the GUI path:

- #1227 makes `Volume::voxelSize()` return the real value for a native-resolution remote volume (today it is 0);
- this PR makes VC3D forward that value to the renderer.

Without #1227 this change is a no-op, by design — the guard above sees 0 and skips.

Verified in two halves, both by running:

- with #1227 applied, `vc_grow_seg_from_seed` on that volume prints `voxelsize: 45.532`, and that number is read straight from `volume->voxelSize()` — the same accessor this call site uses;
- passing `--voxel-size 45.532` to `vc_render_tifxyz` produces the µm scale and DPI in the tables above.

I did not drive the Qt GUI itself; the one-line call site changed here is the link between those two halves, and I'd rather say that plainly than imply a test I didn't run.

Built on Ubuntu 24.04 (gcc, Qt6, Ninja/Release): VC3D compiles and links clean, no new warnings. Full suite on this branch: **109/109 passing**.

---

<sub>Investigation, patch and description done with Claude Code (Opus 5); every number above is from an actual run.</sub>