### PR TITLE
test(core): check thinning traces land on the source geometry

### DIFF
--- a/volume-cartographer/core/test/test_thinning.cpp
+++ b/volume-cartographer/core/test/test_thinning.cpp
@@ -8,6 +8,8 @@
 
 #include <opencv2/core.hpp>
 
+#include <cmath>
+#include <limits>
 #include <vector>
 
 namespace {
@@ -24,6 +26,27 @@ cv::Mat horizontalBar(int rows = 16, int cols = 32, int barRow = 8, int barWidth
 cv::Mat allZeros(int rows = 8, int cols = 8)
 {
     return cv::Mat::zeros(rows, cols, CV_8UC1);
+}
+
+// Concentric annuli of known radius about a known centre — a stand-in for the
+// wrap cross-sections thinning actually runs on. Every foreground pixel sits
+// within thickness/2 of one of `radii`, so every traced point must too.
+cv::Mat concentricAnnuli(int size, double cx, double cy,
+                         const std::vector<double>& radii, double thickness)
+{
+    cv::Mat m = cv::Mat::zeros(size, size, CV_8UC1);
+    for (int r = 0; r < size; ++r) {
+        for (int c = 0; c < size; ++c) {
+            const double d = std::hypot(double(c) - cx, double(r) - cy);
+            for (double rad : radii) {
+                if (std::abs(d - rad) <= thickness / 2.0) {
+                    m.at<uint8_t>(r, c) = 255;
+                    break;
+                }
+            }
+        }
+    }
+    return m;
 }
 
 } // namespace
@@ -151,4 +174,43 @@ TEST_CASE("ThinningStats::accumulate sums all fields")
     CHECK(a.traceSteps == 150);
     CHECK(a.tracesKept == 2);
     CHECK(a.tracesPruned == 1);
+}
+
+// The traces from thinning become the normal-grid polylines, which drive the
+// highest-weighted term in the tracer's loss. The cases above check that
+// tracing runs and that plumbing holds; this one checks the traced points land
+// where the geometry says they should.
+TEST_CASE("customThinningTraceOnly: traced points lie on the source geometry")
+{
+    const int kSize = 256;
+    const double kCentre = 128.0;
+    const double kThickness = 4.0;
+    const std::vector<double> radii{24.0, 40.0, 56.0, 72.0, 88.0, 104.0};
+
+    auto input = concentricAnnuli(kSize, kCentre, kCentre, radii, kThickness);
+    std::vector<std::vector<cv::Point>> traces;
+    customThinningTraceOnly(input, traces);
+    REQUIRE_FALSE(traces.empty());
+
+    std::size_t total = 0;
+    std::size_t offGeometry = 0;
+    double worst = 0.0;
+    for (const auto& trace : traces) {
+        for (const auto& p : trace) {
+            const double d = std::hypot(double(p.x) - kCentre, double(p.y) - kCentre);
+            double best = std::numeric_limits<double>::max();
+            for (double rad : radii)
+                best = std::min(best, std::abs(d - rad));
+            worst = std::max(worst, best);
+            if (best > kThickness / 2.0)
+                ++offGeometry;
+            ++total;
+        }
+    }
+
+    REQUIRE(total > 0);
+    // A centreline through a band of the given thickness cannot be further from
+    // the true radius than half that thickness.
+    CHECK(worst <= kThickness / 2.0);
+    CHECK(offGeometry == 0);
 }


### PR DESCRIPTION
`test_thinning.cpp` covers the entrypoints and the pruning helper well, but every assertion about the traces themselves is structural — *"at least one trace"*, *"traces is empty"*, *"counters moved"*. Nothing checks that a traced point sits where the input geometry says it should.

That matters because those traces become the normal-grid polylines, which feed the **highest-weighted term in the tracer's loss** (`NORMAL: 10`, against `DIST: 1`). An accuracy regression there would quietly degrade every segmentation while every existing assertion still passed — and it would look like "segmentation is hard" rather than a bug.

## The check

Concentric annuli of known radius about a known centre — a stand-in for the wrap cross-sections thinning actually runs on. The bound follows from the geometry rather than from an observed number: **a centreline through a band of thickness `t` cannot be further than `t/2` from the true radius.**

Currently the worst point is **0.995 px against the 2.0 px bound**, across 3001 points in 604 traces.

Pure OpenCV, no volume, no network, ~instant.

## Two things I deliberately did not do

**No assertion on trace count.** Thinning emits many short fragments — 604 for 6 rings — which the grid pipeline assembles later. I measured that before writing the test rather than assuming `traces.size() == 6`; pinning it would be brittle and would encode a fragmentation detail that isn't a contract.

**No tighter tolerance.** 0.995 against 2.0 is a 2× margin and I could have tightened it, but the geometric bound is the one that's defensible and stable across OpenCV versions. I'd rather have a bound that means something than one tuned to today's number.

## Verification

Confirmed the case actually discriminates rather than passing vacuously — forcing the tolerance to 0.01 px:

```
[MESSAGE] worst residual = 0.995146 px over 3001 points
test_thinning.cpp:215: FAILED: CHECK(worst <= 0.01)
```

and with the geometric bound restored: `11 test case(s) passed`. Full suite **109/109** (Ubuntu 24.04, gcc, Ninja/Release).

## Context

This came out of validating `vc_gen_normalgrids` end-to-end against a synthetic phantom — concentric cylindrical sheets with analytically known geometry, generated, then the resulting `.grid` polylines parsed back and compared to ground truth. That came out clean: XY traces 100% within 1.0 px of a true sheet radius with per-radius bias under 0.16 px and no drift, and XZ/YZ correct to a max 0.86 px away from tangency (the larger residuals there were all slices where the cut plane grazes a cylinder, which is a limitation of my two-chord reference model, not of the tool).

So this PR isn't fixing anything — the geometry is sound today. It pins that so it stays sound. Happy to drop it if you'd rather not carry the extra case.

---

<sub>Investigation and test with Claude Code (Opus 5); every number above is from an actual run.</sub>