### PR TITLE
Community projects: add Herculaneum Scroll Tools

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -166,6 +166,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 - [ScrollFiesta -- virtual meshing & unwrapping for the Herculaneum papyri](https://github.com/Hob3rMallow/scrollfiesta_public) by HariSeldon and friends
     - [GPU-accelerated MLS projection for ScrollFiesta](https://github.com/pscamillo/scrollfiesta_public/blob/cuda-mls/BENCHMARKS.md) by pscamillo — OpenMP + CUDA FP32 acceleration, byte-identical, ~6x throughput.
       
+- [Herculaneum Scroll Tools](https://github.com/axiosdevs/herculaneum-scroll-tools) by axiosdevs — CT-consistency QA for the published m7 surface predictions: voxel-exact phantom fractions measured for all 36 samples incl. all 13 grand-prize scrolls (43.3% of positives sit outside the masked CT), with a one-pass `clean` mode ([villa#1114](https://github.com/ScrollPrize/villa/issues/1114)); plus cross-scan registration (2023→2025 rescan, MAD 29 µm), a winding-constraint annotator/verifier in native spiral-input format, and dual-energy high-Z ink-candidate rendering.
+
 ### 📦 Materials
 
 #### 🌟 Highlighted


### PR DESCRIPTION
Adding [Herculaneum Scroll Tools](https://github.com/axiosdevs/herculaneum-scroll-tools) (MIT) to Segmentation → Tools, per the July 2026 Progress Prize submission instructions.

Headline: voxel-exact CT-consistency QA of the published m7 surface predictions — all 36 samples measured incl. all 13 grand-prize scrolls (281B positive voxels checked, 43.3% phantoms outside the masked CT), one-pass clean mode. Numbers reproduced and extended the villa#1114 audit (calibration adopted in-thread). Also ships cross-scan registration, a native-format winding-constraint annotator/verifier (125/125 on PHercParis4), and dual-energy ink-candidate rendering.