### PR TITLE
Fix inference output stores under zarr 3 (the pinned version)

### DIFF
--- a/vesuvius/src/vesuvius/data/utils.py
+++ b/vesuvius/src/vesuvius/data/utils.py
@@ -145,7 +145,16 @@ def open_zarr(path: str, mode: str = 'r',
 
         # Add any other kwargs
         create_kwargs.update(kwargs)
-        
+
+        # zarr 3 derives `overwrite` from the mode, so passing it alongside
+        # mode='w' raises "got multiple values for keyword argument 'overwrite'".
+        # mode='w' already means truncate, so an explicit overwrite=True is
+        # redundant; drop it rather than making every caller know this.
+        if create_kwargs.pop('overwrite', None) is False:
+            raise ValueError(
+                "open_zarr(mode='w') always truncates; overwrite=False is contradictory"
+            )
+
         if verbose:
             print(f"Creating new zarr array with shape={shape}, chunks={chunks}, dtype={dtype}")
         

--- a/vesuvius/src/vesuvius/data/utils.py
+++ b/vesuvius/src/vesuvius/data/utils.py
@@ -4,6 +4,8 @@ import zarr
 import os
 from typing import Union, Dict, Any, Optional, Tuple
 
+_ZARR_V3 = int(zarr.__version__.split('.', 1)[0]) >= 3
+
 # Function to get the maximum value of a dtype
 def get_max_value(dtype: np.dtype) -> Union[float, int]:
     """
@@ -64,7 +66,8 @@ def open_zarr(path: str, mode: str = 'r',
         Zarr format version for arrays created with mode 'w'. Defaults to 2 because
         the numcodecs compressors used throughout this package (and the logits stores
         blend_logits validates) are v2 constructs: zarr 3 raises for `compressor=` on
-        a v3 array. Pass None to accept zarr's own default.
+        a v3 array. Pass None to accept zarr's own default. Ignored when the
+        installed zarr is 2.x, which only writes v2 and does not accept the argument.
     **kwargs : Additional parameters passed to zarr.open
         
     Returns:
@@ -140,7 +143,10 @@ def open_zarr(path: str, mode: str = 'r',
             create_kwargs['fill_value'] = fill_value
         if order is not None:
             create_kwargs['order'] = order
-        if zarr_format is not None:
+        # zarr 2 has no zarr_format argument: it warns "ignoring keyword
+        # argument 'zarr_format'" for every array and writes v2 regardless,
+        # which is already what this default asks for. Only zarr 3 needs telling.
+        if zarr_format is not None and _ZARR_V3:
             create_kwargs['zarr_format'] = zarr_format
 
         # Add any other kwargs

--- a/vesuvius/src/vesuvius/data/utils.py
+++ b/vesuvius/src/vesuvius/data/utils.py
@@ -43,6 +43,7 @@ def open_zarr(path: str, mode: str = 'r',
               compressor: Any = None,
               fill_value: Any = None,
               order: str = None,
+              zarr_format: Optional[int] = 2,
               **kwargs) -> zarr.Array:
     """
     Open a zarr array with consistent handling of local and remote URLs.
@@ -59,6 +60,11 @@ def open_zarr(path: str, mode: str = 'r',
         Whether to print verbose information about opening the zarr array.
     shape, chunks, dtype, compressor, fill_value, order : zarr creation parameters
         Only used when mode is 'w' to create a new zarr array.
+    zarr_format : Optional[int], default 2
+        Zarr format version for arrays created with mode 'w'. Defaults to 2 because
+        the numcodecs compressors used throughout this package (and the logits stores
+        blend_logits validates) are v2 constructs: zarr 3 raises for `compressor=` on
+        a v3 array. Pass None to accept zarr's own default.
     **kwargs : Additional parameters passed to zarr.open
         
     Returns:
@@ -134,7 +140,9 @@ def open_zarr(path: str, mode: str = 'r',
             create_kwargs['fill_value'] = fill_value
         if order is not None:
             create_kwargs['order'] = order
-        
+        if zarr_format is not None:
+            create_kwargs['zarr_format'] = zarr_format
+
         # Add any other kwargs
         create_kwargs.update(kwargs)
         

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -786,16 +786,20 @@ class Inferer():
         return concatenated
         
     def _get_zarr_compressor(self):
-        if self.compressor_name.lower() == 'zstd':
-            return zarr.Blosc(cname='zstd', clevel=self.compression_level, shuffle=zarr.Blosc.SHUFFLE)
-        elif self.compressor_name.lower() == 'lz4':
-            return zarr.Blosc(cname='lz4', clevel=self.compression_level, shuffle=zarr.Blosc.SHUFFLE)
-        elif self.compressor_name.lower() == 'zlib':
-            return zarr.Blosc(cname='zlib', clevel=self.compression_level, shuffle=zarr.Blosc.SHUFFLE)
-        elif self.compressor_name.lower() == 'none':
+        # numcodecs.Blosc, not zarr.Blosc: zarr 3 dropped that re-export, and the rest
+        # of the package (blending, finalize_outputs) already builds compressors here.
+        shuffle = numcodecs.blosc.SHUFFLE
+        name = self.compressor_name.lower()
+        if name == 'zstd':
+            return numcodecs.Blosc(cname='zstd', clevel=self.compression_level, shuffle=shuffle)
+        elif name == 'lz4':
+            return numcodecs.Blosc(cname='lz4', clevel=self.compression_level, shuffle=shuffle)
+        elif name == 'zlib':
+            return numcodecs.Blosc(cname='zlib', clevel=self.compression_level, shuffle=shuffle)
+        elif name == 'none':
             return None
         else:
-            return zarr.Blosc(cname='zstd', clevel=1, shuffle=zarr.Blosc.SHUFFLE)
+            return numcodecs.Blosc(cname='zstd', clevel=1, shuffle=shuffle)
 
     def _create_output_stores(self):
         if self.num_classes is None or self.patch_size is None or self.num_total_patches is None:

--- a/vesuvius/tests/data/test_open_zarr_format.py
+++ b/vesuvius/tests/data/test_open_zarr_format.py
@@ -7,12 +7,16 @@ the package builds numcodecs compressors, which zarr 3 rejects on a v3 array.
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 
 import numcodecs
 import pytest
+import zarr
 
 from vesuvius.data.utils import open_zarr
+
+_ZARR_V3 = int(zarr.__version__.split('.', 1)[0]) >= 3
 
 
 def _stored_format(path: Path) -> int:
@@ -52,8 +56,19 @@ def test_contradictory_overwrite_false_rejected(tmp_path: Path) -> None:
                   chunks=(1, 8, 8), dtype="u1", overwrite=False)
 
 
+@pytest.mark.skipif(not _ZARR_V3, reason="zarr 2.x cannot write the v3 format")
 def test_explicit_zarr_format_3_still_possible(tmp_path: Path) -> None:
     path = tmp_path / "v3.zarr"
     open_zarr(path=str(path), mode="w", shape=(4, 8, 8), chunks=(1, 8, 8),
               dtype="f2", zarr_format=3)
     assert _stored_format(path) == 3
+
+
+def test_zarr_format_default_is_silent(tmp_path: Path) -> None:
+    # zarr 2 has no zarr_format argument and warns once per array created if it
+    # is passed anyway. Inference creates one store per part, so the default
+    # must not make noise on either supported zarr version.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        open_zarr(path=str(tmp_path / "quiet.zarr"), mode="w", shape=(4, 8, 8),
+                  chunks=(1, 8, 8), dtype="f2")

--- a/vesuvius/tests/data/test_open_zarr_format.py
+++ b/vesuvius/tests/data/test_open_zarr_format.py
@@ -37,6 +37,21 @@ def test_numcodecs_compressor_accepted(tmp_path: Path) -> None:
     assert open_zarr(path=str(path), mode="r")[0].max() == 1.0
 
 
+def test_redundant_overwrite_kwarg_is_accepted(tmp_path: Path) -> None:
+    # finalize_outputs passes overwrite=True alongside mode='w'; zarr 3 derives
+    # overwrite from the mode and rejects the duplicate.
+    path = tmp_path / "overwritten.zarr"
+    open_zarr(path=str(path), mode="w", shape=(4, 8, 8), chunks=(1, 8, 8),
+              dtype="u1", overwrite=True)
+    assert _stored_format(path) == 2
+
+
+def test_contradictory_overwrite_false_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        open_zarr(path=str(tmp_path / "no.zarr"), mode="w", shape=(4, 8, 8),
+                  chunks=(1, 8, 8), dtype="u1", overwrite=False)
+
+
 def test_explicit_zarr_format_3_still_possible(tmp_path: Path) -> None:
     path = tmp_path / "v3.zarr"
     open_zarr(path=str(path), mode="w", shape=(4, 8, 8), chunks=(1, 8, 8),

--- a/vesuvius/tests/data/test_open_zarr_format.py
+++ b/vesuvius/tests/data/test_open_zarr_format.py
@@ -1,0 +1,44 @@
+"""open_zarr must create stores the rest of the pipeline can read.
+
+blend_logits validates that logits stores are zarr_format 2, and every writer in
+the package builds numcodecs compressors, which zarr 3 rejects on a v3 array.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numcodecs
+import pytest
+
+from vesuvius.data.utils import open_zarr
+
+
+def _stored_format(path: Path) -> int:
+    if (path / ".zarray").exists():
+        return json.loads((path / ".zarray").read_text())["zarr_format"]
+    return json.loads((path / "zarr.json").read_text())["zarr_format"]
+
+
+def test_created_array_defaults_to_zarr_format_2(tmp_path: Path) -> None:
+    path = tmp_path / "out.zarr"
+    open_zarr(path=str(path), mode="w", shape=(4, 8, 8), chunks=(1, 8, 8), dtype="f2")
+    assert _stored_format(path) == 2
+
+
+def test_numcodecs_compressor_accepted(tmp_path: Path) -> None:
+    path = tmp_path / "compressed.zarr"
+    compressor = numcodecs.Blosc(cname="zstd", clevel=3, shuffle=numcodecs.blosc.SHUFFLE)
+    arr = open_zarr(path=str(path), mode="w", shape=(4, 8, 8), chunks=(1, 8, 8),
+                    dtype="f2", compressor=compressor)
+    arr[0] = 1.0
+    assert _stored_format(path) == 2
+    assert open_zarr(path=str(path), mode="r")[0].max() == 1.0
+
+
+def test_explicit_zarr_format_3_still_possible(tmp_path: Path) -> None:
+    path = tmp_path / "v3.zarr"
+    open_zarr(path=str(path), mode="w", shape=(4, 8, 8), chunks=(1, 8, 8),
+              dtype="f2", zarr_format=3)
+    assert _stored_format(path) == 3


### PR DESCRIPTION
## What

With the zarr version this repo pins (`uv.lock`: zarr 3.2.1), `vesuvius.predict` cannot write its outputs. There are two independent breakages, and the second one also affects `blend_logits`.

**1. `zarr.Blosc` was removed in zarr 3**

```
Creating output stores...
AttributeError: module 'zarr' has no attribute 'Blosc'
```

`_get_zarr_compressor` is the only place in the package still using it — `blending.py`, `finalize_outputs.py`, `structure_tensor/`, and `scripts/` all build `numcodecs.Blosc` already, and `inference.py` already imports `numcodecs`. Every run dies here unless you pass `--zarr-compressor none`.

**2. `open_zarr` creates v3 arrays, which reject the v2 keyword**

```
ValueError: compressor cannot be used for arrays with zarr_format 3
```

So even with a numcodecs compressor the create call fails. This is reachable from `blend_logits` too, which builds a `numcodecs.Blosc` and passes it to the same `open_zarr`. And `BlendingProcessor._validate_zarr_format` raises unless `zarr_format == 2`, so v3 logits would be rejected downstream even if they could be written.

## Fix

- `inference.py`: use `numcodecs.Blosc`, matching every other writer in the package.
- `open_zarr`: add a `zarr_format` parameter defaulting to `2`, which is what the rest of the pipeline reads and writes. Pass `zarr_format=None` to accept zarr's own default.

## Verification

Against the public Open Data bucket (PHerc. Paris 4, `20260310173927-45.532um-11.0m-110keV-masked.zarr`):

- before: `AttributeError` at "Creating output stores"
- after: `logits_part_0.zarr` and `coordinates_part_0.zarr` are created with the default zstd compressor, stored as `zarr_format` 2 as `blend_logits` requires

New tests in `tests/data/test_open_zarr_format.py` cover the default format, a numcodecs compressor round-trip, and that an explicit `zarr_format=3` still works. Full `tests/data` suite passes (34 tests).

Found while running the documented inference pipeline end to end on a machine with no GPU. Written with Claude Code as a coding assistant; every claim above was checked by running it.