### PR TITLE
Volume.meta: don't call len() on a single zarr Array

### DIFF
--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -416,15 +416,19 @@ class Volume:
             print(f"  Global Mean: {self.global_mean}, Global Std: {self.global_std}")
         print(f"Return Type: {self.return_as_type}")
         print(f"Return as Tensor: {self.return_as_tensor}")
-        print(f"Number of Resolution Levels: {len(self.data)}")
         if isinstance(self.data, zarr.Array):
+            # A single array is one resolution level; zarr.Array has no len().
+            print(f"Number of Resolution Levels: 1")
             print(f"  Level 0 Shape: {self.data.shape}, Dtype: {self.data.dtype}")
         elif isinstance(self.data, zarr.Group):
-            for key in sorted(self.data.keys(), key=lambda x: int(x) if x.isdigit() else x):
+            levels = [key for key in sorted(self.data.keys(), key=lambda x: int(x) if x.isdigit() else x)
+                      if isinstance(self.data[key], zarr.Array)]
+            print(f"Number of Resolution Levels: {len(levels)}")
+            for key in levels:
                 arr = self.data[key]
-                if isinstance(arr, zarr.Array):
-                    print(f"  Level {key} Shape: {arr.shape}, Dtype: {arr.dtype}")
+                print(f"  Level {key} Shape: {arr.shape}, Dtype: {arr.dtype}")
         else:
+            print(f"Number of Resolution Levels: {len(self.data)}")
             for idx, store in enumerate(self.data):
                 print(f"  Level {idx} Shape: {store.shape}, Dtype: {store.dtype}")
         if self.inklabel is not None:

--- a/vesuvius/tests/data/test_volume_meta.py
+++ b/vesuvius/tests/data/test_volume_meta.py
@@ -8,6 +8,16 @@ import zarr
 from vesuvius.data.volume import Volume
 
 
+def _add_level(group, name: str, shape) -> None:
+    """Add a resolution level to a group under either supported zarr version.
+
+    zarr 3 renamed Group.create_dataset to Group.create_array; 2.x only has the
+    former, and CI runs both.
+    """
+    create = getattr(group, "create_array", None) or group.create_dataset
+    create(name, shape=shape, chunks=(8, 8, 8), dtype="u1")
+
+
 def _make_volume(data) -> Volume:
     """Build a Volume without running __init__ (which needs network/config)."""
     vol = Volume.__new__(Volume)
@@ -39,8 +49,8 @@ def test_meta_reports_single_array_without_len(tmp_path, capsys) -> None:
 
 def test_meta_reports_multiscale_group(tmp_path, capsys) -> None:
     root = zarr.open_group(str(tmp_path / "multi.zarr"), mode="w")
-    root.create_array("0", shape=(16, 16, 16), chunks=(8, 8, 8), dtype="u1")
-    root.create_array("1", shape=(8, 8, 8), chunks=(8, 8, 8), dtype="u1")
+    _add_level(root, "0", (16, 16, 16))
+    _add_level(root, "1", (8, 8, 8))
     _make_volume(root).meta()
     out = capsys.readouterr().out
     assert "Number of Resolution Levels: 2" in out

--- a/vesuvius/tests/data/test_volume_meta.py
+++ b/vesuvius/tests/data/test_volume_meta.py
@@ -1,0 +1,60 @@
+"""Tests for Volume.meta() across the store layouts Volume accepts."""
+
+from __future__ import annotations
+
+import numpy as np
+import zarr
+
+from vesuvius.data.volume import Volume
+
+
+def _make_volume(data) -> Volume:
+    """Build a Volume without running __init__ (which needs network/config)."""
+    vol = Volume.__new__(Volume)
+    vol.type = "zarr"
+    vol.scroll_id = None
+    vol.segment_id = None
+    vol.energy = None
+    vol.resolution = None
+    vol.url = "memory://test.zarr"
+    vol.dtype = np.dtype("uint8")
+    vol.normalization_scheme = "none"
+    vol.global_mean = None
+    vol.global_std = None
+    vol.return_as_type = "np.float32"
+    vol.return_as_tensor = False
+    vol.inklabel = None
+    vol.data = data
+    return vol
+
+
+def test_meta_reports_single_array_without_len(tmp_path, capsys) -> None:
+    arr = zarr.open(str(tmp_path / "single.zarr"), mode="w",
+                    shape=(16, 16, 16), chunks=(8, 8, 8), dtype="u1")
+    _make_volume(arr).meta()
+    out = capsys.readouterr().out
+    assert "Number of Resolution Levels: 1" in out
+    assert "Level 0 Shape: (16, 16, 16)" in out
+
+
+def test_meta_reports_multiscale_group(tmp_path, capsys) -> None:
+    root = zarr.open_group(str(tmp_path / "multi.zarr"), mode="w")
+    root.create_array("0", shape=(16, 16, 16), chunks=(8, 8, 8), dtype="u1")
+    root.create_array("1", shape=(8, 8, 8), chunks=(8, 8, 8), dtype="u1")
+    _make_volume(root).meta()
+    out = capsys.readouterr().out
+    assert "Number of Resolution Levels: 2" in out
+    assert "Level 0 Shape: (16, 16, 16)" in out
+    assert "Level 1 Shape: (8, 8, 8)" in out
+
+
+def test_meta_reports_sequence_of_arrays(tmp_path, capsys) -> None:
+    arrays = [
+        zarr.open(str(tmp_path / "a.zarr"), mode="w", shape=(16, 16, 16),
+                  chunks=(8, 8, 8), dtype="u1"),
+        zarr.open(str(tmp_path / "b.zarr"), mode="w", shape=(8, 8, 8),
+                  chunks=(8, 8, 8), dtype="u1"),
+    ]
+    _make_volume(arrays).meta()
+    out = capsys.readouterr().out
+    assert "Number of Resolution Levels: 2" in out


### PR DESCRIPTION
## What

`Volume` accepts a `zarr.Array`, a `zarr.Group`, or a sequence of arrays, and `meta()` already branches on all three when printing per-level shapes. The resolution-level count just above that branch calls `len(self.data)` unconditionally, which raises for a `zarr.Array`:

```
TypeError: object of type 'Array' has no len()
```

`meta()` runs whenever a `Volume` is constructed with `verbose=True`, so any verbose run against a store that resolves to a single array dies during initialization:

```
vesuvius.predict --input_dir <volume>.zarr/0 ... --verbose
-> Error initializing Volume: object of type 'Array' has no len()
```

Pointing at an explicit resolution level like `.zarr/0` is the normal way to read a multiscale volume over HTTP, where the group listing comes back empty.

## Fix

Move the count inside the existing branches: a single array is one level, a group counts its array members, a sequence keeps `len()`. Group counting now also ignores non-array members instead of counting them as levels.

Tests in `tests/data/test_volume_meta.py` cover all three layouts.

Found while running the documented inference pipeline against the public Open Data bucket. Written with Claude Code as a coding assistant; verified by running it.