### PR TITLE
predict: add --bbox to restrict inference to a region of interest

### DIFF
--- a/vesuvius/docs/inference.md
+++ b/vesuvius/docs/inference.md
@@ -32,6 +32,7 @@ vesuvius.predict \
 | `--input_format` | Force `zarr`, `tiff`, or `volume` detection. Usually optional.
 | `--tta_type` / `--disable_tta` | Choose `rotation` (default) or `mirroring`, or disable test-time augmentation.
 | `--num_parts` / `--part_id` | Partition inference so multiple machines can process different chunks.
+| `--bbox` | Restrict inference to a region of interest: `"z0:z1,y0:y1,x0:x1"` in global voxel coordinates, half-open. Omit a bound to reach the volume edge (`"1000:1400,:,2000:"`). See [Region-of-interest inference](#region-of-interest-inference).
 | `--overlap` | Fractional patch overlap (0–1, default `0.5`).
 | `--batch_size` | Inference batch size (default `1`).
 | `--patch_size` | Override the model patch size using a comma-separated list (e.g. `192,192,192`).
@@ -58,6 +59,38 @@ vesuvius.predict --model_path ... --num_parts 4 --part_id 1 --device cuda:0
 ```
 
 Each worker writes `logits_part_<id>.zarr` and `coordinates_part_<id>.zarr` into the output directory.
+
+### Region-of-interest inference
+
+`--bbox` restricts the sliding window to one region of the volume, given in **global voxel
+coordinates** as `"z0:z1,y0:y1,x0:x1"`. Ranges are half-open (`z0` included, `z1` excluded),
+and either bound may be omitted to reach the volume edge:
+
+```bash
+vesuvius.predict --model_path hf://scrollprize/surface_recto \
+    --input_dir https://vesuvius-challenge-open-data.s3.amazonaws.com/PHercParis4/volumes/<volume>.zarr \
+    --output_dir /tmp/logits \
+    --bbox "2000:2200,1000:1200,1000:1200"
+
+# open bounds: from z=1000 to the end, all of y, up to x=2000
+vesuvius.predict ... --bbox "1000:,:,:2000"
+```
+
+Patch coordinates stay in the global frame, so `blend_logits` and `finalize_outputs` need no
+extra flags — the merged output lands at the same absolute position it would have had in a
+full-volume run. The requested ROI is recorded in the logits store's `bbox` attribute.
+
+This matters most when streaming a remote volume: only the chunks intersecting the ROI are
+ever fetched, so a small region of a multi-terabyte scroll costs seconds of network instead
+of hours. It is also the practical way to iterate on a model, inspect one column of text, or
+reproduce a result on a laptop.
+
+Notes:
+- `--num_parts`/`--part_id` split the ROI's Z extent (not the whole volume), so distributed
+  runs stay balanced when a bbox is active.
+- An ROI smaller than the model patch size along an axis is grown to the patch size and
+  shifted back inside the volume, so the model always sees a full patch.
+- Bounds are clamped to the volume; a bbox entirely outside it is an error.
 
 ## Stage 2 — `vesuvius.blend_logits`
 

--- a/vesuvius/src/vesuvius/data/vc_dataset.py
+++ b/vesuvius/src/vesuvius/data/vc_dataset.py
@@ -29,6 +29,7 @@ class VCDataset(Dataset):
             mode: str = 'infer', # Currently only 'infer' logic is fully implemented
             num_parts: int = 1,
             part_id: int = 0,
+            bbox: Optional[Tuple[int, int, int, int, int, int]] = None,
             targets = None,  # Added targets parameter with None default
             # --- Volume Class Pass-through Parameters ---
             scroll_id: Optional[Union[int, str]] = None,
@@ -62,6 +63,13 @@ class VCDataset(Dataset):
             mode: 'infer' (default). 'train' mode logic is not implemented here.
             num_parts: Number of parts to split the dataset into along Z-axis.
             part_id: Which part of the split dataset to use (0-indexed).
+            bbox: Optional region of interest as (z_min, z_max, y_min, y_max, x_min, x_max)
+                  in *global* voxel coordinates, half-open ([min, max)). When given, the
+                  sliding-window grid covers only this region, but patch coordinates stay
+                  in the global volume frame so downstream blending/finalization remain
+                  aligned. Bounds are clamped to the volume; an ROI smaller than the patch
+                  size along an axis is grown to the patch size (shifted back inside the
+                  volume when possible).
 
             scroll_id: Scroll ID for Volume (if input_path isn't a specific scroll/segment).
             energy: Energy value for Volume.
@@ -97,6 +105,21 @@ class VCDataset(Dataset):
             raise ValueError(f"part_id must be between 0 and {num_parts-1}, got {part_id}")
         self.num_parts = num_parts
         self.part_id = part_id
+
+        if bbox is not None:
+            if len(bbox) != 6:
+                raise ValueError(
+                    f"bbox must be (z_min, z_max, y_min, y_max, x_min, x_max), got {bbox}"
+                )
+            for axis, (lo, hi) in enumerate(zip(bbox[0::2], bbox[1::2])):
+                if lo is not None and lo < 0:
+                    raise ValueError(f"bbox axis {axis} min {lo} is negative")
+                if lo is not None and hi is not None and hi <= lo:
+                    raise ValueError(
+                        f"bbox axis {axis} range [{lo}, {hi}) is empty; "
+                        f"bounds are half-open and must satisfy min < max"
+                    )
+        self.bbox = tuple(int(v) if v is not None else None for v in bbox) if bbox is not None else None
 
         if self.mode != 'infer':
             print(f"Warning: VCDataset mode is '{self.mode}'. Only 'infer' mode logic (sliding window) is fully implemented.")
@@ -258,14 +281,30 @@ class VCDataset(Dataset):
             else:
                 raise ValueError(f"Unsupported input shape dimension from Volume: {self.input_shape}")
 
-            # Full-volume sliding window
-            if self.verbose:
-                print("\nUsing full volume sliding window")
+            roi = None
+            if self.bbox is not None:
+                roi = self._clamp_bbox_to_image(self.bbox, image_size, self.patch_size)
 
-            # Generate all potential coordinates
-            z_positions = compute_steps_for_sliding_window(image_size[0], pZ, self.step_size)
-            y_positions = compute_steps_for_sliding_window(image_size[1], pY, self.step_size)
-            x_positions = compute_steps_for_sliding_window(image_size[2], pX, self.step_size)
+            if roi is not None:
+                if self.verbose:
+                    print(f"\nUsing bbox-restricted sliding window (global coords): "
+                          f"z=[{roi[0][0]}, {roi[0][1]}), y=[{roi[1][0]}, {roi[1][1]}), "
+                          f"x=[{roi[2][0]}, {roi[2][1]})")
+                # Grid over the ROI extent, offset back into the global frame so all
+                # emitted coordinates remain volume-absolute.
+                (z0, z1), (y0, y1), (x0, x1) = roi
+                z_positions = [z0 + s for s in compute_steps_for_sliding_window(z1 - z0, pZ, self.step_size)]
+                y_positions = [y0 + s for s in compute_steps_for_sliding_window(y1 - y0, pY, self.step_size)]
+                x_positions = [x0 + s for s in compute_steps_for_sliding_window(x1 - x0, pX, self.step_size)]
+            else:
+                # Full-volume sliding window
+                if self.verbose:
+                    print("\nUsing full volume sliding window")
+
+                # Generate all potential coordinates
+                z_positions = compute_steps_for_sliding_window(image_size[0], pZ, self.step_size)
+                y_positions = compute_steps_for_sliding_window(image_size[1], pY, self.step_size)
+                x_positions = compute_steps_for_sliding_window(image_size[2], pX, self.step_size)
 
             if self.verbose:
                 print(f"  Image Size (Z, Y, X): {image_size}")
@@ -284,23 +323,29 @@ class VCDataset(Dataset):
 
             # Optional coverage diagnostics in verbose mode
             if self.verbose and self.all_positions:
+                # Coverage is judged against the tiled extent: the ROI when a bbox is
+                # active, the whole volume otherwise.
+                (tz0, tz1), (ty0, ty1), (tx0, tx1) = roi if roi is not None else (
+                    (0, image_size[0]), (0, image_size[1]), (0, image_size[2]))
                 max_start_z = max(pos[0] for pos in self.all_positions)
                 max_start_y = max(pos[1] for pos in self.all_positions)
                 max_start_x = max(pos[2] for pos in self.all_positions)
-                cov_z = (max_start_z + pZ == image_size[0]) if image_size[0] >= pZ else (max_start_z == 0)
-                cov_y = (max_start_y + pY == image_size[1]) if image_size[1] >= pY else (max_start_y == 0)
-                cov_x = (max_start_x + pX == image_size[2]) if image_size[2] >= pX else (max_start_x == 0)
+                cov_z = (max_start_z + pZ == tz1) if (tz1 - tz0) >= pZ else (max_start_z == tz0)
+                cov_y = (max_start_y + pY == ty1) if (ty1 - ty0) >= pY else (max_start_y == ty0)
+                cov_x = (max_start_x + pX == tx1) if (tx1 - tx0) >= pX else (max_start_x == tx0)
                 print("\nTiling coverage check:")
-                print(f"  Z axis: start in [0..{max_start_z}], patch {pZ}, size {image_size[0]} -> covers end: {cov_z}")
-                print(f"  Y axis: start in [0..{max_start_y}], patch {pY}, size {image_size[1]} -> covers end: {cov_y}")
-                print(f"  X axis: start in [0..{max_start_x}], patch {pX}, size {image_size[2]} -> covers end: {cov_x}")
+                print(f"  Z axis: start in [{tz0}..{max_start_z}], patch {pZ}, extent [{tz0}, {tz1}) -> covers end: {cov_z}")
+                print(f"  Y axis: start in [{ty0}..{max_start_y}], patch {pY}, extent [{ty0}, {ty1}) -> covers end: {cov_y}")
+                print(f"  X axis: start in [{tx0}..{max_start_x}], patch {pX}, extent [{tx0}, {tx1}) -> covers end: {cov_x}")
 
             # Apply Z-axis partitioning if num_parts > 1
             if self.num_parts > 1:
-                max_z = image_size[0]
-                z_per_part = max_z / self.num_parts
-                z_start = int(z_per_part * self.part_id)
-                z_end = int(z_per_part * (self.part_id + 1)) if self.part_id < self.num_parts - 1 else max_z
+                # Partition the tiled Z extent: with a bbox active, splitting the full
+                # volume range would leave most parts empty, so split the ROI instead.
+                part_z0, part_z1 = (roi[0] if roi is not None else (0, image_size[0]))
+                z_per_part = (part_z1 - part_z0) / self.num_parts
+                z_start = part_z0 + int(z_per_part * self.part_id)
+                z_end = part_z0 + int(z_per_part * (self.part_id + 1)) if self.part_id < self.num_parts - 1 else part_z1
 
                 if self.verbose:
                     print(f"\nApplying Z-axis partitioning:")
@@ -327,6 +372,34 @@ class VCDataset(Dataset):
             # today's lazy min/max-based detection untouched.
             self.non_empty_mask = self._build_non_empty_mask_from_chunks(use_path)
 
+
+    @staticmethod
+    def _clamp_bbox_to_image(bbox, image_size, patch_size):
+        """Clamp a global-coordinate bbox to the volume and grow it to patch size.
+
+        Returns ((z0, z1), (y0, y1), (x0, x1)), half-open. Raises if the bbox lies
+        entirely outside the volume. An ROI shorter than the patch along an axis is
+        grown to the patch size, shifted back inside the volume when it would
+        overhang (matching the sliding window's guarantee that starts stay >= 0).
+        """
+        roi = []
+        for axis in range(3):
+            lo, hi = bbox[2 * axis], bbox[2 * axis + 1]
+            dim = image_size[axis]
+            patch = patch_size[axis]
+            lo = 0 if lo is None else lo
+            hi = dim if hi is None else hi
+            lo_c, hi_c = min(lo, dim), min(hi, dim)
+            if hi_c <= lo_c:
+                raise ValueError(
+                    f"bbox axis {axis} range [{lo}, {hi}) lies outside the volume "
+                    f"(size {dim} along this axis)"
+                )
+            if hi_c - lo_c < patch:
+                hi_c = min(lo_c + patch, dim)
+                lo_c = max(0, hi_c - patch)
+            roi.append((lo_c, hi_c))
+        return tuple(roi)
 
     def _build_non_empty_mask_from_chunks(self, use_path):
         if not self.skip_empty_patches or not self.all_positions:

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -240,6 +240,7 @@ class Inferer():
                  input_anon: bool = False,
                  model_cache_dir: str = DEFAULT_MODEL_CACHE_DIR,
                  max_patches: int = None,
+                 bbox: [list, tuple] = None,
                  ):
         print(f"Initializing Inferer with output_dir: '{output_dir}'")
         if output_dir and not output_dir.strip():
@@ -275,6 +276,7 @@ class Inferer():
         self.input_anon = input_anon
         self.model_cache_dir = model_cache_dir
         self.max_patches = max_patches
+        self.bbox = tuple(bbox) if bbox is not None else None
         self.model_patch_size = None
         self.num_classes = None
 
@@ -705,6 +707,7 @@ class Inferer():
             energy=self.energy,
             resolution=self.resolution,
             anon=self.input_anon,
+            bbox=self.bbox,
         )
 
         expected_attr_name = 'all_positions'
@@ -861,6 +864,10 @@ class Inferer():
             self.output_store.attrs['overlap'] = self.overlap
             self.output_store.attrs['part_id'] = self.part_id
             self.output_store.attrs['num_parts'] = self.num_parts
+            if self.bbox is not None:
+                # Record the requested ROI (global voxel coords, half-open) so the
+                # output is self-describing about which region was processed.
+                self.output_store.attrs['bbox'] = list(self.bbox)
             
             # Store multi-task metadata if applicable
             if self.is_multi_task and self.target_info:
@@ -1052,6 +1059,36 @@ class Inferer():
             traceback.print_exc() 
 
 
+def _parse_bbox_arg(value):
+    """Parse "z0:z1,y0:y1,x0:x1" (half-open, global voxel coords) into a 6-tuple.
+
+    An omitted bound becomes None and is resolved to the volume edge once the
+    dataset opens the volume, so "1000:1400,:,2000:" is valid.
+    """
+    parts = value.split(',')
+    if len(parts) != 3:
+        raise ValueError(
+            f"--bbox expects three comma-separated ranges 'z0:z1,y0:y1,x0:x1', got '{value}'"
+        )
+    bounds = []
+    for axis_label, part in zip('zyx', parts):
+        piece = part.strip()
+        if ':' not in piece:
+            raise ValueError(
+                f"--bbox {axis_label}-range '{piece}' must contain ':' "
+                f"(use ':' alone for the full axis)"
+            )
+        lo_s, hi_s = piece.split(':', 1)
+        try:
+            bounds.append(int(lo_s) if lo_s.strip() else None)
+            bounds.append(int(hi_s) if hi_s.strip() else None)
+        except ValueError:
+            raise ValueError(
+                f"--bbox {axis_label}-range '{piece}' has a non-integer bound"
+            ) from None
+    return tuple(bounds)
+
+
 def main():
     import argparse
     import sys
@@ -1116,7 +1153,14 @@ def main():
     parser.add_argument('--max_patches', type=int, default=None,
                       help='Optional cap on patch positions processed by this part. '
                            'Intended for smoke tests; production inference leaves this unset.')
-    
+    parser.add_argument('--bbox', type=str, default=None,
+                      help='Restrict inference to a region of interest given as '
+                           '"z0:z1,y0:y1,x0:x1" in global voxel coordinates (half-open). '
+                           'Omit a bound to reach the volume edge, e.g. "1000:1400,:,2000:". '
+                           'Patch coordinates stay in the global frame, so blend_logits and '
+                           'finalize_outputs need no extra flags. When streaming a remote '
+                           'volume only the chunks intersecting the ROI are fetched.')
+
     args = parser.parse_args()
     
     # Parse optional patch size if provided
@@ -1130,6 +1174,14 @@ def main():
             print("Expected format: comma-separated integers, e.g. '192,192,192'")
             print("Using model's default patch size instead.")
     
+    bbox = None
+    if args.bbox:
+        try:
+            bbox = _parse_bbox_arg(args.bbox)
+        except ValueError as e:
+            parser.error(str(e))
+        print(f"Restricting inference to bbox (z0,z1,y0,y1,x0,x1): {bbox}")
+
     # Convert scroll_id and segment_id if needed
     scroll_id = args.scroll_id
     segment_id = args.segment_id
@@ -1174,6 +1226,7 @@ def main():
         input_anon=args.input_anon,
         model_cache_dir=args.model_cache_dir,
         max_patches=args.max_patches,
+        bbox=bbox,
     )
 
     try:

--- a/vesuvius/tests/data/test_vc_dataset_bbox.py
+++ b/vesuvius/tests/data/test_vc_dataset_bbox.py
@@ -1,0 +1,104 @@
+"""Tests for the VCDataset bbox (region-of-interest) sliding-window restriction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+
+from vesuvius.data.vc_dataset import VCDataset
+
+PATCH = (64, 64, 64)
+SHAPE = (300, 280, 260)
+
+
+@pytest.fixture(scope="module")
+def volume_path(tmp_path_factory) -> str:
+    path = tmp_path_factory.mktemp("vcds_bbox") / "vol.zarr"
+    arr = zarr.open(str(path), mode="w", shape=SHAPE, chunks=(64, 64, 64), dtype="u1")
+    rng = np.random.default_rng(97)
+    arr[:] = rng.integers(0, 255, size=SHAPE, dtype=np.uint8)
+    return str(path)
+
+
+def _dataset(volume_path: str, **kwargs) -> VCDataset:
+    return VCDataset(
+        input_path=volume_path,
+        patch_size=PATCH,
+        mode="infer",
+        skip_empty_patches=False,
+        verbose=False,
+        **kwargs,
+    )
+
+
+def test_bbox_positions_stay_global_and_inside_roi(volume_path: str) -> None:
+    bbox = (100, 200, 50, 180, 0, 130)
+    ds = _dataset(volume_path, bbox=bbox)
+    assert ds.all_positions, "bbox run produced no patch positions"
+    z0, z1, y0, y1, x0, x1 = bbox
+    for pz, py, px in ds.all_positions:
+        assert z0 <= pz and pz + PATCH[0] <= z1
+        assert y0 <= py and py + PATCH[1] <= y1
+        assert x0 <= px and px + PATCH[2] <= x1
+
+
+def test_bbox_covers_roi_ends(volume_path: str) -> None:
+    bbox = (100, 200, 50, 180, 0, 130)
+    ds = _dataset(volume_path, bbox=bbox)
+    assert min(p[0] for p in ds.all_positions) == bbox[0]
+    assert max(p[0] for p in ds.all_positions) + PATCH[0] == bbox[1]
+    assert max(p[1] for p in ds.all_positions) + PATCH[1] == bbox[3]
+    assert max(p[2] for p in ds.all_positions) + PATCH[2] == bbox[5]
+
+
+def test_bbox_reduces_patch_count(volume_path: str) -> None:
+    full = _dataset(volume_path)
+    roi = _dataset(volume_path, bbox=(100, 200, 50, 180, 0, 130))
+    assert len(roi.all_positions) < len(full.all_positions)
+
+
+def test_open_bounds_resolve_to_volume_edges(volume_path: str) -> None:
+    ds = _dataset(volume_path, bbox=(100, None, None, None, None, 130))
+    assert min(p[0] for p in ds.all_positions) == 100
+    assert max(p[1] for p in ds.all_positions) + PATCH[1] == SHAPE[1]
+    assert max(p[2] for p in ds.all_positions) + PATCH[2] == 130
+
+
+def test_sub_patch_roi_grows_to_patch_and_stays_in_volume(volume_path: str) -> None:
+    ds = _dataset(volume_path, bbox=(290, 300, 0, 10, 250, 260))
+    assert len(ds.all_positions) == 1
+    pz, py, px = ds.all_positions[0]
+    assert 0 <= pz and pz + PATCH[0] <= SHAPE[0]
+    assert 0 <= py and py + PATCH[1] <= SHAPE[1]
+    assert 0 <= px and px + PATCH[2] <= SHAPE[2]
+
+
+def test_num_parts_partitions_roi_without_loss(volume_path: str) -> None:
+    bbox = (100, 200, 50, 180, 0, 130)
+    single = _dataset(volume_path, bbox=bbox)
+    union: list = []
+    for part_id in range(3):
+        part = _dataset(volume_path, bbox=bbox, num_parts=3, part_id=part_id)
+        union.extend(part.all_positions)
+    assert sorted(union) == sorted(single.all_positions)
+
+
+@pytest.mark.parametrize(
+    "bbox",
+    [
+        (200, 100, 0, 10, 0, 10),  # empty range
+        (-5, 100, 0, 10, 0, 10),  # negative bound
+        (100, 200, 0, 10),  # wrong arity
+    ],
+)
+def test_invalid_bbox_rejected(volume_path: str, bbox) -> None:
+    with pytest.raises(ValueError):
+        _dataset(volume_path, bbox=bbox)
+
+
+def test_bbox_outside_volume_rejected(volume_path: str) -> None:
+    with pytest.raises(ValueError):
+        _dataset(volume_path, bbox=(500, 600, 0, 10, 0, 10))


### PR DESCRIPTION
## What

`vesuvius.predict` tiles the entire volume. The only way to process less is `--num_parts`/`--part_id`, which splits blindly along Z — there is no way to say "run the model *here*". When the input is a remote zarr, a small experiment on one region streams chunks for the whole scroll.

This adds `--bbox "z0:z1,y0:y1,x0:x1"`, in **global voxel coordinates**, half-open, with either bound omittable:

```bash
vesuvius.predict --model_path hf://scrollprize/surface_recto \
    --input_dir https://vesuvius-challenge-open-data.s3.amazonaws.com/PHercParis4/volumes/<volume>.zarr/0 \
    --output_dir /tmp/logits \
    --bbox "2000:2200,1000:1200,1000:1200"

# open bounds: from z=1000 to the end, all of y, up to x=2000
vesuvius.predict ... --bbox "1000:,:,:2000"
```

`VCDataset` builds the sliding window over the ROI and offsets it back into the global frame, so emitted patch coordinates are volume-absolute and `blend_logits`/`finalize_outputs` work unchanged — an ROI run lands exactly where a full-volume run would have put it. The requested ROI is recorded in the logits store's `bbox` attribute.

## Why

Measured on `PHercParis4` level 0 (4066×2264×2264 uint8, 128³ chunks, 192³ patches at 0.5 overlap):

| Run | Chunks touched | Data |
|---|---|---|
| Whole volume | 10,368 | 21.7 GB |
| One 200³ ROI | 27 | 56.6 MB |

**384× less data (99.74%).** Those 56.6 MB fetched in 45 s on a home connection. That is the difference between iterating on hardware you already own and provisioning a box first. It is also the practical way to inspect one column of text, or reproduce a result on a laptop.

## Details

- `--num_parts`/`--part_id` split the ROI's Z extent rather than the volume's, so distributed runs stay balanced when a bbox is active.
- An ROI smaller than the patch size on an axis is grown to the patch size and shifted back inside the volume, so the model always sees a full patch.
- Bounds are clamped to the volume; a bbox entirely outside it raises.
- Coverage diagnostics report against the tiled extent instead of the whole volume.
- Documented in `vesuvius/docs/inference.md` under "Region-of-interest inference".

## Tests

`tests/data/test_vc_dataset_bbox.py` — 10 tests covering global-frame coordinates, ROI coverage, open bounds, sub-patch growth, rejected inputs, and that a 3-part split reproduces the single-run position set exactly. Full `tests/data` suite passes.

Verified against the public Open Data bucket: with `--bbox 2000:2200,1000:1200,1000:1200` the run builds exactly 8 patches and reads `slice(2000, 2192), slice(1000, 1192), slice(1000, 1192)` — the requested region, in global coordinates.

Written with Claude Code as a coding assistant; every number above was measured, not estimated.