### PR TITLE
Guard the POSIX-only fcntl import in predict

### DIFF
--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -2,7 +2,12 @@ import torch
 import numpy as np
 import zarr
 import os
-import fcntl
+import errno
+try:
+    import fcntl  # POSIX-only; used to serialize model-cache downloads
+except ImportError:  # pragma: no cover - Windows has no fcntl
+    fcntl = None
+    import msvcrt
 import hashlib
 import multiprocessing
 import subprocess
@@ -156,13 +161,34 @@ class _InferenceDeepSupervisionWrapper(torch.nn.Module):
 DEFAULT_MODEL_CACHE_DIR = os.environ.get('VESUVIUS_MODEL_CACHE_DIR', '/tmp/vesuvius-models')
 
 
+def _lock_file_exclusive(fh):
+    """Take an exclusive advisory lock on an open file, on POSIX or Windows.
+
+    Released when the handle closes, matching the previous fcntl.flock usage.
+    """
+    if fcntl is not None:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+    else:
+        # msvcrt locks a byte range; one byte suffices for a lockfile. LK_LOCK
+        # retries for ~10 s and then raises, so loop to mirror LOCK_EX's
+        # blocking. Only contention is worth retrying: anything else (a bad
+        # descriptor, a full disk) would spin here forever, so re-raise it.
+        while True:
+            try:
+                msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+                return
+            except OSError as exc:
+                if exc.errno not in (errno.EACCES, errno.EDEADLK):
+                    raise
+
+
 def _resolve_model_path(model_path: str, cache_dir: str, verbose: bool = False) -> str:
     """Resolve a model_path, downloading from S3 to a local cache if needed.
 
     For s3:// URLs, runs `aws s3 sync` into `<cache_dir>/<sha256(url)>/` and
     returns the local directory path. A `.done` sentinel marks successful
     completion so re-runs reuse the cache. Concurrent downloads of the same
-    model are serialized with fcntl.flock on a per-model lockfile.
+    model are serialized with an exclusive lock on a per-model lockfile.
 
     For non-S3 paths, returns the input unchanged.
     """
@@ -181,7 +207,7 @@ def _resolve_model_path(model_path: str, cache_dir: str, verbose: bool = False) 
         return target
 
     with open(lock_path, 'w') as lock_fh:
-        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        _lock_file_exclusive(lock_fh)
         # Re-check after acquiring the lock in case another process completed.
         if os.path.exists(done):
             if verbose:

--- a/vesuvius/tests/models/run/test_lock_file_exclusive.py
+++ b/vesuvius/tests/models/run/test_lock_file_exclusive.py
@@ -1,0 +1,76 @@
+"""_lock_file_exclusive must block on contention but surface real errors.
+
+The Windows branch retries because msvcrt.locking gives up after ~10 s where
+fcntl.flock waits indefinitely. That retry loop is only correct if it is
+limited to lock contention: any other OSError would otherwise spin forever.
+Both branches are exercised here regardless of host OS by swapping the module
+globals, since CI runs on Linux only.
+"""
+
+from __future__ import annotations
+
+import errno
+
+import pytest
+
+from vesuvius.models.run import inference
+
+
+class _FakeMsvcrt:
+    """Stand-in for msvcrt that fails a fixed number of times, then succeeds."""
+
+    LK_LOCK = 1
+
+    def __init__(self, failures: list[int]) -> None:
+        self._failures = list(failures)
+        self.calls = 0
+
+    def locking(self, fd: int, mode: int, nbytes: int) -> None:
+        self.calls += 1
+        if self._failures:
+            raise OSError(self._failures.pop(0), "locking failed")
+
+
+@pytest.fixture()
+def windows_branch(monkeypatch):
+    """Force _lock_file_exclusive down the no-fcntl path with a fake msvcrt."""
+
+    def _install(failures: list[int]) -> _FakeMsvcrt:
+        fake = _FakeMsvcrt(failures)
+        monkeypatch.setattr(inference, "fcntl", None, raising=False)
+        monkeypatch.setattr(inference, "msvcrt", fake, raising=False)
+        return fake
+
+    return _install
+
+
+def test_retries_until_contention_clears(windows_branch, tmp_path):
+    fake = windows_branch([errno.EDEADLK, errno.EACCES])
+    with open(tmp_path / "lock", "w") as fh:
+        inference._lock_file_exclusive(fh)
+    assert fake.calls == 3
+
+
+@pytest.mark.parametrize("code", [errno.EBADF, errno.ENOSPC, errno.EINVAL])
+def test_non_contention_errors_propagate(windows_branch, tmp_path, code):
+    # Without this the loop would never terminate.
+    windows_branch([code])
+    with open(tmp_path / "lock", "w") as fh:
+        with pytest.raises(OSError) as excinfo:
+            inference._lock_file_exclusive(fh)
+    assert excinfo.value.errno == code
+
+
+def test_posix_branch_uses_flock(monkeypatch, tmp_path):
+    calls = []
+
+    class _FakeFcntl:
+        LOCK_EX = 2
+
+        def flock(self, fh, op):
+            calls.append(op)
+
+    monkeypatch.setattr(inference, "fcntl", _FakeFcntl(), raising=False)
+    with open(tmp_path / "lock", "w") as fh:
+        inference._lock_file_exclusive(fh)
+    assert calls == [_FakeFcntl.LOCK_EX]


### PR DESCRIPTION
## What

`vesuvius/models/run/inference.py` imports `fcntl` at module scope. `fcntl` is POSIX-only, so on Windows the `vesuvius.predict` entry point fails at import time, before any argument is parsed:

```
ModuleNotFoundError: No module named 'fcntl'
```

I know AGENTS.md §1.5 lists Ubuntu and macOS as the targets, so this is not a supported-platform bug — feel free to close it if Windows is explicitly out of scope. Offering it because the guard is small and the same section asks that OS-specific code be guarded with a safe fallback.

## Fix

`fcntl` is used in exactly one place: an advisory lock that serializes concurrent `aws s3 sync` downloads into the model cache. Import it lazily, and add `_lock_file_exclusive()` which uses `fcntl.flock` where available and `msvcrt.locking` otherwise. Lock semantics are unchanged on POSIX, and the lock is still released when the handle closes at the end of the `with` block.

## Verification

`from vesuvius.models.run.inference import main` succeeds on Windows 11 / Python 3.14, and `vesuvius.predict` then runs against the public Open Data bucket. No behaviour change on POSIX: the `fcntl` branch is byte-for-byte the previous call.

Written with Claude Code as a coding assistant.