### PR TITLE
community projects: add region-of-interest inference entry

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -72,6 +72,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [preprocessed-data](https://github.com/usc-caisplusplus/scroll-data-preprocessing): Data preprocessing code and a fully processed version of the dataset in .zarr format to allow for faster training of ink detection models. 
 
+- [Region-of-interest inference for `vesuvius.predict`](https://github.com/ScrollPrize/villa/pull/1241): `--bbox "z0:z1,y0:y1,x0:x1"` restricts inference to one region of a volume, in global voxel coordinates, so `blend_logits` and `finalize_outputs` stay aligned. Only the chunks intersecting the region are streamed — on PHerc. Paris 4 a 200³ region reads 27 chunks (56.6 MB) instead of 10,368 (21.7 GB). By TAUIL Abd Elillah
+
 ## Segmentation
 
 ### 🌟 Highlighted


### PR DESCRIPTION
Adds an entry for the `--bbox` region-of-interest work (#1241) to the community projects list, under *Data access/visualization → Tools*, since what it changes is how much data a run has to read.

Happy to move it to a different section, reword it, or hold this until #1241 is decided on — whatever you prefer.