### PR TITLE
Retry transient remote reads instead of aborting the whole run

### DIFF
--- a/vesuvius/src/vesuvius/data/vc_dataset.py
+++ b/vesuvius/src/vesuvius/data/vc_dataset.py
@@ -45,6 +45,7 @@ class VCDataset(Dataset):
             domain: Optional[str] = None,
             skip_empty_patches: bool = True,  # Whether to skip empty (homogeneous) patches
             anon: bool = False,  # Use anonymous (unsigned) requests for S3 input paths
+            read_retries: int = 4,  # Attempts per read, forwarded to Volume
             ):
         """
         Dataset for nnUNet inference using the Volume class for data access and preprocessing.
@@ -83,6 +84,9 @@ class VCDataset(Dataset):
                              (e.g., 'np.float16', 'np.float32'). Default is 'np.float32'.
             domain: Data source domain for Volume ('dl.ash2txt', 'local'). Auto-detected if None.
             anon: Use anonymous requests for input S3 reads.
+            read_retries: Attempts per read, forwarded to Volume (default 4). Transient
+                remote failures are retried with exponential backoff so one dropped
+                connection does not abort a long streaming run. Pass 1 to disable.
         """
         self.input_path = input_path
         self.input_format = input_format # Keep for informational purposes
@@ -228,6 +232,7 @@ class VCDataset(Dataset):
                 domain=domain,
                 path=use_path,
                 anon=self.anon,
+                read_retries=read_retries,
             )
 
             # Get shape and dtype from the primary resolution level (0)

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import os
+import time
 import yaml
 import json
 from numpy.typing import NDArray
@@ -13,6 +14,49 @@ from io import BytesIO
 from pathlib import Path
 from vesuvius.install.accept_terms import get_installation_path
 import zarr
+
+# Substrings that mark a read as worth retrying. Matching on the message keeps
+# this independent of which stack (aiohttp, botocore, urllib3, ssl) raised:
+# zarr and fsspec wrap those differently across versions and backends.
+_TRANSIENT_READ_MARKERS = (
+    'payload is not completed',
+    'not enough data to satisfy content length',
+    'contentlengtherror',
+    'connection reset',
+    'connection aborted',
+    'connection closed',
+    'server disconnected',
+    'record layer failure',
+    'ssl',
+    'timed out',
+    'timeout',
+    'temporarily unavailable',
+    'slowdown',
+    'throttl',
+    'too many requests',
+    'internal error',
+    'service unavailable',
+    'bad gateway',
+    'gateway timeout',
+    ' 429',
+    ' 500',
+    ' 502',
+    ' 503',
+    ' 504',
+)
+
+
+def _is_transient_read_error(exc: BaseException) -> bool:
+    """True when a read failure looks like a network hiccup rather than a bug."""
+    seen = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        text = f"{type(exc).__name__}: {exc}".lower()
+        if any(marker in text for marker in _TRANSIENT_READ_MARKERS):
+            return True
+        exc = exc.__cause__ or exc.__context__
+    return False
+
 
 # Define the functions needed here to avoid circular imports
 def list_files():
@@ -116,6 +160,7 @@ class Volume:
                  path: Optional[str] = None,
                  download_only: bool = False,
                  anon: bool = False,
+                 read_retries: int = 4,
                  ):
 
         """
@@ -157,6 +202,11 @@ class Volume:
         anon : bool, default = False
             If True, use anonymous (unsigned) requests for S3 access.
             Required for public S3 buckets when no AWS credentials are configured.
+        read_retries : int, default = 4
+            Attempts per read in __getitem__. Transient remote failures — dropped
+            connections, truncated payloads, 429/5xx — are retried with exponential
+            backoff so one hiccup does not abort a long streaming job. Deterministic
+            errors are re-raised immediately. Pass 1 to disable retrying.
         """
 
         # Initialize basic attributes
@@ -170,6 +220,7 @@ class Volume:
         self.path = path
         self.verbose = verbose
         self.anon = anon
+        self.read_retries = max(1, int(read_retries))
         self.inklabel = None  # Initialize inklabel
 
         # --- Input Validation ---
@@ -716,6 +767,30 @@ class Volume:
             else:
                 self.inklabel = np.zeros((1, 1), dtype=np.uint8)  # Fallback if data not loaded
 
+    def _read_with_retry(self, store, coord_idx):
+        """Read a slice from a store, retrying transient remote failures.
+
+        Remote object stores drop connections routinely — truncated payloads,
+        SSL record errors, 5xx, throttling. A caller streaming a whole volume
+        issues one read per patch, so without this a single hiccup propagates
+        out and aborts the job, discarding everything computed so far.
+
+        Deterministic failures (bad coordinates, missing array, auth) are not
+        retried; they re-raise on the first attempt.
+        """
+        delay = 0.5
+        for attempt in range(self.read_retries):
+            try:
+                return store[coord_idx]
+            except Exception as e:
+                if attempt == self.read_retries - 1 or not _is_transient_read_error(e):
+                    raise
+                if self.verbose:
+                    print(f"  transient read error ({type(e).__name__}), retry "
+                          f"{attempt + 1}/{self.read_retries - 1} in {delay:.1f}s: {e}")
+                time.sleep(delay)
+                delay = min(delay * 2, 8.0)
+
     def __getitem__(self, idx: Union[Tuple[Union[int, slice], ...], int]) -> Union[NDArray, torch.Tensor]:
         """
         Gets a sub-volume or slice, applying specified normalization and type conversion.
@@ -808,11 +883,13 @@ class Volume:
         try:
             # Handle the case when self.data is a zarr array directly (from _init_from_zarr_path)
             if isinstance(self.data, zarr.Array):
-                data_slice = self.data[coord_idx]
+                store = self.data
             else:
-                data_slice = self.data[subvolume_idx][coord_idx]
+                store = self.data[subvolume_idx]
 
-            original_dtype = data_slice.dtype  
+            data_slice = self._read_with_retry(store, coord_idx)
+
+            original_dtype = data_slice.dtype
 
             if self.verbose:
                 print(f"  Read slice shape: {data_slice.shape}, dtype: {data_slice.dtype}")

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -238,6 +238,7 @@ class Inferer():
                  hf_token: str = None,
                  model_type: str = 'auto',
                  input_anon: bool = False,
+                 read_retries: int = 4,
                  model_cache_dir: str = DEFAULT_MODEL_CACHE_DIR,
                  max_patches: int = None,
                  bbox: [list, tuple] = None,
@@ -274,6 +275,7 @@ class Inferer():
         self.hf_token = hf_token
         self.model_type = model_type
         self.input_anon = input_anon
+        self.read_retries = read_retries
         self.model_cache_dir = model_cache_dir
         self.max_patches = max_patches
         self.bbox = tuple(bbox) if bbox is not None else None
@@ -708,6 +710,7 @@ class Inferer():
             resolution=self.resolution,
             anon=self.input_anon,
             bbox=self.bbox,
+            read_retries=self.read_retries,
         )
 
         expected_attr_name = 'all_positions'
@@ -1150,6 +1153,11 @@ def main():
                       help=f'Local directory used to cache models downloaded from S3. '
                            f'Only applies when --model_path is an s3:// URL. '
                            f'Default: {DEFAULT_MODEL_CACHE_DIR}')
+    parser.add_argument('--read-retries', dest='read_retries', type=int, default=4,
+                      help='Attempts per patch read (default 4). Transient remote failures '
+                           '(dropped connections, truncated payloads, 429/5xx) are retried '
+                           'with exponential backoff so one hiccup does not abort a long '
+                           'streaming run. Set to 1 to disable.')
     parser.add_argument('--max_patches', type=int, default=None,
                       help='Optional cap on patch positions processed by this part. '
                            'Intended for smoke tests; production inference leaves this unset.')
@@ -1224,6 +1232,7 @@ def main():
         hf_token=args.hf_token,
         model_type=args.model_type,
         input_anon=args.input_anon,
+        read_retries=args.read_retries,
         model_cache_dir=args.model_cache_dir,
         max_patches=args.max_patches,
         bbox=bbox,

--- a/vesuvius/tests/data/test_volume_retry.py
+++ b/vesuvius/tests/data/test_volume_retry.py
@@ -1,0 +1,125 @@
+"""Transient remote read failures must not abort a long streaming run.
+
+Reads go through Volume.__getitem__, so the retry lives there and every caller
+of Volume gets it. These drive the real __getitem__ against a store that fails
+the way an object store does, rather than testing the helper in isolation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vesuvius.data.volume import Volume, _is_transient_read_error
+
+
+class _FlakyStore:
+    """Array-like store that raises a given sequence of errors before serving."""
+
+    def __init__(self, errors: list[BaseException]) -> None:
+        self._errors = list(errors)
+        self.ndim = 3
+        self.shape = (16, 16, 16)
+        self.dtype = np.dtype("uint8")
+        self.reads = 0
+
+    def __getitem__(self, idx):
+        self.reads += 1
+        if self._errors:
+            raise self._errors.pop(0)
+        return np.ones((4, 4, 4), dtype=np.uint8)
+
+
+def _make_volume(store, read_retries: int = 4) -> Volume:
+    """Build a Volume without __init__, which needs network and config."""
+    vol = Volume.__new__(Volume)
+    vol.type = "zarr"
+    vol.data = [store]
+    vol.dtype = store.dtype
+    vol.normalization_scheme = "none"
+    vol.global_mean = None
+    vol.global_std = None
+    vol.intensity_props = None
+    vol.return_as_type = "none"
+    vol.return_as_tensor = False
+    vol.verbose = False
+    vol.read_retries = read_retries
+    return vol
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr("vesuvius.data.volume.time.sleep", lambda _s: None)
+
+
+def _idx():
+    return (slice(0, 4), slice(0, 4), slice(0, 4))
+
+
+def test_transient_error_is_retried_then_succeeds() -> None:
+    store = _FlakyStore([
+        OSError("Response payload is not completed"),
+        OSError("[SSL: RECORD_LAYER_FAILURE] record layer failure"),
+    ])
+    result = _make_volume(store)[_idx()]
+    assert store.reads == 3
+    assert result.shape == (4, 4, 4)
+
+
+def test_transient_error_exhausts_attempts_and_raises() -> None:
+    store = _FlakyStore([OSError("connection reset by peer")] * 5)
+    with pytest.raises(OSError):
+        _make_volume(store, read_retries=3)[_idx()]
+    assert store.reads == 3
+
+
+def test_deterministic_error_is_not_retried() -> None:
+    store = _FlakyStore([IndexError("index 99 is out of bounds")])
+    with pytest.raises(IndexError):
+        _make_volume(store)[_idx()]
+    assert store.reads == 1, "a coding error must fail fast, not be retried"
+
+
+def test_retries_disabled_with_one_attempt() -> None:
+    store = _FlakyStore([OSError("connection reset by peer")] * 3)
+    with pytest.raises(OSError):
+        _make_volume(store, read_retries=1)[_idx()]
+    assert store.reads == 1
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Response payload is not completed: ContentLengthError",
+        "Not enough data to satisfy content length header (received 1202432 of 2097152 bytes)",
+        "[SSL: RECORD_LAYER_FAILURE] record layer failure",
+        "Connection reset by peer",
+        "botocore error: An error occurred (503) when calling GetObject: SlowDown",
+        "read operation timed out",
+    ],
+)
+def test_transient_messages_detected(message: str) -> None:
+    assert _is_transient_read_error(OSError(message))
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        IndexError("index 99 is out of bounds"),
+        KeyError("no such array: 0"),
+        ValueError("patch_size must be a tuple of 3 integers"),
+    ],
+)
+def test_deterministic_errors_not_flagged(exc: BaseException) -> None:
+    assert not _is_transient_read_error(exc)
+
+
+def test_transient_cause_detected_through_wrapper() -> None:
+    # zarr/fsspec wrap the underlying network error; the cause chain must be walked.
+    try:
+        try:
+            raise OSError("Response payload is not completed")
+        except OSError as inner:
+            raise RuntimeError("Failed to get item 6 (pos 8064,3264,3200)") from inner
+    except RuntimeError as wrapped:
+        assert _is_transient_read_error(wrapped)


### PR DESCRIPTION
## What

Streaming inference issues one read per patch, and a single dropped connection propagates out of the DataLoader worker and kills the entire run — discarding every patch already computed. This hit me 6 patches into an 8-patch job against the public Open Data bucket:

```
RuntimeError: Failed to get item 6 (pos 8064,3264,3200): Response payload is not completed:
<ContentLengthError: 400, message='Not enough data to satisfy content length header
(received 1202432 of 2097152 bytes).'>. SSLError(1, '[SSL: RECORD_LAYER_FAILURE] record layer failure')
```

Nothing was wrong with the data or the request — the connection just dropped mid-chunk. On a full scroll over S3, which is hours of reads, hitting at least one of these is close to certain, and today that means starting over.

## Fix

Retry transient read failures with exponential backoff (4 attempts, 0.5 s doubling to 8 s), exposed as `--read-retries` (set `1` to disable).

Transience is judged from the message across the whole `__cause__`/`__context__` chain, because zarr/fsspec wrap aiohttp, botocore, urllib3 and ssl errors differently depending on version and backend — matching on exception classes alone misses most real cases. Deterministic failures (bad coordinates, missing array, auth) are **not** retried and still fail on the first attempt, so a coding error doesn't turn into a slow four-attempt failure.

## Tests

`tests/data/test_vc_dataset_retry.py` — 14 tests: retry-then-succeed, exhaustion, fail-fast on deterministic errors, `--read-retries 1` disabling retries, message classification for the observed failure modes (truncated payload, SSL record failure, connection reset, 503/SlowDown, timeout), and detection through a wrapping `RuntimeError`.

Found while reproducing published surface predictions from public inputs on an ordinary connection. Written with Claude Code as a coding assistant; the failure above is a real one from my own run, not a constructed example.