### PR TITLE
vesuvius-py: predict --bbox: take the patch grid from the volume, so an ROI run matches a full run

### DIFF
--- a/vesuvius/src/vesuvius/data/vc_dataset.py
+++ b/vesuvius/src/vesuvius/data/vc_dataset.py
@@ -290,12 +290,23 @@ class VCDataset(Dataset):
                     print(f"\nUsing bbox-restricted sliding window (global coords): "
                           f"z=[{roi[0][0]}, {roi[0][1]}), y=[{roi[1][0]}, {roi[1][1]}), "
                           f"x=[{roi[2][0]}, {roi[2][1]})")
-                # Grid over the ROI extent, offset back into the global frame so all
-                # emitted coordinates remain volume-absolute.
+                # Build the grid the whole volume would have used, then keep the
+                # patches that touch the ROI. Anchoring the grid to the ROI origin
+                # instead would place patches the full-volume run never places -
+                # a 256-long ROI yields stride 64 where the volume yields ~96 - so
+                # every voxel gets a different set of overlapping patches and the
+                # blended result no longer matches the corresponding sub-region of
+                # a full run. Selecting from the global grid keeps them identical,
+                # which is the whole point of being able to redo one region.
                 (z0, z1), (y0, y1), (x0, x1) = roi
-                z_positions = [z0 + s for s in compute_steps_for_sliding_window(z1 - z0, pZ, self.step_size)]
-                y_positions = [y0 + s for s in compute_steps_for_sliding_window(y1 - y0, pY, self.step_size)]
-                x_positions = [x0 + s for s in compute_steps_for_sliding_window(x1 - x0, pX, self.step_size)]
+
+                def _overlapping(extent, patch, lo, hi):
+                    return [s for s in compute_steps_for_sliding_window(extent, patch, self.step_size)
+                            if s < hi and s + patch > lo]
+
+                z_positions = _overlapping(image_size[0], pZ, z0, z1)
+                y_positions = _overlapping(image_size[1], pY, y0, y1)
+                x_positions = _overlapping(image_size[2], pX, x0, x1)
             else:
                 # Full-volume sliding window
                 if self.verbose:

--- a/vesuvius/src/vesuvius/data/vc_dataset.py
+++ b/vesuvius/src/vesuvius/data/vc_dataset.py
@@ -351,9 +351,16 @@ class VCDataset(Dataset):
 
             # Apply Z-axis partitioning if num_parts > 1
             if self.num_parts > 1:
-                # Partition the tiled Z extent: with a bbox active, splitting the full
-                # volume range would leave most parts empty, so split the ROI instead.
-                part_z0, part_z1 = (roi[0] if roi is not None else (0, image_size[0]))
+                # Partition the Z span the selected patches actually occupy. With a
+                # bbox active, splitting the full volume range would leave most parts
+                # empty; splitting the ROI range instead would silently drop the
+                # patches that start before it, since the grid comes from the whole
+                # volume and the first patch covering the ROI usually begins outside.
+                if self.all_positions:
+                    occupied_z = sorted({pos[0] for pos in self.all_positions})
+                    part_z0, part_z1 = occupied_z[0], occupied_z[-1] + 1
+                else:
+                    part_z0, part_z1 = (0, image_size[0])
                 z_per_part = (part_z1 - part_z0) / self.num_parts
                 z_start = part_z0 + int(z_per_part * self.part_id)
                 z_end = part_z0 + int(z_per_part * (self.part_id + 1)) if self.part_id < self.num_parts - 1 else part_z1

--- a/vesuvius/tests/data/test_vc_dataset_bbox.py
+++ b/vesuvius/tests/data/test_vc_dataset_bbox.py
@@ -9,9 +9,27 @@ import pytest
 import zarr
 
 from vesuvius.data.vc_dataset import VCDataset
+from vesuvius.utils.models.helpers import compute_steps_for_sliding_window
 
 PATCH = (64, 64, 64)
 SHAPE = (300, 280, 260)
+STEP = 0.5
+
+
+def _full_grid(axis: int) -> list[int]:
+    """The positions a full-volume run places along one axis."""
+    return list(compute_steps_for_sliding_window(SHAPE[axis], PATCH[axis], STEP))
+
+
+def _covers(positions, axis: int, lo: int, hi: int) -> bool:
+    """True when the patches leave no gap over [lo, hi)."""
+    spans = sorted((p, p + PATCH[axis]) for p in {q[axis] for q in positions})
+    reach = lo
+    for start, end in spans:
+        if start > reach:
+            return False
+        reach = max(reach, end)
+    return reach >= hi
 
 
 @pytest.fixture(scope="module")
@@ -34,24 +52,46 @@ def _dataset(volume_path: str, **kwargs) -> VCDataset:
     )
 
 
-def test_bbox_positions_stay_global_and_inside_roi(volume_path: str) -> None:
+def test_bbox_positions_come_from_the_full_volume_grid(volume_path: str) -> None:
+    # The point of the flag is to redo one region of a full run. That only holds
+    # if the patches are the ones the full run would have placed there; a grid
+    # anchored to the ROI tiles at a different stride and blends differently.
     bbox = (100, 200, 50, 180, 0, 130)
     ds = _dataset(volume_path, bbox=bbox)
     assert ds.all_positions, "bbox run produced no patch positions"
-    z0, z1, y0, y1, x0, x1 = bbox
-    for pz, py, px in ds.all_positions:
-        assert z0 <= pz and pz + PATCH[0] <= z1
-        assert y0 <= py and py + PATCH[1] <= y1
-        assert x0 <= px and px + PATCH[2] <= x1
+    for axis in range(3):
+        allowed = set(_full_grid(axis))
+        assert {p[axis] for p in ds.all_positions} <= allowed
 
 
-def test_bbox_covers_roi_ends(volume_path: str) -> None:
+def test_bbox_selects_exactly_the_patches_that_touch_the_roi(volume_path: str) -> None:
     bbox = (100, 200, 50, 180, 0, 130)
     ds = _dataset(volume_path, bbox=bbox)
-    assert min(p[0] for p in ds.all_positions) == bbox[0]
-    assert max(p[0] for p in ds.all_positions) + PATCH[0] == bbox[1]
-    assert max(p[1] for p in ds.all_positions) + PATCH[1] == bbox[3]
-    assert max(p[2] for p in ds.all_positions) + PATCH[2] == bbox[5]
+    got = sorted(ds.all_positions)
+    expected = sorted(
+        (z, y, x)
+        for z in _full_grid(0) if z < bbox[1] and z + PATCH[0] > bbox[0]
+        for y in _full_grid(1) if y < bbox[3] and y + PATCH[1] > bbox[2]
+        for x in _full_grid(2) if x < bbox[5] and x + PATCH[2] > bbox[4]
+    )
+    assert got == expected
+
+
+def test_bbox_positions_are_a_subset_of_a_full_run(volume_path: str) -> None:
+    bbox = (100, 200, 50, 180, 0, 130)
+    full = set(_dataset(volume_path).all_positions)
+    roi = set(_dataset(volume_path, bbox=bbox).all_positions)
+    assert roi and roi <= full
+
+
+def test_bbox_covers_the_whole_roi(volume_path: str) -> None:
+    # Patches may overhang the bbox - they have to, since a voxel's blended
+    # value depends on every patch covering it - but no gap may be left inside.
+    bbox = (100, 200, 50, 180, 0, 130)
+    ds = _dataset(volume_path, bbox=bbox)
+    assert _covers(ds.all_positions, 0, bbox[0], bbox[1])
+    assert _covers(ds.all_positions, 1, bbox[2], bbox[3])
+    assert _covers(ds.all_positions, 2, bbox[4], bbox[5])
 
 
 def test_bbox_reduces_patch_count(volume_path: str) -> None:
@@ -62,18 +102,25 @@ def test_bbox_reduces_patch_count(volume_path: str) -> None:
 
 def test_open_bounds_resolve_to_volume_edges(volume_path: str) -> None:
     ds = _dataset(volume_path, bbox=(100, None, None, None, None, 130))
-    assert min(p[0] for p in ds.all_positions) == 100
-    assert max(p[1] for p in ds.all_positions) + PATCH[1] == SHAPE[1]
-    assert max(p[2] for p in ds.all_positions) + PATCH[2] == 130
+    assert _covers(ds.all_positions, 0, 100, SHAPE[0])
+    assert _covers(ds.all_positions, 1, 0, SHAPE[1])
+    assert _covers(ds.all_positions, 2, 0, 130)
+    # An axis left open must reproduce the full-volume grid on that axis.
+    assert sorted({p[1] for p in ds.all_positions}) == _full_grid(1)
 
 
-def test_sub_patch_roi_grows_to_patch_and_stays_in_volume(volume_path: str) -> None:
-    ds = _dataset(volume_path, bbox=(290, 300, 0, 10, 250, 260))
-    assert len(ds.all_positions) == 1
-    pz, py, px = ds.all_positions[0]
-    assert 0 <= pz and pz + PATCH[0] <= SHAPE[0]
-    assert 0 <= py and py + PATCH[1] <= SHAPE[1]
-    assert 0 <= px and px + PATCH[2] <= SHAPE[2]
+def test_sub_patch_roi_stays_in_volume_and_on_the_grid(volume_path: str) -> None:
+    roi = (290, 300, 0, 10, 250, 260)
+    ds = _dataset(volume_path, bbox=roi)
+    assert ds.all_positions
+    for axis in range(3):
+        allowed = set(_full_grid(axis))
+        for pos in ds.all_positions:
+            assert pos[axis] in allowed
+            assert 0 <= pos[axis] and pos[axis] + PATCH[axis] <= SHAPE[axis]
+    assert _covers(ds.all_positions, 0, roi[0], roi[1])
+    assert _covers(ds.all_positions, 1, roi[2], roi[3])
+    assert _covers(ds.all_positions, 2, roi[4], roi[5])
 
 
 def test_num_parts_partitions_roi_without_loss(volume_path: str) -> None:


### PR DESCRIPTION
`--bbox` (#1241, mine) does not reproduce the corresponding region of a full-volume run. I found this while checking whether the published m7 surface predictions can be regenerated from public inputs, and the bbox flag turned out to be the reason they could not.

## The bug

`VCDataset` anchored the sliding window to the ROI origin:

```python
z_positions = [z0 + s for s in compute_steps_for_sliding_window(z1 - z0, pZ, self.step_size)]
```

`compute_steps_for_sliding_window` spreads its positions evenly across whatever extent it is given, so the extent decides the stride. For PHerc0139 with the m7 patch size (192) at the default step 0.5:

| grid | positions near z=8000 | stride |
|---|---|---|
| whole volume (20974) | 7853, 7949, **8045**, 8140, 8236 | ~95.8 |
| 256-long bbox at 8000 | 8000, 8064 | 64 |

Not one position in common. Every voxel in the ROI is therefore covered by a different set of patches, with different Gaussian blending weights, so the blended logits differ from a full run even deep inside the ROI, far from its own edges.

## Measured against the published artifact

The published surface predictions for every scroll come from one model run (`20260413222639` = `hf://scrollprize/surface_m7_nnunet`), and both the model and the CT are public, so the region can be regenerated and compared exactly. PHerc0139, bbox `8000:8256,3200:3456,3200:3456`, scored on the ROI interior (64 voxels trimmed per face), thresholded at 0.2 to match the published `th0.2` artifact:

| grid | Dice vs published | disagreeing voxels |
|---|---|---|
| ROI-anchored (before) | 0.8001 | 181,086 (8.63%) |
| **full-volume grid (after)** | **0.9997** | **266 (0.013%)** |

After the fix all 266 remaining voxels lie within 0.01 of the threshold, which is what float16 storage and autocast leave behind; AUC is 1.0000. Before the fix, a sweep over every threshold from 0.01 to 0.95 topped out at 0.8019, so no calibration or precision difference could account for the difference — it was the patch grid.

Worth stating plainly since it may be useful to others: **the published m7 surface predictions do reproduce from public inputs**, once the grid matches.

## The fix

Build the grid the whole volume would have used, then keep the patches that intersect the ROI. Positions are then always a subset of the full-volume grid, so a bbox run reproduces the corresponding sub-region of a full run — which is the reason to offer the flag at all.

**Cost, stated honestly:** selected patches may overhang the requested bbox by up to one patch, so a run reads a margin around the ROI. That is unavoidable rather than a choice — a voxel's blended value depends on every patch covering it, and those patches extend past the ROI edge. If you would rather keep the old behaviour available for people who want reads strictly bounded, I am happy to add a flag for it; I did not add one because a silently-different result seemed like the wrong default.

## Second bug, found by the new test

With the grid corrected, patches legitimately start *before* the ROI. `--num_parts` partitioned the ROI range and assigned each patch by its starting coordinate, so those patches fell into no part at all and were silently dropped — 60 of 120 positions lost on a 3-way split of the test ROI. Now the partition covers the span the selected patches actually occupy, and the union over all parts is again exactly the single-part run.

## Tests

`tests/data/test_vc_dataset_bbox.py` is rewritten around the invariant that matters:

- positions are drawn from the full-volume grid
- they are exactly the patches intersecting the ROI
- they are a subset of a full run's positions
- they leave no gap inside the ROI
- `num_parts` partitions without loss

The old tests asserted patches lay wholly inside the bbox, which is what the bug looked like from outside. 12 tests, and `pytest tests/data` is 30 passed.

Verified end to end on GPU against the public Open Data bucket: 125 patches, `blend_logits`, then the comparison above.
