### PR TITLE
inference: record whether TTA was used in the prediction output attrs

### DIFF
--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -893,6 +893,13 @@ class Inferer():
             self.output_store.attrs['overlap'] = self.overlap
             self.output_store.attrs['part_id'] = self.part_id
             self.output_store.attrs['num_parts'] = self.num_parts
+            # Record whether test-time augmentation was used. Patch size and overlap are
+            # already here, but TTA is the setting that changes the output most and it
+            # leaves no trace otherwise, so a stored prediction cannot be reproduced from
+            # itself without guessing it.
+            self.output_store.attrs['tta'] = bool(self.do_tta)
+            if self.do_tta:
+                self.output_store.attrs['tta_type'] = self.tta_type
             if self.bbox is not None:
                 # Record the requested ROI (global voxel coords, half-open) so the
                 # output is self-describing about which region was processed.

--- a/vesuvius/tests/models/run/test_inference_run_config_attrs.py
+++ b/vesuvius/tests/models/run/test_inference_run_config_attrs.py
@@ -1,0 +1,87 @@
+"""The output store should record the settings needed to reproduce it.
+
+patch_size and overlap were already stored. TTA was not, and it is the setting that
+changes the output most, so a stored prediction could not be reproduced from itself
+without guessing whether augmentation had been used.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import zarr
+
+from vesuvius.models.run.inference import Inferer
+
+
+def _inferer(tmp_path, *, do_tta: bool, tta_type: str = "mirroring") -> Inferer:
+    """An Inferer with just enough state for _create_output_stores to run.
+
+    __init__ builds a model and a dataset, neither of which this behaviour depends on,
+    so the instance is assembled directly instead.
+    """
+    inf = Inferer.__new__(Inferer)
+    inf.num_classes = 2
+    inf.patch_size = (4, 4, 4)
+    inf.num_total_patches = 1
+    inf.output_dir = str(tmp_path)
+    inf.part_id = 0
+    inf.num_parts = 1
+    inf.overlap = 0.5
+    inf.verbose = False
+    # 'none' short-circuits _get_zarr_compressor, which reaches for zarr.Blosc - absent in
+    # zarr 3. Compression is irrelevant to the attributes under test.
+    inf.compressor_name = "none"
+    inf.compression_level = 1
+    inf.bbox = None
+    inf.is_multi_task = False
+    inf.target_info = None
+    inf.dataset = SimpleNamespace(input_shape=(8, 8, 8))
+    inf.patch_start_coords_list = [(0, 0, 0)]
+    inf.do_tta = do_tta
+    inf.tta_type = tta_type
+    return inf
+
+
+def _attrs(tmp_path):
+    return dict(zarr.open(str(tmp_path / "logits_part_0.zarr"), mode="r").attrs)
+
+
+def test_records_tta_enabled(tmp_path):
+    _inferer(tmp_path, do_tta=True, tta_type="mirroring")._create_output_stores()
+    attrs = _attrs(tmp_path)
+    assert attrs["tta"] is True
+    assert attrs["tta_type"] == "mirroring"
+
+
+def test_records_tta_disabled(tmp_path):
+    _inferer(tmp_path, do_tta=False)._create_output_stores()
+    attrs = _attrs(tmp_path)
+    assert attrs["tta"] is False
+    # tta_type is meaningless when no augmentation ran, so it is not claimed
+    assert "tta_type" not in attrs
+
+
+def test_records_rotation_tta(tmp_path):
+    _inferer(tmp_path, do_tta=True, tta_type="rotation")._create_output_stores()
+    assert _attrs(tmp_path)["tta_type"] == "rotation"
+
+
+def test_tta_is_json_serialisable_bool(tmp_path):
+    """zarr writes .zattrs as JSON, so a numpy bool would not round-trip."""
+    inf = _inferer(tmp_path, do_tta=True)
+    inf.do_tta = 1  # truthy non-bool, as an argparse/config path could supply
+    inf._create_output_stores()
+    assert _attrs(tmp_path)["tta"] is True
+
+
+def test_existing_attrs_still_written(tmp_path):
+    """The new keys must not displace what consumers already read."""
+    _inferer(tmp_path, do_tta=False)._create_output_stores()
+    attrs = _attrs(tmp_path)
+    assert attrs["patch_size"] == [4, 4, 4]
+    assert attrs["overlap"] == 0.5
+    assert attrs["part_id"] == 0
+    assert attrs["num_parts"] == 1
+    assert attrs["original_volume_shape"] == [8, 8, 8]


### PR DESCRIPTION
A stored prediction can't currently be reproduced from itself. The output store already records `patch_size` and `overlap`, but nothing about test-time augmentation — and TTA changes the result more than either of them.

I ran into this while auditing the published surface predictions. Reproducing all 36 takes two different settings, not one:

| region | TTA off | TTA on |
|---|---|---|
| PHerc0139 | **0.9997** | 0.8273 |
| PHerc. Paris 4 | 0.8907 | **0.9999** |

35 of the 36 match with TTA off; PHerc. Paris 4 only matches with mirroring TTA on. The converse is what makes it conclusive rather than a fluke — TTA *breaks* PHerc0139 by about as much as its absence breaks Paris 4. One setting, two scrolls, opposite directions. Each pair is scored on the identical bounding box.

The artifacts record nothing that distinguishes them: their `.zattrs` hold only the boilerplate `multiscales` block. So which setting produced a given published prediction has to be guessed, and I guessed wrong first — I had Paris 4 written up as "not reproducible" before finding the flag.

### The change

Two attributes on the logits store:

```python
self.output_store.attrs['tta'] = bool(self.do_tta)
if self.do_tta:
    self.output_store.attrs['tta_type'] = self.tta_type
```

`blending.py` already copies every attribute from the logits store onto the merged output, so this reaches the final prediction with no change there.

`tta_type` is written only when augmentation actually ran, so a prediction never claims a scheme it didn't use. `bool()` is explicit because `.zattrs` is JSON and a numpy bool wouldn't round-trip.

### Tests

`vesuvius/tests/models/run/test_inference_run_config_attrs.py` — five cases: TTA on, TTA off, rotation TTA, the JSON-serialisable bool, and a check that the existing attributes are still written. 22 pass across `vesuvius/tests/models/run/`.

### Scope

Deliberately just the one missing field, since patch size and overlap are already stored. Happy to widen it — model checkpoint identity and normalization scheme are the other two a consumer can't recover — if you'd rather have the whole set in one go.

Scoring scripts and the per-region results behind the table are at https://github.com/TAUIL-Abd-Elilah/vesuvius-repro (`results/variants/`).
