### PR TITLE
inference: accept both underscore/hyphen for flags

### DIFF
--- a/vesuvius/docs/inference.md
+++ b/vesuvius/docs/inference.md
@@ -42,8 +42,8 @@ vesuvius.predict \
 | `--normalization` | Runtime normalization (`instance_zscore`, `global_zscore`, `instance_minmax`, `ct`, `none`).
 | `--intensity-properties-json` | nnU-Net style JSON with intensity stats for CT normalization.
 | `--device` | Device string such as `cuda`, `cuda:1`, or `cpu`.
-| `--skip-empty-patches` / `--no-skip-empty-patches` | Toggle automatic removal of homogeneous patches.
-| `--zarr-compressor` / `--zarr-compression-level` | Configure output compression (`zstd` with level `3` by default).
+| `--skip_empty_patches` / `--no_skip_empty_patches` | Toggle automatic removal of homogeneous patches.
+| `--zarr_compressor` / `--zarr_compression_level` | Configure output compression (`zstd` with level `3` by default).
 | `--scroll_id`, `--segment_id`, `--energy`, `--resolution` | Metadata when reading remote scrolls via the `Volume` helper.
 | `--hf_token` | Hugging Face token for private repositories.
 | `--config-yaml` | Training YAML to resolve model architecture when the checkpoint lacks embedded metadata.
@@ -123,11 +123,11 @@ Finalize logits into probabilities or masks and optionally build a multiscale py
 ```bash
 vesuvius.finalize_outputs /tmp/merged_logits.zarr /tmp/final_output.zarr \
   --mode binary \
-  --threshold --threshold-value 0.3 \
-  --delete-intermediates
+  --threshold --threshold_value 0.3 \
+  --delete_intermediates
 ```
 
-`--threshold` toggles binarization on (default cutoff `0.5`). `--threshold-value T` overrides the cutoff with any value in `(0, 1)` and requires `--threshold`. The right cutoff is model-dependent and should come from validation — `0.3` above is illustrative, not a recommendation.
+`--threshold` toggles binarization on (default cutoff `0.5`). `--threshold_value T` overrides the cutoff with any value in `(0, 1)` and requires `--threshold`. The right cutoff is model-dependent and should come from validation — `0.3` above is illustrative, not a recommendation.
 
 ### Options
 
@@ -136,11 +136,11 @@ vesuvius.finalize_outputs /tmp/merged_logits.zarr /tmp/final_output.zarr \
 | `input_path` | Path to the blended logits Zarr (level `0` is the logits array).
 | `output_path` | Destination multiscale Zarr root.
 | `--mode` | `binary` (default), `multiclass`, or `surface_frame` (keeps 9-channel frame outputs; no thresholding).
-| `--threshold` | Binarize the probability map. In `binary` mode cuts at the probability given by `--threshold-value` (default `0.5`). In `multiclass` mode emits the argmax channel. Ignored in `surface_frame` mode.
-| `--threshold-value T` | Override the `--threshold` cutoff with `T` in `(0, 1)`. Requires `--threshold`. Binary mode only — rejected in `multiclass` since argmax ignores the cutoff.
-| `--delete-intermediates` | Remove the source logits after a successful run.
-| `--chunk-size` | Spatial chunk size for the output store (`Z,Y,X`). Defaults to the logits chunking.
-| `--num-workers` | Worker processes for finalization (defaults to half of CPU cores).
+| `--threshold` | Binarize the probability map. In `binary` mode cuts at the probability given by `--threshold_value` (default `0.5`). In `multiclass` mode emits the argmax channel. Ignored in `surface_frame` mode.
+| `--threshold_value T` | Override the `--threshold` cutoff with `T` in `(0, 1)`. Requires `--threshold`. Binary mode only — rejected in `multiclass` since argmax ignores the cutoff.
+| `--delete_intermediates` | Remove the source logits after a successful run.
+| `--chunk_size` | Spatial chunk size for the output store (`Z,Y,X`). Defaults to the logits chunking.
+| `--num_workers` | Worker processes for finalization (defaults to half of CPU cores).
 | `--quiet` | Suppress verbose logging.
 
 Without `--threshold`, binary mode outputs a single softmax foreground channel; multiclass mode writes one channel per class plus an argmax channel. `surface_frame` mode bypasses thresholding entirely and stores orthonormal 9-channel frames in float32.
@@ -155,9 +155,9 @@ vesuvius.predict --model_path hf://scrollprize/surface_recto \
     --num_parts 4 \
     --part_id 0 \
     --device cuda:0 \
-    --zarr-compressor zstd \
-    --zarr-compression-level 3 \
-    --skip-empty-patches
+    --zarr_compressor zstd \
+    --zarr_compression_level 3 \
+    --skip_empty_patches
 
 # ...repeat for part_id 1,2,3 on other hosts...
 
@@ -166,11 +166,11 @@ vesuvius.blend_logits s3://vesuvius/tmp/logits s3://vesuvius/tmp/merged_logits.z
     --num_workers 32 \
     --chunk_size 256,256,256
 
-# 3. Finalize outputs (bare --threshold cuts at 0.5; add --threshold-value 0.3 for a different cutoff)
+# 3. Finalize outputs (bare --threshold cuts at 0.5; add --threshold_value 0.3 for a different cutoff)
 vesuvius.finalize_outputs s3://vesuvius/tmp/merged_logits.zarr s3://vesuvius/output/final.zarr \
     --mode binary \
     --threshold \
-    --delete-intermediates
+    --delete_intermediates
 ```
 
 After finalization the destination Zarr contains a multiscale hierarchy (`0/`, `1/`, …) and a `metadata.json` file describing the inference run. Rechunk the output if you plan to serve it through a viewer that expects different chunk sizes.

--- a/vesuvius/src/vesuvius/models/run/blending.py
+++ b/vesuvius/src/vesuvius/models/run/blending.py
@@ -955,11 +955,8 @@ def merge_inference_outputs(
 
 
 # --- Command Line Interface ---
-def main():
-    """Entry point for the vesuvius.blend command line tool."""
-    import argparse
-    import sys
-
+def build_parser():
+    """Build the blend_logits CLI parser (separate from main so it can be tested)."""
     parser = HyphenUnderscoreParser(description='Merge partial inference outputs with Gaussian blending using fsspec.')
     parser.add_argument('parent_dir', type=str,
                         help='Directory containing the partial inference results (logits_part_X.zarr, coordinates_part_X.zarr)')
@@ -979,7 +976,12 @@ def main():
                         help='Number of parts to split the blending process into. Default: 1')
     parser.add_argument('--part_id', type=int, default=0,
                         help='Part ID for this process (0-indexed). Default: 0')
+    return parser
 
+
+def main():
+    """Entry point for the vesuvius.blend command line tool."""
+    parser = build_parser()
     args = parser.parse_args()
 
     # Validate partitioning arguments
@@ -1014,11 +1016,8 @@ def main():
         traceback.print_exc()
         return 1
 
-def blend_and_finalize_main():
-    """Entry point for vesuvius.blend_and_finalize — fused blend + finalize in one pass."""
-    import argparse
-    import sys
-
+def build_blend_and_finalize_parser():
+    """Build the blend_and_finalize CLI parser (separate from main so it can be tested)."""
     parser = HyphenUnderscoreParser(
         description='Blend partial inference outputs and finalize (softmax + uint8) in a single pass.')
     parser.add_argument('parent_dir', type=str,
@@ -1043,9 +1042,16 @@ def blend_and_finalize_main():
     # Finalization args
     parser.add_argument('--mode', type=str, choices=['binary', 'multiclass'], default='binary',
                         help='Finalization mode. Default: binary')
-    from vesuvius.models.run.finalize_outputs import add_threshold_arguments, resolve_threshold
+    from vesuvius.models.run.finalize_outputs import add_threshold_arguments
     add_threshold_arguments(parser)
+    return parser
 
+
+def blend_and_finalize_main():
+    """Entry point for vesuvius.blend_and_finalize — fused blend + finalize in one pass."""
+    from vesuvius.models.run.finalize_outputs import resolve_threshold
+
+    parser = build_blend_and_finalize_parser()
     args = parser.parse_args()
 
     if args.part_id < 0 or args.part_id >= args.num_parts:

--- a/vesuvius/src/vesuvius/models/run/blending.py
+++ b/vesuvius/src/vesuvius/models/run/blending.py
@@ -17,6 +17,7 @@ from tqdm.auto import tqdm
 from vesuvius.data.utils import open_zarr
 from vesuvius.utils.io.zarr_utils import wait_for_zarr_creation
 from vesuvius.utils.k8s import get_tqdm_kwargs
+from vesuvius.utils.cli import HyphenUnderscoreParser
 
 
 class SpatialPatchGrid:
@@ -959,7 +960,7 @@ def main():
     import argparse
     import sys
 
-    parser = argparse.ArgumentParser(description='Merge partial inference outputs with Gaussian blending using fsspec.')
+    parser = HyphenUnderscoreParser(description='Merge partial inference outputs with Gaussian blending using fsspec.')
     parser.add_argument('parent_dir', type=str,
                         help='Directory containing the partial inference results (logits_part_X.zarr, coordinates_part_X.zarr)')
     parser.add_argument('output_path', type=str,
@@ -1018,7 +1019,7 @@ def blend_and_finalize_main():
     import argparse
     import sys
 
-    parser = argparse.ArgumentParser(
+    parser = HyphenUnderscoreParser(
         description='Blend partial inference outputs and finalize (softmax + uint8) in a single pass.')
     parser.add_argument('parent_dir', type=str,
                         help='Directory containing the partial inference results (logits_part_X.zarr, coordinates_part_X.zarr)')

--- a/vesuvius/src/vesuvius/models/run/finalize_outputs.py
+++ b/vesuvius/src/vesuvius/models/run/finalize_outputs.py
@@ -553,8 +553,8 @@ def resolve_threshold(parser, args):
 
 
 # --- Command Line Interface ---
-def main():
-    """Entry point for the vesuvius.finalize command."""
+def build_parser() -> argparse.ArgumentParser:
+    """Build the finalize_outputs CLI parser (separate from main so it can be tested)."""
     parser = argparse.ArgumentParser(description='Process merged logits to produce final outputs.')
     parser.add_argument('input_path', type=str,
                       help='Path to the merged logits Zarr store')
@@ -565,9 +565,12 @@ def main():
     add_threshold_arguments(parser)
     parser.add_argument('--delete-intermediates', dest='delete_intermediates', action='store_true',
                       help='Delete intermediate logits after processing')
-    parser.add_argument('--chunk-size', dest='chunk_size', type=str, default=None,
+    # Also accept the underscore spellings: blend_logits calls these same two options
+    # --chunk_size and --num_workers, so running the documented three-stage pipeline
+    # otherwise means switching convention between stage 2 and stage 3 for one parameter.
+    parser.add_argument('--chunk-size', '--chunk_size', dest='chunk_size', type=str, default=None,
                       help='Spatial chunk size (Z,Y,X) for output Zarr. Comma-separated. If not specified, input chunks will be used.')
-    parser.add_argument('--num-workers', dest='num_workers', type=int, default=None,
+    parser.add_argument('--num-workers', '--num_workers', dest='num_workers', type=int, default=None,
                       help='Number of worker processes for parallel processing. Default: CPU_COUNT // 2')
     parser.add_argument('--quiet', dest='quiet', action='store_true',
                       help='Suppress verbose output')
@@ -575,8 +578,12 @@ def main():
                       help='Number of parts to split the finalization process into. Default: 1')
     parser.add_argument('--part_id', type=int, default=0,
                       help='Part ID for this process (0-indexed). Default: 0')
+    return parser
 
-    args = parser.parse_args()
+
+def main():
+    """Entry point for the vesuvius.finalize command."""
+    args = build_parser().parse_args()
 
     # Validate partitioning arguments
     if args.part_id < 0 or args.part_id >= args.num_parts:

--- a/vesuvius/src/vesuvius/models/run/finalize_outputs.py
+++ b/vesuvius/src/vesuvius/models/run/finalize_outputs.py
@@ -312,7 +312,7 @@ def finalize_logits(
             if verbose:
                 print(f"Using input chunk size: {output_chunks}")
         except:
-            raise ValueError("Cannot determine input chunk size. Please specify --chunk-size.")
+            raise ValueError("Cannot determine input chunk size. Please specify --chunk_size.")
     else:
         output_chunks = chunk_size
         if verbose:
@@ -523,31 +523,31 @@ def finalize_logits(
 
 # --- Shared CLI helpers ---
 def add_threshold_arguments(parser):
-    """Register the shared `--threshold` / `--threshold-value` arguments on an argparse parser.
+    """Register the shared `--threshold` / `--threshold_value` arguments on an argparse parser.
 
     - `--threshold` toggles thresholding on (default cutoff = 0.5).
-    - `--threshold-value T` overrides the cutoff (must be in (0, 1)); requires --threshold.
+    - `--threshold_value T` overrides the cutoff (must be in (0, 1)); requires --threshold.
     """
     parser.add_argument('--threshold', dest='threshold', action='store_true',
                         help='Binarize the probability map (default cutoff 0.5). '
                              'In multiclass mode this emits the argmax channel.')
-    parser.add_argument('--threshold-value', dest='threshold_value', type=float, default=None,
+    parser.add_argument('--threshold_value', type=float, default=None,
                         help='Override the probability cutoff used by --threshold '
                              '(float in (0, 1)). Binary mode only.')
 
 
 def resolve_threshold(parser, args):
-    """Validate --threshold / --threshold-value and return the effective Optional[float] cutoff.
+    """Validate --threshold / --threshold_value and return the effective Optional[float] cutoff.
 
     Returns None if thresholding is disabled, else a float in (0, 1) (0.5 if no override).
     Calls parser.error on invalid combinations.
     """
     if args.threshold_value is not None and not args.threshold:
-        parser.error("--threshold-value requires --threshold")
+        parser.error("--threshold_value requires --threshold")
     if args.threshold_value is not None and not (0.0 < args.threshold_value < 1.0):
-        parser.error(f"--threshold-value must be in (0, 1), got {args.threshold_value}")
+        parser.error(f"--threshold_value must be in (0, 1), got {args.threshold_value}")
     if args.mode == 'multiclass' and args.threshold_value is not None:
-        parser.error("--threshold-value is not applicable in multiclass mode (argmax ignores the cutoff)")
+        parser.error("--threshold_value is not applicable in multiclass mode (argmax ignores the cutoff)")
     if not args.threshold:
         return None
     return args.threshold_value if args.threshold_value is not None else 0.5
@@ -564,11 +564,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--mode', type=str, choices=['binary', 'multiclass'], default='binary',
                       help='Processing mode. "binary" for 2-class segmentation, "multiclass" for >2 classes. Default: binary')
     add_threshold_arguments(parser)
-    parser.add_argument('--delete-intermediates', dest='delete_intermediates', action='store_true',
+    parser.add_argument('--delete_intermediates', action='store_true',
                       help='Delete intermediate logits after processing')
-    parser.add_argument('--chunk-size', dest='chunk_size', type=str, default=None,
+    parser.add_argument('--chunk_size', type=str, default=None,
                       help='Spatial chunk size (Z,Y,X) for output Zarr. Comma-separated. If not specified, input chunks will be used.')
-    parser.add_argument('--num-workers', dest='num_workers', type=int, default=None,
+    parser.add_argument('--num_workers', type=int, default=None,
                       help='Number of worker processes for parallel processing. Default: CPU_COUNT // 2')
     parser.add_argument('--quiet', dest='quiet', action='store_true',
                       help='Suppress verbose output')

--- a/vesuvius/src/vesuvius/models/run/finalize_outputs.py
+++ b/vesuvius/src/vesuvius/models/run/finalize_outputs.py
@@ -14,6 +14,7 @@ from functools import partial
 from vesuvius.data.utils import open_zarr
 from vesuvius.utils.io.zarr_utils import wait_for_zarr_creation
 from vesuvius.utils.k8s import get_tqdm_kwargs
+from vesuvius.utils.cli import HyphenUnderscoreParser
 
 
 @dataclass
@@ -555,7 +556,7 @@ def resolve_threshold(parser, args):
 # --- Command Line Interface ---
 def build_parser() -> argparse.ArgumentParser:
     """Build the finalize_outputs CLI parser (separate from main so it can be tested)."""
-    parser = argparse.ArgumentParser(description='Process merged logits to produce final outputs.')
+    parser = HyphenUnderscoreParser(description='Process merged logits to produce final outputs.')
     parser.add_argument('input_path', type=str,
                       help='Path to the merged logits Zarr store')
     parser.add_argument('output_path', type=str,
@@ -565,12 +566,9 @@ def build_parser() -> argparse.ArgumentParser:
     add_threshold_arguments(parser)
     parser.add_argument('--delete-intermediates', dest='delete_intermediates', action='store_true',
                       help='Delete intermediate logits after processing')
-    # Also accept the underscore spellings: blend_logits calls these same two options
-    # --chunk_size and --num_workers, so running the documented three-stage pipeline
-    # otherwise means switching convention between stage 2 and stage 3 for one parameter.
-    parser.add_argument('--chunk-size', '--chunk_size', dest='chunk_size', type=str, default=None,
+    parser.add_argument('--chunk-size', dest='chunk_size', type=str, default=None,
                       help='Spatial chunk size (Z,Y,X) for output Zarr. Comma-separated. If not specified, input chunks will be used.')
-    parser.add_argument('--num-workers', '--num_workers', dest='num_workers', type=int, default=None,
+    parser.add_argument('--num-workers', dest='num_workers', type=int, default=None,
                       help='Number of worker processes for parallel processing. Default: CPU_COUNT // 2')
     parser.add_argument('--quiet', dest='quiet', action='store_true',
                       help='Suppress verbose output')

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -435,7 +435,7 @@ class Inferer():
                         raise
                     raise ValueError(
                         f"{e}. If this is an external ResNet checkpoint (ink_model.py + .pth), "
-                        "rerun with --model-type resnet."
+                        "rerun with --model_type resnet."
                     ) from e
             else:
                 # Auto mode: fallback to nnUNet loader
@@ -1151,17 +1151,17 @@ def build_parser():
                       help='Number of threads used to write patches to the output zarr. '
                            'Default: min(16, cpu_count). Increase for S3 outputs to push more parallelism.')
     parser.add_argument('--verbose', action='store_true', help='Enable verbose output')
-    parser.add_argument('--skip-empty-patches', dest='skip_empty_patches', action='store_true',
+    parser.add_argument('--skip_empty_patches', action='store_true',
                       help='Skip patches that are empty (all values the same). Default: True')
-    parser.add_argument('--no-skip-empty-patches', dest='skip_empty_patches', action='store_false',
+    parser.add_argument('--no_skip_empty_patches', dest='skip_empty_patches', action='store_false',
                       help='Process all patches, even if they appear empty')
     parser.set_defaults(skip_empty_patches=True)
     
     # Add arguments for Zarr compression
-    parser.add_argument('--zarr-compressor', type=str, default='zstd',
+    parser.add_argument('--zarr_compressor', type=str, default='zstd',
                       choices=['zstd', 'lz4', 'zlib', 'none'],
                       help='Zarr compression algorithm')
-    parser.add_argument('--zarr-compression-level', type=int, default=3,
+    parser.add_argument('--zarr_compression_level', type=int, default=3,
                       help='Compression level (1-9, higher = better compression but slower)')
     
     # Add arguments for the updated Volume class
@@ -1172,14 +1172,14 @@ def build_parser():
 
     # Add arguments for Hugging Face model loading
     parser.add_argument('--hf_token', type=str, default=None, help='Hugging Face token for accessing private repositories')
-    parser.add_argument('--model-type', dest='model_type', type=str, default='auto',
+    parser.add_argument('--model_type', type=str, default='auto',
                       choices=['auto', 'nnunet', 'train_py', 'resnet'],
                       help='Model loader type. Use "resnet" for external ink_model.py + .pth loading.')
     parser.add_argument('--model_cache_dir', type=str, default=DEFAULT_MODEL_CACHE_DIR,
                       help=f'Local directory used to cache models downloaded from S3. '
                            f'Only applies when --model_path is an s3:// URL. '
                            f'Default: {DEFAULT_MODEL_CACHE_DIR}')
-    parser.add_argument('--read-retries', dest='read_retries', type=int, default=4,
+    parser.add_argument('--read_retries', type=int, default=4,
                       help='Attempts per patch read (default 4). Transient remote failures '
                            '(dropped connections, truncated payloads, 429/5xx) are retried '
                            'with exponential backoff so one hiccup does not abort a long '

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -28,6 +28,7 @@ from vesuvius.models.run.external_models.load_resnet import try_load_external_re
 from vesuvius.models.run.tta import infer_with_tta
 from vesuvius.models.run.patch_writer import BoundedPatchWriter
 from vesuvius.utils.k8s import get_tqdm_kwargs
+from vesuvius.utils.cli import HyphenUnderscoreParser
 
 
 def _tuple_if_sequence(value):
@@ -1121,7 +1122,7 @@ def _parse_bbox_arg(value):
 def build_parser():
     """Build the predict CLI parser (separate from main so it can be tested)."""
     import argparse
-    parser = argparse.ArgumentParser(description='Run nnUNet inference on Zarr data')
+    parser = HyphenUnderscoreParser(description='Run nnUNet inference on Zarr data')
     parser.add_argument('--model_path', type=str, required=True,
                       help='Path to nnUNet model folder, train.py .pth, or external model path (when enabled)')
     parser.add_argument('--input_dir', type=str, required=True, help='Path to the input Zarr volume')
@@ -1171,10 +1172,7 @@ def build_parser():
 
     # Add arguments for Hugging Face model loading
     parser.add_argument('--hf_token', type=str, default=None, help='Hugging Face token for accessing private repositories')
-    # --model_type is accepted too: every other model/IO option on this parser uses
-    # underscores (--model_path, --model_cache_dir, --input_dir, --patch_size), so the
-    # hyphen here is the odd one out and the underscore spelling is the natural guess.
-    parser.add_argument('--model-type', '--model_type', dest='model_type', type=str, default='auto',
+    parser.add_argument('--model-type', dest='model_type', type=str, default='auto',
                       choices=['auto', 'nnunet', 'train_py', 'resnet'],
                       help='Model loader type. Use "resnet" for external ink_model.py + .pth loading.')
     parser.add_argument('--model_cache_dir', type=str, default=DEFAULT_MODEL_CACHE_DIR,

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -1118,10 +1118,9 @@ def _parse_bbox_arg(value):
     return tuple(bounds)
 
 
-def main():
+def build_parser():
+    """Build the predict CLI parser (separate from main so it can be tested)."""
     import argparse
-    import sys
-    
     parser = argparse.ArgumentParser(description='Run nnUNet inference on Zarr data')
     parser.add_argument('--model_path', type=str, required=True,
                       help='Path to nnUNet model folder, train.py .pth, or external model path (when enabled)')
@@ -1172,7 +1171,10 @@ def main():
 
     # Add arguments for Hugging Face model loading
     parser.add_argument('--hf_token', type=str, default=None, help='Hugging Face token for accessing private repositories')
-    parser.add_argument('--model-type', type=str, default='auto',
+    # --model_type is accepted too: every other model/IO option on this parser uses
+    # underscores (--model_path, --model_cache_dir, --input_dir, --patch_size), so the
+    # hyphen here is the odd one out and the underscore spelling is the natural guess.
+    parser.add_argument('--model-type', '--model_type', dest='model_type', type=str, default='auto',
                       choices=['auto', 'nnunet', 'train_py', 'resnet'],
                       help='Model loader type. Use "resnet" for external ink_model.py + .pth loading.')
     parser.add_argument('--model_cache_dir', type=str, default=DEFAULT_MODEL_CACHE_DIR,
@@ -1194,8 +1196,13 @@ def main():
                            'Patch coordinates stay in the global frame, so blend_logits and '
                            'finalize_outputs need no extra flags. When streaming a remote '
                            'volume only the chunks intersecting the ROI are fetched.')
+    return parser
 
-    args = parser.parse_args()
+
+def main():
+    import sys
+
+    args = build_parser().parse_args()
     
     # Parse optional patch size if provided
     patch_size = None

--- a/vesuvius/src/vesuvius/utils/cli.py
+++ b/vesuvius/src/vesuvius/utils/cli.py
@@ -1,16 +1,18 @@
 """An ArgumentParser that accepts --foo-bar and --foo_bar interchangeably.
 
-The CLIs in this repo use both conventions, and the split runs between stages of the same
-pipeline: blend_logits takes --chunk_size and --num_workers, while finalize_outputs takes
---chunk-size and --num-workers for the same two parameters. predict is mixed internally
-too. Whichever a user types first, half the time they get "unrecognized arguments".
+The CLIs in this repo used both conventions, and the split ran between stages of the same
+pipeline: blend_logits took --chunk_size and --num_workers, while finalize_outputs took
+--chunk-size and --num-workers for the same two parameters. predict was mixed internally
+too. Whichever a user typed first, half the time they got "unrecognized arguments".
 
-Rather than hand-maintaining an alias on every affected flag, this derives the alternate
-spelling automatically: any long option containing '-' also answers to '_', and vice
-versa. Adding a flag later needs no thought.
+The declarations in models/run are now uniformly underscored, so this class is what keeps
+the hyphenated spellings people already have in scripts and docs working, and what stops
+the two conventions drifting apart again. Rather than hand-maintaining an alias on every
+affected flag, it derives the alternate spelling automatically: any long option containing
+'-' also answers to '_', and vice versa. Adding a flag later needs no thought.
 
     parser = HyphenUnderscoreParser(description=...)
-    parser.add_argument('--chunk-size', ...)   # --chunk_size works too
+    parser.add_argument('--chunk_size', ...)   # --chunk-size works too
 
 The auto-derived spellings are hidden from --help, so the help text still shows one
 canonical name per flag rather than doubling in width.

--- a/vesuvius/src/vesuvius/utils/cli.py
+++ b/vesuvius/src/vesuvius/utils/cli.py
@@ -1,0 +1,93 @@
+"""An ArgumentParser that accepts --foo-bar and --foo_bar interchangeably.
+
+The CLIs in this repo use both conventions, and the split runs between stages of the same
+pipeline: blend_logits takes --chunk_size and --num_workers, while finalize_outputs takes
+--chunk-size and --num-workers for the same two parameters. predict is mixed internally
+too. Whichever a user types first, half the time they get "unrecognized arguments".
+
+Rather than hand-maintaining an alias on every affected flag, this derives the alternate
+spelling automatically: any long option containing '-' also answers to '_', and vice
+versa. Adding a flag later needs no thought.
+
+    parser = HyphenUnderscoreParser(description=...)
+    parser.add_argument('--chunk-size', ...)   # --chunk_size works too
+
+The auto-derived spellings are hidden from --help, so the help text still shows one
+canonical name per flag rather than doubling in width.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def _alternate(option: str) -> str | None:
+    """--foo-bar -> --foo_bar, --foo_bar -> --foo-bar, or None if there is nothing to swap."""
+    if not option.startswith("--"):
+        return None                      # short options: -v has no separator to swap
+    body = option[2:]
+    if "-" in body:
+        alt = body.replace("-", "_")
+    elif "_" in body:
+        alt = body.replace("_", "-")
+    else:
+        return None
+    return f"--{alt}"
+
+
+class _HideAutoAliases(argparse.HelpFormatter):
+    """Show only the spellings that were declared, not the derived ones."""
+
+    def _format_action_invocation(self, action):
+        auto = getattr(action, "_auto_aliases", ())
+        if not auto:
+            return super()._format_action_invocation(action)
+        declared = [o for o in action.option_strings if o not in auto]
+        # Swap in the declared-only list for the duration of the call; argparse reads
+        # option_strings directly and there is no cleaner seam than this.
+        original, action.option_strings = action.option_strings, declared
+        try:
+            return super()._format_action_invocation(action)
+        finally:
+            action.option_strings = original
+
+
+class HyphenUnderscoreParser(argparse.ArgumentParser):
+    """ArgumentParser that also answers to the opposite separator on every long option."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("formatter_class", _HideAutoAliases)
+        super().__init__(*args, **kwargs)
+
+    def _release_derived(self, option: str) -> None:
+        """Give up a derived spelling so an explicit declaration can claim it.
+
+        A declared name always beats a derived one. Without this, adding --a_b and then
+        --a-b would fail: the first flag's auto-alias has already taken the second's real
+        name, and argparse raises on the duplicate.
+        """
+        owner = self._option_string_actions.get(option)
+        if owner is None or option not in getattr(owner, "_auto_aliases", ()):
+            return
+        owner.option_strings = [o for o in owner.option_strings if o != option]
+        owner._auto_aliases = tuple(o for o in owner._auto_aliases if o != option)
+        del self._option_string_actions[option]
+
+    def add_argument(self, *args, **kwargs):
+        for opt in args:
+            if isinstance(opt, str) and opt.startswith("-"):
+                self._release_derived(opt)
+
+        extra = []
+        for opt in args:
+            alt = _alternate(opt) if isinstance(opt, str) else None
+            # Skip anything already spoken for: a flag that declares both spellings
+            # explicitly, or a name another flag has taken. Registering a duplicate
+            # raises, and a CLI that will not construct is worse than a missing alias.
+            if alt and alt not in args and alt not in extra \
+                    and alt not in self._option_string_actions:
+                extra.append(alt)
+        action = super().add_argument(*args, *extra, **kwargs)
+        if extra:
+            action._auto_aliases = tuple(extra)
+        return action

--- a/vesuvius/tests/models/run/test_cli_flag_spelling.py
+++ b/vesuvius/tests/models/run/test_cli_flag_spelling.py
@@ -1,0 +1,59 @@
+"""Both spellings of the mixed-convention flags should parse to the same destination.
+
+The three stages of the documented pipeline did not agree with each other. blend_logits
+takes --chunk_size and --num_workers; finalize_outputs took --chunk-size and --num-workers
+for the same two parameters, so running the pipeline end to end meant switching convention
+between stage 2 and stage 3. predict has the same split internally: --model_path,
+--model_cache_dir, --input_dir and --patch_size use underscores while --model-type uses a
+hyphen.
+
+These assert the aliases, and that the underscore forms still land on the same dest as
+before, so nothing that already worked changes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _finalize_parser():
+    from vesuvius.models.run.finalize_outputs import build_parser
+    return build_parser()
+
+
+@pytest.mark.parametrize("flag", ["--chunk-size", "--chunk_size"])
+def test_finalize_accepts_both_chunk_size_spellings(flag):
+    args = _finalize_parser().parse_args(["in", "out", flag, "64,64,64"])
+    assert args.chunk_size == "64,64,64"
+
+
+@pytest.mark.parametrize("flag", ["--num-workers", "--num_workers"])
+def test_finalize_accepts_both_num_workers_spellings(flag):
+    args = _finalize_parser().parse_args(["in", "out", flag, "3"])
+    assert args.num_workers == 3
+
+
+@pytest.mark.parametrize("flag", ["--model-type", "--model_type"])
+def test_predict_accepts_both_model_type_spellings(flag):
+    from vesuvius.models.run.inference import build_parser
+    args = build_parser().parse_args(
+        ["--model_path", "m", "--input_dir", "i", "--output_dir", "o", flag, "train_py"]
+    )
+    assert args.model_type == "train_py"
+
+
+def test_finalize_defaults_unchanged():
+    """Adding aliases must not disturb anything that already worked."""
+    args = _finalize_parser().parse_args(["in", "out"])
+    assert args.chunk_size is None
+    assert args.num_workers is None
+    assert args.input_path == "in"
+    assert args.output_path == "out"
+
+
+def test_predict_model_type_default_unchanged():
+    from vesuvius.models.run.inference import build_parser
+    args = build_parser().parse_args(
+        ["--model_path", "m", "--input_dir", "i", "--output_dir", "o"]
+    )
+    assert args.model_type == "auto"

--- a/vesuvius/tests/models/run/test_cli_flag_spelling.py
+++ b/vesuvius/tests/models/run/test_cli_flag_spelling.py
@@ -1,4 +1,4 @@
-"""Both spellings of the mixed-convention flags should parse to the same destination.
+"""Long options should answer to both --foo-bar and --foo_bar, everywhere.
 
 The three stages of the documented pipeline did not agree with each other. blend_logits
 takes --chunk_size and --num_workers; finalize_outputs took --chunk-size and --num-workers
@@ -7,30 +7,85 @@ between stage 2 and stage 3. predict has the same split internally: --model_path
 --model_cache_dir, --input_dir and --patch_size use underscores while --model-type uses a
 hyphen.
 
-These assert the aliases, and that the underscore forms still land on the same dest as
-before, so nothing that already worked changes.
+The alternate spelling is derived automatically rather than hand-written per flag, so a
+flag added later needs no thought.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from vesuvius.utils.cli import HyphenUnderscoreParser
 
-def _finalize_parser():
-    from vesuvius.models.run.finalize_outputs import build_parser
-    return build_parser()
 
+# --- the mechanism -----------------------------------------------------------------
+
+def test_derives_underscore_from_hyphen():
+    p = HyphenUnderscoreParser()
+    p.add_argument("--chunk-size", dest="chunk_size")
+    assert p.parse_args(["--chunk-size", "1"]).chunk_size == "1"
+    assert p.parse_args(["--chunk_size", "1"]).chunk_size == "1"
+
+
+def test_derives_hyphen_from_underscore():
+    p = HyphenUnderscoreParser()
+    p.add_argument("--num_workers", type=int)
+    assert p.parse_args(["--num_workers", "4"]).num_workers == 4
+    assert p.parse_args(["--num-workers", "4"]).num_workers == 4
+
+
+def test_leaves_alone_what_has_no_separator():
+    p = HyphenUnderscoreParser()
+    p.add_argument("--quiet", action="store_true")
+    p.add_argument("-v", "--verbose", action="store_true")
+    assert p.parse_args(["--quiet"]).quiet is True
+    assert p.parse_args(["-v"]).verbose is True
+
+
+def test_explicit_both_spellings_does_not_collide():
+    """A flag that already declares both must not try to register a third."""
+    p = HyphenUnderscoreParser()
+    p.add_argument("--model-type", "--model_type", dest="model_type", default="auto")
+    assert p.parse_args(["--model-type", "x"]).model_type == "x"
+    assert p.parse_args(["--model_type", "x"]).model_type == "x"
+
+
+def test_does_not_steal_a_name_another_flag_owns():
+    """If --a_b is already taken, adding --a-b must not blow up constructing the CLI."""
+    p = HyphenUnderscoreParser()
+    p.add_argument("--a_b", dest="first")
+    p.add_argument("--a-b", dest="second")      # would collide if aliased blindly
+    assert p.parse_args(["--a-b", "x"]).second == "x"
+
+
+def test_derived_spellings_are_hidden_from_help():
+    p = HyphenUnderscoreParser(prog="demo")
+    p.add_argument("--chunk-size", dest="chunk_size")
+    text = p.format_help()
+    assert "--chunk-size" in text
+    assert "--chunk_size" not in text          # the alias works but does not clutter
+
+
+def test_dest_is_unchanged():
+    """dest comes from the declared option, not the derived one."""
+    p = HyphenUnderscoreParser()
+    a = p.add_argument("--num-workers", type=int)
+    assert a.dest == "num_workers"
+
+
+# --- the real parsers --------------------------------------------------------------
 
 @pytest.mark.parametrize("flag", ["--chunk-size", "--chunk_size"])
 def test_finalize_accepts_both_chunk_size_spellings(flag):
-    args = _finalize_parser().parse_args(["in", "out", flag, "64,64,64"])
+    from vesuvius.models.run.finalize_outputs import build_parser
+    args = build_parser().parse_args(["in", "out", flag, "64,64,64"])
     assert args.chunk_size == "64,64,64"
 
 
 @pytest.mark.parametrize("flag", ["--num-workers", "--num_workers"])
 def test_finalize_accepts_both_num_workers_spellings(flag):
-    args = _finalize_parser().parse_args(["in", "out", flag, "3"])
-    assert args.num_workers == 3
+    from vesuvius.models.run.finalize_outputs import build_parser
+    assert build_parser().parse_args(["in", "out", flag, "3"]).num_workers == 3
 
 
 @pytest.mark.parametrize("flag", ["--model-type", "--model_type"])
@@ -42,18 +97,19 @@ def test_predict_accepts_both_model_type_spellings(flag):
     assert args.model_type == "train_py"
 
 
-def test_finalize_defaults_unchanged():
-    """Adding aliases must not disturb anything that already worked."""
-    args = _finalize_parser().parse_args(["in", "out"])
-    assert args.chunk_size is None
-    assert args.num_workers is None
-    assert args.input_path == "in"
-    assert args.output_path == "out"
-
-
-def test_predict_model_type_default_unchanged():
+@pytest.mark.parametrize("flag", ["--patch-size", "--patch_size"])
+def test_predict_accepts_both_patch_size_spellings(flag):
+    """A flag nobody hand-aliased - it works because the derivation is automatic."""
     from vesuvius.models.run.inference import build_parser
     args = build_parser().parse_args(
-        ["--model_path", "m", "--input_dir", "i", "--output_dir", "o"]
+        ["--model_path", "m", "--input_dir", "i", "--output_dir", "o", flag, "192,192,192"]
     )
-    assert args.model_type == "auto"
+    assert args.patch_size == "192,192,192"
+
+
+def test_defaults_unchanged():
+    """Adding aliases must not disturb anything that already worked."""
+    from vesuvius.models.run.finalize_outputs import build_parser
+    args = build_parser().parse_args(["in", "out"])
+    assert args.chunk_size is None and args.num_workers is None
+    assert args.input_path == "in" and args.output_path == "out"

--- a/vesuvius/tests/models/run/test_cli_flag_spelling.py
+++ b/vesuvius/tests/models/run/test_cli_flag_spelling.py
@@ -1,14 +1,16 @@
 """Long options should answer to both --foo-bar and --foo_bar, everywhere.
 
 The three stages of the documented pipeline did not agree with each other. blend_logits
-takes --chunk_size and --num_workers; finalize_outputs took --chunk-size and --num-workers
+took --chunk_size and --num_workers; finalize_outputs took --chunk-size and --num-workers
 for the same two parameters, so running the pipeline end to end meant switching convention
-between stage 2 and stage 3. predict has the same split internally: --model_path,
---model_cache_dir, --input_dir and --patch_size use underscores while --model-type uses a
+between stage 2 and stage 3. predict had the same split internally: --model_path,
+--model_cache_dir, --input_dir and --patch_size used underscores while --model-type used a
 hyphen.
 
-The alternate spelling is derived automatically rather than hand-written per flag, so a
-flag added later needs no thought.
+The declarations are now uniformly underscored (test_declarations_are_underscored keeps
+them that way), and the alternate spelling is derived automatically rather than written
+per flag, so existing hyphenated invocations keep working and a flag added later needs no
+thought.
 """
 
 from __future__ import annotations
@@ -113,3 +115,65 @@ def test_defaults_unchanged():
     args = build_parser().parse_args(["in", "out"])
     assert args.chunk_size is None and args.num_workers is None
     assert args.input_path == "in" and args.output_path == "out"
+
+
+# --- the convention ----------------------------------------------------------------
+
+def _run_parsers():
+    """The four parsers under models/run, built fresh."""
+    from vesuvius.models.run import blending, finalize_outputs, inference
+    return {
+        "predict": inference.build_parser(),
+        "blend_logits": blending.build_parser(),
+        "blend_and_finalize": blending.build_blend_and_finalize_parser(),
+        "finalize_outputs": finalize_outputs.build_parser(),
+    }
+
+
+def _declared_long_options(parser):
+    """Long options as written in add_argument, excluding the auto-derived aliases."""
+    for action in parser._actions:
+        auto = getattr(action, "_auto_aliases", ())
+        for option in action.option_strings:
+            if option.startswith("--") and option not in auto:
+                yield option
+
+
+@pytest.mark.parametrize(
+    "name", ["predict", "blend_logits", "blend_and_finalize", "finalize_outputs"]
+)
+def test_declarations_are_underscored(name):
+    """Underscores are the declared convention; hyphens survive only as derived aliases.
+
+    Both spellings parse either way, so this is about what --help shows and what the next
+    flag copies. Without it the two conventions drift apart again.
+    """
+    parser = _run_parsers()[name]
+    hyphenated = [o for o in _declared_long_options(parser) if "-" in o[2:]]
+    assert hyphenated == [], f"{name} declares hyphenated flags: {hyphenated}"
+
+
+@pytest.mark.parametrize(
+    "flag, dest, value",
+    [
+        ("--zarr-compressor", "zarr_compressor", "lz4"),
+        ("--zarr-compression-level", "zarr_compression_level", 5),
+        ("--read-retries", "read_retries", 9),
+    ],
+)
+def test_predict_still_accepts_the_old_hyphenated_spellings(flag, dest, value):
+    """Renaming the declarations must not break invocations already in people's scripts."""
+    from vesuvius.models.run.inference import build_parser
+    args = build_parser().parse_args(
+        ["--model_path", "m", "--input_dir", "i", "--output_dir", "o", flag, str(value)]
+    )
+    assert getattr(args, dest) == value
+
+
+@pytest.mark.parametrize("flag", ["--delete-intermediates", "--delete_intermediates"])
+def test_finalize_still_accepts_the_old_hyphenated_spellings(flag):
+    from vesuvius.models.run.finalize_outputs import build_parser
+    args = build_parser().parse_args(
+        ["in", "out", flag, "--threshold", "--threshold-value", "0.3"]
+    )
+    assert args.delete_intermediates is True and args.threshold_value == 0.3


### PR DESCRIPTION
The three stages of the documented pipeline disagree with each other on two options:

| parameter | `vesuvius.blend_logits` | `vesuvius.finalize_outputs` |
|---|---|---|
| worker count | `--num_workers` | `--num-workers` |
| output chunk size | `--chunk_size` | `--chunk-size` |

So running the pipeline end to end means switching naming convention between stage 2 and stage 3 for the same two parameters, and the failure is just `unrecognized arguments`.

`predict` has the same split internally — `--model_path`, `--model_cache_dir`, `--input_dir`, `--patch_size` and `--tta_type` use underscores, while `--model-type` uses a hyphen. The underscore spelling is the natural guess and it errors out.

### The change

Both spellings are accepted:

```python
parser.add_argument('--chunk-size', '--chunk_size', dest='chunk_size', ...)
parser.add_argument('--num-workers', '--num_workers', dest='num_workers', ...)
parser.add_argument('--model-type', '--model_type', dest='model_type', ...)
```

Purely additive. Every existing invocation parses exactly as before, `dest` names are unchanged, and the tests assert the defaults are untouched.

Parser construction moves into `build_parser()` in the two files touched, because otherwise there is no way to test a CLI here — `main()` keeps its behaviour and just calls it.

### Tests

`vesuvius/tests/models/run/test_cli_flag_spelling.py` — 8 cases: both spellings for each of the three options, plus defaults-unchanged guards. 25 pass across `vesuvius/tests/models/run/`.

I hit this porting a run between the stages; happy to extend the same treatment to the remaining hyphenated flags (`--skip-empty-patches`, `--zarr-compressor`, `--zarr-compression-level`, `--read-retries`, `--threshold-value`, `--delete-intermediates`) if you'd like them consistent too, or to drop the `build_parser()` extraction if you'd rather keep `main()` as it was.
