### PR TITLE
Add TIFXYZ Doctor to community projects

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -73,6 +73,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 - [preprocessed-data](https://github.com/usc-caisplusplus/scroll-data-preprocessing): Data preprocessing code and a fully processed version of the dataset in .zarr format to allow for faster training of ink detection models. 
 - [scroll-data-audit](https://github.com/Bullo27/scroll-data-audit) by Matteo Bulloni. Integrity auditor for the open-data: reconciles the catalog (`metadata.json`) against the actual Zarr arrays, filenames and scan metadata, and verifies multiscale pyramid value-correctness. Reported a Scroll 5 (PHerc0172) catalog shape error ([#1211](https://github.com/ScrollPrize/villa/issues/1211)) and certified the rest of the open-data consistent.
 
+- [TIFXYZ Doctor](https://github.com/aviad12g/tifxyz-doctor) by Aviad. Deterministic, CPU-only preflight and geometry diagnostics for TIFXYZ surface packages: checks raw format integrity and pinned Python/C++ reader interoperability, reports collection-level UUID reuse, and localizes topology and flattening-distortion cues in machine-readable and visual outputs.
+
 - [Region-of-interest inference for `vesuvius.predict`](https://github.com/ScrollPrize/villa/pull/1241): `--bbox "z0:z1,y0:y1,x0:x1"` restricts inference to one region of a volume, in global voxel coordinates, so `blend_logits` and `finalize_outputs` stay aligned. Only the chunks intersecting the region are streamed — on PHerc. Paris 4 a 200³ region reads 27 chunks (56.6 MB) instead of 10,368 (21.7 GB). By TAUIL Abd Elillah
 
 ## Segmentation


### PR DESCRIPTION
## Summary

Adds [TIFXYZ Doctor](https://github.com/aviad12g/tifxyz-doctor) under **Data access/visualization → Tools**.

TIFXYZ Doctor is an MIT-licensed, CPU-only CLI for deterministic TIFXYZ package integrity checks, pinned Python/C++ reader-interoperability diagnostics, recursive collection scans, and localized geometry-review cues.

## Evidence and validation

- 48/48 tests pass
- 10-case real-data smoke benchmark
- 3/3 hash-pinned historical sentinel-only regression; maintainers repaired the affected entries after the report, and fresh audits of all three current registrations pass ([diagnosis](https://discord.com/channels/1079907749569237093/1243576621722767412/1531206054682165309); [remediation confirmation](https://discord.com/channels/1079907749569237093/1243576621722767412/1531220162190245909))
- executable five-case reader differential plus eight exporter-boundary probes
- strict JSON, self-contained HTML, and sparse PNG outputs

The repository documents the corpus-scan denominators, exact source hashes, and interpretation boundaries.