### PR TITLE
vc3d: validate Windows packages and MCP startup

### DIFF
--- a/.github/workflows/vc3d-windows.yml
+++ b/.github/workflows/vc3d-windows.yml
@@ -101,6 +101,9 @@ jobs:
           $binary = Get-Item `
             "${{ github.workspace }}\volume-cartographer\build\ci-windows-mingw\bin\VC3D.exe"
           Write-Host "VC3D.exe size: $($binary.Length) bytes"
+          if ($binary.Length -ge 2GB) {
+            throw "VC3D.exe exceeds the Windows 2 GiB image limit"
+          }
           & "C:\msys64\ucrt64\bin\objdump.exe" -f $binary.FullName
           & $binary.FullName --version
 

--- a/.github/workflows/vc3d-windows.yml
+++ b/.github/workflows/vc3d-windows.yml
@@ -120,6 +120,7 @@ jobs:
           $env:PYTHON = $python
           $env:PATH = "C:\msys64\ucrt64\bin;$env:PATH"
           $env:QT_PLUGIN_PATH = "C:\msys64\ucrt64\share\qt6\plugins"
+          $env:QT_QPA_PLATFORM = "offscreen"
           & $python -m pip install -e .
           & $python -m pip check
           & $python -m unittest -v `

--- a/.github/workflows/vc3d-windows.yml
+++ b/.github/workflows/vc3d-windows.yml
@@ -117,6 +117,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
           $python = (Get-Command python.exe).Source
+          Write-Host "python: $python"
           $env:PYTHON = $python
           $env:PATH = "C:\msys64\ucrt64\bin;$env:PATH"
           $env:QT_PLUGIN_PATH = "C:\msys64\ucrt64\share\qt6\plugins"

--- a/.github/workflows/vc3d-windows.yml
+++ b/.github/workflows/vc3d-windows.yml
@@ -101,10 +101,15 @@ jobs:
         env:
           VC3D_MCP_TEST_BINARY: ${{ github.workspace }}\volume-cartographer\build\ci-windows-mingw\bin\VC3D.exe
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          $python = (Get-Command python.exe).Source
+          $env:PYTHON = $python
           $env:PATH = "C:\msys64\ucrt64\bin;$env:PATH"
           $env:QT_PLUGIN_PATH = "C:\msys64\ucrt64\share\qt6\plugins"
-          python -m pip install -e .
-          python -m unittest -v `
+          & $python -m pip install -e .
+          & $python -m pip check
+          & $python -m unittest -v `
             tests.test_contract `
             tests.test_real_bridge `
             tests.test_windows_pipe `
@@ -128,7 +133,7 @@ jobs:
           $stdout = Join-Path $env:RUNNER_TEMP "vc3d-mcp-launcher.stdout"
           $stderr = Join-Path $env:RUNNER_TEMP "vc3d-mcp-launcher.stderr"
           Remove-Item -LiteralPath $venv -Recurse -Force -ErrorAction SilentlyContinue
-          python -m venv $venv
+          & $python -m venv $venv
           $powershell = (Get-Command powershell.exe).Source
           $launcher = Start-Process `
             -FilePath $powershell `

--- a/.github/workflows/vc3d-windows.yml
+++ b/.github/workflows/vc3d-windows.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   build-windows:
-    name: ${{ github.event_name == 'pull_request' && 'Compile' || 'Build + package' }} (MSYS2 UCRT64)
+    name: Build + package (MSYS2 UCRT64)
     runs-on: windows-latest
     timeout-minutes: 150
     env:
@@ -165,19 +165,29 @@ jobs:
         run: '"${SCCACHE_PATH}" --show-stats'
 
       - name: Package (NSIS installer + ZIP)
-        if: github.event_name != 'pull_request'
         run: |
+          set +e
           cd build/ci-windows-mingw
-          # cpack only reports that makensis failed and points at a log file
-          # inside the build tree, which the job never uploads — so a packaging
-          # break is undiagnosable from the run output alone. Dump the log here.
-          if ! cpack -V; then
-            echo "::group::NSISOutput.log"
-            cat _CPack_Packages/win64/NSIS/NSISOutput.log || echo "(no NSISOutput.log)"
-            echo "::endgroup::"
-            exit 1
+          cpack -V
+          package_rc=$?
+          if (( package_rc != 0 )); then
+            while IFS= read -r log; do
+              echo "::group::$log"
+              cat "$log"
+              echo "::endgroup::"
+            done < <(find _CPack_Packages -name NSISOutput.log -type f)
+            exit "$package_rc"
           fi
           ls -la *.exe *.zip
+
+      - name: Upload packaging diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: VC3D-windows-packaging-diagnostics
+          path: volume-cartographer/build/ci-windows-mingw/_CPack_Packages/**/NSISOutput.log
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload installer artifact
         if: github.event_name != 'pull_request'
@@ -193,7 +203,6 @@ jobs:
       # from plain PowerShell (no MSYS2 on PATH), so any DLL missing from the
       # bundle fails loudly here instead of on a user's machine.
       - name: Smoke test packaged tree
-        if: github.event_name != 'pull_request'
         shell: pwsh
         timeout-minutes: 10
         working-directory: volume-cartographer/build/ci-windows-mingw

--- a/.github/workflows/vc3d-windows.yml
+++ b/.github/workflows/vc3d-windows.yml
@@ -91,6 +91,19 @@ jobs:
       - name: Build
         run: ninja -C build/ci-windows-mingw
 
+      - name: Smoke test build-tree VC3D
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          $env:PATH = "C:\msys64\ucrt64\bin;$env:PATH"
+          $env:QT_PLUGIN_PATH = "C:\msys64\ucrt64\share\qt6\plugins"
+          $binary = Get-Item `
+            "${{ github.workspace }}\volume-cartographer\build\ci-windows-mingw\bin\VC3D.exe"
+          Write-Host "VC3D.exe size: $($binary.Length) bytes"
+          & "C:\msys64\ucrt64\bin\objdump.exe" -f $binary.FullName
+          & $binary.FullName --version
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_runtime.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import shutil
@@ -202,7 +203,7 @@ class AutoLaunchTest(unittest.TestCase):
     def test_windows_launch_uses_its_registry_record_when_stdout_closes(self) -> None:
         class WindowsGuiProcess:
             pid = 4242
-            stdout: list[str] = []
+            stdout = io.StringIO()
             returncode = None
 
             def poll(self):
@@ -242,6 +243,7 @@ class AutoLaunchTest(unittest.TestCase):
 
         self.assertEqual(endpoint, r"\\.\pipe\vc3d-agent-4242")
         self.assertIs(server_module._launched_process, process)
+        self.assertTrue(process.stdout.closed)
 
 
 class NewTailLinesTest(unittest.TestCase):

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_runtime.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_runtime.py
@@ -70,6 +70,7 @@ class RegistryDiscoveryTest(unittest.TestCase):
             [entry.endpoint for entry in entries],
             [newer_path, older_path],
         )
+        self.assertEqual([entry.pid for entry in entries], [1002, 1001])
 
     def test_malformed_file_is_reaped(self) -> None:
         bad_file = os.path.join(self.registry_dir, "99999.json")
@@ -156,6 +157,9 @@ class RegistryResolutionTest(unittest.IsolatedAsyncioTestCase):
 
 
 class AutoLaunchTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        server_module._launched_process = None
+
     def test_volume_package_uses_its_own_cli_option(self) -> None:
         self.assertEqual(
             server_module._launch_command("/tmp/VC3D", "/tmp/demo.volpkg.json"),
@@ -194,6 +198,50 @@ class AutoLaunchTest(unittest.TestCase):
     def test_protocol_check_rejects_stale_bridge(self) -> None:
         with self.assertRaisesRegex(BridgeConnectionError, "expected 1, got None"):
             server_module._validate_protocol({"pong": True})
+
+    def test_windows_launch_uses_its_registry_record_when_stdout_closes(self) -> None:
+        class WindowsGuiProcess:
+            pid = 4242
+            stdout: list[str] = []
+            returncode = None
+
+            def poll(self):
+                return self.returncode
+
+        process = WindowsGuiProcess()
+        entries = [
+            [
+                RegistryEntry(
+                    r"\\.\pipe\stale",
+                    r"C:\Users\runner\.vc3d\agent_bridge\4242.json",
+                    999.0,
+                    pid=4242,
+                )
+            ],
+            [
+                RegistryEntry(
+                    r"\\.\pipe\vc3d-agent-4242",
+                    r"C:\Users\runner\.vc3d\agent_bridge\4242.json",
+                    1001.0,
+                    pid=4242,
+                )
+            ],
+        ]
+        with (
+            mock.patch.object(server_module.os, "name", "nt"),
+            mock.patch.object(server_module.subprocess, "Popen", return_value=process),
+            mock.patch.object(
+                server_module,
+                "discover_registry_entries",
+                side_effect=entries,
+            ),
+            mock.patch.object(server_module.time, "time", return_value=1.0),
+            mock.patch.object(server_module.atexit, "register"),
+        ):
+            endpoint = server_module.launch_vc3d("VC3D.exe", timeout=1.0)
+
+        self.assertEqual(endpoint, r"\\.\pipe\vc3d-agent-4242")
+        self.assertIs(server_module._launched_process, process)
 
 
 class NewTailLinesTest(unittest.TestCase):

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/bridge_client.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/bridge_client.py
@@ -30,6 +30,7 @@ class RegistryEntry:
     endpoint: str
     file_path: str
     started_at: float
+    pid: int | None = None
 
 
 def discover_registry_entries(registry_dir: str = REGISTRY_DIR) -> list[RegistryEntry]:
@@ -72,7 +73,18 @@ def discover_registry_entries(registry_dir: str = REGISTRY_DIR) -> list[Registry
             except OSError:
                 started_at = 0.0
 
-        entries.append(RegistryEntry(path, file_path, started_at))
+        pid_value = obj.get("pid")
+        pid = (
+            int(pid_value)
+            if (
+                isinstance(pid_value, (int, float))
+                and not isinstance(pid_value, bool)
+                and pid_value > 0
+                and int(pid_value) == pid_value
+            )
+            else None
+        )
+        entries.append(RegistryEntry(path, file_path, started_at, pid))
 
     return sorted(entries, key=lambda entry: entry.started_at, reverse=True)
 

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/server.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/server.py
@@ -145,23 +145,21 @@ def launch_vc3d(
 ) -> str:
     """Spawn VC3D with the agent bridge enabled and return its local endpoint.
 
-    A daemon thread drains the child's stdout for the whole process lifetime
-    (with stderr merged in): it detects the ``VC3D-AGENT-BRIDGE: listening ...``
-    handshake line (parsed by ``BridgeClient.socket_path_from_handshake``),
-    signals a ``threading.Event`` with the authoritative ``path=`` value, and
-    keeps reading so VC3D's stdout pipe keeps draining and never blocks VC3D.
+    A daemon thread drains the child's stdout for the whole process lifetime.
+    Unix builds publish the endpoint in a handshake line. Windows GUI
+    executables can detach redirected standard handles while Qt starts, so the
+    launcher instead waits for the matching per-process discovery record.
     Non-handshake lines are forwarded to this process's STDERR only (stdout is
-    reserved for MCP stdio); a bounded tail of recent lines is also retained
-    for error reporting.
+    reserved for MCP stdio); a bounded tail is retained for error reporting.
 
-    Waits up to ``timeout`` seconds for the handshake. A silent-but-live child
-    times out at the deadline; a child that exits before the handshake fails
-    immediately with its captured log tail. Raises ``BridgeConnectionError`` in
-    both failure cases. The process is retained (module global) so it keeps
+    Waits up to ``timeout`` seconds for the endpoint. A silent-but-live child
+    times out at the deadline; a child that exits first fails immediately with
+    its captured log tail. The process is retained (module global) so it keeps
     running for the MCP session and is terminated (escalating) on our exit.
     """
     global _launched_process
 
+    launched_at_ms = int(time.time() * 1000)
     proc = subprocess.Popen(
         _launch_command(binary, volpkg),
         stdout=subprocess.PIPE,
@@ -174,6 +172,7 @@ def launch_vc3d(
 
     handshake: dict[str, str] = {}
     found = threading.Event()
+    output_closed = threading.Event()
     tail: deque[str] = deque(maxlen=200)
 
     def _drain() -> None:
@@ -191,29 +190,44 @@ def launch_vc3d(
                 print(stripped, file=sys.stderr)
             except Exception:  # noqa: BLE001 - stderr sink gone; keep draining
                 pass
-        found.set()  # EOF: unblock the waiter even if no handshake arrived
+        output_closed.set()
 
     threading.Thread(target=_drain, name="vc3d-stdout-drain", daemon=True).start()
 
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if found.wait(timeout=0.1):
-            if "path" in handshake:
-                return handshake["path"]
-            break  # EOF set the event with no handshake
+            return handshake["path"]
         if proc.poll() is not None:
             break
+        if os.name == "nt":
+            endpoint = next(
+                (
+                    entry.endpoint
+                    for entry in discover_registry_entries()
+                    if (
+                        entry.pid == proc.pid
+                        and entry.started_at >= launched_at_ms
+                    )
+                ),
+                None,
+            )
+            if endpoint is not None:
+                return endpoint
+        elif output_closed.is_set():
+            break
 
+    exit_code = proc.poll()
     _terminate_launched_process()
     detail = "\n".join(tail)
-    if proc.returncode is not None:
+    if exit_code is not None:
         raise BridgeConnectionError(
-            f"VC3D ({binary!r}) exited with code {proc.returncode} before printing the "
-            f"agent-bridge handshake line. Last output:\n{detail}"
+            f"VC3D ({binary!r}) exited with code {exit_code} before publishing the "
+            f"agent-bridge endpoint. Last output:\n{detail}"
         )
     raise BridgeConnectionError(
-        f"timed out after {timeout:g}s waiting for VC3D ({binary!r}) to print its "
-        f"agent-bridge handshake line. Last output:\n{detail}"
+        f"timed out after {timeout:g}s waiting for VC3D ({binary!r}) to publish "
+        f"its agent-bridge endpoint. Last output:\n{detail}"
     )
 
 

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/server.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/server.py
@@ -177,19 +177,20 @@ def launch_vc3d(
 
     def _drain() -> None:
         assert proc.stdout is not None
-        for line in proc.stdout:
-            stripped = line.rstrip("\n")
-            tail.append(stripped)
-            if not found.is_set():
-                parsed = BridgeClient.socket_path_from_handshake(line)
-                if parsed is not None:
-                    handshake["path"] = parsed[1]
-                    found.set()
-                    continue
-            try:
-                print(stripped, file=sys.stderr)
-            except Exception:  # noqa: BLE001 - stderr sink gone; keep draining
-                pass
+        with proc.stdout:
+            for line in proc.stdout:
+                stripped = line.rstrip("\n")
+                tail.append(stripped)
+                if not found.is_set():
+                    parsed = BridgeClient.socket_path_from_handshake(line)
+                    if parsed is not None:
+                        handshake["path"] = parsed[1]
+                        found.set()
+                        continue
+                try:
+                    print(stripped, file=sys.stderr)
+                except Exception:  # noqa: BLE001 - stderr sink gone; keep draining
+                    pass
         output_closed.set()
 
     threading.Thread(target=_drain, name="vc3d-stdout-drain", daemon=True).start()


### PR DESCRIPTION
- makes the Windows MCP checks use the setup-python interpreter and fail on install or test errors
- fixes Windows VC3D auto-launch by finding the launched process's named pipe through the existing discovery record
- runs the real bridge offscreen and packages/smoke-tests Windows builds on pull requests
- rejects oversized executables and preserves NSIS diagnostics when packaging fails

Builds on the false-green CI diagnosis in #1261.

Verified in the full native Windows workflow: https://github.com/ScrollPrize/villa/actions/runs/30254788224

Local verification:
- 164 Python tests (2 expected skips)
- `test_volume_pkg`, `agent_bridge_contract`, and `seeding_batch_tracker` (3/3)
- offscreen VC3D smoke: 119 descriptors and 462 invalid-input probes