### PR TITLE
hfsync: don't publish fibers the sync merged but couldn't re-fit

### DIFF
--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -985,3 +985,110 @@ class TestPlannerInputHardening:
             [('fibers/a.json', plan)], set())
         assert peer_fixes == {}
         assert demoted and 'refresh against' in demoted[0][1]
+
+
+class TestClassifyFibers:
+    """hfsync publishes outward, so classify_fibers is a gate: what it puts
+    in `tagged` is uploaded to a Hugging Face bucket, and what it puts in
+    `untagged` is deleted from one."""
+
+    @staticmethod
+    def fiber(tags, **extra):
+        doc = {'type': 'vc3d_fiber', 'version': 1, 'filename': 'f.json',
+               'control_points': [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+               'line_points': [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+               'generation': 1, 'branches': [], 'tags': tags}
+        doc.update(extra)
+        return doc
+
+    @staticmethod
+    def write(tmp_path, name, doc):
+        path = tmp_path / name
+        path.write_text(doc if isinstance(doc, str) else json.dumps(doc))
+        return path
+
+    def test_tagged_fiber_publishes(self, tmp_path):
+        self.write(tmp_path, 'a.json', self.fiber(['reviewed']))
+        tagged, untagged, invalid, deferred = vc_sync.classify_fibers(
+            str(tmp_path), 'reviewed')
+        assert (tagged, untagged, invalid, deferred) == (['a.json'], [], [], [])
+
+    def test_untagged_fiber_is_removable(self, tmp_path):
+        self.write(tmp_path, 'a.json', self.fiber(['draft']))
+        tagged, untagged, invalid, deferred = vc_sync.classify_fibers(
+            str(tmp_path), 'reviewed')
+        assert (tagged, untagged, deferred) == ([], ['a.json'], [])
+
+    def test_needs_reoptimization_is_held_back(self, tmp_path):
+        """A sync-merged fiber's line is a straight-segment placeholder until
+        VC3D re-fits it; publishing it presents unfitted geometry as
+        reviewed."""
+        self.write(tmp_path, 'a.json',
+                   self.fiber(['reviewed', vc_sync.REOPTIMIZE_TAG]))
+        tagged, untagged, invalid, deferred = vc_sync.classify_fibers(
+            str(tmp_path), 'reviewed')
+        assert tagged == []
+        # NOT untagged: a held-back local file must not delete the good copy
+        # already published.
+        assert untagged == []
+        assert invalid == []
+        assert [name for name, _ in deferred] == ['a.json']
+        assert vc_sync.REOPTIMIZE_TAG in deferred[0][1]
+
+    def test_untagged_and_unfitted_is_still_removable(self, tmp_path):
+        """Holding back applies only to fibers claiming the publish tag."""
+        self.write(tmp_path, 'a.json', self.fiber([vc_sync.REOPTIMIZE_TAG]))
+        tagged, untagged, invalid, deferred = vc_sync.classify_fibers(
+            str(tmp_path), 'reviewed')
+        assert (tagged, untagged, deferred) == ([], ['a.json'], [])
+
+    def test_string_tags_do_not_substring_match(self, tmp_path):
+        """`tag in tags` over a string publishes 'unreviewed' as 'reviewed'."""
+        self.write(tmp_path, 'a.json', self.fiber('unreviewed'))
+        tagged, untagged, invalid, deferred = vc_sync.classify_fibers(
+            str(tmp_path), 'reviewed')
+        assert tagged == []
+        assert [name for name, _ in invalid] == ['a.json']
+
+    def test_null_tags_does_not_crash(self, tmp_path):
+        """`tags: null` used to raise TypeError and abort the whole run."""
+        self.write(tmp_path, 'a.json', self.fiber(None))
+        tagged, untagged, invalid, deferred = vc_sync.classify_fibers(
+            str(tmp_path), 'reviewed')
+        assert [name for name, _ in invalid] == ['a.json']
+
+    def test_non_object_root_does_not_crash(self, tmp_path):
+        """A JSON root that isn't an object used to raise AttributeError."""
+        self.write(tmp_path, 'a.json', '[1, 2, 3]')
+        tagged, untagged, invalid, deferred = vc_sync.classify_fibers(
+            str(tmp_path), 'reviewed')
+        assert [name for name, _ in invalid] == ['a.json']
+
+    def test_unloadable_fiber_is_invalid_not_untagged(self, tmp_path):
+        """An unloadable doc is quarantined, not treated as a deletion
+        request for its published namesake."""
+        self.write(tmp_path, 'a.json', self.fiber(['reviewed'], version=2))
+        tagged, untagged, invalid, deferred = vc_sync.classify_fibers(
+            str(tmp_path), 'reviewed')
+        assert (tagged, untagged) == ([], [])
+        assert [name for name, _ in invalid] == ['a.json']
+
+    def test_existing_skips_still_apply(self, tmp_path):
+        (tmp_path / 'empty.json').write_text('')
+        (tmp_path / 'bad.json').write_text('{not json')
+        (tmp_path / '.hidden.json').write_text(json.dumps(self.fiber(['reviewed'])))
+        (tmp_path / 'notes.txt').write_text('x')
+        (tmp_path / 'sub.json').mkdir()
+        tagged, untagged, invalid, deferred = vc_sync.classify_fibers(
+            str(tmp_path), 'reviewed')
+        assert tagged == []
+        assert sorted(name for name, _ in invalid) == ['bad.json', 'empty.json']
+
+    def test_unpublishable_reason_without_fiber_merge(self, monkeypatch):
+        """The fallback path (fiber_merge import failed) must still refuse the
+        shapes that crash the run or mis-tag a fiber."""
+        monkeypatch.setattr(vc_sync, 'fiber_merge', None)
+        assert vc_sync.unpublishable_reason({'tags': ['reviewed']}) is None
+        assert vc_sync.unpublishable_reason({'tags': None})
+        assert vc_sync.unpublishable_reason({'tags': 'unreviewed'})
+        assert vc_sync.unpublishable_reason([1, 2, 3])

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -95,6 +95,10 @@ HASH_MAX_BYTES = 16 * 1024 * 1024
 BASE_DIR_NAME = '.s3sync-base'          # last-synced copies (3-way merge base)
 CONFLICT_DIR_NAME = '.s3sync-conflicts'  # versions preserved before overwrite
 
+# Tag the merge puts on fibers whose line it could not re-fit; mirrored here
+# so hfsync still recognizes them when fiber_merge is unavailable.
+REOPTIMIZE_TAG = getattr(fiber_merge, 'REOPTIMIZE_TAG', 'needs_reoptimization')
+
 class SyncAction(Enum):
     UPLOAD = "upload"
     DOWNLOAD = "download"
@@ -2263,9 +2267,39 @@ def load_hfsync_config(local_dir):
     return config
 
 
+def unpublishable_reason(doc):
+    """Why this parsed JSON must not be published, or None.
+
+    Publishing is outward-facing, so the bar is the one VC3D's loader
+    applies: anything is_fiber_doc rejects would fail to load for whoever
+    downloads it. It also makes `tags` safe to index — a non-list `tags`
+    would otherwise make `tag in tags` a substring test (publishing a
+    fiber tagged 'unreviewed' under the tag 'reviewed') or raise.
+    """
+    if fiber_merge is not None:
+        if not fiber_merge.is_fiber_doc(doc):
+            return "not a loadable vc3d_fiber document"
+        return None
+    # Without fiber_merge, still refuse the shapes that would crash the
+    # run or silently mis-tag a fiber.
+    if not isinstance(doc, dict):
+        return "not a JSON object"
+    tags = doc.get('tags', [])
+    if not (isinstance(tags, list) and all(isinstance(t, str) for t in tags)):
+        return "'tags' is not an array of strings"
+    return None
+
+
 def classify_fibers(local_dir, tag):
-    """Split the directory's fiber JSONs into tagged / untagged / invalid"""
-    tagged, untagged, invalid = [], [], []
+    """Split the directory's fiber JSONs into tagged / untagged / invalid /
+    deferred.
+
+    `deferred` holds fibers that carry the publish tag but are not ready to
+    publish (see REOPTIMIZE_TAG below). Like `invalid`, they are neither
+    uploaded nor removed: a previously published good copy must survive a
+    transient local state.
+    """
+    tagged, untagged, invalid, deferred = [], [], [], []
 
     for name in sorted(os.listdir(local_dir)):
         if name.startswith('.') or not name.endswith('.json'):
@@ -2279,7 +2313,7 @@ def classify_fibers(local_dir, tag):
                 invalid.append((name, "zero-byte file"))
                 continue
             with open(path, 'r') as f:
-                tags = json.load(f).get('tags', [])
+                doc = json.load(f)
         except json.JSONDecodeError as e:
             invalid.append((name, f"unparseable JSON ({e.msg} at line {e.lineno})"))
             continue
@@ -2287,12 +2321,25 @@ def classify_fibers(local_dir, tag):
             invalid.append((name, f"unreadable ({e})"))
             continue
 
-        if tag in tags:
-            tagged.append(name)
-        else:
-            untagged.append(name)
+        problem = unpublishable_reason(doc)
+        if problem:
+            invalid.append((name, problem))
+            continue
 
-    return tagged, untagged, invalid
+        tags = doc.get('tags', [])
+        if tag not in tags:
+            untagged.append(name)
+        elif REOPTIMIZE_TAG in tags:
+            # Sync-merged fibers whose line is still a straight-segment
+            # placeholder between control points; VC3D re-fits them on
+            # load. Publishing one presents unfitted geometry as reviewed.
+            deferred.append(
+                (name, f"carries '{REOPTIMIZE_TAG}' — its line is a "
+                       f"placeholder until VC3D re-fits it"))
+        else:
+            tagged.append(name)
+
+    return tagged, untagged, invalid, deferred
 
 
 def hf_sync(local_dir, dry_run=False):
@@ -2318,11 +2365,14 @@ def hf_sync(local_dir, dry_run=False):
     if dry_run:
         print("--dry-run mode: No changes will be made")
 
-    tagged, untagged, invalid = classify_fibers(local_dir, tag)
+    tagged, untagged, invalid, deferred = classify_fibers(local_dir, tag)
     print(f"\nLocal fibers: {len(tagged)} tagged '{tag}', "
-          f"{len(untagged)} without the tag, {len(invalid)} invalid")
+          f"{len(untagged)} without the tag, {len(invalid)} invalid, "
+          f"{len(deferred)} held back")
     for name, problem in invalid:
         print(f"  ⚠️  Skipping {name}: {problem}")
+    for name, problem in deferred:
+        print(f"  ⏸️  Holding {name}: {problem}")
 
     # Upload (additive): stage tagged files with mtimes preserved so
     # `hf buckets sync` transfers only new or changed ones
@@ -2343,7 +2393,9 @@ def hf_sync(local_dir, dry_run=False):
             shutil.rmtree(staging, ignore_errors=True)
 
     # Removals: only filenames that exist locally WITHOUT the tag and are
-    # present remotely. Files that exist only remotely are never touched.
+    # present remotely. Files that exist only remotely are never touched,
+    # and neither are invalid/held-back ones — a local file we refused to
+    # publish must not take its published predecessor down with it.
     result = subprocess.run([hf_cli, 'buckets', 'list', bucket_path, '-R', '-q'],
                             capture_output=True, text=True)
     if result.returncode != 0:
@@ -2366,12 +2418,14 @@ def hf_sync(local_dir, dry_run=False):
         else:
             print(f"  ❌ Failed to remove {name}: {(rm.stderr or '').strip()}")
 
+    held = f", {len(deferred)} held back" if deferred else ""
     if dry_run:
         print(f"\n--dry-run: {len(tagged)} upload candidates (unchanged files "
-              f"are skipped, see plan above), {len(to_remove)} would be removed")
+              f"are skipped, see plan above), {len(to_remove)} would be "
+              f"removed{held}")
     else:
         print(f"\n✓ Hugging Face sync complete: {len(tagged)} tagged fibers synced, "
-              f"{removed} removed, {len(invalid)} skipped as invalid")
+              f"{removed} removed, {len(invalid)} skipped as invalid{held}")
 
 
 def main():


### PR DESCRIPTION
Follow-up to #1246. `hfsync` is the one path that publishes fiber JSON outward (to a Hugging Face bucket), and `classify_fibers` is its gate: what it returns as `tagged` gets uploaded, and what it returns as `untagged` gets **deleted** from the bucket. It predates the sync-merge work and was never adapted to it.

## The regression #1246 introduced

The merge tags fibers `needs_reoptimization` when it cannot re-fit their line — `line_points` is set to the merged control points verbatim, i.e. straight segments, until VC3D re-fits them on load. If such a fiber also carries the publish tag, the next `hfsync` uploaded it with no warning, presenting unfitted placeholder geometry as reviewed.

It self-heals only if someone opens the fiber in VC3D, accepts the re-optimization prompt, *and* re-runs `hfsync`. Declining the prompt, or working on a machine that only runs the sync script, leaves the degraded copy published indefinitely.

Those fibers now land in a new `deferred` bucket. Like `invalid`, they are **neither uploaded nor removed** — a fiber we refuse to publish must not take its already-published good copy down with it — and each one is reported:

```
  ⏸️  Holding kb_014.json: carries 'needs_reoptimization' — its line is a placeholder until VC3D re-fits it
```

Holding back applies only to fibers claiming the publish tag; an untagged one stays removable as before.

## Two pre-existing holes in the same function

Both are the class of malformed input #1246 hardened `is_fiber_doc` against, in the sibling reader it left untouched:

- **`"tags": "unreviewed"`** (a string rather than a list) made `tag in tags` a *substring* test, so the fiber published under the tag `reviewed`. Because it landed in `tagged` rather than `untagged`, it was also never eligible for removal. An incorrect publish, not just a crash.
- **`"tags": null`** raised `TypeError`, and a JSON root that is not an object raised `AttributeError`. Neither escapes the surrounding `except (JSONDecodeError, OSError, UnicodeDecodeError)`, so one bad file aborted the entire run with a traceback. These failed safe (classification runs before any transfer) but blocked all publishing until someone found the file.

## The fix

Documents are screened with `fiber_merge.is_fiber_doc` before classification — the same bar VC3D's loader applies. Publishing is outward-facing, so a document that would not load for whoever downloads it is quarantined as `invalid` rather than treated as a deletion request for its published namesake. The fallback path for a missing `fiber_merge` (the import is optional) still refuses the shapes that crash the run or mis-tag a fiber.

## Testing

`pytest scripts/tests/` — **122 → 132 passing**. New `TestClassifyFibers` covers each case above plus the ones that must not change: a plain tagged fiber still publishes, an untagged one is still removable, an untagged-and-unfitted one is still removable, and the existing zero-byte / unparseable / hidden-file / non-JSON skips still apply. The `fiber_merge is None` fallback is tested via monkeypatch.

Verified against the original repro directory:

```
tagged (uploaded):    ['good.json']
untagged (removable): []
invalid:              ['null_tags.json', 'root_is_list.json', 'string_tags.json']
deferred (held):      ['merged_unfitted.json']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgd6ttemrfPwirK2y1DNDo