### PR TITLE
spiral: fix checkpoint saving on Windows (fsync needs a writable descriptor)

### DIFF
--- a/volume-cartographer/scripts/spiral/fit_spiral.py
+++ b/volume-cartographer/scripts/spiral/fit_spiral.py
@@ -1836,7 +1836,8 @@ def main(load_only_patches_and_point_collections=False, interactive_driver=None)
         temporary = f'{destination}.tmp-{os.getpid()}-{time.time_ns()}'
         try:
             torch.save(checkpoint_payload(completed_iterations), temporary)
-            with open(temporary, 'rb') as stream:
+            # 'rb+' not 'rb': fsync on Windows (_commit) requires a writable descriptor.
+            with open(temporary, 'rb+') as stream:
                 os.fsync(stream.fileno())
             os.replace(temporary, destination)
             try:


### PR DESCRIPTION
## Problem

`save_model_to` in `fit_spiral.py` flushes the freshly written checkpoint with:

    with open(temporary, 'rb') as stream:
        os.fsync(stream.fileno())

On Windows `os.fsync` maps to `_commit`, which requires a **writable** file
descriptor; on a file opened `'rb'` it fails with `OSError: [Errno 9] Bad file
descriptor`. The exception propagates, the `finally` block deletes the
temporary file, and the fit aborts at its first checkpoint save.

## Real-world occurrence

First native Windows run of `fit_spiral.py` (PHerc. Paris 4 spiral dataset,
z 10600-10900 window, main @ 1162bcab), ~1h45 into preparation, at the
identical `open('rb')` + `os.fsync` pattern that then lived in
`prepare_lasagna_mmap` (file removed since by #1258):

      File ".../scripts/spiral/fit_spiral.py", line 1261, in main
        lasagna_volume = prepare_lasagna_volume(
      File ".../scripts/spiral/lasagna_data.py", line 307, in prepare_lasagna_volume
        store = prepare_lasagna_mmap(
      File ".../scripts/spiral/lasagna_mmap.py", line 484, in prepare_lasagna_mmap
        os.fsync(data_stream.fileno())
    OSError: [Errno 9] Bad file descriptor

The same pattern remains on current `main` in `save_model_to`. It is the only
occurrence left: every other `os.fsync` in the spiral scripts is on a
`'w'`/`'wb'` stream, or on a directory fd already guarded by
`try/except OSError`.

## Minimal reproduction

    import os, tempfile
    path = os.path.join(tempfile.mkdtemp(), 'checkpoint.ckpt')
    with open(path, 'wb') as f:
        f.write(b'payload')
    with open(path, 'rb') as f:
        os.fsync(f.fileno())   # OSError on Windows, fine on POSIX

Windows 11, CPython 3.14.3:

    open('rb') + os.fsync: FAILED -> OSError(9, 'Bad file descriptor')
    open('rb+') + os.fsync: OK

## Fix

Open the temporary file `'rb+'` instead of `'rb'` (one line, plus a comment).
POSIX permits fsync on read-only descriptors and its semantics do not depend
on the access mode, so nothing changes on Linux/macOS; on Windows the
descriptor becomes writable and `_commit` succeeds.

## Validation

- Minimal repro above passes with `'rb+'` on Windows 11 / CPython 3.14.3.
- A verbatim standalone replica of `save_model_to` (real `torch.save`
  payload) was run on Windows in both modes: `'rb'` fails exactly as in the
  traceback and the `finally` block deletes the temporary, so the checkpoint
  is lost; `'rb+'` saves, survives `os.replace`, reads back intact through
  `torch.load`, and traverses the guarded directory-fsync path without
  incident.
- No behavior change expected on POSIX: the current `'rb'` + `os.fsync` pair
  already runs there daily, fsync's contract does not depend on the
  descriptor's access mode, and `'rb+'` only adds write permission to the fd.
- No unit test added: the pattern lives in a closure inside `main()` and only
  a real fit reaches a checkpoint save; the change is a one-character mode
  widening with identical POSIX semantics. Happy to add one if you see a
  reasonable seam.
