### PR TITLE
spiral: drop unused posix-ipc dependency (fixes install on Windows)

### DIFF
--- a/volume-cartographer/scripts/spiral/pyproject.toml
+++ b/volume-cartographer/scripts/spiral/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "numpy>=2.5.0",
     "opencv-python-headless>=4.13.0.92",
     "pillow>=12.2.0",
-    "posix-ipc>=1.3.2",
     "pyro-ppl>=1.9.1",
     "s3fs>=2026.6.0",
     "scipy>=1.18.0",


### PR DESCRIPTION
## Problem

`scripts/spiral/pyproject.toml` declares `posix-ipc>=1.3.2`, but `posix_ipc`
is never imported anywhere in the spiral scripts:

    $ grep -rn "posix_ipc" volume-cartographer/scripts/spiral --include='*.py'
    (no matches)
    $ git log -S posix_ipc --oneline --all -- volume-cartographer/scripts/
    (no commits: never imported at any revision; the pin arrived with the
     pyproject itself in #1088)

posix-ipc publishes no Windows wheels, and its sdist probes the system by
invoking a C compiler, which fails on a stock Windows machine. The stray
declaration alone makes `uv sync` / `uv pip install -e scripts/spiral` /
`pip install -e` fail for every Windows user:

    Resolved 96 packages in 63ms
       Building posix-ipc==1.3.2
      × Failed to build `posix-ipc==1.3.2`
      ├─▶ The build backend returned an error
      ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit code: 1)

          [stderr, abridged]
          File ".../posix-ipc/1.3.2/.../src/build_support/discover_system_info.py",
              line 391, in discover
            realtime_lib_is_needed = sniff_realtime_lib()
          File ".../Lib/subprocess.py", line 1552, in _execute_child
            hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
          FileNotFoundError: [WinError 2] Le fichier spécifié est introuvable
          (localized: "The system cannot find the file specified")

      help: `posix-ipc` (v1.3.2) was included because `spiral` (v0.1.0)
            depends on `posix-ipc`

(Environment: Windows 11, uv, CPython 3.14.3.)

## Fix

Remove the declaration. If there is a historical or planned reason to keep
it, a platform marker would also unblock Windows installs:

    "posix-ipc>=1.3.2; sys_platform != 'win32'",

Happy to switch this PR to the marker if you prefer.

## Validation

- After removal, `uv pip install -e scripts/spiral` completes on native
  Windows (96 packages: torch 2.13.0, tensorstore 0.1.84, vtk 9.6.2, ...).
- In the resulting environment, all 48 top-level modules under
  `scripts/spiral` import cleanly, so nothing needs `posix_ipc` at import
  time either, and
  `python -m pytest tests/test_pcl_sampling.py tests/test_spiral_helpers.py`
  passes (7 tests) on Windows.
- Linux/macOS unaffected: no code imports the module, and uv's resolution
  note above shows `spiral` is its only dependency edge.
