### PR TITLE
spiral: distinguish missing point-collection files from parse failures

### DIFF
--- a/volume-cartographer/scripts/spiral/point_collection.py
+++ b/volume-cartographer/scripts/spiral/point_collection.py
@@ -75,6 +75,11 @@ def load_point_collection(filename: str) -> Optional[Dict[int, Dict[str, Any]]]:
         print(f"Loaded point collection with {len(collections)} collections ({total_points} points)")
         return collections
 
+    except FileNotFoundError:
+        # Default configs list optional annotation files (e.g.
+        # drawn_control_points.json) that may not exist in a dataset.
+        print(f"WARNING: point collection file not found, skipping: {filename}")
+        return None
     except Exception as e:
         print(f"Error loading point collection from {filename}: {e}")
         return None

--- a/volume-cartographer/scripts/spiral/tests/test_point_collection.py
+++ b/volume-cartographer/scripts/spiral/tests/test_point_collection.py
@@ -1,0 +1,82 @@
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+from point_collection import load_point_collection
+
+
+class LoadPointCollectionTests(unittest.TestCase):
+    def test_loads_valid_collection(self):
+        payload = {
+            "vc_pointcollections_json_version": "1",
+            "collections": {
+                "0": {
+                    "name": "col-a",
+                    "points": {
+                        "0": {"p": [1.0, 2.0, 3.0], "wind_a": 1.5},
+                        "1": {"p": [4.0, 5.0, 6.0]},
+                    },
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = os.path.join(temporary, "abs_winding.json")
+            with open(path, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream)
+            loaded = load_point_collection(path)
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(list(loaded.keys()), [0])
+        collection = loaded[0]
+        self.assertEqual(collection["name"], "col-a")
+        self.assertEqual(collection["points"][0]["p"], [1.0, 2.0, 3.0])
+        self.assertEqual(collection["points"][0]["winding_annotation"], 1.5)
+        # Absent winding annotations become NaN, not None.
+        self.assertNotEqual(
+            collection["points"][1]["winding_annotation"],
+            collection["points"][1]["winding_annotation"],
+        )
+
+    def test_missing_file_warns_and_skips(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = os.path.join(temporary, "drawn_control_points.json")
+            output = io.StringIO()
+            with redirect_stdout(output):
+                loaded = load_point_collection(path)
+
+        self.assertIsNone(loaded)
+        message = output.getvalue()
+        self.assertIn("not found", message)
+        self.assertIn(path, message)
+        self.assertNotIn("Error", message)
+
+    def test_malformed_file_still_reports_error(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = os.path.join(temporary, "abs_winding.json")
+            with open(path, "w", encoding="utf-8") as stream:
+                stream.write("{not valid json")
+            output = io.StringIO()
+            with redirect_stdout(output):
+                loaded = load_point_collection(path)
+
+        self.assertIsNone(loaded)
+        self.assertIn("Error loading point collection", output.getvalue())
+
+    def test_unsupported_version_still_reports_error(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = os.path.join(temporary, "abs_winding.json")
+            with open(path, "w", encoding="utf-8") as stream:
+                json.dump({"vc_pointcollections_json_version": "2"}, stream)
+            output = io.StringIO()
+            with redirect_stdout(output):
+                loaded = load_point_collection(path)
+
+        self.assertIsNone(loaded)
+        self.assertIn("Unsupported JSON version", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`load_point_collection` catches every exception the same way, so a missing
file and a corrupt one produce the same console line, and the fit quietly
continues either way:

    Error loading point collection from /data/scrolls/s1/drawn_control_points.json: [Errno 2] No such file or directory: '/data/scrolls/s1/drawn_control_points.json'

Two situations hit this in practice.

**Missing-by-design optional files.** The default `pcl_json_paths` in
`fit_spiral.py` lists `{dataset}/drawn_control_points.json`, but the
published PHerc. Paris 4 spiral dataset does not contain that file
(checked 2026-07-27):

    $ hf buckets ls hf://buckets/scrollprize/datasets/spiral/PHercParis4
           20022  2026-06-17  spiral/PHercParis4/abs_winding.json
                  2026-07-27  spiral/PHercParis4/fibers/
                  2026-07-07  spiral/PHercParis4/lasagna_inputs/
                  2026-07-06  spiral/PHercParis4/outer_shell/
        23972117  2026-07-07  spiral/PHercParis4/patch-overlap-pcls.json
          773507  2026-06-20  spiral/PHercParis4/relative_windings.json
         1695752  2026-06-19  spiral/PHercParis4/same_windings.json
                  2026-07-24  spiral/PHercParis4/tracks/
           12387  2026-05-24  spiral/PHercParis4/umbilicus.json
                  2026-07-07  spiral/PHercParis4/unverified_patches/
                  2026-07-07  spiral/PHercParis4/verified_patches/

so every walkthrough run on the published dataset printed the spurious
error. Commit 76cf8086 on `spiral-hyperparams-jul27` now removes that entry
from the defaults, which fixes the noisy out-of-the-box experience; this PR
is the loader-side companion for the cases that remain (roles supplied by
the interactive session, custom configs, other optional files).

**Genuinely wrong paths.** A typo in a custom `pcl_json_paths`, or a
partially synced local copy of the dataset (the HF sync is resumable, so
partial copies are common), currently produces the same soft "Error" line,
and the fit continues without the constraints the user meant to supply.

## Fix

Catch `FileNotFoundError` separately in `load_point_collection` and say what
actually happened:

    WARNING: point collection file not found, skipping: /data/scrolls/s1/drawn_control_points.json

Genuine parse/schema failures keep the existing error report. Skip-if-missing
matches the semantics the interactive session already applies:
`fit_session.py` marks every conventional pcl entry, including
`drawn_control_points.json`, as `required=False`.

## Validation

New `tests/test_point_collection.py` covers the loader: a valid file loads
(including NaN for absent winding annotations), a missing file warns and
returns None without an "Error" line, malformed JSON and an unsupported
version still report errors.

    $ python -m pytest tests/test_point_collection.py -q
    ....                                                                     [100%]
    4 passed in 2.34s

(Run on Windows 11 / CPython 3.14.3; the logic is platform-independent. No
conflict with `spiral-hyperparams-jul27`: that branch edits `fit_spiral.py`,
this PR touches only `point_collection.py` and tests.)
