### PR TITLE
spiral: fail when the z-ROI filter drops every loaded patch

### DIFF
--- a/volume-cartographer/scripts/spiral/fit_spiral.py
+++ b/volume-cartographer/scripts/spiral/fit_spiral.py
@@ -82,6 +82,7 @@ from sdt_losses import (
 )
 from spiral_helpers import (
     SAMPLING_COUNT_FLOORS,
+    ensure_patches_survive_z_roi,
     erode_patch_valid_region,
     load_patches,
     load_fiber_point_collection,
@@ -891,6 +892,7 @@ def main(load_only_patches_and_point_collections=False, interactive_driver=None)
 
     print(f" loaded {len(verified_patches)} patches")
     print(f" loaded {len(unverified_patches)} unverified patches")
+    loaded_verified, loaded_unverified = len(verified_patches), len(unverified_patches)
 
     for patches in (verified_patches, unverified_patches):
         for patch_id, patch in list(patches.items()):
@@ -910,6 +912,11 @@ def main(load_only_patches_and_point_collections=False, interactive_driver=None)
             # Training retains the base grid and masks, so regenerate this view
             # lazily only for a later exporter that actually requests it.
             patch.release_derived_caches()
+
+    ensure_patches_survive_z_roi(
+        verified_patches, unverified_patches,
+        use_verified_patches or use_unverified_patches,
+        z_begin, z_end, loaded_verified, loaded_unverified)
 
     # ==========================================================================
     # Point collection loading

--- a/volume-cartographer/scripts/spiral/spiral_helpers.py
+++ b/volume-cartographer/scripts/spiral/spiral_helpers.py
@@ -25,6 +25,25 @@ def patch_intersects_z_roi(patch, z_begin, z_end):
     return bool(((zs >= z_begin) & (zs < z_end)).any().item())
 
 
+def ensure_patches_survive_z_roi(verified_patches, unverified_patches,
+                                 patches_requested, z_begin, z_end,
+                                 loaded_verified, loaded_unverified):
+    """Fail loudly when the z-ROI filter drops every loaded patch.
+
+    The 'No patches could be loaded' guard runs before the z-ROI filter,
+    so a window falling in a pack coverage gap used to fit zero patches
+    to a clean exit 0 (#1237). Intentionally patch-free fits pass
+    patches_requested=False and stay exempt.
+    """
+    if patches_requested and not verified_patches and not unverified_patches:
+        raise RuntimeError(
+            f'No patches intersect the fit window z {z_begin}-{z_end}: '
+            f'{loaded_verified} verified + {loaded_unverified} unverified '
+            'patches were loaded, but the z-ROI filter (and erosion) dropped '
+            'them all. Adjust z_begin/z_end to patch coverage, or set '
+            'disable_patches=True to fit without patches intentionally.')
+
+
 def scale_counts_for_z_range(
     config,
     z_begin,

--- a/volume-cartographer/scripts/spiral/tests/test_spiral_helpers.py
+++ b/volume-cartographer/scripts/spiral/tests/test_spiral_helpers.py
@@ -6,7 +6,10 @@ import unittest
 import numpy as np
 from PIL import Image
 
-from spiral_helpers import load_fiber_point_collection
+from spiral_helpers import (
+    ensure_patches_survive_z_roi,
+    load_fiber_point_collection,
+)
 from tifxyz import load_tifxyz
 
 
@@ -68,6 +71,28 @@ class TifxyzMetadataTests(unittest.TestCase):
             patch = load_tifxyz(root)
 
             self.assertEqual(patch.erosion_cells(7), 7)
+
+
+class EnsurePatchesSurviveZRoiTests(unittest.TestCase):
+    def test_window_missing_all_patches_raises(self):
+        with self.assertRaises(RuntimeError) as raised:
+            ensure_patches_survive_z_roi(
+                {}, {}, True, 17600, 18400,
+                loaded_verified=25, loaded_unverified=0)
+        message = str(raised.exception)
+        self.assertIn("z 17600-18400", message)
+        self.assertIn("25 verified", message)
+        self.assertIn("disable_patches", message)
+
+    def test_intentionally_patch_free_fit_is_exempt(self):
+        ensure_patches_survive_z_roi(
+            {}, {}, False, 17600, 18400,
+            loaded_verified=0, loaded_unverified=0)
+
+    def test_surviving_patches_pass(self):
+        ensure_patches_survive_z_roi(
+            {1: object()}, {}, True, 17600, 18400,
+            loaded_verified=25, loaded_unverified=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1237.

## Problem

As traced in #1237 (@pscamillo, verified by @IyanDopico): the only
`>= 1 patch` guard validates the dicts straight out of the pack loader
and runs before the z-ROI intersection filter. A window that falls in
a pack coverage gap therefore fits **zero patches** to a clean
`exit 0`: constraints optimize, meshes save, and nothing warns that
the fit ran without any absolute seed anchoring.

## Fix

Re-check after the erosion + z-ROI filter loop, in a helper next to
`patch_intersects_z_roi`. The guard mirrors the pack-level
`'No patches could be loaded'` one: it only fires when patches were
requested, so intentionally patch-free fits (`disable_patches`, or
`use_*_patches = False`) keep the legitimate zero-patch branch in
`losses.py` untouched, as the issue asked. A hard error matches the
precedent guard's behavior; happy to soften it to a warning if
preferred.

## Validation

- Three new tests in `tests/test_spiral_helpers.py` cover the guard:
  all-dropped raises with the window and loaded counts in the message,
  intentionally patch-free fits stay exempt, surviving patches pass.

      $ python -m pytest tests/test_spiral_helpers.py -q
      .......
      7 passed in 3.11s

- Real-run check against the published PHerc. Paris 4 spiral dataset
  (module globals redirected to the local pack, `load_only` mode). A
  window in a coverage gap (z 50-120) now aborts right after the
  filter:

      loaded 4921 patches
      loaded 40782 unverified patches
      RuntimeError: No patches intersect the fit window z 50-120: 4921
      verified + 40782 unverified patches were loaded, but the z-ROI
      filter (and erosion) dropped them all. Adjust z_begin/z_end to
      patch coverage, or set disable_patches=True to fit without
      patches intentionally.

  A covered window (z 10600-10900) passes the guard silently and
  proceeds to point-collection loading unchanged.

(Windows 11 / CPython 3.14.3; the logic is platform-independent.)
