### PR TITLE
spiral: skip loading patches that meta.json already places outside the z-roi

### DIFF
--- a/volume-cartographer/scripts/spiral/fit_spiral.py
+++ b/volume-cartographer/scripts/spiral/fit_spiral.py
@@ -88,6 +88,7 @@ from spiral_helpers import (
     load_fiber_point_collections,
     scale_counts_for_z_range,
     _infer_shell_outer_winding_idx,
+    patch_dir_may_intersect_z_roi,
     patch_intersects_z_roi,
     save_combined_preview,
 )
@@ -845,13 +846,21 @@ def main(load_only_patches_and_point_collections=False, interactive_driver=None)
 
     def load_patches_from_dir(path):
         patches = {}
+        skipped = 0
         for entry in sorted(os.listdir(path)):
             segment_path = os.path.join(path, entry)
+            # Patches outside the fitted z-roi are dropped a few lines below;
+            # skip reading their grids at all when meta.json already proves it.
+            if not patch_dir_may_intersect_z_roi(segment_path, z_begin, z_end):
+                skipped += 1
+                continue
             try:
                 patches[entry] = load_tifxyz(segment_path)
             except Exception as e:
                 print(f'Failed to load segment {entry}: {e}')
                 continue
+        if skipped:
+            print(f' skipped {skipped} patches outside the z-roi (bbox pre-filter)')
         return patches
 
     filter_tracks_by_shell = (

--- a/volume-cartographer/scripts/spiral/spiral_helpers.py
+++ b/volume-cartographer/scripts/spiral/spiral_helpers.py
@@ -25,6 +25,32 @@ def patch_intersects_z_roi(patch, z_begin, z_end):
     return bool(((zs >= z_begin) & (zs < z_end)).any().item())
 
 
+def patch_dir_may_intersect_z_roi(segment_path, z_begin, z_end):
+    """Cheap conservative pre-filter, from meta.json alone.
+
+    Patches are discarded after loading when they miss the fitted z-roi, but
+    loading materialises three full-resolution tif grids each. On a whole-scroll
+    input set that is tens of thousands of patches read to keep a few hundred.
+    The bbox written by save_tifxyz is enough to exclude most of them without
+    touching the grids.
+
+    Returns True whenever the patch cannot be excluded with certainty (no
+    meta.json, no bbox, sentinel bbox, unreadable json), so the authoritative
+    per-vertex check in patch_intersects_z_roi still decides.
+    """
+    try:
+        with open(os.path.join(segment_path, 'meta.json'), 'r') as meta_json:
+            bbox = json.load(meta_json).get('bbox')
+    except (OSError, ValueError):
+        return True
+    if not bbox or len(bbox) != 2 or len(bbox[0]) != 3 or len(bbox[1]) != 3:
+        return True
+    z_min, z_max = bbox[0][2], bbox[1][2]  # bbox rows are xyz
+    if z_min == -1.0 and z_max == -1.0:  # sentinel written for empty patches
+        return True
+    return z_max >= z_begin and z_min < z_end
+
+
 def scale_counts_for_z_range(
     config,
     z_begin,

--- a/volume-cartographer/scripts/spiral/tests/test_spiral_helpers.py
+++ b/volume-cartographer/scripts/spiral/tests/test_spiral_helpers.py
@@ -6,7 +6,11 @@ import unittest
 import numpy as np
 from PIL import Image
 
-from spiral_helpers import load_fiber_point_collection
+from spiral_helpers import (
+    load_fiber_point_collection,
+    patch_dir_may_intersect_z_roi,
+    patch_intersects_z_roi,
+)
 from tifxyz import load_tifxyz
 
 
@@ -68,6 +72,60 @@ class TifxyzMetadataTests(unittest.TestCase):
             patch = load_tifxyz(root)
 
             self.assertEqual(patch.erosion_cells(7), 7)
+
+
+class PatchDirZRoiPrefilterTests(unittest.TestCase):
+    def _write_patch(self, root, zs, bbox=None, write_meta=True):
+        """A 2x2 patch whose z grid is `zs`; bbox defaults to the true extent."""
+        root.mkdir(parents=True, exist_ok=True)
+        z_grid = np.asarray(zs, dtype=np.float32)
+        for coordinate, values in (
+            ("z", z_grid),
+            ("y", np.zeros_like(z_grid)),
+            ("x", np.zeros_like(z_grid)),
+        ):
+            Image.fromarray(values).save(root / f"{coordinate}.tif")
+        if write_meta:
+            if bbox is None:
+                bbox = [[0.0, 0.0, float(z_grid.min())], [0.0, 0.0, float(z_grid.max())]]
+            (root / "meta.json").write_text(json.dumps({
+                "format": "tifxyz", "scale": [1.0, 1.0], "bbox": bbox,
+            }))
+        return root
+
+    def test_excludes_patch_entirely_outside_the_roi(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = self._write_patch(Path(temporary) / "p", [[500, 501], [502, 503]])
+            self.assertFalse(patch_dir_may_intersect_z_roi(root, 100, 200))
+            # and the authoritative check agrees
+            self.assertFalse(patch_intersects_z_roi(load_tifxyz(root), 100, 200))
+
+    def test_keeps_overlapping_and_boundary_patches(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            inside = self._write_patch(base / "inside", [[120, 130], [140, 150]])
+            straddling = self._write_patch(base / "straddling", [[80, 90], [100, 110]])
+            for root in (inside, straddling):
+                self.assertTrue(patch_dir_may_intersect_z_roi(root, 100, 200))
+                self.assertTrue(patch_intersects_z_roi(load_tifxyz(root), 100, 200))
+
+    def test_conservative_when_metadata_is_unusable(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            no_meta = self._write_patch(base / "no_meta", [[500, 501], [502, 503]],
+                                        write_meta=False)
+            no_bbox = base / "no_bbox"
+            no_bbox.mkdir()
+            (no_bbox / "meta.json").write_text(json.dumps({"scale": [1.0, 1.0]}))
+            sentinel = self._write_patch(
+                base / "sentinel", [[500, 501], [502, 503]],
+                bbox=[[-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]])
+            broken = base / "broken"
+            broken.mkdir()
+            (broken / "meta.json").write_text("{not json")
+
+            for root in (no_meta, no_bbox, sentinel, broken):
+                self.assertTrue(patch_dir_may_intersect_z_roi(root, 100, 200))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fitting a short z-window against a whole-scroll input set reads every patch in the directory before deciding it isn't needed.

**What happens today.** `load_patches_from_dir` calls `load_tifxyz` on every entry, materialising three full-resolution tif grids per patch; `patch_intersects_z_roi` then drops the ones that miss the fitted z-roi a few lines later. On PHerc. Paris 4 fitted over 300 slices that is 45,705 patch directories read to keep ~3,800. On a 64 GB consumer machine the run dies with a host-memory allocation failure during point-to-patch linking, before the optimizer starts.

**The change.** `load_tifxyz` already opens `meta.json` first, so the `bbox` that `save_tifxyz` writes is enough to exclude a patch before touching its grids. For a skipped patch this now reads exactly what it read before, and stops there.

The pre-filter is deliberately conservative: any patch whose metadata is missing, bbox-less, sentinel-valued (`[-1, -1, -1]`) or unparseable is still loaded, so the authoritative per-vertex `patch_intersects_z_roi` check keeps deciding and the resulting patch set is unchanged.

**Measured** (PHerc. Paris 4, z 10600-10900):

| input set | directories | loaded after | skipped |
|---|---|---|---|
| verified | 4,923 | 512 | 89.6% |
| unverified | 40,782 | 3,255 | 92.0% |

All 45,705 directories carry a usable bbox, so the pre-filter decides on metadata alone, at roughly 4 ms per thousand directories. The window that previously died on host memory now completes.

**Equivalence check on real data.** 8,000 patch directories x 5 z-windows (the fitted window, the whole written region 4000-17000, a 20-slice sliver straddling patch edges, and two degenerate ranges) = 39,990 comparisons between the pre-filter and the authoritative check:

- 0 cases where the pre-filter excluded a patch the authoritative check would have kept;
- 27 cases (0.07%) kept by the pre-filter and dropped afterwards, exactly as before;
- 99.93% exact agreement.

**Tests.** `tests/test_spiral_helpers.py` gains coverage for a patch entirely outside the roi, patches overlapping or straddling the boundary, and the four unusable-metadata cases (no `meta.json`, no bbox, sentinel bbox, malformed json). The pre-existing failures in `test_phase_spacing.py`, `test_spiral_service_v2.py` and `test_track_crossing_cache.py` reproduce on `main` without this change.

Found while running `fit_spiral.py` on a small window on Windows with an 8 GB GPU; happy to adjust the approach if you would rather filter elsewhere in the pipeline.
