### PR TITLE
spiral: resolve shell_outer_winding_idx outside the shell-loss branch

### DIFF
--- a/volume-cartographer/scripts/spiral/fit_spiral.py
+++ b/volume-cartographer/scripts/spiral/fit_spiral.py
@@ -88,6 +88,8 @@ from spiral_helpers import (
     load_fiber_point_collections,
     scale_counts_for_z_range,
     _infer_shell_outer_winding_idx,
+    _structurally_disabled_dense_weight_keys,
+    resolve_outer_winding_idx_and_notes,
     patch_intersects_z_roi,
     save_combined_preview,
 )
@@ -1732,9 +1734,9 @@ def main(load_only_patches_and_point_collections=False, interactive_driver=None)
     # ==========================================================================
 
     shell_map = None
-    shell_outer_winding_idx = None
     shell_valid_zyxs_gpu = None
-    if shell_patch is not None and shell_losses_enabled():
+    shell_active = shell_patch is not None and shell_losses_enabled()
+    if shell_active:
         if cfg['loss_weight_shell_outer'] > 0:
             shell_map = ShellPolarMap(
                 shell_patch,
@@ -1746,31 +1748,44 @@ def main(load_only_patches_and_point_collections=False, interactive_driver=None)
             )
         if cfg['loss_weight_shell_patch_radius'] > 0:
             shell_valid_zyxs_gpu = shell_patch.valid_zyxs.to(device=device, dtype=torch.float32)
-        initial_transform = spiral_and_transform.get_slice_to_spiral_transform()
-        initial_dr = spiral_and_transform.get_dr_per_winding()
-        if cfg['shell_outer_winding_idx'] is None:
-            shell_outer_winding_idx = _infer_shell_outer_winding_idx(
-                initial_transform,
-                initial_dr,
-                verified_patches_list,
-                unattached_pcl_strips,
-                cfg,
-                z_begin,
-                z_end,
-                get_or_build_unattached_pcl_flat,
-            )
-            print(f'inferred shell_outer_winding_idx = {shell_outer_winding_idx}')
-        else:
-            shell_outer_winding_idx = int(cfg['shell_outer_winding_idx'])
-            print(f'using configured shell_outer_winding_idx = {shell_outer_winding_idx}')
-        min_gap_expander_num_windings = shell_outer_winding_idx + 3
-        if cfg['gap_expander_num_windings'] < min_gap_expander_num_windings:
-            print(
-                f'WARNING: shell_outer_winding_idx {shell_outer_winding_idx} requires '
-                f'gap_expander_num_windings >= {min_gap_expander_num_windings}, got '
-                f'gap_expander_num_windings {cfg["gap_expander_num_windings"]}; '
-                'increase gap_expander_num_windings or lower shell_outer_winding_idx'
-            )
+
+    def infer_outer_winding_idx_for_this_run():
+        return _infer_shell_outer_winding_idx(
+            spiral_and_transform.get_slice_to_spiral_transform(),
+            spiral_and_transform.get_dr_per_winding(),
+            verified_patches_list,
+            unattached_pcl_strips,
+            cfg,
+            z_begin,
+            z_end,
+            get_or_build_unattached_pcl_flat,
+        )
+
+    # The dense lasagna losses, the symmetric Dirichlet regulariser and the
+    # phase bundle all sample out to this index, with or without shell
+    # losses; the shell path only refines it (inference) when the config
+    # leaves it unset. It used to be resolved on that path only, so every
+    # one of those losses was silently zero on shell-less runs (#1220).
+    shell_outer_winding_idx, outer_winding_notes = resolve_outer_winding_idx_and_notes(
+        cfg, shell_active, infer_outer_winding_idx_for_this_run)
+    for note in outer_winding_notes:
+        print(note)
+
+    dense_inactive_warned = set()
+
+    def warn_if_dense_losses_structurally_disabled():
+        # Like warn_if_sdt_loss_inactive above: loss weights are run-mutable,
+        # so this is re-checked every step and warns once per key.
+        for weight_key in _structurally_disabled_dense_weight_keys(
+                cfg, shell_outer_winding_idx):
+            if weight_key not in dense_inactive_warned:
+                dense_inactive_warned.add(weight_key)
+                print(f'WARNING: {weight_key} > 0 but shell_outer_winding_idx '
+                      'is unresolved (config key is None and no outer shell '
+                      'inferred one); this loss samples the spiral out to that '
+                      'winding and stays INACTIVE. Set shell_outer_winding_idx '
+                      'to enable it (some of these losses also need the '
+                      'phase/SDT assets, see any warnings above).')
 
     # ==========================================================================
     # Optimizer and checkpoint helpers
@@ -2509,9 +2524,10 @@ def main(load_only_patches_and_point_collections=False, interactive_driver=None)
         compute_unverified_patch_dt = not interactive_dt_suppressed and iteration > unverified_patch_dt_start
 
         # Progressive-outward DT gating: winding cutoff that grows from the respective DT start
-        # step. Falls back to the configured shell_outer_winding_idx when shell losses are off so
-        # the feature still works; None => no gating.
-        dt_progressive_outer = shell_outer_winding_idx if shell_outer_winding_idx is not None else cfg['shell_outer_winding_idx']
+        # step. None => no gating. (The local is now resolved from the config
+        # with or without shell losses, so the old fallback to the raw config
+        # value is redundant.)
+        dt_progressive_outer = shell_outer_winding_idx
         patch_dt_max_winding = get_progressive_dt_max_winding(iteration, cfg['loss_start_patch_dt'], dt_progressive_outer)
         track_dt_max_winding = get_progressive_dt_max_winding(iteration, track_dt_start, dt_progressive_outer)
         unverified_patch_dt_max_winding = get_progressive_dt_max_winding(iteration, unverified_patch_dt_start, dt_progressive_outer)
@@ -2666,6 +2682,7 @@ def main(load_only_patches_and_point_collections=False, interactive_driver=None)
                 })
 
         warn_if_sdt_loss_inactive()
+        warn_if_dense_losses_structurally_disabled()
         phase_components_active = phase_mode_active()
         min_spacing_active = cfg['loss_weight_min_spacing'] > 0
         if phase_components_active or min_spacing_active:

--- a/volume-cartographer/scripts/spiral/spiral_helpers.py
+++ b/volume-cartographer/scripts/spiral/spiral_helpers.py
@@ -382,6 +382,88 @@ def _infer_shell_outer_winding_idx(
     return int(observed_max + cfg['shell_outer_winding_margin'])
 
 
+def _resolve_shell_outer_winding_idx(cfg):
+    # Winding bound shared by every sampler that integrates over the spiral
+    # cylinder: the dense lasagna losses, the symmetric Dirichlet
+    # regulariser and the phase bundle (incl. min_spacing). Resolved once per
+    # run from the config; the shell branch may still override it with the
+    # inferred value. None disables those samplers (they early-return zero),
+    # whatever their weights: _structurally_disabled_dense_weight_keys
+    # reports that combination so the run can warn instead of staying silent.
+    configured = cfg['shell_outer_winding_idx']
+    if configured is None:
+        return None
+    try:
+        resolved = int(configured)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f'shell_outer_winding_idx must be an integer >= 2 or None, '
+            f'got {configured!r}')
+    if resolved < 2:
+        # sample_spiral_surface_frame draws windings from [1, idx); 0 and 1
+        # crash multinomial/arange at the first step with an opaque error.
+        raise ValueError(
+            f'shell_outer_winding_idx must be an integer >= 2 or None, '
+            f'got {configured!r}')
+    return resolved
+
+
+def resolve_outer_winding_idx_and_notes(cfg, shell_active, infer_outer_winding_idx):
+    """Resolve the run's outer winding index and the lines to print for it.
+
+    ``infer_outer_winding_idx`` is a zero-argument callable, invoked only
+    when shell losses are active and the config key is None (the historical
+    inference path). Returns ``(index_or_none, notes)``.
+    """
+    idx = _resolve_shell_outer_winding_idx(cfg)
+    notes = []
+    if shell_active:
+        if idx is None:
+            idx = int(infer_outer_winding_idx())
+            notes.append(f'inferred shell_outer_winding_idx = {idx}')
+        else:
+            notes.append(f'using configured shell_outer_winding_idx = {idx}')
+    elif idx is not None:
+        notes.append(
+            'no outer-shell losses; using configured shell_outer_winding_idx '
+            f'= {idx} for the dense and regularisation losses')
+    if idx is not None:
+        min_gap = idx + 3
+        if cfg['gap_expander_num_windings'] < min_gap:
+            notes.append(
+                f'WARNING: shell_outer_winding_idx {idx} requires '
+                f'gap_expander_num_windings >= {min_gap}, got '
+                f'gap_expander_num_windings {cfg["gap_expander_num_windings"]}; '
+                'increase gap_expander_num_windings or lower '
+                'shell_outer_winding_idx')
+    return idx, notes
+
+
+# Every loss weight whose term samples out to shell_outer_winding_idx and is
+# therefore silently zero while that index is unresolved.
+_DENSE_WEIGHT_KEYS_NEEDING_OUTER_WINDING_IDX = (
+    'loss_weight_dense_normals',
+    'loss_weight_dense_spacing',
+    'loss_weight_dense_spacing_count',
+    'loss_weight_dense_spacing_density',
+    'loss_weight_dense_attachment',
+    'loss_weight_min_spacing',
+    'loss_weight_sym_dirichlet',
+)
+
+
+def _structurally_disabled_dense_weight_keys(cfg, shell_outer_winding_idx):
+    """Nonzero weights that cannot produce a loss because no outer winding
+    index could be resolved (config key is None and no outer shell inferred
+    one)."""
+    if shell_outer_winding_idx is not None:
+        return ()
+    return tuple(
+        key for key in _DENSE_WEIGHT_KEYS_NEEDING_OUTER_WINDING_IDX
+        if cfg.get(key, 0.0) > 0
+    )
+
+
 def _warn_if_inputs_exceed_flow_bounds(
     patch_ids,
     patch_extents,

--- a/volume-cartographer/scripts/spiral/tests/test_spiral_helpers.py
+++ b/volume-cartographer/scripts/spiral/tests/test_spiral_helpers.py
@@ -6,7 +6,13 @@ import unittest
 import numpy as np
 from PIL import Image
 
-from spiral_helpers import load_fiber_point_collection
+from spiral_helpers import (
+    _DENSE_WEIGHT_KEYS_NEEDING_OUTER_WINDING_IDX,
+    _resolve_shell_outer_winding_idx,
+    _structurally_disabled_dense_weight_keys,
+    load_fiber_point_collection,
+    resolve_outer_winding_idx_and_notes,
+)
 from tifxyz import load_tifxyz
 
 
@@ -68,6 +74,120 @@ class TifxyzMetadataTests(unittest.TestCase):
             patch = load_tifxyz(root)
 
             self.assertEqual(patch.erosion_cells(7), 7)
+
+
+class ShellOuterWindingIdxResolutionTests(unittest.TestCase):
+    # The index used to be resolved only inside the shell-loss branch, which
+    # silently zeroed the dense lasagna losses, the symmetric Dirichlet
+    # regulariser and the phase bundle on shell-less runs (#1220).
+
+    def _weights(self, value):
+        return {key: value
+                for key in _DENSE_WEIGHT_KEYS_NEEDING_OUTER_WINDING_IDX}
+
+    def test_configured_index_is_coerced_and_returned(self):
+        cfg = {'shell_outer_winding_idx': 130}
+        self.assertEqual(_resolve_shell_outer_winding_idx(cfg), 130)
+
+    def test_float_config_is_coerced_to_int(self):
+        cfg = {'shell_outer_winding_idx': 130.0}
+        resolved = _resolve_shell_outer_winding_idx(cfg)
+        self.assertEqual(resolved, 130)
+        self.assertIsInstance(resolved, int)
+
+    def test_unset_index_stays_none(self):
+        cfg = {'shell_outer_winding_idx': None}
+        self.assertIsNone(_resolve_shell_outer_winding_idx(cfg))
+
+    def test_no_weight_is_reported_when_the_index_resolves(self):
+        self.assertEqual(
+            _structurally_disabled_dense_weight_keys(self._weights(1.0), 130),
+            ())
+
+    def test_every_dense_weight_is_reported_when_unresolved(self):
+        # Locks the real blast radius: every sampler bounded by the index
+        # must be listed here, so adding one without registering it fails.
+        self.assertEqual(
+            _structurally_disabled_dense_weight_keys(self._weights(1.0), None),
+            (
+                'loss_weight_dense_normals',
+                'loss_weight_dense_spacing',
+                'loss_weight_dense_spacing_count',
+                'loss_weight_dense_spacing_density',
+                'loss_weight_dense_attachment',
+                'loss_weight_min_spacing',
+                'loss_weight_sym_dirichlet',
+            ))
+
+    def test_zero_weights_are_not_reported(self):
+        # A deliberately loss-free run must not warn (a shell-less fit with
+        # every dense weight at zero is a valid use-case, not a defect).
+        self.assertEqual(
+            _structurally_disabled_dense_weight_keys(self._weights(0.0), None),
+            ())
+
+    def test_only_the_nonzero_weights_are_reported(self):
+        cfg = self._weights(0.0)
+        cfg['loss_weight_min_spacing'] = 1.0
+        cfg['loss_weight_sym_dirichlet'] = 2.0
+        self.assertEqual(
+            _structurally_disabled_dense_weight_keys(cfg, None),
+            ('loss_weight_min_spacing', 'loss_weight_sym_dirichlet'))
+
+    def test_degenerate_indices_are_rejected_with_a_clear_error(self):
+        # sample_spiral_surface_frame draws windings from [1, idx); 0 and 1
+        # used to crash multinomial at the first step with an opaque error.
+        for bad in (0, 1, -3, 'x', '130.5'):
+            with self.assertRaises(ValueError):
+                _resolve_shell_outer_winding_idx(
+                    {'shell_outer_winding_idx': bad})
+
+
+class ResolveOuterWindingIdxWiringTests(unittest.TestCase):
+    # These lock the wiring decision that used to live inline in
+    # fit_spiral.main (the actual #1220 bug): without shell losses the
+    # configured index must survive, inference must not run, and the
+    # gap-expander control must fire shell or not.
+
+    def _cfg(self, idx, gap=200):
+        return {'shell_outer_winding_idx': idx,
+                'gap_expander_num_windings': gap}
+
+    def test_configured_index_survives_a_shell_less_run(self):
+        idx, notes = resolve_outer_winding_idx_and_notes(
+            self._cfg(130), shell_active=False,
+            infer_outer_winding_idx=self.fail)
+        self.assertEqual(idx, 130)
+        self.assertTrue(any('no outer-shell losses' in n for n in notes))
+
+    def test_unset_index_stays_none_without_a_shell(self):
+        idx, notes = resolve_outer_winding_idx_and_notes(
+            self._cfg(None), shell_active=False,
+            infer_outer_winding_idx=self.fail)
+        self.assertIsNone(idx)
+        self.assertEqual(notes, [])
+
+    def test_inference_runs_only_with_a_shell_and_no_config(self):
+        idx, notes = resolve_outer_winding_idx_and_notes(
+            self._cfg(None), shell_active=True,
+            infer_outer_winding_idx=lambda: 42)
+        self.assertEqual(idx, 42)
+        self.assertTrue(any('inferred' in n for n in notes))
+
+    def test_shell_run_keeps_the_configured_index(self):
+        idx, notes = resolve_outer_winding_idx_and_notes(
+            self._cfg(130), shell_active=True,
+            infer_outer_winding_idx=self.fail)
+        self.assertEqual(idx, 130)
+        self.assertTrue(any('using configured' in n for n in notes))
+
+    def test_gap_expander_control_also_runs_without_a_shell(self):
+        idx, notes = resolve_outer_winding_idx_and_notes(
+            self._cfg(130, gap=130), shell_active=False,
+            infer_outer_winding_idx=self.fail)
+        self.assertEqual(idx, 130)
+        self.assertTrue(any('gap_expander_num_windings >= 133' in n
+                            for n in notes))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses point 1 of #1220 (@IyanDopico). Point 2 is left open, see the note
at the bottom.

## Problem

`shell_outer_winding_idx` was only resolved inside the
`if shell_patch is not None and shell_losses_enabled():` branch. On a run
without an outer shell (or with shell losses ablated to 0, shell present),
the local stayed `None`, and every sampler bounded by it returned zero
silently, whatever its configured weight. With today's default weights that
is five terms, not two:

| term | default weight | needs an asset? |
|---|---|---|
| `dense_normals` | 1e2 | lasagna normals |
| `dense_spacing_phase` | 12 | SDT + lasagna normals |
| `dense_spacing_density` | 12 | SDT + lasagna normals |
| `sym_dirichlet` | 10 | none |
| `min_spacing` | 2 | none |

The docs state the outer shell is optional (spiral tutorial: "and
optionally a mesh of the scroll's outermost surface"; "Set any of them to
None to fit without that input"), and the lasagna volume is loaded whenever
the dense weights are > 0, shell or not, so a shell-less run paid the
loading and then discarded the losses. @IyanDopico lost three diagnostic
runs to this (#1220); shell-less fits are the normal case for scrolls
without human segmentation.

## What changes

- The index is now resolved from the config unconditionally (the fix
  proposed by @IyanDopico in the issue, and the direction @bruniss
  confirmed there: "yes this could probably be brought outside of that
  check"), in a small pure helper in `spiral_helpers.py`. The shell branch keeps its infer/override logic
  untouched: with a shell and `shell_outer_winding_idx: None`, inference
  still runs; without a shell, the configured value applies.
- **Behaviour change, stated plainly**: a shell-less run with the default
  config now computes the five terms above (two of them, `sym_dirichlet`
  and `min_spacing`, need no asset at all). This is the documented meaning
  of the config key; the escape hatch already exists and is unchanged:
  `shell_outer_winding_idx: None` restores the previous numerical behaviour
  (plus the new warning). No new config surface. Shell-less minimal runs
  remain a valid use-case: nothing errors, a run with the key set to None is
  numerically unchanged, and a deliberately loss-free fit stays silent.
- The residual silent case (key set to None, no shell, dense weights > 0)
  now warns once per key, per-step like `warn_if_sdt_loss_inactive` (the
  weights are run-mutable in interactive sessions).
- The `gap_expander_num_windings >= idx + 3` check moves out of the shell
  branch with the resolution (it now fires for shell-less runs too, as it
  already did for shell runs with the shipped defaults).
- The now-redundant fallback in the progressive-DT gating is removed (its
  comment described the old asymmetry).

Touches only `fit_spiral.py`, `spiral_helpers.py` and the tests; no overlap
with the merged Lasagna/SDT data-loading rework (#1258): it touches neither
`lasagna_data.py`, `sparse_cuda_cache.py` nor `sdt_losses.py`.

## Validation

- 6 new tests in `tests/test_spiral_helpers.py` lock the resolution table
  and the exact list of weight keys reported when the index is unresolved
  (so the registry and the test cannot drift apart), plus the
  zero-weight case (a deliberately loss-free shell-less fit stays silent:
  that is a valid use-case, not a defect).

      $ python -m pytest tests/test_spiral_helpers.py -q
      ..........
      10 passed in 2.40s

- Full spiral suite before/after on the same machine (with
  `--ignore=tests/test_sparse_cuda_cache.py`, whose collection needs
  tensorstore): before `9 failed, 283 passed, 20 skipped`, after `9 failed,
  289 passed, 20 skipped` (the 6 new tests). The failing set is identical
  with and without the change, all 9 pre-existing and unrelated.
- Runs WITH an outer shell are semantically unchanged: the branch now tests
  the resolved local instead of re-reading the config, and its
  inference/override logic is otherwise untouched.
- Real-run check on the published PHerc. Paris 4 spiral dataset (z
  10600-10900, 60 steps, shell losses ablated to reproduce the issue's
  scenario, RTX 3060 Ti). On current `main` with `shell_outer_winding_idx:
  130` explicitly configured, step 0 prints `sym_dirichlet = 0.0,
  dense_spacing = 0.0, dense_normals = 0.0`: silently inactive. With this
  PR, same inputs, config and seed: `sym_dirichlet = 0.3, dense_spacing =
  10.8, dense_normals = 33.2` (matching the values a shell run reports on
  this window), plus the new resolution log line. With the key set to None,
  the losses stay `0.0` as before and each configured-but-inactive weight
  gets its warning. All three runs complete end to end.
- @IyanDopico reported (issue, 24/07) that with this change and the index
  set, all five loss families train normally on a shell-less PHerc1218
  window (dense_spacing 71.6 -> 26.6, dense_normals 13.1 -> 7.2 over 30k
  steps); measured pre-#1258/pre-#1274, so on the older storage backend and
  the grad_mag spacing mode.

Happy to reduce this to the warning alone, or to switch the shell-less path
to a capped `min(inferred, configured)` semantics (like `save_mesh` already
does), if either is preferred.

## Note on point 2 of #1220

The mmap fingerprint crash is gone with #1258 (`lasagna_mmap.py` removed),
but remote lasagna packs are still unsupported further down:
`sparse_cuda_cache.py` normalises source paths through `Path()` (which
mangles `https://` to `https:/`) and hard-codes the tensorstore
`{"driver": "file"}` kvstore. Leaving that to a separate discussion; this
PR does not touch it.
---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
