### PR TITLE
community_projects: add ScrollGT and the mesh-only surface renderer

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -290,7 +290,7 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [Vesuvius AutoResearch](https://github.com/mojomast/vesuvius-autoresearch) by mojomast. Autonomous, evidence-gated experiment search for Vesuvius ink-detection research, with reproducible configs, metric contracts, synthetic demo data, and promotion checks.
 
-- [ScrollGT](https://github.com/jonmarrs/scrollgt) by Jon Marrs. Registered human ground-truth evaluation for the open SOTA surface volumes. Bridges the 2023 hand labels onto the re-flattened geometry, scores predictions with a threshold-swept F1 plus an AP-prevalence-lift anti-gaming gate, and publishes held-out baselines (including its author's own near-chance results) so reading ability can be told apart from agreement with another model's output.
+- [ScrollGT](https://github.com/jonmarrs/scrollgt) by Jon Marrs. Human ground-truth evaluation with anti-gaming floors, over three target families: registered ink pixels on the open SOTA surface volumes (2023 hand labels bridged onto the re-flattened geometry, threshold-swept F1 plus an AP-prevalence-lift gate), PHerc 1667 column-level reading, and fiber connectivity on six hand-traced cubes (expected run length with a merge penalty; scoreable with no GPU, model, or network). Published baselines include its author's own near-chance ink results and its own fiber tracer losing to connected components, so reading ability can be told apart from agreement with another model's output.
 
 - [Vesuvius GP+](https://github.com/jaredlandau/Vesuvius-Grandprize-Winner-Plus) by Jared Landau. Updated version of the Grand Prize Ink Detection script with extra features.
   

--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -91,6 +91,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
     - [CPU rendering](https://github.com/schillij95/ThaumatoAnakalyptor/commit/bcd382a0ef59b2a8566ec62a474479ea9d1bb8c2) by Julian Schilliger and Giorgio Angelotti
 
+- [Surface volume renderer for mesh-only segments](https://github.com/jonmarrs/vesuvius-autoresearch/blob/main/docs/SURFACE_RENDERER.md) by Jon Marrs. One-command CLI that rebuilds a detector-ready 26-layer surface volume from a segment's original.obj or its released tifxyz grids, for bucket segments that ship geometry with no surface volume. Validated against released surface volumes on two scrolls (PHerc 1667 center-layer NCC 0.78, all 26 layers matching the released stack).
+
 - [Volumetric Vesuvius Labelling](https://github.com/JamesDarby345/Volumetric_Vesuvius_Labelling) by James Darby. Provide custom tooling the [napari](https://napari.org/stable/) 3d viewer that will help manually annotate volumetric masks of the scrolls to train ML models for 3D segmentation.
 
 - [Autosegmentation preprocessing pipeline](https://github.com/giorgioangel/vesuvius_autoseg_preprocess) (work in progress) collection of scripts to pre-process volumes for autosegmentation. By Giorgio Angelotti
@@ -287,6 +289,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 - [Unsupervised Ink Detection with DINO](https://github.com/jgcarrasco/dino-ink-detection) by Jorge García. Contains experiments related to detecting ink without labels, including a Colab notebook.
 
 - [Vesuvius AutoResearch](https://github.com/mojomast/vesuvius-autoresearch) by mojomast. Autonomous, evidence-gated experiment search for Vesuvius ink-detection research, with reproducible configs, metric contracts, synthetic demo data, and promotion checks.
+
+- [ScrollGT](https://github.com/jonmarrs/scrollgt) by Jon Marrs. Registered human ground-truth evaluation for the open SOTA surface volumes. Bridges the 2023 hand labels onto the re-flattened geometry, scores predictions with a threshold-swept F1 plus an AP-prevalence-lift anti-gaming gate, and publishes held-out baselines (including its author's own near-chance results) so reading ability can be told apart from agreement with another model's output.
 
 - [Vesuvius GP+](https://github.com/jaredlandau/Vesuvius-Grandprize-Winner-Plus) by Jared Landau. Updated version of the Grand Prize Ink Detection script with extra features.
   


### PR DESCRIPTION
## Summary

Adds two entries to `scrollprize.org/docs/20_community_projects.md`, submitted per the July 2026 Progress Prize form's request to link contributions here.

- **ScrollGT** under *Ink Detection > Scroll segments-based Ink Detection > Tools*. Human ground-truth evaluation with anti-gaming floors, across three target families: registered ink pixels on the open SOTA surface volumes (2023 hand labels bridged onto the re-flattened geometry via the segment's `original.obj` UV coordinates, scored with a threshold-swept F1 plus an AP-prevalence-lift gate), PHerc 1667 column-level reading, and **fiber connectivity** on six hand-traced cubes. Published baselines include the author's own models reading near chance on a held-out segment, and the author's own fiber tracer losing to connected components on every cube — the leaderboard is honest about its own results.

- **Surface volume renderer for mesh-only segments** under *Segmentation > Tools*, placed next to the existing rendering entries. Some open-bucket segments ship geometry with no surface volume (both PHerc0332 segments, and PHerc1667's merged full-reading geometry), which blocks ink detection on them entirely. This CLI rebuilds a detector-ready 26-layer surface volume from `original.obj` or the released tifxyz grids, validated against released surface volumes on two scrolls (PHerc 1667 center-layer NCC 0.78, with all 26 emitted layers matching the released stack).

Both are MIT licensed and runnable from a clean clone.

## On the fiber connectivity family

Added because the 2026 open-problems post asks for a way to "identify and separate long fibers with the right connectivity", and states the preference that "a tracer that confidently follows fewer fibers correctly is more useful than one that follows more fibers with a higher error rate."

The measurable finding: **coverage and precision cannot rank a fiber tracer.** Four completely different instance labellings of the same cube — connected components, one instance for everything, one instance per voxel, and 50 random labels — score *identical* coverage (0.9177) and precision (0.2194), because both are properties of the fiber mask rather than of the labelling. Raw ERL alone is gameable too: labelling the whole cube once scores 199.18 against an oracle's 258.27 while its merge-penalized ERL is exactly 0.00. So both ERL variants are always reported together, with the tolerance, and splits and merges are never summed.

Ground truth is the `fiber-skeletons` dataset's `nml/` traces (the shipped `labelsTr` are semantic and cannot support connectivity metrics); the reference mask comes from `scrollprize/fiber_hz_vt`. Each target ships the skeleton and mask at ~250 KB/cube, so the floors reproduce with no GPU, model download, or network — enforced by a test, as is the finding above.

## Notes

Descriptions follow the existing one-bullet format and the diff is additive only (+4 lines, no deletions, no reordering). The fiber family was folded into the existing ScrollGT bullet rather than added as a third entry, to keep the footprint unchanged. Happy to shorten either entry, move them, drop one, or add a separate Segmentation > Tools pointer for the fiber targets if you'd prefer them discoverable there.
