### PR TITLE
VC3D line annotation UI rework: fixed top strip, tag pills, scalebar fix

### DIFF
--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -1819,47 +1819,6 @@ bool LineAnnotationController::canLaunchFromViewer(const CChunkedVolumeViewer* v
                        });
 }
 
-void LineAnnotationController::launchFromViewer(CChunkedVolumeViewer* viewer, const QPointF& /*scenePoint*/)
-{
-    if (!canLaunchFromViewer(viewer)) {
-        return;
-    }
-
-    auto camera = viewer->cameraState();
-    SourceKind sourceKind = SourceKind::Plane;
-    std::shared_ptr<Surface> sourceSurface;
-    cv::Vec3d sourceSliceNormal{
-        camera.zOffsetWorldDir[0],
-        camera.zOffsetWorldDir[1],
-        camera.zOffsetWorldDir[2],
-    };
-
-    if (auto* plane = dynamic_cast<PlaneSurface*>(viewer->currentSurface())) {
-        auto clone = std::make_shared<PlaneSurface>(*plane);
-        const cv::Vec3f normal = plane->normal({0, 0, 0});
-        sourceSliceNormal = {normal[0], normal[1], normal[2]};
-        if (std::isfinite(normal[0]) && std::isfinite(normal[1]) &&
-            std::isfinite(normal[2]) && cv::norm(normal) > 0.0f) {
-            clone->setOrigin(plane->origin() + normal * viewer->normalOffset());
-        }
-        camera.zOffset = 0.0f;
-        camera.zOffsetWorldDir = {0, 0, 0};
-        sourceSurface = clone;
-    } else {
-        sourceKind = SourceKind::Segmentation;
-        sourceSurface = _state->surface("segmentation");
-    }
-
-    auto session = std::make_shared<LineAnnotationSession>();
-    const std::string surfaceName = nextSurfaceName();
-    (void)launchSession(sourceKind,
-                        surfaceName,
-                        std::move(sourceSurface),
-                        camera,
-                        sourceSliceNormal,
-                        std::move(session));
-}
-
 void LineAnnotationController::launchFromViewerAtPoint(CChunkedVolumeViewer* viewer,
                                                        const QPointF& scenePoint,
                                                        bool replaceOwningAnnotation)
@@ -1993,6 +1952,7 @@ bool LineAnnotationController::launchSession(LineAnnotationController::SourceKin
         : cv::Vec3d{0.0, 0.0, 1.0};
 
     _panes.push_back(PaneRecord{_nextPaneId - 1, sourceKind, surfaceName, dialog, session});
+    pushFiberUiState(_panes.back());
     connect(dialog, &LineAnnotationDialog::paneClosed, this, [this](const std::string& name) {
         cleanupSurfaceName(name);
     });
@@ -2005,14 +1965,18 @@ bool LineAnnotationController::launchSession(LineAnnotationController::SourceKin
     connect(dialog,
             &LineAnnotationDialog::lineSeedRequested,
             this,
-            [this, dialog](const std::string& name, cv::Vec3f volumePoint, QPointF) {
-                InitialDirectionMode mode = InitialDirectionMode::Sideways;
-                if (dialog) {
-                    mode = dialog->initialDirectionMode() == LineAnnotationDialog::InitialDirectionMode::ZInOut
-                        ? InitialDirectionMode::ZInOut
-                        : InitialDirectionMode::Sideways;
+            [this](const std::string& name, cv::Vec3f volumePoint, QPointF) {
+                handleLineSeed(name, volumePoint, InitialDirectionMode::ZInOut);
+            });
+    connect(dialog,
+            &LineAnnotationDialog::fiberTagChangeRequested,
+            this,
+            [this, surfaceName](const QString& tag, bool enabled) {
+                auto* pane = paneForSurface(surfaceName);
+                if (!pane || !pane->session || pane->session->fiberId == 0) {
+                    return;
                 }
-                handleLineSeed(name, volumePoint, mode);
+                setFiberTag(pane->session->fiberId, tag, enabled);
             });
     connect(dialog,
             &LineAnnotationDialog::generatedControlPointRequested,
@@ -2862,6 +2826,7 @@ void LineAnnotationController::setFiberManualHvTag(uint64_t fiberId, const QStri
     for (const auto& pane : _panes) {
         if (pane.session && pane.session->fiberId == fiberId) {
             pane.session->fiberManualHvTag = manualTag;
+            pushFiberUiState(pane);
         }
     }
     emitFiberSummaries();
@@ -2911,9 +2876,45 @@ void LineAnnotationController::setFiberTag(uint64_t fiberId, const QString& tag,
     for (const auto& pane : _panes) {
         if (pane.session && pane.session->fiberId == fiberId) {
             pane.session->fiberTags = it->tags;
+            pushFiberUiState(pane);
         }
     }
     emitFiberSummaries();
+}
+
+QString LineAnnotationController::fiberHvDirectionTag(uint64_t fiberId) const
+{
+    const auto it = std::find_if(_fibers.begin(), _fibers.end(), [fiberId](const StoredFiber& fiber) {
+        return fiber.id == fiberId;
+    });
+    if (it == _fibers.end()) {
+        return {};
+    }
+    if (it->manualHvTag == "H" || it->manualHvTag == "V") {
+        return QString::fromStdString(it->manualHvTag);
+    }
+    const std::string automaticTag =
+        vc3d::line_annotation::fiberHvTagToString(it->hvClassification.automaticTag);
+    if (automaticTag == "H" || automaticTag == "V") {
+        return QString::fromStdString(automaticTag);
+    }
+    return {};
+}
+
+void LineAnnotationController::pushFiberUiState(const PaneRecord& pane) const
+{
+    if (!pane.dialog || !pane.session) {
+        return;
+    }
+    const uint64_t fiberId = pane.session->fiberId;
+    pane.dialog->setFiberHvTag(fiberHvDirectionTag(fiberId));
+    const auto it = std::find_if(_fibers.begin(), _fibers.end(), [fiberId](const StoredFiber& fiber) {
+        return fiber.id == fiberId;
+    });
+    const bool loaded = fiberId != 0 && it != _fibers.end();
+    pane.dialog->setFiberTags(knownFiberTags(),
+                              loaded ? it->tags : pane.session->fiberTags,
+                              loaded);
 }
 
 void LineAnnotationController::recalculateFiberHvClassification(uint64_t fiberId)
@@ -2937,6 +2938,11 @@ void LineAnnotationController::recalculateFiberHvClassification(uint64_t fiberId
                       .arg(fiberId)
                       .arg(QString::fromStdString(ex.what())));
         return;
+    }
+    for (const auto& pane : _panes) {
+        if (pane.session && pane.session->fiberId == fiberId) {
+            pushFiberUiState(pane);
+        }
     }
     emitFiberSummaries();
 }
@@ -10029,6 +10035,11 @@ void LineAnnotationController::saveSessionAsFiber(LineAnnotationSession& session
         }
         invalidateFiberAlignmentMetrics(savedFiberId, true);
         addKnownFiberTags(session.fiberTags);
+        for (const auto& pane : _panes) {
+            if (pane.session && pane.session->fiberId == savedFiberId) {
+                pushFiberUiState(pane);
+            }
+        }
         emitFiberSummaries();
         refreshBranchLineViews(savedFiberId);
     } catch (const std::exception& ex) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -166,7 +166,6 @@ public:
     ~LineAnnotationController() override;
 
     bool canLaunchFromViewer(const CChunkedVolumeViewer* viewer) const;
-    void launchFromViewer(CChunkedVolumeViewer* viewer, const QPointF& scenePoint);
     void launchFromViewerAtPoint(CChunkedVolumeViewer* viewer,
                                  const QPointF& scenePoint,
                                  bool replaceOwningAnnotation = true);
@@ -478,6 +477,11 @@ private:
     [[nodiscard]] std::vector<std::filesystem::path> saveGeneratedQuadMeshes(LineAnnotationSession& session);
     [[nodiscard]] PaneRecord* paneForSurface(const std::string& surfaceName);
     [[nodiscard]] const PaneRecord* paneForSurface(const std::string& surfaceName) const;
+    // "H"/"V" from the manual tag, falling back to the automatic classification;
+    // empty when unknown or the fiber isn't loaded.
+    [[nodiscard]] QString fiberHvDirectionTag(uint64_t fiberId) const;
+    // Pushes the H/V tag and the clickable tag buttons to the pane's dialog.
+    void pushFiberUiState(const PaneRecord& pane) const;
     [[nodiscard]] std::optional<std::string> pickDataset(QWidget* parent,
                                                           const std::filesystem::path& startDir) const;
     [[nodiscard]] OptimizationTaskResult runOptimizationTask(std::filesystem::path manifestPath,

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -2114,6 +2114,9 @@ void LineAnnotationDialog::resetGeneratedViews()
     }
     restoreInitialGeneratedViewerCameras();
     updateFixedStripGeometry();
+    // _currentCutFollowsStripMouse was reset by direct assignment above; keep the
+    // pause badge in sync.
+    updatePauseIndicator();
     if (_currentCutViewer) {
         _currentCutViewer->renderVisible(true, "line annotation reset current cut");
     }

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -7,18 +7,22 @@
 #include "LineAnnotationShiftScroll.hpp"
 #include "VCSettings.hpp"
 #include "ViewerManager.hpp"
+#include "elements/ViewerStatsBar.hpp"
 #include "vc/core/util/PlaneSurface.hpp"
 #include "vc/core/util/QuadSurface.hpp"
 
-#include <QAbstractItemView>
+#include <QAction>
 #include <QBrush>
 #include <QCloseEvent>
-#include <QComboBox>
+#include <QCursor>
 #include <QEvent>
 #include <QFont>
+#include <QMenu>
+#include <QMouseEvent>
 #include <QGraphicsPathItem>
 #include <QGraphicsRectItem>
 #include <QGraphicsSimpleTextItem>
+#include <QInputDialog>
 #include <QKeyEvent>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -37,6 +41,7 @@
 #include <QSpinBox>
 #include <QVariant>
 #include <QTimer>
+#include <QToolButton>
 #include <QVariantAnimation>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -206,17 +211,6 @@ QString spanAlignmentMetricToolTip(
     return {};
 }
 
-void installComboEventFilter(QComboBox* combo, QObject* filter)
-{
-    if (!combo || !filter) {
-        return;
-    }
-    combo->installEventFilter(filter);
-    if (auto* popupView = combo->view()) {
-        popupView->installEventFilter(filter);
-    }
-}
-
 QVariantList splitterSizesToVariantList(const QList<int>& sizes)
 {
     QVariantList values;
@@ -318,46 +312,49 @@ LineAnnotationDialog::LineAnnotationDialog(ViewerManager* viewerManager,
     auto* buttonLayout = new QHBoxLayout(buttonRow);
     buttonLayout->setContentsMargins(6, 6, 6, 6);
     buttonLayout->setSpacing(6);
-    _initialDirectionCombo = new QComboBox(buttonRow);
-    _initialDirectionCombo->addItem(tr("sideways"), static_cast<int>(InitialDirectionMode::Sideways));
-    _initialDirectionCombo->addItem(tr("z (in/out)"), static_cast<int>(InitialDirectionMode::ZInOut));
-    _initialDirectionCombo->setCurrentIndex(1);
-    installComboEventFilter(_initialDirectionCombo, this);
-    buttonLayout->addWidget(_initialDirectionCombo);
-    _reoptimizationCombo = new QComboBox(buttonRow);
-    _reoptimizationCombo->addItem(tr("auto-reopt"),
-                                  static_cast<int>(ReoptimizationMode::AutoReoptimize));
-    _reoptimizationCombo->addItem(tr("no optimization"),
-                                  static_cast<int>(ReoptimizationMode::NoOptimization));
-    _reoptimizationCombo->setCurrentIndex(0);
-    installComboEventFilter(_reoptimizationCombo, this);
-    buttonLayout->addWidget(_reoptimizationCombo);
-    connect(_reoptimizationCombo,
-            qOverload<int>(&QComboBox::currentIndexChanged),
-            this,
-            [this](int) {
-                emit reoptimizationModeChanged(reoptimizationMode());
-            });
-    _shiftScrollCombo = new QComboBox(buttonRow);
-    _shiftScrollCombo->addItem(tr("along-line"),
-                               static_cast<int>(ShiftScrollMode::AlongLine));
-    _shiftScrollCombo->addItem(tr("straight"),
-                               static_cast<int>(ShiftScrollMode::StraightNormal));
-    _shiftScrollCombo->setCurrentIndex(0);
-    installComboEventFilter(_shiftScrollCombo, this);
-    buttonLayout->addWidget(_shiftScrollCombo);
-    connect(_shiftScrollCombo,
-            qOverload<int>(&QComboBox::currentIndexChanged),
-            this,
-            [this](int) {
-                handleShiftScrollModeChanged();
-            });
+
+    // Popup menu on a toolbutton rather than a QMenuBar: the dialog can be
+    // embedded as a workspace tab, where its own menu bar would stack under
+    // the main window's.
+    auto* annotationMenuButton = new QToolButton(buttonRow);
+    annotationMenuButton->setObjectName(QStringLiteral("lineAnnotationMenuButton"));
+    annotationMenuButton->setText(tr("Annotation"));
+    annotationMenuButton->setPopupMode(QToolButton::InstantPopup);
+    annotationMenuButton->installEventFilter(this);
+    auto* annotationMenu = new QMenu(annotationMenuButton);
+    annotationMenu->setToolTipsVisible(true);
+    _autoReoptimizeAction = annotationMenu->addAction(tr("Auto-reoptimize"));
+    _autoReoptimizeAction->setCheckable(true);
+    _autoReoptimizeAction->setChecked(true);
+    _autoReoptimizeAction->setToolTip(
+        tr("Checked: re-optimize the line after every control-point edit.\n"
+           "Unchecked: no optimization until \"Reinit reoptimization\" or close."));
+    connect(_autoReoptimizeAction, &QAction::toggled, this, [this](bool checked) {
+        emit reoptimizationModeChanged(checked ? ReoptimizationMode::AutoReoptimize
+                                               : ReoptimizationMode::NoOptimization);
+    });
+    annotationMenu->addSeparator();
+    _fullOptimizationAction = annotationMenu->addAction(tr("Reinit reoptimization"));
+    _fullOptimizationAction->setEnabled(false);
+    connect(_fullOptimizationAction, &QAction::triggered, this, [this]() {
+        emit fullOptimizationRequested();
+    });
+    _showAsMeshAction = annotationMenu->addAction(tr("Show as mesh"));
+    _showAsMeshAction->setEnabled(false);
+    connect(_showAsMeshAction, &QAction::triggered, this, [this]() {
+        emit showAsMeshRequested();
+    });
+    annotationMenuButton->setMenu(annotationMenu);
+    buttonLayout->addWidget(annotationMenuButton);
+
+    auto* centerlineLengthLabel = new QLabel(tr("Length"), buttonRow);
+    centerlineLengthLabel->installEventFilter(this);
+    buttonLayout->addWidget(centerlineLengthLabel);
     _initialCenterlineLengthSpin = new QSpinBox(buttonRow);
     _initialCenterlineLengthSpin->setObjectName(
         QStringLiteral("lineAnnotationInitialCenterlineLengthSpinBox"));
     _initialCenterlineLengthSpin->setRange(100, 1000000);
     _initialCenterlineLengthSpin->setSingleStep(100);
-    _initialCenterlineLengthSpin->setPrefix(tr("Length "));
     _initialCenterlineLengthSpin->setSuffix(tr(" vx"));
     _initialCenterlineLengthSpin->setToolTip(
         tr("Total length of a newly generated centerline, split equally around the seed."));
@@ -411,31 +408,28 @@ LineAnnotationDialog::LineAnnotationDialog(ViewerManager* viewerManager,
             buttonLayout->addWidget(volumeSelector);
         }
     }
-    _sliceStepLabel = new QLabel(this);
-    _sliceStepLabel->setText(tr("Z sens: %1").arg(_viewerManager ? _viewerManager->zScrollSensitivity() : 1.0, 0, 'f', 1));
-    _sliceStepLabel->setToolTip(tr("Z-scroll sensitivity. Use Shift+G / Shift+H to adjust."));
-    _sliceStepLabel->installEventFilter(this);
-    buttonLayout->addWidget(_sliceStepLabel);
-    if (_viewerManager) {
-        connect(_viewerManager, &ViewerManager::zScrollSensitivityChanged, this, [this](double sensitivity) {
-            if (_sliceStepLabel) {
-                _sliceStepLabel->setText(tr("Z sens: %1").arg(sensitivity, 0, 'f', 1));
-            }
-        });
-    }
-    _optimizationStatusLabel = new QLabel(tr("not optimized"), buttonRow);
-    _optimizationStatusLabel->installEventFilter(this);
-    buttonLayout->addWidget(_optimizationStatusLabel);
-    _sideStripIntersectionProgress = new QProgressBar(buttonRow);
-    _sideStripIntersectionProgress->setObjectName(QStringLiteral("lineAnnotationSideStripIntersectionProgress"));
-    _sideStripIntersectionProgress->setRange(0, 1);
-    _sideStripIntersectionProgress->setValue(0);
-    _sideStripIntersectionProgress->setTextVisible(true);
-    _sideStripIntersectionProgress->setFormat(tr("strip intersections: 0"));
-    _sideStripIntersectionProgress->setMinimumWidth(260);
-    _sideStripIntersectionProgress->setVisible(false);
-    _sideStripIntersectionProgress->installEventFilter(this);
-    buttonLayout->addWidget(_sideStripIntersectionProgress);
+    auto* tagsLabel = new QLabel(tr("Tags:"), buttonRow);
+    tagsLabel->installEventFilter(this);
+    buttonLayout->addWidget(tagsLabel);
+    _tagRowWidget = new QWidget(buttonRow);
+    _tagRowWidget->installEventFilter(this);
+    _tagRowWidget->setStyleSheet(QStringLiteral(
+        "QToolButton#lineAnnotationTagButton {"
+        " border: 1px solid rgba(128, 128, 128, 140); border-radius: 9px;"
+        " padding: 2px 10px; background: transparent; }"
+        "QToolButton#lineAnnotationTagButton:checked {"
+        " background-color: rgb(0, 190, 210); border-color: rgb(0, 190, 210);"
+        " color: black; font-weight: 600; }"
+        "QToolButton#lineAnnotationTagButton:disabled {"
+        " border-color: rgba(128, 128, 128, 70); }"));
+    _tagRowLayout = new QHBoxLayout(_tagRowWidget);
+    _tagRowLayout->setContentsMargins(0, 0, 0, 0);
+    _tagRowLayout->setSpacing(4);
+    buttonLayout->addWidget(_tagRowWidget);
+    setFiberTags({}, {}, false);
+    // The side-strip intersection query still runs (it feeds the fiber-
+    // intersection X markers); we just no longer show a progress indicator.
+    // _sideStripIntersectionProgress stays null and its setters no-op.
     _fiberNameLabel = new QLabel(buttonRow);
     _fiberNameLabel->setObjectName(QStringLiteral("lineAnnotationFiberNameLabel"));
     _fiberNameLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
@@ -443,26 +437,12 @@ LineAnnotationDialog::LineAnnotationDialog(ViewerManager* viewerManager,
     _fiberNameLabel->setMinimumWidth(0);
     _fiberNameLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     _fiberNameLabel->installEventFilter(this);
-    _showAsMeshButton = new QPushButton(tr("show as mesh"), buttonRow);
-    _showAsMeshButton->setEnabled(false);
-    _showAsMeshButton->installEventFilter(this);
-    buttonLayout->addWidget(_showAsMeshButton);
-    _fullOptimizationButton = new QPushButton(tr("reinit reopt"), buttonRow);
-    _fullOptimizationButton->setEnabled(false);
-    _fullOptimizationButton->installEventFilter(this);
-    buttonLayout->addWidget(_fullOptimizationButton);
     _resetViewsButton = new QPushButton(tr("Reset views"), buttonRow);
     _resetViewsButton->setEnabled(false);
     _resetViewsButton->installEventFilter(this);
     buttonLayout->addWidget(_resetViewsButton);
     buttonLayout->addWidget(_fiberNameLabel, 1);
     _layout->addWidget(buttonRow, 0);
-    connect(_showAsMeshButton, &QPushButton::clicked, this, [this]() {
-        emit showAsMeshRequested();
-    });
-    connect(_fullOptimizationButton, &QPushButton::clicked, this, [this]() {
-        emit fullOptimizationRequested();
-    });
     connect(_resetViewsButton, &QPushButton::clicked, this, [this]() {
         resetGeneratedViews();
     });
@@ -489,20 +469,12 @@ void LineAnnotationDialog::showWithSavedGeometry()
     }
 }
 
-LineAnnotationDialog::InitialDirectionMode LineAnnotationDialog::initialDirectionMode() const
-{
-    if (!_initialDirectionCombo) {
-        return InitialDirectionMode::Sideways;
-    }
-    return static_cast<InitialDirectionMode>(_initialDirectionCombo->currentData().toInt());
-}
-
 LineAnnotationDialog::ReoptimizationMode LineAnnotationDialog::reoptimizationMode() const
 {
-    if (!_reoptimizationCombo) {
-        return ReoptimizationMode::AutoReoptimize;
+    if (_autoReoptimizeAction && !_autoReoptimizeAction->isChecked()) {
+        return ReoptimizationMode::NoOptimization;
     }
-    return static_cast<ReoptimizationMode>(_reoptimizationCombo->currentData().toInt());
+    return ReoptimizationMode::AutoReoptimize;
 }
 
 int LineAnnotationDialog::initialCenterlineLengthVx() const
@@ -510,14 +482,6 @@ int LineAnnotationDialog::initialCenterlineLengthVx() const
     return _initialCenterlineLengthSpin
         ? _initialCenterlineLengthSpin->value()
         : vc3d::settings::line_annotation::INITIAL_CENTERLINE_LENGTH_VX_DEFAULT;
-}
-
-LineAnnotationDialog::ShiftScrollMode LineAnnotationDialog::shiftScrollMode() const
-{
-    if (!_shiftScrollCombo) {
-        return ShiftScrollMode::AlongLine;
-    }
-    return static_cast<ShiftScrollMode>(_shiftScrollCombo->currentData().toInt());
 }
 
 int LineAnnotationDialog::maxControlPointDistanceVx() const
@@ -702,16 +666,82 @@ void LineAnnotationDialog::setOptimizationBusy(bool busy)
 
 void LineAnnotationDialog::setOptimizationStatus(bool optimized)
 {
-    if (!_optimizationStatusLabel) {
-        return;
-    }
-    _optimizationStatusLabel->setText(optimized ? tr("optimized") : tr("not optimized"));
+    _optimizationStatusOptimized = optimized;
+    updateOptimizationStatusIndicator();
 }
 
 void LineAnnotationDialog::setFiberDisplayName(const QString& name)
 {
     _fiberDisplayName = name;
     updateFiberNameLabel();
+}
+
+void LineAnnotationDialog::setFiberHvTag(const QString& tag)
+{
+    _fiberHvTag = tag.trimmed();
+    updateFiberNameLabel();
+}
+
+void LineAnnotationDialog::setFiberTags(const std::vector<std::string>& knownTags,
+                                        const std::vector<std::string>& activeTags,
+                                        bool enabled)
+{
+    if (!_tagRowWidget || !_tagRowLayout) {
+        return;
+    }
+    while (auto* item = _tagRowLayout->takeAt(0)) {
+        // deleteLater, not delete: a rebuild can be triggered from a slot chain
+        // that started in one of these buttons' own signals.
+        if (auto* widget = item->widget()) {
+            widget->hide();
+            widget->deleteLater();
+        }
+        delete item;
+    }
+
+    const QString disabledToolTip =
+        tr("Tags become editable once the fiber has been saved.");
+    for (const auto& tag : knownTags) {
+        const QString tagText = QString::fromStdString(tag);
+        const bool active = std::find(activeTags.begin(), activeTags.end(), tag) !=
+                            activeTags.end();
+        auto* button = new QToolButton(_tagRowWidget);
+        button->setObjectName(QStringLiteral("lineAnnotationTagButton"));
+        button->setText(active ? QStringLiteral("✓ ") + tagText : tagText);
+        button->setCheckable(true);
+        button->setChecked(active);
+        button->setEnabled(enabled);
+        button->setToolTip(enabled
+            ? tr("Toggle tag \"%1\" on the current fiber").arg(tagText)
+            : disabledToolTip);
+        button->installEventFilter(this);
+        connect(button, &QToolButton::toggled, this, [this, tagText](bool checked) {
+            // Deferred: the handler rebuilds this row, which must not delete the
+            // button while its own toggled signal is still on the stack.
+            QTimer::singleShot(0, this, [this, tagText, checked]() {
+                emit fiberTagChangeRequested(tagText, checked);
+            });
+        });
+        _tagRowLayout->addWidget(button);
+    }
+
+    auto* addButton = new QToolButton(_tagRowWidget);
+    addButton->setObjectName(QStringLiteral("lineAnnotationAddTagButton"));
+    addButton->setText(QStringLiteral("+"));
+    addButton->setEnabled(enabled);
+    addButton->setToolTip(enabled ? tr("Add a new tag to the current fiber")
+                                  : disabledToolTip);
+    addButton->installEventFilter(this);
+    connect(addButton, &QToolButton::clicked, this, [this]() {
+        const QString tag =
+            QInputDialog::getText(this, tr("New tag"), tr("Tag name:")).trimmed();
+        if (!tag.isEmpty()) {
+            QTimer::singleShot(0, this, [this, tag]() {
+                emit fiberTagChangeRequested(tag, true);
+            });
+        }
+    });
+    _tagRowLayout->addWidget(addButton);
 }
 
 void LineAnnotationDialog::setCloseAfterFinalizationAllowed(bool allowed)
@@ -791,11 +821,11 @@ bool LineAnnotationDialog::setGeneratedRows(
         return false;
     }
 
-    if (_showAsMeshButton) {
-        _showAsMeshButton->setEnabled(false);
+    if (_showAsMeshAction) {
+        _showAsMeshAction->setEnabled(false);
     }
-    if (_fullOptimizationButton) {
-        _fullOptimizationButton->setEnabled(false);
+    if (_fullOptimizationAction) {
+        _fullOptimizationAction->setEnabled(false);
     }
     if (_resetViewsButton) {
         _resetViewsButton->setEnabled(false);
@@ -811,6 +841,7 @@ bool LineAnnotationDialog::setGeneratedRows(
     _suppressPaneClosed = false;
     _panes.clear();
     _stripViewers.clear();
+    _fixedStripViewer = nullptr;
     clearFastGeneratedOverlayItemRefs();
     _currentCutViewer = nullptr;
     _sideCutViewer = nullptr;
@@ -859,11 +890,11 @@ bool LineAnnotationDialog::setGeneratedRows(
         }
     }
     const bool ok = !_panes.empty();
-    if (_showAsMeshButton) {
-        _showAsMeshButton->setEnabled(ok);
+    if (_showAsMeshAction) {
+        _showAsMeshAction->setEnabled(ok);
     }
-    if (_fullOptimizationButton) {
-        _fullOptimizationButton->setEnabled(ok);
+    if (_fullOptimizationAction) {
+        _fullOptimizationAction->setEnabled(ok);
     }
     return ok;
 }
@@ -961,11 +992,11 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         return false;
     }
 
-    if (_showAsMeshButton) {
-        _showAsMeshButton->setEnabled(false);
+    if (_showAsMeshAction) {
+        _showAsMeshAction->setEnabled(false);
     }
-    if (_fullOptimizationButton) {
-        _fullOptimizationButton->setEnabled(false);
+    if (_fullOptimizationAction) {
+        _fullOptimizationAction->setEnabled(false);
     }
     if (_resetViewsButton) {
         _resetViewsButton->setEnabled(false);
@@ -1024,6 +1055,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     _generatedTopWidget = nullptr;
     _panes.clear();
     _stripViewers.clear();
+    _fixedStripViewer = nullptr;
     clearFastGeneratedOverlayItemRefs();
     _currentCutViewer = nullptr;
     _sideCutViewer = nullptr;
@@ -1096,11 +1128,8 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         currentViewer->centerOnVolumePoint(_generatedViews.focusPoint, false);
     }
     currentViewer->setShiftScrollOverride(
-        [this](int steps, QPointF, Qt::KeyboardModifiers modifiers) {
-            (void)modifiers;
-            if (shiftScrollMode() == ShiftScrollMode::StraightNormal) {
-                return shiftCurrentCutPlaneNormalOffsetByScrollSteps(steps);
-            }
+        [this](int steps, QPointF, Qt::KeyboardModifiers) {
+            // Always step along the line; the cut plane never leaves it.
             return shiftCurrentLinePositionByScrollSteps(steps);
         });
     bindPaneInteractions(views.currentCutName, currentViewer, false);
@@ -1199,9 +1228,13 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     };
     int stripIndex = 0;
     for (const auto& [surfaceName, title] : stripSpecs) {
+        // Strip 0 (the line surface) is shown as a fixed, non-interactive panel
+        // above the cut views; strip 1 keeps its place in the bottom splitter.
+        const bool fixedStrip = stripIndex == 0;
         auto* base = _viewerManager->createViewerInWidget(
             surfaceName,
-            stripSplitter,
+            fixedStrip ? static_cast<QWidget*>(centralWidget())
+                       : static_cast<QWidget*>(stripSplitter),
             ViewerManager::ViewerRole::Annotation);
         auto* viewer = base ? qobject_cast<CChunkedVolumeViewer*>(base->asQObject()) : nullptr;
         if (!viewer) {
@@ -1229,6 +1262,28 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         }
         viewer->applyCameraState(stripCamera, false);
         bindPaneInteractions(surfaceName, viewer, false);
+        if (fixedStrip) {
+            // Full-width panel between the button row and the cut views. No
+            // mouse-follow or click connections; eventFilter() swallows all input
+            // except Ctrl+right-click, and updateFixedStripGeometry() (called once
+            // all views exist, and on resize) applies the fit-to-width zoom and
+            // fixed height. Registered in _generatedContainers so the rebuild
+            // teardown deletes it like the splitter containers.
+            _layout->insertWidget(1, viewer, 0);
+            _generatedContainers.push_back(viewer);
+            _fixedStripViewer = viewer;
+            if (auto* statsBar = viewer->findChild<ViewerStatsBar*>()) {
+                statsBar->hide();
+            }
+            if (auto* view = viewer->graphicsView()) {
+                view->setProperty("vc_hide_scalebar", true);
+            }
+            _stripViewers.push_back(viewer);
+            _panes.push_back(Pane{surfaceName, viewer, {}});
+            connectGeneratedOverlayRefresh(viewer);
+            ++stripIndex;
+            continue;
+        }
         connect(viewer,
                 &CChunkedVolumeViewer::sendMouseMoveVolume,
                 this,
@@ -1290,15 +1345,20 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     if (_savedOuterSplitterSizes.size() == outerSplitter->count()) {
         outerSplitter->setSizes(_savedOuterSplitterSizes);
     } else {
-        outerSplitter->setSizes({2, 1});
+        // Bottom strip gets ~23% (the old 1/3 reduced by ~30%); the difference
+        // goes to the cut views.
+        outerSplitter->setSizes({23, 7});
     }
 
+    updateFixedStripGeometry();
+    updatePauseIndicator();
+    updateOptimizationStatusIndicator();
     rebuildGeneratedOverlays();
-    if (_showAsMeshButton) {
-        _showAsMeshButton->setEnabled(true);
+    if (_showAsMeshAction) {
+        _showAsMeshAction->setEnabled(true);
     }
-    if (_fullOptimizationButton) {
-        _fullOptimizationButton->setEnabled(true);
+    if (_fullOptimizationAction) {
+        _fullOptimizationAction->setEnabled(true);
     }
     captureInitialGeneratedViewState();
     if (_resetViewsButton) {
@@ -1656,15 +1716,6 @@ void LineAnnotationDialog::previewClosestControlPoint()
     });
 }
 
-bool LineAnnotationDialog::shiftCurrentCutPlaneNormalOffsetByScrollSteps(int steps)
-{
-    return shiftCutPlaneNormalOffsetByScrollSteps(_generatedViews.currentCutSurface.get(),
-                                                  _currentCutViewer,
-                                                  steps,
-                                                  _currentCutNormalOffsetVx,
-                                                  "line annotation current cut normal offset");
-}
-
 bool LineAnnotationDialog::shiftSideCutPlaneNormalOffsetByScrollSteps(int steps)
 {
     return shiftCutPlaneNormalOffsetByScrollSteps(_generatedViews.sideCutSurface.get(),
@@ -1779,36 +1830,6 @@ void LineAnnotationDialog::resetGeneratedCutNormalOffsets(bool forceRender)
     }
 }
 
-void LineAnnotationDialog::handleShiftScrollModeChanged()
-{
-    if (shiftScrollMode() != ShiftScrollMode::AlongLine) {
-        return;
-    }
-
-    const bool wasFollowing = _currentCutFollowsStripMouse;
-    setCurrentCutFollowsStripMouse(true);
-    if (!wasFollowing) {
-        return;
-    }
-
-    const bool currentHadOffset = normalOffsetActive(_currentCutNormalOffsetVx);
-    _currentCutNormalOffsetVx = 0.0;
-    if (_currentCutViewer) {
-        _currentCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
-    }
-    if (!currentHadOffset || !_generatedViews.currentCutSurface) {
-        return;
-    }
-    if (!updatePlaneSurface(_generatedViews.currentCutSurface.get(), _currentLinePosition)) {
-        return;
-    }
-    if (_currentCutViewer) {
-        _currentCutViewer->markSurfaceGeometryChanged();
-        _currentCutViewer->renderVisible(true, "line annotation current cut along-line mode");
-    }
-    rebuildGeneratedDynamicOverlays();
-}
-
 void LineAnnotationDialog::setCutFollowEnabled(bool enabled)
 {
     // Programmatic twin of the private toggle.
@@ -1822,6 +1843,77 @@ void LineAnnotationDialog::setCurrentCutFollowsStripMouse(bool follows)
     if (follows && !wasFollowing) {
         resetGeneratedCutNormalOffsets(true);
     }
+    updatePauseIndicator();
+}
+
+void LineAnnotationDialog::updatePauseIndicator()
+{
+    CChunkedVolumeViewer* bottomStrip = nullptr;
+    for (const auto& stripViewer : _stripViewers) {
+        if (stripViewer && stripViewer != _fixedStripViewer) {
+            bottomStrip = stripViewer;
+            break;
+        }
+    }
+    if (!bottomStrip) {
+        if (_pauseIndicator) {
+            _pauseIndicator->hide();
+        }
+        return;
+    }
+    if (!_pauseIndicator || _pauseIndicator->parentWidget() != bottomStrip) {
+        delete _pauseIndicator;
+        auto* indicator = new QLabel(bottomStrip);
+        indicator->setObjectName(QStringLiteral("lineAnnotationPauseIndicator"));
+        indicator->setText(QStringLiteral("❚❚"));
+        indicator->setStyleSheet(QStringLiteral(
+            "QLabel { color: rgb(0, 245, 255); background-color: rgba(20, 20, 20, 160); "
+            "border-radius: 6px; padding: 6px 14px; font-size: 32px; font-weight: bold; }"));
+        indicator->setAttribute(Qt::WA_TransparentForMouseEvents);
+        indicator->adjustSize();
+        _pauseIndicator = indicator;
+    }
+    _pauseIndicator->move(
+        std::max(0, (bottomStrip->width() - _pauseIndicator->width()) / 2), 10);
+    _pauseIndicator->setVisible(!_currentCutFollowsStripMouse);
+    _pauseIndicator->raise();
+}
+
+void LineAnnotationDialog::updateOptimizationStatusIndicator()
+{
+    CChunkedVolumeViewer* bottomStrip = nullptr;
+    for (const auto& stripViewer : _stripViewers) {
+        if (stripViewer && stripViewer != _fixedStripViewer) {
+            bottomStrip = stripViewer;
+            break;
+        }
+    }
+    if (!bottomStrip) {
+        if (_optimizationStatusLabel) {
+            _optimizationStatusLabel->hide();
+        }
+        return;
+    }
+    if (!_optimizationStatusLabel ||
+        _optimizationStatusLabel->parentWidget() != bottomStrip) {
+        delete _optimizationStatusLabel;
+        auto* label = new QLabel(bottomStrip);
+        label->setObjectName(QStringLiteral("lineAnnotationOptimizationStatusLabel"));
+        label->setAttribute(Qt::WA_TransparentForMouseEvents);
+        _optimizationStatusLabel = label;
+    }
+    _optimizationStatusLabel->setText(
+        _optimizationStatusOptimized ? tr("optimized") : tr("not optimized"));
+    _optimizationStatusLabel->setStyleSheet(QStringLiteral(
+        "QLabel { color: %1; background-color: rgba(20, 20, 20, 160); "
+        "border-radius: 4px; padding: 2px 8px; font-weight: bold; }")
+        .arg(_optimizationStatusOptimized ? QStringLiteral("rgb(40, 220, 120)")
+                                          : QStringLiteral("rgb(255, 80, 80)")));
+    _optimizationStatusLabel->adjustSize();
+    _optimizationStatusLabel->move(
+        std::max(0, bottomStrip->width() - _optimizationStatusLabel->width() - 10), 10);
+    _optimizationStatusLabel->show();
+    _optimizationStatusLabel->raise();
 }
 
 void LineAnnotationDialog::requestGeneratedSideStripIntersections()
@@ -1903,7 +1995,7 @@ void LineAnnotationDialog::installGeneratedViewShortcuts()
     bindRotationShortcut(Qt::Key_A, GeneratedCutRotationAxis::Vertical, -kCurrentCutRotationStepRadians);
     bindRotationShortcut(Qt::Key_D, GeneratedCutRotationAxis::Vertical, kCurrentCutRotationStepRadians);
     bindNavigationShortcut(Qt::Key_E, &LineAnnotationDialog::jumpToPreviousControlPoint);
-    bindNavigationShortcut(Qt::Key_R, &LineAnnotationDialog::previewClosestControlPoint);
+    bindNavigationShortcut(Qt::Key_R, &LineAnnotationDialog::snapPanesToFixedStripCursor);
     bindNavigationShortcut(Qt::Key_T, &LineAnnotationDialog::jumpToNextControlPoint);
 
     auto* spaceShortcut = new QShortcut(QKeySequence(Qt::Key_Space), this);
@@ -1984,7 +2076,9 @@ void LineAnnotationDialog::restoreInitialGeneratedViewerCameras()
         _sideCutViewer->applyCameraState(_initialSideCutCamera, false);
     }
     for (size_t i = 0; i < _stripViewers.size() && i < _initialStripCameras.size(); ++i) {
-        if (_stripViewers[i]) {
+        // The fixed top strip's camera is owned by updateFixedStripGeometry();
+        // restoring a stale capture here could shrink it.
+        if (_stripViewers[i] && _stripViewers[i] != _fixedStripViewer) {
             _stripViewers[i]->applyCameraState(_initialStripCameras[i], false);
         }
     }
@@ -2019,6 +2113,7 @@ void LineAnnotationDialog::resetGeneratedViews()
         }
     }
     restoreInitialGeneratedViewerCameras();
+    updateFixedStripGeometry();
     if (_currentCutViewer) {
         _currentCutViewer->renderVisible(true, "line annotation reset current cut");
     }
@@ -2130,7 +2225,10 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
             _fastStripOverlayItems.resize(index + 1);
         }
         auto& entry = _fastStripOverlayItems[index];
-        const size_t spanLabelCount = _generatedViews.spanAlignmentMetrics.size();
+        // No span-alignment labels on the fixed top strip (kept text-free).
+        const size_t spanLabelCount = viewer == _fixedStripViewer
+            ? 0
+            : _generatedViews.spanAlignmentMetrics.size();
         const bool recreate = entry.viewer != viewer ||
                               entry.surfaceName != surfaceName ||
                               !entry.currentLine ||
@@ -2862,6 +2960,7 @@ void LineAnnotationDialog::resizeEvent(QResizeEvent* event)
     QMainWindow::resizeEvent(event);
     updateOptimizationOverlayGeometry();
     updateFiberNameLabel();
+    updateFixedStripGeometry();
 }
 
 bool LineAnnotationDialog::toggleCurrentCutFollowFromKeyboard()
@@ -2908,8 +3007,44 @@ bool LineAnnotationDialog::handleKeyPress(QKeyEvent* event)
 
 bool LineAnnotationDialog::eventFilter(QObject* watched, QEvent* event)
 {
+    // The fixed top strip is display-only: swallow every mouse/wheel interaction
+    // except the Ctrl+right-click context menu (line position snapping is handled
+    // by the "R" shortcut instead of mouse-follow).
+    if (_fixedStripViewer) {
+        auto* view = _fixedStripViewer->graphicsView();
+        if (view && (watched == view || watched == view->viewport())) {
+            switch (event->type()) {
+            case QEvent::Wheel:
+            case QEvent::MouseMove:
+            case QEvent::MouseButtonDblClick:
+                return true;
+            case QEvent::MouseButtonPress:
+            case QEvent::MouseButtonRelease: {
+                auto* mouseEvent = static_cast<QMouseEvent*>(event);
+                const bool contextClick =
+                    mouseEvent->button() == Qt::RightButton &&
+                    mouseEvent->modifiers().testFlag(Qt::ControlModifier);
+                if (!contextClick) {
+                    return true;
+                }
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
     if (watched == _fiberNameLabel && event->type() == QEvent::Resize) {
         updateFiberNameLabel();
+    }
+    if (_pauseIndicator && watched == _pauseIndicator->parentWidget() &&
+        event->type() == QEvent::Resize) {
+        updatePauseIndicator();
+    }
+    if (_optimizationStatusLabel &&
+        watched == _optimizationStatusLabel->parentWidget() &&
+        event->type() == QEvent::Resize) {
+        updateOptimizationStatusIndicator();
     }
     if (event->type() == QEvent::KeyPress) {
         auto* keyEvent = static_cast<QKeyEvent*>(event);
@@ -2918,6 +3053,89 @@ bool LineAnnotationDialog::eventFilter(QObject* watched, QEvent* event)
         }
     }
     return QMainWindow::eventFilter(watched, event);
+}
+
+void LineAnnotationDialog::updateFixedStripGeometry()
+{
+    if (!_fixedStripViewer || !_hasGeneratedViews) {
+        return;
+    }
+    auto* quad = dynamic_cast<QuadSurface*>(_fixedStripViewer->currentSurface());
+    if (!quad) {
+        return;
+    }
+    const cv::Size size = quad->size();
+    if (size.width <= 0 || size.height <= 0) {
+        return;
+    }
+    auto* content = centralWidget();
+    const int panelWidth = content ? content->width() : width();
+    constexpr int kFixedStripMarginPx = 8;
+    // Height cap: never zoom in beyond what a reference-length (in vx) annotation
+    // gets at fit-to-width. The strip has one column per line sample, so convert
+    // the vx reference into columns via the line-point spacing. Shorter annotations
+    // render narrower than the panel and stay horizontally centered (surfacePtr
+    // 0,0) with wider side margins.
+    constexpr double kFixedStripReferenceLengthVx = 20000.0;
+    float referenceCols = static_cast<float>(size.width);
+    const double spacingVx =
+        vc3d::line_annotation::medianGeneratedLinePointSpacing(_generatedViews.linePoints);
+    if (std::isfinite(spacingVx) && spacingVx > 1.0e-6) {
+        referenceCols = static_cast<float>(kFixedStripReferenceLengthVx / spacingVx);
+    }
+    const float innerWidth =
+        static_cast<float>(std::max(1, panelWidth - 2 * kFixedStripMarginPx));
+    const float zoom = std::clamp(
+        innerWidth / std::max(static_cast<float>(size.width), referenceCols),
+        0.002f,
+        16.0f);
+    const int panelHeight =
+        static_cast<int>(std::lround(static_cast<double>(size.height) * zoom)) +
+        2 * kFixedStripMarginPx;
+    _fixedStripViewer->setFixedHeight(panelHeight);
+
+    CChunkedVolumeViewer::CameraState camera = _fixedStripViewer->cameraState();
+    camera.surfacePtrX = 0.0f;
+    camera.surfacePtrY = 0.0f;
+    camera.zOffset = 0.0f;
+    camera.zOffsetWorldDir = {0, 0, 0};
+    camera.scale = zoom;
+    _fixedStripViewer->applyCameraState(camera, false);
+}
+
+void LineAnnotationDialog::snapPanesToFixedStripCursor()
+{
+    if (!_hasGeneratedViews || !_fixedStripViewer) {
+        return;
+    }
+    auto* view = _fixedStripViewer->graphicsView();
+    auto* viewport = view ? view->viewport() : nullptr;
+    if (!viewport) {
+        return;
+    }
+    const QPoint viewportPos = viewport->mapFromGlobal(QCursor::pos());
+    if (!viewport->rect().contains(viewportPos)) {
+        return;
+    }
+    const double position =
+        linePositionFromStripScene(_fixedStripViewer, view->mapToScene(viewportPos));
+    if (!std::isfinite(position)) {
+        return;
+    }
+    setCurrentLinePosition(position);
+    // Recenter the bottom strip on the snapped position (keeping its zoom), so the
+    // current-position marker can't end up outside a zoomed-in viewport.
+    for (const auto& stripViewer : _stripViewers) {
+        if (!stripViewer || stripViewer == _fixedStripViewer) {
+            continue;
+        }
+        if (const auto center = generatedStripSurfaceCenter(stripViewer, position)) {
+            CChunkedVolumeViewer::CameraState camera = stripViewer->cameraState();
+            camera.surfacePtrX = (*center)[0];
+            camera.surfacePtrY = (*center)[1];
+            stripViewer->applyCameraState(camera, false);
+        }
+    }
 }
 
 void LineAnnotationDialog::updateOptimizationOverlayGeometry()
@@ -2944,11 +3162,15 @@ void LineAnnotationDialog::updateFiberNameLabel()
         return;
     }
 
-    _fiberNameLabel->setText(vc3d::adaptFiberNameToWidth(
-        fullName,
-        _fiberNameLabel->fontMetrics(),
-        _fiberNameLabel->contentsRect().width()));
-    _fiberNameLabel->setToolTip(fullName);
+    const QString hvSuffix = _fiberHvTag.isEmpty()
+        ? QString()
+        : QStringLiteral("  [%1]").arg(_fiberHvTag);
+    const QFontMetrics metrics = _fiberNameLabel->fontMetrics();
+    const int nameWidth = _fiberNameLabel->contentsRect().width() -
+        (hvSuffix.isEmpty() ? 0 : metrics.horizontalAdvance(hvSuffix));
+    _fiberNameLabel->setText(
+        vc3d::adaptFiberNameToWidth(fullName, metrics, nameWidth) + hvSuffix);
+    _fiberNameLabel->setToolTip(fullName + hvSuffix);
 }
 
 void LineAnnotationDialog::restoreWindowGeometry()

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -20,6 +20,7 @@
 #include <opencv2/core/mat.hpp>
 
 class CState;
+class QAction;
 class QComboBox;
 class QGraphicsPathItem;
 class QGraphicsRectItem;
@@ -31,6 +32,7 @@ class QPoint;
 class QProgressBar;
 class QPushButton;
 class QCloseEvent;
+class QHBoxLayout;
 class QResizeEvent;
 class QTimer;
 class QVariantAnimation;
@@ -46,17 +48,9 @@ class LineAnnotationDialog : public QMainWindow
     Q_OBJECT
 
 public:
-    enum class InitialDirectionMode {
-        Sideways,
-        ZInOut,
-    };
     enum class ReoptimizationMode {
         AutoReoptimize,
         NoOptimization,
-    };
-    enum class ShiftScrollMode {
-        AlongLine,
-        StraightNormal,
     };
     using GeneratedControlPointContextResult =
         vc3d::line_annotation::GeneratedControlPointContextResult;
@@ -120,9 +114,7 @@ public:
         const QPoint& globalPos,
         const vc3d::line_annotation::GeneratedLinkCandidateMenuState& linkCandidateState = {});
     const std::vector<Pane>& panes() const { return _panes; }
-    InitialDirectionMode initialDirectionMode() const;
     ReoptimizationMode reoptimizationMode() const;
-    ShiftScrollMode shiftScrollMode() const;
     int initialCenterlineLengthVx() const;
     int maxControlPointDistanceVx() const;
     void setGeneratedControlPoints(std::vector<GeneratedOverlay::ControlPointMarker> controlPoints);
@@ -147,6 +139,13 @@ public:
     void setOptimizationBusy(bool busy);
     void setOptimizationStatus(bool optimized);
     void setFiberDisplayName(const QString& name);
+    // "H"/"V" (or empty) shown next to the fiber name in the top-right label.
+    void setFiberHvTag(const QString& tag);
+    // Rebuilds the clickable tag buttons in the top bar. enabled=false while the
+    // fiber hasn't been saved yet (tag edits need a stored fiber).
+    void setFiberTags(const std::vector<std::string>& knownTags,
+                      const std::vector<std::string>& activeTags,
+                      bool enabled);
     void setCloseAfterFinalizationAllowed(bool allowed);
     void setWorkspaceEmbedded(bool embedded);
     bool workspaceEmbedded() const { return _workspaceEmbedded; }
@@ -191,6 +190,7 @@ signals:
     void generatedSideStripIntersectionQueryRequested(const std::string& surfaceName);
     void showAsMeshRequested();
     void fullOptimizationRequested();
+    void fiberTagChangeRequested(const QString& tag, bool enabled);
     void closeFinalizationRequested(QCloseEvent* event);
     void reoptimizationModeChanged(LineAnnotationDialog::ReoptimizationMode mode);
 
@@ -225,7 +225,6 @@ private:
     void jumpToNextControlPoint();
     void previewClosestControlPoint();
     bool shiftCurrentLinePositionByScrollSteps(int steps);
-    bool shiftCurrentCutPlaneNormalOffsetByScrollSteps(int steps);
     bool shiftSideCutPlaneNormalOffsetByScrollSteps(int steps);
     bool shiftCutPlaneNormalOffsetByScrollSteps(PlaneSurface* plane,
                                                 CChunkedVolumeViewer* viewer,
@@ -234,7 +233,6 @@ private:
                                                 const char* renderReason);
     bool applyCutPlaneNormalOffset(PlaneSurface* plane, double offsetVx) const;
     void resetGeneratedCutNormalOffsets(bool forceRender);
-    void handleShiftScrollModeChanged();
     void setCurrentCutFollowsStripMouse(bool follows);
     void requestGeneratedSideStripIntersections();
     cv::Vec3f branchLinkDirectionForViewer(CChunkedVolumeViewer* viewer,
@@ -278,6 +276,15 @@ private:
                                      QuadSurface* surface,
                                      double linePosition) const;
     bool handleKeyPress(QKeyEvent* event);
+    // Fixed top strip: fit-to-width zoom + auto height, recomputed on resize.
+    void updateFixedStripGeometry();
+    // "R": one-shot jump of the other panes to the cursor's line position on the
+    // fixed top strip (works regardless of follow mode; leaves it unchanged).
+    void snapPanesToFixedStripCursor();
+    // Pause badge on the bottom strip while mouse-follow is toggled off (Space).
+    void updatePauseIndicator();
+    // "optimized"/"not optimized" badge in the bottom strip's top-right corner.
+    void updateOptimizationStatusIndicator();
     void updateOptimizationOverlayGeometry();
     void updateFiberNameLabel();
     void restoreWindowGeometry();
@@ -287,17 +294,18 @@ private:
 
     ViewerManager* _viewerManager = nullptr;
     QVBoxLayout* _layout = nullptr;
-    QComboBox* _initialDirectionCombo = nullptr;
-    QComboBox* _reoptimizationCombo = nullptr;
-    QComboBox* _shiftScrollCombo = nullptr;
+    // Checked = auto-reoptimize after each edit; unchecked = no optimization.
+    QAction* _autoReoptimizeAction = nullptr;
+    QAction* _showAsMeshAction = nullptr;
+    QAction* _fullOptimizationAction = nullptr;
     QSpinBox* _initialCenterlineLengthSpin = nullptr;
     QSpinBox* _maxControlPointDistanceSpin = nullptr;
     QLabel* _fiberNameLabel = nullptr;
-    QLabel* _sliceStepLabel = nullptr;
-    QLabel* _optimizationStatusLabel = nullptr;
+    QPointer<QLabel> _optimizationStatusLabel;
+    bool _optimizationStatusOptimized = false;
+    QWidget* _tagRowWidget = nullptr;
+    QHBoxLayout* _tagRowLayout = nullptr;
     QProgressBar* _sideStripIntersectionProgress = nullptr;
-    QPushButton* _showAsMeshButton = nullptr;
-    QPushButton* _fullOptimizationButton = nullptr;
     QPushButton* _resetViewsButton = nullptr;
     QPointer<QWidget> _optimizationOverlay;
     QMdiArea* _mdiArea = nullptr;
@@ -307,6 +315,7 @@ private:
     bool _closing = false;
     bool _workspaceEmbedded = false;
     QString _fiberDisplayName;
+    QString _fiberHvTag;
 
     QWidget* _generatedTopWidget = nullptr;
     std::vector<QPointer<QWidget>> _generatedContainers;
@@ -329,6 +338,10 @@ private:
     QPointer<CChunkedVolumeViewer> _currentCutViewer;
     QPointer<CChunkedVolumeViewer> _sideCutViewer;
     std::vector<QPointer<CChunkedVolumeViewer>> _stripViewers;
+    // _stripViewers[0], shown as a fixed-height, non-interactive panel above the
+    // cut views instead of inside the strip splitter.
+    QPointer<CChunkedVolumeViewer> _fixedStripViewer;
+    QPointer<QLabel> _pauseIndicator;
     GeneratedViews _generatedViews;
     // Double-precision copy of _generatedViews.linePoints, built once when views are
     // generated so the per-cursor-move side plane fit doesn't reconvert the whole polyline.

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -322,7 +322,9 @@ namespace line_annotation {
     constexpr int INITIAL_CENTERLINE_LENGTH_VX_DEFAULT = 2400;
     constexpr auto MAX_CONTROL_POINT_DISTANCE_VX = "lineAnnotation/max_control_point_distance_vx";
     constexpr int MAX_CONTROL_POINT_DISTANCE_VX_DEFAULT = 0;
-    constexpr auto OUTER_SPLITTER_SIZES = "lineAnnotation/outer_splitter_sizes";
+    // "_v2" retires ratios saved before the fixed top strip / smaller bottom
+    // strip layout; old values would override the new default proportions.
+    constexpr auto OUTER_SPLITTER_SIZES = "lineAnnotation/outer_splitter_sizes_v2";
     constexpr auto TOP_SPLITTER_SIZES = "lineAnnotation/top_splitter_sizes";
     constexpr auto STRIP_SPLITTER_SIZES = "lineAnnotation/strip_splitter_sizes";
     constexpr auto CURRENT_CUT_ZOOM = "lineAnnotation/current_cut_zoom";

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -1601,11 +1601,17 @@ void CChunkedVolumeViewer::updateScalebarScale()
     // zarr level is sampled, not the physical size of the view.
     if (!_view || !_volume)
         return;
-    double voxel = _volume->voxelSize();
-    if (!(voxel > 0.0) || !(_scale > 0.0f))
+    if (!(_scale > 0.0f))
         return;
-    const double umPerScenePx = voxel / static_cast<double>(_scale);
-    _view->setVoxelSize(umPerScenePx, umPerScenePx);
+    // No positive voxel size in the volume metadata: fall back to voxel units so
+    // the bar still tracks zoom (an early return here would freeze the scalebar
+    // at the view's default µm/px forever).
+    double voxel = _volume->voxelSize();
+    const bool physical = voxel > 0.0;
+    if (!physical)
+        voxel = 1.0;
+    const double unitsPerScenePx = voxel / static_cast<double>(_scale);
+    _view->setVoxelSize(unitsPerScenePx, unitsPerScenePx, physical);
 }
 
 void CChunkedVolumeViewer::resizeFramebuffer()

--- a/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.cpp
@@ -47,6 +47,10 @@ CVolumeViewerView::ScaleBarLabel CVolumeViewerView::formatScaleBarLength(double 
 void CVolumeViewerView::drawForeground(QPainter* p, const QRectF& sceneRect)
 {
     QGraphicsView::drawForeground(p, sceneRect);
+    if (property("vc_hide_scalebar").toBool()) {
+        drawTiltHandle(p);
+        return;
+    }
     const double dpr = devicePixelRatioF();
     const double m11 = transform().m11();
     const int vpW = viewport()->width();
@@ -54,12 +58,14 @@ void CVolumeViewerView::drawForeground(QPainter* p, const QRectF& sceneRect)
 
     // Recompute cached scalebar only when inputs change
     if (_cachedM11 != m11 || _cachedDpr != dpr || _cachedVpW != vpW ||
-        _cachedVpH != vpH || _cachedVx != m_vx || _scalebarCacheDirty) {
+        _cachedVpH != vpH || _cachedVx != m_vx ||
+        _cachedPhysicalUnits != m_physicalUnits || _scalebarCacheDirty) {
         _cachedM11 = m11;
         _cachedDpr = dpr;
         _cachedVpW = vpW;
         _cachedVpH = vpH;
         _cachedVx = m_vx;
+        _cachedPhysicalUnits = m_physicalUnits;
         _scalebarCacheDirty = false;
 
         _cachedFont = p->font();
@@ -72,7 +78,9 @@ void CVolumeViewerView::drawForeground(QPainter* p, const QRectF& sceneRect)
         double barUm = chooseNiceLength(wUm / 4.0);
         _cachedBarPx = barUm * pxPerUm;
 
-        _cachedBarLabel = formatScaleBarLength(barUm).text;
+        _cachedBarLabel = m_physicalUnits
+            ? formatScaleBarLength(barUm).text
+            : QString::number(barUm) + QStringLiteral(" vx");
     }
 
     p->save();

--- a/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.hpp
@@ -28,7 +28,15 @@ public:
     void keyPressEvent(QKeyEvent *event) override;
     void keyReleaseEvent(QKeyEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
-    void setVoxelSize(double sx, double sy) { m_vx = sx; m_vy = sy; update(); }
+    // physical=false: sx/sy are voxels (not µm) per scene px; the scalebar
+    // labels in "vx" instead of physical units.
+    void setVoxelSize(double sx, double sy, bool physical = true)
+    {
+        m_vx = sx;
+        m_vy = sy;
+        m_physicalUnits = physical;
+        update();
+    }
     static ScaleBarLabel formatScaleBarLength(double barUm);
     void setMiddleButtonPanEnabled(bool enabled) { _middleButtonPanEnabled = enabled; }
     bool middleButtonPanEnabled() const { return _middleButtonPanEnabled; }
@@ -93,8 +101,9 @@ private:
     void drawTiltHandle(QPainter* painter) const;
     bool pointInSceneWidget(const QPointF& viewportPos) const;
 
-    // µm per scene-unit (pixel)
+    // µm (or voxels, when !m_physicalUnits) per scene-unit (pixel)
     double m_vx = 32.0, m_vy = 32.0;
+    bool m_physicalUnits = true;
     bool _middleButtonPanEnabled = true;
     bool _scrollPanDisabled = false;
     bool _sceneWidgetMouseCapture = false;
@@ -107,6 +116,7 @@ private:
     mutable double _cachedDpr = 0;
     mutable int _cachedVpW = 0;
     mutable int _cachedVpH = 0;
+    mutable bool _cachedPhysicalUnits = true;
     mutable double _cachedVx = 0;
 
     TiltHandleMode _tiltHandleMode = TiltHandleMode::Hidden;


### PR DESCRIPTION
Reworks the line annotation GUI layout and top bar, and fixes the broken viewer scalebar.

## Line annotation layout

- **Fixed top strip**: the line-surface strip moves from the bottom splitter to a fixed full-width panel above the cut views. Fit-to-width zoom recomputed on resize, with a height cap at the fit height of a 20000 vx annotation — shorter annotations render at that same height, horizontally centered with wider black side margins. The panel is display-only: no pan/zoom/clicks/mouse-follow, no green stats text, no scalebar, no span-metric labels; only the existing Ctrl+right-click context menu works. "Reset views" no longer touches it (previously restored a stale camera captured before the window had its final size, shrinking the panel).
- **"R" snap** (replaces the closest-control-point preview): with the cursor over the top strip, R jumps the cut views to that line position — regardless of follow mode — and recenters the bottom strip on it so the position marker can't land off-screen when zoomed in.
- **Bottom strip**: default height reduced ~30% (outer splitter 23:7; settings key bumped to `outer_splitter_sizes_v2` so previously saved ratios don't override the new default). A centered ❚❚ badge appears while Space has mouse-follow paused, and a green/red **optimized / not optimized** badge sits in its top-right corner (moved out of the top bar).

## Top bar

- New **Annotation** popup button (left of Length): auto-reoptimize as a single on/off checkable item (unchecked = no optimization), plus *Reinit reoptimization* and *Show as mesh*. Replaces the reopt combo and the two buttons without adding a second menu bar in the embedded workspace tab.
- **Clickable tag pills** + a "+" new-tag button, synced both ways with the Fibers panel via the existing `setFiberTag` path (validate → save JSON → sync open sessions). Pills are accent-filled with a ✓ when active; disabled until the fiber's first save. Emissions are deferred one tick — the tag row rebuild would otherwise delete the emitting button mid-signal (crashed with SIGSEGV).
- Fiber name label now appends the **[H]/[V]** designation (manual tag first, else automatic classification), kept live on manual changes and score recalcs.
- Removed: Z sens readout (still shown in the viewer overlay; Shift+G/H still work), the strip-intersections progress bar (the query itself still runs and feeds the intersection markers), the unused sideways / z (in/out) direction combo (all live seed paths hardcode ZInOut; also removed the caller-less `launchFromViewer`), and the along-line / straight shift-scroll combo (current cut is now always along-line). "Length" is a label next to the spinbox instead of a prefix inside it.

## Scalebar fix

`updateScalebarScale()` early-returned when the volume reports no positive voxelsize, so the view's µm/px stayed frozen at its default forever and the bar never responded to zoom — a regression from #1110, which dropped the fallback added by #1029. It now falls back to voxel units: the bar always tracks zoom, and labels honestly in `vx` when no physical size is known (volumes with a real voxelsize keep µm/mm labels unchanged).

Built and manually exercised against a live vpkg (open/annotate/tag/save, reopen from the fiber panel, workspace-embedded and free-window modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EW9xAtf3HtgHotu4zSExJ1