### PR TITLE
line annotation: fix SIGSEGV during generated-view teardown (#1286 follow-up)

### DIFF
--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -1364,6 +1364,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     }
 
     updateFixedStripGeometry();
+    updateStripRenderLevelFloors();
     updatePauseIndicator();
     updateOptimizationStatusIndicator();
     rebuildGeneratedOverlays();
@@ -2216,6 +2217,10 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     if (_closing || !_hasGeneratedViews) {
         return;
     }
+
+    // Runs after every render/zoom via the overlay-refresh connection, which
+    // keeps the strips' LOD floor tracking user zoom changes.
+    updateStripRenderLevelFloors();
 
     const auto markerColorForState =
         [](vc3d::line_annotation::GeneratedCurrentLineMarkerState state) {
@@ -3138,6 +3143,41 @@ void LineAnnotationDialog::updateFixedStripGeometry()
     camera.zOffsetWorldDir = {0, 0, 0};
     camera.scale = zoom;
     _fixedStripViewer->applyCameraState(camera, false);
+}
+
+void LineAnnotationDialog::updateStripRenderLevelFloors()
+{
+    if (!_hasGeneratedViews) {
+        return;
+    }
+    const double spacingVx =
+        vc3d::line_annotation::medianGeneratedLinePointSpacing(_generatedViews.linePoints);
+    if (!std::isfinite(spacingVx) || spacingVx <= 0.0) {
+        return;
+    }
+    for (const auto& stripViewer : _stripViewers) {
+        if (!stripViewer) {
+            continue;
+        }
+        const float zoom = stripViewer->cameraState().scale;
+        if (!(zoom > 0.0f)) {
+            continue;
+        }
+        // The strip quad has one column per line sample, so the true footprint
+        // is spacingVx volume voxels per screen pixel at zoom 1 -- which the
+        // viewer's zoom-only LOD pick cannot see. Match its 0.5 zoom bias.
+        int minLevel = 0;
+        const double volumeVxPerScreenPx = spacingVx / static_cast<double>(zoom);
+        if (volumeVxPerScreenPx > 1.0) {
+            minLevel = std::clamp(
+                static_cast<int>(std::floor(std::log2(volumeVxPerScreenPx * 0.5))),
+                0,
+                8);
+        }
+        if (stripViewer->property("vc_min_render_level").toInt() != minLevel) {
+            stripViewer->setProperty("vc_min_render_level", minLevel);
+        }
+    }
 }
 
 void LineAnnotationDialog::snapPanesToFixedStripCursor()

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -948,7 +948,13 @@ void LineAnnotationDialog::connectGeneratedOverlayRefresh(CChunkedVolumeViewer* 
                     return;
                 }
                 _generatedOverlayRefreshQueued = false;
-                rebuildGeneratedOverlays();
+                // This fires after every rendered frame (overlaysUpdated), which
+                // runs continuously while tiles stream in. Only re-project the
+                // overlays; do NOT re-request side-strip intersections here —
+                // that handler snapshots every fiber and hashes the whole strip
+                // grid per call, and the data it depends on only changes via the
+                // explicit setGenerated*() paths, which already re-request.
+                rebuildGeneratedOverlays(false);
             });
         }));
 }
@@ -3108,9 +3114,24 @@ void LineAnnotationDialog::updateFixedStripGeometry()
     const int panelHeight =
         static_cast<int>(std::lround(static_cast<double>(size.height) * zoom)) +
         2 * kFixedStripMarginPx;
-    _fixedStripViewer->setFixedHeight(panelHeight);
+    // No-op guards: this runs on every dialog resize, and applyCameraState kicks
+    // a render + overlaysUpdated (which feeds the per-frame overlay-refresh
+    // path); don't re-apply an unchanged height or camera.
+    if (_fixedStripViewer->minimumHeight() != panelHeight ||
+        _fixedStripViewer->maximumHeight() != panelHeight) {
+        _fixedStripViewer->setFixedHeight(panelHeight);
+    }
 
-    CChunkedVolumeViewer::CameraState camera = _fixedStripViewer->cameraState();
+    const CChunkedVolumeViewer::CameraState current = _fixedStripViewer->cameraState();
+    const bool cameraUpToDate =
+        std::abs(current.scale - zoom) <= zoom * 1.0e-4f &&
+        current.surfacePtrX == 0.0f &&
+        current.surfacePtrY == 0.0f &&
+        current.zOffset == 0.0f;
+    if (cameraUpToDate) {
+        return;
+    }
+    CChunkedVolumeViewer::CameraState camera = current;
     camera.surfacePtrX = 0.0f;
     camera.surfacePtrY = 0.0f;
     camera.zOffset = 0.0f;

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -832,6 +832,15 @@ bool LineAnnotationDialog::setGeneratedRows(
     }
 
     clearGeneratedOverlayRefreshConnections();
+    // Drop all viewer references BEFORE deleting the widgets: destruction
+    // delivers events through our eventFilter, which must not dereference a
+    // half-destroyed viewer (QPointers only clear once ~QObject runs).
+    _panes.clear();
+    _stripViewers.clear();
+    _fixedStripViewer = nullptr;
+    clearFastGeneratedOverlayItemRefs();
+    _currentCutViewer = nullptr;
+    _sideCutViewer = nullptr;
     _suppressPaneClosed = true;
     if (_mdiArea) {
         _layout->removeWidget(_mdiArea);
@@ -839,12 +848,6 @@ bool LineAnnotationDialog::setGeneratedRows(
         _mdiArea = nullptr;
     }
     _suppressPaneClosed = false;
-    _panes.clear();
-    _stripViewers.clear();
-    _fixedStripViewer = nullptr;
-    clearFastGeneratedOverlayItemRefs();
-    _currentCutViewer = nullptr;
-    _sideCutViewer = nullptr;
     _hasGeneratedViews = false;
     _currentCutManualRotation = cv::Matx33f::eye();
     _currentCutManualRotationActive = false;
@@ -1038,6 +1041,16 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     }
 
     clearGeneratedOverlayRefreshConnections();
+    // Drop all viewer references BEFORE deleting the widgets: destroying a
+    // viewer synchronously delivers events (ChildRemoved/Hide/...) through our
+    // eventFilter, which must not dereference a half-destroyed viewer via
+    // _fixedStripViewer/_stripViewers (QPointers only clear once ~QObject runs).
+    _panes.clear();
+    _stripViewers.clear();
+    _fixedStripViewer = nullptr;
+    clearFastGeneratedOverlayItemRefs();
+    _currentCutViewer = nullptr;
+    _sideCutViewer = nullptr;
     _suppressPaneClosed = true;
     if (_mdiArea) {
         _layout->removeWidget(_mdiArea);
@@ -1053,12 +1066,6 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     }
     _generatedContainers.clear();
     _generatedTopWidget = nullptr;
-    _panes.clear();
-    _stripViewers.clear();
-    _fixedStripViewer = nullptr;
-    clearFastGeneratedOverlayItemRefs();
-    _currentCutViewer = nullptr;
-    _sideCutViewer = nullptr;
 
     _generatedViews = views;
     _linePointsd.clear();
@@ -3012,30 +3019,36 @@ bool LineAnnotationDialog::eventFilter(QObject* watched, QEvent* event)
 {
     // The fixed top strip is display-only: swallow every mouse/wheel interaction
     // except the Ctrl+right-click context menu (line position snapping is handled
-    // by the "R" shortcut instead of mouse-follow).
-    if (_fixedStripViewer) {
-        auto* view = _fixedStripViewer->graphicsView();
-        if (view && (watched == view || watched == view->viewport())) {
-            switch (event->type()) {
-            case QEvent::Wheel:
-            case QEvent::MouseMove:
-            case QEvent::MouseButtonDblClick:
-                return true;
-            case QEvent::MouseButtonPress:
-            case QEvent::MouseButtonRelease: {
-                auto* mouseEvent = static_cast<QMouseEvent*>(event);
-                const bool contextClick =
-                    mouseEvent->button() == Qt::RightButton &&
-                    mouseEvent->modifiers().testFlag(Qt::ControlModifier);
-                if (!contextClick) {
+    // by the "R" shortcut instead of mouse-follow). Check the event type BEFORE
+    // touching the viewer: widget destruction delivers events (ChildRemoved,
+    // Hide, ...) through this filter while the viewer is half-destroyed, and
+    // calling into it then crashes; input events can't arrive at that point.
+    switch (event->type()) {
+    case QEvent::Wheel:
+    case QEvent::MouseMove:
+    case QEvent::MouseButtonDblClick:
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonRelease:
+        if (_fixedStripViewer) {
+            auto* view = _fixedStripViewer->graphicsView();
+            if (view && (watched == view || watched == view->viewport())) {
+                if (event->type() == QEvent::MouseButtonPress ||
+                    event->type() == QEvent::MouseButtonRelease) {
+                    auto* mouseEvent = static_cast<QMouseEvent*>(event);
+                    const bool contextClick =
+                        mouseEvent->button() == Qt::RightButton &&
+                        mouseEvent->modifiers().testFlag(Qt::ControlModifier);
+                    if (!contextClick) {
+                        return true;
+                    }
+                } else {
                     return true;
                 }
-                break;
-            }
-            default:
-                break;
             }
         }
+        break;
+    default:
+        break;
     }
     if (watched == _fiberNameLabel && event->type() == QEvent::Resize) {
         updateFiberNameLabel();

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -278,6 +278,9 @@ private:
     bool handleKeyPress(QKeyEvent* event);
     // Fixed top strip: fit-to-width zoom + auto height, recomputed on resize.
     void updateFixedStripGeometry();
+    // Render-LOD floor for the strip viewers, derived from line-sample spacing
+    // and each strip's current zoom (see vc_min_render_level in the viewer).
+    void updateStripRenderLevelFloors();
     // "R": one-shot jump of the other panes to the cursor's line position on the
     // fixed top strip (works regardless of follow mode; leaves it unchanged).
     void snapPanesToFixedStripCursor();

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -1732,6 +1732,12 @@ int CChunkedVolumeViewer::renderStartLevel(bool preferSurfaceResolution) const
     if (preferSurfaceResolution && !_surfaceCache && level < levelCount - 1)
         level -= kSurfaceResolutionLevelBias;
     level = std::max(level, _maxDisplayedResolution);
+    // Per-viewer LOD floor for quads that sample the volume sparsely (e.g. the
+    // line annotation strips: one column per line sample, several vx apart).
+    // There the screen zoom under-estimates the volume-space footprint by the
+    // sample spacing, and level-0 requests along a long annotation thrash the
+    // chunk cache (endless chunk-ready re-renders).
+    level = std::max(level, property("vc_min_render_level").toInt());
     return std::clamp(level, 0, levelCount - 1);
 }
 


### PR DESCRIPTION
Fixes a crash introduced by #1286, hit in the field on every generated-view rebuild (e.g. re-optimization after placing a control point).

## Crash

```
finishOptimization → materializeGeneratedViews → setGeneratedLineViews
  → ~CChunkedVolumeViewer (teardown delete loop)
    → Qt event delivery → LineAnnotationDialog::eventFilter → PC=0 (SEGV_MAPERR)
```

`setGeneratedLineViews`'s teardown deletes the pane widgets **before** nulling `_fixedStripViewer`. Widget destruction synchronously delivers events (ChildRemoved/Hide/…) to objects the dialog filters, so `eventFilter` ran mid-destruction and called `graphicsView()` on the half-destroyed viewer — the QPointer only clears once `~QObject` runs, well after the derived destructor — and the virtual call went through a torn-down vtable to address 0.

## Fix (two layers)

1. **Teardown ordering**: drop `_panes` / `_stripViewers` / `_fixedStripViewer` / fast-overlay refs / cut-viewer pointers *before* deleting `_mdiArea` and the generated containers, in both teardown paths (`setGeneratedRows`, `setGeneratedLineViews`).
2. **eventFilter hardening**: check the event type *before* dereferencing the viewer. Only spontaneous input events (wheel/mouse) reach the fixed-strip swallow logic, and those cannot arrive while a widget is being destroyed; destruction-cascade events now fall through untouched.

Either layer alone prevents this crash; both together keep the filter safe against any future teardown path.

Builds clean. The crashing path runs on every control-point placement with auto-reoptimize on, so a quick smoke test (open a fiber, place a couple of control points, reopen, close) exercises the fix directly — I have not yet run that GUI flow against this build, so please give it that smoke test before/at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EW9xAtf3HtgHotu4zSExJ1
