### PR TITLE
VC3D line annotation: fix post-#1286 crash, placement flash, and pane jitter

### DIFF
--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -7293,10 +7293,28 @@ bool LineAnnotationController::materializeGeneratedViews(LineAnnotationSession& 
     generatedViews.spanAlignmentMetrics =
         generatedSpanAlignmentMetricsForSession(session);
 
+    // Re-registration replaces planes that live viewers render immediately, and
+    // the dialog only re-poses them to the current line position afterwards.
+    // Seed each new plane with the previous plane's pose (when one exists) so
+    // the surfaceChanged frame is visually continuous instead of flashing the
+    // seed-point view on every control-point placement.
+    const auto carryOverPreviousPose = [this](const std::string& name,
+                                              const std::shared_ptr<PlaneSurface>& plane) {
+        const auto previous =
+            std::dynamic_pointer_cast<PlaneSurface>(_state->surface(name));
+        if (!previous) {
+            return;
+        }
+        plane->setFromNormalAndUp(previous->origin(),
+                                  previous->normal({0.0f, 0.0f, 0.0f}),
+                                  previous->basisY());
+    };
+
     generatedViews.currentCutName = generatedPrefix + "_line_current_cut";
     generatedViews.currentCutSurface = std::make_shared<PlaneSurface>(
         seedPoint,
         cv::Vec3f{1.0f, 0.0f, 0.0f});
+    carryOverPreviousPose(generatedViews.currentCutName, generatedViews.currentCutSurface);
     _state->setSurface(generatedViews.currentCutName, generatedViews.currentCutSurface);
     session.generatedSurfaceNames.push_back(generatedViews.currentCutName);
 
@@ -7304,6 +7322,7 @@ bool LineAnnotationController::materializeGeneratedViews(LineAnnotationSession& 
     generatedViews.sideCutSurface = std::make_shared<PlaneSurface>(
         seedPoint,
         cv::Vec3f{1.0f, 0.0f, 0.0f});
+    carryOverPreviousPose(generatedViews.sideCutName, generatedViews.sideCutSurface);
     _state->setSurface(generatedViews.sideCutName, generatedViews.sideCutSurface);
     session.generatedSurfaceNames.push_back(generatedViews.sideCutName);
 

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -2817,6 +2817,12 @@ void LineAnnotationController::setFiberManualHvTag(uint64_t fiberId, const QStri
         scheduleFiberSave(*it);
     } catch (const std::exception& ex) {
         it->manualHvTag = previousManualTag;
+        for (const auto& pane : _panes) {
+            if (pane.session && pane.session->fiberId == fiberId) {
+                pane.session->fiberManualHvTag = previousManualTag;
+                pushFiberUiState(pane);
+            }
+        }
         showError(tr("Could not save fiber %1: %2")
                       .arg(fiberId)
                       .arg(QString::fromStdString(ex.what())));
@@ -2867,6 +2873,12 @@ void LineAnnotationController::setFiberTag(uint64_t fiberId, const QString& tag,
         scheduleFiberSave(*it);
     } catch (const std::exception& ex) {
         it->tags = previousTags;
+        for (const auto& pane : _panes) {
+            if (pane.session && pane.session->fiberId == fiberId) {
+                pane.session->fiberTags = previousTags;
+                pushFiberUiState(pane);
+            }
+        }
         showError(tr("Could not save fiber %1: %2")
                       .arg(fiberId)
                       .arg(QString::fromStdString(ex.what())));

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -1042,6 +1042,10 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                 stripViewer->renderVisible(true, "line annotation views updated");
             }
         }
+        // Adopting the re-registered surfaces cleared each viewer's scene
+        // (onSurfaceChanged does _scene->clear()), deleting the pooled overlay
+        // items; drop our cached pointers so the rebuild recreates them.
+        clearFastGeneratedOverlayItemRefs();
         updateFixedStripGeometry();
         updatePauseIndicator();
         updateOptimizationStatusIndicator();

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -995,6 +995,69 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         return false;
     }
 
+    // In-place update: every control-point placement re-materializes the views,
+    // and the controller re-registers the new surfaces in CState under the SAME
+    // names before calling us, so the live viewers have already adopted them via
+    // surfaceChanged (view centers preserved). Rebuilding the panes -- the
+    // previous behavior -- destroyed and recreated all four viewers, producing a
+    // visible blank/jump on every placement.
+    if (_hasGeneratedViews && _currentCutViewer && _sideCutViewer &&
+        _stripViewers.size() == 2 && _stripViewers[0] && _stripViewers[1] &&
+        _generatedViews.currentCutName == views.currentCutName &&
+        _generatedViews.sideCutName == views.sideCutName &&
+        _generatedViews.lineSurfaceName == views.lineSurfaceName &&
+        _generatedViews.lineSideSliceName == views.lineSideSliceName) {
+        const double previousLinePosition = _currentLinePosition;
+        _generatedViews = views;
+        _linePointsd.clear();
+        _linePointsd.reserve(_generatedViews.linePoints.size());
+        for (const auto& p : _generatedViews.linePoints) {
+            _linePointsd.emplace_back(p[0], p[1], p[2]);
+        }
+        _sideFitBracket[0] = SideFit{};
+        _sideFitBracket[1] = SideFit{};
+        _generatedControlIndex =
+            vc3d::line_annotation::buildGeneratedControlPointLinePositionIndex(
+                _generatedViews.controlPoints);
+        const double maxLinePosition =
+            static_cast<double>(_generatedViews.linePoints.size() - 1);
+        _currentLinePosition =
+            std::clamp(previousLinePosition, 0.0, maxLinePosition);
+        _currentCutNormalOffsetVx = 0.0;
+        _sideCutNormalOffsetVx = 0.0;
+        _currentCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
+        _sideCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
+        if (!updatePlaneSurface(_generatedViews.currentCutSurface.get(),
+                                _currentLinePosition) ||
+            !updateSidePlaneSurface(_generatedViews.sideCutSurface.get(),
+                                    _currentLinePosition)) {
+            return false;
+        }
+        _currentCutViewer->markSurfaceGeometryChanged();
+        _currentCutViewer->renderVisible(true, "line annotation views updated");
+        _sideCutViewer->markSurfaceGeometryChanged();
+        _sideCutViewer->renderVisible(true, "line annotation views updated");
+        for (const auto& stripViewer : _stripViewers) {
+            if (stripViewer) {
+                stripViewer->renderVisible(true, "line annotation views updated");
+            }
+        }
+        updateFixedStripGeometry();
+        updatePauseIndicator();
+        updateOptimizationStatusIndicator();
+        rebuildGeneratedOverlays();
+        if (_showAsMeshAction) {
+            _showAsMeshAction->setEnabled(true);
+        }
+        if (_fullOptimizationAction) {
+            _fullOptimizationAction->setEnabled(true);
+        }
+        if (_resetViewsButton) {
+            _resetViewsButton->setEnabled(true);
+        }
+        return true;
+    }
+
     if (_showAsMeshAction) {
         _showAsMeshAction->setEnabled(false);
     }

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -7,7 +7,6 @@
 #include "LineAnnotationShiftScroll.hpp"
 #include "VCSettings.hpp"
 #include "ViewerManager.hpp"
-#include "elements/ViewerStatsBar.hpp"
 #include "vc/core/util/PlaneSurface.hpp"
 #include "vc/core/util/QuadSurface.hpp"
 
@@ -19,6 +18,8 @@
 #include <QFont>
 #include <QMenu>
 #include <QMouseEvent>
+#include <QPaintEvent>
+#include <QPainter>
 #include <QGraphicsPathItem>
 #include <QGraphicsRectItem>
 #include <QGraphicsSimpleTextItem>
@@ -287,6 +288,128 @@ cv::Vec3f normalizedOrNan(const cv::Vec3f& vector)
     }
     return vector * (1.0f / n);
 }
+
+constexpr int kOverviewBarHeightPx = 48;
+
+// Schematic overview of the annotation shown above the cut views: a straight
+// line with the control points, replacing the previous volume-rendered top
+// strip (no rendering at all). Fixed height; the annotation compresses
+// horizontally as it grows. Display-only except Ctrl+right-click on a control
+// point, which invokes controlContextRequested with the dot's line position.
+class LineAnnotationOverviewBar final : public QWidget
+{
+public:
+    struct ControlDot {
+        double linePosition = 0.0;
+        QColor color;
+        qreal radius = 4.5;
+    };
+
+    using QWidget::QWidget;
+
+    std::function<void(double, QPoint)> controlContextRequested;
+
+    void setLineData(size_t linePointCount, std::vector<ControlDot> dots)
+    {
+        _linePointCount = linePointCount;
+        _dots = std::move(dots);
+        update();
+    }
+
+    void setCurrentPosition(double position, const QColor& color)
+    {
+        _currentPosition = position;
+        _currentColor = color;
+        update();
+    }
+
+    std::optional<double> linePositionAtLocalX(qreal x) const
+    {
+        const qreal inner = innerWidth();
+        if (_linePointCount < 2 || inner <= 0.0) {
+            return std::nullopt;
+        }
+        const double t =
+            std::clamp((x - kMarginPx) / static_cast<double>(inner), 0.0, 1.0);
+        return t * static_cast<double>(_linePointCount - 1);
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter painter(this);
+        painter.fillRect(rect(), Qt::black);
+        if (_linePointCount < 2) {
+            return;
+        }
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        const qreal midY = height() * 0.5;
+        painter.setPen(QPen(QColor(190, 190, 190), 2.0));
+        painter.drawLine(QPointF(kMarginPx, midY),
+                         QPointF(width() - kMarginPx, midY));
+
+        if (std::isfinite(_currentPosition)) {
+            painter.setPen(QPen(_currentColor, 2.0));
+            const qreal x = xForLinePosition(_currentPosition);
+            painter.drawLine(QPointF(x, 4.0), QPointF(x, height() - 4.0));
+        }
+
+        for (const ControlDot& dot : _dots) {
+            if (!std::isfinite(dot.linePosition)) {
+                continue;
+            }
+            const qreal x = xForLinePosition(dot.linePosition);
+            painter.setPen(QPen(dot.color.darker(150), 1.0));
+            painter.setBrush(dot.color);
+            painter.drawEllipse(QPointF(x, midY), dot.radius, dot.radius);
+        }
+    }
+
+    void mousePressEvent(QMouseEvent* event) override
+    {
+        if (event->button() == Qt::RightButton &&
+            event->modifiers().testFlag(Qt::ControlModifier) &&
+            controlContextRequested && _linePointCount >= 2) {
+            constexpr qreal kHitRadiusPx = 8.0;
+            const qreal x = event->position().x();
+            const ControlDot* best = nullptr;
+            qreal bestDistance = kHitRadiusPx;
+            for (const ControlDot& dot : _dots) {
+                if (!std::isfinite(dot.linePosition)) {
+                    continue;
+                }
+                const qreal distance =
+                    std::abs(xForLinePosition(dot.linePosition) - x);
+                if (distance <= bestDistance) {
+                    bestDistance = distance;
+                    best = &dot;
+                }
+            }
+            if (best) {
+                controlContextRequested(best->linePosition,
+                                        event->globalPosition().toPoint());
+            }
+        }
+        event->accept();  // display-only otherwise
+    }
+
+private:
+    static constexpr qreal kMarginPx = 8.0;
+
+    qreal innerWidth() const { return width() - 2.0 * kMarginPx; }
+
+    qreal xForLinePosition(double position) const
+    {
+        const double t = std::clamp(
+            position / static_cast<double>(_linePointCount - 1), 0.0, 1.0);
+        return kMarginPx + static_cast<qreal>(t) * innerWidth();
+    }
+
+    size_t _linePointCount = 0;
+    std::vector<ControlDot> _dots;
+    double _currentPosition = std::numeric_limits<double>::quiet_NaN();
+    QColor _currentColor{0, 245, 255};
+};
 
 } // namespace
 
@@ -837,7 +960,7 @@ bool LineAnnotationDialog::setGeneratedRows(
     // half-destroyed viewer (QPointers only clear once ~QObject runs).
     _panes.clear();
     _stripViewers.clear();
-    _fixedStripViewer = nullptr;
+    _overviewBar = nullptr;
     clearFastGeneratedOverlayItemRefs();
     _currentCutViewer = nullptr;
     _sideCutViewer = nullptr;
@@ -1002,7 +1125,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     // previous behavior -- destroyed and recreated all four viewers, producing a
     // visible blank/jump on every placement.
     if (_hasGeneratedViews && _currentCutViewer && _sideCutViewer &&
-        _stripViewers.size() == 2 && _stripViewers[0] && _stripViewers[1] &&
+        _stripViewers.size() == 1 && _stripViewers[0] &&
         _generatedViews.currentCutName == views.currentCutName &&
         _generatedViews.sideCutName == views.sideCutName &&
         _generatedViews.lineSurfaceName == views.lineSurfaceName &&
@@ -1046,7 +1169,6 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         // (onSurfaceChanged does _scene->clear()), deleting the pooled overlay
         // items; drop our cached pointers so the rebuild recreates them.
         clearFastGeneratedOverlayItemRefs();
-        updateFixedStripGeometry();
         updatePauseIndicator();
         updateOptimizationStatusIndicator();
         rebuildGeneratedOverlays();
@@ -1111,10 +1233,10 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     // Drop all viewer references BEFORE deleting the widgets: destroying a
     // viewer synchronously delivers events (ChildRemoved/Hide/...) through our
     // eventFilter, which must not dereference a half-destroyed viewer via
-    // _fixedStripViewer/_stripViewers (QPointers only clear once ~QObject runs).
+    // _stripViewers/cut viewers (QPointers only clear once ~QObject runs).
     _panes.clear();
     _stripViewers.clear();
-    _fixedStripViewer = nullptr;
+    _overviewBar = nullptr;
     clearFastGeneratedOverlayItemRefs();
     _currentCutViewer = nullptr;
     _sideCutViewer = nullptr;
@@ -1296,28 +1418,36 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     _generatedStripSplitter = stripSplitter;
     outerSplitter->addWidget(stripSplitter);
 
-    const std::pair<std::string, QString> stripSpecs[] = {
-        {views.lineSurfaceName, views.lineSurfaceTitle},
-        {views.lineSideSliceName, views.lineSideSliceTitle},
+    // Schematic overview bar between the button row and the cut views: a
+    // straight line with the control points, no volume rendering at all. Fixed
+    // height; the annotation compresses horizontally as it grows. Registered in
+    // _generatedContainers so the rebuild teardown deletes it like the splitter
+    // containers.
+    auto* overviewBar = new LineAnnotationOverviewBar(centralWidget());
+    overviewBar->setObjectName(QStringLiteral("lineAnnotationOverviewBar"));
+    overviewBar->setFixedHeight(kOverviewBarHeightPx);
+    overviewBar->controlContextRequested = [this](double linePosition,
+                                                  QPoint globalPos) {
+        forwardOverviewControlContextMenu(linePosition, globalPos);
     };
-    int stripIndex = 0;
-    for (const auto& [surfaceName, title] : stripSpecs) {
-        // Strip 0 (the line surface) is shown as a fixed, non-interactive panel
-        // above the cut views; strip 1 keeps its place in the bottom splitter.
-        const bool fixedStrip = stripIndex == 0;
+    _layout->insertWidget(1, overviewBar, 0);
+    _generatedContainers.push_back(overviewBar);
+    _overviewBar = overviewBar;
+
+    {
+        const std::string& surfaceName = views.lineSideSliceName;
         auto* base = _viewerManager->createViewerInWidget(
             surfaceName,
-            fixedStrip ? static_cast<QWidget*>(centralWidget())
-                       : static_cast<QWidget*>(stripSplitter),
+            stripSplitter,
             ViewerManager::ViewerRole::Annotation);
         auto* viewer = base ? qobject_cast<CChunkedVolumeViewer*>(base->asQObject()) : nullptr;
         if (!viewer) {
             return false;
         }
-        viewer->setObjectName(title);
-        const bool haveStripCamera = static_cast<size_t>(stripIndex) < stripCameras.size();
+        viewer->setObjectName(views.lineSideSliceTitle);
+        const bool haveStripCamera = !stripCameras.empty();
         auto stripCamera = haveStripCamera
-            ? stripCameras[static_cast<size_t>(stripIndex)]
+            ? stripCameras.front()
             : generatedPaneCamera(viewer, camera);
         if (!haveStripCamera) {
             if (const auto center =
@@ -1330,34 +1460,12 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                     views.initialStripLinePositionRange)) {
                 stripCamera.scale = *focusedScale;
             }
-            if (static_cast<size_t>(stripIndex) < _savedStripZooms.size()) {
-                stripCamera.scale = _savedStripZooms[static_cast<size_t>(stripIndex)];
+            if (!_savedStripZooms.empty()) {
+                stripCamera.scale = _savedStripZooms.front();
             }
         }
         viewer->applyCameraState(stripCamera, false);
         bindPaneInteractions(surfaceName, viewer, false);
-        if (fixedStrip) {
-            // Full-width panel between the button row and the cut views. No
-            // mouse-follow or click connections; eventFilter() swallows all input
-            // except Ctrl+right-click, and updateFixedStripGeometry() (called once
-            // all views exist, and on resize) applies the fit-to-width zoom and
-            // fixed height. Registered in _generatedContainers so the rebuild
-            // teardown deletes it like the splitter containers.
-            _layout->insertWidget(1, viewer, 0);
-            _generatedContainers.push_back(viewer);
-            _fixedStripViewer = viewer;
-            if (auto* statsBar = viewer->findChild<ViewerStatsBar*>()) {
-                statsBar->hide();
-            }
-            if (auto* view = viewer->graphicsView()) {
-                view->setProperty("vc_hide_scalebar", true);
-            }
-            _stripViewers.push_back(viewer);
-            _panes.push_back(Pane{surfaceName, viewer, {}});
-            connectGeneratedOverlayRefresh(viewer);
-            ++stripIndex;
-            continue;
-        }
         connect(viewer,
                 &CChunkedVolumeViewer::sendMouseMoveVolume,
                 this,
@@ -1400,11 +1508,9 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         _stripViewers.push_back(viewer);
         _panes.push_back(Pane{surfaceName, viewer, {}});
         connectGeneratedOverlayRefresh(viewer);
-        ++stripIndex;
     }
 
     stripSplitter->setStretchFactor(0, 1);
-    stripSplitter->setStretchFactor(1, 1);
     outerSplitter->setStretchFactor(0, 2);
     outerSplitter->setStretchFactor(1, 1);
 
@@ -1424,7 +1530,6 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         outerSplitter->setSizes({23, 7});
     }
 
-    updateFixedStripGeometry();
     updatePauseIndicator();
     updateOptimizationStatusIndicator();
     rebuildGeneratedOverlays();
@@ -1924,7 +2029,7 @@ void LineAnnotationDialog::updatePauseIndicator()
 {
     CChunkedVolumeViewer* bottomStrip = nullptr;
     for (const auto& stripViewer : _stripViewers) {
-        if (stripViewer && stripViewer != _fixedStripViewer) {
+        if (stripViewer) {
             bottomStrip = stripViewer;
             break;
         }
@@ -1957,7 +2062,7 @@ void LineAnnotationDialog::updateOptimizationStatusIndicator()
 {
     CChunkedVolumeViewer* bottomStrip = nullptr;
     for (const auto& stripViewer : _stripViewers) {
-        if (stripViewer && stripViewer != _fixedStripViewer) {
+        if (stripViewer) {
             bottomStrip = stripViewer;
             break;
         }
@@ -2069,7 +2174,7 @@ void LineAnnotationDialog::installGeneratedViewShortcuts()
     bindRotationShortcut(Qt::Key_A, GeneratedCutRotationAxis::Vertical, -kCurrentCutRotationStepRadians);
     bindRotationShortcut(Qt::Key_D, GeneratedCutRotationAxis::Vertical, kCurrentCutRotationStepRadians);
     bindNavigationShortcut(Qt::Key_E, &LineAnnotationDialog::jumpToPreviousControlPoint);
-    bindNavigationShortcut(Qt::Key_R, &LineAnnotationDialog::snapPanesToFixedStripCursor);
+    bindNavigationShortcut(Qt::Key_R, &LineAnnotationDialog::snapPanesToOverviewCursor);
     bindNavigationShortcut(Qt::Key_T, &LineAnnotationDialog::jumpToNextControlPoint);
 
     auto* spaceShortcut = new QShortcut(QKeySequence(Qt::Key_Space), this);
@@ -2150,9 +2255,7 @@ void LineAnnotationDialog::restoreInitialGeneratedViewerCameras()
         _sideCutViewer->applyCameraState(_initialSideCutCamera, false);
     }
     for (size_t i = 0; i < _stripViewers.size() && i < _initialStripCameras.size(); ++i) {
-        // The fixed top strip's camera is owned by updateFixedStripGeometry();
-        // restoring a stale capture here could shrink it.
-        if (_stripViewers[i] && _stripViewers[i] != _fixedStripViewer) {
+        if (_stripViewers[i]) {
             _stripViewers[i]->applyCameraState(_initialStripCameras[i], false);
         }
     }
@@ -2187,7 +2290,6 @@ void LineAnnotationDialog::resetGeneratedViews()
         }
     }
     restoreInitialGeneratedViewerCameras();
-    updateFixedStripGeometry();
     // _currentCutFollowsStripMouse was reset by direct assignment above; keep the
     // pause badge in sync.
     updatePauseIndicator();
@@ -2251,12 +2353,9 @@ void LineAnnotationDialog::rebuildGeneratedStaticStripOverlays()
         if (!viewer) {
             continue;
         }
-        const std::string key = i == 0 ? _generatedViews.lineSurfaceName
-                                       : _generatedViews.lineSideSliceName;
+        const std::string key = _generatedViews.lineSideSliceName;
         GeneratedOverlay strip = staticStripOverlay();
-        if (i == 1) {
-            strip.fiberIntersections = _generatedViews.fiberIntersections;
-        }
+        strip.fiberIntersections = _generatedViews.fiberIntersections;
         applyOverlayForViewer(staticStripOverlayKey(key), viewer, strip);
     }
 
@@ -2277,6 +2376,10 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     if (_closing || !_hasGeneratedViews) {
         return;
     }
+
+    // The schematic overview bar tracks the same inputs (control points +
+    // current position) as the dynamic overlays; refresh it on the same cadence.
+    updateOverviewBar();
 
     const auto markerColorForState =
         [](vc3d::line_annotation::GeneratedCurrentLineMarkerState state) {
@@ -2302,10 +2405,7 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
             _fastStripOverlayItems.resize(index + 1);
         }
         auto& entry = _fastStripOverlayItems[index];
-        // No span-alignment labels on the fixed top strip (kept text-free).
-        const size_t spanLabelCount = viewer == _fixedStripViewer
-            ? 0
-            : _generatedViews.spanAlignmentMetrics.size();
+        const size_t spanLabelCount = _generatedViews.spanAlignmentMetrics.size();
         const bool recreate = entry.viewer != viewer ||
                               entry.surfaceName != surfaceName ||
                               !entry.currentLine ||
@@ -2365,8 +2465,7 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         if (!viewer) {
             continue;
         }
-        const std::string key = i == 0 ? _generatedViews.lineSurfaceName
-                                       : _generatedViews.lineSideSliceName;
+        const std::string key = _generatedViews.lineSideSliceName;
         auto* entry = ensureStripItems(i, viewer, key);
         auto* quad = dynamic_cast<QuadSurface*>(viewer->currentSurface());
         if (!entry || !quad) {
@@ -3037,7 +3136,6 @@ void LineAnnotationDialog::resizeEvent(QResizeEvent* event)
     QMainWindow::resizeEvent(event);
     updateOptimizationOverlayGeometry();
     updateFiberNameLabel();
-    updateFixedStripGeometry();
 }
 
 bool LineAnnotationDialog::toggleCurrentCutFollowFromKeyboard()
@@ -3084,39 +3182,6 @@ bool LineAnnotationDialog::handleKeyPress(QKeyEvent* event)
 
 bool LineAnnotationDialog::eventFilter(QObject* watched, QEvent* event)
 {
-    // The fixed top strip is display-only: swallow every mouse/wheel interaction
-    // except the Ctrl+right-click context menu (line position snapping is handled
-    // by the "R" shortcut instead of mouse-follow). Check the event type BEFORE
-    // touching the viewer: widget destruction delivers events (ChildRemoved,
-    // Hide, ...) through this filter while the viewer is half-destroyed, and
-    // calling into it then crashes; input events can't arrive at that point.
-    switch (event->type()) {
-    case QEvent::Wheel:
-    case QEvent::MouseMove:
-    case QEvent::MouseButtonDblClick:
-    case QEvent::MouseButtonPress:
-    case QEvent::MouseButtonRelease:
-        if (_fixedStripViewer) {
-            auto* view = _fixedStripViewer->graphicsView();
-            if (view && (watched == view || watched == view->viewport())) {
-                if (event->type() == QEvent::MouseButtonPress ||
-                    event->type() == QEvent::MouseButtonRelease) {
-                    auto* mouseEvent = static_cast<QMouseEvent*>(event);
-                    const bool contextClick =
-                        mouseEvent->button() == Qt::RightButton &&
-                        mouseEvent->modifiers().testFlag(Qt::ControlModifier);
-                    if (!contextClick) {
-                        return true;
-                    }
-                } else {
-                    return true;
-                }
-            }
-        }
-        break;
-    default:
-        break;
-    }
     if (watched == _fiberNameLabel && event->type() == QEvent::Resize) {
         updateFiberNameLabel();
     }
@@ -3138,81 +3203,102 @@ bool LineAnnotationDialog::eventFilter(QObject* watched, QEvent* event)
     return QMainWindow::eventFilter(watched, event);
 }
 
-void LineAnnotationDialog::updateFixedStripGeometry()
+void LineAnnotationDialog::updateOverviewBar()
 {
-    if (!_fixedStripViewer || !_hasGeneratedViews) {
+    auto* bar = static_cast<LineAnnotationOverviewBar*>(_overviewBar.data());
+    if (!bar || !_hasGeneratedViews) {
         return;
     }
-    auto* quad = dynamic_cast<QuadSurface*>(_fixedStripViewer->currentSurface());
-    if (!quad) {
-        return;
-    }
-    const cv::Size size = quad->size();
-    if (size.width <= 0 || size.height <= 0) {
-        return;
-    }
-    auto* content = centralWidget();
-    const int panelWidth = content ? content->width() : width();
-    constexpr int kFixedStripMarginPx = 8;
-    // Height cap: never zoom in beyond what a reference-length (in vx) annotation
-    // gets at fit-to-width. The strip has one column per line sample, so convert
-    // the vx reference into columns via the line-point spacing. Shorter annotations
-    // render narrower than the panel and stay horizontally centered (surfacePtr
-    // 0,0) with wider side margins.
-    constexpr double kFixedStripReferenceLengthVx = 20000.0;
-    float referenceCols = static_cast<float>(size.width);
-    const double spacingVx =
-        vc3d::line_annotation::medianGeneratedLinePointSpacing(_generatedViews.linePoints);
-    if (std::isfinite(spacingVx) && spacingVx > 1.0e-6) {
-        referenceCols = static_cast<float>(kFixedStripReferenceLengthVx / spacingVx);
-    }
-    const float innerWidth =
-        static_cast<float>(std::max(1, panelWidth - 2 * kFixedStripMarginPx));
-    const float zoom = std::clamp(
-        innerWidth / std::max(static_cast<float>(size.width), referenceCols),
-        0.002f,
-        16.0f);
-    const int panelHeight =
-        static_cast<int>(std::lround(static_cast<double>(size.height) * zoom)) +
-        2 * kFixedStripMarginPx;
-    _fixedStripViewer->setFixedHeight(panelHeight);
 
-    CChunkedVolumeViewer::CameraState camera = _fixedStripViewer->cameraState();
-    camera.surfacePtrX = 0.0f;
-    camera.surfacePtrY = 0.0f;
-    camera.zOffset = 0.0f;
-    camera.zOffsetWorldDir = {0, 0, 0};
-    camera.scale = zoom;
-    _fixedStripViewer->applyCameraState(camera, false);
+    std::vector<LineAnnotationOverviewBar::ControlDot> dots;
+    dots.reserve(_generatedViews.controlPoints.size());
+    for (const auto& control : _generatedViews.controlPoints) {
+        if (!std::isfinite(control.linePosition)) {
+            continue;
+        }
+        LineAnnotationOverviewBar::ControlDot dot;
+        dot.linePosition = control.linePosition;
+        // Same state palette as the cut-view overlays.
+        if (control.isLinkCandidate) {
+            dot.color = QColor(60, 235, 120);
+        } else if (control.hasPendingLinks) {
+            dot.color = QColor(80, 150, 255);
+        } else if (control.hasBranches) {
+            dot.color = QColor(210, 95, 255);
+        } else {
+            dot.color = QColor(255, 230, 0);
+        }
+        dot.radius = control.isSeed ? 6.0 : 4.5;
+        dots.push_back(dot);
+    }
+    bar->setLineData(_generatedViews.linePoints.size(), std::move(dots));
+
+    QColor markerColor(0, 245, 255);
+    switch (currentLineMarkerState()) {
+    case vc3d::line_annotation::GeneratedCurrentLineMarkerState::Allowed:
+        markerColor = QColor(40, 220, 120);
+        break;
+    case vc3d::line_annotation::GeneratedCurrentLineMarkerState::Blocked:
+        markerColor = QColor(255, 70, 70);
+        break;
+    default:
+        break;
+    }
+    bar->setCurrentPosition(_currentLinePosition, markerColor);
 }
 
-void LineAnnotationDialog::snapPanesToFixedStripCursor()
+void LineAnnotationDialog::forwardOverviewControlContextMenu(double linePosition,
+                                                             QPoint globalPos)
 {
-    if (!_hasGeneratedViews || !_fixedStripViewer) {
+    if (!_hasGeneratedViews || _stripViewers.empty()) {
         return;
     }
-    auto* view = _fixedStripViewer->graphicsView();
-    auto* viewport = view ? view->viewport() : nullptr;
-    if (!viewport) {
+    CChunkedVolumeViewer* strip = _stripViewers.front().data();
+    auto* quad = strip ? dynamic_cast<QuadSurface*>(strip->currentSurface()) : nullptr;
+    auto* view = strip ? strip->graphicsView() : nullptr;
+    if (!quad || !view) {
         return;
     }
-    const QPoint viewportPos = viewport->mapFromGlobal(QCursor::pos());
-    if (!viewport->rect().contains(viewportPos)) {
+    const QPointF scenePoint = stripLinePositionToScene(strip, quad, linePosition);
+    if (!std::isfinite(scenePoint.x()) || !std::isfinite(scenePoint.y())) {
         return;
     }
-    const double position =
-        linePositionFromStripScene(_fixedStripViewer, view->mapToScene(viewportPos));
-    if (!std::isfinite(position)) {
+    // Emit the strip view's own context-menu signal: CWindow routes it through
+    // the controller, which supplies link-candidate state and shows the same
+    // menu an in-viewer Ctrl+right-click would. The synthesized scene point
+    // round-trips to the clicked control point's line position, and the menu
+    // pops at the overview-bar cursor via globalPos.
+    QMetaObject::invokeMethod(
+        view,
+        "sendAnnotationContextMenuRequested",
+        Qt::DirectConnection,
+        Q_ARG(QPointF, scenePoint),
+        Q_ARG(QPoint, globalPos),
+        Q_ARG(Qt::KeyboardModifiers, Qt::KeyboardModifiers(Qt::ControlModifier)));
+}
+
+void LineAnnotationDialog::snapPanesToOverviewCursor()
+{
+    auto* bar = static_cast<LineAnnotationOverviewBar*>(_overviewBar.data());
+    if (!_hasGeneratedViews || !bar) {
         return;
     }
-    setCurrentLinePosition(position);
+    const QPoint localPos = bar->mapFromGlobal(QCursor::pos());
+    if (!bar->rect().contains(localPos)) {
+        return;
+    }
+    const auto position = bar->linePositionAtLocalX(localPos.x());
+    if (!position) {
+        return;
+    }
+    setCurrentLinePosition(*position);
     // Recenter the bottom strip on the snapped position (keeping its zoom), so the
     // current-position marker can't end up outside a zoomed-in viewport.
     for (const auto& stripViewer : _stripViewers) {
-        if (!stripViewer || stripViewer == _fixedStripViewer) {
+        if (!stripViewer) {
             continue;
         }
-        if (const auto center = generatedStripSurfaceCenter(stripViewer, position)) {
+        if (const auto center = generatedStripSurfaceCenter(stripViewer, *position)) {
             CChunkedVolumeViewer::CameraState camera = stripViewer->cameraState();
             camera.surfacePtrX = (*center)[0];
             camera.surfacePtrY = (*center)[1];

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -964,6 +964,7 @@ bool LineAnnotationDialog::setGeneratedRows(
     _currentCutOverlaySwapPending = false;
     _sideCutOverlaySwapPending = false;
     _stripOverlaySwapPending = false;
+    _pendingPlacementFocus.reset();
     clearFastGeneratedOverlayItemRefs();
     _currentCutViewer = nullptr;
     _sideCutViewer = nullptr;
@@ -1138,6 +1139,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         // surfaces (hooks below), so overlays and image update together.
         _heldGeneratedViews = _generatedViews;
         _heldControlIndex = _generatedControlIndex;
+        _heldLinePosition = _currentLinePosition;
         _currentCutOverlaySwapPending = true;
         _sideCutOverlaySwapPending = true;
         _stripOverlaySwapPending = true;
@@ -1156,8 +1158,24 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                 _generatedViews.controlPoints);
         const double maxLinePosition =
             static_cast<double>(_generatedViews.linePoints.size() - 1);
+        // After a control-point placement, land the current position on the
+        // control point that resulted from the click (positions renumber when
+        // the line is re-optimized, so the old numeric position is ambiguous).
+        double targetLinePosition = previousLinePosition;
+        if (_pendingPlacementFocus) {
+            if (const auto nearest =
+                    vc3d::line_annotation::nearestGeneratedControlPointIndex(
+                        _generatedViews.controlPoints, *_pendingPlacementFocus)) {
+                const double controlPosition =
+                    _generatedViews.controlPoints[*nearest].linePosition;
+                if (std::isfinite(controlPosition)) {
+                    targetLinePosition = controlPosition;
+                }
+            }
+            _pendingPlacementFocus.reset();
+        }
         _currentLinePosition =
-            std::clamp(previousLinePosition, 0.0, maxLinePosition);
+            std::clamp(targetLinePosition, 0.0, maxLinePosition);
         _currentCutNormalOffsetVx = 0.0;
         _sideCutNormalOffsetVx = 0.0;
         _currentCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
@@ -1174,6 +1192,9 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         _sideCutViewer->renderVisible(true, "line annotation views updated");
         for (const auto& stripViewer : _stripViewers) {
             if (stripViewer) {
+                // Bump the strip's geometry epoch too, so the swap hooks below
+                // can tell post-update frames from stale in-flight ones.
+                stripViewer->markSurfaceGeometryChanged();
                 stripViewer->renderVisible(true, "line annotation views updated");
             }
         }
@@ -1181,9 +1202,11 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         // (onSurfaceChanged does _scene->clear()), deleting the pooled overlay
         // items; drop our cached pointers so the rebuild recreates them.
         clearFastGeneratedOverlayItemRefs();
-        // One-shot per pane: swap that pane to the new overlays only once it
-        // has adopted a rendered frame (renderFrameCompleted fires exactly at
-        // frame adoption); until then rebuilds draw from the held views.
+        // Per pane: swap to the new overlays only once the pane DISPLAYS a
+        // frame of the post-update geometry. renderFrameCompleted fires at
+        // every frame adoption, and a render submitted before the placement
+        // can adopt first -- so gate on the displayed frame's geometry epoch
+        // matching the viewer's current one instead of on the first adoption.
         const auto hookOverlaySwap = [this](CChunkedVolumeViewer* viewer,
                                             bool LineAnnotationDialog::*pendingFlag) {
             if (!viewer) {
@@ -1195,11 +1218,16 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                 viewer,
                 &CChunkedVolumeViewer::renderFrameCompleted,
                 this,
-                [this, connection, pendingFlag](std::uint64_t, double) {
-                    QObject::disconnect(*connection);
+                [this, viewer, connection, pendingFlag](std::uint64_t, double) {
                     if (_closing) {
+                        QObject::disconnect(*connection);
                         return;
                     }
+                    if (viewer->displayedSurfaceGeometryEpoch() !=
+                        viewer->surfaceGeometryEpoch()) {
+                        return;  // stale in-flight frame; keep waiting
+                    }
+                    QObject::disconnect(*connection);
                     this->*pendingFlag = false;
                     rebuildGeneratedStaticStripOverlays();
                     rebuildGeneratedDynamicOverlays();
@@ -1282,6 +1310,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     _currentCutOverlaySwapPending = false;
     _sideCutOverlaySwapPending = false;
     _stripOverlaySwapPending = false;
+    _pendingPlacementFocus.reset();
     clearFastGeneratedOverlayItemRefs();
     _currentCutViewer = nullptr;
     _sideCutViewer = nullptr;
@@ -1390,6 +1419,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                         return;
                     }
                     setCurrentCutFollowsStripMouse(true);
+                    _pendingPlacementFocus = volumePoint;
                     emit generatedControlPointRequested(_generatedViews.currentCutName,
                                                         volumePoint,
                                                         _currentLinePosition);
@@ -1444,6 +1474,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                         return;
                     }
                     setCurrentCutFollowsStripMouse(true);
+                    _pendingPlacementFocus = volumePoint;
                     emit generatedControlPointRequested(_generatedViews.sideCutName,
                                                         volumePoint,
                                                         _currentLinePosition);
@@ -1545,6 +1576,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                             if (!controlPointPlacementAllowedAt(position)) {
                                 return;
                             }
+                            _pendingPlacementFocus = volumePoint;
                             emit generatedControlPointRequested(surfaceName, volumePoint, position);
                         }
                     }
@@ -2527,6 +2559,8 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         QuadSurface* quad = _stripOverlaySwapPending
             ? _heldGeneratedViews.lineSideSlice.get()
             : dynamic_cast<QuadSurface*>(viewer->currentSurface());
+        const double stripPosition =
+            _stripOverlaySwapPending ? _heldLinePosition : _currentLinePosition;
         if (!entry || !quad) {
             continue;
         }
@@ -2539,7 +2573,7 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         const QPointF currentScenePoint =
             vc3d::line_annotation::generatedStripLinePositionToScene(viewer,
                                                                       quad,
-                                                                      _currentLinePosition);
+                                                                      stripPosition);
         auto* view = viewer->graphicsView();
         auto* viewport = view ? view->viewport() : nullptr;
         if (std::isfinite(currentScenePoint.x()) &&
@@ -2642,9 +2676,11 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
             _sideCutOverlaySwapPending ? _heldGeneratedViews : _generatedViews;
         const auto& sideIndex =
             _sideCutOverlaySwapPending ? _heldControlIndex : _generatedControlIndex;
+        const double sidePosition =
+            _sideCutOverlaySwapPending ? _heldLinePosition : _currentLinePosition;
         GeneratedOverlay sideOverlay = zSliceOverlay(sideViews,
                                                      sideIndex,
-                                                     _currentLinePosition,
+                                                     sidePosition,
                                                      true,
                                                      _sideCutViewer,
                                                      _generatedViews.sideCutSurface.get());
@@ -2654,7 +2690,7 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         // position so the highlight tracks the cursor as it moves along the line. Use the
         // (possibly held) sideViews line points so the marker matches the displayed image.
         const cv::Vec3f currentPoint = vc3d::line_annotation::interpolatedGeneratedLinePoint(
-            sideViews.linePoints, _currentLinePosition);
+            sideViews.linePoints, sidePosition);
         if (finitePoint(currentPoint)) {
             sideOverlay.pointMarker = currentPoint;
             sideOverlay.emphasizedPointMarker = true;
@@ -2790,9 +2826,20 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
                                  _fastCurrentCutOverlayItems.fiberIntersectionConnectors});
     }
 
+    // During an in-place update, draw from the held pre-update views until this
+    // pane's first re-optimized frame lands.
+    const GeneratedViews& cutViews =
+        _currentCutOverlaySwapPending ? _heldGeneratedViews : _generatedViews;
+    const auto& cutIndex =
+        _currentCutOverlaySwapPending ? _heldControlIndex : _generatedControlIndex;
+    const double cutPosition =
+        _currentCutOverlaySwapPending ? _heldLinePosition : _currentLinePosition;
+
     QPointF centerScenePoint;
     if (normalOffsetActive(_currentCutNormalOffsetVx)) {
-        centerScenePoint = viewer->volumeToScene(interpolatedLinePoint(_currentLinePosition));
+        centerScenePoint = viewer->volumeToScene(
+            vc3d::line_annotation::interpolatedGeneratedLinePoint(
+                cutViews.linePoints, cutPosition));
     } else {
         centerScenePoint = viewer->surfaceCoordsToScene(0.0f, 0.0f);
     }
@@ -2802,13 +2849,6 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     }
     _fastCurrentCutOverlayItems.centerPoint->setPath(centerPath);
 
-    // During an in-place update, draw from the held pre-update views until this
-    // pane's first re-optimized frame lands.
-    const GeneratedViews& cutViews =
-        _currentCutOverlaySwapPending ? _heldGeneratedViews : _generatedViews;
-    const auto& cutIndex =
-        _currentCutOverlaySwapPending ? _heldControlIndex : _generatedControlIndex;
-
     QPainterPath controlPath;
     QPainterPath seedPath;
     QPainterPath linkCandidatePath;
@@ -2816,8 +2856,8 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     QPainterPath pendingBranchControlPath;
     const double lineRadius =
         std::max(0.5, (_viewerManager ? _viewerManager->zScrollSensitivity() : 1.0) * 0.5);
-    const double lower = _currentLinePosition - lineRadius;
-    const double upper = _currentLinePosition + lineRadius;
+    const double lower = cutPosition - lineRadius;
+    const double upper = cutPosition + lineRadius;
     const auto& indices = cutIndex.sortedControlIndices;
     const auto positionForIndex = [&cutViews](size_t controlIndex) {
         return cutViews.controlPoints[controlIndex].linePosition;

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -832,6 +832,15 @@ bool LineAnnotationDialog::setGeneratedRows(
     }
 
     clearGeneratedOverlayRefreshConnections();
+    // Drop all viewer references BEFORE deleting the widgets: destruction
+    // delivers events through our eventFilter, which must not dereference a
+    // half-destroyed viewer (QPointers only clear once ~QObject runs).
+    _panes.clear();
+    _stripViewers.clear();
+    _fixedStripViewer = nullptr;
+    clearFastGeneratedOverlayItemRefs();
+    _currentCutViewer = nullptr;
+    _sideCutViewer = nullptr;
     _suppressPaneClosed = true;
     if (_mdiArea) {
         _layout->removeWidget(_mdiArea);
@@ -839,12 +848,6 @@ bool LineAnnotationDialog::setGeneratedRows(
         _mdiArea = nullptr;
     }
     _suppressPaneClosed = false;
-    _panes.clear();
-    _stripViewers.clear();
-    _fixedStripViewer = nullptr;
-    clearFastGeneratedOverlayItemRefs();
-    _currentCutViewer = nullptr;
-    _sideCutViewer = nullptr;
     _hasGeneratedViews = false;
     _currentCutManualRotation = cv::Matx33f::eye();
     _currentCutManualRotationActive = false;
@@ -1038,6 +1041,16 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     }
 
     clearGeneratedOverlayRefreshConnections();
+    // Drop all viewer references BEFORE deleting the widgets: destroying a
+    // viewer synchronously delivers events (ChildRemoved/Hide/...) through our
+    // eventFilter, which must not dereference a half-destroyed viewer via
+    // _fixedStripViewer/_stripViewers (QPointers only clear once ~QObject runs).
+    _panes.clear();
+    _stripViewers.clear();
+    _fixedStripViewer = nullptr;
+    clearFastGeneratedOverlayItemRefs();
+    _currentCutViewer = nullptr;
+    _sideCutViewer = nullptr;
     _suppressPaneClosed = true;
     if (_mdiArea) {
         _layout->removeWidget(_mdiArea);
@@ -1053,12 +1066,6 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     }
     _generatedContainers.clear();
     _generatedTopWidget = nullptr;
-    _panes.clear();
-    _stripViewers.clear();
-    _fixedStripViewer = nullptr;
-    clearFastGeneratedOverlayItemRefs();
-    _currentCutViewer = nullptr;
-    _sideCutViewer = nullptr;
 
     _generatedViews = views;
     _linePointsd.clear();
@@ -3012,30 +3019,36 @@ bool LineAnnotationDialog::eventFilter(QObject* watched, QEvent* event)
 {
     // The fixed top strip is display-only: swallow every mouse/wheel interaction
     // except the Ctrl+right-click context menu (line position snapping is handled
-    // by the "R" shortcut instead of mouse-follow).
-    if (_fixedStripViewer) {
-        auto* view = _fixedStripViewer->graphicsView();
-        if (view && (watched == view || watched == view->viewport())) {
-            switch (event->type()) {
-            case QEvent::Wheel:
-            case QEvent::MouseMove:
-            case QEvent::MouseButtonDblClick:
-                return true;
-            case QEvent::MouseButtonPress:
-            case QEvent::MouseButtonRelease: {
-                auto* mouseEvent = static_cast<QMouseEvent*>(event);
-                const bool contextClick =
-                    mouseEvent->button() == Qt::RightButton &&
-                    mouseEvent->modifiers().testFlag(Qt::ControlModifier);
-                if (!contextClick) {
+    // by the "R" shortcut instead of mouse-follow). Check the event type BEFORE
+    // touching the viewer: widget destruction delivers events (ChildRemoved,
+    // Hide, ...) through this filter while the viewer is half-destroyed, and
+    // calling into it then crashes; input events can't arrive at that point.
+    switch (event->type()) {
+    case QEvent::Wheel:
+    case QEvent::MouseMove:
+    case QEvent::MouseButtonDblClick:
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonRelease:
+        if (_fixedStripViewer) {
+            auto* view = _fixedStripViewer->graphicsView();
+            if (view && (watched == view || watched == view->viewport())) {
+                if (event->type() == QEvent::MouseButtonPress ||
+                    event->type() == QEvent::MouseButtonRelease) {
+                    auto* mouseEvent = static_cast<QMouseEvent*>(event);
+                    const bool contextClick =
+                        mouseEvent->button() == Qt::RightButton &&
+                        mouseEvent->modifiers().testFlag(Qt::ControlModifier);
+                    if (!contextClick) {
+                        return true;
+                    }
+                } else {
                     return true;
                 }
-                break;
-            }
-            default:
-                break;
             }
         }
+        break;
+    default:
+        break;
     }
     if (watched == _fiberNameLabel && event->type() == QEvent::Resize) {
         updateFiberNameLabel();

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -2683,7 +2683,7 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
                                                      sidePosition,
                                                      true,
                                                      _sideCutViewer,
-                                                     _generatedViews.sideCutSurface.get());
+                                                     sideViews.sideCutSurface.get());
         sideOverlay.linePoints = sideViews.linePoints;
         // Highlight the live cursor position on the line. The cross-slice overlay's emphasized
         // marker otherwise sits at the static focus/seed point; override it to the current

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -961,6 +961,9 @@ bool LineAnnotationDialog::setGeneratedRows(
     _panes.clear();
     _stripViewers.clear();
     _overviewBar = nullptr;
+    _currentCutOverlaySwapPending = false;
+    _sideCutOverlaySwapPending = false;
+    _stripOverlaySwapPending = false;
     clearFastGeneratedOverlayItemRefs();
     _currentCutViewer = nullptr;
     _sideCutViewer = nullptr;
@@ -1130,6 +1133,15 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         _generatedViews.sideCutName == views.sideCutName &&
         _generatedViews.lineSurfaceName == views.lineSurfaceName &&
         _generatedViews.lineSideSliceName == views.lineSideSliceName) {
+        // Snapshot the on-screen view data: each pane keeps drawing its overlays
+        // from this until it adopts a rendered frame of the re-optimized
+        // surfaces (hooks below), so overlays and image update together.
+        _heldGeneratedViews = _generatedViews;
+        _heldControlIndex = _generatedControlIndex;
+        _currentCutOverlaySwapPending = true;
+        _sideCutOverlaySwapPending = true;
+        _stripOverlaySwapPending = true;
+
         const double previousLinePosition = _currentLinePosition;
         _generatedViews = views;
         _linePointsd.clear();
@@ -1169,6 +1181,36 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         // (onSurfaceChanged does _scene->clear()), deleting the pooled overlay
         // items; drop our cached pointers so the rebuild recreates them.
         clearFastGeneratedOverlayItemRefs();
+        // One-shot per pane: swap that pane to the new overlays only once it
+        // has adopted a rendered frame (renderFrameCompleted fires exactly at
+        // frame adoption); until then rebuilds draw from the held views.
+        const auto hookOverlaySwap = [this](CChunkedVolumeViewer* viewer,
+                                            bool LineAnnotationDialog::*pendingFlag) {
+            if (!viewer) {
+                this->*pendingFlag = false;
+                return;
+            }
+            auto connection = std::make_shared<QMetaObject::Connection>();
+            *connection = connect(
+                viewer,
+                &CChunkedVolumeViewer::renderFrameCompleted,
+                this,
+                [this, connection, pendingFlag](std::uint64_t, double) {
+                    QObject::disconnect(*connection);
+                    if (_closing) {
+                        return;
+                    }
+                    this->*pendingFlag = false;
+                    rebuildGeneratedStaticStripOverlays();
+                    rebuildGeneratedDynamicOverlays();
+                });
+        };
+        hookOverlaySwap(_currentCutViewer.data(),
+                        &LineAnnotationDialog::_currentCutOverlaySwapPending);
+        hookOverlaySwap(_sideCutViewer.data(),
+                        &LineAnnotationDialog::_sideCutOverlaySwapPending);
+        hookOverlaySwap(_stripViewers.front().data(),
+                        &LineAnnotationDialog::_stripOverlaySwapPending);
         updatePauseIndicator();
         updateOptimizationStatusIndicator();
         rebuildGeneratedOverlays();
@@ -1237,6 +1279,9 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     _panes.clear();
     _stripViewers.clear();
     _overviewBar = nullptr;
+    _currentCutOverlaySwapPending = false;
+    _sideCutOverlaySwapPending = false;
+    _stripOverlaySwapPending = false;
     clearFastGeneratedOverlayItemRefs();
     _currentCutViewer = nullptr;
     _sideCutViewer = nullptr;
@@ -2325,18 +2370,21 @@ LineAnnotationDialog::GeneratedOverlay LineAnnotationDialog::staticStripOverlay(
     return vc3d::line_annotation::makeGeneratedStaticStripOverlay(_generatedViews);
 }
 
-LineAnnotationDialog::GeneratedOverlay LineAnnotationDialog::zSliceOverlay(double linePosition,
-                                                                           bool emphasized,
-                                                                           CChunkedVolumeViewer* viewer,
-                                                                           PlaneSurface* plane) const
+LineAnnotationDialog::GeneratedOverlay LineAnnotationDialog::zSliceOverlay(
+    const GeneratedViews& views,
+    const vc3d::line_annotation::GeneratedControlPointLinePositionIndex& controlIndex,
+    double linePosition,
+    bool emphasized,
+    CChunkedVolumeViewer* viewer,
+    PlaneSurface* plane) const
 {
     (void)emphasized;
     return vc3d::line_annotation::makeGeneratedCrossSliceControlOverlayForPlane(
-        _generatedViews,
+        views,
         linePosition,
         viewer,
         plane,
-        &_generatedControlIndex);
+        &controlIndex);
 }
 
 void LineAnnotationDialog::rebuildGeneratedStaticStripOverlays()
@@ -2354,8 +2402,13 @@ void LineAnnotationDialog::rebuildGeneratedStaticStripOverlays()
             continue;
         }
         const std::string key = _generatedViews.lineSideSliceName;
-        GeneratedOverlay strip = staticStripOverlay();
-        strip.fiberIntersections = _generatedViews.fiberIntersections;
+        // While an in-place update waits for the strip's first re-optimized
+        // frame, keep drawing the pre-update overlay.
+        const GeneratedViews& stripViews =
+            _stripOverlaySwapPending ? _heldGeneratedViews : _generatedViews;
+        GeneratedOverlay strip =
+            vc3d::line_annotation::makeGeneratedStaticStripOverlay(stripViews);
+        strip.fiberIntersections = stripViews.fiberIntersections;
         applyOverlayForViewer(staticStripOverlayKey(key), viewer, strip);
     }
 
@@ -2577,12 +2630,19 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     if (_sideCutViewer && _generatedViews.sideCutSurface) {
         // Draw the full line on the side view by projecting each line point onto the plane and
         // connecting consecutive points (linear interpolation), in addition to the current-position
-        // marker and nearby control points from the cross-slice overlay.
-        GeneratedOverlay sideOverlay = zSliceOverlay(_currentLinePosition,
+        // marker and nearby control points from the cross-slice overlay. During an in-place
+        // update, draw from the held pre-update views until this pane's new frame lands.
+        const GeneratedViews& sideViews =
+            _sideCutOverlaySwapPending ? _heldGeneratedViews : _generatedViews;
+        const auto& sideIndex =
+            _sideCutOverlaySwapPending ? _heldControlIndex : _generatedControlIndex;
+        GeneratedOverlay sideOverlay = zSliceOverlay(sideViews,
+                                                     sideIndex,
+                                                     _currentLinePosition,
                                                      true,
                                                      _sideCutViewer,
                                                      _generatedViews.sideCutSurface.get());
-        sideOverlay.linePoints = _generatedViews.linePoints;
+        sideOverlay.linePoints = sideViews.linePoints;
         // Highlight the live cursor position on the line. The cross-slice overlay's emphasized
         // marker otherwise sits at the static focus/seed point; override it to the current
         // position so the highlight tracks the cursor as it moves along the line.
@@ -2734,6 +2794,13 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     }
     _fastCurrentCutOverlayItems.centerPoint->setPath(centerPath);
 
+    // During an in-place update, draw from the held pre-update views until this
+    // pane's first re-optimized frame lands.
+    const GeneratedViews& cutViews =
+        _currentCutOverlaySwapPending ? _heldGeneratedViews : _generatedViews;
+    const auto& cutIndex =
+        _currentCutOverlaySwapPending ? _heldControlIndex : _generatedControlIndex;
+
     QPainterPath controlPath;
     QPainterPath seedPath;
     QPainterPath linkCandidatePath;
@@ -2743,9 +2810,9 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         std::max(0.5, (_viewerManager ? _viewerManager->zScrollSensitivity() : 1.0) * 0.5);
     const double lower = _currentLinePosition - lineRadius;
     const double upper = _currentLinePosition + lineRadius;
-    const auto& indices = _generatedControlIndex.sortedControlIndices;
-    const auto positionForIndex = [this](size_t controlIndex) {
-        return _generatedViews.controlPoints[controlIndex].linePosition;
+    const auto& indices = cutIndex.sortedControlIndices;
+    const auto positionForIndex = [&cutViews](size_t controlIndex) {
+        return cutViews.controlPoints[controlIndex].linePosition;
     };
     const auto lowerIt = std::lower_bound(
         indices.begin(),
@@ -2756,10 +2823,10 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         });
     for (auto it = lowerIt; it != indices.end(); ++it) {
         const size_t controlIndex = *it;
-        if (controlIndex >= _generatedViews.controlPoints.size()) {
+        if (controlIndex >= cutViews.controlPoints.size()) {
             continue;
         }
-        const auto& control = _generatedViews.controlPoints[controlIndex];
+        const auto& control = cutViews.controlPoints[controlIndex];
         if (!std::isfinite(control.linePosition)) {
             continue;
         }
@@ -2797,14 +2864,14 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     QPainterPath branchLinkFiberIntersectionPath;
     QPainterPath pendingBranchLinkFiberIntersectionPath;
     QPainterPath fiberIntersectionConnectorPath;
-    auto* currentCutPlane = _generatedViews.currentCutSurface.get();
+    auto* currentCutPlane = cutViews.currentCutSurface.get();
     const std::optional<float> intersectionThreshold =
-        (currentCutPlane && !_generatedViews.fiberIntersections.empty())
+        (currentCutPlane && !cutViews.fiberIntersections.empty())
             ? vc3d::line_annotation::generatedCrossSliceControlPointDistanceThreshold(viewer)
             : std::nullopt;
     if (intersectionThreshold) {
         constexpr qreal kIntersectionArm = 7.5;
-        for (const auto& intersection : _generatedViews.fiberIntersections) {
+        for (const auto& intersection : cutViews.fiberIntersections) {
             if (!finitePoint(intersection.point)) {
                 continue;
             }

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -2520,7 +2520,13 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         }
         const std::string key = _generatedViews.lineSideSliceName;
         auto* entry = ensureStripItems(i, viewer, key);
-        auto* quad = dynamic_cast<QuadSurface*>(viewer->currentSurface());
+        // While this pane's overlay swap is pending, map the current-position
+        // marker (and span labels) through the held pre-update strip surface so
+        // they stay consistent with the stale image instead of jumping a beat
+        // ahead of it.
+        QuadSurface* quad = _stripOverlaySwapPending
+            ? _heldGeneratedViews.lineSideSlice.get()
+            : dynamic_cast<QuadSurface*>(viewer->currentSurface());
         if (!entry || !quad) {
             continue;
         }
@@ -2645,8 +2651,10 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         sideOverlay.linePoints = sideViews.linePoints;
         // Highlight the live cursor position on the line. The cross-slice overlay's emphasized
         // marker otherwise sits at the static focus/seed point; override it to the current
-        // position so the highlight tracks the cursor as it moves along the line.
-        const cv::Vec3f currentPoint = interpolatedLinePoint(_currentLinePosition);
+        // position so the highlight tracks the cursor as it moves along the line. Use the
+        // (possibly held) sideViews line points so the marker matches the displayed image.
+        const cv::Vec3f currentPoint = vc3d::line_annotation::interpolatedGeneratedLinePoint(
+            sideViews.linePoints, _currentLinePosition);
         if (finitePoint(currentPoint)) {
             sideOverlay.pointMarker = currentPoint;
             sideOverlay.emphasizedPointMarker = true;

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <map>
 #include <limits>
+#include <optional>
 #include <string>
 #include <vector>
 #include <utility>
@@ -350,9 +351,16 @@ private:
     // together with the revised image instead of a beat earlier on the stale one.
     GeneratedViews _heldGeneratedViews;
     vc3d::line_annotation::GeneratedControlPointLinePositionIndex _heldControlIndex;
+    // Line position the held overlays were drawn at; panes with a pending swap
+    // keep their position markers here until their new frame lands.
+    double _heldLinePosition = 0.0;
     bool _currentCutOverlaySwapPending = false;
     bool _sideCutOverlaySwapPending = false;
     bool _stripOverlaySwapPending = false;
+    // Volume point of the most recent control-point placement click; the next
+    // in-place update moves the current line position onto the control point
+    // nearest to it, so the marker lands on the new point with the new image.
+    std::optional<cv::Vec3f> _pendingPlacementFocus;
     std::vector<QPointer<CChunkedVolumeViewer>> _stripViewers;
     // Schematic fixed-height bar above the cut views: a straight line with the
     // control points (LineAnnotationOverviewBar, file-local in the .cpp).

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -260,7 +260,9 @@ private:
     void clearControlPointContextPreview(const std::string& surfaceName,
                                          CChunkedVolumeViewer* viewer);
     GeneratedOverlay staticStripOverlay() const;
-    GeneratedOverlay zSliceOverlay(double linePosition,
+    GeneratedOverlay zSliceOverlay(const GeneratedViews& views,
+                                   const vc3d::line_annotation::GeneratedControlPointLinePositionIndex& controlIndex,
+                                   double linePosition,
                                    bool emphasized,
                                    CChunkedVolumeViewer* viewer,
                                    PlaneSurface* plane) const;
@@ -342,6 +344,15 @@ private:
     FastCurrentCutOverlayItems _fastCurrentCutOverlayItems;
     QPointer<CChunkedVolumeViewer> _currentCutViewer;
     QPointer<CChunkedVolumeViewer> _sideCutViewer;
+    // In-place updates: keep drawing each pane's overlays from the pre-update
+    // views until THAT pane adopts its first rendered frame of the re-optimized
+    // surfaces (renderFrameCompleted), so a newly placed control point appears
+    // together with the revised image instead of a beat earlier on the stale one.
+    GeneratedViews _heldGeneratedViews;
+    vc3d::line_annotation::GeneratedControlPointLinePositionIndex _heldControlIndex;
+    bool _currentCutOverlaySwapPending = false;
+    bool _sideCutOverlaySwapPending = false;
+    bool _stripOverlaySwapPending = false;
     std::vector<QPointer<CChunkedVolumeViewer>> _stripViewers;
     // Schematic fixed-height bar above the cut views: a straight line with the
     // control points (LineAnnotationOverviewBar, file-local in the .cpp).

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -276,11 +276,16 @@ private:
                                      QuadSurface* surface,
                                      double linePosition) const;
     bool handleKeyPress(QKeyEvent* event);
-    // Fixed top strip: fit-to-width zoom + auto height, recomputed on resize.
-    void updateFixedStripGeometry();
+    // Pushes line length, control dots, and the current-position marker to the
+    // schematic overview bar.
+    void updateOverviewBar();
+    // Ctrl+right-click on an overview-bar control point: synthesize the matching
+    // bottom-strip scene point and route through its context-menu signal so the
+    // controller-supplied menu behaves exactly like an in-viewer click.
+    void forwardOverviewControlContextMenu(double linePosition, QPoint globalPos);
     // "R": one-shot jump of the other panes to the cursor's line position on the
-    // fixed top strip (works regardless of follow mode; leaves it unchanged).
-    void snapPanesToFixedStripCursor();
+    // overview bar (works regardless of follow mode; leaves it unchanged).
+    void snapPanesToOverviewCursor();
     // Pause badge on the bottom strip while mouse-follow is toggled off (Space).
     void updatePauseIndicator();
     // "optimized"/"not optimized" badge in the bottom strip's top-right corner.
@@ -338,9 +343,9 @@ private:
     QPointer<CChunkedVolumeViewer> _currentCutViewer;
     QPointer<CChunkedVolumeViewer> _sideCutViewer;
     std::vector<QPointer<CChunkedVolumeViewer>> _stripViewers;
-    // _stripViewers[0], shown as a fixed-height, non-interactive panel above the
-    // cut views instead of inside the strip splitter.
-    QPointer<CChunkedVolumeViewer> _fixedStripViewer;
+    // Schematic fixed-height bar above the cut views: a straight line with the
+    // control points (LineAnnotationOverviewBar, file-local in the .cpp).
+    QPointer<QWidget> _overviewBar;
     QPointer<QLabel> _pauseIndicator;
     GeneratedViews _generatedViews;
     // Double-precision copy of _generatedViews.linePoints, built once when views are

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -2725,12 +2725,18 @@ void CChunkedVolumeViewer::submitRender(const char* reason, std::source_location
     if (!busy) {
         resizeFramebuffer();
     }
-    const int fbW = !_framebuffer.isNull()
-        ? _framebuffer.width()
-        : (_view && _view->viewport() ? std::max(1, _view->viewport()->width()) : 1);
-    const int fbH = !_framebuffer.isNull()
-        ? _framebuffer.height()
-        : (_view && _view->viewport() ? std::max(1, _view->viewport()->height()) : 1);
+    // Capture the job at the VIEWPORT size, never the displayed framebuffer's:
+    // _framebuffer may hold a stale-size result adopted while the pane was
+    // resizing (renders in flight across a layout change), and sizing new jobs
+    // from it re-captures the stale size on every busy-time submit -- the pane
+    // then ping-pongs between the two sizes for as long as renders keep coming
+    // (visible as the image jittering up/down after a generated-view rebuild).
+    const int fbW = _view && _view->viewport()
+        ? std::max(1, _view->viewport()->width())
+        : (!_framebuffer.isNull() ? _framebuffer.width() : 1);
+    const int fbH = _view && _view->viewport()
+        ? std::max(1, _view->viewport()->height())
+        : (!_framebuffer.isNull() ? _framebuffer.height() : 1);
     auto job = captureRenderJob(reason, caller, surf, fbW, fbH, std::chrono::steady_clock::now());
     if (!job) {
         profile.setDetails("action=skip invalid_job");
@@ -2821,12 +2827,15 @@ void CChunkedVolumeViewer::finishRenderOnMainThread(std::shared_ptr<RenderResult
     if (!_pendingRenderJob) {
         auto surf = _surfWeak.lock();
         if (surf && _volume && _chunkArray) {
-            const int fbW = !_framebuffer.isNull()
-                ? _framebuffer.width()
-                : (_view && _view->viewport() ? std::max(1, _view->viewport()->width()) : 1);
-            const int fbH = !_framebuffer.isNull()
-                ? _framebuffer.height()
-                : (_view && _view->viewport() ? std::max(1, _view->viewport()->height()) : 1);
+            // Viewport size, not _framebuffer: the framebuffer was just replaced
+            // by this result, so sizing the staleness check from it would make a
+            // stale-size result always look "equivalent" and never catch up.
+            const int fbW = _view && _view->viewport()
+                ? std::max(1, _view->viewport()->width())
+                : (!_framebuffer.isNull() ? _framebuffer.width() : 1);
+            const int fbH = _view && _view->viewport()
+                ? std::max(1, _view->viewport()->height())
+                : (!_framebuffer.isNull() ? _framebuffer.height() : 1);
             auto latest = captureRenderJob("catch up after stale presentation",
                                            std::source_location::current(),
                                            surf,

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -229,6 +229,14 @@ public:
     bool isMeasurementActive() const;
     void clearMeasurement();
     void markSurfaceGeometryChanged();
+    // Geometry-epoch introspection: lets callers tell whether the currently
+    // DISPLAYED frame was rendered from the current surface geometry (stale
+    // in-flight frames adopt with an older epoch).
+    std::uint64_t surfaceGeometryEpoch() const { return _surfaceGeometryEpoch; }
+    std::uint64_t displayedSurfaceGeometryEpoch() const
+    {
+        return _displayedRenderJob ? _displayedRenderJob->surfaceGeometryEpoch : 0;
+    }
     void setShiftScrollOverride(ShiftScrollOverride override) { _shiftScrollOverride = std::move(override); }
 
     CVolumeViewerView* graphicsView() const override { return _view; }


### PR DESCRIPTION
Follow-up to #1286, replacing the closed #1288. Fixes the field-reported problems in the reworked line annotation GUI — the teardown SIGSEGV, the continuous "jitter" of pane contents, and the flash/jump on every control-point placement — and replaces the volume-rendered top strip with a schematic overview bar. All root-caused from crash reports and an fb-mapping trace, and verified interactively on a live vpkg through several rounds.

## Commits

1. **Teardown SIGSEGV fix**: rebuilding the generated views deleted the pane widgets while the dialog's cached viewer pointers still referenced them; destruction-cascade events reached `eventFilter`, which called into a half-destroyed viewer (QPointers only clear in `~QObject`) and jumped through a torn-down vtable. Viewer refs are now dropped before any widget deletion.

2. **Render fix — jobs sized from the viewport, not the displayed framebuffer** (root cause of the continuous jitter): a render in flight across a layout change gets adopted at the old pane size, and `submitRender` sized busy-time job captures from the displayed `_framebuffer` — re-propagating whichever stale size was on screen for as long as anything kept submitting. The fb-mapping trace showed a pane alternating between 2292x618 and 2292x573 results with an identical camera (a 22.5px wobble of image + overlays together). The "catch up after stale presentation" recovery was defeated by the same bug. Both capture sites now use the viewport size.

3. **In-place generated-view updates** (root cause of the per-placement blank/jump): every placement re-materializes the views, and the dialog responded by destroying and recreating all viewers. The controller re-registers the new surfaces under the same CState names and viewers adopt same-name swaps live, so when the pane set is unchanged the dialog now just refreshes its own state and re-renders — cameras, splitters, badges, and event filters survive, and user pan/zoom is preserved exactly across placements. (Follow-up commit: the surface swap clears each viewer's scene, so the pooled overlay-item refs are dropped for recreation.)

4. **Cut-plane pose carry-over**: re-materialization constructed the new cut planes at the seed point; live viewers rendered that pose for one frame before the dialog re-posed them (a flash back to the "original view" per placement). New planes now inherit the previous plane's pose so the `surfaceChanged` frame is visually continuous.

5. **Schematic overview bar**: the fixed top strip no longer renders volume data at all. It is a 48px bar drawing a straight line with the control points (same state palette as the cut views, larger seed dot) and the current-position marker; the annotation compresses horizontally as it grows. Hover + "R" snaps the other panes to the cursor's line position, and Ctrl+right-click near a control point opens the same controller-supplied context menu (routed by synthesizing the matching bottom-strip scene point through that view's context-menu signal); clicks away from a control point do nothing. This removes the strip viewer that needed fit-zoom management, input swallowing, and LOD care, along with all its render and chunk traffic.

6. **Per-pane overlay/image sync**: with in-place updates, new overlays previously appeared instantly while each pane's re-render was still in flight, so a placed control point landed on the stale image a beat before the image revised. The dialog now snapshots the pre-update views (including the line position, which the markers draw from); every overlay builder draws from the held copy until its pane **displays** a frame of the post-update geometry — gated on the viewer's surface-geometry epoch rather than first adoption, since renders submitted before the placement can adopt first. Placement clicks record the clicked volume point and the update moves the current position onto the resulting control point (positions renumber on re-optimization), so at swap time the position marker lands exactly on the new control point, together with the control point and the revised image. The overview bar intentionally still updates instantly as click feedback.

## Verification

Exercised on a live vpkg: repeated control-point placement with auto-reoptimize (previously crashed, then flashed, then jittered), long-session idling (previously developed continuous wobble), strip zoom in/out, R-snap, Ctrl+right-click menus from the overview bar, Reset views, reopen from the fiber panel. Current behavior: placements update in place with no blank/flash/jump, overlays and imagery stay coherent per pane, no jitter recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EW9xAtf3HtgHotu4zSExJ1

