### PR TITLE
apps: vc_tifxyz_selfcross, a report-only self-intersection census for tifxyz surfaces

### DIFF
--- a/volume-cartographer/apps/CMakeLists.txt
+++ b/volume-cartographer/apps/CMakeLists.txt
@@ -129,6 +129,9 @@ target_link_libraries(vc_cut_windings vc_core opencv_core)
 add_executable(vc_tifxyz_winding src/vc_tifxyz_winding.cpp)
 target_link_libraries(vc_tifxyz_winding vc_core)
 
+add_executable(vc_tifxyz_selfcross src/vc_tifxyz_selfcross.cpp)
+target_link_libraries(vc_tifxyz_selfcross vc_core Boost::program_options opencv_core)
+
 add_executable(vc_calc_surface_metrics src/vc_calc_surface_metrics.cpp)
 target_link_libraries(vc_calc_surface_metrics vc_core Boost::program_options)
 
@@ -255,7 +258,8 @@ set(VC_CLI_TARGETS
     vc_seg_add_overlap vc_grow_seg_from_segments vc_tifxyz2obj vc_obj_uv_lift
     vc_tifxyz2zarr_sparse vc_add_ignore_label vc_obj2tifxyz
     vc_obj2tifxyz_legacy vc_flatten vc_tifxyz_inp_mask vc_tifxyz_trim
-    vc_straighten vc_cut_windings vc_tifxyz_winding vc_calc_surface_metrics
+    vc_straighten vc_cut_windings vc_tifxyz_winding vc_tifxyz_selfcross
+    vc_calc_surface_metrics
     vc_lasagna_line_probe vc_fiber_trace_metric vc_lasagna_maxflow_graph
     vc_atlas_inspect vc_atlas_constraints_export vc_atlas_pred_snap_rebuild
     vc_tifxyz_gengt vc_diffuse_winding vc_tifxyz_mmap_prepare
@@ -285,7 +289,8 @@ if(VC_USE_PCH)
         vc_seg_add_overlap vc_grow_seg_from_segments vc_tifxyz2obj
         vc_tifxyz2zarr_sparse vc_add_ignore_label vc_obj2tifxyz
         vc_obj2tifxyz_legacy vc_flatten vc_tifxyz_inp_mask vc_tifxyz_trim
-        vc_cut_windings vc_tifxyz_winding vc_calc_surface_metrics
+        vc_cut_windings vc_tifxyz_winding vc_tifxyz_selfcross
+        vc_calc_surface_metrics
         vc_lasagna_line_probe vc_fiber_trace_metric vc_lasagna_maxflow_graph vc_atlas_inspect vc_atlas_constraints_export vc_tifxyz_gengt vc_diffuse_winding vc_create_segment_mask
         vc_merge_tifxyz vc_merge_patch vc_visualize vc_volpkg_convert vc_transform_geom
         vc_gen_normalgrids vc_ngrids vc_tifxyz2rgb vc_rgb2tifxyz vc_thinning

--- a/volume-cartographer/apps/src/vc_tifxyz_selfcross.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz_selfcross.cpp
@@ -1,0 +1,641 @@
+// vc_tifxyz_selfcross: report where a tifxyz surface passes through itself.
+//
+// An embedded surface cannot pass through itself, however tightly the wraps
+// are packed, so a transverse self-intersection in a trace is a defect with
+// no innocent reading -- unlike proximity, which in a crushed scroll can be
+// arbitrarily small and still correct. This tool censuses one surface's
+// triangles for non-adjacent transverse contacts and reports them; it never
+// modifies anything.
+//
+// Contacts are classified rather than collapsed to yes/no:
+//
+//   transverse  the two triangle interiors genuinely pass through each other
+//   coplanar    (near) coplanar with overlapping projections -- two sheets
+//               pressed flat look like this, so it is reported, not counted
+//               as a crossing
+//   grazing     a vertex or edge sits within tolerance of the other plane,
+//               so the sign data the interval test relies on is not
+//               trustworthy; reported separately rather than guessed at
+//
+// Adjacency is excluded by grid index: quads within --exclude cells of each
+// other in both v and u share vertices, and their triangles sharing space is
+// what a surface does. Everything beyond that window is nonlocal.
+//
+// Each quad is split into triangles both ways (--diagonal runs one; the
+// default runs both and reports them separately), because a twisted quad can
+// cross under one triangulation and not the other.
+//
+// The census runs on the surface as this codebase loads it: z <= 0 cells are
+// invalid and mask.tif applies. The same method run on a raw tifxyz that
+// counts z <= 0 cells as valid can differ slightly (measured 1.49% of contact
+// rows across one 185-trace corpus, with no clean/not-clean verdict changed).
+//
+// Exit codes: 0 = census ran (regardless of what it found), 1 = error,
+// 3 = --fail-on-crossing was given and transverse contacts were found.
+
+#include "vc/core/util/QuadSurface.hpp"
+#include "vc/core/PointCollections.hpp"
+#include "utils/Json.hpp"
+
+#include <boost/program_options.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace po = boost::program_options;
+
+namespace {
+
+// ------------------------------------------------------------ the predicate
+//
+// Moller's interval-overlap triangle test, with the degenerate branches
+// surfaced instead of collapsed into "no intersection", and the plane
+// tolerance derived from the operands. The inputs are float32 coordinates
+// running to ~1e4 voxels, where one ULP is already ~1e-3 voxels; a fixed
+// 1e-6 tolerance would be a thousand times finer than the data's own
+// representation and would classify representation noise.
+
+constexpr double FLT_EPS = 1.1920929e-7;
+constexpr double EPS_SCALE = 16.0;
+
+// Interval overlaps at or below this are touches, not penetrations. Float32
+// spacing near coordinate 5,000 is ~5e-4 voxels, so anything finer than this
+// is below the input's own resolution.
+constexpr double TOUCH_TOL = 1e-3;
+
+inline double plane_eps(double mag) {
+    return std::max(1e-9, EPS_SCALE * FLT_EPS * mag);
+}
+
+struct Vec3 {
+    double x = 0, y = 0, z = 0;
+    Vec3() = default;
+    Vec3(double a, double b, double c) : x(a), y(b), z(c) {}
+    Vec3 operator-(const Vec3& o) const { return {x - o.x, y - o.y, z - o.z}; }
+    Vec3 operator+(const Vec3& o) const { return {x + o.x, y + o.y, z + o.z}; }
+    Vec3 operator*(double s) const { return {x * s, y * s, z * s}; }
+};
+
+inline double dot(const Vec3& a, const Vec3& b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+inline Vec3 cross(const Vec3& a, const Vec3& b) {
+    return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
+}
+inline double norm(const Vec3& a) { return std::sqrt(dot(a, a)); }
+
+struct Tri {
+    Vec3 a, b, c;
+    int32_t v = 0, u = 0;   // grid origin of the owning quad
+    int32_t t = 0;          // triangle index within the quad (0/1)
+};
+
+enum Verdict { NONE = 0, TRANSVERSE = 1, COPLANAR = 2, GRAZING = 3 };
+
+struct TriTriResult {
+    Verdict verdict = NONE;
+    double penetration = 0.0;   // Euclidean length of the shared segment
+    double angle_deg = 0.0;     // between the two triangle planes
+};
+
+bool tri2d_overlap(const Vec3 tri1[3], const Vec3 tri2[3], const Vec3& n) {
+    int drop = 0;
+    double ax = std::fabs(n.x), ay = std::fabs(n.y), az = std::fabs(n.z);
+    if (ay > ax && ay > az) drop = 1;
+    else if (az > ax && az > ay) drop = 2;
+
+    auto proj = [drop](const Vec3& p) -> std::pair<double, double> {
+        if (drop == 0) return {p.y, p.z};
+        if (drop == 1) return {p.x, p.z};
+        return {p.x, p.y};
+    };
+    std::pair<double, double> P[3], Q[3];
+    for (int i = 0; i < 3; ++i) { P[i] = proj(tri1[i]); Q[i] = proj(tri2[i]); }
+
+    auto separated = [&](const std::pair<double, double> A[3],
+                         const std::pair<double, double> B[3]) {
+        for (int i = 0; i < 3; ++i) {
+            int j = (i + 1) % 3;
+            double ex = A[j].first - A[i].first;
+            double ey = A[j].second - A[i].second;
+            double refs[3];
+            for (int k = 0; k < 3; ++k)
+                refs[k] = -ey * (B[k].first - A[i].first)
+                        + ex * (B[k].second - A[i].second);
+            double selfSide = -ey * (A[(i + 2) % 3].first - A[i].first)
+                            + ex * (A[(i + 2) % 3].second - A[i].second);
+            bool allOpposite = true;
+            for (int k = 0; k < 3; ++k)
+                if (refs[k] * selfSide > -1e-12) { allOpposite = false; break; }
+            if (allOpposite) return true;
+        }
+        return false;
+    };
+    if (separated(P, Q)) return false;
+    if (separated(Q, P)) return false;
+    return true;
+}
+
+TriTriResult tri_tri(const Tri& T1, const Tri& T2) {
+    const Vec3 p1[3] = {T1.a, T1.b, T1.c};
+    const Vec3 p2[3] = {T2.a, T2.b, T2.c};
+
+    // Bounding-box separation first. Beyond the speedup this is load-bearing:
+    // without it a triangle far away from T2 but near T2's INFINITE plane
+    // would be classified grazing, which says nothing about touching.
+    {
+        double lo1[3] = {std::min({p1[0].x, p1[1].x, p1[2].x}),
+                         std::min({p1[0].y, p1[1].y, p1[2].y}),
+                         std::min({p1[0].z, p1[1].z, p1[2].z})};
+        double hi1[3] = {std::max({p1[0].x, p1[1].x, p1[2].x}),
+                         std::max({p1[0].y, p1[1].y, p1[2].y}),
+                         std::max({p1[0].z, p1[1].z, p1[2].z})};
+        double lo2[3] = {std::min({p2[0].x, p2[1].x, p2[2].x}),
+                         std::min({p2[0].y, p2[1].y, p2[2].y}),
+                         std::min({p2[0].z, p2[1].z, p2[2].z})};
+        double hi2[3] = {std::max({p2[0].x, p2[1].x, p2[2].x}),
+                         std::max({p2[0].y, p2[1].y, p2[2].y}),
+                         std::max({p2[0].z, p2[1].z, p2[2].z})};
+        for (int k = 0; k < 3; ++k)
+            if (hi1[k] < lo2[k] - TOUCH_TOL || hi2[k] < lo1[k] - TOUCH_TOL)
+                return {NONE, 0.0, 0.0};
+    }
+
+    Vec3 n2 = cross(p2[1] - p2[0], p2[2] - p2[0]);
+    double l2 = norm(n2);
+    Vec3 n1 = cross(p1[1] - p1[0], p1[2] - p1[0]);
+    double l1 = norm(n1);
+    if (l1 < 1e-12 || l2 < 1e-12) return {GRAZING, 0.0, 0.0};   // degenerate
+    n1 = n1 * (1.0 / l1);
+    n2 = n2 * (1.0 / l2);
+
+    double d1[3], d2[3];
+    for (int i = 0; i < 3; ++i) d1[i] = dot(n2, p1[i] - p2[0]);
+    for (int i = 0; i < 3; ++i) d2[i] = dot(n1, p2[i] - p1[0]);
+
+    double mag = 0.0;
+    for (const Vec3& p : {p1[0], p1[1], p1[2], p2[0], p2[1], p2[2]})
+        mag = std::max(mag, std::max(std::fabs(p.x),
+                       std::max(std::fabs(p.y), std::fabs(p.z))));
+    const double EPS = plane_eps(mag);
+
+    bool graze = false;
+    for (int i = 0; i < 3; ++i) {
+        if (std::fabs(d1[i]) < EPS) graze = true;
+        if (std::fabs(d2[i]) < EPS) graze = true;
+    }
+
+    auto allSameSign = [EPS](const double d[3]) {
+        return (d[0] > EPS && d[1] > EPS && d[2] > EPS)
+            || (d[0] < -EPS && d[1] < -EPS && d[2] < -EPS);
+    };
+    if (allSameSign(d1) || allSameSign(d2)) return {NONE, 0.0, 0.0};
+
+    const double ang = std::acos(std::min(1.0, std::fabs(dot(n1, n2))))
+                     * 180.0 / 3.14159265358979323846;
+
+    bool coplanar = std::fabs(d1[0]) < EPS && std::fabs(d1[1]) < EPS
+                 && std::fabs(d1[2]) < EPS;
+    if (coplanar)
+        return tri2d_overlap(p1, p2, n1) ? TriTriResult{COPLANAR, 0.0, ang}
+                                         : TriTriResult{NONE, 0.0, ang};
+    if (graze) return {GRAZING, 0.0, ang};
+
+    Vec3 D = cross(n1, n2);
+    double ax = std::fabs(D.x), ay = std::fabs(D.y), az = std::fabs(D.z);
+    int idx = (ay > ax && ay > az) ? 1 : ((az > ax && az > ay) ? 2 : 0);
+    auto comp = [idx](const Vec3& p) {
+        return idx == 0 ? p.x : (idx == 1 ? p.y : p.z);
+    };
+
+    // The parameter interval of one triangle along the intersection line. The
+    // vertex alone on its side of the other plane is the apex.
+    auto interval = [&](const Vec3 p[3], const double d[3],
+                        double& t0, double& t1) {
+        int apex = -1;
+        for (int i = 0; i < 3; ++i) {
+            int j = (i + 1) % 3, k = (i + 2) % 3;
+            if ((d[i] > 0 && d[j] <= 0 && d[k] <= 0)
+             || (d[i] < 0 && d[j] >= 0 && d[k] >= 0)) { apex = i; break; }
+        }
+        if (apex < 0) return false;
+        int j = (apex + 1) % 3, k = (apex + 2) % 3;
+        double pa = comp(p[apex]);
+        t0 = pa + (comp(p[j]) - pa) * (d[apex] / (d[apex] - d[j]));
+        t1 = pa + (comp(p[k]) - pa) * (d[apex] / (d[apex] - d[k]));
+        if (t0 > t1) std::swap(t0, t1);
+        return true;
+    };
+
+    double a0, a1, b0, b1;
+    if (!interval(p1, d1, a0, a1)) return {GRAZING, 0.0, ang};
+    if (!interval(p2, d2, b0, b1)) return {GRAZING, 0.0, ang};
+
+    // The overlap is a projection onto one axis, shorter than the true shared
+    // segment by the direction cosine; dividing restores Euclidean length,
+    // which is what "penetration" should mean to a reader. Intervals that
+    // merely meet at a point are a touch, not a crossing.
+    const double dlen = norm(D);
+    const double dcos = dlen > 1e-12
+        ? std::fabs((idx == 0 ? D.x : (idx == 1 ? D.y : D.z)) / dlen) : 1.0;
+    const double proj = std::min(a1, b1) - std::max(a0, b0);
+    if (proj <= 0.0) return {NONE, 0.0, ang};
+    const double pen = proj / std::max(dcos, 1e-9);
+    if (pen <= TOUCH_TOL) return {GRAZING, pen, ang};
+    return {TRANSVERSE, pen, ang};
+}
+
+// -------------------------------------------------------------- the census
+
+struct Contact {
+    int32_t v1, u1, v2, u2;
+    int32_t t1, t2;
+    int verdict;
+    float penetration, angle_deg;
+    Vec3 site;   // midpoint of the two triangle centroids, for the overlay
+};
+
+struct CensusCounts {
+    size_t triangles = 0, quads_dropped = 0, pairs_tested = 0;
+    size_t transverse = 0, coplanar = 0, grazing = 0;
+};
+
+inline bool valid_point(const cv::Vec3f& p) {
+    return (p[0] != -1.f || p[1] != -1.f || p[2] != -1.f)
+        && std::isfinite(p[0]) && std::isfinite(p[1]) && std::isfinite(p[2]);
+}
+
+// One pass over one triangulation. Deterministic by construction: a triangle
+// pair can share several broad-phase cells, and testing it in each would
+// count it once per thread that happens to visit one -- the count would move
+// with scheduling. Instead every pair is owned by exactly one cell, the one
+// containing the minimum corner of the two bounding boxes' overlap, and is
+// tested only there. No shared state, and the answer does not depend on
+// thread count. Results are sorted before returning, so equal inputs give
+// byte-equal outputs.
+CensusCounts census(const cv::Mat_<cv::Vec3f>& P, int diagonal, double cell,
+                    int exclude, double maxedge, int nthreads,
+                    std::vector<Contact>& out)
+{
+    CensusCounts counts;
+
+    std::vector<Tri> tris;
+    for (int v = 0; v + 1 < P.rows; ++v) {
+        for (int u = 0; u + 1 < P.cols; ++u) {
+            const cv::Vec3f& q00 = P(v, u);
+            const cv::Vec3f& q10 = P(v + 1, u);
+            const cv::Vec3f& q01 = P(v, u + 1);
+            const cv::Vec3f& q11 = P(v + 1, u + 1);
+            if (!valid_point(q00) || !valid_point(q10)
+             || !valid_point(q01) || !valid_point(q11))
+                continue;
+            Vec3 p00{q00[0], q00[1], q00[2]}, p10{q10[0], q10[1], q10[2]};
+            Vec3 p01{q01[0], q01[1], q01[2]}, p11{q11[0], q11[1], q11[2]};
+            if (maxedge > 0) {
+                // Not cosmetic. A grid can hold discontinuities where two
+                // adjacent valid cells sit far apart in 3D; a triangle built
+                // across such a gap spans many wraps and crosses everything
+                // it passes through, purely because the mesh has a hole.
+                double e = std::max(std::max(norm(p01 - p00), norm(p11 - p01)),
+                          std::max(std::max(norm(p10 - p11), norm(p00 - p10)),
+                                   std::max(norm(p11 - p00), norm(p10 - p01))));
+                if (e > maxedge) { ++counts.quads_dropped; continue; }
+            }
+            if (diagonal == 0) {
+                tris.push_back({p00, p01, p11, v, u, 0});
+                tris.push_back({p00, p11, p10, v, u, 1});
+            } else {
+                tris.push_back({p00, p01, p10, v, u, 0});
+                tris.push_back({p01, p11, p10, v, u, 1});
+            }
+        }
+    }
+    counts.triangles = tris.size();
+    if (tris.empty()) return counts;
+
+    // Uniform-grid broad phase.
+    Vec3 lo{1e30, 1e30, 1e30}, hi{-1e30, -1e30, -1e30};
+    for (const Tri& t : tris) {
+        for (const Vec3& p : {t.a, t.b, t.c}) {
+            lo.x = std::min(lo.x, p.x); hi.x = std::max(hi.x, p.x);
+            lo.y = std::min(lo.y, p.y); hi.y = std::max(hi.y, p.y);
+            lo.z = std::min(lo.z, p.z); hi.z = std::max(hi.z, p.z);
+        }
+    }
+    const int nx = std::max(1, (int)((hi.x - lo.x) / cell) + 1);
+    const int ny = std::max(1, (int)((hi.y - lo.y) / cell) + 1);
+    auto cellIdx = [&](int i, int j, int k) {
+        return ((size_t)k * ny + j) * nx + i;
+    };
+    std::unordered_map<size_t, std::vector<uint32_t>> buckets;
+    buckets.reserve(tris.size());
+    for (uint32_t ti = 0; ti < tris.size(); ++ti) {
+        const Tri& t = tris[ti];
+        double tx0 = std::min({t.a.x, t.b.x, t.c.x});
+        double tx1 = std::max({t.a.x, t.b.x, t.c.x});
+        double ty0 = std::min({t.a.y, t.b.y, t.c.y});
+        double ty1 = std::max({t.a.y, t.b.y, t.c.y});
+        double tz0 = std::min({t.a.z, t.b.z, t.c.z});
+        double tz1 = std::max({t.a.z, t.b.z, t.c.z});
+        int i0 = (int)((tx0 - lo.x) / cell), i1 = (int)((tx1 - lo.x) / cell);
+        int j0 = (int)((ty0 - lo.y) / cell), j1 = (int)((ty1 - lo.y) / cell);
+        int k0 = (int)((tz0 - lo.z) / cell), k1 = (int)((tz1 - lo.z) / cell);
+        for (int k = k0; k <= k1; ++k)
+            for (int j = j0; j <= j1; ++j)
+                for (int i = i0; i <= i1; ++i)
+                    buckets[cellIdx(i, j, k)].push_back(ti);
+    }
+    std::vector<std::pair<size_t, const std::vector<uint32_t>*>> cells;
+    cells.reserve(buckets.size());
+    for (auto& kv : buckets)
+        if (kv.second.size() > 1) cells.emplace_back(kv.first, &kv.second);
+    std::sort(cells.begin(), cells.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    auto ownerCell = [&](const Tri& A, const Tri& B) {
+        double ox = std::max(std::min({A.a.x, A.b.x, A.c.x}),
+                             std::min({B.a.x, B.b.x, B.c.x}));
+        double oy = std::max(std::min({A.a.y, A.b.y, A.c.y}),
+                             std::min({B.a.y, B.b.y, B.c.y}));
+        double oz = std::max(std::min({A.a.z, A.b.z, A.c.z}),
+                             std::min({B.a.z, B.b.z, B.c.z}));
+        return cellIdx((int)((ox - lo.x) / cell), (int)((oy - lo.y) / cell),
+                       (int)((oz - lo.z) / cell));
+    };
+
+    std::vector<std::vector<Contact>> perThread(nthreads);
+    std::atomic<size_t> next{0};
+    std::atomic<size_t> tested{0};
+
+    auto worker = [&](int id) {
+        auto& outv = perThread[id];
+        size_t local = 0;
+        for (;;) {
+            size_t ci = next.fetch_add(1);
+            if (ci >= cells.size()) break;
+            const size_t key = cells[ci].first;
+            const std::vector<uint32_t>& c = *cells[ci].second;
+            for (size_t a = 0; a < c.size(); ++a) {
+                for (size_t b = a + 1; b < c.size(); ++b) {
+                    const Tri& T1 = tris[c[a]];
+                    const Tri& T2 = tris[c[b]];
+                    // Quads within Chebyshev distance `exclude` share at
+                    // least one vertex at exclude = 1, so this is exactly
+                    // shared-vertex/shared-edge exclusion.
+                    if (std::abs(T1.v - T2.v) <= exclude
+                        && std::abs(T1.u - T2.u) <= exclude) continue;
+                    if (ownerCell(T1, T2) != key) continue;
+                    ++local;
+                    TriTriResult r = tri_tri(T1, T2);
+                    if (r.verdict != NONE) {
+                        // Canonical endpoint order: the lexicographically
+                        // smaller (v,u,t) is side 1, so every reader sees one
+                        // identity per geometric pair.
+                        bool swap = std::make_tuple(T1.v, T1.u, T1.t)
+                                  > std::make_tuple(T2.v, T2.u, T2.t);
+                        const Tri& A = swap ? T2 : T1;
+                        const Tri& B = swap ? T1 : T2;
+                        Vec3 ca = (A.a + A.b + A.c) * (1.0 / 3.0);
+                        Vec3 cb = (B.a + B.b + B.c) * (1.0 / 3.0);
+                        outv.push_back({A.v, A.u, B.v, B.u, A.t, B.t,
+                                        (int)r.verdict, (float)r.penetration,
+                                        (float)r.angle_deg,
+                                        (ca + cb) * 0.5});
+                    }
+                }
+            }
+        }
+        tested.fetch_add(local);
+    };
+    std::vector<std::thread> pool;
+    for (int t = 0; t < nthreads; ++t) pool.emplace_back(worker, t);
+    for (auto& t : pool) t.join();
+    counts.pairs_tested = tested.load();
+
+    size_t total = 0;
+    for (auto& v : perThread) total += v.size();
+    out.reserve(out.size() + total);
+    size_t first = out.size();
+    for (auto& v : perThread) out.insert(out.end(), v.begin(), v.end());
+    std::sort(out.begin() + first, out.end(),
+              [](const Contact& x, const Contact& y) {
+        return std::tie(x.v1, x.u1, x.t1, x.v2, x.u2, x.t2)
+             < std::tie(y.v1, y.u1, y.t1, y.v2, y.u2, y.t2);
+    });
+    for (size_t i = first; i < out.size(); ++i) {
+        if (out[i].verdict == TRANSVERSE) ++counts.transverse;
+        else if (out[i].verdict == COPLANAR) ++counts.coplanar;
+        else ++counts.grazing;
+    }
+    return counts;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    po::options_description desc(
+        "Census a tifxyz surface for non-adjacent transverse "
+        "self-intersections.\nReport-only: nothing is modified");
+    desc.add_options()
+        ("help,h", "Print help")
+        ("surface", po::value<std::string>(),
+         "Input tifxyz surface directory")
+        ("output,o", po::value<std::string>(),
+         "Output report file (.json)")
+        ("collection", po::value<std::string>(),
+         "Also write crossing sites as a point collection (.json), "
+         "loadable in VC3D")
+        ("exclude", po::value<int>()->default_value(1),
+         "Chebyshev grid-index adjacency exclusion; 1 = shared-vertex "
+         "neighbours")
+        ("maxedge", po::value<double>()->default_value(60.0),
+         "Drop quads with any edge longer than this (voxels); a triangle "
+         "built across a grid discontinuity crosses everything it passes "
+         "through. 0 disables")
+        ("cell", po::value<double>()->default_value(40.0),
+         "Broad-phase cell size (voxels); affects speed only")
+        ("threads", po::value<int>()->default_value(0),
+         "Worker threads; 0 = hardware concurrency")
+        ("max-collection-points", po::value<int>()->default_value(10000),
+         "Cap on overlay points written to --collection")
+        ("fail-on-crossing",
+         "Exit with code 3 if any transverse contact is found, for use "
+         "as a gate in scripts");
+
+    po::positional_options_description pos;
+    pos.add("surface", 1);
+
+    po::variables_map vm;
+    try {
+        po::store(po::command_line_parser(argc, argv)
+                      .options(desc).positional(pos).run(), vm);
+        po::notify(vm);
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1;
+    }
+
+    if (vm.count("help") || !vm.count("surface") || !vm.count("output")) {
+        std::cout << desc << std::endl;
+        return vm.count("help") ? 0 : 1;
+    }
+
+    const std::string surface_path = vm["surface"].as<std::string>();
+    const std::string output_path = vm["output"].as<std::string>();
+    const int exclude = vm["exclude"].as<int>();
+    const double maxedge = vm["maxedge"].as<double>();
+    const double cell = vm["cell"].as<double>();
+    int nthreads = vm["threads"].as<int>();
+    if (nthreads <= 0) nthreads = (int)std::thread::hardware_concurrency();
+    if (nthreads <= 0) nthreads = 4;
+
+    std::unique_ptr<QuadSurface> surface;
+    try {
+        surface = load_quad_from_tifxyz(surface_path);
+    } catch (const std::exception& e) {
+        std::cerr << "Error: failed to load surface from " << surface_path
+                  << ": " << e.what() << std::endl;
+        return 1;
+    }
+    const cv::Mat_<cv::Vec3f>& P = *surface->rawPointsPtr();
+
+    const auto t0 = std::chrono::steady_clock::now();
+
+    // Both triangulations, reported separately. A twisted quad can cross
+    // under one diagonal and not the other; a surface is only called clean
+    // here when both censuses find nothing transverse.
+    std::vector<Contact> contacts[2];
+    CensusCounts counts[2];
+    for (int d = 0; d < 2; ++d) {
+        counts[d] = census(P, d, cell, exclude, maxedge, nthreads,
+                           contacts[d]);
+        std::cerr << "diagonal " << d << ": " << counts[d].triangles
+                  << " triangles, " << counts[d].pairs_tested
+                  << " pairs tested, " << counts[d].transverse
+                  << " transverse, " << counts[d].coplanar << " coplanar, "
+                  << counts[d].grazing << " grazing" << std::endl;
+    }
+    const double wall = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - t0).count();
+
+    const size_t transverse_total = counts[0].transverse
+                                  + counts[1].transverse;
+
+    utils::Json report = utils::Json::object();
+    report["tool"] = "vc_tifxyz_selfcross";
+    report["report_only"] = true;
+    report["surface"] = surface_path;
+    report["clean_of_transverse_self_intersection"] =
+        (transverse_total == 0);
+    report["note"] = std::string(
+        "'clean' means zero non-adjacent transverse contacts under both quad "
+        "triangulations, on the surface as loaded here (z <= 0 invalid, mask "
+        "applied). Coplanar and grazing contacts are reported but are not "
+        "crossings: two sheets pressed flat against each other are coplanar.");
+    utils::Json params = utils::Json::object();
+    params["exclude"] = exclude;
+    params["maxedge"] = maxedge;
+    params["touch_tolerance"] = TOUCH_TOL;
+    params["diagonals"] = utils::Json::array();
+    params["diagonals"].push_back(0);
+    params["diagonals"].push_back(1);
+    report["parameters"] = params;
+    report["grid_rows"] = P.rows;
+    report["grid_cols"] = P.cols;
+    // Timing goes to stderr, not into the report: with it there, two runs on
+    // the same surface would produce different bytes, and a byte-reproducible
+    // report is worth more than an embedded stopwatch.
+    std::cerr << "census wall time: " << wall << " s" << std::endl;
+
+    utils::Json diags = utils::Json::array();
+    for (int d = 0; d < 2; ++d) {
+        utils::Json jd = utils::Json::object();
+        jd["diagonal"] = d;
+        jd["triangles"] = (uint64_t)counts[d].triangles;
+        jd["quads_dropped_for_edge_length"] = (uint64_t)counts[d].quads_dropped;
+        jd["pairs_tested"] = (uint64_t)counts[d].pairs_tested;
+        jd["transverse"] = (uint64_t)counts[d].transverse;
+        jd["coplanar"] = (uint64_t)counts[d].coplanar;
+        jd["grazing"] = (uint64_t)counts[d].grazing;
+        utils::Json rows = utils::Json::array();
+        for (const Contact& c : contacts[d]) {
+            if (c.verdict != TRANSVERSE)
+                continue;
+            utils::Json r = utils::Json::object();
+            r["quad1"] = utils::Json::array();
+            r["quad1"].push_back(c.v1); r["quad1"].push_back(c.u1);
+            r["quad2"] = utils::Json::array();
+            r["quad2"].push_back(c.v2); r["quad2"].push_back(c.u2);
+            r["tri1"] = c.t1; r["tri2"] = c.t2;
+            r["penetration_vx"] = (double)c.penetration;
+            r["angle_deg"] = (double)c.angle_deg;
+            r["site"] = utils::Json::array();
+            r["site"].push_back(c.site.x);
+            r["site"].push_back(c.site.y);
+            r["site"].push_back(c.site.z);
+            rows.push_back(std::move(r));
+        }
+        jd["transverse_contacts"] = std::move(rows);
+        diags.push_back(std::move(jd));
+    }
+    report["census"] = std::move(diags);
+
+    std::ofstream o(output_path);
+    if (!o.is_open()) {
+        std::cerr << "Error: failed to open output file " << output_path
+                  << std::endl;
+        return 1;
+    }
+    o << report.dump(4);
+    o.close();
+    std::cout << "Report written to " << output_path << std::endl;
+
+    if (vm.count("collection")) {
+        // Written through PointCollections itself, so the file is readable
+        // wherever point collections are.
+        const int cap = vm["max-collection-points"].as<int>();
+        PointCollections coll;
+        const std::string name = "selfcross-transverse";
+        coll.addCollection(name);
+        coll.setCollectionColor(coll.getCollectionId(name),
+                                cv::Vec3f(1.0f, 0.1f, 0.1f));
+        std::vector<cv::Vec3f> pts;
+        for (int d = 0; d < 2 && (int)pts.size() < cap; ++d)
+            for (const Contact& c : contacts[d]) {
+                if (c.verdict != TRANSVERSE) continue;
+                if ((int)pts.size() >= cap) break;
+                pts.emplace_back((float)c.site.x, (float)c.site.y,
+                                 (float)c.site.z);
+            }
+        coll.addPoints(name, pts);
+        const std::string coll_path = vm["collection"].as<std::string>();
+        if (!coll.saveToJSON(coll_path)) {
+            std::cerr << "Error: failed to write point collection to "
+                      << coll_path << std::endl;
+            return 1;
+        }
+        std::cout << "Point collection (" << pts.size()
+                  << " sites) written to " << coll_path << std::endl;
+    }
+
+    std::cout << (transverse_total == 0
+        ? "No non-adjacent transverse self-intersection found."
+        : "Surface has non-adjacent transverse self-intersections: "
+          + std::to_string(counts[0].transverse) + " contacts on diagonal 0, "
+          + std::to_string(counts[1].transverse) + " on diagonal 1.")
+        << std::endl;
+
+    if (transverse_total > 0 && vm.count("fail-on-crossing"))
+        return 3;
+    return 0;
+}

--- a/volume-cartographer/apps/src/vc_tifxyz_selfcross.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz_selfcross.cpp
@@ -13,9 +13,10 @@
 //   coplanar    (near) coplanar with overlapping projections -- two sheets
 //               pressed flat look like this, so it is reported, not counted
 //               as a crossing
-//   grazing     a vertex or edge sits within tolerance of the other plane,
-//               so the sign data the interval test relies on is not
-//               trustworthy; reported separately rather than guessed at
+//   grazing     the sign or interval data the test relies on is numerically
+//               ambiguous AND the triangles come within the touch tolerance
+//               of each other; ambiguity about a pair that never comes near
+//               contact is not reported at all
 //
 // Adjacency is excluded by grid index: quads within --exclude cells of each
 // other in both v and u share vertices, and their triangles sharing space is
@@ -45,6 +46,7 @@
 #include <boost/program_options.hpp>
 
 #include <chrono>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -79,7 +81,9 @@ int main(int argc, char** argv)
          "built across a grid discontinuity crosses everything it passes "
          "through. 0 disables")
         ("cell", po::value<double>()->default_value(40.0),
-         "Broad-phase cell size (voxels); affects speed only")
+         "Broad-phase cell size (voxels); affects speed, never contact "
+         "verdicts or counts (bucket ranges are expanded by the touch "
+         "tolerance)")
         ("threads", po::value<int>()->default_value(0),
          "Worker threads; 0 = hardware concurrency")
         ("max-collection-points", po::value<int>()->default_value(10000),
@@ -127,9 +131,12 @@ int main(int argc, char** argv)
                   << std::endl;
         return 1;
     }
-    if (maxedge < 0) {
-        std::cerr << "Error: --maxedge must be >= 0, with 0 disabling the "
-                     "filter (got " << maxedge << ")" << std::endl;
+    if (maxedge < 0 || !std::isfinite(maxedge)) {
+        // NaN fails both < 0 and > 0, which would silently disable the
+        // filter rather than complain.
+        std::cerr << "Error: --maxedge must be a finite number >= 0, with 0 "
+                     "disabling the filter (got " << maxedge << ")"
+                  << std::endl;
         return 1;
     }
 
@@ -151,8 +158,13 @@ int main(int argc, char** argv)
     std::vector<Contact> contacts[2];
     CensusCounts counts[2];
     for (int d = 0; d < 2; ++d) {
-        counts[d] = vc_selfcross::census(P, d, cell, exclude, maxedge,
-                                         nthreads, contacts[d]);
+        try {
+            counts[d] = vc_selfcross::census(P, d, cell, exclude, maxedge,
+                                             nthreads, contacts[d]);
+        } catch (const std::invalid_argument& e) {
+            std::cerr << "Error: " << e.what() << std::endl;
+            return 1;
+        }
         std::cerr << "diagonal " << d << ": " << counts[d].triangles
                   << " triangles, " << counts[d].pairs_tested
                   << " pairs tested, " << counts[d].transverse
@@ -179,6 +191,9 @@ int main(int argc, char** argv)
     utils::Json params = utils::Json::object();
     params["exclude"] = exclude;
     params["maxedge"] = maxedge;
+    // Recorded for provenance even though contact counts are independent of
+    // it: pairs_tested legitimately varies with the broad-phase cell size.
+    params["cell"] = cell;
     params["touch_tolerance"] = vc_selfcross::TOUCH_TOL;
     params["diagonals"] = utils::Json::array();
     params["diagonals"].push_back(0);
@@ -234,7 +249,21 @@ int main(int argc, char** argv)
         return 1;
     }
     o << report.dump(4);
+    o.flush();
+    // A full disk or quota failure surfaces here, not at open(). Claiming
+    // "Report written" and exiting 0 on a failed write would defeat the one
+    // job a report-only tool has.
+    if (!o.good()) {
+        std::cerr << "Error: failed while writing " << output_path
+                  << std::endl;
+        return 1;
+    }
     o.close();
+    if (o.fail()) {
+        std::cerr << "Error: failed to finish writing " << output_path
+                  << std::endl;
+        return 1;
+    }
     std::cout << "Report written to " << output_path << std::endl;
 
     if (vm.count("collection")) {

--- a/volume-cartographer/apps/src/vc_tifxyz_selfcross.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz_selfcross.cpp
@@ -21,17 +21,22 @@
 // other in both v and u share vertices, and their triangles sharing space is
 // what a surface does. Everything beyond that window is nonlocal.
 //
-// Each quad is split into triangles both ways (--diagonal runs one; the
-// default runs both and reports them separately), because a twisted quad can
-// cross under one triangulation and not the other.
+// Each quad is split into triangles both ways and the two censuses are
+// reported separately, because a twisted quad can cross under one
+// triangulation and not the other.
 //
 // The census runs on the surface as this codebase loads it: z <= 0 cells are
 // invalid and mask.tif applies. The same method run on a raw tifxyz that
 // counts z <= 0 cells as valid can differ slightly (measured 1.49% of contact
 // rows across one 185-trace corpus, with no clean/not-clean verdict changed).
 //
+// The census kernel lives in vc_tifxyz_selfcross_impl.hpp so the regression
+// tests (core/test/test_tifxyz_selfcross.cpp) run the identical code.
+//
 // Exit codes: 0 = census ran (regardless of what it found), 1 = error,
 // 3 = --fail-on-crossing was given and transverse contacts were found.
+
+#include "vc_tifxyz_selfcross_impl.hpp"
 
 #include "vc/core/util/QuadSurface.hpp"
 #include "vc/core/PointCollections.hpp"
@@ -39,407 +44,18 @@
 
 #include <boost/program_options.hpp>
 
-#include <algorithm>
-#include <atomic>
 #include <chrono>
-#include <cmath>
-#include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <string>
 #include <thread>
-#include <tuple>
-#include <unordered_map>
 #include <vector>
 
 namespace po = boost::program_options;
 
-namespace {
-
-// ------------------------------------------------------------ the predicate
-//
-// Moller's interval-overlap triangle test, with the degenerate branches
-// surfaced instead of collapsed into "no intersection", and the plane
-// tolerance derived from the operands. The inputs are float32 coordinates
-// running to ~1e4 voxels, where one ULP is already ~1e-3 voxels; a fixed
-// 1e-6 tolerance would be a thousand times finer than the data's own
-// representation and would classify representation noise.
-
-constexpr double FLT_EPS = 1.1920929e-7;
-constexpr double EPS_SCALE = 16.0;
-
-// Interval overlaps at or below this are touches, not penetrations. Float32
-// spacing near coordinate 5,000 is ~5e-4 voxels, so anything finer than this
-// is below the input's own resolution.
-constexpr double TOUCH_TOL = 1e-3;
-
-inline double plane_eps(double mag) {
-    return std::max(1e-9, EPS_SCALE * FLT_EPS * mag);
-}
-
-struct Vec3 {
-    double x = 0, y = 0, z = 0;
-    Vec3() = default;
-    Vec3(double a, double b, double c) : x(a), y(b), z(c) {}
-    Vec3 operator-(const Vec3& o) const { return {x - o.x, y - o.y, z - o.z}; }
-    Vec3 operator+(const Vec3& o) const { return {x + o.x, y + o.y, z + o.z}; }
-    Vec3 operator*(double s) const { return {x * s, y * s, z * s}; }
-};
-
-inline double dot(const Vec3& a, const Vec3& b) {
-    return a.x * b.x + a.y * b.y + a.z * b.z;
-}
-inline Vec3 cross(const Vec3& a, const Vec3& b) {
-    return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
-}
-inline double norm(const Vec3& a) { return std::sqrt(dot(a, a)); }
-
-struct Tri {
-    Vec3 a, b, c;
-    int32_t v = 0, u = 0;   // grid origin of the owning quad
-    int32_t t = 0;          // triangle index within the quad (0/1)
-};
-
-enum Verdict { NONE = 0, TRANSVERSE = 1, COPLANAR = 2, GRAZING = 3 };
-
-struct TriTriResult {
-    Verdict verdict = NONE;
-    double penetration = 0.0;   // Euclidean length of the shared segment
-    double angle_deg = 0.0;     // between the two triangle planes
-};
-
-bool tri2d_overlap(const Vec3 tri1[3], const Vec3 tri2[3], const Vec3& n) {
-    int drop = 0;
-    double ax = std::fabs(n.x), ay = std::fabs(n.y), az = std::fabs(n.z);
-    if (ay > ax && ay > az) drop = 1;
-    else if (az > ax && az > ay) drop = 2;
-
-    auto proj = [drop](const Vec3& p) -> std::pair<double, double> {
-        if (drop == 0) return {p.y, p.z};
-        if (drop == 1) return {p.x, p.z};
-        return {p.x, p.y};
-    };
-    std::pair<double, double> P[3], Q[3];
-    for (int i = 0; i < 3; ++i) { P[i] = proj(tri1[i]); Q[i] = proj(tri2[i]); }
-
-    auto separated = [&](const std::pair<double, double> A[3],
-                         const std::pair<double, double> B[3]) {
-        for (int i = 0; i < 3; ++i) {
-            int j = (i + 1) % 3;
-            double ex = A[j].first - A[i].first;
-            double ey = A[j].second - A[i].second;
-            double refs[3];
-            for (int k = 0; k < 3; ++k)
-                refs[k] = -ey * (B[k].first - A[i].first)
-                        + ex * (B[k].second - A[i].second);
-            double selfSide = -ey * (A[(i + 2) % 3].first - A[i].first)
-                            + ex * (A[(i + 2) % 3].second - A[i].second);
-            bool allOpposite = true;
-            for (int k = 0; k < 3; ++k)
-                if (refs[k] * selfSide > -1e-12) { allOpposite = false; break; }
-            if (allOpposite) return true;
-        }
-        return false;
-    };
-    if (separated(P, Q)) return false;
-    if (separated(Q, P)) return false;
-    return true;
-}
-
-TriTriResult tri_tri(const Tri& T1, const Tri& T2) {
-    const Vec3 p1[3] = {T1.a, T1.b, T1.c};
-    const Vec3 p2[3] = {T2.a, T2.b, T2.c};
-
-    // Bounding-box separation first. Beyond the speedup this is load-bearing:
-    // without it a triangle far away from T2 but near T2's INFINITE plane
-    // would be classified grazing, which says nothing about touching.
-    {
-        double lo1[3] = {std::min({p1[0].x, p1[1].x, p1[2].x}),
-                         std::min({p1[0].y, p1[1].y, p1[2].y}),
-                         std::min({p1[0].z, p1[1].z, p1[2].z})};
-        double hi1[3] = {std::max({p1[0].x, p1[1].x, p1[2].x}),
-                         std::max({p1[0].y, p1[1].y, p1[2].y}),
-                         std::max({p1[0].z, p1[1].z, p1[2].z})};
-        double lo2[3] = {std::min({p2[0].x, p2[1].x, p2[2].x}),
-                         std::min({p2[0].y, p2[1].y, p2[2].y}),
-                         std::min({p2[0].z, p2[1].z, p2[2].z})};
-        double hi2[3] = {std::max({p2[0].x, p2[1].x, p2[2].x}),
-                         std::max({p2[0].y, p2[1].y, p2[2].y}),
-                         std::max({p2[0].z, p2[1].z, p2[2].z})};
-        for (int k = 0; k < 3; ++k)
-            if (hi1[k] < lo2[k] - TOUCH_TOL || hi2[k] < lo1[k] - TOUCH_TOL)
-                return {NONE, 0.0, 0.0};
-    }
-
-    Vec3 n2 = cross(p2[1] - p2[0], p2[2] - p2[0]);
-    double l2 = norm(n2);
-    Vec3 n1 = cross(p1[1] - p1[0], p1[2] - p1[0]);
-    double l1 = norm(n1);
-    if (l1 < 1e-12 || l2 < 1e-12) return {GRAZING, 0.0, 0.0};   // degenerate
-    n1 = n1 * (1.0 / l1);
-    n2 = n2 * (1.0 / l2);
-
-    double d1[3], d2[3];
-    for (int i = 0; i < 3; ++i) d1[i] = dot(n2, p1[i] - p2[0]);
-    for (int i = 0; i < 3; ++i) d2[i] = dot(n1, p2[i] - p1[0]);
-
-    double mag = 0.0;
-    for (const Vec3& p : {p1[0], p1[1], p1[2], p2[0], p2[1], p2[2]})
-        mag = std::max(mag, std::max(std::fabs(p.x),
-                       std::max(std::fabs(p.y), std::fabs(p.z))));
-    const double EPS = plane_eps(mag);
-
-    bool graze = false;
-    for (int i = 0; i < 3; ++i) {
-        if (std::fabs(d1[i]) < EPS) graze = true;
-        if (std::fabs(d2[i]) < EPS) graze = true;
-    }
-
-    auto allSameSign = [EPS](const double d[3]) {
-        return (d[0] > EPS && d[1] > EPS && d[2] > EPS)
-            || (d[0] < -EPS && d[1] < -EPS && d[2] < -EPS);
-    };
-    if (allSameSign(d1) || allSameSign(d2)) return {NONE, 0.0, 0.0};
-
-    const double ang = std::acos(std::min(1.0, std::fabs(dot(n1, n2))))
-                     * 180.0 / 3.14159265358979323846;
-
-    bool coplanar = std::fabs(d1[0]) < EPS && std::fabs(d1[1]) < EPS
-                 && std::fabs(d1[2]) < EPS;
-    if (coplanar)
-        return tri2d_overlap(p1, p2, n1) ? TriTriResult{COPLANAR, 0.0, ang}
-                                         : TriTriResult{NONE, 0.0, ang};
-    if (graze) return {GRAZING, 0.0, ang};
-
-    Vec3 D = cross(n1, n2);
-    double ax = std::fabs(D.x), ay = std::fabs(D.y), az = std::fabs(D.z);
-    int idx = (ay > ax && ay > az) ? 1 : ((az > ax && az > ay) ? 2 : 0);
-    auto comp = [idx](const Vec3& p) {
-        return idx == 0 ? p.x : (idx == 1 ? p.y : p.z);
-    };
-
-    // The parameter interval of one triangle along the intersection line. The
-    // vertex alone on its side of the other plane is the apex.
-    auto interval = [&](const Vec3 p[3], const double d[3],
-                        double& t0, double& t1) {
-        int apex = -1;
-        for (int i = 0; i < 3; ++i) {
-            int j = (i + 1) % 3, k = (i + 2) % 3;
-            if ((d[i] > 0 && d[j] <= 0 && d[k] <= 0)
-             || (d[i] < 0 && d[j] >= 0 && d[k] >= 0)) { apex = i; break; }
-        }
-        if (apex < 0) return false;
-        int j = (apex + 1) % 3, k = (apex + 2) % 3;
-        double pa = comp(p[apex]);
-        t0 = pa + (comp(p[j]) - pa) * (d[apex] / (d[apex] - d[j]));
-        t1 = pa + (comp(p[k]) - pa) * (d[apex] / (d[apex] - d[k]));
-        if (t0 > t1) std::swap(t0, t1);
-        return true;
-    };
-
-    double a0, a1, b0, b1;
-    if (!interval(p1, d1, a0, a1)) return {GRAZING, 0.0, ang};
-    if (!interval(p2, d2, b0, b1)) return {GRAZING, 0.0, ang};
-
-    // The overlap is a projection onto one axis, shorter than the true shared
-    // segment by the direction cosine; dividing restores Euclidean length,
-    // which is what "penetration" should mean to a reader. Intervals that
-    // merely meet at a point are a touch, not a crossing.
-    const double dlen = norm(D);
-    const double dcos = dlen > 1e-12
-        ? std::fabs((idx == 0 ? D.x : (idx == 1 ? D.y : D.z)) / dlen) : 1.0;
-    const double proj = std::min(a1, b1) - std::max(a0, b0);
-    if (proj <= 0.0) return {NONE, 0.0, ang};
-    const double pen = proj / std::max(dcos, 1e-9);
-    if (pen <= TOUCH_TOL) return {GRAZING, pen, ang};
-    return {TRANSVERSE, pen, ang};
-}
-
-// -------------------------------------------------------------- the census
-
-struct Contact {
-    int32_t v1, u1, v2, u2;
-    int32_t t1, t2;
-    int verdict;
-    float penetration, angle_deg;
-    Vec3 site;   // midpoint of the two triangle centroids, for the overlay
-};
-
-struct CensusCounts {
-    size_t triangles = 0, quads_dropped = 0, pairs_tested = 0;
-    size_t transverse = 0, coplanar = 0, grazing = 0;
-};
-
-inline bool valid_point(const cv::Vec3f& p) {
-    return (p[0] != -1.f || p[1] != -1.f || p[2] != -1.f)
-        && std::isfinite(p[0]) && std::isfinite(p[1]) && std::isfinite(p[2]);
-}
-
-// One pass over one triangulation. Deterministic by construction: a triangle
-// pair can share several broad-phase cells, and testing it in each would
-// count it once per thread that happens to visit one -- the count would move
-// with scheduling. Instead every pair is owned by exactly one cell, the one
-// containing the minimum corner of the two bounding boxes' overlap, and is
-// tested only there. No shared state, and the answer does not depend on
-// thread count. Results are sorted before returning, so equal inputs give
-// byte-equal outputs.
-CensusCounts census(const cv::Mat_<cv::Vec3f>& P, int diagonal, double cell,
-                    int exclude, double maxedge, int nthreads,
-                    std::vector<Contact>& out)
-{
-    CensusCounts counts;
-
-    std::vector<Tri> tris;
-    for (int v = 0; v + 1 < P.rows; ++v) {
-        for (int u = 0; u + 1 < P.cols; ++u) {
-            const cv::Vec3f& q00 = P(v, u);
-            const cv::Vec3f& q10 = P(v + 1, u);
-            const cv::Vec3f& q01 = P(v, u + 1);
-            const cv::Vec3f& q11 = P(v + 1, u + 1);
-            if (!valid_point(q00) || !valid_point(q10)
-             || !valid_point(q01) || !valid_point(q11))
-                continue;
-            Vec3 p00{q00[0], q00[1], q00[2]}, p10{q10[0], q10[1], q10[2]};
-            Vec3 p01{q01[0], q01[1], q01[2]}, p11{q11[0], q11[1], q11[2]};
-            if (maxedge > 0) {
-                // Not cosmetic. A grid can hold discontinuities where two
-                // adjacent valid cells sit far apart in 3D; a triangle built
-                // across such a gap spans many wraps and crosses everything
-                // it passes through, purely because the mesh has a hole.
-                double e = std::max(std::max(norm(p01 - p00), norm(p11 - p01)),
-                          std::max(std::max(norm(p10 - p11), norm(p00 - p10)),
-                                   std::max(norm(p11 - p00), norm(p10 - p01))));
-                if (e > maxedge) { ++counts.quads_dropped; continue; }
-            }
-            if (diagonal == 0) {
-                tris.push_back({p00, p01, p11, v, u, 0});
-                tris.push_back({p00, p11, p10, v, u, 1});
-            } else {
-                tris.push_back({p00, p01, p10, v, u, 0});
-                tris.push_back({p01, p11, p10, v, u, 1});
-            }
-        }
-    }
-    counts.triangles = tris.size();
-    if (tris.empty()) return counts;
-
-    // Uniform-grid broad phase.
-    Vec3 lo{1e30, 1e30, 1e30}, hi{-1e30, -1e30, -1e30};
-    for (const Tri& t : tris) {
-        for (const Vec3& p : {t.a, t.b, t.c}) {
-            lo.x = std::min(lo.x, p.x); hi.x = std::max(hi.x, p.x);
-            lo.y = std::min(lo.y, p.y); hi.y = std::max(hi.y, p.y);
-            lo.z = std::min(lo.z, p.z); hi.z = std::max(hi.z, p.z);
-        }
-    }
-    const int nx = std::max(1, (int)((hi.x - lo.x) / cell) + 1);
-    const int ny = std::max(1, (int)((hi.y - lo.y) / cell) + 1);
-    auto cellIdx = [&](int i, int j, int k) {
-        return ((size_t)k * ny + j) * nx + i;
-    };
-    std::unordered_map<size_t, std::vector<uint32_t>> buckets;
-    buckets.reserve(tris.size());
-    for (uint32_t ti = 0; ti < tris.size(); ++ti) {
-        const Tri& t = tris[ti];
-        double tx0 = std::min({t.a.x, t.b.x, t.c.x});
-        double tx1 = std::max({t.a.x, t.b.x, t.c.x});
-        double ty0 = std::min({t.a.y, t.b.y, t.c.y});
-        double ty1 = std::max({t.a.y, t.b.y, t.c.y});
-        double tz0 = std::min({t.a.z, t.b.z, t.c.z});
-        double tz1 = std::max({t.a.z, t.b.z, t.c.z});
-        int i0 = (int)((tx0 - lo.x) / cell), i1 = (int)((tx1 - lo.x) / cell);
-        int j0 = (int)((ty0 - lo.y) / cell), j1 = (int)((ty1 - lo.y) / cell);
-        int k0 = (int)((tz0 - lo.z) / cell), k1 = (int)((tz1 - lo.z) / cell);
-        for (int k = k0; k <= k1; ++k)
-            for (int j = j0; j <= j1; ++j)
-                for (int i = i0; i <= i1; ++i)
-                    buckets[cellIdx(i, j, k)].push_back(ti);
-    }
-    std::vector<std::pair<size_t, const std::vector<uint32_t>*>> cells;
-    cells.reserve(buckets.size());
-    for (auto& kv : buckets)
-        if (kv.second.size() > 1) cells.emplace_back(kv.first, &kv.second);
-    std::sort(cells.begin(), cells.end(),
-              [](const auto& a, const auto& b) { return a.first < b.first; });
-
-    auto ownerCell = [&](const Tri& A, const Tri& B) {
-        double ox = std::max(std::min({A.a.x, A.b.x, A.c.x}),
-                             std::min({B.a.x, B.b.x, B.c.x}));
-        double oy = std::max(std::min({A.a.y, A.b.y, A.c.y}),
-                             std::min({B.a.y, B.b.y, B.c.y}));
-        double oz = std::max(std::min({A.a.z, A.b.z, A.c.z}),
-                             std::min({B.a.z, B.b.z, B.c.z}));
-        return cellIdx((int)((ox - lo.x) / cell), (int)((oy - lo.y) / cell),
-                       (int)((oz - lo.z) / cell));
-    };
-
-    std::vector<std::vector<Contact>> perThread(nthreads);
-    std::atomic<size_t> next{0};
-    std::atomic<size_t> tested{0};
-
-    auto worker = [&](int id) {
-        auto& outv = perThread[id];
-        size_t local = 0;
-        for (;;) {
-            size_t ci = next.fetch_add(1);
-            if (ci >= cells.size()) break;
-            const size_t key = cells[ci].first;
-            const std::vector<uint32_t>& c = *cells[ci].second;
-            for (size_t a = 0; a < c.size(); ++a) {
-                for (size_t b = a + 1; b < c.size(); ++b) {
-                    const Tri& T1 = tris[c[a]];
-                    const Tri& T2 = tris[c[b]];
-                    // Quads within Chebyshev distance `exclude` share at
-                    // least one vertex at exclude = 1, so this is exactly
-                    // shared-vertex/shared-edge exclusion.
-                    if (std::abs(T1.v - T2.v) <= exclude
-                        && std::abs(T1.u - T2.u) <= exclude) continue;
-                    if (ownerCell(T1, T2) != key) continue;
-                    ++local;
-                    TriTriResult r = tri_tri(T1, T2);
-                    if (r.verdict != NONE) {
-                        // Canonical endpoint order: the lexicographically
-                        // smaller (v,u,t) is side 1, so every reader sees one
-                        // identity per geometric pair.
-                        bool swap = std::make_tuple(T1.v, T1.u, T1.t)
-                                  > std::make_tuple(T2.v, T2.u, T2.t);
-                        const Tri& A = swap ? T2 : T1;
-                        const Tri& B = swap ? T1 : T2;
-                        Vec3 ca = (A.a + A.b + A.c) * (1.0 / 3.0);
-                        Vec3 cb = (B.a + B.b + B.c) * (1.0 / 3.0);
-                        outv.push_back({A.v, A.u, B.v, B.u, A.t, B.t,
-                                        (int)r.verdict, (float)r.penetration,
-                                        (float)r.angle_deg,
-                                        (ca + cb) * 0.5});
-                    }
-                }
-            }
-        }
-        tested.fetch_add(local);
-    };
-    std::vector<std::thread> pool;
-    for (int t = 0; t < nthreads; ++t) pool.emplace_back(worker, t);
-    for (auto& t : pool) t.join();
-    counts.pairs_tested = tested.load();
-
-    size_t total = 0;
-    for (auto& v : perThread) total += v.size();
-    out.reserve(out.size() + total);
-    size_t first = out.size();
-    for (auto& v : perThread) out.insert(out.end(), v.begin(), v.end());
-    std::sort(out.begin() + first, out.end(),
-              [](const Contact& x, const Contact& y) {
-        return std::tie(x.v1, x.u1, x.t1, x.v2, x.u2, x.t2)
-             < std::tie(y.v1, y.u1, y.t1, y.v2, y.u2, y.t2);
-    });
-    for (size_t i = first; i < out.size(); ++i) {
-        if (out[i].verdict == TRANSVERSE) ++counts.transverse;
-        else if (out[i].verdict == COPLANAR) ++counts.coplanar;
-        else ++counts.grazing;
-    }
-    return counts;
-}
-
-}  // namespace
+using vc_selfcross::Contact;
+using vc_selfcross::CensusCounts;
+using vc_selfcross::TRANSVERSE;
 
 int main(int argc, char** argv)
 {
@@ -499,6 +115,24 @@ int main(int argc, char** argv)
     if (nthreads <= 0) nthreads = (int)std::thread::hardware_concurrency();
     if (nthreads <= 0) nthreads = 4;
 
+    // The census refuses these too; checking here turns them into a usage
+    // message rather than an exception trace.
+    if (!(cell > 0.0) || !std::isfinite(cell)) {
+        std::cerr << "Error: --cell must be a finite positive number of "
+                     "voxels (got " << cell << ")" << std::endl;
+        return 1;
+    }
+    if (exclude < 0) {
+        std::cerr << "Error: --exclude must be >= 0 (got " << exclude << ")"
+                  << std::endl;
+        return 1;
+    }
+    if (maxedge < 0) {
+        std::cerr << "Error: --maxedge must be >= 0, with 0 disabling the "
+                     "filter (got " << maxedge << ")" << std::endl;
+        return 1;
+    }
+
     std::unique_ptr<QuadSurface> surface;
     try {
         surface = load_quad_from_tifxyz(surface_path);
@@ -517,8 +151,8 @@ int main(int argc, char** argv)
     std::vector<Contact> contacts[2];
     CensusCounts counts[2];
     for (int d = 0; d < 2; ++d) {
-        counts[d] = census(P, d, cell, exclude, maxedge, nthreads,
-                           contacts[d]);
+        counts[d] = vc_selfcross::census(P, d, cell, exclude, maxedge,
+                                         nthreads, contacts[d]);
         std::cerr << "diagonal " << d << ": " << counts[d].triangles
                   << " triangles, " << counts[d].pairs_tested
                   << " pairs tested, " << counts[d].transverse
@@ -545,7 +179,7 @@ int main(int argc, char** argv)
     utils::Json params = utils::Json::object();
     params["exclude"] = exclude;
     params["maxedge"] = maxedge;
-    params["touch_tolerance"] = TOUCH_TOL;
+    params["touch_tolerance"] = vc_selfcross::TOUCH_TOL;
     params["diagonals"] = utils::Json::array();
     params["diagonals"].push_back(0);
     params["diagonals"].push_back(1);
@@ -579,6 +213,9 @@ int main(int argc, char** argv)
             r["tri1"] = c.t1; r["tri2"] = c.t2;
             r["penetration_vx"] = (double)c.penetration;
             r["angle_deg"] = (double)c.angle_deg;
+            // The midpoint of the two triangles' shared intersection
+            // segment: a point both interiors contain, not a centroid
+            // average that can sit off the crossing for long triangles.
             r["site"] = utils::Json::array();
             r["site"].push_back(c.site.x);
             r["site"].push_back(c.site.y);

--- a/volume-cartographer/apps/src/vc_tifxyz_selfcross_impl.hpp
+++ b/volume-cartographer/apps/src/vc_tifxyz_selfcross_impl.hpp
@@ -110,6 +110,112 @@ inline bool tri2d_overlap(const Vec3 tri1[3], const Vec3 tri2[3], const Vec3& n)
     return true;
 }
 
+// Minimum distance between two triangles, geometrically complete in
+// floating-point arithmetic: vertex-face and edge-edge candidates, plus an
+// edge-through-face test so a piercing pair reports distance zero. Used to
+// keep "grazing" honest -- a vertex near the other triangle's INFINITE
+// plane says nothing about the triangles touching, so a grazing verdict is
+// only reported when the triangles come within the touch tolerance of each
+// other. A degenerate (zero-area) triangle is its own boundary, so its
+// distance is covered by the edge-edge terms; vertex-face and piercing
+// terms are skipped when their target is degenerate, because the
+// closest-point barycentric denominator vanishes there.
+inline double point_triangle_dist(const Vec3& p, const Vec3& a,
+                                  const Vec3& b, const Vec3& c) {
+    // Ericson, Real-Time Collision Detection, 5.1.5.
+    Vec3 ab = b - a, ac = c - a, ap = p - a;
+    double d1 = dot(ab, ap), d2 = dot(ac, ap);
+    if (d1 <= 0.0 && d2 <= 0.0) return norm(ap);
+    Vec3 bp = p - b;
+    double d3 = dot(ab, bp), d4 = dot(ac, bp);
+    if (d3 >= 0.0 && d4 <= d3) return norm(bp);
+    double vc = d1 * d4 - d3 * d2;
+    if (vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0) {
+        double v = d1 / (d1 - d3);
+        return norm(ap - ab * v);
+    }
+    Vec3 cp = p - c;
+    double d5 = dot(ab, cp), d6 = dot(ac, cp);
+    if (d6 >= 0.0 && d5 <= d6) return norm(cp);
+    double vb = d5 * d2 - d1 * d6;
+    if (vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0) {
+        double w = d2 / (d2 - d6);
+        return norm(ap - ac * w);
+    }
+    double va = d3 * d6 - d5 * d4;
+    if (va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0) {
+        double w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+        return norm(p - (b + (c - b) * w));
+    }
+    double denom = 1.0 / (va + vb + vc);
+    double v = vb * denom, w = vc * denom;
+    return norm(p - (a + ab * v + ac * w));
+}
+
+inline double segment_segment_dist(const Vec3& p1, const Vec3& q1,
+                                   const Vec3& p2, const Vec3& q2) {
+    // Ericson 5.1.9, with degenerate segments handled by clamping.
+    Vec3 d1 = q1 - p1, d2 = q2 - p2, r = p1 - p2;
+    double a = dot(d1, d1), e = dot(d2, d2), f = dot(d2, r);
+    double s = 0.0, t = 0.0;
+    if (a <= 1e-18 && e <= 1e-18) return norm(r);
+    if (a <= 1e-18) {
+        t = std::min(1.0, std::max(0.0, f / e));
+    } else {
+        double c = dot(d1, r);
+        if (e <= 1e-18) {
+            s = std::min(1.0, std::max(0.0, -c / a));
+        } else {
+            double b = dot(d1, d2), denom = a * e - b * b;
+            s = denom > 1e-18
+                ? std::min(1.0, std::max(0.0, (b * f - c * e) / denom)) : 0.0;
+            t = (b * s + f) / e;
+            if (t < 0.0) {
+                t = 0.0; s = std::min(1.0, std::max(0.0, -c / a));
+            } else if (t > 1.0) {
+                t = 1.0; s = std::min(1.0, std::max(0.0, (b - c) / a));
+            }
+        }
+    }
+    return norm((p1 + d1 * s) - (p2 + d2 * t));
+}
+
+inline bool edge_pierces_triangle(const Vec3& p, const Vec3& q,
+                                  const Vec3& a, const Vec3& b,
+                                  const Vec3& c) {
+    Vec3 n = cross(b - a, c - a);
+    double dp = dot(n, p - a), dq = dot(n, q - a);
+    if (dp * dq >= 0.0) return false;         // endpoints not on both sides
+    Vec3 x = p + (q - p) * (dp / (dp - dq));  // crossing point in the plane
+    // inside iff x is on the inner side of all three edges
+    if (dot(cross(b - a, x - a), n) < 0.0) return false;
+    if (dot(cross(c - b, x - b), n) < 0.0) return false;
+    if (dot(cross(a - c, x - c), n) < 0.0) return false;
+    return true;
+}
+
+inline double tri_tri_min_dist(const Vec3 p1[3], const Vec3 p2[3],
+                               bool deg1 = false, bool deg2 = false) {
+    for (int i = 0; i < 3; ++i) {
+        if (!deg2 && edge_pierces_triangle(p1[i], p1[(i + 1) % 3],
+                                           p2[0], p2[1], p2[2])) return 0.0;
+        if (!deg1 && edge_pierces_triangle(p2[i], p2[(i + 1) % 3],
+                                           p1[0], p1[1], p1[2])) return 0.0;
+    }
+    double m = 1e300;
+    for (int i = 0; i < 3; ++i) {
+        if (!deg2)
+            m = std::min(m, point_triangle_dist(p1[i], p2[0], p2[1], p2[2]));
+        if (!deg1)
+            m = std::min(m, point_triangle_dist(p2[i], p1[0], p1[1], p1[2]));
+    }
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j)
+            m = std::min(m, segment_segment_dist(
+                p1[i], p1[(i + 1) % 3], p2[j], p2[(j + 1) % 3]));
+    return m;
+}
+
 inline TriTriResult tri_tri(const Tri& T1, const Tri& T2) {
     const Vec3 p1[3] = {T1.a, T1.b, T1.c};
     const Vec3 p2[3] = {T2.a, T2.b, T2.c};
@@ -139,7 +245,15 @@ inline TriTriResult tri_tri(const Tri& T1, const Tri& T2) {
     double l2 = norm(n2);
     Vec3 n1 = cross(p1[1] - p1[0], p1[2] - p1[0]);
     double l1 = norm(n1);
-    if (l1 < 1e-12 || l2 < 1e-12) return {GRAZING, 0.0, 0.0, {}};   // degenerate
+    if (l1 < 1e-12 || l2 < 1e-12) {
+        // A degenerate (zero-area) triangle cannot be classified by plane
+        // signs, but that alone does not make it a contact: two collapsed
+        // triangles with overlapping boxes can be well separated. Grazing
+        // still requires the pair to come within the touch tolerance.
+        return tri_tri_min_dist(p1, p2, l1 < 1e-12, l2 < 1e-12) <= TOUCH_TOL
+            ? TriTriResult{GRAZING, 0.0, 0.0, {}}
+            : TriTriResult{NONE, 0.0, 0.0, {}};
+    }
     n1 = n1 * (1.0 / l1);
     n2 = n2 * (1.0 / l2);
 
@@ -173,7 +287,16 @@ inline TriTriResult tri_tri(const Tri& T1, const Tri& T2) {
     if (coplanar)
         return tri2d_overlap(p1, p2, n1) ? TriTriResult{COPLANAR, 0.0, ang, {}}
                                          : TriTriResult{NONE, 0.0, ang, {}};
-    if (graze) return {GRAZING, 0.0, ang, {}};
+    if (graze) {
+        // The flag only says a vertex sits near the other triangle's
+        // INFINITE plane, which is compatible with the triangles being far
+        // apart. Grazing is a statement about the data's resolution, so it
+        // is only reported when the triangles actually come within the
+        // touch tolerance of each other; otherwise they are disjoint.
+        return tri_tri_min_dist(p1, p2) <= TOUCH_TOL
+            ? TriTriResult{GRAZING, 0.0, ang, {}}
+            : TriTriResult{NONE, 0.0, ang, {}};
+    }
 
     Vec3 D = cross(n1, n2);
     double ax = std::fabs(D.x), ay = std::fabs(D.y), az = std::fabs(D.z);
@@ -209,8 +332,10 @@ inline TriTriResult tri_tri(const Tri& T1, const Tri& T2) {
 
     double a0, a1, b0, b1;
     Vec3 A0, A1, B0, B1;
-    if (!interval(p1, d1, a0, a1, A0, A1)) return {GRAZING, 0.0, ang, {}};
-    if (!interval(p2, d2, b0, b1, B0, B1)) return {GRAZING, 0.0, ang, {}};
+    if (!interval(p1, d1, a0, a1, A0, A1) || !interval(p2, d2, b0, b1, B0, B1))
+        return tri_tri_min_dist(p1, p2) <= TOUCH_TOL
+            ? TriTriResult{GRAZING, 0.0, ang, {}}
+            : TriTriResult{NONE, 0.0, ang, {}};
 
     // The overlap is a projection onto one axis, shorter than the true shared
     // segment by the direction cosine; dividing restores Euclidean length,
@@ -255,10 +380,10 @@ inline bool valid_point(const cv::Vec3f& p) {
 // pair can share several broad-phase cells, and testing it in each would
 // count it once per thread that happens to visit one -- the count would move
 // with scheduling. Instead every pair is owned by exactly one cell, the one
-// containing the minimum corner of the two bounding boxes' overlap, and is
-// tested only there. No shared state, and the answer does not depend on
-// thread count. Results are sorted before returning, so equal inputs give
-// byte-equal outputs.
+// containing the minimum corner of the two tolerance-expanded bounding
+// boxes' overlap, and is tested only there. No shared state, so the answer
+// depends on neither thread count nor cell size. Results are sorted before
+// returning, so equal inputs give byte-equal outputs.
 inline CensusCounts census(const cv::Mat_<cv::Vec3f>& P, int diagonal,
                            double cell, int exclude, double maxedge,
                            int nthreads, std::vector<Contact>& out)
@@ -312,6 +437,15 @@ inline CensusCounts census(const cv::Mat_<cv::Vec3f>& P, int diagonal,
     if (tris.empty()) return counts;
 
     // Uniform-grid broad phase.
+    //
+    // Every bucket range is expanded by the touch tolerance the narrow phase
+    // honours: tri_tri accepts pairs whose boxes come within TOUCH_TOL, so
+    // bucketing unexpanded boxes would let a sub-tolerance pair fall into
+    // different cells near a bucket boundary and never meet -- and whether
+    // that happened would depend on where the boundaries fall, i.e. on
+    // --cell. With the expansion, any pair the narrow phase could accept
+    // shares at least one bucket at every cell size, and the owner-cell rule
+    // below picks exactly one of them, so counts are independent of --cell.
     Vec3 lo{1e30, 1e30, 1e30}, hi{-1e30, -1e30, -1e30};
     for (const Tri& t : tris) {
         for (const Vec3& p : {t.a, t.b, t.c}) {
@@ -320,10 +454,28 @@ inline CensusCounts census(const cv::Mat_<cv::Vec3f>& P, int diagonal,
             lo.z = std::min(lo.z, p.z); hi.z = std::max(hi.z, p.z);
         }
     }
-    const int nx = std::max(1, (int)((hi.x - lo.x) / cell) + 1);
-    const int ny = std::max(1, (int)((hi.y - lo.y) / cell) + 1);
-    auto cellIdx = [&](int i, int j, int k) {
-        return ((size_t)k * ny + j) * nx + i;
+    // Index origin below every expanded box, so coordinates are nonnegative
+    // and float-to-int truncation equals floor everywhere.
+    const Vec3 org{lo.x - TOUCH_TOL, lo.y - TOUCH_TOL, lo.z - TOUCH_TOL};
+    // A finite positive cell can still be small enough that span/cell
+    // overflows the index type or turns each triangle's bucket loop
+    // astronomical. Both are refused with instructions, not undefined --
+    // and the check happens on the DOUBLE quotient, before any conversion
+    // to integer, because the conversion itself is what overflows.
+    constexpr double MAX_AXIS_CELLS = double(int64_t(1) << 21);
+    for (double span : {hi.x - org.x, hi.y - org.y, hi.z - org.z}) {
+        const double q = (span + TOUCH_TOL) / cell;
+        if (!std::isfinite(q) || q >= MAX_AXIS_CELLS)
+            throw std::invalid_argument(
+                "selfcross: cell size is too small for this surface's "
+                "extent (more than 2^21 broad-phase cells on one axis); "
+                "increase cell");
+    }
+    auto axisIdx = [&](double x, double o) { return (int64_t)((x - o) / cell); };
+    const int64_t nx = axisIdx(hi.x + TOUCH_TOL, org.x) + 1;
+    const int64_t ny = axisIdx(hi.y + TOUCH_TOL, org.y) + 1;
+    auto cellIdx = [&](int64_t i, int64_t j, int64_t k) {
+        return ((size_t)k * (size_t)ny + (size_t)j) * (size_t)nx + (size_t)i;
     };
     std::unordered_map<size_t, std::vector<uint32_t>> buckets;
     buckets.reserve(tris.size());
@@ -335,12 +487,23 @@ inline CensusCounts census(const cv::Mat_<cv::Vec3f>& P, int diagonal,
         double ty1 = std::max({t.a.y, t.b.y, t.c.y});
         double tz0 = std::min({t.a.z, t.b.z, t.c.z});
         double tz1 = std::max({t.a.z, t.b.z, t.c.z});
-        int i0 = (int)((tx0 - lo.x) / cell), i1 = (int)((tx1 - lo.x) / cell);
-        int j0 = (int)((ty0 - lo.y) / cell), j1 = (int)((ty1 - lo.y) / cell);
-        int k0 = (int)((tz0 - lo.z) / cell), k1 = (int)((tz1 - lo.z) / cell);
-        for (int k = k0; k <= k1; ++k)
-            for (int j = j0; j <= j1; ++j)
-                for (int i = i0; i <= i1; ++i)
+        int64_t i0 = axisIdx(tx0 - TOUCH_TOL, org.x);
+        int64_t i1 = axisIdx(tx1 + TOUCH_TOL, org.x);
+        int64_t j0 = axisIdx(ty0 - TOUCH_TOL, org.y);
+        int64_t j1 = axisIdx(ty1 + TOUCH_TOL, org.y);
+        int64_t k0 = axisIdx(tz0 - TOUCH_TOL, org.z);
+        int64_t k1 = axisIdx(tz1 + TOUCH_TOL, org.z);
+        // In double, not int64: three per-axis spans near the 2^21 cap
+        // would overflow a signed multiply before the comparison.
+        const double span = double(i1 - i0 + 1) * double(j1 - j0 + 1)
+                          * double(k1 - k0 + 1);
+        if (span > 2'000'000.0)
+            throw std::invalid_argument(
+                "selfcross: a triangle spans over 2e6 broad-phase cells; "
+                "increase cell (or use maxedge to drop degenerate quads)");
+        for (int64_t k = k0; k <= k1; ++k)
+            for (int64_t j = j0; j <= j1; ++j)
+                for (int64_t i = i0; i <= i1; ++i)
                     buckets[cellIdx(i, j, k)].push_back(ti);
     }
     std::vector<std::pair<size_t, const std::vector<uint32_t>*>> cells;
@@ -351,14 +514,18 @@ inline CensusCounts census(const cv::Mat_<cv::Vec3f>& P, int diagonal,
               [](const auto& a, const auto& b) { return a.first < b.first; });
 
     auto ownerCell = [&](const Tri& A, const Tri& B) {
+        // The minimum corner of the two EXPANDED boxes' overlap. Whenever
+        // the expanded boxes overlap on every axis, this corner lies inside
+        // both triangles' inserted ranges (truncation is monotone), so both
+        // bucketed the owning cell and the pair is tested exactly once.
         double ox = std::max(std::min({A.a.x, A.b.x, A.c.x}),
-                             std::min({B.a.x, B.b.x, B.c.x}));
+                             std::min({B.a.x, B.b.x, B.c.x})) - TOUCH_TOL;
         double oy = std::max(std::min({A.a.y, A.b.y, A.c.y}),
-                             std::min({B.a.y, B.b.y, B.c.y}));
+                             std::min({B.a.y, B.b.y, B.c.y})) - TOUCH_TOL;
         double oz = std::max(std::min({A.a.z, A.b.z, A.c.z}),
-                             std::min({B.a.z, B.b.z, B.c.z}));
-        return cellIdx((int)((ox - lo.x) / cell), (int)((oy - lo.y) / cell),
-                       (int)((oz - lo.z) / cell));
+                             std::min({B.a.z, B.b.z, B.c.z})) - TOUCH_TOL;
+        return cellIdx(axisIdx(ox, org.x), axisIdx(oy, org.y),
+                       axisIdx(oz, org.z));
     };
 
     std::vector<std::vector<Contact>> perThread(nthreads);

--- a/volume-cartographer/apps/src/vc_tifxyz_selfcross_impl.hpp
+++ b/volume-cartographer/apps/src/vc_tifxyz_selfcross_impl.hpp
@@ -1,0 +1,428 @@
+// Census kernel for vc_tifxyz_selfcross: does a tifxyz surface pass through
+// itself? Header-only so the command-line app and the regression tests run
+// the identical code; see vc_tifxyz_selfcross.cpp for the tool and
+// core/test/test_tifxyz_selfcross.cpp for the fixtures.
+#pragma once
+
+#include <opencv2/core/mat.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace vc_selfcross {
+
+// ------------------------------------------------------------ the predicate
+//
+// Moller's interval-overlap triangle test, with the degenerate branches
+// surfaced instead of collapsed into "no intersection", and the plane
+// tolerance derived from the operands. The inputs are float32 coordinates
+// running to ~1e4 voxels, where one ULP is already ~1e-3 voxels; a fixed
+// 1e-6 tolerance would be a thousand times finer than the data's own
+// representation and would classify representation noise.
+
+constexpr double FLT_EPS = 1.1920929e-7;
+constexpr double EPS_SCALE = 16.0;
+
+// Interval overlaps at or below this are touches, not penetrations. Float32
+// spacing near coordinate 5,000 is ~5e-4 voxels, so anything finer than this
+// is below the input's own resolution.
+constexpr double TOUCH_TOL = 1e-3;
+
+inline double plane_eps(double mag) {
+    return std::max(1e-9, EPS_SCALE * FLT_EPS * mag);
+}
+
+struct Vec3 {
+    double x = 0, y = 0, z = 0;
+    Vec3() = default;
+    Vec3(double a, double b, double c) : x(a), y(b), z(c) {}
+    Vec3 operator-(const Vec3& o) const { return {x - o.x, y - o.y, z - o.z}; }
+    Vec3 operator+(const Vec3& o) const { return {x + o.x, y + o.y, z + o.z}; }
+    Vec3 operator*(double s) const { return {x * s, y * s, z * s}; }
+};
+
+inline double dot(const Vec3& a, const Vec3& b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+inline Vec3 cross(const Vec3& a, const Vec3& b) {
+    return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
+}
+inline double norm(const Vec3& a) { return std::sqrt(dot(a, a)); }
+
+struct Tri {
+    Vec3 a, b, c;
+    int32_t v = 0, u = 0;   // grid origin of the owning quad
+    int32_t t = 0;          // triangle index within the quad (0/1)
+};
+
+enum Verdict { NONE = 0, TRANSVERSE = 1, COPLANAR = 2, GRAZING = 3 };
+
+struct TriTriResult {
+    Verdict verdict = NONE;
+    double penetration = 0.0;   // Euclidean length of the shared segment
+    double angle_deg = 0.0;     // between the two triangle planes
+    Vec3 site{};                // midpoint of the shared segment; TRANSVERSE only
+};
+
+inline bool tri2d_overlap(const Vec3 tri1[3], const Vec3 tri2[3], const Vec3& n) {
+    int drop = 0;
+    double ax = std::fabs(n.x), ay = std::fabs(n.y), az = std::fabs(n.z);
+    if (ay > ax && ay > az) drop = 1;
+    else if (az > ax && az > ay) drop = 2;
+
+    auto proj = [drop](const Vec3& p) -> std::pair<double, double> {
+        if (drop == 0) return {p.y, p.z};
+        if (drop == 1) return {p.x, p.z};
+        return {p.x, p.y};
+    };
+    std::pair<double, double> P[3], Q[3];
+    for (int i = 0; i < 3; ++i) { P[i] = proj(tri1[i]); Q[i] = proj(tri2[i]); }
+
+    auto separated = [&](const std::pair<double, double> A[3],
+                         const std::pair<double, double> B[3]) {
+        for (int i = 0; i < 3; ++i) {
+            int j = (i + 1) % 3;
+            double ex = A[j].first - A[i].first;
+            double ey = A[j].second - A[i].second;
+            double refs[3];
+            for (int k = 0; k < 3; ++k)
+                refs[k] = -ey * (B[k].first - A[i].first)
+                        + ex * (B[k].second - A[i].second);
+            double selfSide = -ey * (A[(i + 2) % 3].first - A[i].first)
+                            + ex * (A[(i + 2) % 3].second - A[i].second);
+            bool allOpposite = true;
+            for (int k = 0; k < 3; ++k)
+                if (refs[k] * selfSide > -1e-12) { allOpposite = false; break; }
+            if (allOpposite) return true;
+        }
+        return false;
+    };
+    if (separated(P, Q)) return false;
+    if (separated(Q, P)) return false;
+    return true;
+}
+
+inline TriTriResult tri_tri(const Tri& T1, const Tri& T2) {
+    const Vec3 p1[3] = {T1.a, T1.b, T1.c};
+    const Vec3 p2[3] = {T2.a, T2.b, T2.c};
+
+    // Bounding-box separation first. Beyond the speedup this is load-bearing:
+    // without it a triangle far away from T2 but near T2's INFINITE plane
+    // would be classified grazing, which says nothing about touching.
+    {
+        double lo1[3] = {std::min({p1[0].x, p1[1].x, p1[2].x}),
+                         std::min({p1[0].y, p1[1].y, p1[2].y}),
+                         std::min({p1[0].z, p1[1].z, p1[2].z})};
+        double hi1[3] = {std::max({p1[0].x, p1[1].x, p1[2].x}),
+                         std::max({p1[0].y, p1[1].y, p1[2].y}),
+                         std::max({p1[0].z, p1[1].z, p1[2].z})};
+        double lo2[3] = {std::min({p2[0].x, p2[1].x, p2[2].x}),
+                         std::min({p2[0].y, p2[1].y, p2[2].y}),
+                         std::min({p2[0].z, p2[1].z, p2[2].z})};
+        double hi2[3] = {std::max({p2[0].x, p2[1].x, p2[2].x}),
+                         std::max({p2[0].y, p2[1].y, p2[2].y}),
+                         std::max({p2[0].z, p2[1].z, p2[2].z})};
+        for (int k = 0; k < 3; ++k)
+            if (hi1[k] < lo2[k] - TOUCH_TOL || hi2[k] < lo1[k] - TOUCH_TOL)
+                return {NONE, 0.0, 0.0, {}};
+    }
+
+    Vec3 n2 = cross(p2[1] - p2[0], p2[2] - p2[0]);
+    double l2 = norm(n2);
+    Vec3 n1 = cross(p1[1] - p1[0], p1[2] - p1[0]);
+    double l1 = norm(n1);
+    if (l1 < 1e-12 || l2 < 1e-12) return {GRAZING, 0.0, 0.0, {}};   // degenerate
+    n1 = n1 * (1.0 / l1);
+    n2 = n2 * (1.0 / l2);
+
+    double d1[3], d2[3];
+    for (int i = 0; i < 3; ++i) d1[i] = dot(n2, p1[i] - p2[0]);
+    for (int i = 0; i < 3; ++i) d2[i] = dot(n1, p2[i] - p1[0]);
+
+    double mag = 0.0;
+    for (const Vec3& p : {p1[0], p1[1], p1[2], p2[0], p2[1], p2[2]})
+        mag = std::max(mag, std::max(std::fabs(p.x),
+                       std::max(std::fabs(p.y), std::fabs(p.z))));
+    const double EPS = plane_eps(mag);
+
+    bool graze = false;
+    for (int i = 0; i < 3; ++i) {
+        if (std::fabs(d1[i]) < EPS) graze = true;
+        if (std::fabs(d2[i]) < EPS) graze = true;
+    }
+
+    auto allSameSign = [EPS](const double d[3]) {
+        return (d[0] > EPS && d[1] > EPS && d[2] > EPS)
+            || (d[0] < -EPS && d[1] < -EPS && d[2] < -EPS);
+    };
+    if (allSameSign(d1) || allSameSign(d2)) return {NONE, 0.0, 0.0, {}};
+
+    const double ang = std::acos(std::min(1.0, std::fabs(dot(n1, n2))))
+                     * 180.0 / 3.14159265358979323846;
+
+    bool coplanar = std::fabs(d1[0]) < EPS && std::fabs(d1[1]) < EPS
+                 && std::fabs(d1[2]) < EPS;
+    if (coplanar)
+        return tri2d_overlap(p1, p2, n1) ? TriTriResult{COPLANAR, 0.0, ang, {}}
+                                         : TriTriResult{NONE, 0.0, ang, {}};
+    if (graze) return {GRAZING, 0.0, ang, {}};
+
+    Vec3 D = cross(n1, n2);
+    double ax = std::fabs(D.x), ay = std::fabs(D.y), az = std::fabs(D.z);
+    int idx = (ay > ax && ay > az) ? 1 : ((az > ax && az > ay) ? 2 : 0);
+    auto comp = [idx](const Vec3& p) {
+        return idx == 0 ? p.x : (idx == 1 ? p.y : p.z);
+    };
+
+    // The parameter interval of one triangle along the intersection line,
+    // with the 3D endpoints kept: the reported crossing site is derived from
+    // the shared segment itself, not from triangle centroids, which for long
+    // or skew triangles can sit voxels away from the actual intersection.
+    // The parameters are the endpoints' `comp` coordinates, computed from
+    // the same per-component expression as before, so verdicts, penetrations
+    // and angles are unchanged by carrying the endpoints along.
+    auto interval = [&](const Vec3 p[3], const double d[3],
+                        double& t0, double& t1, Vec3& q0, Vec3& q1) {
+        int apex = -1;
+        for (int i = 0; i < 3; ++i) {
+            int j = (i + 1) % 3, k = (i + 2) % 3;
+            if ((d[i] > 0 && d[j] <= 0 && d[k] <= 0)
+             || (d[i] < 0 && d[j] >= 0 && d[k] >= 0)) { apex = i; break; }
+        }
+        if (apex < 0) return false;
+        int j = (apex + 1) % 3, k = (apex + 2) % 3;
+        q0 = p[apex] + (p[j] - p[apex]) * (d[apex] / (d[apex] - d[j]));
+        q1 = p[apex] + (p[k] - p[apex]) * (d[apex] / (d[apex] - d[k]));
+        t0 = comp(q0);
+        t1 = comp(q1);
+        if (t0 > t1) { std::swap(t0, t1); std::swap(q0, q1); }
+        return true;
+    };
+
+    double a0, a1, b0, b1;
+    Vec3 A0, A1, B0, B1;
+    if (!interval(p1, d1, a0, a1, A0, A1)) return {GRAZING, 0.0, ang, {}};
+    if (!interval(p2, d2, b0, b1, B0, B1)) return {GRAZING, 0.0, ang, {}};
+
+    // The overlap is a projection onto one axis, shorter than the true shared
+    // segment by the direction cosine; dividing restores Euclidean length,
+    // which is what "penetration" should mean to a reader. Intervals that
+    // merely meet at a point are a touch, not a crossing.
+    const double dlen = norm(D);
+    const double dcos = dlen > 1e-12
+        ? std::fabs((idx == 0 ? D.x : (idx == 1 ? D.y : D.z)) / dlen) : 1.0;
+    const double proj = std::min(a1, b1) - std::max(a0, b0);
+    if (proj <= 0.0) return {NONE, 0.0, ang, {}};
+    const double pen = proj / std::max(dcos, 1e-9);
+    if (pen <= TOUCH_TOL) return {GRAZING, pen, ang, {}};
+    // Both triangles' segments lie on the one intersection line, so the
+    // shared segment runs from the larger of the two starts to the smaller
+    // of the two ends; its midpoint is a point both interiors contain.
+    const Vec3& s0 = (a0 > b0) ? A0 : B0;
+    const Vec3& s1 = (a1 < b1) ? A1 : B1;
+    return {TRANSVERSE, pen, ang, (s0 + s1) * 0.5};
+}
+
+// -------------------------------------------------------------- the census
+
+struct Contact {
+    int32_t v1, u1, v2, u2;
+    int32_t t1, t2;
+    int verdict;
+    float penetration, angle_deg;
+    Vec3 site;   // on the intersection segment for transverse contacts
+};
+
+struct CensusCounts {
+    size_t triangles = 0, quads_dropped = 0, pairs_tested = 0;
+    size_t transverse = 0, coplanar = 0, grazing = 0;
+};
+
+inline bool valid_point(const cv::Vec3f& p) {
+    return (p[0] != -1.f || p[1] != -1.f || p[2] != -1.f)
+        && std::isfinite(p[0]) && std::isfinite(p[1]) && std::isfinite(p[2]);
+}
+
+// One pass over one triangulation. Deterministic by construction: a triangle
+// pair can share several broad-phase cells, and testing it in each would
+// count it once per thread that happens to visit one -- the count would move
+// with scheduling. Instead every pair is owned by exactly one cell, the one
+// containing the minimum corner of the two bounding boxes' overlap, and is
+// tested only there. No shared state, and the answer does not depend on
+// thread count. Results are sorted before returning, so equal inputs give
+// byte-equal outputs.
+inline CensusCounts census(const cv::Mat_<cv::Vec3f>& P, int diagonal,
+                           double cell, int exclude, double maxedge,
+                           int nthreads, std::vector<Contact>& out)
+{
+    // A nonpositive cell is not a coarser grid, it is undefined behaviour:
+    // zero divides to infinity whose int conversion is UB, and a negative
+    // value reverses every bucket range so triangles never share a cell and
+    // a crossing surface censuses clean. Refuse rather than misreport.
+    if (!(cell > 0.0) || !std::isfinite(cell))
+        throw std::invalid_argument("selfcross: cell size must be a finite "
+                                    "positive number of voxels");
+    if (exclude < 0)
+        throw std::invalid_argument("selfcross: exclude must be >= 0");
+    if (nthreads <= 0) nthreads = (int)std::thread::hardware_concurrency();
+    if (nthreads <= 0) nthreads = 4;
+
+    CensusCounts counts;
+
+    std::vector<Tri> tris;
+    for (int v = 0; v + 1 < P.rows; ++v) {
+        for (int u = 0; u + 1 < P.cols; ++u) {
+            const cv::Vec3f& q00 = P(v, u);
+            const cv::Vec3f& q10 = P(v + 1, u);
+            const cv::Vec3f& q01 = P(v, u + 1);
+            const cv::Vec3f& q11 = P(v + 1, u + 1);
+            if (!valid_point(q00) || !valid_point(q10)
+             || !valid_point(q01) || !valid_point(q11))
+                continue;
+            Vec3 p00{q00[0], q00[1], q00[2]}, p10{q10[0], q10[1], q10[2]};
+            Vec3 p01{q01[0], q01[1], q01[2]}, p11{q11[0], q11[1], q11[2]};
+            if (maxedge > 0) {
+                // Not cosmetic. A grid can hold discontinuities where two
+                // adjacent valid cells sit far apart in 3D; a triangle built
+                // across such a gap spans many wraps and crosses everything
+                // it passes through, purely because the mesh has a hole.
+                double e = std::max(std::max(norm(p01 - p00), norm(p11 - p01)),
+                          std::max(std::max(norm(p10 - p11), norm(p00 - p10)),
+                                   std::max(norm(p11 - p00), norm(p10 - p01))));
+                if (e > maxedge) { ++counts.quads_dropped; continue; }
+            }
+            if (diagonal == 0) {
+                tris.push_back({p00, p01, p11, v, u, 0});
+                tris.push_back({p00, p11, p10, v, u, 1});
+            } else {
+                tris.push_back({p00, p01, p10, v, u, 0});
+                tris.push_back({p01, p11, p10, v, u, 1});
+            }
+        }
+    }
+    counts.triangles = tris.size();
+    if (tris.empty()) return counts;
+
+    // Uniform-grid broad phase.
+    Vec3 lo{1e30, 1e30, 1e30}, hi{-1e30, -1e30, -1e30};
+    for (const Tri& t : tris) {
+        for (const Vec3& p : {t.a, t.b, t.c}) {
+            lo.x = std::min(lo.x, p.x); hi.x = std::max(hi.x, p.x);
+            lo.y = std::min(lo.y, p.y); hi.y = std::max(hi.y, p.y);
+            lo.z = std::min(lo.z, p.z); hi.z = std::max(hi.z, p.z);
+        }
+    }
+    const int nx = std::max(1, (int)((hi.x - lo.x) / cell) + 1);
+    const int ny = std::max(1, (int)((hi.y - lo.y) / cell) + 1);
+    auto cellIdx = [&](int i, int j, int k) {
+        return ((size_t)k * ny + j) * nx + i;
+    };
+    std::unordered_map<size_t, std::vector<uint32_t>> buckets;
+    buckets.reserve(tris.size());
+    for (uint32_t ti = 0; ti < tris.size(); ++ti) {
+        const Tri& t = tris[ti];
+        double tx0 = std::min({t.a.x, t.b.x, t.c.x});
+        double tx1 = std::max({t.a.x, t.b.x, t.c.x});
+        double ty0 = std::min({t.a.y, t.b.y, t.c.y});
+        double ty1 = std::max({t.a.y, t.b.y, t.c.y});
+        double tz0 = std::min({t.a.z, t.b.z, t.c.z});
+        double tz1 = std::max({t.a.z, t.b.z, t.c.z});
+        int i0 = (int)((tx0 - lo.x) / cell), i1 = (int)((tx1 - lo.x) / cell);
+        int j0 = (int)((ty0 - lo.y) / cell), j1 = (int)((ty1 - lo.y) / cell);
+        int k0 = (int)((tz0 - lo.z) / cell), k1 = (int)((tz1 - lo.z) / cell);
+        for (int k = k0; k <= k1; ++k)
+            for (int j = j0; j <= j1; ++j)
+                for (int i = i0; i <= i1; ++i)
+                    buckets[cellIdx(i, j, k)].push_back(ti);
+    }
+    std::vector<std::pair<size_t, const std::vector<uint32_t>*>> cells;
+    cells.reserve(buckets.size());
+    for (auto& kv : buckets)
+        if (kv.second.size() > 1) cells.emplace_back(kv.first, &kv.second);
+    std::sort(cells.begin(), cells.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    auto ownerCell = [&](const Tri& A, const Tri& B) {
+        double ox = std::max(std::min({A.a.x, A.b.x, A.c.x}),
+                             std::min({B.a.x, B.b.x, B.c.x}));
+        double oy = std::max(std::min({A.a.y, A.b.y, A.c.y}),
+                             std::min({B.a.y, B.b.y, B.c.y}));
+        double oz = std::max(std::min({A.a.z, A.b.z, A.c.z}),
+                             std::min({B.a.z, B.b.z, B.c.z}));
+        return cellIdx((int)((ox - lo.x) / cell), (int)((oy - lo.y) / cell),
+                       (int)((oz - lo.z) / cell));
+    };
+
+    std::vector<std::vector<Contact>> perThread(nthreads);
+    std::atomic<size_t> next{0};
+    std::atomic<size_t> tested{0};
+
+    auto worker = [&](int id) {
+        auto& outv = perThread[id];
+        size_t local = 0;
+        for (;;) {
+            size_t ci = next.fetch_add(1);
+            if (ci >= cells.size()) break;
+            const size_t key = cells[ci].first;
+            const std::vector<uint32_t>& c = *cells[ci].second;
+            for (size_t a = 0; a < c.size(); ++a) {
+                for (size_t b = a + 1; b < c.size(); ++b) {
+                    const Tri& T1 = tris[c[a]];
+                    const Tri& T2 = tris[c[b]];
+                    // Quads within Chebyshev distance `exclude` share at
+                    // least one vertex at exclude = 1, so this is exactly
+                    // shared-vertex/shared-edge exclusion.
+                    if (std::abs(T1.v - T2.v) <= exclude
+                        && std::abs(T1.u - T2.u) <= exclude) continue;
+                    if (ownerCell(T1, T2) != key) continue;
+                    ++local;
+                    TriTriResult r = tri_tri(T1, T2);
+                    if (r.verdict != NONE) {
+                        // Canonical endpoint order: the lexicographically
+                        // smaller (v,u,t) is side 1, so every reader sees one
+                        // identity per geometric pair.
+                        bool swap = std::make_tuple(T1.v, T1.u, T1.t)
+                                  > std::make_tuple(T2.v, T2.u, T2.t);
+                        const Tri& A = swap ? T2 : T1;
+                        const Tri& B = swap ? T1 : T2;
+                        outv.push_back({A.v, A.u, B.v, B.u, A.t, B.t,
+                                        (int)r.verdict, (float)r.penetration,
+                                        (float)r.angle_deg, r.site});
+                    }
+                }
+            }
+        }
+        tested.fetch_add(local);
+    };
+    std::vector<std::thread> pool;
+    for (int t = 0; t < nthreads; ++t) pool.emplace_back(worker, t);
+    for (auto& t : pool) t.join();
+    counts.pairs_tested = tested.load();
+
+    size_t total = 0;
+    for (auto& v : perThread) total += v.size();
+    out.reserve(out.size() + total);
+    size_t first = out.size();
+    for (auto& v : perThread) out.insert(out.end(), v.begin(), v.end());
+    std::sort(out.begin() + first, out.end(),
+              [](const Contact& x, const Contact& y) {
+        return std::tie(x.v1, x.u1, x.t1, x.v2, x.u2, x.t2)
+             < std::tie(y.v1, y.u1, y.t1, y.v2, y.u2, y.t2);
+    });
+    for (size_t i = first; i < out.size(); ++i) {
+        if (out[i].verdict == TRANSVERSE) ++counts.transverse;
+        else if (out[i].verdict == COPLANAR) ++counts.coplanar;
+        else ++counts.grazing;
+    }
+    return counts;
+}
+
+}  // namespace vc_selfcross

--- a/volume-cartographer/core/src/PointCollections.cpp
+++ b/volume-cartographer/core/src/PointCollections.cpp
@@ -570,7 +570,18 @@ bool PointCollections::saveToJSON(const std::string& filename) const
         return false;
     }
     o << j.dump(4);
+    o.flush();
+    // A full disk or quota failure surfaces here, not at open(); without
+    // this check the write is reported successful and the file is truncated.
+    if (!o.good()) {
+        std::cerr << "Failed while writing: " << filename << std::endl;
+        return false;
+    }
     o.close();
+    if (o.fail()) {
+        std::cerr << "Failed to finish writing: " << filename << std::endl;
+        return false;
+    }
     return true;
 }
 

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -469,11 +469,16 @@ vc_add_test(NAME test_atlas LIBS doctest::doctest vc_atlas)
 vc_add_test(NAME test_tifxyz_selfcross LIBS doctest::doctest opencv_core)
 
 # End-to-end CLI contract for the same tool: exit codes, report
-# serialization, collection envelope. Needs the binary built first.
-vc_add_test(NAME test_tifxyz_selfcross_cli
-    LIBS doctest::doctest vc_core opencv_core opencv_imgcodecs
-    DEFS VC_SELFCROSS_BIN="$<TARGET_FILE:vc_tifxyz_selfcross>")
-add_dependencies(test_tifxyz_selfcross_cli vc_tifxyz_selfcross)
+# serialization, collection envelope. Needs the binary, so it only exists
+# in configurations that build the apps -- the test shards configure with
+# VC_BUILD_APPS=OFF and apps/ returns before the target is created, which
+# would make the TARGET_FILE expression a configure error.
+if(TARGET vc_tifxyz_selfcross)
+    vc_add_test(NAME test_tifxyz_selfcross_cli
+        LIBS doctest::doctest vc_core opencv_core opencv_imgcodecs
+        DEFS VC_SELFCROSS_BIN="$<TARGET_FILE:vc_tifxyz_selfcross>")
+    add_dependencies(test_tifxyz_selfcross_cli vc_tifxyz_selfcross)
+endif()
 
 vc_add_test(NAME test_fiber_intersections LIBS doctest::doctest vc_atlas)
 

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -468,6 +468,13 @@ vc_add_test(NAME test_atlas LIBS doctest::doctest vc_atlas)
 # with the command-line tool so the tested code is the shipped code).
 vc_add_test(NAME test_tifxyz_selfcross LIBS doctest::doctest opencv_core)
 
+# End-to-end CLI contract for the same tool: exit codes, report
+# serialization, collection envelope. Needs the binary built first.
+vc_add_test(NAME test_tifxyz_selfcross_cli
+    LIBS doctest::doctest vc_core opencv_core opencv_imgcodecs
+    DEFS VC_SELFCROSS_BIN="$<TARGET_FILE:vc_tifxyz_selfcross>")
+add_dependencies(test_tifxyz_selfcross_cli vc_tifxyz_selfcross)
+
 vc_add_test(NAME test_fiber_intersections LIBS doctest::doctest vc_atlas)
 
 vc_add_test(NAME test_remote_url)

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -464,6 +464,10 @@ vc_add_test(NAME test_lasagna_normal_sampler LIBS doctest::doctest vc_atlas)
 
 vc_add_test(NAME test_atlas LIBS doctest::doctest vc_atlas)
 
+# The vc_tifxyz_selfcross census kernel (header-only under apps/src, shared
+# with the command-line tool so the tested code is the shipped code).
+vc_add_test(NAME test_tifxyz_selfcross LIBS doctest::doctest opencv_core)
+
 vc_add_test(NAME test_fiber_intersections LIBS doctest::doctest vc_atlas)
 
 vc_add_test(NAME test_remote_url)

--- a/volume-cartographer/core/test/test_tifxyz_selfcross.cpp
+++ b/volume-cartographer/core/test/test_tifxyz_selfcross.cpp
@@ -1,0 +1,249 @@
+// Regression fixtures for the vc_tifxyz_selfcross census kernel.
+//
+// The kernel classifies triangle-pair contacts as transverse, coplanar or
+// grazing, and the distinctions are the point: two sheets pressed flat are
+// coplanar, an exact edge-on meeting is a touch, and only interiors passing
+// through each other is transverse. Synthetic fixtures are full of exactly
+// those coincidences -- a sheet whose vertex row lands on the other's plane
+// TOUCHES it, one at exactly a vertex column meets it along mesh edges --
+// so each fixture below states which trap it exists to pin down.
+//
+// The grids follow the stitch trick: two sub-sheets separated by a band of
+// invalid rows wider than the adjacency exclusion, so every contact between
+// them is non-adjacent by construction.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "vc_test.hpp"
+
+#include "../../apps/src/vc_tifxyz_selfcross_impl.hpp"
+
+#include <opencv2/core/mat.hpp>
+
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+
+using vc_selfcross::Contact;
+using vc_selfcross::CensusCounts;
+using vc_selfcross::census;
+using vc_selfcross::COPLANAR;
+using vc_selfcross::GRAZING;
+using vc_selfcross::TRANSVERSE;
+
+namespace {
+
+constexpr int GAP = 4;   // invalid rows between sub-sheets; exclusion is 1
+
+const cv::Vec3f INVALID(-1.f, -1.f, -1.f);
+
+// A flat sheet in the plane z = z0, rows*cols, pitch 4.
+void put_plane(cv::Mat_<cv::Vec3f>& P, int row0, int rows, int cols,
+               double z0)
+{
+    for (int v = 0; v < rows; ++v)
+        for (int u = 0; u < cols; ++u)
+            P(row0 + v, u) = cv::Vec3f(4.f * u, 4.f * v, (float)z0);
+}
+
+cv::Mat_<cv::Vec3f> blank(int rows, int cols)
+{
+    cv::Mat_<cv::Vec3f> P(rows, cols);
+    P.setTo(INVALID);
+    return P;
+}
+
+struct Run {
+    CensusCounts counts;
+    std::vector<Contact> contacts;
+};
+
+Run run(const cv::Mat_<cv::Vec3f>& P, int diagonal, double cell = 40.0,
+        int exclude = 1, double maxedge = 60.0, int threads = 2)
+{
+    Run r;
+    r.counts = census(P, diagonal, cell, exclude, maxedge, threads,
+                      r.contacts);
+    return r;
+}
+
+}  // namespace
+
+TEST_CASE("a flat sheet censuses clean under both triangulations")
+{
+    cv::Mat_<cv::Vec3f> P = blank(12, 16);
+    put_plane(P, 0, 12, 16, 5.0);
+    for (int d = 0; d < 2; ++d) {
+        Run r = run(P, d);
+        CHECK(r.counts.triangles == 11u * 15u * 2u);
+        CHECK(r.counts.transverse == 0u);
+        CHECK(r.counts.coplanar == 0u);
+        CHECK(r.counts.grazing == 0u);
+    }
+}
+
+TEST_CASE("a sheet driven through a plane is transverse, and the site lies "
+          "on the crossing")
+{
+    // The second sub-sheet is TILTED and OFFSET. An axis-aligned sheet at a
+    // whole multiple of the grid pitch meets the plane exactly along mesh
+    // edges, which is a touch, not a penetration -- the fixture that taught
+    // this is the grazing test below.
+    cv::Mat_<cv::Vec3f> P = blank(10 + GAP + 10, 12);
+    put_plane(P, 0, 10, 12, 5.0);
+    for (int v = 0; v < 10; ++v)
+        for (int u = 0; u < 12; ++u)
+            P(10 + GAP + v, u) = cv::Vec3f(
+                4.f * u + 0.3f * v + 1.7f,          // tilted in x
+                4.f * v,
+                (float)(4.0 * (u - 5) + 2.0 + 5.0)); // crosses z = 5 off-grid
+    for (int d = 0; d < 2; ++d) {
+        Run r = run(P, d);
+        CHECK(r.counts.transverse > 0u);
+        for (const Contact& c : r.contacts) {
+            if (c.verdict != TRANSVERSE) continue;
+            // one end on each side of the invalid band
+            const bool v1_lower = c.v1 < 10, v2_lower = c.v2 < 10;
+            CHECK(v1_lower != v2_lower);
+            // the reported site sits on the plane sub-sheet (z = 5) to
+            // within the contact's own penetration depth -- a centroid
+            // midpoint would not satisfy this for skew pairs
+            CHECK(std::fabs(c.site.z - 5.0) <= c.penetration + 1e-6);
+            CHECK(c.penetration > 0.0f);
+        }
+    }
+}
+
+TEST_CASE("two sheets pressed flat are coplanar, never transverse")
+{
+    cv::Mat_<cv::Vec3f> P = blank(8 + GAP + 8, 10);
+    put_plane(P, 0, 8, 10, 5.0);
+    put_plane(P, 8 + GAP, 8, 10, 5.0);   // the same geometry again
+    for (int d = 0; d < 2; ++d) {
+        Run r = run(P, d);
+        CHECK(r.counts.transverse == 0u);
+        CHECK(r.counts.coplanar > 0u);
+    }
+}
+
+TEST_CASE("an exact edge-on meeting is grazing, not transverse")
+{
+    // A vertical sheet whose bottom vertex ROW lies exactly in the plane
+    // z = 5: every meeting is along mesh edges and vertices, where the sign
+    // data the interval test relies on is not trustworthy. The kernel must
+    // report the uncertainty rather than promote it to a crossing.
+    cv::Mat_<cv::Vec3f> P = blank(8 + GAP + 8, 10);
+    put_plane(P, 0, 8, 10, 5.0);
+    for (int v = 0; v < 8; ++v)
+        for (int u = 0; u < 10; ++u)
+            P(8 + GAP + v, u) = cv::Vec3f(4.f * u, 4.f * v, 5.f + 4.f * u);
+    for (int d = 0; d < 2; ++d) {
+        Run r = run(P, d);
+        CHECK(r.counts.transverse == 0u);
+        CHECK(r.counts.grazing > 0u);
+    }
+}
+
+TEST_CASE("adjacency exclusion is honoured and reported pairs are canonical")
+{
+    // Reuse the transverse fixture: no emitted contact may join quads
+    // within the Chebyshev exclusion window, and every row must carry the
+    // lexicographically smaller endpoint first, so a reader sees exactly
+    // one identity per geometric pair.
+    cv::Mat_<cv::Vec3f> P = blank(10 + GAP + 10, 12);
+    put_plane(P, 0, 10, 12, 5.0);
+    for (int v = 0; v < 10; ++v)
+        for (int u = 0; u < 12; ++u)
+            P(10 + GAP + v, u) = cv::Vec3f(4.f * u + 0.3f * v + 1.7f, 4.f * v,
+                                           (float)(4.0 * (u - 5) + 7.0));
+    Run r = run(P, 0);
+    REQUIRE(!r.contacts.empty());
+    for (const Contact& c : r.contacts) {
+        const bool adjacent = std::abs(c.v1 - c.v2) <= 1
+                           && std::abs(c.u1 - c.u2) <= 1;
+        CHECK(!adjacent);
+        CHECK(std::make_tuple(c.v1, c.u1, c.t1)
+              <= std::make_tuple(c.v2, c.u2, c.t2));
+    }
+}
+
+TEST_CASE("results do not depend on thread count or broad-phase cell size")
+{
+    // A pair can share several broad-phase cells; it is owned by exactly
+    // one, so neither scheduling nor the cell size may move any count.
+    // Historically a per-thread dedup produced counts that tracked the
+    // thread count, and a missing bbox pre-filter produced grazing counts
+    // that tracked the cell size -- this pins both down.
+    cv::Mat_<cv::Vec3f> P = blank(10 + GAP + 10, 12);
+    put_plane(P, 0, 10, 12, 5.0);
+    for (int v = 0; v < 10; ++v)
+        for (int u = 0; u < 12; ++u)
+            P(10 + GAP + v, u) = cv::Vec3f(4.f * u + 0.3f * v + 1.7f, 4.f * v,
+                                           (float)(4.0 * (u - 5) + 7.0));
+    Run ref = run(P, 0, 40.0, 1, 60.0, 1);
+    REQUIRE(ref.counts.transverse > 0u);
+    for (int threads : {2, 5}) {
+        Run r = run(P, 0, 40.0, 1, 60.0, threads);
+        CHECK(r.contacts.size() == ref.contacts.size());
+        for (size_t i = 0; i < r.contacts.size(); ++i) {
+            CHECK(r.contacts[i].v1 == ref.contacts[i].v1);
+            CHECK(r.contacts[i].u1 == ref.contacts[i].u1);
+            CHECK(r.contacts[i].v2 == ref.contacts[i].v2);
+            CHECK(r.contacts[i].u2 == ref.contacts[i].u2);
+            CHECK(r.contacts[i].verdict == ref.contacts[i].verdict);
+        }
+    }
+    for (double cell : {7.0, 21.0, 160.0}) {
+        Run r = run(P, 0, cell);
+        CHECK(r.counts.transverse == ref.counts.transverse);
+        CHECK(r.counts.coplanar == ref.counts.coplanar);
+        CHECK(r.counts.grazing == ref.counts.grazing);
+    }
+}
+
+TEST_CASE("quads spanning a grid discontinuity are dropped, not censused")
+{
+    // Two adjacent valid columns sitting far apart in 3D produce a triangle
+    // that spans the gap and crosses everything in its path purely because
+    // the mesh has a hole there. maxedge exists to drop it.
+    cv::Mat_<cv::Vec3f> P = blank(6 + GAP + 6, 8);
+    put_plane(P, 0, 6, 8, 5.0);
+    for (int v = 0; v < 6; ++v)
+        for (int u = 0; u < 8; ++u)
+            P(6 + GAP + v, u) = cv::Vec3f(
+                4.f * u + (u >= 4 ? 500.f : 0.f) + 1.7f + 0.3f * v,
+                4.f * v, (float)(4.0 * (u - 2) + 7.0));
+    Run gated = run(P, 0);
+    CHECK(gated.counts.quads_dropped > 0u);
+    Run open = run(P, 0, 40.0, 1, /*maxedge=*/0.0);
+    CHECK(open.counts.quads_dropped == 0u);
+    CHECK(open.counts.triangles > gated.counts.triangles);
+}
+
+TEST_CASE("a nonpositive or non-finite cell size is refused")
+{
+    // cell = 0 divides to infinity whose int conversion is undefined; a
+    // negative cell reverses every bucket range so triangles never share a
+    // cell and a crossing surface would census CLEAN. Refusing is the only
+    // honest answer.
+    cv::Mat_<cv::Vec3f> P = blank(4, 4);
+    put_plane(P, 0, 4, 4, 5.0);
+    std::vector<Contact> out;
+    CHECK_THROWS_AS(census(P, 0, 0.0, 1, 60.0, 1, out),
+                    std::invalid_argument);
+    CHECK_THROWS_AS(census(P, 0, -8.0, 1, 60.0, 1, out),
+                    std::invalid_argument);
+    CHECK_THROWS_AS(census(P, 0, 40.0, -1, 60.0, 1, out),
+                    std::invalid_argument);
+}
+
+TEST_CASE("invalid and non-finite points never form quads")
+{
+    cv::Mat_<cv::Vec3f> P = blank(6, 6);
+    put_plane(P, 0, 6, 6, 5.0);
+    P(2, 2) = INVALID;
+    P(4, 4) = cv::Vec3f(std::nanf(""), 0.f, 5.f);
+    Run r = run(P, 0);
+    // each poisoned vertex kills its four surrounding quads
+    CHECK(r.counts.triangles == (5u * 5u - 8u) * 2u);
+    CHECK(r.counts.transverse == 0u);
+}

--- a/volume-cartographer/core/test/test_tifxyz_selfcross.cpp
+++ b/volume-cartographer/core/test/test_tifxyz_selfcross.cpp
@@ -20,6 +20,7 @@
 #include <opencv2/core/mat.hpp>
 
 #include <cmath>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -28,7 +29,11 @@ using vc_selfcross::CensusCounts;
 using vc_selfcross::census;
 using vc_selfcross::COPLANAR;
 using vc_selfcross::GRAZING;
+using vc_selfcross::NONE;
 using vc_selfcross::TRANSVERSE;
+using vc_selfcross::Tri;
+using vc_selfcross::Vec3;
+using vc_selfcross::tri_tri;
 
 namespace {
 
@@ -166,6 +171,28 @@ TEST_CASE("adjacency exclusion is honoured and reported pairs are canonical")
     }
 }
 
+TEST_CASE("disjoint triangles near each other's infinite plane are not "
+          "grazing")
+{
+    // Two nearly coplanar right triangles whose bounding boxes overlap at a
+    // corner while the triangles themselves stay ~2.7 apart. Every vertex
+    // of one lies within plane tolerance of the OTHER's infinite plane, but
+    // proximity to an infinite plane says nothing about touching: reporting
+    // this as grazing inflates the count with pairs that are simply
+    // disjoint. The verdict must be no contact at all.
+    Tri a{{0, 0, 5}, {4, 0, 5}, {0, 4, 5}, 0, 0, 0};
+    Tri b{{3.9, 3.9, 5.000004}, {8, 3.9, 5.000008}, {3.9, 8, 5.000008},
+          10, 10, 0};
+    CHECK(tri_tri(a, b).verdict == NONE);
+
+    // ...while the same pair moved into genuine contact IS reported: slide
+    // b so its corner vertex sits on a's interior.
+    Tri c{{1.0, 1.0, 5.000004}, {8, 1.0, 5.000008}, {1.0, 8, 5.000008},
+          10, 10, 0};
+    auto r = tri_tri(a, c);
+    CHECK(r.verdict != NONE);
+}
+
 TEST_CASE("results do not depend on thread count or broad-phase cell size")
 {
     // A pair can share several broad-phase cells; it is owned by exactly
@@ -198,6 +225,82 @@ TEST_CASE("results do not depend on thread count or broad-phase cell size")
         CHECK(r.counts.coplanar == ref.counts.coplanar);
         CHECK(r.counts.grazing == ref.counts.grazing);
     }
+}
+
+TEST_CASE("sub-tolerance contacts are found at every cell size")
+{
+    // The narrow phase accepts pairs whose boxes come within TOUCH_TOL, so
+    // the broad phase must bucket expanded boxes -- otherwise a pair
+    // separated by less than the tolerance can straddle a bucket boundary
+    // at one cell size and share a bucket at another, and the counts move
+    // with --cell. Two flat sheets 5e-5 apart -- inside the plane tolerance
+    // at this magnitude, so every pair classifies (as coplanar), and inside
+    // the gap a bucket boundary could fall into. The counts must agree
+    // across cell sizes, and the fixture is offset in x so geometry sits
+    // near bucket boundaries at the default size.
+    cv::Mat_<cv::Vec3f> P = blank(8 + GAP + 8, 10);
+    for (int v = 0; v < 8; ++v)
+        for (int u = 0; u < 10; ++u) {
+            P(v, u) = cv::Vec3f(4.f * u + 39.9f, 4.f * v, 5.f);
+            P(8 + GAP + v, u) = cv::Vec3f(4.f * u + 39.9f, 4.f * v,
+                                          5.f + 5e-5f);
+        }
+    Run ref = run(P, 0, 40.0);
+    CHECK(ref.counts.coplanar + ref.counts.grazing > 0u);
+    for (double cell : {5.0, 39.95, 100.0, 400.0}) {
+        Run r = run(P, 0, cell);
+        CHECK(r.counts.transverse == ref.counts.transverse);
+        CHECK(r.counts.coplanar == ref.counts.coplanar);
+        CHECK(r.counts.grazing == ref.counts.grazing);
+    }
+}
+
+TEST_CASE("a cell size far below the surface's extent is refused, not "
+          "undefined")
+{
+    // Positive and finite is not enough: span/cell can overflow the index
+    // arithmetic, and each triangle's bucket loop can turn astronomical.
+    // The refusal must fire on the DOUBLE quotient, before any integer
+    // conversion, so the denormal-smallest cell is the probe that matters.
+    cv::Mat_<cv::Vec3f> P = blank(6, 6);
+    put_plane(P, 0, 6, 6, 5.0);
+    std::vector<Contact> out;
+    CHECK_THROWS_AS(census(P, 0, 1e-7, 1, 60.0, 1, out),
+                    std::invalid_argument);
+    CHECK_THROWS_AS(census(P, 0, std::numeric_limits<double>::min(), 1,
+                           60.0, 1, out),
+                    std::invalid_argument);
+    CHECK_THROWS_AS(census(P, 0, std::numeric_limits<double>::denorm_min(),
+                           1, 60.0, 1, out),
+                    std::invalid_argument);
+}
+
+TEST_CASE("degenerate triangles obey the same distance-gated grazing rule")
+{
+    // A zero-area triangle cannot be classified by plane signs, but that
+    // alone is not contact: two collapsed triangles with overlapping boxes
+    // can be far apart. Grazing still requires coming within the touch
+    // tolerance; genuine touching still reports.
+    const Tri seg_far{{0, 0, 5}, {8, 0, 5}, {4, 0, 5}, 0, 0, 0};
+    const Tri seg_near{{0, 4, 5}, {8, 4, 5}, {4, 4, 5}, 9, 9, 0};
+    // collapsed vs collapsed, boxes overlap in x/z, 4 apart in y
+    CHECK(tri_tri(seg_far, seg_near).verdict == NONE);
+
+    // a collapsed triangle genuinely touching a proper one
+    const Tri plane{{0, 0, 5}, {8, 0, 5}, {0, 8, 5}, 0, 0, 0};
+    const Tri seg_touch{{1, 1, 5}, {3, 1, 5}, {2, 1, 5}, 9, 9, 0};
+    CHECK(tri_tri(plane, seg_touch).verdict == GRAZING);
+
+    // two coincident collapsed triangles
+    const Tri seg_a{{0, 0, 5}, {8, 0, 5}, {4, 0, 5}, 0, 0, 0};
+    const Tri seg_b{{0, 0, 5}, {8, 0, 5}, {4, 0, 5}, 9, 9, 0};
+    CHECK(tri_tri(seg_a, seg_b).verdict == GRAZING);
+
+    // a collapsed triangle beyond the proper one's hypotenuse (x + y = 8):
+    // boxes overlap, but the nearest segment point (4,6) sits 1.41 from the
+    // triangle -- comfortably outside the touch tolerance
+    const Tri seg_off{{4, 6, 5}, {8, 6, 5}, {6, 6, 5}, 9, 9, 0};
+    CHECK(tri_tri(plane, seg_off).verdict == NONE);
 }
 
 TEST_CASE("quads spanning a grid discontinuity are dropped, not censused")

--- a/volume-cartographer/core/test/test_tifxyz_selfcross_cli.cpp
+++ b/volume-cartographer/core/test/test_tifxyz_selfcross_cli.cpp
@@ -173,6 +173,13 @@ TEST_CASE("bad arguments and unwritable outputs exit 1, not 0")
         CHECK(run_cli({surf.string(), "-o", "/dev/full"}) == 1);
         CHECK(run_cli({surf.string(), "-o", out,
                        "--collection", "/nonexistent-dir/c.json"}) == 1);
+        // Mid-write failure on the COLLECTION path: needs the surface to
+        // actually have crossing sites, and saveToJSON to check its stream
+        // rather than only the open.
+        const fs::path xsurf = tmp.path / "x.tifxyz";
+        write_tifxyz(xsurf, true);
+        CHECK(run_cli({xsurf.string(), "-o", out,
+                       "--collection", "/dev/full"}) == 1);
     }
 }
 

--- a/volume-cartographer/core/test/test_tifxyz_selfcross_cli.cpp
+++ b/volume-cartographer/core/test/test_tifxyz_selfcross_cli.cpp
@@ -1,0 +1,195 @@
+// End-to-end tests for the vc_tifxyz_selfcross command line: exit codes,
+// report serialization, and the point-collection output. The kernel has its
+// own fixtures in test_tifxyz_selfcross.cpp; this file covers what only the
+// binary does -- argument validation, the report contract, the collection
+// envelope, and the --fail-on-crossing gate scripts rely on.
+//
+// The binary path arrives from CMake as VC_SELFCROSS_BIN. Fixtures are tiny
+// tifxyz directories written with OpenCV's TIFF encoder into a fresh temp
+// directory, the same three-plane + meta.json layout the loader reads.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "vc_test.hpp"
+
+#include "utils/Json.hpp"
+
+#include <opencv2/core/mat.hpp>
+#include <opencv2/imgcodecs.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+TEST_CASE("cli tests are POSIX-only") {}
+#else
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// A grid whose upper block is a flat plane and, when `crossing` is set,
+// whose lower block is a tilted sheet driven through it; the two blocks are
+// separated by four invalid rows so every contact is non-adjacent.
+void write_tifxyz(const fs::path& dir, bool crossing)
+{
+    const int rows = crossing ? 24 : 10, cols = 12;
+    cv::Mat x(rows, cols, CV_32F, cv::Scalar(-1.f));
+    cv::Mat y(rows, cols, CV_32F, cv::Scalar(-1.f));
+    cv::Mat z(rows, cols, CV_32F, cv::Scalar(-1.f));
+    for (int v = 0; v < 10; ++v)
+        for (int u = 0; u < cols; ++u) {
+            x.at<float>(v, u) = 4.f * u;
+            y.at<float>(v, u) = 4.f * v;
+            z.at<float>(v, u) = 5.f;
+        }
+    if (crossing)
+        for (int v = 0; v < 10; ++v)
+            for (int u = 0; u < cols; ++u) {
+                x.at<float>(14 + v, u) = 4.f * u + 0.3f * v + 1.7f;
+                y.at<float>(14 + v, u) = 4.f * v;
+                z.at<float>(14 + v, u) = (float)(4.0 * (u - 5) + 7.0);
+            }
+    fs::create_directories(dir);
+    REQUIRE(cv::imwrite((dir / "x.tif").string(), x));
+    REQUIRE(cv::imwrite((dir / "y.tif").string(), y));
+    REQUIRE(cv::imwrite((dir / "z.tif").string(), z));
+    std::ofstream meta(dir / "meta.json");
+    // The loader requires both fields; uuid must be a string.
+    meta << "{\"scale\": [1.0, 1.0], \"uuid\": \"cli-fixture\"}\n";
+    REQUIRE(meta.good());
+}
+
+// Single-quote every argument so paths containing spaces or shell
+// metacharacters cannot break the command or execute as syntax.
+std::string sh(const std::string& s)
+{
+    std::string q = "'";
+    for (char c : s)
+        if (c == '\'') q += "'\\''"; else q += c;
+    return q + "'";
+}
+
+int run_cli(const std::vector<std::string>& args)
+{
+    std::string cmd = sh(VC_SELFCROSS_BIN);
+    for (const auto& a : args) cmd += " " + sh(a);
+    cmd += " >/dev/null 2>&1";
+    int rc = std::system(cmd.c_str());
+    REQUIRE(rc != -1);
+    return WIFEXITED(rc) ? WEXITSTATUS(rc) : -2;
+}
+
+struct TempDir {
+    fs::path path;
+    TempDir()
+    {
+        path = fs::temp_directory_path()
+             / ("vc_selfcross_cli_" + std::to_string(::getpid()));
+        fs::create_directories(path);
+    }
+    ~TempDir() { std::error_code ec; fs::remove_all(path, ec); }
+};
+
+}  // namespace
+
+TEST_CASE("clean surface: exit 0 even under --fail-on-crossing, report "
+          "says clean")
+{
+    TempDir tmp;
+    const fs::path surf = tmp.path / "clean.tifxyz";
+    write_tifxyz(surf, false);
+    const fs::path report = tmp.path / "report.json";
+    CHECK(run_cli({surf.string(), "-o", report.string(),
+                   "--fail-on-crossing"}) == 0);
+    utils::Json j = utils::Json::parse_file(report);
+    CHECK(j["clean_of_transverse_self_intersection"].get_bool());
+    CHECK(j["report_only"].get_bool());
+    for (size_t d = 0; d < 2; ++d) {
+        CHECK(j["census"][d]["transverse"].get_int() == 0);
+        CHECK(j["census"][d]["triangles"].get_int() > 0);
+    }
+}
+
+TEST_CASE("crossing surface: exit 3 under --fail-on-crossing, 0 without, "
+          "contacts serialized, collection loadable")
+{
+    TempDir tmp;
+    const fs::path surf = tmp.path / "cross.tifxyz";
+    write_tifxyz(surf, true);
+    const fs::path report = tmp.path / "report.json";
+    const fs::path coll = tmp.path / "sites.json";
+
+    CHECK(run_cli({surf.string(), "-o", report.string(),
+                   "--collection", coll.string(),
+                   "--fail-on-crossing"}) == 3);
+    CHECK(run_cli({surf.string(), "-o", report.string()}) == 0);
+
+    utils::Json j = utils::Json::parse_file(report);
+    CHECK(!j["clean_of_transverse_self_intersection"].get_bool());
+    bool any = false;
+    for (size_t d = 0; d < 2; ++d) {
+        const utils::Json& jd = j["census"][d];
+        if (jd["transverse"].get_int() == 0) continue;
+        any = true;
+        const utils::Json& rows = jd["transverse_contacts"];
+        CHECK((int64_t)rows.size() == jd["transverse"].get_int());
+        const utils::Json& first = rows[size_t(0)];
+        CHECK(first["site"].size() == 3);
+        CHECK(first["penetration_vx"].get_float() > 0.0);
+    }
+    CHECK(any);
+
+    // The collection must carry the envelope the point-collection loader
+    // demands; without it the file is silently unloadable in the viewer.
+    utils::Json c = utils::Json::parse_file(coll);
+    CHECK(c["vc_pointcollections_json_version"].get_string() == "1");
+    CHECK(c["collections"].size() > 0);
+}
+
+TEST_CASE("bad arguments and unwritable outputs exit 1, not 0")
+{
+    TempDir tmp;
+    const fs::path surf = tmp.path / "clean.tifxyz";
+    write_tifxyz(surf, false);
+    const std::string out = (tmp.path / "r.json").string();
+    CHECK(run_cli({surf.string(), "-o", out, "--cell", "0"}) == 1);
+    CHECK(run_cli({surf.string(), "-o", out, "--cell", "-3"}) == 1);
+    CHECK(run_cli({surf.string(), "-o", out, "--cell", "1e-300"}) == 1);
+    CHECK(run_cli({surf.string(), "-o", out, "--exclude", "-1"}) == 1);
+    CHECK(run_cli({surf.string(), "-o", out, "--maxedge", "-1"}) == 1);
+    CHECK(run_cli({surf.string(), "-o", out, "--maxedge", "nan"}) == 1);
+    CHECK(run_cli({surf.string(), "-o", "/nonexistent-dir/r.json"}) == 1);
+    CHECK(run_cli({(tmp.path / "missing.tifxyz").string(), "-o", out}) == 1);
+    // Failure DURING the write, not at open: /dev/full accepts the open and
+    // fails the flush. "Report written" plus exit 0 here would defeat the
+    // one job a report-only tool has.
+    if (fs::exists("/dev/full")) {
+        CHECK(run_cli({surf.string(), "-o", "/dev/full"}) == 1);
+        CHECK(run_cli({surf.string(), "-o", out,
+                       "--collection", "/nonexistent-dir/c.json"}) == 1);
+    }
+}
+
+TEST_CASE("reports are byte-identical across runs and thread counts")
+{
+    TempDir tmp;
+    const fs::path surf = tmp.path / "cross.tifxyz";
+    write_tifxyz(surf, true);
+    const fs::path a = tmp.path / "a.json", b = tmp.path / "b.json";
+    REQUIRE(run_cli({surf.string(), "-o", a.string()}) == 0);
+    REQUIRE(run_cli({surf.string(), "-o", b.string(), "--threads", "1"})
+            == 0);
+    std::ifstream fa(a, std::ios::binary), fb(b, std::ios::binary);
+    std::string sa((std::istreambuf_iterator<char>(fa)), {});
+    std::string sb((std::istreambuf_iterator<char>(fb)), {});
+    CHECK(sa == sb);
+    CHECK(!sa.empty());
+}
+
+#endif  // _WIN32

--- a/volume-cartographer/docs/tifxyz_selfcross.md
+++ b/volume-cartographer/docs/tifxyz_selfcross.md
@@ -1,0 +1,81 @@
+# tifxyz Self-Intersection Census
+
+`vc_tifxyz_selfcross` reports where a tifxyz surface passes through itself.
+It is report-only: it writes a JSON report and, optionally, a point
+collection of crossing sites, and never modifies the surface.
+
+## Why transverse contacts specifically
+
+Proximity between wraps is normal in a crushed scroll and can be arbitrarily
+small while the trace is correct, so no distance threshold separates good
+traces from bad ones. A transverse self-intersection is different in kind: an
+embedded surface cannot pass through itself, so a triangle of the trace
+crossing another triangle of the same trace is a defect with no innocent
+reading, and no threshold to argue about.
+
+Contacts are classified rather than collapsed into yes/no:
+
+- `transverse` — the two triangle interiors pass through each other. This is
+  the defect signal.
+- `coplanar` — (near) coplanar triangles with overlapping projections. Two
+  sheets pressed flat against each other look like this, so it is reported
+  but never counted as a crossing.
+- `grazing` — a vertex or edge lies within tolerance of the other triangle's
+  plane, so the sign data the interval test depends on is not trustworthy at
+  the input's own float32 resolution. Reported separately rather than
+  guessed at.
+
+Adjacent quads (Chebyshev distance `--exclude` in grid indices, default 1 =
+shared-vertex neighbours) are excluded: their triangles sharing space is what
+a surface does. Every quad is triangulated both ways and the two censuses are
+reported separately, because a twisted quad can cross under one diagonal and
+not the other; a surface is only called clean when both find nothing.
+
+## Usage
+
+```sh
+vc_tifxyz_selfcross <surface.tifxyz> -o report.json
+vc_tifxyz_selfcross <surface.tifxyz> -o report.json --collection sites.json
+vc_tifxyz_selfcross <surface.tifxyz> -o report.json --fail-on-crossing
+```
+
+The report carries per-diagonal counts and every transverse contact with its
+quad indices, penetration depth (voxels), crossing angle, and a 3D site. The
+`--collection` file is written through `PointCollections::saveToJSON`, so it
+loads in VC3D like any other point collection and the sites can be inspected
+in place.
+
+Exit codes: `0` census ran (whatever it found), `1` error, `3` transverse
+contacts found and `--fail-on-crossing` was given — usable as a gate in
+scripts, e.g. after an export or before a merge.
+
+## What the numbers mean
+
+Counts are triangle-pair contacts summed per triangulation, not distinct
+crossing events: one crossing region typically produces several contacts.
+They rank severity; they do not count places.
+
+The census runs on the surface as this codebase loads it (`z <= 0` cells
+invalid, `mask.tif` applied). The same method applied to a raw tifxyz that
+treats `z <= 0` cells as valid can differ slightly in contact counts
+(measured 1.49% of rows over one 185-trace corpus, with no clean/not-clean
+verdict changing).
+
+A clean result means exactly: zero non-adjacent transverse contacts under
+both triangulations, at the stated exclusion and edge-length filter. It is
+not a statement about coplanar or grazing contacts, and not a general
+statement of surface quality.
+
+`--maxedge` (default 60 voxels) drops quads with any edge longer than the
+limit before testing. This is not cosmetic: a grid can contain
+discontinuities where two adjacent valid cells sit far apart in 3D, and a
+triangle built across such a gap spans many wraps and crosses everything in
+its path purely because the mesh has a hole there.
+
+## Determinism
+
+Two runs on the same surface produce identical reports regardless of thread
+count. A triangle pair can share several broad-phase cells; each pair is
+owned by exactly one cell (the one containing the minimum corner of the two
+bounding boxes' overlap) and tested only there, and results are sorted into
+canonical order before writing.


### PR DESCRIPTION
## What this adds

A standalone command-line tool that reports where a tifxyz surface passes
through itself. Proximity between wraps is normal in a crushed scroll and can
be arbitrarily small while the trace is correct, so no distance threshold
separates good traces from bad ones — but an embedded surface cannot pass
through itself, so a transverse self-intersection is a defect with no
innocent reading. The tool censuses all non-adjacent triangle pairs under
both quad triangulations and classifies each contact as transverse, coplanar
(two sheets pressed flat — reported, never counted as a crossing), or grazing
(within tolerance of the other plane — reported rather than guessed at).

It is report-only: a JSON report, an optional point collection of crossing
sites written through `PointCollections::saveToJSON` (so it loads in VC3D
like any other collection), and `--fail-on-crossing` for use as a gate in
scripts (exit 3, distinct from exit 1 = error).

## Why it might be useful

The same census, run externally, recently found 5 self-intersecting patches
in the 84,316-patch verified dataset, which its publisher then removed. It
has also been run over every published tifxyz trace (278 traces across 12
samples); method and full results are at
https://github.com/joe-carr-data/windcheck. This PR brings the check into
the tree so it can run right after an export, with no external tooling.

## Usage

```sh
vc_tifxyz_selfcross <surface.tifxyz> -o report.json --collection sites.json
vc_tifxyz_selfcross <surface.tifxyz> -o report.json --fail-on-crossing
```

Measured on a published Scroll 5 trace (804×521 grid, 416,398 triangles,
~3.1M candidate pairs per triangulation): 0.22 s wall, and it reproduces the
externally recorded result for that trace exactly (4 transverse contacts
under one triangulation, 7 under the other, contact identities included).

## Properties

- Deterministic: identical runs give byte-identical reports at any thread
  count. Each triangle pair is owned by exactly one broad-phase cell and
  tested only there; output is sorted into canonical order.
- Runs on the surface as this codebase loads it (z <= 0 invalid, mask
  applied), stated in the report. The same method on a raw tifxyz that keeps
  z <= 0 cells can differ slightly (measured 1.49% of contact rows across a
  185-trace corpus, with no clean/not-clean verdict changing).
- Plane tolerance scales with operand magnitude (float32 ULP at ~1e4 voxels
  is ~1e-3 vx, so a fixed 1e-6 would classify representation noise).
- Quads with any edge over `--maxedge` (default 60 vx) are dropped:
  a triangle built across a grid discontinuity spans many wraps and crosses
  everything in its path purely because the mesh has a hole there.

## What it deliberately does not do

Touches no existing target or behaviour: new app + CMake registration +
one docs page (`docs/tifxyz_selfcross.md`). No repair, no excision, no GUI,
no change to GrowSurface, export, or any return code. Single surface only.
Counts are triangle-pair contacts, not distinct crossing events; they rank
severity rather than count places.

Built and verified with the repo's own builder image
(`docker build --target builder`) and `ci-release-gcc` preset.
