### PR TITLE
Add spiralcheck to community projects

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -187,6 +187,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [TIFXYZ Doctor](https://github.com/aviad12g/tifxyz-doctor) by Aviad Cohen — deterministic QA and triage for TIFXYZ surface grids, with sparse overlays and reproducible corpus/reader checks. v0.2 adds an overlap-component-isolated benchmark on 709 official human-reviewed PHercParis4 `same_wrap` patches; its frozen cue localizes abrupt synthetic normal-offset steps while byte-identical null controls and the reported gradual-transition miss rate bound the claim.
 
+- [spiralcheck](https://github.com/Nicodol/spiralcheck) by Nicolas Dolegieviez. Held-out evaluation for whole-scroll spiral fits: scores a finished run from its output meshes alone (CPU-only, no checkpoint, producer-agnostic) against verified patches withheld from that fit, and measures geometrically how much of the withheld evidence actually sits within touching distance of the fit's real inputs — on PHerc. Paris 4, 54.8% of a naive name-level split leaked that way, which no hash-level check can see. Also ships ground-truth-free winding-order checks around the umbilicus, a planted-defect matrix with computed null-control bounds, and `spiralcheck demo`, which runs the whole pipeline on a synthetic scroll with planted defects and needs no data.
+
 ### 📦 Materials
 
 #### 🌟 Highlighted


### PR DESCRIPTION
Adds spiralcheck to the community projects page: a standalone, CPU-only, held-out evaluation suite for whole-scroll spiral fits, built for the "devise better evaluation suites" item of the 2026 open problems.

It scores a finished fit post hoc, from its output meshes alone, against verified patches withheld from that fit: a seeded, family-grouped split with a SHA-256 manifest and refuse-to-score audits, plus a geometric measurement of how much of the withheld evidence actually sits within touching distance of the fit's real inputs (54.8% of a naive name-level split, on PHerc. Paris 4, which no hash-level check can see). It also carries ground-truth-free winding-order checks around the umbilicus, and a demo command that runs the whole pipeline on a synthetic scroll with planted defects, so it can be tried with no data at all.

Validation, controls, and a demonstration on two real fit_spiral runs are documented in VALIDATION.md, including the corrections our own review rounds forced on earlier published numbers.

Building the suite also surfaced four fixes now merged here: #1267, #1268, #1269, #1279.

Repo: https://github.com/Nicodol/spiralcheck (MIT, CI on Linux/Windows/macOS)