### PR TITLE
spiral: add known-deformation phantom generator and truth-referenced …

### DIFF
--- a/volume-cartographer/scripts/spiral/export_phantom_dataset.py
+++ b/volume-cartographer/scripts/spiral/export_phantom_dataset.py
@@ -1,0 +1,156 @@
+"""Export a synth_phantom phantom as a fit_spiral-consumable dataset.
+
+Writes the minimal input layout the fitter's loaders read:
+
+  <out>/umbilicus.json           {"control_points": [{"z","y","x"}, ...]},
+                                 from the phantom's own (known) curve
+  <out>/verified_patches/<id>/   tifxyz patch grids (written by tifxyz.
+                                 save_tifxyz, so the format always matches the
+                                 loader) sampled from TRUE winding surfaces,
+                                 plus winding.tif carrying the absolute
+                                 winding annotation in the fit's convention
+                                 (shifted_radius == winding * dr_per_winding)
+  <out>/dataset_meta.json        provenance + the knob values
+
+Because patches are derived from truth, their quality is a *dial* rather than
+an accident of annotation effort -- which turns the open-problems doc's "label
+quality is now one of the main unwrapping bottlenecks" from a belief into a
+measurable curve:
+
+  --coverage        fraction of each winding's arc covered by patches
+  --winding-stride  annotate every Nth winding only
+  --position-noise  iid Gaussian vertex corruption, in voxels (label
+                    imprecision -- labels that "wiggle" off the true surface)
+  --no-winding-annotations  drop winding.tif (geometry-only patches)
+
+Scoring a fit trained on each exported variant with winding_error.py measures
+exactly how much label quantity/quality the fit needs.
+
+The production fitter is CUDA-only (fit_spiral.py builds its patch atlas on
+'cuda'); this exporter is device-free, so datasets can be produced anywhere
+and fitted on a GPU host. fit_phantom_reference.py is the CPU path.
+"""
+
+import json
+import os
+
+import click
+import numpy as np
+import tifffile
+import torch
+
+from checkpoint_io import load_checkpoint_cpu
+from synth_phantom import build_model_from_phantom_checkpoint
+from tifxyz import save_tifxyz
+
+
+def export_umbilicus(umbilicus_zyx, path):
+    points = [{'z': float(z), 'y': float(y), 'x': float(x)}
+              for z, y, x in umbilicus_zyx.tolist()]
+    with open(path, 'w') as f:
+        json.dump({'control_points': points}, f)
+
+
+@torch.no_grad()
+def winding_surface_grid(model, winding, theta0, theta1, z0, z1, step, device):
+    """A [rows=z, cols=theta] grid on true winding `winding`, arc [theta0,
+    theta1), mapped into slice space through the phantom's spiral->slice map.
+
+    Returns (zyxs [H, W, 3] float32 numpy, winding_annotation [H, W] float32).
+    Column spacing targets `step` voxels of arc length at the winding's mean
+    radius, matching the row spacing so the tifxyz scale is square.
+    """
+    dr = float(model.get_dr_per_winding())
+    mean_radius = (winding + 0.5) * dr
+    num_cols = max(2, int(round((theta1 - theta0) * mean_radius / step)))
+    num_rows = max(2, int(round((z1 - z0) / step)))
+    theta = torch.linspace(theta0, theta1, num_cols)
+    z = torch.linspace(z0, z1, num_rows)
+    zz, tt = torch.meshgrid(z, theta, indexing='ij')
+    radius = (winding + tt / (2 * torch.pi)) * dr
+    spiral = torch.stack([zz, torch.sin(tt) * radius, torch.cos(tt) * radius], dim=-1)
+    slice_to_spiral = model.get_slice_to_spiral_transform()
+    zyxs = slice_to_spiral.inv(spiral.reshape(-1, 3).to(device))
+    # Absolute winding in the fit's convention (get_patch_abs_winding_loss:
+    # shifted_radius == winding * dr_per_winding): constant along the sheet --
+    # the winding INDEX, not the radius parameter k + theta/2pi. Annotating the
+    # latter injects a screw-dislocation error with mean +0.5 windings.
+    annotation = torch.full_like(tt, float(winding))
+    return (zyxs.reshape(num_rows, num_cols, 3).cpu().numpy().astype(np.float32),
+            annotation.numpy().astype(np.float32))
+
+
+@click.command()
+@click.option('--phantom', required=True, type=click.Path(exists=True, file_okay=False),
+              help='synth_phantom output directory.')
+@click.option('--out', required=True, type=click.Path(file_okay=False),
+              help='Dataset output directory.')
+@click.option('--coverage', default=0.6, type=click.FloatRange(0., 1.),
+              help='Fraction of each winding arc covered by patches.')
+@click.option('--patch-arc-deg', default=90., type=float,
+              help='Arc length of each individual patch, degrees.')
+@click.option('--winding-stride', default=1, type=int,
+              help='Export patches on every Nth winding.')
+@click.option('--step', default=4., type=float,
+              help='Patch grid spacing in voxels (both axes).')
+@click.option('--position-noise', default=0., type=float,
+              help='Gaussian vertex position noise std, voxels (label imprecision).')
+@click.option('--winding-annotations/--no-winding-annotations', default=True,
+              help='Write per-vertex absolute winding annotations (winding.tif).')
+@click.option('--z-margin', default=2., type=float,
+              help='Patch z inset from the volume faces, voxels.')
+@click.option('--seed', default=0, type=int)
+@click.option('--device', default='cpu')
+def main(phantom, out, coverage, patch_arc_deg, winding_stride, step,
+         position_noise, winding_annotations, z_margin, seed, device):
+    rng = np.random.default_rng(seed)
+    device = torch.device(device)
+    checkpoint = load_checkpoint_cpu(os.path.join(phantom, 'phantom_checkpoint.pt'))
+    model = build_model_from_phantom_checkpoint(checkpoint, device)
+    meta = json.load(open(os.path.join(phantom, 'meta.json')))
+
+    patches_dir = os.path.join(out, 'verified_patches')
+    os.makedirs(patches_dir, exist_ok=True)
+    export_umbilicus(checkpoint['umbilicus_zyx'], os.path.join(out, 'umbilicus.json'))
+
+    z0, z1 = z_margin, meta['z_size'] - 1 - z_margin
+    patch_arc = np.deg2rad(patch_arc_deg)
+    num_patches = 0
+    for winding in range(meta['first_winding'], meta['last_winding'] + 1, winding_stride):
+        # Random patch starts along the arc until the coverage budget is spent;
+        # gaps between patches are the realistic case (tracing never covers a
+        # winding completely).
+        budget = coverage * 2 * np.pi
+        starts = []
+        while budget > 0:
+            arc = min(patch_arc, budget)
+            starts.append((float(rng.uniform(0, 2 * np.pi - arc)), arc))
+            budget -= patch_arc
+        for theta0, arc in starts:
+            zyxs, annotation = winding_surface_grid(
+                model, winding, theta0, theta0 + arc, z0, z1, step, device)
+            if position_noise > 0:
+                zyxs = zyxs + rng.standard_normal(zyxs.shape).astype(np.float32) * position_noise
+            uuid = f'phantom_w{winding:03d}_t{int(np.rad2deg(theta0)):03d}'
+            save_tifxyz(zyxs, patches_dir, uuid, step_size=int(round(step)),
+                        voxel_size_um=1.0, source='synth_phantom')
+            if winding_annotations:
+                tifffile.imwrite(os.path.join(patches_dir, uuid, 'winding.tif'),
+                                 annotation)
+            num_patches += 1
+
+    with open(os.path.join(out, 'dataset_meta.json'), 'w') as f:
+        json.dump({
+            'phantom_dir': os.path.abspath(phantom),
+            'phantom_meta': meta,
+            'coverage': coverage, 'patch_arc_deg': patch_arc_deg,
+            'winding_stride': winding_stride, 'step': step,
+            'position_noise': position_noise,
+            'winding_annotations': winding_annotations,
+            'seed': seed, 'num_patches': num_patches,
+        }, f, indent=2)
+    click.echo(f'{num_patches} patches -> {patches_dir}')
+
+
+if __name__ == '__main__':
+    main()

--- a/volume-cartographer/scripts/spiral/export_phantom_dataset.py
+++ b/volume-cartographer/scripts/spiral/export_phantom_dataset.py
@@ -24,7 +24,12 @@ measurable curve:
   --no-winding-annotations  drop winding.tif (geometry-only patches)
 
 Scoring a fit trained on each exported variant with winding_error.py measures
-exactly how much label quantity/quality the fit needs.
+how much label quantity/quality that fitter needs. Scope caveat: dial curves
+produced with fit_phantom_reference.py (a single-loss baseline) characterise
+the BASELINE's sensitivity, not the production fitter's -- fit_spiral carries
+DT/track/normal losses that may absorb label defects very differently. Treat
+reference-fitter curves as demonstrations of the dials until the production
+fitter is run on the same exported datasets (CUDA host required).
 
 The production fitter is CUDA-only (fit_spiral.py builds its patch atlas on
 'cuda'); this exporter is device-free, so datasets can be produced anywhere

--- a/volume-cartographer/scripts/spiral/fit_phantom_reference.py
+++ b/volume-cartographer/scripts/spiral/fit_phantom_reference.py
@@ -1,0 +1,172 @@
+"""CPU reference fitter for phantom datasets: the recovery experiment.
+
+Fits a fresh SpiralAndTransform (the production model class) to a dataset
+exported by export_phantom_dataset.py, using only the exported patches'
+absolute winding annotations -- then the result can be scored against the
+phantom's known truth with winding_error.py. This closes the phantom ->
+dataset -> fit -> truth-referenced-score loop end to end on any machine.
+
+This is deliberately NOT fit_spiral.py: the production fitter is CUDA-only
+(its patch atlas and training loop hard-code 'cuda') and optimises a large
+family of losses (patch DT, tracks, dense normals, spacing, ...). This
+reference fitter optimises the same *model* with one loss -- Huber on
+(predicted winding - annotated winding - gauge), the same quantity
+get_patch_abs_winding_loss anchors (shifted_radius == winding *
+dr_per_winding) -- so its scores are a baseline, a lower bound on what the
+production fitter should achieve on the same dataset, not a reimplementation
+of it. Run the production fitter on the exported dataset on a CUDA host for
+the real number.
+
+What the fitter is allowed to see: the exported patches, the umbilicus curve
+(human-provided in production too), and volume/lattice geometry from
+dataset_meta.json (operator-chosen in production). It never reads the
+phantom's sampled deformation parameters.
+
+Winding-annotation caveat: a winding field jumps by 1 across the canonical
+theta=0 ray, so samples whose *current* predicted theta sits within
+--seam-margin of that ray are dropped from each step's loss (mirroring the
+production loss's L-strip seam unwrapping, at reference-fitter fidelity).
+
+Output: a phantom-style checkpoint (carries its umbilicus, so winding_error
+consumes it directly via --candidate-checkpoint).
+"""
+
+import json
+import os
+
+import click
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from sample_spiral import get_theta_and_radii
+from synth_phantom import build_model, make_phantom_config
+from tifxyz import load_tifxyz
+
+
+def load_dataset(dataset_dir):
+    meta = json.load(open(os.path.join(dataset_dir, 'dataset_meta.json')))
+    if not meta['winding_annotations']:
+        raise click.UsageError(
+            'this reference fitter needs winding annotations; re-export without '
+            '--no-winding-annotations')
+    umbilicus = json.load(open(os.path.join(dataset_dir, 'umbilicus.json')))
+    umbilicus_zyx = torch.tensor(
+        [[p['z'], p['y'], p['x']] for p in
+         sorted(umbilicus['control_points'], key=lambda p: p['z'])],
+        dtype=torch.float32)
+
+    patches_dir = os.path.join(dataset_dir, 'verified_patches')
+    zyxs, windings = [], []
+    for entry in sorted(os.listdir(patches_dir)):
+        patch = load_tifxyz(os.path.join(patches_dir, entry))
+        if not isinstance(patch.winding, torch.Tensor):
+            raise click.UsageError(f'{entry} has no per-vertex winding annotation')
+        zyxs.append(patch.zyxs.reshape(-1, 3))
+        windings.append(patch.winding.reshape(-1))
+    return meta, umbilicus_zyx, torch.cat(zyxs), torch.cat(windings)
+
+
+@click.command()
+@click.option('--dataset', required=True, type=click.Path(exists=True, file_okay=False),
+              help='export_phantom_dataset.py output directory.')
+@click.option('--out', required=True, type=click.Path(dir_okay=False),
+              help='Fitted checkpoint output path (.pt).')
+@click.option('--steps', default=600, type=int)
+@click.option('--batch', default=8192, type=int)
+@click.option('--lr', default=3e-4, type=float,
+              help='Adam learning rate (production base rate is 3e-5 over many '
+                   'more iterations; the reference fit runs hotter and shorter).')
+@click.option('--huber-delta', default=0.25, type=float,
+              help='Huber transition point, in windings.')
+@click.option('--seam-margin', default=0.15, type=float,
+              help='Drop samples within this angle (radians) of the theta=0 ray.')
+@click.option('--reg-gap', default=0., type=float,
+              help='L2 weight on effective log winding gaps: a prior toward '
+                   'uniform spacing between annotated sheets. The annotation '
+                   'loss alone leaves inter-sheet interpolation unconstrained '
+                   '(a stand-in for the production DT/density losses).')
+@click.option('--reg-flow', default=0., type=float,
+              help='L2 weight on the flow velocity field (prior toward the '
+                   'identity deformation off the annotated surfaces).')
+@click.option('--seed', default=0, type=int)
+@click.option('--device', default='cpu')
+def main(dataset, out, steps, batch, lr, huber_delta, seam_margin, reg_gap,
+         reg_flow, seed, device):
+    torch.manual_seed(seed)
+    device = torch.device(device)
+    meta, umbilicus_zyx, zyxs, windings = load_dataset(dataset)
+    pm = meta['phantom_meta']
+    click.echo(f"{len(zyxs)} annotated vertices from {meta['num_patches']} patches")
+
+    z_margin = max(8, pm['z_size'] // 4)
+    cfg = make_phantom_config(pm['z_size'], pm['yx_size'], pm['dr_per_winding'],
+                              num_table_windings=pm['last_winding'] + 8,
+                              z_margin=z_margin)
+    model = build_model(cfg, 0, pm['z_size'], umbilicus_zyx, 'CW', device)
+    model.train().requires_grad_(True)
+    gauge = torch.zeros([], device=device, requires_grad=True)
+    optimiser = torch.optim.Adam([*model.parameters(), gauge], lr=lr)
+
+    zyxs = zyxs.to(device)
+    windings = windings.to(device)
+    losses = []
+    for step in tqdm(range(steps), desc='fit'):
+        idx = torch.randint(0, len(zyxs), [min(batch, len(zyxs))], device=device)
+        transform = model.get_slice_to_spiral_transform()
+        spiral = transform(zyxs[idx])
+        dr = model.get_dr_per_winding()
+        theta, _, shifted = get_theta_and_radii(spiral[..., 1:], dr)
+        residual = shifted / dr - windings[idx] - gauge
+        keep = torch.minimum(theta, 2 * torch.pi - theta) > seam_margin
+        loss = F_huber(residual[keep], huber_delta)
+        if reg_gap > 0:
+            # Effective log gap = logits * lr_scale * 2e2 (GapExpandingTransform).
+            eff = model.gap_expander_params.logits * (
+                cfg['model_gap_expander_lr_scale'] * 2.e2)
+            loss = loss + reg_gap * eff.pow(2).mean()
+        if reg_flow > 0:
+            loss = loss + reg_flow * sum(
+                flow.pow(2).mean() for field in model.flow_fields
+                for flow in field.flows)
+        optimiser.zero_grad()
+        loss.backward()
+        # The flow field routes its gradients through a shared accumulator
+        # (see CartesianFlowField); flush it into .grad like the production
+        # loop does before stepping.
+        for field in model.flow_fields:
+            field.apply_accumulated_field_grad()
+        optimiser.step()
+        losses.append(float(loss))
+        if (step + 1) % 100 == 0:
+            tqdm.write(f'step {step + 1}: loss {np.mean(losses[-100:]):.5f} '
+                       f'windings, dr {float(dr):.3f}, gauge {float(gauge):+.3f}')
+
+    model.eval().requires_grad_(False)
+    torch.save({
+        'schema_version': 2,
+        'phantom_schema_version': 1,  # phantom-style: carries its umbilicus
+        'spiral_and_transform': model.state_dict(),
+        'cfg': cfg,
+        'z_begin': 0,
+        'z_end': pm['z_size'],
+        'spiral_outward_sense': 'CW',
+        'umbilicus_zyx': umbilicus_zyx.cpu(),
+        'reference_fit': {'dataset': os.path.abspath(dataset), 'steps': steps,
+                          'lr': lr, 'batch': batch, 'seed': seed,
+                          'reg_gap': reg_gap, 'reg_flow': reg_flow,
+                          'final_loss': float(np.mean(losses[-50:])),
+                          'gauge': float(gauge)},
+    }, out)
+    click.echo(f'fitted checkpoint -> {out} '
+               f'(final loss {np.mean(losses[-50:]):.5f} windings)')
+
+
+def F_huber(residual, delta):
+    absr = residual.abs()
+    quadratic = 0.5 * residual ** 2 / delta
+    return torch.where(absr <= delta, quadratic, absr - 0.5 * delta).mean()
+
+
+if __name__ == '__main__':
+    main()

--- a/volume-cartographer/scripts/spiral/fit_phantom_reference.py
+++ b/volume-cartographer/scripts/spiral/fit_phantom_reference.py
@@ -93,10 +93,15 @@ def load_dataset(dataset_dir):
 @click.option('--reg-flow', default=0., type=float,
               help='L2 weight on the flow velocity field (prior toward the '
                    'identity deformation off the annotated surfaces).')
+@click.option('--reg-flow-smooth', default=0., type=float,
+              help='L2 weight on flow-lattice finite differences. Magnitude '
+                   'penalties bound how far the deformation strays; this '
+                   'bounds how fast it wiggles between constraints -- the '
+                   'jagged-surface failure mode on sparse real traces.')
 @click.option('--seed', default=0, type=int)
 @click.option('--device', default='cpu')
 def main(dataset, out, steps, batch, lr, huber_delta, seam_margin, reg_gap,
-         reg_flow, seed, device):
+         reg_flow, reg_flow_smooth, seed, device):
     torch.manual_seed(seed)
     device = torch.device(device)
     meta, umbilicus_zyx, zyxs, windings = load_dataset(dataset)
@@ -145,6 +150,13 @@ def main(dataset, out, steps, batch, lr, huber_delta, seam_margin, reg_gap,
             loss = loss + reg_flow * sum(
                 flow.pow(2).mean() for field in model.flow_fields
                 for flow in field.flows)
+        if reg_flow_smooth > 0:
+            # Skip singleton lattice dims: diff there is empty and its mean
+            # is NaN, which silently poisons the whole loss.
+            loss = loss + reg_flow_smooth * sum(
+                torch.diff(flow, dim=dim).pow(2).mean()
+                for field in model.flow_fields for flow in field.flows
+                for dim in (2, 3, 4) if flow.shape[dim] > 1)
         optimiser.zero_grad()
         loss.backward()
         # The flow field routes its gradients through a shared accumulator
@@ -171,6 +183,7 @@ def main(dataset, out, steps, batch, lr, huber_delta, seam_margin, reg_gap,
         'reference_fit': {'dataset': os.path.abspath(dataset), 'steps': steps,
                           'lr': lr, 'batch': batch, 'seed': seed,
                           'reg_gap': reg_gap, 'reg_flow': reg_flow,
+                          'reg_flow_smooth': reg_flow_smooth,
                           'final_loss': float(np.mean(losses[-50:])),
                           'gauge': float(gauge)},
     }, out)

--- a/volume-cartographer/scripts/spiral/fit_phantom_reference.py
+++ b/volume-cartographer/scripts/spiral/fit_phantom_reference.py
@@ -62,8 +62,12 @@ def load_dataset(dataset_dir):
         patch = load_tifxyz(os.path.join(patches_dir, entry))
         if not isinstance(patch.winding, torch.Tensor):
             raise click.UsageError(f'{entry} has no per-vertex winding annotation')
-        zyxs.append(patch.zyxs.reshape(-1, 3))
-        windings.append(patch.winding.reshape(-1))
+        # Sparse grids mark missing cells with the -1 sentinel; training on
+        # those would anchor the fit to garbage coordinates (phantom exports
+        # are fully valid, so this only bites on real traced data).
+        valid = patch.valid_vertex_mask.reshape(-1)
+        zyxs.append(patch.zyxs.reshape(-1, 3)[valid])
+        windings.append(patch.winding.reshape(-1)[valid])
     return meta, umbilicus_zyx, torch.cat(zyxs), torch.cat(windings)
 
 
@@ -105,7 +109,19 @@ def main(dataset, out, steps, batch, lr, huber_delta, seam_margin, reg_gap,
                               z_margin=z_margin)
     model = build_model(cfg, 0, pm['z_size'], umbilicus_zyx, 'CW', device)
     model.train().requires_grad_(True)
-    gauge = torch.zeros([], device=device, requires_grad=True)
+    # Initialise the gauge at the median initial residual: annotations may
+    # carry a large constant winding offset (any theta-origin / numbering
+    # convention is valid), and at lr * steps the gauge scalar can only travel
+    # a fraction of a winding during the fit -- a mis-initialised gauge
+    # otherwise leaves the whole fit stuck at |offset| windings of loss.
+    with torch.no_grad():
+        transform0 = model.get_slice_to_spiral_transform()
+        dr0 = model.get_dr_per_winding()
+        _, _, shifted0 = get_theta_and_radii(
+            transform0(zyxs.to(device))[..., 1:], dr0)
+        gauge0 = (shifted0 / dr0 - windings.to(device)).median()
+    gauge = gauge0.clone().requires_grad_(True)
+    click.echo(f'gauge initialised to {float(gauge0):+.3f} windings')
     optimiser = torch.optim.Adam([*model.parameters(), gauge], lr=lr)
 
     zyxs = zyxs.to(device)

--- a/volume-cartographer/scripts/spiral/measure_real_scroll.py
+++ b/volume-cartographer/scripts/spiral/measure_real_scroll.py
@@ -1,0 +1,90 @@
+"""Measure real-scroll CT statistics to calibrate synth_phantom realism knobs.
+
+Streams two small crops (native-res texture + downsampled overview) from an
+OME-Zarr scroll volume over plain HTTP -- the Vesuvius open-data bucket needs
+no auth -- and reports the quantities the phantom imitates: gap/sheet
+intensity levels, layer-spacing autocorrelation, and the high-frequency noise
+floor. The pherc0009b preset in synth_phantom.PRESETS records the values this
+script measured at the PHerc0009B volume centre; rerun it (or point it at
+another scroll/position) to recalibrate or add presets.
+
+Total transfer is ~100 MB; nothing is written except the comparison PNG.
+"""
+
+import click
+import numpy as np
+import scipy.signal
+import zarr
+from scipy.ndimage import gaussian_filter
+
+DEFAULT_URL = ('https://vesuvius-challenge-open-data.s3.us-east-1.amazonaws.com/'
+               'PHerc0009B/volumes/20250820154339-2.401um-0.3m-77keV-masked.zarr')
+
+
+@click.command()
+@click.option('--url', default=DEFAULT_URL, show_default=False,
+              help='OME-Zarr volume URL (default: PHerc0009B 2.4um masked).')
+@click.option('--position', nargs=3, type=int, default=(14556, 14129, 14129),
+              help='z y x centre of the native-res crop.')
+@click.option('--crop-half', default=384, type=int,
+              help='Half-size of the native crop (crop is 2*half squared).')
+@click.option('--voxel-um', default=2.401, type=float,
+              help='Voxel size in microns, for reporting spacing in um.')
+@click.option('--out-png', default=None, type=click.Path(dir_okay=False),
+              help='Optionally write an overview/crop comparison figure.')
+def main(url, position, crop_half, voxel_um, out_png):
+    cz, cy, cx = position
+    group = zarr.open_group(url, mode='r')
+    levels = sorted(int(k) for k in group.array_keys())
+    coarse = levels[min(3, len(levels) - 1)]
+    ds = 2 ** coarse
+
+    crop = group['0'][cz, cy - crop_half:cy + crop_half, cx - crop_half:cx + crop_half]
+    overview = group[str(coarse)][cz // ds, :, :]
+    click.echo(f'native crop {crop.shape} {crop.dtype}; ds{ds} overview {overview.shape}')
+
+    fg = crop[crop > 0]
+    if len(fg) == 0:
+        raise click.UsageError('crop is entirely masked; pick a position inside the scroll')
+    click.echo(f'nonzero fraction {(crop > 0).mean():.3f}')
+    for q in (1, 10, 25, 50, 75, 90, 99):
+        click.echo(f'  p{q:02d}: {np.percentile(fg, q):.0f}/255')
+    gap_level = np.percentile(fg, 25) / 255
+    sheet_level = np.percentile(fg, 85) / 255
+    click.echo(f'gap level ~p25 = {gap_level:.2f}; sheet level ~p85 = {sheet_level:.2f}')
+
+    # Layer spacing: averaged autocorrelation of mean-subtracted line profiles;
+    # the first prominent off-centre peak is the dominant layer period. At a
+    # bunched location this measures pack-to-pack spacing rather than
+    # sheet-to-sheet -- inspect the PNG before trusting a single number.
+    rows = crop[range(0, crop.shape[0], 24)].astype(np.float32)
+    rows = rows - rows.mean(axis=1, keepdims=True)
+    ac = np.mean([np.correlate(r, r, mode='full') for r in rows], axis=0)
+    ac = ac[len(ac) // 2:] / ac[len(ac) // 2]
+    peaks, _ = scipy.signal.find_peaks(ac, prominence=0.02)
+    if len(peaks):
+        click.echo(f'layer-spacing autocorrelation peaks (voxels): {peaks[:6].tolist()}'
+                   f' => ~{peaks[0] * voxel_um:.0f} um')
+
+    residual = crop.astype(np.float32) - gaussian_filter(crop.astype(np.float32), 2.)
+    click.echo(f'high-frequency noise std inside papyrus: '
+               f'{residual[crop > 0].std() / 255:.3f}')
+
+    if out_png:
+        import matplotlib
+        matplotlib.use('Agg')
+        import matplotlib.pyplot as plt
+        fig, axes = plt.subplots(1, 2, figsize=(14, 7))
+        axes[0].imshow(overview, cmap='gray')
+        axes[0].set_title(f'ds{ds} overview, z={cz}')
+        axes[1].imshow(crop, cmap='gray')
+        axes[1].set_title(f'native crop at ({cy},{cx})')
+        for ax in axes:
+            ax.axis('off')
+        plt.tight_layout()
+        plt.savefig(out_png, dpi=110)
+        click.echo(f'wrote {out_png}')
+
+
+if __name__ == '__main__':
+    main()

--- a/volume-cartographer/scripts/spiral/measure_real_scroll.py
+++ b/volume-cartographer/scripts/spiral/measure_real_scroll.py
@@ -35,12 +35,16 @@ DEFAULT_URL = ('https://vesuvius-challenge-open-data.s3.us-east-1.amazonaws.com/
 def main(url, position, crop_half, voxel_um, out_png):
     cz, cy, cx = position
     group = zarr.open_group(url, mode='r')
-    levels = sorted(int(k) for k in group.array_keys())
-    coarse = levels[min(3, len(levels) - 1)]
-    ds = 2 ** coarse
+    # An HTTP store cannot list directories, so array_keys() comes back empty
+    # for remote volumes; the OME-Zarr multiscales metadata is the reliable
+    # way to enumerate resolution levels (and their downsample factors).
+    datasets = group.attrs['multiscales'][0]['datasets']
+    coarse_entry = datasets[min(3, len(datasets) - 1)]
+    ds = round(coarse_entry['coordinateTransformations'][0]['scale'][0])
 
-    crop = group['0'][cz, cy - crop_half:cy + crop_half, cx - crop_half:cx + crop_half]
-    overview = group[str(coarse)][cz // ds, :, :]
+    crop = group[datasets[0]['path']][
+        cz, cy - crop_half:cy + crop_half, cx - crop_half:cx + crop_half]
+    overview = group[coarse_entry['path']][cz // ds, :, :]
     click.echo(f'native crop {crop.shape} {crop.dtype}; ds{ds} overview {overview.shape}')
 
     fg = crop[crop > 0]

--- a/volume-cartographer/scripts/spiral/synth_phantom.py
+++ b/volume-cartographer/scripts/spiral/synth_phantom.py
@@ -1,0 +1,354 @@
+"""Synthetic known-deformation phantom generator for the spiral fit.
+
+Generates a scroll-like test volume by sampling a *random known* deformation
+using the production transform stack itself (SpiralAndTransform: gap expander,
+integrated-flow diffeomorphism, per-z linear, umbilicus), then rendering the
+canonical Archimedean spiral through it. Because the deformation is known, the
+phantom ships with exact per-voxel ground truth that no real scroll has:
+
+  volume.tif    uint8   CT-like rendered volume [Z, Y, X]
+  winding.tif   float32 true fractional winding number at every voxel
+  mask.tif      uint8   0 = outside annulus, 1 = valid, 2 = valid but torn
+  phantom_checkpoint.pt  fit-shaped checkpoint ('spiral_and_transform', 'cfg',
+                         'z_begin', 'z_end', 'spiral_outward_sense') plus
+                         'umbilicus_zyx' (UmbilicusTransform keeps its curve as
+                         plain attributes, so it is NOT in the state_dict) and
+                         a 'phantom' block recording seed + knobs
+  meta.json     provenance: seed, knobs, inverse round-trip error
+
+Ground-truth convention: truth is the *forward* slice->spiral map exactly as
+integrated (the same RK4 the fit uses), so winding.tif is exact by definition;
+only users of transform.inv see numerical inversion error, which is measured
+and reported in meta.json ('roundtrip_*').
+
+Honest realism caveats, staged deliberately:
+  - Tears are signal dropout only (intensity set to background inside a random
+    box); the geometry stays a smooth diffeomorphism. Topological tears --
+    where the winding field itself is cut -- are NOT modelled, matching the
+    (known) limitation of the production transform.
+  - Haze is a uniform Gaussian blur, not a physically-motivated decoherence
+    model; compression-dependent haze is future work.
+A method that aces this phantom can still fail on real scrolls; the phantom
+bounds correctness from below, it does not certify it.
+"""
+
+import json
+import os
+
+import click
+import numpy as np
+import scipy.ndimage
+import tifffile
+import torch
+import torch.nn.functional as F
+from tqdm import tqdm
+
+import sample_spiral
+from config import Config
+from sample_spiral import get_theta_and_radii
+from transforms import SpiralAndTransform
+
+PHANTOM_SCHEMA_VERSION = 1
+
+
+def make_phantom_config(z_size, yx_size, dr_per_winding, num_table_windings, z_margin):
+    """A full fit Config with the model_* keys sized for a small phantom.
+
+    Starting from the real Config (rather than a hand-rolled dict) keeps the
+    phantom checkpoint loadable by any tool that reads fit checkpoints.
+    """
+    cfg = Config().as_dict()
+    cfg['model_initial_dr_per_winding'] = float(dr_per_winding)
+    cfg['model_flow_bounds_radius'] = yx_size // 2
+    cfg['model_flow_bounds_z_margin'] = z_margin
+    # Keep every parameter lattice non-degenerate at phantom sizes: the fit's
+    # default resolutions assume full-scroll z extents and integer-divide to
+    # zero-size lattices on small volumes (CartesianFlowField's LR lattice is
+    # resolution // 6 per axis; the linear and gap lattices are z extent //
+    # their respective resolutions).
+    z_extent = z_size + 2 * z_margin
+    cfg['model_flow_voxel_resolution'] = max(1, min(
+        z_extent // 6, yx_size // 6, cfg['model_flow_voxel_resolution']))
+    cfg['model_linear_z_resolution'] = min(z_extent, cfg['model_linear_z_resolution'])
+    cfg['model_gap_expander_logit_resolution'] = min(
+        z_extent, cfg['model_gap_expander_logit_resolution'])
+    cfg['model_gap_expander_num_windings'] = num_table_windings
+    return cfg
+
+
+def build_model(cfg, z_begin, z_end, umbilicus_zyx, spiral_outward_sense, device):
+    """Construct SpiralAndTransform the same way find_inconsistent_windings
+    rebuilds one from a checkpoint (flow box from cfg bounds + model z-range)."""
+    r = cfg['model_flow_bounds_radius']
+    flow_min = torch.tensor([z_begin - cfg['model_flow_bounds_z_margin'], -r, -r],
+                            dtype=torch.int64, device=device)
+    flow_max = torch.tensor([z_end + cfg['model_flow_bounds_z_margin'], r, r],
+                            dtype=torch.int64, device=device)
+    model = SpiralAndTransform(
+        flow_integration_steps=cfg['model_num_flow_integration_steps'],
+        flow_integration_solver=cfg['model_flow_integration_solver'],
+        flow_min_corner_zyx=flow_min,
+        flow_max_corner_zyx=flow_max,
+        umbilicus_zyx=umbilicus_zyx.to(device),
+        config=cfg,
+        spiral_outward_sense=spiral_outward_sense,
+    )
+    model.to(device)
+    model.eval()
+    return model
+
+
+def build_model_from_phantom_checkpoint(checkpoint, device):
+    """Rebuild the exact phantom transform from a phantom_checkpoint.pt payload."""
+    model = build_model(
+        checkpoint['cfg'],
+        int(checkpoint['z_begin']),
+        int(checkpoint['z_end']),
+        checkpoint['umbilicus_zyx'].to(device),
+        checkpoint['spiral_outward_sense'],
+        device,
+    )
+    model.load_state_dict(checkpoint['spiral_and_transform'])
+    return model
+
+
+def _smooth_noise_like(param, rng, sigma):
+    """Zero-mean unit-std noise of param's shape, Gaussian-smoothed over the
+    trailing spatial axes so the sampled fields are smooth on the lattice."""
+    noise = rng.standard_normal(tuple(param.shape)).astype(np.float32)
+    spatial_axes = tuple(range(param.ndim - len(param.shape[2:]), param.ndim)) if param.ndim > 2 else tuple(range(param.ndim))
+    if sigma > 0:
+        noise = scipy.ndimage.gaussian_filter(noise, sigma=sigma, axes=spatial_axes)
+    std = noise.std()
+    if std > 0:
+        noise /= std
+    return torch.from_numpy(noise)
+
+
+@torch.no_grad()
+def randomise_model(model, rng, flow_std, gap_log_std, linear_std, flow_smooth_sigma):
+    """Fill the model's parameters with a random smooth deformation.
+
+    Magnitude knobs are expressed in each stage's *effective* units and divided
+    by the training-time learning-rate scales, so knob values survive changes
+    to those scales:
+      flow_std       velocity in normalised flow-box units (~= displacement as
+                     a fraction of the flow-box extent, since t spans 1)
+      gap_log_std    std of the log winding-gap multiplier (0.15 -> gaps vary
+                     roughly x0.74..x1.35): compression/expansion of spacing
+      linear_std     std of the per-z 2x2 log-matrix L entries (M = expm(L)):
+                     mild anisotropy/shear
+    """
+    # Randomise the HR flow lattice only (the LR one would upsample to a
+    # near-constant field at phantom sizes); smoothing keeps it diffeomorphic
+    # in practice at these magnitudes.
+    hr_flow = model.flow_field.flows[1]
+    hr_flow.copy_(_smooth_noise_like(hr_flow, rng, flow_smooth_sigma) * flow_std)
+    model.flow_field.flows[0].zero_()
+    for extra in model.extra_flow_fields:
+        extra.flows[0].zero_()
+        extra.flows[1].zero_()
+
+    # Effective log gap = logits * lr_scale * 2e2 (GapExpandingTransform);
+    # invert that so gap_log_std is in log-gap units. Logit 0 is pinned by the
+    # transform itself, no need to zero it here.
+    gap_logits = model.gap_expander_params.logits
+    gap_scale = model.cfg['model_gap_expander_lr_scale'] * 2.e2
+    gap_logits.copy_(_smooth_noise_like(gap_logits, rng, flow_smooth_sigma) * (gap_log_std / gap_scale))
+
+    # Effective L = logits * linear_logits_scale (SpiralAndTransform).
+    linear = model.linear_logits
+    linear.copy_(_smooth_noise_like(linear, rng, 0.) * (linear_std / model.linear_logits_scale))
+
+    model.requires_grad_(False)
+
+
+def make_umbilicus(z_begin, z_end, z_margin, centre_yx, amplitude, rng):
+    """A gently wandering central curve around the volume centre, dense in z so
+    UmbilicusTransform's own sigma=75 smoothing has samples to work with."""
+    zs = np.arange(z_begin - z_margin, z_end + z_margin, dtype=np.float32)
+    wiggle = rng.standard_normal((len(zs), 2)).astype(np.float32)
+    wiggle = scipy.ndimage.gaussian_filter1d(wiggle, sigma=24., axis=0, mode='nearest')
+    std = wiggle.std(axis=0, keepdims=True)
+    wiggle = wiggle / np.where(std > 0, std, 1.) * amplitude
+    yx = centre_yx[None, :] + wiggle
+    return torch.from_numpy(np.concatenate([zs[:, None], yx], axis=-1))
+
+
+@torch.no_grad()
+def render(model, z_size, yx_size, first_winding, last_winding, sheet_sigma,
+           device, chunk_size=200_000):
+    """Render the deformed spiral into slice space, with exact per-voxel truth.
+
+    Returns (volume [0,1] float32, winding float32, valid mask bool), each
+    shaped [Z, Y, X]. Winding truth is shifted_radius / dr -- the same readout
+    find_inconsistent_windings calls "the model's raw winding number".
+    """
+    transform = model.get_slice_to_spiral_transform()
+    dr = model.get_dr_per_winding()
+
+    zs = torch.arange(z_size, dtype=torch.float32)
+    ys = torch.arange(yx_size, dtype=torch.float32)
+    grid = torch.cartesian_prod(zs, ys, ys)  # [N, 3] zyx, voxel centres
+
+    density = torch.empty(len(grid), dtype=torch.float32)
+    winding = torch.empty(len(grid), dtype=torch.float32)
+    for start in tqdm(range(0, len(grid), chunk_size), desc='render'):
+        chunk = grid[start : start + chunk_size].to(device)
+        spiral = transform(chunk)
+        _, _, shifted = get_theta_and_radii(spiral[..., 1:], dr)
+        winding[start : start + chunk_size] = (shifted / dr).cpu()
+        density[start : start + chunk_size] = sample_spiral.get_spiral_density(
+            spiral[..., 1:], dr_per_winding=dr, sigma=sheet_sigma,
+            winding_range=(first_winding, last_winding + 1),
+        ).cpu()
+
+    shape = (z_size, yx_size, yx_size)
+    winding = winding.view(shape).numpy()
+    density = density.view(shape).numpy()
+    valid = (winding >= first_winding) & (winding <= last_winding)
+    return density, winding, valid
+
+
+def apply_tears(volume, valid, num_tears, rng, background):
+    """Signal-dropout tears: random boxes forced to background intensity.
+    Geometry (and winding truth) is untouched -- see module docstring. Boxes
+    are centred on random valid voxels: the annulus is a thin ring, so a
+    volume-uniform box would usually miss the papyrus entirely."""
+    tear_mask = np.zeros(volume.shape, dtype=bool)
+    z_size, y_size, x_size = volume.shape
+    valid_idx = np.stack(np.nonzero(valid), axis=-1)
+    for _ in range(num_tears):
+        cz, cy, cx = valid_idx[rng.integers(0, len(valid_idx))]
+        dz = rng.integers(z_size // 4, z_size + 1)
+        dy = rng.integers(8, max(9, y_size // 8))
+        dx = rng.integers(8, max(9, x_size // 8))
+        box = np.zeros_like(tear_mask)
+        box[max(0, cz - dz // 2) : cz + dz // 2 + 1,
+            max(0, cy - dy // 2) : cy + dy // 2 + 1,
+            max(0, cx - dx // 2) : cx + dx // 2 + 1] = True
+        tear_mask |= box & valid
+    volume[tear_mask] = background
+    return tear_mask
+
+
+@torch.no_grad()
+def measure_roundtrip(model, valid, num_points, rng, device):
+    """Slice -> spiral -> slice numerical inversion error on random valid voxels."""
+    idx = np.stack(np.nonzero(valid), axis=-1)
+    sel = idx[rng.integers(0, len(idx), size=min(num_points, len(idx)))]
+    pts = torch.from_numpy(sel.astype(np.float32)).to(device)
+    transform = model.get_slice_to_spiral_transform()
+    err = (transform.inv(transform(pts)) - pts).norm(dim=-1).cpu().numpy()
+    return {
+        'roundtrip_p50_vox': float(np.percentile(err, 50)),
+        'roundtrip_p95_vox': float(np.percentile(err, 95)),
+        'roundtrip_max_vox': float(err.max()),
+    }
+
+
+@click.command()
+@click.option('--out', required=True, type=click.Path(file_okay=False),
+              help='Output directory for the phantom files.')
+@click.option('--seed', default=0, type=int, help='RNG seed; same seed -> same phantom.')
+@click.option('--z-size', default=64, type=int, help='Volume z extent in voxels.')
+@click.option('--yx-size', default=384, type=int, help='Volume y and x extent in voxels.')
+@click.option('--dr-per-winding', default=16., type=float,
+              help='Canonical winding spacing in voxels (fit default: 16).')
+@click.option('--first-winding', default=2, type=int,
+              help='Innermost rendered winding (leaves a hollow core, like real scrolls).')
+@click.option('--flow-std', default=0.01, type=float,
+              help='Diffeomorphism velocity std in normalised flow-box units.')
+@click.option('--gap-log-std', default=0.15, type=float,
+              help='Std of log winding-gap multiplier (spacing compression/expansion).')
+@click.option('--linear-std', default=0.08, type=float,
+              help='Std of the per-z linear-stage log-matrix entries.')
+@click.option('--flow-smooth-sigma', default=1.5, type=float,
+              help='Gaussian smoothing (lattice cells) applied to sampled fields.')
+@click.option('--umbilicus-amplitude', default=3., type=float,
+              help='Std of the umbilicus wander around the volume centre, in voxels.')
+@click.option('--sheet-sigma', default=1.5, type=float,
+              help='Rendered sheet half-thickness (Gaussian sigma, voxels).')
+@click.option('--noise-std', default=0.03, type=float, help='Additive Gaussian noise std.')
+@click.option('--haze-sigma', default=0., type=float,
+              help='Uniform Gaussian blur sigma in voxels (0 disables).')
+@click.option('--num-tears', default=0, type=int,
+              help='Random signal-dropout tear boxes (geometry untouched).')
+@click.option('--spiral-outward-sense', default='CW', type=click.Choice(['CW', 'ACW']))
+@click.option('--device', default='cpu', help="torch device ('cpu', 'cuda', ...).")
+def main(out, seed, z_size, yx_size, dr_per_winding, first_winding, flow_std,
+         gap_log_std, linear_std, flow_smooth_sigma, umbilicus_amplitude,
+         sheet_sigma, noise_std, haze_sigma, num_tears, spiral_outward_sense, device):
+    rng = np.random.default_rng(seed)
+    torch.manual_seed(seed)
+    device = torch.device(device)
+
+    z_margin = max(8, z_size // 4)
+    centre = np.array([yx_size / 2., yx_size / 2.], dtype=np.float32)
+    # Keep the outermost rendered winding clear of the volume edge and of the
+    # umbilicus wander, so the annulus is fully observed.
+    max_radius = yx_size / 2. - 4. * umbilicus_amplitude - 2. * dr_per_winding
+    last_winding = int(max_radius / dr_per_winding) - 1
+    if last_winding <= first_winding:
+        raise click.UsageError('volume too small for the requested dr-per-winding')
+
+    cfg = make_phantom_config(z_size, yx_size, dr_per_winding,
+                              num_table_windings=last_winding + 8, z_margin=z_margin)
+    umbilicus_zyx = make_umbilicus(0, z_size, z_margin, centre, umbilicus_amplitude, rng)
+    model = build_model(cfg, 0, z_size, umbilicus_zyx, spiral_outward_sense, device)
+    randomise_model(model, rng, flow_std, gap_log_std, linear_std, flow_smooth_sigma)
+
+    volume, winding, valid = render(
+        model, z_size, yx_size, first_winding, last_winding, sheet_sigma, device)
+
+    background = 0.15
+    volume = background + volume * (0.75 - background)
+    if haze_sigma > 0:
+        volume = scipy.ndimage.gaussian_filter(volume, sigma=haze_sigma)
+    tear_mask = apply_tears(volume, valid, num_tears, rng, background) \
+        if num_tears > 0 else np.zeros_like(valid)
+    if noise_std > 0:
+        volume = volume + rng.standard_normal(volume.shape).astype(np.float32) * noise_std
+
+    roundtrip = measure_roundtrip(model, valid, num_points=20_000, rng=rng, device=device)
+
+    os.makedirs(out, exist_ok=True)
+    tifffile.imwrite(os.path.join(out, 'volume.tif'),
+                     (np.clip(volume, 0., 1.) * 255).astype(np.uint8))
+    tifffile.imwrite(os.path.join(out, 'winding.tif'), winding.astype(np.float32))
+    mask = valid.astype(np.uint8)
+    mask[tear_mask] = 2
+    tifffile.imwrite(os.path.join(out, 'mask.tif'), mask)
+
+    knobs = {
+        'seed': seed, 'z_size': z_size, 'yx_size': yx_size,
+        'dr_per_winding': dr_per_winding, 'first_winding': first_winding,
+        'last_winding': last_winding, 'flow_std': flow_std,
+        'gap_log_std': gap_log_std, 'linear_std': linear_std,
+        'flow_smooth_sigma': flow_smooth_sigma,
+        'umbilicus_amplitude': umbilicus_amplitude, 'sheet_sigma': sheet_sigma,
+        'noise_std': noise_std, 'haze_sigma': haze_sigma, 'num_tears': num_tears,
+    }
+    torch.save({
+        'schema_version': 2,
+        'phantom_schema_version': PHANTOM_SCHEMA_VERSION,
+        'spiral_and_transform': model.state_dict(),
+        'cfg': cfg,
+        'z_begin': 0,
+        'z_end': z_size,
+        'spiral_outward_sense': spiral_outward_sense,
+        'umbilicus_zyx': umbilicus_zyx.cpu(),
+        'phantom': knobs,
+    }, os.path.join(out, 'phantom_checkpoint.pt'))
+    with open(os.path.join(out, 'meta.json'), 'w') as f:
+        json.dump({**knobs, **roundtrip,
+                   'valid_voxels': int(valid.sum()),
+                   'torn_voxels': int(tear_mask.sum())}, f, indent=2)
+
+    click.echo(f'phantom written to {out}: windings {first_winding}..{last_winding}, '
+               f"{int(valid.sum())} valid voxels, "
+               f"inverse round-trip p95 {roundtrip['roundtrip_p95_vox']:.4f} vox")
+
+
+if __name__ == '__main__':
+    main()

--- a/volume-cartographer/scripts/spiral/synth_phantom.py
+++ b/volume-cartographer/scripts/spiral/synth_phantom.py
@@ -30,6 +30,18 @@ Honest realism caveats, staged deliberately:
     model; compression-dependent haze is future work.
 A method that aces this phantom can still fail on real scrolls; the phantom
 bounds correctness from below, it does not certify it.
+
+Realism calibration: --preset pherc0009b sets the intensity/texture/deformation
+knobs to values measured from the real PHerc0009B 2.4 um masked open-data
+volume (see measure_real_scroll.py for the reproducible measurement): murky
+gaps at ~0.29 rather than clean background, sheets at ~0.65 with within-sheet
+fiber texture and sparse bright speckles, wilder gap variation, and stronger
+anisotropy. Fiber texture is generated in CANONICAL space, so it deforms with
+the papyrus, as real fibers do. Two knowing simplifications: the preset's
+dr-per-winding is compute-bounded, below the ~90-200 voxel spacing measured in
+the real volume, and the cosine-bank texture reads as smooth marbling where
+real sheets are granular fiber bundles -- state both when quoting preset
+results.
 """
 
 import json
@@ -49,6 +61,21 @@ from sample_spiral import get_theta_and_radii
 from transforms import SpiralAndTransform
 
 PHANTOM_SCHEMA_VERSION = 1
+
+# Knob values measured from real scans (see module docstring). A preset only
+# overrides knobs the user left at their defaults, so explicit flags win.
+PRESETS = {
+    # PHerc0009B 2.4um masked volume, measured by measure_real_scroll.py at
+    # the volume centre: gap ~p25 0.29, sheet ~p85 0.65, high-freq noise
+    # 0.034, strong pack-bunching and flattening. dr is compute-bounded below
+    # the real ~90-200 voxel spacing (see docstring).
+    'pherc0009b': {
+        'dr_per_winding': 32., 'sheet_sigma': 7., 'gap_level': 0.29,
+        'sheet_level': 0.65, 'fiber_amp': 0.35, 'speckle_amp': 0.25,
+        'noise_std': 0.034, 'gap_log_std': 0.5, 'linear_std': 0.3,
+        'flow_std': 0.015,
+    },
+}
 
 
 def make_phantom_config(z_size, yx_size, dr_per_winding, num_table_windings, z_margin):
@@ -175,39 +202,86 @@ def make_umbilicus(z_begin, z_end, z_margin, centre_yx, amplitude, rng):
     return torch.from_numpy(np.concatenate([zs[:, None], yx], axis=-1))
 
 
+def _cosine_bank(rng, num, k_winding, k_turn, k_z):
+    """A seeded bank of 3D cosines over canonical (winding, theta, z)
+    coordinates -- cheap procedural noise that needs no lattice storage and is
+    evaluated at arbitrary points. Frequency ranges are (lo, hi) tuples in
+    cycles per winding / per full turn / per z-voxel."""
+    bank = {
+        'k_w': torch.tensor(rng.uniform(*k_winding, num), dtype=torch.float32),
+        'k_t': torch.tensor(rng.uniform(*k_turn, num), dtype=torch.float32),
+        'k_z': torch.tensor(rng.uniform(*k_z, num), dtype=torch.float32),
+        'phase': torch.tensor(rng.uniform(0, 2 * np.pi, num), dtype=torch.float32),
+        'amp': torch.tensor(rng.dirichlet(np.ones(num)), dtype=torch.float32),
+    }
+    # Normalise so the summed field has approximately unit std.
+    bank['scale'] = float(1. / np.sqrt((bank['amp'].numpy() ** 2).sum() / 2))
+    return bank
+
+
+def _eval_bank(bank, w, theta, z, device):
+    args = (2 * torch.pi) * (
+        bank['k_w'].to(device) * w[..., None]
+        + bank['k_t'].to(device) * (theta[..., None] / (2 * torch.pi))
+        + bank['k_z'].to(device) * z[..., None]) + bank['phase'].to(device)
+    return (torch.cos(args) * bank['amp'].to(device)).sum(-1) * bank['scale']
+
+
 @torch.no_grad()
 def render(model, z_size, yx_size, first_winding, last_winding, sheet_sigma,
-           device, chunk_size=200_000):
+           gap_level, sheet_level, fiber_amp, speckle_amp, rng, device,
+           chunk_size=200_000):
     """Render the deformed spiral into slice space, with exact per-voxel truth.
 
     Returns (volume [0,1] float32, winding float32, valid mask bool), each
     shaped [Z, Y, X]. Winding truth is shifted_radius / dr -- the same readout
     find_inconsistent_windings calls "the model's raw winding number".
+
+    Intensity model: lerp(gap_level, textured sheet_level, sheet density).
+    With fiber_amp/speckle_amp zero this reduces to the original clean
+    two-level rendering. Fiber texture and speckles are evaluated on CANONICAL
+    (winding, theta, z) coordinates so they deform with the papyrus; fiber
+    frequencies are anisotropic (fast across the sheet thickness, slow along
+    it), giving the streaky along-sheet grain real scans show.
     """
     transform = model.get_slice_to_spiral_transform()
     dr = model.get_dr_per_winding()
+    fiber_bank = _cosine_bank(rng, 12, k_winding=(3., 9.), k_turn=(8., 60.),
+                              k_z=(0.02, 0.15))
+    speckle_bank = _cosine_bank(rng, 12, k_winding=(8., 20.), k_turn=(60., 200.),
+                                k_z=(0.1, 0.4))
 
     zs = torch.arange(z_size, dtype=torch.float32)
     ys = torch.arange(yx_size, dtype=torch.float32)
     grid = torch.cartesian_prod(zs, ys, ys)  # [N, 3] zyx, voxel centres
 
-    density = torch.empty(len(grid), dtype=torch.float32)
+    volume = torch.empty(len(grid), dtype=torch.float32)
     winding = torch.empty(len(grid), dtype=torch.float32)
     for start in tqdm(range(0, len(grid), chunk_size), desc='render'):
         chunk = grid[start : start + chunk_size].to(device)
         spiral = transform(chunk)
-        _, _, shifted = get_theta_and_radii(spiral[..., 1:], dr)
-        winding[start : start + chunk_size] = (shifted / dr).cpu()
-        density[start : start + chunk_size] = sample_spiral.get_spiral_density(
+        theta, _, shifted = get_theta_and_radii(spiral[..., 1:], dr)
+        w = shifted / dr
+        winding[start : start + chunk_size] = w.cpu()
+        density = sample_spiral.get_spiral_density(
             spiral[..., 1:], dr_per_winding=dr, sigma=sheet_sigma,
-            winding_range=(first_winding, last_winding + 1),
-        ).cpu()
+            winding_range=(first_winding, last_winding + 1))
+        sheet = sheet_level * torch.ones_like(density)
+        if fiber_amp > 0:
+            sheet = sheet * (1 + fiber_amp * _eval_bank(
+                fiber_bank, w, theta, chunk[..., 0], device))
+        if speckle_amp > 0:
+            # Sparse bright inclusions: the positive tail of a second field.
+            speck = _eval_bank(speckle_bank, w, theta, chunk[..., 0], device)
+            sheet = sheet + speckle_amp * torch.relu(speck - 2.)
+        volume[start : start + chunk_size] = (
+            gap_level + density * (sheet - gap_level)).cpu()
 
     shape = (z_size, yx_size, yx_size)
     winding = winding.view(shape).numpy()
-    density = density.view(shape).numpy()
+    volume = volume.view(shape).numpy()
     valid = (winding >= first_winding) & (winding <= last_winding)
-    return density, winding, valid
+    return volume, winding, valid
 
 
 def apply_tears(volume, valid, num_tears, rng, background):
@@ -269,6 +343,17 @@ def measure_roundtrip(model, valid, num_points, rng, device):
               help='Std of the umbilicus wander around the volume centre, in voxels.')
 @click.option('--sheet-sigma', default=1.5, type=float,
               help='Rendered sheet half-thickness (Gaussian sigma, voxels).')
+@click.option('--gap-level', default=0.15, type=float,
+              help='Intensity between sheets (real gaps are murky, ~0.29).')
+@click.option('--sheet-level', default=0.75, type=float,
+              help='Sheet intensity (real sheets measure ~0.65).')
+@click.option('--fiber-amp', default=0., type=float,
+              help='Within-sheet fiber texture amplitude (0 disables).')
+@click.option('--speckle-amp', default=0., type=float,
+              help='Bright-inclusion speckle amplitude (0 disables).')
+@click.option('--preset', default=None, type=click.Choice(sorted(PRESETS)),
+              help='Apply knob values calibrated against a real scan; '
+                   'explicitly passed flags still win.')
 @click.option('--noise-std', default=0.03, type=float, help='Additive Gaussian noise std.')
 @click.option('--haze-sigma', default=0., type=float,
               help='Uniform Gaussian blur sigma in voxels (0 disables).')
@@ -278,7 +363,20 @@ def measure_roundtrip(model, valid, num_points, rng, device):
 @click.option('--device', default='cpu', help="torch device ('cpu', 'cuda', ...).")
 def main(out, seed, z_size, yx_size, dr_per_winding, first_winding, flow_std,
          gap_log_std, linear_std, flow_smooth_sigma, umbilicus_amplitude,
-         sheet_sigma, noise_std, haze_sigma, num_tears, spiral_outward_sense, device):
+         sheet_sigma, gap_level, sheet_level, fiber_amp, speckle_amp, preset,
+         noise_std, haze_sigma, num_tears, spiral_outward_sense, device):
+    if preset is not None:
+        source = click.get_current_context().get_parameter_source
+        overrides = {name: value for name, value in PRESETS[preset].items()
+                     if source(name) == click.core.ParameterSource.DEFAULT}
+        (dr_per_winding, sheet_sigma, gap_level, sheet_level, fiber_amp,
+         speckle_amp, noise_std, gap_log_std, linear_std, flow_std) = [
+            overrides.get(name, value) for name, value in [
+                ('dr_per_winding', dr_per_winding), ('sheet_sigma', sheet_sigma),
+                ('gap_level', gap_level), ('sheet_level', sheet_level),
+                ('fiber_amp', fiber_amp), ('speckle_amp', speckle_amp),
+                ('noise_std', noise_std), ('gap_log_std', gap_log_std),
+                ('linear_std', linear_std), ('flow_std', flow_std)]]
     rng = np.random.default_rng(seed)
     torch.manual_seed(seed)
     device = torch.device(device)
@@ -299,13 +397,12 @@ def main(out, seed, z_size, yx_size, dr_per_winding, first_winding, flow_std,
     randomise_model(model, rng, flow_std, gap_log_std, linear_std, flow_smooth_sigma)
 
     volume, winding, valid = render(
-        model, z_size, yx_size, first_winding, last_winding, sheet_sigma, device)
+        model, z_size, yx_size, first_winding, last_winding, sheet_sigma,
+        gap_level, sheet_level, fiber_amp, speckle_amp, rng, device)
 
-    background = 0.15
-    volume = background + volume * (0.75 - background)
     if haze_sigma > 0:
         volume = scipy.ndimage.gaussian_filter(volume, sigma=haze_sigma)
-    tear_mask = apply_tears(volume, valid, num_tears, rng, background) \
+    tear_mask = apply_tears(volume, valid, num_tears, rng, gap_level) \
         if num_tears > 0 else np.zeros_like(valid)
     if noise_std > 0:
         volume = volume + rng.standard_normal(volume.shape).astype(np.float32) * noise_std
@@ -327,6 +424,8 @@ def main(out, seed, z_size, yx_size, dr_per_winding, first_winding, flow_std,
         'gap_log_std': gap_log_std, 'linear_std': linear_std,
         'flow_smooth_sigma': flow_smooth_sigma,
         'umbilicus_amplitude': umbilicus_amplitude, 'sheet_sigma': sheet_sigma,
+        'gap_level': gap_level, 'sheet_level': sheet_level,
+        'fiber_amp': fiber_amp, 'speckle_amp': speckle_amp, 'preset': preset,
         'noise_std': noise_std, 'haze_sigma': haze_sigma, 'num_tears': num_tears,
     }
     torch.save({

--- a/volume-cartographer/scripts/spiral/tests/test_export_phantom_dataset.py
+++ b/volume-cartographer/scripts/spiral/tests/test_export_phantom_dataset.py
@@ -1,0 +1,100 @@
+"""Tests for export_phantom_dataset + fit_phantom_reference.
+
+Reuses test_synth_phantom's tiny CLI-generated phantom. The load-bearing
+invariants: exported patch vertices must lie exactly on true integer windings
+(in the fit's shifted_radius/dr convention -- the annotation-convention bug
+this would have caught injected a mean +0.5-winding screw dislocation), and
+the reference fitter must measurably improve on the unfitted model when
+scored against phantom truth.
+"""
+
+import json
+import os
+
+import numpy as np
+import pytest
+import torch
+from click.testing import CliRunner
+
+import export_phantom_dataset
+import fit_phantom_reference
+from checkpoint_io import load_checkpoint_cpu
+from synth_phantom import build_model_from_phantom_checkpoint
+from tifxyz import load_tifxyz
+from winding_error import evaluate, load_phantom, winding_and_theta
+from test_synth_phantom import generate_phantom
+
+
+@pytest.fixture(scope='module')
+def phantom_dir(tmp_path_factory):
+    return generate_phantom(str(tmp_path_factory.mktemp('phantom')))
+
+
+@pytest.fixture(scope='module')
+def dataset_dir(phantom_dir, tmp_path_factory):
+    out = str(tmp_path_factory.mktemp('dataset'))
+    result = CliRunner().invoke(export_phantom_dataset.main, [
+        '--phantom', phantom_dir, '--out', out, '--step', '2', '--coverage', '0.7'])
+    assert result.exit_code == 0, result.output
+    return out
+
+
+def test_umbilicus_json_schema(dataset_dir):
+    data = json.load(open(os.path.join(dataset_dir, 'umbilicus.json')))
+    points = data['control_points']
+    assert len(points) > 0 and all(set(p) == {'z', 'y', 'x'} for p in points)
+
+
+def test_patch_vertices_lie_on_true_windings(phantom_dir, dataset_dir):
+    # The whole point of truth-derived patches: every vertex sits exactly on
+    # its annotated winding, in the SAME convention the fit anchors
+    # (shifted_radius == winding * dr). A convention mismatch (e.g. annotating
+    # the radius parameter k + theta/2pi) shows up here as a 0..1 sawtooth.
+    _, model, _ = load_phantom(phantom_dir, torch.device('cpu'))
+    patches_dir = os.path.join(dataset_dir, 'verified_patches')
+    for entry in sorted(os.listdir(patches_dir)):
+        patch = load_tifxyz(os.path.join(patches_dir, entry))
+        w_true, _ = winding_and_theta(model, patch.zyxs.reshape(-1, 3))
+        annotation = patch.winding.reshape(-1).numpy()
+        assert np.abs(w_true - annotation).max() < 0.02, entry
+        # Annotations are constant per patch: the winding index.
+        assert np.allclose(annotation, np.round(annotation[0]))
+
+
+def test_position_noise_corrupts_vertices(phantom_dir, dataset_dir, tmp_path):
+    noisy = str(tmp_path / 'noisy')
+    result = CliRunner().invoke(export_phantom_dataset.main, [
+        '--phantom', phantom_dir, '--out', noisy, '--step', '2',
+        '--coverage', '0.7', '--position-noise', '2.0'])
+    assert result.exit_code == 0, result.output
+    entry = sorted(os.listdir(os.path.join(dataset_dir, 'verified_patches')))[0]
+    clean_patch = load_tifxyz(os.path.join(dataset_dir, 'verified_patches', entry))
+    noisy_patch = load_tifxyz(os.path.join(noisy, 'verified_patches', entry))
+    displacement = (clean_patch.zyxs - noisy_patch.zyxs).norm(dim=-1)
+    assert 1.0 < displacement.mean() < 6.0  # ~ chi(3) mean at sigma 2
+
+
+def test_reference_fit_improves_over_init(phantom_dir, dataset_dir, tmp_path):
+    fitted_path = str(tmp_path / 'fitted.pt')
+    result = CliRunner().invoke(fit_phantom_reference.main, [
+        '--dataset', dataset_dir, '--out', fitted_path, '--steps', '200',
+        '--reg-gap', '0.01', '--reg-flow', '0.1'])
+    assert result.exit_code == 0, result.output
+
+    _, phantom_model, mask = load_phantom(phantom_dir, torch.device('cpu'))
+    checkpoint = load_checkpoint_cpu(fitted_path)
+    fitted = build_model_from_phantom_checkpoint(checkpoint, torch.device('cpu'))
+    # Init baseline: the same architecture, freshly constructed (identity
+    # deformation, dr at its configured init) -- NOT zeroed parameters, which
+    # would also zero the dr logit and produce a nonsense spiral.
+    from synth_phantom import build_model
+    init = build_model(checkpoint['cfg'], int(checkpoint['z_begin']),
+                       int(checkpoint['z_end']), checkpoint['umbilicus_zyx'],
+                       checkpoint['spiral_outward_sense'], torch.device('cpu'))
+
+    def mae(model):
+        return evaluate(phantom_model, mask, ('model', model), num_points=20_000,
+                        cut_margin=0.1, seed=0, device=torch.device('cpu'))['overall']['mae']
+
+    init_mae, fitted_mae = mae(init), mae(fitted)
+    assert fitted_mae < init_mae * 0.7, (init_mae, fitted_mae)

--- a/volume-cartographer/scripts/spiral/tests/test_export_phantom_dataset.py
+++ b/volume-cartographer/scripts/spiral/tests/test_export_phantom_dataset.py
@@ -74,6 +74,32 @@ def test_position_noise_corrupts_vertices(phantom_dir, dataset_dir, tmp_path):
     assert 1.0 < displacement.mean() < 6.0  # ~ chi(3) mean at sigma 2
 
 
+def test_tifxyz_candidate_mode(phantom_dir, dataset_dir, tmp_path):
+    # Exported patches ARE tifxyz surfaces on true windings, so scoring them
+    # through the mesh mode must report near-zero on-surface error, zero
+    # grid discontinuities, and near-zero annotation disagreement -- while a
+    # noisy export must score measurably off-surface.
+    from winding_error import evaluate_tifxyz, load_tifxyz_candidates
+    _, model, _ = load_phantom(phantom_dir, torch.device('cpu'))
+    clean = evaluate_tifxyz(
+        model, load_tifxyz_candidates(os.path.join(dataset_dir, 'verified_patches')),
+        cut_margin=0.1)
+    assert clean['overall']['on_surface_mae'] < 0.01
+    assert clean['overall']['grid_discontinuity_frac'] == 0.
+    for p in clean['per_patch'].values():
+        assert p['winding_agreement']['mae'] < 0.01
+
+    noisy_dir = str(tmp_path / 'noisy_for_mesh')
+    result = CliRunner().invoke(export_phantom_dataset.main, [
+        '--phantom', phantom_dir, '--out', noisy_dir, '--step', '2',
+        '--coverage', '0.7', '--position-noise', '3.0'])
+    assert result.exit_code == 0, result.output
+    noisy = evaluate_tifxyz(
+        model, load_tifxyz_candidates(os.path.join(noisy_dir, 'verified_patches')),
+        cut_margin=0.1)
+    assert noisy['overall']['on_surface_mae'] > clean['overall']['on_surface_mae'] * 5
+
+
 def test_reference_fit_improves_over_init(phantom_dir, dataset_dir, tmp_path):
     fitted_path = str(tmp_path / 'fitted.pt')
     result = CliRunner().invoke(fit_phantom_reference.main, [

--- a/volume-cartographer/scripts/spiral/tests/test_synth_phantom.py
+++ b/volume-cartographer/scripts/spiral/tests/test_synth_phantom.py
@@ -138,6 +138,29 @@ def test_perturbed_deformation_scores_worse(phantom):
     assert worse['overall']['mae'] > max(identical['overall']['mae'] * 10, 1e-4)
 
 
+def test_preset_texture_preserves_truth(tmp_path):
+    # The pherc0009b preset changes RENDERING (fiber texture, speckles, murky
+    # gaps) and deformation magnitudes -- never the truth convention. The
+    # identical candidate must still score exactly zero, and the volume must
+    # actually carry the textured intensity statistics.
+    out = str(tmp_path / 'preset')
+    result = CliRunner().invoke(synth_phantom.main, [
+        '--out', out, '--preset', 'pherc0009b', '--seed', str(SEED),
+        '--z-size', '16', '--yx-size', '448', '--num-tears', '0'])
+    assert result.exit_code == 0, result.output
+    checkpoint, model, mask = load_phantom(out, torch.device('cpu'))
+    scored = evaluate(model, mask, ('model', model), num_points=10_000,
+                      cut_margin=0.1, seed=0, device=torch.device('cpu'))
+    assert scored['overall']['mae'] < 1e-6
+    meta = json.load(open(os.path.join(out, 'meta.json')))
+    assert meta['preset'] == 'pherc0009b'
+    assert meta['fiber_amp'] > 0 and meta['gap_level'] == pytest.approx(0.29)
+    volume = tifffile.imread(os.path.join(out, 'volume.tif'))
+    sheets = volume[mask > 0]
+    # Textured sheets must vary well beyond the additive noise floor.
+    assert sheets.std() > 20  # uint8 units; noise_std alone would be ~9
+
+
 def test_shape_mismatch_rejected(phantom):
     with pytest.raises(Exception):
         bad = np.zeros((4, 4, 4), dtype=np.float32)

--- a/volume-cartographer/scripts/spiral/tests/test_synth_phantom.py
+++ b/volume-cartographer/scripts/spiral/tests/test_synth_phantom.py
@@ -1,0 +1,146 @@
+"""Tests for the synth_phantom / winding_error pair.
+
+A shared tiny phantom is generated once through the real CLI entry point (so
+the file contract -- volume/winding/mask/checkpoint/meta -- is what's tested),
+then the metric harness is exercised against candidates with known defects:
+identical (zero error), constant offset (pure gauge, must align away), partial
+sheet shift (must show up as switch rate, not gauge), and a perturbed
+deformation (must score worse than identical).
+"""
+
+import json
+import os
+
+import numpy as np
+import pytest
+import tifffile
+import torch
+from click.testing import CliRunner
+
+import synth_phantom
+from winding_error import evaluate, load_phantom
+
+SEED = 3
+PHANTOM_ARGS = ['--seed', str(SEED), '--z-size', '16', '--yx-size', '192',
+                '--dr-per-winding', '12', '--num-tears', '2']
+
+
+def generate_phantom(out_dir):
+    result = CliRunner().invoke(synth_phantom.main, ['--out', out_dir, *PHANTOM_ARGS])
+    assert result.exit_code == 0, result.output
+    return out_dir
+
+
+@pytest.fixture(scope='module')
+def phantom_dir(tmp_path_factory):
+    return generate_phantom(str(tmp_path_factory.mktemp('phantom')))
+
+
+@pytest.fixture(scope='module')
+def phantom(phantom_dir):
+    checkpoint, model, mask = load_phantom(phantom_dir, torch.device('cpu'))
+    return {'dir': phantom_dir, 'checkpoint': checkpoint, 'model': model, 'mask': mask}
+
+
+def run_eval(phantom, candidate, num_points=20_000):
+    return evaluate(phantom['model'], phantom['mask'], candidate,
+                    num_points=num_points, cut_margin=0.1, seed=0,
+                    device=torch.device('cpu'))
+
+
+def test_outputs_exist_and_consistent(phantom_dir):
+    volume = tifffile.imread(os.path.join(phantom_dir, 'volume.tif'))
+    winding = tifffile.imread(os.path.join(phantom_dir, 'winding.tif'))
+    mask = tifffile.imread(os.path.join(phantom_dir, 'mask.tif'))
+    assert volume.shape == winding.shape == mask.shape == (16, 192, 192)
+    assert volume.dtype == np.uint8 and winding.dtype == np.float32
+    meta = json.load(open(os.path.join(phantom_dir, 'meta.json')))
+    assert meta['valid_voxels'] == int((mask > 0).sum())
+    # Winding truth must respect the annulus the mask claims.
+    w_valid = winding[mask > 0]
+    assert w_valid.min() >= meta['first_winding']
+    assert w_valid.max() <= meta['last_winding']
+
+
+def test_tears_land_on_papyrus(phantom_dir):
+    # Regression: volume-uniform tear boxes usually missed the thin annulus,
+    # silently producing phantoms with zero torn voxels.
+    meta = json.load(open(os.path.join(phantom_dir, 'meta.json')))
+    assert meta['torn_voxels'] > 0
+    mask = tifffile.imread(os.path.join(phantom_dir, 'mask.tif'))
+    assert (mask == 2).sum() == meta['torn_voxels']
+
+
+def test_roundtrip_invertibility(phantom_dir):
+    meta = json.load(open(os.path.join(phantom_dir, 'meta.json')))
+    assert meta['roundtrip_p95_vox'] < 0.01
+
+
+def test_determinism(phantom_dir, tmp_path):
+    other = generate_phantom(str(tmp_path / 'phantom_again'))
+    for name in ('volume.tif', 'winding.tif', 'mask.tif'):
+        a = tifffile.imread(os.path.join(phantom_dir, name))
+        b = tifffile.imread(os.path.join(other, name))
+        np.testing.assert_array_equal(a, b)
+
+
+def test_identical_candidate_scores_zero(phantom):
+    result = run_eval(phantom, ('model', phantom['model']))
+    assert result['overall']['mae'] < 1e-6
+    assert result['overall']['switch_rate'] == 0.
+    assert abs(result['gauge_offset']) < 1e-6
+
+
+def test_winding_volume_candidate_scores_zero(phantom):
+    winding = tifffile.imread(os.path.join(phantom['dir'], 'winding.tif'))
+    result = run_eval(phantom, ('volume', winding))
+    assert result['overall']['mae'] < 1e-6
+
+
+def test_constant_offset_is_gauge_aligned_away(phantom):
+    # A constant winding offset is pure gauge (theta-origin choice) and must
+    # be absorbed by alignment, not reported as error.
+    winding = tifffile.imread(os.path.join(phantom['dir'], 'winding.tif')) + 0.37
+    result = run_eval(phantom, ('volume', winding))
+    assert abs(result['gauge_offset'] - 0.37) < 0.02
+    assert result['overall']['mae'] < 0.02
+    assert result['raw_mae'] > 0.3  # ...but the unaligned figure still shows it
+
+
+def test_partial_sheet_shift_shows_as_switches(phantom):
+    # Shifting a clear minority of the field by one winding is a genuine
+    # sheet-switch defect: median alignment must pin the gauge to the
+    # unshifted majority, and the shifted minority must land in the
+    # switch-rate figure -- roughly its volume fraction.
+    winding = tifffile.imread(os.path.join(phantom['dir'], 'winding.tif')).copy()
+    shifted_region = np.zeros_like(winding, dtype=bool)
+    shifted_region[3 * winding.shape[0] // 4 :] = True  # top z-quarter
+    winding[shifted_region] += 1.
+    result = run_eval(phantom, ('volume', winding))
+    assert abs(result['gauge_offset']) < 0.05
+    assert 0.1 < result['overall']['switch_rate'] < 0.45
+    mask = phantom['mask']
+    shifted_frac = (shifted_region & (mask > 0)).sum() / (mask > 0).sum()
+    assert result['overall']['switch_rate'] == pytest.approx(shifted_frac, abs=0.05)
+
+
+def test_perturbed_deformation_scores_worse(phantom):
+    from synth_phantom import build_model_from_phantom_checkpoint
+    perturbed = build_model_from_phantom_checkpoint(
+        phantom['checkpoint'], torch.device('cpu'))
+    with torch.no_grad():
+        hr = perturbed.flow_field.flows[1]
+        hr.add_(torch.from_numpy(
+            np.random.default_rng(1).standard_normal(tuple(hr.shape))
+            .astype(np.float32)) * 0.005)
+    identical = run_eval(phantom, ('model', phantom['model']))
+    worse = run_eval(phantom, ('model', perturbed))
+    assert worse['overall']['mae'] > max(identical['overall']['mae'] * 10, 1e-4)
+
+
+def test_shape_mismatch_rejected(phantom):
+    with pytest.raises(Exception):
+        bad = np.zeros((4, 4, 4), dtype=np.float32)
+        # evaluate indexes the volume at phantom voxel coordinates; a wrong
+        # grid must fail loudly, not silently score garbage.
+        run_eval(phantom, ('volume', bad))

--- a/volume-cartographer/scripts/spiral/trace_real_windings.py
+++ b/volume-cartographer/scripts/spiral/trace_real_windings.py
@@ -1,0 +1,221 @@
+"""Classical (no-ML) winding tracing of a real scroll slab -> a
+fit_phantom_reference-compatible dataset. Defaults reproduce the PHerc0172
+reroll demo end to end; the full sequence is:
+
+  python trace_real_windings.py --out /tmp/p172_dataset
+  python fit_phantom_reference.py --dataset /tmp/p172_dataset \
+      --out /tmp/p172_fit.pt --steps 1200 \
+      --reg-gap 0.03 --reg-flow 1.0 --reg-flow-smooth 100
+  python unroll_real_fit.py --checkpoint /tmp/p172_fit.pt \
+      --out-prefix /tmp/p172
+
+Method: stream a z-slab from an open-data OME-Zarr volume (cached locally),
+cast rays from the per-slice umbilicus (mask centroid), find intensity peaks
+(sheet crossings), link peaks across neighbouring rays by radius continuity
+into fragments, and assign each fragment an absolute winding index via its
+spiral phase coordinate with a shared per-theta radial-offset correction
+(estimated once, on the mid slice -- per-slice corrections can shift a whole
+slice's indices by one and shred the cross-z assembly). Fragments of each
+index jointly fill a [z, theta] surface grid, written as tifxyz + winding.tif.
+
+Honest limitations, measured on PHerc0172 (see the branch history):
+integer mis-indexing noise survives in the output (about 40% of holdout
+residuals sit near nonzero integer shifts), and the resulting sparse
+constraints underdetermine the deformation between them -- classical tracing
+is a demo-grade constraint source, not a replacement for dense surface
+predictions. PHerc0172 winds anticlockwise, so the default --mirror-x flips
+the slab to make the whole chain CW; unrolled images must be re-flipped for
+display (unroll_real_fit.py does).
+"""
+
+import json
+import os
+
+import click
+import numpy as np
+import scipy.ndimage
+import scipy.signal
+import tifffile
+import zarr
+
+from tifxyz import save_tifxyz
+
+DEFAULT_VOLUME = ('https://vesuvius-challenge-open-data.s3.us-east-1.amazonaws.com/'
+                  'PHerc0172/volumes/20241024131839-7.910um-53keV-masked.zarr')
+
+
+def fetch_slab(volume_url, level, z0, z_size, cache_path):
+    if cache_path and os.path.exists(cache_path):
+        return np.load(cache_path).astype(np.float32)
+    group = zarr.open_group(volume_url, mode='r')
+    path = next(d['path'] for d in group.attrs['multiscales'][0]['datasets']
+                if d['path'] == str(level))
+    slab = group[path][z0:z0 + z_size]
+    if cache_path:
+        np.save(cache_path, slab)
+    return slab.astype(np.float32)
+
+
+def trace_slice(img, cy, cx, thetas, radii_samples, match_tol, max_ray_gap,
+                min_arc, peak_distance, peak_prominence):
+    """Track peaks over rays; returns fragments as {theta_idx: radius}."""
+    H, W = img.shape
+    smoothed = scipy.ndimage.gaussian_filter(img, 1.0)
+    active, done = [], []
+    for ti, t in enumerate(thetas):
+        ys = cy + radii_samples * np.sin(t)
+        xs = cx + radii_samples * np.cos(t)
+        inside = (ys >= 0) & (ys < H - 1) & (xs >= 0) & (xs < W - 1)
+        prof = np.zeros(len(radii_samples))
+        prof[inside] = scipy.ndimage.map_coordinates(
+            smoothed, [ys[inside], xs[inside]], order=1)
+        peaks, _ = scipy.signal.find_peaks(
+            prof, distance=peak_distance, prominence=peak_prominence)
+        radii = radii_samples[peaks]
+        used = np.zeros(len(radii), dtype=bool)
+        for tr in active:
+            if len(radii) == 0:
+                continue
+            d = np.abs(radii - tr['last_r'])
+            d[used] = np.inf
+            j = int(np.argmin(d))
+            if d[j] < match_tol:
+                tr['pts'][ti] = radii[j]
+                tr['last_r'] = radii[j]
+                tr['last_ti'] = ti
+                used[j] = True
+        for j in np.nonzero(~used)[0]:
+            active.append({'pts': {ti: radii[j]}, 'last_r': radii[j], 'last_ti': ti})
+        still = []
+        for tr in active:
+            (done if ti - tr['last_ti'] > max_ray_gap else still).append(tr)
+        active = still
+    done += active
+    return [t['pts'] for t in done if len(t['pts']) >= min_arc]
+
+
+def index_fragments(tracks, dr, thetas, num_angles, delta=None):
+    """Absolute winding index per fragment via the spiral phase coordinate;
+    pass a shared per-theta offset field `delta` so all slices agree."""
+    def phases(d):
+        return np.array([float(np.median(
+            [(t[ti] - thetas[ti] / (2 * np.pi) * dr - d[ti]) / dr for ti in t]))
+            for t in tracks])
+
+    if delta is None:
+        k1 = np.round(phases(np.zeros(num_angles)))
+        resid = [[] for _ in range(num_angles)]
+        for t, k in zip(tracks, k1):
+            for ti in t:
+                resid[ti].append(t[ti] - (thetas[ti] / (2 * np.pi) + k) * dr)
+        delta = np.array([np.median(r) if r else 0. for r in resid])
+        delta = scipy.ndimage.uniform_filter1d(delta, 31, mode='wrap')
+        delta -= delta.mean()  # keep annotations near the raw spiral phase
+    return [(int(k), t) for k, t in zip(np.round(phases(delta)), tracks)], delta
+
+
+@click.command()
+@click.option('--volume-url', default=DEFAULT_VOLUME, show_default=False,
+              help='OME-Zarr volume (default: PHerc0172 7.91um masked).')
+@click.option('--level', default=3, type=int, help='Resolution level (ds 2^level).')
+@click.option('--z0', default=1280, type=int, help='Slab start z at that level.')
+@click.option('--z-size', default=32, type=int)
+@click.option('--slab-cache', default=None, type=click.Path(dir_okay=False),
+              help='Cache the fetched slab as .npy (reused if present).')
+@click.option('--mirror-x/--no-mirror-x', default=True,
+              help='Flip x so an ACW-wound scroll becomes CW (PHerc0172 needs it).')
+@click.option('--out', required=True, type=click.Path(file_okay=False))
+@click.option('--r-min', default=60., type=float)
+@click.option('--r-max', default=470., type=float)
+@click.option('--z-step', default=2, type=int, help='Trace every Nth slice.')
+@click.option('--theta-step', default=3, type=int, help='Grid column spacing, degrees.')
+@click.option('--min-coverage', default=0.15, type=float,
+              help='Drop winding grids with fewer valid cells than this fraction.')
+def main(volume_url, level, z0, z_size, slab_cache, mirror_x, out, r_min, r_max,
+         z_step, theta_step, min_coverage):
+    slab = fetch_slab(volume_url, level, z0, z_size, slab_cache)
+    if mirror_x:
+        slab = slab[:, :, ::-1].copy()
+    Z, H, W = slab.shape
+    click.echo(f'slab {slab.shape}{" (x-mirrored -> CW)" if mirror_x else ""}')
+
+    centroids = np.array([[c.mean() for c in np.nonzero(slab[z] > 0)] for z in range(Z)])
+    centroids = scipy.ndimage.median_filter(centroids, size=(5, 1))
+    num_angles = 360
+    thetas = np.deg2rad(np.arange(num_angles))
+    radii_samples = np.arange(r_min, r_max, 0.5)
+    trace_kwargs = dict(thetas=thetas, radii_samples=radii_samples, match_tol=2.5,
+                        max_ray_gap=6, min_arc=40, peak_distance=8, peak_prominence=10)
+
+    # dr: median peak-to-peak spacing with the SAME detector the tracker uses
+    # (autocorrelation latches onto the coarser pack-bunching scale instead).
+    z_list = list(range(0, Z, z_step))
+    mid_z = z_list[len(z_list) // 2]
+    mid_img = scipy.ndimage.gaussian_filter(slab[mid_z], 1.0)
+    spac = []
+    for tdeg in range(0, 360, 15):
+        t = thetas[tdeg]
+        ys, xs = centroids[mid_z][0] + radii_samples * np.sin(t), centroids[mid_z][1] + radii_samples * np.cos(t)
+        inside = (ys >= 0) & (ys < H - 1) & (xs >= 0) & (xs < W - 1)
+        prof = np.zeros(len(radii_samples))
+        prof[inside] = scipy.ndimage.map_coordinates(mid_img, [ys[inside], xs[inside]], order=1)
+        peaks, _ = scipy.signal.find_peaks(prof, distance=8, prominence=10)
+        spac.extend(np.diff(radii_samples[peaks]))
+    dr = float(np.median(spac))
+    click.echo(f'dr per winding estimate: {dr:.2f} vox')
+
+    _, shared_delta = index_fragments(
+        trace_slice(slab[mid_z], *centroids[mid_z], **trace_kwargs),
+        dr, thetas, num_angles)
+    per_slice = {}
+    for z in z_list:
+        fragments = trace_slice(slab[z], *centroids[z], **trace_kwargs)
+        per_slice[z], _ = index_fragments(fragments, dr, thetas, num_angles, shared_delta)
+
+    theta_cols = list(range(0, num_angles, theta_step))
+    all_k = sorted({k for frs in per_slice.values() for k, _ in frs})
+    surfaces = {}
+    for k in range(max(0, min(all_k)), max(all_k) + 1):
+        grid = np.full((len(z_list), len(theta_cols), 3), -1., dtype=np.float32)
+        for zi, z in enumerate(z_list):
+            cy, cx = centroids[z]
+            for kk, t in per_slice[z]:
+                if kk != k:
+                    continue
+                for ci, tdeg in enumerate(theta_cols):
+                    if tdeg in t:
+                        r, th = t[tdeg], thetas[tdeg]
+                        grid[zi, ci] = (z, cy + r * np.sin(th), cx + r * np.cos(th))
+        if (grid[..., 0] >= 0).mean() > min_coverage:
+            surfaces[k] = grid
+
+    patches_dir = os.path.join(out, 'verified_patches')
+    os.makedirs(patches_dir, exist_ok=True)
+    with open(os.path.join(out, 'umbilicus.json'), 'w') as f:
+        json.dump({'control_points': [
+            {'z': float(z), 'y': float(centroids[z][0]), 'x': float(centroids[z][1])}
+            for z in range(Z)]}, f)
+    for k, grid in surfaces.items():
+        uuid = f'traced_w{k:03d}'
+        save_tifxyz(grid, patches_dir, uuid, step_size=4,
+                    voxel_size_um=7.91 * 2 ** level, source='trace_real_windings')
+        tifffile.imwrite(os.path.join(patches_dir, uuid, 'winding.tif'),
+                         np.full(grid.shape[:2], float(k), dtype=np.float32))
+
+    coverage = float(np.mean([(g[..., 0] >= 0).mean() for g in surfaces.values()]))
+    with open(os.path.join(out, 'dataset_meta.json'), 'w') as f:
+        json.dump({
+            'winding_annotations': True, 'num_patches': len(surfaces),
+            'position_noise': 0.0, 'coverage': coverage,
+            'source': {'volume_url': volume_url, 'level': level, 'z0': z0,
+                       'z_size': z_size, 'mirror_x': mirror_x},
+            'phantom_meta': {'z_size': int(Z), 'yx_size': int(max(H, W)),
+                             'dr_per_winding': dr, 'first_winding': 0,
+                             'last_winding': int(max(surfaces))},
+        }, f, indent=2)
+    click.echo(f'{len(surfaces)} winding surfaces -> {out} '
+               f'(mean coverage {coverage:.2f}, dr {dr:.2f})')
+
+
+if __name__ == '__main__':
+    main()

--- a/volume-cartographer/scripts/spiral/unroll_real_fit.py
+++ b/volume-cartographer/scripts/spiral/unroll_real_fit.py
@@ -1,0 +1,112 @@
+"""Render a fitted real-scroll reroll: winding-curve overlay on the mid
+slice, and the unrolled strips (fitted vs unfitted-circles baseline). Part 3
+of the reproducible demo sequence documented in trace_real_windings.py.
+
+The slab fetch parameters must match the trace run (they are read from the
+dataset's dataset_meta.json when --dataset is given, which is the reliable
+way). If the trace mirrored x, unrolled strips are re-flipped for display.
+"""
+
+import json
+import os
+
+import click
+import numpy as np
+import scipy.ndimage
+import torch
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+from checkpoint_io import load_checkpoint_cpu
+from synth_phantom import build_model, build_model_from_phantom_checkpoint
+from trace_real_windings import fetch_slab
+
+
+@click.command()
+@click.option('--checkpoint', required=True, type=click.Path(exists=True, dir_okay=False),
+              help='fit_phantom_reference output for the traced dataset.')
+@click.option('--dataset', required=True, type=click.Path(exists=True, file_okay=False),
+              help='trace_real_windings output dir (slab source + mirror flag).')
+@click.option('--slab-cache', default=None, type=click.Path(dir_okay=False))
+@click.option('--out-prefix', required=True,
+              help='Writes <prefix>_overlay.png and <prefix>_unrolled.png.')
+@click.option('--k-lo', default=8, type=int)
+@click.option('--k-hi', default=36, type=int)
+@click.option('--k-step', default=4, type=int)
+def main(checkpoint, dataset, slab_cache, out_prefix, k_lo, k_hi, k_step):
+    meta = json.load(open(os.path.join(dataset, 'dataset_meta.json')))
+    src = meta['source']
+    slab = fetch_slab(src['volume_url'], src['level'], src['z0'],
+                      src['z_size'], slab_cache)
+    if src['mirror_x']:
+        slab = slab[:, :, ::-1].copy()
+    Z = slab.shape[0]
+
+    ckpt = load_checkpoint_cpu(checkpoint)
+    fitted = build_model_from_phantom_checkpoint(ckpt, torch.device('cpu'))
+    init = build_model(ckpt['cfg'], 0, Z, ckpt['umbilicus_zyx'],
+                       ckpt['spiral_outward_sense'], torch.device('cpu'))
+    gauge = float(ckpt['reference_fit']['gauge'])
+    dr = float(fitted.get_dr_per_winding())
+    click.echo(f'fitted dr {dr:.3f}, gauge {gauge:+.3f}')
+
+    def unroll(model, gauge_off):
+        tt = torch.tensor(np.deg2rad(np.arange(0, 360, 0.5)), dtype=torch.float32)
+        spiral_to_slice = model.get_slice_to_spiral_transform().inv
+        strips = []
+        for k in range(k_lo, k_hi + 1, k_step):
+            radius = (k + gauge_off + tt / (2 * np.pi)) * dr
+            rows = []
+            for z in range(Z):
+                pts = torch.stack([torch.full_like(tt, float(z)),
+                                   torch.sin(tt) * radius,
+                                   torch.cos(tt) * radius], dim=-1)
+                with torch.no_grad():
+                    sp = spiral_to_slice(pts).numpy()
+                rows.append(scipy.ndimage.map_coordinates(
+                    slab, [sp[:, 0], sp[:, 1], sp[:, 2]], order=1, cval=0.))
+            strips.append(np.array(rows))
+        return strips
+
+    fitted_strips = unroll(fitted, gauge)
+    init_strips = unroll(init, 0.)
+    sep = np.full((4, fitted_strips[0].shape[1]), 255.)
+
+    def montage(strips):
+        rows = []
+        for s in strips:
+            rows += [s, sep]
+        return np.concatenate(rows[:-1], axis=0)
+
+    flip = -1 if src['mirror_x'] else 1
+    fig, axes = plt.subplots(2, 1, figsize=(20, 14))
+    axes[0].imshow(montage(init_strips)[:, ::flip], cmap='gray', aspect='auto')
+    axes[0].set_title(f'UNFITTED baseline (concentric circles): windings {k_lo}..{k_hi} step {k_step}')
+    axes[1].imshow(montage(fitted_strips)[:, ::flip], cmap='gray', aspect='auto')
+    axes[1].set_title('FITTED reroll: same windings')
+    for a in axes:
+        a.axis('off')
+    plt.tight_layout()
+    plt.savefig(f'{out_prefix}_unrolled.png', dpi=110)
+
+    fig2, ax = plt.subplots(figsize=(14, 10))
+    ax.imshow(slab[Z // 2], cmap='gray')
+    tt = torch.tensor(np.deg2rad(np.arange(0, 360, 1.)), dtype=torch.float32)
+    spiral_to_slice = fitted.get_slice_to_spiral_transform().inv
+    for k in range(k_lo, k_hi + 1, 2):
+        radius = (k + gauge + tt / (2 * np.pi)) * dr
+        pts = torch.stack([torch.full_like(tt, float(Z // 2)),
+                           torch.sin(tt) * radius, torch.cos(tt) * radius], dim=-1)
+        with torch.no_grad():
+            sp = spiral_to_slice(pts).numpy()
+        ax.plot(sp[:, 2], sp[:, 1], lw=0.6)
+    ax.set_title('fitted winding surfaces over mid slice (QC; mirrored frame)')
+    ax.axis('off')
+    plt.tight_layout()
+    plt.savefig(f'{out_prefix}_overlay.png', dpi=110)
+    click.echo(f'wrote {out_prefix}_unrolled.png, {out_prefix}_overlay.png')
+
+
+if __name__ == '__main__':
+    main()

--- a/volume-cartographer/scripts/spiral/winding_error.py
+++ b/volume-cartographer/scripts/spiral/winding_error.py
@@ -11,6 +11,14 @@ candidate winding solution against a phantom's exact per-voxel winding field:
   per-winding     MAE binned by true winding index (where does it drift?)
   torn vs clean   breakdown over the phantom's signal-dropout tear regions
 
+Relation to spiralcheck (github.com/Nicodol/spiralcheck): complementary, not
+competing. spiralcheck scores REAL whole-scroll fits from their output meshes
+against held-out human-verified patches -- evaluation this tool cannot do,
+since real scrolls have no truth. This tool scores against EXACT synthetic
+truth at every voxel, including regions no human annotated -- evaluation
+held-out patches cannot do, since they inherit human labels' locations and
+noise. Use spiralcheck on real fits; use this on phantoms.
+
 Candidates:
   --candidate-checkpoint      a phantom checkpoint (self-tests, method dev) or
                               a real fit checkpoint (needs --umbilicus, loaded
@@ -19,11 +27,25 @@ Candidates:
                               phantom's voxel grid -- so ANY method that
                               produces a winding field (e.g. a lasagna winding
                               volume) can be scored, not just spiral fits
+  --candidate-tifxyz          a tifxyz surface directory (or a directory of
+                              them) -- the pipeline's lingua franca, and what
+                              spiralcheck consumes -- scored by where its
+                              vertices actually sit in phantom truth
 
 Gauge: a candidate fit of the same volume can differ from the phantom by a
 constant winding offset (theta-origin / winding-index choice), so residuals
 are aligned by their median before scoring; raw (unaligned) MAE is also
-reported. Opposite-sense (CW vs ACW) candidates are not auto-detected.
+reported. KNOWN CONSEQUENCE: a globally constant mis-count (every voxel
+off by exactly +1 winding) is absorbed as gauge and scores as zero error --
+inspect the reported gauge offset, which is where such errors surface.
+Opposite-sense (CW vs ACW) candidates are not auto-detected.
+
+Topology caveat: switch rate is a POINTWISE assignment metric, not a
+connectivity metric -- it does not detect all topological defects (the
+surface-detection Kaggle competition used deliberately topology-aware scoring
+for that reason, and spiralcheck's intrinsic winding-order checks cover
+related ground). The tifxyz mode's grid-discontinuity figure is a first
+topology-flavoured check, not a substitute.
 
 Branch cut: a winding field w = (r - theta*dr/2pi)/dr necessarily jumps by 1
 across its theta=0 ray. When truth and candidate place that ray differently, a
@@ -44,6 +66,7 @@ import torch
 from checkpoint_io import load_checkpoint_cpu
 from sample_spiral import get_theta_and_radii
 from synth_phantom import build_model_from_phantom_checkpoint, build_model
+from tifxyz import load_tifxyz
 
 
 def load_phantom(phantom_dir, device):
@@ -179,6 +202,96 @@ def evaluate(phantom_model, mask, candidate, num_points, cut_margin, seed, devic
     return score(w_true, w_cand, torn, cut_ok)
 
 
+def load_tifxyz_candidates(path):
+    """A single tifxyz directory (contains x.tif) or a directory of them."""
+    if os.path.exists(os.path.join(path, 'x.tif')):
+        entries = [path]
+    else:
+        entries = sorted(
+            os.path.join(path, e) for e in os.listdir(path)
+            if os.path.exists(os.path.join(path, e, 'x.tif')))
+    if not entries:
+        raise click.UsageError(f'{path} contains no tifxyz surfaces')
+    return [(os.path.basename(e), load_tifxyz(e)) for e in entries]
+
+
+@torch.no_grad()
+def evaluate_tifxyz(phantom_model, patches, cut_margin):
+    """Score tifxyz surfaces by where their vertices sit in phantom truth.
+
+    on_surface: |w_true - round(w_true)| per valid vertex -- distance from ANY
+      true sheet, in winding units. Zero for a perfect surface regardless of
+      which winding it traces, so it needs no gauge.
+    grid_discontinuity: fraction of grid-adjacent valid vertex pairs whose
+      TRUE windings differ by > 0.5 -- the mesh jumps sheets between
+      neighbouring grid cells. Pairs straddling the theta=0 cut are excluded
+      (w_true legitimately jumps by 1 there on a continuous spiral surface).
+    winding_agreement: only when the surface carries per-vertex winding.tif
+      annotations -- gauge-aligned agreement with truth, as for other modes.
+    """
+    per_patch = {}
+    for name, patch in patches:
+        zyxs = patch.zyxs.reshape(-1, 3)
+        valid = patch.valid_vertex_mask.reshape(-1).numpy()
+        w_true, theta = winding_and_theta(phantom_model, zyxs)
+        on_surface = np.abs(w_true - np.round(w_true))[valid]
+
+        h, w = patch.zyxs.shape[:2]
+        w_grid = w_true.reshape(h, w)
+        theta_grid = theta.reshape(h, w)
+        valid_grid = valid.reshape(h, w)
+        pair_jumps = []
+        for da, db in (((slice(None), slice(None, -1)), (slice(None), slice(1, None))),
+                       ((slice(None, -1), slice(None)), (slice(1, None), slice(None)))):
+            both = valid_grid[da] & valid_grid[db]
+            not_seam = np.abs(theta_grid[da] - theta_grid[db]) < np.pi
+            sel = both & not_seam
+            pair_jumps.append(np.abs(w_grid[da] - w_grid[db])[sel] > 0.5)
+        jumps = np.concatenate(pair_jumps)
+
+        agreement = None
+        if isinstance(patch.winding, torch.Tensor):
+            annotated = patch.winding.reshape(-1).numpy()[valid]
+            cut_ok = cut_distance(theta[valid]) > cut_margin
+            residual = (w_true[valid] - annotated)[cut_ok]
+            offset = float(np.median(residual))
+            aligned = residual - offset
+            agreement = {'gauge_offset': offset,
+                         'mae': float(np.abs(aligned).mean()),
+                         'switch_rate': float((np.abs(aligned) > 0.5).mean())}
+        per_patch[name] = {
+            'num_valid_vertices': int(valid.sum()),
+            'on_surface_mae': float(on_surface.mean()),
+            'on_surface_p95': float(np.percentile(on_surface, 95)),
+            'grid_discontinuity_frac': float(jumps.mean()) if len(jumps) else 0.,
+            'winding_agreement': agreement,
+        }
+    total = sum(p['num_valid_vertices'] for p in per_patch.values())
+    overall = {
+        'num_patches': len(per_patch),
+        'num_valid_vertices': total,
+        'on_surface_mae': float(sum(
+            p['on_surface_mae'] * p['num_valid_vertices'] for p in per_patch.values()) / total),
+        'grid_discontinuity_frac': float(np.mean(
+            [p['grid_discontinuity_frac'] for p in per_patch.values()])),
+    }
+    return {'overall': overall, 'per_patch': per_patch}
+
+
+def print_tifxyz_report(result):
+    o = result['overall']
+    click.echo(f"{o['num_patches']} surfaces, {o['num_valid_vertices']} valid vertices")
+    click.echo(f"on-surface MAE {o['on_surface_mae']:.4f} windings; "
+               f"grid discontinuity {o['grid_discontinuity_frac'] * 100:.2f}% of pairs")
+    for name, p in sorted(result['per_patch'].items()):
+        agreement = p['winding_agreement']
+        suffix = (f"  agreement MAE {agreement['mae']:.4f} "
+                  f"(gauge {agreement['gauge_offset']:+.3f})" if agreement else '')
+        click.echo(f"  {name}: on-surface {p['on_surface_mae']:.4f}, "
+                   f"p95 {p['on_surface_p95']:.4f}, "
+                   f"discont {p['grid_discontinuity_frac'] * 100:.2f}%{suffix}")
+
+
 @torch.no_grad()
 def run_self_test(phantom_dir, num_points, cut_margin, seed, device):
     """Sanity-check the harness itself: the phantom scored against itself must
@@ -216,6 +329,9 @@ def run_self_test(phantom_dir, num_points, cut_margin, seed, device):
 @click.option('--candidate-winding-volume', default=None,
               type=click.Path(exists=True, dir_okay=False),
               help='Candidate float32 winding TIFF on the phantom voxel grid.')
+@click.option('--candidate-tifxyz', default=None,
+              type=click.Path(exists=True, file_okay=False),
+              help='Candidate tifxyz surface directory (or directory of them).')
 @click.option('--umbilicus', default=None, type=click.Path(exists=True, dir_okay=False),
               help='umbilicus json for real fit checkpoints (phantom checkpoints '
                    'carry their own).')
@@ -229,19 +345,32 @@ def run_self_test(phantom_dir, num_points, cut_margin, seed, device):
 @click.option('--self-test', is_flag=True,
               help='Ignore candidates; verify the harness on the phantom itself.')
 @click.option('--device', default='cpu', help="torch device ('cpu', 'cuda', ...).")
-def main(phantom, candidate_checkpoint, candidate_winding_volume, umbilicus,
-         num_points, cut_margin, seed, output, self_test, device):
+def main(phantom, candidate_checkpoint, candidate_winding_volume,
+         candidate_tifxyz, umbilicus, num_points, cut_margin, seed, output,
+         self_test, device):
     device = torch.device(device)
 
     if self_test:
         raise SystemExit(0 if run_self_test(phantom, num_points, cut_margin,
                                             seed, device) else 1)
 
-    if (candidate_checkpoint is None) == (candidate_winding_volume is None):
+    given = [c for c in (candidate_checkpoint, candidate_winding_volume,
+                         candidate_tifxyz) if c is not None]
+    if len(given) != 1:
         raise click.UsageError(
-            'pass exactly one of --candidate-checkpoint / --candidate-winding-volume')
+            'pass exactly one of --candidate-checkpoint / '
+            '--candidate-winding-volume / --candidate-tifxyz')
 
     _, phantom_model, mask = load_phantom(phantom, device)
+    if candidate_tifxyz is not None:
+        result = evaluate_tifxyz(phantom_model,
+                                 load_tifxyz_candidates(candidate_tifxyz),
+                                 cut_margin)
+        print_tifxyz_report(result)
+        if output is not None:
+            with open(output, 'w') as f:
+                json.dump(result, f, indent=2)
+        return
     if candidate_checkpoint is not None:
         candidate = ('model', load_candidate_model(candidate_checkpoint, umbilicus, device))
     else:

--- a/volume-cartographer/scripts/spiral/winding_error.py
+++ b/volume-cartographer/scripts/spiral/winding_error.py
@@ -1,0 +1,263 @@
+"""Ground-truth winding-error metrics against a synth_phantom phantom.
+
+The spiral fit is currently scored by self-consistency (satisfaction_metrics:
+agreement with its own input constraints) and by an indirect ink-coverage
+proxy (get_ink_metrics). Neither compares against truth. This tool scores a
+candidate winding solution against a phantom's exact per-voxel winding field:
+
+  MAE / RMSE      of the recovered fractional winding (gauge-aligned, below)
+  switch rate     fraction of points assigned to the wrong winding
+                  (|aligned residual| > 0.5) -- the sheet-switch failure mode
+  per-winding     MAE binned by true winding index (where does it drift?)
+  torn vs clean   breakdown over the phantom's signal-dropout tear regions
+
+Candidates:
+  --candidate-checkpoint      a phantom checkpoint (self-tests, method dev) or
+                              a real fit checkpoint (needs --umbilicus, loaded
+                              via fit_spiral's own umbilicus reader)
+  --candidate-winding-volume  a float32 TIFF of per-voxel winding on the
+                              phantom's voxel grid -- so ANY method that
+                              produces a winding field (e.g. a lasagna winding
+                              volume) can be scored, not just spiral fits
+
+Gauge: a candidate fit of the same volume can differ from the phantom by a
+constant winding offset (theta-origin / winding-index choice), so residuals
+are aligned by their median before scoring; raw (unaligned) MAE is also
+reported. Opposite-sense (CW vs ACW) candidates are not auto-detected.
+
+Branch cut: a winding field w = (r - theta*dr/2pi)/dr necessarily jumps by 1
+across its theta=0 ray. When truth and candidate place that ray differently, a
+thin angular band shows spurious +-1 residuals even for a perfect candidate.
+Points within --cut-margin radians of either transform's cut are excluded
+(excluded fraction is reported); volume candidates only get the truth-side
+exclusion, since their cut placement is unknown.
+"""
+
+import json
+import os
+
+import click
+import numpy as np
+import tifffile
+import torch
+
+from checkpoint_io import load_checkpoint_cpu
+from sample_spiral import get_theta_and_radii
+from synth_phantom import build_model_from_phantom_checkpoint, build_model
+
+
+def load_phantom(phantom_dir, device):
+    checkpoint = load_checkpoint_cpu(os.path.join(phantom_dir, 'phantom_checkpoint.pt'))
+    if 'phantom_schema_version' not in checkpoint:
+        raise click.UsageError(f'{phantom_dir} is not a synth_phantom output')
+    model = build_model_from_phantom_checkpoint(checkpoint, device)
+    mask = tifffile.imread(os.path.join(phantom_dir, 'mask.tif'))
+    return checkpoint, model, mask
+
+
+def load_candidate_model(path, umbilicus_path, device):
+    checkpoint = load_checkpoint_cpu(path)
+    if 'umbilicus_zyx' in checkpoint:  # phantom-style checkpoint, self-contained
+        return build_model_from_phantom_checkpoint(checkpoint, device)
+    if umbilicus_path is None:
+        raise click.UsageError(
+            'real fit checkpoints do not store their umbilicus; pass --umbilicus')
+    # Reuse fit_spiral's own umbilicus reader rather than re-implementing its
+    # json format here; imported lazily since fit_spiral is a heavy module.
+    import fit_spiral as fs
+    z_begin, z_end = int(checkpoint['z_begin']), int(checkpoint['z_end'])
+    all_zs = np.arange(z_begin, z_end)
+    yx = fs.json_umbilicus_z_to_yx(umbilicus_path, coordinate_scale=1.0)(all_zs)
+    umbilicus_zyx = torch.from_numpy(
+        np.concatenate([all_zs[:, None], yx], axis=-1).astype(np.float32))
+    cfg = fs.Config().as_dict()
+    cfg.update(checkpoint['cfg'])
+    model = build_model(cfg, z_begin, z_end, umbilicus_zyx,
+                        checkpoint['spiral_outward_sense'], device)
+    model.load_state_dict(checkpoint['spiral_and_transform'])
+    return model
+
+
+@torch.no_grad()
+def winding_and_theta(model, zyx):
+    """Fractional winding (shifted_radius / dr, the fit's raw winding number)
+    and canonical theta for slice-space points."""
+    transform = model.get_slice_to_spiral_transform()
+    dr = model.get_dr_per_winding()
+    spiral = transform(zyx)
+    theta, _, shifted = get_theta_and_radii(spiral[..., 1:], dr)
+    return (shifted / dr).cpu().numpy(), theta.cpu().numpy()
+
+
+def sample_eval_points(mask, num_points, rng):
+    """Random valid voxel centres; returns (zyx float32 [N,3], torn bool [N])."""
+    idx = np.stack(np.nonzero(mask > 0), axis=-1)
+    sel = idx[rng.integers(0, len(idx), size=min(num_points, len(idx)))]
+    torn = mask[sel[:, 0], sel[:, 1], sel[:, 2]] == 2
+    return sel.astype(np.float32), torn
+
+
+def cut_distance(theta):
+    return np.minimum(theta, 2 * np.pi - theta)
+
+
+def score(w_true, w_cand, torn, cut_ok):
+    """Gauge-aligned residual statistics; see module docstring for definitions."""
+    residual = (w_cand - w_true)[cut_ok]
+    torn = torn[cut_ok]
+    offset = float(np.median(residual))
+    aligned = residual - offset
+
+    def stats(sel):
+        r = aligned[sel]
+        if len(r) == 0:
+            return None
+        return {
+            'n': int(len(r)),
+            'mae': float(np.abs(r).mean()),
+            'rmse': float(np.sqrt((r ** 2).mean())),
+            'switch_rate': float((np.abs(r) > 0.5).mean()),
+        }
+
+    per_winding = {}
+    bins = np.floor(w_true[cut_ok]).astype(np.int64)
+    for b in np.unique(bins):
+        per_winding[int(b)] = stats(bins == b)
+
+    return {
+        'gauge_offset': offset,
+        'raw_mae': float(np.abs(residual).mean()),
+        'cut_excluded_frac': float(1. - cut_ok.mean()),
+        'overall': stats(np.ones(len(aligned), dtype=bool)),
+        'clean': stats(~torn),
+        'torn': stats(torn),
+        'per_winding': per_winding,
+    }
+
+
+def print_report(result):
+    o = result['overall']
+    click.echo(f"gauge offset {result['gauge_offset']:+.3f} windings; "
+               f"cut-excluded {result['cut_excluded_frac'] * 100:.1f}% of samples")
+    click.echo(f"overall  n={o['n']}  MAE {o['mae']:.4f}  RMSE {o['rmse']:.4f}  "
+               f"switch {o['switch_rate'] * 100:.2f}%   (raw MAE {result['raw_mae']:.4f})")
+    for name in ('clean', 'torn'):
+        s = result[name]
+        if s is not None:
+            click.echo(f"{name:8s} n={s['n']}  MAE {s['mae']:.4f}  "
+                       f"switch {s['switch_rate'] * 100:.2f}%")
+    click.echo('per-winding MAE / switch%:')
+    for b, s in sorted(result['per_winding'].items()):
+        click.echo(f'  w={b:3d}  {s["mae"]:.4f}  {s["switch_rate"] * 100:6.2f}%  (n={s["n"]})')
+
+
+def evaluate(phantom_model, mask, candidate, num_points, cut_margin, seed, device,
+             chunk_size=200_000):
+    """candidate: ('model', SpiralAndTransform) or ('volume', float32 ndarray)."""
+    rng = np.random.default_rng(seed)
+    zyx_np, torn = sample_eval_points(mask, num_points, rng)
+
+    w_true = np.empty(len(zyx_np), dtype=np.float32)
+    theta_true = np.empty(len(zyx_np), dtype=np.float32)
+    kind, payload = candidate
+    w_cand = np.empty(len(zyx_np), dtype=np.float32)
+    theta_cand = None if kind == 'volume' else np.empty(len(zyx_np), dtype=np.float32)
+
+    for start in range(0, len(zyx_np), chunk_size):
+        sl = slice(start, start + chunk_size)
+        chunk = torch.from_numpy(zyx_np[sl]).to(device)
+        w_true[sl], theta_true[sl] = winding_and_theta(phantom_model, chunk)
+        if kind == 'model':
+            w_cand[sl], theta_cand[sl] = winding_and_theta(payload, chunk)
+    if kind == 'volume':
+        ij = zyx_np.astype(np.int64)
+        w_cand = payload[ij[:, 0], ij[:, 1], ij[:, 2]].astype(np.float32)
+
+    cut_ok = cut_distance(theta_true) > cut_margin
+    if theta_cand is not None:
+        cut_ok &= cut_distance(theta_cand) > cut_margin
+    return score(w_true, w_cand, torn, cut_ok)
+
+
+@torch.no_grad()
+def run_self_test(phantom_dir, num_points, cut_margin, seed, device):
+    """Sanity-check the harness itself: the phantom scored against itself must
+    be ~exact, and against a perturbed copy must be measurably worse."""
+    checkpoint, model, mask = load_phantom(phantom_dir, device)
+    identical = evaluate(model, mask, ('model', model), num_points, cut_margin,
+                         seed, device)
+
+    perturbed = build_model_from_phantom_checkpoint(checkpoint, device)
+    with torch.no_grad():
+        hr = perturbed.flow_field.flows[1]
+        hr.add_(torch.from_numpy(
+            np.random.default_rng(seed + 1).standard_normal(tuple(hr.shape))
+            .astype(np.float32)).to(hr.device) * 0.005)
+    worse = evaluate(model, mask, ('model', perturbed), num_points, cut_margin,
+                     seed, device)
+
+    click.echo('--- phantom vs itself (expect ~0) ---')
+    print_report(identical)
+    click.echo('--- phantom vs perturbed copy (expect > 0) ---')
+    print_report(worse)
+
+    ok = (identical['overall']['mae'] < 1e-3
+          and worse['overall']['mae'] > identical['overall']['mae'] * 10)
+    click.echo(f'self-test {"PASSED" if ok else "FAILED"}')
+    return ok
+
+
+@click.command()
+@click.option('--phantom', required=True, type=click.Path(exists=True, file_okay=False),
+              help='synth_phantom output directory (the ground truth).')
+@click.option('--candidate-checkpoint', default=None,
+              type=click.Path(exists=True, dir_okay=False),
+              help='Candidate phantom or fit checkpoint to score.')
+@click.option('--candidate-winding-volume', default=None,
+              type=click.Path(exists=True, dir_okay=False),
+              help='Candidate float32 winding TIFF on the phantom voxel grid.')
+@click.option('--umbilicus', default=None, type=click.Path(exists=True, dir_okay=False),
+              help='umbilicus json for real fit checkpoints (phantom checkpoints '
+                   'carry their own).')
+@click.option('--num-points', default=200_000, type=int,
+              help='Evaluation samples drawn from the phantom mask.')
+@click.option('--cut-margin', default=0.1, type=float,
+              help='Angular exclusion band around each theta=0 branch cut, radians.')
+@click.option('--seed', default=0, type=int)
+@click.option('--output', default=None, type=click.Path(dir_okay=False),
+              help='Write the full metrics dict as json.')
+@click.option('--self-test', is_flag=True,
+              help='Ignore candidates; verify the harness on the phantom itself.')
+@click.option('--device', default='cpu', help="torch device ('cpu', 'cuda', ...).")
+def main(phantom, candidate_checkpoint, candidate_winding_volume, umbilicus,
+         num_points, cut_margin, seed, output, self_test, device):
+    device = torch.device(device)
+
+    if self_test:
+        raise SystemExit(0 if run_self_test(phantom, num_points, cut_margin,
+                                            seed, device) else 1)
+
+    if (candidate_checkpoint is None) == (candidate_winding_volume is None):
+        raise click.UsageError(
+            'pass exactly one of --candidate-checkpoint / --candidate-winding-volume')
+
+    _, phantom_model, mask = load_phantom(phantom, device)
+    if candidate_checkpoint is not None:
+        candidate = ('model', load_candidate_model(candidate_checkpoint, umbilicus, device))
+    else:
+        volume = tifffile.imread(candidate_winding_volume)
+        if volume.shape != mask.shape:
+            raise click.UsageError(
+                f'winding volume shape {volume.shape} != phantom shape {mask.shape}')
+        candidate = ('volume', volume)
+
+    result = evaluate(phantom_model, mask, candidate, num_points, cut_margin,
+                      seed, device)
+    print_report(result)
+    if output is not None:
+        with open(output, 'w') as f:
+            json.dump(result, f, indent=2)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
…eval harness

The spiral fit is currently evaluated by self-consistency (agreement with its own input constraints) and an indirect ink-coverage proxy; neither compares against ground truth. This adds:

- synth_phantom.py: generates scroll-like test volumes by sampling a random KNOWN deformation through the production SpiralAndTransform stack, with exact per-voxel winding ground truth, staged realism knobs (noise, haze, signal-dropout tears), and a fit-shaped checkpoint.
- winding_error.py: scores any candidate (fit checkpoint or plain winding volume, e.g. lasagna output) against phantom truth: winding MAE/RMSE, sheet-switch rate, per-winding and torn-region breakdowns, with gauge alignment and theta=0 branch-cut exclusion.
- export_phantom_dataset.py: writes a phantom as a fit_spiral-consumable dataset (umbilicus.json + verified_patches tifxyz with absolute winding annotations), with label quantity/quality dials (coverage, winding stride, position noise).
- fit_phantom_reference.py: CPU reference fitter closing the loop end-to-end (the production fitter is CUDA-only); a baseline, not a reimplementation.

First results on a 48x320x320 phantom: reference fit recovers the winding field to 0.055 MAE / 0% sheet switches with clean labels; 2 voxels of label position noise erases the value of annotation entirely (fit MAE 0.225 vs unfitted 0.223) - a first quantification of the label-quality bottleneck.