### PR TITLE
tests: make the volume-cartographer suite build and pass on Windows, and fix cancel() for console tools

### DIFF
--- a/volume-cartographer/apps/VC3D/CommandLineToolRunner.cpp
+++ b/volume-cartographer/apps/VC3D/CommandLineToolRunner.cpp
@@ -9,12 +9,17 @@
 #include <QMessageBox>
 #include <QClipboard>
 #include <QApplication>
+#include <QPointer>
+#include <QTimer>
 
 #include <cmath>
 #include <utility>
 
 
 namespace {
+
+// Grace period between terminate() and the kill() fallback in cancel().
+constexpr int kCancelGracePeriodMs = 1000;
 
 QString quoteArg(const QString& arg)
 {
@@ -457,9 +462,28 @@ bool CommandLineToolRunner::executeCustomCommand(const QString& command,
 
 void CommandLineToolRunner::cancel()
 {
-    if (_process && _process->state() != QProcess::NotRunning) {
-        _process->terminate();
+    if (!_process || _process->state() == QProcess::NotRunning) {
+        return;
     }
+
+    _process->terminate();
+
+    // On Windows terminate() posts WM_CLOSE, which the console-mode vc_* tools have
+    // no message loop to receive: the process keeps running and cancelling silently
+    // does nothing at all. Fall back to kill(), the same way LasagnaServiceManager
+    // and the other service managers already do. Deferred rather than a blocking
+    // waitForFinished() because cancel() runs on the GUI thread.
+    // The QProcess object is created once and reused across runs, so the pid is what
+    // identifies *this* run: without it a cancel followed by a quick relaunch would
+    // let the timer kill the new process instead.
+    QPointer<QProcess> process(_process);
+    const qint64 cancelledPid = _process->processId();
+    QTimer::singleShot(kCancelGracePeriodMs, this, [process, cancelledPid]() {
+        if (process && process->state() != QProcess::NotRunning
+            && process->processId() == cancelledPid) {
+            process->kill();
+        }
+    });
 }
 
 bool CommandLineToolRunner::isRunning() const

--- a/volume-cartographer/apps/VC3D/test/test_command_line_tool_runner.cpp
+++ b/volume-cartographer/apps/VC3D/test/test_command_line_tool_runner.cpp
@@ -1,6 +1,5 @@
-#include <csignal>
-
 #include <QApplication>
+#include <QDir>
 #include <QFile>
 #include <QScopeGuard>
 #include <QTemporaryFile>
@@ -76,8 +75,12 @@ int runChild(const QStringList& arguments)
         return 0;
     }
     if (mode == "crash") {
-        std::raise(SIGKILL);
-        return 1;
+        // std::abort() rather than raise(SIGKILL): SIGKILL is POSIX-only, so this
+        // file did not compile on Windows at all. It is also the only portable way
+        // to get QProcess::CrashExit on both platforms — under MinGW every
+        // raise(SIG*) returns through the default handler and exits normally, which
+        // QProcess reports as NormalExit.
+        std::abort();
     }
     if (mode == "write-omp" && marker + 2 < arguments.size()) {
         QFile output(arguments.at(marker + 2));
@@ -130,7 +133,13 @@ private slots:
 
     void failedStartFinishesOnce()
     {
-        QTemporaryFile invalidProgram;
+        // The name needs an executable suffix: QFileInfo::isExecutable() is
+        // extension-based on Windows, so an unsuffixed temporary is rejected by
+        // the runner before it ever tries to start a process - which is not the
+        // path this test is exercising. Harmless on POSIX, where the permission
+        // bit set below is what counts.
+        QTemporaryFile invalidProgram(QDir::tempPath()
+                                      + "/vc3d-failed-start-XXXXXX.exe");
         QVERIFY(invalidProgram.open());
         invalidProgram.write("#!/definitely/missing/command-runner-interpreter\n");
         invalidProgram.close();
@@ -168,6 +177,34 @@ private slots:
         QVERIFY(startHelper(runner, "success"));
         QTRY_COMPARE_WITH_TIMEOUT(finished.count(), 2, 3000);
         QVERIFY(completionSucceeded(finished, 1));
+    }
+
+    void cancelDoesNotKillARunStartedRightAfterIt()
+    {
+        // cancel() schedules a deferred kill() as a fallback for platforms where
+        // terminate() does not stop a console process. The QProcess object is reused
+        // across runs, so that fallback must not land on whatever is running when it
+        // finally fires.
+        CommandLineToolRunner runner(nullptr, {});
+        QSignalSpy finished(&runner, &CommandLineToolRunner::toolFinished);
+
+        QVERIFY(startHelper(runner, "wait"));
+        QTRY_VERIFY_WITH_TIMEOUT(runner.isRunning(), 1000);
+        runner.cancel();
+        QTRY_COMPARE_WITH_TIMEOUT(finished.count(), 1, 5000);
+
+        // The replacement has to still be running when the deferred kill fires, so
+        // start another long one and outlive the grace period before checking.
+        QVERIFY(startHelper(runner, "wait"));
+        QTRY_VERIFY_WITH_TIMEOUT(runner.isRunning(), 1000);
+        QTest::qWait(2000);
+
+        QVERIFY2(runner.isRunning(),
+                 "the deferred kill from the first cancel() reached the second run");
+        QCOMPARE(finished.count(), 1);
+
+        runner.cancel();
+        QTRY_COMPARE_WITH_TIMEOUT(finished.count(), 2, 5000);
     }
 
     void pendingProcessErrorOverridesCleanExit()

--- a/volume-cartographer/core/test/test_chunk_cache_persist.cpp
+++ b/volume-cartographer/core/test/test_chunk_cache_persist.cpp
@@ -263,15 +263,21 @@ TEST_CASE("stats: startup scan ignores files newer than its cutoff")
     writeSizedFile(target / "0.bin", 31);
     writeSizedFile(target / "1.empty", 1);
 
-    auto f = std::make_shared<CountingFetcher>();
-    auto c = makeCache(f, persist);
-
+    // Stamp the "too new" file before the cache exists. The scan runs on a worker
+    // thread with a cutoff taken at construction, so writing this file afterwards
+    // races the scan: on a slower filesystem the scan can read post.bin before the
+    // future timestamp is applied and count it. Preparing it up front keeps the
+    // timestamp strictly greater than the cutoff without depending on timing.
     writeSizedFile(target / "post.bin", 17);
     std::error_code ec;
     fs::last_write_time(
         target / "post.bin",
         fs::file_time_type::clock::now() + std::chrono::seconds{10},
         ec);
+    REQUIRE_FALSE(ec);
+
+    auto f = std::make_shared<CountingFetcher>();
+    auto c = makeCache(f, persist);
 
     auto s = waitForStats(*c, [](const ChunkCache::Stats& s) {
         return !s.persistentCacheScanInFlight;

--- a/volume-cartographer/core/test/test_gridstore.cpp
+++ b/volume-cartographer/core/test/test_gridstore.cpp
@@ -163,12 +163,16 @@ TEST_CASE("save / load round-trips data")
         gs.save(path, opts);
     }
 
-    GridStore loaded(path);
-    CHECK(loaded.size() == cv::Size(100, 100));
-    auto all = loaded.get_all();
-    CHECK(all.size() == 2);
-    auto in_lo = loaded.get(cv::Rect(0, 0, 10, 10));
-    CHECK(in_lo.size() == 1);
+    // Nested scope: the mmap-backed GridStore must be destroyed before the file
+    // can be deleted. Windows refuses to remove a file that is still mapped.
+    {
+        GridStore loaded(path);
+        CHECK(loaded.size() == cv::Size(100, 100));
+        auto all = loaded.get_all();
+        CHECK(all.size() == 2);
+        auto in_lo = loaded.get(cv::Rect(0, 0, 10, 10));
+        CHECK(in_lo.size() == 1);
+    }
 
     std::filesystem::remove(path);
 }
@@ -182,8 +186,10 @@ TEST_CASE("save with default options compiles & roundtrips")
         gs.add(diagonal(4, 1, 1, {1, 1}));
         gs.save(path);
     }
-    GridStore loaded(path);
-    CHECK(loaded.get_all().size() == 1);
+    {
+        GridStore loaded(path);
+        CHECK(loaded.get_all().size() == 1);
+    }
     std::filesystem::remove(path);
 }
 
@@ -196,8 +202,10 @@ TEST_CASE("save throws on a read-only (mmap-loaded) store")
         gs.add(diagonal(3));
         gs.save(path);
     }
-    GridStore loaded(path);
-    CHECK_THROWS_AS(loaded.save(tmpPath("save_readonly_2.bin")), std::runtime_error);
+    {
+        GridStore loaded(path);
+        CHECK_THROWS_AS(loaded.save(tmpPath("save_readonly_2.bin")), std::runtime_error);
+    }
     std::filesystem::remove(path);
 }
 
@@ -210,8 +218,10 @@ TEST_CASE("add throws on a read-only (mmap-loaded) store")
         gs.add(diagonal(3));
         gs.save(path);
     }
-    GridStore loaded(path);
-    CHECK_THROWS_AS(loaded.add(diagonal(3)), std::runtime_error);
+    {
+        GridStore loaded(path);
+        CHECK_THROWS_AS(loaded.add(diagonal(3)), std::runtime_error);
+    }
     std::filesystem::remove(path);
 }
 

--- a/volume-cartographer/core/test/test_gridstore_branches.cpp
+++ b/volume-cartographer/core/test/test_gridstore_branches.cpp
@@ -88,25 +88,29 @@ TEST_CASE("repeated queries hit the seglist cache (read-only store)")
         gs.save(p.string());
     }
 
-    GridStore loaded(p.string());
-    auto stats0 = loaded.cacheStats();
+    // Nested scope: the mmap-backed GridStore must be destroyed before the file
+    // can be deleted. Windows refuses to remove a file that is still mapped.
+    {
+        GridStore loaded(p.string());
+        auto stats0 = loaded.cacheStats();
 
-    // First query: pure cache misses
-    auto r1 = loaded.get(cv::Rect(0, 0, 50, 50));
-    CHECK_FALSE(r1.empty());
+        // First query: pure cache misses
+        auto r1 = loaded.get(cv::Rect(0, 0, 50, 50));
+        CHECK_FALSE(r1.empty());
 
-    auto stats1 = loaded.cacheStats();
-    CHECK(stats1.decodedPathMisses >= stats0.decodedPathMisses);
+        auto stats1 = loaded.cacheStats();
+        CHECK(stats1.decodedPathMisses >= stats0.decodedPathMisses);
 
-    // Second identical query: should produce cache hits
-    auto r2 = loaded.get(cv::Rect(0, 0, 50, 50));
-    auto stats2 = loaded.cacheStats();
-    CHECK(stats2.decodedPathHits > stats1.decodedPathHits);
+        // Second identical query: should produce cache hits
+        auto r2 = loaded.get(cv::Rect(0, 0, 50, 50));
+        auto stats2 = loaded.cacheStats();
+        CHECK(stats2.decodedPathHits > stats1.decodedPathHits);
 
-    loaded.resetCacheStats();
-    auto stats3 = loaded.cacheStats();
-    CHECK(stats3.decodedPathHits == 0);
-    CHECK(stats3.decodedPathMisses == 0);
+        loaded.resetCacheStats();
+        auto stats3 = loaded.cacheStats();
+        CHECK(stats3.decodedPathHits == 0);
+        CHECK(stats3.decodedPathMisses == 0);
+    }
 
     fs::remove(p);
 }
@@ -137,15 +141,17 @@ TEST_CASE("forEach with read-only (mmap-loaded) store")
         gs.add(diagonal(4, cv::Point(50, 50)));
         gs.save(p.string());
     }
-    GridStore loaded(p.string());
-    GridStore::QueryScratch scratch;
-    int count = 0;
-    loaded.forEach(cv::Rect(0, 0, 100, 100), scratch,
-                   [&](const std::shared_ptr<std::vector<cv::Point>>& path) {
-                       CHECK(path);
-                       ++count;
-                   });
-    CHECK(count == 2);
+    {
+        GridStore loaded(p.string());
+        GridStore::QueryScratch scratch;
+        int count = 0;
+        loaded.forEach(cv::Rect(0, 0, 100, 100), scratch,
+                       [&](const std::shared_ptr<std::vector<cv::Point>>& path) {
+                           CHECK(path);
+                           ++count;
+                       });
+        CHECK(count == 2);
+    }
     fs::remove(p);
 }
 
@@ -157,9 +163,11 @@ TEST_CASE("get(center, radius) with read-only store")
         gs.add(diagonal(5));
         gs.save(p.string());
     }
-    GridStore loaded(p.string());
-    auto hits = loaded.get(cv::Point2f(2.f, 2.f), 5.f);
-    CHECK(hits.size() == 1);
+    {
+        GridStore loaded(p.string());
+        auto hits = loaded.get(cv::Point2f(2.f, 2.f), 5.f);
+        CHECK(hits.size() == 1);
+    }
     fs::remove(p);
 }
 

--- a/volume-cartographer/core/test/test_gridstore_malformed.cpp
+++ b/volume-cartographer/core/test/test_gridstore_malformed.cpp
@@ -47,9 +47,14 @@ std::vector<uint8_t> makeValidFileBytes(const std::string& path)
         gs.add(diagonal(5, {50, 50}));
         gs.save(path);
     }
-    std::ifstream in(path, std::ios::binary);
-    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)),
-                               std::istreambuf_iterator<char>());
+    // Read in a nested scope: Windows refuses to delete a file that still has an
+    // open handle, so the stream has to be closed before the remove() below.
+    std::vector<uint8_t> bytes;
+    {
+        std::ifstream in(path, std::ios::binary);
+        bytes.assign((std::istreambuf_iterator<char>(in)),
+                     std::istreambuf_iterator<char>());
+    }
     std::filesystem::remove(path);
     return bytes;
 }
@@ -95,9 +100,13 @@ TEST_CASE("GridStore: a valid file still loads (hardening does not reject good f
     const auto path = tmpPath("valid.bin");
     writeBytes(path, bytes);
 
-    GridStore loaded(path);
-    CHECK(loaded.size() == cv::Size(100, 100));
-    CHECK(loaded.get_all().size() == 2);
+    // Nested scope: the mmap-backed GridStore must be destroyed before the file
+    // can be deleted. Windows refuses to remove a file that is still mapped.
+    {
+        GridStore loaded(path);
+        CHECK(loaded.size() == cv::Size(100, 100));
+        CHECK(loaded.get_all().size() == 2);
+    }
 
     std::filesystem::remove(path);
 }

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -1,6 +1,8 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
+#include <QtGlobal>
+
 #include "CState.hpp"
 #include "FiberSliceGeometry.hpp"
 #include "LineAnnotationFiberClassification.hpp"
@@ -647,14 +649,16 @@ TEST_CASE("line annotation failed multi fiber save keeps recovery backups")
     writeText(first, "{\"old\":\"a\"}\n");
     writeText(second, "{\"old\":\"b\"}\n");
 
-    setenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE", "1", 1);
+    // qputenv/qunsetenv rather than setenv/unsetenv: those are POSIX-only and this
+    // file did not compile on Windows. The Qt spellings are portable and need no ifdef.
+    qputenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE", "1");
     std::vector<vc3d::line_annotation::FiberSavePayload> payloads{
         {1, 2, first, nlohmann::json{{"new", "a"}}},
         {2, 3, second, nlohmann::json{{"new", "b"}}},
     };
 
     const auto result = vc3d::line_annotation::runFiberSaveJob(12, std::move(payloads));
-    unsetenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE");
+    qunsetenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE");
 
     CHECK_FALSE(result.ok);
     CHECK(result.error.find("Injected failure") != std::string::npos);

--- a/volume-cartographer/core/test/test_normal_grid_volume.cpp
+++ b/volume-cartographer/core/test/test_normal_grid_volume.cpp
@@ -170,15 +170,19 @@ TEST_CASE("get_grid with a real (committed) GridStore file is read back")
         gs.add({cv::Point(0, 0), cv::Point(5, 5), cv::Point(10, 10)});
         gs.save((d / "xy" / "000000.grid").string());
     }
-    NormalGridVolume v(d.string());
-    auto g = v.get_grid(0, 0);
-    REQUIRE(g != nullptr);
-    CHECK(g->numSegments() >= 1);
-    // A second lookup hits the cache.
-    auto stats_before = v.cacheStats();
-    auto g2 = v.get_grid(0, 0);
-    CHECK(g2 != nullptr);
-    auto stats_after = v.cacheStats();
-    CHECK(stats_after.gridHits > stats_before.gridHits);
+    // Nested scope: the mmap-backed store must be destroyed before the directory
+    // can be deleted. Windows refuses to remove a file that is still mapped.
+    {
+        NormalGridVolume v(d.string());
+        auto g = v.get_grid(0, 0);
+        REQUIRE(g != nullptr);
+        CHECK(g->numSegments() >= 1);
+        // A second lookup hits the cache.
+        auto stats_before = v.cacheStats();
+        auto g2 = v.get_grid(0, 0);
+        CHECK(g2 != nullptr);
+        auto stats_after = v.cacheStats();
+        CHECK(stats_after.gridHits > stats_before.gridHits);
+    }
     fs::remove_all(d);
 }

--- a/volume-cartographer/core/test/test_quadsurface_extras.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_extras.cpp
@@ -297,6 +297,11 @@ TEST_CASE("mapped SurfacePatchIndex rebuild keeps disk-backed surfaces lazy")
     CHECK(hit->surface == lazy);
     CHECK_FALSE(lazy->isLoaded());
 
+    // Release the disk-backed surface before deleting its directory: Windows
+    // refuses to remove files that are still mapped.
+    index = SurfacePatchIndex{};
+    lazy.reset();
+
     fs::remove_all(root);
 }
 


### PR DESCRIPTION
The test tree does not compile on Windows. `ci-windows-mingw` sets `VC_TESTING=OFF`, so the registered test targets are only ever built on Linux and macOS — where the POSIX APIs the tests reach for happen to exist. Windows ships an official installer on every release, so nothing that breaks there is currently caught.

Making the suite build surfaced a real bug, which is why this is one change and not two: with the tests finally running, `cancelFinishesOnceAndRunnerIsReusable` failed on Windows, and the failure crashed the test binary outright. Splitting the portability work from the fix would leave a PR that cannot claim a green suite.

**No `#ifdef` anywhere in this PR.** Every fix is portable by construction.

## What changed

### Compile failures — these blocked the whole tree

| file | problem | fix |
|---|---|---|
| `apps/VC3D/test/test_command_line_tool_runner.cpp` | `std::raise(SIGKILL)` — POSIX-only | `std::abort()` |
| `core/test/test_line_annotation_generated_views.cpp` | `setenv`/`unsetenv` — POSIX-only | `qputenv`/`qunsetenv` + explicit `<QtGlobal>` |

Production code already handles both correctly, which is what makes this a test-tree gap rather than a codebase-wide one: `LasagnaServiceManager.cpp:877` guards its `SIGKILL` with `#ifdef Q_OS_UNIX`, and `VCAppMain.cpp:53` carries a `vcSetEnv` helper commented *"POSIX setenv with an MSVCRT/UCRT fallback (Windows has no setenv)"*.

`std::abort()` is used rather than another signal under an `#ifdef` because under MinGW every `raise(SIG*)` returns through the default handler and exits normally, which `QProcess` reports as `NormalExit` — while the test asserts `CrashExit`:

| | `raise(SIGABRT/SIGSEGV/SIGILL/SIGTERM)` | `std::abort()` |
|---|---|---|
| Windows (MinGW) | NormalExit, code 3 | **CrashExit** |
| Linux (glibc) | CrashExit | **CrashExit** |

It is correct on both, and removes the now-unused `<csignal>` include.

### Runtime failures

**Deleting a file that is still mapped or open** (5 tests) — `test_gridstore.cpp`, `test_gridstore_branches.cpp`, `test_gridstore_malformed.cpp`, `test_normal_grid_volume.cpp`, `test_quadsurface_extras.cpp`. POSIX allows unlinking an open or mapped file; Windows refuses. In each case the owner of the mapping was still in scope at the `remove()` call, so it is now confined to a nested scope or released explicitly. Not a production defect: `GridStore` holds its mapping in an RAII member and `~GridStore()` releases it correctly.

**`isExecutable()` is extension-based on Windows** (1 test) — `failedStartFinishesOnce` built its stand-in program from a `QTemporaryFile` whose random name has no extension, so the runner rejected it before starting a process, a different code path from the one the test exercises. The temporary now carries a `.exe` suffix, harmless on POSIX where the permission bit set just below is what counts.

**A genuine race** (1 test) — `stats: startup scan ignores files newer than its cutoff` wrote `post.bin` *after* constructing the cache. The scan runs on a worker thread with a cutoff captured at construction, so the write raced it: the scan could read `post.bin` before its future timestamp was applied and count it — 49 bytes instead of 32. This can fail on any loaded machine; Windows merely exposes it by being slower at directory iteration. The file is now stamped before the cache exists, which removes the race without changing what the test asserts, and a previously ignored `error_code` is checked so a broken premise fails loudly instead of as a confusing byte-count mismatch.

### The cancellation bug the tests found

`cancel()` only called `QProcess::terminate()`, which posts `WM_CLOSE`. Console applications have no message loop, so the `vc_*` tools ignore it: the user cancels, the interface reports success, and the process keeps running for hours. This also hung cancellation from the agent bridge.

Fixed with a deferred `kill()` fallback after a grace period, so `terminate()` still gets its chance to shut the process down cleanly first. The `QProcess` object is reused across runs, so the deferred kill is guarded against landing on a later run that started in the meantime.

Adds a regression test for that guard, verified to fail without the change: it cancels a long-running helper, starts another immediately, and asserts the replacement is still alive after the grace period has elapsed.

## How to build and run

```bash
# Linux
cmake --preset ci-release-gcc -DVC_TESTING=ON
ninja -C build/ci-release-gcc
cd build/ci-release-gcc && QT_QPA_PLATFORM=offscreen ctest --timeout 180 -j4

# Windows (MSYS2 UCRT64)
cmake --preset ci-windows-mingw -DVC_TESTING=ON
ninja -C build/ci-windows-mingw
cd build/ci-windows-mingw && QT_QPA_PLATFORM=offscreen ctest --timeout 180 -j4
```

## How this was verified

**Windows** (MSYS2 UCRT64, gcc 16.1.0, Qt 6.11.1, CMake 4.4.0): the test tree went from *not compiling at all* to **112/112 passing**.

Every assertion in the touched tests is preserved one-for-one; only scoping and indentation changed. No test was weakened to make it pass.

## Risks and limitations

- I have only run the suite on Windows against this branch, so please let CI confirm Linux and macOS. The changes are confined to test code plus the one `cancel()` fix and add no platform conditionals, so POSIX behaviour should be unchanged — but that is reasoning, not a measurement, and I would rather say so than imply otherwise.
- On Linux `terminate()` already stops these tools, so the deferred `kill()` normally finds the process gone; the guard covers that case.
- `std::abort()` may produce a core dump where `ulimit` allows it. That is noise in a test log, not a failure.
