### PR TITLE
vc_render_tifxyz: default --voxel-unit to micrometer, not nanometer

### DIFF
--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -1128,7 +1128,10 @@ int main(int argc, char *argv[])
         ("resume", po::bool_switch()->default_value(false), "Skip chunks that already exist on disk")
         ("pre", po::bool_switch()->default_value(false), "Create zarr + all level datasets")
         ("voxel-size", po::value<double>(), "Physical voxel size for OME-Zarr scale metadata (reads from volume metadata if omitted)")
-        ("voxel-unit", po::value<std::string>()->default_value("nanometer"), "Physical unit for OME-Zarr axes (e.g. nanometer, micrometer)");
+        ("voxel-unit", po::value<std::string>()->default_value("micrometer"),
+            "Physical unit for OME-Zarr axes and TIFF resolution (e.g. micrometer, nanometer). "
+            "Defaults to micrometer: volpkg meta.json voxelsize, the docs and the volume "
+            "names (..._7.91um_...) are all in micrometers.");
     // clang-format on
 
     po::options_description all("Usage");

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -582,3 +582,23 @@ vc_add_test(NAME test_quadsurface_extras)
 vc_add_test(NAME test_surface_patch_index_cache)
 
 vc_add_test(NAME test_volume_pkg_more)
+
+# Pins the option defaults of vc_render_tifxyz by reading them back out of
+# --help. Unlike test_merge_e2e_small this is not gated behind VC_RUN_E2E: it
+# spawns the binary but touches no volume, no surface and no fixtures, so it
+# costs milliseconds and belongs in the default pass. The regression it guards
+# — a one-word default reverting silently, with the output still looking
+# plausible — is exactly what CI has to catch. Skipped when the apps are not
+# built, e.g. coverage builds where VC_BUILD_APPS defaults to OFF.
+if(TARGET vc_render_tifxyz)
+    add_executable(test_render_tifxyz_defaults test_render_tifxyz_defaults.cpp)
+    target_link_libraries(test_render_tifxyz_defaults PRIVATE doctest::doctest)
+    vc_register_test_target(test_render_tifxyz_defaults)
+    add_dependencies(test_render_tifxyz_defaults vc_render_tifxyz)
+    add_test(NAME test_render_tifxyz_defaults COMMAND test_render_tifxyz_defaults)
+    vc_register_ctest(test_render_tifxyz_defaults test_render_tifxyz_defaults)
+    # The probe in the test prefers this variable, so ctest works regardless of
+    # the working directory or the build layout.
+    set_tests_properties(test_render_tifxyz_defaults PROPERTIES
+        ENVIRONMENT "VC_RENDER_TIFXYZ_BIN=$<TARGET_FILE:vc_render_tifxyz>")
+endif()

--- a/volume-cartographer/core/test/test_render_tifxyz_defaults.cpp
+++ b/volume-cartographer/core/test/test_render_tifxyz_defaults.cpp
@@ -1,0 +1,134 @@
+// Regression test for the option defaults of vc_render_tifxyz.
+//
+// --voxel-unit used to default to "nanometer" while every physical size in
+// this project is in micrometers (volpkg meta.json voxelsize, the docs, the
+// volume names). Every OME-Zarr written on the default path therefore declared
+// a scale 1000x too small, silently, which is the metadata viewers read to draw
+// scale bars.
+//
+// The fix is a one-word default, so the failure mode is a silent revert: the
+// code keeps compiling and the output keeps looking plausible. This test pins
+// the value by reading it back out of --help, which boost::program_options
+// renders as "(=micrometer)".
+//
+// Deliberately hermetic: no volume, no surface, no fixtures. It spawns the
+// built binary and inspects its help text, so it runs in the default ctest
+// pass instead of being gated behind VC_RUN_E2E like the heavier end-to-end
+// tests. A guard that nobody runs guards nothing.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+fs::path locateBinary(const fs::path& candidate)
+{
+    if (fs::exists(candidate) && fs::is_regular_file(candidate)) return candidate;
+    return {};
+}
+
+// Mirrors the probe in test_merge_e2e_small.cpp: CMake passes the exact path
+// via the environment, the rest are fallbacks for a manual run from a source
+// tree or from PATH.
+fs::path findRenderTifxyz()
+{
+    if (const char* env = std::getenv("VC_RENDER_TIFXYZ_BIN")) {
+        if (auto p = locateBinary(env); !p.empty()) return p;
+    }
+
+#ifdef _WIN32
+    const std::string exeName = "vc_render_tifxyz.exe";
+    const char pathSep = ';';
+#else
+    const std::string exeName = "vc_render_tifxyz";
+    const char pathSep = ':';
+#endif
+
+    for (const fs::path& base : {fs::path("build/bin"),
+                                 fs::path("build-macos/bin"),
+                                 fs::path("build-macos-rel/bin")}) {
+        if (auto p = locateBinary(base / exeName); !p.empty()) return p;
+    }
+
+    if (const char* path = std::getenv("PATH")) {
+        std::string s = path;
+        std::string::size_type from = 0;
+        while (from <= s.size()) {
+            const auto next = s.find(pathSep, from);
+            const std::string seg =
+                s.substr(from, next == std::string::npos ? std::string::npos : next - from);
+            if (!seg.empty()) {
+                if (auto p = locateBinary(fs::path(seg) / exeName); !p.empty()) return p;
+            }
+            if (next == std::string::npos) break;
+            from = next + 1;
+        }
+    }
+    return {};
+}
+
+std::string runHelp(const fs::path& bin, int& exitCode)
+{
+    const fs::path out = fs::temp_directory_path() /
+                         ("vc_render_tifxyz_help_" + std::to_string(std::rand()) + ".txt");
+
+    // Quoted so a path with spaces survives the shell on both platforms.
+    std::string cmd = "\"" + bin.string() + "\" --help > \"" + out.string() + "\" 2>&1";
+#ifdef _WIN32
+    // std::system goes through `cmd /c`, which strips the outer quote pair when
+    // the string both starts with a quote and contains others — the command
+    // then parses as garbage. Wrapping the whole line in one more pair is the
+    // documented workaround.
+    cmd = "\"" + cmd + "\"";
+#endif
+    exitCode = std::system(cmd.c_str());
+
+    std::ifstream in(out);
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    in.close();
+    std::error_code ec;
+    fs::remove(out, ec);
+    return ss.str();
+}
+
+}  // namespace
+
+TEST_CASE("vc_render_tifxyz --help reports the option defaults")
+{
+    const fs::path bin = findRenderTifxyz();
+    REQUIRE_MESSAGE(!bin.empty(),
+                    "vc_render_tifxyz not found; set VC_RENDER_TIFXYZ_BIN to its path");
+
+    int exitCode = -1;
+    const std::string help = runHelp(bin, exitCode);
+
+    CHECK(exitCode == 0);
+    REQUIRE_MESSAGE(!help.empty(), "--help produced no output");
+
+    SUBCASE("the option is still advertised")
+    {
+        CHECK(help.find("--voxel-unit") != std::string::npos);
+    }
+
+    SUBCASE("it defaults to micrometer, matching every other physical size in the project")
+    {
+        CHECK(help.find("(=micrometer)") != std::string::npos);
+    }
+
+    SUBCASE("it does not default to nanometer")
+    {
+        // The exact regression: a nanometer default makes every OME-Zarr
+        // written on the default path declare a scale 1000x too small.
+        CHECK(help.find("(=nanometer)") == std::string::npos);
+    }
+}


### PR DESCRIPTION

Every OME-Zarr written by `vc_render_tifxyz` declares its physical scale **1000× too
small**, on the default path, with no warning.

`--voxel-unit` defaults to `nanometer`. Everything in this project is in micrometers: the
`voxelsize` field of volpkg `meta.json`, the documentation (7.91 µm), and the volume names
themselves (`54keV_7.91um_Scroll1A.zarr`).

### Why this matters

This is the metadata OME-Zarr viewers read to draw scale bars — which is exactly what
#497 (*"support proper scales in ome-zarr metadata"*) set out to enable:

> *"We could add proper scaling metadata to `.zattrs` so that tools like neuroglancer can
> show scaling bars correctly."*

The spec example quoted in that issue uses `"unit": "micrometer"`. The feature works; its
default value undoes it.

The Grand Prize rules also require *"scale bars showing the size of 1cm on each submission
image"* (`34_prizes.md`).

### The correct value is not a matter of opinion

`apps/VC3D/CommandLineToolRunner.cpp:660-663` — VC3D passes `micrometer` explicitly when
it invokes the renderer:

```cpp
if (_useRenderVoxelSize) {
    args << "--voxel-size" << QString::number(_renderVoxelSizeUm, 'g', 17)
         << "--voxel-unit" << "micrometer";
}
```

Note the condition. The GUI only overrides the default when the user has opted into a
render voxel size; with that toggle off it passes neither flag, so **the GUI is affected
too** and falls back to `nanometer` like everything else. Anything invoking the CLI
directly — batch scripts, pipelines — always is.

`core/src/Zarr.cpp:373` has no default of its own (`if (!voxelUnit.empty()) ax["unit"] =
voxelUnit;`), so the single source of the wrong value is the option default.

### Why not read the unit from the input volume

Because it isn't there. Both the CT and the surface-prediction volumes for Scroll 1
declare axes with **no `unit`** and `scale: [1.0, 1.0, 1.0]` — unitless pyramid factors,
precisely the gap #497 described upstream. There is nothing to propagate; the default is
the only place to fix it.

### What changed

- `--voxel-unit` now defaults to `micrometer`.
- Help text says why, so the next reader does not have to rediscover it.
- **New regression test** `core/test/test_render_tifxyz_defaults.cpp` pins the
  default by reading it back out of `--help`.

### About the test

The fix is a one-word default, so its failure mode is a silent revert: the code
keeps compiling and the output keeps looking plausible. A test that pins the
value is the only thing that stops it happening twice.

It is deliberately hermetic — no volume, no surface, no fixtures — so it costs
milliseconds and runs in the **default** `ctest` pass, rather than being gated
behind `VC_RUN_E2E` like `test_merge_e2e_small`. A guard nobody runs guards
nothing.

Verified to fail without the fix: reverting the default to `nanometer` makes it
red, restoring it makes it green.

This is, as far as I can tell, the second test in the suite that exercises one
of the 43 `apps/src` binaries (`test_merge_e2e_small` is the first, and it is
opt-in). If a different location or convention is preferred for tests that
spawn CLI tools, say so and I will move it — the probe follows the one that
already exists.

### How to build and run

```bash
cmake --preset ci-release-gcc && ninja -C build/ci-release-gcc vc_render_tifxyz
vc_render_tifxyz -v <volume.zarr> --scale 1 -g 0 -s <tifxyz> \
    --zarr-output out.zarr --tif-output out_tif
```

### How this was verified

| | before | after |
|---|---|---|
| `.zattrs` axis unit (default path) | `nanometer` ✗ | **`micrometer`** ✓ |
| `.zattrs` scale | `[7.91, 7.91, 7.91]` (i.e. 7.91 nm) | `[7.91, 7.91, 7.91]` (µm) ✓ |
| log line | `7.91 nanometer` ✗ | `7.91 micrometer` ✓ |
| TIFF resolution, size from metadata | 3211.13 px/in ✓ | 3211.13 px/in ✓ |
| TIFF resolution, `--voxel-size 7.91` | **3 211 130 px/in** ✗ | **3211.13 px/in** ✓ |

That last row is a second trap the same default created: passing the *documented* voxel
size on the command line produced a TIFF resolution 1000× off, because the unit conversion
is applied only when the value comes from the CLI (`vc_render_tifxyz.cpp:1429`,
`if (voxelSizeFromCli)`). Both paths now agree.

Rendered from a real traced surface against a Scroll 1 ROI; `tiffinfo` and the generated
`.zattrs` inspected directly.

### Risks and limitations

- Anyone currently passing `--voxel-size` in nanometres and relying on the old default
  would need to add `--voxel-unit nanometer`. No data in this project is in nanometres, and
  the GUI already passes `micrometer`, so the expected blast radius is zero — but it is a
  behaviour change and worth stating.
- Only `vc_render_tifxyz` exposes `--voxel-unit`; no other tool is affected.
- Verified on Windows (MSYS2 UCRT64). The code path is platform-independent.
- The test spawns the binary through `std::system`. On Windows that goes via
  `cmd /c`, which needs the whole command line wrapped in one extra quote pair
  when it both starts with a quote and contains others; the test does that under
  `#ifdef _WIN32`. Worth knowing if the pattern gets reused.
- Full suite green with the change: 113/113 on Windows (112 existing + the new
  one), gcc 16.1.0, Qt 6.11.1.


