### PR TITLE
cmake: warn instead of silently dropping the -march baseline

### DIFF
--- a/volume-cartographer/CMakeLists.txt
+++ b/volume-cartographer/CMakeLists.txt
@@ -226,6 +226,23 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
     add_compile_options(-pipe -march=armv8.2-a)
 else()
+    # Reaching here silently drops the architecture baseline the branches above
+    # set, so warn instead of shipping a quietly deoptimised build. An empty
+    # CMAKE_SYSTEM_PROCESSOR is the case seen in practice: CMake derives it from
+    # PROCESSOR_ARCHITECTURE on Windows, and a shell without that variable
+    # yields "", which matches none of the branches. On Linux that costs the
+    # documented -march=x86-64-v3 floor with no other symptom.
+    if(NOT CMAKE_SYSTEM_PROCESSOR)
+        message(WARNING
+            "CMAKE_SYSTEM_PROCESSOR is empty, so no -march baseline was applied. "
+            "The build falls back to the compiler default, losing the x86-64-v3 "
+            "floor on Linux. Check that PROCESSOR_ARCHITECTURE is set in the "
+            "environment (Windows) or pass -DCMAKE_SYSTEM_PROCESSOR explicitly.")
+    else()
+        message(WARNING
+            "Unrecognised CMAKE_SYSTEM_PROCESSOR '${CMAKE_SYSTEM_PROCESSOR}': no "
+            "-march baseline was applied and the build uses the compiler default.")
+    endif()
     add_compile_options(-pipe)
 endif()
 


### PR DESCRIPTION

The architecture-baseline block ends in an `else()` that applies only `-pipe`. Reaching it
means the build silently loses the baseline the branches above would have set — on Linux
that is the `-march=x86-64-v3` floor the comment two lines up documents as intentional.

Nothing is printed. The build succeeds, the binaries run, and the only symptom is that they
are slower than the project intends.

### This is not hypothetical

We hit it. A build of `1162bcab` produced a `compile_commands.json` with **zero**
occurrences of `-march`, and the generated `CMakeSystem.cmake` explained why:

```cmake
set(CMAKE_HOST_SYSTEM_PROCESSOR "")
set(CMAKE_SYSTEM_PROCESSOR "")
```

Empty, so `MATCHES "^(x86_64|amd64|AMD64)$"` fails and control falls through.

### Root cause, reproduced

CMake derives `CMAKE_HOST_SYSTEM_PROCESSOR` from `PROCESSOR_ARCHITECTURE` on Windows. Run
the configure from an environment where that variable is unset or empty and both variables
come out as the empty string:

```
$ PROCESSOR_ARCHITECTURE= cmake -S . -B build-probe
-- CMAKE_SYSTEM_PROCESSOR = ''
```

Reproduced deliberately on a machine that otherwise reports `AMD64` correctly, so this is a
property of the environment the configure runs in, not of the host.

On Linux the same fall-through is reachable whenever `CMAKE_SYSTEM_PROCESSOR` is unset,
empty or unrecognised — cross-compilation, a toolchain file that does not set it, an
exotic arch — and there it costs the documented `x86-64-v3` floor.

### What changed

Nothing about which flags are applied. The `else()` now says what happened, and
distinguishes the two ways of getting there:

- **empty** `CMAKE_SYSTEM_PROCESSOR` — names `PROCESSOR_ARCHITECTURE` as the usual culprit
  and suggests passing `-DCMAKE_SYSTEM_PROCESSOR` explicitly;
- **unrecognised** value — reports the value so it is obvious what was not matched.

`message(WARNING)` rather than `FATAL_ERROR`: falling through is legitimate on
architectures the block does not enumerate, and this should not break those builds.

### Why a warning is the whole fix

The failure mode is silence, not incorrectness. Anyone who sees the warning can decide
whether they care; today there is nothing to see. It also makes the condition greppable in
CI logs, which is how a regression like ours would have been caught the day it appeared.

### How to build and run

```bash
cmake --preset ci-release-gcc          # normal path, no warning
```

To see it fire, clear `PROCESSOR_ARCHITECTURE` in the environment — that is the
mechanism, and it is what CMake derives the value from:

```bash
PROCESSOR_ARCHITECTURE= cmake -S volume-cartographer -B /tmp/probe -G Ninja
```

```
CMake Warning at CMakeLists.txt:225 (message):
  CMAKE_SYSTEM_PROCESSOR is empty, so no -march baseline was applied.  The
  build falls back to the compiler default, losing the x86-64-v3 floor on
  Linux.  Check that PROCESSOR_ARCHITECTURE is set in the environment
  (Windows) or pass -DCMAKE_SYSTEM_PROCESSOR explicitly.
```

Passing `-DCMAKE_SYSTEM_PROCESSOR=` on the command line does **not** reproduce
it: CMake fills the variable in during system detection, so the cache entry is
overwritten before the block runs.

### Risks and limitations

- Configure-time output only; no effect on generated build rules or on any binary.
- Projects that legitimately build on an unlisted architecture will now see a warning on
  every configure. That is the intended trade-off, and the message says what to pass to
  silence it.
- Verified on Windows (MSYS2 UCRT64, CMake 4.4.0). The logic is platform-independent.


