### PR TITLE
vc_grow_seg_from_seed: note when running with an unbounded thread count

### DIFF
--- a/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
+++ b/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
@@ -570,8 +570,22 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (thread_limit)
+    if (thread_limit) {
         omp_set_num_threads(thread_limit);
+    }
+    else if (omp_get_max_threads() > 8) {
+        // Tracing throughput peaks at a small thread count and degrades well
+        // past it: measured on an i7-10700F (8C/16T) and a Ryzen 9 8940HX
+        // (16C/32T), wall time per cm2 traced is lowest at 4 threads on both,
+        // and running unbounded costs 2.2x and 3.5x respectively. The penalty
+        // grows with core count, so the default is worst exactly on the large
+        // machines used for batch tracing. VC3D already passes thread_limit=1
+        // when it launches this tool (SegmentationCommandHandler.cpp).
+        std::cout << "NOTE: running with " << omp_get_max_threads()
+                  << " OpenMP threads; tracing does not scale past a few threads. "
+                  << "Set \"thread_limit\" in the params JSON (VC3D uses 1) or "
+                  << "OMP_NUM_THREADS to cap it." << std::endl;
+    }
 
     std::unique_ptr<QuadSurface> resume_surf;
     if (mode == "resume") {


### PR DESCRIPTION

`thread_limit` defaults to `0`, which means "use every core". On every machine and workload
we measured, that is the **worst** value available — and it gets worse the larger the
machine.

Wall time per cm² traced, median of 4 runs, `OMP_NUM_THREADS` fixed per column:

| threads | 1 | 2 | **4** | 8 | 16 | 32 |
|---|---|---|---|---|---|---|
| i7-10700F (8C/16T) | 6.55 | — | **2.71** | 3.50 | 6.02 | — |
| Ryzen 9 8940HX (16C/32T) | 5.47 | 3.76 | **2.53** | 3.72 | 5.71 | 8.84 |

The optimum sits at 4 threads on both, and it does not move with 4× the L3, with a trace 5×
smaller, or on a dense CT volume instead of a sparse surface prediction.

Running unbounded costs **2.2× on 8 cores and 3.5× on 16**. The penalty grows with core
count, so the default is worst exactly on the machines used for batch tracing.

### What changed

One `else if` branch. When `thread_limit` is unset **and** the OpenMP team would exceed 8
threads, the tool prints a note naming the two levers.

Nothing else: no default changed, no behaviour changed, no output changed.

### Why not just change the default

Because the thread count changes the traced surface. The tracer is not deterministic with
more than one thread, and the number of threads is one of the inputs that decides which
points get added in which generation — so flipping the default would silently alter results
for every existing user. That is a decision for the project, not something to slip into a
performance fix. The data for it is in the issue.

### The project already knows the right value

VC3D inserts `thread_limit = 1` when it launches this same tool
(`apps/VC3D/SegmentationCommandHandler.cpp:3313`), and `VCAppMain.cpp:165` calls
`omp_set_num_threads(1)`. The only in-tree caller opts out of the default path, which is
likely why this went unnoticed.

### How to build and run

```bash
cmake --preset ci-release-gcc && ninja -C build/ci-release-gcc vc_grow_seg_from_seed
vc_grow_seg_from_seed -v <volume.zarr> -t <out> -p params.json -s 1680 2192 1536
```

On a host with more than 8 hardware threads and no `thread_limit` in the params, the note
appears once at startup. With `"thread_limit": 4` in the params, or with `OMP_NUM_THREADS`
set below the threshold, it does not.

### How this was verified

| | note printed |
|---|---|
| 32 OpenMP threads, `thread_limit` unset | yes |
| `"thread_limit": 1` in params | no |

Full suite green with the change: 113/113 on Windows (MSYS2 UCRT64, gcc 16.1.0).

### Risks and limitations

- One extra line on stdout for users on large hosts who have not set the knob. Scripts
  parsing stdout for the `generated surface` line are unaffected; the note is emitted at
  startup, long before it.
- The threshold of 8 is a judgement call, chosen so it stays quiet on the laptop-class
  machines where the default is least harmful. Happy to change it or gate it behind a flag.
- The measurements are on one workload family (`seed` mode, surface-prediction and CT
  volumes of Scroll 1) on two x86-64 machines. The direction is consistent across all of
  them; the exact optimum may differ elsewhere, which is why the note names the levers
  rather than prescribing a number.


