### PR TITLE
docs: add vesuvius-io-audit to community projects

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -75,6 +75,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [Region-of-interest inference for `vesuvius.predict`](https://github.com/ScrollPrize/villa/pull/1241): `--bbox "z0:z1,y0:y1,x0:x1"` restricts inference to one region of a volume, in global voxel coordinates, so `blend_logits` and `finalize_outputs` stay aligned. Only the chunks intersecting the region are streamed — on PHerc. Paris 4 a 200³ region reads 27 chunks (56.6 MB) instead of 10,368 (21.7 GB). By TAUIL Abd Elillah
 
+- [vesuvius-io-audit](https://github.com/aistae/vesuvius-io-audit) by Alisher Kuanyshbay. Byte-level audit of the data read path. Found that `vesuvius.predict` has no chunk cache — re-reading the identical patch transfers the full amount again — giving ~17x more traffic than needed on default settings (12.2 GB where 0.72 GB suffices), traced to `LRUStoreCache` being removed in zarr 3 so `use_volume_store_cache` became a no-op ([#1325](https://github.com/ScrollPrize/villa/issues/1325)). Also quantifies unaligned access (a single 512x512 slice costs 128x its payload; a half-chunk-offset 256³ cube costs +238%) and shows Z-order patch traversal would cut a further 57% once a cache exists — simulator validated against measured transfers to within 3%.
+
 - [vesuvius-catalog](https://github.com/Schurkai/vesuvius-catalog): scriptable catalog CLI/library for the open-data bucket - answers which samples have segments, ink outputs or surface predictions at which resolutions, resolves S3/HTTPS data URLs (JSON/CSV output for scripting), and includes working openers for the bucket's OME-Zarr v2 stores under zarr-python 3.
 
 ## Segmentation


### PR DESCRIPTION
Adds [vesuvius-io-audit](https://github.com/aistae/vesuvius-io-audit) under Data access → Tools.

The project measures how many bytes the data read path actually transfers versus how many it needs:

- **No chunk cache in the inference path.** Re-reading the identical patch transfers the full amount again (16.78 MB both times). On default settings this is ~17× more traffic than necessary — 12.2 GB where 0.72 GB suffices. Traced to `LRUStoreCache` being removed in zarr 3, which turned `use_volume_store_cache` into a no-op. Filed as #1325.
- **Unaligned access costs.** A single 512×512 slice downloads 33.55 MB for a 0.26 MB payload (128×); a 256³ cube offset by half a chunk touches 27 chunks instead of 8 (+238%).
- **Traversal order.** Patch positions are enumerated row-major, which does not match the chunk layout; Z-order would cut a further 57% once a cache exists. The simulator behind that figure is validated against measured transfers to within 3%.

All scripts are CPU-only and read megabytes, not terabytes. Raw numbers from every run are included in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)