### PR TITLE
test: fix LRU probe order race that flakes test_chunk_cache under parallel ctest

### DIFF
--- a/volume-cartographer/core/test/test_chunk_cache.cpp
+++ b/volume-cartographer/core/test/test_chunk_cache.cpp
@@ -486,11 +486,14 @@ TEST_CASE("ChunkCache: recently touched entries never exceed capacity")
     CHECK(waitForResolved(*c, 0, 0, 1, 0).status == ChunkStatus::Data);
     CHECK(waitForResolved(*c, 0, 0, 1, 1).status == ChunkStatus::Data);
 
-    // Strict LRU retains only the two most recent chunks.
+    // Strict LRU retains only the two most recent chunks. Probe the expected
+    // survivors BEFORE the evicted chunk: tryGetChunk on a missing entry
+    // queues a background re-fetch, and its store evicts exactly the entries
+    // asserted next (a race that flaked under parallel ctest load).
     CHECK(c->stats().decodedBytes <= 128);
-    CHECK(c->tryGetChunk(0, 0, 0, 0).status == ChunkStatus::MissQueued);
     CHECK(c->tryGetChunk(0, 0, 1, 0).status == ChunkStatus::Data);
     CHECK(c->tryGetChunk(0, 0, 1, 1).status == ChunkStatus::Data);
+    CHECK(c->tryGetChunk(0, 0, 0, 0).status == ChunkStatus::MissQueued);
 }
 
 TEST_CASE("ChunkCache: every store enforces the configured byte capacity")


### PR DESCRIPTION
`test_chunk_cache` flakes under parallel ctest (observed on current main while verifying #1229: failed in a `-j6` run, passed in isolation and on rerun). This pins the cause and fixes it.

## The race

In *"recently touched entries never exceed capacity"*, the evicted chunk was probed **first**:

```cpp
CHECK(c->tryGetChunk(0, 0, 0, 0).status == ChunkStatus::MissQueued);  // queues a re-fetch!
CHECK(c->tryGetChunk(0, 0, 1, 0).status == ChunkStatus::Data);
CHECK(c->tryGetChunk(0, 0, 1, 1).status == ChunkStatus::Data);
```

`tryGetChunk` on a missing entry is not a passive probe — it returns `MissQueued` **and queues a background re-fetch**. When that fetch lands (timing-dependent), its store evicts the LRU entry, which is exactly the chunk the next `CHECK` asserts is still cached; that probe, now a miss, queues another fetch that evicts the last one. The assertions race the fetch worker, which is why both `Data` probes always fail together.

## Evidence

- **Baseline:** 6 concurrent instances × 8 rounds → **24/48 failures**, always lines 492–493; 0 failures solo.
- **Mechanism proof:** inserting a 50 ms sleep after the `MissQueued` probe (giving the queued fetch time to land) → **10/10 failures with no concurrency at all**.
- **After this fix** (probe the expected survivors before the evicted chunk): **0/48** under identical concurrency, and 0/12 re-verified on current main (`c13d012`).

## Notes

- The other `MissQueued` probes in the file are safe: two end their test case, and in *"every store enforces the configured byte capacity"* the subsequent `Data` probe targets the most-recent entry, which the re-fetch's LRU eviction cannot remove.
- No product code changed; diff is the reorder plus a comment warning that `tryGetChunk` enqueues work.

<sub>Diagnosed, fixed and verified by an AI agent (Claude, Anthropic) working autonomously under the direction of @Bullo27; measurements as reported above were run locally on Ubuntu 24.04 (fork PRs get no CI here).</sub>