### PR TITLE
cmake(macos): search frameworks last

### DIFF
--- a/volume-cartographer/CMakePresets.json
+++ b/volume-cartographer/CMakePresets.json
@@ -177,7 +177,7 @@
     {
       "name": "macos-homebrew-llvm",
       "displayName": "macOS Homebrew LLVM",
-      "description": "Native macOS build using Homebrew LLVM/Clang, lld, and Homebrew binutils. The only Apple-toolchain pieces in the loop are SDKROOT (system headers/frameworks) and libSystem, because there is no Homebrew alternative for those.",
+      "description": "Native macOS build using Homebrew LLVM/Clang, lld, and Homebrew binutils. The only Apple-toolchain pieces in the loop are SDKROOT (system headers/frameworks) and libSystem, because there is no Homebrew alternative for those. CMAKE_FIND_FRAMEWORK=LAST because CMake's macOS default searches /Library/Frameworks ahead of the Homebrew prefix: any third-party framework that vendors a common C library wins the header search while the library still resolves to Homebrew. Mono.framework vendors libtiff, which is enough to pair Mono's tiff.h with Homebrew's libtiff.dylib.",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build-macos",
       "cacheVariables": {
@@ -202,6 +202,7 @@
         "CMAKE_SHARED_LINKER_FLAGS_INIT": "-fuse-ld=lld",
         "CMAKE_MODULE_LINKER_FLAGS_INIT": "-fuse-ld=lld",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3",
+        "CMAKE_FIND_FRAMEWORK": "LAST",
         "VC_TESTING": "OFF"
       }
     }


### PR DESCRIPTION
On macOS with Homebrew LLVM, `find_package(TIFF)` can resolve to a mismatched pair: headers from a framework, library from Homebrew.

`CMAKE_FIND_FRAMEWORK` defaults to `FIRST` on Apple platforms. `find_path(TIFF_INCLUDE_DIR tiff.h)` therefore searches every framework's `Headers/` before the Homebrew prefix, and any framework shipping a `tiff.h` wins — on this machine that is `/Library/Frameworks/Mono.framework/Headers`. `find_library(TIFF_LIBRARY tiff)` then finds no `tiff.framework` and falls through to `libtiff.dylib` under Homebrew. CMake reports `TIFF_FOUND`, and the build compiles against one version's headers while linking another's library.

Setting `CMAKE_FIND_FRAMEWORK` to `LAST` in the `macos-homebrew-llvm` preset makes package config and Homebrew take precedence, and leaves genuine framework-only dependencies still findable.

## Reproducing it is narrower than I first said

I originally reported this as reproducible from the preset alone. It is not, and I would rather say so than let the claim stand: `nlohmann_json`'s include directory usually arrives first and masks the framework header. It reproduces through `scripts/build_macos.sh` on a machine with Mono installed, which is how I hit it.

So this is hardening rather than a fix for something CI sees. It is inert on every non-Apple platform, and `macos-15` CI exercises this preset.

## Scope

One line in one preset. An earlier version of this PR also added `Boost::headers` to two targets; I dropped that half after checking the include path more carefully, and this description now matches the diff.
