### PR TITLE
VC3D: fiber split/merge workflows and same-orientation link colors

### DIFF
--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -3983,6 +3983,26 @@ void LineAnnotationController::cleanupIntersectionInspectionSurfaces()
     _intersectionInspection->generatedSurfaceContexts.clear();
 }
 
+void LineAnnotationController::closeIntersectionInspectionForRetiredFibers(
+    const std::vector<uint64_t>& fiberIds)
+{
+    if (!_intersectionInspection) {
+        return;
+    }
+    const auto sessionHoldsRetiredFiber =
+        [&fiberIds](const std::shared_ptr<LineAnnotationSession>& session) {
+            return session &&
+                std::find(fiberIds.begin(), fiberIds.end(), session->fiberId) !=
+                fiberIds.end();
+        };
+    if (!sessionHoldsRetiredFiber(_intersectionInspection->sourceLineSession) &&
+        !sessionHoldsRetiredFiber(_intersectionInspection->targetLineSession)) {
+        return;
+    }
+    cleanupIntersectionInspectionSurfaces();
+    _intersectionInspection.reset();
+}
+
 bool LineAnnotationController::updateIntersectionFollowSlice(bool sourceSideFlag,
                                                              double linePosition,
                                                              const char* reason)
@@ -7274,26 +7294,41 @@ void LineAnnotationController::handleGeneratedControlPointMergeWithCandidate(
         closeFiberWindowForSurface(paneSurfaceName);
         // The close finalization may schedule an async save of an original;
         // flush it before retiring the files so they cannot be resurrected.
+        // A failure among the flushed saves (the redirected peer links ride
+        // this queue) keeps the originals on disk AND in memory: disk and
+        // panel then agree, showing the originals beside the merged fiber.
+        const uint64_t saveFailuresBefore = _fiberSaveFailureCount;
         waitForFiberSaves();
-        // All-or-nothing: a failure restores both originals in place.
-        const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
-            ++_nextFiberSaveSequence, {}, {clickedPath, farPath});
-        if (!retireResult.ok) {
-            showError(tr("Could not retire the original fiber files: %1")
-                          .arg(QString::fromStdString(retireResult.error)),
+        bool retired = _fiberSaveFailureCount == saveFailuresBefore;
+        if (!retired) {
+            showError(tr("A pending fiber save failed; the original fiber "
+                         "files were kept."),
                       suppressErrors);
+        } else {
+            // All-or-nothing: a failure restores both originals in place.
+            const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
+                ++_nextFiberSaveSequence, {}, {clickedPath, farPath});
+            retired = retireResult.ok;
+            if (!retired) {
+                showError(tr("Could not retire the original fiber files: %1")
+                              .arg(QString::fromStdString(retireResult.error)),
+                          suppressErrors);
+            }
         }
-        _fibers.erase(std::remove_if(_fibers.begin(),
-                                     _fibers.end(),
-                                     [clickedId, farId](const StoredFiber& fiber) {
-                                         return fiber.id == clickedId ||
-                                             fiber.id == farId;
-                                     }),
-                      _fibers.end());
-        invalidateFiberAlignmentMetrics(clickedId, false);
-        invalidateFiberAlignmentMetrics(farId, false);
-        emit fibersDeleted(
-            {std::min(clickedId, farId), std::max(clickedId, farId)});
+        if (retired) {
+            _fibers.erase(std::remove_if(_fibers.begin(),
+                                         _fibers.end(),
+                                         [clickedId, farId](const StoredFiber& fiber) {
+                                             return fiber.id == clickedId ||
+                                                 fiber.id == farId;
+                                         }),
+                          _fibers.end());
+            invalidateFiberAlignmentMetrics(clickedId, false);
+            invalidateFiberAlignmentMetrics(farId, false);
+            emit fibersDeleted(
+                {std::min(clickedId, farId), std::max(clickedId, farId)});
+            closeIntersectionInspectionForRetiredFibers({clickedId, farId});
+        }
 
         // Re-fit the merged line (join span + extrapolation tails); consumes
         // the needs_reoptimization tag, which otherwise re-prompts on load.
@@ -7649,24 +7684,39 @@ void LineAnnotationController::handleGeneratedControlPointSplitFromCandidate(
                                  reopenControlIndex, suppressErrors]() {
         closeFiberWindowForSurface(paneSurfaceName);
         // The close finalization may schedule an async save of the original;
-        // flush it before retiring the file so it cannot be resurrected.
+        // flush it before retiring the file so it cannot be resurrected. A
+        // failure among the flushed saves (the redirected peer links ride
+        // this queue) keeps the original on disk AND in memory: disk and
+        // panel then agree, showing the original beside its halves.
+        const uint64_t saveFailuresBefore = _fiberSaveFailureCount;
         waitForFiberSaves();
-        const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
-            ++_nextFiberSaveSequence, {}, {parentPath});
-        if (!retireResult.ok) {
-            showError(tr("Could not retire the original fiber file %1: %2")
-                          .arg(QString::fromStdString(parentPath.string()))
-                          .arg(QString::fromStdString(retireResult.error)),
+        bool retired = _fiberSaveFailureCount == saveFailuresBefore;
+        if (!retired) {
+            showError(tr("A pending fiber save failed; the original fiber "
+                         "file was kept."),
                       suppressErrors);
+        } else {
+            const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
+                ++_nextFiberSaveSequence, {}, {parentPath});
+            retired = retireResult.ok;
+            if (!retired) {
+                showError(tr("Could not retire the original fiber file %1: %2")
+                              .arg(QString::fromStdString(parentPath.string()))
+                              .arg(QString::fromStdString(retireResult.error)),
+                          suppressErrors);
+            }
         }
-        _fibers.erase(std::remove_if(_fibers.begin(),
-                                     _fibers.end(),
-                                     [parentId](const StoredFiber& fiber) {
-                                         return fiber.id == parentId;
-                                     }),
-                      _fibers.end());
-        invalidateFiberAlignmentMetrics(parentId, false);
-        emit fibersDeleted({parentId});
+        if (retired) {
+            _fibers.erase(std::remove_if(_fibers.begin(),
+                                         _fibers.end(),
+                                         [parentId](const StoredFiber& fiber) {
+                                             return fiber.id == parentId;
+                                         }),
+                          _fibers.end());
+            invalidateFiberAlignmentMetrics(parentId, false);
+            emit fibersDeleted({parentId});
+            closeIntersectionInspectionForRetiredFibers({parentId});
+        }
 
         // Re-fit both halves so their lines regrow extrapolation tails past
         // the split CPs. Consumes the needs_reoptimization tag set at
@@ -12632,6 +12682,7 @@ void LineAnnotationController::finishFiberSaveJob(
             emit fiberSaved(result.fiberIds[i], generation);
         }
     } else {
+        ++_fiberSaveFailureCount;
         errorMessage = tr("Could not save fiber data: %1")
                            .arg(QString::fromStdString(result.error));
         if (!result.recoveryFiles.empty()) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -4003,6 +4003,23 @@ void LineAnnotationController::closeIntersectionInspectionForRetiredFibers(
     _intersectionInspection.reset();
 }
 
+void LineAnnotationController::closeDialogPanesForFibers(
+    const std::vector<uint64_t>& fiberIds)
+{
+    // Collect first: closing mutates pane state through queued events.
+    std::vector<std::string> surfaceNames;
+    for (const auto& pane : _panes) {
+        if (pane.session && pane.dialog &&
+            std::find(fiberIds.begin(), fiberIds.end(), pane.session->fiberId) !=
+                fiberIds.end()) {
+            surfaceNames.push_back(pane.surfaceName);
+        }
+    }
+    for (const auto& surfaceName : surfaceNames) {
+        closeFiberWindowForSurface(surfaceName);
+    }
+}
+
 bool LineAnnotationController::updateIntersectionFollowSlice(bool sourceSideFlag,
                                                              double linePosition,
                                                              const char* reason)
@@ -7001,7 +7018,6 @@ void LineAnnotationController::handleGeneratedControlPointMergeWithCandidate(
     const uint64_t clickedId = clicked.id;
     const std::string clickedFileName = clicked.fileName;
     const std::filesystem::path clickedPath = fiberPath(clicked);
-    const std::string paneSurfaceName = pane->surfaceName;
 
     const LinkCandidate candidate = *_linkCandidate;
     // The candidate fiber can be open in a dialog-less editing session with
@@ -7289,9 +7305,9 @@ void LineAnnotationController::handleGeneratedControlPointMergeWithCandidate(
     // its frames are still below us. Retire the originals and re-fit the
     // merged line on a clean stack.
     QTimer::singleShot(0, this, [this, clickedId, farId, clickedPath, farPath,
-                                 paneSurfaceName, mergedId, mergedFileName,
+                                 mergedId, mergedFileName,
                                  joinControlIndex, suppressErrors]() {
-        closeFiberWindowForSurface(paneSurfaceName);
+        closeDialogPanesForFibers({clickedId, farId});
         // The close finalization may schedule an async save of an original;
         // flush it before retiring the files so they cannot be resurrected.
         // A failure among the flushed saves (the redirected peer links ride
@@ -7328,6 +7344,15 @@ void LineAnnotationController::handleGeneratedControlPointMergeWithCandidate(
             emit fibersDeleted(
                 {std::min(clickedId, farId), std::max(clickedId, farId)});
             closeIntersectionInspectionForRetiredFibers({clickedId, farId});
+        } else {
+            // The originals live on; surviving sessions must be saveable
+            // again or later edits would be silently dropped.
+            for (const auto& otherPane : _panes) {
+                if (otherPane.session && (otherPane.session->fiberId == clickedId ||
+                                          otherPane.session->fiberId == farId)) {
+                    otherPane.session->suppressFiberSave = false;
+                }
+            }
         }
 
         // Re-fit the merged line (join span + extrapolation tails); consumes
@@ -7428,7 +7453,6 @@ void LineAnnotationController::handleGeneratedControlPointSplitFromCandidate(
     const uint64_t parentId = parent.id;
     const std::string parentFileName = parent.fileName;
     const std::filesystem::path parentPath = fiberPath(parent);
-    const std::string paneSurfaceName = pane->surfaceName;
 
     const LinkCandidate candidate = *_splitCandidate;
     const auto candidateIndex = matchingStoredControlPointIndex(
@@ -7678,11 +7702,11 @@ void LineAnnotationController::handleGeneratedControlPointSplitFromCandidate(
     // loops that would process the closed dialog's deferred deletion while
     // its frames are still below us. Retire the original and re-fit the
     // halves on a clean stack.
-    QTimer::singleShot(0, this, [this, parentId, parentPath, paneSurfaceName,
+    QTimer::singleShot(0, this, [this, parentId, parentPath,
                                  prefixFiberId, suffixFiberId, prefixFileName,
                                  suffixFileName, reopenFiberId,
                                  reopenControlIndex, suppressErrors]() {
-        closeFiberWindowForSurface(paneSurfaceName);
+        closeDialogPanesForFibers({parentId});
         // The close finalization may schedule an async save of the original;
         // flush it before retiring the file so it cannot be resurrected. A
         // failure among the flushed saves (the redirected peer links ride
@@ -7716,6 +7740,14 @@ void LineAnnotationController::handleGeneratedControlPointSplitFromCandidate(
             invalidateFiberAlignmentMetrics(parentId, false);
             emit fibersDeleted({parentId});
             closeIntersectionInspectionForRetiredFibers({parentId});
+        } else {
+            // The original lives on; surviving sessions must be saveable
+            // again or later edits would be silently dropped.
+            for (const auto& otherPane : _panes) {
+                if (otherPane.session && otherPane.session->fiberId == parentId) {
+                    otherPane.session->suppressFiberSave = false;
+                }
+            }
         }
 
         // Re-fit both halves so their lines regrow extrapolation tails past

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -1876,6 +1876,62 @@ bool LineAnnotationController::confirmFiberOptimizationModeChange(
     return prompt.clickedButton() == proceedButton;
 }
 
+void LineAnnotationController::setMergeModePickerForTesting(
+    std::function<std::optional<vc3d::line_annotation::FiberOptimizationMode>(
+        vc3d::line_annotation::FiberOptimizationMode,
+        vc3d::line_annotation::FiberOptimizationMode)> picker)
+{
+    _mergeModePicker = std::move(picker);
+}
+
+std::optional<vc3d::line_annotation::FiberOptimizationMode>
+LineAnnotationController::pickMergeOptimizationMode(
+    const LineAnnotationSession& session,
+    vc3d::line_annotation::FiberOptimizationMode clickedMode,
+    vc3d::line_annotation::FiberOptimizationMode candidateMode)
+{
+    if (clickedMode == candidateMode) {
+        return clickedMode;
+    }
+    if (_mergeModePicker) {
+        return _mergeModePicker(clickedMode, candidateMode);
+    }
+    if (session.suppressErrorDialogs || _errorDialogsSuppressed) {
+        // Agent-driven flows cannot answer modals; the clicked fiber's mode
+        // is the deterministic default.
+        return clickedMode;
+    }
+    const auto modeLabel =
+        [](vc3d::line_annotation::FiberOptimizationMode mode) {
+            return mode ==
+                    vc3d::line_annotation::FiberOptimizationMode::NativeFiberTrace3d
+                ? tr("Fiber model")
+                : tr("Lasagna");
+        };
+    QMessageBox prompt(_parentWidget.data());
+    prompt.setIcon(QMessageBox::Question);
+    prompt.setWindowTitle(tr("Merge with different modes"));
+    prompt.setText(tr("The two fibers use different interpolation modes. "
+                      "The merged fiber will be re-optimized under the "
+                      "chosen mode."));
+    auto* clickedButton =
+        prompt.addButton(tr("Keep %1 (this fiber)").arg(modeLabel(clickedMode)),
+                         QMessageBox::AcceptRole);
+    auto* candidateButton =
+        prompt.addButton(tr("Keep %1 (candidate)").arg(modeLabel(candidateMode)),
+                         QMessageBox::AcceptRole);
+    prompt.addButton(QMessageBox::Cancel);
+    prompt.setDefaultButton(clickedButton);
+    prompt.exec();
+    if (prompt.clickedButton() == clickedButton) {
+        return clickedMode;
+    }
+    if (prompt.clickedButton() == candidateButton) {
+        return candidateMode;
+    }
+    return std::nullopt;
+}
+
 void LineAnnotationController::setVolumeSelectorFactory(VolumeSelectorFactory factory)
 {
     _volumeSelectorFactory = std::move(factory);
@@ -2134,6 +2190,32 @@ bool LineAnnotationController::launchSession(LineAnnotationController::SourceKin
             this,
             [this](const std::string& name, size_t controlPointIndex, cv::Vec3f volumePoint) {
                 handleGeneratedControlPointLinkWithCandidate(name, controlPointIndex, volumePoint);
+            });
+    connect(dialog,
+            &LineAnnotationDialog::generatedControlPointMergeWithCandidateRequested,
+            this,
+            [this](const std::string& name, size_t controlPointIndex, cv::Vec3f volumePoint) {
+                handleGeneratedControlPointMergeWithCandidate(name, controlPointIndex, volumePoint);
+            });
+    connect(dialog,
+            &LineAnnotationDialog::generatedControlPointSplitCandidateRequested,
+            this,
+            [this](const std::string& name, size_t controlPointIndex, cv::Vec3f volumePoint) {
+                handleGeneratedControlPointSplitCandidate(name, controlPointIndex, volumePoint);
+            });
+    connect(dialog,
+            &LineAnnotationDialog::generatedControlPointSplitFromCandidateRequested,
+            this,
+            [this](const std::string& name, size_t controlPointIndex, cv::Vec3f volumePoint) {
+                handleGeneratedControlPointSplitFromCandidate(name, controlPointIndex,
+                                                              volumePoint, false);
+            });
+    connect(dialog,
+            &LineAnnotationDialog::generatedControlPointSplitAndLinkFromCandidateRequested,
+            this,
+            [this](const std::string& name, size_t controlPointIndex, cv::Vec3f volumePoint) {
+                handleGeneratedControlPointSplitFromCandidate(name, controlPointIndex,
+                                                              volumePoint, true);
             });
     connect(dialog,
             &LineAnnotationDialog::generatedNearbyAnnotationOpenRequested,
@@ -2627,6 +2709,11 @@ void LineAnnotationController::deleteFibers(std::vector<uint64_t> fiberIds)
                                              deletedIds.end(),
                                              _linkCandidate->fiberId)) {
         _linkCandidate.reset();
+    }
+    if (_splitCandidate && std::binary_search(deletedIds.begin(),
+                                              deletedIds.end(),
+                                              _splitCandidate->fiberId)) {
+        _splitCandidate.reset();
     }
 
     _fibers.erase(std::remove_if(_fibers.begin(),
@@ -5091,12 +5178,42 @@ std::vector<vc3d::line_annotation::GeneratedOverlay::ControlPointMarker>
 LineAnnotationController::controlMarkersForSession(const LineAnnotationSession& session) const
 {
     auto markers = generatedControlMarkers(session.controlPoints, session.branches);
+    // Same-orientation links (H-H / V-V) get the orange warning palette; an
+    // unclassified fiber on either side keeps the default H-V colors.
+    const QString localHvTag = fiberHvDirectionTag(session.fiberId);
+    if (!localHvTag.isEmpty()) {
+        for (const auto& branch : session.branches) {
+            if (branch.controlPointIndex < 0 ||
+                static_cast<size_t>(branch.controlPointIndex) >= markers.size()) {
+                continue;
+            }
+            if (fiberHvDirectionTag(branch.branchFiberId) != localHvTag) {
+                continue;
+            }
+            auto& marker = markers[static_cast<size_t>(branch.controlPointIndex)];
+            if (branch.pending) {
+                marker.hasSameHvPendingLinks = true;
+            } else {
+                marker.hasSameHvBranches = true;
+            }
+        }
+    }
     if (_linkCandidate && _linkCandidate->fiberId != 0 &&
         session.fiberId == _linkCandidate->fiberId) {
         for (size_t i = 0; i < session.controlPoints.size() && i < markers.size(); ++i) {
             if (pointsApproximatelyEqual(session.controlPoints[i].volumePoint,
                                          _linkCandidate->position)) {
                 markers[i].isLinkCandidate = true;
+                break;
+            }
+        }
+    }
+    if (_splitCandidate && _splitCandidate->fiberId != 0 &&
+        session.fiberId == _splitCandidate->fiberId) {
+        for (size_t i = 0; i < session.controlPoints.size() && i < markers.size(); ++i) {
+            if (pointsApproximatelyEqual(session.controlPoints[i].volumePoint,
+                                         _splitCandidate->position)) {
+                markers[i].isSplitCandidate = true;
                 break;
             }
         }
@@ -5150,6 +5267,78 @@ LineAnnotationController::linkCandidateMenuState(const LineAnnotationSession& se
     return state;
 }
 
+vc3d::line_annotation::GeneratedLinkCandidateMenuState
+LineAnnotationController::mergeCandidateMenuState(const LineAnnotationSession& session) const
+{
+    vc3d::line_annotation::GeneratedLinkCandidateMenuState state;
+    if (!_linkCandidate || _linkCandidate->fiberId == 0) {
+        return state;
+    }
+    if (session.fiberId != 0 && session.fiberId == _linkCandidate->fiberId) {
+        // Same-fiber refusal already surfaces on the link action.
+        return state;
+    }
+    // Merging joins fiber endpoints; gate on the candidate side here, the
+    // clicked side is validated in the handler.
+    const auto fiberIt = std::find_if(
+        _fibers.begin(), _fibers.end(), [this](const StoredFiber& fiber) {
+            return fiber.id == _linkCandidate->fiberId;
+        });
+    if (fiberIt == _fibers.end()) {
+        return state;
+    }
+    const auto candidateIndex = matchingStoredControlPointIndex(
+        fiberIt->controlPoints,
+        _linkCandidate->storedControlPointIndexHint,
+        _linkCandidate->position);
+    if (!candidateIndex) {
+        return state;
+    }
+    if (*candidateIndex != 0 &&
+        static_cast<size_t>(*candidateIndex) + 1 != fiberIt->controlPoints.size()) {
+        state.enabled = false;
+        state.label = tr("Merge with candidate (not an endpoint)");
+        return state;
+    }
+    state.enabled = true;
+    state.label = tr("Merge with candidate (Fiber %1)")
+                      .arg(static_cast<qulonglong>(_linkCandidate->fiberId));
+    return state;
+}
+
+vc3d::line_annotation::GeneratedLinkCandidateMenuState
+LineAnnotationController::splitCandidateMenuState(const LineAnnotationSession& session) const
+{
+    vc3d::line_annotation::GeneratedLinkCandidateMenuState state;
+    if (!_splitCandidate || _splitCandidate->fiberId == 0) {
+        return state;
+    }
+    if (session.fiberId == 0 || session.fiberId != _splitCandidate->fiberId) {
+        state.enabled = false;
+        state.label = tr("Split from candidate (different fiber)");
+    } else if (session.controlPoints.size() < 4) {
+        state.enabled = false;
+        state.label = tr("Split from candidate (needs 2 control points per half)");
+    } else {
+        state.enabled = true;
+        state.label = tr("Split from candidate, different winding");
+    }
+    return state;
+}
+
+vc3d::line_annotation::GeneratedLinkCandidateMenuState
+LineAnnotationController::splitAndLinkCandidateMenuState(const LineAnnotationSession& session) const
+{
+    // Disabled states show a single greyed base action; the and-link
+    // variant only appears alongside an actionable split.
+    auto state = splitCandidateMenuState(session);
+    if (!state.enabled) {
+        return {};
+    }
+    state.label = tr("Split from candidate and link");
+    return state;
+}
+
 bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolumeViewer* viewer,
                                                                     const QPointF& scenePoint,
                                                                     const QPoint& globalPos)
@@ -5174,7 +5363,10 @@ bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolu
             viewer,
             scenePoint,
             globalPos,
-            linkCandidateMenuState(*pane->session));
+            linkCandidateMenuState(*pane->session),
+            splitCandidateMenuState(*pane->session),
+            splitAndLinkCandidateMenuState(*pane->session),
+            mergeCandidateMenuState(*pane->session));
     } else if (_intersectionInspection) {
         const auto contextIt =
             _intersectionInspection->generatedSurfaceContexts.find(viewer->surfName());
@@ -5211,6 +5403,14 @@ bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolu
         const auto candidateState = linkCandidateMenuState(*pane->session);
         options.linkWithCandidateEnabled = candidateState.enabled;
         options.linkWithCandidateLabel = candidateState.label;
+        const auto mergeState = mergeCandidateMenuState(*pane->session);
+        options.mergeWithCandidateEnabled = mergeState.enabled;
+        options.mergeWithCandidateLabel = mergeState.label;
+        const auto splitState = splitCandidateMenuState(*pane->session);
+        options.splitFromCandidateEnabled = splitState.enabled;
+        options.splitFromCandidateLabel = splitState.label;
+        options.splitFromCandidateAndLinkLabel =
+            splitAndLinkCandidateMenuState(*pane->session).label;
         if (auto* plane = dynamic_cast<PlaneSurface*>(viewer->currentSurface())) {
             options.branchLinkDirection = plane->normal({0.0f, 0.0f, 0.0f});
         }
@@ -5245,6 +5445,36 @@ bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolu
             handleGeneratedControlPointLinkWithCandidate(surfaceName,
                                                          controlPointIndex,
                                                          volumePoint);
+        };
+        options.mergeWithCandidate = [this, surfaceName = viewer->surfName()](
+                                         size_t controlPointIndex,
+                                         cv::Vec3f volumePoint) {
+            handleGeneratedControlPointMergeWithCandidate(surfaceName,
+                                                          controlPointIndex,
+                                                          volumePoint);
+        };
+        options.designateSplitCandidate = [this, surfaceName = viewer->surfName()](
+                                              size_t controlPointIndex,
+                                              cv::Vec3f volumePoint) {
+            handleGeneratedControlPointSplitCandidate(surfaceName,
+                                                      controlPointIndex,
+                                                      volumePoint);
+        };
+        options.splitFromCandidate = [this, surfaceName = viewer->surfName()](
+                                         size_t controlPointIndex,
+                                         cv::Vec3f volumePoint) {
+            handleGeneratedControlPointSplitFromCandidate(surfaceName,
+                                                          controlPointIndex,
+                                                          volumePoint,
+                                                          false);
+        };
+        options.splitFromCandidateAndLink = [this, surfaceName = viewer->surfName()](
+                                                size_t controlPointIndex,
+                                                cv::Vec3f volumePoint) {
+            handleGeneratedControlPointSplitFromCandidate(surfaceName,
+                                                          controlPointIndex,
+                                                          volumePoint,
+                                                          true);
         };
         options.unlinkBranch = [this, surfaceName = viewer->surfName()](
                                    size_t controlPointIndex,
@@ -6709,6 +6939,709 @@ void LineAnnotationController::handleGeneratedControlPointLinkWithCandidate(
             generatedSpanAlignmentMetricsForSession(session));
     }
     refreshBranchLineViews(localFiberId);
+}
+
+void LineAnnotationController::handleGeneratedControlPointMergeWithCandidate(
+    const std::string& surfaceName,
+    size_t controlPointIndex,
+    cv::Vec3f volumePoint)
+{
+    (void)volumePoint;
+    auto* pane = paneForSurface(surfaceName);
+    if (!pane || !pane->session) {
+        return;
+    }
+    auto& session = *pane->session;
+    if (session.taskState == LineAnnotationSession::TaskState::Running) {
+        showError(tr("Line optimization is already running."));
+        return;
+    }
+    if (controlPointIndex >= session.controlPoints.size()) {
+        return;
+    }
+    if (!_linkCandidate || _linkCandidate->fiberId == 0) {
+        showError(tr("No link candidate is designated."));
+        return;
+    }
+    ensureSessionFiberIdentity(session);
+    if (session.fiberId == 0) {
+        session.fiberId = nextFiberId();
+    }
+    if (session.fiberId == _linkCandidate->fiberId) {
+        showError(tr("The merge candidate is on this fiber; designate a candidate on a "
+                     "different fiber."));
+        return;
+    }
+    const bool suppressErrors = session.suppressErrorDialogs;
+
+    // Bake unsaved session edits into a stored snapshot; everything below
+    // works on snapshots so no in-memory state mutates until the merged
+    // fiber is safely on disk.
+    const StoredFiber clicked = storedFiberFromSession(session);
+    const uint64_t clickedId = clicked.id;
+    const std::string clickedFileName = clicked.fileName;
+    const std::filesystem::path clickedPath = fiberPath(clicked);
+    const std::string paneSurfaceName = pane->surfaceName;
+
+    const LinkCandidate candidate = *_linkCandidate;
+    const auto candidateIt = std::find_if(
+        _fibers.begin(), _fibers.end(), [&candidate](const StoredFiber& fiber) {
+            return fiber.id == candidate.fiberId;
+        });
+    if (candidateIt == _fibers.end()) {
+        _linkCandidate.reset();
+        showError(tr("The merge candidate's fiber no longer exists."), suppressErrors);
+        return;
+    }
+    const StoredFiber far = *candidateIt;
+    const uint64_t farId = far.id;
+    const std::string farFileName = far.fileName;
+    const std::filesystem::path farPath = fiberPath(far);
+
+    const auto candidateIndex = matchingStoredControlPointIndex(
+        far.controlPoints, candidate.storedControlPointIndexHint, candidate.position);
+    if (!candidateIndex) {
+        _linkCandidate.reset();
+        showError(tr("The merge candidate control point no longer exists."),
+                  suppressErrors);
+        return;
+    }
+    int clickedIndexHint = -1;
+    const auto storedIndexMap = storedIndexMapForSessionControls(session.controlPoints);
+    if (controlPointIndex < storedIndexMap.size()) {
+        clickedIndexHint = storedIndexMap[controlPointIndex];
+    }
+    const auto clickedIndex = matchingStoredControlPointIndex(
+        clicked.controlPoints,
+        clickedIndexHint,
+        session.controlPoints[controlPointIndex].volumePoint);
+    if (!clickedIndex) {
+        showError(tr("Could not resolve the clicked control point."), suppressErrors);
+        return;
+    }
+    const size_t clickedCount = clicked.controlPoints.size();
+    const size_t farCount = far.controlPoints.size();
+    const bool clickedIsEndpoint = *clickedIndex == 0 ||
+        static_cast<size_t>(*clickedIndex) + 1 == clickedCount;
+    const bool candidateIsEndpoint = *candidateIndex == 0 ||
+        static_cast<size_t>(*candidateIndex) + 1 == farCount;
+    if (!clickedIsEndpoint || !candidateIsEndpoint) {
+        showError(tr("Merge joins fiber endpoints; pick the first or last "
+                     "control point on both fibers."),
+                  suppressErrors);
+        return;
+    }
+
+    // The only consumable mutual link is one between exactly the two merge
+    // endpoints; anything else connecting these fibers blocks the merge.
+    const auto isPairLink = [&](const FiberBranchRef& branch, uint64_t otherId,
+                                const std::string& otherFile, int localIdx,
+                                int otherIdx) {
+        return branchReferencesFiber(branch, otherId, otherFile) &&
+            branch.controlPointIndex == localIdx &&
+            branch.branchControlPointIndex == otherIdx;
+    };
+    for (const auto& branch : clicked.branches) {
+        if (branchReferencesFiber(branch, farId, farFileName) &&
+            !isPairLink(branch, farId, farFileName, *clickedIndex, *candidateIndex)) {
+            showError(tr("These fibers are linked elsewhere; unlink first."),
+                      suppressErrors);
+            return;
+        }
+    }
+    for (const auto& branch : far.branches) {
+        if (branchReferencesFiber(branch, clickedId, clickedFileName) &&
+            !isPairLink(branch, clickedId, clickedFileName, *candidateIndex,
+                        *clickedIndex)) {
+            showError(tr("These fibers are linked elsewhere; unlink first."),
+                      suppressErrors);
+            return;
+        }
+    }
+
+    const auto pickedMode = pickMergeOptimizationMode(
+        session, clicked.optimizationMode, far.optimizationMode);
+    if (!pickedMode) {
+        return;
+    }
+
+    // Orient both sides so the clicked fiber ends at the join and the
+    // candidate fiber starts at it; the merged line reads clicked-first.
+    const bool reverseClicked = *clickedIndex == 0;
+    const bool reverseCandidate =
+        static_cast<size_t>(*candidateIndex) + 1 == farCount;
+    std::vector<vc3d::line_annotation::StoredControlPoint> clickedControls =
+        reverseClicked
+            ? vc3d::line_annotation::reversedStoredControlPoints(clicked.controlPoints)
+            : clicked.controlPoints;
+    std::vector<cv::Vec3d> clickedLine = clicked.linePoints;
+    if (reverseClicked) {
+        std::reverse(clickedLine.begin(), clickedLine.end());
+    }
+    std::vector<vc3d::line_annotation::StoredControlPoint> farControls =
+        reverseCandidate
+            ? vc3d::line_annotation::reversedStoredControlPoints(far.controlPoints)
+            : far.controlPoints;
+    std::vector<cv::Vec3d> farLine = far.linePoints;
+    if (reverseCandidate) {
+        std::reverse(farLine.begin(), farLine.end());
+    }
+    auto geometry = vc3d::line_annotation::computeFiberMergeGeometry(
+        clickedControls, clickedLine, farControls, farLine);
+    if (!geometry) {
+        showError(tr("Cannot merge: the stored control points do not resolve "
+                     "on the stored lines."),
+                  suppressErrors);
+        return;
+    }
+    const auto clickedRemap = [&](int idx) {
+        return reverseClicked ? static_cast<int>(clickedCount) - 1 - idx : idx;
+    };
+    const auto farRemap = [&](int idx) {
+        const int within = reverseCandidate
+            ? static_cast<int>(farCount) - 1 - idx
+            : idx;
+        return static_cast<int>(clickedCount) + within;
+    };
+
+    StoredFiber merged;
+    merged.username = currentFiberUsername();
+    merged.startedAt = currentFiberDateTimeString();
+    merged.sequence = nextFiberSequenceForUsername(merged.username);
+    merged.fileName = vc3d::line_annotation::fiberFileName(
+        merged.username, merged.startedAt, merged.sequence);
+    merged.id = std::max(nextFiberId(), std::max(clickedId, farId) + 1);
+    merged.generation = 1;
+    merged.controlPoints = std::move(geometry->controlPoints);
+    merged.linePoints = std::move(geometry->linePoints);
+    merged.optimizationMode = *pickedMode;
+    merged.manualHvTag =
+        clicked.manualHvTag == far.manualHvTag ? clicked.manualHvTag : std::string{};
+    for (const auto& tag : clicked.tags) {
+        addUniqueSorted(merged.tags, tag);
+    }
+    for (const auto& tag : far.tags) {
+        addUniqueSorted(merged.tags, tag);
+    }
+    // The join span has no real geometry until the merged line is re-fit.
+    addUniqueSorted(merged.tags, std::string{kNeedsReoptimizationTag});
+    merged.hvClassification = vc3d::line_annotation::classifyFiberHv(
+        vc3d::line_annotation::storedControlPointPositions(merged.controlPoints));
+    // Third-party links only: the pair link between the merge endpoints is
+    // consumed, and other mutual links were rejected above.
+    for (const auto& branch : clicked.branches) {
+        if (branchReferencesFiber(branch, farId, farFileName) ||
+            branch.controlPointIndex < 0) {
+            continue;
+        }
+        FiberBranchRef moved = branch;
+        moved.controlPointIndex = clickedRemap(branch.controlPointIndex);
+        merged.branches.push_back(std::move(moved));
+    }
+    for (const auto& branch : far.branches) {
+        if (branchReferencesFiber(branch, clickedId, clickedFileName) ||
+            branch.controlPointIndex < 0) {
+            continue;
+        }
+        FiberBranchRef moved = branch;
+        moved.controlPointIndex = farRemap(branch.controlPointIndex);
+        merged.branches.push_back(std::move(moved));
+    }
+
+    // Persist the merged fiber before touching any in-memory state.
+    try {
+        saveFiberNow(merged);
+    } catch (const std::exception& ex) {
+        showError(tr("Could not save the merged fiber: %1")
+                      .arg(QString::fromStdString(ex.what())),
+                  suppressErrors);
+        return;
+    }
+
+    const uint64_t mergedId = merged.id;
+    const std::string mergedFileName = merged.fileName;
+    const size_t joinControlIndex = geometry->joinControlIndex;
+    {
+        auto it = std::find_if(
+            _fibers.begin(), _fibers.end(), [&merged](const StoredFiber& existing) {
+                return (!merged.fileName.empty() &&
+                        existing.fileName == merged.fileName) ||
+                    existing.id == merged.id;
+            });
+        if (it == _fibers.end()) {
+            _fibers.push_back(std::move(merged));
+        } else {
+            *it = std::move(merged);
+        }
+    }
+
+    // Redirect third-party reciprocal refs from either original onto the
+    // merged fiber, indices through the orientation remaps.
+    std::vector<uint64_t> affectedFiberIds;
+    const auto redirectBranches = [&](std::vector<FiberBranchRef>& branches,
+                                      uint64_t ownerFiberId) {
+        bool changed = false;
+        for (auto& branch : branches) {
+            const bool toClicked =
+                branchReferencesFiber(branch, clickedId, clickedFileName);
+            const bool toFar = branchReferencesFiber(branch, farId, farFileName);
+            if ((!toClicked && !toFar) || branch.branchControlPointIndex < 0) {
+                continue;
+            }
+            branch.branchFiberId = mergedId;
+            branch.branchFileName = mergedFileName;
+            branch.branchControlPointIndex = toClicked
+                ? clickedRemap(branch.branchControlPointIndex)
+                : farRemap(branch.branchControlPointIndex);
+            changed = true;
+        }
+        if (changed) {
+            addUniqueFiberId(affectedFiberIds, ownerFiberId);
+        }
+    };
+    for (const auto& otherPane : _panes) {
+        if (otherPane.session && otherPane.session->fiberId != clickedId &&
+            otherPane.session->fiberId != farId) {
+            redirectBranches(otherPane.session->branches, otherPane.session->fiberId);
+        }
+    }
+    for (auto& fiber : _fibers) {
+        if (fiber.id != clickedId && fiber.id != farId) {
+            redirectBranches(fiber.branches, fiber.id);
+        }
+    }
+    scheduleBranchMetadataSaves(affectedFiberIds, 0);
+
+    _linkCandidate.reset();
+    if (_splitCandidate &&
+        (_splitCandidate->fiberId == clickedId || _splitCandidate->fiberId == farId)) {
+        _splitCandidate.reset();
+    }
+
+    // Retire both originals. Not deleteFibers: removeBranchLinksToFiber
+    // would strip the peer links just redirected. suppressFiberSave covers
+    // dialog-less inspection sessions too.
+    for (const auto& otherPane : _panes) {
+        if (otherPane.session && (otherPane.session->fiberId == clickedId ||
+                                  otherPane.session->fiberId == farId)) {
+            otherPane.session->suppressFiberSave = true;
+        }
+    }
+    // This handler runs inside the dialog's own menu-callback stack, and
+    // both waitForFiberSaves and the re-optimization spin nested event
+    // loops that would process the closed dialog's deferred deletion while
+    // its frames are still below us. Retire the originals and re-fit the
+    // merged line on a clean stack.
+    QTimer::singleShot(0, this, [this, clickedId, farId, clickedPath, farPath,
+                                 paneSurfaceName, mergedId, mergedFileName,
+                                 joinControlIndex, suppressErrors]() {
+        closeFiberWindowForSurface(paneSurfaceName);
+        // The close finalization may schedule an async save of an original;
+        // flush it before removing the files so they cannot be resurrected.
+        waitForFiberSaves();
+        std::error_code removeError;
+        if (!std::filesystem::remove(clickedPath, removeError) || removeError) {
+            showError(tr("Could not delete the original fiber file %1.")
+                          .arg(QString::fromStdString(clickedPath.string())),
+                      suppressErrors);
+        }
+        removeError.clear();
+        if (!std::filesystem::remove(farPath, removeError) || removeError) {
+            showError(tr("Could not delete the original fiber file %1.")
+                          .arg(QString::fromStdString(farPath.string())),
+                      suppressErrors);
+        }
+        _fibers.erase(std::remove_if(_fibers.begin(),
+                                     _fibers.end(),
+                                     [clickedId, farId](const StoredFiber& fiber) {
+                                         return fiber.id == clickedId ||
+                                             fiber.id == farId;
+                                     }),
+                      _fibers.end());
+        invalidateFiberAlignmentMetrics(clickedId, false);
+        invalidateFiberAlignmentMetrics(farId, false);
+        emit fibersDeleted(
+            {std::min(clickedId, farId), std::max(clickedId, farId)});
+
+        // Re-fit the merged line (join span + extrapolation tails); consumes
+        // the needs_reoptimization tag, which otherwise re-prompts on load.
+        reoptimizeMergedFibers({mergedFileName});
+
+        invalidateFiberAlignmentMetrics(mergedId, true);
+        emitFiberSummaries();
+        refreshBranchLineViews();
+        openFiberAtControlPoint(mergedId, static_cast<int>(joinControlIndex));
+    });
+}
+
+void LineAnnotationController::handleGeneratedControlPointSplitCandidate(
+    const std::string& surfaceName,
+    size_t controlPointIndex,
+    cv::Vec3f volumePoint)
+{
+    (void)volumePoint;
+    auto* pane = paneForSurface(surfaceName);
+    if (!pane || !pane->session) {
+        return;
+    }
+    auto& session = *pane->session;
+    if (controlPointIndex >= session.controlPoints.size()) {
+        return;
+    }
+    // Unlike the link candidate, a linked CP is a legal split point: its
+    // branch links are remapped onto the halves rather than severed.
+    const cv::Vec3d candidatePosition = session.controlPoints[controlPointIndex].volumePoint;
+    if (!finitePoint(candidatePosition)) {
+        showError(tr("Could not determine a finite position for the split candidate."));
+        return;
+    }
+    ensureSessionFiberIdentity(session);
+    if (session.fiberId == 0) {
+        session.fiberId = nextFiberId();
+    }
+
+    LinkCandidate candidate;
+    candidate.fiberId = session.fiberId;
+    candidate.fiberFileName = session.fiberFileName;
+    candidate.position = candidatePosition;
+    const auto storedIndexMap = storedIndexMapForSessionControls(session.controlPoints);
+    if (controlPointIndex < storedIndexMap.size()) {
+        candidate.storedControlPointIndexHint = storedIndexMap[controlPointIndex];
+    }
+    _splitCandidate = candidate;
+
+    if (pane->dialog) {
+        pane->dialog->setGeneratedBranchOverlayData(
+            controlMarkersForSession(session),
+            generatedBranchLinePointsForSession(session),
+            generatedBranchLinkMarkers(session.branches),
+            false,
+            generatedSpanAlignmentMetricsForSession(session));
+    }
+}
+
+void LineAnnotationController::handleGeneratedControlPointSplitFromCandidate(
+    const std::string& surfaceName,
+    size_t controlPointIndex,
+    cv::Vec3f volumePoint,
+    bool linkHalves)
+{
+    (void)volumePoint;
+    auto* pane = paneForSurface(surfaceName);
+    if (!pane || !pane->session) {
+        return;
+    }
+    auto& session = *pane->session;
+    if (session.taskState == LineAnnotationSession::TaskState::Running) {
+        showError(tr("Line optimization is already running."));
+        return;
+    }
+    if (controlPointIndex >= session.controlPoints.size()) {
+        return;
+    }
+    if (!_splitCandidate || _splitCandidate->fiberId == 0) {
+        showError(tr("No split candidate is designated."));
+        return;
+    }
+    ensureSessionFiberIdentity(session);
+    if (session.fiberId == 0) {
+        session.fiberId = nextFiberId();
+    }
+    if (session.fiberId != _splitCandidate->fiberId) {
+        showError(tr("The split candidate is on a different fiber; designate one on "
+                     "this fiber."));
+        return;
+    }
+    const bool suppressErrors = session.suppressErrorDialogs;
+
+    // Bake unsaved session edits (and the branch-metadata sync they imply)
+    // into a stored snapshot; everything below works on that snapshot so no
+    // in-memory state mutates until both halves are safely on disk.
+    const StoredFiber parent = storedFiberFromSession(session);
+    const uint64_t parentId = parent.id;
+    const std::string parentFileName = parent.fileName;
+    const std::filesystem::path parentPath = fiberPath(parent);
+    const std::string paneSurfaceName = pane->surfaceName;
+
+    const LinkCandidate candidate = *_splitCandidate;
+    const auto candidateIndex = matchingStoredControlPointIndex(
+        parent.controlPoints,
+        candidate.storedControlPointIndexHint,
+        candidate.position);
+    if (!candidateIndex) {
+        _splitCandidate.reset();
+        showError(tr("The split candidate control point no longer exists."), suppressErrors);
+        return;
+    }
+    int clickedIndexHint = -1;
+    const auto storedIndexMap = storedIndexMapForSessionControls(session.controlPoints);
+    if (controlPointIndex < storedIndexMap.size()) {
+        clickedIndexHint = storedIndexMap[controlPointIndex];
+    }
+    const auto clickedIndex = matchingStoredControlPointIndex(
+        parent.controlPoints,
+        clickedIndexHint,
+        session.controlPoints[controlPointIndex].volumePoint);
+    if (!clickedIndex) {
+        showError(tr("Could not resolve the clicked control point."), suppressErrors);
+        return;
+    }
+    if (std::abs(*clickedIndex - *candidateIndex) != 1) {
+        showError(tr("Split requires the control point adjacent to the candidate."),
+                  suppressErrors);
+        return;
+    }
+    const size_t splitAfter = static_cast<size_t>(std::min(*clickedIndex, *candidateIndex));
+    const auto plan = vc3d::line_annotation::computeFiberSplitPlan(
+        vc3d::line_annotation::storedControlPointPositions(parent.controlPoints),
+        parent.linePoints,
+        splitAfter);
+    if (!plan) {
+        showError(tr("Cannot split here: each half must keep at least 2 control "
+                     "points on the stored line."),
+                  suppressErrors);
+        return;
+    }
+
+    // Both halves are brand-new fibers: fresh canonical identities, geometry
+    // and per-span metadata inherited verbatim, branch links partitioned by
+    // control-point range.
+    const std::string username = currentFiberUsername();
+    const std::string startedAt = currentFiberDateTimeString();
+    const uint64_t prefixSequence = nextFiberSequenceForUsername(username);
+    const uint64_t prefixId = std::max(nextFiberId(), parentId + 1);
+
+    const auto makeHalf = [&](uint64_t id, uint64_t sequence) {
+        StoredFiber half;
+        half.id = id;
+        half.username = username;
+        half.startedAt = startedAt;
+        half.sequence = sequence;
+        half.fileName = vc3d::line_annotation::fiberFileName(username, startedAt, sequence);
+        half.generation = 1;
+        half.manualHvTag = parent.manualHvTag;
+        half.tags = parent.tags;
+        // The parent's extrapolated tails don't survive the cut: each half
+        // ends exactly on its split CP until its line is re-fit. The tag
+        // arms the immediate re-optimization below and, should that batch
+        // abort, the next load's prompt.
+        addUniqueSorted(half.tags, std::string{kNeedsReoptimizationTag});
+        half.optimizationMode = parent.optimizationMode;
+        return half;
+    };
+    StoredFiber prefix = makeHalf(prefixId, prefixSequence);
+    StoredFiber suffix = makeHalf(prefixId + 1, prefixSequence + 1);
+
+    prefix.controlPoints.assign(parent.controlPoints.begin(),
+                                parent.controlPoints.begin() + plan->prefixControlCount);
+    // The removed span's descriptor lives on the new final CP; clearing it
+    // is the span deletion and restores the v3 final-CP contract.
+    prefix.controlPoints.back().segmentToNext.reset();
+    prefix.linePoints.assign(parent.linePoints.begin(),
+                             parent.linePoints.begin() + plan->prefixLineCount);
+    suffix.controlPoints.assign(parent.controlPoints.begin() + plan->suffixControlBegin,
+                                parent.controlPoints.end());
+    suffix.linePoints.assign(parent.linePoints.begin() + plan->suffixLineBegin,
+                             parent.linePoints.end());
+
+    for (const auto& branch : parent.branches) {
+        const auto remapped =
+            vc3d::line_annotation::remappedSplitControlPointIndex(*plan,
+                                                                  branch.controlPointIndex);
+        if (!remapped) {
+            continue;
+        }
+        FiberBranchRef moved = branch;
+        moved.controlPointIndex = remapped->second;
+        (remapped->first ? suffix : prefix).branches.push_back(std::move(moved));
+    }
+    prefix.hvClassification = vc3d::line_annotation::classifyFiberHv(
+        vc3d::line_annotation::storedControlPointPositions(prefix.controlPoints));
+    suffix.hvClassification = vc3d::line_annotation::classifyFiberHv(
+        vc3d::line_annotation::storedControlPointPositions(suffix.controlPoints));
+
+    if (linkHalves) {
+        // "Split from candidate and link": record the boundary connection as
+        // a reciprocal branch link. It lands pending like any manual link —
+        // the split asserts these are different fibers, but whether they
+        // share a winding is a separate call for a reviewer to approve.
+        const cv::Vec3d prefixPoint = prefix.controlPoints.back();
+        const cv::Vec3d suffixPoint = suffix.controlPoints.front();
+        const cv::Vec3d fallbackDirection = normalizedOrZero(suffixPoint - prefixPoint);
+
+        FiberBranchRef prefixRef;
+        prefixRef.pending = true;
+        prefixRef.controlPointIndex =
+            static_cast<int>(prefix.controlPoints.size()) - 1;
+        prefixRef.branchFiberId = suffix.id;
+        prefixRef.branchControlPointIndex = 0;
+        prefixRef.branchFileName = suffix.fileName;
+        prefixRef.controlPointDirection = endpointTangentFromLinePoints(
+            prefix.linePoints, prefixPoint, fallbackDirection);
+        prefixRef.branchControlPointDirection = endpointTangentFromLinePoints(
+            suffix.linePoints, suffixPoint, -fallbackDirection);
+        prefixRef.controlPointPosition = prefixPoint;
+        prefixRef.branchControlPointPosition = suffixPoint;
+
+        FiberBranchRef suffixRef;
+        suffixRef.pending = true;
+        suffixRef.controlPointIndex = 0;
+        suffixRef.branchFiberId = prefix.id;
+        suffixRef.branchControlPointIndex = prefixRef.controlPointIndex;
+        suffixRef.branchFileName = prefix.fileName;
+        suffixRef.controlPointDirection = prefixRef.branchControlPointDirection;
+        suffixRef.branchControlPointDirection = prefixRef.controlPointDirection;
+        suffixRef.controlPointPosition = suffixPoint;
+        suffixRef.branchControlPointPosition = prefixPoint;
+
+        prefix.branches.push_back(std::move(prefixRef));
+        suffix.branches.push_back(std::move(suffixRef));
+    }
+
+    // Persist both halves before touching any in-memory state; a failure
+    // here aborts the split with nothing to roll back.
+    try {
+        saveFiberNow(prefix);
+        try {
+            saveFiberNow(suffix);
+        } catch (...) {
+            std::error_code removeError;
+            std::filesystem::remove(fiberPath(prefix), removeError);
+            throw;
+        }
+    } catch (const std::exception& ex) {
+        showError(tr("Could not save the split fibers: %1")
+                      .arg(QString::fromStdString(ex.what())),
+                  suppressErrors);
+        return;
+    }
+
+    const auto upsertFiber = [this](StoredFiber fiber) {
+        auto it = std::find_if(
+            _fibers.begin(),
+            _fibers.end(),
+            [&fiber](const StoredFiber& existing) {
+                return (!fiber.fileName.empty() && existing.fileName == fiber.fileName) ||
+                       existing.id == fiber.id;
+            });
+        if (it == _fibers.end()) {
+            _fibers.push_back(std::move(fiber));
+        } else {
+            *it = std::move(fiber);
+        }
+    };
+    const uint64_t prefixFiberId = prefix.id;
+    const uint64_t suffixFiberId = suffix.id;
+    const std::string prefixFileName = prefix.fileName;
+    const std::string suffixFileName = suffix.fileName;
+    upsertFiber(std::move(prefix));
+    upsertFiber(std::move(suffix));
+
+    // Fan-out of syncBranchFiberFileRename: reciprocal refs on peers move to
+    // whichever half now owns their control point.
+    std::vector<uint64_t> affectedFiberIds;
+    const auto redirectBranches = [&](std::vector<FiberBranchRef>& branches,
+                                      uint64_t ownerFiberId) {
+        bool changed = false;
+        for (auto& branch : branches) {
+            if (!branchReferencesFiber(branch, parentId, parentFileName)) {
+                continue;
+            }
+            const auto remapped = vc3d::line_annotation::remappedSplitControlPointIndex(
+                *plan, branch.branchControlPointIndex);
+            if (!remapped) {
+                continue;
+            }
+            const auto halfIt = std::find_if(
+                _fibers.begin(),
+                _fibers.end(),
+                [halfId = remapped->first ? suffixFiberId : prefixFiberId](
+                    const StoredFiber& fiber) { return fiber.id == halfId; });
+            if (halfIt == _fibers.end()) {
+                continue;
+            }
+            branch.branchFiberId = halfIt->id;
+            branch.branchFileName = halfIt->fileName;
+            branch.branchControlPointIndex = remapped->second;
+            changed = true;
+        }
+        if (changed) {
+            addUniqueFiberId(affectedFiberIds, ownerFiberId);
+        }
+    };
+    for (const auto& otherPane : _panes) {
+        if (otherPane.session && otherPane.session->fiberId != parentId) {
+            redirectBranches(otherPane.session->branches, otherPane.session->fiberId);
+        }
+    }
+    for (auto& fiber : _fibers) {
+        redirectBranches(fiber.branches, fiber.id);
+    }
+    scheduleBranchMetadataSaves(affectedFiberIds, parentId);
+
+    _splitCandidate.reset();
+    if (_linkCandidate && _linkCandidate->fiberId == parentId) {
+        _linkCandidate.reset();
+    }
+
+    // Retire the original. Not deleteFibers: removeBranchLinksToFiber would
+    // strip and re-save the peer links redirected above. cleanupSurfaceName
+    // runs on the deferred dialog destruction and skips the closing save via
+    // suppressFiberSave.
+    for (const auto& otherPane : _panes) {
+        if (otherPane.session && otherPane.session->fiberId == parentId) {
+            otherPane.session->suppressFiberSave = true;
+        }
+    }
+    const auto reopenTarget =
+        vc3d::line_annotation::remappedSplitControlPointIndex(*plan, *candidateIndex);
+    const uint64_t reopenFiberId = reopenTarget && reopenTarget->first
+        ? suffixFiberId
+        : prefixFiberId;
+    const int reopenControlIndex = reopenTarget ? reopenTarget->second : -1;
+
+    // This handler runs inside the dialog's own menu-callback stack, and
+    // both waitForFiberSaves and the re-optimization spin nested event
+    // loops that would process the closed dialog's deferred deletion while
+    // its frames are still below us. Retire the original and re-fit the
+    // halves on a clean stack.
+    QTimer::singleShot(0, this, [this, parentId, parentPath, paneSurfaceName,
+                                 prefixFiberId, suffixFiberId, prefixFileName,
+                                 suffixFileName, reopenFiberId,
+                                 reopenControlIndex, suppressErrors]() {
+        closeFiberWindowForSurface(paneSurfaceName);
+        // The close finalization may schedule an async save of the original;
+        // flush it before removing the file so it cannot be resurrected.
+        waitForFiberSaves();
+        std::error_code removeError;
+        if (!std::filesystem::remove(parentPath, removeError) || removeError) {
+            showError(tr("Could not delete the original fiber file %1.")
+                          .arg(QString::fromStdString(parentPath.string())),
+                      suppressErrors);
+        }
+        _fibers.erase(std::remove_if(_fibers.begin(),
+                                     _fibers.end(),
+                                     [parentId](const StoredFiber& fiber) {
+                                         return fiber.id == parentId;
+                                     }),
+                      _fibers.end());
+        invalidateFiberAlignmentMetrics(parentId, false);
+        emit fibersDeleted({parentId});
+
+        // Re-fit both halves so their lines regrow extrapolation tails past
+        // the split CPs. Consumes the needs_reoptimization tag set at
+        // creation; an aborted batch keeps it for the next load's prompt.
+        reoptimizeMergedFibers({prefixFileName, suffixFileName});
+
+        invalidateFiberAlignmentMetrics(prefixFiberId, true);
+        invalidateFiberAlignmentMetrics(suffixFiberId, true);
+        emitFiberSummaries();
+        refreshBranchLineViews();
+
+        if (reopenControlIndex >= 0) {
+            openFiberAtControlPoint(reopenFiberId, reopenControlIndex);
+        }
+    });
 }
 
 void LineAnnotationController::handleGeneratedControlPointUnlink(
@@ -8742,6 +9675,7 @@ void LineAnnotationController::loadFibersForCurrentPackage()
     // Runtime fiber ids are reassigned per package load; a surviving candidate
     // could silently point at an unrelated fiber with the same id.
     _linkCandidate.reset();
+    _splitCandidate.reset();
     _fibers.clear();
     _fiberAlignmentMetrics.clear();
     _pendingFiberAlignmentMetrics.clear();

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -7174,14 +7174,24 @@ void LineAnnotationController::handleGeneratedControlPointMergeWithCandidate(
         merged.branches.push_back(std::move(moved));
     }
 
-    // Persist the merged fiber before touching any in-memory state.
-    try {
-        saveFiberNow(merged);
-    } catch (const std::exception& ex) {
-        showError(tr("Could not save the merged fiber: %1")
-                      .arg(QString::fromStdString(ex.what())),
-                  suppressErrors);
+    // Persist the merged fiber (temp write + atomic rename) before touching
+    // any in-memory state.
+    std::error_code collisionError;
+    if (std::filesystem::exists(fiberPath(merged), collisionError)) {
+        showError(tr("A fiber file with the new name already exists."), suppressErrors);
         return;
+    }
+    {
+        const auto saveResult = vc3d::line_annotation::runFiberSaveJob(
+            ++_nextFiberSaveSequence,
+            {vc3d::line_annotation::FiberSavePayload{
+                merged.id, merged.generation, fiberPath(merged), fiberToJson(merged)}});
+        if (!saveResult.ok) {
+            showError(tr("Could not save the merged fiber: %1")
+                          .arg(QString::fromStdString(saveResult.error)),
+                      suppressErrors);
+            return;
+        }
     }
 
     const uint64_t mergedId = merged.id;
@@ -7263,18 +7273,14 @@ void LineAnnotationController::handleGeneratedControlPointMergeWithCandidate(
                                  joinControlIndex, suppressErrors]() {
         closeFiberWindowForSurface(paneSurfaceName);
         // The close finalization may schedule an async save of an original;
-        // flush it before removing the files so they cannot be resurrected.
+        // flush it before retiring the files so they cannot be resurrected.
         waitForFiberSaves();
-        std::error_code removeError;
-        if (!std::filesystem::remove(clickedPath, removeError) || removeError) {
-            showError(tr("Could not delete the original fiber file %1.")
-                          .arg(QString::fromStdString(clickedPath.string())),
-                      suppressErrors);
-        }
-        removeError.clear();
-        if (!std::filesystem::remove(farPath, removeError) || removeError) {
-            showError(tr("Could not delete the original fiber file %1.")
-                          .arg(QString::fromStdString(farPath.string())),
+        // All-or-nothing: a failure restores both originals in place.
+        const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
+            ++_nextFiberSaveSequence, {}, {clickedPath, farPath});
+        if (!retireResult.ok) {
+            showError(tr("Could not retire the original fiber files: %1")
+                          .arg(QString::fromStdString(retireResult.error)),
                       suppressErrors);
         }
         _fibers.erase(std::remove_if(_fibers.begin(),
@@ -7524,22 +7530,28 @@ void LineAnnotationController::handleGeneratedControlPointSplitFromCandidate(
         suffix.branches.push_back(std::move(suffixRef));
     }
 
-    // Persist both halves before touching any in-memory state; a failure
-    // here aborts the split with nothing to roll back.
-    try {
-        saveFiberNow(prefix);
-        try {
-            saveFiberNow(suffix);
-        } catch (...) {
-            std::error_code removeError;
-            std::filesystem::remove(fiberPath(prefix), removeError);
-            throw;
-        }
-    } catch (const std::exception& ex) {
-        showError(tr("Could not save the split fibers: %1")
-                      .arg(QString::fromStdString(ex.what())),
-                  suppressErrors);
+    // Persist both halves in one transaction (temp writes + atomic renames
+    // with rollback) before touching any in-memory state; a failure aborts
+    // the split with nothing to undo.
+    std::error_code collisionError;
+    if (std::filesystem::exists(fiberPath(prefix), collisionError) ||
+        std::filesystem::exists(fiberPath(suffix), collisionError)) {
+        showError(tr("A fiber file with the new name already exists."), suppressErrors);
         return;
+    }
+    {
+        const auto saveResult = vc3d::line_annotation::runFiberSaveJob(
+            ++_nextFiberSaveSequence,
+            {vc3d::line_annotation::FiberSavePayload{
+                 prefix.id, prefix.generation, fiberPath(prefix), fiberToJson(prefix)},
+             vc3d::line_annotation::FiberSavePayload{
+                 suffix.id, suffix.generation, fiberPath(suffix), fiberToJson(suffix)}});
+        if (!saveResult.ok) {
+            showError(tr("Could not save the split fibers: %1")
+                          .arg(QString::fromStdString(saveResult.error)),
+                      suppressErrors);
+            return;
+        }
     }
 
     const auto upsertFiber = [this](StoredFiber fiber) {
@@ -7637,12 +7649,14 @@ void LineAnnotationController::handleGeneratedControlPointSplitFromCandidate(
                                  reopenControlIndex, suppressErrors]() {
         closeFiberWindowForSurface(paneSurfaceName);
         // The close finalization may schedule an async save of the original;
-        // flush it before removing the file so it cannot be resurrected.
+        // flush it before retiring the file so it cannot be resurrected.
         waitForFiberSaves();
-        std::error_code removeError;
-        if (!std::filesystem::remove(parentPath, removeError) || removeError) {
-            showError(tr("Could not delete the original fiber file %1.")
-                          .arg(QString::fromStdString(parentPath.string())),
+        const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
+            ++_nextFiberSaveSequence, {}, {parentPath});
+        if (!retireResult.ok) {
+            showError(tr("Could not retire the original fiber file %1: %2")
+                          .arg(QString::fromStdString(parentPath.string()))
+                          .arg(QString::fromStdString(retireResult.error)),
                       suppressErrors);
         }
         _fibers.erase(std::remove_if(_fibers.begin(),

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -6984,6 +6984,32 @@ void LineAnnotationController::handleGeneratedControlPointMergeWithCandidate(
     const std::string paneSurfaceName = pane->surfaceName;
 
     const LinkCandidate candidate = *_linkCandidate;
+    // The candidate fiber can be open in a dialog-less editing session with
+    // unsaved changes; merging (and then deleting) the stale stored snapshot
+    // would discard them. Bake such a session into _fibers first — same
+    // eligibility guards as scheduleBranchMetadataSaves.
+    for (const auto& otherPane : _panes) {
+        if (!otherPane.session ||
+            otherPane.session->fiberId != candidate.fiberId ||
+            otherPane.session->suppressFiberSave ||
+            otherPane.session->taskState != LineAnnotationSession::TaskState::Succeeded ||
+            otherPane.session->optimizedLine.points.empty() ||
+            otherPane.session->controlPoints.empty()) {
+            continue;
+        }
+        StoredFiber liveFar = storedFiberFromSession(*otherPane.session);
+        auto liveIt = std::find_if(
+            _fibers.begin(), _fibers.end(), [&liveFar](const StoredFiber& fiber) {
+                return fiber.id == liveFar.id ||
+                    (!liveFar.fileName.empty() && fiber.fileName == liveFar.fileName);
+            });
+        if (liveIt == _fibers.end()) {
+            _fibers.push_back(std::move(liveFar));
+        } else {
+            *liveIt = std::move(liveFar);
+        }
+        break;
+    }
     const auto candidateIt = std::find_if(
         _fibers.begin(), _fibers.end(), [&candidate](const StoredFiber& fiber) {
             return fiber.id == candidate.fiberId;

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -5316,23 +5316,48 @@ LineAnnotationController::mergeCandidateMenuState(const LineAnnotationSession& s
         return state;
     }
     // Merging joins fiber endpoints; gate on the candidate side here, the
-    // clicked side is validated in the handler.
-    const auto fiberIt = std::find_if(
-        _fibers.begin(), _fibers.end(), [this](const StoredFiber& fiber) {
-            return fiber.id == _linkCandidate->fiberId;
-        });
-    if (fiberIt == _fibers.end()) {
-        return state;
+    // clicked side is validated in the handler. Prefer a live editing
+    // session's geometry so enablement agrees with the handler, which
+    // bakes such a session before merging.
+    std::optional<int> candidateIndex;
+    size_t controlCount = 0;
+    bool candidateResolved = false;
+    for (const auto& pane : _panes) {
+        if (!pane.session || pane.session->fiberId != _linkCandidate->fiberId) {
+            continue;
+        }
+        const auto sessionIndex = sessionControlPointIndexByPosition(
+            pane.session->controlPoints, _linkCandidate->position);
+        if (sessionIndex) {
+            const auto storedIndexMap =
+                storedIndexMapForSessionControls(pane.session->controlPoints);
+            if (static_cast<size_t>(*sessionIndex) < storedIndexMap.size()) {
+                candidateIndex = storedIndexMap[*sessionIndex];
+            }
+        }
+        controlCount = pane.session->controlPoints.size();
+        candidateResolved = true;
+        break;
     }
-    const auto candidateIndex = matchingStoredControlPointIndex(
-        fiberIt->controlPoints,
-        _linkCandidate->storedControlPointIndexHint,
-        _linkCandidate->position);
+    if (!candidateResolved) {
+        const auto fiberIt = std::find_if(
+            _fibers.begin(), _fibers.end(), [this](const StoredFiber& fiber) {
+                return fiber.id == _linkCandidate->fiberId;
+            });
+        if (fiberIt == _fibers.end()) {
+            return state;
+        }
+        candidateIndex = matchingStoredControlPointIndex(
+            fiberIt->controlPoints,
+            _linkCandidate->storedControlPointIndexHint,
+            _linkCandidate->position);
+        controlCount = fiberIt->controlPoints.size();
+    }
     if (!candidateIndex) {
         return state;
     }
     if (*candidateIndex != 0 &&
-        static_cast<size_t>(*candidateIndex) + 1 != fiberIt->controlPoints.size()) {
+        static_cast<size_t>(*candidateIndex) + 1 != controlCount) {
         state.enabled = false;
         state.label = tr("Merge with candidate (not an endpoint)");
         return state;
@@ -7308,52 +7333,62 @@ void LineAnnotationController::handleGeneratedControlPointMergeWithCandidate(
                                  mergedId, mergedFileName,
                                  joinControlIndex, suppressErrors]() {
         closeDialogPanesForFibers({clickedId, farId});
-        // The close finalization may schedule an async save of an original;
-        // flush it before retiring the files so they cannot be resurrected.
-        // A failure among the flushed saves (the redirected peer links ride
-        // this queue) keeps the originals on disk AND in memory: disk and
-        // panel then agree, showing the originals beside the merged fiber.
-        const uint64_t saveFailuresBefore = _fiberSaveFailureCount;
-        waitForFiberSaves();
-        bool retired = _fiberSaveFailureCount == saveFailuresBefore;
-        if (!retired) {
-            showError(tr("A pending fiber save failed; the original fiber "
-                         "files were kept."),
-                      suppressErrors);
-        } else {
-            // All-or-nothing: a failure restores both originals in place.
-            const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
-                ++_nextFiberSaveSequence, {}, {clickedPath, farPath});
-            retired = retireResult.ok;
-            if (!retired) {
-                showError(tr("Could not retire the original fiber files: %1")
-                              .arg(QString::fromStdString(retireResult.error)),
-                          suppressErrors);
-            }
-        }
-        if (retired) {
-            _fibers.erase(std::remove_if(_fibers.begin(),
-                                         _fibers.end(),
-                                         [clickedId, farId](const StoredFiber& fiber) {
-                                             return fiber.id == clickedId ||
-                                                 fiber.id == farId;
-                                         }),
-                          _fibers.end());
-            invalidateFiberAlignmentMetrics(clickedId, false);
-            invalidateFiberAlignmentMetrics(farId, false);
-            emit fibersDeleted(
-                {std::min(clickedId, farId), std::max(clickedId, farId)});
-            closeIntersectionInspectionForRetiredFibers({clickedId, farId});
-        } else {
-            // The originals live on; surviving sessions must be saveable
-            // again or later edits would be silently dropped.
+        closeIntersectionInspectionForRetiredFibers({clickedId, farId});
+        // Fail loudly instead of reconciling: on any problem below, the
+        // originals are kept, their surviving sessions are made saveable
+        // again, and a full reload rebuilds memory from disk (branch refs
+        // re-derive from branch_file; the merged fiber's
+        // needs_reoptimization tag re-prompts the re-fit). The user
+        // resolves the duplicate old/new fibers.
+        const auto bailOut = [this, clickedId, farId,
+                              suppressErrors](const QString& reason) {
             for (const auto& otherPane : _panes) {
                 if (otherPane.session && (otherPane.session->fiberId == clickedId ||
                                           otherPane.session->fiberId == farId)) {
                     otherPane.session->suppressFiberSave = false;
                 }
             }
+            showError(tr("The merge could not be completed: %1\nThe original "
+                         "fibers were kept; reloading fibers from disk.")
+                          .arg(reason),
+                      suppressErrors);
+            loadFibersForCurrentPackage();
+        };
+        // Flush the queue (the redirected peer links ride it) and the close
+        // before retiring, so a failed save or a pane that refused to close
+        // (failed finalization) is caught while the originals still exist.
+        const uint64_t saveFailuresBefore = _fiberSaveFailureCount;
+        waitForFiberSaves();
+        if (_fiberSaveFailureCount != saveFailuresBefore) {
+            bailOut(tr("a pending fiber save failed"));
+            return;
         }
+        for (const auto& otherPane : _panes) {
+            if (otherPane.session && otherPane.dialog &&
+                (otherPane.session->fiberId == clickedId ||
+                 otherPane.session->fiberId == farId)) {
+                bailOut(tr("the annotation workspace did not close"));
+                return;
+            }
+        }
+        // All-or-nothing: a failure restores both originals in place.
+        const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
+            ++_nextFiberSaveSequence, {}, {clickedPath, farPath});
+        if (!retireResult.ok) {
+            bailOut(QString::fromStdString(retireResult.error));
+            return;
+        }
+        _fibers.erase(std::remove_if(_fibers.begin(),
+                                     _fibers.end(),
+                                     [clickedId, farId](const StoredFiber& fiber) {
+                                         return fiber.id == clickedId ||
+                                             fiber.id == farId;
+                                     }),
+                      _fibers.end());
+        invalidateFiberAlignmentMetrics(clickedId, false);
+        invalidateFiberAlignmentMetrics(farId, false);
+        emit fibersDeleted(
+            {std::min(clickedId, farId), std::max(clickedId, farId)});
 
         // Re-fit the merged line (join span + extrapolation tails); consumes
         // the needs_reoptimization tag, which otherwise re-prompts on load.
@@ -7707,48 +7742,54 @@ void LineAnnotationController::handleGeneratedControlPointSplitFromCandidate(
                                  suffixFileName, reopenFiberId,
                                  reopenControlIndex, suppressErrors]() {
         closeDialogPanesForFibers({parentId});
-        // The close finalization may schedule an async save of the original;
-        // flush it before retiring the file so it cannot be resurrected. A
-        // failure among the flushed saves (the redirected peer links ride
-        // this queue) keeps the original on disk AND in memory: disk and
-        // panel then agree, showing the original beside its halves.
-        const uint64_t saveFailuresBefore = _fiberSaveFailureCount;
-        waitForFiberSaves();
-        bool retired = _fiberSaveFailureCount == saveFailuresBefore;
-        if (!retired) {
-            showError(tr("A pending fiber save failed; the original fiber "
-                         "file was kept."),
-                      suppressErrors);
-        } else {
-            const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
-                ++_nextFiberSaveSequence, {}, {parentPath});
-            retired = retireResult.ok;
-            if (!retired) {
-                showError(tr("Could not retire the original fiber file %1: %2")
-                              .arg(QString::fromStdString(parentPath.string()))
-                              .arg(QString::fromStdString(retireResult.error)),
-                          suppressErrors);
-            }
-        }
-        if (retired) {
-            _fibers.erase(std::remove_if(_fibers.begin(),
-                                         _fibers.end(),
-                                         [parentId](const StoredFiber& fiber) {
-                                             return fiber.id == parentId;
-                                         }),
-                          _fibers.end());
-            invalidateFiberAlignmentMetrics(parentId, false);
-            emit fibersDeleted({parentId});
-            closeIntersectionInspectionForRetiredFibers({parentId});
-        } else {
-            // The original lives on; surviving sessions must be saveable
-            // again or later edits would be silently dropped.
+        closeIntersectionInspectionForRetiredFibers({parentId});
+        // Fail loudly instead of reconciling: on any problem below, the
+        // original is kept, its surviving sessions are made saveable again,
+        // and a full reload rebuilds memory from disk (branch refs re-derive
+        // from branch_file; the halves' needs_reoptimization tag re-prompts
+        // the re-fit). The user resolves the duplicate old/new fibers.
+        const auto bailOut = [this, parentId, suppressErrors](const QString& reason) {
             for (const auto& otherPane : _panes) {
                 if (otherPane.session && otherPane.session->fiberId == parentId) {
                     otherPane.session->suppressFiberSave = false;
                 }
             }
+            showError(tr("The split could not be completed: %1\nThe original "
+                         "fiber was kept; reloading fibers from disk.")
+                          .arg(reason),
+                      suppressErrors);
+            loadFibersForCurrentPackage();
+        };
+        // Flush the queue (the redirected peer links ride it) and the close
+        // before retiring, so a failed save or a pane that refused to close
+        // (failed finalization) is caught while the original still exists.
+        const uint64_t saveFailuresBefore = _fiberSaveFailureCount;
+        waitForFiberSaves();
+        if (_fiberSaveFailureCount != saveFailuresBefore) {
+            bailOut(tr("a pending fiber save failed"));
+            return;
         }
+        for (const auto& otherPane : _panes) {
+            if (otherPane.session && otherPane.dialog &&
+                otherPane.session->fiberId == parentId) {
+                bailOut(tr("the annotation workspace did not close"));
+                return;
+            }
+        }
+        const auto retireResult = vc3d::line_annotation::runFiberSaveJob(
+            ++_nextFiberSaveSequence, {}, {parentPath});
+        if (!retireResult.ok) {
+            bailOut(QString::fromStdString(retireResult.error));
+            return;
+        }
+        _fibers.erase(std::remove_if(_fibers.begin(),
+                                     _fibers.end(),
+                                     [parentId](const StoredFiber& fiber) {
+                                         return fiber.id == parentId;
+                                     }),
+                      _fibers.end());
+        invalidateFiberAlignmentMetrics(parentId, false);
+        emit fibersDeleted({parentId});
 
         // Re-fit both halves so their lines regrow extrapolation tails past
         // the split CPs. Consumes the needs_reoptimization tag set at

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -748,6 +748,12 @@ private:
     // saveOpenFibersHeadless (no waiting).
     void saveOpenFibersCore();
     void cleanupIntersectionInspectionSurfaces();
+    // Tears down the intersection-inspection workspace when one of its
+    // editing sessions holds a fiber that was just retired (split/merge);
+    // otherwise the pane would stay open and editable with all saves
+    // suppressed.
+    void closeIntersectionInspectionForRetiredFibers(
+        const std::vector<uint64_t>& fiberIds);
     // Returns false on failure; with a non-null `errorMessage` the failure is
     // reported there (dialog-free), otherwise via showError (interactive).
     bool rebuildIntersectionInspection(QString* errorMessage = nullptr);
@@ -789,6 +795,10 @@ private:
     QPointer<QFutureWatcher<FiberSaveTaskResult>> _fiberSaveWatcher;
     uint64_t _nextFiberSaveSequence = 0;
     bool _fiberSaveRunning = false;
+    // Total failed save jobs; callers compare before/after a
+    // waitForFiberSaves() flush to gate destructive follow-ups (fiber
+    // retirement) on the flushed saves having actually succeeded.
+    uint64_t _fiberSaveFailureCount = 0;
     mutable std::shared_ptr<FiberSaveBatchTracker> _activeFiberSaveBatch;
     uint64_t _nextSideStripIntersectionToken = 0;
     uint64_t _latestSideStripIntersectionToken = 0;

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -754,6 +754,11 @@ private:
     // suppressed.
     void closeIntersectionInspectionForRetiredFibers(
         const std::vector<uint64_t>& fiberIds);
+    // Closes every dialog pane whose session holds one of the fibers. The
+    // single-dialog invariant means at most the invoking pane matches
+    // today; sweeping by fiber id keeps split/merge retirement correct by
+    // construction rather than by that invariant.
+    void closeDialogPanesForFibers(const std::vector<uint64_t>& fiberIds);
     // Returns false on failure; with a non-null `errorMessage` the failure is
     // reported there (dialog-free), otherwise via showError (interactive).
     bool rebuildIntersectionInspection(QString* errorMessage = nullptr);

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -267,6 +267,13 @@ public:
     // whether to proceed.
     void setModeChangeConfirmationForTesting(
         std::function<bool(vc3d::line_annotation::FiberOptimizationMode)> confirmer);
+    // Replaces the modal QMessageBox shown when the two fibers of a merge
+    // carry different optimization modes; the callback receives (clicked,
+    // candidate) modes and returns the mode to keep, or nullopt to cancel.
+    void setMergeModePickerForTesting(
+        std::function<std::optional<vc3d::line_annotation::FiberOptimizationMode>(
+            vc3d::line_annotation::FiberOptimizationMode,
+            vc3d::line_annotation::FiberOptimizationMode)> picker);
     void setVolumeSelectorFactory(VolumeSelectorFactory factory);
     void setSurfacePanel(SurfacePanelController* panel);
     void setCurrentAtlasDirectory(std::optional<std::filesystem::path> atlasDir);
@@ -463,6 +470,27 @@ private:
     void handleGeneratedControlPointLinkWithCandidate(const std::string& surfaceName,
                                                       size_t controlPointIndex,
                                                       cv::Vec3f volumePoint);
+    // Concatenates the link candidate's fiber onto the session's fiber
+    // end-to-end (both control points must be endpoints) into one brand-new
+    // fiber: tags unioned, third-party links remapped, the pair link between
+    // the merge endpoints consumed, both originals deleted, the merged line
+    // re-optimized and reopened at the join.
+    void handleGeneratedControlPointMergeWithCandidate(const std::string& surfaceName,
+                                                       size_t controlPointIndex,
+                                                       cv::Vec3f volumePoint);
+    void handleGeneratedControlPointSplitCandidate(const std::string& surfaceName,
+                                                   size_t controlPointIndex,
+                                                   cv::Vec3f volumePoint);
+    // Splits the session's fiber between the split candidate and the clicked
+    // adjacent control point into two brand-new fibers (fresh identities,
+    // tags/mode/span metadata inherited, branch links remapped onto the
+    // halves), deletes the original, and reopens the candidate's half.
+    // linkHalves additionally records a reciprocal branch link between the
+    // two boundary control points ("Split from candidate and link").
+    void handleGeneratedControlPointSplitFromCandidate(const std::string& surfaceName,
+                                                       size_t controlPointIndex,
+                                                       cv::Vec3f volumePoint,
+                                                       bool linkHalves);
     void handleGeneratedOpenNearbyAnnotation(uint64_t fiberId, cv::Vec3f volumePoint);
     void handleGeneratedControlPointUnlink(const std::string& surfaceName,
                                            size_t controlPointIndex,
@@ -477,6 +505,12 @@ private:
         controlMarkersForSession(const LineAnnotationSession& session) const;
     [[nodiscard]] vc3d::line_annotation::GeneratedLinkCandidateMenuState
         linkCandidateMenuState(const LineAnnotationSession& session) const;
+    [[nodiscard]] vc3d::line_annotation::GeneratedLinkCandidateMenuState
+        splitCandidateMenuState(const LineAnnotationSession& session) const;
+    [[nodiscard]] vc3d::line_annotation::GeneratedLinkCandidateMenuState
+        splitAndLinkCandidateMenuState(const LineAnnotationSession& session) const;
+    [[nodiscard]] vc3d::line_annotation::GeneratedLinkCandidateMenuState
+        mergeCandidateMenuState(const LineAnnotationSession& session) const;
     [[nodiscard]] std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker>
         markLinkCandidateFiberIntersections(
             std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker> markers,
@@ -558,6 +592,14 @@ private:
     [[nodiscard]] bool confirmFiberOptimizationModeChange(
         const LineAnnotationSession& session,
         vc3d::line_annotation::FiberOptimizationMode requestedMode);
+    // Modal picker when the two fibers of a merge carry different
+    // optimization modes; nullopt cancels the merge. Suppressed
+    // (agent-driven) sessions take the clicked fiber's mode.
+    [[nodiscard]] std::optional<vc3d::line_annotation::FiberOptimizationMode>
+        pickMergeOptimizationMode(
+            const LineAnnotationSession& session,
+            vc3d::line_annotation::FiberOptimizationMode clickedMode,
+            vc3d::line_annotation::FiberOptimizationMode candidateMode);
     // fileNames, not runtime ids: ids are densely reassigned on reloads,
     // which can happen while the prompt's modal spins.
     void reoptimizeMergedFibers(const std::vector<std::string>& fiberFileNames);
@@ -765,15 +807,21 @@ private:
     OptimizationTaskFactory _optimizationTaskFactory;
     std::function<bool(vc3d::line_annotation::FiberOptimizationMode)>
         _modeChangeConfirmation;
+    std::function<std::optional<vc3d::line_annotation::FiberOptimizationMode>(
+        vc3d::line_annotation::FiberOptimizationMode,
+        vc3d::line_annotation::FiberOptimizationMode)>
+        _mergeModePicker;
     bool _errorDialogsSuppressed = false;
     // Deduplicates the deferred re-optimization prompt across reentrant
     // fiber (re)loads.
     bool _reoptimizationPromptPending = false;
     mutable QString _lastSuppressedError;
 
-    // Transient (in-memory only) staging state for linking two existing control
-    // points across fibers. Position is the primary key; the stored index is a
-    // hint re-resolved at link time because indices are remapped on save.
+    // Transient (in-memory only) staging state for a designated control
+    // point: linking two CPs across fibers (_linkCandidate) or splitting a
+    // fiber between adjacent CPs (_splitCandidate). Position is the primary
+    // key; the stored index is a hint re-resolved at use time because
+    // indices are remapped on save.
     struct LinkCandidate {
         uint64_t fiberId = 0;
         std::string fiberFileName;
@@ -781,4 +829,5 @@ private:
         int storedControlPointIndexHint = -1;
     };
     std::optional<LinkCandidate> _linkCandidate;
+    std::optional<LinkCandidate> _splitCandidate;
 };

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -1903,7 +1903,10 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(
     CChunkedVolumeViewer* viewer,
     const QPointF& scenePoint,
     const QPoint& globalPos,
-    const vc3d::line_annotation::GeneratedLinkCandidateMenuState& linkCandidateState)
+    const vc3d::line_annotation::GeneratedLinkCandidateMenuState& linkCandidateState,
+    const vc3d::line_annotation::GeneratedLinkCandidateMenuState& splitCandidateState,
+    const vc3d::line_annotation::GeneratedLinkCandidateMenuState& splitAndLinkCandidateState,
+    const vc3d::line_annotation::GeneratedLinkCandidateMenuState& mergeCandidateState)
 {
     if (!viewer || !_hasGeneratedViews || _generatedViews.controlPoints.empty() ||
         _generatedViews.linePoints.empty()) {
@@ -1970,6 +1973,11 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(
     options.stripViewer = stripViewer;
     options.linkWithCandidateEnabled = linkCandidateState.enabled;
     options.linkWithCandidateLabel = linkCandidateState.label;
+    options.mergeWithCandidateEnabled = mergeCandidateState.enabled;
+    options.mergeWithCandidateLabel = mergeCandidateState.label;
+    options.splitFromCandidateEnabled = splitCandidateState.enabled;
+    options.splitFromCandidateLabel = splitCandidateState.label;
+    options.splitFromCandidateAndLinkLabel = splitAndLinkCandidateState.label;
     options.branchLinkDirection = branchLinkDirectionForViewer(viewer, linePosition);
     options.deleteControlPoint = [this, surfaceName](double selectedLinePosition,
                                                      cv::Vec3f selectedPoint) {
@@ -2001,6 +2009,30 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(
         emit generatedControlPointLinkWithCandidateRequested(surfaceName,
                                                              controlPointIndex,
                                                              volumePoint);
+    };
+    options.mergeWithCandidate = [this, surfaceName](size_t controlPointIndex,
+                                                     cv::Vec3f volumePoint) {
+        emit generatedControlPointMergeWithCandidateRequested(surfaceName,
+                                                              controlPointIndex,
+                                                              volumePoint);
+    };
+    options.designateSplitCandidate = [this, surfaceName](size_t controlPointIndex,
+                                                          cv::Vec3f volumePoint) {
+        emit generatedControlPointSplitCandidateRequested(surfaceName,
+                                                          controlPointIndex,
+                                                          volumePoint);
+    };
+    options.splitFromCandidate = [this, surfaceName](size_t controlPointIndex,
+                                                     cv::Vec3f volumePoint) {
+        emit generatedControlPointSplitFromCandidateRequested(surfaceName,
+                                                              controlPointIndex,
+                                                              volumePoint);
+    };
+    options.splitFromCandidateAndLink = [this, surfaceName](size_t controlPointIndex,
+                                                            cv::Vec3f volumePoint) {
+        emit generatedControlPointSplitAndLinkFromCandidateRequested(surfaceName,
+                                                                     controlPointIndex,
+                                                                     volumePoint);
     };
     options.openNearbyAnnotation = [this](uint64_t fiberId, cv::Vec3f volumePoint) {
         emit generatedNearbyAnnotationOpenRequested(fiberId, volumePoint);
@@ -3074,8 +3106,11 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         !_fastCurrentCutOverlayItems.controlPoints ||
         !_fastCurrentCutOverlayItems.seedPoints ||
         !_fastCurrentCutOverlayItems.linkCandidatePoints ||
+        !_fastCurrentCutOverlayItems.splitCandidatePoints ||
         !_fastCurrentCutOverlayItems.branchControlPoints ||
         !_fastCurrentCutOverlayItems.pendingBranchControlPoints ||
+        !_fastCurrentCutOverlayItems.sameHvBranchControlPoints ||
+        !_fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints ||
         !_fastCurrentCutOverlayItems.fiberIntersections ||
         !_fastCurrentCutOverlayItems.linkCandidateFiberIntersections ||
         !_fastCurrentCutOverlayItems.branchLinkFiberIntersections ||
@@ -3115,6 +3150,14 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         _fastCurrentCutOverlayItems.linkCandidatePoints->setBrush(linkCandidateBrush);
         _fastCurrentCutOverlayItems.linkCandidatePoints->setZValue(163.0);
 
+        QPen splitCandidatePen(QColor(235, 60, 60, 245));
+        splitCandidatePen.setWidthF(2.0);
+        QBrush splitCandidateBrush(QColor(235, 60, 60, 175));
+        _fastCurrentCutOverlayItems.splitCandidatePoints = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.splitCandidatePoints->setPen(splitCandidatePen);
+        _fastCurrentCutOverlayItems.splitCandidatePoints->setBrush(splitCandidateBrush);
+        _fastCurrentCutOverlayItems.splitCandidatePoints->setZValue(163.5);
+
         QPen branchControlPen(QColor(210, 95, 255, 245));
         branchControlPen.setWidthF(2.0);
         QBrush branchControlBrush(QColor(210, 95, 255, 175));
@@ -3131,6 +3174,25 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         _fastCurrentCutOverlayItems.pendingBranchControlPoints->setBrush(
             pendingBranchControlBrush);
         _fastCurrentCutOverlayItems.pendingBranchControlPoints->setZValue(162.5);
+
+        QPen sameHvBranchControlPen(QColor(255, 140, 0, 245));
+        sameHvBranchControlPen.setWidthF(2.0);
+        QBrush sameHvBranchControlBrush(QColor(255, 140, 0, 175));
+        _fastCurrentCutOverlayItems.sameHvBranchControlPoints = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.sameHvBranchControlPoints->setPen(sameHvBranchControlPen);
+        _fastCurrentCutOverlayItems.sameHvBranchControlPoints->setBrush(
+            sameHvBranchControlBrush);
+        _fastCurrentCutOverlayItems.sameHvBranchControlPoints->setZValue(162.0);
+
+        QPen sameHvPendingBranchControlPen(QColor(255, 190, 120, 245));
+        sameHvPendingBranchControlPen.setWidthF(2.0);
+        QBrush sameHvPendingBranchControlBrush(QColor(255, 190, 120, 175));
+        _fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints = new QGraphicsPathItem();
+        _fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints->setPen(
+            sameHvPendingBranchControlPen);
+        _fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints->setBrush(
+            sameHvPendingBranchControlBrush);
+        _fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints->setZValue(162.5);
 
         QPen fiberIntersectionPen(QColor(255, 245, 75, 245));
         fiberIntersectionPen.setWidthF(1.25);
@@ -3181,8 +3243,11 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
                                  _fastCurrentCutOverlayItems.controlPoints,
                                  _fastCurrentCutOverlayItems.seedPoints,
                                  _fastCurrentCutOverlayItems.linkCandidatePoints,
+                                 _fastCurrentCutOverlayItems.splitCandidatePoints,
                                  _fastCurrentCutOverlayItems.branchControlPoints,
                                  _fastCurrentCutOverlayItems.pendingBranchControlPoints,
+                                 _fastCurrentCutOverlayItems.sameHvBranchControlPoints,
+                                 _fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints,
                                  _fastCurrentCutOverlayItems.fiberIntersections,
                                  _fastCurrentCutOverlayItems.linkCandidateFiberIntersections,
                                  _fastCurrentCutOverlayItems.branchLinkFiberIntersections,
@@ -3216,8 +3281,11 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     QPainterPath controlPath;
     QPainterPath seedPath;
     QPainterPath linkCandidatePath;
+    QPainterPath splitCandidatePath;
     QPainterPath branchControlPath;
     QPainterPath pendingBranchControlPath;
+    QPainterPath sameHvBranchControlPath;
+    QPainterPath sameHvPendingBranchControlPath;
     const double lineRadius =
         std::max(0.5, (_viewerManager ? _viewerManager->zScrollSensitivity() : 1.0) * 0.5);
     const double lower = cutPosition - lineRadius;
@@ -3252,13 +3320,19 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         if (!std::isfinite(scenePoint.x()) || !std::isfinite(scenePoint.y())) {
             continue;
         }
-        if (control.isLinkCandidate) {
+        if (control.isSplitCandidate) {
+            splitCandidatePath.addEllipse(scenePoint, control.isSeed ? 11.0 : 10.0,
+                                          control.isSeed ? 11.0 : 10.0);
+        } else if (control.isLinkCandidate) {
             linkCandidatePath.addEllipse(scenePoint, control.isSeed ? 11.0 : 10.0,
                                          control.isSeed ? 11.0 : 10.0);
         } else if (control.hasPendingLinks) {
-            pendingBranchControlPath.addEllipse(scenePoint, 12.0, 12.0);
+            (control.hasSameHvPendingLinks ? sameHvPendingBranchControlPath
+                                           : pendingBranchControlPath)
+                .addEllipse(scenePoint, 12.0, 12.0);
         } else if (control.hasBranches) {
-            branchControlPath.addEllipse(scenePoint, 12.0, 12.0);
+            (control.hasSameHvBranches ? sameHvBranchControlPath : branchControlPath)
+                .addEllipse(scenePoint, 12.0, 12.0);
         } else if (control.isSeed) {
             seedPath.addEllipse(scenePoint, 11.0, 11.0);
         } else {
@@ -3268,8 +3342,12 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     _fastCurrentCutOverlayItems.controlPoints->setPath(controlPath);
     _fastCurrentCutOverlayItems.seedPoints->setPath(seedPath);
     _fastCurrentCutOverlayItems.linkCandidatePoints->setPath(linkCandidatePath);
+    _fastCurrentCutOverlayItems.splitCandidatePoints->setPath(splitCandidatePath);
     _fastCurrentCutOverlayItems.branchControlPoints->setPath(branchControlPath);
     _fastCurrentCutOverlayItems.pendingBranchControlPoints->setPath(pendingBranchControlPath);
+    _fastCurrentCutOverlayItems.sameHvBranchControlPoints->setPath(sameHvBranchControlPath);
+    _fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints->setPath(
+        sameHvPendingBranchControlPath);
 
     QPainterPath fiberIntersectionPath;
     QPainterPath linkCandidateFiberIntersectionPath;
@@ -3698,12 +3776,16 @@ void LineAnnotationDialog::updateOverviewBar()
         LineAnnotationOverviewBar::ControlDot dot;
         dot.linePosition = control.linePosition;
         // Same state palette as the cut-view overlays.
-        if (control.isLinkCandidate) {
+        if (control.isSplitCandidate) {
+            dot.color = QColor(235, 60, 60);
+        } else if (control.isLinkCandidate) {
             dot.color = QColor(60, 235, 120);
         } else if (control.hasPendingLinks) {
-            dot.color = QColor(80, 150, 255);
+            dot.color = control.hasSameHvPendingLinks ? QColor(255, 190, 120)
+                                                      : QColor(80, 150, 255);
         } else if (control.hasBranches) {
-            dot.color = QColor(210, 95, 255);
+            dot.color = control.hasSameHvBranches ? QColor(255, 140, 0)
+                                                  : QColor(210, 95, 255);
         } else {
             dot.color = QColor(255, 230, 0);
         }

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -83,8 +83,11 @@ public:
         QGraphicsPathItem* controlPoints = nullptr;
         QGraphicsPathItem* seedPoints = nullptr;
         QGraphicsPathItem* linkCandidatePoints = nullptr;
+        QGraphicsPathItem* splitCandidatePoints = nullptr;
         QGraphicsPathItem* branchControlPoints = nullptr;
         QGraphicsPathItem* pendingBranchControlPoints = nullptr;
+        QGraphicsPathItem* sameHvBranchControlPoints = nullptr;
+        QGraphicsPathItem* sameHvPendingBranchControlPoints = nullptr;
         QGraphicsPathItem* fiberIntersections = nullptr;
         QGraphicsPathItem* linkCandidateFiberIntersections = nullptr;
         QGraphicsPathItem* branchLinkFiberIntersections = nullptr;
@@ -116,7 +119,10 @@ public:
         CChunkedVolumeViewer* viewer,
         const QPointF& scenePoint,
         const QPoint& globalPos,
-        const vc3d::line_annotation::GeneratedLinkCandidateMenuState& linkCandidateState = {});
+        const vc3d::line_annotation::GeneratedLinkCandidateMenuState& linkCandidateState = {},
+        const vc3d::line_annotation::GeneratedLinkCandidateMenuState& splitCandidateState = {},
+        const vc3d::line_annotation::GeneratedLinkCandidateMenuState& splitAndLinkCandidateState = {},
+        const vc3d::line_annotation::GeneratedLinkCandidateMenuState& mergeCandidateState = {});
     const std::vector<Pane>& panes() const { return _panes; }
     ReoptimizationMode reoptimizationMode() const;
     int initialCenterlineLengthVx() const;
@@ -189,6 +195,18 @@ signals:
     void generatedControlPointLinkWithCandidateRequested(const std::string& surfaceName,
                                                          size_t controlPointIndex,
                                                          cv::Vec3f volumePoint);
+    void generatedControlPointMergeWithCandidateRequested(const std::string& surfaceName,
+                                                          size_t controlPointIndex,
+                                                          cv::Vec3f volumePoint);
+    void generatedControlPointSplitCandidateRequested(const std::string& surfaceName,
+                                                      size_t controlPointIndex,
+                                                      cv::Vec3f volumePoint);
+    void generatedControlPointSplitFromCandidateRequested(const std::string& surfaceName,
+                                                          size_t controlPointIndex,
+                                                          cv::Vec3f volumePoint);
+    void generatedControlPointSplitAndLinkFromCandidateRequested(const std::string& surfaceName,
+                                                                 size_t controlPointIndex,
+                                                                 cv::Vec3f volumePoint);
     void generatedNearbyAnnotationOpenRequested(uint64_t fiberId, cv::Vec3f volumePoint);
     void generatedControlPointUnlinkRequested(const std::string& surfaceName,
                                               size_t controlPointIndex,

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSaveJob.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSaveJob.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <stdexcept>
+#include <utility>
 
 namespace fs = std::filesystem;
 
@@ -31,7 +32,8 @@ fs::path uniqueRecoveryPath(const fs::path& finalPath, uint64_t sequence, size_t
 } // namespace
 
 FiberSaveJobResult runFiberSaveJob(uint64_t sequence,
-                                   std::vector<FiberSavePayload> payloads)
+                                   std::vector<FiberSavePayload> payloads,
+                                   std::vector<std::filesystem::path> retirePaths)
 {
     FiberSaveJobResult result;
     result.ok = false;
@@ -45,6 +47,10 @@ FiberSaveJobResult runFiberSaveJob(uint64_t sequence,
     const bool multiFiberSave = payloads.size() > 1;
     std::vector<fs::path> tempPaths;
     tempPaths.reserve(payloads.size());
+    // (original path, backup path) for every retirement performed, so a
+    // failure can rename each backup straight back into place.
+    std::vector<std::pair<fs::path, fs::path>> retiredMoves;
+    retiredMoves.reserve(retirePaths.size());
     try {
         for (size_t i = 0; i < payloads.size(); ++i) {
             const auto& payload = payloads[i];
@@ -90,6 +96,31 @@ FiberSaveJobResult runFiberSaveJob(uint64_t sequence,
             }
         }
 
+        // Retire originals before the renames: an atomic move into the
+        // dot-prefixed sibling directory doubles as the backup, and nothing
+        // has been renamed into place yet when a move fails.
+        for (size_t i = 0; i < retirePaths.size(); ++i) {
+            const fs::path& retirePath = retirePaths[i];
+            std::error_code ec;
+            if (!fs::exists(retirePath, ec)) {
+                continue;
+            }
+            const fs::path retiredDir = retirePath.parent_path() / ".retired";
+            fs::create_directories(retiredDir, ec);
+            if (ec) {
+                throw std::runtime_error("Failed to create " + retiredDir.string() +
+                                         ": " + ec.message());
+            }
+            const fs::path backupPath = uniqueRecoveryPath(
+                retiredDir / retirePath.filename(), sequence, i);
+            fs::rename(retirePath, backupPath, ec);
+            if (ec) {
+                throw std::runtime_error("Failed to retire " + retirePath.string() +
+                                         ": " + ec.message());
+            }
+            retiredMoves.emplace_back(retirePath, backupPath);
+        }
+
         const bool failAfterFirst =
             std::getenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE") != nullptr;
         for (size_t i = 0; i < payloads.size(); ++i) {
@@ -105,17 +136,34 @@ FiberSaveJobResult runFiberSaveJob(uint64_t sequence,
             }
         }
 
+        // Backups go only after every rename succeeded. Leftovers in
+        // .retired/ are invisible to the loaders and to sync, so removal
+        // errors are ignored.
         for (const auto& recoveryPath : result.recoveryFiles) {
             std::error_code ec;
             fs::remove(recoveryPath, ec);
         }
         result.recoveryFiles.clear();
+        for (const auto& [retirePath, backupPath] : retiredMoves) {
+            (void)retirePath;
+            std::error_code ec;
+            fs::remove(backupPath, ec);
+        }
         result.ok = true;
     } catch (const std::exception& ex) {
         result.error = ex.what();
         for (const auto& tempPath : tempPaths) {
             std::error_code ec;
             fs::remove(tempPath, ec);
+        }
+        // Restore retirements; a backup that cannot be moved back is
+        // surfaced like a kept recovery file.
+        for (const auto& [retirePath, backupPath] : retiredMoves) {
+            std::error_code ec;
+            fs::rename(backupPath, retirePath, ec);
+            if (ec) {
+                result.recoveryFiles.push_back(backupPath);
+            }
         }
     }
     return result;

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSaveJob.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSaveJob.cpp
@@ -51,6 +51,13 @@ FiberSaveJobResult runFiberSaveJob(uint64_t sequence,
     // failure can rename each backup straight back into place.
     std::vector<std::pair<fs::path, fs::path>> retiredMoves;
     retiredMoves.reserve(retirePaths.size());
+    // Whether each payload target existed before its rename, and how many
+    // renames landed: a failure removes renamed targets that had no
+    // previous content, so a partial batch cannot leave orphan new files
+    // (pre-existing targets keep the new content plus their recovery copy).
+    std::vector<bool> targetExisted;
+    targetExisted.reserve(payloads.size());
+    size_t renamedCount = 0;
     try {
         for (size_t i = 0; i < payloads.size(); ++i) {
             const auto& payload = payloads[i];
@@ -125,12 +132,14 @@ FiberSaveJobResult runFiberSaveJob(uint64_t sequence,
             std::getenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE") != nullptr;
         for (size_t i = 0; i < payloads.size(); ++i) {
             std::error_code ec;
+            targetExisted.push_back(fs::exists(payloads[i].path, ec));
             fs::rename(tempPaths[i], payloads[i].path, ec);
             if (ec) {
                 throw std::runtime_error("Failed to replace " +
                                          payloads[i].path.string() + ": " +
                                          ec.message());
             }
+            renamedCount = i + 1;
             if (failAfterFirst && multiFiberSave && i == 0) {
                 throw std::runtime_error("Injected failure after first fiber replacement");
             }
@@ -155,6 +164,14 @@ FiberSaveJobResult runFiberSaveJob(uint64_t sequence,
         for (const auto& tempPath : tempPaths) {
             std::error_code ec;
             fs::remove(tempPath, ec);
+        }
+        // Remove renamed targets that did not exist before the job so a
+        // partial batch leaves no orphan new files behind.
+        for (size_t i = 0; i < renamedCount && i < targetExisted.size(); ++i) {
+            if (!targetExisted[i]) {
+                std::error_code ec;
+                fs::remove(payloads[i].path, ec);
+            }
         }
         // Restore retirements; a backup that cannot be moved back is
         // surfaced like a kept recovery file.

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSaveJob.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSaveJob.hpp
@@ -24,7 +24,15 @@ struct FiberSaveJobResult {
     std::string error;
 };
 
+// Writes every payload (temp file + atomic rename, recovery backups of
+// overwritten targets on multi-file saves) and retires every existing
+// retirePath by moving it into a sibling ".retired" directory before the
+// renames; the retired backups are removed only after every rename
+// succeeded, and restored to their original paths on failure. Retirement
+// is therefore all-or-nothing across the batch. ".retired" is dot-prefixed
+// so the fiber loaders and vc_sync ignore it (the .s3sync-conflicts rule).
 FiberSaveJobResult runFiberSaveJob(uint64_t sequence,
-                                   std::vector<FiberSavePayload> payloads);
+                                   std::vector<FiberSavePayload> payloads,
+                                   std::vector<std::filesystem::path> retirePaths = {});
 
 } // namespace vc3d::line_annotation

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
@@ -1225,6 +1225,143 @@ void invalidateSegmentsAdjacentToControl(std::vector<LineControlPoint>& controls
     (void)found;
 }
 
+namespace
+{
+
+// The loader's exact-membership scan (kControlPointMatchEpsilon in
+// core/src/Atlas.cpp): controls must be an ordered subset of the dense
+// line, so geometry sliced at these indices reloads cleanly.
+std::optional<std::vector<size_t>> orderedControlLineIndices(
+    const std::vector<cv::Vec3d>& controlPoints,
+    const std::vector<cv::Vec3d>& linePoints)
+{
+    constexpr double kMatchEpsilon = 1.0e-8;
+    constexpr double kMaxDistanceSq = kMatchEpsilon * kMatchEpsilon;
+    std::vector<size_t> lineIndices;
+    lineIndices.reserve(controlPoints.size());
+    size_t nextLineIndex = 0;
+    for (const auto& control : controlPoints) {
+        std::optional<size_t> matched;
+        for (size_t j = nextLineIndex; j < linePoints.size(); ++j) {
+            const cv::Vec3d delta = control - linePoints[j];
+            if (delta.dot(delta) <= kMaxDistanceSq) {
+                matched = j;
+                break;
+            }
+        }
+        if (!matched) {
+            return std::nullopt;
+        }
+        lineIndices.push_back(*matched);
+        nextLineIndex = *matched + 1;
+    }
+    return lineIndices;
+}
+
+}  // namespace
+
+std::optional<FiberSplitPlan> computeFiberSplitPlan(
+    const std::vector<cv::Vec3d>& controlPoints,
+    const std::vector<cv::Vec3d>& linePoints,
+    size_t splitAfterControlIndex)
+{
+    // Both halves must keep at least 2 control points.
+    if (splitAfterControlIndex < 1 ||
+        splitAfterControlIndex + 3 > controlPoints.size()) {
+        return std::nullopt;
+    }
+    const auto scannedIndices = orderedControlLineIndices(controlPoints, linePoints);
+    if (!scannedIndices) {
+        return std::nullopt;
+    }
+    const std::vector<size_t>& lineIndices = *scannedIndices;
+
+    FiberSplitPlan plan;
+    plan.splitAfterControlIndex = splitAfterControlIndex;
+    plan.prefixControlCount = splitAfterControlIndex + 1;
+    plan.prefixLineCount = lineIndices[splitAfterControlIndex] + 1;
+    plan.suffixControlBegin = splitAfterControlIndex + 1;
+    plan.suffixLineBegin = lineIndices[splitAfterControlIndex + 1];
+    return plan;
+}
+
+std::optional<std::pair<bool, int>> remappedSplitControlPointIndex(
+    const FiberSplitPlan& plan, int controlPointIndex)
+{
+    if (controlPointIndex < 0) {
+        return std::nullopt;
+    }
+    const auto index = static_cast<size_t>(controlPointIndex);
+    if (index < plan.suffixControlBegin) {
+        return std::make_pair(false, controlPointIndex);
+    }
+    return std::make_pair(true,
+                          static_cast<int>(index - plan.suffixControlBegin));
+}
+
+std::vector<StoredControlPoint> reversedStoredControlPoints(
+    const std::vector<StoredControlPoint>& controls)
+{
+    const size_t count = controls.size();
+    std::vector<StoredControlPoint> reversed;
+    reversed.reserve(count);
+    for (size_t j = 0; j < count; ++j) {
+        StoredControlPoint control{
+            static_cast<const cv::Vec3d&>(controls[count - 1 - j])};
+        // Span j of the reversed fiber is span (n-2-j) of the original run
+        // in the opposite direction; its descriptor travels with it. The
+        // new final CP carries none.
+        if (j + 1 < count) {
+            control.segmentToNext = controls[count - 2 - j].segmentToNext;
+        }
+        reversed.push_back(std::move(control));
+    }
+    return reversed;
+}
+
+std::optional<FiberMergeGeometry> computeFiberMergeGeometry(
+    const std::vector<StoredControlPoint>& aControls,
+    const std::vector<cv::Vec3d>& aLine,
+    const std::vector<StoredControlPoint>& bControls,
+    const std::vector<cv::Vec3d>& bLine)
+{
+    if (aControls.size() < 2 || bControls.size() < 2) {
+        return std::nullopt;
+    }
+    const auto aIndices =
+        orderedControlLineIndices(storedControlPointPositions(aControls), aLine);
+    const auto bIndices =
+        orderedControlLineIndices(storedControlPointPositions(bControls), bLine);
+    if (!aIndices || !bIndices) {
+        return std::nullopt;
+    }
+
+    FiberMergeGeometry merged;
+    merged.controlPoints.reserve(aControls.size() + bControls.size());
+    merged.controlPoints.assign(aControls.begin(), aControls.end());
+    merged.joinControlIndex = aControls.size() - 1;
+    // The join span is fresh geometry with no producer yet; the default
+    // global/lasagna descriptor matches the serializer's back-fill and
+    // keeps in-memory span consumers valid until the re-fit replaces it.
+    FiberTraceSegmentMetadata joinMetadata;
+    joinMetadata.interpGoal = SegmentInterpolationGoal::Global;
+    joinMetadata.interpMode = SegmentInterpolationMode::Lasagna;
+    joinMetadata.message = "lasagna";
+    merged.controlPoints[merged.joinControlIndex].segmentToNext =
+        std::move(joinMetadata);
+    merged.controlPoints.insert(merged.controlPoints.end(),
+                                bControls.begin(), bControls.end());
+
+    // Drop both extrapolated tails: line points past a's last CP and before
+    // b's first CP would sit between the join CPs and break the strict
+    // line-order mapping in the optimizer.
+    merged.linePoints.assign(aLine.begin(),
+                             aLine.begin() + aIndices->back() + 1);
+    merged.linePoints.insert(merged.linePoints.end(),
+                             bLine.begin() + bIndices->front(), bLine.end());
+    return merged;
+}
+
 void invalidateSegmentSplitByInsertedControl(std::vector<LineControlPoint>& controls, size_t insertedIndex)
 {
     if (insertedIndex >= controls.size()) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.hpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <nlohmann/json_fwd.hpp>
@@ -206,5 +207,58 @@ void validateStoredControlPoints(const std::vector<StoredControlPoint>& controls
     std::vector<vc::lasagna::LineControlPoint> optimized, const std::vector<LineControlPoint>& original);
 void invalidateSegmentsAdjacentToControl(std::vector<LineControlPoint>& controls, size_t controlIndex);
 void invalidateSegmentSplitByInsertedControl(std::vector<LineControlPoint>& controls, size_t insertedIndex);
+
+// Where to cut a fiber's stored geometry between adjacent control points a
+// and a+1: the prefix keeps [0..a] and the suffix [a+1..end], and the dense
+// line points of the removed a->a+1 span belong to neither half.
+struct FiberSplitPlan {
+    size_t splitAfterControlIndex = 0;  // a
+    size_t prefixControlCount = 0;      // a+1 control points: [0..a]
+    size_t prefixLineCount = 0;         // line points [0..lineIndex(a)]
+    size_t suffixControlBegin = 0;      // a+1
+    size_t suffixLineBegin = 0;         // lineIndex(a+1)
+};
+
+// Returns nullopt when splitAfterControlIndex is out of range, either half
+// would keep fewer than 2 control points, or the control points are not an
+// ordered subset of linePoints under the loader's exact-membership
+// tolerance (vc::atlas::validateFiberInputControlPoints).
+[[nodiscard]] std::optional<FiberSplitPlan> computeFiberSplitPlan(
+    const std::vector<cv::Vec3d>& controlPoints,
+    const std::vector<cv::Vec3d>& linePoints,
+    size_t splitAfterControlIndex);
+
+// Post-split home of a stored control index: {inSuffix, remappedIndex}.
+// Prefix indices are unchanged; suffix indices shift down by
+// suffixControlBegin. nullopt for negative indices.
+[[nodiscard]] std::optional<std::pair<bool, int>> remappedSplitControlPointIndex(
+    const FiberSplitPlan& plan, int controlPointIndex);
+
+// Reversed stored geometry. Each span descriptor moves with its span:
+// reversed CP j carries original CP (n-2-j)'s segmentToNext, and the new
+// final CP has none (v3 contract).
+[[nodiscard]] std::vector<StoredControlPoint> reversedStoredControlPoints(
+    const std::vector<StoredControlPoint>& controls);
+
+// End-to-end concatenation of two fibers whose inputs are pre-oriented so
+// `a` ends at the join and `b` starts at it.
+struct FiberMergeGeometry {
+    std::vector<StoredControlPoint> controlPoints;  // a + b
+    std::vector<cv::Vec3d> linePoints;   // a.line[0..idx(a.last)] + b.line[idx(b.first)..]
+    size_t joinControlIndex = 0;         // a.controlPoints.size() - 1
+};
+
+// Slices both extrapolated tails at the boundary CPs via the same exact
+// ordered-subset scan as computeFiberSplitPlan (raw concatenation leaves
+// tail points between the join CPs and breaks the optimizer's strict
+// line-order mapping), and synthesizes the join span's descriptor on a's
+// last CP so in-memory consumers that dereference every non-final
+// descriptor keep working. nullopt when either side has fewer than 2
+// control points or fails the ordered scan.
+[[nodiscard]] std::optional<FiberMergeGeometry> computeFiberMergeGeometry(
+    const std::vector<StoredControlPoint>& aControls,
+    const std::vector<cv::Vec3d>& aLine,
+    const std::vector<StoredControlPoint>& bControls,
+    const std::vector<cv::Vec3d>& bLine);
 
 }  // namespace vc3d::line_annotation

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
@@ -275,21 +275,40 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
     pendingBranchControlPointStyle.brushColor = QColor(80, 150, 255, 175);
     pendingBranchControlPointStyle.z = 162.5;
 
+    ViewerOverlayControllerBase::OverlayStyle sameHvBranchControlPointStyle = branchControlPointStyle;
+    sameHvBranchControlPointStyle.penColor = QColor(255, 140, 0, 245);
+    sameHvBranchControlPointStyle.brushColor = QColor(255, 140, 0, 175);
+
+    ViewerOverlayControllerBase::OverlayStyle sameHvPendingBranchControlPointStyle =
+        pendingBranchControlPointStyle;
+    sameHvPendingBranchControlPointStyle.penColor = QColor(255, 190, 120, 245);
+    sameHvPendingBranchControlPointStyle.brushColor = QColor(255, 190, 120, 175);
+
     ViewerOverlayControllerBase::OverlayStyle linkCandidateControlPointStyle = branchControlPointStyle;
     linkCandidateControlPointStyle.penColor = QColor(60, 235, 120, 245);
     linkCandidateControlPointStyle.brushColor = QColor(60, 235, 120, 175);
     linkCandidateControlPointStyle.z = 163.0;
 
+    ViewerOverlayControllerBase::OverlayStyle splitCandidateControlPointStyle = branchControlPointStyle;
+    splitCandidateControlPointStyle.penColor = QColor(235, 60, 60, 245);
+    splitCandidateControlPointStyle.brushColor = QColor(235, 60, 60, 175);
+    splitCandidateControlPointStyle.z = 163.5;
+
     auto controlStyleForMarker = [&](const GeneratedOverlay::ControlPointMarker& control)
         -> const ViewerOverlayControllerBase::OverlayStyle& {
+        if (control.isSplitCandidate) {
+            return splitCandidateControlPointStyle;
+        }
         if (control.isLinkCandidate) {
             return linkCandidateControlPointStyle;
         }
         if (control.hasPendingLinks) {
-            return pendingBranchControlPointStyle;
+            return control.hasSameHvPendingLinks ? sameHvPendingBranchControlPointStyle
+                                                 : pendingBranchControlPointStyle;
         }
         if (control.hasBranches) {
-            return branchControlPointStyle;
+            return control.hasSameHvBranches ? sameHvBranchControlPointStyle
+                                             : branchControlPointStyle;
         }
         return control.isSeed ? seedStyle : controlPointStyle;
     };
@@ -863,6 +882,15 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
             selectedControlIndex != std::numeric_limits<size_t>::max() &&
             !selectedControl.hasBranches);
     }
+    // Linked CPs are legal split points (their links are remapped onto the
+    // halves), so unlike the link candidate there is no hasBranches gate.
+    QAction* designateSplitCandidateAction = nullptr;
+    if (options.designateSplitCandidate) {
+        designateSplitCandidateAction =
+            menu.addAction(QWidget::tr("Designate as split candidate"));
+        designateSplitCandidateAction->setEnabled(
+            selectedControlIndex != std::numeric_limits<size_t>::max());
+    }
     std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>> openBranchActions;
     if (!selectedControl.branchLinks.empty()) {
         QMenu* branchMenu = menu.addMenu(QWidget::tr("Go to linked annotation"));
@@ -960,6 +988,31 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
             selectedControlIndex != std::numeric_limits<size_t>::max() &&
             !selectedControl.hasBranches);
     }
+    // No hasBranches gate: the merge consumes the very pending link the two
+    // endpoint CPs typically already carry.
+    QAction* mergeWithCandidateAction = nullptr;
+    if (options.mergeWithCandidate && !options.mergeWithCandidateLabel.isEmpty()) {
+        mergeWithCandidateAction = menu.addAction(options.mergeWithCandidateLabel);
+        mergeWithCandidateAction->setEnabled(
+            options.mergeWithCandidateEnabled &&
+            selectedControlIndex != std::numeric_limits<size_t>::max());
+    }
+    QAction* splitFromCandidateAction = nullptr;
+    if (options.splitFromCandidate && !options.splitFromCandidateLabel.isEmpty()) {
+        splitFromCandidateAction = menu.addAction(options.splitFromCandidateLabel);
+        splitFromCandidateAction->setEnabled(
+            options.splitFromCandidateEnabled &&
+            selectedControlIndex != std::numeric_limits<size_t>::max());
+    }
+    QAction* splitFromCandidateAndLinkAction = nullptr;
+    if (options.splitFromCandidateAndLink &&
+        !options.splitFromCandidateAndLinkLabel.isEmpty()) {
+        splitFromCandidateAndLinkAction =
+            menu.addAction(options.splitFromCandidateAndLinkLabel);
+        splitFromCandidateAndLinkAction->setEnabled(
+            options.splitFromCandidateEnabled &&
+            selectedControlIndex != std::numeric_limits<size_t>::max());
+    }
     QAction* openNearbyAnnotationAction = nullptr;
     if (options.openNearbyAnnotation && nearbyIntersection) {
         openNearbyAnnotationAction = menu.addAction(
@@ -1034,6 +1087,30 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
         selected == linkWithCandidateAction &&
         linkWithCandidateAction->isEnabled()) {
         options.linkWithCandidate(selectedControlIndex, selectedControl.point);
+        return GeneratedControlPointContextResult::Handled;
+    }
+    if (mergeWithCandidateAction &&
+        selected == mergeWithCandidateAction &&
+        mergeWithCandidateAction->isEnabled()) {
+        options.mergeWithCandidate(selectedControlIndex, selectedControl.point);
+        return GeneratedControlPointContextResult::Handled;
+    }
+    if (designateSplitCandidateAction &&
+        selected == designateSplitCandidateAction &&
+        designateSplitCandidateAction->isEnabled()) {
+        options.designateSplitCandidate(selectedControlIndex, selectedControl.point);
+        return GeneratedControlPointContextResult::Handled;
+    }
+    if (splitFromCandidateAction &&
+        selected == splitFromCandidateAction &&
+        splitFromCandidateAction->isEnabled()) {
+        options.splitFromCandidate(selectedControlIndex, selectedControl.point);
+        return GeneratedControlPointContextResult::Handled;
+    }
+    if (splitFromCandidateAndLinkAction &&
+        selected == splitFromCandidateAndLinkAction &&
+        splitFromCandidateAndLinkAction->isEnabled()) {
+        options.splitFromCandidateAndLink(selectedControlIndex, selectedControl.point);
         return GeneratedControlPointContextResult::Handled;
     }
     if (openNearbyAnnotationAction && selected == openNearbyAnnotationAction) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
@@ -53,7 +53,13 @@ struct GeneratedOverlay {
         bool isSeed = false;
         bool hasBranches = false;
         bool hasPendingLinks = false;
+        // Same-orientation links (H-H / V-V) render in the orange warning
+        // palette; H-V links keep the default blue/purple. Set by the
+        // controller, which owns the fiber HV state.
+        bool hasSameHvBranches = false;
+        bool hasSameHvPendingLinks = false;
         bool isLinkCandidate = false;
+        bool isSplitCandidate = false;
         bool hasTracedSegmentToNext = false;
         std::string interpolationGoal = "global";
         char interpolationModeMarker = 'L';
@@ -968,6 +974,11 @@ struct GeneratedControlPointContextMenuOptions {
     bool stripViewer = false;
     bool linkWithCandidateEnabled = false;
     QString linkWithCandidateLabel;
+    bool mergeWithCandidateEnabled = false;
+    QString mergeWithCandidateLabel;
+    bool splitFromCandidateEnabled = false;
+    QString splitFromCandidateLabel;
+    QString splitFromCandidateAndLinkLabel;
     cv::Vec3f branchLinkDirection{std::numeric_limits<float>::quiet_NaN(),
                                   std::numeric_limits<float>::quiet_NaN(),
                                   std::numeric_limits<float>::quiet_NaN()};
@@ -979,6 +990,10 @@ struct GeneratedControlPointContextMenuOptions {
     std::function<void(size_t, uint64_t, int, bool)> setBranchLinkPending;
     std::function<void(size_t, cv::Vec3f)> designateLinkCandidate;
     std::function<void(size_t, cv::Vec3f)> linkWithCandidate;
+    std::function<void(size_t, cv::Vec3f)> mergeWithCandidate;
+    std::function<void(size_t, cv::Vec3f)> designateSplitCandidate;
+    std::function<void(size_t, cv::Vec3f)> splitFromCandidate;
+    std::function<void(size_t, cv::Vec3f)> splitFromCandidateAndLink;
     std::function<void(uint64_t, cv::Vec3f)> openNearbyAnnotation;
     std::function<void(size_t, size_t, std::string)> setSegmentInterpolationGoal;
 };

--- a/volume-cartographer/core/test/test_fiber_trace_review.cpp
+++ b/volume-cartographer/core/test/test_fiber_trace_review.cpp
@@ -6,6 +6,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -171,4 +172,232 @@ TEST_CASE("default lasagna segment metadata matches the migration fixture")
         CHECK(actual.at("config").at(key).is_number_integer());
     }
     CHECK_NOTHROW(vc::fiber_tracer::detail::validateSegmentMetadata(actual));
+}
+
+TEST_CASE("computeFiberSplitPlan slices at exact ordered line indices")
+{
+    using vc3d::line_annotation::computeFiberSplitPlan;
+    using vc3d::line_annotation::remappedSplitControlPointIndex;
+
+    // 9 line points on the x axis; 5 controls at line indices 0, 2, 4, 6, 8.
+    std::vector<cv::Vec3d> linePoints;
+    for (int i = 0; i < 9; ++i) {
+        linePoints.emplace_back(static_cast<double>(i), 0.0, 0.0);
+    }
+    std::vector<cv::Vec3d> controls{linePoints[0], linePoints[2], linePoints[4],
+                                    linePoints[6], linePoints[8]};
+
+    const auto plan = computeFiberSplitPlan(controls, linePoints, 1);
+    REQUIRE(plan.has_value());
+    CHECK(plan->splitAfterControlIndex == 1);
+    CHECK(plan->prefixControlCount == 2);
+    CHECK(plan->prefixLineCount == 3);   // line points [0..2]
+    CHECK(plan->suffixControlBegin == 2);
+    CHECK(plan->suffixLineBegin == 4);   // line index of control 2
+
+    const auto prefixHome = remappedSplitControlPointIndex(*plan, 1);
+    REQUIRE(prefixHome.has_value());
+    CHECK_FALSE(prefixHome->first);
+    CHECK(prefixHome->second == 1);
+    const auto suffixFirst = remappedSplitControlPointIndex(*plan, 2);
+    REQUIRE(suffixFirst.has_value());
+    CHECK(suffixFirst->first);
+    CHECK(suffixFirst->second == 0);
+    const auto suffixLast = remappedSplitControlPointIndex(*plan, 4);
+    REQUIRE(suffixLast.has_value());
+    CHECK(suffixLast->first);
+    CHECK(suffixLast->second == 2);
+    CHECK_FALSE(remappedSplitControlPointIndex(*plan, -1).has_value());
+}
+
+TEST_CASE("computeFiberSplitPlan enforces two control points per half")
+{
+    using vc3d::line_annotation::computeFiberSplitPlan;
+
+    std::vector<cv::Vec3d> linePoints;
+    for (int i = 0; i < 9; ++i) {
+        linePoints.emplace_back(static_cast<double>(i), 0.0, 0.0);
+    }
+    const std::vector<cv::Vec3d> controls{linePoints[0], linePoints[2],
+                                          linePoints[4], linePoints[6],
+                                          linePoints[8]};
+
+    CHECK_FALSE(computeFiberSplitPlan(controls, linePoints, 0).has_value());
+    CHECK(computeFiberSplitPlan(controls, linePoints, 2).has_value());
+    CHECK_FALSE(computeFiberSplitPlan(controls, linePoints, 3).has_value());
+    CHECK_FALSE(computeFiberSplitPlan(controls, linePoints, 17).has_value());
+
+    // A 4-control fiber has exactly one legal cut.
+    const std::vector<cv::Vec3d> fourControls{linePoints[0], linePoints[2],
+                                              linePoints[4], linePoints[6]};
+    CHECK(computeFiberSplitPlan(fourControls, linePoints, 1).has_value());
+    CHECK_FALSE(computeFiberSplitPlan(fourControls, linePoints, 2).has_value());
+}
+
+TEST_CASE("computeFiberSplitPlan applies the loader's exact-membership scan")
+{
+    using vc3d::line_annotation::computeFiberSplitPlan;
+
+    std::vector<cv::Vec3d> linePoints;
+    for (int i = 0; i < 9; ++i) {
+        linePoints.emplace_back(static_cast<double>(i), 0.0, 0.0);
+    }
+    std::vector<cv::Vec3d> controls{linePoints[0], linePoints[2], linePoints[4],
+                                    linePoints[6]};
+
+    // A control nudged beyond the 1e-8 tolerance no longer matches its line
+    // point; within the tolerance it still does.
+    controls[1][1] = 1.0e-7;
+    CHECK_FALSE(computeFiberSplitPlan(controls, linePoints, 1).has_value());
+    controls[1][1] = 1.0e-9;
+    CHECK(computeFiberSplitPlan(controls, linePoints, 1).has_value());
+
+    // Coincident line points: the forward scan must keep advancing, so two
+    // controls sharing one position match distinct line indices.
+    std::vector<cv::Vec3d> repeatedLine{{0.0, 0.0, 0.0}, {1.0, 0.0, 0.0},
+                                        {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0},
+                                        {3.0, 0.0, 0.0}, {4.0, 0.0, 0.0}};
+    const std::vector<cv::Vec3d> repeatedControls{{0.0, 0.0, 0.0}, {1.0, 0.0, 0.0},
+                                                  {1.0, 0.0, 0.0}, {3.0, 0.0, 0.0}};
+    const auto repeatedPlan = computeFiberSplitPlan(repeatedControls, repeatedLine, 1);
+    REQUIRE(repeatedPlan.has_value());
+    CHECK(repeatedPlan->prefixLineCount == 2);  // first "1" belongs to the prefix
+    CHECK(repeatedPlan->suffixLineBegin == 2);  // second "1" starts the suffix
+}
+
+TEST_CASE("reversedStoredControlPoints shifts span descriptors with their spans")
+{
+    using vc3d::line_annotation::reversedStoredControlPoints;
+
+    // 4 CPs, 3 spans with distinct interp modes: T, L, C.
+    std::vector<StoredControlPoint> controls;
+    for (int i = 0; i < 4; ++i) {
+        controls.emplace_back(cv::Vec3d(static_cast<double>(i), 0.0, 0.0));
+    }
+    controls[0].segmentToNext = segmentWithMode(SegmentInterpolationMode::Trace);
+    controls[1].segmentToNext = segmentWithMode(SegmentInterpolationMode::Lasagna);
+    controls[2].segmentToNext = segmentWithMode(SegmentInterpolationMode::Cspline);
+
+    const auto reversed = reversedStoredControlPoints(controls);
+    REQUIRE(reversed.size() == 4);
+    // Positions reversed.
+    CHECK(static_cast<cv::Vec3d>(reversed[0]) == cv::Vec3d(3.0, 0.0, 0.0));
+    CHECK(static_cast<cv::Vec3d>(reversed[3]) == cv::Vec3d(0.0, 0.0, 0.0));
+    // Reversed span j carries original span (n-2-j)'s descriptor.
+    REQUIRE(reversed[0].segmentToNext.has_value());
+    CHECK(reversed[0].segmentToNext->interpMode == SegmentInterpolationMode::Cspline);
+    REQUIRE(reversed[1].segmentToNext.has_value());
+    CHECK(reversed[1].segmentToNext->interpMode == SegmentInterpolationMode::Lasagna);
+    REQUIRE(reversed[2].segmentToNext.has_value());
+    CHECK(reversed[2].segmentToNext->interpMode == SegmentInterpolationMode::Trace);
+    // The new final CP carries no descriptor (v3 contract).
+    CHECK_FALSE(reversed[3].segmentToNext.has_value());
+
+    CHECK(reversedStoredControlPoints({}).empty());
+    std::vector<StoredControlPoint> single{
+        StoredControlPoint{cv::Vec3d(1.0, 2.0, 3.0)}};
+    const auto reversedSingle = reversedStoredControlPoints(single);
+    REQUIRE(reversedSingle.size() == 1);
+    CHECK_FALSE(reversedSingle[0].segmentToNext.has_value());
+}
+
+TEST_CASE("computeFiberMergeGeometry slices tails and synthesizes the join span")
+{
+    using vc3d::line_annotation::computeFiberMergeGeometry;
+    using vc3d::line_annotation::SegmentInterpolationGoal;
+    using vc3d::line_annotation::validateStoredControlPoints;
+
+    // Side a: CPs at x = 1, 3 on a line 0..5 (tails at 0, 4, 5).
+    std::vector<StoredControlPoint> aControls{
+        StoredControlPoint{cv::Vec3d(1.0, 0.0, 0.0)},
+        StoredControlPoint{cv::Vec3d(3.0, 0.0, 0.0)}};
+    aControls[0].segmentToNext = segmentWithMode(SegmentInterpolationMode::Trace);
+    std::vector<cv::Vec3d> aLine;
+    for (int i = 0; i <= 5; ++i) {
+        aLine.emplace_back(static_cast<double>(i), 0.0, 0.0);
+    }
+    // Side b: CPs at y = 11, 13 on a line y = 9..14 (tails at 9, 10, 14).
+    std::vector<StoredControlPoint> bControls{
+        StoredControlPoint{cv::Vec3d(0.0, 11.0, 0.0)},
+        StoredControlPoint{cv::Vec3d(0.0, 13.0, 0.0)}};
+    bControls[0].segmentToNext = segmentWithMode(SegmentInterpolationMode::Cspline);
+    std::vector<cv::Vec3d> bLine;
+    for (int i = 9; i <= 14; ++i) {
+        bLine.emplace_back(0.0, static_cast<double>(i), 0.0);
+    }
+
+    const auto merged = computeFiberMergeGeometry(aControls, aLine, bControls, bLine);
+    REQUIRE(merged.has_value());
+    REQUIRE(merged->controlPoints.size() == 4);
+    CHECK(merged->joinControlIndex == 1);
+    // a tail (x=4,5) and b tail (y=9,10) dropped: line runs x=0..3 then y=11..14.
+    REQUIRE(merged->linePoints.size() == 8);
+    CHECK(merged->linePoints[3] == cv::Vec3d(3.0, 0.0, 0.0));
+    CHECK(merged->linePoints[4] == cv::Vec3d(0.0, 11.0, 0.0));
+    // Join descriptor synthesized on a's former final CP; b's descriptors ride.
+    REQUIRE(merged->controlPoints[1].segmentToNext.has_value());
+    CHECK(merged->controlPoints[1].segmentToNext->interpGoal ==
+          SegmentInterpolationGoal::Global);
+    CHECK(merged->controlPoints[1].segmentToNext->interpMode ==
+          SegmentInterpolationMode::Lasagna);
+    REQUIRE(merged->controlPoints[2].segmentToNext.has_value());
+    CHECK(merged->controlPoints[2].segmentToNext->interpMode ==
+          SegmentInterpolationMode::Cspline);
+    CHECK_NOTHROW(validateStoredControlPoints(merged->controlPoints));
+
+    // A control off its line breaks the ordered scan.
+    auto badControls = aControls;
+    badControls[1] = StoredControlPoint{cv::Vec3d(3.0, 1.0e-6, 0.0)};
+    CHECK_FALSE(
+        computeFiberMergeGeometry(badControls, aLine, bControls, bLine).has_value());
+    // Fewer than 2 CPs per side is not mergeable.
+    CHECK_FALSE(computeFiberMergeGeometry({aControls[0]}, aLine, bControls, bLine)
+                    .has_value());
+}
+
+TEST_CASE("reverse-then-merge covers the endpoint orientation recipe")
+{
+    using vc3d::line_annotation::computeFiberMergeGeometry;
+    using vc3d::line_annotation::reversedStoredControlPoints;
+
+    // Fiber whose merge endpoint is its FIRST CP: reverse it so it ends at
+    // the join, then merge; the reversed side must still pass the scan.
+    std::vector<StoredControlPoint> controls{
+        StoredControlPoint{cv::Vec3d(5.0, 0.0, 0.0)},   // merge endpoint
+        StoredControlPoint{cv::Vec3d(7.0, 0.0, 0.0)}};
+    controls[0].segmentToNext = segmentWithMode(SegmentInterpolationMode::Trace);
+    std::vector<cv::Vec3d> line{{4.0, 0.0, 0.0}, {5.0, 0.0, 0.0},
+                                {6.0, 0.0, 0.0}, {7.0, 0.0, 0.0},
+                                {8.0, 0.0, 0.0}};
+
+    auto reversedControls = reversedStoredControlPoints(controls);
+    auto reversedLine = line;
+    std::reverse(reversedLine.begin(), reversedLine.end());
+
+    std::vector<StoredControlPoint> bControls{
+        StoredControlPoint{cv::Vec3d(3.0, 0.0, 0.0)},
+        StoredControlPoint{cv::Vec3d(1.0, 0.0, 0.0)}};
+    std::vector<cv::Vec3d> bLine{{3.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {1.0, 0.0, 0.0}};
+
+    const auto merged =
+        computeFiberMergeGeometry(reversedControls, reversedLine, bControls, bLine);
+    REQUIRE(merged.has_value());
+    REQUIRE(merged->controlPoints.size() == 4);
+    // Reversed side runs 7 -> 5; join meets b running 3 -> 1.
+    CHECK(static_cast<cv::Vec3d>(merged->controlPoints[0]) == cv::Vec3d(7.0, 0.0, 0.0));
+    CHECK(static_cast<cv::Vec3d>(merged->controlPoints[1]) == cv::Vec3d(5.0, 0.0, 0.0));
+    CHECK(static_cast<cv::Vec3d>(merged->controlPoints[2]) == cv::Vec3d(3.0, 0.0, 0.0));
+    // The reversed side's span descriptor traveled with its span, and the
+    // join descriptor replaced it on the new boundary CP.
+    REQUIRE(merged->controlPoints[0].segmentToNext.has_value());
+    CHECK(merged->controlPoints[0].segmentToNext->interpMode ==
+          SegmentInterpolationMode::Trace);
+    REQUIRE(merged->controlPoints[1].segmentToNext.has_value());
+    CHECK(merged->controlPoints[1].segmentToNext->interpMode ==
+          SegmentInterpolationMode::Lasagna);
+    // Tails dropped on both sides of the join: 5.0 then 3.0 consecutive.
+    CHECK(merged->linePoints[merged->linePoints.size() - 4] ==
+          cv::Vec3d(5.0, 0.0, 0.0));
+    CHECK(merged->linePoints[merged->linePoints.size() - 3] ==
+          cv::Vec3d(3.0, 0.0, 0.0));
 }

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -702,6 +702,80 @@ TEST_CASE("line annotation failed multi fiber save keeps recovery backups")
     std::filesystem::remove_all(dir);
 }
 
+TEST_CASE("line annotation save retires originals only after renames succeed")
+{
+    const auto dir = makeTempSaveDir("retire_success");
+    const auto original = dir / "fiber_old.json";
+    const auto target = dir / "fiber_new.json";
+    writeText(original, "{\"old\":true}\n");
+
+    const auto result = vc3d::line_annotation::runFiberSaveJob(
+        13,
+        {{1, 1, target, nlohmann::json{{"new", true}}}},
+        {original});
+
+    CHECK(result.ok);
+    CHECK(readText(target).find("\"new\": true") != std::string::npos);
+    CHECK_FALSE(std::filesystem::exists(original));
+    // The backup is removed after success; only the empty dot-directory
+    // may remain, which every fiber scanner ignores.
+    const auto retiredDir = dir / ".retired";
+    if (std::filesystem::exists(retiredDir)) {
+        CHECK(std::filesystem::is_empty(retiredDir));
+    }
+    std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("line annotation retire-only job is all-or-nothing")
+{
+    const auto dir = makeTempSaveDir("retire_only");
+    const auto first = dir / "fiber_a.json";
+    const auto second = dir / "fiber_b.json";
+    const auto missing = dir / "fiber_gone.json";
+    writeText(first, "{\"a\":true}\n");
+    writeText(second, "{\"b\":true}\n");
+
+    const auto result = vc3d::line_annotation::runFiberSaveJob(
+        14, {}, {first, second, missing});
+
+    CHECK(result.ok);
+    CHECK_FALSE(std::filesystem::exists(first));
+    CHECK_FALSE(std::filesystem::exists(second));
+    const auto retiredDir = dir / ".retired";
+    if (std::filesystem::exists(retiredDir)) {
+        CHECK(std::filesystem::is_empty(retiredDir));
+    }
+    std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("line annotation failed save restores retired originals")
+{
+    const auto dir = makeTempSaveDir("retire_failure");
+    const auto original = dir / "fiber_old.json";
+    const auto firstTarget = dir / "fiber_a.json";
+    const auto secondTarget = dir / "fiber_b.json";
+    writeText(original, "{\"old\":true}\n");
+
+    setenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE", "1", 1);
+    const auto result = vc3d::line_annotation::runFiberSaveJob(
+        15,
+        {{1, 1, firstTarget, nlohmann::json{{"new", "a"}}},
+         {2, 1, secondTarget, nlohmann::json{{"new", "b"}}}},
+        {original});
+    unsetenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE");
+
+    CHECK_FALSE(result.ok);
+    // The retired original is renamed straight back into place.
+    CHECK(std::filesystem::exists(original));
+    CHECK(readText(original).find("\"old\": true") != std::string::npos ||
+          readText(original).find("\"old\":true") != std::string::npos);
+    const auto retiredDir = dir / ".retired";
+    if (std::filesystem::exists(retiredDir)) {
+        CHECK(std::filesystem::is_empty(retiredDir));
+    }
+    std::filesystem::remove_all(dir);
+}
+
 TEST_CASE("line annotation intersection display h side uses manual tags before scores")
 {
     using vc3d::line_annotation::FiberHvClassification;

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -773,6 +773,32 @@ TEST_CASE("line annotation failed save restores retired originals")
     if (std::filesystem::exists(retiredDir)) {
         CHECK(std::filesystem::is_empty(retiredDir));
     }
+    // The renamed-in brand-new target is removed too: no orphan half of an
+    // aborted batch survives.
+    CHECK_FALSE(std::filesystem::exists(firstTarget));
+    CHECK_FALSE(std::filesystem::exists(secondTarget));
+    std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("line annotation failed multi fiber save removes orphan new targets")
+{
+    const auto dir = makeTempSaveDir("orphan_targets");
+    const auto first = dir / "fiber_new_a.json";
+    const auto second = dir / "fiber_new_b.json";
+
+    setenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE", "1", 1);
+    const auto result = vc3d::line_annotation::runFiberSaveJob(
+        16,
+        {{1, 1, first, nlohmann::json{{"new", "a"}}},
+         {2, 1, second, nlohmann::json{{"new", "b"}}}});
+    unsetenv("VC3D_FIBER_SAVE_FAIL_AFTER_FIRST_REPLACE");
+
+    CHECK_FALSE(result.ok);
+    // Neither brand-new target survives the aborted batch; a pre-existing
+    // target would instead keep the new content plus its recovery copy.
+    CHECK_FALSE(std::filesystem::exists(first));
+    CHECK_FALSE(std::filesystem::exists(second));
+    CHECK(recoveryFilesIn(dir).empty());
     std::filesystem::remove_all(dir);
 }
 


### PR DESCRIPTION
Follow-up to #1324. Three related additions to the Line Annotation GUI, all modeled on the existing link-candidate workflow, plus the pure geometry helpers they need.

## Split workflow

Ctrl+right-click a control point → **Designate as split candidate** (renders red in all candidate palette sites); ctrl+right-click the adjacent CP → two actions:

- **Split from candidate, different winding** — the fiber becomes two brand-new fibers: prefix `0..a`, suffix `a+1..end`, connecting span dropped (its descriptor cleared per the v3 final-CP contract). Fresh canonical identities; tags, optimization mode, and per-span `segment_to_next` inherited verbatim; manual H/V kept with automatic scores recomputed; branch links partitioned with peer reciprocals redirected to the owning half. The original is deleted and the candidate's half reopens at the candidate CP.
- **Split from candidate and link** — same split plus a **pending** reciprocal link between the two boundary CPs: the split asserts these are different fibers, but same-winding is a separate determination for a reviewer to approve.

Each half must keep ≥2 control points; halves are written synchronously before any in-memory mutation (a save failure aborts with nothing to roll back).

## Merge with candidate

The link menu gains **Merge with candidate** when the candidate and clicked CPs are both *endpoints* of *different* fibers (greyed with a reason otherwise). Sides are oriented so the join meets end-to-end — fiber reversal moves each span descriptor with its span — and both extrapolated tails are sliced at the boundary CPs via the loader's exact ordered-subset scan (raw concatenation breaks the optimizer's strict line-order mapping). Tags union; optimization-mode conflicts prompt (suppressed/agent sessions take the clicked fiber's mode; `setMergeModePickerForTesting` seam); manual H/V keeps only agreement; the pair link between the merge endpoints is consumed; any other mutual link blocks the merge; third-party links redirect to the merged fiber. Both originals are deleted and the merged fiber reopens at the join.

## Shared mechanics

- Both operations tag their results `needs_reoptimization` and immediately re-fit via the merged-fiber machinery, so lines regrow extrapolation tails (and the merge's join span gets real geometry); an aborted batch keeps the tag for the existing load-time prompt.
- The retire/re-fit/reopen tail is deferred with `QTimer::singleShot(0, …)`: the handlers run inside the dialog's own menu-callback stack, and the nested event loops in `waitForFiberSaves`/re-optimization would otherwise process the closed dialog's deferred deletion under its own frames (observed SIGABRT during testing). `waitForFiberSaves()` also flushes any close-triggered async save before the original files are removed.
- Originals are retired directly (not via `deleteFibers`, whose `removeBranchLinksToFiber` would strip the just-redirected peer links).

## Same-orientation link colors

H–H / V–V links (manual H/V tag falling back to automatic) render the node **light orange** while pending and **orange** when approved, in all four palette sites (overlay styles, fast current-cut path, cross-slice, overview bar). H–V links keep the existing blue/purple palette; unclassified fibers on either side keep the defaults.

## Tests

`core/test/test_fiber_trace_review.cpp` (no CMake change): `computeFiberSplitPlan` slicing/bounds/tolerance/coincident-point cases, `reversedStoredControlPoints` descriptor-shift matrix, `computeFiberMergeGeometry` tail-slicing/join-descriptor/ordered-scan-failure cases, and a composed reverse-then-merge orientation case. GUI-smoke-tested: split, split-and-link, merge, and the crash repro above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvKbK7HXygY2yjjtkvJs2H