### PR TITLE
predict: add --resume so an interrupted whole-scroll run is not lost

### DIFF
--- a/vesuvius/src/vesuvius/data/vc_dataset.py
+++ b/vesuvius/src/vesuvius/data/vc_dataset.py
@@ -498,10 +498,30 @@ class VCDataset(Dataset):
         is unchanged.
         """
         mask = getattr(self, 'non_empty_mask', None)
-        if mask is None or len(mask) != len(self.all_positions):
+        if mask is not None and len(mask) != len(self.all_positions):
+            mask = None
+        completed = getattr(self, 'completed_indices', None)
+
+        if mask is None and not completed:
             return self
-        indices = np.flatnonzero(mask).tolist()
+
+        if mask is None:
+            indices = list(range(len(self.all_positions)))
+        else:
+            indices = np.flatnonzero(mask).tolist()
+
+        if completed:
+            indices = [i for i in indices if i not in completed]
         return torch.utils.data.Subset(self, indices)
+
+    def set_completed_indices(self, completed):
+        """Exclude already-written patches from the view the DataLoader iterates.
+
+        Used by `--resume`. Kept separate from `non_empty_mask` because the two mean
+        different things: a patch can be skipped because it is empty, or because a previous
+        run already wrote it, and only the second is recoverable state.
+        """
+        self.completed_indices = set(int(i) for i in completed) if completed else set()
 
 
     def set_distributed(self, rank: int, world_size: int):

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -911,7 +911,8 @@ class Inferer():
         prediction reproducible only under a setting no artifact mentioned.
         """
         return self._json_scalar_dict({
-            'input': str(self.input_dir),
+            # the constructor takes input_dir= but stores it as self.input
+            'input': str(self.input),
             'bbox': None if self.bbox is None else list(self.bbox),
             'patch_size': list(self.patch_size) if self.patch_size is not None else None,
             'overlap': self.overlap,
@@ -919,7 +920,8 @@ class Inferer():
             'num_parts': self.num_parts,
             'part_id': self.part_id,
             'model_path': str(self.model_path),
-            'tta': None if self.disable_tta else self.tta_type,
+            # the CLI flag is --disable_tta; the instance stores the positive form
+            'tta': self.tta_type if self.do_tta else None,
             'normalization': self.normalization_scheme,
             'num_total_patches': self.num_total_patches,
         })

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -13,6 +13,7 @@ import hashlib
 import multiprocessing
 import subprocess
 import threading
+import time
 import fsspec
 import numcodecs
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
@@ -1141,32 +1142,54 @@ class Inferer():
 
         progress_lock = threading.Lock()
 
-        # Completion bookkeeping for --resume. The manifest is flushed every
-        # RESUME_FLUSH_EVERY writes rather than on every write: rewriting it per patch would
-        # add an fsync to each one, and the cost of a stale manifest is only that a handful
-        # of patches get recomputed, which is exactly what a resume is for.
-        RESUME_FLUSH_EVERY = 64
+        # Completion bookkeeping for --resume. The manifest is not rewritten on every write,
+        # which would put an fsync in front of each patch; it is flushed periodically, and the
+        # interval is the worst-case amount of work a hard kill can cost.
+        #
+        # A count-only interval is not enough, and the first end-to-end test proved it: the
+        # run was interrupted after 63 writes with the interval at 64, so nothing was ever
+        # persisted and the resume had nothing to find. A checkpoint whose survival depends on
+        # reaching a counter is not a checkpoint. Whichever of the two limits comes first wins.
+        RESUME_FLUSH_EVERY = 16
+        RESUME_FLUSH_SECONDS = 30.0
         resuming = getattr(self, 'resume', False)
         completed = set(getattr(self, 'resume_completed', None) or ())
-        resume_state = {'since_flush': 0}
+        resume_state = {'since_flush': 0, 'last_flush': time.monotonic()}
 
         def on_written(write_index):
             if not resuming:
                 return
+            snapshot = None
             with progress_lock:
                 completed.add(int(write_index))
                 resume_state['since_flush'] += 1
-                flush = resume_state['since_flush'] >= RESUME_FLUSH_EVERY
-                if flush:
+                now = time.monotonic()
+                if (resume_state['since_flush'] >= RESUME_FLUSH_EVERY
+                        or now - resume_state['last_flush'] >= RESUME_FLUSH_SECONDS):
                     resume_state['since_flush'] = 0
+                    resume_state['last_flush'] = now
                     snapshot = set(completed)
-            if flush:
+            if snapshot is not None:
                 self._write_manifest(snapshot)
 
         def to_device(tensor):
             return tensor.to(self.device, non_blocking=(self.device.type == 'cuda'))
 
-        with tqdm(total=self.num_active_patches, desc=f"Inferring Part {self.part_id}", **get_tqdm_kwargs()) as pbar:
+        def flush_manifest():
+            """Persist whatever is complete. Safe to call more than once."""
+            if not resuming:
+                return
+            with progress_lock:
+                snapshot = set(completed)
+            self._write_manifest(snapshot)
+            return snapshot
+
+        # Ctrl-C and unhandled errors still checkpoint what finished, by wrapping the whole
+        # inference block rather than the loop body. A hard kill (TerminateProcess on Windows,
+        # SIGKILL, power loss) cannot run this, which is why the periodic flush above exists
+        # and is what actually bounds the loss.
+        try:
+          with tqdm(total=self.num_active_patches, desc=f"Inferring Part {self.part_id}", **get_tqdm_kwargs()) as pbar:
             def on_progress():
                 with progress_lock:
                     self.current_patch_write_index += 1
@@ -1246,6 +1269,9 @@ class Inferer():
 
             total_wait = writer.total_wait_seconds
             elapsed = writer.elapsed_seconds
+        except BaseException:
+            flush_manifest()
+            raise
 
         # Final flush after the writer pool has drained, so the manifest reflects every patch
         # the store actually accepted. Note this correctly records EMPTY patches as done:
@@ -1253,8 +1279,8 @@ class Inferer():
         # lands on disk. That is the whole reason completion is tracked here and not by
         # listing the store -- on a masked scroll volume most patches are empty, and a
         # listing-based resume would rerun all of them on every restart, forever.
-        if getattr(self, "resume", False):
-            self._write_manifest(completed)
+        if resuming:
+            flush_manifest()
             print(f"--resume: manifest records {len(completed)} of "
                   f"{self.num_total_patches} patches complete")
 

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -790,6 +790,13 @@ class Inferer():
             self.resume_completed = self._load_completed()
             if self.resume_completed is None:
                 print("--resume: no previous run found in this output_dir; starting from scratch")
+            elif not hasattr(self.dataset, 'set_completed_indices'):
+                # Fail rather than quietly recompute everything: a resume that silently does
+                # nothing looks like a resume that worked until the bill arrives.
+                raise RuntimeError(
+                    f"--resume is not supported for {type(self.dataset).__name__}, which does "
+                    "not implement set_completed_indices()."
+                )
             else:
                 self.dataset.set_completed_indices(self.resume_completed)
                 print(f"--resume: {len(self.resume_completed)} of {self.num_total_patches} "
@@ -877,6 +884,23 @@ class Inferer():
     def _manifest_path(self):
         return os.path.join(self.output_dir, f"completed_part_{self.part_id}.json")
 
+    @staticmethod
+    def _json_scalar(value):
+        """Coerce numpy scalars to Python ones so the manifest is JSON-serialisable.
+
+        patch_size and num_classes arrive from the model config and are frequently numpy
+        integers. json.dump raises on those AFTER opening the output file, which leaves a
+        zero-byte .tmp behind and no manifest -- so the run appears to work and every
+        subsequent --resume silently finds nothing to resume. That is how this was found.
+        """
+        if isinstance(value, np.generic):
+            return value.item()
+        if isinstance(value, np.ndarray):
+            return [Inferer._json_scalar(v) for v in value.tolist()]
+        if isinstance(value, (list, tuple)):
+            return [Inferer._json_scalar(v) for v in value]
+        return value
+
     def _run_signature(self):
         """What must match for a resume to be legitimate.
 
@@ -885,7 +909,7 @@ class Inferer():
         ways, with nothing recording the split -- the exact failure that made a published
         prediction reproducible only under a setting no artifact mentioned.
         """
-        return {
+        return self._json_scalar_dict({
             'input': str(self.input_dir),
             'bbox': None if self.bbox is None else list(self.bbox),
             'patch_size': list(self.patch_size) if self.patch_size is not None else None,
@@ -897,7 +921,11 @@ class Inferer():
             'tta': None if self.disable_tta else self.tta_type,
             'normalization': self.normalization_scheme,
             'num_total_patches': self.num_total_patches,
-        }
+        })
+
+    @staticmethod
+    def _json_scalar_dict(d):
+        return {k: Inferer._json_scalar(v) for k, v in d.items()}
 
     def _load_completed(self):
         """Completed patch indices from a previous run, or None if there is nothing to resume.
@@ -932,12 +960,22 @@ class Inferer():
         """Rewrite the manifest atomically. Small (ints), so simplicity beats appending."""
         path = self._manifest_path()
         tmp = path + '.tmp'
-        with open(tmp, 'w') as fh:
-            json.dump({'signature': self._run_signature(),
-                       'completed': sorted(int(i) for i in completed)}, fh)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.replace(tmp, path)
+        payload = {'signature': self._run_signature(),
+                   'completed': sorted(int(i) for i in completed)}
+        try:
+            with open(tmp, 'w') as fh:
+                json.dump(payload, fh)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, path)
+        except Exception:
+            # Leaving a zero-byte .tmp and no manifest is worse than failing loudly: the run
+            # looks fine and every later --resume silently finds nothing to resume.
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
 
     def _create_output_stores(self):
         if self.num_classes is None or self.patch_size is None or self.num_total_patches is None:

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -3,6 +3,7 @@ import numpy as np
 import zarr
 import os
 import errno
+import json
 try:
     import fcntl  # POSIX-only; used to serialize model-cache downloads
 except ImportError:  # pragma: no cover - Windows has no fcntl
@@ -269,6 +270,7 @@ class Inferer():
                  model_cache_dir: str = DEFAULT_MODEL_CACHE_DIR,
                  max_patches: int = None,
                  bbox: [list, tuple] = None,
+                 resume: bool = False,
                  ):
         print(f"Initializing Inferer with output_dir: '{output_dir}'")
         if output_dir and not output_dir.strip():
@@ -306,6 +308,10 @@ class Inferer():
         self.model_cache_dir = model_cache_dir
         self.max_patches = max_patches
         self.bbox = tuple(bbox) if bbox is not None else None
+        self.resume = resume
+        # Patch indices a previous run already wrote. Empty set == resume requested but
+        # nothing recoverable found; None == not resuming, so the store is created fresh.
+        self.resume_completed = None
         self.model_patch_size = None
         self.num_classes = None
 
@@ -776,6 +782,19 @@ class Inferer():
         # over non-empty patches when the input zarr's chunk occupancy has been
         # pre-indexed). len(loader_dataset) drives tqdm and the written-count
         # assertion below, so progress/ETA reflect only patches the model actually sees.
+        # Resume is applied here rather than in _run_inference because the completed set has
+        # to be known before the DataLoader is built, and the manifest's signature check needs
+        # num_total_patches, which is only known once the dataset exists. This is the one
+        # point where both are true.
+        if getattr(self, "resume", False):
+            self.resume_completed = self._load_completed()
+            if self.resume_completed is None:
+                print("--resume: no previous run found in this output_dir; starting from scratch")
+            else:
+                self.dataset.set_completed_indices(self.resume_completed)
+                print(f"--resume: {len(self.resume_completed)} of {self.num_total_patches} "
+                      f"patches already written; skipping them")
+
         loader_dataset = self.dataset.active_view()
         self.num_active_patches = len(loader_dataset)
         if self.verbose:
@@ -842,6 +861,84 @@ class Inferer():
         else:
             return numcodecs.Blosc(cname='zstd', clevel=1, shuffle=shuffle)
 
+    # --- resume support -------------------------------------------------------------
+    #
+    # A whole-scroll pass is hours to days of streaming, so an interrupted run is normal
+    # rather than exceptional. Without resume the only options are to rerun everything or
+    # to hand-slice the volume with --num_parts, and a dead shard is still a dead shard.
+    #
+    # The logits store is already chunked one-chunk-per-patch, so a finished patch is
+    # individually addressable. It is NOT enough to list the chunks that exist, though:
+    # write_empty_chunks=False means a patch that legitimately produced all zeros writes no
+    # chunk at all, and on a masked scroll volume those are the majority. Listing chunks
+    # would therefore re-run every empty patch on every resume. So completion is recorded
+    # explicitly, in an append-only sidecar next to the store.
+
+    def _manifest_path(self):
+        return os.path.join(self.output_dir, f"completed_part_{self.part_id}.json")
+
+    def _run_signature(self):
+        """What must match for a resume to be legitimate.
+
+        Deliberately strict. Silently resuming a run whose patch grid, model or TTA setting
+        differs would produce one output store containing patches computed two different
+        ways, with nothing recording the split -- the exact failure that made a published
+        prediction reproducible only under a setting no artifact mentioned.
+        """
+        return {
+            'input': str(self.input_dir),
+            'bbox': None if self.bbox is None else list(self.bbox),
+            'patch_size': list(self.patch_size) if self.patch_size is not None else None,
+            'overlap': self.overlap,
+            'num_classes': self.num_classes,
+            'num_parts': self.num_parts,
+            'part_id': self.part_id,
+            'model_path': str(self.model_path),
+            'tta': None if self.disable_tta else self.tta_type,
+            'normalization': self.normalization_scheme,
+            'num_total_patches': self.num_total_patches,
+        }
+
+    def _load_completed(self):
+        """Completed patch indices from a previous run, or None if there is nothing to resume.
+
+        Returns None (rather than an empty set) when no usable manifest exists, so the caller
+        can tell "resume from nothing" apart from "resume from a run that finished 0 patches".
+        """
+        path = self._manifest_path()
+        if not os.path.exists(path):
+            return None
+        try:
+            with open(path, 'r') as fh:
+                data = json.load(fh)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"--resume: ignoring unreadable manifest at {path} ({e}); starting over")
+            return None
+
+        want, got = self._run_signature(), data.get('signature')
+        if got != want:
+            differing = sorted(k for k in want if want.get(k) != (got or {}).get(k))
+            raise RuntimeError(
+                f"--resume refused: {path} was written by a different run.\n"
+                f"  differing: {', '.join(differing) or 'unknown'}\n"
+                f"  previous:  { {k: (got or {}).get(k) for k in differing} }\n"
+                f"  requested: { {k: want[k] for k in differing} }\n"
+                "Resuming would mix patches computed under different settings into one store. "
+                "Point --output_dir somewhere else, or drop --resume to start over."
+            )
+        return set(int(i) for i in data.get('completed', []))
+
+    def _write_manifest(self, completed):
+        """Rewrite the manifest atomically. Small (ints), so simplicity beats appending."""
+        path = self._manifest_path()
+        tmp = path + '.tmp'
+        with open(tmp, 'w') as fh:
+            json.dump({'signature': self._run_signature(),
+                       'completed': sorted(int(i) for i in completed)}, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+
     def _create_output_stores(self):
         if self.num_classes is None or self.patch_size is None or self.num_total_patches is None:
             raise RuntimeError("Cannot create output stores: model/patch info missing.")
@@ -852,24 +949,48 @@ class Inferer():
         output_shape = (self.num_total_patches, self.num_classes, *self.patch_size)
         output_chunks = (1, self.num_classes, *self.patch_size)  # we align chunks to patch size for better write performance
         main_store_path = os.path.join(self.output_dir, f"logits_part_{self.part_id}.zarr")
-        
-        print(f"Creating output store at: {main_store_path}")
-        
-        self.output_store = open_zarr(
-            path=main_store_path, 
-            mode='w',  
-            storage_options={'anon': False} if main_store_path.startswith('s3://') else None,
-            verbose=self.verbose,
-            shape=output_shape,
-            chunks=output_chunks,
-            dtype=np.float16,  
-            compressor=compressor,
-            write_empty_chunks=False  # we skip empty chunks here so we don't write all zero patches to the array but keep
-                                      # the proper indices for later re-zarring 
-        )
-        
-        print(f"Created zarr array at {main_store_path} with shape {self.output_store.shape}")
-        
+
+        # mode='w' recreates the array and discards every chunk already written, so a resume
+        # must reopen in place instead. _load_completed() has already refused anything whose
+        # signature disagrees, so by here the existing store is known to be the same run.
+        # getattr, not attribute access: several tests build an Inferer via __new__ and set
+        # only the fields their behaviour needs, and a new attribute should not break them.
+        if getattr(self, 'resume_completed', None):
+            print(f"Reopening output store for resume at: {main_store_path}")
+            self.output_store = open_zarr(
+                path=main_store_path,
+                mode='r+',
+                storage_options={'anon': False} if main_store_path.startswith('s3://') else None,
+                verbose=self.verbose,
+            )
+            if tuple(self.output_store.shape) != tuple(output_shape):
+                raise RuntimeError(
+                    f"--resume refused: existing store at {main_store_path} has shape "
+                    f"{tuple(self.output_store.shape)}, expected {tuple(output_shape)}."
+                )
+            print(f"Reopened zarr array with shape {self.output_store.shape}")
+        else:
+            print(f"Creating output store at: {main_store_path}")
+
+            self.output_store = open_zarr(
+                path=main_store_path,
+                mode='w',
+                storage_options={'anon': False} if main_store_path.startswith('s3://') else None,
+                verbose=self.verbose,
+                shape=output_shape,
+                chunks=output_chunks,
+                dtype=np.float16,
+                compressor=compressor,
+                write_empty_chunks=False  # we skip empty chunks here so we don't write all zero patches to the array but keep
+                                          # the proper indices for later re-zarring
+            )
+
+            print(f"Created zarr array at {main_store_path} with shape {self.output_store.shape}")
+
+        # The coordinates store is rewritten either way: it is small, fully determined by the
+        # patch grid, and identical on a legitimate resume, so recreating it costs nothing and
+        # keeps the two stores from drifting apart.
+
         self.coords_store_path = os.path.join(self.output_dir, f"coordinates_part_{self.part_id}.zarr")
         coord_shape = (self.num_total_patches, len(self.patch_size))
         # zarr rejects chunks with a zero dimension even when shape[0] is 0, so floor at 1.
@@ -982,6 +1103,28 @@ class Inferer():
 
         progress_lock = threading.Lock()
 
+        # Completion bookkeeping for --resume. The manifest is flushed every
+        # RESUME_FLUSH_EVERY writes rather than on every write: rewriting it per patch would
+        # add an fsync to each one, and the cost of a stale manifest is only that a handful
+        # of patches get recomputed, which is exactly what a resume is for.
+        RESUME_FLUSH_EVERY = 64
+        resuming = getattr(self, 'resume', False)
+        completed = set(getattr(self, 'resume_completed', None) or ())
+        resume_state = {'since_flush': 0}
+
+        def on_written(write_index):
+            if not resuming:
+                return
+            with progress_lock:
+                completed.add(int(write_index))
+                resume_state['since_flush'] += 1
+                flush = resume_state['since_flush'] >= RESUME_FLUSH_EVERY
+                if flush:
+                    resume_state['since_flush'] = 0
+                    snapshot = set(completed)
+            if flush:
+                self._write_manifest(snapshot)
+
         def to_device(tensor):
             return tensor.to(self.device, non_blocking=(self.device.type == 'cuda'))
 
@@ -996,6 +1139,7 @@ class Inferer():
                 max_workers=max_workers,
                 pbar=pbar,
                 on_progress=on_progress,
+                on_written=on_written if resuming else None,
             ) as writer:
                 if self.verbose:
                     print(f"Writer pool: {writer.max_workers} workers, max in-flight: {writer.max_inflight}")
@@ -1064,6 +1208,17 @@ class Inferer():
 
             total_wait = writer.total_wait_seconds
             elapsed = writer.elapsed_seconds
+
+        # Final flush after the writer pool has drained, so the manifest reflects every patch
+        # the store actually accepted. Note this correctly records EMPTY patches as done:
+        # they are submitted like any other, write_empty_chunks=False simply means no chunk
+        # lands on disk. That is the whole reason completion is tracked here and not by
+        # listing the store -- on a masked scroll volume most patches are empty, and a
+        # listing-based resume would rerun all of them on every restart, forever.
+        if getattr(self, "resume", False):
+            self._write_manifest(completed)
+            print(f"--resume: manifest records {len(completed)} of "
+                  f"{self.num_total_patches} patches complete")
 
         if total_wait > 0:
             pct = (total_wait / elapsed * 100.0) if elapsed > 0 else 0.0
@@ -1214,6 +1369,12 @@ def build_parser():
                            'Patch coordinates stay in the global frame, so blend_logits and '
                            'finalize_outputs need no extra flags. When streaming a remote '
                            'volume only the chunks intersecting the ROI are fetched.')
+    parser.add_argument('--resume', action='store_true',
+                      help='Continue a previous run in the same --output_dir instead of '
+                           'starting over. Patches already written are skipped and the '
+                           'existing logits store is appended to rather than recreated. '
+                           'Refuses to resume if the volume, bbox, patch size, overlap, '
+                           'model, TTA setting or part split differ from the previous run.')
     return parser
 
 
@@ -1287,6 +1448,7 @@ def main():
         model_cache_dir=args.model_cache_dir,
         max_patches=args.max_patches,
         bbox=bbox,
+        resume=args.resume,
     )
 
     try:

--- a/vesuvius/src/vesuvius/models/run/patch_writer.py
+++ b/vesuvius/src/vesuvius/models/run/patch_writer.py
@@ -17,10 +17,14 @@ class BoundedPatchWriter:
     """
 
     def __init__(self, output_store, max_workers, *, pbar=None,
-                 on_progress=None, stall_report_interval=5.0):
+                 on_progress=None, on_written=None, stall_report_interval=5.0):
         self._store = output_store
         self._pbar = pbar
         self._on_progress = on_progress
+        # on_written(write_index) fires only after the patch is durably in the store, which
+        # is what --resume records. Kept separate from on_progress, which is a bare counter
+        # for the progress bar and has no index to give.
+        self._on_written = on_written
         self._max_workers = max_workers
         self._max_inflight = max_workers * 2
         self._inflight = threading.BoundedSemaphore(self._max_inflight)
@@ -77,6 +81,11 @@ class BoundedPatchWriter:
     def _write(self, write_index, patch_data):
         try:
             self._store[write_index] = patch_data
+            # Order matters: record completion only after the assignment returns, and never
+            # in the except branch. A resume that trusts a patch the store never accepted
+            # would leave a permanent hole that no later run goes back for.
+            if self._on_written is not None:
+                self._on_written(write_index)
             if self._on_progress is not None:
                 self._on_progress()
         except Exception as e:

--- a/vesuvius/tests/models/run/test_inference_resume.py
+++ b/vesuvius/tests/models/run/test_inference_resume.py
@@ -1,0 +1,174 @@
+"""An interrupted inference run should be worth something afterwards.
+
+A whole-scroll pass streams for hours, so interruption is ordinary rather than exceptional.
+Before --resume the only outcome was to start over: _create_output_stores opened the logits
+store with mode='w', which recreates the array and discards every patch already written.
+
+Two things carry the behaviour and both are tested here:
+
+  * completion is recorded in a manifest, NOT by listing the chunks present in the store.
+    write_empty_chunks=False means a patch that produced all zeros writes no chunk at all,
+    and on a masked scroll volume those are the majority - so a listing-based resume would
+    rerun every empty patch on every restart, forever.
+
+  * a resume whose settings differ from the previous run is refused rather than merged. One
+    store holding patches computed two different ways, with nothing recording the split, is
+    the failure that made a published prediction reproducible only under a TTA setting no
+    artifact mentioned.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import zarr
+
+from vesuvius.models.run.inference import Inferer
+
+
+def _inferer(tmp_path, **overrides) -> Inferer:
+    """An Inferer with just enough state for the resume helpers and store creation.
+
+    __init__ builds a model and a dataset, neither of which this behaviour depends on, so
+    the instance is assembled directly (same approach as test_inference_run_config_attrs).
+    """
+    inf = Inferer.__new__(Inferer)
+    inf.num_classes = 2
+    inf.patch_size = (4, 4, 4)
+    inf.num_total_patches = 8
+    inf.output_dir = str(tmp_path)
+    inf.part_id = 0
+    inf.num_parts = 1
+    inf.overlap = 0.5
+    inf.verbose = False
+    # 'none' short-circuits _get_zarr_compressor, which reaches for zarr.Blosc - absent in
+    # zarr 3. Compression is irrelevant to everything under test.
+    inf.compressor_name = "none"
+    inf.compression_level = 1
+    inf.bbox = None
+    inf.input_dir = "https://example.invalid/scroll.zarr/0"
+    inf.model_path = "/models/m7"
+    inf.disable_tta = True
+    inf.tta_type = "mirroring"
+    inf.do_tta = False
+    inf.normalization_scheme = "instance_zscore"
+    inf.is_multi_task = False
+    inf.target_info = None
+    inf.resume = False
+    inf.resume_completed = None
+    inf.dataset = SimpleNamespace(input_shape=(16, 16, 16))
+    inf.patch_start_coords_list = [(i, 0, 0) for i in range(inf.num_total_patches)]
+    for k, v in overrides.items():
+        setattr(inf, k, v)
+    return inf
+
+
+def test_manifest_round_trips(tmp_path):
+    inf = _inferer(tmp_path)
+    inf._write_manifest({3, 1, 2})
+    assert inf._load_completed() == {1, 2, 3}
+
+
+def test_no_manifest_reads_as_nothing_to_resume(tmp_path):
+    # None rather than set(): the caller must be able to tell "no previous run" apart from
+    # "a previous run that completed zero patches".
+    assert _inferer(tmp_path)._load_completed() is None
+
+
+def test_unreadable_manifest_does_not_raise(tmp_path):
+    inf = _inferer(tmp_path)
+    with open(inf._manifest_path(), "w") as fh:
+        fh.write("{not json")
+    assert inf._load_completed() is None
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("bbox", (0, 4, 0, 4, 0, 4)),
+        ("patch_size", (8, 8, 8)),
+        ("overlap", 0.25),
+        ("model_path", "/models/other"),
+        ("disable_tta", False),
+        ("num_total_patches", 9),
+        ("num_parts", 2),
+        ("input_dir", "https://example.invalid/other.zarr/0"),
+    ],
+)
+def test_resume_refuses_a_different_run(tmp_path, field, value):
+    _inferer(tmp_path)._write_manifest({0, 1})
+    changed = _inferer(tmp_path, **{field: value})
+    with pytest.raises(RuntimeError, match="resume refused"):
+        changed._load_completed()
+
+
+def test_each_part_resumes_from_its_own_manifest(tmp_path):
+    """A different --part_id is not a mismatch, it is a different job.
+
+    The manifest is per part, so part 1 finds nothing to resume rather than being refused.
+    Re-sharding is the dangerous case, and that shows up as a changed num_parts, which is
+    covered above.
+    """
+    _inferer(tmp_path, part_id=0)._write_manifest({0, 1})
+    assert _inferer(tmp_path, part_id=1)._load_completed() is None
+    assert _inferer(tmp_path, part_id=0)._load_completed() == {0, 1}
+
+
+def test_refusal_names_the_field_that_differs(tmp_path):
+    _inferer(tmp_path)._write_manifest({0})
+    changed = _inferer(tmp_path, overlap=0.25)
+    with pytest.raises(RuntimeError, match="overlap"):
+        changed._load_completed()
+
+
+def test_resume_reopens_the_store_instead_of_recreating_it(tmp_path):
+    """The point of the whole feature: previously written patches must survive."""
+    first = _inferer(tmp_path)
+    first._create_output_stores()
+    first.output_store[2] = np.full((2, 4, 4, 4), 7, dtype=np.float16)
+    assert first.output_store[2].max() == 7
+
+    again = _inferer(tmp_path, resume=True, resume_completed={2})
+    again._create_output_stores()
+    assert again.output_store[2].max() == 7, "resume recreated the store and lost the patch"
+
+
+def test_without_resume_the_store_is_recreated(tmp_path):
+    """The behaviour --resume exists to avoid, pinned so it cannot regress silently."""
+    first = _inferer(tmp_path)
+    first._create_output_stores()
+    first.output_store[2] = np.full((2, 4, 4, 4), 7, dtype=np.float16)
+
+    fresh = _inferer(tmp_path)
+    fresh._create_output_stores()
+    assert fresh.output_store[2].max() == 0
+
+
+def test_resume_refuses_a_store_of_the_wrong_shape(tmp_path):
+    first = _inferer(tmp_path)
+    first._create_output_stores()
+
+    grown = _inferer(tmp_path, num_total_patches=16, resume=True, resume_completed={0})
+    with pytest.raises(RuntimeError, match="resume refused"):
+        grown._create_output_stores()
+
+
+def test_manifest_records_patches_that_wrote_no_chunk(tmp_path):
+    """An all-zero patch writes no chunk (write_empty_chunks=False) but IS complete.
+
+    This is why completion is tracked explicitly rather than by listing the store: the
+    store cannot distinguish "done and empty" from "not done".
+    """
+    inf = _inferer(tmp_path)
+    inf._create_output_stores()
+    inf.output_store[5] = np.zeros((2, 4, 4, 4), dtype=np.float16)
+
+    store_path = tmp_path / "logits_part_0.zarr"
+    chunk_files = [p for p in store_path.rglob("*") if p.is_file() and not p.name.startswith(".")]
+    assert chunk_files == [], "an all-zero patch should not have written a chunk"
+
+    inf._write_manifest({5})
+    assert inf._load_completed() == {5}

--- a/vesuvius/tests/models/run/test_inference_resume.py
+++ b/vesuvius/tests/models/run/test_inference_resume.py
@@ -72,6 +72,33 @@ def test_manifest_round_trips(tmp_path):
     assert inf._load_completed() == {1, 2, 3}
 
 
+def test_manifest_survives_numpy_typed_config(tmp_path):
+    """patch_size and num_classes arrive from the model config as numpy integers.
+
+    json.dump raises on those *after* opening the file, which left a zero-byte .tmp and no
+    manifest -- so the run looked fine and every later --resume silently found nothing to
+    resume. The first end-to-end run failed exactly this way; the unit tests above did not
+    catch it because they all use plain Python ints.
+    """
+    inf = _inferer(
+        tmp_path,
+        patch_size=np.array([4, 4, 4]),
+        num_classes=np.int64(2),
+        num_total_patches=np.int64(8),
+        overlap=np.float64(0.5),
+    )
+    inf._write_manifest({np.int64(1), 2})
+    assert inf._load_completed() == {1, 2}
+    assert not list(tmp_path.glob("*.tmp")), "a failed write must not leave a .tmp behind"
+
+
+def test_failed_manifest_write_leaves_no_tmp(tmp_path):
+    inf = _inferer(tmp_path, normalization_scheme=object())  # not JSON-serialisable
+    with pytest.raises(TypeError):
+        inf._write_manifest({0})
+    assert not list(tmp_path.glob("*.tmp"))
+
+
 def test_no_manifest_reads_as_nothing_to_resume(tmp_path):
     # None rather than set(): the caller must be able to tell "no previous run" apart from
     # "a previous run that completed zero patches".

--- a/vesuvius/tests/models/run/test_inference_resume.py
+++ b/vesuvius/tests/models/run/test_inference_resume.py
@@ -49,9 +49,9 @@ def _inferer(tmp_path, **overrides) -> Inferer:
     inf.compressor_name = "none"
     inf.compression_level = 1
     inf.bbox = None
-    inf.input_dir = "https://example.invalid/scroll.zarr/0"
+    # the constructor parameter is input_dir=, but it is stored as self.input
+    inf.input = "https://example.invalid/scroll.zarr/0"
     inf.model_path = "/models/m7"
-    inf.disable_tta = True
     inf.tta_type = "mirroring"
     inf.do_tta = False
     inf.normalization_scheme = "instance_zscore"
@@ -64,6 +64,26 @@ def _inferer(tmp_path, **overrides) -> Inferer:
     for k, v in overrides.items():
         setattr(inf, k, v)
     return inf
+
+
+def test_signature_only_reads_attributes_the_constructor_sets():
+    """Every self.X in _run_signature must actually exist on a real Inferer.
+
+    This exists because it did not. The signature read self.input_dir, which is the
+    constructor's parameter name; the value is stored as self.input. Nothing caught it --
+    the fixture above assigns attributes by hand, so it happily created the missing one,
+    and the failure only appeared in a live run, inside a writer thread, reported as
+    "Error writing patch 8". Fixtures test the fixture's shape, not production's.
+    """
+    import inspect
+    import re
+
+    sig_src = inspect.getsource(Inferer._run_signature)
+    init_src = inspect.getsource(Inferer.__init__)
+    assigned = set(re.findall(r"self\.(\w+)\s*=", init_src))
+    read = set(re.findall(r"self\.(\w+)", sig_src)) - {"_json_scalar_dict", "_json_scalar"}
+    missing = sorted(read - assigned)
+    assert not missing, f"_run_signature reads attributes __init__ never sets: {missing}"
 
 
 def test_manifest_round_trips(tmp_path):
@@ -119,10 +139,10 @@ def test_unreadable_manifest_does_not_raise(tmp_path):
         ("patch_size", (8, 8, 8)),
         ("overlap", 0.25),
         ("model_path", "/models/other"),
-        ("disable_tta", False),
+        ("do_tta", True),
         ("num_total_patches", 9),
         ("num_parts", 2),
-        ("input_dir", "https://example.invalid/other.zarr/0"),
+        ("input", "https://example.invalid/other.zarr/0"),
     ],
 )
 def test_resume_refuses_a_different_run(tmp_path, field, value):


### PR DESCRIPTION
## The problem

A whole-scroll inference pass streams for hours. Measuring the I/O side of it in #1325: PHerc1218 is 1.34 TB, and at the 11 MB/s my connection sustains that is ~36 h even under the best traversal policy, ~43 days with no chunk cache at all. At that length interruption is ordinary — a dropped connection, a reboot, a laptop lid.

Today an interrupted run is worth nothing. `_create_output_stores` opens `logits_part_{id}.zarr` with `mode='w'`, which recreates the array, so restarting the same command discards every patch already computed.

I measured it rather than assuming it. A 384³ region of PHerc1218 at level 0, 216 patches: killed the run after 182 s with 64 patches on disk, then reran the identical command and sampled the store every 5 s.

```
t=0s  64 chunks     t=20s   0 chunks   <- store recreated
t=5s  64 chunks     t=30s   3 chunks
t=10s 64 chunks     t=35s   5 chunks
t=15s 64 chunks     t=40s   7 chunks
```

The count holds, collapses to zero, and starts again from three. `--num_parts`/`--part_id` do not help: they split the work up front, and a dead shard is still a dead shard.

## What this adds

`--resume` continues a previous run in the same `--output_dir`: patches already written are skipped, and the existing logits store is appended to rather than recreated.

```
vesuvius.predict --input_dir <url> --output_dir out --bbox z0:z1,y0:y1,x0:x1 --resume
```

Two details drove the design and both are load-bearing.

**Completion is recorded in a manifest, not inferred by listing the store.** The logits array is chunked one-chunk-per-patch, so it is tempting to treat "chunk exists" as "patch done". That is wrong here: `write_empty_chunks=False` is set deliberately, so a patch that produces all zeros writes no chunk at all. The store therefore cannot distinguish *done and empty* from *not done* — and on a masked scroll volume the empty patches are the majority, so a listing-based resume would rerun all of them on every restart, forever. Empty patches are submitted to the writer like any other, so `on_written` records them correctly. `completed_part_{id}.json` sits beside the store and is rewritten atomically.

**A resume whose settings differ is refused, not merged.** The signature covers the input volume, bbox, patch size, overlap, model, TTA setting, normalization, part split and patch count, and the error names the fields that differ:

```
--resume refused: out/completed_part_0.json was written by a different run.
  differing: overlap, tta
```

One store holding patches computed two different ways, with nothing recording the split, is the failure mode behind #1250 and #1253 — a published prediction that turned out to reproduce only under a TTA setting no artifact mentioned. It seemed worth making that unrepresentable rather than documented.

The manifest is flushed on whichever comes first, 16 writes or 30 seconds, rather than per patch — so a crash costs a bounded handful of recomputed patches instead of an fsync on every write, and the time limit bounds the loss regardless of throughput.

`BoundedPatchWriter` gains an optional `on_written(index)` callback, fired only after the store accepts the patch and never from the error path — a resume that trusted a patch the store rejected would leave a permanent hole no later run goes back for. It is kept separate from `on_progress`, which is a bare counter for the progress bar and has no index to give.

Patch indices, the coordinates store and its attributes are unchanged, so `blend_logits` and `finalize_outputs` need no flags and see exactly what they see today.

## Tests

`vesuvius/tests/models/run/test_inference_resume.py`, 20 cases: manifest round trip, missing and corrupt manifests, refusal on each differing field, per-part manifests, that resume reopens the store rather than recreating it, that a plain run still recreates it, that a store of the wrong shape is refused, that a patch which wrote no chunk is still recorded complete, that a manifest built from numpy scalars serialises, that no `.tmp` survives a failed write, and a guard that parses `__init__` for `self.X =` and asserts the run signature reads nothing else.

Nearby suites pass unchanged: `tests/models/run` is 67 passed, and `tests/models/run` plus `tests/data` together are 119 passed, 1 skipped.

## End to end

Same region, same interruption, with the flag. Run 1 was killed with 54 patch chunks on disk and a manifest recording 51 complete; run 2 was the identical command with `--resume`:

```
--resume: 51 of 216 patches already written; skipping them
```

Chunks on disk through the restart: `54, 54, 54, 54, 54, 54, 54, 54, 54, 55, 57, 61, 62, 64 …`

It holds flat while the resumed run works through what is left, then climbs — against `64, 64, 64, 0, 3, 5, 7` for the same sequence without the flag.

Three things this caught that the unit tests did not, all fixed here:

- `patch_size` and `num_classes` arrive as numpy integers, and `json.dump` raises on those *after* opening the file — leaving a zero-byte `.tmp`, no manifest, and a run that looked fine.
- Flushing the manifest every N writes is not enough on its own: the first run was interrupted after 63 writes with the interval at 64, so nothing was ever persisted. It now flushes on 16 writes **or** 30 seconds, whichever comes first, and on the way out of Ctrl-C or an exception.
- The signature read `self.input_dir` and `self.disable_tta`, neither of which exists — the instance stores `self.input` and `self.do_tta`. There is now a test that parses `__init__` for `self.X =` and asserts the signature reads nothing else; it caught the second one immediately after the first was fixed by hand.


Related: #1241 and #1247 added `--bbox` and made an ROI run select from the full-volume grid; #1253 recorded TTA provenance in the output attrs. This is the same thread — making a long streamed run something you can trust and finish.
