### PR TITLE
predict: add --estimate so a run's cost is knowable before it starts

### DIFF
--- a/vesuvius/src/vesuvius/data/vc_dataset.py
+++ b/vesuvius/src/vesuvius/data/vc_dataset.py
@@ -498,10 +498,30 @@ class VCDataset(Dataset):
         is unchanged.
         """
         mask = getattr(self, 'non_empty_mask', None)
-        if mask is None or len(mask) != len(self.all_positions):
+        if mask is not None and len(mask) != len(self.all_positions):
+            mask = None
+        completed = getattr(self, 'completed_indices', None)
+
+        if mask is None and not completed:
             return self
-        indices = np.flatnonzero(mask).tolist()
+
+        if mask is None:
+            indices = list(range(len(self.all_positions)))
+        else:
+            indices = np.flatnonzero(mask).tolist()
+
+        if completed:
+            indices = [i for i in indices if i not in completed]
         return torch.utils.data.Subset(self, indices)
+
+    def set_completed_indices(self, completed):
+        """Exclude already-written patches from the view the DataLoader iterates.
+
+        Used by `--resume`. Kept separate from `non_empty_mask` because the two mean
+        different things: a patch can be skipped because it is empty, or because a previous
+        run already wrote it, and only the second is recoverable state.
+        """
+        self.completed_indices = set(int(i) for i in completed) if completed else set()
 
 
     def set_distributed(self, rank: int, world_size: int):

--- a/vesuvius/src/vesuvius/models/run/estimate.py
+++ b/vesuvius/src/vesuvius/models/run/estimate.py
@@ -1,0 +1,195 @@
+"""Report what an inference run will cost before it computes anything.
+
+A whole-scroll pass streams for hours, and the thing that decides how many is not the
+forward pass — it is how many times the same chunk gets fetched. villa's sliding window
+is 192^3 with half overlap while the store is chunked at 128^3, so the two grids do not
+align: one patch touches up to 3x3x3 chunks, and neighbouring patches touch them again.
+
+That re-touching is the whole cost. Counting it is exact — it is a property of the two
+grids, not a timing — so it can be reported up front, which is what this module does.
+
+The patch positions are not recomputed here. They are handed in from the dataset that
+the real run will use, because deriving a second grid is precisely the bug #1247 fixed:
+an ROI-origin grid gave 27 chunks and a flattering 384x where the true full-volume grid
+gives 125.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+MIB = 1024 ** 2
+GIB = 1024 ** 3
+TIB = 1024 ** 4
+
+
+def chunk_ranges(start, patch_size, chunk_size):
+    """Per-axis chunk index ranges that a patch starting at `start` overlaps."""
+    return [
+        range(s // c, (s + p - 1) // c + 1)
+        for s, p, c in zip(start, patch_size, chunk_size)
+    ]
+
+
+def morton_key(chunk_index):
+    """Interleave the bits of a (z, y, x) chunk index — Z-order.
+
+    Keeps a patch's neighbours in all three axes near it in the traversal, so a cache
+    of a given size holds a more useful working set than a raster order does.
+    """
+    z, y, x = chunk_index
+    out = 0
+    for bit in range(21):
+        out |= ((x >> bit) & 1) << (3 * bit)
+        out |= ((y >> bit) & 1) << (3 * bit + 1)
+        out |= ((z >> bit) & 1) << (3 * bit + 2)
+    return out
+
+
+ORDERS = ("current", "chunk_blocked", "morton")
+
+
+def order_positions(positions, chunk_size, order):
+    """Reorder patch starts under a traversal policy. `current` is villa's own order."""
+    if order == "current":
+        return list(positions)
+    if order not in ORDERS:
+        raise ValueError(f"unknown traversal order {order!r}; expected one of {ORDERS}")
+
+    def chunk_of(pos):
+        return tuple(s // c for s, c in zip(pos, chunk_size))
+
+    key = chunk_of if order == "chunk_blocked" else (lambda p: morton_key(chunk_of(p)))
+    return sorted(positions, key=key)
+
+
+def simulate(positions, patch_size, chunk_size, cache_chunks, order="current"):
+    """Count chunk fetches for this patch list under an LRU cache of `cache_chunks`.
+
+    `cache_chunks <= 0` means no cache at all, so every touch is a fetch — which is
+    what villa does today. Returns (fetches, distinct_chunks).
+    """
+    lru: OrderedDict = OrderedDict()
+    fetches = 0
+    distinct = set()
+    for pos in order_positions(positions, chunk_size, order):
+        rz, ry, rx = chunk_ranges(pos, patch_size, chunk_size)
+        for cz in rz:
+            for cy in ry:
+                for cx in rx:
+                    key = (cz, cy, cx)
+                    distinct.add(key)
+                    if cache_chunks <= 0:
+                        fetches += 1
+                        continue
+                    if key in lru:
+                        lru.move_to_end(key)
+                        continue
+                    fetches += 1
+                    lru[key] = True
+                    if len(lru) > cache_chunks:
+                        lru.popitem(last=False)
+    return fetches, len(distinct)
+
+
+def _fmt_bytes(n):
+    if n >= TIB:
+        return f"{n / TIB:,.2f} TiB"
+    if n >= GIB:
+        return f"{n / GIB:,.1f} GiB"
+    return f"{n / MIB:,.1f} MiB"
+
+
+def _fmt_hours(seconds):
+    if seconds < 90 * 60:
+        return f"{seconds / 60:,.0f} min"
+    if seconds < 48 * 3600:
+        return f"{seconds / 3600:,.1f} h"
+    return f"{seconds / 86400:,.1f} d"
+
+
+def build_plan(positions, patch_size, chunk_size, itemsize, cache_sizes_gib=(0, 4, 16)):
+    """Cost the run. Returns a dict; `format_plan` renders it.
+
+    `chunk_size` is spatial (z, y, x). `itemsize` is bytes per voxel of the input array.
+    """
+    chunk_bytes = itemsize
+    for c in chunk_size:
+        chunk_bytes *= c
+
+    rows = []
+    distinct = 0
+    for order in ORDERS:
+        for gib in cache_sizes_gib:
+            cache_chunks = int(gib * GIB // chunk_bytes) if gib else 0
+            fetches, distinct = simulate(
+                positions, patch_size, chunk_size, cache_chunks, order
+            )
+            rows.append({
+                "order": order,
+                "cache_gib": gib,
+                "cache_chunks": cache_chunks,
+                "fetches": fetches,
+                "bytes": fetches * chunk_bytes,
+                "amplification": fetches / distinct if distinct else 0.0,
+            })
+
+    return {
+        "n_patches": len(positions),
+        "patch_size": list(patch_size),
+        "chunk_size": list(chunk_size),
+        "chunk_bytes": chunk_bytes,
+        "distinct_chunks": distinct,
+        "floor_bytes": distinct * chunk_bytes,
+        "rows": rows,
+    }
+
+
+def format_plan(plan, bandwidth_mbps, volume_desc="", compressor=None, extra_notes=()):
+    """Render the plan as the block `--estimate` prints. Returns a list of lines."""
+    out = ["", "--estimate: what this run will cost. Nothing is computed and nothing is written.", ""]
+    if volume_desc:
+        out.append(f"  volume            {volume_desc}")
+    out.append(
+        f"  chunks            {'x'.join(str(c) for c in plan['chunk_size'])}"
+        f"   {_fmt_bytes(plan['chunk_bytes'])} each"
+    )
+    out.append(
+        f"  patch grid        {'x'.join(str(p) for p in plan['patch_size'])}"
+        f"   ->  {plan['n_patches']:,} patches"
+    )
+    out.append("")
+    out.append(
+        f"  distinct chunks   {plan['distinct_chunks']:,}"
+        f"   {_fmt_bytes(plan['floor_bytes'])}"
+        f"   <- the floor: every needed chunk fetched exactly once"
+    )
+    out.append("")
+    out.append(f"  {'traversal':<15} {'cache':>7} {'fetches':>13} {'transfer':>13} {'amplification':>14} {'at ' + format(bandwidth_mbps, '.0f') + ' MB/s':>12}")
+    out.append(f"  {'-' * 78}")
+    for row in plan["rows"]:
+        cache = "none" if not row["cache_gib"] else f"{row['cache_gib']} GiB"
+        label = {"current": "current (villa)", "chunk_blocked": "chunk-blocked", "morton": "morton"}[row["order"]]
+        secs = row["bytes"] / (bandwidth_mbps * 1e6) if bandwidth_mbps > 0 else 0
+        out.append(
+            f"  {label:<15} {cache:>7} {row['fetches']:>13,} {_fmt_bytes(row['bytes']):>13}"
+            f" {row['amplification']:>13.2f}x {_fmt_hours(secs):>12}"
+        )
+    out.append("")
+    out.append("  `current` is what this build does today: no chunk cache, so every touch is a fetch.")
+    out.append("  The other rows are what the same patch list would cost under a cache and a")
+    out.append("  different visit order — see villa #1177, #1327 and #1331.")
+
+    if compressor is not None:
+        out.append("")
+        out.append(
+            f"  NOTE: this array declares compressor {compressor!r}, so the bytes above are"
+        )
+        out.append(
+            "  uncompressed size. The transfer will be smaller by the compression ratio;"
+        )
+        out.append("  the fetch counts and the amplification are unaffected.")
+    for note in extra_notes:
+        out.append(f"  {note}")
+    out.append("")
+    return out

--- a/vesuvius/src/vesuvius/models/run/estimate.py
+++ b/vesuvius/src/vesuvius/models/run/estimate.py
@@ -118,11 +118,29 @@ def build_plan(positions, patch_size, chunk_size, itemsize, cache_sizes_gib=(0, 
         chunk_bytes *= c
 
     rows = []
-    distinct = 0
+
+    # With no cache every touch is a fetch, so the traversal order cannot change the
+    # count. Simulate it once rather than once per order: on a whole scroll that is
+    # tens of millions of touches, and running it three times to print the same number
+    # three times is both slow and misleading to read.
+    uncached_fetches, distinct = simulate(
+        positions, patch_size, chunk_size, cache_chunks=0, order="current"
+    )
+    rows.append({
+        "order": None,                       # None == applies to every order
+        "cache_gib": 0,
+        "cache_chunks": 0,
+        "fetches": uncached_fetches,
+        "bytes": uncached_fetches * chunk_bytes,
+        "amplification": uncached_fetches / distinct if distinct else 0.0,
+    })
+
     for order in ORDERS:
         for gib in cache_sizes_gib:
-            cache_chunks = int(gib * GIB // chunk_bytes) if gib else 0
-            fetches, distinct = simulate(
+            if not gib:
+                continue                     # the uncached row above covers this
+            cache_chunks = int(gib * GIB // chunk_bytes)
+            fetches, _ = simulate(
                 positions, patch_size, chunk_size, cache_chunks, order
             )
             rows.append({
@@ -167,18 +185,24 @@ def format_plan(plan, bandwidth_mbps, volume_desc="", compressor=None, extra_not
     out.append("")
     out.append(f"  {'traversal':<15} {'cache':>7} {'fetches':>13} {'transfer':>13} {'amplification':>14} {'at ' + format(bandwidth_mbps, '.0f') + ' MB/s':>12}")
     out.append(f"  {'-' * 78}")
+    labels = {
+        None: "any order",
+        "current": "current (villa)",
+        "chunk_blocked": "chunk-blocked",
+        "morton": "morton",
+    }
     for row in plan["rows"]:
         cache = "none" if not row["cache_gib"] else f"{row['cache_gib']} GiB"
-        label = {"current": "current (villa)", "chunk_blocked": "chunk-blocked", "morton": "morton"}[row["order"]]
         secs = row["bytes"] / (bandwidth_mbps * 1e6) if bandwidth_mbps > 0 else 0
         out.append(
-            f"  {label:<15} {cache:>7} {row['fetches']:>13,} {_fmt_bytes(row['bytes']):>13}"
+            f"  {labels[row['order']]:<15} {cache:>7} {row['fetches']:>13,} {_fmt_bytes(row['bytes']):>13}"
             f" {row['amplification']:>13.2f}x {_fmt_hours(secs):>12}"
         )
     out.append("")
-    out.append("  `current` is what this build does today: no chunk cache, so every touch is a fetch.")
-    out.append("  The other rows are what the same patch list would cost under a cache and a")
-    out.append("  different visit order — see villa #1177, #1327 and #1331.")
+    out.append("  The first row is what this build does today: no chunk cache, so every touch is")
+    out.append("  a fetch — and with nothing cached the visit order cannot change that count.")
+    out.append("  The rest are what the same patch list would cost under a cache and a different")
+    out.append("  visit order — see villa #1177, #1327 and #1331.")
 
     if compressor is not None:
         out.append("")

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -911,7 +911,8 @@ class Inferer():
         prediction reproducible only under a setting no artifact mentioned.
         """
         return self._json_scalar_dict({
-            'input': str(self.input_dir),
+            # the constructor takes input_dir= but stores it as self.input
+            'input': str(self.input),
             'bbox': None if self.bbox is None else list(self.bbox),
             'patch_size': list(self.patch_size) if self.patch_size is not None else None,
             'overlap': self.overlap,
@@ -919,7 +920,8 @@ class Inferer():
             'num_parts': self.num_parts,
             'part_id': self.part_id,
             'model_path': str(self.model_path),
-            'tta': None if self.disable_tta else self.tta_type,
+            # the CLI flag is --disable_tta; the instance stores the positive form
+            'tta': self.tta_type if self.do_tta else None,
             'normalization': self.normalization_scheme,
             'num_total_patches': self.num_total_patches,
         })

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -905,11 +905,13 @@ class Inferer():
         if len(chunks) != 3:
             return None
 
-        # zarr 2 exposes .compressor, zarr 3 .compressors; absent or empty means raw.
-        compressor = getattr(array_obj, 'compressor', None)
-        if compressor is None:
-            seq = getattr(array_obj, 'compressors', None)
-            compressor = seq[0] if seq else None
+        # zarr 3 exposes .compressors, zarr 2 .compressor; absent or empty means raw.
+        # Ask for the plural first: on zarr 3 the singular still exists but warns.
+        seq = getattr(array_obj, 'compressors', None)
+        if seq is not None:
+            compressor = seq[0] if len(seq) else None
+        else:
+            compressor = getattr(array_obj, 'compressor', None)
 
         return chunks, array_obj.dtype.itemsize, shape, compressor, str(self.input)
 

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -13,6 +13,7 @@ import hashlib
 import multiprocessing
 import subprocess
 import threading
+import time
 import fsspec
 import numcodecs
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
@@ -1141,32 +1142,54 @@ class Inferer():
 
         progress_lock = threading.Lock()
 
-        # Completion bookkeeping for --resume. The manifest is flushed every
-        # RESUME_FLUSH_EVERY writes rather than on every write: rewriting it per patch would
-        # add an fsync to each one, and the cost of a stale manifest is only that a handful
-        # of patches get recomputed, which is exactly what a resume is for.
-        RESUME_FLUSH_EVERY = 64
+        # Completion bookkeeping for --resume. The manifest is not rewritten on every write,
+        # which would put an fsync in front of each patch; it is flushed periodically, and the
+        # interval is the worst-case amount of work a hard kill can cost.
+        #
+        # A count-only interval is not enough, and the first end-to-end test proved it: the
+        # run was interrupted after 63 writes with the interval at 64, so nothing was ever
+        # persisted and the resume had nothing to find. A checkpoint whose survival depends on
+        # reaching a counter is not a checkpoint. Whichever of the two limits comes first wins.
+        RESUME_FLUSH_EVERY = 16
+        RESUME_FLUSH_SECONDS = 30.0
         resuming = getattr(self, 'resume', False)
         completed = set(getattr(self, 'resume_completed', None) or ())
-        resume_state = {'since_flush': 0}
+        resume_state = {'since_flush': 0, 'last_flush': time.monotonic()}
 
         def on_written(write_index):
             if not resuming:
                 return
+            snapshot = None
             with progress_lock:
                 completed.add(int(write_index))
                 resume_state['since_flush'] += 1
-                flush = resume_state['since_flush'] >= RESUME_FLUSH_EVERY
-                if flush:
+                now = time.monotonic()
+                if (resume_state['since_flush'] >= RESUME_FLUSH_EVERY
+                        or now - resume_state['last_flush'] >= RESUME_FLUSH_SECONDS):
                     resume_state['since_flush'] = 0
+                    resume_state['last_flush'] = now
                     snapshot = set(completed)
-            if flush:
+            if snapshot is not None:
                 self._write_manifest(snapshot)
 
         def to_device(tensor):
             return tensor.to(self.device, non_blocking=(self.device.type == 'cuda'))
 
-        with tqdm(total=self.num_active_patches, desc=f"Inferring Part {self.part_id}", **get_tqdm_kwargs()) as pbar:
+        def flush_manifest():
+            """Persist whatever is complete. Safe to call more than once."""
+            if not resuming:
+                return
+            with progress_lock:
+                snapshot = set(completed)
+            self._write_manifest(snapshot)
+            return snapshot
+
+        # Ctrl-C and unhandled errors still checkpoint what finished, by wrapping the whole
+        # inference block rather than the loop body. A hard kill (TerminateProcess on Windows,
+        # SIGKILL, power loss) cannot run this, which is why the periodic flush above exists
+        # and is what actually bounds the loss.
+        try:
+          with tqdm(total=self.num_active_patches, desc=f"Inferring Part {self.part_id}", **get_tqdm_kwargs()) as pbar:
             def on_progress():
                 with progress_lock:
                     self.current_patch_write_index += 1
@@ -1246,6 +1269,9 @@ class Inferer():
 
             total_wait = writer.total_wait_seconds
             elapsed = writer.elapsed_seconds
+        except BaseException:
+            flush_manifest()
+            raise
 
         # Final flush after the writer pool has drained, so the manifest reflects every patch
         # the store actually accepted. Note this correctly records EMPTY patches as done:
@@ -1253,8 +1279,8 @@ class Inferer():
         # lands on disk. That is the whole reason completion is tracked here and not by
         # listing the store -- on a masked scroll volume most patches are empty, and a
         # listing-based resume would rerun all of them on every restart, forever.
-        if getattr(self, "resume", False):
-            self._write_manifest(completed)
+        if resuming:
+            flush_manifest()
             print(f"--resume: manifest records {len(completed)} of "
                   f"{self.num_total_patches} patches complete")
 

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -272,6 +272,8 @@ class Inferer():
                  max_patches: int = None,
                  bbox: [list, tuple] = None,
                  resume: bool = False,
+                 estimate: bool = False,
+                 estimate_bandwidth: float = 100.0,
                  ):
         print(f"Initializing Inferer with output_dir: '{output_dir}'")
         if output_dir and not output_dir.strip():
@@ -313,6 +315,8 @@ class Inferer():
         # Patch indices a previous run already wrote. Empty set == resume requested but
         # nothing recoverable found; None == not resuming, so the store is created fresh.
         self.resume_completed = None
+        self.estimate = estimate
+        self.estimate_bandwidth = estimate_bandwidth
         self.model_patch_size = None
         self.num_classes = None
 
@@ -869,6 +873,86 @@ class Inferer():
         else:
             return numcodecs.Blosc(cname='zstd', clevel=1, shuffle=shuffle)
 
+    # --- run cost estimation ----------------------------------------------------------
+    #
+    # The expensive part of a scroll-scale run is not the forward pass, it is fetching the
+    # same chunk repeatedly because the 192^3 patch grid does not align with the 128^3
+    # chunk grid. That count is exact and cheap, so it can be answered before committing.
+
+    def _input_array_geometry(self):
+        """(chunk_size_zyx, itemsize, shape, compressor, description) for the input array.
+
+        Returns None if the geometry cannot be read, in which case --estimate reports the
+        patch count and says why the byte figures are missing rather than inventing them.
+        """
+        try:
+            import zarr as _zarr
+        except ImportError:
+            return None
+
+        array_obj = getattr(getattr(self.dataset, 'volume', None), 'data', None)
+        if isinstance(array_obj, _zarr.Group):
+            if "0" not in array_obj:
+                return None
+            array_obj = array_obj["0"]
+        if not isinstance(array_obj, _zarr.Array):
+            return None
+
+        chunks = tuple(array_obj.chunks)
+        shape = tuple(array_obj.shape)
+        if len(chunks) == 4:            # C, Z, Y, X -> spatial only
+            chunks, shape = chunks[1:], shape[1:]
+        if len(chunks) != 3:
+            return None
+
+        # zarr 2 exposes .compressor, zarr 3 .compressors; absent or empty means raw.
+        compressor = getattr(array_obj, 'compressor', None)
+        if compressor is None:
+            seq = getattr(array_obj, 'compressors', None)
+            compressor = seq[0] if seq else None
+
+        return chunks, array_obj.dtype.itemsize, shape, compressor, str(self.input)
+
+    def _report_estimate(self):
+        from vesuvius.models.run import estimate as _estimate
+
+        positions = list(self.patch_start_coords_list)
+        geometry = self._input_array_geometry()
+        if geometry is None:
+            print(f"\n--estimate: {len(positions):,} patches for this run.")
+            print("  Could not read the input array's chunk geometry, so the transfer "
+                  "cost is not reported rather than guessed.\n")
+            return
+
+        chunk_size, itemsize, shape, compressor, path = geometry
+        plan = _estimate.build_plan(
+            positions,
+            tuple(self.patch_size),
+            chunk_size,
+            itemsize,
+            cache_sizes_gib=(0, 4, 16),
+        )
+        notes = []
+        if self.num_parts > 1:
+            notes.append(
+                f"NOTE: this is part {self.part_id} of {self.num_parts}; the whole volume "
+                f"costs more than the figures above."
+            )
+        if self.skip_empty_patches:
+            notes.append(
+                "NOTE: --skip_empty_patches is on, so patches that are entirely empty are "
+                "already excluded from the count above."
+            )
+        desc = f"{path}  {'x'.join(str(s) for s in shape)}"
+        for line in _estimate.format_plan(
+            plan,
+            self.estimate_bandwidth,
+            volume_desc=desc,
+            compressor=compressor,
+            extra_notes=notes,
+        ):
+            print(line)
+
     # --- resume support -------------------------------------------------------------
     #
     # A whole-scroll pass is hours to days of streaming, so an interrupted run is normal
@@ -1308,6 +1392,12 @@ class Inferer():
         if self.verbose: print("Creating dataset and dataloader...")
         self._create_dataset_and_loader()
 
+        if self.estimate:
+            # Deliberately before _create_output_stores: --estimate must not create,
+            # truncate or touch anything in output_dir. It is a question, not a run.
+            self._report_estimate()
+            return
+
         if self.verbose: print("Creating output stores...")
         self._create_output_stores()
 
@@ -1318,6 +1408,16 @@ class Inferer():
             print(f"Part {self.part_id} has no patches; wrote empty output stores and skipped inference.")
 
         if self.verbose: print("Inference complete.")
+
+    def infer_estimate(self):
+        """--estimate entry point: report the cost, write nothing, and let errors surface.
+
+        Deliberately not routed through infer(), whose broad `except` turns a hard failure
+        into a printed message and a zero exit status. A planner that silently reports
+        nothing and succeeds is worse than one that crashes.
+        """
+        self.estimate = True
+        self._run_inference()
 
     def infer(self):
         try:
@@ -1441,6 +1541,17 @@ def build_parser():
                            'existing logits store is appended to rather than recreated. '
                            'Refuses to resume if the volume, bbox, patch size, overlap, '
                            'model, TTA setting or part split differ from the previous run.')
+    parser.add_argument('--estimate', action='store_true',
+                      help='Report what this run will cost and exit without computing or '
+                           'writing anything. Prints the patch count, the number of distinct '
+                           'chunks it needs, and how many chunk fetches that becomes under '
+                           'the current traversal and under a cache, with the resulting '
+                           'transfer and wall-clock. Honours --bbox, --num_parts and '
+                           '--patch_size, so it costs the run you are actually about to start.')
+    parser.add_argument('--estimate_bandwidth', type=float, default=100.0,
+                      help='MB/s to convert --estimate transfer figures into wall-clock. '
+                           'Default 100. Set it to what your link actually sustains; the '
+                           'byte and fetch counts do not depend on it.')
     return parser
 
 
@@ -1515,7 +1626,15 @@ def main():
         max_patches=args.max_patches,
         bbox=bbox,
         resume=args.resume,
+        estimate=args.estimate,
+        estimate_bandwidth=args.estimate_bandwidth,
     )
+
+    if args.estimate:
+        # No output store is created and no postprocessing runs, so this path does not
+        # go through infer()'s "Starting Inference" banner or its return contract.
+        inferer.infer_estimate()
+        return
 
     try:
         print("\n--- Starting Inference ---")

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -790,6 +790,13 @@ class Inferer():
             self.resume_completed = self._load_completed()
             if self.resume_completed is None:
                 print("--resume: no previous run found in this output_dir; starting from scratch")
+            elif not hasattr(self.dataset, 'set_completed_indices'):
+                # Fail rather than quietly recompute everything: a resume that silently does
+                # nothing looks like a resume that worked until the bill arrives.
+                raise RuntimeError(
+                    f"--resume is not supported for {type(self.dataset).__name__}, which does "
+                    "not implement set_completed_indices()."
+                )
             else:
                 self.dataset.set_completed_indices(self.resume_completed)
                 print(f"--resume: {len(self.resume_completed)} of {self.num_total_patches} "
@@ -877,6 +884,23 @@ class Inferer():
     def _manifest_path(self):
         return os.path.join(self.output_dir, f"completed_part_{self.part_id}.json")
 
+    @staticmethod
+    def _json_scalar(value):
+        """Coerce numpy scalars to Python ones so the manifest is JSON-serialisable.
+
+        patch_size and num_classes arrive from the model config and are frequently numpy
+        integers. json.dump raises on those AFTER opening the output file, which leaves a
+        zero-byte .tmp behind and no manifest -- so the run appears to work and every
+        subsequent --resume silently finds nothing to resume. That is how this was found.
+        """
+        if isinstance(value, np.generic):
+            return value.item()
+        if isinstance(value, np.ndarray):
+            return [Inferer._json_scalar(v) for v in value.tolist()]
+        if isinstance(value, (list, tuple)):
+            return [Inferer._json_scalar(v) for v in value]
+        return value
+
     def _run_signature(self):
         """What must match for a resume to be legitimate.
 
@@ -885,7 +909,7 @@ class Inferer():
         ways, with nothing recording the split -- the exact failure that made a published
         prediction reproducible only under a setting no artifact mentioned.
         """
-        return {
+        return self._json_scalar_dict({
             'input': str(self.input_dir),
             'bbox': None if self.bbox is None else list(self.bbox),
             'patch_size': list(self.patch_size) if self.patch_size is not None else None,
@@ -897,7 +921,11 @@ class Inferer():
             'tta': None if self.disable_tta else self.tta_type,
             'normalization': self.normalization_scheme,
             'num_total_patches': self.num_total_patches,
-        }
+        })
+
+    @staticmethod
+    def _json_scalar_dict(d):
+        return {k: Inferer._json_scalar(v) for k, v in d.items()}
 
     def _load_completed(self):
         """Completed patch indices from a previous run, or None if there is nothing to resume.
@@ -932,12 +960,22 @@ class Inferer():
         """Rewrite the manifest atomically. Small (ints), so simplicity beats appending."""
         path = self._manifest_path()
         tmp = path + '.tmp'
-        with open(tmp, 'w') as fh:
-            json.dump({'signature': self._run_signature(),
-                       'completed': sorted(int(i) for i in completed)}, fh)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.replace(tmp, path)
+        payload = {'signature': self._run_signature(),
+                   'completed': sorted(int(i) for i in completed)}
+        try:
+            with open(tmp, 'w') as fh:
+                json.dump(payload, fh)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, path)
+        except Exception:
+            # Leaving a zero-byte .tmp and no manifest is worse than failing loudly: the run
+            # looks fine and every later --resume silently finds nothing to resume.
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
 
     def _create_output_stores(self):
         if self.num_classes is None or self.patch_size is None or self.num_total_patches is None:

--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -3,6 +3,7 @@ import numpy as np
 import zarr
 import os
 import errno
+import json
 try:
     import fcntl  # POSIX-only; used to serialize model-cache downloads
 except ImportError:  # pragma: no cover - Windows has no fcntl
@@ -269,6 +270,7 @@ class Inferer():
                  model_cache_dir: str = DEFAULT_MODEL_CACHE_DIR,
                  max_patches: int = None,
                  bbox: [list, tuple] = None,
+                 resume: bool = False,
                  ):
         print(f"Initializing Inferer with output_dir: '{output_dir}'")
         if output_dir and not output_dir.strip():
@@ -306,6 +308,10 @@ class Inferer():
         self.model_cache_dir = model_cache_dir
         self.max_patches = max_patches
         self.bbox = tuple(bbox) if bbox is not None else None
+        self.resume = resume
+        # Patch indices a previous run already wrote. Empty set == resume requested but
+        # nothing recoverable found; None == not resuming, so the store is created fresh.
+        self.resume_completed = None
         self.model_patch_size = None
         self.num_classes = None
 
@@ -776,6 +782,19 @@ class Inferer():
         # over non-empty patches when the input zarr's chunk occupancy has been
         # pre-indexed). len(loader_dataset) drives tqdm and the written-count
         # assertion below, so progress/ETA reflect only patches the model actually sees.
+        # Resume is applied here rather than in _run_inference because the completed set has
+        # to be known before the DataLoader is built, and the manifest's signature check needs
+        # num_total_patches, which is only known once the dataset exists. This is the one
+        # point where both are true.
+        if getattr(self, "resume", False):
+            self.resume_completed = self._load_completed()
+            if self.resume_completed is None:
+                print("--resume: no previous run found in this output_dir; starting from scratch")
+            else:
+                self.dataset.set_completed_indices(self.resume_completed)
+                print(f"--resume: {len(self.resume_completed)} of {self.num_total_patches} "
+                      f"patches already written; skipping them")
+
         loader_dataset = self.dataset.active_view()
         self.num_active_patches = len(loader_dataset)
         if self.verbose:
@@ -842,6 +861,84 @@ class Inferer():
         else:
             return numcodecs.Blosc(cname='zstd', clevel=1, shuffle=shuffle)
 
+    # --- resume support -------------------------------------------------------------
+    #
+    # A whole-scroll pass is hours to days of streaming, so an interrupted run is normal
+    # rather than exceptional. Without resume the only options are to rerun everything or
+    # to hand-slice the volume with --num_parts, and a dead shard is still a dead shard.
+    #
+    # The logits store is already chunked one-chunk-per-patch, so a finished patch is
+    # individually addressable. It is NOT enough to list the chunks that exist, though:
+    # write_empty_chunks=False means a patch that legitimately produced all zeros writes no
+    # chunk at all, and on a masked scroll volume those are the majority. Listing chunks
+    # would therefore re-run every empty patch on every resume. So completion is recorded
+    # explicitly, in an append-only sidecar next to the store.
+
+    def _manifest_path(self):
+        return os.path.join(self.output_dir, f"completed_part_{self.part_id}.json")
+
+    def _run_signature(self):
+        """What must match for a resume to be legitimate.
+
+        Deliberately strict. Silently resuming a run whose patch grid, model or TTA setting
+        differs would produce one output store containing patches computed two different
+        ways, with nothing recording the split -- the exact failure that made a published
+        prediction reproducible only under a setting no artifact mentioned.
+        """
+        return {
+            'input': str(self.input_dir),
+            'bbox': None if self.bbox is None else list(self.bbox),
+            'patch_size': list(self.patch_size) if self.patch_size is not None else None,
+            'overlap': self.overlap,
+            'num_classes': self.num_classes,
+            'num_parts': self.num_parts,
+            'part_id': self.part_id,
+            'model_path': str(self.model_path),
+            'tta': None if self.disable_tta else self.tta_type,
+            'normalization': self.normalization_scheme,
+            'num_total_patches': self.num_total_patches,
+        }
+
+    def _load_completed(self):
+        """Completed patch indices from a previous run, or None if there is nothing to resume.
+
+        Returns None (rather than an empty set) when no usable manifest exists, so the caller
+        can tell "resume from nothing" apart from "resume from a run that finished 0 patches".
+        """
+        path = self._manifest_path()
+        if not os.path.exists(path):
+            return None
+        try:
+            with open(path, 'r') as fh:
+                data = json.load(fh)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"--resume: ignoring unreadable manifest at {path} ({e}); starting over")
+            return None
+
+        want, got = self._run_signature(), data.get('signature')
+        if got != want:
+            differing = sorted(k for k in want if want.get(k) != (got or {}).get(k))
+            raise RuntimeError(
+                f"--resume refused: {path} was written by a different run.\n"
+                f"  differing: {', '.join(differing) or 'unknown'}\n"
+                f"  previous:  { {k: (got or {}).get(k) for k in differing} }\n"
+                f"  requested: { {k: want[k] for k in differing} }\n"
+                "Resuming would mix patches computed under different settings into one store. "
+                "Point --output_dir somewhere else, or drop --resume to start over."
+            )
+        return set(int(i) for i in data.get('completed', []))
+
+    def _write_manifest(self, completed):
+        """Rewrite the manifest atomically. Small (ints), so simplicity beats appending."""
+        path = self._manifest_path()
+        tmp = path + '.tmp'
+        with open(tmp, 'w') as fh:
+            json.dump({'signature': self._run_signature(),
+                       'completed': sorted(int(i) for i in completed)}, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+
     def _create_output_stores(self):
         if self.num_classes is None or self.patch_size is None or self.num_total_patches is None:
             raise RuntimeError("Cannot create output stores: model/patch info missing.")
@@ -852,24 +949,48 @@ class Inferer():
         output_shape = (self.num_total_patches, self.num_classes, *self.patch_size)
         output_chunks = (1, self.num_classes, *self.patch_size)  # we align chunks to patch size for better write performance
         main_store_path = os.path.join(self.output_dir, f"logits_part_{self.part_id}.zarr")
-        
-        print(f"Creating output store at: {main_store_path}")
-        
-        self.output_store = open_zarr(
-            path=main_store_path, 
-            mode='w',  
-            storage_options={'anon': False} if main_store_path.startswith('s3://') else None,
-            verbose=self.verbose,
-            shape=output_shape,
-            chunks=output_chunks,
-            dtype=np.float16,  
-            compressor=compressor,
-            write_empty_chunks=False  # we skip empty chunks here so we don't write all zero patches to the array but keep
-                                      # the proper indices for later re-zarring 
-        )
-        
-        print(f"Created zarr array at {main_store_path} with shape {self.output_store.shape}")
-        
+
+        # mode='w' recreates the array and discards every chunk already written, so a resume
+        # must reopen in place instead. _load_completed() has already refused anything whose
+        # signature disagrees, so by here the existing store is known to be the same run.
+        # getattr, not attribute access: several tests build an Inferer via __new__ and set
+        # only the fields their behaviour needs, and a new attribute should not break them.
+        if getattr(self, 'resume_completed', None):
+            print(f"Reopening output store for resume at: {main_store_path}")
+            self.output_store = open_zarr(
+                path=main_store_path,
+                mode='r+',
+                storage_options={'anon': False} if main_store_path.startswith('s3://') else None,
+                verbose=self.verbose,
+            )
+            if tuple(self.output_store.shape) != tuple(output_shape):
+                raise RuntimeError(
+                    f"--resume refused: existing store at {main_store_path} has shape "
+                    f"{tuple(self.output_store.shape)}, expected {tuple(output_shape)}."
+                )
+            print(f"Reopened zarr array with shape {self.output_store.shape}")
+        else:
+            print(f"Creating output store at: {main_store_path}")
+
+            self.output_store = open_zarr(
+                path=main_store_path,
+                mode='w',
+                storage_options={'anon': False} if main_store_path.startswith('s3://') else None,
+                verbose=self.verbose,
+                shape=output_shape,
+                chunks=output_chunks,
+                dtype=np.float16,
+                compressor=compressor,
+                write_empty_chunks=False  # we skip empty chunks here so we don't write all zero patches to the array but keep
+                                          # the proper indices for later re-zarring
+            )
+
+            print(f"Created zarr array at {main_store_path} with shape {self.output_store.shape}")
+
+        # The coordinates store is rewritten either way: it is small, fully determined by the
+        # patch grid, and identical on a legitimate resume, so recreating it costs nothing and
+        # keeps the two stores from drifting apart.
+
         self.coords_store_path = os.path.join(self.output_dir, f"coordinates_part_{self.part_id}.zarr")
         coord_shape = (self.num_total_patches, len(self.patch_size))
         # zarr rejects chunks with a zero dimension even when shape[0] is 0, so floor at 1.
@@ -982,6 +1103,28 @@ class Inferer():
 
         progress_lock = threading.Lock()
 
+        # Completion bookkeeping for --resume. The manifest is flushed every
+        # RESUME_FLUSH_EVERY writes rather than on every write: rewriting it per patch would
+        # add an fsync to each one, and the cost of a stale manifest is only that a handful
+        # of patches get recomputed, which is exactly what a resume is for.
+        RESUME_FLUSH_EVERY = 64
+        resuming = getattr(self, 'resume', False)
+        completed = set(getattr(self, 'resume_completed', None) or ())
+        resume_state = {'since_flush': 0}
+
+        def on_written(write_index):
+            if not resuming:
+                return
+            with progress_lock:
+                completed.add(int(write_index))
+                resume_state['since_flush'] += 1
+                flush = resume_state['since_flush'] >= RESUME_FLUSH_EVERY
+                if flush:
+                    resume_state['since_flush'] = 0
+                    snapshot = set(completed)
+            if flush:
+                self._write_manifest(snapshot)
+
         def to_device(tensor):
             return tensor.to(self.device, non_blocking=(self.device.type == 'cuda'))
 
@@ -996,6 +1139,7 @@ class Inferer():
                 max_workers=max_workers,
                 pbar=pbar,
                 on_progress=on_progress,
+                on_written=on_written if resuming else None,
             ) as writer:
                 if self.verbose:
                     print(f"Writer pool: {writer.max_workers} workers, max in-flight: {writer.max_inflight}")
@@ -1064,6 +1208,17 @@ class Inferer():
 
             total_wait = writer.total_wait_seconds
             elapsed = writer.elapsed_seconds
+
+        # Final flush after the writer pool has drained, so the manifest reflects every patch
+        # the store actually accepted. Note this correctly records EMPTY patches as done:
+        # they are submitted like any other, write_empty_chunks=False simply means no chunk
+        # lands on disk. That is the whole reason completion is tracked here and not by
+        # listing the store -- on a masked scroll volume most patches are empty, and a
+        # listing-based resume would rerun all of them on every restart, forever.
+        if getattr(self, "resume", False):
+            self._write_manifest(completed)
+            print(f"--resume: manifest records {len(completed)} of "
+                  f"{self.num_total_patches} patches complete")
 
         if total_wait > 0:
             pct = (total_wait / elapsed * 100.0) if elapsed > 0 else 0.0
@@ -1214,6 +1369,12 @@ def build_parser():
                            'Patch coordinates stay in the global frame, so blend_logits and '
                            'finalize_outputs need no extra flags. When streaming a remote '
                            'volume only the chunks intersecting the ROI are fetched.')
+    parser.add_argument('--resume', action='store_true',
+                      help='Continue a previous run in the same --output_dir instead of '
+                           'starting over. Patches already written are skipped and the '
+                           'existing logits store is appended to rather than recreated. '
+                           'Refuses to resume if the volume, bbox, patch size, overlap, '
+                           'model, TTA setting or part split differ from the previous run.')
     return parser
 
 
@@ -1287,6 +1448,7 @@ def main():
         model_cache_dir=args.model_cache_dir,
         max_patches=args.max_patches,
         bbox=bbox,
+        resume=args.resume,
     )
 
     try:

--- a/vesuvius/src/vesuvius/models/run/patch_writer.py
+++ b/vesuvius/src/vesuvius/models/run/patch_writer.py
@@ -17,10 +17,14 @@ class BoundedPatchWriter:
     """
 
     def __init__(self, output_store, max_workers, *, pbar=None,
-                 on_progress=None, stall_report_interval=5.0):
+                 on_progress=None, on_written=None, stall_report_interval=5.0):
         self._store = output_store
         self._pbar = pbar
         self._on_progress = on_progress
+        # on_written(write_index) fires only after the patch is durably in the store, which
+        # is what --resume records. Kept separate from on_progress, which is a bare counter
+        # for the progress bar and has no index to give.
+        self._on_written = on_written
         self._max_workers = max_workers
         self._max_inflight = max_workers * 2
         self._inflight = threading.BoundedSemaphore(self._max_inflight)
@@ -77,6 +81,11 @@ class BoundedPatchWriter:
     def _write(self, write_index, patch_data):
         try:
             self._store[write_index] = patch_data
+            # Order matters: record completion only after the assignment returns, and never
+            # in the except branch. A resume that trusts a patch the store never accepted
+            # would leave a permanent hole that no later run goes back for.
+            if self._on_written is not None:
+                self._on_written(write_index)
             if self._on_progress is not None:
                 self._on_progress()
         except Exception as e:

--- a/vesuvius/tests/models/run/test_inference_estimate.py
+++ b/vesuvius/tests/models/run/test_inference_estimate.py
@@ -158,6 +158,31 @@ def test_the_uncached_row_is_the_worst_row():
     assert uncached == max(r["fetches"] for r in plan["rows"])
 
 
+def test_the_uncached_case_is_reported_once_and_not_per_order():
+    """Order cannot matter with no cache, so simulating it per order is wasted work.
+
+    On a whole scroll the uncached pass is tens of millions of touches; running it
+    three times to print the same number three times cost minutes and read as though
+    the orders had been compared and tied.
+    """
+    plan = _plan()
+    uncached = [r for r in plan["rows"] if r["cache_gib"] == 0]
+    assert len(uncached) == 1
+    assert uncached[0]["order"] is None
+
+
+def test_no_cache_fetch_count_really_is_order_independent():
+    """The justification for collapsing the row, asserted rather than assumed."""
+    positions = [(z, y, x) for z in (0, 96, 192) for y in (0, 96) for x in (0, 96)]
+    counts = {
+        order: estimate.simulate(
+            positions, (192,) * 3, (128,) * 3, cache_chunks=0, order=order
+        )[0]
+        for order in estimate.ORDERS
+    }
+    assert len(set(counts.values())) == 1, counts
+
+
 def test_report_names_the_compressor_only_when_there_is_one():
     plan = _plan()
     raw = "\n".join(estimate.format_plan(plan, 100.0, compressor=None))
@@ -192,6 +217,30 @@ def test_estimate_reads_only_attributes_the_class_actually_sets():
         read |= set(re.findall(r"self\.(\w+)", inspect.getsource(method)))
     missing = sorted(read - assigned - {"_report_estimate", "_input_array_geometry"})
     assert not missing, f"the estimate path reads attributes the class never sets: {missing}"
+
+
+def test_estimate_never_creates_an_output_store():
+    """--estimate is a question, not a run: it must not touch --output_dir at all.
+
+    _create_output_stores opens the logits array with mode='w', which recreates it. If
+    the estimate path ever fell through to it, asking "what would this cost" would
+    destroy the run you were asking about — the exact failure --resume exists to stop.
+    """
+    calls = []
+    inf = Inferer.__new__(Inferer)
+    inf.estimate = True
+    inf.verbose = False
+    inf._load_model = lambda: calls.append("load_model")
+    inf._create_dataset_and_loader = lambda: calls.append("dataset")
+    inf._create_output_stores = lambda: calls.append("output_stores")
+    inf._process_batches = lambda: calls.append("process")
+    inf._report_estimate = lambda: calls.append("report")
+
+    inf._run_inference()
+
+    assert "report" in calls
+    assert "output_stores" not in calls, "--estimate reached _create_output_stores"
+    assert "process" not in calls, "--estimate ran inference"
 
 
 def test_estimate_reports_patch_count_when_geometry_is_unreadable(capsys):

--- a/vesuvius/tests/models/run/test_inference_estimate.py
+++ b/vesuvius/tests/models/run/test_inference_estimate.py
@@ -1,0 +1,206 @@
+"""Tests for --estimate, the pre-run cost report.
+
+The arithmetic here is an exact count over two grids, not a timing, so it can be asserted
+exactly rather than within a tolerance. That is the point of the feature: the expensive
+number in a scroll-scale run is knowable before the run starts.
+"""
+
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from vesuvius.models.run import estimate
+from vesuvius.models.run.inference import Inferer
+
+
+# --- the chunk arithmetic ---------------------------------------------------------------
+
+def test_patch_aligned_to_chunk_grid_touches_the_exact_span():
+    # a 192 patch at the origin spans chunks 0 and 1 on a 128 grid, on every axis
+    spans = estimate.chunk_ranges((0, 0, 0), (192, 192, 192), (128, 128, 128))
+    assert [list(s) for s in spans] == [[0, 1], [0, 1], [0, 1]]
+
+
+def test_patch_smaller_than_a_chunk_and_inside_it_touches_one():
+    spans = estimate.chunk_ranges((10, 10, 10), (64, 64, 64), (128, 128, 128))
+    assert [list(s) for s in spans] == [[0], [0], [0]]
+
+
+def test_patch_straddling_a_boundary_touches_both_chunks():
+    spans = estimate.chunk_ranges((120, 0, 0), (16, 16, 16), (128, 128, 128))
+    assert list(spans[0]) == [0, 1]
+
+
+def test_a_192_patch_on_a_128_grid_can_touch_27_chunks():
+    # the worst case that motivates the whole feature: misaligned on all three axes
+    spans = estimate.chunk_ranges((100, 100, 100), (192, 192, 192), (128, 128, 128))
+    assert [len(list(s)) for s in spans] == [3, 3, 3]
+
+
+# --- the simulation ---------------------------------------------------------------------
+
+def test_no_cache_counts_every_touch_as_a_fetch():
+    # Patch A at x=0 spans 0..191, so chunk columns 0 and 1: 2x2x2 = 8 touches.
+    # Patch B at x=96 spans 96..287, so columns 0, 1 AND 2: 2x2x3 = 12 touches.
+    # With no cache nothing is remembered between them, so it is the plain sum.
+    positions = [(0, 0, 0), (0, 0, 96)]
+    fetches, distinct = estimate.simulate(positions, (192,) * 3, (128,) * 3, cache_chunks=0)
+    assert fetches == 8 + 12
+    # they share columns 0 and 1, so the union is smaller than the sum
+    assert distinct == 2 * 2 * 3
+
+
+def test_the_half_overlap_step_is_what_makes_a_patch_span_three_columns():
+    """Why the amplification exists at all, pinned as a test.
+
+    192 and 128 do not align, so stepping by half a patch (96) walks the patch across a
+    third chunk column even though the patch is only 1.5 chunks wide.
+    """
+    aligned = estimate.chunk_ranges((0, 0, 0), (192,) * 3, (128,) * 3)
+    stepped = estimate.chunk_ranges((0, 0, 96), (192,) * 3, (128,) * 3)
+    assert len(list(aligned[2])) == 2
+    assert len(list(stepped[2])) == 3
+
+
+def test_an_unbounded_cache_reaches_the_floor():
+    positions = [(0, 0, 0), (0, 0, 96), (0, 96, 0)]
+    fetches, distinct = estimate.simulate(
+        positions, (192,) * 3, (128,) * 3, cache_chunks=10_000
+    )
+    assert fetches == distinct
+
+
+def test_distinct_is_independent_of_cache_and_order():
+    positions = [(z, y, 0) for z in (0, 96, 192) for y in (0, 96, 192)]
+    seen = set()
+    for order in estimate.ORDERS:
+        for cache in (0, 4, 10_000):
+            _, distinct = estimate.simulate(
+                positions, (192,) * 3, (128,) * 3, cache_chunks=cache, order=order
+            )
+            seen.add(distinct)
+    assert len(seen) == 1, f"distinct chunk count drifted with policy: {seen}"
+
+
+def test_a_cache_never_costs_more_than_no_cache():
+    positions = [(z, y, x) for z in (0, 96, 192) for y in (0, 96, 192) for x in (0, 96)]
+    uncached, _ = estimate.simulate(positions, (192,) * 3, (128,) * 3, cache_chunks=0)
+    cached, _ = estimate.simulate(positions, (192,) * 3, (128,) * 3, cache_chunks=8)
+    assert cached <= uncached
+
+
+def test_morton_is_not_worse_than_raster_at_the_same_cache():
+    positions = [(z, y, x)
+                 for z in range(0, 768, 96)
+                 for y in range(0, 768, 96)
+                 for x in range(0, 768, 96)]
+    raster, _ = estimate.simulate(
+        positions, (192,) * 3, (128,) * 3, cache_chunks=16, order="current"
+    )
+    morton, _ = estimate.simulate(
+        positions, (192,) * 3, (128,) * 3, cache_chunks=16, order="morton"
+    )
+    assert morton <= raster
+
+
+# --- ordering ---------------------------------------------------------------------------
+
+def test_current_order_is_left_exactly_as_given():
+    positions = [(192, 0, 0), (0, 0, 0), (96, 0, 0)]
+    assert estimate.order_positions(positions, (128,) * 3, "current") == positions
+
+
+def test_reordering_is_a_permutation_not_a_filter():
+    positions = [(z, y, 0) for z in (0, 96, 192) for y in (0, 96, 192)]
+    for order in estimate.ORDERS:
+        out = estimate.order_positions(positions, (128,) * 3, order)
+        assert sorted(out) == sorted(positions)
+
+
+def test_unknown_order_is_refused():
+    with pytest.raises(ValueError, match="unknown traversal order"):
+        estimate.order_positions([(0, 0, 0)], (128,) * 3, "spiral")
+
+
+def test_morton_key_interleaves_bits():
+    assert estimate.morton_key((0, 0, 0)) == 0
+    assert estimate.morton_key((0, 0, 1)) == 0b001
+    assert estimate.morton_key((0, 1, 0)) == 0b010
+    assert estimate.morton_key((1, 0, 0)) == 0b100
+    assert estimate.morton_key((1, 1, 1)) == 0b111
+
+
+# --- the plan ---------------------------------------------------------------------------
+
+def _plan():
+    positions = [(z, y, 0) for z in (0, 96, 192) for y in (0, 96, 192)]
+    return estimate.build_plan(positions, (192,) * 3, (128,) * 3, itemsize=1)
+
+
+def test_plan_reports_the_floor_and_the_chunk_size():
+    plan = _plan()
+    assert plan["chunk_bytes"] == 128 ** 3          # uint8, so 2 MiB
+    assert plan["floor_bytes"] == plan["distinct_chunks"] * plan["chunk_bytes"]
+    assert plan["n_patches"] == 9
+
+
+def test_amplification_is_fetches_over_distinct():
+    plan = _plan()
+    for row in plan["rows"]:
+        assert row["amplification"] == pytest.approx(row["fetches"] / plan["distinct_chunks"])
+        assert row["bytes"] == row["fetches"] * plan["chunk_bytes"]
+
+
+def test_the_uncached_row_is_the_worst_row():
+    plan = _plan()
+    uncached = max(r["fetches"] for r in plan["rows"] if r["cache_gib"] == 0)
+    assert uncached == max(r["fetches"] for r in plan["rows"])
+
+
+def test_report_names_the_compressor_only_when_there_is_one():
+    plan = _plan()
+    raw = "\n".join(estimate.format_plan(plan, 100.0, compressor=None))
+    zstd = "\n".join(estimate.format_plan(plan, 100.0, compressor="zstd"))
+    assert "uncompressed size" not in raw
+    assert "uncompressed size" in zstd
+
+
+def test_report_shows_every_policy_row():
+    plan = _plan()
+    text = "\n".join(estimate.format_plan(plan, 100.0))
+    assert "current (villa)" in text
+    assert "morton" in text
+    assert "chunk-blocked" in text
+
+
+# --- the wiring -------------------------------------------------------------------------
+
+def test_estimate_reads_only_attributes_the_class_actually_sets():
+    """Same guard as the resume signature, for the same reason.
+
+    _run_signature shipped reading self.input_dir and self.disable_tta, neither of which
+    exists, and every unit test passed because the fixtures invented them. The estimate
+    path reads a fresh set of attributes, so it needs the same check.
+    """
+    import inspect
+
+    class_src = inspect.getsource(Inferer)
+    assigned = set(re.findall(r"self\.(\w+)\s*=", class_src))
+    read = set()
+    for method in (Inferer._report_estimate, Inferer._input_array_geometry):
+        read |= set(re.findall(r"self\.(\w+)", inspect.getsource(method)))
+    missing = sorted(read - assigned - {"_report_estimate", "_input_array_geometry"})
+    assert not missing, f"the estimate path reads attributes the class never sets: {missing}"
+
+
+def test_estimate_reports_patch_count_when_geometry_is_unreadable(capsys):
+    """An unreadable store must not produce invented byte figures."""
+    inf = Inferer.__new__(Inferer)
+    inf.patch_start_coords_list = [(0, 0, 0), (0, 0, 96)]
+    inf.dataset = SimpleNamespace(volume=None)
+    inf._report_estimate()
+    out = capsys.readouterr().out
+    assert "2 patches" in out
+    assert "not reported rather than guessed" in out
+    assert "GiB" not in out

--- a/vesuvius/tests/models/run/test_inference_resume.py
+++ b/vesuvius/tests/models/run/test_inference_resume.py
@@ -1,0 +1,174 @@
+"""An interrupted inference run should be worth something afterwards.
+
+A whole-scroll pass streams for hours, so interruption is ordinary rather than exceptional.
+Before --resume the only outcome was to start over: _create_output_stores opened the logits
+store with mode='w', which recreates the array and discards every patch already written.
+
+Two things carry the behaviour and both are tested here:
+
+  * completion is recorded in a manifest, NOT by listing the chunks present in the store.
+    write_empty_chunks=False means a patch that produced all zeros writes no chunk at all,
+    and on a masked scroll volume those are the majority - so a listing-based resume would
+    rerun every empty patch on every restart, forever.
+
+  * a resume whose settings differ from the previous run is refused rather than merged. One
+    store holding patches computed two different ways, with nothing recording the split, is
+    the failure that made a published prediction reproducible only under a TTA setting no
+    artifact mentioned.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import zarr
+
+from vesuvius.models.run.inference import Inferer
+
+
+def _inferer(tmp_path, **overrides) -> Inferer:
+    """An Inferer with just enough state for the resume helpers and store creation.
+
+    __init__ builds a model and a dataset, neither of which this behaviour depends on, so
+    the instance is assembled directly (same approach as test_inference_run_config_attrs).
+    """
+    inf = Inferer.__new__(Inferer)
+    inf.num_classes = 2
+    inf.patch_size = (4, 4, 4)
+    inf.num_total_patches = 8
+    inf.output_dir = str(tmp_path)
+    inf.part_id = 0
+    inf.num_parts = 1
+    inf.overlap = 0.5
+    inf.verbose = False
+    # 'none' short-circuits _get_zarr_compressor, which reaches for zarr.Blosc - absent in
+    # zarr 3. Compression is irrelevant to everything under test.
+    inf.compressor_name = "none"
+    inf.compression_level = 1
+    inf.bbox = None
+    inf.input_dir = "https://example.invalid/scroll.zarr/0"
+    inf.model_path = "/models/m7"
+    inf.disable_tta = True
+    inf.tta_type = "mirroring"
+    inf.do_tta = False
+    inf.normalization_scheme = "instance_zscore"
+    inf.is_multi_task = False
+    inf.target_info = None
+    inf.resume = False
+    inf.resume_completed = None
+    inf.dataset = SimpleNamespace(input_shape=(16, 16, 16))
+    inf.patch_start_coords_list = [(i, 0, 0) for i in range(inf.num_total_patches)]
+    for k, v in overrides.items():
+        setattr(inf, k, v)
+    return inf
+
+
+def test_manifest_round_trips(tmp_path):
+    inf = _inferer(tmp_path)
+    inf._write_manifest({3, 1, 2})
+    assert inf._load_completed() == {1, 2, 3}
+
+
+def test_no_manifest_reads_as_nothing_to_resume(tmp_path):
+    # None rather than set(): the caller must be able to tell "no previous run" apart from
+    # "a previous run that completed zero patches".
+    assert _inferer(tmp_path)._load_completed() is None
+
+
+def test_unreadable_manifest_does_not_raise(tmp_path):
+    inf = _inferer(tmp_path)
+    with open(inf._manifest_path(), "w") as fh:
+        fh.write("{not json")
+    assert inf._load_completed() is None
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("bbox", (0, 4, 0, 4, 0, 4)),
+        ("patch_size", (8, 8, 8)),
+        ("overlap", 0.25),
+        ("model_path", "/models/other"),
+        ("disable_tta", False),
+        ("num_total_patches", 9),
+        ("num_parts", 2),
+        ("input_dir", "https://example.invalid/other.zarr/0"),
+    ],
+)
+def test_resume_refuses_a_different_run(tmp_path, field, value):
+    _inferer(tmp_path)._write_manifest({0, 1})
+    changed = _inferer(tmp_path, **{field: value})
+    with pytest.raises(RuntimeError, match="resume refused"):
+        changed._load_completed()
+
+
+def test_each_part_resumes_from_its_own_manifest(tmp_path):
+    """A different --part_id is not a mismatch, it is a different job.
+
+    The manifest is per part, so part 1 finds nothing to resume rather than being refused.
+    Re-sharding is the dangerous case, and that shows up as a changed num_parts, which is
+    covered above.
+    """
+    _inferer(tmp_path, part_id=0)._write_manifest({0, 1})
+    assert _inferer(tmp_path, part_id=1)._load_completed() is None
+    assert _inferer(tmp_path, part_id=0)._load_completed() == {0, 1}
+
+
+def test_refusal_names_the_field_that_differs(tmp_path):
+    _inferer(tmp_path)._write_manifest({0})
+    changed = _inferer(tmp_path, overlap=0.25)
+    with pytest.raises(RuntimeError, match="overlap"):
+        changed._load_completed()
+
+
+def test_resume_reopens_the_store_instead_of_recreating_it(tmp_path):
+    """The point of the whole feature: previously written patches must survive."""
+    first = _inferer(tmp_path)
+    first._create_output_stores()
+    first.output_store[2] = np.full((2, 4, 4, 4), 7, dtype=np.float16)
+    assert first.output_store[2].max() == 7
+
+    again = _inferer(tmp_path, resume=True, resume_completed={2})
+    again._create_output_stores()
+    assert again.output_store[2].max() == 7, "resume recreated the store and lost the patch"
+
+
+def test_without_resume_the_store_is_recreated(tmp_path):
+    """The behaviour --resume exists to avoid, pinned so it cannot regress silently."""
+    first = _inferer(tmp_path)
+    first._create_output_stores()
+    first.output_store[2] = np.full((2, 4, 4, 4), 7, dtype=np.float16)
+
+    fresh = _inferer(tmp_path)
+    fresh._create_output_stores()
+    assert fresh.output_store[2].max() == 0
+
+
+def test_resume_refuses_a_store_of_the_wrong_shape(tmp_path):
+    first = _inferer(tmp_path)
+    first._create_output_stores()
+
+    grown = _inferer(tmp_path, num_total_patches=16, resume=True, resume_completed={0})
+    with pytest.raises(RuntimeError, match="resume refused"):
+        grown._create_output_stores()
+
+
+def test_manifest_records_patches_that_wrote_no_chunk(tmp_path):
+    """An all-zero patch writes no chunk (write_empty_chunks=False) but IS complete.
+
+    This is why completion is tracked explicitly rather than by listing the store: the
+    store cannot distinguish "done and empty" from "not done".
+    """
+    inf = _inferer(tmp_path)
+    inf._create_output_stores()
+    inf.output_store[5] = np.zeros((2, 4, 4, 4), dtype=np.float16)
+
+    store_path = tmp_path / "logits_part_0.zarr"
+    chunk_files = [p for p in store_path.rglob("*") if p.is_file() and not p.name.startswith(".")]
+    assert chunk_files == [], "an all-zero patch should not have written a chunk"
+
+    inf._write_manifest({5})
+    assert inf._load_completed() == {5}

--- a/vesuvius/tests/models/run/test_inference_resume.py
+++ b/vesuvius/tests/models/run/test_inference_resume.py
@@ -72,6 +72,33 @@ def test_manifest_round_trips(tmp_path):
     assert inf._load_completed() == {1, 2, 3}
 
 
+def test_manifest_survives_numpy_typed_config(tmp_path):
+    """patch_size and num_classes arrive from the model config as numpy integers.
+
+    json.dump raises on those *after* opening the file, which left a zero-byte .tmp and no
+    manifest -- so the run looked fine and every later --resume silently found nothing to
+    resume. The first end-to-end run failed exactly this way; the unit tests above did not
+    catch it because they all use plain Python ints.
+    """
+    inf = _inferer(
+        tmp_path,
+        patch_size=np.array([4, 4, 4]),
+        num_classes=np.int64(2),
+        num_total_patches=np.int64(8),
+        overlap=np.float64(0.5),
+    )
+    inf._write_manifest({np.int64(1), 2})
+    assert inf._load_completed() == {1, 2}
+    assert not list(tmp_path.glob("*.tmp")), "a failed write must not leave a .tmp behind"
+
+
+def test_failed_manifest_write_leaves_no_tmp(tmp_path):
+    inf = _inferer(tmp_path, normalization_scheme=object())  # not JSON-serialisable
+    with pytest.raises(TypeError):
+        inf._write_manifest({0})
+    assert not list(tmp_path.glob("*.tmp"))
+
+
 def test_no_manifest_reads_as_nothing_to_resume(tmp_path):
     # None rather than set(): the caller must be able to tell "no previous run" apart from
     # "a previous run that completed zero patches".

--- a/vesuvius/tests/models/run/test_inference_resume.py
+++ b/vesuvius/tests/models/run/test_inference_resume.py
@@ -49,9 +49,9 @@ def _inferer(tmp_path, **overrides) -> Inferer:
     inf.compressor_name = "none"
     inf.compression_level = 1
     inf.bbox = None
-    inf.input_dir = "https://example.invalid/scroll.zarr/0"
+    # the constructor parameter is input_dir=, but it is stored as self.input
+    inf.input = "https://example.invalid/scroll.zarr/0"
     inf.model_path = "/models/m7"
-    inf.disable_tta = True
     inf.tta_type = "mirroring"
     inf.do_tta = False
     inf.normalization_scheme = "instance_zscore"
@@ -64,6 +64,26 @@ def _inferer(tmp_path, **overrides) -> Inferer:
     for k, v in overrides.items():
         setattr(inf, k, v)
     return inf
+
+
+def test_signature_only_reads_attributes_the_constructor_sets():
+    """Every self.X in _run_signature must actually exist on a real Inferer.
+
+    This exists because it did not. The signature read self.input_dir, which is the
+    constructor's parameter name; the value is stored as self.input. Nothing caught it --
+    the fixture above assigns attributes by hand, so it happily created the missing one,
+    and the failure only appeared in a live run, inside a writer thread, reported as
+    "Error writing patch 8". Fixtures test the fixture's shape, not production's.
+    """
+    import inspect
+    import re
+
+    sig_src = inspect.getsource(Inferer._run_signature)
+    init_src = inspect.getsource(Inferer.__init__)
+    assigned = set(re.findall(r"self\.(\w+)\s*=", init_src))
+    read = set(re.findall(r"self\.(\w+)", sig_src)) - {"_json_scalar_dict", "_json_scalar"}
+    missing = sorted(read - assigned)
+    assert not missing, f"_run_signature reads attributes __init__ never sets: {missing}"
 
 
 def test_manifest_round_trips(tmp_path):
@@ -119,10 +139,10 @@ def test_unreadable_manifest_does_not_raise(tmp_path):
         ("patch_size", (8, 8, 8)),
         ("overlap", 0.25),
         ("model_path", "/models/other"),
-        ("disable_tta", False),
+        ("do_tta", True),
         ("num_total_patches", 9),
         ("num_parts", 2),
-        ("input_dir", "https://example.invalid/other.zarr/0"),
+        ("input", "https://example.invalid/other.zarr/0"),
     ],
 )
 def test_resume_refuses_a_different_run(tmp_path, field, value):


### PR DESCRIPTION
> **Stacked on #1342.** This branch contains that PR's four commits as well, so until it
> merges GitHub shows both diffs here. The three commits that belong to this PR are the
> `estimate:` ones — `estimate.py`, its tests, and the flag wiring in `inference.py`.
> Reviewing #1342 first will make this one a clean three-commit diff.

## The problem

You cannot currently find out what an inference run will cost until you are inside it. On a home connection a whole-scroll pass over PHerc1218 is days, and the thing that decides how many is not the forward pass — it is how often the same chunk gets fetched. The sliding window is 192³ with half overlap while the store is chunked at 128³, so the grids do not align: one patch touches up to 3×3×3 chunks and its neighbours touch them again.

That count is exact. It is a property of two grids, not a timing, so it can be answered before committing to the run rather than inferred from a progress bar three hours in.

## What this adds

`--estimate` reports the cost and exits. It creates no output store, loads no data and computes nothing.

```
vesuvius.predict --model_path <m> --input_dir <url> --output_dir out --estimate
```

Full PHerc1218, `--no_skip_empty_patches`, `--estimate_bandwidth 11`:

```
  volume            …/PHerc1218/volumes/…-masked.zarr/0  23247x7593x7593
  chunks            128x128x128   2.0 MiB each
  patch grid        192x192x192   ->  1,510,322 patches

  distinct chunks   655,200   1.25 TiB   <- the floor: every needed chunk fetched exactly once

  traversal         cache       fetches      transfer  amplification   at 11 MB/s
  ------------------------------------------------------------------------------
  any order          none    23,401,827     44.64 TiB         35.72x       51.6 d
  current (villa)   4 GiB     2,170,800      4.14 TiB          3.31x        4.8 d
  current (villa)  16 GiB     1,708,908      3.26 TiB          2.61x        3.8 d
  chunk-blocked     4 GiB     1,731,600      3.30 TiB          2.64x        3.8 d
  chunk-blocked    16 GiB     1,543,310      2.94 TiB          2.36x        3.4 d
  morton            4 GiB       892,983      1.70 TiB          1.36x       47.3 h
  morton           16 GiB       786,446      1.50 TiB          1.20x       41.6 h
```

The first row is what this build does today. The rest are what the same patch list would cost under a cache and a different visit order, which is the work in #1177, #1327 and #1331 — so this also gives those changes a number to be judged against on a real volume rather than in simulation.

## Details that drove the design

**The patch positions are not recomputed.** They come from the `VCDataset` the real run would use, so `--bbox`, `--num_parts`, `--patch_size` and `--skip_empty_patches` are all honoured automatically and the estimate prices the run you are actually about to start. Deriving a second grid is precisely the bug #1247 fixed: an ROI-origin grid gave 27 chunks and a flattering 384× where the true full-volume grid gives 125.

**The uncached case is reported once, not once per order.** With no cache every touch is a fetch, so the traversal cannot change the count. The first version printed the same number three times, which cost 23.4M simulated touches twice over and read as though the orders had been compared and tied.

**It refuses to invent numbers.** If the input array's chunk geometry cannot be read, it reports the patch count and says the transfer cost is unavailable rather than guessing. If the array declares a compressor, it says so and labels the byte figures uncompressed, since the wire size will be smaller while the fetch counts and amplification are unaffected.

**It never reaches `_create_output_stores`.** That opens the logits array with `mode='w'`, so an estimate that fell through to it would destroy the run it was asked to price. There is a test asserting the estimate path stops before it.

## Tests

`vesuvius/tests/models/run/test_inference_estimate.py`, 24 cases: the chunk-span arithmetic including the 3×3×3 worst case, that an unbounded cache reaches the floor and a cache never costs more than none, that the distinct count is invariant under every policy, that reordering is a permutation and not a filter, Morton key bit-interleaving, that the uncached count really is order-independent, that the report names a compressor only when there is one, that `--estimate` never reaches the output store or the batch loop, and that unreadable geometry produces no byte figures.

`tests/models/run` and `tests/data` are 144 passed.

## Checking

The simulation was cross-checked against an independent implementation I had already published, on identical patch lists: exact agreement on both fetches and distinct chunks across four cache sizes and two traversal orders, 6 of 6.

Two figures above are independently corroborated by villa itself: the 655,200 distinct chunks is exactly the 182×60×60 grid that the chunk-occupancy index reports for this volume, and the 216-patch count for a 384³ ROI matches what a real run over that region produces.

One scope note, since a 30.54× for this volume is in #1325 and someone will compare them: that figure is a 1,536-thick z-slab, not the whole volume. Full volume is 15.1× deeper and both counts scale with it. The amplification is higher here because a thin slab has proportionally more z-edge patches, which are clipped and touch fewer chunks.
