### PR TITLE
fix(render): bind remote multiscale datasets by numeric path, not array index

### DIFF
--- a/volume-cartographer/core/include/vc/core/render/ZarrChunkFetcher.hpp
+++ b/volume-cartographer/core/include/vc/core/render/ZarrChunkFetcher.hpp
@@ -11,7 +11,10 @@
 #include <string>
 #include <vector>
 
-namespace utils { class ZarrArray; }
+namespace utils {
+class Store;
+class ZarrArray;
+}
 
 namespace vc::render {
 
@@ -44,6 +47,15 @@ OpenedChunkedZarr openHttpZarrPyramid(
 OpenedChunkedZarr validateAndRebaseVcPyramid(
     OpenedChunkedZarr opened,
     int baseScaleLevel);
+
+// Map multiscales[0].datasets of the store's .zattrs to (physicalLevel, key)
+// pairs. All-numeric dataset paths bind by their value — exporters may publish
+// only levels >= some scaledown, and positional binding would register the
+// coarse array as full resolution. Exposed for deterministic synthetic tests;
+// the remote open uses the same implementation.
+std::vector<std::pair<int, std::string>> remoteLevelKeysFromZattrs(
+    const std::shared_ptr<utils::Store>& store,
+    int firstLevel);
 
 std::unique_ptr<ChunkCache> createChunkCache(
     OpenedChunkedZarr opened,

--- a/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
+++ b/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
@@ -24,6 +24,11 @@
 
 namespace vc::render {
 
+// Upper bound on physical pyramid levels considered when probing a remote
+// store, and on the level number accepted from a numeric multiscale dataset
+// path — the two must agree or discovery and binding drift apart.
+inline constexpr int kMaxProbedRemoteLevels = 32;
+
 namespace {
 
 class HttpStatusError final : public std::runtime_error {
@@ -538,6 +543,21 @@ std::vector<int> localLevelNumbers(const std::filesystem::path& root)
     return levels;
 }
 
+
+void addRemoteLevelFromKey(
+    OpenedChunkedZarr& opened,
+    const std::shared_ptr<utils::Store>& store,
+    const std::string& key,
+    int physicalLevel)
+{
+    auto array = utils::ZarrArray::open(store, key, vc::buildZarrCodecRegistry(1));
+    if (array.metadata().dtype == utils::ZarrDtype::uint16)
+        array = utils::ZarrArray::open(store, key, vc::buildZarrCodecRegistry(2));
+    addPhysicalLevel(opened, physicalLevel, std::move(array));
+}
+
+} // namespace
+
 std::vector<std::pair<int, std::string>> remoteLevelKeysFromZattrs(
     const std::shared_ptr<utils::Store>& store,
     int firstLevel)
@@ -569,26 +589,48 @@ std::vector<std::pair<int, std::string>> remoteLevelKeysFromZattrs(
             path.erase(path.begin());
         while (!path.empty() && path.back() == '/')
             path.pop_back();
-        if (!path.empty() && datasetIndex >= firstLevel)
+        if (!path.empty())
             keys.emplace_back(datasetIndex, std::move(path));
         ++datasetIndex;
     }
+
+    // Physical levels come from the dataset paths when every path is a small
+    // decimal number: exporters that publish only levels >= first_level (e.g.
+    // lasagna/tiled_predict3d.py) advertise datasets like ["3","4"], and
+    // binding those by array position would register the coarse array as full
+    // resolution. Non-numeric dataset names carry no level number, so they
+    // keep the positional binding.
+    const auto numericLevel = [](const std::string& path) -> std::optional<int> {
+        if (path.empty() || path.size() > 2)
+            return std::nullopt;
+        for (const char c : path) {
+            if (std::isdigit(static_cast<unsigned char>(c)) == 0)
+                return std::nullopt;
+        }
+        const int level = std::stoi(path);
+        if (level >= kMaxProbedRemoteLevels)
+            return std::nullopt;
+        return level;
+    };
+    bool allNumericPaths = !keys.empty();
+    for (const auto& [index, path] : keys) {
+        if (!numericLevel(path)) {
+            allNumericPaths = false;
+            break;
+        }
+    }
+    if (allNumericPaths) {
+        for (auto& [level, path] : keys)
+            level = *numericLevel(path);
+    }
+
+    keys.erase(std::remove_if(keys.begin(), keys.end(),
+                              [&](const auto& entry) {
+                                  return entry.first < firstLevel;
+                              }),
+               keys.end());
     return keys;
 }
-
-void addRemoteLevelFromKey(
-    OpenedChunkedZarr& opened,
-    const std::shared_ptr<utils::Store>& store,
-    const std::string& key,
-    int physicalLevel)
-{
-    auto array = utils::ZarrArray::open(store, key, vc::buildZarrCodecRegistry(1));
-    if (array.metadata().dtype == utils::ZarrDtype::uint16)
-        array = utils::ZarrArray::open(store, key, vc::buildZarrCodecRegistry(2));
-    addPhysicalLevel(opened, physicalLevel, std::move(array));
-}
-
-} // namespace
 
 OpenedChunkedZarr validateAndRebaseVcPyramid(
     OpenedChunkedZarr opened,
@@ -707,7 +749,7 @@ OpenedChunkedZarr openHttpZarrPyramid(
             }
         } else {
             bool sawGap = false;
-            for (int physicalLevel = 0; physicalLevel < 32; ++physicalLevel) {
+            for (int physicalLevel = 0; physicalLevel < kMaxProbedRemoteLevels; ++physicalLevel) {
                 const auto key = std::to_string(physicalLevel);
                 const bool present = store->exists(key + "/.zarray") ||
                                      store->exists(key + "/zarr.json");
@@ -736,7 +778,7 @@ OpenedChunkedZarr openHttpZarrPyramid(
         return opened;
     }
 
-    for (int physicalLevel = firstPhysicalLevel; physicalLevel < 32; ++physicalLevel) {
+    for (int physicalLevel = firstPhysicalLevel; physicalLevel < kMaxProbedRemoteLevels; ++physicalLevel) {
         const auto key = std::to_string(physicalLevel);
         try {
             addRemoteLevelFromKey(opened, store, key, physicalLevel);

--- a/volume-cartographer/core/test/test_zarr_chunk_fetcher.cpp
+++ b/volume-cartographer/core/test/test_zarr_chunk_fetcher.cpp
@@ -8,9 +8,15 @@
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/types/VcDataset.hpp"
 
+#include <utils/zarr.hpp>
+
 #include <filesystem>
+#include <fstream>
+#include <memory>
 #include <random>
 #include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -97,6 +103,56 @@ TEST_CASE("createChunkCache wraps openLocalZarrPyramid result")
         /*decodedByteCapacity=*/1ULL << 20);
     REQUIRE(cache);
     CHECK(cache->numLevels() >= 1);
+    fs::remove_all(d);
+}
+
+TEST_CASE("remoteLevelKeysFromZattrs binds numeric dataset paths by value")
+{
+    // A scaledown export (lasagna/tiled_predict3d.py with first_level=2)
+    // advertises only its coarse datasets; positional binding would register
+    // the level-2 array as full resolution.
+    auto d = tmpDir("zattrs_numeric");
+    {
+        std::ofstream f(d / ".zattrs");
+        f << R"({"multiscales":[{"datasets":[{"path":"2"},{"path":"3"}]}]})";
+    }
+    auto store = std::make_shared<utils::FileSystemStore>(d);
+    const auto keys = vc::render::remoteLevelKeysFromZattrs(store, 0);
+    REQUIRE(keys.size() == 2);
+    CHECK(keys[0] == std::pair<int, std::string>{2, "2"});
+    CHECK(keys[1] == std::pair<int, std::string>{3, "3"});
+    fs::remove_all(d);
+}
+
+TEST_CASE("remoteLevelKeysFromZattrs keeps positional binding for named datasets")
+{
+    auto d = tmpDir("zattrs_named");
+    {
+        std::ofstream f(d / ".zattrs");
+        f << R"({"multiscales":[{"datasets":[{"path":"s0"},{"path":"s1"}]}]})";
+    }
+    auto store = std::make_shared<utils::FileSystemStore>(d);
+    const auto keys = vc::render::remoteLevelKeysFromZattrs(store, 0);
+    REQUIRE(keys.size() == 2);
+    CHECK(keys[0] == std::pair<int, std::string>{0, "s0"});
+    CHECK(keys[1] == std::pair<int, std::string>{1, "s1"});
+    fs::remove_all(d);
+}
+
+TEST_CASE("remoteLevelKeysFromZattrs is unchanged for standard zero-based pyramids")
+{
+    auto d = tmpDir("zattrs_standard");
+    {
+        std::ofstream f(d / ".zattrs");
+        f << R"({"multiscales":[{"datasets":[{"path":"0"},{"path":"1"},{"path":"2"}]}]})";
+    }
+    auto store = std::make_shared<utils::FileSystemStore>(d);
+    const auto keys = vc::render::remoteLevelKeysFromZattrs(store, 0);
+    REQUIRE(keys.size() == 3);
+    for (int level = 0; level < 3; ++level) {
+        CHECK(keys[static_cast<std::size_t>(level)] ==
+              std::pair<int, std::string>{level, std::to_string(level)});
+    }
     fs::remove_all(d);
 }
 


### PR DESCRIPTION
Fixes #1346.

`remoteLevelKeysFromZattrs` mapped each `multiscales[0].datasets` entry to a physical pyramid level by its **position in the array**. Scaledown exports — `lasagna/tiled_predict3d.py::_create_omezarr` with `first_level = product.level > 0` — advertise only their coarse datasets (e.g. `["3","4"]`), so the level-3 array was registered as **physical level 0 with an identity transform**: over HTTP the volume opened with `2^first_level`-wrong dimensions and every coordinate silently misregistered, while the same zarr opened locally (directory scan by name) was handled correctly.

### Change (3 files, +128/−18)

* `ZarrChunkFetcher.cpp` — when every dataset path is a small decimal number, bind each dataset to `int(path)`; the remote open then produces the same sparse placeholder pyramid the local scan produces, which `Volume::NewFromUrl` already handles (`firstPresentLevel`). Non-numeric dataset names (`s0`-style) keep the positional binding, so nothing changes for them. The probe-loop cap and the accepted numeric range now share one constant (`kMaxProbedRemoteLevels`) so discovery and binding cannot drift apart. The `firstLevel` filter is applied to the *bound* level (its only current caller passes 0, so behavior there is identical).
* `ZarrChunkFetcher.hpp` — declares `remoteLevelKeysFromZattrs` (moved out of the anonymous namespace) for deterministic tests, same pattern as `validateAndRebaseVcPyramid`.
* `test_zarr_chunk_fetcher.cpp` — three new cases via `utils::FileSystemStore`: numeric suffix binding (`["2","3"]` → levels 2,3 — **fails before the fix** with 0,1), named datasets keep positional binding, and standard zero-based pyramids are byte-for-byte unchanged.

### Measured (fixtures from #1346, served with `python3 -m http.server`)

| | before | after |
|---|---|---|
| remote grow on scaledown-2 artifact | `zarr dataset size for scale group 0 [32, 48, 40]` — coarse array as full res; out-of-bounds seed silently reads 26; exit 0 on 4×-wrong geometry | volume opens as a correct sparse pyramid (base 128×192×160, level 2 present) — identical to the local open; with #1344's guard: clean fail-fast `present levels: 2` |
| remote render `--remote-url … -g 2` (present level) | n/a | renders the sheet correctly (60×60), exit 0 |
| remote render `--remote-url … -g 0` (absent level) | silent all-black (via #1343) | `Error: group index 0 not available in remote zarr (present levels: 2)` |
| local behavior | correct | unchanged (binding function not on the local path) |

The two "after" guard messages come from #1344 (independent branch, no file overlap); this PR is what makes the remote open produce the sparse pyramid those guards can see.

### Tests

`test_zarr_chunk_fetcher`: 13/13 (10 existing + 3 new). Full suite: **120/121** — the single failure is the pre-existing `test_chunk_cache` concurrency flake (#1330), also failing on unmodified main. `test_volume_live_s3` (real S3 catalog volume with a standard zero-based `.zattrs`) passes, which is the strongest no-regression control for normal pyramids.

Not addressed here (as flagged in #1346): the no-`.zattrs` sparse-remote probe loop still rethrows at level 0 — separate small gap, does not affect the exporter's artifacts, happy to follow up if wanted.

---
*Analysis, fix and verification done with AI assistance (Claude); all transcripts above are from actual local runs.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKT3CfY4msFhzjd1cXzbrp