### PR TITLE
Repair and harden Progress Prize rollover automation

### DIFF
--- a/.github/actions/progress-prizes-google/action.yml
+++ b/.github/actions/progress-prizes-google/action.yml
@@ -3,7 +3,7 @@ description: Run one guarded Progress Prize Google Forms operation from a truste
 
 inputs:
   operation:
-    description: validate, bootstrap, prepare, activate, verify, or cleanup
+    description: validate, bootstrap, prepare, activate, reconcile-active, verify, or cleanup
     required: true
   environment:
     description: staging or production
@@ -130,7 +130,7 @@ runs:
         test "$REF" = refs/heads/main
         test "$EVENT_NAME" = workflow_dispatch
         case "$OPERATION" in
-          validate|bootstrap|prepare|activate|verify|cleanup) ;;
+          validate|bootstrap|prepare|activate|reconcile-active|verify|cleanup) ;;
           *) exit 1 ;;
         esac
         case "$EXPECT_FAULT" in true|false) ;; *) exit 1 ;; esac
@@ -148,7 +148,7 @@ runs:
         fi
         case "$OPERATION" in
           validate|bootstrap) test -n "$SOURCE_CYCLE" ;;
-          prepare|activate|verify|cleanup) test -n "$TARGET_CYCLE" ;;
+          prepare|activate|reconcile-active|verify|cleanup) test -n "$TARGET_CYCLE" ;;
         esac
         if test "$OPERATION" = bootstrap; then test "$SOURCE_CYCLE" = 2026-07 || exit 1; fi
         if test "$OPERATION" = activate; then
@@ -165,6 +165,16 @@ runs:
           test "$OPERATION" = bootstrap
           test "$SOURCE_CYCLE" = 2026-07
           test "$TARGET_CYCLE" = 2026-08
+        fi
+        if test "$OPERATION" = reconcile-active; then
+          test "$EVENT_NAME" = workflow_dispatch
+          test -z "$SIMULATED_NOW"
+          test -z "$FAULT"
+          test "$EXPECT_FAULT" = false
+          test "$DRY_RUN" = false
+          test "$ALLOW_ACTIVATION_REWIND" = false
+          test -z "$HEAD_SHA"
+          test -z "$BASE_SHA"
         fi
         if test "$AUTOMATION_ENVIRONMENT" = production; then
           test "$OPERATION" != bootstrap

--- a/.github/progress-prizes-github.mjs
+++ b/.github/progress-prizes-github.mjs
@@ -23,6 +23,22 @@ const REPOSITORY_ID = 890972577;
 const OWNER_ID = 121906140;
 const GITHUB_ACTIONS_BOT_ID = 41898282;
 const PAGE_PATH = 'scrollprize.org/docs/34_prizes.md';
+const SAFE_DIAGNOSTIC_CODES = new Set([
+  'ambiguous-pr',
+  'completed-state-missing',
+  'invalid-main-ref',
+  'invalid-page-head',
+  'invalid-pr-association',
+  'main-ref-moved',
+  'unexpected-error',
+]);
+
+class SafeCoordinationError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.diagnosticCode = code;
+  }
+}
 
 function previewRunId(status) {
   const match = /^https:\/\/github\.com\/ScrollPrize\/villa\/actions\/runs\/([1-9]\d*)$/
@@ -48,6 +64,19 @@ function latestPreviewStatus(statuses) {
 
 function fail(message) {
   throw new Error(message);
+}
+
+function failWithDiagnostic(code, message) {
+  if (!SAFE_DIAGNOSTIC_CODES.has(code) || code === 'unexpected-error') {
+    fail('Invalid safe diagnostic code.');
+  }
+  throw new SafeCoordinationError(code, message);
+}
+
+export function safeDiagnosticCode(error) {
+  return SAFE_DIAGNOSTIC_CODES.has(error?.diagnosticCode)
+    ? error.diagnosticCode
+    : 'unexpected-error';
 }
 
 function parseArgs(argv) {
@@ -183,7 +212,10 @@ export function activationCommitNeedsRefresh(commit, { headSha, baseSha } = {}) 
     || commit.files[0]?.filename !== PAGE_PATH
     || commit.files[0]?.status !== 'modified'
   ) {
-    fail('Only a page-only commit with a stale parent may be refreshed.');
+    failWithDiagnostic(
+      'invalid-page-head',
+      'Only a page-only commit with a stale parent may be refreshed.',
+    );
   }
   const parentSha = assertSha(commit.parents[0]?.sha ?? '');
   return parentSha !== baseSha;
@@ -292,29 +324,53 @@ export async function resolveProductionActivationState({
   const contract = assertAutomationBranch(head, base);
   if (contract.kind !== 'production') fail('Activation-state recovery is production-only.');
   const pulls = await listPulls();
-  if (!Array.isArray(pulls) || pulls.length > 1) fail('Production activation PR state is ambiguous.');
+  if (!Array.isArray(pulls) || pulls.length > 1) {
+    failWithDiagnostic('ambiguous-pr', 'Production activation PR state is ambiguous.');
+  }
+  const ref = await readMainRef();
+  if (
+    ref?.ref !== 'refs/heads/main'
+    || ref?.object?.type !== 'commit'
+    || !/^[a-f0-9]{40}$/.test(ref.object.sha ?? '')
+  ) {
+    failWithDiagnostic('invalid-main-ref', 'The authoritative production main ref is invalid.');
+  }
+  const baseSha = ref.object.sha;
+  if (baseSha !== trustedBaseSha) {
+    failWithDiagnostic('main-ref-moved', 'Production main moved after the workflow was dispatched.');
+  }
   let state;
   let sha;
-  let baseSha;
   let number = '';
   let refreshRequired = false;
   if (pulls.length === 1) {
     const pull = pulls[0];
-    sha = assertSha(pull.head?.sha ?? '');
-    baseSha = assertSha(pull.base?.sha ?? '');
-    if (baseSha !== trustedBaseSha) fail('Production main moved after the workflow was dispatched.');
-    assertPullBinding(pull, { head, base, headSha: sha, baseSha });
+    try {
+      assertPullAssociation(pull, { head, base });
+      sha = assertSha(pull.head?.sha ?? '');
+      // pull.base.sha is cached pull metadata. Validate its shape, but never use it
+      // to decide whether the authoritative refs/heads/main has moved.
+      assertSha(pull.base?.sha ?? '');
+      if (!Number.isInteger(pull.number) || pull.number < 1) fail('Invalid pull request number.');
+    } catch {
+      failWithDiagnostic(
+        'invalid-pr-association',
+        'The production activation pull request association is invalid.',
+      );
+    }
     const commit = await readCommit(sha);
     refreshRequired = activationCommitNeedsRefresh(commit, { headSha: sha, baseSha });
     state = 'pending';
     number = String(pull.number);
   } else {
-    const ref = await readMainRef();
-    sha = assertSha(ref?.object?.sha ?? '');
-    if (sha !== trustedBaseSha) fail('Production main moved after the workflow was dispatched.');
-    baseSha = sha;
+    sha = baseSha;
     const page = await readPage(sha);
-    if (page.cycle !== targetCycle) fail('Neither a pending PR nor a completed production cycle exists.');
+    if (page.cycle !== targetCycle) {
+      failWithDiagnostic(
+        'completed-state-missing',
+        'Neither a pending PR nor a completed production cycle exists.',
+      );
+    }
     state = 'completed';
   }
   return {
@@ -647,8 +703,10 @@ async function main(argv) {
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
     await main(process.argv.slice(2));
-  } catch {
-    process.stderr.write('Progress Prize GitHub coordination failed safely.\n');
+  } catch (error) {
+    process.stderr.write(
+      `Progress Prize GitHub coordination failed safely [${safeDiagnosticCode(error)}].\n`,
+    );
     process.exitCode = 1;
   }
 }

--- a/.github/workflows/progress-prizes-production.yml
+++ b/.github/workflows/progress-prizes-production.yml
@@ -17,6 +17,7 @@ on:
           - dry-run
           - prepare
           - activate
+          - reconcile-active
           - verify
       source-cycle:
         description: Source cycle (YYYY-MM)
@@ -81,7 +82,7 @@ jobs:
           assert.match(process.env.HEAD_SHA ?? '', /^[a-f0-9]{40}$/);
           assert.equal(process.env.EVENT_NAME, 'workflow_dispatch');
           assert.equal(
-            new Set(['validate', 'dry-run', 'prepare', 'activate', 'verify'])
+            new Set(['validate', 'dry-run', 'prepare', 'activate', 'reconcile-active', 'verify'])
               .has(process.env.OPERATION ?? ''),
             true,
           );
@@ -95,6 +96,9 @@ jobs:
             : `${sourceYear}-${String(sourceMonth + 1).padStart(2, '0')}`;
           assert.equal(process.env.TARGET_CYCLE, target);
           if (process.env.REQUEST_ID !== '') assert.match(process.env.REQUEST_ID, /^[1-9]\d*$/);
+          if (process.env.OPERATION === 'reconcile-active') {
+            assert.equal(process.env.REQUEST_ID, '');
+          }
           NODE
 
   validate:
@@ -192,6 +196,69 @@ jobs:
             ].join('\n'),
           );
           NODE
+
+  reconcile-approval:
+    name: Approve marker-only active-state reconciliation
+    if: inputs.operation == 'reconcile-active'
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    environment: progress-prizes-production-activation
+    permissions: {}
+    steps:
+      - name: Bind approval to a manual exact-main reconciliation
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          TRIGGER_SHA: ${{ github.sha }}
+          REQUEST_ID: ${{ inputs['request-id'] }}
+          SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_NAME" = workflow_dispatch
+          test "$REF" = refs/heads/main
+          [[ "$TRIGGER_SHA" =~ ^[a-f0-9]{40}$ ]]
+          test -z "$REQUEST_ID"
+          [[ "$SOURCE_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]
+          [[ "$TARGET_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]]
+
+  reconcile-active:
+    name: Audit and reconcile only active Drive markers
+    if: inputs.operation == 'reconcile-active'
+    needs:
+      - preflight
+      - reconcile-approval
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the exact trusted trigger commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Reconcile only the verified active Drive markers
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: reconcile-active
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          branch: main
+          target-branch: main
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
 
   prepare-google:
     if: inputs.operation == 'prepare'

--- a/.github/workflows/progress-prizes-rehearsal.yml
+++ b/.github/workflows/progress-prizes-rehearsal.yml
@@ -679,10 +679,146 @@ jobs:
           source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
           editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
 
+  reconcile-active-once:
+    if: inputs.operation == 'full-rehearsal'
+    needs:
+      - merge-smoke
+      - prove-activation-idempotency
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-staging
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      responder-uri: ${{ steps.google.outputs['responder-uri'] }}
+    steps:
+      - name: Check out trusted Google operation
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Fetch exact merged smoke page as data
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ needs.merge-smoke.outputs['merge-sha'] }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { writeFile } from 'node:fs/promises';
+
+          const sha = process.env.MERGE_SHA ?? '';
+          if (!/^[a-f0-9]{40}$/i.test(sha)) throw new Error('Missing exact smoke merge SHA.');
+          const url = new URL('https://api.github.com/repos/ScrollPrize/villa/contents/scrollprize.org/docs/34_prizes.md');
+          url.searchParams.set('ref', sha);
+          const response = await fetch(url, {
+            redirect: 'error',
+            headers: {
+              accept: 'application/vnd.github.raw+json',
+              authorization: `Bearer ${process.env.GH_TOKEN}`,
+              'user-agent': 'progress-prize-rollover',
+              'x-github-api-version': '2022-11-28',
+            },
+          });
+          if (response.status !== 200) throw new Error('Could not read the exact merged smoke page.');
+          const body = await response.text();
+          if (Buffer.byteLength(body, 'utf8') > 1024 * 1024) throw new Error('Managed page response is too large.');
+          await writeFile('scrollprize.org/docs/34_prizes.md', body, { mode: 0o600 });
+          NODE
+      - name: Reconcile active staging markers once
+        id: google
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: reconcile-active
+          environment: staging
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          branch: codex/progress-prize-smoke-20260720
+          target-branch: codex/progress-prize-smoke-base-20260720
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
+          archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+
+  reconcile-active-twice:
+    if: inputs.operation == 'full-rehearsal'
+    needs:
+      - merge-smoke
+      - reconcile-active-once
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-staging
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      responder-uri: ${{ steps.google.outputs['responder-uri'] }}
+    steps:
+      - name: Check out trusted Google operation
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Fetch exact merged smoke page as data
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ needs.merge-smoke.outputs['merge-sha'] }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { writeFile } from 'node:fs/promises';
+
+          const sha = process.env.MERGE_SHA ?? '';
+          if (!/^[a-f0-9]{40}$/i.test(sha)) throw new Error('Missing exact smoke merge SHA.');
+          const url = new URL('https://api.github.com/repos/ScrollPrize/villa/contents/scrollprize.org/docs/34_prizes.md');
+          url.searchParams.set('ref', sha);
+          const response = await fetch(url, {
+            redirect: 'error',
+            headers: {
+              accept: 'application/vnd.github.raw+json',
+              authorization: `Bearer ${process.env.GH_TOKEN}`,
+              'user-agent': 'progress-prize-rollover',
+              'x-github-api-version': '2022-11-28',
+            },
+          });
+          if (response.status !== 200) throw new Error('Could not read the exact merged smoke page.');
+          const body = await response.text();
+          if (Buffer.byteLength(body, 'utf8') > 1024 * 1024) throw new Error('Managed page response is too large.');
+          await writeFile('scrollprize.org/docs/34_prizes.md', body, { mode: 0o600 });
+          NODE
+      - name: Reconcile active staging markers twice
+        id: google
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: reconcile-active
+          environment: staging
+          source-cycle: ${{ inputs['source-cycle'] }}
+          target-cycle: ${{ inputs['target-cycle'] }}
+          branch: codex/progress-prize-smoke-20260720
+          target-branch: codex/progress-prize-smoke-base-20260720
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          staging-folder-id: ${{ secrets.PROGRESS_PRIZE_STAGING_FOLDER_ID }}
+          archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+
   cleanup-full-rehearsal:
     if: inputs.operation == 'full-rehearsal'
     needs:
-      - prove-activation-idempotency
+      - reconcile-active-twice
       - verify-post-merge-preview
     runs-on: ubuntu-24.04
     timeout-minutes: 20

--- a/.github/workflows/progress-prizes-schedule.yml
+++ b/.github/workflows/progress-prizes-schedule.yml
@@ -10,7 +10,7 @@ on:
       timezone: America/Los_Angeles
     - cron: "17 0 1 * *"
       timezone: America/Los_Angeles
-    - cron: "47 6 1 * *"
+    - cron: "47 6 1-7 * *"
       timezone: America/Los_Angeles
 
 permissions: {}
@@ -48,7 +48,7 @@ jobs:
             '17 6 * * *',
             '40 23 28-31 * *',
             '17 0 1 * *',
-            '47 6 1 * *',
+            '47 6 1-7 * *',
           ]);
           assert.equal(process.env.REPOSITORY, 'ScrollPrize/villa');
           assert.equal(process.env.REPOSITORY_ID, '890972577');

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -35,9 +35,9 @@ repository secret, file, log, cache, or artifact.
   on a Vercel `repository_dispatch`. It never checks out or executes deployed
   branch code.
 - `progress-prizes-production.yml` provides guarded `validate`, `dry-run`,
-  `prepare`, `activate`, and `verify` operations after the complete staging
-  rehearsal has passed. Every authenticated job is literal in that top-level
-  workflow and calls the same local action exercised by staging.
+  `prepare`, `activate`, `reconcile-active`, and `verify` operations after the
+  complete staging rehearsal has passed. Every authenticated job is literal in
+  that top-level workflow and calls the same local action exercised by staging.
 - `progress-prizes-schedule.yml` is the secret-free scheduler added only after
   production `validate` and `dry-run` passed. Reaching `main` enables its
   Pacific-time schedules; a manual dispatch is permanently restricted to a
@@ -428,6 +428,15 @@ the immediately following month. Leave `request-id` empty for every manual run.
   Google token, authenticates at cutoff, reacquires a zero-wait GitHub lease,
   closes the source, opens and reload-verifies the target, then merges only the
   activated commit.
+- `reconcile-active` is a manual break-glass repair for a rollover that humans
+  already completed. Run `verify active` first. Reconciliation proceeds only if
+  the old form is published and closed, the new form is published and open, the
+  website points exactly to the new responder URL, and titles, structure,
+  linked-Sheet status, capabilities, ACLs, and copy fingerprint all match. It
+  requires the same secret-free activation Environment approval and may update
+  only the source `CLOSED` and target `ACTIVE` Drive `appProperties`. It never
+  changes a form, response, permission, folder, publishing state, or website
+  file. A second run is read-only and succeeds idempotently.
 
 If preparation, activation, or merge stops, rerun the same operation and cycle.
 Managed Drive markers make Google copy and close/open recovery idempotent. A

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -447,6 +447,34 @@ Never use simulated time, fault controls, alternate branches, or staging folders
 for production; those inputs are absent and the shared action rejects them
 before authentication.
 
+Manual recovery uses public controls only; Google configuration stays inside the
+protected Environment:
+
+```bash
+gh workflow run progress-prizes-production.yml --ref main \
+  -f operation=activate -f source-cycle=2026-07 -f target-cycle=2026-08 \
+  -f verify-mode=active
+gh workflow run progress-prizes-production.yml --ref main \
+  -f operation=verify -f source-cycle=2026-07 -f target-cycle=2026-08 \
+  -f verify-mode=active
+gh workflow run progress-prizes-production.yml --ref main \
+  -f operation=reconcile-active -f source-cycle=2026-07 -f target-cycle=2026-08 \
+  -f verify-mode=active
+```
+
+The trusted GitHub coordinator prints only these diagnostic codes:
+`main-ref-moved`, `ambiguous-pr`, `invalid-page-head`,
+`invalid-pr-association`, `invalid-main-ref`, `completed-state-missing`, and
+`unexpected-error`. The code is safe to include in an incident report; API
+bodies and private identifiers are never printed.
+
+Generated `codex/progress-prize-YYYY-MM` branches and their PRs are strictly
+marker-only. Never push a human guideline, copy, or formatting commit to a
+generated rollover branch. Put editorial changes on a separate branch and PR;
+otherwise the exact one-commit/one-file activation gate will reject the
+rollover. Production never deletes an old form or any response. The cleanup
+operation is staging-only and cannot be selected in the production workflow.
+
 ## Automated schedule and immediate smoke
 
 The scheduler owns no Google or Vercel configuration, protected Environment,
@@ -464,10 +492,13 @@ bound to the exact child run ID and public Actions URL.
   observed date is the actual last calendar day. The production workflow—not
   the scheduler—runs tests and the Vercel gate, requests human approval, waits
   for cutoff without a Google token, then authenticates.
-- `00:17` and `06:47` Pacific on the first day are independent recovery probes.
-  Delayed final-day events retain the previous source cycle through that first
-  day, while every day-two event no-ops. If an exact production run is already
-  nonterminal, the scheduler does not enqueue a stale duplicate.
+- `00:17` Pacific remains a first-day recovery probe. `06:47` Pacific retries
+  on days 1–7, always targeting the previous month's incomplete rollover. A
+  delayed day-7 event may cross local midnight before the day-8 slot; a true
+  day-8 event no-ops. If an exact production run is already nonterminal, the
+  scheduler does not enqueue a stale duplicate. A completed rollover reaches
+  read-only active verification and never creates another form or repeats
+  publishing mutations.
 
 Production and scheduler concurrency groups never cancel an in-progress run and
 use GitHub's queued concurrency mode so a manual race cannot silently replace a

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
@@ -361,6 +361,9 @@ function assertAutomationOptions(command, options) {
   if (options.fault !== undefined && !['bootstrap', 'prepare', 'activate'].includes(command)) {
     throw new Error('--fault is accepted only by bootstrap, prepare, and activate');
   }
+  if (command === 'reconcile-active' && options['simulated-now'] !== undefined) {
+    throw new Error('reconcile-active rejects --simulated-now');
+  }
   if (command === 'bootstrap') {
     const sourceCycle = requireOption(options, 'source-cycle');
     parseCycle(sourceCycle);
@@ -410,7 +413,14 @@ function assertAutomationOptions(command, options) {
 }
 
 function collaboratorPermissions(command, env) {
-  if (!['validate', 'bootstrap', 'prepare', 'activate', 'verify'].includes(command)) return [];
+  if (![
+    'validate',
+    'bootstrap',
+    'prepare',
+    'activate',
+    'reconcile-active',
+    'verify',
+  ].includes(command)) return [];
   return [{
     type: 'group',
     role: 'writer',
@@ -475,6 +485,9 @@ export async function runAutomationCli(argv, {
   // This validation deliberately precedes token access, Google client creation,
   // responder URL resolution, and every filesystem/network call.
   const runtime = buildRuntime(options, env);
+  if (command === 'reconcile-active' && runtime.eventName !== 'workflow_dispatch') {
+    throw new Error('reconcile-active requires a manual workflow_dispatch event');
+  }
   assertRolloverRuntimeSafety(runtime, {
     faultInjection: options.fault,
     allowActivationRewind: options['allow-activation-rewind'] === true,
@@ -565,6 +578,12 @@ export async function runAutomationCli(argv, {
         preparationDays,
         faultInjection: options.fault,
         headSha: activation.headSha,
+      });
+    } else if (command === 'reconcile-active') {
+      result = await rollover.reconcileActive({
+        targetCycle,
+        sourceFormId: productionSourceFormId,
+        collaboratorPermissions: collaborators,
       });
     } else if (command === 'verify') {
       result = await rollover.verify({

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
@@ -82,6 +82,7 @@ function fakeRolloverFactory({ result, capture }) {
       'bootstrapStagingSource',
       'prepare',
       'activate',
+      'reconcileActive',
       'verify',
       'cleanup',
     ].map((method) => [method, async (input) => {
@@ -673,11 +674,16 @@ test('top-level CLI keeps page validate compatibility and routes source-cycle va
   assert.equal(capture.dependencies.runtime.stagingServiceAccountEmail, PRIVATE.account);
 });
 
-test('bootstrap, verify, and cleanup commands map to the corresponding service operations', async () => {
+test('bootstrap, reconcile, verify, and cleanup commands map to service operations', async () => {
   for (const [argv, method, expectedMode] of [
     [
       ['bootstrap', '--source-cycle', '2026-07', '--dry-run'],
       'bootstrapStagingSource',
+      undefined,
+    ],
+    [
+      ['reconcile-active', '--target-cycle', '2026-08', '--source-cycle', '2026-07'],
+      'reconcileActive',
       undefined,
     ],
     [
@@ -704,6 +710,80 @@ test('bootstrap, verify, and cleanup commands map to the corresponding service o
     assert.equal(capture.method, method);
     if (expectedMode !== undefined) assert.equal(capture.input.mode, expectedMode);
   }
+});
+
+test('reconcile-active is manual-only and rejects staging controls before token or I/O', async () => {
+  for (const [argv, env, expected] of [
+    [
+      ['reconcile-active', '--target-cycle', '2026-08'],
+      productionEnv({ GOOGLE_ACCESS_TOKEN: undefined, GITHUB_EVENT_NAME: 'schedule' }),
+      /manual workflow_dispatch/,
+    ],
+    [
+      [
+        'reconcile-active',
+        '--target-cycle', '2026-08',
+        '--simulated-now', '2026-08-06T12:00:00Z',
+      ],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /rejects --simulated-now/,
+    ],
+    [
+      ['reconcile-active', '--target-cycle', '2026-08', '--fault', 'after-copy'],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /--fault is accepted only/,
+    ],
+    [
+      ['reconcile-active', '--target-cycle', '2026-08', '--dry-run'],
+      stagingEnv({ GOOGLE_ACCESS_TOKEN: undefined }),
+      /--dry-run is accepted only/,
+    ],
+  ]) {
+    let clientCalls = 0;
+    let fileCalls = 0;
+    await assert.rejects(
+      runAutomationCli(argv, {
+        env,
+        googleFactory: () => { clientCalls += 1; return {}; },
+        read: async () => { fileCalls += 1; return ''; },
+        write: async () => { fileCalls += 1; },
+        output: () => {},
+      }),
+      expected,
+    );
+    assert.equal(clientCalls, 0);
+    assert.equal(fileCalls, 0);
+  }
+});
+
+test('production reconcile-active passes only the protected source and editor group', async () => {
+  const capture = {};
+  await runAutomationCli([
+    'reconcile-active',
+    '--target-cycle', '2026-08',
+    '--source-cycle', '2026-07',
+  ], {
+    env: productionEnv({ PROGRESS_PRIZE_BRANCH: 'main' }),
+    googleFactory: () => ({}),
+    rolloverFactory: fakeRolloverFactory({
+      capture,
+      result: {
+        action: 'reconcile-active',
+        status: 'active',
+        sourceCycle: '2026-07',
+        targetCycle: '2026-08',
+        responderUri: RESPONDER,
+      },
+    }),
+    output: () => {},
+  });
+  assert.equal(capture.method, 'reconcileActive');
+  assert.equal(capture.input.sourceFormId, PRIVATE.form);
+  assert.deepEqual(capture.input.collaboratorPermissions, [{
+    type: 'group',
+    role: 'writer',
+    emailAddress: 'production-editors@private.example',
+  }]);
 });
 
 test('bootstrap routes the explicit staging activation rewind and consecutive target cycle', async () => {

--- a/scrollprize.org/scripts/progress-prizes/cli-args.mjs
+++ b/scrollprize.org/scripts/progress-prizes/cli-args.mjs
@@ -23,6 +23,7 @@ export const GOOGLE_COMMANDS = Object.freeze([
   'bootstrap',
   'prepare',
   'activate',
+  'reconcile-active',
   'verify',
   'cleanup',
 ]);
@@ -110,6 +111,7 @@ export const GOOGLE_CLI_USAGE = `Google automation (private values are environme
     [--allow-activation-rewind --target-cycle YYYY-MM]
   node automation-cli.mjs prepare --target-cycle YYYY-MM [--source-cycle YYYY-MM] [--dry-run]
   node automation-cli.mjs activate --target-cycle YYYY-MM [--source-cycle YYYY-MM] [--fault STEP]
+  node automation-cli.mjs reconcile-active --target-cycle YYYY-MM [--source-cycle YYYY-MM]
   node automation-cli.mjs verify --target-cycle YYYY-MM [--source-cycle YYYY-MM] \\
     [--mode prepared|active|cleaned]
   node automation-cli.mjs cleanup --target-cycle YYYY-MM [--source-cycle YYYY-MM]

--- a/scrollprize.org/scripts/progress-prizes/production-workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/production-workflow-contract.test.mjs
@@ -9,6 +9,7 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../.
 const googleJobs = [
   'validate',
   'dry-run',
+  'reconcile-active',
   'prepare-google',
   'activate-production',
   'verify-completed-activation',
@@ -24,6 +25,7 @@ const githubOnlyJobs = [
   'activation-binding',
   'activation-gate',
   'activation-approval',
+  'reconcile-approval',
   'merge',
   'verify-prepared-state',
   'report-scheduled-failure',
@@ -112,6 +114,8 @@ test('production accepts only a secret-free manual dispatch contract', async () 
   assert.match(preflight, /assert\.equal\(process\.env\.EVENT_NAME, 'workflow_dispatch'\)/);
   assert.match(preflight, /process\.env\.TARGET_CYCLE, target/);
   assert.match(preflight, /\^\[1-9\]\\d\*\$/);
+  assert.match(preflight, /process\.env\.OPERATION === 'reconcile-active'/);
+  assert.match(preflight, /assert\.equal\(process\.env\.REQUEST_ID, ''\)/);
   assert.deepEqual(
     new Set(jobNames(source)),
     new Set([...googleJobs, ...githubOnlyJobs]),
@@ -148,6 +152,7 @@ test('production preflight executes a strict valid and invalid control matrix', 
     { OPERATION: 'cleanup' },
     { TARGET_CYCLE: '2026-09' },
     { REQUEST_ID: 'untrusted' },
+    { OPERATION: 'reconcile-active', REQUEST_ID: '123' },
   ]) {
     assert.notEqual(execute(overrides).status, 0, JSON.stringify(overrides));
   }
@@ -236,11 +241,44 @@ test('GitHub control-plane jobs have no Google identity or OIDC', async () => {
   const approval = jobBlock(source, 'activation-approval');
   assert.match(approval, /environment: progress-prizes-production-activation/);
   assert.match(approval, /permissions: \{\}/);
+  const reconciliationApproval = jobBlock(source, 'reconcile-approval');
+  assert.match(reconciliationApproval, /environment: progress-prizes-production-activation/);
+  assert.match(reconciliationApproval, /permissions: \{\}/);
+  assert.match(reconciliationApproval, /test -z "\$REQUEST_ID"/);
   const reporter = jobBlock(source, 'report-scheduled-failure');
   assert.match(reporter, /permissions:\n      issues: write/);
   assert.match(reporter, /\/search\/issues\?\$\{query\}/);
   assert.match(reporter, /search\.total_count > 100/);
   assert.match(reporter, /Google identifiers, ACL identities, and operation output are intentionally omitted/);
+});
+
+test('reconcile-active requires secret-free approval and permits only marker metadata writes', async () => {
+  const production = await productionWorkflow();
+  const action = await googleAction();
+  const approval = jobBlock(production, 'reconcile-approval');
+  const reconciliation = jobBlock(production, 'reconcile-active');
+
+  assert.match(approval, /^    if: inputs\.operation == 'reconcile-active'$/m);
+  assert.match(approval, /^    needs: preflight$/m);
+  assert.doesNotMatch(approval, /secrets\.|id-token|google-github-actions/);
+  assert.match(
+    reconciliation,
+    /needs:\n      - preflight\n      - reconcile-approval/,
+  );
+  assert.match(reconciliation, /^          operation: reconcile-active$/m);
+  assert.match(reconciliation, /^          branch: main$/m);
+  assert.match(reconciliation, /^          target-branch: main$/m);
+  assert.doesNotMatch(reconciliation, /simulated-now:|fault:|dry-run:|head-sha:|base-sha:/);
+
+  assert.match(action, /test "\$OPERATION" = reconcile-active/);
+  assert.match(action, /test -z "\$SIMULATED_NOW"/);
+  assert.match(action, /test -z "\$FAULT"/);
+  assert.match(action, /test -z "\$HEAD_SHA"/);
+  assert.match(action, /test -z "\$BASE_SHA"/);
+  assert.match(
+    action,
+    /if: inputs\.operation != 'validate' && inputs\.operation != 'verify' && inputs\['dry-run'\] != 'true'/,
+  );
 });
 
 test('every privileged checkout executes the immutable trigger code', async () => {

--- a/scrollprize.org/scripts/progress-prizes/rollover.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.mjs
@@ -59,6 +59,20 @@ const REQUIRED_GOOGLE_METHODS = Object.freeze([
 
 const ALLOWED_EVENTS = new Set(['schedule', 'workflow_dispatch']);
 const ALLOWED_VERIFY_MODES = new Set(['prepared', 'active', 'cleaned']);
+const RECONCILABLE_SOURCE_STATES = new Set([
+  undefined,
+  ROLLOVER_FILE_STATES.COPIED,
+  ROLLOVER_FILE_STATES.PREPARED,
+  ROLLOVER_FILE_STATES.ACTIVATING,
+  ROLLOVER_FILE_STATES.ACTIVE,
+  ROLLOVER_FILE_STATES.CLOSED,
+]);
+const RECONCILABLE_TARGET_STATES = new Set([
+  ROLLOVER_FILE_STATES.COPIED,
+  ROLLOVER_FILE_STATES.PREPARED,
+  ROLLOVER_FILE_STATES.ACTIVATING,
+  ROLLOVER_FILE_STATES.ACTIVE,
+]);
 const GOOGLE_FORM_MIME_TYPE = 'application/vnd.google-apps.form';
 const GOOGLE_FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
 const INITIAL_EXPLICIT_SOURCE_CYCLE = '2026-07';
@@ -769,6 +783,36 @@ function activationTransition(sourceSnapshot, targetSnapshot) {
     && targetState === ROLLOVER_FILE_STATES.ACTIVE
   ) return 'active';
   throw new Error('Forms are not in an allowed activation or recovery state');
+}
+
+function reconciliationMarkerState(sourceSnapshot, targetSnapshot, {
+  sourceCycle,
+  targetCycle,
+} = {}) {
+  const sourceProperties = sourceSnapshot.file.appProperties ?? {};
+  const targetProperties = targetSnapshot.file.appProperties ?? {};
+  if (
+    !RECONCILABLE_SOURCE_STATES.has(sourceProperties.state)
+    || !RECONCILABLE_TARGET_STATES.has(targetProperties.state)
+  ) {
+    throw new Error('Drive state metadata is outside guarded active reconciliation');
+  }
+  if (
+    (hasValue(sourceProperties.targetCycle) && sourceProperties.targetCycle !== targetCycle)
+    || (hasValue(targetProperties.sourceCycle) && targetProperties.sourceCycle !== sourceCycle)
+  ) {
+    throw new Error('Drive cycle metadata is outside guarded active reconciliation');
+  }
+  return Object.freeze({
+    healthy: sourceProperties.state === ROLLOVER_FILE_STATES.CLOSED
+      && sourceProperties.targetCycle === targetCycle
+      && targetProperties.state === ROLLOVER_FILE_STATES.ACTIVE
+      && targetProperties.sourceCycle === sourceCycle,
+    sourceState: sourceProperties.state,
+    sourceTargetCycle: sourceProperties.targetCycle,
+    targetState: targetProperties.state,
+    targetSourceCycle: targetProperties.sourceCycle,
+  });
 }
 
 async function ensurePublishState(google, form, expected) {
@@ -1959,7 +2003,7 @@ export function createRolloverService({
     });
   }
 
-  async function loadActivationState({
+  async function loadActivationPair({
     targetCycle,
     sourceFormId,
     collaboratorPermissions,
@@ -2008,7 +2052,14 @@ export function createRolloverService({
       source,
       sourceSnapshot,
       targetSnapshot,
-      transition: activationTransition(sourceSnapshot, targetSnapshot),
+    });
+  }
+
+  async function loadActivationState(options) {
+    const pair = await loadActivationPair(options);
+    return Object.freeze({
+      ...pair,
+      transition: activationTransition(pair.sourceSnapshot, pair.targetSnapshot),
     });
   }
 
@@ -2152,6 +2203,99 @@ export function createRolloverService({
     });
   }
 
+  async function reconcileActive({
+    targetCycle,
+    sourceFormId,
+    collaboratorPermissions = [],
+    copySourceCollaborators = true,
+  } = {}) {
+    if (runtime.eventName !== 'workflow_dispatch') {
+      throw new Error('Active-state reconciliation requires a manual workflow_dispatch event');
+    }
+    if (hasValue(runtime.simulatedNow)) {
+      throw new Error('Active-state reconciliation rejects simulated clocks');
+    }
+    assertMutationContext(runtime);
+    parseCycle(targetCycle);
+    const sourceCycle = previousCycle(targetCycle);
+    assertCollaboratorConfiguration(
+      collaboratorPermissions,
+      runtime.serviceAccountEmail,
+      runtime.driveAdminEmail,
+    );
+
+    const loadAudit = async () => {
+      const pair = await loadActivationPair({
+        targetCycle,
+        sourceFormId,
+        collaboratorPermissions,
+        copySourceCollaborators,
+        sourceCycle,
+      });
+      assertExpectedPublishing(pair.sourceSnapshot.form, {
+        isPublished: true,
+        isAcceptingResponses: false,
+      });
+      assertExpectedPublishing(pair.targetSnapshot.form, {
+        isPublished: true,
+        isAcceptingResponses: true,
+      });
+      return Object.freeze({
+        ...pair,
+        markers: reconciliationMarkerState(pair.sourceSnapshot, pair.targetSnapshot, {
+          sourceCycle,
+          targetCycle,
+        }),
+      });
+    };
+
+    let audit = await loadAudit();
+    const reconciliationRequired = !audit.markers.healthy;
+    if (reconciliationRequired) {
+      if (
+        audit.markers.sourceState !== ROLLOVER_FILE_STATES.CLOSED
+        || audit.markers.sourceTargetCycle !== targetCycle
+      ) {
+        await markFile(audit.sourceSnapshot.file, ROLLOVER_FILE_STATES.CLOSED, {
+          targetCycle,
+        }, {
+          expectedAppProperties: {
+            state: audit.markers.sourceState,
+            targetCycle: audit.markers.sourceTargetCycle,
+          },
+        });
+      }
+      if (
+        audit.markers.targetState !== ROLLOVER_FILE_STATES.ACTIVE
+        || audit.markers.targetSourceCycle !== sourceCycle
+      ) {
+        await markFile(audit.targetSnapshot.file, ROLLOVER_FILE_STATES.ACTIVE, {
+          sourceCycle,
+        }, {
+          expectedAppProperties: {
+            state: audit.markers.targetState,
+            sourceCycle: audit.markers.targetSourceCycle,
+          },
+        });
+      }
+      audit = await loadAudit();
+      if (!audit.markers.healthy) {
+        throw new Error('Active-state reconciliation did not reach the exact managed marker state');
+      }
+    }
+
+    return Object.freeze({
+      action: 'reconcile-active',
+      status: 'active',
+      sourceCycle,
+      targetCycle,
+      reconciled: reconciliationRequired,
+      sourceAcceptingResponses: false,
+      targetAcceptingResponses: true,
+      responderUri: assertPublicResponderUri(audit.targetSnapshot.form.responderUri),
+    });
+  }
+
   async function verify({
     targetCycle,
     sourceFormId,
@@ -2248,6 +2392,13 @@ export function createRolloverService({
         isPublished: true,
         isAcceptingResponses: true,
       });
+      const markers = reconciliationMarkerState(sourceSnapshot, targetSnapshot, {
+        sourceCycle,
+        targetCycle,
+      });
+      if (!markers.healthy) {
+        throw new Error('Active form pair has stale managed Drive state metadata');
+      }
     } else {
       assertStagingIdentity(runtime);
       assertNonEmptyString(runtime.archiveFolderId, 'archiveFolderId');
@@ -2366,6 +2517,7 @@ export function createRolloverService({
     bootstrapStagingSource,
     prepare,
     activate,
+    reconcileActive,
     verify,
     cleanup,
   });

--- a/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
@@ -471,6 +471,47 @@ async function closedActivationCheckpoint() {
   };
 }
 
+async function manuallyActivatedProductionPair() {
+  const google = grantProductionSourceAccess(new FakeGoogle());
+  const page = new MemoryPage();
+  const preparation = service({
+    google,
+    page,
+    runtime: productionRuntime(),
+    clock: fixedClock('2026-07-26T12:00:00Z'),
+  });
+  await preparation.rollover.prepare({
+    targetCycle: '2026-08',
+    sourceFormId: LIVE_FORM_ID,
+    collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+  });
+  const target = google.managed(ROLLOVER_FILE_ROLES.TARGET, '2026-08')[0];
+  google.forms.get(LIVE_FORM_ID).publishSettings.publishState = {
+    isPublished: true,
+    isAcceptingResponses: false,
+  };
+  google.forms.get(target.id).publishSettings.publishState = {
+    isPublished: true,
+    isAcceptingResponses: true,
+  };
+  google.calls.length = 0;
+  page.writes.length = 0;
+  return {
+    google,
+    page,
+    target,
+    rollover: service({
+      google,
+      page,
+      runtime: productionRuntime({
+        eventName: 'workflow_dispatch',
+        branch: 'main',
+      }),
+      clock: fixedClock('2026-08-06T12:00:00Z'),
+    }).rollover,
+  };
+}
+
 test('validate performs a read-only production preflight and resolves the public short URL', async () => {
   const google = grantProductionSourceAccess(new FakeGoogle());
   const context = service({
@@ -2085,6 +2126,217 @@ test('a missing later managed source cannot fall back to the stale initial form 
     google.calls.some(({ fileId, formId }) => fileId === LIVE_FORM_ID || formId === LIVE_FORM_ID),
     false,
   );
+});
+
+test('reconcile-active repairs only stale Drive markers and is idempotent', async () => {
+  const context = await manuallyActivatedProductionPair();
+  const pageBefore = context.page.content;
+  const sourcePublishingBefore = clone(
+    context.google.forms.get(LIVE_FORM_ID).publishSettings.publishState,
+  );
+  const targetPublishingBefore = clone(
+    context.google.forms.get(context.target.id).publishSettings.publishState,
+  );
+  const sourcePermissionsBefore = clone(context.google.permissions.get(LIVE_FORM_ID));
+  const targetPermissionsBefore = clone(context.google.permissions.get(context.target.id));
+
+  await assert.rejects(
+    context.rollover.verify({
+      targetCycle: '2026-08',
+      sourceFormId: LIVE_FORM_ID,
+      mode: 'active',
+      collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+    }),
+    /stale managed Drive state metadata/,
+  );
+  assert.equal(
+    context.google.calls.some(({ method }) => [
+      'copyFile',
+      'updateFile',
+      'createPermission',
+      'deletePermission',
+      'updateFormTitle',
+      'setPublishState',
+    ].includes(method)),
+    false,
+  );
+  context.google.calls.length = 0;
+
+  const first = await context.rollover.reconcileActive({
+    targetCycle: '2026-08',
+    sourceFormId: LIVE_FORM_ID,
+    collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+  });
+  assert.equal(first.action, 'reconcile-active');
+  assert.equal(first.status, 'active');
+  assert.equal(first.reconciled, true);
+  assert.equal(
+    context.google.files.get(LIVE_FORM_ID).appProperties.state,
+    ROLLOVER_FILE_STATES.CLOSED,
+  );
+  assert.equal(context.google.files.get(LIVE_FORM_ID).appProperties.targetCycle, '2026-08');
+  assert.equal(
+    context.google.files.get(context.target.id).appProperties.state,
+    ROLLOVER_FILE_STATES.ACTIVE,
+  );
+  assert.equal(context.target.appProperties.sourceCycle, '2026-07');
+
+  const mutations = context.google.calls.filter(({ method }) => [
+    'copyFile',
+    'updateFile',
+    'createPermission',
+    'deletePermission',
+    'updateFormTitle',
+    'setPublishState',
+  ].includes(method));
+  assert.equal(mutations.length, 2);
+  assert.deepEqual(mutations.map(({ method, fileId, appProperties }) => ({
+    method,
+    fileId,
+    state: appProperties?.state,
+  })), [
+    { method: 'updateFile', fileId: LIVE_FORM_ID, state: ROLLOVER_FILE_STATES.CLOSED },
+    { method: 'updateFile', fileId: context.target.id, state: ROLLOVER_FILE_STATES.ACTIVE },
+  ]);
+  assert.deepEqual(
+    context.google.forms.get(LIVE_FORM_ID).publishSettings.publishState,
+    sourcePublishingBefore,
+  );
+  assert.deepEqual(
+    context.google.forms.get(context.target.id).publishSettings.publishState,
+    targetPublishingBefore,
+  );
+  assert.deepEqual(context.google.permissions.get(LIVE_FORM_ID), sourcePermissionsBefore);
+  assert.deepEqual(context.google.permissions.get(context.target.id), targetPermissionsBefore);
+  assert.equal(context.page.content, pageBefore);
+  assert.deepEqual(context.page.writes, []);
+  assert.equal((await context.rollover.verify({
+    targetCycle: '2026-08',
+    sourceFormId: LIVE_FORM_ID,
+    mode: 'active',
+    collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+  })).status, 'valid');
+
+  context.google.calls.length = 0;
+  const second = await context.rollover.reconcileActive({
+    targetCycle: '2026-08',
+    sourceFormId: LIVE_FORM_ID,
+    collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+  });
+  assert.equal(second.reconciled, false);
+  assert.equal(
+    context.google.calls.some(({ method }) => method === 'updateFile'),
+    false,
+  );
+});
+
+for (const scenario of [
+  {
+    name: 'source publishing mismatch',
+    mutate({ google }) {
+      google.forms.get(LIVE_FORM_ID).publishSettings.publishState.isAcceptingResponses = true;
+    },
+    error: /publishing state/,
+  },
+  {
+    name: 'target ACL mismatch',
+    mutate({ google, target }) {
+      google.permissions.get(target.id).push({
+        id: 'unexpected-reconciliation-editor',
+        type: 'user',
+        role: 'writer',
+        emailAddress: 'unexpected-reconciliation-editor@example.org',
+      });
+    },
+    error: /permissions do not match/,
+  },
+  {
+    name: 'target structure mismatch',
+    mutate({ google, target }) {
+      google.forms.get(target.id).items[0].title = 'Changed after manual activation';
+    },
+    error: /structure or settings do not match/,
+  },
+  {
+    name: 'target title mismatch',
+    mutate({ google, target }) {
+      google.forms.get(target.id).info.title = 'Wrong title';
+    },
+    error: /visible form title/,
+  },
+  {
+    name: 'linked response Sheet',
+    mutate({ google, target }) {
+      google.forms.get(target.id).linkedSheetId = 'private-linked-sheet';
+    },
+    error: /linked response Sheet/,
+  },
+  {
+    name: 'website cycle mismatch',
+    mutate({ page }) {
+      page.content = pageMarkdown('2026-07', LIVE_RESPONDER);
+    },
+    error: /Managed website cycle/,
+  },
+  {
+    name: 'website responder mismatch',
+    mutate({ page }) {
+      page.content = pageMarkdown(
+        '2026-08',
+        'https://docs.google.com/forms/d/e/different-public-id/viewform',
+      );
+    },
+    error: /website responder URL/,
+  },
+  {
+    name: 'wrong Drive cycle binding',
+    mutate({ target }) {
+      target.appProperties.sourceCycle = '2026-06';
+    },
+    error: /Drive cycle metadata/,
+  },
+]) {
+  test(`reconcile-active performs zero writes on ${scenario.name}`, async () => {
+    const context = await manuallyActivatedProductionPair();
+    scenario.mutate(context);
+    context.google.calls.length = 0;
+    context.page.writes.length = 0;
+    await assert.rejects(
+      context.rollover.reconcileActive({
+        targetCycle: '2026-08',
+        sourceFormId: LIVE_FORM_ID,
+        collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+      }),
+      scenario.error,
+    );
+    assert.equal(
+      context.google.calls.some(({ method }) => [
+        'copyFile',
+        'updateFile',
+        'createPermission',
+        'deletePermission',
+        'updateFormTitle',
+        'setPublishState',
+      ].includes(method)),
+      false,
+    );
+    assert.deepEqual(context.page.writes, []);
+  });
+}
+
+test('reconcile-active rejects schedulers and simulated clocks before Google reads', async () => {
+  for (const runtime of [
+    productionRuntime(),
+    stagingRuntime(),
+  ]) {
+    const google = new FakeGoogle();
+    const rollover = service({ google, runtime }).rollover;
+    await assert.rejects(
+      rollover.reconcileActive({ targetCycle: '2026-08' }),
+      /manual workflow_dispatch|rejects simulated clocks/,
+    );
+    assert.equal(google.calls.length, 0);
+  }
 });
 
 test('activate requires the injected preview gate before closing the source', async () => {

--- a/scrollprize.org/scripts/progress-prizes/schedule-workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule-workflow-contract.test.mjs
@@ -66,7 +66,7 @@ test('scheduler exposes only a real-clock manual smoke and four Pacific schedule
     '17 6 * * *',
     '40 23 28-31 * *',
     '17 0 1 * *',
-    '47 6 1 * *',
+    '47 6 1-7 * *',
   ];
 
   assert.match(triggers, /^on:\n  workflow_dispatch:\n  schedule:/m);

--- a/scrollprize.org/scripts/progress-prizes/schedule.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule.mjs
@@ -15,7 +15,7 @@ export const SCHEDULE_CRONS = Object.freeze({
   PREPARE: '17 6 * * *',
   PRE_CUTOFF: '40 23 28-31 * *',
   EARLY_RECOVERY: '17 0 1 * *',
-  LATE_RECOVERY: '47 6 1 * *',
+  LATE_RECOVERY: '47 6 1-7 * *',
 });
 
 // Workflow-facing alias kept explicit so the public control contract reads as
@@ -67,6 +67,10 @@ function previousCalendarDate(parts) {
 
 function isFirstDay(parts) {
   return parts.day === 1;
+}
+
+function isLateRecoveryDay(parts) {
+  return parts.day >= 1 && parts.day <= 7;
 }
 
 function isLastDay(parts) {
@@ -160,12 +164,22 @@ function dispatchPlan({
   });
 }
 
-function classifyObservedTime(observedAt, local) {
+function classifyObservedTime(observedAt, local, scheduledCron) {
   const localCycle = formatCycle(local.year, local.month);
 
-  // The whole first Pacific calendar day is reserved for bounded activation
-  // recovery. A run delayed into day two must never select the previous cycle.
-  if (isFirstDay(local)) {
+  const lateRecoveryOrigin = scheduledCron === SCHEDULE_CRONS.LATE_RECOVERY
+    ? scheduledOriginDate(observedAt, local, scheduledCron)
+    : undefined;
+  const delayedDaySevenRecovery = local.day === 8
+    && lateRecoveryOrigin !== undefined
+    && lateRecoveryOrigin.year === local.year
+    && lateRecoveryOrigin.month === local.month
+    && lateRecoveryOrigin.day === 7;
+
+  // The first seven Pacific calendar days are bounded recovery days for the
+  // previous month's rollover. A delayed day-seven 06:47 event may cross local
+  // midnight, but a true day-eight event must never select the previous cycle.
+  if (isLateRecoveryDay(local) || delayedDaySevenRecovery) {
     const sourceCycle = previousCycle(localCycle);
     const activationAt = getCycleDeadline(sourceCycle).cutoffAt;
     const lateRecoveryAt = pacificDateTimeToInstant({
@@ -234,7 +248,16 @@ function scheduledActivationIsDue({ scheduledCron, observedAt, local }) {
       || (isFirstDay(local) && isLastDay(previousCalendarDate(local)));
   }
   const origin = scheduledOriginDate(observedAt, local, scheduledCron);
-  return isFirstDay(origin) && isFirstDay(local);
+  if (scheduledCron === SCHEDULE_CRONS.EARLY_RECOVERY) {
+    return isFirstDay(origin) && isFirstDay(local);
+  }
+  return isLateRecoveryDay(origin)
+    && origin.year === local.year
+    && origin.month === local.month
+    && (
+      isLateRecoveryDay(local)
+      || (origin.day === 7 && local.day === 8)
+    );
 }
 
 /**
@@ -242,8 +265,8 @@ function scheduledActivationIsDue({ scheduledCron, observedAt, local }) {
  * instant and its trusted GitHub trigger context.
  *
  * Schedule slots are intentionally not interchangeable: only the daily 06:17
- * slot can prepare. The three activation slots may recover a delayed final-day
- * run during the first Pacific day, but never during day two.
+ * slot can prepare. The pre-cutoff and 00:17 slots retain first-day recovery;
+ * the 06:47 slot retries the previous month's incomplete rollover on days 1–7.
  */
 export function planScheduleDispatch({
   now = new Date(),
@@ -276,7 +299,7 @@ export function planScheduleDispatch({
     });
   }
 
-  const classified = classifyObservedTime(observedAt, local);
+  const classified = classifyObservedTime(observedAt, local, trustedCron);
 
   if (classified === undefined) {
     return noDispatch({

--- a/scrollprize.org/scripts/progress-prizes/schedule.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule.test.mjs
@@ -19,7 +19,7 @@ test('schedule constants use the four exact Pacific cron slots', () => {
     PREPARE: '17 6 * * *',
     PRE_CUTOFF: '40 23 28-31 * *',
     EARLY_RECOVERY: '17 0 1 * *',
-    LATE_RECOVERY: '47 6 1 * *',
+    LATE_RECOVERY: '47 6 1-7 * *',
   });
   assert.equal(PROGRESS_PRIZE_SCHEDULES, SCHEDULE_CRONS);
 });
@@ -147,6 +147,36 @@ test('first-day recovery slots dispatch at 00:17 and 06:47 Pacific', () => {
   assert.equal(late.targetCycle, '2026-08');
 });
 
+test('late recovery targets the previous rollover on days 1, 2, and 7', () => {
+  for (const [now, sourceCycle, targetCycle] of [
+    ['2026-08-01T13:47:00Z', '2026-07', '2026-08'],
+    ['2026-08-02T13:47:00Z', '2026-07', '2026-08'],
+    ['2026-08-07T13:47:00Z', '2026-07', '2026-08'],
+  ]) {
+    const recovery = plan(now, SCHEDULE_CRONS.LATE_RECOVERY);
+    assert.equal(recovery.dispatch, true, now);
+    assert.equal(recovery.operation, SCHEDULE_OPERATIONS.ACTIVATE, now);
+    assert.equal(recovery.reason, SCHEDULE_REASONS.LATE_RECOVERY, now);
+    assert.equal(recovery.sourceCycle, sourceCycle, now);
+    assert.equal(recovery.targetCycle, targetCycle, now);
+  }
+});
+
+test('late recovery handles PDT, PST, leap February, and December rollover', () => {
+  for (const [now, sourceCycle, targetCycle, activationAt] of [
+    ['2026-08-07T13:47:00Z', '2026-07', '2026-08', '2026-08-01T07:00:00.000Z'],
+    ['2026-12-07T14:47:00Z', '2026-11', '2026-12', '2026-12-01T08:00:00.000Z'],
+    ['2028-03-07T14:47:00Z', '2028-02', '2028-03', '2028-03-01T08:00:00.000Z'],
+    ['2027-01-07T14:47:00Z', '2026-12', '2027-01', '2027-01-01T08:00:00.000Z'],
+  ]) {
+    const recovery = plan(now, SCHEDULE_CRONS.LATE_RECOVERY);
+    assert.equal(recovery.operation, SCHEDULE_OPERATIONS.ACTIVATE, now);
+    assert.equal(recovery.sourceCycle, sourceCycle, now);
+    assert.equal(recovery.targetCycle, targetCycle, now);
+    assert.equal(recovery.activationAt.toISOString(), activationAt, now);
+  }
+});
+
 test('delayed activation events recover by their actual first-day Pacific window', () => {
   const delayedPreCutoff = plan('2026-08-01T07:43:00Z', SCHEDULE_CRONS.PRE_CUTOFF);
   assert.equal(delayedPreCutoff.operation, SCHEDULE_OPERATIONS.ACTIVATE);
@@ -174,19 +204,30 @@ test('delayed activation events recover by their actual first-day Pacific window
   assert.equal(preCutoffDelayedToEndOfFirstDay.sourceCycle, '2026-07');
 });
 
-test('day-two delays always no-op instead of selecting a stale cycle', () => {
-  for (const cron of [
-    SCHEDULE_CRONS.PRE_CUTOFF,
-    SCHEDULE_CRONS.EARLY_RECOVERY,
-    SCHEDULE_CRONS.LATE_RECOVERY,
-  ]) {
+test('cutoff and 00:17 recovery slots remain bounded to the first day', () => {
+  for (const cron of [SCHEDULE_CRONS.PRE_CUTOFF, SCHEDULE_CRONS.EARLY_RECOVERY]) {
     const dayTwo = plan('2026-08-02T07:17:00Z', cron);
     assert.equal(dayTwo.dispatch, false, cron);
     assert.equal(dayTwo.operation, SCHEDULE_OPERATIONS.NONE, cron);
-    assert.equal(dayTwo.reason, SCHEDULE_REASONS.OUTSIDE_WINDOW, cron);
-    assert.equal(dayTwo.sourceCycle, '2026-08');
-    assert.equal(dayTwo.targetCycle, '2026-09');
+    assert.equal(dayTwo.reason, SCHEDULE_REASONS.SLOT_NOT_DUE, cron);
+    assert.equal(dayTwo.sourceCycle, '2026-07');
+    assert.equal(dayTwo.targetCycle, '2026-08');
   }
+});
+
+test('a delayed day-seven recovery may cross midnight but day eight no-ops', () => {
+  const delayed = plan('2026-08-08T10:00:00Z', SCHEDULE_CRONS.LATE_RECOVERY);
+  assert.equal(delayed.dispatch, true);
+  assert.equal(delayed.operation, SCHEDULE_OPERATIONS.ACTIVATE);
+  assert.equal(delayed.sourceCycle, '2026-07');
+  assert.equal(delayed.targetCycle, '2026-08');
+
+  const dayEight = plan('2026-08-08T13:47:00Z', SCHEDULE_CRONS.LATE_RECOVERY);
+  assert.equal(dayEight.dispatch, false);
+  assert.equal(dayEight.operation, SCHEDULE_OPERATIONS.NONE);
+  assert.equal(dayEight.reason, SCHEDULE_REASONS.OUTSIDE_WINDOW);
+  assert.equal(dayEight.sourceCycle, '2026-08');
+  assert.equal(dayEight.targetCycle, '2026-09');
 });
 
 test('manual dispatch is always a real-clock dry-run with consecutive Pacific cycles', () => {

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -512,6 +512,54 @@ test('composite production activation guard requires an exact immutable base lea
   }
 });
 
+test('composite reconcile-active guard is manual, real-clock, and marker-only', async () => {
+  const action = await googleAction();
+  const guard = literalRunScripts(action)[0]?.source;
+  const valid = {
+    REPOSITORY: 'ScrollPrize/villa',
+    REPOSITORY_ID: '890972577',
+    REPOSITORY_OWNER_ID: '121906140',
+    REF: 'refs/heads/main',
+    AUTOMATION_ENVIRONMENT: 'production',
+    EVENT_NAME: 'workflow_dispatch',
+    OPERATION: 'reconcile-active',
+    SIMULATED_NOW: '',
+    FAULT: '',
+    EXPECT_FAULT: 'false',
+    DRY_RUN: 'false',
+    ALLOW_ACTIVATION_REWIND: 'false',
+    VERIFY_MODE: 'active',
+    BRANCH: 'main',
+    TARGET_BRANCH: 'main',
+    SOURCE_CYCLE: '2026-07',
+    TARGET_CYCLE: '2026-08',
+    HEAD_SHA: '',
+    BASE_SHA: '',
+  };
+  const run = (override = {}) => spawnSync('bash', ['--noprofile', '--norc'], {
+    input: guard,
+    encoding: 'utf8',
+    env: { ...valid, ...override },
+  });
+
+  assert.equal(run().status, 0);
+  for (const override of [
+    { EVENT_NAME: 'schedule' },
+    { EVENT_NAME: 'pull_request' },
+    { REF: 'refs/pull/123/merge' },
+    { SIMULATED_NOW: '2026-08-06T12:00:00.000Z' },
+    { FAULT: 'after-copy' },
+    { EXPECT_FAULT: 'true', FAULT: 'after-copy' },
+    { DRY_RUN: 'true' },
+    { ALLOW_ACTIVATION_REWIND: 'true' },
+    { HEAD_SHA: 'a'.repeat(40) },
+    { BASE_SHA: 'b'.repeat(40) },
+    { TARGET_BRANCH: 'feature/test' },
+  ]) {
+    assert.notEqual(run(override).status, 0, JSON.stringify(override));
+  }
+});
+
 test('rehearsal controls are fixed to staging and its ephemeral branches', async () => {
   const rehearsal = await workflow('progress-prizes-rehearsal.yml');
   assert.match(rehearsal, /^on:\n  workflow_dispatch:/m);

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -37,6 +37,8 @@ const googleJobNames = [
   'recover-activate',
   'verify-active',
   'prove-activation-idempotency',
+  'reconcile-active-once',
+  'reconcile-active-twice',
   'cleanup-full-rehearsal',
   'verify-cleaned-full-rehearsal',
   'cleanup-standalone',
@@ -577,6 +579,8 @@ test('rehearsal controls are fixed to staging and its ephemeral branches', async
   assert.match(rehearsal, /expect-fault: true/g);
   assert.match(rehearsal, /verify-post-merge-preview/);
   assert.match(rehearsal, /prove-activation-idempotency/);
+  assert.match(rehearsal, /reconcile-active-once/);
+  assert.match(rehearsal, /reconcile-active-twice/);
   assert.match(rehearsal, /verify-cleaned-full-rehearsal/);
   assert.match(rehearsal, /actions: read\n      checks: read/);
   assert.match(rehearsal, /actions: read\n      contents: read\n      statuses: read/);
@@ -598,6 +602,18 @@ test('rehearsal controls are fixed to staging and its ephemeral branches', async
   for (const name of googleJobNames.filter((name) => name !== 'bootstrap-staging')) {
     assert.doesNotMatch(jobBlock(rehearsal, name), /allow-activation-rewind/);
   }
+  for (const name of ['reconcile-active-once', 'reconcile-active-twice']) {
+    const reconciliation = jobBlock(rehearsal, name);
+    assert.match(reconciliation, /^          operation: reconcile-active$/m);
+    assert.match(reconciliation, /^          environment: staging$/m);
+    assert.match(reconciliation, /Fetch exact merged smoke page as data/);
+    assert.match(reconciliation, /MERGE_SHA: \$\{\{ needs\.merge-smoke\.outputs\['merge-sha'\] \}\}/);
+    assert.doesNotMatch(reconciliation, /simulated-now:|fault:|expect-fault:|head-sha:|base-sha:/);
+  }
+  assert.match(
+    jobBlock(rehearsal, 'cleanup-full-rehearsal'),
+    /^      - reconcile-active-twice$/m,
+  );
 
   const pagePr = await workflow('progress-prizes-page-pr.yml');
   assert.match(pagePr, /--force-with-lease=\"refs\/heads\/\$HEAD_BRANCH:\$REMOTE_HEAD_SHA\"/);

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -14,6 +14,7 @@ import {
   gateSnapshot,
   isTrustedPreviewRun,
   resolveProductionActivationState,
+  safeDiagnosticCode,
   waitForPullBinding,
 } from '../../../.github/progress-prizes-github.mjs';
 
@@ -945,6 +946,10 @@ test('production activation-state recovery distinguishes exact, stale, and compl
   const pending = await resolveProductionActivationState(options, {
     listPulls: async () => [pull],
     readCommit: async () => exactCommit,
+    readMainRef: async () => ({
+      ref: 'refs/heads/main',
+      object: { type: 'commit', sha: baseSha },
+    }),
   });
   assert.deepEqual(pending, {
     state: 'pending',
@@ -957,12 +962,38 @@ test('production activation-state recovery distinguishes exact, stale, and compl
   const stale = await resolveProductionActivationState(options, {
     listPulls: async () => [pull],
     readCommit: async () => ({ ...exactCommit, parents: [{ sha: staleSha }] }),
+    readMainRef: async () => ({
+      ref: 'refs/heads/main',
+      object: { type: 'commit', sha: baseSha },
+    }),
   });
   assert.equal(stale.refreshRequired, true);
 
+  const incidentRegression = await resolveProductionActivationState(options, {
+    listPulls: async () => [{
+      ...pull,
+      base: { ...pull.base, sha: 'd'.repeat(40) },
+    }],
+    readCommit: async () => ({ ...exactCommit, parents: [{ sha: staleSha }] }),
+    readMainRef: async () => ({
+      ref: 'refs/heads/main',
+      object: { type: 'commit', sha: baseSha },
+    }),
+  });
+  assert.deepEqual(incidentRegression, {
+    state: 'pending',
+    headSha,
+    baseSha,
+    pullNumber: '42',
+    refreshRequired: true,
+  });
+
   const completed = await resolveProductionActivationState(options, {
     listPulls: async () => [],
-    readMainRef: async () => ({ object: { sha: baseSha } }),
+    readMainRef: async () => ({
+      ref: 'refs/heads/main',
+      object: { type: 'commit', sha: baseSha },
+    }),
     readPage: async () => ({ cycle: '2026-08' }),
   });
   assert.deepEqual(completed, {
@@ -997,21 +1028,80 @@ test('production activation-state recovery fails closed on ambiguous or drifting
 
   await assert.rejects(
     resolveProductionActivationState(options, { listPulls: async () => [pull, pull] }),
-    /ambiguous/,
+    (error) => safeDiagnosticCode(error) === 'ambiguous-pr',
   );
   await assert.rejects(
     resolveProductionActivationState(options, {
-      listPulls: async () => [{ ...pull, base: { ...pull.base, sha: 'c'.repeat(40) } }],
+      listPulls: async () => [pull],
+      readMainRef: async () => ({
+        ref: 'refs/heads/main',
+        object: { type: 'commit', sha: 'c'.repeat(40) },
+      }),
     }),
-    /main moved/,
+    (error) => safeDiagnosticCode(error) === 'main-ref-moved',
   );
   await assert.rejects(
     resolveProductionActivationState(options, {
       listPulls: async () => [],
-      readMainRef: async () => ({ object: { sha: baseSha } }),
+      readMainRef: async () => ({
+        ref: 'refs/heads/main',
+        object: { type: 'commit', sha: baseSha },
+      }),
       readPage: async () => ({ cycle: '2026-07' }),
     }),
-    /Neither a pending PR nor a completed production cycle exists/,
+    (error) => safeDiagnosticCode(error) === 'completed-state-missing',
+  );
+
+  await assert.rejects(
+    resolveProductionActivationState(options, {
+      listPulls: async () => [{
+        ...pull,
+        head: { ...pull.head, repo: { id: 123, full_name: 'untrusted/fork' } },
+      }],
+      readMainRef: async () => ({
+        ref: 'refs/heads/main',
+        object: { type: 'commit', sha: baseSha },
+      }),
+    }),
+    (error) => safeDiagnosticCode(error) === 'invalid-pr-association',
+  );
+
+  await assert.rejects(
+    resolveProductionActivationState(options, {
+      listPulls: async () => [pull],
+      readCommit: async () => ({
+        sha: headSha,
+        parents: [{ sha: baseSha }],
+        files: [
+          { filename: 'scrollprize.org/docs/34_prizes.md', status: 'modified' },
+          { filename: '.github/workflows/untrusted.yml', status: 'added' },
+        ],
+      }),
+      readMainRef: async () => ({
+        ref: 'refs/heads/main',
+        object: { type: 'commit', sha: baseSha },
+      }),
+    }),
+    (error) => safeDiagnosticCode(error) === 'invalid-page-head',
+  );
+});
+
+test('GitHub coordination diagnostics are bounded to an allowlist', () => {
+  assert.equal(safeDiagnosticCode({ diagnosticCode: 'main-ref-moved' }), 'main-ref-moved');
+  assert.equal(safeDiagnosticCode({
+    diagnosticCode: 'private-id-from-api-body',
+    message: 'sensitive response body',
+  }), 'unexpected-error');
+
+  const result = spawnSync(process.execPath, [
+    resolve(repositoryRoot, '.github/progress-prizes-github.mjs'),
+    'unknown-command',
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, '');
+  assert.equal(
+    result.stderr,
+    'Progress Prize GitHub coordination failed safely [unexpected-error].\n',
   );
 });
 


### PR DESCRIPTION
## Summary

- resolve activation against authoritative `refs/heads/main` while treating PR base metadata as advisory
- add a manual, approval-gated, marker-only `reconcile-active` operation
- retry late activation recovery at 06:47 Pacific on days 1–7
- keep generated rollover PRs marker-only and exercise reconciliation twice in the staging rehearsal

Old forms and responses are never deleted or altered by these changes. Production form contents, publishing, permissions, and website state are untouched by deployment. Google authentication remains private through Environment-scoped WIF.

## Milestone commits

1. `fix(scrollprize): resolve activation against current main`
2. `fix(scrollprize): add guarded rollover reconciliation`
3. `ci(scrollprize): extend guarded activation recovery`

## Verification

- 308 Node tests
- syntax checks for all Progress Prize `.mjs` files
- actionlint with only the documented `concurrency.queue` schema exception
- `git diff --check`
- protected-value leakage scan (local protected-config file was absent; no protected values were available to compare)

This PR remains draft until the live stale-base smoke and complete staging Google rehearsal pass.