### PR TITLE
Keep rehearsal production validation inside production WIF

### DIFF
--- a/.github/progress-prizes-schedule.mjs
+++ b/.github/progress-prizes-schedule.mjs
@@ -26,7 +26,9 @@ export const NONTERMINAL_RUN_STATUSES = Object.freeze([
 
 const NONTERMINAL_STATUS_SET = new Set(NONTERMINAL_RUN_STATUSES);
 const RUN_STATUS_SET = new Set([...NONTERMINAL_RUN_STATUSES, 'completed']);
-const OPERATIONS = new Set(['dry-run', 'prepare', 'activate']);
+// `validate` is used only by the manual staging rehearsal proxy. The scheduler
+// itself still produces only dry-run, prepare, or activate plans.
+const OPERATIONS = new Set(['validate', 'dry-run', 'prepare', 'activate']);
 const DEDUPE_REASONS = new Set([
   'production-idle',
   'production-run-nonterminal',

--- a/.github/workflows/progress-prizes-rehearsal.yml
+++ b/.github/workflows/progress-prizes-rehearsal.yml
@@ -143,38 +143,55 @@ jobs:
     needs: preflight
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    environment: progress-prizes-production
     permissions:
+      actions: write
       contents: read
-      id-token: write
-    outputs:
-      responder-uri: ${{ steps.google.outputs['responder-uri'] }}
     steps:
-      - name: Check out trusted Google operation
+      - name: Check out trusted production validation proxy
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
           clean: true
           fetch-depth: 1
-      - name: Validate production Google Form
-        id: google
-        uses: ./.github/actions/progress-prizes-google
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          operation: validate
-          environment: production
-          source-cycle: ${{ inputs['source-cycle'] }}
-          branch: main
-          target-branch: main
-          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
-          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          staging-service-account-email: ${{ secrets.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL }}
-          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
-          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
-          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
-          archive-folder-id: ${{ secrets.PROGRESS_PRIZE_ARCHIVE_FOLDER_ID }}
-          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
-          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
+          node-version: 24
+      - name: Dispatch the exact production read-only validation
+        id: child
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SOURCE_CYCLE: ${{ inputs['source-cycle'] }}
+          TARGET_CYCLE: ${{ inputs['target-cycle'] }}
+          REQUEST_ID: ${{ github.run_id }}
+        run: >-
+          node .github/progress-prizes-schedule.mjs dispatch
+          --operation validate
+          --source-cycle "$SOURCE_CYCLE"
+          --target-cycle "$TARGET_CYCLE"
+          --request-id "$REQUEST_ID"
+      - name: Bind the exact child validation run
+        env:
+          CHILD_RUN_ID: ${{ steps.child.outputs['child-run-id'] }}
+          CHILD_RUN_URL: ${{ steps.child.outputs['child-run-html-url'] }}
+          DISPATCHED: ${{ steps.child.outputs.dispatched }}
+        run: |
+          set -euo pipefail
+          test "$DISPATCHED" = true
+          [[ "$CHILD_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          test "$CHILD_RUN_URL" = "https://github.com/ScrollPrize/villa/actions/runs/$CHILD_RUN_ID"
+          printf '%s\n' \
+            '### Read-only production validation proxy' \
+            '' \
+            "- Child run: $CHILD_RUN_URL" \
+            '- Google authentication is confined to the production workflow.' \
+            '' >>"$GITHUB_STEP_SUMMARY"
+      - name: Await the exact production validation result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHILD_RUN_ID: ${{ steps.child.outputs['child-run-id'] }}
+        run: gh run watch "$CHILD_RUN_ID" --repo ScrollPrize/villa --exit-status
 
   bootstrap-staging:
     if: >-

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -255,8 +255,12 @@ assertion.workflow_sha == assertion.sha
 The schedule milestone does not receive Google configuration or OIDC. It
 computes the Pacific window and dispatches this exact production workflow with
 `GITHUB_TOKEN`; GitHub documents `workflow_dispatch` as an event that is allowed
-to create a new run from `GITHUB_TOKEN`. The production WIF condition therefore
-does not need to permit the schedule workflow path or a `schedule` event.
+to create a new run from `GITHUB_TOKEN`. The rehearsal uses the same pattern for
+its read-only production preflight: it dispatches `validate`, binds the exact
+returned child run, and awaits its result. Production Google authentication
+therefore remains confined to the production workflow. The production WIF
+condition does not need to permit the schedule or rehearsal workflow paths, or
+a `schedule` event.
 
 Bind only that provider principal to its matching service account with
 `roles/iam.workloadIdentityUser`. Use the numeric Google project number when

--- a/scrollprize.org/scripts/progress-prizes/schedule-github.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule-github.test.mjs
@@ -431,6 +431,16 @@ test('dispatch body is fixed, consecutive, prepared, and numeric', () => {
     '9007199254740993',
   );
 
+  assert.equal(
+    buildProductionDispatch({
+      operation: 'validate',
+      sourceCycle: '2026-07',
+      targetCycle: '2026-08',
+      requestId: '20260720',
+    }).inputs.operation,
+    'validate',
+  );
+
   for (const input of [
     { operation: 'none', sourceCycle: '2026-07', targetCycle: '2026-08', requestId: '1' },
     { operation: 'prepare', sourceCycle: '2026-07', targetCycle: '2026-09', requestId: '1' },
@@ -459,7 +469,7 @@ test('dispatch posts only the fixed production request and validates exact child
     assert.deepEqual(JSON.parse(options.body), {
       ref: 'main',
       inputs: {
-        operation: 'dry-run',
+        operation: 'validate',
         'source-cycle': '2026-07',
         'target-cycle': '2026-08',
         'verify-mode': 'prepared',
@@ -476,7 +486,7 @@ test('dispatch posts only the fixed production request and validates exact child
 
   assert.deepEqual(
     await dispatchProductionWorkflow({
-      operation: 'dry-run',
+      operation: 'validate',
       sourceCycle: '2026-07',
       targetCycle: '2026-08',
       requestId: '9988',

--- a/scrollprize.org/scripts/progress-prizes/schedule-workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule-workflow-contract.test.mjs
@@ -247,7 +247,7 @@ test('dedupe and dispatch use only the tested fixed helper contract', async () =
   assert.match(helper, /expectedStatus: 200/);
   assert.match(helper, /redirect: 'error'/);
   assert.match(helper, /MAX_GITHUB_RESPONSE_BYTES = 256 \* 1024/);
-  assert.match(helper, /new Set\(\['dry-run', 'prepare', 'activate'\]\)/);
+  assert.match(helper, /new Set\(\['validate', 'dry-run', 'prepare', 'activate'\]\)/);
   assert.match(helper, /'requested'[\s\S]*'queued'[\s\S]*'pending'[\s\S]*'waiting'[\s\S]*'in_progress'/);
   assert.match(
     helper,

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -28,7 +28,6 @@ const workflowNames = [
   'progress-prizes-vercel-preview.yml',
 ];
 const googleJobNames = [
-  'validate-production',
   'bootstrap-staging',
   'inject-copy-fault',
   'recover-prepare',
@@ -177,16 +176,15 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
 
   for (const name of googleJobNames) {
     const protectedJob = jobBlock(rehearsal, name);
-    const environment = name === 'validate-production' ? 'production' : 'staging';
     assert.match(protectedJob, /runs-on: ubuntu-24\.04/);
     assert.match(protectedJob, /timeout-minutes: 20/);
-    assert.match(protectedJob, new RegExp(`environment: progress-prizes-${environment}`));
+    assert.match(protectedJob, /environment: progress-prizes-staging/);
     assert.match(protectedJob, /contents: read\n      id-token: write/);
     assert.match(protectedJob, /ref: \$\{\{ github\.sha \}\}/);
     assert.match(protectedJob, /persist-credentials: false/);
     assert.match(protectedJob, /id: google/);
     assert.match(protectedJob, /uses: \.\/\.github\/actions\/progress-prizes-google/);
-    assert.match(protectedJob, new RegExp(`^          environment: ${environment}$`, 'm'));
+    assert.match(protectedJob, /^          environment: staging$/m);
     assert.match(
       protectedJob,
       /responder-uri: \$\{\{ steps\.google\.outputs\['responder-uri'\] \}\}/,
@@ -209,24 +207,27 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
   assert.doesNotMatch(rehearsal, /ref: refs\/heads\/main/);
   assert.equal(
     [...rehearsal.matchAll(/environment: progress-prizes-production/g)].length,
-    1,
+    0,
   );
   assert.equal(
     [...rehearsal.matchAll(/environment: progress-prizes-staging/g)].length,
-    googleJobNames.length - 1,
+    googleJobNames.length,
   );
   const productionValidationJob = jobBlock(rehearsal, 'validate-production');
-  assert.match(
-    productionValidationJob,
-    /^          staging-service-account-email: \$\{\{ secrets\.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL \}\}$/m,
-  );
+  assert.match(productionValidationJob, /actions: write\n      contents: read/);
+  assert.match(productionValidationJob, /progress-prizes-schedule\.mjs dispatch/);
+  assert.match(productionValidationJob, /--operation validate/);
+  assert.match(productionValidationJob, /REQUEST_ID: \$\{\{ github\.run_id \}\}/);
+  assert.match(productionValidationJob, /steps\.child\.outputs\['child-run-id'\]/);
+  assert.match(productionValidationJob, /gh run watch "\$CHILD_RUN_ID" --repo ScrollPrize\/villa --exit-status/);
+  assert.doesNotMatch(productionValidationJob, /id-token:|environment: progress-prizes-|secrets\./);
   assert.equal(
     [...rehearsal.matchAll(/secrets\.PROGRESS_PRIZE_STAGING_SERVICE_ACCOUNT_EMAIL/g)].length,
     googleJobNames.length,
     'every Google job must receive an independently protected staging identity',
   );
   assert.doesNotMatch(productionValidationJob, /staging-folder-id|PROGRESS_PRIZE_STAGING_FOLDER_ID/);
-  for (const name of googleJobNames.filter((name) => name !== 'validate-production')) {
+  for (const name of googleJobNames) {
     const stagingJob = jobBlock(rehearsal, name);
     assert.match(
       stagingJob,
@@ -239,7 +240,7 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
   }
   assert.equal(
     [...rehearsal.matchAll(/secrets\.PROGRESS_PRIZE_STAGING_FOLDER_ID/g)].length,
-    googleJobNames.length - 1,
+    googleJobNames.length,
   );
 
   for (const name of jobNames(rehearsal).filter((name) => !googleJobNames.includes(name))) {


### PR DESCRIPTION
## Summary

- remove production OIDC, Environment secrets, and Google configuration from the staging rehearsal validation job
- dispatch the hard-coded production workflow `validate` operation and bind the exact returned child run
- await that exact child result before staging bootstrap
- keep the production WIF provider restricted to `progress-prizes-production.yml@refs/heads/main`

This follow-up was found during live rollout: production WIF correctly rejected direct authentication from the rehearsal workflow.

## Verification

- 308 dependency-free Node tests
- all Progress Prize Node syntax checks
- actionlint with only the documented `concurrency.queue` schema exception
- `git diff --check`
- no Google secret, reusable credential, or protected identifier added

The current July source has a linked response Sheet, so the deployed read-only validation is expected to stop safely until that policy decision is resolved. This PR does not alter any form, response, ACL, marker, or website content.