### PR TITLE
Automate private monthly Progress Prize response Sheets

### DIFF
--- a/.github/actions/progress-prizes-google/action.yml
+++ b/.github/actions/progress-prizes-google/action.yml
@@ -3,7 +3,7 @@ description: Run one guarded Progress Prize Google Forms operation from a truste
 
 inputs:
   operation:
-    description: validate, bootstrap, prepare, activate, reconcile-active, verify, or cleanup
+    description: validate, bootstrap, prepare, sync-responses, activate, reconcile-active, verify, or cleanup
     required: true
   environment:
     description: staging or production
@@ -130,7 +130,7 @@ runs:
         test "$REF" = refs/heads/main
         test "$EVENT_NAME" = workflow_dispatch
         case "$OPERATION" in
-          validate|bootstrap|prepare|activate|reconcile-active|verify|cleanup) ;;
+          validate|bootstrap|prepare|sync-responses|activate|reconcile-active|verify|cleanup) ;;
           *) exit 1 ;;
         esac
         case "$EXPECT_FAULT" in true|false) ;; *) exit 1 ;; esac
@@ -147,7 +147,7 @@ runs:
           [[ "$TARGET_CYCLE" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]] || exit 1
         fi
         case "$OPERATION" in
-          validate|bootstrap) test -n "$SOURCE_CYCLE" ;;
+          validate|bootstrap|sync-responses) test -n "$SOURCE_CYCLE" ;;
           prepare|activate|reconcile-active|verify|cleanup) test -n "$TARGET_CYCLE" ;;
         esac
         if test "$OPERATION" = bootstrap; then test "$SOURCE_CYCLE" = 2026-07 || exit 1; fi
@@ -339,12 +339,14 @@ runs:
         access_token_lifetime: 1200s
         access_token_scopes: |-
           https://www.googleapis.com/auth/forms.body.readonly
+          https://www.googleapis.com/auth/forms.responses.readonly
           https://www.googleapis.com/auth/drive.readonly
+          https://www.googleapis.com/auth/spreadsheets.readonly
         create_credentials_file: false
         export_environment_variables: false
 
     - name: Authenticate mutating operations without a credential file
-      if: inputs.operation != 'validate' && inputs.operation != 'verify' && inputs['dry-run'] != 'true'
+      if: inputs.operation != 'validate' && inputs.operation != 'verify' && inputs.operation != 'sync-responses' && inputs.operation != 'reconcile-active' && inputs['dry-run'] != 'true'
       id: auth-write
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
@@ -354,7 +356,43 @@ runs:
         access_token_lifetime: 1200s
         access_token_scopes: |-
           https://www.googleapis.com/auth/forms.body
+          https://www.googleapis.com/auth/forms.responses.readonly
           https://www.googleapis.com/auth/drive
+          https://www.googleapis.com/auth/spreadsheets
+        create_credentials_file: false
+        export_environment_variables: false
+
+    - name: Authenticate append-only response sync without a credential file
+      if: inputs.operation == 'sync-responses'
+      id: auth-sync
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      with:
+        workload_identity_provider: ${{ inputs['workload-identity-provider'] }}
+        service_account: ${{ inputs['service-account-email'] }}
+        token_format: access_token
+        access_token_lifetime: 1200s
+        access_token_scopes: |-
+          https://www.googleapis.com/auth/forms.body.readonly
+          https://www.googleapis.com/auth/forms.responses.readonly
+          https://www.googleapis.com/auth/drive
+          https://www.googleapis.com/auth/spreadsheets
+        create_credentials_file: false
+        export_environment_variables: false
+
+    - name: Authenticate marker-only reconciliation without a credential file
+      if: inputs.operation == 'reconcile-active'
+      id: auth-reconcile
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      with:
+        workload_identity_provider: ${{ inputs['workload-identity-provider'] }}
+        service_account: ${{ inputs['service-account-email'] }}
+        token_format: access_token
+        access_token_lifetime: 1200s
+        access_token_scopes: |-
+          https://www.googleapis.com/auth/forms.body.readonly
+          https://www.googleapis.com/auth/forms.responses.readonly
+          https://www.googleapis.com/auth/drive
+          https://www.googleapis.com/auth/spreadsheets.readonly
         create_credentials_file: false
         export_environment_variables: false
 
@@ -393,7 +431,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.environment == 'production' && inputs.operation == 'activate' && inputs['github-token'] || '' }}
-        GOOGLE_ACCESS_TOKEN: ${{ steps['auth-read'].outputs.access_token || steps['auth-write'].outputs.access_token }}
+        GOOGLE_ACCESS_TOKEN: ${{ steps['auth-read'].outputs.access_token || steps['auth-write'].outputs.access_token || steps['auth-sync'].outputs.access_token || steps['auth-reconcile'].outputs.access_token }}
         PROGRESS_PRIZE_ENVIRONMENT: ${{ inputs.environment }}
         PROGRESS_PRIZE_EVENT_NAME: ${{ github.event_name }}
         PROGRESS_PRIZE_DRIVE_ID: ${{ inputs['drive-id'] }}

--- a/.github/progress-prizes-schedule.mjs
+++ b/.github/progress-prizes-schedule.mjs
@@ -27,8 +27,15 @@ export const NONTERMINAL_RUN_STATUSES = Object.freeze([
 const NONTERMINAL_STATUS_SET = new Set(NONTERMINAL_RUN_STATUSES);
 const RUN_STATUS_SET = new Set([...NONTERMINAL_RUN_STATUSES, 'completed']);
 // `validate` is used only by the manual staging rehearsal proxy. The scheduler
-// itself still produces only dry-run, prepare, or activate plans.
-const OPERATIONS = new Set(['validate', 'dry-run', 'prepare', 'activate']);
+// itself still produces only dry-run, prepare, sync-responses, or activate
+// plans.
+const OPERATIONS = new Set([
+  'validate',
+  'dry-run',
+  'prepare',
+  'sync-responses',
+  'activate',
+]);
 const DEDUPE_REASONS = new Set([
   'production-idle',
   'production-run-nonterminal',

--- a/.github/workflows/progress-prizes-production.yml
+++ b/.github/workflows/progress-prizes-production.yml
@@ -16,6 +16,7 @@ on:
           - validate
           - dry-run
           - prepare
+          - sync-responses
           - activate
           - reconcile-active
           - verify
@@ -82,7 +83,15 @@ jobs:
           assert.match(process.env.HEAD_SHA ?? '', /^[a-f0-9]{40}$/);
           assert.equal(process.env.EVENT_NAME, 'workflow_dispatch');
           assert.equal(
-            new Set(['validate', 'dry-run', 'prepare', 'activate', 'reconcile-active', 'verify'])
+            new Set([
+              'validate',
+              'dry-run',
+              'prepare',
+              'sync-responses',
+              'activate',
+              'reconcile-active',
+              'verify',
+            ])
               .has(process.env.OPERATION ?? ''),
             true,
           );
@@ -196,6 +205,40 @@ jobs:
             ].join('\n'),
           );
           NODE
+
+  sync-responses:
+    name: Append new responses to the current monthly Sheet
+    if: inputs.operation == 'sync-responses'
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: progress-prizes-production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the exact trusted trigger commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+      - name: Append only previously unseen response IDs
+        uses: ./.github/actions/progress-prizes-google
+        with:
+          operation: sync-responses
+          environment: production
+          source-cycle: ${{ inputs['source-cycle'] }}
+          branch: main
+          target-branch: main
+          workload-identity-provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account-email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          drive-admin-email: ${{ secrets.PROGRESS_PRIZE_DRIVE_ADMIN_EMAIL }}
+          drive-id: ${{ secrets.PROGRESS_PRIZE_DRIVE_ID }}
+          folder-id: ${{ secrets.PROGRESS_PRIZE_FOLDER_ID }}
+          source-form-id: ${{ secrets.PROGRESS_PRIZE_SOURCE_FORM_ID }}
+          editor-group-email: ${{ secrets.PROGRESS_PRIZE_EDITOR_GROUP_EMAIL }}
 
   reconcile-approval:
     name: Approve marker-only active-state reconciliation
@@ -840,6 +883,7 @@ jobs:
       (needs.preflight.result == 'failure' ||
        needs.validate.result == 'failure' ||
        needs.dry-run.result == 'failure' ||
+       needs.sync-responses.result == 'failure' ||
        needs.prepare-google.result == 'failure' ||
        needs.prepare-page.result == 'failure' ||
        needs.activation-state.result == 'failure' ||
@@ -858,6 +902,7 @@ jobs:
       - preflight
       - validate
       - dry-run
+      - sync-responses
       - prepare-google
       - prepare-page
       - activation-state

--- a/.github/workflows/progress-prizes-schedule.yml
+++ b/.github/workflows/progress-prizes-schedule.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: "17 6 * * *"
       timezone: America/Los_Angeles
+    - cron: "27 7 * * *"
+      timezone: America/Los_Angeles
     - cron: "40 23 28-31 * *"
       timezone: America/Los_Angeles
     - cron: "17 0 1 * *"
@@ -46,6 +48,7 @@ jobs:
 
           const allowedSchedules = new Set([
             '17 6 * * *',
+            '27 7 * * *',
             '40 23 28-31 * *',
             '17 0 1 * *',
             '47 6 1-7 * *',

--- a/scrollprize.org/scripts/progress-prizes/README.md
+++ b/scrollprize.org/scripts/progress-prizes/README.md
@@ -6,6 +6,16 @@ the exact Vercel preview commit, then closes the old form before opening the new
 one. The cutoff is midnight immediately after the last calendar day in
 `America/Los_Angeles` (the published deadline remains 11:59pm Pacific).
 
+Each managed monthly form also has one distinct private Google Spreadsheet.
+The Form is the canonical response store; the automation reads responses with
+the Forms Responses API and appends previously unseen response IDs to that
+month's spreadsheet. It never updates, clears, sorts, deletes, or replaces a
+response row. Before opening the next form, activation closes and performs a
+final append-only sync of the old form, then opens the already prepared target.
+An existing Google Forms-linked Sheet is detected and left completely
+untouched; the automation never reads its cells, changes its link, moves it, or
+deletes it.
+
 A fresh copy is closed at the first possible Forms API call, before title, ACL,
 or capability reconciliation. At cutoff, the fingerprint-bound target records
 durable activation intent before the source is closed. Activation refetches and
@@ -35,9 +45,10 @@ repository secret, file, log, cache, or artifact.
   on a Vercel `repository_dispatch`. It never checks out or executes deployed
   branch code.
 - `progress-prizes-production.yml` provides guarded `validate`, `dry-run`,
-  `prepare`, `activate`, `reconcile-active`, and `verify` operations after the
-  complete staging rehearsal has passed. Every authenticated job is literal in
-  that top-level workflow and calls the same local action exercised by staging.
+  `prepare`, `sync-responses`, `activate`, `reconcile-active`, and `verify`
+  operations after the complete staging rehearsal has passed. Every
+  authenticated job is literal in that top-level workflow and calls the same
+  local action exercised by staging.
 - `progress-prizes-schedule.yml` is the secret-free scheduler added only after
   production `validate` and `dry-run` passed. Reaching `main` enables its
   Pacific-time schedules; a manual dispatch is permanently restricted to a
@@ -208,9 +219,9 @@ refresh token, or other reusable credential.
 
 ## Google WIF setup
 
-Enable the Google Forms and Drive APIs. Create separate service accounts and
-separate WIF providers (or equivalently isolated provider conditions) for staging
-and production. Map these GitHub OIDC claims:
+Enable the Google Forms, Drive, and Sheets APIs. Create separate service
+accounts and separate WIF providers (or equivalently isolated provider
+conditions) for staging and production. Map these GitHub OIDC claims:
 
 ```text
 google.subject                 = assertion.sub
@@ -265,14 +276,15 @@ a `schedule` event.
 Bind only that provider principal to its matching service account with
 `roles/iam.workloadIdentityUser`. Use the numeric Google project number when
 constructing the `principalSet` member. Do not grant one provider impersonation
-rights on both accounts. The workflow asks for a 1200-second access token scoped
-to read-only Forms/Drive scopes for `validate`, `verify`, and dry runs. Mutations
-use `forms.body` plus `drive`: this headless workflow must find a pre-existing
-form and app-property-managed files in a Shared Drive, which `drive.file` cannot
-reliably authorize without an interactive picker. The separate service accounts,
-the two exact-file ACLs on the initial My Drive form, and the isolated Shared
-Drive ACLs bound the writable resources. Credential-file creation and global
-environment export remain disabled.
+rights on both accounts. The workflow asks for a 1200-second access token.
+`validate`, `verify`, and dry runs use read-only Forms body/response, Drive, and
+Sheets scopes. Mutations use `forms.body`, read-only `forms.responses`, `drive`,
+and `spreadsheets`: this headless workflow must find pre-existing forms and
+app-property-managed files in a Shared Drive, which `drive.file` cannot reliably
+authorize without an interactive picker. The Forms response scope is always
+read-only. The separate service accounts, the two exact-file ACLs on the initial
+My Drive form, and the isolated Shared Drive ACLs bound the writable resources.
+Credential-file creation and global environment export remain disabled.
 
 Google file access is controlled separately by Shared Drive and form ACLs. WIF
 impersonation alone grants no Drive access. The staging identity has read/copy
@@ -421,8 +433,15 @@ the immediately following month. Leave `request-id` empty for every manual run.
   fixed to seven days.
 - `prepare` is safe to dispatch repeatedly. It succeeds without opening a page
   PR outside the seven-day window. Inside the window it resumes the one managed
-  target for the cycle, keeps it published but closed, and reconstructs the one
-  marker-only draft page PR.
+  target for the cycle, creates or resumes that target's distinct private
+  response spreadsheet, keeps the form published but closed, and reconstructs
+  the one marker-only draft page PR.
+- `sync-responses` verifies that the requested source cycle is the currently
+  open form named on the website, then appends only response IDs not already in
+  its managed monthly spreadsheet. The operation creates the spreadsheet if
+  needed and is safe to repeat. It does not require the activation reviewer,
+  cannot change the website or form, and emits counts rather than response or
+  spreadsheet identifiers.
 - `verify` with `prepared` requires that exact page-only PR on current `main`;
   `active` requires the completed website and Google close/open state.
 - `activate` should be dispatched near 23:40 Pacific on the final day. The exact
@@ -430,8 +449,8 @@ the immediately following month. Leave `request-id` empty for every manual run.
   cutoff is at most one hour away (or has passed), through the secret-free
   `progress-prizes-production-activation` Environment. The job waits without a
   Google token, authenticates at cutoff, reacquires a zero-wait GitHub lease,
-  closes the source, opens and reload-verifies the target, then merges only the
-  activated commit.
+  closes the source, performs its final append-only response sync, opens and
+  reload-verifies the target, then merges only the activated commit.
 - `reconcile-active` is a manual break-glass repair for a rollover that humans
   already completed. Run `verify active` first. Reconciliation proceeds only if
   the old form is published and closed, the new form is published and open, the
@@ -479,6 +498,48 @@ otherwise the exact one-commit/one-file activation gate will reject the
 rollover. Production never deletes an old form or any response. The cleanup
 operation is staging-only and cannot be selected in the production workflow.
 
+## Monthly response spreadsheets
+
+The automation uses a private, app-property-managed spreadsheet rather than
+asking Google Forms to create a native response destination. The Forms API
+exposes `linkedSheetId` only as output, and a headless WIF service account cannot
+use the interactive Forms UI picker. This keeps authentication keyless while
+retaining Forms as the authoritative response record.
+
+One spreadsheet is created in the same environment's active Shared Drive folder
+for each form cycle. It is fingerprint-bound to that exact form and receives
+only the configured direct internal editor collaborators plus the inherited
+Shared Drive Managers. It never receives the anonymous responder permission.
+The first row is a stable header; every later row contains the response ID,
+timestamps, respondent email when Google supplies it, answers aligned by
+question ID, and a raw-answer JSON fallback. Appends use `RAW` input mode so a
+response beginning with `=` is stored as data, not evaluated as a formula.
+
+The append protocol first scans column A for existing response IDs, obtains all
+current Form responses through the read-only Forms Responses API, and appends
+only unseen IDs. After an ambiguous network failure it scans the IDs again
+before retrying, preventing a duplicate append. A later edit to a Form response
+does not rewrite its existing spreadsheet row; the latest canonical value
+remains available in Google Forms. There are intentionally no code paths for
+Sheets value update, clear, row deletion, spreadsheet deletion, or production
+file movement.
+
+Existing native linked Sheets are legacy records. Their IDs are treated as
+private, and their cells, ACLs, filenames, folders, and Form linkage are never
+mutated. A managed append-only spreadsheet may coexist with a legacy linked
+Sheet for the initial cycle. Old forms and all production monthly spreadsheets
+stay in place for response review after rollover.
+
+To backfill or check the currently active month without waiting for the daily
+schedule, dispatch only public cycle controls; no Google identifier is supplied
+on the command line:
+
+```bash
+gh workflow run progress-prizes-production.yml --ref main \
+  -f operation=sync-responses -f source-cycle=2026-08 -f target-cycle=2026-09 \
+  -f verify-mode=prepared
+```
+
 ## Automated schedule and immediate smoke
 
 The scheduler owns no Google or Vercel configuration, protected Environment,
@@ -492,6 +553,10 @@ bound to the exact child run ID and public Actions URL.
   seven-day window and after cutoff. Once an exact page-only draft PR already
   sits directly above current `main`, it skips repeated preparation instead of
   force-pushing a new commit and restarting checks.
+- `07:27` Pacific is the daily append-only response sync for the currently
+  active Pacific month. It is suppressed while another production rollover job
+  is nonterminal and fails closed if the form, website, or managed spreadsheet
+  binding is inconsistent.
 - `23:40` Pacific on candidate final days dispatches activation only when the
   observed date is the actual last calendar day. The production workflow—not
   the scheduler—runs tests and the Vercel gate, requests human approval, waits

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.mjs
@@ -40,6 +40,7 @@ const OUTPUT_STATUSES = new Set([
   'archived',
   'planned',
   'prepared',
+  'synced',
   'valid',
   'waiting',
 ]);
@@ -417,6 +418,7 @@ function collaboratorPermissions(command, env) {
     'validate',
     'bootstrap',
     'prepare',
+    'sync-responses',
     'activate',
     'reconcile-active',
     'verify',
@@ -531,6 +533,16 @@ export async function runAutomationCli(argv, {
     parseCycle(sourceCycle);
     result = await rollover.validate({
       sourceFormId: requiredEnv(env, AUTOMATION_ENV.SOURCE_FORM_ID),
+      sourceCycle,
+      collaboratorPermissions: collaborators,
+    });
+  } else if (command === 'sync-responses') {
+    const sourceCycle = requireOption(options, 'source-cycle');
+    parseCycle(sourceCycle);
+    result = await rollover.syncResponses({
+      sourceFormId: runtime.environment === 'production'
+        ? requiredEnv(env, AUTOMATION_ENV.SOURCE_FORM_ID)
+        : undefined,
       sourceCycle,
       collaboratorPermissions: collaborators,
     });

--- a/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/automation-cli.test.mjs
@@ -81,6 +81,7 @@ function fakeRolloverFactory({ result, capture }) {
       'validate',
       'bootstrapStagingSource',
       'prepare',
+      'syncResponses',
       'activate',
       'reconcileActive',
       'verify',
@@ -674,11 +675,16 @@ test('top-level CLI keeps page validate compatibility and routes source-cycle va
   assert.equal(capture.dependencies.runtime.stagingServiceAccountEmail, PRIVATE.account);
 });
 
-test('bootstrap, reconcile, verify, and cleanup commands map to service operations', async () => {
+test('bootstrap, response sync, reconcile, verify, and cleanup commands map to service operations', async () => {
   for (const [argv, method, expectedMode] of [
     [
       ['bootstrap', '--source-cycle', '2026-07', '--dry-run'],
       'bootstrapStagingSource',
+      undefined,
+    ],
+    [
+      ['sync-responses', '--source-cycle', '2026-08'],
+      'syncResponses',
       undefined,
     ],
     [
@@ -709,7 +715,41 @@ test('bootstrap, reconcile, verify, and cleanup commands map to service operatio
     });
     assert.equal(capture.method, method);
     if (expectedMode !== undefined) assert.equal(capture.input.mode, expectedMode);
+    if (method === 'syncResponses') assert.equal(capture.input.sourceCycle, '2026-08');
   }
+});
+
+test('production response sync receives only protected configuration and emits counts without IDs', async () => {
+  const capture = {};
+  const outputs = [];
+  await runAutomationCli(['sync-responses', '--source-cycle', '2026-08'], {
+    env: productionEnv({ PROGRESS_PRIZE_BRANCH: 'main' }),
+    googleFactory: () => ({}),
+    rolloverFactory: fakeRolloverFactory({
+      capture,
+      result: {
+        action: 'sync-responses',
+        status: 'synced',
+        sourceCycle: '2026-08',
+        responseSheetCreated: true,
+        responsesAppended: 3,
+        totalResponseCount: 3,
+        spreadsheetId: 'private-managed-sheet-id',
+      },
+    }),
+    output: (value) => outputs.push(value),
+  });
+
+  assert.equal(capture.method, 'syncResponses');
+  assert.equal(capture.input.sourceFormId, PRIVATE.form);
+  assert.deepEqual(capture.input.collaboratorPermissions, [{
+    type: 'group',
+    role: 'writer',
+    emailAddress: 'production-editors@private.example',
+  }]);
+  assert.equal(outputs.length, 1);
+  assert.equal(outputs[0].includes('private-managed-sheet-id'), false);
+  assert.match(outputs[0], /"spreadsheetId":"\[REDACTED\]"/);
 });
 
 test('reconcile-active is manual-only and rejects staging controls before token or I/O', async () => {

--- a/scrollprize.org/scripts/progress-prizes/cli-args.mjs
+++ b/scrollprize.org/scripts/progress-prizes/cli-args.mjs
@@ -22,6 +22,7 @@ export const GOOGLE_COMMANDS = Object.freeze([
   'validate',
   'bootstrap',
   'prepare',
+  'sync-responses',
   'activate',
   'reconcile-active',
   'verify',
@@ -110,6 +111,7 @@ export const GOOGLE_CLI_USAGE = `Google automation (private values are environme
   node automation-cli.mjs bootstrap --source-cycle YYYY-MM [--dry-run] [staging controls]
     [--allow-activation-rewind --target-cycle YYYY-MM]
   node automation-cli.mjs prepare --target-cycle YYYY-MM [--source-cycle YYYY-MM] [--dry-run]
+  node automation-cli.mjs sync-responses --source-cycle YYYY-MM
   node automation-cli.mjs activate --target-cycle YYYY-MM [--source-cycle YYYY-MM] [--fault STEP]
   node automation-cli.mjs reconcile-active --target-cycle YYYY-MM [--source-cycle YYYY-MM]
   node automation-cli.mjs verify --target-cycle YYYY-MM [--source-cycle YYYY-MM] \\

--- a/scrollprize.org/scripts/progress-prizes/google-api.mjs
+++ b/scrollprize.org/scripts/progress-prizes/google-api.mjs
@@ -820,6 +820,19 @@ export function createGoogleApiClient({
     },
   });
 
+  const spreadsheets = Object.freeze({
+    async get({ spreadsheetId }) {
+      return transport.sheets(`/spreadsheets/${encodePath(spreadsheetId, "spreadsheetId")}`, {
+        operation: "sheets.spreadsheets.get",
+        query: {
+          includeGridData: false,
+          fields: "spreadsheetId,sheets.properties(sheetId,title,index,sheetType,hidden)",
+        },
+      });
+    },
+    values,
+  });
+
   return Object.freeze({
     drive: Object.freeze({ files, permissions }),
     forms,
@@ -852,14 +865,15 @@ export function createGoogleApiClient({
     },
     setPublishState: (options) => forms.setPublishSettings(options),
     listFormResponses: (options) => forms.listResponses(options),
+    getSpreadsheet: (options) => spreadsheets.get(options),
     getSheetValues: (options) => values.get(options),
     appendSheetValues: (options) => values.append(options),
-    sheets: Object.freeze({ values }),
+    sheets: spreadsheets,
   });
 }
 
 function isSensitiveKey(key) {
-  return /(?:authorization|access[_-]?token|refresh[_-]?token|credential|private[_-]?key|service[_-]?account|form[_-]?id|file[_-]?id|folder[_-]?id|permission[_-]?id|email(?:address)?|editor(?:uri|url)?|domain)/i.test(
+  return /(?:authorization|access[_-]?token|refresh[_-]?token|credential|private[_-]?key|service[_-]?account|form[_-]?id|file[_-]?id|folder[_-]?id|permission[_-]?id|(?:spread)?sheet[_-]?id|linked[_-]?sheet|email(?:address)?|editor(?:uri|url)?|domain)/i.test(
     key,
   );
 }
@@ -868,6 +882,10 @@ function redactString(value, secrets) {
   let redacted = value.replace(/Bearer\s+[A-Za-z0-9._~+\/-]+=*/gi, `Bearer ${REDACTED}`);
   redacted = redacted.replace(
     /https:\/\/docs\.google\.com\/forms\/d\/(?!e\/)[^/\s]+\/(?:edit|preview|viewform)(?:[^\s]*)?/gi,
+    REDACTED,
+  );
+  redacted = redacted.replace(
+    /https:\/\/docs\.google\.com\/spreadsheets\/d\/[^/\s]+\/(?:edit|preview)(?:[^\s]*)?/gi,
     REDACTED,
   );
   redacted = redacted.replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, REDACTED);

--- a/scrollprize.org/scripts/progress-prizes/google-api.mjs
+++ b/scrollprize.org/scripts/progress-prizes/google-api.mjs
@@ -1,5 +1,6 @@
 const DRIVE_API_BASE = "https://www.googleapis.com/drive/v3";
 const FORMS_API_BASE = "https://forms.googleapis.com/v1";
+const SHEETS_API_BASE = "https://sheets.googleapis.com/v4";
 
 const DEFAULT_RETRY = Object.freeze({
   maxAttempts: 5,
@@ -151,6 +152,7 @@ function createTransport({
   retry,
   driveApiBase,
   formsApiBase,
+  sheetsApiBase,
 }) {
   if (accessToken !== undefined && getAccessToken !== undefined) {
     throw new TypeError("Provide either accessToken or getAccessToken, not both");
@@ -265,6 +267,14 @@ function createTransport({
       return requestJson({
         operation: options.operation ?? "forms.request",
         baseUrl: formsApiBase,
+        path,
+        ...options,
+      });
+    },
+    sheets(path, options = {}) {
+      return requestJson({
+        operation: options.operation ?? "sheets.request",
+        baseUrl: sheetsApiBase,
         path,
         ...options,
       });
@@ -448,6 +458,7 @@ export function createGoogleApiClient({
   retry,
   driveApiBase = DRIVE_API_BASE,
   formsApiBase = FORMS_API_BASE,
+  sheetsApiBase = SHEETS_API_BASE,
 } = {}) {
   const transport = createTransport({
     accessToken,
@@ -459,6 +470,7 @@ export function createGoogleApiClient({
     retry,
     driveApiBase,
     formsApiBase,
+    sheetsApiBase,
   });
 
   const files = Object.freeze({
@@ -496,6 +508,39 @@ export function createGoogleApiClient({
         body,
         // A lost response to files.copy is ambiguous: retrying here can create a
         // second form. The orchestrator resumes by searching appProperties instead.
+        retry: { ...operationRetry, maxAttempts: 1 },
+      });
+    },
+
+    async create({
+      name,
+      mimeType,
+      parentId,
+      appProperties,
+      fields = DEFAULT_FILE_FIELDS,
+      retry: operationRetry,
+    }) {
+      assertNonEmptyString(name, "name");
+      assertNonEmptyString(mimeType, "mimeType");
+      assertNonEmptyString(parentId, "parentId");
+      if (appProperties !== undefined) assertPlainObject(appProperties, "appProperties");
+
+      return transport.drive("/files", {
+        operation: "drive.files.create",
+        method: "POST",
+        query: {
+          supportsAllDrives: true,
+          ignoreDefaultVisibility: true,
+          fields,
+        },
+        body: {
+          name,
+          mimeType,
+          parents: [parentId],
+          ...(appProperties === undefined ? {} : { appProperties }),
+        },
+        // A lost response is ambiguous. The orchestrator resumes by searching
+        // the unique managed appProperties before attempting another create.
         retry: { ...operationRetry, maxAttempts: 1 },
       });
     },
@@ -720,6 +765,59 @@ export function createGoogleApiClient({
         retry: operationRetry,
       });
     },
+
+    async listResponses({ formId, pageSize = 1_000 }) {
+      if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 5_000) {
+        throw new TypeError("pageSize must be an integer from 1 through 5000");
+      }
+      return collectPages(
+        (pageToken) => transport.forms(`/forms/${encodePath(formId, "formId")}/responses`, {
+          operation: "forms.responses.list",
+          query: { pageSize, pageToken },
+        }),
+        "responses",
+      );
+    },
+  });
+
+  const values = Object.freeze({
+    async get({ spreadsheetId, range }) {
+      assertNonEmptyString(range, "range");
+      return transport.sheets(
+        `/spreadsheets/${encodePath(spreadsheetId, "spreadsheetId")}/values/${encodePath(range, "range")}`,
+        {
+          operation: "sheets.spreadsheets.values.get",
+          query: {
+            majorDimension: "ROWS",
+            valueRenderOption: "UNFORMATTED_VALUE",
+            dateTimeRenderOption: "FORMATTED_STRING",
+          },
+        },
+      );
+    },
+
+    async append({ spreadsheetId, range, rows, retry: operationRetry }) {
+      assertNonEmptyString(range, "range");
+      if (!Array.isArray(rows) || rows.length === 0 || rows.some((row) => !Array.isArray(row))) {
+        throw new TypeError("rows must be a non-empty array of arrays");
+      }
+      return transport.sheets(
+        `/spreadsheets/${encodePath(spreadsheetId, "spreadsheetId")}/values/${encodePath(range, "range")}:append`,
+        {
+          operation: "sheets.spreadsheets.values.append",
+          method: "POST",
+          query: {
+            valueInputOption: "RAW",
+            insertDataOption: "INSERT_ROWS",
+            includeValuesInResponse: false,
+          },
+          body: { majorDimension: "ROWS", values: rows },
+          // A lost append response is ambiguous. The orchestrator always reads
+          // stable response IDs again before retrying, preventing duplicate rows.
+          retry: { ...operationRetry, maxAttempts: 1 },
+        },
+      );
+    },
   });
 
   return Object.freeze({
@@ -727,6 +825,7 @@ export function createGoogleApiClient({
     forms,
     getForm: (options) => forms.get(options),
     getFile: (options) => files.get(options),
+    createFile: (options) => files.create(options),
     listFilesByAppProperties: (options) => files.listByAppProperties(options),
     copyFile: (options) => files.copy(options),
     updateFile: (options) => files.update(options),
@@ -752,6 +851,10 @@ export function createGoogleApiClient({
       });
     },
     setPublishState: (options) => forms.setPublishSettings(options),
+    listFormResponses: (options) => forms.listResponses(options),
+    getSheetValues: (options) => values.get(options),
+    appendSheetValues: (options) => values.append(options),
+    sheets: Object.freeze({ values }),
   });
 }
 
@@ -802,9 +905,13 @@ export function redactForLog(value, { secrets = [] } = {}) {
 export const GOOGLE_API_READ_SCOPES = Object.freeze([
   "https://www.googleapis.com/auth/drive.readonly",
   "https://www.googleapis.com/auth/forms.body.readonly",
+  "https://www.googleapis.com/auth/forms.responses.readonly",
+  "https://www.googleapis.com/auth/spreadsheets.readonly",
 ]);
 
 export const GOOGLE_API_SCOPES = Object.freeze([
   "https://www.googleapis.com/auth/drive",
   "https://www.googleapis.com/auth/forms.body",
+  "https://www.googleapis.com/auth/forms.responses.readonly",
+  "https://www.googleapis.com/auth/spreadsheets",
 ]);

--- a/scrollprize.org/scripts/progress-prizes/google-api.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/google-api.test.mjs
@@ -220,6 +220,50 @@ test("does not retry non-idempotent Drive copies after an ambiguous network fail
   assert.equal(mock.calls.length, 1);
 });
 
+test("creates one private managed Spreadsheet in the explicit Shared Drive folder", async () => {
+  const { client, mock } = clientFor([jsonResponse({ id: "monthly-sheet" })]);
+
+  await client.createFile({
+    name: "August 2026 Progress Prize Responses",
+    mimeType: "application/vnd.google-apps.spreadsheet",
+    parentId: "private-active-folder",
+    appProperties: {
+      managedBy: "scrollprize-progress-prizes",
+      role: "responses",
+      cycle: "2026-08",
+    },
+  });
+
+  assert.equal(mock.calls[0].url.pathname, "/drive/v3/files");
+  assert.equal(mock.calls[0].url.searchParams.get("supportsAllDrives"), "true");
+  assert.equal(mock.calls[0].url.searchParams.get("ignoreDefaultVisibility"), "true");
+  assert.deepEqual(JSON.parse(mock.calls[0].options.body), {
+    name: "August 2026 Progress Prize Responses",
+    mimeType: "application/vnd.google-apps.spreadsheet",
+    parents: ["private-active-folder"],
+    appProperties: {
+      managedBy: "scrollprize-progress-prizes",
+      role: "responses",
+      cycle: "2026-08",
+    },
+  });
+});
+
+test("does not retry an ambiguous Spreadsheet creation", async () => {
+  const { client, mock } = clientFor([
+    new TypeError("connection closed after the server may have created the sheet"),
+    jsonResponse({ id: "duplicate" }),
+  ]);
+
+  await assert.rejects(client.createFile({
+    name: "August 2026 Progress Prize Responses",
+    mimeType: "application/vnd.google-apps.spreadsheet",
+    parentId: "private-active-folder",
+    appProperties: { cycle: "2026-08" },
+  }), /network error after 1 attempts/);
+  assert.equal(mock.calls.length, 1);
+});
+
 test("gets, updates the title of, and changes publishing for a form", async () => {
   const { client, mock } = clientFor([
     jsonResponse({ formId: "form", revisionId: "rev-1" }),
@@ -278,6 +322,71 @@ test("validates Form write controls and impossible publish states before fetchin
     /cannot accept responses/,
   );
   assert.equal(mock.calls.length, 0);
+});
+
+test("paginates Form responses without requesting response mutation authority", async () => {
+  const { client, mock } = clientFor([
+    jsonResponse({ responses: [{ responseId: "one" }], nextPageToken: "next" }),
+    jsonResponse({ responses: [{ responseId: "two" }] }),
+  ]);
+
+  assert.deepEqual(await client.listFormResponses({ formId: "private-form" }), [
+    { responseId: "one" },
+    { responseId: "two" },
+  ]);
+  assert.equal(mock.calls[0].url.pathname, "/v1/forms/private-form/responses");
+  assert.equal(mock.calls[0].url.searchParams.get("pageSize"), "1000");
+  assert.equal(mock.calls[1].url.searchParams.get("pageToken"), "next");
+});
+
+test("reads a bounded Sheet range and appends only raw inserted rows", async () => {
+  const { client, mock } = clientFor([
+    jsonResponse({ range: "Form responses!A:A", values: [["Response ID"], ["one"]] }),
+    jsonResponse({ updates: { updatedRows: 1 } }),
+  ]);
+
+  assert.deepEqual(await client.getSheetValues({
+    spreadsheetId: "private-sheet",
+    range: "Form responses!A:A",
+  }), {
+    range: "Form responses!A:A",
+    values: [["Response ID"], ["one"]],
+  });
+  await client.appendSheetValues({
+    spreadsheetId: "private-sheet",
+    range: "Form responses!A:Z",
+    rows: [["two", "2026-08-06T12:00:00Z"]],
+  });
+
+  assert.equal(
+    mock.calls[0].url.pathname,
+    "/v4/spreadsheets/private-sheet/values/Form%20responses!A%3AA",
+  );
+  assert.equal(mock.calls[0].url.searchParams.get("majorDimension"), "ROWS");
+  assert.equal(
+    mock.calls[1].url.pathname,
+    "/v4/spreadsheets/private-sheet/values/Form%20responses!A%3AZ:append",
+  );
+  assert.equal(mock.calls[1].url.searchParams.get("valueInputOption"), "RAW");
+  assert.equal(mock.calls[1].url.searchParams.get("insertDataOption"), "INSERT_ROWS");
+  assert.deepEqual(JSON.parse(mock.calls[1].options.body), {
+    majorDimension: "ROWS",
+    values: [["two", "2026-08-06T12:00:00Z"]],
+  });
+});
+
+test("does not retry an ambiguous append that may already have written rows", async () => {
+  const { client, mock } = clientFor([
+    new TypeError("connection closed after the server may have appended rows"),
+    jsonResponse({ updates: { updatedRows: 1 } }),
+  ]);
+
+  await assert.rejects(client.appendSheetValues({
+    spreadsheetId: "private-sheet",
+    range: "Form responses!A:Z",
+    rows: [["one"]],
+  }), /network error after 1 attempts/);
+  assert.equal(mock.calls.length, 1);
 });
 
 test("paginates, creates, and deletes Drive permissions", async () => {
@@ -362,9 +471,13 @@ test("exports read-only validation and ACL-bounded headless write scopes", () =>
   assert.deepEqual(GOOGLE_API_READ_SCOPES, [
     "https://www.googleapis.com/auth/drive.readonly",
     "https://www.googleapis.com/auth/forms.body.readonly",
+    "https://www.googleapis.com/auth/forms.responses.readonly",
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
   ]);
   assert.deepEqual(GOOGLE_API_SCOPES, [
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/forms.body",
+    "https://www.googleapis.com/auth/forms.responses.readonly",
+    "https://www.googleapis.com/auth/spreadsheets",
   ]);
 });

--- a/scrollprize.org/scripts/progress-prizes/google-api.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/google-api.test.mjs
@@ -341,10 +341,18 @@ test("paginates Form responses without requesting response mutation authority", 
 
 test("reads a bounded Sheet range and appends only raw inserted rows", async () => {
   const { client, mock } = clientFor([
+    jsonResponse({
+      spreadsheetId: "private-sheet",
+      sheets: [{ properties: { sheetId: 0, title: "Form responses", index: 0 } }],
+    }),
     jsonResponse({ range: "Form responses!A:A", values: [["Response ID"], ["one"]] }),
     jsonResponse({ updates: { updatedRows: 1 } }),
   ]);
 
+  assert.deepEqual(await client.getSpreadsheet({ spreadsheetId: "private-sheet" }), {
+    spreadsheetId: "private-sheet",
+    sheets: [{ properties: { sheetId: 0, title: "Form responses", index: 0 } }],
+  });
   assert.deepEqual(await client.getSheetValues({
     spreadsheetId: "private-sheet",
     range: "Form responses!A:A",
@@ -359,17 +367,19 @@ test("reads a bounded Sheet range and appends only raw inserted rows", async () 
   });
 
   assert.equal(
-    mock.calls[0].url.pathname,
+    mock.calls[1].url.pathname,
     "/v4/spreadsheets/private-sheet/values/Form%20responses!A%3AA",
   );
-  assert.equal(mock.calls[0].url.searchParams.get("majorDimension"), "ROWS");
+  assert.equal(mock.calls[0].url.pathname, "/v4/spreadsheets/private-sheet");
+  assert.equal(mock.calls[0].url.searchParams.get("includeGridData"), "false");
+  assert.equal(mock.calls[1].url.searchParams.get("majorDimension"), "ROWS");
   assert.equal(
-    mock.calls[1].url.pathname,
+    mock.calls[2].url.pathname,
     "/v4/spreadsheets/private-sheet/values/Form%20responses!A%3AZ:append",
   );
-  assert.equal(mock.calls[1].url.searchParams.get("valueInputOption"), "RAW");
-  assert.equal(mock.calls[1].url.searchParams.get("insertDataOption"), "INSERT_ROWS");
-  assert.deepEqual(JSON.parse(mock.calls[1].options.body), {
+  assert.equal(mock.calls[2].url.searchParams.get("valueInputOption"), "RAW");
+  assert.equal(mock.calls[2].url.searchParams.get("insertDataOption"), "INSERT_ROWS");
+  assert.deepEqual(JSON.parse(mock.calls[2].options.body), {
     majorDimension: "ROWS",
     values: [["two", "2026-08-06T12:00:00Z"]],
   });
@@ -452,15 +462,19 @@ test("redacts tokens, internal IDs, ACL identities, and editor links but keeps r
   const redacted = redactForLog(
     {
       formId: "private-form-id",
+      spreadsheetId: "private-spreadsheet-id",
+      linkedSheetId: "private-legacy-sheet-id",
       permission: { emailAddress: "editor@example.org" },
       responderUri,
-      note: "Bearer token-value and secret-value at https://docs.google.com/forms/d/editor-id/viewform",
+      note: "Bearer token-value and secret-value at https://docs.google.com/spreadsheets/d/private-id/edit",
     },
     { secrets: ["secret-value"] },
   );
 
   assert.deepEqual(redacted, {
     formId: "[REDACTED]",
+    spreadsheetId: "[REDACTED]",
+    linkedSheetId: "[REDACTED]",
     permission: { emailAddress: "[REDACTED]" },
     responderUri,
     note: "Bearer [REDACTED] and [REDACTED] at [REDACTED]",

--- a/scrollprize.org/scripts/progress-prizes/production-workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/production-workflow-contract.test.mjs
@@ -9,6 +9,7 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../.
 const googleJobs = [
   'validate',
   'dry-run',
+  'sync-responses',
   'reconcile-active',
   'prepare-google',
   'activate-production',
@@ -214,6 +215,22 @@ test('production dry-run immediately exercises a read-only public proposal', asy
   );
 });
 
+test('response sync is append-only, reviewer-free, and isolated from GitHub writes', async () => {
+  const production = await productionWorkflow();
+  const sync = jobBlock(production, 'sync-responses');
+
+  assert.match(sync, /^    if: inputs\.operation == 'sync-responses'$/m);
+  assert.match(sync, /^    needs: preflight$/m);
+  assert.match(sync, /^    environment: progress-prizes-production$/m);
+  assert.match(sync, /permissions:\n      contents: read\n      id-token: write/);
+  assert.match(sync, /^          operation: sync-responses$/m);
+  assert.match(sync, /^          source-cycle: \$\{\{ inputs\['source-cycle'\] \}\}$/m);
+  assert.match(sync, /^          branch: main$/m);
+  assert.match(sync, /^          target-branch: main$/m);
+  assert.doesNotMatch(sync, /activation-approval|pull-requests: write|contents: write/);
+  assert.doesNotMatch(sync, /simulated-now:|fault:|dry-run:|head-sha:|base-sha:/);
+});
+
 test('normal preparation no-ops safely outside the seven-day window', async () => {
   const production = await productionWorkflow();
   const google = jobBlock(production, 'prepare-google');
@@ -277,8 +294,9 @@ test('reconcile-active requires secret-free approval and permits only marker met
   assert.match(action, /test -z "\$BASE_SHA"/);
   assert.match(
     action,
-    /if: inputs\.operation != 'validate' && inputs\.operation != 'verify' && inputs\['dry-run'\] != 'true'/,
+    /if: inputs\.operation != 'validate' && inputs\.operation != 'verify' && inputs\.operation != 'sync-responses' && inputs\.operation != 'reconcile-active' && inputs\['dry-run'\] != 'true'/,
   );
+  assert.match(action, /Authenticate marker-only reconciliation without a credential file/);
 });
 
 test('every privileged checkout executes the immutable trigger code', async () => {

--- a/scrollprize.org/scripts/progress-prizes/response-sheets.mjs
+++ b/scrollprize.org/scripts/progress-prizes/response-sheets.mjs
@@ -1,0 +1,162 @@
+export const RESPONSE_SHEET_MIME_TYPE = 'application/vnd.google-apps.spreadsheet';
+export const RESPONSE_SHEET_ROLE = 'responses';
+export const RESPONSE_SHEET_TAB_FALLBACK = 'Sheet1';
+export const RESPONSE_SHEET_STATIC_HEADERS = Object.freeze([
+  'Response ID',
+  'Created at',
+  'Last submitted at',
+  'Respondent email',
+]);
+
+function assertNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (value === null || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, canonicalJson(child)]),
+  );
+}
+
+function collectQuestions(items, result = [], parentTitle = '') {
+  for (const item of items ?? []) {
+    if (item === null || typeof item !== 'object') continue;
+    const itemTitle = typeof item.title === 'string' && item.title.trim() !== ''
+      ? item.title.trim()
+      : parentTitle;
+    const question = item.questionItem?.question;
+    if (typeof question?.questionId === 'string' && question.questionId !== '') {
+      result.push(Object.freeze({
+        questionId: question.questionId,
+        title: itemTitle || 'Untitled question',
+      }));
+    }
+    for (const groupedQuestion of item.questionGroupItem?.questions ?? []) {
+      if (
+        groupedQuestion
+        && typeof groupedQuestion.questionId === 'string'
+        && groupedQuestion.questionId !== ''
+      ) {
+        const rowTitle = typeof groupedQuestion.rowQuestion?.title === 'string'
+          ? groupedQuestion.rowQuestion.title.trim()
+          : '';
+        result.push(Object.freeze({
+          questionId: groupedQuestion.questionId,
+          title: [itemTitle, rowTitle].filter(Boolean).join(' — ') || 'Untitled question',
+        }));
+      }
+    }
+    if (Array.isArray(item.pageBreakItem?.items)) {
+      collectQuestions(item.pageBreakItem.items, result, itemTitle);
+    }
+  }
+  return result;
+}
+
+export function responseSheetQuestions(form) {
+  const questions = collectQuestions(form?.items);
+  const ids = new Set();
+  for (const question of questions) {
+    if (ids.has(question.questionId)) {
+      throw new Error('Form structure contains a duplicate question identifier');
+    }
+    ids.add(question.questionId);
+  }
+  return Object.freeze(questions);
+}
+
+export function responseSheetHeaders(form) {
+  const questionHeaders = responseSheetQuestions(form).map(
+    ({ questionId, title }) => `${title} [${questionId}]`,
+  );
+  return Object.freeze([
+    ...RESPONSE_SHEET_STATIC_HEADERS,
+    ...questionHeaders,
+    'Raw answers JSON',
+  ]);
+}
+
+function readableAnswer(answer) {
+  const text = answer?.textAnswers?.answers;
+  if (Array.isArray(text)) {
+    return text.map((entry) => entry?.value ?? '').join('\n');
+  }
+  const files = answer?.fileUploadAnswers?.answers;
+  if (Array.isArray(files)) {
+    return files.map((entry) => entry?.fileName ?? '').join('\n');
+  }
+  return answer === undefined ? '' : JSON.stringify(canonicalJson(answer));
+}
+
+export function responseSheetRow(form, response) {
+  if (response === null || typeof response !== 'object' || Array.isArray(response)) {
+    throw new TypeError('response must be an object');
+  }
+  const responseId = assertNonEmptyString(response.responseId, 'response.responseId');
+  const createTime = assertNonEmptyString(response.createTime, 'response.createTime');
+  const lastSubmittedTime = assertNonEmptyString(
+    response.lastSubmittedTime,
+    'response.lastSubmittedTime',
+  );
+  const answers = response.answers ?? {};
+  if (answers === null || typeof answers !== 'object' || Array.isArray(answers)) {
+    throw new TypeError('response.answers must be an object when supplied');
+  }
+  return Object.freeze([
+    responseId,
+    createTime,
+    lastSubmittedTime,
+    typeof response.respondentEmail === 'string' ? response.respondentEmail : '',
+    ...responseSheetQuestions(form).map(
+      ({ questionId }) => readableAnswer(answers[questionId]),
+    ),
+    JSON.stringify(canonicalJson(answers)),
+  ]);
+}
+
+export function assertResponseSheetHeader(valueRange, expectedHeaders) {
+  if (!Array.isArray(expectedHeaders) || expectedHeaders.length === 0) {
+    throw new TypeError('expectedHeaders must be a non-empty array');
+  }
+  const values = valueRange?.values;
+  if (!Array.isArray(values) || values.length !== 1 || !Array.isArray(values[0])) {
+    throw new Error('Managed response Sheet header is missing or malformed');
+  }
+  if (JSON.stringify(values[0]) !== JSON.stringify(expectedHeaders)) {
+    throw new Error('Managed response Sheet header does not match the form structure');
+  }
+}
+
+export function responseIdsFromValueRange(valueRange) {
+  const values = valueRange?.values;
+  if (values === undefined) return new Set();
+  if (!Array.isArray(values) || values.some((row) => !Array.isArray(row))) {
+    throw new Error('Managed response Sheet ID column is malformed');
+  }
+  const ids = new Set();
+  for (const [index, row] of values.entries()) {
+    if (index === 0) {
+      if (row[0] !== RESPONSE_SHEET_STATIC_HEADERS[0]) {
+        throw new Error('Managed response Sheet ID column has an unexpected header');
+      }
+      continue;
+    }
+    if (row.length === 0 || row[0] === '') continue;
+    if (typeof row[0] !== 'string' || ids.has(row[0])) {
+      throw new Error('Managed response Sheet contains an invalid or duplicate response ID');
+    }
+    ids.add(row[0]);
+  }
+  return ids;
+}
+
+export function quoteSheetTitle(title) {
+  return `'${assertNonEmptyString(title, 'sheet title').replaceAll("'", "''")}'`;
+}

--- a/scrollprize.org/scripts/progress-prizes/response-sheets.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/response-sheets.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  RESPONSE_SHEET_STATIC_HEADERS,
+  assertResponseSheetHeader,
+  quoteSheetTitle,
+  responseIdsFromValueRange,
+  responseSheetHeaders,
+  responseSheetQuestions,
+  responseSheetRow,
+} from './response-sheets.mjs';
+
+function formFixture() {
+  return {
+    items: [
+      {
+        title: 'Your full name',
+        questionItem: { question: { questionId: 'name' } },
+      },
+      {
+        title: 'Availability',
+        questionGroupItem: {
+          questions: [
+            { questionId: 'monday', rowQuestion: { title: 'Monday' } },
+            { questionId: 'tuesday', rowQuestion: { title: 'Tuesday' } },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+test('derives stable response columns from ordinary and grouped questions', () => {
+  const form = formFixture();
+  assert.deepEqual(responseSheetQuestions(form), [
+    { questionId: 'name', title: 'Your full name' },
+    { questionId: 'monday', title: 'Availability — Monday' },
+    { questionId: 'tuesday', title: 'Availability — Tuesday' },
+  ]);
+  assert.deepEqual(responseSheetHeaders(form), [
+    ...RESPONSE_SHEET_STATIC_HEADERS,
+    'Your full name [name]',
+    'Availability — Monday [monday]',
+    'Availability — Tuesday [tuesday]',
+    'Raw answers JSON',
+  ]);
+});
+
+test('serializes one response without interpreting formula-like answer text', () => {
+  const form = formFixture();
+  const row = responseSheetRow(form, {
+    responseId: 'response-one',
+    createTime: '2026-08-06T12:00:00Z',
+    lastSubmittedTime: '2026-08-06T12:01:00Z',
+    respondentEmail: 'entrant@example.org',
+    answers: {
+      name: { textAnswers: { answers: [{ value: '=IMPORTXML("private")' }] } },
+      monday: { textAnswers: { answers: [{ value: 'Yes' }] } },
+    },
+  });
+
+  assert.equal(row[0], 'response-one');
+  assert.equal(row[4], '=IMPORTXML("private")');
+  assert.equal(row[5], 'Yes');
+  assert.equal(row[6], '');
+  assert.deepEqual(JSON.parse(row.at(-1)), {
+    monday: { textAnswers: { answers: [{ value: 'Yes' }] } },
+    name: { textAnswers: { answers: [{ value: '=IMPORTXML("private")' }] } },
+  });
+});
+
+test('requires an exact immutable header before appending response rows', () => {
+  const headers = responseSheetHeaders(formFixture());
+  assert.doesNotThrow(() => assertResponseSheetHeader({ values: [headers] }, headers));
+  assert.throws(
+    () => assertResponseSheetHeader({ values: [[...headers, 'Human-added column']] }, headers),
+    /does not match/,
+  );
+  assert.throws(() => assertResponseSheetHeader({}, headers), /missing or malformed/);
+});
+
+test('deduplicates only stable response IDs and fails closed on existing duplicates', () => {
+  assert.deepEqual(
+    [...responseIdsFromValueRange({ values: [['Response ID'], ['one'], ['two'], []] })],
+    ['one', 'two'],
+  );
+  assert.throws(
+    () => responseIdsFromValueRange({ values: [['Response ID'], ['one'], ['one']] }),
+    /duplicate response ID/,
+  );
+  assert.throws(
+    () => responseIdsFromValueRange({ values: [['Wrong header']] }),
+    /unexpected header/,
+  );
+});
+
+test('quotes Sheet tab titles without allowing range injection', () => {
+  assert.equal(quoteSheetTitle("Entrants' responses"), "'Entrants'' responses'");
+});

--- a/scrollprize.org/scripts/progress-prizes/rollover.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.mjs
@@ -21,12 +21,22 @@ import {
   normalizePermissionForCreate,
   permissionIdentityKey,
 } from './google-api.mjs';
+import {
+  RESPONSE_SHEET_MIME_TYPE,
+  RESPONSE_SHEET_ROLE,
+  assertResponseSheetHeader,
+  quoteSheetTitle,
+  responseIdsFromValueRange,
+  responseSheetHeaders,
+  responseSheetRow,
+} from './response-sheets.mjs';
 
 export const ROLLOVER_MANAGED_BY = 'scrollprize-progress-prizes';
 
 export const ROLLOVER_FILE_ROLES = Object.freeze({
   SOURCE: 'source',
   TARGET: 'target',
+  RESPONSES: RESPONSE_SHEET_ROLE,
 });
 
 export const ROLLOVER_FILE_STATES = Object.freeze({
@@ -47,6 +57,7 @@ export const ROLLOVER_FAULTS = Object.freeze({
 const REQUIRED_GOOGLE_METHODS = Object.freeze([
   'getForm',
   'getFile',
+  'createFile',
   'listFilesByAppProperties',
   'copyFile',
   'updateFile',
@@ -55,6 +66,10 @@ const REQUIRED_GOOGLE_METHODS = Object.freeze([
   'deletePermission',
   'updateFormTitle',
   'setPublishState',
+  'listFormResponses',
+  'getSpreadsheet',
+  'getSheetValues',
+  'appendSheetValues',
 ]);
 
 const ALLOWED_EVENTS = new Set(['schedule', 'workflow_dispatch']);
@@ -356,12 +371,6 @@ function publishState(form) {
     throw new Error('Form reports an invalid publishing state');
   }
   return state;
-}
-
-function assertNoLinkedSheet(form) {
-  if (hasValue(form?.linkedSheetId)) {
-    throw new Error('Form has a linked response Sheet; automatic rollover is intentionally disabled');
-  }
 }
 
 function canonicalize(value) {
@@ -908,6 +917,19 @@ function sourceFingerprint(runtime, sourceCycle, sourceFileId) {
     .digest('hex');
 }
 
+function responseSheetFingerprint(runtime, cycle, formFileId) {
+  return createHash('sha256')
+    .update(`${runtime.environment}\0${cycle}\0responses\0${formFileId}`)
+    .digest('hex');
+}
+
+function responseSheetTitle(runtime, clock, cycle) {
+  const deadline = getCycleDeadline(cycle);
+  const title = `${deadline.monthName} ${deadline.year} Progress Prize Responses`;
+  if (runtime.environment === AUTOMATION_ENVIRONMENTS.PRODUCTION) return title;
+  return `[SMOKE RESPONSES ${smokeDate(runtime, clock)}] ${title}`;
+}
+
 function assertSourceFingerprint(targetFile, sourceFile, runtime, sourceCycle) {
   const expected = sourceFingerprint(runtime, sourceCycle, sourceFile.id);
   if (targetFile?.appProperties?.sourceFingerprint !== expected) {
@@ -986,6 +1008,270 @@ export function createRolloverService({
       throw new Error(`Managed ${role} form is missing for cycle ${cycle}`);
     }
     return file;
+  }
+
+  function assertManagedResponseSheet(file, cycle, formFileId, {
+    state,
+    requireActiveFolder = true,
+  } = {}) {
+    if (
+      file?.mimeType !== RESPONSE_SHEET_MIME_TYPE
+      || file.trashed === true
+      || file.driveId !== runtime.driveId
+      || (requireActiveFolder && !file.parents?.includes(runtime.folderId))
+    ) {
+      throw new Error('Managed response Sheet is not in the configured Shared Drive folder');
+    }
+    const expected = {
+      ...managedQuery(runtime, RESPONSE_SHEET_ROLE, cycle),
+      formFingerprint: responseSheetFingerprint(runtime, cycle, formFileId),
+      ...(state === undefined ? {} : { state }),
+    };
+    if (Object.entries(expected).some(
+      ([key, value]) => file.appProperties?.[key] !== value,
+    )) {
+      throw new Error('Managed response Sheet metadata does not match its form cycle');
+    }
+    if (file.name !== responseSheetTitle(runtime, clock, cycle)) {
+      throw new Error('Managed response Sheet filename does not match its form cycle');
+    }
+    assertSourceCapabilities(file, ['canEdit', 'canShare']);
+  }
+
+  async function findResponseSheet(cycle, formFileId, options = {}) {
+    const files = await google.listFilesByAppProperties({
+      appProperties: managedQuery(runtime, RESPONSE_SHEET_ROLE, cycle),
+      driveId: runtime.driveId,
+    });
+    if (files.length > 1) {
+      throw new Error(`Multiple managed response Sheets exist for cycle ${cycle}; refusing to guess`);
+    }
+    if (files[0] !== undefined) {
+      assertManagedResponseSheet(files[0], cycle, formFileId, options);
+    }
+    return files[0];
+  }
+
+  function responseSheetPermissions(formPermissions) {
+    return uniquePermissions(
+      filterDirectCollaboratorPermissions(formPermissions).filter((permission) => (
+        !isGoogleServiceAccountIdentity(permission)
+        && !isAutomationIdentity(permission, runtime.serviceAccountEmail)
+        && !isDriveAdminIdentity(permission, runtime.driveAdminEmail)
+      )),
+    );
+  }
+
+  async function responseSheetTab(spreadsheetId) {
+    const spreadsheet = await google.getSpreadsheet({ spreadsheetId });
+    const first = spreadsheet?.sheets?.find(
+      (sheet) => (sheet?.properties?.index ?? 0) === 0,
+    );
+    if (
+      spreadsheet?.spreadsheetId !== spreadsheetId
+      || (first?.properties?.sheetType ?? 'GRID') !== 'GRID'
+      || first.properties.hidden === true
+      || typeof first.properties.title !== 'string'
+      || first.properties.title === ''
+    ) {
+      throw new Error('Managed response Sheet does not expose one usable primary grid');
+    }
+    return quoteSheetTitle(first.properties.title);
+  }
+
+  async function inspectResponseSheet({
+    cycle,
+    formSnapshot,
+    requireExisting = true,
+    expectedState,
+    inspectResponses = false,
+    requireActiveFolder = true,
+  }) {
+    const sheet = await findResponseSheet(cycle, formSnapshot.file.id, {
+      state: expectedState,
+      requireActiveFolder,
+    });
+    if (sheet === undefined) {
+      if (requireExisting) {
+        throw new Error(`Managed response Sheet is missing for cycle ${cycle}`);
+      }
+      return Object.freeze({ exists: false, pendingCount: undefined });
+    }
+    const expectedPermissions = responseSheetPermissions(formSnapshot.permissions);
+    const permissions = await google.getAllPermissions({ fileId: sheet.id });
+    assertPermissionsMatch(expectedPermissions, permissions, { runtime });
+
+    const tab = await responseSheetTab(sheet.id);
+    const headers = responseSheetHeaders(formSnapshot.form);
+    const header = await google.getSheetValues({
+      spreadsheetId: sheet.id,
+      range: `${tab}!1:1`,
+    });
+    assertResponseSheetHeader(header, headers);
+    const idColumn = await google.getSheetValues({
+      spreadsheetId: sheet.id,
+      range: `${tab}!A:A`,
+    });
+    const responseIds = responseIdsFromValueRange(idColumn);
+    let pendingCount;
+    if (inspectResponses) {
+      const responses = await google.listFormResponses({ formId: formSnapshot.form.formId });
+      const listedIds = new Set();
+      for (const response of responses) {
+        assertNonEmptyString(response?.responseId, 'response.responseId');
+        if (listedIds.has(response.responseId)) {
+          throw new Error('Forms API returned a duplicate response identifier');
+        }
+        listedIds.add(response.responseId);
+      }
+      pendingCount = responses.filter(({ responseId }) => !responseIds.has(responseId)).length;
+    }
+    return Object.freeze({
+      exists: true,
+      sheet,
+      tab,
+      headers,
+      responseIds,
+      pendingCount,
+    });
+  }
+
+  async function ensureResponseSheet({
+    cycle,
+    formSnapshot,
+    state,
+    dryRun = false,
+    sync = true,
+  }) {
+    let sheet = await findResponseSheet(cycle, formSnapshot.file.id);
+    if (sheet === undefined && dryRun) {
+      return Object.freeze({
+        exists: false,
+        created: false,
+        appendedCount: 0,
+        totalResponseCount: undefined,
+      });
+    }
+    let created = false;
+    if (sheet === undefined) {
+      sheet = await google.createFile({
+        name: responseSheetTitle(runtime, clock, cycle),
+        mimeType: RESPONSE_SHEET_MIME_TYPE,
+        parentId: runtime.folderId,
+        appProperties: {
+          ...managedProperties(runtime, RESPONSE_SHEET_ROLE, cycle, state),
+          formFingerprint: responseSheetFingerprint(runtime, cycle, formSnapshot.file.id),
+        },
+      });
+      assertNonEmptyString(sheet?.id, 'created response Sheet ID');
+      created = true;
+    }
+    assertManagedResponseSheet(sheet, cycle, formSnapshot.file.id);
+    const expectedPermissions = responseSheetPermissions(formSnapshot.permissions);
+    await ensurePermissions(google, sheet.id, expectedPermissions, { runtime });
+    const tab = await responseSheetTab(sheet.id);
+    const headers = responseSheetHeaders(formSnapshot.form);
+    let header = await google.getSheetValues({
+      spreadsheetId: sheet.id,
+      range: `${tab}!1:1`,
+    });
+    if (!Array.isArray(header?.values) || header.values.length === 0) {
+      const existingIds = await google.getSheetValues({
+        spreadsheetId: sheet.id,
+        range: `${tab}!A:A`,
+      });
+      if (Array.isArray(existingIds?.values) && existingIds.values.length > 0) {
+        throw new Error('Managed response Sheet contains data without its immutable header');
+      }
+      await google.appendSheetValues({
+        spreadsheetId: sheet.id,
+        range: `${tab}!A:ZZZ`,
+        rows: [headers],
+      });
+      header = await google.getSheetValues({
+        spreadsheetId: sheet.id,
+        range: `${tab}!1:1`,
+      });
+    }
+    assertResponseSheetHeader(header, headers);
+
+    let appendedCount = 0;
+    let totalResponseCount;
+    if (sync) {
+      const responses = await google.listFormResponses({ formId: formSnapshot.form.formId });
+      const listedIds = new Set();
+      for (const response of responses) {
+        assertNonEmptyString(response?.responseId, 'response.responseId');
+        if (listedIds.has(response.responseId)) {
+          throw new Error('Forms API returned a duplicate response identifier');
+        }
+        listedIds.add(response.responseId);
+      }
+      totalResponseCount = responses.length;
+      const idColumn = await google.getSheetValues({
+        spreadsheetId: sheet.id,
+        range: `${tab}!A:A`,
+      });
+      const existingIds = responseIdsFromValueRange(idColumn);
+      const pending = responses
+        .filter(({ responseId }) => !existingIds.has(responseId))
+        .sort((left, right) => (
+          String(left.createTime).localeCompare(String(right.createTime))
+          || left.responseId.localeCompare(right.responseId)
+        ));
+      for (let index = 0; index < pending.length; index += 200) {
+        const batch = pending.slice(index, index + 200);
+        await google.appendSheetValues({
+          spreadsheetId: sheet.id,
+          range: `${tab}!A:ZZZ`,
+          rows: batch.map((response) => responseSheetRow(formSnapshot.form, response)),
+        });
+        appendedCount += batch.length;
+      }
+      const finalIds = responseIdsFromValueRange(await google.getSheetValues({
+        spreadsheetId: sheet.id,
+        range: `${tab}!A:A`,
+      }));
+      if ([...listedIds].some((responseId) => !finalIds.has(responseId))) {
+        throw new Error('Managed response Sheet did not retain every listed response ID');
+      }
+    }
+    sheet = await markFile(sheet, state, {
+      formFingerprint: responseSheetFingerprint(runtime, cycle, formSnapshot.file.id),
+    });
+    assertManagedResponseSheet(sheet, cycle, formSnapshot.file.id, { state });
+    return Object.freeze({
+      exists: true,
+      created,
+      appendedCount,
+      totalResponseCount,
+    });
+  }
+
+  async function assertResponseCoverage({
+    cycle,
+    formSnapshot,
+    expectedState,
+    allowLegacy = false,
+    requireFullySynced = false,
+  }) {
+    const managed = await inspectResponseSheet({
+      cycle,
+      formSnapshot,
+      requireExisting: false,
+      expectedState,
+      inspectResponses: requireFullySynced,
+    });
+    if (!managed.exists) {
+      if (allowLegacy && hasValue(formSnapshot.form.linkedSheetId)) {
+        return Object.freeze({ mode: 'legacy-linked', pendingCount: undefined });
+      }
+      throw new Error(`Managed response Sheet is missing for cycle ${cycle}`);
+    }
+    if (requireFullySynced && managed.pendingCount !== 0) {
+      throw new Error('Closed form has responses missing from its managed response Sheet');
+    }
+    return Object.freeze({ mode: 'managed', pendingCount: managed.pendingCount });
   }
 
   function assertResolvedSourceLocation(resolution, file) {
@@ -1148,7 +1434,6 @@ export function createRolloverService({
       google.getForm({ formId: file.id }),
       google.getFile({ fileId: file.id }),
     ]);
-    assertNoLinkedSheet(form);
     publishState(form);
     assertPublicResponderUri(form.responderUri);
     return { form, file: currentFile };
@@ -1262,11 +1547,19 @@ export function createRolloverService({
     if (verifyPage) {
       await assertPageState(sourceCycle, snapshot.form.responderUri);
     }
+    const responseSheet = await inspectResponseSheet({
+      cycle: sourceCycle,
+      formSnapshot: snapshot,
+      requireExisting: false,
+      inspectResponses: true,
+    });
     return Object.freeze({
       action: 'validate',
       status: 'valid',
       ...publicSummary({ cycle: sourceCycle, title: expectedTitle, ...snapshot }),
-      hasLinkedSheet: false,
+      hasLinkedSheet: hasValue(snapshot.form.linkedSheetId),
+      hasManagedResponseSheet: responseSheet.exists,
+      pendingResponseCount: responseSheet.pendingCount,
     });
   }
 
@@ -1742,11 +2035,19 @@ export function createRolloverService({
       });
     }
 
+    const responseSheet = await ensureResponseSheet({
+      cycle: sourceCycle,
+      formSnapshot: stagedSnapshot,
+      state: ROLLOVER_FILE_STATES.ACTIVE,
+    });
+
     return Object.freeze({
       action: 'bootstrap',
       status: 'active',
       created,
       resumed: !created,
+      responseSheetCreated: responseSheet.created,
+      responsesAppended: responseSheet.appendedCount,
       ...publicSummary({ cycle: sourceCycle, title, ...stagedSnapshot }),
     });
   }
@@ -1914,6 +2215,11 @@ export function createRolloverService({
         existing.permissions,
         { runtime },
       );
+      const responseSheet = await inspectResponseSheet({
+        cycle: targetCycle,
+        formSnapshot: existing,
+        requireExisting: false,
+      });
       return Object.freeze({
         action: 'prepare',
         status: 'planned',
@@ -1922,6 +2228,7 @@ export function createRolloverService({
         title: managedTitle(runtime, clock, ROLLOVER_FILE_ROLES.TARGET, targetCycle),
         created: false,
         resumed: true,
+        hasManagedResponseSheet: responseSheet.exists,
         responderUri: assertPublicResponderUri(existing.form.responderUri),
       });
     }
@@ -1961,8 +2268,19 @@ export function createRolloverService({
       isPublished: true,
       isAcceptingResponses: false,
     });
-    await markFile(targetSnapshot.file, ROLLOVER_FILE_STATES.PREPARED, {
+    targetSnapshot.file = await markFile(targetSnapshot.file, ROLLOVER_FILE_STATES.PREPARED, {
       sourceCycle: rollover.sourceCycle,
+    });
+
+    const sourceResponseSheet = await ensureResponseSheet({
+      cycle: rollover.sourceCycle,
+      formSnapshot: sourceSnapshot,
+      state: ROLLOVER_FILE_STATES.ACTIVE,
+    });
+    const targetResponseSheet = await ensureResponseSheet({
+      cycle: targetCycle,
+      formSnapshot: targetSnapshot,
+      state: ROLLOVER_FILE_STATES.PREPARED,
     });
 
     const markdown = await page.read();
@@ -1999,6 +2317,8 @@ export function createRolloverService({
       created,
       resumed: !created,
       pageChanged: update.changed,
+      sourceResponsesAppended: sourceResponseSheet.appendedCount,
+      targetResponseSheetCreated: targetResponseSheet.created,
       ...publicSummary({ cycle: targetCycle, title, ...targetSnapshot }),
     });
   }
@@ -2123,7 +2443,30 @@ export function createRolloverService({
       initialState.targetSnapshot.form.responderUri,
     );
 
+    await Promise.all([
+      inspectResponseSheet({
+        cycle: rollover.sourceCycle,
+        formSnapshot: currentState.sourceSnapshot,
+      }),
+      inspectResponseSheet({
+        cycle: targetCycle,
+        formSnapshot: currentState.targetSnapshot,
+      }),
+    ]);
+
     if (currentState.transition === 'active') {
+      const [sourceResponseSheet, targetResponseSheet] = await Promise.all([
+        ensureResponseSheet({
+          cycle: rollover.sourceCycle,
+          formSnapshot: currentState.sourceSnapshot,
+          state: ROLLOVER_FILE_STATES.CLOSED,
+        }),
+        ensureResponseSheet({
+          cycle: targetCycle,
+          formSnapshot: currentState.targetSnapshot,
+          state: ROLLOVER_FILE_STATES.ACTIVE,
+        }),
+      ]);
       return Object.freeze({
         action: 'activate',
         status: 'active',
@@ -2131,6 +2474,8 @@ export function createRolloverService({
         targetCycle,
         sourceAcceptingResponses: false,
         targetAcceptingResponses: true,
+        sourceResponsesAppended: sourceResponseSheet.appendedCount,
+        targetResponsesAppended: targetResponseSheet.appendedCount,
         responderUri: assertPublicResponderUri(currentState.targetSnapshot.form.responderUri),
       });
     }
@@ -2155,12 +2500,23 @@ export function createRolloverService({
       }
     }
 
+    const sourceResponseSheet = await ensureResponseSheet({
+      cycle: rollover.sourceCycle,
+      formSnapshot: { ...currentState.sourceSnapshot, form: sourceForm },
+      state: ROLLOVER_FILE_STATES.CLOSED,
+    });
+
     const targetForm = await ensurePublishState(google, currentState.targetSnapshot.form, {
       isPublished: true,
       isAcceptingResponses: true,
     });
     await markFile(currentState.targetSnapshot.file, ROLLOVER_FILE_STATES.ACTIVE, {
       sourceCycle: rollover.sourceCycle,
+    });
+    const targetResponseSheet = await ensureResponseSheet({
+      cycle: targetCycle,
+      formSnapshot: { ...currentState.targetSnapshot, form: targetForm },
+      state: ROLLOVER_FILE_STATES.ACTIVE,
     });
 
     assertExpectedPublishing(sourceForm, {
@@ -2199,7 +2555,56 @@ export function createRolloverService({
       targetCycle,
       sourceAcceptingResponses: false,
       targetAcceptingResponses: true,
+      sourceResponsesAppended: sourceResponseSheet.appendedCount,
+      targetResponsesAppended: targetResponseSheet.appendedCount,
       responderUri: assertPublicResponderUri(finalState.targetSnapshot.form.responderUri),
+    });
+  }
+
+  async function syncResponses({
+    sourceCycle,
+    sourceFormId,
+    collaboratorPermissions = [],
+  } = {}) {
+    assertMutationContext(runtime);
+    parseCycle(sourceCycle);
+    assertCollaboratorConfiguration(
+      collaboratorPermissions,
+      runtime.serviceAccountEmail,
+      runtime.driveAdminEmail,
+    );
+    const source = await resolveSource({ sourceFormId, sourceCycle });
+    const snapshot = await loadSnapshot(source.file);
+    assertResolvedSourceAccess(source, snapshot);
+    assertRequiredSourcePermissions(snapshot.permissions, collaboratorPermissions);
+    assertTitle(
+      snapshot.form,
+      snapshot.file,
+      managedTitle(
+        runtime,
+        clock,
+        source.role ?? ROLLOVER_FILE_ROLES.SOURCE,
+        sourceCycle,
+      ),
+    );
+    assertExpectedPublishing(snapshot.form, {
+      isPublished: true,
+      isAcceptingResponses: true,
+    });
+    await assertPageState(sourceCycle, snapshot.form.responderUri);
+    const responseSheet = await ensureResponseSheet({
+      cycle: sourceCycle,
+      formSnapshot: snapshot,
+      state: ROLLOVER_FILE_STATES.ACTIVE,
+    });
+    return Object.freeze({
+      action: 'sync-responses',
+      status: 'synced',
+      sourceCycle,
+      responseSheetCreated: responseSheet.created,
+      responsesAppended: responseSheet.appendedCount,
+      totalResponseCount: responseSheet.totalResponseCount,
+      hasLinkedSheet: hasValue(snapshot.form.linkedSheetId),
     });
   }
 
@@ -2383,6 +2788,19 @@ export function createRolloverService({
         isPublished: true,
         isAcceptingResponses: false,
       });
+      await Promise.all([
+        assertResponseCoverage({
+          cycle: sourceCycle,
+          formSnapshot: sourceSnapshot,
+          expectedState: ROLLOVER_FILE_STATES.ACTIVE,
+          allowLegacy: true,
+        }),
+        assertResponseCoverage({
+          cycle: targetCycle,
+          formSnapshot: targetSnapshot,
+          expectedState: ROLLOVER_FILE_STATES.PREPARED,
+        }),
+      ]);
     } else if (mode === 'active') {
       assertExpectedPublishing(sourceSnapshot.form, {
         isPublished: true,
@@ -2399,6 +2817,20 @@ export function createRolloverService({
       if (!markers.healthy) {
         throw new Error('Active form pair has stale managed Drive state metadata');
       }
+      await Promise.all([
+        assertResponseCoverage({
+          cycle: sourceCycle,
+          formSnapshot: sourceSnapshot,
+          expectedState: ROLLOVER_FILE_STATES.CLOSED,
+          allowLegacy: true,
+          requireFullySynced: true,
+        }),
+        assertResponseCoverage({
+          cycle: targetCycle,
+          formSnapshot: targetSnapshot,
+          expectedState: ROLLOVER_FILE_STATES.ACTIVE,
+        }),
+      ]);
     } else {
       assertStagingIdentity(runtime);
       assertNonEmptyString(runtime.archiveFolderId, 'archiveFolderId');
@@ -2425,6 +2857,27 @@ export function createRolloverService({
           throw new Error('Cleaned staging forms are not in the configured archive state');
         }
       }
+      for (const [cycle, snapshot] of [
+        [sourceCycle, sourceSnapshot],
+        [targetCycle, targetSnapshot],
+      ]) {
+        const responseSheet = await inspectResponseSheet({
+          cycle,
+          formSnapshot: snapshot,
+          requireExisting: false,
+          expectedState: ROLLOVER_FILE_STATES.ARCHIVED,
+          requireActiveFolder: false,
+        });
+        if (
+          responseSheet.exists
+          && (
+            !responseSheet.sheet.parents?.includes(runtime.archiveFolderId)
+            || responseSheet.sheet.parents?.includes(runtime.folderId)
+          )
+        ) {
+          throw new Error('Cleaned staging response Sheet is not in the configured archive state');
+        }
+      }
     }
 
     if (mode !== 'cleaned') {
@@ -2445,19 +2898,19 @@ export function createRolloverService({
     parseCycle(targetCycle);
     assertNonEmptyString(runtime.archiveFolderId, 'archiveFolderId');
     const sourceCycle = previousCycle(targetCycle);
-    const files = [
+    const formFiles = [
       await requireManagedFile(ROLLOVER_FILE_ROLES.SOURCE, sourceCycle, { inActiveFolder: false }),
       await requireManagedFile(ROLLOVER_FILE_ROLES.TARGET, targetCycle, { inActiveFolder: false }),
     ];
 
-    const permissionsByFile = new Map(await Promise.all(files.map(async (file) => {
+    const permissionsByFile = new Map(await Promise.all(formFiles.map(async (file) => {
       const permissions = await google.getAllPermissions({ fileId: file.id });
       assertSharedDriveManagerPermissions(permissions, runtime);
       assertNoInheritedOrAdministrativeFormCollaborators(permissions, runtime);
       return [file.id, permissions];
     })));
 
-    for (const file of files) {
+    for (const file of formFiles) {
       let form = await google.getForm({ formId: file.id });
       form = await ensurePublishState(google, form, {
         isPublished: false,
@@ -2503,12 +2956,40 @@ export function createRolloverService({
       });
     }
 
+    const formSnapshots = await Promise.all(formFiles.map((file) => loadSnapshot(file)));
+    const responseSheets = (await Promise.all([
+      findResponseSheet(sourceCycle, formSnapshots[0].file.id, { requireActiveFolder: false }),
+      findResponseSheet(targetCycle, formSnapshots[1].file.id, { requireActiveFolder: false }),
+    ])).filter(Boolean);
+    for (const sheet of responseSheets) {
+      const current = await google.getFile({ fileId: sheet.id });
+      const parents = current.parents ?? [];
+      const needsParentMove = !parents.includes(runtime.archiveFolderId)
+        || parents.includes(runtime.folderId);
+      const needsState = current.appProperties?.state !== ROLLOVER_FILE_STATES.ARCHIVED;
+      if (needsParentMove || needsState) {
+        await google.updateFile({
+          fileId: current.id,
+          appProperties: {
+            ...(current.appProperties ?? {}),
+            state: ROLLOVER_FILE_STATES.ARCHIVED,
+          },
+          addParentIds: parents.includes(runtime.archiveFolderId)
+            ? undefined
+            : [runtime.archiveFolderId],
+          removeParentIds: parents.includes(runtime.folderId)
+            ? [runtime.folderId]
+            : undefined,
+        });
+      }
+    }
+
     return Object.freeze({
       action: 'cleanup',
       status: 'archived',
       sourceCycle,
       targetCycle,
-      archivedCount: files.length,
+      archivedCount: formFiles.length + responseSheets.length,
     });
   }
 
@@ -2517,6 +2998,7 @@ export function createRolloverService({
     bootstrapStagingSource,
     prepare,
     activate,
+    syncResponses,
     reconcileActive,
     verify,
     cleanup,

--- a/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/rollover.test.mjs
@@ -121,6 +121,9 @@ class FakeGoogle {
     this.calls = [];
     this.nextFile = 1;
     this.nextPermission = 1;
+    this.spreadsheets = new Map();
+    this.sheetRows = new Map();
+    this.responses = new Map([[LIVE_FORM_ID, []]]);
     this.files = new Map([
       [LIVE_FORM_ID, {
         id: LIVE_FORM_ID,
@@ -303,7 +306,40 @@ class FakeGoogle {
     form.responderUri = `https://docs.google.com/forms/d/e/public-${id}/viewform`;
     this.files.set(id, file);
     this.forms.set(id, form);
+    this.responses.set(id, []);
     this.permissions.set(id, clone(this.permissions.get(parentId) ?? []));
+    return clone(file);
+  }
+
+  async createFile({ name, mimeType, parentId, appProperties }) {
+    this.record('createFile', { name, mimeType, parentId, appProperties });
+    const destination = this.requireFile(parentId);
+    const id = `managed-sheet-${this.nextFile++}`;
+    const file = {
+      id,
+      name,
+      mimeType,
+      parents: [parentId],
+      driveId: destination.driveId,
+      appProperties: clone(appProperties),
+      trashed: false,
+      capabilities: { canCopy: true, canEdit: true, canShare: true },
+    };
+    this.files.set(id, file);
+    this.permissions.set(id, clone(this.permissions.get(parentId) ?? []));
+    this.spreadsheets.set(id, {
+      spreadsheetId: id,
+      sheets: [{
+        properties: {
+          sheetId: 0,
+          title: 'Sheet1',
+          index: 0,
+          sheetType: 'GRID',
+          hidden: false,
+        },
+      }],
+    });
+    this.sheetRows.set(id, []);
     return clone(file);
   }
 
@@ -358,6 +394,42 @@ class FakeGoogle {
     return clone(form.publishSettings);
   }
 
+  async listFormResponses({ formId }) {
+    this.record('listFormResponses', { formId });
+    return clone(this.responses.get(formId) ?? []);
+  }
+
+  async getSpreadsheet({ spreadsheetId }) {
+    this.record('getSpreadsheet', { spreadsheetId });
+    const spreadsheet = this.spreadsheets.get(spreadsheetId);
+    if (!spreadsheet) throw new Error(`Missing fake spreadsheet ${spreadsheetId}`);
+    return clone(spreadsheet);
+  }
+
+  async getSheetValues({ spreadsheetId, range }) {
+    this.record('getSheetValues', { spreadsheetId, range });
+    const rows = this.sheetRows.get(spreadsheetId);
+    if (!rows) throw new Error(`Missing fake spreadsheet rows ${spreadsheetId}`);
+    if (range.endsWith('!1:1')) {
+      return rows.length === 0 ? {} : { values: [clone(rows[0])] };
+    }
+    if (range.endsWith('!A:A')) {
+      return rows.length === 0
+        ? {}
+        : { values: rows.map((row) => (row[0] === undefined ? [] : [clone(row[0])])) };
+    }
+    throw new Error(`Unsupported fake Sheet range ${range}`);
+  }
+
+  async appendSheetValues({ spreadsheetId, range, rows }) {
+    this.record('appendSheetValues', { spreadsheetId, range, rows });
+    if (!range.endsWith('!A:ZZZ')) throw new Error(`Unsupported fake append range ${range}`);
+    const current = this.sheetRows.get(spreadsheetId);
+    if (!current) throw new Error(`Missing fake spreadsheet rows ${spreadsheetId}`);
+    current.push(...clone(rows));
+    return { updates: { updatedRows: rows.length } };
+  }
+
   managed(role, cycle) {
     return [...this.files.values()].filter((file) =>
       file.appProperties?.managedBy === ROLLOVER_MANAGED_BY
@@ -368,6 +440,20 @@ class FakeGoogle {
 
 function fixedClock(instant) {
   return { now: () => new Date(instant) };
+}
+
+function fakeFormResponse(google, formId, responseId, value = 'Example entrant') {
+  const form = google.forms.get(formId);
+  const questionId = form.items[0].questionItem.question.questionId;
+  return {
+    responseId,
+    createTime: '2026-07-30T12:00:00Z',
+    lastSubmittedTime: '2026-07-30T12:00:01Z',
+    respondentEmail: 'entrant@example.org',
+    answers: {
+      [questionId]: { textAnswers: { answers: [{ value }] } },
+    },
+  };
 }
 
 function grantProductionSourceAccess(google) {
@@ -494,6 +580,10 @@ async function manuallyActivatedProductionPair() {
     isPublished: true,
     isAcceptingResponses: true,
   };
+  google.managed(ROLLOVER_FILE_ROLES.RESPONSES, '2026-07')[0].appProperties.state =
+    ROLLOVER_FILE_STATES.CLOSED;
+  google.managed(ROLLOVER_FILE_ROLES.RESPONSES, '2026-08')[0].appProperties.state =
+    ROLLOVER_FILE_STATES.ACTIVE;
   google.calls.length = 0;
   page.writes.length = 0;
   return {
@@ -543,17 +633,32 @@ test('validate performs a read-only production preflight and resolves the public
   );
 });
 
-test('validate safely stops for linked Sheets and legacy publish settings', async () => {
-  const linkedGoogle = new FakeGoogle();
+test('validate treats existing linked Sheets as immutable legacy destinations', async () => {
+  const linkedGoogle = grantProductionSourceAccess(new FakeGoogle());
   linkedGoogle.forms.get(LIVE_FORM_ID).linkedSheetId = 'private-sheet';
   const linked = service({
     google: linkedGoogle,
     runtime: productionRuntime(),
   });
-  await assert.rejects(
-    linked.rollover.validate({ sourceFormId: LIVE_FORM_ID, sourceCycle: '2026-07' }),
-    /linked response Sheet/,
+  const result = await linked.rollover.validate({
+    sourceFormId: LIVE_FORM_ID,
+    sourceCycle: '2026-07',
+    collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+  });
+  assert.equal(result.hasLinkedSheet, true);
+  assert.equal(result.hasManagedResponseSheet, false);
+  assert.equal(
+    linkedGoogle.calls.some(({ method }) => [
+      'createFile',
+      'appendSheetValues',
+      'updateFile',
+      'deletePermission',
+    ].includes(method)),
+    false,
   );
+});
+
+test('validate still stops safely for legacy publish settings', async () => {
 
   const legacyGoogle = new FakeGoogle();
   delete legacyGoogle.forms.get(LIVE_FORM_ID).publishSettings;
@@ -1893,6 +1998,147 @@ test('prepare resumes the one appProperties copy after an injected failure and w
   });
 });
 
+test('prepare creates distinct private monthly response Sheets without touching legacy destinations', async () => {
+  const google = new FakeGoogle();
+  google.forms.get(LIVE_FORM_ID).linkedSheetId = 'private-legacy-sheet';
+  const page = new MemoryPage();
+  await service({ google, page }).rollover.bootstrapStagingSource({
+    sourceFormId: LIVE_FORM_ID,
+    sourceCycle: '2026-07',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+  });
+  const source = google.managed(ROLLOVER_FILE_ROLES.SOURCE, '2026-07')[0];
+  google.responses.set(source.id, [fakeFormResponse(google, source.id, 'source-response')]);
+
+  const result = await service({ google, page }).rollover.prepare({
+    targetCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+  });
+  const sourceSheet = google.managed(ROLLOVER_FILE_ROLES.RESPONSES, '2026-07')[0];
+  const targetSheet = google.managed(ROLLOVER_FILE_ROLES.RESPONSES, '2026-08')[0];
+  assert.ok(sourceSheet);
+  assert.ok(targetSheet);
+  assert.notEqual(sourceSheet.id, targetSheet.id);
+  assert.equal(result.sourceResponsesAppended, 1);
+  assert.equal(result.targetResponseSheetCreated, true);
+  assert.equal(google.sheetRows.get(sourceSheet.id)[1][0], 'source-response');
+  assert.equal(google.forms.get(LIVE_FORM_ID).linkedSheetId, 'private-legacy-sheet');
+  for (const sheet of [sourceSheet, targetSheet]) {
+    assert.equal(
+      google.permissions.get(sheet.id).some(({ view, type }) => (
+        view === 'published' || type === 'anyone'
+      )),
+      false,
+    );
+    assert.equal(
+      google.permissions.get(sheet.id).some(({ emailAddress }) => (
+        emailAddress === STAGING_EDITOR
+      )),
+      true,
+    );
+  }
+});
+
+test('sync-responses is append-only, idempotent, and never rewrites an existing response row', async () => {
+  const google = new FakeGoogle();
+  const page = new MemoryPage();
+  await bootstrapAndPrepare(service({ google, page }));
+  const activation = service({
+    google,
+    page,
+    clock: fixedClock('2026-08-01T07:00:01Z'),
+    runtime: stagingRuntime({ simulatedNow: '2026-08-01T07:00:01Z' }),
+  });
+  await activation.rollover.activate({ targetCycle: '2026-08' });
+  const target = google.managed(ROLLOVER_FILE_ROLES.TARGET, '2026-08')[0];
+  const sheet = google.managed(ROLLOVER_FILE_ROLES.RESPONSES, '2026-08')[0];
+  google.forms.get(target.id).linkedSheetId = 'private-existing-linked-sheet';
+  google.responses.set(target.id, [fakeFormResponse(google, target.id, 'one', '=not-a-formula')]);
+
+  const sync = service({
+    google,
+    page,
+    clock: fixedClock('2026-08-06T12:00:00Z'),
+    runtime: stagingRuntime({ simulatedNow: '2026-08-06T12:00:00Z' }),
+  }).rollover;
+  const first = await sync.syncResponses({
+    sourceCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+  });
+  assert.equal(first.responsesAppended, 1);
+  const immutableFirstRow = clone(google.sheetRows.get(sheet.id)[1]);
+
+  google.responses.get(target.id)[0].answers = {
+    [google.forms.get(target.id).items[0].questionItem.question.questionId]: {
+      textAnswers: { answers: [{ value: 'edited later in Forms' }] },
+    },
+  };
+  google.responses.get(target.id).push(fakeFormResponse(google, target.id, 'two', 'Second'));
+  const second = await sync.syncResponses({
+    sourceCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+  });
+  const third = await sync.syncResponses({
+    sourceCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+  });
+
+  assert.equal(second.responsesAppended, 1);
+  assert.equal(third.responsesAppended, 0);
+  assert.deepEqual(google.sheetRows.get(sheet.id)[1], immutableFirstRow);
+  assert.deepEqual(
+    google.sheetRows.get(sheet.id).slice(1).map((row) => row[0]),
+    ['one', 'two'],
+  );
+  assert.equal(google.forms.get(target.id).linkedSheetId, 'private-existing-linked-sheet');
+});
+
+test('sync-responses recovers an ambiguous append by rescanning response IDs', async () => {
+  const google = new FakeGoogle();
+  const page = new MemoryPage();
+  await bootstrapAndPrepare(service({ google, page }));
+  const activation = service({
+    google,
+    page,
+    clock: fixedClock('2026-08-01T07:00:01Z'),
+    runtime: stagingRuntime({ simulatedNow: '2026-08-01T07:00:01Z' }),
+  });
+  await activation.rollover.activate({ targetCycle: '2026-08' });
+  const target = google.managed(ROLLOVER_FILE_ROLES.TARGET, '2026-08')[0];
+  const sheet = google.managed(ROLLOVER_FILE_ROLES.RESPONSES, '2026-08')[0];
+  google.responses.set(target.id, [fakeFormResponse(google, target.id, 'ambiguous')]);
+
+  const originalAppend = google.appendSheetValues.bind(google);
+  let failOnce = true;
+  google.appendSheetValues = async (options) => {
+    const result = await originalAppend(options);
+    if (failOnce) {
+      failOnce = false;
+      throw new Error('fixed ambiguous append failure');
+    }
+    return result;
+  };
+  const sync = service({
+    google,
+    page,
+    clock: fixedClock('2026-08-06T12:00:00Z'),
+    runtime: stagingRuntime({ simulatedNow: '2026-08-06T12:00:00Z' }),
+  }).rollover;
+  await assert.rejects(sync.syncResponses({
+    sourceCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+  }), /ambiguous append/);
+  const recovered = await sync.syncResponses({
+    sourceCycle: '2026-08',
+    collaboratorPermissions: [STAGING_EDITOR_PERMISSION],
+  });
+  assert.equal(recovered.responsesAppended, 0);
+  assert.deepEqual(
+    google.sheetRows.get(sheet.id).slice(1).map((row) => row[0]),
+    ['ambiguous'],
+  );
+});
+
 test('prepare refuses to copy a source that is no longer live', async () => {
   const context = service();
   await context.rollover.bootstrapStagingSource({
@@ -2265,13 +2511,6 @@ for (const scenario of [
     error: /visible form title/,
   },
   {
-    name: 'linked response Sheet',
-    mutate({ google, target }) {
-      google.forms.get(target.id).linkedSheetId = 'private-linked-sheet';
-    },
-    error: /linked response Sheet/,
-  },
-  {
     name: 'website cycle mismatch',
     mutate({ page }) {
       page.content = pageMarkdown('2026-07', LIVE_RESPONDER);
@@ -2323,6 +2562,30 @@ for (const scenario of [
     assert.deepEqual(context.page.writes, []);
   });
 }
+
+test('reconcile-active never touches a legacy linked response Sheet', async () => {
+  const context = await manuallyActivatedProductionPair();
+  context.google.forms.get(context.target.id).linkedSheetId = 'private-linked-sheet';
+  const result = await context.rollover.reconcileActive({
+    targetCycle: '2026-08',
+    sourceFormId: LIVE_FORM_ID,
+    collaboratorPermissions: [PRODUCTION_EDITOR_PERMISSION],
+  });
+  assert.equal(result.status, 'active');
+  assert.equal(
+    context.google.forms.get(context.target.id).linkedSheetId,
+    'private-linked-sheet',
+  );
+  assert.equal(
+    context.google.calls.some(({ method }) => [
+      'createFile',
+      'appendSheetValues',
+      'deletePermission',
+      'setPublishState',
+    ].includes(method)),
+    false,
+  );
+});
 
 test('reconcile-active rejects schedulers and simulated clocks before Google reads', async () => {
   for (const runtime of [
@@ -2647,6 +2910,49 @@ test('activate recovers after closing the source, opens the target once, and is 
   assert.equal(gateCalls.length, 3);
   assert.equal(gateCalls[0].responderUri, google.forms.get(target.id).responderUri);
   assert.equal((await active.rollover.verify({ targetCycle: '2026-08', mode: 'active' })).status, 'valid');
+});
+
+test('activation closes the source, appends its final responses, then opens the target', async () => {
+  const google = new FakeGoogle();
+  const page = new MemoryPage();
+  await bootstrapAndPrepare(service({ google, page }));
+  const source = google.managed(ROLLOVER_FILE_ROLES.SOURCE, '2026-07')[0];
+  const target = google.managed(ROLLOVER_FILE_ROLES.TARGET, '2026-08')[0];
+  const sourceSheet = google.managed(ROLLOVER_FILE_ROLES.RESPONSES, '2026-07')[0];
+  google.forms.get(source.id).linkedSheetId = 'private-legacy-source-sheet';
+  google.responses.set(source.id, [fakeFormResponse(google, source.id, 'last-response')]);
+  const canonicalResponsesBefore = clone(google.responses.get(source.id));
+  google.calls.length = 0;
+
+  const active = service({
+    google,
+    page,
+    clock: fixedClock('2026-08-01T07:00:01Z'),
+    runtime: stagingRuntime({ simulatedNow: '2026-08-01T07:00:01Z' }),
+  });
+  const result = await active.rollover.activate({ targetCycle: '2026-08' });
+  const closeIndex = google.calls.findIndex((call) => (
+    call.method === 'setPublishState'
+    && call.formId === source.id
+    && call.isAcceptingResponses === false
+  ));
+  const appendIndex = google.calls.findIndex((call) => (
+    call.method === 'appendSheetValues'
+    && call.spreadsheetId === sourceSheet.id
+  ));
+  const openIndex = google.calls.findIndex((call) => (
+    call.method === 'setPublishState'
+    && call.formId === target.id
+    && call.isAcceptingResponses === true
+  ));
+
+  assert.equal(result.sourceResponsesAppended, 1);
+  assert.equal(closeIndex >= 0, true);
+  assert.equal(appendIndex > closeIndex, true);
+  assert.equal(openIndex > appendIndex, true);
+  assert.deepEqual(google.responses.get(source.id), canonicalResponsesBefore);
+  assert.equal(google.forms.get(source.id).linkedSheetId, 'private-legacy-source-sheet');
+  assert.equal(sourceSheet.appProperties.state, ROLLOVER_FILE_STATES.CLOSED);
 });
 
 test('explicit staging bootstrap rewinds only the exact close-fault checkpoint', async () => {
@@ -3236,6 +3542,14 @@ test('cleanup is staging-only, unpublishes both forms, removes public access, ar
   });
   await active.rollover.activate({ targetCycle: '2026-08' });
 
+  const responseSheets = [
+    google.managed(ROLLOVER_FILE_ROLES.RESPONSES, '2026-07')[0],
+    google.managed(ROLLOVER_FILE_ROLES.RESPONSES, '2026-08')[0],
+  ];
+  const responseRowsBeforeCleanup = new Map(responseSheets.map(
+    (sheet) => [sheet.id, clone(google.sheetRows.get(sheet.id))],
+  ));
+
   for (const file of [
     google.managed(ROLLOVER_FILE_ROLES.SOURCE, '2026-07')[0],
     google.managed(ROLLOVER_FILE_ROLES.TARGET, '2026-08')[0],
@@ -3250,8 +3564,8 @@ test('cleanup is staging-only, unpublishes both forms, removes public access, ar
 
   const first = await active.rollover.cleanup({ targetCycle: '2026-08' });
   const second = await active.rollover.cleanup({ targetCycle: '2026-08' });
-  assert.equal(first.archivedCount, 2);
-  assert.equal(second.archivedCount, 2);
+  assert.equal(first.archivedCount, 4);
+  assert.equal(second.archivedCount, 4);
   for (const file of [
     google.managed(ROLLOVER_FILE_ROLES.SOURCE, '2026-07')[0],
     google.managed(ROLLOVER_FILE_ROLES.TARGET, '2026-08')[0],
@@ -3270,6 +3584,11 @@ test('cleanup is staging-only, unpublishes both forms, removes public access, ar
     );
     assert.deepEqual(file.parents, ['private-staging-archive']);
     assert.equal(file.appProperties.state, ROLLOVER_FILE_STATES.ARCHIVED);
+  }
+  for (const sheet of responseSheets) {
+    assert.deepEqual(sheet.parents, ['private-staging-archive']);
+    assert.equal(sheet.appProperties.state, ROLLOVER_FILE_STATES.ARCHIVED);
+    assert.deepEqual(google.sheetRows.get(sheet.id), responseRowsBeforeCleanup.get(sheet.id));
   }
   assert.equal((await active.rollover.verify({ targetCycle: '2026-08', mode: 'cleaned' })).status, 'valid');
 

--- a/scrollprize.org/scripts/progress-prizes/schedule-github.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule-github.test.mjs
@@ -441,6 +441,16 @@ test('dispatch body is fixed, consecutive, prepared, and numeric', () => {
     'validate',
   );
 
+  assert.equal(
+    buildProductionDispatch({
+      operation: 'sync-responses',
+      sourceCycle: '2026-08',
+      targetCycle: '2026-09',
+      requestId: '20260806',
+    }).inputs.operation,
+    'sync-responses',
+  );
+
   for (const input of [
     { operation: 'none', sourceCycle: '2026-07', targetCycle: '2026-08', requestId: '1' },
     { operation: 'prepare', sourceCycle: '2026-07', targetCycle: '2026-09', requestId: '1' },

--- a/scrollprize.org/scripts/progress-prizes/schedule-workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule-workflow-contract.test.mjs
@@ -59,11 +59,12 @@ function literalRunScripts(workflow) {
   return scripts;
 }
 
-test('scheduler exposes only a real-clock manual smoke and four Pacific schedules', async () => {
+test('scheduler exposes only a real-clock manual smoke and five Pacific schedules', async () => {
   const workflow = await source(schedulePath);
   const triggers = workflow.slice(0, workflow.indexOf('\npermissions:'));
   const expectedCrons = [
     '17 6 * * *',
+    '27 7 * * *',
     '40 23 28-31 * *',
     '17 0 1 * *',
     '47 6 1-7 * *',
@@ -214,7 +215,7 @@ test('workflow wiring makes manual scheduler dispatch read-only dry-run only', a
     assert.equal(result.status, 0, result.stderr);
     const output = await readFile(outputPath, 'utf8');
     assert.match(output, /^operation=dry-run$/m);
-    assert.doesNotMatch(output, /^operation=(?:prepare|activate)$/m);
+    assert.doesNotMatch(output, /^operation=(?:prepare|sync-responses|activate)$/m);
   } finally {
     await rm(temporary, { recursive: true, force: true });
   }
@@ -247,7 +248,10 @@ test('dedupe and dispatch use only the tested fixed helper contract', async () =
   assert.match(helper, /expectedStatus: 200/);
   assert.match(helper, /redirect: 'error'/);
   assert.match(helper, /MAX_GITHUB_RESPONSE_BYTES = 256 \* 1024/);
-  assert.match(helper, /new Set\(\['validate', 'dry-run', 'prepare', 'activate'\]\)/);
+  assert.match(
+    helper,
+    /'validate',[\s\S]*'dry-run',[\s\S]*'prepare',[\s\S]*'sync-responses',[\s\S]*'activate'/,
+  );
   assert.match(helper, /'requested'[\s\S]*'queued'[\s\S]*'pending'[\s\S]*'waiting'[\s\S]*'in_progress'/);
   assert.match(
     helper,

--- a/scrollprize.org/scripts/progress-prizes/schedule.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule.mjs
@@ -13,6 +13,7 @@ import {
 
 export const SCHEDULE_CRONS = Object.freeze({
   PREPARE: '17 6 * * *',
+  SYNC_RESPONSES: '27 7 * * *',
   PRE_CUTOFF: '40 23 28-31 * *',
   EARLY_RECOVERY: '17 0 1 * *',
   LATE_RECOVERY: '47 6 1-7 * *',
@@ -26,6 +27,7 @@ export const SCHEDULE_OPERATIONS = Object.freeze({
   NONE: 'none',
   DRY_RUN: 'dry-run',
   PREPARE: 'prepare',
+  SYNC_RESPONSES: 'sync-responses',
   ACTIVATE: 'activate',
 });
 
@@ -35,6 +37,7 @@ export const SCHEDULE_REASONS = Object.freeze({
   SLOT_NOT_DUE: 'schedule-slot-not-due',
   MANUAL_DRY_RUN: 'manual-dry-run',
   PREPARATION: 'preparation-window',
+  RESPONSE_SYNC: 'response-sync',
   PRE_CUTOFF: 'pre-cutoff',
   EARLY_RECOVERY: 'early-recovery',
   LATE_RECOVERY: 'late-recovery',
@@ -79,6 +82,9 @@ function isLastDay(parts) {
 
 function cronWallTime(cron) {
   if (cron === SCHEDULE_CRONS.PREPARE) return Object.freeze({ hour: 6, minute: 17 });
+  if (cron === SCHEDULE_CRONS.SYNC_RESPONSES) {
+    return Object.freeze({ hour: 7, minute: 27 });
+  }
   if (cron === SCHEDULE_CRONS.PRE_CUTOFF) return Object.freeze({ hour: 23, minute: 40 });
   if (cron === SCHEDULE_CRONS.EARLY_RECOVERY) return Object.freeze({ hour: 0, minute: 17 });
   if (cron === SCHEDULE_CRONS.LATE_RECOVERY) return Object.freeze({ hour: 6, minute: 47 });
@@ -265,8 +271,9 @@ function scheduledActivationIsDue({ scheduledCron, observedAt, local }) {
  * instant and its trusted GitHub trigger context.
  *
  * Schedule slots are intentionally not interchangeable: only the daily 06:17
- * slot can prepare. The pre-cutoff and 00:17 slots retain first-day recovery;
- * the 06:47 slot retries the previous month's incomplete rollover on days 1–7.
+ * slot can prepare, and only the daily 07:27 slot can append responses. The
+ * pre-cutoff and 00:17 slots retain first-day recovery; the 06:47 slot retries
+ * the previous month's incomplete rollover on days 1–7.
  */
 export function planScheduleDispatch({
   now = new Date(),
@@ -289,6 +296,28 @@ export function planScheduleDispatch({
     return dispatchPlan({
       operation: SCHEDULE_OPERATIONS.DRY_RUN,
       reason: SCHEDULE_REASONS.MANUAL_DRY_RUN,
+      eventName,
+      scheduledCron: trustedCron,
+      observedAt,
+      sourceCycle,
+      targetCycle,
+      preparationOpensAt: subtractPacificCalendarDays(activationAt, PREPARATION_DAYS),
+      activationAt,
+    });
+  }
+
+  // Response mirroring is deliberately independent of the preparation and
+  // activation windows. It targets the form that should be active for the
+  // observed Pacific month. Production workflow concurrency suppresses this
+  // dispatch while a rollover is nonterminal, and the Google operation fails
+  // closed if the website and form are not exactly active for this cycle.
+  if (trustedCron === SCHEDULE_CRONS.SYNC_RESPONSES) {
+    const sourceCycle = currentPacificCycle;
+    const targetCycle = nextCycle(sourceCycle);
+    const activationAt = getCycleDeadline(sourceCycle).cutoffAt;
+    return dispatchPlan({
+      operation: SCHEDULE_OPERATIONS.SYNC_RESPONSES,
+      reason: SCHEDULE_REASONS.RESPONSE_SYNC,
       eventName,
       scheduledCron: trustedCron,
       observedAt,

--- a/scrollprize.org/scripts/progress-prizes/schedule.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/schedule.test.mjs
@@ -14,14 +14,45 @@ function plan(now, scheduledCron, eventName = 'schedule') {
   return planScheduleDispatch({ now, eventName, scheduledCron });
 }
 
-test('schedule constants use the four exact Pacific cron slots', () => {
+test('schedule constants use the five exact Pacific cron slots', () => {
   assert.deepEqual(SCHEDULE_CRONS, {
     PREPARE: '17 6 * * *',
+    SYNC_RESPONSES: '27 7 * * *',
     PRE_CUTOFF: '40 23 28-31 * *',
     EARLY_RECOVERY: '17 0 1 * *',
     LATE_RECOVERY: '47 6 1-7 * *',
   });
   assert.equal(PROGRESS_PRIZE_SCHEDULES, SCHEDULE_CRONS);
+});
+
+test('the daily response sync follows the current Pacific cycle in PDT and PST', () => {
+  for (const [now, sourceCycle, targetCycle, activationAt] of [
+    ['2026-08-06T14:27:00Z', '2026-08', '2026-09', '2026-09-01T07:00:00.000Z'],
+    ['2026-12-06T15:27:00Z', '2026-12', '2027-01', '2027-01-01T08:00:00.000Z'],
+    ['2027-01-01T15:27:00Z', '2027-01', '2027-02', '2027-02-01T08:00:00.000Z'],
+  ]) {
+    const sync = plan(now, SCHEDULE_CRONS.SYNC_RESPONSES);
+    assert.equal(sync.dispatch, true, now);
+    assert.equal(sync.operation, SCHEDULE_OPERATIONS.SYNC_RESPONSES, now);
+    assert.equal(sync.reason, SCHEDULE_REASONS.RESPONSE_SYNC, now);
+    assert.equal(sync.sourceCycle, sourceCycle, now);
+    assert.equal(sync.targetCycle, targetCycle, now);
+    assert.equal(sync.activationAt.toISOString(), activationAt, now);
+  }
+});
+
+test('the response-sync slot never substitutes for preparation or activation', () => {
+  const preparationWindow = plan(
+    '2026-07-28T14:27:00Z',
+    SCHEDULE_CRONS.SYNC_RESPONSES,
+  );
+  assert.equal(preparationWindow.operation, SCHEDULE_OPERATIONS.SYNC_RESPONSES);
+  assert.equal(preparationWindow.sourceCycle, '2026-07');
+
+  const firstDay = plan('2026-08-01T14:27:00Z', SCHEDULE_CRONS.SYNC_RESPONSES);
+  assert.equal(firstDay.operation, SCHEDULE_OPERATIONS.SYNC_RESPONSES);
+  assert.equal(firstDay.sourceCycle, '2026-08');
+  assert.equal(firstDay.targetCycle, '2026-09');
 });
 
 test('only the preparation slot dispatches during the seven-day window', () => {

--- a/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
+++ b/scrollprize.org/scripts/progress-prizes/workflow-contract.test.mjs
@@ -288,7 +288,7 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
     'the composite must receive protected values only through explicit inputs',
   );
   assert.doesNotMatch(rehearsal, /google-github-actions\/auth/);
-  assert.equal([...action.matchAll(/google-github-actions\/auth@/g)].length, 2);
+  assert.equal([...action.matchAll(/google-github-actions\/auth@/g)].length, 4);
   assert.match(action, /create_credentials_file: false/);
   assert.match(action, /export_environment_variables: false/);
   assert.match(action, /printf '::add-mask::%s\\n' "\$value"/);
@@ -313,15 +313,23 @@ test('Google OIDC is confined to direct literal Environment jobs and one composi
     action,
     /test "\$PROGRESS_PRIZE_FOLDER_ID" = "\$PROGRESS_PRIZE_STAGING_FOLDER_ID"/,
   );
-  assert.equal([...action.matchAll(/access_token_lifetime: 1200s/g)].length, 2);
+  assert.equal([...action.matchAll(/access_token_lifetime: 1200s/g)].length, 4);
   assert.doesNotMatch(action, /access_token_scopes: >-/);
   assert.match(
     action,
-    /access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\.readonly/,
+    /access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.responses\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/spreadsheets\.readonly/,
   );
   assert.match(
     action,
-    /access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\n/,
+    /access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.responses\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\n\s+https:\/\/www\.googleapis\.com\/auth\/spreadsheets\n/,
+  );
+  assert.match(
+    action,
+    /Authenticate append-only response sync without a credential file[\s\S]*access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.responses\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\n\s+https:\/\/www\.googleapis\.com\/auth\/spreadsheets\n/,
+  );
+  assert.match(
+    action,
+    /Authenticate marker-only reconciliation without a credential file[\s\S]*access_token_scopes: \|-\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.body\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/forms\.responses\.readonly\n\s+https:\/\/www\.googleapis\.com\/auth\/drive\n\s+https:\/\/www\.googleapis\.com\/auth\/spreadsheets\.readonly\n/,
   );
   assert.doesNotMatch(action, /drive\.file/);
   assert.match(action, /automation-cli\.mjs/);


### PR DESCRIPTION
## Summary

- create one private, fingerprint-bound Google Spreadsheet for each managed monthly Form
- mirror Form responses append-only by stable response ID while keeping Google Forms canonical
- leave every legacy linked Sheet and all existing responses untouched
- perform a final source sync after closing it and before opening the next form
- add a guarded manual and daily `sync-responses` production operation with isolated WIF scopes

## Safety properties

- no response update, clear, delete, sort, replacement, or production file-move API exists
- existing linked-Sheet cells, ACLs, filenames, folders, and linkage are never accessed for mutation
- ambiguous appends recover by rescanning response IDs before retry
- only counts and the intentionally public responder URL can cross the protected job boundary
- no Google credential or private identifier is committed

## Verification

- `node --test "scripts/progress-prizes/**/*.test.mjs" "src/components/atlas/**/*.test.js"` (327 tests passed)
- all Progress Prize `.mjs` files pass `node --check`
- all Progress Prize workflow/action YAML parses successfully
- workflow contract tests validate Bash syntax, immutable action pins, OIDC isolation, scopes, and scheduler wiring
- `git diff --check` passed
- protected-value leakage scan passed