### PR TITLE
Spiral: opt-in self-intersection census at preview publication

### DIFF
--- a/volume-cartographer/scripts/spiral/spiral_service.py
+++ b/volume-cartographer/scripts/spiral/spiral_service.py
@@ -704,6 +704,164 @@ def _find_lasagna_service():
         "set LASAGNA_SERVICE_PATH")
 
 
+class PreviewSelfcrossRejected(RuntimeError):
+    """A flattened preview was withheld by the self-intersection policy."""
+
+
+# A hung census must not hang publication forever: past this the run is
+# state "error", which fails closed in reject mode.
+SELFCROSS_TIMEOUT_SECONDS = 3600
+
+
+def _find_selfcross_tool():
+    """Locate vc_tifxyz_selfcross, or None when it is not installed.
+
+    VC_SELFCROSS_PATH wins when set; a set-but-missing path is an error
+    rather than a silent fallback, so a typo cannot quietly disable the
+    check. Otherwise the tool is taken from PATH.
+    """
+    configured = str(os.environ.get("VC_SELFCROSS_PATH") or "").strip()
+    if configured:
+        candidate = Path(configured).expanduser()
+        if not candidate.is_file():
+            raise RuntimeError(
+                f"VC_SELFCROSS_PATH is set but not a file: {candidate}")
+        return candidate.resolve()
+    found = shutil.which("vc_tifxyz_selfcross")
+    return Path(found).resolve() if found else None
+
+
+def _census_flattened_preview(surface_dir, output_dir, tool=None):
+    """Census a flattened tifxyz for transverse self-intersection.
+
+    Runs vc_tifxyz_selfcross (both quad triangulations) on the surface,
+    writing its JSON report and point collection into ``output_dir``.
+    Returns a manifest-ready summary whose ``state`` is one of:
+
+    - ``clean``   -- census ran; zero transverse contacts either diagonal
+    - ``dirty``   -- census ran; transverse contacts exist
+    - ``not_run`` -- the tool is not installed
+    - ``error``   -- the tool failed or produced an unreadable report
+
+    Never raises; policy decisions belong to the caller.
+    """
+    summary = {"state": "not_run", "tool": None, "report": None,
+               "collection": None, "transverse": None, "detail": None}
+    try:
+        if tool is None:
+            tool = _find_selfcross_tool()
+    except RuntimeError as exc:
+        summary["state"] = "error"
+        summary["detail"] = str(exc)
+        return summary
+    if tool is None:
+        summary["detail"] = ("vc_tifxyz_selfcross not found; install it or "
+                             "set VC_SELFCROSS_PATH")
+        return summary
+    # Only the basename is published: the manifest travels with the
+    # preview, and an absolute executable path is host detail, not census
+    # provenance.
+    summary["tool"] = Path(tool).name
+    report_path = Path(output_dir) / "selfcross-report.json"
+    collection_path = Path(output_dir) / "selfcross-sites.json"
+
+    def failed(detail):
+        # Never leave partial diagnostics behind: a report the summary
+        # does not vouch for must not ship inside the generation.
+        report_path.unlink(missing_ok=True)
+        collection_path.unlink(missing_ok=True)
+        summary["state"] = "error"
+        summary["detail"] = detail
+        return summary
+
+    try:
+        proc = subprocess.run(
+            [str(tool), str(surface_dir), "-o", str(report_path),
+             "--collection", str(collection_path)],
+            capture_output=True, text=True,
+            timeout=SELFCROSS_TIMEOUT_SECONDS)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return failed(f"vc_tifxyz_selfcross failed to run: {exc}")
+    if proc.returncode != 0:
+        return failed(f"vc_tifxyz_selfcross exited "
+                      f"{proc.returncode}: {proc.stderr[-500:]}")
+    # The report is validated, not trusted: cleanliness is derived from
+    # the per-diagonal counts, and the tool's own clean flag must agree
+    # with them or the whole census is an error.
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        census = report["census"]
+        if not isinstance(census, list) or len(census) != 2:
+            raise ValueError("expected exactly 2 census entries")
+        transverse = {}
+        for entry in census:
+            diagonal = entry["diagonal"]
+            if diagonal not in (0, 1) or f"d{diagonal}" in transverse:
+                raise ValueError(f"unexpected diagonal record: {diagonal!r}")
+            count = entry["transverse"]
+            if isinstance(count, bool) or not isinstance(count, int) \
+                    or count < 0:
+                raise ValueError(
+                    f"bad transverse count for diagonal {diagonal}: "
+                    f"{count!r}")
+            transverse[f"d{diagonal}"] = count
+        clean = report["clean_of_transverse_self_intersection"]
+        if not isinstance(clean, bool):
+            raise ValueError(f"clean flag is not boolean: {clean!r}")
+        if clean != (transverse["d0"] == 0 and transverse["d1"] == 0):
+            raise ValueError(
+                f"clean flag {clean} contradicts counts {transverse}")
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        return failed(f"invalid selfcross report: {exc}")
+    summary["state"] = "clean" if clean else "dirty"
+    summary["report"] = report_path.name
+    if collection_path.is_file():
+        summary["collection"] = collection_path.name
+    summary["transverse"] = transverse
+    return summary
+
+
+def _apply_preview_selfcross_policy(policy, surface_dir, publish_root,
+                                    publish_parent, generation, published):
+    """Enforce the preview self-intersection policy at the commit boundary.
+
+    ``off`` returns immediately and touches nothing. Otherwise the census
+    summary is recorded in the ``published`` manifest dict, and in
+    ``reject`` mode any state other than ``clean`` raises
+    PreviewSelfcrossRejected -- after writing the rejection evidence to
+    ``publish_parent``, which survives the staging directory's cleanup.
+    """
+    if policy == "off":
+        return None
+    summary = _census_flattened_preview(surface_dir, publish_root)
+    summary["policy"] = policy
+    published["selfcross"] = summary
+    if policy == "reject" and summary["state"] != "clean":
+        evidence = dict(summary)
+        evidence["generation"] = int(generation)
+        report_name = summary.get("report")
+        if report_name:
+            try:
+                evidence["report_json"] = json.loads(
+                    (Path(publish_root) / report_name).read_text(
+                        encoding="utf-8"))
+            except (OSError, ValueError):
+                pass
+        # Unique per attempt: a crash/restart retry of the same generation
+        # must add evidence, never overwrite it.
+        evidence_path = Path(publish_parent) / (
+            f"generation-{generation}.selfcross-rejection-"
+            f"{secrets.token_hex(4)}.json")
+        evidence_path.write_text(json.dumps(evidence, indent=2) + "\n",
+                                 encoding="utf-8")
+        raise PreviewSelfcrossRejected(
+            f"Refusing to publish preview generation {generation}: "
+            f"self-intersection census state is {summary['state']!r} "
+            f"({summary.get('detail') or summary.get('transverse')}); "
+            f"evidence at {evidence_path}")
+    return summary
+
+
 def _md5_file(path):
     digest = hashlib.md5(usedforsecurity=False)
     with Path(path).open("rb") as stream:
@@ -1102,7 +1260,8 @@ def _stop_process_group(process):
 
 class ServiceState:
     def __init__(self, dataset_root=None, dataset_resolution=None,
-                 service_name=None, session_name="", logs=None, gpu_ids=(0,)):
+                 service_name=None, session_name="", logs=None, gpu_ids=(0,),
+                 preview_selfcross="off"):
         self.lock = threading.RLock()
         self.session = None
         self.session_id = None
@@ -1123,6 +1282,7 @@ class ServiceState:
         self.session_name = str(session_name or "")
         self.logs = logs if logs is not None else ServiceLogBuffer()
         self.gpu_ids = tuple(gpu_ids)
+        self.preview_selfcross = str(preview_selfcross or "off")
         self.artifacts = ArtifactRegistry()
         self.uploads = {}
         self.ephemeral_records = []
@@ -2099,6 +2259,15 @@ class ServiceState:
                     published.pop("run_diff", None)
                 else:
                     published["run_diff"] = run_diff
+                selfcross_policy = getattr(self, "preview_selfcross", "off")
+                if selfcross_policy != "off":
+                    start_stage(
+                        "finalizing",
+                        "Censusing preview for self-intersection",
+                        step=0, total_steps=0, overall_progress=0.0)
+                    _apply_preview_selfcross_policy(
+                        selfcross_policy, flattened_surface, publish_root,
+                        publish_parent, generation, published)
                 (publish_root / "manifest.json").write_text(
                     json.dumps(published, indent=2) + "\n",
                     encoding="utf-8")
@@ -2950,6 +3119,14 @@ def main(argv=None):
     parser.add_argument(
         "--gpus", type=parse_gpu_ids, default=(0,), metavar="DEVICE[,DEVICE...]",
         help="Physical CUDA device indices to use (default: 0; example: 0,1,2,3)")
+    parser.add_argument(
+        "--preview-selfcross", choices=("off", "report", "reject"),
+        default="off",
+        help="Self-intersection census of the flattened preview at "
+             "publication (vc_tifxyz_selfcross, both triangulations). "
+             "'report' records the result in the preview manifest; "
+             "'reject' additionally withholds publication unless the "
+             "census is clean, keeping the previous preview. Default off.")
     args = parser.parse_args(argv)
 
     # fit_spiral and Torch are imported lazily when a session is loaded. Narrow
@@ -3025,7 +3202,8 @@ def main(argv=None):
                          service_name=args.service_name,
                          session_name=args.session_name or "",
                          logs=logs,
-                         gpu_ids=args.gpus)
+                         gpu_ids=args.gpus,
+                         preview_selfcross=args.preview_selfcross)
     # A stable, operator-chosen port must survive TIME_WAIT restarts; an
     # ephemeral port must not reuse an address it did not own.
     SpiralServer.allow_reuse_address = args.port != 0

--- a/volume-cartographer/scripts/spiral/tests/test_spiral_selfcross.py
+++ b/volume-cartographer/scripts/spiral/tests/test_spiral_selfcross.py
@@ -1,0 +1,285 @@
+"""Tests for the preview self-intersection publication policy.
+
+The census tool is faked with small executables so every state the policy
+distinguishes -- clean, dirty, tool failure, tool absent -- is exercised
+without a compiled vc_tifxyz_selfcross or a Lasagna run. The one contract
+these tests pin above all others: ``off`` touches nothing, and a rejection
+leaves the previously published preview exactly as it was.
+"""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from spiral_service import (PreviewSelfcrossRejected,
+                            _apply_preview_selfcross_policy,
+                            _census_flattened_preview,
+                            _find_selfcross_tool)
+
+CLEAN_REPORT = {
+    "clean_of_transverse_self_intersection": True,
+    "census": [
+        {"diagonal": 0, "transverse": 0},
+        {"diagonal": 1, "transverse": 0},
+    ],
+}
+DIRTY_REPORT = {
+    "clean_of_transverse_self_intersection": False,
+    "census": [
+        {"diagonal": 0, "transverse": 12},
+        {"diagonal": 1, "transverse": 9},
+    ],
+}
+
+
+def _tree_digest(root):
+    digest = hashlib.sha256()
+    for path in sorted(Path(root).rglob("*")):
+        digest.update(str(path.relative_to(root)).encode())
+        if path.is_file():
+            digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+class SelfcrossFixture(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="spiral_selfcross_test_"))
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self.surface = self.root / "surface-lasagna.tifxyz"
+        self.surface.mkdir()
+        (self.surface / "meta.json").write_text("{}")
+        self.publish_parent = self.root / "published"
+        self.publish_parent.mkdir()
+        self.publish_root = self.publish_parent / ".generation-2.incoming"
+        self.publish_root.mkdir()
+        (self.publish_root / "loss.png").write_bytes(b"loss")
+
+    def fake_tool(self, report=None, exit_code=0, with_collection=True):
+        """An executable standing in for vc_tifxyz_selfcross."""
+        tool = self.root / "fake_selfcross"
+        payload = json.dumps(report or {})
+        lines = ["#!/bin/sh"]
+        if report is not None:
+            lines.append(f"cat > \"$3\" <<'JSON'\n{payload}\nJSON")
+        if with_collection and report is not None:
+            lines.append('printf \'{"collections": {}}\' > "$5"')
+        lines.append(f"exit {exit_code}")
+        tool.write_text("\n".join(lines) + "\n")
+        tool.chmod(tool.stat().st_mode | stat.S_IXUSR)
+        return tool
+
+    def apply(self, policy, tool, generation=2, published=None):
+        published = published if published is not None else {}
+        with mock.patch.dict(os.environ,
+                             {"VC_SELFCROSS_PATH": str(tool)} if tool
+                             else {}, clear=False):
+            if tool is None:
+                os.environ.pop("VC_SELFCROSS_PATH", None)
+            _apply_preview_selfcross_policy(
+                policy, self.surface, self.publish_root,
+                self.publish_parent, generation, published)
+        return published
+
+
+class CleanPreviewPublishes(SelfcrossFixture):
+    def test_reject_mode_passes_a_clean_census_through(self):
+        tool = self.fake_tool(CLEAN_REPORT)
+        published = self.apply("reject", tool)
+        entry = published["selfcross"]
+        self.assertEqual(entry["state"], "clean")
+        self.assertEqual(entry["policy"], "reject")
+        self.assertEqual(entry["transverse"], {"d0": 0, "d1": 0})
+        self.assertEqual(entry["report"], "selfcross-report.json")
+        self.assertEqual(entry["collection"], "selfcross-sites.json")
+        self.assertEqual(entry["tool"], "fake_selfcross")
+        # both artifacts live inside the generation being published
+        self.assertTrue((self.publish_root / "selfcross-report.json").is_file())
+        self.assertTrue((self.publish_root / "selfcross-sites.json").is_file())
+        # nothing was withheld: no rejection evidence appeared
+        self.assertEqual(
+            list(self.publish_parent.glob("*.selfcross-rejection-*.json")), [])
+
+
+class CrossingPreviewIsWithheld(SelfcrossFixture):
+    def test_reject_mode_raises_before_promotion_with_evidence(self):
+        tool = self.fake_tool(DIRTY_REPORT)
+        with self.assertRaises(PreviewSelfcrossRejected):
+            self.apply("reject", tool)
+        candidates = sorted(self.publish_parent.glob(
+            "generation-2.selfcross-rejection-*.json"))
+        self.assertEqual(len(candidates), 1,
+                         "rejection evidence must survive staging cleanup")
+        evidence = json.loads(candidates[0].read_text())
+        self.assertEqual(evidence["state"], "dirty")
+        self.assertEqual(evidence["generation"], 2)
+        self.assertEqual(evidence["transverse"], {"d0": 12, "d1": 9})
+        self.assertFalse(
+            evidence["report_json"]["clean_of_transverse_self_intersection"])
+
+
+class ReportModePublishesWithDiagnostics(SelfcrossFixture):
+    def test_dirty_census_is_recorded_but_never_blocks(self):
+        tool = self.fake_tool(DIRTY_REPORT)
+        published = self.apply("report", tool)   # must not raise
+        entry = published["selfcross"]
+        self.assertEqual(entry["state"], "dirty")
+        self.assertEqual(entry["transverse"], {"d0": 12, "d1": 9})
+        self.assertTrue((self.publish_root / "selfcross-report.json").is_file())
+        self.assertEqual(
+            list(self.publish_parent.glob("*.selfcross-rejection-*.json")), [])
+
+    def test_tool_failure_is_recorded_but_never_blocks(self):
+        tool = self.fake_tool(report=None, exit_code=1)
+        published = self.apply("report", tool)   # must not raise
+        self.assertEqual(published["selfcross"]["state"], "error")
+
+
+class ToolFailureDoesNotPublish(SelfcrossFixture):
+    def test_reject_mode_fails_closed_on_tool_error(self):
+        tool = self.fake_tool(report=None, exit_code=1)
+        with self.assertRaises(PreviewSelfcrossRejected):
+            self.apply("reject", tool)
+        evidence = json.loads(next(self.publish_parent.glob(
+            "generation-2.selfcross-rejection-*.json")).read_text())
+        self.assertEqual(evidence["state"], "error")
+
+    def test_reject_mode_fails_closed_when_tool_is_absent(self):
+        with mock.patch("spiral_service.shutil.which", return_value=None):
+            with self.assertRaises(PreviewSelfcrossRejected):
+                self.apply("reject", None)
+        evidence = json.loads(next(self.publish_parent.glob(
+            "generation-2.selfcross-rejection-*.json")).read_text())
+        self.assertEqual(evidence["state"], "not_run")
+
+    def test_unreadable_report_is_an_error(self):
+        tool = self.fake_tool({"unexpected": "shape"})
+        summary = _census_flattened_preview(
+            self.surface, self.publish_root, tool=tool)
+        self.assertEqual(summary["state"], "error")
+        self.assertIn("invalid selfcross report", summary["detail"])
+
+
+class ReportSchemaIsValidatedNotTrusted(SelfcrossFixture):
+    """R49: cleanliness derives from validated counts; the tool's own
+    flag must agree with them, and partial diagnostics never ship."""
+
+    MISSING_DIAGONAL = {
+        "clean_of_transverse_self_intersection": True,
+        "census": [{"diagonal": 0, "transverse": 0}],
+    }
+    LYING_CLEAN_FLAG = {
+        "clean_of_transverse_self_intersection": True,
+        "census": [
+            {"diagonal": 0, "transverse": 3},
+            {"diagonal": 1, "transverse": 0},
+        ],
+    }
+
+    def test_missing_diagonal_is_an_error_and_fails_closed(self):
+        tool = self.fake_tool(self.MISSING_DIAGONAL)
+        summary = _census_flattened_preview(
+            self.surface, self.publish_root, tool=tool)
+        self.assertEqual(summary["state"], "error")
+        with self.assertRaises(PreviewSelfcrossRejected):
+            self.apply("reject", tool)
+
+    def test_clean_flag_contradicting_counts_is_an_error_and_fails_closed(
+            self):
+        tool = self.fake_tool(self.LYING_CLEAN_FLAG)
+        summary = _census_flattened_preview(
+            self.surface, self.publish_root, tool=tool)
+        self.assertEqual(summary["state"], "error")
+        self.assertIn("contradicts", summary["detail"])
+        with self.assertRaises(PreviewSelfcrossRejected):
+            self.apply("reject", tool)
+
+    def test_failed_census_leaves_no_partial_diagnostics(self):
+        # a valid report written, then the tool dies (e.g. while writing
+        # the point collection): nothing may remain in the generation
+        tool = self.fake_tool(CLEAN_REPORT, exit_code=1)
+        summary = _census_flattened_preview(
+            self.surface, self.publish_root, tool=tool)
+        self.assertEqual(summary["state"], "error")
+        self.assertFalse(
+            (self.publish_root / "selfcross-report.json").exists())
+        self.assertFalse(
+            (self.publish_root / "selfcross-sites.json").exists())
+
+    def test_invalid_report_is_also_cleaned_up(self):
+        tool = self.fake_tool(self.LYING_CLEAN_FLAG)
+        _census_flattened_preview(self.surface, self.publish_root, tool=tool)
+        self.assertFalse(
+            (self.publish_root / "selfcross-report.json").exists())
+        self.assertFalse(
+            (self.publish_root / "selfcross-sites.json").exists())
+
+
+class OffIsByteIdentical(SelfcrossFixture):
+    def test_off_touches_neither_staging_nor_manifest_nor_environment(self):
+        # a tool that would explode if ever invoked (created BEFORE the
+        # baseline digest so only the policy could change the tree)
+        bomb = self.fake_tool(report=None, exit_code=99)
+        before = _tree_digest(self.root)
+        published = {"surface_id": "s", "schema_version": 3}
+        manifest_before = dict(published)
+        result = _apply_preview_selfcross_policy(
+            "off", self.surface, self.publish_root,
+            self.publish_parent, 2, published)
+        self.assertIsNone(result)
+        self.assertEqual(published, manifest_before)
+        self.assertEqual(_tree_digest(self.root), before,
+                         "'off' must leave every byte untouched")
+        self.assertNotIn("selfcross", published)
+        del bomb
+
+
+class EarlierPreviewSurvivesRejection(SelfcrossFixture):
+    def test_generation_1_is_untouched_when_generation_2_is_rejected(self):
+        # generation-1 was published earlier and must not change
+        final_1 = self.publish_parent / "generation-1"
+        final_1.mkdir()
+        (final_1 / "manifest.json").write_text(
+            json.dumps({"surface_id": "gen1"}))
+        (final_1 / "surface.bin").write_bytes(b"gen1-bytes")
+        gen1_before = _tree_digest(final_1)
+
+        tool = self.fake_tool(DIRTY_REPORT)
+        with self.assertRaises(PreviewSelfcrossRejected):
+            self.apply("reject", tool)
+        # mimic the service's failure path: staging is discarded
+        shutil.rmtree(self.publish_root, ignore_errors=True)
+
+        self.assertEqual(_tree_digest(final_1), gen1_before,
+                         "a rejection must not disturb the published preview")
+        self.assertFalse((self.publish_parent / "generation-2").exists(),
+                         "the rejected generation must never be promoted")
+        self.assertEqual(len(list(self.publish_parent.glob(
+            "generation-2.selfcross-rejection-*.json"))), 1)
+
+
+class ToolDiscovery(unittest.TestCase):
+    def test_set_but_missing_override_is_an_error_not_a_fallback(self):
+        with mock.patch.dict(os.environ,
+                             {"VC_SELFCROSS_PATH": "/nonexistent/tool"}):
+            with self.assertRaises(RuntimeError):
+                _find_selfcross_tool()
+
+    def test_absent_tool_resolves_to_none(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VC_SELFCROSS_PATH", None)
+            with mock.patch("spiral_service.shutil.which",
+                            return_value=None):
+                self.assertIsNone(_find_selfcross_tool())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Spiral service publishes Lasagna-flattened previews with an atomic generation promotion, and the previous good preview already survives any pre-promotion failure. This adds an opt-in policy that reports transverse self-intersections at that boundary or withholds a preview unless the census is clean.

`--preview-selfcross off|report|reject` (default `off`, publication path untouched). In `report` mode the flattened surface is censused with `vc_tifxyz_selfcross` under both quad triangulations and the result is recorded in the preview manifest (state, per-diagonal transverse counts) and, when the census completes successfully, the JSON report and point collection are stored inside the generation, so the sites can be inspected in VC3D. In `reject` mode publication is additionally withheld unless the census is clean: tool failures fail closed, rejection evidence is written next to the published generations, and the previously published preview stays available. The tool resolves from `VC_SELFCROSS_PATH` or `PATH`; a set-but-missing override is an error rather than a silent fallback. The report is validated rather than trusted: exactly two diagonal records with non-negative integer counts, and a clean flag that agrees with them, or the census is an error and its partial diagnostics are removed. No repair logic: report or refuse, never modify.

Tests: 15 new unit tests cover all four census states, fail-closed rejection, durable evidence, byte-identical `off`, schema validation (including a clean flag contradicting its own counts), partial-diagnostic cleanup, and survival of the earlier preview across a rejection. They use fake tool executables, so no compiled binary or Lasagna run is needed. With the real binary: a known self-crossing trace censuses dirty (4 and 7 transverse contacts by diagonal) in 0.5s and a clean surface censuses clean in 0.4s. Both smoke inputs completed in under a second; these timings are integration checks, not a benchmark of full Spiral previews.