### PR TITLE
VC3D: anchor line annotation cut views to the sampled sheet normals

### DIFF
--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -9361,6 +9361,88 @@ void LineAnnotationController::updateGeneratedViewMetricsForFiber(uint64_t fiber
     }
 }
 
+std::vector<cv::Vec3f> LineAnnotationController::orientedLineNormalsForSession(
+    const LineAnnotationSession& session)
+{
+    constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
+    std::vector<cv::Vec3f> normals;
+    normals.reserve(session.optimizedLine.points.size());
+
+    std::shared_ptr<Volume> volume;
+    try {
+        volume = _state ? _state->currentVolume() : nullptr;
+    } catch (...) {
+        volume.reset();
+    }
+
+    fs::path volpkgRoot;
+    if (_state && _state->vpkg()) {
+        auto vpkg = _state->vpkg();
+        volpkgRoot = vpkg->path().empty()
+            ? fs::path(vpkg->getVolpkgDirectory())
+            : vpkg->path().parent_path();
+    }
+    if (!_scrollUmbilicusLoadAttempted || volpkgRoot != _scrollUmbilicusRoot) {
+        _scrollUmbilicusLoadAttempted = true;
+        _scrollUmbilicusRoot = volpkgRoot;
+        _scrollUmbilicus.reset();
+        try {
+            if (!volpkgRoot.empty() && volume) {
+                const cv::Vec3i volumeShape{volume->numSlices(),
+                                            volume->sliceHeight(),
+                                            volume->sliceWidth()};
+                for (const char* name : {"umbilicus.json", "estimated_umbilicus.json"}) {
+                    const fs::path candidate = volpkgRoot / name;
+                    if (fs::exists(candidate)) {
+                        _scrollUmbilicus =
+                            vc::core::util::Umbilicus::FromFile(candidate, volumeShape);
+                        break;
+                    }
+                }
+            }
+        } catch (...) {
+            _scrollUmbilicus.reset();
+        }
+    }
+
+    cv::Vec2f volumeCenterXY{kNan, kNan};
+    if (volume) {
+        volumeCenterXY = {static_cast<float>(volume->sliceWidth()) * 0.5f,
+                          static_cast<float>(volume->sliceHeight()) * 0.5f};
+    }
+
+    for (const auto& point : session.optimizedLine.points) {
+        const cv::Vec3d sampled = normalizedOrZero(point.sampledNormal.normal);
+        if (!point.sampledNormal.valid || !finiteDirection(sampled)) {
+            normals.push_back({kNan, kNan, kNan});
+            continue;
+        }
+        cv::Vec3f normal = toVec3f(sampled);
+        const cv::Vec3f position = toVec3f(point.position);
+        cv::Vec3f towardCenter{kNan, kNan, kNan};
+        if (_scrollUmbilicus) {
+            try {
+                towardCenter = _scrollUmbilicus->vector_to_umbilicus(position);
+            } catch (...) {
+            }
+        }
+        if (!std::isfinite(towardCenter[0]) && std::isfinite(volumeCenterXY[0])) {
+            towardCenter = {volumeCenterXY[0] - position[0],
+                            volumeCenterXY[1] - position[1],
+                            0.0f};
+        }
+        // Sign convention: normals point away from the scroll center. The
+        // dialog uses them directly as the cut view's up hint, and the
+        // viewer's scene y renders downward, so this puts the fiber's
+        // center-facing surface at the top of the view.
+        if (std::isfinite(towardCenter[0]) && normal.dot(towardCenter) > 0.0f) {
+            normal = -normal;
+        }
+        normals.push_back(normal);
+    }
+    return normals;
+}
+
 bool LineAnnotationController::materializeGeneratedViews(LineAnnotationSession& session)
 {
     if (!_state) {
@@ -9422,6 +9504,7 @@ bool LineAnnotationController::materializeGeneratedViews(LineAnnotationSession& 
     generatedViews.lineSideSlice = views.lineSideSlice;
     generatedViews.linePoints = std::move(linePoints);
     generatedViews.lineUpVectors = views.lineUpVectors;
+    generatedViews.lineNormals = orientedLineNormalsForSession(session);
     generatedViews.branchLinePoints = generatedBranchLinePointsForSession(session);
     generatedViews.branchLinks = generatedBranchLinkMarkers(session.branches);
     generatedViews.seedPoint = seedPoint;

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -26,6 +26,7 @@
 #include "LineAnnotationFiberSegments.hpp"
 #include "LineAnnotationGeneratedViews.hpp"
 #include "vc/atlas/FiberIntersections.hpp"
+#include "vc/core/util/Umbilicus.hpp"
 #include "vc/lasagna/LineOptimizer.hpp"
 #include "volume_viewers/CChunkedVolumeViewer.hpp"
 
@@ -549,6 +550,11 @@ private:
                                          std::optional<std::vector<size_t>> dirtySegments = std::nullopt,
                                          bool globalGoalsOnly = false) const;
     void finishOptimization(const std::string& surfaceName);
+    // Per-line-point sampled sheet normals, sign-oriented away from the
+    // scroll center (umbilicus when available, volume XY center otherwise);
+    // NaN entries mark invalid samples.
+    [[nodiscard]] std::vector<cv::Vec3f> orientedLineNormalsForSession(
+        const LineAnnotationSession& session);
     bool materializeGeneratedViews(LineAnnotationSession& session);
     bool materializeGeneratedViews(LineAnnotationSession& session,
                                    const std::string& surfacePrefix);
@@ -796,6 +802,13 @@ private:
     bool _fiberMetricsPending = false;
     std::unique_ptr<IntersectionInspectionSession> _intersectionInspection;
     std::unique_ptr<FiberSliceOverlayController> _fiberSliceOverlay;
+    // Scroll-center reference for orienting generated-view normals; loaded
+    // lazily from the volpkg's umbilicus file and re-attempted when the
+    // volpkg root changes. nullopt after a failed attempt (volume-center
+    // fallback is used instead).
+    std::optional<vc::core::util::Umbilicus> _scrollUmbilicus;
+    std::filesystem::path _scrollUmbilicusRoot;
+    bool _scrollUmbilicusLoadAttempted = false;
     std::deque<FiberSaveJob> _pendingFiberSaveJobs;
     QPointer<QFutureWatcher<FiberSaveTaskResult>> _fiberSaveWatcher;
     uint64_t _nextFiberSaveSequence = 0;

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -1,7 +1,6 @@
 #include "LineAnnotationDialog.hpp"
 
 #include "FiberNameDisplay.hpp"
-#include "FiberSliceGeometry.hpp"
 #include "Keybinds.hpp"
 #include "LineAnnotationGeneratedViews.hpp"
 #include "LineAnnotationShiftScroll.hpp"
@@ -62,7 +61,6 @@ namespace {
 // Half-width (in line-point indices) of the window used to least-squares-fit the side-view
 // plane orientation around the cursor. The fit is interpolated between adjacent window centers
 // so the orientation tracks the cursor continuously (see updateSidePlaneSurface).
-constexpr int kSideFitHalfWindow = 20;
 constexpr float kCurrentCutRotationStepRadians = 3.14159265358979323846f / 36.0f;
 constexpr bool kGeneratedLineAnnotationOverlaysEnabled = true;
 constexpr char kGeneratedDynamicCurrentCutOverlayKey[] = "line-z-slice-current";
@@ -1386,13 +1384,6 @@ bool LineAnnotationDialog::setGeneratedLineViews(
 
         const double previousLinePosition = _currentLinePosition;
         _generatedViews = views;
-        _linePointsd.clear();
-        _linePointsd.reserve(_generatedViews.linePoints.size());
-        for (const auto& p : _generatedViews.linePoints) {
-            _linePointsd.emplace_back(p[0], p[1], p[2]);
-        }
-        _sideFitBracket[0] = SideFit{};
-        _sideFitBracket[1] = SideFit{};
         _generatedControlIndex =
             vc3d::line_annotation::buildGeneratedControlPointLinePositionIndex(
                 _generatedViews.controlPoints);
@@ -1602,13 +1593,6 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     _generatedTopWidget = nullptr;
 
     _generatedViews = views;
-    _linePointsd.clear();
-    _linePointsd.reserve(_generatedViews.linePoints.size());
-    for (const auto& p : _generatedViews.linePoints) {
-        _linePointsd.emplace_back(p[0], p[1], p[2]);
-    }
-    _sideFitBracket[0] = SideFit{};
-    _sideFitBracket[1] = SideFit{};
     _generatedControlIndex =
         vc3d::line_annotation::buildGeneratedControlPointLinePositionIndex(
             _generatedViews.controlPoints);
@@ -3494,6 +3478,54 @@ cv::Vec3f LineAnnotationDialog::interpolatedLineUp(double linePosition, const cv
     return normalizedOrNan(up);
 }
 
+cv::Vec3f LineAnnotationDialog::interpolatedOrientedNormal(double linePosition) const
+{
+    const cv::Vec3f nan{std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN()};
+    const auto& normals = _generatedViews.lineNormals;
+    if (normals.empty() || !std::isfinite(linePosition)) {
+        return nan;
+    }
+
+    const double position = std::clamp(
+        linePosition, 0.0, static_cast<double>(normals.size() - 1));
+    const int lower = static_cast<int>(std::floor(position));
+    const int upper = std::min<int>(lower + 1, static_cast<int>(normals.size()) - 1);
+    const cv::Vec3f lowerNormal = normals[static_cast<size_t>(lower)];
+    cv::Vec3f upperNormal = normals[static_cast<size_t>(upper)];
+    if (!finitePoint(lowerNormal) || !finitePoint(upperNormal) ||
+        cv::norm(lowerNormal) <= 1.0e-6f ||
+        cv::norm(upperNormal) <= 1.0e-6f) {
+        return nan;
+    }
+    if (lowerNormal.dot(upperNormal) < 0.0f) {
+        upperNormal = -upperNormal;
+    }
+
+    const float t = static_cast<float>(position - static_cast<double>(lower));
+    return normalizedOrNan(lowerNormal * (1.0f - t) + upperNormal * t);
+}
+
+cv::Vec3f LineAnnotationDialog::interpolatedLineNormal(double linePosition,
+                                                       const cv::Vec3f& tangent) const
+{
+    const cv::Vec3f nan{std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN(),
+                        std::numeric_limits<float>::quiet_NaN()};
+    cv::Vec3f up = interpolatedOrientedNormal(linePosition);
+    if (!finitePoint(up)) {
+        return nan;
+    }
+    up -= tangent * up.dot(tangent);
+    // A tiny projection means the sheet normal runs nearly along the tangent
+    // (extreme bend): the direction is unstable, so let the caller fall back.
+    if (cv::norm(up) <= 0.1f) {
+        return nan;
+    }
+    return normalizedOrNan(up);
+}
+
 bool LineAnnotationDialog::updatePlaneSurface(PlaneSurface* plane, double linePosition) const
 {
     if (!plane) {
@@ -3501,7 +3533,16 @@ bool LineAnnotationDialog::updatePlaneSurface(PlaneSurface* plane, double linePo
     }
     const cv::Vec3f origin = interpolatedLinePoint(linePosition);
     const cv::Vec3f tangent = interpolatedLineTangent(linePosition);
-    const cv::Vec3f upHint = interpolatedLineUp(linePosition, tangent);
+    // Display up for the cut: the sampled sheet normal, sign-oriented away
+    // from the scroll center (with the scene's y-down rendering this shows
+    // the sheet horizontal with the fiber's center-facing surface at the top
+    // of the view) -- and the orientation is a pure function of the line
+    // position. The transported line up remains the fallback where samples
+    // are missing or, at extreme bends, nearly parallel to the tangent.
+    cv::Vec3f upHint = interpolatedLineNormal(linePosition, tangent);
+    if (!finitePoint(upHint)) {
+        upHint = interpolatedLineUp(linePosition, tangent);
+    }
     if (!finitePoint(origin) || !finitePoint(tangent) || !finitePoint(upHint) ||
         cv::norm(tangent) <= 1.0e-6f ||
         cv::norm(upHint) <= 1.0e-6f) {
@@ -3524,137 +3565,38 @@ bool LineAnnotationDialog::updatePlaneSurface(PlaneSurface* plane, double linePo
     return true;
 }
 
-bool LineAnnotationDialog::computeSideFit(int center, cv::Vec3f& normal, cv::Vec3f& upHint) const
-{
-    const auto& linePoints = _generatedViews.linePoints;
-    const int count = static_cast<int>(linePoints.size());
-    if (count < 3) {
-        return false;
-    }
-    center = std::clamp(center, 0, count - 1);
-    const int first = std::max(0, center - kSideFitHalfWindow);
-    const int last = std::min(count - 1, center + kSideFitHalfWindow);
-
-    vc3d::fiber_slice::ControlSpanSelection span;
-    span.firstLineIndex = static_cast<size_t>(first);
-    span.lastLineIndex = static_cast<size_t>(last);
-    span.samples.reserve(static_cast<size_t>(last - first + 1));
-    cv::Vec3d centroid{0.0, 0.0, 0.0};
-    for (int i = first; i <= last; ++i) {
-        const cv::Vec3f& p = linePoints[static_cast<size_t>(i)];
-        if (!finitePoint(p)) {
-            continue;
-        }
-        const cv::Vec3d pd(p[0], p[1], p[2]);
-        span.samples.push_back(pd);
-        centroid += pd;
-    }
-    if (span.samples.size() < 3) {
-        return false;
-    }
-    span.centroid = centroid * (1.0 / static_cast<double>(span.samples.size()));
-    span.valid = true;
-
-    // fitLeastSquaresPlane reads linePoints[firstLineIndex/lastLineIndex] to derive the in-plane
-    // direction hint, so it needs the full polyline as cv::Vec3d. _linePointsd is the cached
-    // double-precision copy built once when the views were generated.
-    const auto fit = vc3d::fiber_slice::fitLeastSquaresPlane(span, _linePointsd);
-    if (!fit.valid) {
-        return false;
-    }
-    normal = cv::Vec3f(static_cast<float>(fit.normal[0]),
-                       static_cast<float>(fit.normal[1]),
-                       static_cast<float>(fit.normal[2]));
-    upHint = cv::Vec3f(static_cast<float>(fit.upHint[0]),
-                       static_cast<float>(fit.upHint[1]),
-                       static_cast<float>(fit.upHint[2]));
-    if (!finitePoint(normal) || !finitePoint(upHint) ||
-        cv::norm(normal) <= 1.0e-6f || cv::norm(upHint) <= 1.0e-6f) {
-        return false;
-    }
-    return true;
-}
-
-bool LineAnnotationDialog::updateSidePlaneSurface(PlaneSurface* plane, double linePosition)
+bool LineAnnotationDialog::updateSidePlaneSurface(PlaneSurface* plane, double linePosition) const
 {
     if (!plane) {
         return false;
     }
-    const int count = static_cast<int>(_generatedViews.linePoints.size());
-    if (count < 3) {
+    const cv::Vec3f origin = interpolatedLinePoint(linePosition);
+    const cv::Vec3f tangent = interpolatedLineTangent(linePosition);
+    if (!finitePoint(origin) || !finitePoint(tangent) ||
+        cv::norm(tangent) <= 1.0e-6f) {
         return false;
     }
-
-    // Continuous side-view orientation: fit the best-fit plane at the two integer window centers
-    // straddling the cursor and interpolate between them by the fractional position. Each fit
-    // depends only on the static line geometry, so we cache the two bracketing fits and recompute
-    // a center only when the straddle shifts (typically once per integer crossing). This keeps
-    // the orientation smooth -- no snapping at discrete window centers -- while staying cheap.
-    const double pos = std::clamp(linePosition, 0.0, static_cast<double>(count - 1));
-    const int lowerCenter = static_cast<int>(std::floor(pos));
-    const int upperCenter = std::min(lowerCenter + 1, count - 1);
-    const int wantCenters[2] = {lowerCenter, upperCenter};
-
-    SideFit next[2];
-    for (int slot = 0; slot < 2; ++slot) {
-        next[slot].center = wantCenters[slot];
-        bool reused = false;
-        for (const SideFit& cached : _sideFitBracket) {
-            if (cached.valid && cached.center == wantCenters[slot]) {
-                next[slot] = cached;
-                reused = true;
-                break;
-            }
-        }
-        if (!reused) {
-            next[slot].valid =
-                computeSideFit(wantCenters[slot], next[slot].normal, next[slot].upHint);
-        }
+    // The side cut is the current cut's frame rotated a quarter turn: the
+    // plane spanned by the line tangent and the (away-from-center oriented)
+    // sheet normal, viewed with the fiber vertical. A windowed PCA fit of
+    // the line was used here before, but its plane tumbles where the fiber's
+    // cross-fiber wander is nearly isotropic (no well-defined local fiber
+    // plane); the sheet frame is always defined and keeps both cut views
+    // consistent. normal = sheetNormal x tangent puts the stored sheet
+    // normal on the view's x axis, so the direction shown at the top of the
+    // current cut (toward the scroll center) points screen-left.
+    cv::Vec3f sheetNormal = interpolatedLineNormal(linePosition, tangent);
+    if (!finitePoint(sheetNormal)) {
+        sheetNormal = interpolatedLineUp(linePosition, tangent);
     }
-    _sideFitBracket[0] = next[0];
-    _sideFitBracket[1] = next[1];
-
-    cv::Vec3f normal;
-    cv::Vec3f upHint;
-    if (next[0].valid && next[1].valid) {
-        cv::Vec3f normal1 = next[1].normal;
-        cv::Vec3f upHint1 = next[1].upHint;
-        // PCA normals/up hints are sign-arbitrary; align the upper fit to the lower one before
-        // blending so interpolation doesn't cancel them out near a sign flip.
-        if (next[0].normal.dot(normal1) < 0.0f) {
-            normal1 = -normal1;
-        }
-        if (next[0].upHint.dot(upHint1) < 0.0f) {
-            upHint1 = -upHint1;
-        }
-        const float t = static_cast<float>(pos - static_cast<double>(lowerCenter));
-        normal = next[0].normal * (1.0f - t) + normal1 * t;
-        upHint = next[0].upHint * (1.0f - t) + upHint1 * t;
-    } else if (next[0].valid || next[1].valid) {
-        const SideFit& fit = next[0].valid ? next[0] : next[1];
-        normal = fit.normal;
-        upHint = fit.upHint;
-    } else {
+    if (!finitePoint(sheetNormal) || cv::norm(sheetNormal) <= 1.0e-6f) {
         return false;
     }
-
-    normal = normalizedOrNan(normal);
+    const cv::Vec3f normal = normalizedOrNan(sheetNormal.cross(tangent));
     if (!finitePoint(normal)) {
         return false;
     }
-    upHint -= normal * upHint.dot(normal);
-    upHint = normalizedOrNan(upHint);
-    if (!finitePoint(upHint)) {
-        return false;
-    }
-
-    // Keep the plane centered on the cursor position rather than a window centroid; the origin
-    // slides smoothly along the line while the interpolated orientation tracks it continuously.
-    const cv::Vec3f origin = interpolatedLinePoint(pos);
-    if (!finitePoint(origin)) {
-        return false;
-    }
-    plane->setFromNormalAndUp(origin, normal, upHint);
+    plane->setFromNormalAndUp(origin, normal, tangent);
     return true;
 }
 

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -310,11 +310,15 @@ private:
     cv::Vec3f interpolatedLinePoint(double linePosition) const;
     cv::Vec3f interpolatedLineTangent(double linePosition) const;
     cv::Vec3f interpolatedLineUp(double linePosition, const cv::Vec3f& tangent) const;
+    // Interpolated sampled sheet normal (oriented away from the scroll
+    // center, see GeneratedViews::lineNormals). NaN when samples are missing.
+    cv::Vec3f interpolatedOrientedNormal(double linePosition) const;
+    // The same normal projected perpendicular to the tangent. NaN when the
+    // projection is unstable (normal nearly parallel to the tangent, i.e.
+    // extreme bends).
+    cv::Vec3f interpolatedLineNormal(double linePosition, const cv::Vec3f& tangent) const;
     bool updatePlaneSurface(PlaneSurface* plane, double linePosition) const;
-    bool updateSidePlaneSurface(PlaneSurface* plane, double linePosition);
-    // Least-squares fit of the side-view plane orientation for the window centered on the given
-    // (integer) line index. Pure/cacheable: depends only on the static line geometry.
-    bool computeSideFit(int center, cv::Vec3f& normal, cv::Vec3f& upHint) const;
+    bool updateSidePlaneSurface(PlaneSurface* plane, double linePosition) const;
     QPointF stripLinePositionToScene(CChunkedVolumeViewer* viewer,
                                      QuadSurface* surface,
                                      double linePosition) const;
@@ -417,21 +421,6 @@ private:
     QPointer<QWidget> _overviewBar;
     QPointer<QLabel> _pauseIndicator;
     GeneratedViews _generatedViews;
-    // Double-precision copy of _generatedViews.linePoints, built once when views are
-    // generated so the per-cursor-move side plane fit doesn't reconvert the whole polyline.
-    std::vector<cv::Vec3d> _linePointsd;
-    // Cached side-view best-fit plane orientations for the two integer window centers that
-    // straddle the current fractional position. The fit depends only on the (static) line
-    // geometry, so we recompute a center only when the straddling bracket shifts; between the
-    // two cached fits we interpolate by the fractional position so the side view re-orients
-    // continuously instead of snapping at discrete window centers.
-    struct SideFit {
-        int center = std::numeric_limits<int>::min();
-        cv::Vec3f normal{0.0f, 0.0f, 0.0f};
-        cv::Vec3f upHint{0.0f, 0.0f, 0.0f};
-        bool valid = false;
-    };
-    SideFit _sideFitBracket[2];
     bool _hasGeneratedViews = false;
     // Coalescing of the mouse-follow line-position updates onto a ~render-tick cadence.
     // requestCurrentLinePosition() stashes the latest position here and (re)arms the timer;

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
@@ -177,6 +177,10 @@ struct GeneratedViews {
     std::shared_ptr<PlaneSurface> sideCutSurface;
     std::vector<cv::Vec3f> linePoints;
     std::vector<cv::Vec3f> lineUpVectors;
+    // Per-line-point sampled sheet normals, sign-oriented away from the
+    // scroll center (NaN where the sample is invalid). Empty when
+    // unavailable.
+    std::vector<cv::Vec3f> lineNormals;
     std::vector<std::vector<cv::Vec3f>> branchLinePoints;
     cv::Vec3f seedPoint{std::numeric_limits<float>::quiet_NaN(),
                         std::numeric_limits<float>::quiet_NaN(),


### PR DESCRIPTION
## Problem

While navigating along a fiber in the line annotation dialog, the top-left "Current Line Cut" pane could rotate rapidly — at trace-splice kinks baked into fiber polylines its frame turned by up to ~50°/line index — and the top-right "Line Side Cut" pane intermittently mirrored left/right and occasionally tumbled through large plane pivots. Together these made tracking features by eye very difficult.

## Cause

Two independent instabilities, one per pane:

- The **current cut** derived its display "up" from the per-position transported line up vectors, which twist along the line, so the cross-section rolled while navigating. (A fixed reference direction can't fix this either: where the fiber tangent wanders — measured stretches sweep 463° of normal rotation for a net 17° — the in-plane projection of *any* fixed world direction oscillates by 8–31° of roll.)
- The **side cut** was a windowed least-squares (PCA) plane fit of the polyline. Its normal is sign-arbitrary per window (mirroring the view as the sign convention flipped between windows), and where the fiber's cross-fiber wander is nearly isotropic there is no well-defined local fiber plane at all, so the fitted normal tumbles — measured eigenvalue ratios drop to ~1.3–2.4 in the affected stretches with the normal swinging 8–28° per 2 indices.

## Fix

Derive both panes from one deterministic, physically-anchored frame: the smoothed line tangent plus the **sampled sheet normal** (the lasagna normal field the optimizer already samples per line point), sign-oriented **away from the scroll center** — via the volpkg's `umbilicus.json` when present (`estimated_umbilicus.json`, then volume XY center as fallbacks).

- **Current cut**: normal = tangent, up = oriented sheet normal → the sheet lies horizontal with the fiber's center-facing surface at the top of the view.
- **Side cut**: normal = sheetNormal × tangent, up = tangent → the fiber stays vertical and the toward-center direction points screen-left, by construction. The PCA fit machinery in the dialog is removed.
- Orientation is a pure function of the line position: jumps, coalesced mouse moves, and reopening all produce identical frames; nothing depends on navigation history.
- Where normal samples are missing or nearly parallel to the tangent (extreme bends), both panes fall back to the previous transported-line-up behavior.

## Testing

- Full suite passes (121/121 ctest targets).
- Verified interactively on `lt…000547` (trace-splice kinks that previously spun the current cut), `kb…000147` (side-view mirror flips at CP5 and plane tumbling between CP4–CP5), and `lt…000629`/`lt…000656`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwMADtc1quqwJd88AoJNo8