### PR TITLE
scrollprize.org: add a Press page

### DIFF
--- a/scrollprize.org/docs/09_faq.md
+++ b/scrollprize.org/docs/09_faq.md
@@ -479,7 +479,7 @@ If you want to contribute money to support our operational costs or to increase 
 
 ### I’m a journalist and I would like to interview someone from Vesuvius Challenge!
 
-Please email press@scrollprize.org.
+Please see our [Press page](/press).
 
 ### Do you have a scroll that looks like the Nintendo logo from GoldenEye N64?
 

--- a/scrollprize.org/docs/40_press.md
+++ b/scrollprize.org/docs/40_press.md
@@ -1,0 +1,53 @@
+---
+title: "Press"
+hide_table_of_contents: true
+---
+
+<head>
+  <html data-theme="dark" />
+
+  <meta
+    name="description"
+    content="Press and media inquiries for Vesuvius Challenge, the effort to read the Herculaneum scrolls with X-ray CT scanning and machine learning."
+  />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://scrollprize.org" />
+  <meta property="og:title" content="Vesuvius Challenge" />
+  <meta
+    property="og:description"
+    content="Press and media inquiries for Vesuvius Challenge, the effort to read the Herculaneum scrolls with X-ray CT scanning and machine learning."
+  />
+  <meta
+    property="og:image"
+    content="https://scrollprize.org/img/social/opengraph.jpg"
+  />
+
+  <meta property="twitter:card" content="summary_large_image" />
+  <meta property="twitter:url" content="https://scrollprize.org" />
+  <meta property="twitter:title" content="Vesuvius Challenge" />
+  <meta
+    property="twitter:description"
+    content="Press and media inquiries for Vesuvius Challenge, the effort to read the Herculaneum scrolls with X-ray CT scanning and machine learning."
+  />
+  <meta
+    property="twitter:image"
+    content="https://scrollprize.org/img/social/opengraph.jpg"
+  />
+</head>
+
+import TOCInline from '@theme/TOCInline';
+
+# Press
+
+For press and media inquiries, please email [press@scrollprize.org](mailto:press@scrollprize.org).
+
+To keep our public messaging accurate and consistent, only Vesuvius Challenge's Project Lead and co-founders are authorized to initiate contact with press and media on the project's behalf. You can find out who currently holds these roles on our [team page](/#team).
+
+We read every message and will do our best to get back to you.
+
+***
+
+<TOCInline
+  toc={toc}
+/>

--- a/scrollprize.org/docusaurus.config.js
+++ b/scrollprize.org/docusaurus.config.js
@@ -240,6 +240,7 @@ const config = {
               label: "Donate",
               position: "left",
             },
+            { to: "/press", label: "Press", position: "left" },
             {
               href: "https://discord.gg/V4fJhvtaQn",
               label: "Join Discord",
@@ -286,10 +287,6 @@ const config = {
                 {
                   label: "Jobs",
                   to: "/jobs",
-                },
-                {
-                  label: "Press",
-                  to: "/press",
                 },
               ],
             },

--- a/scrollprize.org/docusaurus.config.js
+++ b/scrollprize.org/docusaurus.config.js
@@ -235,12 +235,12 @@ const config = {
                 },
               ],
             },
+            { to: "/press", label: "Press", position: "left" },
             {
               href: "https://donate.stripe.com/aEUg101vt9eN8gM144",
               label: "Donate",
               position: "left",
             },
-            { to: "/press", label: "Press", position: "left" },
             {
               href: "https://discord.gg/V4fJhvtaQn",
               label: "Join Discord",

--- a/scrollprize.org/docusaurus.config.js
+++ b/scrollprize.org/docusaurus.config.js
@@ -287,6 +287,10 @@ const config = {
                   label: "Jobs",
                   to: "/jobs",
                 },
+                {
+                  label: "Press",
+                  to: "/press",
+                },
               ],
             },
           ],

--- a/scrollprize.org/src/css/chat.css
+++ b/scrollprize.org/src/css/chat.css
@@ -518,24 +518,6 @@
   }
 }
 
-/* At >=768px the footer collapses into one row with its link list flush
-   against the container's right edge (chrome.css §12), which is exactly
-   where the trigger floats. --ifm-container-width is pinned to 1080px
-   (chrome.css), so on common desktop widths the container has little to no
-   natural side margin — reserve room explicitly so the last link is never
-   rendered underneath the trigger. Sized to each breakpoint's trigger
-   footprint (icon + label + padding + its own right offset) with margin. */
-@media (min-width: 768px) and (max-width: 996px) {
-  .footer .container {
-    padding-right: calc(140px + env(safe-area-inset-right));
-  }
-}
-@media (min-width: 997px) {
-  .footer .container {
-    padding-right: calc(260px + env(safe-area-inset-right));
-  }
-}
-
 /* ==========================================================================
    §11 Virtual Philodemus identity (avatar chip, header subtitle, trigger label)
    ========================================================================== */

--- a/scrollprize.org/src/css/chat.css
+++ b/scrollprize.org/src/css/chat.css
@@ -518,6 +518,24 @@
   }
 }
 
+/* At >=768px the footer collapses into one row with its link list flush
+   against the container's right edge (chrome.css §12), which is exactly
+   where the trigger floats. --ifm-container-width is pinned to 1080px
+   (chrome.css), so on common desktop widths the container has little to no
+   natural side margin — reserve room explicitly so the last link is never
+   rendered underneath the trigger. Sized to each breakpoint's trigger
+   footprint (icon + label + padding + its own right offset) with margin. */
+@media (min-width: 768px) and (max-width: 996px) {
+  .footer .container {
+    padding-right: calc(140px + env(safe-area-inset-right));
+  }
+}
+@media (min-width: 997px) {
+  .footer .container {
+    padding-right: calc(260px + env(safe-area-inset-right));
+  }
+}
+
 /* ==========================================================================
    §11 Virtual Philodemus identity (avatar chip, header subtitle, trigger label)
    ========================================================================== */


### PR DESCRIPTION
## Summary
- Adds a dedicated `/press` page (`docs/40_press.md`, modeled on the existing `/jobs` page) pointing press/media inquiries to press@scrollprize.org
- States that only the Project Lead and co-founders are authorized to initiate press/media outreach on the project's behalf, linking to the homepage team credits (`/#team`) as the single source of truth for who holds those roles
- Links the new page from the footer (next to Jobs)
- Updates the FAQ's journalist entry to link to `/press` instead of duplicating the contact info

## Test plan
- [x] Verified `/press` route, footer link, and FAQ link resolve correctly via the Docusaurus dev server (`onBrokenLinks`/`onBrokenAnchors` are set to `throw`, so a broken route/anchor would fail loudly)
- [x] Confirmed the `/#team` anchor exists in `Landing.js` (`id="team"`)
- [ ] Full production build not verified locally — this sandbox is missing the unrelated `three` package in `node_modules` (pre-existing, declared in `package.json`), which blocks `docusaurus build` regardless of this change; Vercel's fresh install won't hit it

🤖 Generated with [Claude Code](https://claude.com/claude-code)