### PR TITLE
ink-detection: weight the blend denominator with the same kernel in the resnet3d inference scripts

### DIFF
--- a/ink-detection/inference_resnet3d.py
+++ b/ink-detection/inference_resnet3d.py
@@ -630,9 +630,10 @@ def predict_fn(test_loader, model, device, test_xyxys,pred_shape):
         for i, (x1, y1, x2, y2) in enumerate(xys):
             mask_pred[y1:y2, x1:x2] += np.multiply(F.interpolate(y_preds[i].unsqueeze(0).float(),scale_factor=4,mode='bilinear').squeeze(0).squeeze(0).numpy(),kernel)
             # mask_pred[y1:y2, x1:x2] += F.interpolate(y_preds[i].unsqueeze(0).unsqueeze(0).float(),scale_factor=4,mode='bilinear').squeeze(0).squeeze(0).numpy()
-            mask_count[y1:y2, x1:x2] += np.ones((CFG.size, CFG.size))
+            mask_count[y1:y2, x1:x2] += kernel
 
-    mask_pred /= mask_count
+    mask_pred = np.divide(mask_pred, mask_count,
+                          out=np.zeros_like(mask_pred), where=mask_count > 0)
     # mask_pred/=mask_pred.max()
     return mask_pred
     # return losses.avg,[]

--- a/ink-detection/inference_resnet3d_3d_decoder.py
+++ b/ink-detection/inference_resnet3d_3d_decoder.py
@@ -334,9 +334,10 @@ def predict_fn(test_loader, model, device, test_xyxys, pred_shape):
             mask_pred[y1:y2, x1:x2] += np.multiply(
                 F.interpolate(y_preds[i].unsqueeze(0).float(), scale_factor=4, mode='bilinear').squeeze(0).squeeze(0).numpy(),
                 kernel)
-            mask_count[y1:y2, x1:x2] += np.ones((CFG.size, CFG.size))
+            mask_count[y1:y2, x1:x2] += kernel
 
-    mask_pred /= mask_count
+    mask_pred = np.divide(mask_pred, mask_count,
+                          out=np.zeros_like(mask_pred), where=mask_count > 0)
     return mask_pred
 
 


### PR DESCRIPTION
Same defect as #1374, in the two resnet3d inference scripts: `predict_fn` weights the overlap-add numerator with a gaussian and the denominator with ones.

`inference_resnet3d.py:631,633,635` and `inference_resnet3d_3d_decoder.py:336,337,339`.

## What it costs, per file

The kernel is normalised to max 1, so its mean is 0.732 and the interior is attenuated by 27% regardless of tile size. The ripple depends on both, and it is the part a threshold cannot absorb. On a synthetic constant field of 0.700:

| file | `CFG.size` | stride | output | ripple |
|---|---|---|---|---|
| `inference_resnet3d.py` | 64 | `64 // 3` = 21 | 0.5139 | 0.1029 |
| `inference_resnet3d_3d_decoder.py` | 256 | `256 // 5` = 51 | 0.5127 | 0.0609 |

0.700 × 0.7321 = 0.5125, so the attenuation is exactly the kernel mean. Accumulating the same kernel on both sides returns 0.7000 flat.

## The unguarded division

Neither script guards the divide, unlike `inference_timesformer.py`. Tiles are enqueued conditionally in both — the 3d_decoder skips a tile where the image is all zero, `inference_resnet3d.py` where the fragment mask is zero — so uncovered pixels reach `mask_pred /= mask_count` as 0/0. The fix uses the idiom already at `inference_resnet3d.py:525`:

```python
mask_pred = np.divide(mask_pred, mask_count, out=np.zeros_like(mask_pred), where=mask_count > 0)
```

## Scope

Every standalone inference script in `ink-detection/` had this except `optimized_inference/inference.py`, which normalises both kernels to sum 1 and accumulates the same one on both sides. The Lightning `validation_step` stitchers are fine: they accumulate an unweighted prediction against ones, which is a plain average and self-consistent.

**This changes inference output for anyone running these two paths.** Happy to squash into #1374 if one PR is easier to review.

Agent-assisted, as `AGENTS.md` anticipates.
