### PR TITLE
VC3D: add trust-safe unverified TIFXYZ hints to Spiral

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -2575,7 +2575,12 @@ CWindow::CWindow(size_t cacheSizeGB, RenderBenchOptions benchOptions) :
         // The "Add to current spiral fit" context actions are greyed out
         // unless a Spiral session is active on the connected service.
         connect(_spiralWorkspace, &SpiralWorkspace::spiralSessionActiveChanged, this, [this](bool active) {
-            if (_surfacePanel) _surfacePanel->setSpiralFitAvailable(active);
+            if (_surfacePanel) {
+                _surfacePanel->setSpiralFitAvailable(active);
+                _surfacePanel->setUnverifiedSpiralHintAvailable(
+                    active && _spiralWorkspace
+                    && _spiralWorkspace->supportsUnverifiedPatchUploads());
+            }
             if (_fiberWidget) _fiberWidget->setSpiralFitAvailable(active);
         });
     }
@@ -6984,7 +6989,7 @@ void CWindow::CreateWidgets(void)
                 showStatusBarMessage(tr("Copied segment path to clipboard: %1").arg(path), 3000);
             });
     connect(_surfacePanel.get(), &SurfacePanelController::addSurfaceToSpiralFitRequested,
-            this, [this](const QString& segmentId) {
+            this, [this](const QString& segmentId, bool unverified) {
                 if (!_spiralWorkspace) {
                     return;
                 }
@@ -6996,8 +7001,11 @@ void CWindow::CreateWidgets(void)
                     showStatusBarMessage(tr("Cannot resolve an on-disk TIFXYZ directory for %1").arg(segmentId), 5000);
                     return;
                 }
-                _spiralWorkspace->addPatchToCurrentFit(
-                    QString::fromStdString(surf->path.string()), surf);
+                const QString path = QString::fromStdString(surf->path.string());
+                if (unverified)
+                    _spiralWorkspace->addUnverifiedPatchToCurrentFit(path, surf);
+                else
+                    _spiralWorkspace->addPatchToCurrentFit(path, surf);
             });
     connect(_surfacePanel.get(), &SurfacePanelController::renderSegmentRequested,
             this, [this](const QString& segmentId) {

--- a/volume-cartographer/apps/VC3D/SpiralPanel.cpp
+++ b/volume-cartographer/apps/VC3D/SpiralPanel.cpp
@@ -15,6 +15,7 @@
 #include <QDialog>
 #include <QDir>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QFormLayout>
 #include <QGridLayout>
 #include <QHBoxLayout>
@@ -29,6 +30,7 @@
 #include <QPlainTextEdit>
 #include <QProgressBar>
 #include <QPushButton>
+#include <QRegularExpression>
 #include <QScrollArea>
 #include <QSettings>
 #include <QSignalBlocker>
@@ -581,6 +583,10 @@ SpiralPanel::SpiralPanel(SpiralServiceManager* service, QWidget* parent)
     _ephemeralList->setObjectName(QStringLiteral("spiralEphemeralList"));
     _ephemeralList->setMaximumHeight(80);
     _ephemeralList->setSelectionMode(QAbstractItemView::SingleSelection);
+    _addUnverifiedHint = new QPushButton(tr("Add unverified hint\u2026"), runContents);
+    _addUnverifiedHint->setEnabled(false);
+    _addUnverifiedHint->setToolTip(
+        tr("Upload a local TIFXYZ directory, such as ScrollFiesta output, as low-trust evidence for the next run"));
     _commitInputs = new QPushButton(tr("Commit current inputs"), runContents);
     _commitInputs->setEnabled(false);
     _commitInputs->setToolTip(tr("Copy the session's added inputs into their dataset locations"));
@@ -591,6 +597,7 @@ SpiralPanel::SpiralPanel(SpiralServiceManager* service, QWidget* parent)
     _commitHint = new QLabel(runContents);
     _commitHint->setWordWrap(true);
     auto* commitRow = new QHBoxLayout;
+    commitRow->addWidget(_addUnverifiedHint);
     commitRow->addWidget(_commitInputs);
     commitRow->addWidget(_removeInput);
     commitRow->addStretch(1);
@@ -900,12 +907,64 @@ SpiralPanel::SpiralPanel(SpiralServiceManager* service, QWidget* parent)
     connect(_commitInputs, &QPushButton::clicked, this, [this]() {
         if (QMessageBox::question(this, tr("Commit inputs"),
                                   tr("Move the added inputs into the dataset? Patches go to "
-                                     "verified_patches/, fibers to fibers/, and PCL documents "
+                                     "their verified_patches/ or unverified_patches/ trust "
+                                     "pool, fibers to fibers/, and PCL documents "
                                      "merge into their conventional role file (control-point "
                                      "lines go to drawn_control_points.json; "
                                      "same-winding point collections go to same_windings.json)."))
             != QMessageBox::Yes) return;
         _service->commitInputs();
+    });
+    connect(_addUnverifiedHint, &QPushButton::clicked, this, [this]() {
+        if (!_service->supportsPatchClassification()) {
+            _warnings->setText(
+                tr("The connected Spiral service must be updated before it can preserve unverified hints."));
+            return;
+        }
+        QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
+        const QString initial = settings.value(
+            QStringLiteral("spiral/last_unverified_hint_directory"),
+            QDir::homePath()).toString();
+        const QString directory = QFileDialog::getExistingDirectory(
+            this, tr("Select an unverified TIFXYZ hint"), initial);
+        if (directory.isEmpty()) return;
+        const QDir hint(directory);
+        const QStringList required{
+            QStringLiteral("x.tif"), QStringLiteral("y.tif"),
+            QStringLiteral("z.tif"), QStringLiteral("meta.json")};
+        QStringList missing;
+        for (const QString& name : required)
+            if (!hint.exists(name)) missing.push_back(name);
+        if (!missing.isEmpty()) {
+            QMessageBox::warning(
+                this, tr("Invalid TIFXYZ hint"),
+                tr("The selected directory is missing: %1")
+                    .arg(missing.join(QStringLiteral(", "))));
+            return;
+        }
+        settings.setValue(
+            QStringLiteral("spiral/last_unverified_hint_directory"),
+            QFileInfo(directory).absolutePath());
+        QString inputId = QFileInfo(directory).fileName();
+        const QRegularExpression safeId(
+            QStringLiteral("^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"));
+        if (!safeId.match(inputId).hasMatch()) {
+            bool accepted = false;
+            inputId = QInputDialog::getText(
+                this, tr("Name the unverified hint"),
+                tr("Dataset-safe id (letters, numbers, dot, underscore, hyphen):"),
+                QLineEdit::Normal, inputId, &accepted).trimmed();
+            if (!accepted || inputId.isEmpty()) return;
+            if (!safeId.match(inputId).hasMatch()) {
+                QMessageBox::warning(
+                    this, tr("Invalid hint id"),
+                    tr("The hint id must start with a letter or number and use only letters, numbers, dot, underscore, or hyphen (maximum 128 characters)."));
+                return;
+            }
+        }
+        _service->uploadPatch(
+            directory, inputId,
+            SpiralServiceManager::PatchClassification::Unverified);
     });
     connect(_ephemeralList, &QListWidget::itemSelectionChanged, this, [this]() {
         const QListWidgetItem* item = _ephemeralList->currentItem();
@@ -1714,6 +1773,8 @@ void SpiralPanel::updateStatus(const QJsonObject& status)
     _run->setEnabled(_connected && runnable && !_reloadRequired);
     _stop->setEnabled(state == "Running");
     _save->setEnabled(_connected && runnable);
+    _addUnverifiedHint->setEnabled(
+        _connected && runnable && _service->supportsPatchClassification());
     _downloadCheckpoint->setEnabled(
         _connected && runnable && !_checkpointDownloadActive);
 
@@ -1747,6 +1808,10 @@ void SpiralPanel::updateStatus(const QJsonObject& status)
                 .arg(kind, id, input.value(QStringLiteral("state")).toString());
             if (input.value(QStringLiteral("committed")).toBool())
                 label += tr(", committed");
+            const QString classification =
+                input.value(QStringLiteral("classification")).toString();
+            if (!classification.isEmpty())
+                label += tr(" (%1)").arg(classification);
             const QString role = input.value(QStringLiteral("role")).toString();
             if (!role.isEmpty()) label += tr(" (%1)").arg(role);
             auto* item = new QListWidgetItem(label, _ephemeralList);

--- a/volume-cartographer/apps/VC3D/SpiralPanel.hpp
+++ b/volume-cartographer/apps/VC3D/SpiralPanel.hpp
@@ -165,6 +165,7 @@ private:
 
     // Ephemeral inputs
     QListWidget* _ephemeralList = nullptr;
+    QPushButton* _addUnverifiedHint = nullptr;
     QPushButton* _commitInputs = nullptr;
     QPushButton* _removeInput = nullptr;
     QLabel* _commitHint = nullptr;

--- a/volume-cartographer/apps/VC3D/SpiralServiceManager.cpp
+++ b/volume-cartographer/apps/VC3D/SpiralServiceManager.cpp
@@ -193,6 +193,7 @@ void SpiralServiceManager::connectToService(const SpiralServiceProfile& profile)
     _statusFailures = 0;
     _hasActiveSession = false;
     _serviceOwnsDataset = false;
+    _supportsPatchClassification = false;
     _remoteLogsInFlight = false;
     _restartInProgress = false;
     _remoteLogFailures = 0;
@@ -351,6 +352,13 @@ void SpiralServiceManager::handleHealth(const QJsonObject& health)
         return;
     }
     _serviceOwnsDataset = health.value(QStringLiteral("dataset_owned")).toBool();
+    _supportsPatchClassification = false;
+    for (const QJsonValue& value : health.value(QStringLiteral("capabilities")).toArray()) {
+        if (value.toString() == QStringLiteral("patch_classification")) {
+            _supportsPatchClassification = true;
+            break;
+        }
+    }
     _artifactCache->setEndpoint(endpointFingerprint(), _network,
                                 [this](const QString& path, int timeoutMs) {
                                     return makeRequest(path, timeoutMs);
@@ -403,6 +411,7 @@ void SpiralServiceManager::disconnectFromService()
     _statusInFlight = false;
     _remoteLogsInFlight = false;
     _restartInProgress = false;
+    _supportsPatchClassification = false;
     _artifactCache->clearEndpoint();
     _synchronizedSessionId.clear();
     _tunnel->stop();
@@ -907,9 +916,18 @@ void SpiralServiceManager::removeEphemeralInput(const QString& kind, const QStri
     });
 }
 
-void SpiralServiceManager::uploadPatch(const QString& directory, const QString& inputId)
+void SpiralServiceManager::uploadPatch(
+    const QString& directory, const QString& inputId,
+    PatchClassification classification)
 {
     if (!isReady()) { emit inputUploadFinished(inputId, tr("Spiral service is not connected")); return; }
+    if (classification == PatchClassification::Unverified
+        && !_supportsPatchClassification) {
+        emit inputUploadFinished(
+            inputId,
+            tr("The connected Spiral service cannot preserve unverified patch classification; update the service first"));
+        return;
+    }
     const quint64 generation = _connectionGeneration;
     auto* watcher = new QFutureWatcher<QJsonObject>(this);
     connect(watcher, &QFutureWatcher<QJsonObject>::finished, this,
@@ -933,7 +951,7 @@ void SpiralServiceManager::uploadPatch(const QString& directory, const QString& 
                          emit inputUploadFinished(inputId, error);
                      });
             });
-    watcher->setFuture(QtConcurrent::run([directory, inputId]() -> QJsonObject {
+    watcher->setFuture(QtConcurrent::run([directory, inputId, classification]() -> QJsonObject {
         QJsonArray files;
         QDirIterator it(directory, QDir::Files, QDirIterator::Subdirectories);
         const QDir base(directory);
@@ -952,9 +970,15 @@ void SpiralServiceManager::uploadPatch(const QString& directory, const QString& 
         }
         if (files.isEmpty())
             return {{QStringLiteral("error"), tr("The patch directory %1 is empty").arg(directory)}};
-        return {{QStringLiteral("kind"), QStringLiteral("patch")},
-                {QStringLiteral("id"), inputId},
-                {QStringLiteral("files"), files}};
+        QJsonObject request{{QStringLiteral("kind"), QStringLiteral("patch")},
+                            {QStringLiteral("id"), inputId},
+                            {QStringLiteral("files"), files}};
+        // Preserve the legacy verified request shape for older services.
+        // Unverified uploads have already passed the capability check above.
+        if (classification == PatchClassification::Unverified)
+            request.insert(QStringLiteral("classification"),
+                           QStringLiteral("unverified"));
+        return request;
     }));
 }
 

--- a/volume-cartographer/apps/VC3D/SpiralServiceManager.hpp
+++ b/volume-cartographer/apps/VC3D/SpiralServiceManager.hpp
@@ -37,6 +37,9 @@ public:
                                  Reconnecting, Failed };
     Q_ENUM(ConnectionState)
 
+    enum class PatchClassification { Verified, Unverified };
+    Q_ENUM(PatchClassification)
+
     explicit SpiralServiceManager(QObject* parent = nullptr);
     ~SpiralServiceManager() override;
 
@@ -54,6 +57,7 @@ public:
     bool isReady() const { return _connectionState == ConnectionState::Ready; }
     bool hasActiveSession() const { return _hasActiveSession; }
     bool serviceOwnsDataset() const { return _serviceOwnsDataset; }
+    bool supportsPatchClassification() const { return _supportsPatchClassification; }
     QJsonObject advertisedDataset() const { return _advertisedDataset; }
     const SpiralServiceProfile& profile() const { return _profile; }
     bool ownsProcess() const;
@@ -71,7 +75,9 @@ public:
     void downloadCheckpoint(const QString& localPath);
     void deleteSession();
     void commitInputs();
-    void uploadPatch(const QString& directory, const QString& inputId);
+    void uploadPatch(
+        const QString& directory, const QString& inputId,
+        PatchClassification classification = PatchClassification::Verified);
     void uploadJsonInput(const QString& kind, const QString& filePath,
                          const QString& inputId, const QString& role = {});
     // Remove an added input that has not joined the resident fit yet.
@@ -173,6 +179,7 @@ private:
     int _statusFailures = 0;
     bool _hasActiveSession = false;
     bool _serviceOwnsDataset = false;
+    bool _supportsPatchClassification = false;
     bool _remoteLogsInFlight = false;
     bool _restartInProgress = false;
     QElapsedTimer _restartElapsed;

--- a/volume-cartographer/apps/VC3D/SpiralWorkspace.cpp
+++ b/volume-cartographer/apps/VC3D/SpiralWorkspace.cpp
@@ -710,6 +710,11 @@ bool SpiralWorkspace::hasActiveSpiralSession() const
     return _service && _service->hasActiveSession();
 }
 
+bool SpiralWorkspace::supportsUnverifiedPatchUploads() const
+{
+    return _service && _service->supportsPatchClassification();
+}
+
 void SpiralWorkspace::addPatchToCurrentFit(
     const QString& tifxyzDirectory, const std::shared_ptr<QuadSurface>& surface)
 {
@@ -718,6 +723,26 @@ void SpiralWorkspace::addPatchToCurrentFit(
     registerPendingPatchSurface(inputId, surface);
     statusBar()->showMessage(tr("Uploading patch %1 to the Spiral session…").arg(inputId));
     _service->uploadPatch(tifxyzDirectory, inputId);
+}
+
+void SpiralWorkspace::addUnverifiedPatchToCurrentFit(
+    const QString& tifxyzDirectory, const std::shared_ptr<QuadSurface>& surface)
+{
+    if (!_service) return;
+    const QString inputId = QFileInfo(tifxyzDirectory).fileName();
+    if (!_service->supportsPatchClassification()) {
+        statusBar()->showMessage(
+            tr("The connected Spiral service cannot preserve unverified patch classification; update it before adding %1")
+                .arg(inputId),
+            15000);
+        return;
+    }
+    registerPendingPatchSurface(inputId, surface);
+    statusBar()->showMessage(
+        tr("Uploading %1 as an unverified Spiral hint\u2026").arg(inputId));
+    _service->uploadPatch(
+        tifxyzDirectory, inputId,
+        SpiralServiceManager::PatchClassification::Unverified);
 }
 
 void SpiralWorkspace::addFiberToCurrentFit(const QString& fiberJsonPath)

--- a/volume-cartographer/apps/VC3D/SpiralWorkspace.hpp
+++ b/volume-cartographer/apps/VC3D/SpiralWorkspace.hpp
@@ -46,8 +46,12 @@ public:
 
     // Cross-panel entry points for "Add to current spiral fit".
     bool hasActiveSpiralSession() const;
+    bool supportsUnverifiedPatchUploads() const;
     void addPatchToCurrentFit(const QString& tifxyzDirectory,
                               const std::shared_ptr<QuadSurface>& surface = {});
+    void addUnverifiedPatchToCurrentFit(
+        const QString& tifxyzDirectory,
+        const std::shared_ptr<QuadSurface>& surface = {});
     void addFiberToCurrentFit(const QString& fiberJsonPath);
     void requestSessionExit(std::function<void()> continuation);
     bool hasPendingBrushWork() const;

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
@@ -1251,8 +1251,26 @@ void SurfacePanelController::showContextMenu(const QPoint& pos)
         ? tr("Upload this patch to the active Spiral session; it is used on the next run")
         : tr("No Spiral session is active on the connected service"));
     connect(addToSpiralAction, &QAction::triggered, this, [this, segmentId]() {
-        emit addSurfaceToSpiralFitRequested(segmentId);
+        emit addSurfaceToSpiralFitRequested(segmentId, false);
     });
+
+    QAction* addUnverifiedHintAction =
+        contextMenu.addAction(tr("Add as unverified Spiral hint"));
+    addUnverifiedHintAction->setEnabled(
+        selectedSegmentIds.size() <= 1 && isLocal
+        && _unverifiedSpiralHintAvailable);
+    addUnverifiedHintAction->setToolTip(
+        !_spiralFitAvailable
+            ? tr("No Spiral session is active on the connected service")
+        : !_unverifiedSpiralHintAvailable
+            ? tr("The connected Spiral service must be updated to preserve unverified classification")
+            : !isLocal
+                ? tr("Materialize the TIFXYZ surface locally before uploading it")
+                : tr("Upload low-trust TIFXYZ evidence, such as ScrollFiesta output, for the next run; Spiral masks it near trusted geometry and never promotes it to verified"));
+    connect(addUnverifiedHintAction, &QAction::triggered, this,
+            [this, segmentId]() {
+                emit addSurfaceToSpiralFitRequested(segmentId, true);
+            });
 
     QMenu* maskMenu = contextMenu.addMenu(tr("Mask"));
     maskMenu->setEnabled(isCurrentFolderSegment);

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.hpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.hpp
@@ -152,6 +152,12 @@ public:
     // Enables the "Add to current spiral fit" context action while a Spiral
     // session is active on the connected service.
     void setSpiralFitAvailable(bool available) { _spiralFitAvailable = available; }
+    // Fail closed when connected to an older service that cannot preserve the
+    // unverified trust classification.
+    void setUnverifiedSpiralHintAvailable(bool available)
+    {
+        _unverifiedSpiralHintAvailable = available;
+    }
 
     /// Outcome of an asynchronous single-segment fetch request. Only `Started`
     /// implies the completion callback will fire later (on the main thread);
@@ -182,7 +188,7 @@ signals:
     void filtersApplied(int hiddenCount);
     void surfaceActivated(const QString& id, QuadSurface* surface);
     void copySegmentPathRequested(const QString& segmentId);
-    void addSurfaceToSpiralFitRequested(const QString& segmentId);
+    void addSurfaceToSpiralFitRequested(const QString& segmentId, bool unverified);
     void renderSegmentRequested(const QString& segmentId);
     void growSegmentRequested(const QString& segmentId);
     void convertToObjRequested(const QString& segmentId);
@@ -272,6 +278,7 @@ private:
     QMetaObject::Connection _pointSetModelConnection;
     bool _configuringFilters{false};
     bool _spiralFitAvailable{false};
+    bool _unverifiedSpiralHintAvailable{false};
     bool _selectionLocked{false};
     QStringList _lockedSelectionIds;
     bool _selectionLockNotified{false};

--- a/volume-cartographer/scripts/spiral/README.md
+++ b/volume-cartographer/scripts/spiral/README.md
@@ -48,6 +48,24 @@ resolution to clients. Remote clients can add ephemeral inputs, commit them,
 and change run parameters, but cannot repoint the session at different host
 paths.
 
+### Unverified TIFXYZ hints
+
+The running-fit panel can upload a local TIFXYZ directory, including a
+ScrollFiesta export, with **Add unverified hint...**. A local surface also has
+**Add as unverified Spiral hint** in its context menu. The upload protocol
+carries `classification: "unverified"` through staging, status, resident-fit
+incorporation, and commit; clients that omit the field retain the historical
+`verified` default.
+
+Unverified hints have a structural trust boundary. They use only Spiral's
+separate unverified radius/DT losses, are masked near trusted geometry, never
+join the verified atlas or interactive influence anchors, and commit only to
+`unverified_patches/`. Patch identifiers are checked against both trust pools,
+so a hint cannot shadow or overwrite verified geometry. VC3D enables these
+actions only when the service advertises the `patch_classification`
+capability, preventing an older service from silently treating a hint as
+verified.
+
 ### Creating the Spiral Python environment
 
 The service host needs the Spiral environment (a CUDA-capable PyTorch plus the

--- a/volume-cartographer/scripts/spiral/fit_spiral.py
+++ b/volume-cartographer/scripts/spiral/fit_spiral.py
@@ -41,6 +41,10 @@ from lasagna_data import prepare_lasagna_volume, prepare_surf_sdt_volume
 from checkpoint_io import load_checkpoint_cpu
 from influence import make_influence_state, subsample_rows
 from native_spiral import load_native_spiral_sampling
+from interactive_patch_trust import (
+    collect_trusted_collection_points,
+    select_interactive_patch_pool,
+)
 from tifxyz import load_tifxyz
 from geom_utils import bilinear_atlas_lookup, interp1d
 from point_collection import (
@@ -657,6 +661,12 @@ def main(
             unverified_patches = load_patches_from_dir(
                 unverified_patches_path, 'unverified patches')
 
+    # Keep source identities even when erosion, ROI filtering, or later trusted
+    # remasking removes a patch from a resident training pool. Reusing such an
+    # id for an interactive patch would make a later reload ambiguous.
+    known_verified_patch_ids = set(verified_patches)
+    known_unverified_patch_ids = set(unverified_patches)
+
     if (not verified_patches and not unverified_patches
             and (use_verified_patches or use_unverified_patches)):
         raise RuntimeError('No patches could be loaded')
@@ -1227,6 +1237,7 @@ def main(
     unverified_patches_list = []
     unverified_patch_sampling_probabilities = None
     unverified_patch_atlas = None
+    interactive_unverified_patch_paths = {}
     using_tracks = (
         (cfg['loss_weight_track_radius'] > 0 or cfg['loss_weight_track_dt'] > 0)
         and bool(tracks)
@@ -1236,7 +1247,7 @@ def main(
     # Untrusted 'unverified' patches: mask away wherever they fall near trusted geometry (verified
     # patch vertices + pcl strips, same anchor cloud used for snap-anchors / track-exclusion), then
     # build their own sampling cache + GPU atlas. They feed only their own radius/DT losses.
-    if unverified_patches or using_tracks:
+    if unverified_patches or using_tracks or interactive_driver is not None:
         # Build a cKDTree over the scroll-space anchor points (CPU) for fixed-radius
         # nearest-neighbour queries.
         verified_patches_and_pcls_np = verified_patches_and_pcls_cpu.numpy()
@@ -1394,11 +1405,24 @@ def main(
         unverified_patch_sampling_probabilities = prepare_patch_sampling_cache(unverified_patches_list)
         unverified_patch_atlas = PatchGpuAtlas(unverified_patches, device='cuda')
 
-    def rebuild_unverified_patch_inputs(exclusion_radius):
+    def rebuild_unverified_patch_inputs(
+            exclusion_radius, geometry_tree=None, include_ids=None):
         """Reload only the unverified-patch pool for a Run-boundary mask edit."""
-        if not unverified_patches_path:
+        if not unverified_patches_path and not interactive_unverified_patch_paths:
             return {}, [], None, None
-        candidates = load_patches_from_dir(unverified_patches_path)
+        candidates = (
+            load_patches_from_dir(unverified_patches_path)
+            if unverified_patches_path else {})
+        if include_ids is not None:
+            candidates = {
+                patch_id: patch for patch_id, patch in candidates.items()
+                if patch_id in include_ids}
+        for patch_id, path in interactive_unverified_patch_paths.items():
+            # A committed hint may now also be visible under the dataset's
+            # unverified directory; do not load the same id twice.
+            if (include_ids is None or patch_id in include_ids) \
+                    and patch_id not in candidates:
+                candidates[patch_id] = load_tifxyz(path)
         for patch_id, patch in list(candidates.items()):
             cells_to_erode = patch.erosion_cells(cfg['patch_erode_patches'])
             if (cells_to_erode > 0
@@ -1411,7 +1435,9 @@ def main(
             patch.release_derived_caches()
         candidates, n_masked, n_dropped = \
             _mask_unverified_patches_near_trusted_geometry(
-                candidates, trusted_geometry_tree, exclusion_radius)
+                candidates,
+                trusted_geometry_tree if geometry_tree is None else geometry_tree,
+                exclusion_radius)
         print(
             f'unverified patches: remasked {n_masked} vertices near trusted '
             f'geometry (radius {exclusion_radius:.1f}), dropped {n_dropped}; '
@@ -2150,6 +2176,11 @@ def main(
         same items in the same order on every rank.
         """
         nonlocal patch_sampling_probabilities, next_id, influence_state
+        nonlocal unverified_patch_sampling_probabilities
+        nonlocal unverified_patches, unverified_patches_list
+        nonlocal unverified_patch_atlas, trusted_geometry_tree
+        nonlocal interactive_unverified_patch_paths
+        nonlocal known_verified_patch_ids, known_unverified_patch_ids
         nonlocal interactive_influence_loss_weight, interactive_influence_anchor_samples
         nonlocal interactive_dt_resume_iteration
         # Incorporation has its own saved RNG envelope so adding inputs does
@@ -2164,7 +2195,13 @@ def main(
             clear_interactive_influence()
             run_cfg = dict(cfg)
             run_cfg.update(dict(influence_config or {}))
-            new_patches = {}
+            # Preserve identity even if a prior boundary was interrupted after
+            # changing a resident dictionary but before its final bookkeeping.
+            known_verified_patch_ids.update(verified_patches)
+            known_unverified_patch_ids.update(unverified_patches)
+            new_verified_patches = {}
+            new_unverified_patches = {}
+            new_unverified_patch_paths = {}
             new_collections = {}
             for record in records:
                 kind = record.get('kind')
@@ -2173,8 +2210,10 @@ def main(
                 if kind == 'patch':
                     if cfg['input_disable_patches']:
                         raise RuntimeError('disable_patches=True: this session takes no patches')
-                    if input_id in verified_patches or input_id in new_patches:
-                        raise RuntimeError(f'Patch {input_id!r} is already part of this session')
+                    classification, target_pool = select_interactive_patch_pool(
+                        record,
+                        known_verified_patch_ids, known_unverified_patch_ids,
+                        new_verified_patches, new_unverified_patches)
                     patch = load_tifxyz(path)
                     cells_to_erode = patch.erosion_cells(cfg['patch_erode_patches'])
                     if cells_to_erode > 0 and not erode_patch_valid_region(patch, cells_to_erode):
@@ -2184,7 +2223,9 @@ def main(
                             f'Patch {input_id!r} does not intersect the fitted z range '
                             f'[{z_begin}, {z_end})')
                     patch.release_derived_caches()
-                    new_patches[input_id] = patch
+                    target_pool[input_id] = patch
+                    if classification == 'unverified':
+                        new_unverified_patch_paths[input_id] = path
                 elif kind == 'fiber':
                     pcl = load_fiber_point_collection(
                         path, next_id, min_point_spacing=cfg['pcl_fiber_min_point_spacing'])
@@ -2219,32 +2260,21 @@ def main(
                 build_pcl_sampling_strata(
                     pcl['sampling_group'] for pcl in new_collections.values())
 
-            # ---- Patches: sampling caches, probabilities, atlas append ----
-            if new_patches:
-                for patch in new_patches.values():
-                    prepare_patch_sampling_cache([patch])
-                verified_patches.update(new_patches)
-                verified_patches_list.extend(new_patches.values())
-                areas = np.array([float(p.area) for p in verified_patches_list],
-                                 dtype=np.float32)
-                inv_weights = areas ** 0.5
-                patch_sampling_probabilities = inv_weights / inv_weights.sum()
-                patch_atlas.append_patches(new_patches)
-                if cfg['dt_target_mode'] == 'whole_object_quantile':
-                    prepare_patch_dt_target_samples(
-                        list(new_patches.values()),
-                        cfg['sample_count_patch_dt_target_points'], cfg['dt_target_max_stride'],
-                    )
-
             # ---- Point collections: link, classify, strip-materialise ----
+            new_cross_patch_values = []
+            new_unattached_strips = []
+            new_unattached_sampling_groups = []
+            new_unattached = {}
             if new_collections:
                 for pcl in new_collections.values():
                     for point in pcl['points'].values():
                         point['zyx'] = np.array(
                             [point['p'][2], point['p'][1], point['p'][0]],
                             dtype=np.float32)
+                candidate_verified_patches = dict(verified_patches)
+                candidate_verified_patches.update(new_verified_patches)
                 link_points_to_patches(
-                    verified_patches,
+                    candidate_verified_patches,
                     new_collections,
                     tolerance=link_distance_tolerance,
                     surface_index_tolerance=link_distance_tolerance,
@@ -2252,7 +2282,6 @@ def main(
                     general_hit_policy='largest_area',
                 )
                 new_cross_patch = {}
-                new_unattached = {}
                 for pid, pcl in new_collections.items():
                     num_attached = sum(1 for point in pcl['points'].values() if 'on_patch' in point)
                     num_unattached = len(pcl['points']) - num_attached
@@ -2300,11 +2329,11 @@ def main(
                         if 'on_patch' not in point:
                             continue
                         pid = point['on_patch']['id']
-                        if pid not in verified_patches:
+                        if pid not in candidate_verified_patches:
                             continue
                         points_by_patch.setdefault(pid, []).append(point)
                     pcl['points_by_patch'] = points_by_patch
-                    cross_patch_pcls.append(pcl)
+                    new_cross_patch_values.append(pcl)
 
                 min_point_spacing = cfg['pcl_unattached_pcl_min_point_spacing']
                 for pcl_id, pcl in new_unattached.items():
@@ -2326,29 +2355,157 @@ def main(
                         keep.append(len(zyxs) - 1)
                         zyxs = zyxs[keep]
                         windings = windings[keep]
-                    unattached_pcl_strips.append({
+                    new_unattached_strips.append({
                         'id': pcl_id,
                         'name': pcl.get('name'),
                         'source_file': pcl.get('source_file'),
                         'zyxs': zyxs,
                         'windings': windings,
                     })
-                    unattached_strip_sampling_groups.append(pcl.get('sampling_group'))
-                # The flat GPU bundle is derived from the strip list; drop it so
-                # the next consumer rebuilds it including the appended strips.
+                    new_unattached_sampling_groups.append(
+                        pcl.get('sampling_group'))
+
+            # New trusted inputs immediately extend the exclusion cloud used
+            # to protect trusted geometry from an unverified hint arriving in
+            # the same boundary. Only materialised unattached PCL strips are
+            # added; attached PCL points are already represented by verified
+            # patch geometry.
+            updated_trusted_geometry_tree = trusted_geometry_tree
+            rebuilt_existing_unverified = None
+            trusted_additions = []
+            for patch in new_verified_patches.values():
+                z_flat = patch.zyxs.reshape(-1, 3).to(dtype=torch.float32)
+                valid_flat = patch.valid_vertex_mask.reshape(-1)
+                z_in_roi = (z_flat[:, 0] >= z_begin) & (z_flat[:, 0] < z_end)
+                if (valid_flat & z_in_roi).any():
+                    trusted_additions.append(z_flat[valid_flat & z_in_roi].numpy())
+            collection_points = collect_trusted_collection_points(
+                new_unattached, z_begin, z_end)
+            if len(collection_points):
+                trusted_additions.append(collection_points)
+
+            if trusted_additions:
+                additions = np.ascontiguousarray(
+                    np.concatenate(trusted_additions, axis=0), dtype=np.float32)
+                if trusted_geometry_tree is not None:
+                    additions = np.concatenate(
+                        [trusted_geometry_tree.data, additions], axis=0)
+                updated_trusted_geometry_tree = cKDTree(additions)
+
+                # A newly trusted patch or point collection also has authority
+                # over unverified geometry that was already resident. Reload
+                # those patches from pristine sources and remask them against
+                # the enlarged trusted cloud before replacing their atlas.
+                if unverified_patches:
+                    rebuilt_existing_unverified = \
+                        rebuild_unverified_patch_inputs(
+                            float(cfg['patch_unverified_patch_exclusion_radius']),
+                            updated_trusted_geometry_tree,
+                            include_ids=set(unverified_patches))
+
+            if new_unverified_patches:
+                exclusion_radius = float(
+                    cfg['patch_unverified_patch_exclusion_radius'])
+                (masked_unverified_patches, n_masked_vertices,
+                 n_dropped_patches) = _mask_unverified_patches_near_trusted_geometry(
+                    new_unverified_patches, updated_trusted_geometry_tree,
+                    exclusion_radius)
+                if n_dropped_patches:
+                    raise RuntimeError(
+                        f'{n_dropped_patches} unverified patch(es) have no valid quads '
+                        'after trusted-geometry exclusion')
+                if n_masked_vertices:
+                    print(
+                        f'interactive unverified patches: masked {n_masked_vertices} '
+                        f'vertices near trusted geometry (radius {exclusion_radius:.1f})')
+                new_unverified_patches = masked_unverified_patches
+
+            # ---- Patches: sampling caches, probabilities, atlas append ----
+            if new_verified_patches:
+                for patch in new_verified_patches.values():
+                    prepare_patch_sampling_cache([patch])
+                verified_patches.update(new_verified_patches)
+                verified_patches_list.extend(new_verified_patches.values())
+                areas = np.array([float(p.area) for p in verified_patches_list],
+                                 dtype=np.float32)
+                inv_weights = areas ** 0.5
+                patch_sampling_probabilities = inv_weights / inv_weights.sum()
+                patch_atlas.append_patches(new_verified_patches)
+                if cfg['dt_target_mode'] == 'whole_object_quantile':
+                    prepare_patch_dt_target_samples(
+                        list(new_verified_patches.values()),
+                        cfg['sample_count_patch_dt_target_points'], cfg['dt_target_max_stride'],
+                    )
+
+            if new_collections:
+                cross_patch_pcls.extend(new_cross_patch_values)
+                unattached_pcl_strips.extend(new_unattached_strips)
+                unattached_strip_sampling_groups.extend(
+                    new_unattached_sampling_groups)
+                # The flat GPU bundle is derived from the strip list; drop it
+                # so the next consumer includes the appended strips.
                 unattached_pcl_strips.flat = None
-                # Sampling strata index into the (now longer) pools.
                 rebuild_pcl_sampling_strata()
 
-            if new_patches or new_collections:
+            # Publish the new trust boundary only after the point collections
+            # have passed their linking and annotation validation. Existing
+            # unverified inputs are replaced before new hints are appended, so
+            # both groups use the same enlarged exclusion cloud.
+            trusted_geometry_tree = updated_trusted_geometry_tree
+            if rebuilt_existing_unverified is not None:
+                (unverified_patches, unverified_patches_list,
+                 unverified_patch_sampling_probabilities,
+                 unverified_patch_atlas) = rebuilt_existing_unverified
+                if (cfg['dt_target_mode'] == 'whole_object_quantile'
+                        and unverified_patches_list):
+                    prepare_patch_dt_target_samples(
+                        unverified_patches_list,
+                        cfg['sample_count_patch_dt_target_points'],
+                        cfg['dt_target_max_stride'])
+
+            if new_unverified_patches:
+                for patch in new_unverified_patches.values():
+                    prepare_patch_sampling_cache([patch])
+                if unverified_patch_atlas is None:
+                    unverified_patch_atlas = PatchGpuAtlas(
+                        new_unverified_patches, device='cuda')
+                else:
+                    unverified_patch_atlas.append_patches(
+                        new_unverified_patches)
+                unverified_patches.update(new_unverified_patches)
+                unverified_patches_list.extend(new_unverified_patches.values())
+                interactive_unverified_patch_paths.update(
+                    new_unverified_patch_paths)
+                areas = np.array(
+                    [float(p.area) for p in unverified_patches_list],
+                    dtype=np.float32)
+                inv_weights = areas ** 0.5
+                unverified_patch_sampling_probabilities = \
+                    inv_weights / inv_weights.sum()
+                if cfg['dt_target_mode'] == 'whole_object_quantile':
+                    prepare_patch_dt_target_samples(
+                        list(new_unverified_patches.values()),
+                        cfg['sample_count_patch_dt_target_points'],
+                        cfg['dt_target_max_stride'],
+                    )
+
+            known_verified_patch_ids.update(new_verified_patches)
+            known_unverified_patch_ids.update(new_unverified_patches)
+
+            if (new_verified_patches or new_unverified_patches
+                    or new_collections):
                 # Whole-object DT target caches index the (now longer) object
                 # pools; force recomputation on next use.
                 dt_target_cache_manager.reset()
 
-            if run_cfg['influence_enabled'] and (new_patches or new_collections):
+            # Influence anchors are a trusted correction channel. Unverified
+            # hints deliberately stay out of it and affect only their existing
+            # low-trust radius/DT losses.
+            if run_cfg['influence_enabled'] and (
+                    new_verified_patches or new_collections):
                 influence_state = make_influence_state(run_cfg, torch.device('cuda'))
                 influence_state.activate_or_extend_(
-                    new_patches=new_patches,
+                    new_patches=new_verified_patches,
                     new_collections=new_collections,
                     spiral_and_transform=spiral_and_transform,
                     optimiser=optimiser,
@@ -2373,7 +2530,8 @@ def main(
             )
             interactive_dt_resume_iteration = dt_resume_iteration
 
-            print(f'incorporated {len(new_patches)} patches and '
+            print(f'incorporated {len(new_verified_patches)} verified patches, '
+                  f'{len(new_unverified_patches)} unverified patches, and '
                   f'{len(new_collections)} point collections into the resident session; '
                   f'DT losses disabled until iteration {interactive_dt_resume_iteration}')
         finally:

--- a/volume-cartographer/scripts/spiral/interactive_patch_trust.py
+++ b/volume-cartographer/scripts/spiral/interactive_patch_trust.py
@@ -1,0 +1,53 @@
+"""Trust routing for patches appended to a resident Spiral fit."""
+
+import numpy as np
+
+
+def select_interactive_patch_pool(
+        record, verified_patches, unverified_patches,
+        pending_verified_patches, pending_unverified_patches):
+    """Return the only pool an uploaded patch may enter.
+
+    The service validates this field before staging, but the resident fitter
+    treats its input records as untrusted too. Keeping duplicate detection
+    cross-pool prevents an identifier from changing trust level by shadowing a
+    source patch, including one filtered out of the resident training pool.
+    """
+    input_id = record.get('id')
+    if not isinstance(input_id, str) or not input_id:
+        raise RuntimeError('An interactive patch record has no valid id')
+    classification = record.get('classification', 'verified')
+    if classification not in ('verified', 'unverified'):
+        raise RuntimeError(
+            f'Patch {input_id!r} has invalid classification {classification!r}')
+    if any(input_id in patches for patches in (
+            verified_patches, unverified_patches,
+            pending_verified_patches, pending_unverified_patches)):
+        raise RuntimeError(f'Patch {input_id!r} is already part of this session')
+    target = (pending_verified_patches if classification == 'verified'
+              else pending_unverified_patches)
+    return classification, target
+
+
+def collect_trusted_collection_points(collections, z_begin, z_end):
+    """Return finite in-ROI PCL points in the fitter's z-y-x order."""
+    chunks = []
+    for pcl in collections.values():
+        points = pcl.get('points', {})
+        if not points:
+            continue
+        points_xyz = []
+        for point in points.values():
+            xyz = np.asarray(point.get('p'), dtype=np.float32)
+            if xyz.shape != (3,):
+                raise RuntimeError('Point-collection coordinates must be x-y-z triples')
+            points_xyz.append(xyz)
+        points_zyx = np.stack(points_xyz, axis=0)[:, ::-1]
+        in_roi = (
+            np.isfinite(points_zyx).all(axis=1)
+            & (points_zyx[:, 0] >= z_begin)
+            & (points_zyx[:, 0] < z_end))
+        if in_roi.any():
+            chunks.append(points_zyx[in_roi])
+    return (np.concatenate(chunks, axis=0)
+            if chunks else np.empty((0, 3), dtype=np.float32))

--- a/volume-cartographer/scripts/spiral/spiral_service.py
+++ b/volume-cartographer/scripts/spiral/spiral_service.py
@@ -53,7 +53,7 @@ from fit_session import (API_VERSION, PclRole, parse_session_request,
 from config import Config
 
 
-SERVICE_VERSION = "6.1.0"
+SERVICE_VERSION = "6.2.0"
 MAX_BODY_BYTES = 4 * 1024 * 1024
 MAX_DEDUPLICATED_COMMANDS = 256
 TRANSFER_CHUNK_BYTES = 1024 * 1024
@@ -90,6 +90,8 @@ _PCL_ROLE_FILES = {
     PclRole.SAME_WINDING.value: "same_windings.json",
     PclRole.DRAWN_CONTROL_POINTS.value: "drawn_control_points.json",
 }
+
+_PATCH_CLASSIFICATIONS = frozenset(("verified", "unverified"))
 
 # Base input paths are owned by the service when it was launched with
 # --dataset; a load request may then only choose among service-advertised
@@ -531,16 +533,17 @@ class ArtifactRegistry:
 
 
 class Upload:
-    __slots__ = ("upload_id", "session_id", "kind", "role", "input_id",
+    __slots__ = ("upload_id", "session_id", "kind", "role", "classification", "input_id",
                  "manifest", "staging_dir", "received", "record", "created",
                  "lock")
 
-    def __init__(self, upload_id, session_id, kind, role, input_id, manifest,
-                 staging_dir):
+    def __init__(self, upload_id, session_id, kind, role, classification,
+                 input_id, manifest, staging_dir):
         self.upload_id = upload_id
         self.session_id = session_id
         self.kind = kind
         self.role = role
+        self.classification = classification
         self.input_id = input_id
         self.manifest = manifest
         self.staging_dir = staging_dir
@@ -1148,6 +1151,7 @@ class ServiceState:
         return {
             "api_version": API_VERSION,
             "service_version": SERVICE_VERSION,
+            "capabilities": ["patch_classification"],
             "service_name": self.service_name,
             "session_name": self.session_name,
             "session_id": self.session_id,
@@ -1232,7 +1236,9 @@ class ServiceState:
                 {"id": record["id"], "kind": record["kind"],
                  "role": record.get("role"), "state": record["state"],
                  "bytes": record["bytes"],
-                 "committed": bool(record.get("committed"))}
+                 "committed": bool(record.get("committed")),
+                 **({"classification": record.get("classification", "verified")}
+                    if record["kind"] == "patch" else {})}
                 for record in self.ephemeral_records
             ]
             available, reason = self._commit_availability()
@@ -2216,6 +2222,18 @@ class ServiceState:
         if kind not in ("patch", "fiber", "pcl", "checkpoint"):
             raise ApiError(HTTPStatus.BAD_REQUEST,
                            "Input kind must be one of patch, fiber, pcl, checkpoint")
+        classification = None
+        if kind == "patch":
+            classification = request.get("classification", "verified")
+            if not isinstance(classification, str) \
+                    or classification not in _PATCH_CLASSIFICATIONS:
+                raise ApiError(
+                    HTTPStatus.BAD_REQUEST,
+                    "Patch classification must be verified or unverified")
+        elif "classification" in request:
+            raise ApiError(
+                HTTPStatus.BAD_REQUEST,
+                "Only patch uploads may declare a classification")
         role = request.get("role")
         if kind == "pcl":
             if role not in _PCL_ROLE_FILES:
@@ -2292,8 +2310,8 @@ class ServiceState:
                                    "The ephemeral input quota is exhausted")
             upload_id = secrets.token_hex(16)
             staging = self._staging_root() / upload_id
-            upload = Upload(upload_id, self.session_id, kind, role, input_id,
-                            manifest, staging)
+            upload = Upload(upload_id, self.session_id, kind, role,
+                            classification, input_id, manifest, staging)
             self.uploads[upload_id] = upload
         staging.mkdir(parents=True, exist_ok=True)
         return {**self._base(), "upload_id": upload_id, "accepted": True}
@@ -2393,6 +2411,8 @@ class ServiceState:
                 "state": "pending",
                 "upload_id": upload.upload_id,
             }
+            if upload.kind == "patch":
+                record["classification"] = upload.classification
             upload.record = record
         with self.lock:
             self.ephemeral_records.append(record)
@@ -2500,17 +2520,32 @@ class ServiceState:
                            and not record.get("committed")]
                 paths = self.session_paths
             dataset_root = Path(paths.dataset_root)
-            patches_dir = Path(paths.verified_patches) if paths.verified_patches \
+            verified_patches_dir = Path(paths.verified_patches) if paths.verified_patches \
                 else dataset_root / "verified_patches"
+            unverified_patches_dir = Path(paths.unverified_patches) if paths.unverified_patches \
+                else dataset_root / "unverified_patches"
             fibers_dir = Path(paths.fibers) if paths.fibers else dataset_root / "fibers"
+
+            def patch_destination(record):
+                classification = record.get("classification", "verified")
+                if classification == "verified":
+                    return verified_patches_dir / record["id"]
+                if classification == "unverified":
+                    return unverified_patches_dir / record["id"]
+                raise ApiError(
+                    HTTPStatus.CONFLICT,
+                    f"Patch {record['id']!r} has an invalid classification")
 
             # Collision checks and publications share the same dataset lock, so
             # cooperating service processes cannot race an existence check.
             for record in records:
-                if record["kind"] == "patch" and (patches_dir / record["id"]).exists():
-                    raise ApiError(
-                        HTTPStatus.CONFLICT,
-                        f"A patch named {record['id']!r} already exists in the dataset")
+                if record["kind"] == "patch":
+                    patch_id = record["id"]
+                    if (verified_patches_dir / patch_id).exists() \
+                            or (unverified_patches_dir / patch_id).exists():
+                        raise ApiError(
+                            HTTPStatus.CONFLICT,
+                            f"A patch named {patch_id!r} already exists in the dataset")
                 if record["kind"] == "fiber" and \
                         (fibers_dir / f"{record['id']}.json").exists():
                     raise ApiError(
@@ -2522,10 +2557,16 @@ class ServiceState:
                 source = Path(record["path"])
                 # A still-pending record keeps its staged copy: it remains the
                 # incorporation source for the next run, so committing never
-                # removes an input from the live session's queue.
-                keep_source = record["state"] == "pending"
+                # removes an input from the live session's queue. Incorporated
+                # unverified patches also keep their pristine session copy so
+                # the fitter can safely remask them if the trusted-exclusion
+                # radius changes. Session teardown removes the ephemeral tree.
+                keep_source = (
+                    record["state"] == "pending"
+                    or (record["kind"] == "patch"
+                        and record.get("classification") == "unverified"))
                 if record["kind"] == "patch":
-                    _copy_publish(source, patches_dir / record["id"], keep_source)
+                    _copy_publish(source, patch_destination(record), keep_source)
                 elif record["kind"] == "fiber":
                     _copy_publish(source, fibers_dir / f"{record['id']}.json", keep_source)
                 else:
@@ -2554,11 +2595,17 @@ class ServiceState:
                 for record in records:
                     record["committed"] = True
                 # Committed records that already joined the resident fit are
-                # done; pending ones stay queued for the next run.
+                # done; pending ones stay queued for the next run. An
+                # unverified patch retains its record and pristine staged
+                # source for live exclusion-radius remasking. Keeping the
+                # record also keeps those bytes inside the ephemeral quota.
                 self.ephemeral_records = [
                     record for record in self.ephemeral_records
                     if not (record.get("committed")
-                            and record["state"] == "incorporated")
+                            and record["state"] == "incorporated"
+                            and not (record["kind"] == "patch"
+                                     and record.get("classification")
+                                     == "unverified"))
                 ]
                 if self.dataset_resolution is not None:
                     self.dataset_resolution = resolve_dataset_root(

--- a/volume-cartographer/scripts/spiral/tests/test_interactive_patch_trust.py
+++ b/volume-cartographer/scripts/spiral/tests/test_interactive_patch_trust.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+import sys
+import unittest
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from interactive_patch_trust import (
+    collect_trusted_collection_points,
+    select_interactive_patch_pool,
+)
+
+
+def _select(record, verified=None, unverified=None,
+            pending_verified=None, pending_unverified=None):
+    verified = {} if verified is None else verified
+    unverified = {} if unverified is None else unverified
+    pending_verified = {} if pending_verified is None else pending_verified
+    pending_unverified = {} if pending_unverified is None else pending_unverified
+    return select_interactive_patch_pool(
+        record, verified, unverified, pending_verified, pending_unverified)
+
+
+class InteractivePatchTrustTests(unittest.TestCase):
+    def test_legacy_record_defaults_only_to_verified_pool(self):
+        pending_verified = {}
+        pending_unverified = {}
+
+        classification, target = _select(
+            {'id': 'legacy-patch'}, pending_verified=pending_verified,
+            pending_unverified=pending_unverified)
+
+        self.assertEqual(classification, 'verified')
+        self.assertIs(target, pending_verified)
+        self.assertIsNot(target, pending_unverified)
+
+    def test_unverified_record_selects_only_unverified_pool(self):
+        pending_verified = {}
+        pending_unverified = {}
+
+        classification, target = _select(
+            {'id': 'scrollfiesta-hint', 'classification': 'unverified'},
+            pending_verified=pending_verified,
+            pending_unverified=pending_unverified)
+
+        self.assertEqual(classification, 'unverified')
+        self.assertIs(target, pending_unverified)
+        self.assertIsNot(target, pending_verified)
+
+    def test_fitter_rejects_unknown_explicit_classification(self):
+        for classification in (None, '', 'trusted', 'UNVERIFIED', 1):
+            with self.subTest(classification=classification):
+                with self.assertRaisesRegex(RuntimeError, 'invalid classification'):
+                    _select({'id': 'hint', 'classification': classification})
+
+    def test_duplicate_identifier_is_rejected_across_every_trust_pool(self):
+        for pool_name in (
+                'verified', 'unverified',
+                'pending_verified', 'pending_unverified'):
+            with self.subTest(pool_name=pool_name):
+                pools = {
+                    'verified': {},
+                    'unverified': {},
+                    'pending_verified': {},
+                    'pending_unverified': {},
+                }
+                pools[pool_name]['shared-id'] = object()
+                with self.assertRaisesRegex(
+                        RuntimeError, 'already part of this session'):
+                    _select(
+                        {'id': 'shared-id', 'classification': 'unverified'},
+                        **pools)
+
+    def test_filtered_source_identifier_remains_reserved(self):
+        with self.assertRaisesRegex(
+                RuntimeError, 'already part of this session'):
+            _select(
+                {'id': 'outside-roi', 'classification': 'unverified'},
+                verified={'outside-roi'})
+
+    def test_new_point_collections_extend_the_trusted_exclusion_cloud(self):
+        collections = {
+            1: {'points': {
+                '0': {'p': [10.0, 20.0, 30.0]},
+                '1': {'p': [11.0, 21.0, 31.0]},
+                '2': {'p': [12.0, 22.0, 99.0]},
+                '3': {'p': [float('nan'), 23.0, 32.0]},
+            }},
+            2: {'points': {}},
+        }
+
+        points = collect_trusted_collection_points(collections, 25, 40)
+
+        np.testing.assert_array_equal(
+            points,
+            np.array([[30.0, 20.0, 10.0],
+                      [31.0, 21.0, 11.0]], dtype=np.float32))
+
+    def test_malformed_trusted_collection_point_is_rejected(self):
+        collections = {1: {'points': {'0': {'p': [1.0, 2.0]}}}}
+        with self.assertRaisesRegex(RuntimeError, 'x-y-z triples'):
+            collect_trusted_collection_points(collections, 0, 10)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/volume-cartographer/scripts/spiral/tests/test_spiral_service_v2.py
+++ b/volume-cartographer/scripts/spiral/tests/test_spiral_service_v2.py
@@ -167,7 +167,7 @@ def _digest(data):
     return hashlib.sha256(data).hexdigest()
 
 
-def _upload_input(state, kind, input_id, files, role=None):
+def _upload_input(state, kind, input_id, files, role=None, classification=None):
     request = {
         "kind": kind, "id": input_id,
         "files": [{"name": name, "size": len(data), "sha256": _digest(data)}
@@ -175,6 +175,8 @@ def _upload_input(state, kind, input_id, files, role=None):
     }
     if role:
         request["role"] = role
+    if classification is not None:
+        request["classification"] = classification
     upload_id = state.begin_upload(request)["upload_id"]
     for name, data in files.items():
         state.receive_upload_file(upload_id, name, io.BytesIO(data), len(data))
@@ -337,6 +339,7 @@ class AuthenticationTests(HttpServiceFixture):
         health = json.loads(payload)
         self.assertEqual(health["api_version"], API_VERSION)
         self.assertIn("service_version", health)
+        self.assertIn("patch_classification", health["capabilities"])
         self.assertIn("service_name", health)
         self.assertIn("session_name", health)
         self.assertIn("session_generation", health)
@@ -745,6 +748,7 @@ class UploadTests(unittest.TestCase):
         response = self.state.finalize_upload(upload_id)
         record = response["input"]
         self.assertEqual(record["state"], "pending")
+        self.assertEqual(record["classification"], "verified")
         published = Path(record["path"])
         self.assertTrue((published / "meta.json").is_file())
         self.assertIn(".spiral-ephemeral", str(published))
@@ -755,6 +759,42 @@ class UploadTests(unittest.TestCase):
         # Finalize is idempotent.
         self.assertEqual(self.state.finalize_upload(upload_id)["input"]["id"],
                          "patch-1")
+
+    def test_unverified_patch_classification_survives_into_the_next_run(self):
+        session = self._session()
+        upload_id = _upload_input(
+            self.state, "patch", "scrollfiesta-hint", PATCH_FILES,
+            classification="unverified")
+        record = self.state.finalize_upload(upload_id)["input"]
+        self.assertEqual(record["classification"], "unverified")
+        self.assertEqual(
+            self.state.status()["ephemeral_inputs"][0]["classification"],
+            "unverified")
+
+        _planned_run(self.state, {"iterations": 2})
+        _, pending, _, _, _ = session.run_calls[-1]
+        self.assertEqual(pending[0]["classification"], "unverified")
+
+    def test_invalid_or_misplaced_patch_classification_is_rejected_before_staging(self):
+        self._session()
+        manifest = [{"name": "meta.json", "size": 1, "sha256": "0" * 64}]
+        for classification in (None, "", "trusted", "UNVERIFIED", 1, ["unverified"]):
+            with self.subTest(classification=classification):
+                with self.assertRaisesRegex(ApiError, "classification") as caught:
+                    self.state.begin_upload({
+                        "kind": "patch", "id": "hint", "files": manifest,
+                        "classification": classification,
+                    })
+                self.assertEqual(caught.exception.status, 400)
+        with self.assertRaisesRegex(ApiError, "Only patch uploads") as caught:
+            self.state.begin_upload({
+                "kind": "fiber", "id": "fiber", "files": manifest,
+                "classification": "unverified",
+            })
+        self.assertEqual(caught.exception.status, 400)
+        self.assertEqual(self.state.uploads, {})
+        staging = self.output / ".spiral-upload-staging"
+        self.assertFalse(staging.exists())
 
     def test_finalize_rejects_missing_files_and_digest_mismatch(self):
         self._session()
@@ -1220,8 +1260,10 @@ class CommitTests(unittest.TestCase):
         os.chmod(self.dataset, 0o755)
         self.temporary.cleanup()
 
-    def _finalize(self, kind, input_id, files, role=None):
-        upload_id = _upload_input(self.state, kind, input_id, files, role=role)
+    def _finalize(self, kind, input_id, files, role=None, classification=None):
+        upload_id = _upload_input(
+            self.state, kind, input_id, files, role=role,
+            classification=classification)
         return self.state.finalize_upload(upload_id)["input"]
 
     def test_commit_publishes_patches_fibers_and_merges_role_pcls(self):
@@ -1248,6 +1290,43 @@ class CommitTests(unittest.TestCase):
                          {"patch-9", "fiber-9", "pcl-9"})
         self.assertTrue(all(record["committed"] and record["state"] == "pending"
                             for record in inputs))
+
+    def test_unverified_patch_commits_only_to_the_unverified_pool(self):
+        record = self._finalize(
+            "patch", "scrollfiesta-hint", PATCH_FILES,
+            classification="unverified")
+        self.assertEqual(record["classification"], "unverified")
+
+        self.state.commit_inputs()
+
+        self.assertTrue((self.dataset / "unverified_patches" /
+                         "scrollfiesta-hint" / "meta.json").is_file())
+        self.assertFalse((self.dataset / "verified_patches" /
+                          "scrollfiesta-hint").exists())
+        pending = self.state.status()["ephemeral_inputs"][0]
+        self.assertTrue(pending["committed"])
+        self.assertEqual(pending["classification"], "unverified")
+
+    def test_incorporated_unverified_patch_keeps_pristine_session_source_for_remasking(self):
+        record = self._finalize(
+            "patch", "scrollfiesta-hint", PATCH_FILES,
+            classification="unverified")
+        staged = Path(record["path"])
+        _planned_run(self.state, {"iterations": 1})
+        _, pending, mark, _, _ = self.session.run_calls[-1]
+        mark(pending)
+
+        self.state.commit_inputs()
+
+        self.assertTrue(staged.is_dir())
+        self.assertTrue((staged / "meta.json").is_file())
+        self.assertTrue((self.dataset / "unverified_patches" /
+                         "scrollfiesta-hint" / "meta.json").is_file())
+        retained = self.state.status()["ephemeral_inputs"]
+        self.assertEqual(len(retained), 1)
+        self.assertEqual(retained[0]["state"], "incorporated")
+        self.assertTrue(retained[0]["committed"])
+        self.assertEqual(retained[0]["classification"], "unverified")
 
     def test_concurrent_service_commits_serialize_pcl_merges(self):
         output_b = self.root / "output-b"
@@ -1438,6 +1517,29 @@ class CommitTests(unittest.TestCase):
         self.assertEqual((existing / "meta.json").read_text(), "original")
         # The ephemeral input is untouched and still usable.
         self.assertEqual(self.state.status()["ephemeral_inputs"][0]["state"], "pending")
+
+    def test_patch_identifier_cannot_shadow_the_other_trust_pool(self):
+        existing = self.dataset / "verified_patches" / "shared-id"
+        existing.mkdir()
+        (existing / "meta.json").write_text("verified original")
+        self._finalize(
+            "patch", "shared-id", PATCH_FILES, classification="unverified")
+        with self.assertRaisesRegex(ApiError, "already exists") as caught:
+            self.state.commit_inputs()
+        self.assertEqual(caught.exception.status, 409)
+        self.assertEqual((existing / "meta.json").read_text(), "verified original")
+        self.assertFalse((self.dataset / "unverified_patches" / "shared-id").exists())
+
+    def test_verified_patch_cannot_shadow_an_unverified_patch(self):
+        existing = self.dataset / "unverified_patches" / "shared-id"
+        existing.mkdir(parents=True)
+        (existing / "meta.json").write_text("unverified original")
+        self._finalize("patch", "shared-id", PATCH_FILES)
+        with self.assertRaisesRegex(ApiError, "already exists") as caught:
+            self.state.commit_inputs()
+        self.assertEqual(caught.exception.status, 409)
+        self.assertEqual((existing / "meta.json").read_text(), "unverified original")
+        self.assertFalse((self.dataset / "verified_patches" / "shared-id").exists())
 
     def test_commit_on_read_only_dataset_is_reported_unavailable(self):
         self._finalize("patch", "patch-2", PATCH_FILES)


### PR DESCRIPTION
## Summary

Add an explicit low-trust path for bringing external TIFXYZ geometry, including
ScrollFiesta exports, into a running Spiral fit without promoting it to verified
geometry.

- add **Add unverified hint...** to the running-fit panel and **Add as
  unverified Spiral hint** to local surfaces
- carry an optional patch `classification` through upload, status, resident
  incorporation, and commit; omitted classification remains `verified`
- keep unverified hints in Spiral's existing unverified atlas/losses, outside
  verified geometry and interactive influence anchors
- mask hints near trusted verified-patch/PCL geometry, including trusted inputs
  added in the same pause boundary, and remask resident hints when trust grows
- commit hints only to `unverified_patches/` and reject identifiers colliding
  with either trust pool
- advertise a service capability so updated VC3D fails closed rather than
  sending an unverified hint to an older service

## Motivation

This is the next integration step after [#1155](https://github.com/ScrollPrize/villa/pull/1155),
whose opening rationale records that the Vesuvius team asked for ScrollFiesta in
VC3D and first added the native Windows build path needed to support it.

VC3D and Spiral already distinguish verified and unverified patch pools, but
the interactive upload path treated every added patch as verified. That makes
direct integration of automatically generated geometry unsafe: useful hints
could not enter a resident fit without silently crossing the trust boundary.

This change connects the existing low-trust model to the interactive workflow
while preserving the historical verified behavior for old clients and ordinary
surface uploads.

## Trust and compatibility guarantees

- only exact `verified` / `unverified` classifications are accepted
- old clients omit the field and retain the verified default
- verified VC3D uploads retain the legacy request shape
- unverified VC3D uploads require the advertised `patch_classification`
  capability
- source identifiers remain reserved even if erosion, ROI filtering, or later
  trusted masking removes a patch from the resident training pool
- committed unverified inputs retain a pristine session source for safe
  remasking; their bytes remain charged to the session quota
- no ScrollFiesta runtime or dependency is bundled

## Validation

- 15 focused protocol, trust-routing, trusted-PCL, compatibility, collision,
  commit, and source-retention tests pass
- all 96 platform-applicable tests in `test_spiral_service_v2.py` pass locally;
  the five remaining local failures are existing Windows/POSIX-semantics tests
- compiled ScrollFiesta `scroll_unroll --selftest` passes with zero failures,
  including TIFXYZ export
- Villa parses the compiled-exporter fixture as `(21, 21, 3)`, 441 valid
  vertices, area 400.0
- the service accepts all seven exporter files as unverified, publishes only
  under `unverified_patches/`, and preserves ScrollFiesta provenance
- [native CI](https://github.com/TAUIL-Abd-Elilah/villa/actions/runs/31282883258):
  Linux VC3D compile/offscreen smoke, macOS compile, C++ tests, and compile
  shards pass
- [Windows CI](https://github.com/TAUIL-Abd-Elilah/villa/actions/runs/31282883267):
  MSYS2 configure/build and the Windows MCP support test pass; release
  packaging and packaged-tree smoke are intentionally skipped for PR events
- [CodeQL](https://github.com/TAUIL-Abd-Elilah/villa/actions/runs/31282883305):
  every changed controller/component/core/tools shard passes
