### PR TITLE
Add a physical evaluation harness for surface predictions (cross-scan ground truth)

### DIFF
--- a/scripts/physical_eval/README.md
+++ b/scripts/physical_eval/README.md
@@ -1,0 +1,29 @@
+# Physical evaluation harness for surface predictions
+
+Evaluates any binary surface prediction volume against ground-truth labels derived from a second, higher-resolution scan of the same scroll, rather than from another model or from mesh-derived annotations.
+
+Two label volumes exist so far, built by registering the scroll pairs that have two public scans (split-half validated at 4.1 um and 2.4 um median error):
+
+- PHerc0139: 9.362 um frame, truth from the 1.129 um scan
+- PHerc1203 (Grand Prize list): 9.362 um frame, truth from the 2.403 um scan, including compressed and boundary-poor tissue
+
+The label volumes (uint8 bit flags: valid / material / centerline / recto_band, plus boundary_poor for PHerc1203), the registration transforms, and the audit built on them are at
+https://github.com/7jycwjmbfn-eng/pherc0139-physical-audit (labels attached to the release).
+
+## Usage
+
+```bash
+python3 eval_surface_pred.py LABELS.zarr PRED.zarr PRED_LEVEL
+```
+
+`PRED_LEVEL` is the pyramid level of the prediction volume (0 or 1); level 0 is max-pooled to the label grid. Dependencies: numpy, scipy, numcodecs.
+
+Reported metrics, each alongside a shifted-null control (the same prediction displaced 1.2 mm in-plane):
+
+- point recall at 19 / 37 / 56 um from truth sheet centerlines
+- arc-level recall and fully-missed rate over 1.2 mm sheet stretches
+- recto-side overlap ratio
+
+The null control matters in dense tissue: on PHerc1203 the null alone reaches 64.6 percent point recall at 37 um, so radius metrics without it overread performance exactly where the hard failures live.
+
+Checked against the published m7 volume for PHerc0139, the harness reproduces the audit numbers in the repository above to four decimals from the packaged files alone.

--- a/scripts/physical_eval/README.md
+++ b/scripts/physical_eval/README.md
@@ -7,7 +7,7 @@ Two label volumes exist so far, built by registering the scroll pairs that have 
 - PHerc0139: 9.362 um frame, truth from the 1.129 um scan
 - PHerc1203 (Grand Prize list): 9.362 um frame, truth from the 2.403 um scan, including compressed and boundary-poor tissue
 
-The label volumes (uint8 bit flags: valid / material / centerline / recto_band, plus boundary_poor for PHerc1203), the registration transforms, and the audit built on them are at
+The label volumes (uint8 bit flags: valid / material / centerline / recto_band, plus boundary_poor for PHerc1203, which flags material whose gap visibility falls under 0.40 and covers 72.8 percent of material voxels there rather than a small minority), the registration transforms, and the audit built on them are at
 https://github.com/7jycwjmbfn-eng/pherc0139-physical-audit (labels attached to the release).
 
 ## Usage
@@ -24,11 +24,13 @@ Reported metrics, each alongside a shifted-null control (the same prediction dis
 - arc-level recall and fully-missed rate over 1.2 mm sheet stretches
 - `side_inward`, the fraction of centerline points where the prediction sits on the inward (recto) side of the sheet, with both its shifted null and an ideal-recto ceiling built from the truth (`side_inward_null`, `side_inward_ideal`, `side_skill_of_ideal`)
 
-One metric stands outside that rule. `recto_side_ratio` is a raw mass-overlap quantity, prediction mass on the recto band against the verso side, and it carries no control; it is kept for continuity and is not the side metric the audit quotes. The estimator behind `side_inward` self-tests on synthetic stripes at four angles before any volume is read, and each of its three arms selects its own points under the same 3-voxel rule.
+One metric stands outside that rule. `recto_side_ratio` is a raw mass-overlap quantity, prediction mass on the recto band against the verso side, and it carries no control; it is kept for continuity and is not the side metric the audit quotes. The estimator behind `side_inward` self-tests on synthetic stripes at four angles before any volume is read.
+
+The side arms are conditioned, which matters if you plan to freeze against the calibrated skill. `side_inward` keeps coherent centerline points with the prediction within 3 voxels. `side_inward_null` and `side_inward_ideal` keep the subset of *those* points that also has their own band within 3 voxels, so the populations are real, real AND null, real AND ideal, and the calibration is a within-real comparison. This reproduces what the audit pass does. The `_full` variants of both controls drop the conditioning and select from the whole coherent centerline set; each arm reports its own decided count. `side_inward` is identical under either reading, since the real arm is the same set both ways, so un-nesting moves the controls only.
 
 The null control matters in dense tissue: on PHerc1203 the null alone reaches 64.6 percent point recall at 37 um, so radius metrics without it overread performance exactly where the hard failures live.
 
-Run against the published m7 volumes, the harness output is committed in the repository above at `results/eval_selfcheck_0139.json` and `results/1203/eval_selfcheck_1203.json`, so a rerun can be diffed against a file. The point and arc numbers match the audit to four decimals; the side arm agrees to three, because the audit took sheet normals from the registered high-resolution grayscale and the harness takes them from the packaged material mask.
+Run against the published m7 volumes, the harness output is committed in the repository above at `results/eval_selfcheck_0139.json` and `results/1203/eval_selfcheck_1203.json`, so a rerun can be diffed against a file. The point and arc numbers match the audit to four decimals, as does the side null; the inward fraction and ceiling agree to three. The harness takes sheet normals from the packaged material mask because the label package does not carry the high-resolution grayscale the audit used, which moves the decided count by 0.09 percent on PHerc0139.
 
 Label tarball hashes:
 

--- a/scripts/physical_eval/README.md
+++ b/scripts/physical_eval/README.md
@@ -7,7 +7,7 @@ Two label volumes exist so far, built by registering the scroll pairs that have 
 - PHerc0139: 9.362 um frame, truth from the 1.129 um scan
 - PHerc1203 (Grand Prize list): 9.362 um frame, truth from the 2.403 um scan, including compressed and boundary-poor tissue
 
-The label volumes (uint8 bit flags: valid / material / centerline / recto_band, plus boundary_poor for PHerc1203, which flags material whose gap visibility falls under 0.40 and covers 72.8 percent of material voxels there rather than a small minority), the registration transforms, and the audit built on them are at
+The label volumes (uint8 bit flags: valid / material / centerline / recto_band, plus boundary_poor for PHerc1203, which flags material whose gap visibility falls under 0.40 and covers 74.6 percent of material voxels there rather than a small minority), the registration transforms, and the audit built on them are at
 https://github.com/7jycwjmbfn-eng/pherc0139-physical-audit (labels attached to the release).
 
 ## Usage

--- a/scripts/physical_eval/README.md
+++ b/scripts/physical_eval/README.md
@@ -22,8 +22,17 @@ Reported metrics, each alongside a shifted-null control (the same prediction dis
 
 - point recall at 19 / 37 / 56 um from truth sheet centerlines
 - arc-level recall and fully-missed rate over 1.2 mm sheet stretches
-- recto-side overlap ratio
+- `side_inward`, the fraction of centerline points where the prediction sits on the inward (recto) side of the sheet, with both its shifted null and an ideal-recto ceiling built from the truth (`side_inward_null`, `side_inward_ideal`, `side_skill_of_ideal`)
+
+One metric stands outside that rule. `recto_side_ratio` is a raw mass-overlap quantity, prediction mass on the recto band against the verso side, and it carries no control; it is kept for continuity and is not the side metric the audit quotes. The estimator behind `side_inward` self-tests on synthetic stripes at four angles before any volume is read, and each of its three arms selects its own points under the same 3-voxel rule.
 
 The null control matters in dense tissue: on PHerc1203 the null alone reaches 64.6 percent point recall at 37 um, so radius metrics without it overread performance exactly where the hard failures live.
 
-Checked against the published m7 volume for PHerc0139, the harness reproduces the audit numbers in the repository above to four decimals from the packaged files alone.
+Run against the published m7 volumes, the harness output is committed in the repository above at `results/eval_selfcheck_0139.json` and `results/1203/eval_selfcheck_1203.json`, so a rerun can be diffed against a file. The point and arc numbers match the audit to four decimals; the side arm agrees to three, because the audit took sheet normals from the registered high-resolution grayscale and the harness takes them from the packaged material mask.
+
+Label tarball hashes:
+
+```
+labels0139_L1.tar  sha256 42fe53b760c2c9347d9f215bafa68beec8e96121d03549dab56a52a9a0a9e8dd
+labels1203_L1.tar  sha256 32a09f6081342b0f015b258ec577d0296ff23a55892af9785689d8a55bff344c
+```

--- a/scripts/physical_eval/eval_surface_pred.py
+++ b/scripts/physical_eval/eval_surface_pred.py
@@ -83,6 +83,21 @@ SIDE_STEP = 2.0        # sampling offset along the sheet normal, voxels
 SIDE_COH_MIN = 0.3     # structure-tensor coherence floor
 
 
+def _dist(band):
+    """Distance to the nearest set voxel, infinite if the band is empty.
+
+    A slice is scored on its truth alone, so a prediction that is empty or
+    nearly so has to stay in its own denominator and score zero rather than
+    drop the slice. scipy's transform does not give that for free: with no
+    set voxel it treats outside-the-array as background and returns 1.0 at
+    the border, which would read as a hit. Raised by TAUIL-Abd-Elilah on
+    the villa PR.
+    """
+    if not band.any():
+        return np.full(band.shape, np.inf)
+    return ndi.distance_transform_edt(~band)
+
+
 def normal_field(g):
     """Per-pixel sheet normal from the 2D structure tensor."""
     gy, gx = ndi.sobel(g, 0), ndi.sobel(g, 1)
@@ -163,14 +178,14 @@ def side_stats(acc, tb, pb, pbs, recto_k, ys, xs, cd):
     inner = near[coh]                         # real-near subset of it
     yn, xn = ya[inner], xa[inner]
     nyn, nxn = ny[inner], nx[inner]
-    dpred = ndi.distance_transform_edt(~pb)
+    dpred = _dist(pb)
     i, o = _inward_counts(dpred, yn, xn, nyn, nxn)
     acc["side_in"] += i
     acc["side_out"] += o
     for band, key in ((pbs, "null"), (recto_k, "ideal")):
         if not band.any():
             continue
-        d = ndi.distance_transform_edt(~band)
+        d = _dist(band)
         sel = d[yn, xn] <= 3                  # conditioned, as the report
         if sel.sum() > 100:
             i, o = _inward_counts(d, yn[sel], xn[sel], nyn[sel], nxn[sel])
@@ -215,9 +230,9 @@ def main(labels_path, pred_path, pred_level):
             tb = material[k]
             pb = pred[k] & valid[k]
             ctr = (lab[k] & 4) > 0
-            if ctr.sum() < 500 or pb.sum() < 100:
+            if ctr.sum() < 500:
                 continue
-            dpred = ndi.distance_transform_edt(~pb)
+            dpred = _dist(pb)
             ys, xs = np.nonzero(ctr)
             cd = dpred[ys, xs]
             acc["n_ctr"] += len(ys)
@@ -225,7 +240,7 @@ def main(labels_path, pred_path, pred_level):
                 acc["hits"][r] += int((cd <= r).sum())
             pbs = np.zeros_like(pb)
             pbs[NULL_SHIFT:] = pb[:-NULL_SHIFT]
-            dnull = ndi.distance_transform_edt(~pbs)
+            dnull = _dist(pbs)
             nd = dnull[ys, xs]
             acc["null2"] += int((nd <= 2).sum())
             lab2, _ = ndi.label(ctr, structure=np.ones((3, 3), int))

--- a/scripts/physical_eval/eval_surface_pred.py
+++ b/scripts/physical_eval/eval_surface_pred.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Evaluate any surface prediction against the PHerc0139 physical truth labels.
+
+Standalone: needs numpy, scipy, numcodecs. Usage:
+
+  python3 eval_surface_pred.py LABELS.zarr PRED.zarr PRED_LEVEL
+
+LABELS.zarr : the packaged truth (uint8 bit flags, L1 grid, see .zattrs)
+PRED.zarr   : binary prediction volume on the SAME lo volume's grid
+PRED_LEVEL  : pyramid level of PRED (0 or 1); level 0 is max-pooled to L1
+
+Reports, each with a shifted-null control printed alongside:
+  point recall at 1/2/3 L1 voxels (19/37/56 um)
+  arc-level recall (1.2 mm sheet stretches, >=50% covered) and fully-missed
+  recto-side overlap ratio (prediction mass on recto band vs verso side)
+"""
+import json
+import sys
+from pathlib import Path
+
+import numcodecs
+import numpy as np
+from scipy import ndimage as ndi
+
+NULL_SHIFT = 64
+
+
+def read_chunk(root, comp, cz, cy, cx, ch, dtype=np.uint8):
+    f = Path(root) / str(cz) / str(cy) / str(cx)
+    if not f.is_file():
+        return None
+    raw = f.read_bytes()
+    if comp is not None:
+        raw = comp.decode(raw)
+    a = np.frombuffer(raw, dtype)
+    if a.size != ch ** 3:            # tolerate truncated edge chunks
+        nz = a.size // (ch * ch)
+        blk = np.zeros((ch, ch, ch), dtype)
+        blk[:nz] = a.reshape(nz, ch, ch)
+        return blk
+    return a.reshape(ch, ch, ch)
+
+
+def open_zarr(root):
+    m = json.loads((Path(root) / ".zarray").read_text())
+    comp = numcodecs.get_codec(m["compressor"]) if m["compressor"] else None
+    return m, comp
+
+
+def read_box(root, z0, z1, y0, y1, x0, x1):
+    m, comp = open_zarr(root)
+    ch = m["chunks"][0]
+    out = np.zeros((z1 - z0, y1 - y0, x1 - x0), np.uint8)
+    for cz in range(z0 // ch, -(-z1 // ch)):
+        for cy in range(y0 // ch, -(-y1 // ch)):
+            for cx in range(x0 // ch, -(-x1 // ch)):
+                blk = read_chunk(root, comp, cz, cy, cx, ch)
+                if blk is None:
+                    continue
+                az, ay, ax = cz * ch, cy * ch, cx * ch
+                s = [slice(max(az, z0), min(az + ch, z1)),
+                     slice(max(ay, y0), min(ay + ch, y1)),
+                     slice(max(ax, x0), min(ax + ch, x1))]
+                if any(sl.stop <= sl.start for sl in s):
+                    continue
+                out[s[0].start - z0:s[0].stop - z0,
+                    s[1].start - y0:s[1].stop - y0,
+                    s[2].start - x0:s[2].stop - x0] = \
+                    blk[s[0].start - az:s[0].stop - az,
+                        s[1].start - ay:s[1].stop - ay,
+                        s[2].start - ax:s[2].stop - ax]
+    return out
+
+
+def main(labels_path, pred_path, pred_level):
+    attrs = json.loads((Path(labels_path) / ".zattrs").read_text())
+    oz, oy, ox = attrs["origin_l1"]
+    meta, _ = open_zarr(labels_path)
+    Z, Y, X = meta["shape"]
+    acc = dict(n_ctr=0, hits={1: 0, 2: 0, 3: 0}, null2=0,
+               n_arc=0, arc_hit=0, arc_gone=0, narc_hit=0, narc_gone=0,
+               pred_on_recto=0, pred_on_verso=0)
+    step = 96
+    for z0 in range(0, Z, step):
+        z1 = min(z0 + step, Z)
+        lab = read_box(labels_path, z0, z1, 0, Y, 0, X)
+        gz0, gz1 = oz + z0, oz + z1
+        if pred_level == 1:
+            pred = read_box(pred_path, gz0, gz1, oy, oy + Y, ox, ox + X) > 0
+        else:
+            p0 = read_box(pred_path, 2 * gz0, 2 * gz1, 2 * oy,
+                          2 * (oy + Y), 2 * ox, 2 * (ox + X))
+            pred = p0.reshape(z1 - z0, 2, Y, 2, X, 2).max((1, 3, 5)) > 0
+            del p0
+        valid = (lab & 1) > 0
+        material = (lab & 2) > 0
+        recto = (lab & 8) > 0
+        for k in range(0, lab.shape[0], 4):
+            tb = material[k]
+            pb = pred[k] & valid[k]
+            ctr = (lab[k] & 4) > 0
+            if ctr.sum() < 500 or pb.sum() < 100:
+                continue
+            dpred = ndi.distance_transform_edt(~pb)
+            ys, xs = np.nonzero(ctr)
+            cd = dpred[ys, xs]
+            acc["n_ctr"] += len(ys)
+            for r in (1, 2, 3):
+                acc["hits"][r] += int((cd <= r).sum())
+            pbs = np.zeros_like(pb)
+            pbs[NULL_SHIFT:] = pb[:-NULL_SHIFT]
+            dnull = ndi.distance_transform_edt(~pbs)
+            nd = dnull[ys, xs]
+            acc["null2"] += int((nd <= 2).sum())
+            lab2, _ = ndi.label(ctr, structure=np.ones((3, 3), int))
+            lv = lab2[ys, xs]
+            aid = (lv.astype(np.int64) * 10_000_000
+                   + (ys // 64).astype(np.int64) * 2000 + xs // 64)
+            _, inv = np.unique(aid, return_inverse=True)
+            cnt = np.bincount(inv)
+            cov = np.bincount(inv, weights=(cd <= 2)) / cnt
+            ncov = np.bincount(inv, weights=(nd <= 2)) / cnt
+            big = cnt >= 20
+            acc["n_arc"] += int(big.sum())
+            acc["arc_hit"] += int((cov[big] >= 0.5).sum())
+            acc["arc_gone"] += int((big & (cov < 0.1)).sum())
+            acc["narc_hit"] += int((ncov[big] >= 0.5).sum())
+            acc["narc_gone"] += int((big & (ncov < 0.1)).sum())
+            near = ndi.binary_dilation(tb, iterations=2)
+            acc["pred_on_recto"] += int((pb & recto[k]).sum())
+            acc["pred_on_verso"] += int(
+                (pb & near & tb & ~recto[k]).sum())
+        print(f"z {z0}-{z1} done", file=sys.stderr, flush=True)
+    n = max(acc["n_ctr"], 1)
+    na = max(acc["n_arc"], 1)
+    side_n = max(acc["pred_on_recto"] + acc["pred_on_verso"], 1)
+    out = dict(
+        n_centerline=acc["n_ctr"],
+        recall_19um=round(acc["hits"][1] / n, 4),
+        recall_37um=round(acc["hits"][2] / n, 4),
+        recall_56um=round(acc["hits"][3] / n, 4),
+        null_recall_37um=round(acc["null2"] / n, 4),
+        n_arcs=acc["n_arc"],
+        arc_recall=round(acc["arc_hit"] / na, 4),
+        arc_fully_missed=round(acc["arc_gone"] / na, 4),
+        null_arc_recall=round(acc["narc_hit"] / na, 4),
+        null_arc_fully_missed=round(acc["narc_gone"] / na, 4),
+        recto_side_ratio=round(acc["pred_on_recto"] / side_n, 4))
+    print(json.dumps(out, indent=1))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2], int(sys.argv[3]))

--- a/scripts/physical_eval/eval_surface_pred.py
+++ b/scripts/physical_eval/eval_surface_pred.py
@@ -121,47 +121,66 @@ def selftest_normal():
 def side_stats(acc, tb, pb, pbs, recto_k, ys, xs, cd):
     """Side-of-sheet placement with its shifted null and ideal ceiling.
 
-    Same instrument for all three arms: at truth centerline points that
-    have the band in question within 3 voxels, sample that band's distance
-    field 2 voxels to either side along the local sheet normal, oriented
-    inward by the radial sign, and count which side is closer. The ideal
-    arm reads the packaged recto_band, so the ceiling says how much side
-    signal a perfect recto prediction shows under this estimator.
+    At a truth centerline point, sample a band's distance field 2 voxels to
+    either side along the local sheet normal, oriented inward by the radial
+    sign, and count which side is closer. Points need local structure to
+    carry a normal at all, so every arm starts from the same coherence
+    floor. The ideal arm reads the packaged recto_band, so the ceiling says
+    how much side signal a perfect recto prediction shows here.
+
+    Which points each arm keeps is worth stating, because the report's pass
+    conditions and this reproduces that. The real arm keeps coherent points
+    with the prediction within 3 voxels. The `_null` and `_ideal` arms keep
+    the subset of THOSE points that also has their own band within 3
+    voxels, so the populations are real, real AND null, real AND ideal, and
+    the calibration is a within-real comparison. The `_full` variants of
+    both controls drop that conditioning and select from the whole coherent
+    centerline set instead, which is what un-nesting the arms would give.
+    The real arm is identical under either reading, so `side_inward` does
+    not move between them; only the controls do.
 
     One difference from the report's pass: there the normals came from the
-    registered 1.129 um grayscale, which the label package does not carry,
-    so here they come from the smoothed material mask instead.
+    registered high-resolution grayscale, which the label package does not
+    carry, so here they come from the smoothed material mask instead. On
+    PHerc0139 that shifts the decided count by 0.09 percent and leaves the
+    fractions where they were.
     """
     near = cd <= 3
     if near.sum() < 100:
         return
-    yn, xn = ys[near], xs[near]
     nyf, nxf, cohf = normal_field(
         ndi.gaussian_filter(tb.astype(np.float32), 1.5))
-    ny, nx = nyf[yn, xn], nxf[yn, xn]
+    coh = cohf[ys, xs] > SIDE_COH_MIN
+    if (near & coh).sum() < 100:
+        return
+    ya, xa = ys[coh], xs[coh]                 # whole coherent centerline set
+    ny, nx = nyf[ya, xa], nxf[ya, xa]
     m = np.nonzero(tb)
     cy, cx = m[0].mean(), m[1].mean()
-    flip = (ny * (yn - cy) + nx * (xn - cx)) < 0
+    flip = (ny * (ya - cy) + nx * (xa - cx)) < 0
     ny = np.where(flip, -ny, ny)
     nx = np.where(flip, -nx, nx)
-    ok = cohf[yn, xn] > SIDE_COH_MIN
-    if ok.sum() < 100:
-        return
-    yn, xn, ny, nx = yn[ok], xn[ok], ny[ok], nx[ok]
+    inner = near[coh]                         # real-near subset of it
+    yn, xn = ya[inner], xa[inner]
+    nyn, nxn = ny[inner], nx[inner]
     dpred = ndi.distance_transform_edt(~pb)
-    i, o = _inward_counts(dpred, yn, xn, ny, nx)
+    i, o = _inward_counts(dpred, yn, xn, nyn, nxn)
     acc["side_in"] += i
     acc["side_out"] += o
     for band, key in ((pbs, "null"), (recto_k, "ideal")):
         if not band.any():
             continue
         d = ndi.distance_transform_edt(~band)
-        sel = d[yn, xn] <= 3
-        if sel.sum() <= 100:
-            continue
-        i, o = _inward_counts(d, yn[sel], xn[sel], ny[sel], nx[sel])
-        acc[f"side_{key}_in"] += i
-        acc[f"side_{key}_out"] += o
+        sel = d[yn, xn] <= 3                  # conditioned, as the report
+        if sel.sum() > 100:
+            i, o = _inward_counts(d, yn[sel], xn[sel], nyn[sel], nxn[sel])
+            acc[f"side_{key}_in"] += i
+            acc[f"side_{key}_out"] += o
+        sela = d[ya, xa] <= 3                 # unconditioned
+        if sela.sum() > 100:
+            i, o = _inward_counts(d, ya[sela], xa[sela], ny[sela], nx[sela])
+            acc[f"side_{key}_full_in"] += i
+            acc[f"side_{key}_full_out"] += o
 
 
 def main(labels_path, pred_path, pred_level):
@@ -174,7 +193,9 @@ def main(labels_path, pred_path, pred_level):
                n_arc=0, arc_hit=0, arc_gone=0, narc_hit=0, narc_gone=0,
                pred_on_recto=0, pred_on_verso=0,
                side_in=0, side_out=0, side_null_in=0, side_null_out=0,
-               side_ideal_in=0, side_ideal_out=0)
+               side_ideal_in=0, side_ideal_out=0,
+               side_null_full_in=0, side_null_full_out=0,
+               side_ideal_full_in=0, side_ideal_full_out=0)
     step = 96
     for z0 in range(0, Z, step):
         z1 = min(z0 + step, Z)
@@ -245,17 +266,29 @@ def main(labels_path, pred_path, pred_level):
     dec = max(acc["side_in"] + acc["side_out"], 1)
     dec_n = max(acc["side_null_in"] + acc["side_null_out"], 1)
     dec_i = max(acc["side_ideal_in"] + acc["side_ideal_out"], 1)
+    dec_nf = max(acc["side_null_full_in"] + acc["side_null_full_out"], 1)
+    dec_if = max(acc["side_ideal_full_in"] + acc["side_ideal_full_out"], 1)
     inward = acc["side_in"] / dec
     null_inward = acc["side_null_in"] / dec_n
     ideal_inward = acc["side_ideal_in"] / dec_i
+    null_full = acc["side_null_full_in"] / dec_nf
+    ideal_full = acc["side_ideal_full_in"] / dec_if
     out.update(
         side_n_decided=dec,
         side_inward=round(inward, 4),
         side_inward_null=round(null_inward, 4),
+        side_n_null_decided=dec_n,
         side_inward_ideal=round(ideal_inward, 4),
+        side_n_ideal_decided=dec_i,
         side_skill_of_ideal=round(
             (inward - null_inward) / max(ideal_inward - null_inward, 1e-9),
-            4))
+            4),
+        side_inward_null_full=round(null_full, 4),
+        side_n_null_full_decided=dec_nf,
+        side_inward_ideal_full=round(ideal_full, 4),
+        side_n_ideal_full_decided=dec_if,
+        side_skill_of_ideal_full=round(
+            (inward - null_full) / max(ideal_full - null_full, 1e-9), 4))
     print(json.dumps(out, indent=1))
 
 

--- a/scripts/physical_eval/eval_surface_pred.py
+++ b/scripts/physical_eval/eval_surface_pred.py
@@ -12,7 +12,13 @@ PRED_LEVEL  : pyramid level of PRED (0 or 1); level 0 is max-pooled to L1
 Reports, each with a shifted-null control printed alongside:
   point recall at 1/2/3 L1 voxels (19/37/56 um)
   arc-level recall (1.2 mm sheet stretches, >=50% covered) and fully-missed
-  recto-side overlap ratio (prediction mass on recto band vs verso side)
+  side placement: the per-point inward fraction of the report's side audit,
+    with its shifted null and its ideal-recto-band ceiling
+
+`recto_side_ratio` is a separate and simpler statistic: the share of
+predicted mass that lands on the recto band, counted over voxels rather
+than over centerline points. It is not the report's side metric and does
+not carry the same controls; read `side_inward` for that.
 """
 import json
 import sys
@@ -21,6 +27,7 @@ from pathlib import Path
 import numcodecs
 import numpy as np
 from scipy import ndimage as ndi
+from scipy.ndimage import map_coordinates
 
 NULL_SHIFT = 64
 
@@ -72,14 +79,102 @@ def read_box(root, z0, z1, y0, y1, x0, x1):
     return out
 
 
+SIDE_STEP = 2.0        # sampling offset along the sheet normal, voxels
+SIDE_COH_MIN = 0.3     # structure-tensor coherence floor
+
+
+def normal_field(g):
+    """Per-pixel sheet normal from the 2D structure tensor."""
+    gy, gx = ndi.sobel(g, 0), ndi.sobel(g, 1)
+    Jyy = ndi.gaussian_filter(gy * gy, 6)
+    Jyx = ndi.gaussian_filter(gy * gx, 6)
+    Jxx = ndi.gaussian_filter(gx * gx, 6)
+    phi = 0.5 * np.arctan2(2 * Jyx, Jyy - Jxx)
+    tr, det = Jyy + Jxx, Jyy * Jxx - Jyx * Jyx
+    disc = np.sqrt(np.maximum(tr * tr / 4 - det, 0))
+    lam1, lam2 = tr / 2 + disc, tr / 2 - disc
+    coher = (lam1 - lam2) / np.maximum(lam1 + lam2, 1e-9)
+    return np.cos(phi), np.sin(phi), coher
+
+
+def _inward_counts(dfield, ys, xs, ny, nx):
+    """(inward, outward) decisions: which side of the sheet is closer."""
+    din = map_coordinates(dfield, [ys - SIDE_STEP * ny,
+                                   xs - SIDE_STEP * nx], order=1)
+    dout = map_coordinates(dfield, [ys + SIDE_STEP * ny,
+                                    xs + SIDE_STEP * nx], order=1)
+    return int((din < dout - 0.25).sum()), int((dout < din - 0.25).sum())
+
+
+def selftest_normal():
+    """The normal estimator has to recover a known stripe orientation."""
+    yy, xx = np.mgrid[0:200, 0:200].astype(np.float32)
+    for ang in (0.0, 30.0, 77.0, 120.0):
+        a = np.deg2rad(ang)
+        ny, nx, coh = normal_field(
+            np.sin((yy * np.cos(a) + xx * np.sin(a)) * 2.0))
+        dot = abs(ny[100, 100] * np.cos(a) + nx[100, 100] * np.sin(a))
+        assert dot > 0.97 and coh[100, 100] > 0.9, (ang, dot)
+    print("normal_field selftest OK", file=sys.stderr, flush=True)
+
+
+def side_stats(acc, tb, pb, pbs, recto_k, ys, xs, cd):
+    """Side-of-sheet placement with its shifted null and ideal ceiling.
+
+    Same instrument for all three arms: at truth centerline points that
+    have the band in question within 3 voxels, sample that band's distance
+    field 2 voxels to either side along the local sheet normal, oriented
+    inward by the radial sign, and count which side is closer. The ideal
+    arm reads the packaged recto_band, so the ceiling says how much side
+    signal a perfect recto prediction shows under this estimator.
+
+    One difference from the report's pass: there the normals came from the
+    registered 1.129 um grayscale, which the label package does not carry,
+    so here they come from the smoothed material mask instead.
+    """
+    near = cd <= 3
+    if near.sum() < 100:
+        return
+    yn, xn = ys[near], xs[near]
+    nyf, nxf, cohf = normal_field(
+        ndi.gaussian_filter(tb.astype(np.float32), 1.5))
+    ny, nx = nyf[yn, xn], nxf[yn, xn]
+    m = np.nonzero(tb)
+    cy, cx = m[0].mean(), m[1].mean()
+    flip = (ny * (yn - cy) + nx * (xn - cx)) < 0
+    ny = np.where(flip, -ny, ny)
+    nx = np.where(flip, -nx, nx)
+    ok = cohf[yn, xn] > SIDE_COH_MIN
+    if ok.sum() < 100:
+        return
+    yn, xn, ny, nx = yn[ok], xn[ok], ny[ok], nx[ok]
+    dpred = ndi.distance_transform_edt(~pb)
+    i, o = _inward_counts(dpred, yn, xn, ny, nx)
+    acc["side_in"] += i
+    acc["side_out"] += o
+    for band, key in ((pbs, "null"), (recto_k, "ideal")):
+        if not band.any():
+            continue
+        d = ndi.distance_transform_edt(~band)
+        sel = d[yn, xn] <= 3
+        if sel.sum() <= 100:
+            continue
+        i, o = _inward_counts(d, yn[sel], xn[sel], ny[sel], nx[sel])
+        acc[f"side_{key}_in"] += i
+        acc[f"side_{key}_out"] += o
+
+
 def main(labels_path, pred_path, pred_level):
+    selftest_normal()
     attrs = json.loads((Path(labels_path) / ".zattrs").read_text())
     oz, oy, ox = attrs["origin_l1"]
     meta, _ = open_zarr(labels_path)
     Z, Y, X = meta["shape"]
     acc = dict(n_ctr=0, hits={1: 0, 2: 0, 3: 0}, null2=0,
                n_arc=0, arc_hit=0, arc_gone=0, narc_hit=0, narc_gone=0,
-               pred_on_recto=0, pred_on_verso=0)
+               pred_on_recto=0, pred_on_verso=0,
+               side_in=0, side_out=0, side_null_in=0, side_null_out=0,
+               side_ideal_in=0, side_ideal_out=0)
     step = 96
     for z0 in range(0, Z, step):
         z1 = min(z0 + step, Z)
@@ -130,6 +225,7 @@ def main(labels_path, pred_path, pred_level):
             acc["pred_on_recto"] += int((pb & recto[k]).sum())
             acc["pred_on_verso"] += int(
                 (pb & near & tb & ~recto[k]).sum())
+            side_stats(acc, tb, pb, pbs, recto[k], ys, xs, cd)
         print(f"z {z0}-{z1} done", file=sys.stderr, flush=True)
     n = max(acc["n_ctr"], 1)
     na = max(acc["n_arc"], 1)
@@ -146,6 +242,20 @@ def main(labels_path, pred_path, pred_level):
         null_arc_recall=round(acc["narc_hit"] / na, 4),
         null_arc_fully_missed=round(acc["narc_gone"] / na, 4),
         recto_side_ratio=round(acc["pred_on_recto"] / side_n, 4))
+    dec = max(acc["side_in"] + acc["side_out"], 1)
+    dec_n = max(acc["side_null_in"] + acc["side_null_out"], 1)
+    dec_i = max(acc["side_ideal_in"] + acc["side_ideal_out"], 1)
+    inward = acc["side_in"] / dec
+    null_inward = acc["side_null_in"] / dec_n
+    ideal_inward = acc["side_ideal_in"] / dec_i
+    out.update(
+        side_n_decided=dec,
+        side_inward=round(inward, 4),
+        side_inward_null=round(null_inward, 4),
+        side_inward_ideal=round(ideal_inward, 4),
+        side_skill_of_ideal=round(
+            (inward - null_inward) / max(ideal_inward - null_inward, 1e-9),
+            4))
     print(json.dumps(out, indent=1))
 
 

--- a/scripts/physical_eval/test_empty_prediction_denominator.py
+++ b/scripts/physical_eval/test_empty_prediction_denominator.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""A slice is scored on its truth, whatever the prediction does.
+
+The evaluator used to skip a slice whose prediction held fewer than 100
+voxels, which took that slice's truth out of the denominator along with its
+failures. A sparse prediction could then score well by disappearing from the
+hard slices rather than by covering them. Raised by TAUIL-Abd-Elilah on the
+villa PR; his own regression is at
+https://github.com/TAUIL-Abd-Elilah/vesuvius-repro (test_physical_normalization_ab.py).
+
+This builds three small zarr volumes over one truth and runs the shipped
+entry point on each:
+
+  empty    no predicted voxel at all      must score 0, not vanish
+  sparse   a handful of voxels            must keep the same denominator
+  dense    covers the sheets              must score well
+
+The denominator has to be identical across all three, since the truth is.
+
+  python3 test_empty_prediction_denominator.py
+
+Exit 0 on success.
+"""
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numcodecs
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+EVAL = HERE / "eval_surface_pred.py"
+CH = 64
+SHAPE = (64, 256, 256)
+
+
+def write_zarr(root, arr, chunk=CH, compress=True):
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    comp = numcodecs.Blosc() if compress else None
+    meta = {
+        "zarr_format": 2, "shape": list(arr.shape),
+        "chunks": [chunk] * 3, "dtype": "|u1", "fill_value": 0,
+        "order": "C", "dimension_separator": "/", "filters": None,
+        "compressor": (comp.get_config() if comp else None),
+    }
+    (root / ".zarray").write_text(json.dumps(meta))
+    nz, ny, nx = [-(-s // chunk) for s in arr.shape]
+    for cz in range(nz):
+        for cy in range(ny):
+            for cx in range(nx):
+                blk = np.zeros((chunk, chunk, chunk), np.uint8)
+                sub = arr[cz * chunk:(cz + 1) * chunk,
+                          cy * chunk:(cy + 1) * chunk,
+                          cx * chunk:(cx + 1) * chunk]
+                blk[:sub.shape[0], :sub.shape[1], :sub.shape[2]] = sub
+                d = root / str(cz) / str(cy)
+                d.mkdir(parents=True, exist_ok=True)
+                raw = blk.tobytes()
+                (d / str(cx)).write_bytes(comp.encode(raw) if comp else raw)
+
+
+def build_truth():
+    """Flat stacked sheets: material, its centerline, a recto band."""
+    z, y, x = SHAPE
+    lab = np.zeros(SHAPE, np.uint8)
+    lab |= 1                                    # valid everywhere
+    for y0 in range(20, y - 20, 16):
+        lab[:, y0:y0 + 5, :] |= 2               # material, 5 voxels thick
+        lab[:, y0 + 2, :] |= 4                  # centerline, the middle one
+        lab[:, y0, :] |= 8                      # recto band, inward face
+    return lab
+
+
+def build_pred(kind):
+    p = np.zeros(SHAPE, np.uint8)
+    if kind == "empty":
+        return p
+    if kind == "sparse":
+        p[:, 22, 10:40] = 1                     # a few voxels on one sheet
+        return p
+    for y0 in range(20, SHAPE[1] - 20, 16):     # dense: sits on every sheet
+        p[:, y0 + 1, :] = 1
+    return p
+
+
+def run(labels, pred):
+    r = subprocess.run(
+        [sys.executable, str(EVAL), str(labels), str(pred), "1"],
+        capture_output=True, text=True)
+    if r.returncode != 0:
+        print(r.stdout[-2000:])
+        print(r.stderr[-2000:])
+        raise SystemExit(f"evaluator failed on {pred}")
+    return json.loads(r.stdout)
+
+
+def main():
+    tmp = Path(tempfile.mkdtemp(prefix="evaltest_"))
+    try:
+        lab = build_truth()
+        labels = tmp / "labels.zarr"
+        write_zarr(labels, lab)
+        (labels / ".zattrs").write_text(json.dumps(
+            {"origin_l1": [0, 0, 0], "bits": {
+                "valid": 1, "material": 2, "centerline": 4,
+                "recto_band": 8}}))
+
+        out = {}
+        for kind in ("empty", "sparse", "dense"):
+            p = tmp / f"pred_{kind}.zarr"
+            write_zarr(p, build_pred(kind))
+            out[kind] = run(labels, p)
+            o = out[kind]
+            print(f"{kind:7s} n_centerline {o['n_centerline']:8d}  "
+                  f"n_arcs {o['n_arcs']:5d}  recall_37um {o['recall_37um']:.4f}"
+                  f"  arc_recall {o['arc_recall']:.4f}"
+                  f"  fully_missed {o['arc_fully_missed']:.4f}")
+
+        fail = []
+        base = out["dense"]["n_centerline"]
+        if base <= 0:
+            fail.append("dense run scored no centerline points at all")
+        for kind in ("empty", "sparse"):
+            if out[kind]["n_centerline"] != base:
+                fail.append(
+                    f"{kind} denominator {out[kind]['n_centerline']} differs "
+                    f"from dense {base}: the truth left with the prediction")
+            if out[kind]["n_arcs"] != out["dense"]["n_arcs"]:
+                fail.append(f"{kind} arc denominator moved")
+        e = out["empty"]
+        for f in ("recall_19um", "recall_37um", "recall_56um", "arc_recall"):
+            if e[f] != 0.0:
+                fail.append(f"empty prediction scored {f}={e[f]}, expected 0")
+        if e["arc_fully_missed"] != 1.0:
+            fail.append(f"empty prediction fully_missed "
+                        f"{e['arc_fully_missed']}, expected 1.0")
+        if not (out["sparse"]["recall_37um"] < out["dense"]["recall_37um"]):
+            fail.append("sparse did not score below dense")
+
+        print()
+        if fail:
+            for f in fail:
+                print("FAIL:", f)
+            return 1
+        print("PASS: the denominator is set by the truth alone; an empty "
+              "prediction scores zero and keeps every arc as fully missed")
+        return 0
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/physical_eval/test_side_arms_equivalence.py
+++ b/scripts/physical_eval/test_side_arms_equivalence.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""The side arms' un-nesting must not move the real or conditioned arms.
+
+Adding the _full control variants meant reordering two filters: the old
+side_stats took near-the-prediction first and the coherence floor second,
+the current one takes coherence first so the whole coherent centerline set
+stays available for the unconditioned arms. Set intersection says those
+select the same points, which is the kind of claim worth handing to a
+machine. This holds the pre-change implementation next to the shipped one
+and runs both over synthetic stacked sheets.
+
+  python3 test_side_arms_equivalence.py
+
+Exit 0 means the real and conditioned arms are bit-identical and the
+unconditioned arm is strictly wider.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+from scipy import ndimage as ndi
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import eval_surface_pred as E
+
+
+def old_side_stats(acc, tb, pb, pbs, recto_k, ys, xs, cd):
+    """Verbatim pre-change implementation."""
+    near = cd <= 3
+    if near.sum() < 100:
+        return
+    yn, xn = ys[near], xs[near]
+    nyf, nxf, cohf = E.normal_field(
+        ndi.gaussian_filter(tb.astype(np.float32), 1.5))
+    ny, nx = nyf[yn, xn], nxf[yn, xn]
+    m = np.nonzero(tb)
+    cy, cx = m[0].mean(), m[1].mean()
+    flip = (ny * (yn - cy) + nx * (xn - cx)) < 0
+    ny = np.where(flip, -ny, ny)
+    nx = np.where(flip, -nx, nx)
+    ok = cohf[yn, xn] > E.SIDE_COH_MIN
+    if ok.sum() < 100:
+        return
+    yn, xn, ny, nx = yn[ok], xn[ok], ny[ok], nx[ok]
+    dpred = ndi.distance_transform_edt(~pb)
+    i, o = E._inward_counts(dpred, yn, xn, ny, nx)
+    acc["side_in"] += i
+    acc["side_out"] += o
+    for band, key in ((pbs, "null"), (recto_k, "ideal")):
+        if not band.any():
+            continue
+        d = ndi.distance_transform_edt(~band)
+        sel = d[yn, xn] <= 3
+        if sel.sum() <= 100:
+            continue
+        i, o = E._inward_counts(d, yn[sel], xn[sel], ny[sel], nx[sel])
+        acc[f"side_{key}_in"] += i
+        acc[f"side_{key}_out"] += o
+
+
+def blank():
+    return dict(side_in=0, side_out=0, side_null_in=0, side_null_out=0,
+                side_ideal_in=0, side_ideal_out=0,
+                side_null_full_in=0, side_null_full_out=0,
+                side_ideal_full_in=0, side_ideal_full_out=0)
+
+
+def make_slice(seed, H=420, W=420):
+    """Curved stacked sheets, a prediction band offset to one side."""
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:H, 0:W].astype(np.float32)
+    cy, cx = H / 2, W / 2
+    r = np.hypot(yy - cy, xx - cx)
+    pitch = 14.0 + rng.uniform(-2, 2)
+    phase = rng.uniform(0, pitch)
+    band = np.abs(((r + phase) % pitch) - pitch / 2)
+    tb = band < 2.2
+    # centerline: local ridge of the distance transform inside material
+    dt = ndi.distance_transform_edt(tb)
+    ctr = tb & (dt >= ndi.maximum_filter(dt, 3)) & (dt >= 1)
+    # prediction: the material shifted radially outward by ~1.5 voxels,
+    # with holes punched in, so it lands on one side of the centerline
+    shift = 1.5
+    rr = r - shift
+    pb = np.abs(((rr + phase) % pitch) - pitch / 2) < 1.4
+    holes = rng.random((H, W)) < 0.12
+    pb = pb & ~ndi.binary_dilation(holes, iterations=2)
+    # ideal recto band: inward-facing material boundary
+    recto = tb & (np.abs(((r + phase + 1.6) % pitch) - pitch / 2) >= 2.2)
+    pbs = np.zeros_like(pb)
+    pbs[E.NULL_SHIFT:] = pb[:-E.NULL_SHIFT]
+    return tb, pb, pbs, recto, ctr
+
+
+def main():
+    tot_old, tot_new = blank(), blank()
+    checked = 0
+    for seed in range(12):
+        tb, pb, pbs, recto, ctr = make_slice(seed)
+        if ctr.sum() < 500 or pb.sum() < 100:
+            continue
+        dpred = ndi.distance_transform_edt(~pb)
+        ys, xs = np.nonzero(ctr)
+        cd = dpred[ys, xs]
+        a_old, a_new = blank(), blank()
+        old_side_stats(a_old, tb, pb, pbs, recto, ys, xs, cd)
+        E.side_stats(a_new, tb, pb, pbs, recto, ys, xs, cd)
+        for k in a_old:
+            tot_old[k] += a_old[k]
+            tot_new[k] += a_new[k]
+        checked += 1
+
+    print(f"slices exercised: {checked}")
+    shared = ["side_in", "side_out", "side_null_in", "side_null_out",
+              "side_ideal_in", "side_ideal_out"]
+    bad = [k for k in shared if tot_old[k] != tot_new[k]]
+    for k in shared:
+        flag = "MISMATCH" if tot_old[k] != tot_new[k] else "ok"
+        print(f"  {k:22s} old {tot_old[k]:9d}  new {tot_new[k]:9d}  {flag}")
+    print("  --- new-only arms ---")
+    for k in ["side_null_full_in", "side_null_full_out",
+              "side_ideal_full_in", "side_ideal_full_out"]:
+        print(f"  {k:22s} {tot_new[k]:9d}")
+
+    dec = tot_new["side_in"] + tot_new["side_out"]
+    dn = tot_new["side_null_in"] + tot_new["side_null_out"]
+    dnf = tot_new["side_null_full_in"] + tot_new["side_null_full_out"]
+    if dec and dn and dnf:
+        print(f"\n  inward          {tot_new['side_in']/dec:.4f}")
+        print(f"  null cond       {tot_new['side_null_in']/dn:.4f}"
+              f"   (n={dn})")
+        print(f"  null full       {tot_new['side_null_full_in']/dnf:.4f}"
+              f"   (n={dnf})")
+
+    if checked < 3:
+        print("\nINCONCLUSIVE: too few slices exercised the code path")
+        return 2
+    if bad:
+        print(f"\nFAIL: real/conditioned arms moved: {bad}")
+        return 1
+    if dnf <= dn:
+        print("\nSUSPECT: unconditioned null is not larger than conditioned;"
+              " the new arm may not be selecting from the full set")
+        return 1
+    print("\nPASS: real and conditioned arms bit-identical, full arm wider")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a small standalone harness that scores any binary surface prediction against ground truth taken from a second, higher-resolution scan of the same scroll, instead of from another model or from mesh-derived labels.

Context: #193 closed after both model-free validation legs failed (a CT statistic with window bias, and a validator model at chance level), and #1309 was closed because success on a synthetic phantom does not establish success on real scrolls. A second physical scan of the same object avoids all three problems: the reference is real, and no model or annotation is in the loop. Two scroll pairs currently have the required data, PHerc0139 (truth at 1.129 um) and Grand-Prize PHerc1203 (truth at 2.403 um, including compressed tissue); registrations are split-half validated at 4.1 and 2.4 um median error, well inside the 19-56 um scoring tolerances.

The harness is one file (numpy + scipy + numcodecs) and reads the label volumes published at https://github.com/7jycwjmbfn-eng/pherc0139-physical-audit (release assets). Every metric it reports carries a shifted-null control, the same prediction displaced 1.2 mm in-plane. The null turns out to matter: on PHerc1203 it alone reaches 64.6 percent point recall at 37 um, so any radius metric without a null overreads performance in exactly the tissue where the hard failures live. One printed field stands outside that rule and is labelled as such, `recto_side_ratio`, a raw mass-overlap quantity kept for continuity; the side metric to read is `side_inward`, which ships with both its null and an ideal-recto ceiling built from the truth.

Reproduction: the harness output on both scrolls is committed in the linked repository (`results/eval_selfcheck_0139.json` and `results/1203/eval_selfcheck_1203.json`), so a rerun is diffed against a file rather than against prose. The point and arc numbers match the audit to four decimals, as does the side null; the inward fraction and ceiling agree to three, because the harness takes sheet normals from the packaged material mask while the audit used the high-resolution grayscale the label package does not carry. That substitution moves the decided count by 0.09 percent on PHerc0139.

Two revisions since this PR opened, both from review in #191:

- @TAUIL-Abd-Elilah found that the three side arms are nested rather than independently drawn: the real arm keeps points with the prediction within 3 voxels, and the null and ideal arms select inside that subset. That reproduces what the audit pass does, and it had never been stated. The harness now emits `_full` variants selecting each control from the whole coherent centerline set, plus a decided count per arm, so both readings are visible. Un-nesting moves the controls only, worth 0.31 points of skill on PHerc0139 and 0.10 on PHerc1203; `test_side_arms_equivalence.py` checks that the real arm does not move.
- Checking that led to a documentation defect in the label release: the `boundary_poor` bit covers 74.6 percent of material voxels on PHerc1203, not the 7-14 percent figure the README had described it with, which came from a different instrument. Both volumes now ship a full census of what every bit plane covers.

Findings from running the harness on the published volumes for both scrolls (fully-missed sheet stretches, side-of-sheet placement, the #1364 caveat on what generated those volumes) are written up in the linked repository.

Happy to move the file elsewhere in the tree, rename things, or split the labels documentation out, whatever fits your conventions.
