### PR TITLE
scrollprize.org: pin Node.js to 24.x for Vercel

### DIFF
--- a/scrollprize.org/package.json
+++ b/scrollprize.org/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "packageManager": "yarn@4.6.0",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "preinstall": "[ \"${AGENTS_AGENT_MODE:-0}\" != \"1\" ] || [ \"${AGENTS_ALLOW_INSTALL:-0}\" = \"1\" ] || { echo \"Install is disabled by default in agent mode. Set AGENTS_ALLOW_INSTALL=1 to install dependencies.\"; exit 1; }",
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary
- Vercel is deprecating Node.js 20 for builds/functions on October 1, 2026, and the scrollprize.org project's warning flagged it as still using Node 20 (or older) via Vercel's Project Settings default — nothing in the repo pinned a version.
- Adds `engines.node: "24.x"` to `scrollprize.org/package.json`, which overrides the Vercel dashboard setting on the next deploy and keeps production consistent with the Node 24 already used by the progress-prizes GitHub Actions workflows.

## Manual follow-up (outside this PR)
- Update the Vercel dashboard: Project → Settings → Build and Deployment → Node.js Version → select **24.x**, so it's not left stale/out of sync with `package.json`.

## Test plan
- [x] `yarn install` locally with the new `engines` field completes without a hard failure (only unrelated peer-dependency warnings).
- [x] After merge and the Vercel dashboard update, confirm the next deployment's build log shows Node 24.x and the "Node.js 20 or older" warning banner clears.