### PR TITLE
spiral: add deterministic CUDA gap interpolation

### DIFF
--- a/volume-cartographer/scripts/spiral/tests/test_deterministic_gap_sample.py
+++ b/volume-cartographer/scripts/spiral/tests/test_deterministic_gap_sample.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+import transforms
 from transforms import (
     GapExpanderParams,
     GapExpandingTransform,
@@ -47,6 +48,35 @@ def test_bilinear_border_forward_matches_grid_sample_on_cpu():
     actual = _bilinear_sample_2d_border(values, x, y)
     expected = grid_sample_reference(values, x, y)
     torch.testing.assert_close(actual, expected, rtol=2e-15, atol=5e-15)
+
+
+def test_gap_transform_keeps_grid_sample_path_on_cpu(monkeypatch):
+    params = GapExpanderParams(
+        resolution=4.0,
+        min_z=0.0,
+        max_z=32.0,
+        num_windings=7,
+        dr_per_winding=12.0,
+    )
+    transform = GapExpandingTransform(
+        params=params,
+        dr_per_winding=torch.tensor(12.0),
+        min_z=0.0,
+        max_z=32.0,
+        gap_expander_lr_scale=1.0,
+    )
+    theta = torch.linspace(0.0, 2 * torch.pi, 17)
+    z = torch.linspace(0.0, 32.0, 17)
+
+    def unexpected_custom_sampler(*_args, **_kwargs):
+        raise AssertionError('the deterministic fallback is CUDA-only')
+
+    monkeypatch.setattr(
+        transforms, '_bilinear_sample_2d_border', unexpected_custom_sampler)
+    with deterministic_algorithms():
+        sampled = transform.get_logits_by_winding(theta, z)
+    assert sampled.shape == (17, 6)
+    assert torch.isfinite(sampled).all()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required')

--- a/volume-cartographer/scripts/spiral/tests/test_deterministic_gap_sample.py
+++ b/volume-cartographer/scripts/spiral/tests/test_deterministic_gap_sample.py
@@ -1,0 +1,163 @@
+import contextlib
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from transforms import (
+    GapExpanderParams,
+    GapExpandingTransform,
+    _bilinear_sample_2d_border,
+)
+
+
+@contextlib.contextmanager
+def deterministic_algorithms(enabled=True):
+    previous = torch.are_deterministic_algorithms_enabled()
+    previous_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    torch.use_deterministic_algorithms(enabled, warn_only=False)
+    try:
+        yield
+    finally:
+        torch.use_deterministic_algorithms(
+            previous, warn_only=previous_warn_only)
+
+
+def grid_sample_reference(values, x, y):
+    grid = torch.stack([x, y], dim=-1).reshape(1, -1, 1, 2)
+    return F.grid_sample(
+        values,
+        grid,
+        mode='bilinear',
+        padding_mode='border',
+        align_corners=True,
+    ).reshape_as(x)
+
+
+def test_bilinear_border_forward_matches_grid_sample_on_cpu():
+    values = torch.arange(35, dtype=torch.float64).view(1, 1, 5, 7)
+    x = torch.tensor([
+        [-2.0, -1.0, -0.75, 0.0, 0.6, 1.0, 2.0],
+        [float('nan'), float('-inf'), -0.2, 0.2, 0.9, float('inf'), 1.2],
+    ], dtype=torch.float64)
+    y = torch.tensor([
+        [-2.0, -1.0, -0.4, 0.0, 0.7, 1.0, 2.0],
+        [float('nan'), float('-inf'), -0.8, 0.3, 0.95, float('inf'), 1.1],
+    ], dtype=torch.float64)
+    actual = _bilinear_sample_2d_border(values, x, y)
+    expected = grid_sample_reference(values, x, y)
+    torch.testing.assert_close(actual, expected, rtol=2e-15, atol=5e-15)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required')
+def test_cuda_values_and_interior_gradients_match_grid_sample():
+    generator = torch.Generator(device='cuda').manual_seed(9917)
+    x_data = torch.rand(9, 13, device='cuda', generator=generator) * 1.8 - 0.9
+    y_data = torch.rand(9, 13, device='cuda', generator=generator) * 1.8 - 0.9
+    loss_weights = torch.randn(9, 13, device='cuda', generator=generator)
+
+    reference_values = torch.randn(
+        1, 1, 11, 17, device='cuda', generator=generator, requires_grad=True)
+    reference_x = x_data.detach().clone().requires_grad_(True)
+    reference_y = y_data.detach().clone().requires_grad_(True)
+    reference = grid_sample_reference(reference_values, reference_x, reference_y)
+    reference_grads = torch.autograd.grad(
+        (reference * loss_weights).sum(),
+        (reference_values, reference_x, reference_y),
+    )
+
+    actual_values = reference_values.detach().clone().requires_grad_(True)
+    actual_x = x_data.detach().clone().requires_grad_(True)
+    actual_y = y_data.detach().clone().requires_grad_(True)
+    actual = _bilinear_sample_2d_border(actual_values, actual_x, actual_y)
+    actual_grads = torch.autograd.grad(
+        (actual * loss_weights).sum(),
+        (actual_values, actual_x, actual_y),
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=2e-6, atol=2e-7)
+    for got, wanted in zip(actual_grads, reference_grads):
+        torch.testing.assert_close(got, wanted, rtol=3e-5, atol=3e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required')
+def test_cuda_border_coordinate_gradients_match_grid_sample():
+    values_data = torch.arange(35, device='cuda', dtype=torch.float32).view(1, 1, 5, 7)
+    x_data = torch.tensor(
+        [-1.2, -1.0, -0.999, 0.0, 0.999, 1.0, 1.2], device='cuda')
+    y_data = torch.tensor(
+        [-1.2, -1.0, -0.999, 0.0, 0.999, 1.0, 1.2], device='cuda')
+
+    reference_values = values_data.clone().requires_grad_(True)
+    reference_x = x_data.clone().requires_grad_(True)
+    reference_y = y_data.clone().requires_grad_(True)
+    reference = grid_sample_reference(reference_values, reference_x, reference_y)
+    reference_grads = torch.autograd.grad(
+        reference.sum(), (reference_values, reference_x, reference_y))
+
+    actual_values = values_data.clone().requires_grad_(True)
+    actual_x = x_data.clone().requires_grad_(True)
+    actual_y = y_data.clone().requires_grad_(True)
+    actual = _bilinear_sample_2d_border(actual_values, actual_x, actual_y)
+    actual_grads = torch.autograd.grad(
+        actual.sum(), (actual_values, actual_x, actual_y))
+
+    torch.testing.assert_close(actual, reference, rtol=2e-6, atol=2e-6)
+    for got, wanted in zip(actual_grads, reference_grads):
+        torch.testing.assert_close(got, wanted, rtol=2e-6, atol=2e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required')
+def test_cuda_backward_is_bitwise_repeatable_under_hard_determinism():
+    generator = torch.Generator().manual_seed(4271)
+    values_cpu = torch.randn(1, 1, 12, 19, generator=generator)
+    x_cpu = torch.rand(17, 23, generator=generator) * 2.4 - 1.2
+    y_cpu = torch.rand(17, 23, generator=generator) * 2.4 - 1.2
+    weights_cpu = torch.randn(17, 23, generator=generator)
+
+    def run_once():
+        values = values_cpu.cuda().requires_grad_(True)
+        x = x_cpu.cuda().requires_grad_(True)
+        y = y_cpu.cuda().requires_grad_(True)
+        result = _bilinear_sample_2d_border(values, x, y)
+        grads = torch.autograd.grad(
+            (result * weights_cpu.cuda()).sum(), (values, x, y))
+        return (result.detach().cpu(), *(grad.detach().cpu() for grad in grads))
+
+    with deterministic_algorithms():
+        first = run_once()
+        second = run_once()
+    for got, wanted in zip(second, first):
+        torch.testing.assert_close(got, wanted, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required')
+def test_gap_transform_uses_deterministic_sampler_and_preserves_pin():
+    device = torch.device('cuda')
+    params = GapExpanderParams(
+        resolution=4.0,
+        min_z=0.0,
+        max_z=32.0,
+        num_windings=7,
+        dr_per_winding=12.0,
+    ).to(device)
+    generator = torch.Generator(device=device).manual_seed(717)
+    with torch.no_grad():
+        params.logits.copy_(torch.randn(
+            params.logits.shape, device=device, generator=generator) * 1e-4)
+    transform = GapExpandingTransform(
+        params=params,
+        dr_per_winding=torch.tensor(12.0, device=device),
+        min_z=0.0,
+        max_z=32.0,
+        gap_expander_lr_scale=1.0,
+    )
+    theta = (torch.rand(31, device=device, generator=generator) * 2 * torch.pi).requires_grad_(True)
+    z = (torch.rand(31, device=device, generator=generator) * 32).requires_grad_(True)
+
+    with deterministic_algorithms():
+        sampled = transform.get_logits_by_winding(theta, z)
+        sampled.square().sum().backward()
+    assert torch.isfinite(sampled).all()
+    assert torch.isfinite(params.logits.grad).all()
+    assert torch.count_nonzero(params.logits.grad[..., 0]) == 0

--- a/volume-cartographer/scripts/spiral/transforms.py
+++ b/volume-cartographer/scripts/spiral/transforms.py
@@ -16,6 +16,62 @@ from geom_utils import expm_2x2, interp1d
 from sample_spiral import get_bounding_windings, get_theta_and_radii
 
 
+def _bilinear_sample_2d_border(input_2d, x_normalised, y_normalised):
+    """Sample a single 2-D plane without CUDA grid-sampler atomics.
+
+    This is the ``N=C=1``, bilinear, border-padded, ``align_corners=True``
+    subset used by :class:`GapExpandingTransform`.  ``index_select`` has a
+    deterministic CUDA backward in supported PyTorch builds, whereas
+    ``grid_sample``'s CUDA input-gradient path does not.
+    """
+    if input_2d.ndim != 4 or input_2d.shape[:2] != (1, 1):
+        raise ValueError('deterministic gap sampling requires input shape [1, 1, H, W]')
+    if x_normalised.shape != y_normalised.shape:
+        raise ValueError('deterministic gap-sampling coordinates must have matching shapes')
+
+    height, width = input_2d.shape[-2:]
+    # Grid-sampler documents NaN grid coordinates as -1.  Infinite values are
+    # outside the domain and border padding maps them to the corresponding edge.
+    x_normalised = torch.nan_to_num(
+        x_normalised, nan=-1.0, posinf=1.0, neginf=-1.0)
+    y_normalised = torch.nan_to_num(
+        y_normalised, nan=-1.0, posinf=1.0, neginf=-1.0)
+    def clip_with_border_gradient(coordinate, upper):
+        # ATen's border sampler deliberately sets the coordinate derivative to
+        # zero at and beyond either edge.  torch.clamp alone has derivative one
+        # exactly on the edge, so preserve the clipped forward value while
+        # supplying ATen's strict-interior derivative.
+        clipped = coordinate.clamp(0, upper)
+        interior = ((coordinate > 0) & (coordinate < upper)).to(coordinate.dtype)
+        return clipped.detach() + (coordinate - coordinate.detach()) * interior
+
+    x = clip_with_border_gradient(
+        (x_normalised + 1) * 0.5 * (width - 1), width - 1)
+    y = clip_with_border_gradient(
+        (y_normalised + 1) * 0.5 * (height - 1), height - 1)
+
+    x0 = x.floor().to(torch.int64)
+    y0 = y.floor().to(torch.int64)
+    x1 = (x0 + 1).clamp(max=width - 1)
+    y1 = (y0 + 1).clamp(max=height - 1)
+    wx = x - x0.to(x.dtype)
+    wy = y - y0.to(y.dtype)
+
+    flat = input_2d.reshape(-1)
+
+    def gather(yi, xi):
+        indices = (yi * width + xi).reshape(-1)
+        return flat.index_select(0, indices).view_as(x)
+
+    v00 = gather(y0, x0)
+    v01 = gather(y0, x1)
+    v10 = gather(y1, x0)
+    v11 = gather(y1, x1)
+    top = torch.lerp(v00, v01, wx)
+    bottom = torch.lerp(v10, v11, wx)
+    return torch.lerp(top, bottom, wy)
+
+
 class IntegratedFlowDiffeomorphism(pyro.distributions.transforms.Transform):
 
     domain = pyro.distributions.constraints.real_vector
@@ -184,6 +240,12 @@ class GapExpandingTransform(pyro.distributions.transforms.Transform):
         winding_coords_normalised = (
             winding_coords / winding_first_logit_idx[-1] * 2 - 1)
         z_normalised = (z - self.min_z) / (self.max_z - self.min_z) * 2 - 1
+        if torch.are_deterministic_algorithms_enabled():
+            return _bilinear_sample_2d_border(
+                self._get_pinned_scaled_logits(),
+                winding_coords_normalised,
+                z_normalised[..., None].expand(*theta.shape, num_windings),
+            )
         return F.grid_sample(
             self._get_pinned_scaled_logits(),
             torch.stack([winding_coords_normalised, z_normalised[..., None].expand(*theta.shape, num_windings)], dim=-1).view(1, -1, num_windings, 2),

--- a/volume-cartographer/scripts/spiral/transforms.py
+++ b/volume-cartographer/scripts/spiral/transforms.py
@@ -240,14 +240,15 @@ class GapExpandingTransform(pyro.distributions.transforms.Transform):
         winding_coords_normalised = (
             winding_coords / winding_first_logit_idx[-1] * 2 - 1)
         z_normalised = (z - self.min_z) / (self.max_z - self.min_z) * 2 - 1
-        if torch.are_deterministic_algorithms_enabled():
+        logits = self._get_pinned_scaled_logits()
+        if logits.is_cuda and torch.are_deterministic_algorithms_enabled():
             return _bilinear_sample_2d_border(
-                self._get_pinned_scaled_logits(),
+                logits,
                 winding_coords_normalised,
                 z_normalised[..., None].expand(*theta.shape, num_windings),
             )
         return F.grid_sample(
-            self._get_pinned_scaled_logits(),
+            logits,
             torch.stack([winding_coords_normalised, z_normalised[..., None].expand(*theta.shape, num_windings)], dim=-1).view(1, -1, num_windings, 2),
             mode='bilinear',
             padding_mode='border',


### PR DESCRIPTION
## Summary

Make the production Spiral gap lookup compatible with PyTorch hard-deterministic CUDA execution.

- keep the existing `grid_sample` path unchanged during normal execution and on non-CUDA devices
- when `torch.use_deterministic_algorithms(True)` is active on CUDA, use the exact N=C=1, bilinear, border-padded, `align_corners=True` subset needed by `GapExpandingTransform`
- preserve ATen's zero coordinate gradient at and beyond the border
- cover forward values, input/coordinate gradients, border gradients, pinning, and bitwise repeated backward

## Why

A current-main production Spiral fit on PHerc0125 reached the first optimizer update under PyTorch hard determinism and stopped at:

```text
grid_sampler_2d_backward_cuda does not have a deterministic implementation
```

The unsupported operation was the eager gap-expander lookup. The Cartesian flow path has its own sparse backward; on the tested PyTorch 2.13.0+cu126 / RTX 3090 environment, the other repeated-destination operations used by this fit were accepted in hard-deterministic mode.

This patch specializes only the gap lookup that has the fixed shape/mode contract above. It does not replace general `grid_sample`, and it does not change the default path.

## Validation

```text
python -m pytest -q \
  tests/test_deterministic_gap_sample.py \
  tests/test_phase_spacing.py

38 passed, 1 skipped
```

The CUDA tests compare the specialized sampler with `grid_sample` for values and gradients, including exact border coordinates, and require bitwise equality across repeated hard-deterministic backward passes.

I also ran two isolated production compatibility sessions from the same completed-iteration-1 PHerc0125 checkpoint through completed iteration 20. Both completed without warnings or resource-floor violations. Non-timing metrics at iterations 2, 5, 10, and 20 were exactly equal; the path-independent preview payloads were byte-identical; and a recursive comparison found every tensor, NumPy/RNG state, optimizer/scheduler/config value, and scientific scalar equal.

One preregistered literal gate still reported failure because it required the complete checkpoint dictionaries to be equal while each checkpoint intentionally records its own `input_manifest.output_directory`. The recursive audit found that provenance string to be the only difference. I am stating that failure explicitly: the result supports method compatibility and deterministic scientific state, not fit quality or any claim that the raw checkpoint files themselves are byte-identical.

## Scope

This is reproducibility plumbing. It makes hard-deterministic production execution possible for the tested path; it does not claim better fit quality, cross-scroll generality, or complete reproducibility across PyTorch/CUDA releases.
