### PR TITLE
vesuvius: honor nnU-Net plan normalization in predict

### DIFF
--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -109,6 +109,87 @@ def _checkpoint_normalization_scheme(checkpoint_data):
     return image_normalization
 
 
+_NNUNET_NORMALIZATION_MAP = {
+    'CTNormalization': 'ct',
+    'ZScoreNormalization': 'instance_zscore',
+    'NoNormalization': 'none',
+    'RescaleTo01Normalization': 'instance_minmax',
+}
+
+
+def _nnunet_normalization_from_model_info(model_info):
+    """Return the normalization declared by an nnU-Net model's plans.
+
+    ``load_model_for_inference`` already returns the nnU-Net configuration and
+    plans managers.  Keep their native metadata authoritative rather than
+    silently falling back to the CLI's per-patch z-score default.
+
+    VCDataset currently accepts one normalization contract for the entire
+    input, so reject multi-channel plans instead of applying one channel's
+    fingerprint to another.
+    """
+    configuration_manager = model_info.get('configuration_manager')
+    plans_manager = model_info.get('plans_manager')
+    if configuration_manager is None or plans_manager is None:
+        return None, None
+
+    schemes = getattr(configuration_manager, 'normalization_schemes', None)
+    if schemes is None:
+        return None, None
+    if isinstance(schemes, str):
+        schemes = [schemes]
+    else:
+        schemes = list(schemes)
+    if len(schemes) != 1:
+        raise ValueError(
+            'vesuvius.predict cannot reproduce nnU-Net normalization for '
+            f'{len(schemes)} input channels; expected exactly one scheme')
+
+    native_scheme = schemes[0]
+    if not isinstance(native_scheme, str):
+        native_scheme = getattr(native_scheme, '__name__', str(native_scheme))
+    native_scheme = native_scheme.rsplit('.', 1)[-1]
+    try:
+        scheme = _NNUNET_NORMALIZATION_MAP[native_scheme]
+    except KeyError as exc:
+        raise ValueError(
+            'Unsupported nnU-Net normalization scheme in plans.json: '
+            f'{native_scheme!r}') from exc
+
+    use_mask = getattr(configuration_manager, 'use_mask_for_norm', None)
+    if isinstance(use_mask, (list, tuple)):
+        use_mask = use_mask[0] if use_mask else None
+    if scheme == 'instance_zscore' and bool(use_mask):
+        raise ValueError(
+            'nnU-Net plans require masked Z-score normalization, which '
+            'vesuvius.predict cannot reproduce without the preprocessing mask')
+
+    intensity_properties = None
+    if scheme == 'ct':
+        per_channel = getattr(
+            plans_manager, 'foreground_intensity_properties_per_channel', None)
+        if not isinstance(per_channel, dict):
+            raise ValueError(
+                'nnU-Net CTNormalization requires '
+                'foreground_intensity_properties_per_channel in plans.json')
+        intensity_properties = per_channel.get('0', per_channel.get(0))
+        required = {
+            'mean', 'std', 'percentile_00_5', 'percentile_99_5',
+        }
+        if not isinstance(intensity_properties, dict):
+            raise ValueError(
+                'nnU-Net CTNormalization requires intensity properties for '
+                'input channel 0')
+        missing = sorted(required.difference(intensity_properties))
+        if missing:
+            raise ValueError(
+                'nnU-Net CTNormalization channel-0 intensity properties are '
+                f'missing: {", ".join(missing)}')
+        intensity_properties = dict(intensity_properties)
+
+    return scheme, intensity_properties
+
+
 def _select_evenly_spaced_middle_indices(candidate_indices, limit):
     """Select a deterministic, small representative subset of patch indices."""
     candidates = list(candidate_indices)
@@ -447,6 +528,26 @@ class Inferer():
                     verbose=self.verbose
                 )
         
+        # Prefer normalization metadata returned directly by train.py/external
+        # loaders. For nnU-Net, derive it from the plans managers that the
+        # loader already returns.
+        model_scheme = model_info.get('normalization_scheme')
+        model_intensity_properties = model_info.get('intensity_properties')
+        if model_scheme is None:
+            model_scheme, nnunet_intensity_properties = \
+                _nnunet_normalization_from_model_info(model_info)
+            if model_intensity_properties is None:
+                model_intensity_properties = nnunet_intensity_properties
+        if model_scheme is not None:
+            self.model_normalization_scheme = model_scheme
+            if model_scheme != self.normalization_scheme:
+                print(
+                    'Using model-declared normalization '
+                    f'{model_scheme!r} instead of CLI/default '
+                    f'{self.normalization_scheme!r}.')
+        if model_intensity_properties is not None:
+            self.model_intensity_properties = model_intensity_properties
+
         # model loader returns a dict, network is the actual model
         model = model_info['network']
         model.eval()
@@ -727,6 +828,7 @@ class Inferer():
             normalization_scheme=normalization_scheme,
             global_mean=global_mean,
             global_std=global_std,
+            intensity_props=self.model_intensity_properties,
             input_format=self.input_format,
             verbose=self.verbose,
             mode='infer',
@@ -1163,7 +1265,7 @@ def build_parser():
                       help='Optional: Override patch size, comma-separated (e.g., "192,192,192"). If not provided, uses the model\'s default patch size.')
     parser.add_argument('--save_softmax', action='store_true', help='Save softmax outputs')
     parser.add_argument('--normalization', type=str, default='instance_zscore',
-                      help='Normalization scheme (instance_zscore, global_zscore, instance_minmax, none)')
+                      help='Normalization scheme (instance_zscore, global_zscore, instance_minmax, percentile_minmax, ct, none)')
     parser.add_argument('--device', type=str, default='cuda', help='Device to use (cuda, cpu)')
     parser.add_argument('--num_workers', type=int, default=4,
                       help='Number of DataLoader workers. Use 0 in low /dev/shm environments (e.g. Docker).')

--- a/vesuvius/src/vesuvius/utils/models/load_nnunet_model.py
+++ b/vesuvius/src/vesuvius/utils/models/load_nnunet_model.py
@@ -1,5 +1,6 @@
 import ast
 import importlib
+import inspect
 import os
 import json
 import torch
@@ -15,6 +16,7 @@ import shutil
 
 from nnunetv2.utilities.label_handling.label_handling import determine_num_input_channels
 from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
+from nnunetv2.utilities.get_network_from_plans import get_network_from_plans
 from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
 import nnunetv2
 import torch.nn as nn
@@ -119,27 +121,50 @@ def initialize_network(architecture_class_name: str,
         The initialized network
     """
 
-    for i in arch_init_kwargs_req_import:
-        if i != "":
-            exec(f"import {i}")
-            
-    network_class = recursive_find_python_class(
-        os.path.join(nnunetv2.__path__[0], "network_architecture"),
+    return get_network_from_plans(
         architecture_class_name,
-        current_module="nnunetv2.network_architecture"
-    )
-    
-    if network_class is None:
-        raise RuntimeError(f"Network architecture class {architecture_class_name} not found in nnunetv2.network_architecture.")
-    
-    network = network_class(
-        input_channels=num_input_channels,
-        num_classes=num_output_channels,
+        arch_init_kwargs,
+        arch_init_kwargs_req_import,
+        num_input_channels,
+        num_output_channels,
+        allow_init=True,
         deep_supervision=enable_deep_supervision,
-        **arch_init_kwargs
     )
-    
-    return network
+
+
+def _build_network_from_trainer(
+    trainer_class,
+    plans_manager,
+    configuration_manager,
+    num_input_channels: int,
+    num_output_channels: int,
+):
+    """Call the network builder used by the installed nnU-Net version.
+
+    nnU-Net 2.8 changed this static method from architecture arguments to
+    plans/configuration managers. Inspect the declared parameters rather than
+    catching ``TypeError``, so errors raised inside a trainer are not mistaken
+    for an API-version mismatch.
+    """
+    build_network = trainer_class.build_network_architecture
+    parameters = inspect.signature(build_network).parameters
+    if 'plans_manager' in parameters and 'configuration_manager' in parameters:
+        return build_network(
+            plans_manager,
+            configuration_manager,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision=False,
+        )
+
+    return build_network(
+        configuration_manager.network_arch_class_name,
+        configuration_manager.network_arch_init_kwargs,
+        configuration_manager.network_arch_init_kwargs_req_import,
+        num_input_channels,
+        num_output_channels,
+        enable_deep_supervision=False,
+    )
 
 def load_model(model_folder: str, fold: Union[int, str] = 0, checkpoint_name: str = 'checkpoint_final.pth', 
             device='cuda', custom_plans_json=None, custom_dataset_json=None, verbose: bool = False, rank: int = 0):
@@ -238,13 +263,12 @@ def load_model(model_folder: str, fold: Union[int, str] = 0, checkpoint_name: st
         if should_print:
             print(f"Resolved trainer {trainer_name} from {trainer_class.__module__}")
         try:
-            network = trainer_class.build_network_architecture(
-                configuration_manager.network_arch_class_name,
-                configuration_manager.network_arch_init_kwargs,
-                configuration_manager.network_arch_init_kwargs_req_import,
+            network = _build_network_from_trainer(
+                trainer_class,
+                plans_manager,
+                configuration_manager,
                 num_input_channels,
                 label_manager.num_segmentation_heads,
-                enable_deep_supervision=False
             )
         except Exception as e:
             raise RuntimeError(

--- a/vesuvius/tests/models/run/test_inference_nnunet_normalization.py
+++ b/vesuvius/tests/models/run/test_inference_nnunet_normalization.py
@@ -1,0 +1,166 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+import zarr
+
+from nnunetv2.preprocessing.normalization.default_normalization_schemes import (
+    CTNormalization,
+)
+
+from vesuvius.data.volume import Volume
+from vesuvius.models.run import inference
+from vesuvius.models.run.inference import (
+    Inferer,
+    _nnunet_normalization_from_model_info,
+)
+
+
+CT_PROPERTIES = {
+    'mean': 87.5442,
+    'std': 47.7438,
+    'percentile_00_5': 0.0,
+    'percentile_99_5': 212.0,
+}
+
+
+def nnunet_model_info(
+    scheme='CTNormalization',
+    *,
+    intensity_properties=None,
+    use_mask=False,
+):
+    if intensity_properties is None:
+        intensity_properties = CT_PROPERTIES
+    return {
+        'configuration_manager': SimpleNamespace(
+            normalization_schemes=[scheme],
+            use_mask_for_norm=[use_mask],
+        ),
+        'plans_manager': SimpleNamespace(
+            foreground_intensity_properties_per_channel={
+                '0': intensity_properties,
+            },
+        ),
+    }
+
+
+def test_nnunet_ct_normalization_uses_channel_zero_fingerprint():
+    scheme, properties = _nnunet_normalization_from_model_info(
+        nnunet_model_info())
+
+    assert scheme == 'ct'
+    assert properties == CT_PROPERTIES
+    assert properties is not CT_PROPERTIES
+
+
+def test_volume_ct_normalization_matches_nnunet(tmp_path):
+    source = np.array(
+        [[[-10, 0, 42], [88, 150, 212]], [[213, 255, 100], [1, 87, 200]]],
+        dtype=np.int16,
+    )
+    path = tmp_path / 'input.zarr'
+    array = zarr.open(
+        str(path), mode='w', shape=source.shape, chunks=source.shape,
+        dtype=source.dtype,
+    )
+    array[:] = source
+
+    volume = Volume(
+        type='zarr',
+        path=str(path),
+        normalization_scheme='ct',
+        intensity_props=CT_PROPERTIES,
+        return_as_type='np.float32',
+        return_as_tensor=False,
+    )
+    expected = CTNormalization(
+        use_mask_for_norm=False,
+        intensityproperties=CT_PROPERTIES,
+    ).run(source.copy())
+
+    np.testing.assert_array_equal(volume[:, :, :], expected)
+
+
+@pytest.mark.parametrize(
+    ('native', 'expected'),
+    [
+        ('ZScoreNormalization', 'instance_zscore'),
+        ('NoNormalization', 'none'),
+        ('RescaleTo01Normalization', 'instance_minmax'),
+    ],
+)
+def test_nnunet_supported_normalization_mapping(native, expected):
+    scheme, properties = _nnunet_normalization_from_model_info(
+        nnunet_model_info(native))
+
+    assert scheme == expected
+    assert properties is None
+
+
+def test_nnunet_unknown_normalization_fails_instead_of_silent_fallback():
+    with pytest.raises(ValueError, match='Unsupported nnU-Net normalization'):
+        _nnunet_normalization_from_model_info(
+            nnunet_model_info('RGBTo01Normalization'))
+
+
+def test_nnunet_masked_zscore_fails_instead_of_changing_semantics():
+    with pytest.raises(ValueError, match='masked Z-score'):
+        _nnunet_normalization_from_model_info(
+            nnunet_model_info('ZScoreNormalization', use_mask=True))
+
+
+def test_nnunet_multichannel_normalization_fails_explicitly():
+    model_info = nnunet_model_info()
+    model_info['configuration_manager'].normalization_schemes = [
+        'CTNormalization', 'CTNormalization',
+    ]
+
+    with pytest.raises(ValueError, match='2 input channels'):
+        _nnunet_normalization_from_model_info(model_info)
+
+
+def test_dataset_receives_ct_intensity_properties(monkeypatch):
+    captured = {}
+
+    class FakeDataset:
+        collate_fn = staticmethod(lambda batch: batch)
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.all_positions = []
+
+        def __len__(self):
+            return 0
+
+    monkeypatch.setattr(inference, 'VCDataset', FakeDataset)
+
+    inferer = Inferer.__new__(Inferer)
+    inferer.model_normalization_scheme = 'ct'
+    inferer.model_intensity_properties = dict(CT_PROPERTIES)
+    inferer.normalization_scheme = 'instance_zscore'
+    inferer.input = 'unused.zarr'
+    inferer.patch_size = (8, 8, 8)
+    inferer.overlap = 0.5
+    inferer.num_parts = 1
+    inferer.part_id = 0
+    inferer.input_format = 'zarr'
+    inferer.verbose = False
+    inferer.skip_empty_patches = False
+    inferer.scroll_id = None
+    inferer.segment_id = None
+    inferer.energy = None
+    inferer.resolution = None
+    inferer.input_anon = False
+    inferer.bbox = None
+    inferer.read_retries = 1
+    inferer.device = torch.device('cpu')
+    inferer.max_patches = None
+
+    dataset, dataloader = inferer._create_dataset_and_loader()
+
+    assert dataset is inferer.dataset
+    assert dataloader is None
+    assert captured['normalization_scheme'] == 'ct'
+    assert captured['intensity_props'] == CT_PROPERTIES

--- a/vesuvius/tests/utils/models/test_load_nnunet_model_compatibility.py
+++ b/vesuvius/tests/utils/models/test_load_nnunet_model_compatibility.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+
+from vesuvius.utils.models import load_nnunet_model
+from vesuvius.utils.models.load_nnunet_model import (
+    _build_network_from_trainer,
+    initialize_network,
+)
+
+
+def configuration():
+    return SimpleNamespace(
+        network_arch_class_name='example.Network',
+        network_arch_init_kwargs={'depth': 3},
+        network_arch_init_kwargs_req_import=['conv_op'],
+    )
+
+
+def test_build_network_uses_legacy_nnunet_trainer_signature():
+    calls = []
+    network = object()
+
+    class LegacyTrainer:
+        @staticmethod
+        def build_network_architecture(
+            architecture_class_name,
+            arch_init_kwargs,
+            arch_init_kwargs_req_import,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision=True,
+        ):
+            calls.append((
+                architecture_class_name,
+                arch_init_kwargs,
+                arch_init_kwargs_req_import,
+                num_input_channels,
+                num_output_channels,
+                enable_deep_supervision,
+            ))
+            return network
+
+    result = _build_network_from_trainer(
+        LegacyTrainer,
+        plans_manager=object(),
+        configuration_manager=configuration(),
+        num_input_channels=1,
+        num_output_channels=2,
+    )
+
+    assert result is network
+    assert calls == [(
+        'example.Network', {'depth': 3}, ['conv_op'], 1, 2, False,
+    )]
+
+
+def test_build_network_uses_current_nnunet_trainer_signature():
+    calls = []
+    network = object()
+    plans_manager = object()
+    configuration_manager = configuration()
+
+    class CurrentTrainer:
+        @staticmethod
+        def build_network_architecture(
+            plans_manager,
+            configuration_manager,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision=True,
+        ):
+            calls.append((
+                plans_manager,
+                configuration_manager,
+                num_input_channels,
+                num_output_channels,
+                enable_deep_supervision,
+            ))
+            return network
+
+    result = _build_network_from_trainer(
+        CurrentTrainer,
+        plans_manager=plans_manager,
+        configuration_manager=configuration_manager,
+        num_input_channels=1,
+        num_output_channels=2,
+    )
+
+    assert result is network
+    assert calls == [(
+        plans_manager, configuration_manager, 1, 2, False,
+    )]
+
+
+def test_initialize_network_uses_nnunet_factory(monkeypatch):
+    calls = []
+    network = object()
+
+    def fake_get_network_from_plans(*args, **kwargs):
+        calls.append((args, kwargs))
+        return network
+
+    monkeypatch.setattr(
+        load_nnunet_model,
+        'get_network_from_plans',
+        fake_get_network_from_plans,
+    )
+
+    result = initialize_network(
+        'example.Network',
+        {'conv_op': 'torch.nn.Conv3d'},
+        ['conv_op'],
+        num_input_channels=1,
+        num_output_channels=2,
+        enable_deep_supervision=False,
+    )
+
+    assert result is network
+    assert calls == [(
+        (
+            'example.Network',
+            {'conv_op': 'torch.nn.Conv3d'},
+            ['conv_op'],
+            1,
+            2,
+        ),
+        {'allow_init': True, 'deep_supervision': False},
+    )]


### PR DESCRIPTION
## Problem

`vesuvius.predict` loads an nnU-Net model's architecture and weights but ignores the normalization declared in `plans.json`. It therefore silently keeps the CLI default, `instance_zscore`, even when a checkpoint was trained with `CTNormalization`.

This is the inference mismatch diagnosed in #1364. The issue's 60-volume reproduction reports median recall/precision changing from 0.7740/0.4459 to 0.9109/0.6680 after using the model's CT normalization.

The same issue identifies two blockers around that path: the nnU-Net 2.8 trainer API differs from villa's vendored 2.5 API, and the missing-trainer fallback imports kwarg names such as `conv_op` instead of resolving the class paths stored in those kwargs.

## Change

- derive the native normalization scheme from the nnU-Net configuration manager already returned by the loader
- pass channel-0 CT fingerprint statistics through `VCDataset` to `Volume`
- visibly report when model metadata overrides the CLI/default
- fail explicitly for unsupported, masked-Z-score, or multi-channel contracts instead of silently changing semantics
- preserve explicit normalization metadata from train.py/external checkpoints
- support both nnU-Net 2.5 and 2.8 `build_network_architecture` signatures by inspecting the declared parameters, without swallowing errors raised inside a trainer
- use nnU-Net's own `get_network_from_plans` for the missing-trainer fallback

Inference exception propagation is intentionally left to #1414, which now owns the stronger fix for #1360; this PR no longer touches that hunk.

Supported native mappings use villa's existing implementations: `CTNormalization`, `ZScoreNormalization`, `NoNormalization`, and `RescaleTo01Normalization`.

## Validation

- Loaded the public `surface_m7` checkpoint through the full `Inferer._load_model` path on CPU:
  - resolved `CTNormalization -> ct`
  - mean `87.54424285888672`, std `47.74376678466797`
  - clipping bounds `[0.0, 212.0]`
  - patch size `(192, 192, 192)`
- Constructed the same public model through the repaired direct fallback: `ResidualEncoderUNet`, 1 input channel, 2 output heads.
- New numerical test compares villa's CT-normalized volume exactly against nnU-Net's own `CTNormalization`, including out-of-range clipping.
- Compatibility tests exercise both the vendored 2.5 trainer signature and the 2.8.1 signature.
- `119 passed, 1 skipped`:
  `pytest tests/models/run tests/data tests/utils/models/test_load_nnunet_model_compatibility.py -m "not slow and not network" -q`

Fixes #1364.
