### PR TITLE
Report failures in the exit code in three CLI tools

### DIFF
--- a/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
+++ b/volume-cartographer/apps/src/vc_gen_normalgrids.cpp
@@ -432,7 +432,8 @@ static void log_chunk_io(
 } // namespace
 
 void run_generate(const po::variables_map& vm);
-void run_convert(const po::variables_map& vm);
+// Returns non-zero if any file failed to convert.
+int run_convert(const po::variables_map& vm);
 void run_pyramid(const po::variables_map& vm);
 
 static void print_usage() {
@@ -600,7 +601,9 @@ int main(int argc, char* argv[]) {
             std::cout << convert_desc << std::endl;
             return 1;
         }
-        run_convert(convert_vm);
+        if (run_convert(convert_vm) != 0) {
+            return 1;
+        }
 
     } else if (cmd == "pyramid") {
         po::options_description pyramid_desc(
@@ -1000,7 +1003,8 @@ void run_pyramid(const po::variables_map& vm) {
     std::cout << "Pyramid complete: " << output_root << std::endl;
 }
 
-void run_convert(const po::variables_map& vm) {
+int run_convert(const po::variables_map& vm)
+{
     fs::path input_dir = vm["input"].as<std::string>();
     int new_grid_step = vm["grid-step"].as<int>();
     std::cout << "Scanning directory: " << input_dir << " with new grid step: " << new_grid_step << std::endl;
@@ -1081,8 +1085,12 @@ void run_convert(const po::variables_map& vm) {
               << ", Converted: " << converted_count
               << ", Skipped: " << skipped_count
               << ", Errors: " << error_count << std::endl;
-}
 
+    // Let the exit code carry what the summary already says. Every per-file
+    // failure was counted and printed, but a batch where every single file
+    // failed still exited 0, so a calling script could not tell.
+    return error_count > 0 ? 1 : 0;
+}
 
 void run_generate(const po::variables_map& vm) {
     const auto total_start = std::chrono::steady_clock::now();

--- a/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz2obj.cpp
@@ -183,7 +183,10 @@ static cv::Mat_<cv::Vec3f> build_vertex_normals_from_faces(
     return nsum;
 }
 
-static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_fn, bool normalize_uv, bool align_grid, float keep_percent, bool clean_surface, float clean_sigma_k, bool inpaint_holes)
+// Returns false if the OBJ could not be written, so main() can fail instead of
+// reporting a clean conversion for a file that never made it to disk.
+static bool surf_write_obj(
+    QuadSurface* surf, const std::filesystem::path& out_fn, bool normalize_uv, bool align_grid, float keep_percent, bool clean_surface, float clean_sigma_k, bool inpaint_holes)
 {
     cv::Mat_<cv::Vec3f> points = surf->rawPoints();
     
@@ -247,7 +250,7 @@ static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_f
     std::ofstream out(out_fn);
     if (!out) {
         std::cerr << "Failed to open for write: " << out_fn << "\n";
-        return;
+        return false;
     }
     out << std::fixed << std::setprecision(6);
 
@@ -306,6 +309,11 @@ static void surf_write_obj(QuadSurface *surf, const std::filesystem::path &out_f
                            << c01 << "/" << c01 << "/" << c01 << " "
                            << c11 << "/" << c11 << "/" << c11 << '\n';
             }
+
+    // Also report a write that started fine and then failed - a full disk shows
+    // up here rather than at open time.
+    out.flush();
+    return static_cast<bool>(out);
 }
 
 int main(int argc, char *argv[])
@@ -391,7 +399,10 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    surf_write_obj(surf.get(), obj_path, normalize_uv, align_grid, keep_percent, clean_surface, clean_sigma_k, inpaint_holes);
+    if (!surf_write_obj(surf.get(), obj_path, normalize_uv, align_grid, keep_percent, clean_surface, clean_sigma_k, inpaint_holes)) {
+        std::cerr << "error: failed to write " << obj_path << std::endl;
+        return EXIT_FAILURE;
+    }
 
     return EXIT_SUCCESS;
 }

--- a/volume-cartographer/apps/src/vc_visualize.cpp
+++ b/volume-cartographer/apps/src/vc_visualize.cpp
@@ -37,8 +37,9 @@ class SegmentRenderer {
 
     std::map<std::string, int> segment_color_map_;
 
-    // Surfaces that were requested but could not be loaded. They are skipped so
-    // the rest still renders, but main() needs to know they went missing.
+    // Surfaces requested by the current render() that could not be loaded. They
+    // are skipped so the rest still renders, but main() needs to know they went
+    // missing. Reset at the start of each render(), alongside the colour map.
     int failed_surface_loads_ = 0;
 
     cv::Vec3b getColormapColor(int index, int total_count) {
@@ -116,7 +117,7 @@ class SegmentRenderer {
     }
 
 public:
-    // Number of requested surfaces that failed to load during the last render.
+    // Number of requested surfaces that failed to load in the most recent render().
     int failedSurfaceLoads() const { return failed_surface_loads_; }
 
     SegmentRenderer(const fs::path& volpkg_path, const std::string& volume_id) {
@@ -158,6 +159,7 @@ private:
         std::cout << "Rendering " << source << " for segment: " << target_segment_id << std::endl;
 
         segment_color_map_.clear();
+        failed_surface_loads_ = 0;
 
         // Load target segment
         auto target_surf = vpkg_->loadSurface(target_segment_id);
@@ -381,7 +383,12 @@ private:
 
         for (const auto& seq_id : original_sequence) {
             auto surf = vpkg_->loadSurface(seq_id);
-            if (surf && segment_color_map_.find(seq_id) != segment_color_map_.end()) {
+            // Only a failed load counts: an id absent from the colour map was
+            // deliberately left out of the sorted sequence, which is not an error.
+            if (!surf) {
+                std::cerr << "Failed to load surface: " << seq_id << std::endl;
+                failed_surface_loads_++;
+            } else if (segment_color_map_.find(seq_id) != segment_color_map_.end()) {
                 surfaces.push_back({seq_id, surf, segment_color_map_[seq_id]});
             }
 

--- a/volume-cartographer/apps/src/vc_visualize.cpp
+++ b/volume-cartographer/apps/src/vc_visualize.cpp
@@ -37,6 +37,10 @@ class SegmentRenderer {
 
     std::map<std::string, int> segment_color_map_;
 
+    // Surfaces that were requested but could not be loaded. They are skipped so
+    // the rest still renders, but main() needs to know they went missing.
+    int failed_surface_loads_ = 0;
+
     cv::Vec3b getColormapColor(int index, int total_count) {
         int gray_value = (index * 255) / std::max(1, total_count - 1);
 
@@ -112,6 +116,9 @@ class SegmentRenderer {
     }
 
 public:
+    // Number of requested surfaces that failed to load during the last render.
+    int failedSurfaceLoads() const { return failed_surface_loads_; }
+
     SegmentRenderer(const fs::path& volpkg_path, const std::string& volume_id) {
         if (fs::is_directory(volpkg_path)) {
             throw std::runtime_error(
@@ -348,6 +355,7 @@ private:
                 color_idx++;
             } else {
                 std::cerr << "Failed to load surface: " << surf_id << std::endl;
+                failed_surface_loads_++;
             }
         }
 
@@ -601,6 +609,13 @@ int main(int argc, char* argv[]) {
 
         SegmentRenderer renderer(volpkg_path, volume_id);
         renderer.render(segment_id, output_path, overlap_source, filter, stride);
+
+        if (renderer.failedSurfaceLoads() > 0) {
+            std::cerr << "Error: " << renderer.failedSurfaceLoads()
+                      << " requested surface(s) could not be loaded and are missing "
+                         "from the render\n";
+            return EXIT_FAILURE;
+        }
 
         return EXIT_SUCCESS;
 


### PR DESCRIPTION
Three CLI tools detect a failure, print it, and then exit 0 anyway. Anything
scripting them — a sweep over a scroll, a batch conversion — cannot tell a failed
run from a clean one by exit code, which is the only signal it gets.

### The three

**`vc_tifxyz2obj`** — `surf_write_obj()` is `void`. If the OBJ cannot be opened for
writing it logs to stderr and returns; `main()` then returns `EXIT_SUCCESS`
unconditionally. An export that produced no file at all reports success. It now
returns `bool`, and also reports a write that fails *after* a successful open — a
full disk surfaces there rather than at open time. The function is `static` with a
single call site, so the signature change stays local.

**`vc_gen_normalgrids convert`** — `run_convert()` counts every per-file failure in
`error_count`, prints it in the progress line and again in the final summary, and
returns `void`; the call site ignores it. A batch where every single file failed
still exited 0. It now returns non-zero when `error_count > 0`.

**`vc_visualize`** — a surface that fails to load is skipped and the render
continues without it. Continuing is reasonable; saying nothing about it is not,
since the exit code then claims a complete render. The renderer now counts failed
loads and `main()` reports them.

There are two loading paths and both are covered: `loadSurfaces()`, and
`loadSequenceSurfaces()` which it tail-calls when `--overlap-source sequence` is
used. The sequence path was worse than the other one — it did not even log the
failure — so with a sequence source surfaces disappeared completely silently. Only
a null surface counts there; an id missing from the colour map left the loop for a
legitimate reason (it was not part of the sorted sequence) and is not a failure.

**This changes behaviour, deliberately and narrowly:** the render is still written,
with the surfaces that did load, exactly as before. Only the exit code changes. If
you would rather a partial render stayed a success, say so and I will gate it — but
right now nothing distinguishes "rendered everything" from "rendered what was left".

### Verification

Built in the CI dependency image
(`ghcr.io/scrollprize/vc3d-deps/linux:sha-0c371b1d…`) with the `cli-compile` job's
configuration, no warnings in the touched files. Same inputs, binaries from before
and after the change:

| scenario | before | after |
|---|---|---|
| `vc_tifxyz2obj`, output under a directory that does not exist | **exit 0**, no file written | exit 1 |
| `vc_gen_normalgrids convert`, every `.grid` unparseable | **exit 0**, summary says `Errors: 2` | exit 1, same summary |
| `vc_tifxyz2obj`, valid output path | exit 0, 2879107 bytes | exit 0, 2879107 bytes |
| `vc_gen_normalgrids convert`, nothing to do | exit 0 | exit 0 |

The bottom two rows matter as much as the top two: the successful paths are
unchanged, byte for byte. A fix that turned ordinary runs into failures would be
worse than the bug.

### What I could not test

`vc_visualize` needs a real volpkg, which I do not have, so that change rests on
reading the code rather than on a run. The failure is easy to reach in principle:
`VolumePkg::loadSurface()` returns `nullptr` for an id that is not present, so one
mistyped segment id silently drops a surface from the render.

### One I withdrew

While preparing this I also had `vc_grow_seg_from_segments.cpp:1482`
(`if (!surf) return EXIT_SUCCESS;`) on the list. It does not belong: `grow_surf_from_surfs()`
returns null only when its seed is null, `grow_surf_from_surfs_impl()` has a single
top-level `return surf;` with `surf = new QuadSurface(...)`, and `main()`'s seed
comes from `new`. The branch cannot execute. Mentioning it here only so the absence
is deliberate rather than an oversight.

### Disclosure

The analysis and this patch were produced with Claude Code working under my
direction. Every claim above was checked against the source and, where stated,
confirmed by the runs named.
