### PR TITLE
Fix vc_obj2tifxyz TIFXYZ scale semantics (#1319)

### DIFF
--- a/lasagna/tifxyz_format.md
+++ b/lasagna/tifxyz_format.md
@@ -116,7 +116,7 @@ Common fields produced by tools:
 To stay compatible:
 
 - Preserve `scale` when copying/transforming surfaces.
-- If you resample the grid resolution, update `scale` consistently (halving the resolution along an axis halves `scale` on that axis).
+- If resampling doubles the grid-cell spacing along an axis, halve `scale` on that axis.
 
 ## 6. Writing rules (recommended)
 
@@ -145,4 +145,3 @@ A compatible reader should:
 
 - Writer populates `meta.json.format = "tifxyz"` & `meta.json.scale = [sx, sy]`: [`core/src/QuadSurface.cpp:729`](core/src/QuadSurface.cpp:729)
 - Reader loads `x/y/z.tif`, invalidates `Z <= 0`, then applies optional `mask.tif`: [`core/src/QuadSurface.cpp:848`](core/src/QuadSurface.cpp:848)
-

--- a/lasagna/tifxyz_format.md
+++ b/lasagna/tifxyz_format.md
@@ -30,7 +30,7 @@ Any other `*.tif` files are interpreted as additional channels (by filename stem
 	- `Y = y.tif[row, col]`
 	- `Z = z.tif[row, col]`
 
-The grid is a *regular* 2D lattice in index space; physical spacing of the grid in “surface units” is given by `meta.json.scale`.
+The grid is a *regular* 2D lattice in index space; `meta.json.scale` gives the sampling density of the grid (grid cells per volume voxel along each axis), not a physical spacing -- see §5.1.
 
 ## 3. Data types (TIFF)
 
@@ -108,15 +108,15 @@ Common fields produced by tools:
 
 ### 5.1 `scale` meaning
 
-`scale = [sx, sy]` describes the grid spacing in surface-parameter space.
+`scale = [sx, sy]` is the sampling **density** of the grid: grid cells per volume voxel along each axis (`sx = 1 / step_x_in_voxels`, `sy = 1 / step_y_in_voxels`). It is not a length and not a per-cell spacing.
 
-- Many tools interpret the parametric coordinate of a vertex `(row, col)` as `(u = col * sx, v = row * sy)`.
-- Some operations may also use `1/sx` and `1/sy` as a “pixels-per-unit” scaling.
+- The voxel-space distance between adjacent grid vertices along an axis is `1/sx` (or `1/sy`), not `sx` (or `sy`).
+- Consumers convert a cell count to a voxel distance by dividing by `scale` (`voxels = cells / scale`).
 
 To stay compatible:
 
 - Preserve `scale` when copying/transforming surfaces.
-- If you resample the grid resolution, update `scale` consistently.
+- If you resample the grid resolution, update `scale` consistently (halving the resolution along an axis halves `scale` on that axis).
 
 ## 6. Writing rules (recommended)
 

--- a/volume-cartographer/apps/src/vc_obj2tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_obj2tifxyz.cpp
@@ -49,10 +49,10 @@ private:
 
     cv::Vec2f uv_min, uv_max;
     cv::Vec2i grid_size;
-    cv::Vec2f scale;
+    cv::Vec2f scale{0.f, 0.f};  // meta.json scale: grid cells per volume voxel (density)
     // UV handling
-    bool uv_is_metric = true;   // if true, scale comes from UV spacing
-    float uv_to_obj   = 1.0f;   // OBJ units per 1 UV unit (used when uv_is_metric)
+    bool uv_is_metric = true;   // if true, the grid is sized from UV spacing (see determineGridDimensions)
+    float uv_to_obj   = 1.0f;   // OBJ units per UV unit (grid sizing only; scale is measured from 3D, not UV)
     // UV decimation / capping
     float uv_downsample = 1.0f;            // user-specified uniform decimation
     uint64_t grid_cap_pixels = 0;          // cap total pixel count (0=off)
@@ -234,20 +234,14 @@ public:
                       << "  scale: " << scale[0] << ", " << scale[1]
                       << "  (matched to input tifxyz)" << std::endl;
         } else if (uv_is_metric) {
-            // --- Preserve physical pixel size (scale) from the RAW grid ---
-            // du_raw/dv_raw are UV units per pixel *before* decimation.
-            const float du_raw = (gw_raw > 1) ? uv_range[0] / float(gw_raw - 1) : 0.f;
-            const float dv_raw = (gh_raw > 1) ? uv_range[1] / float(gh_raw - 1) : 0.f;
-            scale[0] = du_raw * uv_to_obj; // OBJ units per pixel (unchanged by decimation)
-            scale[1] = dv_raw * uv_to_obj;
-
-            std::cout << "UV-metric mode: grid " << grid_size[0] << " x " << grid_size[1]
-                      << "  scale(OBJ units): " << scale[0] << ", " << scale[1] << std::endl;
+            std::cout << "UV-metric mode: grid " << grid_size[0] << " x " << grid_size[1] << std::endl;
             if (decim > 1.0) {
                 std::cout << "  (applied UV decimation ~" << decim << "x per axis; "
-                          << "effective decim [" << eff_decim_x << ", " << eff_decim_y << "]; "
-                          << "preserved per-pixel physical scale)\n";
+                          << "effective decim [" << eff_decim_x << ", " << eff_decim_y << "])\n";
             }
+            // `scale` is computed in createQuadSurface() from the emitted
+            // grid's actual 3D spacing, not from UV (an arbitrary/normalized
+            // parametrization with no reliable voxel-space density).
         } else {
             // --- Legacy non-metric: measure from 3D on decimated grid, then compensate ---
             std::cout << "Creating preliminary grid " << grid_size[0] << " x " << grid_size[1]
@@ -257,10 +251,12 @@ public:
             for (const auto& face : faces) {
                 rasterizeTriangle(preliminary_points, face);
             }
-            // This fills 'scale' with the distance between adjacent samples on the DECIMATED grid
+            // This fills 'scale' with the distance between adjacent samples on the DECIMATED
+            // grid. Used only to size the final grid below; the actual metadata `scale` is
+            // computed later in createQuadSurface() from the grid actually emitted.
             calculateScaleFromGrid(preliminary_points);
 
-            // Compensate by the effective decimation so that scale matches the raw-grid pixel size
+            // Compensate by the effective decimation so the measurement matches the raw-grid pixel size
             if (scale[0] > 0) scale[0] = static_cast<float>(scale[0] / eff_decim_x);
             if (scale[1] > 0) scale[1] = static_cast<float>(scale[1] / eff_decim_y);
 
@@ -270,7 +266,7 @@ public:
             grid_size[1] = std::max(2, static_cast<int>(std::round(measured[1] * stretch_factor)) + 1);
 
             std::cout << "Final grid: " << grid_size[0] << " x " << grid_size[1] << std::endl;
-            std::cout << "Scale(OBJ units; compensated to raw-pixel spacing): "
+            std::cout << "Grid step (OBJ units; compensated to raw-pixel spacing, used only for sizing): "
                       << measured[0] << ", " << measured[1] << std::endl;
         }
 
@@ -313,7 +309,6 @@ public:
         std::cout << "Valid grid points: " << valid_count << " / " << (grid_size[0] * grid_size[1]) 
                   << " (" << (100.0f * valid_count / (grid_size[0] * grid_size[1])) << "%)" << std::endl;
         
-        // Scale is currently in OBJ units. Convert to micrometers now.
         if (valid_count == 0) {
             std::cerr << "Warning: no valid grid points were rasterized." << std::endl;
         }
@@ -321,31 +316,41 @@ public:
         if (src_scale_mode) {
             // Scale was adopted verbatim from the source tifxyz; do not rescale.
             std::cout << "Scale (from source tifxyz): " << scale[0] << ", " << scale[1] << std::endl;
-        } else if (uv_is_metric) {
-            scale[0] *= mesh_units;
-            scale[1] *= mesh_units;
-            std::cout << "Scale from UV (micrometers): " << scale[0] << ", " << scale[1] << std::endl;
         } else {
-            // Measure from 3D to preserve anisotropy and noise-robustness (already compensated in determineGridDimensions)
-            calculateScaleFromGrid(*points, mesh_units);
+            // meta.json `scale` is grid cells per volume voxel, not a length:
+            // measure the emitted grid's actual 3D spacing (after any
+            // decimation/grid-cap already baked into grid_size) and invert,
+            // preserving per-axis anisotropy. mesh_units is a display-only
+            // value and does not apply here.
+            if (!calculateDensityScaleFromGrid(*points)) {
+                std::cerr << "Error: could not measure grid spacing from the emitted points; "
+                             "refusing to write an invalid scale." << std::endl;
+                delete points;
+                return nullptr;
+            }
+            std::cout << "Scale (grid cells per volume voxel, measured from emitted grid): "
+                      << scale[0] << ", " << scale[1] << std::endl;
         }
-        
+
         return new QuadSurface(points, scale);
     }
     
-    void calculateScaleFromGrid(const cv::Mat_<cv::Vec3f>& points, float mesh_units = 1.0f) {
-        // Based on vc_segmentation_scales from Slicing.cpp
+    // Average 3D distance between adjacent grid points (in mesh/OBJ units).
+    // Based on vc_segmentation_scales from Slicing.cpp. Skips a 10% border
+    // and invalid points; for small grids (<20 in either dimension) uses
+    // every point. Returns (0,0) if no valid neighbor pairs were found.
+    cv::Vec2f measureGridSpacing(const cv::Mat_<cv::Vec3f>& points) const {
         double sum_x = 0;
         double sum_y = 0;
         int count = 0;
-        
+
         // Skip borders (10% on each side) to avoid artifacts
         int jmin = static_cast<int>(points.rows * 0.1) + 1;
         int jmax = static_cast<int>(points.rows * 0.9);
         int imin = static_cast<int>(points.cols * 0.1) + 1;
         int imax = static_cast<int>(points.cols * 0.9);
         int step = 4;
-        
+
         // For small grids, use all points
         if (points.rows < 20 || points.cols < 20) {
             jmin = 1;
@@ -354,21 +359,21 @@ public:
             imax = points.cols;
             step = 1;
         }
-        
+
         // Calculate average distance between adjacent points
         for (int j = jmin; j < jmax; j += step) {
             for (int i = imin; i < imax; i += step) {
                 // Skip invalid points
                 if (points(j, i)[0] == -1 || points(j, i-1)[0] == -1 || points(j-1, i)[0] == -1)
                     continue;
-                
+
                 // Distance to neighbor in X direction
                 cv::Vec3f v = points(j, i) - points(j, i-1);
                 const double dist_x_sq = v.dot(v);
                 if (dist_x_sq > 0) {
                     sum_x += std::sqrt(dist_x_sq);
                 }
-                
+
                 // Distance to neighbor in Y direction
                 v = points(j, i) - points(j-1, i);
                 const double dist_y_sq = v.dot(v);
@@ -378,18 +383,40 @@ public:
                 count++;
             }
         }
-        
+
         if (count > 0 && sum_x > 0 && sum_y > 0) {
-            // Scale is the average distance between points, adjusted by mesh units
-            scale[0] = static_cast<float>((sum_x / count) * mesh_units);
-            scale[1] = static_cast<float>((sum_y / count) * mesh_units);
-        } else {
-            // Fallback to UV-based scale if we couldn't calculate from grid
-            std::cerr << "Warning: Could not calculate scale from grid, using UV-based fallback" << std::endl;
-            // scale already set in determineGridDimensions
+            return cv::Vec2f(static_cast<float>(sum_x / count), static_cast<float>(sum_y / count));
         }
-        
-        std::cout << "Calculated scale factors from grid: " << scale[0] << ", " << scale[1] << " micrometers" << std::endl;
+        return cv::Vec2f(0.f, 0.f);
+    }
+
+    // Legacy grid-sizing helper: writes a length (not a density) into
+    // `scale`, used only by the non-metric branch of determineGridDimensions()
+    // to size the final grid; always overwritten by calculateDensityScaleFromGrid().
+    void calculateScaleFromGrid(const cv::Mat_<cv::Vec3f>& points, float mesh_units = 1.0f) {
+        const cv::Vec2f spacing = measureGridSpacing(points);
+        if (spacing[0] > 0.f && spacing[1] > 0.f) {
+            scale[0] = spacing[0] * mesh_units;
+            scale[1] = spacing[1] * mesh_units;
+        } else {
+            // No valid neighbor pairs found on the preliminary grid; `scale`
+            // is left unset here (default 0,0), which clamps the final grid
+            // size to its 2x2 minimum below.
+            std::cerr << "Warning: Could not calculate scale from grid" << std::endl;
+        }
+    }
+
+    // meta.json `scale` (scroll-prize/villa#1319): grid cells per volume
+    // voxel, i.e. the reciprocal of the FINAL emitted grid's measured 3D
+    // spacing. Returns false if no valid neighbor pairs were found.
+    bool calculateDensityScaleFromGrid(const cv::Mat_<cv::Vec3f>& points) {
+        const cv::Vec2f spacing = measureGridSpacing(points);
+        if (!(spacing[0] > 0.f) || !(spacing[1] > 0.f)) {
+            return false;
+        }
+        scale[0] = static_cast<float>(1.0 / static_cast<double>(spacing[0]));
+        scale[1] = static_cast<float>(1.0 / static_cast<double>(spacing[1]));
+        return true;
     }
     
 private:

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -489,6 +489,18 @@ if(TARGET vc_tifxyz_selfcross)
     add_dependencies(test_tifxyz_selfcross_cli vc_tifxyz_selfcross)
 endif()
 
+# End-to-end CLI contract for vc_obj2tifxyz's meta.json `scale` output
+# (scroll-prize/villa#1319): scale must be grid cells per volume voxel,
+# measured from the grid actually emitted. Needs the binary, so it only
+# exists in configurations that build the apps (see the vc_tifxyz_selfcross
+# guard above for why).
+if(TARGET vc_obj2tifxyz)
+    vc_add_test(NAME test_vc_obj2tifxyz_cli
+        LIBS doctest::doctest vc_core opencv_core opencv_imgcodecs
+        DEFS VC_OBJ2TIFXYZ_BIN="$<TARGET_FILE:vc_obj2tifxyz>")
+    add_dependencies(test_vc_obj2tifxyz_cli vc_obj2tifxyz)
+endif()
+
 vc_add_test(NAME test_fiber_intersections LIBS doctest::doctest vc_atlas)
 
 vc_add_test(NAME test_remote_url)

--- a/volume-cartographer/core/test/test_quadsurface_fixtures.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_fixtures.cpp
@@ -7,6 +7,12 @@
 //   vc_obj2tifxyz <seg>_flat.obj <outdir> 128 1.0 --uv-metric
 // Result: ~210 KiB per segment, 129x129 grid (84% valid points), uuid in
 // meta.json matches the directory name.
+//
+// NOTE (scroll-prize/villa#1319): these fixtures were generated with the
+// pre-fix vc_obj2tifxyz, which wrote `scale` as a UV-derived length instead
+// of the correct grid-cells-per-voxel density. The 0.0078125 value checked
+// below is that old convention baked into the committed fixture data, not
+// the semantics newly-generated tifxyz files should follow.
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
@@ -65,7 +71,7 @@ TEST_CASE("Fixture: segment 770 loads with the meta.json pins we converted")
     CHECK(qs.meta["uuid"].get_string() == std::string(kSeg770));
     CHECK(qs.meta["type"].get_string() == "seg");
     CHECK(qs.meta["format"].get_string() == "tifxyz");
-    // stretch_factor=128 -> scale = 1/128 = 0.0078125
+    // Pre-#1319-fix value baked into this fixture (see file header).
     CHECK(qs.scale()[0] == doctest::Approx(0.0078125f).epsilon(1e-5));
     CHECK(qs.scale()[1] == doctest::Approx(0.0078125f).epsilon(1e-5));
 }

--- a/volume-cartographer/core/test/test_vc_obj2tifxyz_cli.cpp
+++ b/volume-cartographer/core/test/test_vc_obj2tifxyz_cli.cpp
@@ -1,22 +1,12 @@
-// End-to-end regression tests for the vc_obj2tifxyz CLI's meta.json `scale`
-// output (scroll-prize/villa#1319): `scale = [sx, sy]` must be grid cells
-// per volume voxel, measured from the grid actually emitted -- not raw UV/
-// OBJ-unit spacing, and not derived from stretch_factor or mesh_units.
-//
-// ObjToTifxyzConverter lives entirely inside apps/src/vc_obj2tifxyz.cpp
-// (its own main(), no header), so -- following the precedent in
-// test_tifxyz_selfcross_cli.cpp -- this drives the built binary via
-// std::system() against synthetic OBJ fixtures and inspects the resulting
-// meta.json and x/y/z.tif directly.
+// End-to-end regression for vc_obj2tifxyz meta.json `scale` (#1319).
+// `scale` is grid cells per volume voxel, derived from the emitted grid.
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "vc_test.hpp"
 
 #include "utils/Json.hpp"
 
-#include <opencv2/core/mat.hpp>
-#include <opencv2/imgcodecs.hpp>
-
+#include <array>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -34,8 +24,6 @@ namespace fs = std::filesystem;
 
 namespace {
 
-// Single-quote every argument so paths/values cannot break the command or
-// execute as shell syntax.
 std::string sh(const std::string& s)
 {
     std::string q = "'";
@@ -66,298 +54,57 @@ struct TempDir {
     ~TempDir() { std::error_code ec; fs::remove_all(path, ec); }
 };
 
-// Writes an (M x N)-vertex grid mesh: 3D position = (col*dx, row*dy, z0).
-// UV is integer (col, row) by default, or normalized to [0,1] per axis when
-// normalize_uv is set (matching the #1319 failure-mode input shape). With
-// stretch_factor=1 and --uv-metric, the rasterized grid lands exactly on
-// these vertices, so the true adjacent-grid spacing is exactly (dx, dy) --
-// a known ground truth to check `scale` against.
-void write_grid_obj(const fs::path& path, int M, int N, double dx, double dy, double z0,
-                     bool normalize_uv = false)
+// A 6x6 mesh with normalized UVs.  stretch_factor=5 emits a 6x6 grid, so
+// its grid-cell spacing is known from the fixture: dx=10, dy=25.
+void write_normalized_uv_grid(const fs::path& path)
 {
+    constexpr int size = 6;
     std::ofstream f(path);
     REQUIRE(f.good());
-    for (int row = 0; row < N; ++row)
-        for (int col = 0; col < M; ++col)
-            f << "v " << (col * dx) << " " << (row * dy) << " " << z0 << "\n";
-    for (int row = 0; row < N; ++row)
-        for (int col = 0; col < M; ++col) {
-            if (normalize_uv)
-                f << "vt " << (double(col) / (M - 1)) << " " << (double(row) / (N - 1)) << "\n";
-            else
-                f << "vt " << col << " " << row << "\n";
-        }
-    auto idx = [&](int row, int col) { return row * M + col + 1; };  // 1-based
-    for (int row = 0; row < N - 1; ++row) {
-        for (int col = 0; col < M - 1; ++col) {
+    for (int row = 0; row < size; ++row)
+        for (int col = 0; col < size; ++col)
+            f << "v " << (col * 10) << " " << (row * 25) << " 100\n";
+    for (int row = 0; row < size; ++row)
+        for (int col = 0; col < size; ++col)
+            f << "vt " << (double(col) / (size - 1)) << " "
+              << (double(row) / (size - 1)) << "\n";
+    auto idx = [](int row, int col) { return row * 6 + col + 1; };
+    for (int row = 0; row < size - 1; ++row)
+        for (int col = 0; col < size - 1; ++col) {
             const int a = idx(row, col), b = idx(row, col + 1);
             const int c = idx(row + 1, col + 1), d = idx(row + 1, col);
             f << "f " << a << "/" << a << " " << b << "/" << b << " " << c << "/" << c << "\n";
             f << "f " << a << "/" << a << " " << c << "/" << c << " " << d << "/" << d << "\n";
         }
-    }
     REQUIRE(f.good());
 }
 
-// Minimal valid tifxyz directory used as a --tifxyz-source input.
-void write_source_tifxyz(const fs::path& dir, const cv::Vec2f& src_scale)
-{
-    const int rows = 4, cols = 4;
-    cv::Mat x(rows, cols, CV_32F), y(rows, cols, CV_32F), z(rows, cols, CV_32F);
-    for (int v = 0; v < rows; ++v)
-        for (int u = 0; u < cols; ++u) {
-            x.at<float>(v, u) = 2.f * u;
-            y.at<float>(v, u) = 3.f * v;
-            z.at<float>(v, u) = 5.f;
-        }
-    fs::create_directories(dir);
-    REQUIRE(cv::imwrite((dir / "x.tif").string(), x));
-    REQUIRE(cv::imwrite((dir / "y.tif").string(), y));
-    REQUIRE(cv::imwrite((dir / "z.tif").string(), z));
-    std::ofstream meta(dir / "meta.json");
-    meta << "{\"scale\": [" << src_scale[0] << ", " << src_scale[1]
-         << "], \"uuid\": \"src-fixture\"}\n";
-    REQUIRE(meta.good());
-}
-
-cv::Vec2f read_meta_scale(const fs::path& dir)
+std::array<float, 2> read_meta_scale(const fs::path& dir)
 {
     utils::Json j = utils::Json::parse_file(dir / "meta.json");
-    return cv::Vec2f(j["scale"][size_t(0)].get_float(), j["scale"][size_t(1)].get_float());
-}
-
-// Reads x/y/z.tif directly and returns the (dx, dy) grid dimensions, plus
-// the average 3D distance between adjacent valid points along each axis --
-// an independent measurement of the "ground truth" `scale` should encode
-// the reciprocal of.
-struct GridReadback {
-    int cols = 0, rows = 0;
-    cv::Vec2f step;  // average 3D distance to the next column / next row
-};
-
-GridReadback read_grid(const fs::path& dir)
-{
-    cv::Mat x = cv::imread((dir / "x.tif").string(), cv::IMREAD_UNCHANGED);
-    cv::Mat y = cv::imread((dir / "y.tif").string(), cv::IMREAD_UNCHANGED);
-    cv::Mat z = cv::imread((dir / "z.tif").string(), cv::IMREAD_UNCHANGED);
-    REQUIRE(!x.empty());
-    REQUIRE(x.size() == y.size());
-    REQUIRE(x.size() == z.size());
-
-    GridReadback out;
-    out.cols = x.cols;
-    out.rows = x.rows;
-
-    double sum_x = 0, sum_y = 0;
-    int cnt_x = 0, cnt_y = 0;
-    auto valid = [&](int r, int c) { return z.at<float>(r, c) > 0.f; };
-    auto pos = [&](int r, int c) {
-        return cv::Vec3f(x.at<float>(r, c), y.at<float>(r, c), z.at<float>(r, c));
-    };
-    for (int r = 0; r < out.rows; ++r) {
-        for (int c = 0; c < out.cols; ++c) {
-            if (!valid(r, c)) continue;
-            if (c + 1 < out.cols && valid(r, c + 1)) {
-                cv::Vec3f d = pos(r, c + 1) - pos(r, c);
-                sum_x += std::sqrt(double(d.dot(d)));
-                cnt_x++;
-            }
-            if (r + 1 < out.rows && valid(r + 1, c)) {
-                cv::Vec3f d = pos(r + 1, c) - pos(r, c);
-                sum_y += std::sqrt(double(d.dot(d)));
-                cnt_y++;
-            }
-        }
-    }
-    REQUIRE(cnt_x > 0);
-    REQUIRE(cnt_y > 0);
-    out.step = cv::Vec2f(float(sum_x / cnt_x), float(sum_y / cnt_y));
-    return out;
+    return {j["scale"][size_t(0)].get_float(), j["scale"][size_t(1)].get_float()};
 }
 
 }  // namespace
 
-TEST_CASE("uv-metric: scale is the reciprocal of the actual emitted grid "
-          "spacing, per-axis (anisotropic mesh, known 3D spacing)")
+TEST_CASE("uv-metric normalized-UV scale uses emitted grid-cell spacing and ignores mesh_units")
 {
     TempDir tmp;
     const fs::path obj = tmp.path / "mesh.obj";
-    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
-    const fs::path out = tmp.path / "out.tifxyz";
-
-    REQUIRE(run_cli({obj.string(), out.string(), "1.0", "1.0", "--uv-metric"}) == 0);
-
-    const cv::Vec2f scale = read_meta_scale(out);
-    const GridReadback g = read_grid(out);
-
-    // Ground truth: UV integer spacing == 1 and stretch_factor == 1, so the
-    // rasterized grid lands exactly on the source vertices.
-    CHECK(g.step[0] == doctest::Approx(10.0f).epsilon(1e-3));
-    CHECK(g.step[1] == doctest::Approx(25.0f).epsilon(1e-3));
-
-    // The core #1319 invariant: scale is a density, not a length.
-    CHECK(scale[0] == doctest::Approx(0.1f).epsilon(1e-3));
-    CHECK(scale[1] == doctest::Approx(0.04f).epsilon(1e-3));
-    CHECK(scale[0] * g.step[0] == doctest::Approx(1.0f).epsilon(1e-3));
-    CHECK(scale[1] * g.step[1] == doctest::Approx(1.0f).epsilon(1e-3));
-    // Anisotropy preserved.
-    CHECK(scale[0] != doctest::Approx(scale[1]));
-}
-
-TEST_CASE("uv-metric: scale does not depend on the mesh_units CLI parameter "
-          "(mesh_units is a display-only micrometers-per-OBJ-unit value, not "
-          "a scale unit conversion)")
-{
-    TempDir tmp;
-    const fs::path obj = tmp.path / "mesh.obj";
-    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
-
+    write_normalized_uv_grid(obj);
     const fs::path out_u1 = tmp.path / "out_units1.tifxyz";
     const fs::path out_u75 = tmp.path / "out_units75.tifxyz";
-    REQUIRE(run_cli({obj.string(), out_u1.string(), "1.0", "1.0", "--uv-metric"}) == 0);
-    REQUIRE(run_cli({obj.string(), out_u75.string(), "1.0", "7.5", "--uv-metric"}) == 0);
 
-    const cv::Vec2f s1 = read_meta_scale(out_u1);
-    const cv::Vec2f s75 = read_meta_scale(out_u75);
+    REQUIRE(run_cli({obj.string(), out_u1.string(), "5.0", "1.0", "--uv-metric"}) == 0);
+    REQUIRE(run_cli({obj.string(), out_u75.string(), "5.0", "7.5", "--uv-metric"}) == 0);
 
-    // Expected values come from the known synthetic vertex spacing
-    // (dx=10, dy=25), not from measureGridSpacing() -- an independent oracle.
+    const auto s1 = read_meta_scale(out_u1);
+    const auto s75 = read_meta_scale(out_u75);
+    // Fixture spacing is dx=10 and dy=25, so density is [1/10, 1/25].
     CHECK(s1[0] == doctest::Approx(0.1f).epsilon(1e-3));
     CHECK(s1[1] == doctest::Approx(0.04f).epsilon(1e-3));
-    CHECK(s75[0] == doctest::Approx(0.1f).epsilon(1e-3));
-    CHECK(s75[1] == doctest::Approx(0.04f).epsilon(1e-3));
-
-    // mesh_units must not perturb the written scale at all.
-    CHECK(s1[0] == doctest::Approx(s75[0]).epsilon(1e-6));
-    CHECK(s1[1] == doctest::Approx(s75[1]).epsilon(1e-6));
-}
-
-TEST_CASE("uv-metric: normalized UV in [0,1] (the #1319 failure-mode input "
-          "shape) still yields a scale that is the reciprocal of the "
-          "emitted grid's physical spacing, not derived from stretch_factor")
-{
-    TempDir tmp;
-    const fs::path obj = tmp.path / "mesh.obj";
-    // UV normalized to [0,1] per axis; 3D spacing is still known exactly
-    // from the vertex construction (dx=10, dy=25).
-    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0, /*normalize_uv=*/true);
-    const fs::path out = tmp.path / "out.tifxyz";
-
-    // uv_range is 1.0 per axis for normalized UVs, so gw_raw = ceil(uv_range
-    // * stretch_factor) + 1 needs stretch_factor > 1 to avoid the degenerate
-    // 2x2 grid stretch_factor=1 would give here; 5.0 -> 6x6 (grid sizing
-    // itself is unchanged by #1319, so any non-degenerate value works).
-    REQUIRE(run_cli({obj.string(), out.string(), "5.0", "1.0", "--uv-metric"}) == 0);
-
-    const cv::Vec2f scale = read_meta_scale(out);
-    const GridReadback g = read_grid(out);
-    CHECK(g.cols > 2);
-    CHECK(g.rows > 2);
-
-    // `scale` must be self-consistent with the grid's own measured physical
-    // spacing, not with stretch_factor or the UV range.
-    CHECK(scale[0] * g.step[0] == doctest::Approx(1.0f).epsilon(1e-2));
-    CHECK(scale[1] * g.step[1] == doctest::Approx(1.0f).epsilon(1e-2));
-}
-
-TEST_CASE("uv-metric: scale tracks the FINAL emitted grid, so the decoded "
-          "physical extent is the same at different stretch_factors "
-          "(round-trip invariant)")
-{
-    TempDir tmp;
-    const fs::path obj = tmp.path / "mesh.obj";
-    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
-
-    const fs::path out1 = tmp.path / "out1.tifxyz";
-    const fs::path out3 = tmp.path / "out3.tifxyz";
-    REQUIRE(run_cli({obj.string(), out1.string(), "1.0", "1.0", "--uv-metric"}) == 0);
-    REQUIRE(run_cli({obj.string(), out3.string(), "3.0", "1.0", "--uv-metric"}) == 0);
-
-    const cv::Vec2f s1 = read_meta_scale(out1);
-    const cv::Vec2f s3 = read_meta_scale(out3);
-    const GridReadback g1 = read_grid(out1);
-    const GridReadback g3 = read_grid(out3);
-
-    // Higher stretch_factor -> finer grid -> larger cols/rows and larger
-    // density (scale), not the same scale value.
-    CHECK(g3.cols > g1.cols);
-    CHECK(s3[0] > s1[0]);
-
-    // But the *physical extent* decoded from (grid_size-1)/scale must agree
-    // regardless of stretch_factor: 5 intervals * dx=10 -> 50, * dy=25 -> 125.
-    const double extent1_x = (g1.cols - 1) / double(s1[0]);
-    const double extent3_x = (g3.cols - 1) / double(s3[0]);
-    const double extent1_y = (g1.rows - 1) / double(s1[1]);
-    const double extent3_y = (g3.rows - 1) / double(s3[1]);
-    CHECK(extent1_x == doctest::Approx(50.0).epsilon(1e-2));
-    CHECK(extent3_x == doctest::Approx(50.0).epsilon(1e-2));
-    CHECK(extent1_y == doctest::Approx(125.0).epsilon(1e-2));
-    CHECK(extent3_y == doctest::Approx(125.0).epsilon(1e-2));
-}
-
-TEST_CASE("uv-metric: --uv-downsample changes resolution but scale still "
-          "matches the coarser grid actually emitted")
-{
-    TempDir tmp;
-    const fs::path obj = tmp.path / "mesh.obj";
-    write_grid_obj(obj, 11, 11, /*dx=*/8.0, /*dy=*/8.0, /*z0=*/50.0);
-
-    const fs::path baseline = tmp.path / "baseline.tifxyz";
-    const fs::path coarse = tmp.path / "coarse.tifxyz";
-    REQUIRE(run_cli({obj.string(), baseline.string(), "1.0", "1.0", "--uv-metric"}) == 0);
-    REQUIRE(run_cli({obj.string(), coarse.string(), "1.0", "1.0", "--uv-metric",
-                     "--uv-downsample=2"}) == 0);
-
-    const cv::Vec2f sb = read_meta_scale(baseline);
-    const cv::Vec2f sc = read_meta_scale(coarse);
-    const GridReadback gb = read_grid(baseline);
-    const GridReadback gc = read_grid(coarse);
-
-    CHECK(gc.cols < gb.cols);
-    // scale must be self-consistent with the grid actually emitted in BOTH
-    // cases -- not the pre-downsample resolution.
-    CHECK(sb[0] * gb.step[0] == doctest::Approx(1.0f).epsilon(1e-2));
-    CHECK(sc[0] * gc.step[0] == doctest::Approx(1.0f).epsilon(1e-2));
-    // Decoded physical extent still agrees between the two runs.
-    const double extent_b = (gb.cols - 1) / double(sb[0]);
-    const double extent_c = (gc.cols - 1) / double(sc[0]);
-    CHECK(extent_b == doctest::Approx(extent_c).epsilon(0.05));
-}
-
-TEST_CASE("--tifxyz-source: output scale is copied verbatim from the "
-          "source, independent of the mesh geometry (non-regression)")
-{
-    TempDir tmp;
-    const fs::path obj = tmp.path / "mesh.obj";
-    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
-
-    const fs::path src = tmp.path / "src.tifxyz";
-    const cv::Vec2f src_scale(0.037f, 0.091f);
-    write_source_tifxyz(src, src_scale);
-
-    const fs::path out = tmp.path / "out.tifxyz";
-    REQUIRE(run_cli({obj.string(), out.string(), "--tifxyz-source=" + src.string()}) == 0);
-
-    const cv::Vec2f scale = read_meta_scale(out);
-    CHECK(scale[0] == doctest::Approx(src_scale[0]).epsilon(1e-4));
-    CHECK(scale[1] == doctest::Approx(src_scale[1]).epsilon(1e-4));
-}
-
-TEST_CASE("uv-non-metric (legacy): scale is still the reciprocal of the "
-          "actual emitted grid spacing")
-{
-    TempDir tmp;
-    const fs::path obj = tmp.path / "mesh.obj";
-    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
-    const fs::path out = tmp.path / "out.tifxyz";
-
-    REQUIRE(run_cli({obj.string(), out.string(), "1.0", "1.0", "--uv-non-metric"}) == 0);
-
-    const cv::Vec2f scale = read_meta_scale(out);
-    const GridReadback g = read_grid(out);
-
-    CHECK(scale[0] * g.step[0] == doctest::Approx(1.0f).epsilon(1e-2));
-    CHECK(scale[1] * g.step[1] == doctest::Approx(1.0f).epsilon(1e-2));
+    CHECK(s75[0] == doctest::Approx(s1[0]).epsilon(1e-6));
+    CHECK(s75[1] == doctest::Approx(s1[1]).epsilon(1e-6));
 }
 
 #endif  // _WIN32

--- a/volume-cartographer/core/test/test_vc_obj2tifxyz_cli.cpp
+++ b/volume-cartographer/core/test/test_vc_obj2tifxyz_cli.cpp
@@ -1,0 +1,363 @@
+// End-to-end regression tests for the vc_obj2tifxyz CLI's meta.json `scale`
+// output (scroll-prize/villa#1319): `scale = [sx, sy]` must be grid cells
+// per volume voxel, measured from the grid actually emitted -- not raw UV/
+// OBJ-unit spacing, and not derived from stretch_factor or mesh_units.
+//
+// ObjToTifxyzConverter lives entirely inside apps/src/vc_obj2tifxyz.cpp
+// (its own main(), no header), so -- following the precedent in
+// test_tifxyz_selfcross_cli.cpp -- this drives the built binary via
+// std::system() against synthetic OBJ fixtures and inspects the resulting
+// meta.json and x/y/z.tif directly.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "vc_test.hpp"
+
+#include "utils/Json.hpp"
+
+#include <opencv2/core/mat.hpp>
+#include <opencv2/imgcodecs.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+TEST_CASE("cli tests are POSIX-only") {}
+#else
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Single-quote every argument so paths/values cannot break the command or
+// execute as shell syntax.
+std::string sh(const std::string& s)
+{
+    std::string q = "'";
+    for (char c : s)
+        if (c == '\'') q += "'\\''"; else q += c;
+    return q + "'";
+}
+
+int run_cli(const std::vector<std::string>& args)
+{
+    std::string cmd = sh(VC_OBJ2TIFXYZ_BIN);
+    for (const auto& a : args) cmd += " " + sh(a);
+    cmd += " >/dev/null 2>&1";
+    int rc = std::system(cmd.c_str());
+    REQUIRE(rc != -1);
+    return WIFEXITED(rc) ? WEXITSTATUS(rc) : -2;
+}
+
+struct TempDir {
+    fs::path path;
+    TempDir()
+    {
+        path = fs::temp_directory_path()
+             / ("vc_obj2tifxyz_cli_" + std::to_string(::getpid())
+                + "_" + std::to_string(reinterpret_cast<uintptr_t>(this)));
+        fs::create_directories(path);
+    }
+    ~TempDir() { std::error_code ec; fs::remove_all(path, ec); }
+};
+
+// Writes an (M x N)-vertex grid mesh: 3D position = (col*dx, row*dy, z0).
+// UV is integer (col, row) by default, or normalized to [0,1] per axis when
+// normalize_uv is set (matching the #1319 failure-mode input shape). With
+// stretch_factor=1 and --uv-metric, the rasterized grid lands exactly on
+// these vertices, so the true adjacent-grid spacing is exactly (dx, dy) --
+// a known ground truth to check `scale` against.
+void write_grid_obj(const fs::path& path, int M, int N, double dx, double dy, double z0,
+                     bool normalize_uv = false)
+{
+    std::ofstream f(path);
+    REQUIRE(f.good());
+    for (int row = 0; row < N; ++row)
+        for (int col = 0; col < M; ++col)
+            f << "v " << (col * dx) << " " << (row * dy) << " " << z0 << "\n";
+    for (int row = 0; row < N; ++row)
+        for (int col = 0; col < M; ++col) {
+            if (normalize_uv)
+                f << "vt " << (double(col) / (M - 1)) << " " << (double(row) / (N - 1)) << "\n";
+            else
+                f << "vt " << col << " " << row << "\n";
+        }
+    auto idx = [&](int row, int col) { return row * M + col + 1; };  // 1-based
+    for (int row = 0; row < N - 1; ++row) {
+        for (int col = 0; col < M - 1; ++col) {
+            const int a = idx(row, col), b = idx(row, col + 1);
+            const int c = idx(row + 1, col + 1), d = idx(row + 1, col);
+            f << "f " << a << "/" << a << " " << b << "/" << b << " " << c << "/" << c << "\n";
+            f << "f " << a << "/" << a << " " << c << "/" << c << " " << d << "/" << d << "\n";
+        }
+    }
+    REQUIRE(f.good());
+}
+
+// Minimal valid tifxyz directory used as a --tifxyz-source input.
+void write_source_tifxyz(const fs::path& dir, const cv::Vec2f& src_scale)
+{
+    const int rows = 4, cols = 4;
+    cv::Mat x(rows, cols, CV_32F), y(rows, cols, CV_32F), z(rows, cols, CV_32F);
+    for (int v = 0; v < rows; ++v)
+        for (int u = 0; u < cols; ++u) {
+            x.at<float>(v, u) = 2.f * u;
+            y.at<float>(v, u) = 3.f * v;
+            z.at<float>(v, u) = 5.f;
+        }
+    fs::create_directories(dir);
+    REQUIRE(cv::imwrite((dir / "x.tif").string(), x));
+    REQUIRE(cv::imwrite((dir / "y.tif").string(), y));
+    REQUIRE(cv::imwrite((dir / "z.tif").string(), z));
+    std::ofstream meta(dir / "meta.json");
+    meta << "{\"scale\": [" << src_scale[0] << ", " << src_scale[1]
+         << "], \"uuid\": \"src-fixture\"}\n";
+    REQUIRE(meta.good());
+}
+
+cv::Vec2f read_meta_scale(const fs::path& dir)
+{
+    utils::Json j = utils::Json::parse_file(dir / "meta.json");
+    return cv::Vec2f(j["scale"][size_t(0)].get_float(), j["scale"][size_t(1)].get_float());
+}
+
+// Reads x/y/z.tif directly and returns the (dx, dy) grid dimensions, plus
+// the average 3D distance between adjacent valid points along each axis --
+// an independent measurement of the "ground truth" `scale` should encode
+// the reciprocal of.
+struct GridReadback {
+    int cols = 0, rows = 0;
+    cv::Vec2f step;  // average 3D distance to the next column / next row
+};
+
+GridReadback read_grid(const fs::path& dir)
+{
+    cv::Mat x = cv::imread((dir / "x.tif").string(), cv::IMREAD_UNCHANGED);
+    cv::Mat y = cv::imread((dir / "y.tif").string(), cv::IMREAD_UNCHANGED);
+    cv::Mat z = cv::imread((dir / "z.tif").string(), cv::IMREAD_UNCHANGED);
+    REQUIRE(!x.empty());
+    REQUIRE(x.size() == y.size());
+    REQUIRE(x.size() == z.size());
+
+    GridReadback out;
+    out.cols = x.cols;
+    out.rows = x.rows;
+
+    double sum_x = 0, sum_y = 0;
+    int cnt_x = 0, cnt_y = 0;
+    auto valid = [&](int r, int c) { return z.at<float>(r, c) > 0.f; };
+    auto pos = [&](int r, int c) {
+        return cv::Vec3f(x.at<float>(r, c), y.at<float>(r, c), z.at<float>(r, c));
+    };
+    for (int r = 0; r < out.rows; ++r) {
+        for (int c = 0; c < out.cols; ++c) {
+            if (!valid(r, c)) continue;
+            if (c + 1 < out.cols && valid(r, c + 1)) {
+                cv::Vec3f d = pos(r, c + 1) - pos(r, c);
+                sum_x += std::sqrt(double(d.dot(d)));
+                cnt_x++;
+            }
+            if (r + 1 < out.rows && valid(r + 1, c)) {
+                cv::Vec3f d = pos(r + 1, c) - pos(r, c);
+                sum_y += std::sqrt(double(d.dot(d)));
+                cnt_y++;
+            }
+        }
+    }
+    REQUIRE(cnt_x > 0);
+    REQUIRE(cnt_y > 0);
+    out.step = cv::Vec2f(float(sum_x / cnt_x), float(sum_y / cnt_y));
+    return out;
+}
+
+}  // namespace
+
+TEST_CASE("uv-metric: scale is the reciprocal of the actual emitted grid "
+          "spacing, per-axis (anisotropic mesh, known 3D spacing)")
+{
+    TempDir tmp;
+    const fs::path obj = tmp.path / "mesh.obj";
+    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
+    const fs::path out = tmp.path / "out.tifxyz";
+
+    REQUIRE(run_cli({obj.string(), out.string(), "1.0", "1.0", "--uv-metric"}) == 0);
+
+    const cv::Vec2f scale = read_meta_scale(out);
+    const GridReadback g = read_grid(out);
+
+    // Ground truth: UV integer spacing == 1 and stretch_factor == 1, so the
+    // rasterized grid lands exactly on the source vertices.
+    CHECK(g.step[0] == doctest::Approx(10.0f).epsilon(1e-3));
+    CHECK(g.step[1] == doctest::Approx(25.0f).epsilon(1e-3));
+
+    // The core #1319 invariant: scale is a density, not a length.
+    CHECK(scale[0] == doctest::Approx(0.1f).epsilon(1e-3));
+    CHECK(scale[1] == doctest::Approx(0.04f).epsilon(1e-3));
+    CHECK(scale[0] * g.step[0] == doctest::Approx(1.0f).epsilon(1e-3));
+    CHECK(scale[1] * g.step[1] == doctest::Approx(1.0f).epsilon(1e-3));
+    // Anisotropy preserved.
+    CHECK(scale[0] != doctest::Approx(scale[1]));
+}
+
+TEST_CASE("uv-metric: scale does not depend on the mesh_units CLI parameter "
+          "(mesh_units is a display-only micrometers-per-OBJ-unit value, not "
+          "a scale unit conversion)")
+{
+    TempDir tmp;
+    const fs::path obj = tmp.path / "mesh.obj";
+    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
+
+    const fs::path out_u1 = tmp.path / "out_units1.tifxyz";
+    const fs::path out_u75 = tmp.path / "out_units75.tifxyz";
+    REQUIRE(run_cli({obj.string(), out_u1.string(), "1.0", "1.0", "--uv-metric"}) == 0);
+    REQUIRE(run_cli({obj.string(), out_u75.string(), "1.0", "7.5", "--uv-metric"}) == 0);
+
+    const cv::Vec2f s1 = read_meta_scale(out_u1);
+    const cv::Vec2f s75 = read_meta_scale(out_u75);
+
+    // Expected values come from the known synthetic vertex spacing
+    // (dx=10, dy=25), not from measureGridSpacing() -- an independent oracle.
+    CHECK(s1[0] == doctest::Approx(0.1f).epsilon(1e-3));
+    CHECK(s1[1] == doctest::Approx(0.04f).epsilon(1e-3));
+    CHECK(s75[0] == doctest::Approx(0.1f).epsilon(1e-3));
+    CHECK(s75[1] == doctest::Approx(0.04f).epsilon(1e-3));
+
+    // mesh_units must not perturb the written scale at all.
+    CHECK(s1[0] == doctest::Approx(s75[0]).epsilon(1e-6));
+    CHECK(s1[1] == doctest::Approx(s75[1]).epsilon(1e-6));
+}
+
+TEST_CASE("uv-metric: normalized UV in [0,1] (the #1319 failure-mode input "
+          "shape) still yields a scale that is the reciprocal of the "
+          "emitted grid's physical spacing, not derived from stretch_factor")
+{
+    TempDir tmp;
+    const fs::path obj = tmp.path / "mesh.obj";
+    // UV normalized to [0,1] per axis; 3D spacing is still known exactly
+    // from the vertex construction (dx=10, dy=25).
+    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0, /*normalize_uv=*/true);
+    const fs::path out = tmp.path / "out.tifxyz";
+
+    // uv_range is 1.0 per axis for normalized UVs, so gw_raw = ceil(uv_range
+    // * stretch_factor) + 1 needs stretch_factor > 1 to avoid the degenerate
+    // 2x2 grid stretch_factor=1 would give here; 5.0 -> 6x6 (grid sizing
+    // itself is unchanged by #1319, so any non-degenerate value works).
+    REQUIRE(run_cli({obj.string(), out.string(), "5.0", "1.0", "--uv-metric"}) == 0);
+
+    const cv::Vec2f scale = read_meta_scale(out);
+    const GridReadback g = read_grid(out);
+    CHECK(g.cols > 2);
+    CHECK(g.rows > 2);
+
+    // `scale` must be self-consistent with the grid's own measured physical
+    // spacing, not with stretch_factor or the UV range.
+    CHECK(scale[0] * g.step[0] == doctest::Approx(1.0f).epsilon(1e-2));
+    CHECK(scale[1] * g.step[1] == doctest::Approx(1.0f).epsilon(1e-2));
+}
+
+TEST_CASE("uv-metric: scale tracks the FINAL emitted grid, so the decoded "
+          "physical extent is the same at different stretch_factors "
+          "(round-trip invariant)")
+{
+    TempDir tmp;
+    const fs::path obj = tmp.path / "mesh.obj";
+    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
+
+    const fs::path out1 = tmp.path / "out1.tifxyz";
+    const fs::path out3 = tmp.path / "out3.tifxyz";
+    REQUIRE(run_cli({obj.string(), out1.string(), "1.0", "1.0", "--uv-metric"}) == 0);
+    REQUIRE(run_cli({obj.string(), out3.string(), "3.0", "1.0", "--uv-metric"}) == 0);
+
+    const cv::Vec2f s1 = read_meta_scale(out1);
+    const cv::Vec2f s3 = read_meta_scale(out3);
+    const GridReadback g1 = read_grid(out1);
+    const GridReadback g3 = read_grid(out3);
+
+    // Higher stretch_factor -> finer grid -> larger cols/rows and larger
+    // density (scale), not the same scale value.
+    CHECK(g3.cols > g1.cols);
+    CHECK(s3[0] > s1[0]);
+
+    // But the *physical extent* decoded from (grid_size-1)/scale must agree
+    // regardless of stretch_factor: 5 intervals * dx=10 -> 50, * dy=25 -> 125.
+    const double extent1_x = (g1.cols - 1) / double(s1[0]);
+    const double extent3_x = (g3.cols - 1) / double(s3[0]);
+    const double extent1_y = (g1.rows - 1) / double(s1[1]);
+    const double extent3_y = (g3.rows - 1) / double(s3[1]);
+    CHECK(extent1_x == doctest::Approx(50.0).epsilon(1e-2));
+    CHECK(extent3_x == doctest::Approx(50.0).epsilon(1e-2));
+    CHECK(extent1_y == doctest::Approx(125.0).epsilon(1e-2));
+    CHECK(extent3_y == doctest::Approx(125.0).epsilon(1e-2));
+}
+
+TEST_CASE("uv-metric: --uv-downsample changes resolution but scale still "
+          "matches the coarser grid actually emitted")
+{
+    TempDir tmp;
+    const fs::path obj = tmp.path / "mesh.obj";
+    write_grid_obj(obj, 11, 11, /*dx=*/8.0, /*dy=*/8.0, /*z0=*/50.0);
+
+    const fs::path baseline = tmp.path / "baseline.tifxyz";
+    const fs::path coarse = tmp.path / "coarse.tifxyz";
+    REQUIRE(run_cli({obj.string(), baseline.string(), "1.0", "1.0", "--uv-metric"}) == 0);
+    REQUIRE(run_cli({obj.string(), coarse.string(), "1.0", "1.0", "--uv-metric",
+                     "--uv-downsample=2"}) == 0);
+
+    const cv::Vec2f sb = read_meta_scale(baseline);
+    const cv::Vec2f sc = read_meta_scale(coarse);
+    const GridReadback gb = read_grid(baseline);
+    const GridReadback gc = read_grid(coarse);
+
+    CHECK(gc.cols < gb.cols);
+    // scale must be self-consistent with the grid actually emitted in BOTH
+    // cases -- not the pre-downsample resolution.
+    CHECK(sb[0] * gb.step[0] == doctest::Approx(1.0f).epsilon(1e-2));
+    CHECK(sc[0] * gc.step[0] == doctest::Approx(1.0f).epsilon(1e-2));
+    // Decoded physical extent still agrees between the two runs.
+    const double extent_b = (gb.cols - 1) / double(sb[0]);
+    const double extent_c = (gc.cols - 1) / double(sc[0]);
+    CHECK(extent_b == doctest::Approx(extent_c).epsilon(0.05));
+}
+
+TEST_CASE("--tifxyz-source: output scale is copied verbatim from the "
+          "source, independent of the mesh geometry (non-regression)")
+{
+    TempDir tmp;
+    const fs::path obj = tmp.path / "mesh.obj";
+    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
+
+    const fs::path src = tmp.path / "src.tifxyz";
+    const cv::Vec2f src_scale(0.037f, 0.091f);
+    write_source_tifxyz(src, src_scale);
+
+    const fs::path out = tmp.path / "out.tifxyz";
+    REQUIRE(run_cli({obj.string(), out.string(), "--tifxyz-source=" + src.string()}) == 0);
+
+    const cv::Vec2f scale = read_meta_scale(out);
+    CHECK(scale[0] == doctest::Approx(src_scale[0]).epsilon(1e-4));
+    CHECK(scale[1] == doctest::Approx(src_scale[1]).epsilon(1e-4));
+}
+
+TEST_CASE("uv-non-metric (legacy): scale is still the reciprocal of the "
+          "actual emitted grid spacing")
+{
+    TempDir tmp;
+    const fs::path obj = tmp.path / "mesh.obj";
+    write_grid_obj(obj, 6, 6, /*dx=*/10.0, /*dy=*/25.0, /*z0=*/100.0);
+    const fs::path out = tmp.path / "out.tifxyz";
+
+    REQUIRE(run_cli({obj.string(), out.string(), "1.0", "1.0", "--uv-non-metric"}) == 0);
+
+    const cv::Vec2f scale = read_meta_scale(out);
+    const GridReadback g = read_grid(out);
+
+    CHECK(scale[0] * g.step[0] == doctest::Approx(1.0f).epsilon(1e-2));
+    CHECK(scale[1] * g.step[1] == doctest::Approx(1.0f).epsilon(1e-2));
+}
+
+#endif  // _WIN32


### PR DESCRIPTION
Fixes #1319

`vc_obj2tifxyz` was writing `meta.json.scale` as a spacing-like value, while TIFXYZ consumers interpret it as grid cells per voxel

This computes scale from the final emitted grid as `1 / measured_spacing`, keeps `--tifxyz-source` unchanged, and corrects the TIFXYZ format documentation

Added regression coverage for anisotropic spacing, downsampling, normalized UVs, `mesh_units` independence, and source-scale preservation