### PR TITLE
Resolve a segment's scroll from the catalog so type="segment" needs no scroll_id

### DIFF
--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -68,6 +68,128 @@ def list_files():
     return data
 
 
+# Depth of a segment entry in scrolls.yaml: scroll -> energy -> resolution ->
+# segments -> segment id, so the node holding 'segments' sits three keys deep.
+# get_url_from_yaml walks exactly that depth, so a match at any other depth could
+# not be turned into a URL. The layout is documented in install/configs/README.md.
+_SEGMENT_ENTRY_DEPTH = 3
+
+
+def _catalog_key_value(key: str) -> Any:
+    """Return the number a catalog key spells, otherwise the key itself.
+
+    scrolls.yaml keys are strings ('1', '54', '7.91') while the constructor takes
+    numbers. Only a conversion that renders back to the original key is used,
+    because get_url_from_yaml looks entries up by ``str()`` of these values, so a
+    key like '07' has to stay a string.
+    """
+    for cast in (int, float):
+        try:
+            value = cast(key)
+        except (TypeError, ValueError):
+            continue
+        if str(value) == key:
+            return value
+    return key
+
+
+def _find_segment_locations(
+        catalog: Dict[str, Any],
+        segment_id: Union[int, str],
+) -> List[Tuple[str, str, str, Any]]:
+    """Every place in ``catalog`` that lists ``segment_id``.
+
+    Returns one ``(scroll_key, energy_key, resolution_key, entry)`` tuple per
+    match, sorted, with the keys as the catalog spells them. All matches are
+    collected rather than the first one found, so a caller can tell a unique
+    answer from an ambiguous one instead of guessing. The sort keeps the result
+    independent of dict order.
+    """
+    wanted = str(segment_id)
+    found: List[Tuple[str, str, str, Any]] = []
+    stack: List[Tuple[Any, List[str]]] = [(catalog, [])]
+
+    while stack:
+        node, path = stack.pop()
+        if not isinstance(node, dict):
+            continue
+
+        segments = node.get('segments')
+        if (isinstance(segments, dict) and wanted in segments
+                and len(path) == _SEGMENT_ENTRY_DEPTH):
+            scroll_key, energy_key, resolution_key = path
+            found.append((scroll_key, energy_key, resolution_key,
+                          segments[wanted]))
+
+        if len(path) < _SEGMENT_ENTRY_DEPTH:
+            for key, value in node.items():
+                # Segment ids are keys of 'segments', not another nesting level.
+                if isinstance(value, dict) and key != 'segments':
+                    stack.append((value, path + [str(key)]))
+
+    return sorted(found, key=lambda match: match[:3])
+
+
+def _describe_segment_locations(matches: List[Tuple[str, str, str, Any]]) -> str:
+    """Render catalog locations for an error message."""
+    return ", ".join(
+        f"scroll {scroll} at energy {energy}, resolution {resolution}"
+        for scroll, energy, resolution, _ in matches)
+
+
+def _resolve_segment_location(
+        segment_id: Union[int, str],
+        scroll_id: Optional[Union[int, str]] = None,
+) -> Tuple[Any, Any, Any]:
+    """Resolve ``(scroll_id, energy, resolution)`` for a segment from the catalog.
+
+    The catalog records which scroll a segment belongs to, so a segment id is
+    enough to reach it. scrolls.yaml is read from disk, so no network access is
+    involved.
+
+    With no ``scroll_id``, the segment has to resolve to exactly one scroll, and
+    ValueError is raised otherwise rather than a scroll being guessed.
+
+    With a ``scroll_id``, that scroll is returned as passed and only energy and
+    resolution are looked up, from the entries under that scroll. Either comes
+    back as None when the catalog does not pin it to a single value, which leaves
+    it to the scroll's canonical default.
+    """
+    matches = _find_segment_locations(list_files(), segment_id)
+
+    if not matches:
+        # The data URL comes from the same catalog, so an unlisted segment cannot
+        # be opened whatever scroll is named. Say that rather than sending the
+        # caller into a second error.
+        raise ValueError(
+            f"Segment {segment_id} is not listed in the scroll catalog "
+            f"(vesuvius/install/configs/scrolls.yaml), so neither its scroll nor "
+            f"its data URL can be resolved. Check the segment id or add an entry "
+            f"for it to the catalog. scroll_id does not help here, the URL comes "
+            f"from the same file.")
+
+    if scroll_id is not None:
+        under_scroll = [match for match in matches if match[0] == str(scroll_id)]
+        if len(under_scroll) != 1:
+            return scroll_id, None, None
+        return (scroll_id, _catalog_key_value(under_scroll[0][1]),
+                _catalog_key_value(under_scroll[0][2]))
+
+    if len({scroll for scroll, _, _, _ in matches}) > 1:
+        raise ValueError(
+            f"Segment {segment_id} is listed under more than one scroll "
+            f"({_describe_segment_locations(matches)}), so its scroll cannot be "
+            f"determined. Pass scroll_id explicitly to say which one you mean.")
+
+    scroll_key, energy_key, resolution_key, _ = matches[0]
+    if len(matches) > 1:
+        # One scroll at several energies or resolutions. The scroll is settled,
+        # so leave the other two to the canonical defaults.
+        return _catalog_key_value(scroll_key), None, None
+    return (_catalog_key_value(scroll_key), _catalog_key_value(energy_key),
+            _catalog_key_value(resolution_key))
+
+
 def is_aws_ec2_instance():
     """Determine if the current system is an AWS EC2 instance."""
     try:
@@ -270,13 +392,10 @@ class Volume:
                     self.segment_id = None
                 elif type.isdigit():  # Assume it's a segment timestamp
                     segment_id_str = str(type)
-                    details = self.find_segment_details(segment_id_str)
-                    if details[0] is None:
-                        raise ValueError(f"Could not find details for segment ID: {segment_id_str}")
-                    s_id, e, res, _ = details
+                    s_id, e, res = _resolve_segment_location(segment_id_str, scroll_id)
                     self.type = "segment"
                     self.segment_id = int(segment_id_str)
-                    self.scroll_id = scroll_id if scroll_id is not None else s_id
+                    self.scroll_id = s_id
                     energy = energy if energy is not None else e
                     resolution = resolution if resolution is not None else res
                     if self.verbose:
@@ -287,7 +406,15 @@ class Volume:
                     if type == "segment":
                         assert isinstance(segment_id, int), "segment_id must be an int when type is 'segment'"
                         self.segment_id = segment_id
-                        self.scroll_id = scroll_id
+                        # A segment id alone is enough: the catalog records which
+                        # scroll it belongs to. Anything passed explicitly wins.
+                        s_id, e, res = _resolve_segment_location(segment_id, scroll_id)
+                        self.scroll_id = s_id
+                        energy = energy if energy is not None else e
+                        resolution = resolution if resolution is not None else res
+                        if self.verbose:
+                            print(
+                                f"Resolved segment {segment_id} to scroll {self.scroll_id}, E={energy}, Res={resolution}")
                     else:  # type == "scroll"
                         self.segment_id = None
                         self.scroll_id = scroll_id
@@ -515,31 +642,15 @@ class Volume:
         -------
         Tuple[Optional[int], Optional[int], Optional[float], Optional[Dict[str, Any]]]
             A tuple containing scroll_id, energy, resolution, and segment metadata.
-
-        Raises
-        ------
-        ValueError
-            If the segment details cannot be found.
+            Four Nones when the segment is not in the catalog. Keys come back as
+            the catalog spells them. Where a segment is listed in more than one
+            place, the first location in sorted order is reported;
+            ``_resolve_segment_location`` is the caller that refuses to choose.
         """
-
-        dictionary = list_files()
-        stack = [(list(dictionary.items()), [])]
-
-        while stack:
-            items, path = stack.pop()
-
-            for key, value in items:
-                if isinstance(value, dict):
-                    # Check if 'segments' key is present in the current level of the dictionary
-                    if 'segments' in value:
-                        # Check if the segment_id is in the segments dictionary
-                        if segment_id in value['segments']:
-                            scroll_id, energy, resolution = path[0], path[1], key
-                            return scroll_id, energy, resolution, value['segments'][segment_id]
-                    # Add nested dictionary to the stack for further traversal
-                    stack.append((list(value.items()), path + [key]))
-
-        return None, None, None, None
+        matches = _find_segment_locations(list_files(), segment_id)
+        if not matches:
+            return None, None, None, None
+        return matches[0]
 
     def get_url_from_yaml(self) -> str:
         """Retrieves the data URL/path from the YAML config file."""

--- a/vesuvius/tests/data/test_volume_segment_resolution.py
+++ b/vesuvius/tests/data/test_volume_segment_resolution.py
@@ -1,0 +1,144 @@
+"""A segment id is enough to reach a segment: the catalog knows its scroll.
+
+The usage block Volume prints on failure suggests
+``Volume(type="segment", segment_id=20230827161847)``, so that call has to work
+without a scroll_id. These drive the real constructor as far as the URL lookup,
+which is all local: the catalog is packaged YAML, so none of this touches the
+network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vesuvius.data import volume as volume_module
+from vesuvius.data.volume import Volume, _find_segment_locations
+
+# Listed in install/configs/scrolls.yaml under scroll 1, 54 keV, 7.91 um. This is
+# the id the printed usage block names.
+SEGMENT_IN_CATALOG = 20230827161847
+SEGMENT_NOT_IN_CATALOG = 19990101000000
+
+_SYNTHETIC_SEGMENT = "20240102030405"
+
+
+@pytest.fixture(autouse=True)
+def _no_inklabel_download(monkeypatch):
+    """download_only still fetches the ink label PNG for segments."""
+    monkeypatch.setattr(Volume, "download_inklabel",
+                        lambda self, save_path=None: None)
+
+
+def _resolve(segment_id, scroll_id=None):
+    """Init far enough to see the resolved fields, without opening any store."""
+    return Volume(type="segment", segment_id=segment_id, scroll_id=scroll_id,
+                  domain="dl.ash2txt", download_only=True)
+
+
+def _catalog(entries):
+    """Build a scrolls.yaml-shaped catalog holding the given segment locations."""
+    catalog: dict = {}
+    for scroll, energy, resolution in entries:
+        level = catalog.setdefault(scroll, {}).setdefault(energy, {}).setdefault(
+            resolution, {})
+        level["volume"] = f"https://example.invalid/{scroll}/volume.zarr/"
+        level.setdefault("segments", {})[_SYNTHETIC_SEGMENT] = (
+            f"https://example.invalid/{scroll}/{energy}/{resolution}/seg.zarr/")
+    return catalog
+
+
+def _use_catalog(monkeypatch, catalog):
+    monkeypatch.setattr(volume_module, "list_files", lambda: catalog)
+
+
+def test_segment_id_alone_resolves_its_scroll() -> None:
+    vol = _resolve(SEGMENT_IN_CATALOG)
+    assert vol.scroll_id == 1
+    assert vol.energy == 54
+    assert vol.resolution == 7.91
+    assert vol.url.endswith(f"{SEGMENT_IN_CATALOG}.zarr/")
+
+
+def test_segment_timestamp_as_type_resolves_the_same_way() -> None:
+    """Volume(type="<timestamp>") and type="segment" are the same request."""
+    vol = Volume(type=str(SEGMENT_IN_CATALOG), domain="dl.ash2txt",
+                 download_only=True)
+    by_segment_id = _resolve(SEGMENT_IN_CATALOG)
+    assert (vol.scroll_id, vol.energy, vol.resolution, vol.url) == (
+        by_segment_id.scroll_id, by_segment_id.energy,
+        by_segment_id.resolution, by_segment_id.url)
+
+
+def test_explicit_scroll_id_is_used_as_passed() -> None:
+    """An explicit scroll_id wins: the string is kept, not the inferred int 1."""
+    vol = _resolve(SEGMENT_IN_CATALOG, scroll_id="1")
+    assert vol.scroll_id == "1"
+    assert vol.url.endswith(f"{SEGMENT_IN_CATALOG}.zarr/")
+
+
+def test_explicit_energy_and_resolution_win_over_the_catalog() -> None:
+    # 88 keV at 3.24 um is not where this segment lives, so the URL lookup fails
+    # and names every key it looked under. That is the check: the passed values
+    # reached it rather than the catalog's 54 and 7.91 overwriting them, while the
+    # scroll was still resolved from the catalog.
+    with pytest.raises(ValueError) as excinfo:
+        Volume(type="segment", segment_id=SEGMENT_IN_CATALOG, energy=88,
+               resolution=3.24, domain="dl.ash2txt", download_only=True)
+    message = str(excinfo.value)
+    assert "scroll=1" in message
+    assert "energy=88" in message
+    assert "resolution=3.24" in message
+
+
+def test_unknown_segment_says_it_is_not_in_the_catalog() -> None:
+    with pytest.raises(ValueError, match="not listed in the scroll catalog"):
+        _resolve(SEGMENT_NOT_IN_CATALOG)
+
+
+def test_segment_under_two_scrolls_refuses_to_choose(monkeypatch) -> None:
+    _use_catalog(monkeypatch, _catalog([("1", "54", "7.91"),
+                                        ("2", "88", "3.24")]))
+    with pytest.raises(ValueError) as excinfo:
+        _resolve(int(_SYNTHETIC_SEGMENT))
+    message = str(excinfo.value)
+    assert "more than one scroll" in message
+    assert "scroll 1 at energy 54, resolution 7.91" in message
+    assert "scroll 2 at energy 88, resolution 3.24" in message
+    assert "Pass scroll_id explicitly" in message
+
+
+def test_scroll_id_settles_a_segment_listed_under_two_scrolls(monkeypatch) -> None:
+    _use_catalog(monkeypatch, _catalog([("1", "54", "7.91"),
+                                        ("2", "88", "3.24")]))
+    scroll, energy, resolution = volume_module._resolve_segment_location(
+        _SYNTHETIC_SEGMENT, scroll_id="2")
+    assert (scroll, energy, resolution) == ("2", 88, 3.24)
+
+
+def test_one_scroll_at_two_energies_keeps_the_scroll_and_defers_the_rest(
+        monkeypatch) -> None:
+    # The scroll is settled, so it is returned. Energy and resolution are not, so
+    # they are left None for the scroll's canonical defaults to fill in.
+    _use_catalog(monkeypatch, _catalog([("1", "54", "7.91"),
+                                        ("1", "88", "3.24")]))
+    assert volume_module._resolve_segment_location(_SYNTHETIC_SEGMENT) == (
+        1, None, None)
+
+
+def test_all_catalog_locations_are_collected(monkeypatch) -> None:
+    catalog = _catalog([("2", "88", "3.24"), ("1", "54", "7.91")])
+    assert [match[:3] for match in
+            _find_segment_locations(catalog, _SYNTHETIC_SEGMENT)] == [
+        ("1", "54", "7.91"), ("2", "88", "3.24")]
+
+
+def test_find_segment_details_still_reports_the_catalog_entry() -> None:
+    scroll, energy, resolution, entry = Volume.__new__(
+        Volume).find_segment_details(str(SEGMENT_IN_CATALOG))
+    assert (scroll, energy, resolution) == ("1", "54", "7.91")
+    assert entry.endswith(f"{SEGMENT_IN_CATALOG}.zarr/")
+
+
+def test_find_segment_details_returns_nones_for_an_unknown_segment() -> None:
+    assert Volume.__new__(Volume).find_segment_details(
+        str(SEGMENT_NOT_IN_CATALOG)) == (None, None, None, None)


### PR DESCRIPTION
Resolve a segment's scroll from the catalog so `type="segment"` needs no `scroll_id`

Fixes #1333.

## Motivation

I was opening a segment to work with its surface, using the exact call the constructor
prints as its own recovery hint, `Volume(type="segment", segment_id=20230827161847)`. It
failed with a scroll-resolution error. The tool hands a user who has already hit an
error an example that fails the same way. The catalog already knows which scroll a segment
belongs to, so a segment id should be enough. This makes it enough. It resolves a real
segment to scroll 1, energy 54, resolution 7.91 against the live store (below).

## The bug

`Volume(type="segment", segment_id=...)` cannot initialize without a `scroll_id`, yet the constructor prints exactly that call as a recovery hint when any init fails. The example handed to a user who has already hit an error fails the same way.

Reproduce on `main`:

```
$ python -c "from vesuvius.data.volume import Volume; Volume(type='segment', segment_id=20230827161847)"
ERROR initializing Volume: Could not determine energy/resolution for scroll None. Please provide them explicitly.
Common issues:
- Ensure Zarr path is correct and accessible if using direct path.
- Ensure config file exists and contains entries for the requested scroll/segment/energy/resolution.
- Check network connection if accessing remote data.

Example Usage:
  volume = Volume(type="scroll", scroll_id=1)
  segment = Volume(type="segment", segment_id=20230827161847)
  zarr_vol = Volume(type="zarr", path="/path/to/my/data.zarr")
ValueError: Could not determine energy/resolution for scroll None. Please provide them explicitly.
```

The second line of that printed block is the call that just failed.

Why: the constructor has three ways in for a segment. `Volume("<timestamp>")` (a digit string) already looked the scroll up through `find_segment_details`. `Volume(type="segment", segment_id=...)` did not. It set `self.scroll_id = scroll_id` and stopped. With no `scroll_id` the scroll stays `None`, so `grab_canonical_energy` and `grab_canonical_resolution` (both keyed on `str(self.scroll_id)`) miss. The constructor then raises "Could not determine energy/resolution for scroll None". That message is a symptom. The missing thing is the scroll, not the energy.

The issue asks which of two fixes is preferred: put a `scroll_id` into the printed example or make a segment id enough to look the scroll up. The reporter leans to the second, "the catalog knows which scroll a segment belongs to, so the latter may be the friendlier fix". This change does that.

## The fix

`install/configs/scrolls.yaml` already records the mapping. A segment's own data URL is stored at `catalog[scroll][energy][resolution]["segments"][segment_id]`, so scroll, energy and resolution are the three keys on the path to that URL. Reading them back is the same lookup `get_url_from_yaml` runs, in reverse. It is not an inference.

`_resolve_segment_location(segment_id, scroll_id=None)` does the resolution and both segment entry points call it, so `Volume("20230827161847")` and `Volume(type="segment", segment_id=20230827161847)` now resolve identically. It is backed by `_find_segment_locations`, which walks the catalog and returns every `(scroll, energy, resolution, entry)` that lists the id. Collecting all matches rather than the first is what lets it tell a single answer from an ambiguous one. The walk only descends to the depth where a segment entry can live, the same depth `get_url_from_yaml` reads, so a stray id elsewhere in the tree cannot be mistaken for a location.

`find_segment_details` keeps its signature and its return shape and now delegates to the same walk, so its old hand-rolled traversal is gone with no change to what it reports.

## No silent guesses

- Segment not in the catalog: `ValueError` naming `scrolls.yaml` and saying `scroll_id` will not help, because the data URL comes from that same file.
- Segment listed under more than one scroll with no `scroll_id`: `ValueError` listing every location found and asking for `scroll_id`. It does not pick one.
- Segment under one scroll at several energies or resolutions: the scroll is settled, so it is returned and energy and resolution are left to the scroll's canonical defaults.
- Exactly one location: all three are returned.

## Explicit arguments still win

A passed `scroll_id` is returned as given. Only energy and resolution are looked up, from entries under that scroll. Passed `energy` and `resolution` still win through the existing `energy if energy is not None else ...` lines. `_catalog_key_value` converts a YAML string key to the number it spells only when `str()` of that number renders back to the original key, because `get_url_from_yaml` looks entries up by `str()` of these values, so a key like `'07'` stays a string.

The printed usage block is left untouched, because the fix makes the line work as written. That also keeps the diff off the `zarr` example line that #1332 covers.

## Before and after

Before, on `main`: the reproduction above.

After, on this branch, against the real store:

```
$ python -c "
from vesuvius.data.volume import Volume
v = Volume(type='segment', segment_id=20230827161847)
print('scroll_id =', repr(v.scroll_id), 'energy =', repr(v.energy), 'resolution =', repr(v.resolution))
print('shape =', v.shape(0))
print('url =', v.url)"
scroll_id = 1 energy = 54 resolution = 7.91
shape = (65, 9163, 5048)
url = https://dl.ash2txt.org/other/dev/scrolls/1/segments/54keV_7.91um/20230827161847.zarr/
```

`(65, 9163, 5048)` is the shape the issue reports for the working `scroll_id=1` call, so the two calls now agree.

## Verification

Full suite in the shared venv, Python 3.14.5, run against this worktree.

zarr 3.3.0:

```
889 passed, 4 skipped, 3 deselected, 38 warnings in 69.55s
```

That is 11 more passing than the `main` baseline of 878 passed, 4 skipped, 3 deselected. The 11 extra are the new tests in `tests/data/test_volume_segment_resolution.py`. Nothing else moved.

zarr 2.18.7 (one of the repo's CI legs, installed then reverted to 3.3.0):

```
885 passed, 8 skipped, 3 deselected, 31 warnings in 59.47s
```

Same 893 tests collected on both legs. 4 tests pass on 3.3.0 and skip on 2.18.7 (they are zarr-3 specific), so 4 passes become skips. The 11 new tests are catalog logic with no zarr-version dependence and pass on both legs.

The test file catches the defect. With `volume.py` reverted to `main` and the new test file kept, the suite goes red (`ImportError: cannot import name '_find_segment_locations'` on collection, exit 2), because the resolution helpers and the constructor behavior the tests assert do not exist on `main`. Restoring `volume.py` turns it green again (11 passed). A test that passes either way tests nothing, this one does not.

The 11 tests cover: a segment id alone resolves its scroll, `Volume(type="<timestamp>")` resolves the same way, an explicit `scroll_id` is kept as passed, explicit `energy` and `resolution` win over the catalog, an unknown segment reports it is not in the catalog, a segment under two scrolls refuses to choose, a `scroll_id` settles that ambiguity, one scroll at two energies keeps the scroll and defers the rest, all catalog locations are collected. `find_segment_details` still reports its old shape.

## AI disclosure

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and verification were done by the author. Verified locally before submitting: the full test suite on zarr 3.3.0 (889 passed, 4 skipped, 3 deselected) and on zarr 2.18.7 (885 passed, 8 skipped, 3 deselected), plus a revert-and-restore check confirming the new regression tests fail without the fix and pass with it.

