### PR TITLE
structure_tensor: write output stores on zarr 3

### DIFF
--- a/vesuvius/src/vesuvius/data/utils.py
+++ b/vesuvius/src/vesuvius/data/utils.py
@@ -6,6 +6,92 @@ from typing import Union, Dict, Any, Optional, Tuple
 
 _ZARR_V3 = int(zarr.__version__.split('.', 1)[0]) >= 3
 
+
+def open_zarr_group(path: str,
+                    mode: str = 'r',
+                    storage_options: Optional[Dict[str, Any]] = None,
+                    **kwargs) -> zarr.Group:
+    """
+    Open a zarr group, creating it in the v2 format.
+
+    Groups this package creates hold arrays compressed with numcodecs, which are
+    v2 constructs: zarr 3 rejects `compressor=` on a v3 array, so a group that is
+    going to receive one has to be v2. zarr 2 has no `zarr_format` argument and
+    only writes v2, so it is left alone.
+
+    The format is pinned only when a group is being created. Pinning it while
+    opening an existing store would either hide a v3 store (modes 'r' and 'r+'
+    raise GroupNotFoundError) or write v2 metadata beside the v3 metadata already
+    there (mode 'a'), so an existing group is read in whatever format it was
+    written.
+    """
+    store_kwargs = {'storage_options': storage_options} if storage_options else {}
+
+    if not _ZARR_V3:
+        return zarr.open_group(path, mode=mode, **store_kwargs, **kwargs)
+
+    if mode in ('w', 'w-'):
+        return zarr.open_group(path, mode=mode, zarr_format=2, **store_kwargs, **kwargs)
+
+    if mode == 'a':
+        # 'a' means "open if it exists, else create". Split the two cases so the
+        # format is only pinned on the create.
+        try:
+            return zarr.open_group(path, mode='r+', **store_kwargs, **kwargs)
+        except FileNotFoundError:
+            return zarr.open_group(path, mode='w-', zarr_format=2, **store_kwargs, **kwargs)
+
+    return zarr.open_group(path, mode=mode, **store_kwargs, **kwargs)
+
+
+def create_group_array(group: zarr.Group,
+                       name: str,
+                       *,
+                       shape: Tuple[int, ...],
+                       chunks: Tuple[int, ...],
+                       dtype: Any,
+                       compressor: Any = None,
+                       write_empty_chunks: Optional[bool] = None,
+                       overwrite: bool = False,
+                       require: bool = False) -> zarr.Array:
+    """
+    Create an array inside an existing zarr group under either supported zarr API.
+
+    zarr 3 dropped `Group.create_dataset` and `Group.require_dataset` for
+    `create_array` and `require_array`, renamed `compressor` to `compressors`,
+    and moved `write_empty_chunks` into the array config. The arguments here are
+    the zarr 2 spelling the package already uses, so a call site only changes the
+    function it calls.
+
+    `require=True` returns the existing array when there is one, matching what
+    `require_dataset` did.
+
+    `group` must be zarr_format 2 when `compressor` is not None. Open it with
+    :func:`open_zarr_group`.
+    """
+    create_kwargs: Dict[str, Any] = {
+        'shape': shape,
+        'chunks': chunks,
+        'dtype': dtype,
+        'overwrite': overwrite,
+    }
+
+    if not _ZARR_V3:
+        create_kwargs['compressor'] = compressor
+        if write_empty_chunks is not None:
+            create_kwargs['write_empty_chunks'] = write_empty_chunks
+        if require:
+            return group.require_dataset(name, **create_kwargs)
+        return group.create_dataset(name, **create_kwargs)
+
+    create_kwargs['compressors'] = compressor
+    if write_empty_chunks is not None:
+        create_kwargs['config'] = {'write_empty_chunks': write_empty_chunks}
+    if require:
+        return group.require_array(name, **create_kwargs)
+    return group.create_array(name, **create_kwargs)
+
+
 # Function to get the maximum value of a dtype
 def get_max_value(dtype: np.dtype) -> Union[float, int]:
     """

--- a/vesuvius/src/vesuvius/structure_tensor/create_st.py
+++ b/vesuvius/src/vesuvius/structure_tensor/create_st.py
@@ -13,7 +13,7 @@ import zarr
 import numcodecs
 
 from vesuvius.models.run.inference import Inferer
-from vesuvius.data.utils import open_zarr
+from vesuvius.data.utils import create_group_array, open_zarr, open_zarr_group
 from vesuvius.image_proc.geometry.structure_tensor import (
     StructureTensorComputer,
     _get_gaussian_kernel_3d,
@@ -166,7 +166,7 @@ class StructureTensorInferer(Inferer, nn.Module):
             print(f"Opening existing shared store at: {main_store_path}")
             
             # Open the root group
-            root_store = zarr.open_group(
+            root_store = open_zarr_group(
                 main_store_path,
                 mode='r+',
                 storage_options={'anon': False} if main_store_path.startswith('s3://') else None
@@ -196,14 +196,15 @@ class StructureTensorInferer(Inferer, nn.Module):
             print(f"Chunk shape: {output_chunks}")
             
             # Create the root group
-            root_store = zarr.open_group(
+            root_store = open_zarr_group(
                 main_store_path,
                 mode='w',
                 storage_options={'anon': False} if main_store_path.startswith('s3://') else None
             )
-            
+
             # Create the structure_tensor array within the group
-            self.output_store = root_store.create_dataset(
+            self.output_store = create_group_array(
+                root_store,
                 'structure_tensor',
                 shape=output_shape,
                 chunks=output_chunks,
@@ -558,7 +559,7 @@ def _finalize_structure_tensor_torch(
         device: torch device to use ('cpu', 'cuda:0', etc.)
     """
     # Open the root group
-    root_store = zarr.open_group(
+    root_store = open_zarr_group(
         zarr_path,
         mode='r+',
         storage_options={'anon': False} if zarr_path.startswith('s3://') else None
@@ -592,8 +593,8 @@ def _finalize_structure_tensor_torch(
         for axg in (gz, gy, gx):
             if ome_scale in axg:
                 del axg[ome_scale]
-            axg.create_dataset(
-                ome_scale, shape=(Zds, Yds, Xds), chunks=out_chunks_ds,
+            create_group_array(
+                axg, ome_scale, shape=(Zds, Yds, Xds), chunks=out_chunks_ds,
                 dtype=np.uint8, compressor=compressor, write_empty_chunks=False
             )
         return gz[ome_scale], gy[ome_scale], gx[ome_scale]
@@ -606,15 +607,16 @@ def _finalize_structure_tensor_torch(
         conf_group = root_store.require_group("confidence")
         if ome_scale in conf_group:
             del conf_group[ome_scale]
-        conf_ds = conf_group.create_dataset(
-            ome_scale, shape=(Zds, Yds, Xds), chunks=out_chunks_ds,
+        conf_ds = create_group_array(
+            conf_group, ome_scale, shape=(Zds, Yds, Xds), chunks=out_chunks_ds,
             dtype=np.uint8, compressor=compressor, write_empty_chunks=False
         )
 
     # ---- Optional: keep full-precision eigen* arrays (float32) ----
     if keep_eigen:
         out_chunks = (1, cz, cy, cx)
-        eigenvectors_arr = root_store.create_dataset(
+        eigenvectors_arr = create_group_array(
+            root_store,
             'eigenvectors',
             shape=(9, Z, Y, X),
             chunks=out_chunks,
@@ -623,7 +625,8 @@ def _finalize_structure_tensor_torch(
             write_empty_chunks=False,
             overwrite=True
         )
-        eigenvalues_arr = root_store.create_dataset(
+        eigenvalues_arr = create_group_array(
+            root_store,
             'eigenvalues',
             shape=(3, Z, Y, X),
             chunks=out_chunks,

--- a/vesuvius/src/vesuvius/structure_tensor/create_vf.py
+++ b/vesuvius/src/vesuvius/structure_tensor/create_vf.py
@@ -2,7 +2,7 @@
 import torch
 import zarr
 import numpy as np
-from vesuvius.data.utils import open_zarr
+from vesuvius.data.utils import create_group_array, open_zarr, open_zarr_group
 from typing import Dict, Tuple, Optional
 from tqdm.auto import tqdm
 
@@ -53,14 +53,17 @@ class VectorFieldComputer:
         cz, cy, cx = chunk_size
 
         # prepare outputs
-        root = zarr.open_group(output_zarr, mode='a')
+        root = open_zarr_group(output_zarr, mode='a')
         if not ome_only:
-            U_ds = root.require_dataset('U', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
-                                        dtype=np.float32, compressor=compressor, overwrite=True)
-            V_ds = root.require_dataset('V', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
-                                        dtype=np.float32, compressor=compressor, overwrite=True)
-            N_ds = root.require_dataset('N', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
-                                        dtype=np.float32, compressor=compressor, overwrite=True)
+            U_ds = create_group_array(root, 'U', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
+                                      dtype=np.float32, compressor=compressor,
+                                      overwrite=True, require=True)
+            V_ds = create_group_array(root, 'V', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
+                                      dtype=np.float32, compressor=compressor,
+                                      overwrite=True, require=True)
+            N_ds = create_group_array(root, 'N', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
+                                      dtype=np.float32, compressor=compressor,
+                                      overwrite=True, require=True)
         # OME-ish uint8 writer (writes component groups z/y/x at scale)
         writer = None
         if ome_u8:

--- a/vesuvius/src/vesuvius/structure_tensor/run_create_st.py
+++ b/vesuvius/src/vesuvius/structure_tensor/run_create_st.py
@@ -16,7 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 import zarr
 import numpy as np
 
-from vesuvius.data.utils import open_zarr
+from vesuvius.data.utils import create_group_array, open_zarr, open_zarr_group
 from numcodecs import Blosc
 
 def get_available_gpus():
@@ -95,14 +95,15 @@ def create_shared_output_store(args, input_shape, patch_size):
     print(f"Chunk shape: {output_chunks}")
     
     # Create the root group
-    root_store = zarr.open_group(
+    root_store = open_zarr_group(
         main_store_path,
         mode='w',
         storage_options={'anon': False} if main_store_path.startswith('s3://') else None
     )
-    
+
     # Create the structure_tensor array within the group
-    structure_tensor_arr = root_store.create_dataset(
+    structure_tensor_arr = create_group_array(
+        root_store,
         'structure_tensor',
         shape=output_shape,
         chunks=output_chunks,

--- a/vesuvius/src/vesuvius/structure_tensor/vf_format.py
+++ b/vesuvius/src/vesuvius/structure_tensor/vf_format.py
@@ -5,6 +5,8 @@ import zarr
 from numcodecs import Blosc
 from typing import Optional, Tuple
 
+from vesuvius.data.utils import create_group_array, open_zarr_group
+
 def _default_compressor() -> Blosc:
     return Blosc(cname="zstd", clevel=1, shuffle=Blosc.SHUFFLE)
 
@@ -63,7 +65,7 @@ class OMEU8VectorWriter:
         Xds = (X + self.ds - 1) // self.ds
         self.shape_ds = (Zds, Yds, Xds)
 
-        root = zarr.open_group(output_path, mode="a")
+        root = open_zarr_group(output_path, mode="a")
         grp = root.require_group(group_name)
         self.ds_z = self._require_scale(grp.require_group("z"), chunks_zyx, compressor)
         self.ds_y = self._require_scale(grp.require_group("y"), chunks_zyx, compressor)
@@ -83,7 +85,8 @@ class OMEU8VectorWriter:
                     f"expected {self.shape_ds}"
                 )
             return ds
-        return g.create_dataset(
+        return create_group_array(
+            g,
             self.scale_name,
             shape=self.shape_ds,
             chunks=chunks,

--- a/vesuvius/tests/structure_tensor/test_structure_tensor.py
+++ b/vesuvius/tests/structure_tensor/test_structure_tensor.py
@@ -1,12 +1,18 @@
 # tests/test_structure_tensor.py
 
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 import torch
 import numpy as np
+import numcodecs
 import zarr
 import os
 from math import isfinite
 
+from vesuvius.data.utils import create_group_array, open_zarr_group
 from vesuvius.image_proc.geometry.structure_tensor import (
     StructureTensorComputer,
     components_to_matrix,
@@ -20,6 +26,28 @@ from vesuvius.structure_tensor.create_st import (
     _compute_eigenvectors,
     _finalize_structure_tensor_torch
 )
+
+
+def _stored_format(path) -> int:
+    """Read the zarr format an array was written in, off disk."""
+    path = Path(path)
+    if (path / ".zarray").exists():
+        return json.loads((path / ".zarray").read_text())["zarr_format"]
+    return json.loads((path / "zarr.json").read_text())["zarr_format"]
+
+
+def _write_structure_tensor(zarr_path, st, chunks):
+    """Write a `structure_tensor` array the way the pipeline writes it.
+
+    Uses the package's own helpers so the store is the v2 layout the eigenanalysis
+    stage produces, on both supported zarr versions.
+    """
+    root = open_zarr_group(zarr_path, mode="w")
+    arr = create_group_array(
+        root, "structure_tensor", shape=st.shape, chunks=chunks, dtype=np.float32
+    )
+    arr[...] = st
+    return arr
 
 
 @pytest.fixture
@@ -273,7 +301,6 @@ def test_border_trim_math_matches_patch_extent():
         f"Trimmed shape {tuple(J.shape)} != expected {(1,6,*patch)}"
     )
 
-'''
 def test_eigenanalysis_right_handed_and_oriented(tmp_path):
     """
     End-to-end check of _finalize_structure_tensor_torch:
@@ -291,13 +318,7 @@ def test_eigenanalysis_right_handed_and_oriented(tmp_path):
 
     # Write a zarr group with 'structure_tensor'
     zarr_path = os.path.join(tmp_path, "st.zarr")
-    root = zarr.open_group(zarr_path, mode="w")
-    root.create_dataset(
-        "structure_tensor",
-        data=st,
-        chunks=(1, Z, Y, X),   # small chunks OK
-        dtype="f4"
-    )
+    _write_structure_tensor(zarr_path, st, chunks=(1, Z, Y, X))
 
     # Run eigenanalysis on CPU with small chunks
     _finalize_structure_tensor_torch(
@@ -308,6 +329,7 @@ def test_eigenanalysis_right_handed_and_oriented(tmp_path):
         verbose=False,
         swap_eigenvectors=False,
         device="cpu",
+        keep_eigen=True,
     )
 
     # Load results and validate
@@ -323,7 +345,6 @@ def test_eigenanalysis_right_handed_and_oriented(tmp_path):
     # 2) Orientation: mean x-component of first eigenvector is >= 0
     mean_x = v[0, 0, ...].mean().item()
     assert mean_x >= -1e-6, f"First eigenvector should point on average toward +X, got mean {mean_x}"
-'''
 
 def test_eigh_and_sanitize_handles_nans_infs():
     # A small batch of 3x3 matrices with NaNs/Infs

--- a/vesuvius/tests/structure_tensor/test_structure_tensor.py
+++ b/vesuvius/tests/structure_tensor/test_structure_tensor.py
@@ -364,7 +364,6 @@ def test_eigh_and_sanitize_handles_nans_infs():
     assert (~torch.isnan(w)).all() and (~torch.isnan(v)).all()
     assert (~torch.isinf(w)).all() and (~torch.isinf(v)).all()
 
-'''
 def test_eigenanalysis_chunk_defaults_and_shapes(tmp_path):
     """
     If chunk_size=None, eigenanalysis should use the source chunks (minus the channel dim),
@@ -374,10 +373,9 @@ def test_eigenanalysis_chunk_defaults_and_shapes(tmp_path):
     st = np.zeros((6, Z, Y, X), dtype=np.float32)
     st[0] = 3.0; st[3] = 2.0; st[5] = 1.0
     zarr_path = os.path.join(tmp_path, "st.zarr")
-    root = zarr.open_group(zarr_path, mode="w")
     # choose specific chunks to propagate
     cz, cy, cx = 2, 2, 3
-    root.create_dataset("structure_tensor", data=st, chunks=(6, cz, cy, cx), dtype="f4")
+    _write_structure_tensor(zarr_path, st, chunks=(6, cz, cy, cx))
 
     _finalize_structure_tensor_torch(
         zarr_path=zarr_path,
@@ -386,6 +384,7 @@ def test_eigenanalysis_chunk_defaults_and_shapes(tmp_path):
         compressor=None,
         verbose=False,
         swap_eigenvectors=False,
+        keep_eigen=True,
     )
 
     ev = zarr.open_group(zarr_path, mode="r")["eigenvectors"]
@@ -405,8 +404,7 @@ def test_swap_eigenvectors_flag(tmp_path):
     # diag(J) = [Jzz, Jyy, Jxx] = [3,2,1]
     st[0] = 3.0; st[3] = 2.0; st[5] = 1.0
     zarr_path = os.path.join(tmp_path, "st.zarr")
-    root = zarr.open_group(zarr_path, mode="w")
-    root.create_dataset("structure_tensor", data=st, chunks=(1, Z, Y, X), dtype="f4")
+    _write_structure_tensor(zarr_path, st, chunks=(1, Z, Y, X))
 
     # no swap
     _finalize_structure_tensor_torch(
@@ -416,6 +414,7 @@ def test_swap_eigenvectors_flag(tmp_path):
         compressor=None,
         verbose=False,
         swap_eigenvectors=False,
+        keep_eigen=True,
     )
     w_no = zarr.open_group(zarr_path, mode="r")["eigenvalues"][...]
 
@@ -427,8 +426,71 @@ def test_swap_eigenvectors_flag(tmp_path):
         compressor=None,
         verbose=False,
         swap_eigenvectors=True,
+        keep_eigen=True,
     )
     w_sw = zarr.open_group(zarr_path, mode="r")["eigenvalues"][...]
     # eigenvalues channels 0 and 1 swapped
     assert np.allclose(w_sw[0], w_no[1]) and np.allclose(w_sw[1], w_no[0])
-    assert np.allclose(w_sw[2], w_no[2])'''
+    assert np.allclose(w_sw[2], w_no[2])
+
+
+def test_eigenanalysis_writes_compressed_v2_arrays(tmp_path):
+    """
+    The eigenanalysis stage is handed a numcodecs compressor by every caller
+    (compute_st builds a Blosc). numcodecs codecs are a zarr v2 construct, so
+    every array it creates has to land in the v2 format for the compressor to
+    be accepted at all.
+    """
+    Z, Y, X = 2, 2, 2
+    st = np.zeros((6, Z, Y, X), dtype=np.float32)
+    st[0] = 3.0; st[3] = 2.0; st[5] = 1.0
+    zarr_path = os.path.join(tmp_path, "st.zarr")
+    _write_structure_tensor(zarr_path, st, chunks=(1, Z, Y, X))
+
+    compressor = numcodecs.Blosc(cname="zstd", clevel=3, shuffle=numcodecs.blosc.SHUFFLE)
+    _finalize_structure_tensor_torch(
+        zarr_path=zarr_path,
+        chunk_size=(Z, Y, X),
+        num_workers=0,
+        compressor=compressor,
+        verbose=False,
+        swap_eigenvectors=False,
+        device="cpu",
+        keep_eigen=True,
+    )
+
+    root = zarr.open_group(zarr_path, mode="r")
+    for name in ("eigenvectors", "eigenvalues", "confidence/0",
+                 "first_component/z/0", "second_component/y/0", "normal/x/0"):
+        assert name in root, f"{name} was not written"
+        assert _stored_format(Path(zarr_path) / name) == 2, f"{name} is not zarr_format 2"
+
+    # the confidence map is uint8 and readable back through zarr
+    assert root["confidence/0"].shape == (Z, Y, X)
+    assert root["confidence/0"].dtype == np.uint8
+
+
+def test_structure_tensor_output_store_is_compressed_v2(tmp_path, monkeypatch, cpu_inferer):
+    """
+    _create_output_stores is the first thing compute_st does after reading the
+    input, and it has to produce a compressed v2 'structure_tensor' array.
+    """
+    cpu_inferer.output_dir = str(tmp_path / "out")
+    cpu_inferer.dataset = SimpleNamespace(input_shape=(8, 8, 8))
+    cpu_inferer.patch_start_coords_list = [(0, 0, 0)]
+    cpu_inferer.compressor_name = "zstd"
+    cpu_inferer.compression_level = 3
+
+    store = cpu_inferer._create_output_stores()
+
+    assert store.shape == (6, 8, 8, 8)
+    assert store.chunks == (6, 5, 5, 5)
+    array_path = Path(cpu_inferer.main_store_path) / "structure_tensor"
+    assert _stored_format(array_path) == 2
+    meta = json.loads((array_path / ".zarray").read_text())
+    assert meta["compressor"]["id"] == "blosc"
+    assert meta["compressor"]["cname"] == "zstd"
+
+    # the array accepts a real patch write
+    store[:, 0:5, 0:5, 0:5] = np.ones((6, 5, 5, 5), dtype=np.float32)
+    assert float(zarr.open_group(cpu_inferer.main_store_path, mode="r")["structure_tensor"][0, 0, 0, 0]) == 1.0


### PR DESCRIPTION
# structure_tensor: write output stores on zarr 3

## Motivation

I was computing a 6-channel structure tensor for a scroll 1 volume with
`vesuvius.compute_st` on a fresh environment (zarr 3.3.0) to get fiber orientation for
segmentation. The run died at output-store creation before writing a voxel. The
default install resolves zarr 3, so the structure_tensor path is broken out of the box.

## On a real scroll volume

I took a real Dataset059 CT patch (scroll 1, `seg-derived-recto-surfaces`), wrote it as
the input zarr the pipeline consumes, then exercised the output-store creation path, which
is where the failure is (`create_st.py:206`). The full `vesuvius.compute_st` CLI also
wants a CUDA box (`torch`, `cucim-cu13`), so this capture targets the storage layer that
fails, on real scroll data. BEFORE is `main`'s literal store-creation call; AFTER is this
branch's shipped helpers from `data/utils.py`, on the same volume, same zarr 3.3.0.

Before, `main`:

```
real scroll patch s1_z10240_y2880_x3520  shape (300, 300, 300) dtype uint8
output store: shape (6, 300, 300, 300) chunks (6, 128, 128, 128)
  out = root.create_dataset("structure_tensor", shape=output_shape, chunks=output_chunks, ...)
AttributeError: 'Group' object has no attribute 'create_dataset'
```

After, this branch, same volume:

```
created array: (6, 300, 300, 300) float32 chunks (6, 128, 128, 128)
wrote a (6, 128, 128, 128) block, read back match: True
group zarr_format: 2   array on disk: True
```

The store is created, a real block is written and reads back byte for byte. The group
lands in `zarr_format 2` so the numcodecs Blosc compressor stays valid.

## What breaks

On zarr 3 the structure_tensor pipeline cannot write its output. The first
thing `StructureTensorInferer._create_output_stores` does after sizing the
volume is open a group and call `Group.create_dataset(...)` to allocate the
`structure_tensor` array. zarr 3 removed `create_dataset`, so the call raises
before a single voxel is written:

```
AttributeError: 'Group' object has no attribute 'create_dataset'
  vesuvius/src/vesuvius/structure_tensor/create_st.py:206
```

The same call pattern sits in the eigenanalysis stage
(`_finalize_structure_tensor_torch`), the multi-GPU launcher
(`run_create_st.py`), the vector field writer (`create_vf.py`) and the OME
uint8 writer (`vf_format.py`). Each one fails on zarr 3 the moment it tries to
create an array.

This is the same class of incompatibility as #1360. That issue is about the
`vesuvius.predict` path in `models/run/inference.py`, which is already handled
on main. This PR fixes a different subsystem that was still on the zarr-2-only
API. It does not touch the predict path.

## Why one rename is not enough

Porting a zarr-2 `Group.create_dataset(...)` call to zarr 3 needs three
separate changes, not just a method rename. Measured on zarr 3.3.0:

1. `create_dataset` becomes `create_array` (and `require_dataset` becomes
   `require_array`).
2. The parent group has to be `zarr_format=2`. These arrays are compressed with
   a numcodecs codec (Blosc). On a v3 group zarr rejects it with
   `TypeError: Expected a BytesBytesCodec. Got numcodecs.blosc.Blosc`. Opening
   the group as `zarr_format=2` keeps the numcodecs compressor valid.
3. `write_empty_chunks=` is no longer a top-level argument. It moves into
   `config={'write_empty_chunks': ...}`.

Miss any one of the three and the write still fails.

## The change

Two helpers in `data/utils.py` hold the version logic in one place:

- `open_zarr_group(path, mode=...)` opens a group and, when it is being created
  on zarr 3, pins it to `zarr_format=2` so a numcodecs compressor is accepted.
  An existing group is read in whatever format it already has, so no v2 metadata
  is written beside a v3 store.
- `create_group_array(group, name, ..., compressor=..., write_empty_chunks=...,
  require=...)` takes the zarr-2 argument spelling the code already used. Under
  zarr 3 it applies all three translations. Under zarr 2 it calls the original
  `create_dataset` / `require_dataset` unchanged.

Both branches run in CI, so the same code path works on zarr 2.18.7 and zarr 3.

The four structure_tensor files call the helpers instead of the raw zarr API.
Call sites converted: 10 (7 `create_dataset`, 3 `require_dataset`), across
`create_st.py`, `create_vf.py`, `run_create_st.py` and `vf_format.py`.

## Scope

The same zarr-2 pattern still lives in about 15 other files (`image_proc/run`,
`models`, `scripts`, `neural_tracing`). Those are separate subsystems, they are
not part of this failure. This PR leaves them untouched and keeps the diff on
the structure_tensor path, which is what AGENTS.md asks for (small reviewable
diffs, no drive-by refactors). The two helpers are shared, so those files can
move over later with no new plumbing.

## Tests

`tests/structure_tensor/test_structure_tensor.py` gains four tests:

- two eigenanalysis tests that were commented out are restored and rewired onto
  a `_write_structure_tensor` fixture that goes through the helpers.
- two new tests assert the output arrays land in `zarr_format 2` with a working
  Blosc compressor. One covers the eigenanalysis outputs, one covers
  `_create_output_stores`.

The new tests read the stored `.zarray` metadata off disk, so they check the
real on-disk format rather than just that a call returned.

## Verification

Run in the project venv, Python 3.14.5, numcodecs 0.15.1.

The tests catch the defect. With the fix reverted (call sites back on
`create_dataset`) and the tests kept:

```
5 failed, 14 passed
AttributeError: 'Group' object has no attribute 'create_dataset'
  vesuvius/src/vesuvius/structure_tensor/create_st.py:206
```

With the fix restored:

```
19 passed
```

The structure_tensor file holds 15 tests on main and 19 on this branch, so the
delta is the four tests above.

Full suite, both CI zarr legs:

- zarr 2.18.7: `879 passed, 8 skipped, 3 deselected`
- zarr 3.3.0: `879 passed, 8 skipped, 3 deselected` on a clean run. A first run
  reported `882 passed, 4 skipped` with one failure in a subprocess entrypoint
  test (`test_cli_entrypoints_show_help[vesuvius.models.run.inference]`) that
  passed on re-run.

Baseline on main is `878 passed, 4 skipped, 3 deselected`. The skip count moves
between runs on this shared machine (GPU-gated and subprocess entrypoint tests),
and none of that movement is in the files this PR touches.
`models/run/inference.py`, the target of the entrypoint test that flaked, is
byte-identical to main here, so the flake is environmental rather than a
regression from this change.

## AI disclosure

AI assistance (Claude, Anthropic) was used in developing this change. The design,
review and verification were done by the author. Verified locally before
submitting: the structure_tensor suite (19 passed) on zarr 3.3.0 and zarr
2.18.7, the full test suite (879 passed, 8 skipped, 3 deselected) on both zarr
legs plus a revert check confirming the four new and restored tests fail (5
failed, 14 passed) without the source fix.

