### PR TITLE
vesuvius/README.md: pin a minimum version in the documented install

### DIFF
--- a/vesuvius/README.md
+++ b/vesuvius/README.md
@@ -63,9 +63,16 @@ To get started, we recommend these notebooks that jump right in:
 `vesuvius` can be installed with `pip`.
 Then, before using the library for the first time, accept the license terms:
 ```sh
-$ pip install vesuvius
+$ pip install "vesuvius>=0.2.0"
 $ vesuvius.accept_terms --yes
 ```
+
+> **Note:** the `>=0.2.0` bound is deliberate. The published wheels support Python 3.10–3.13,
+> while this repository targets Python 3.14 (`.python-version`, `requires-python`). Without the
+> bound, `pip install vesuvius` on Python 3.14 prints `Successfully installed vesuvius-0.1.10`
+> and exits 0 — a December 2024 build from before the 0.2 API that provides 1 of the 12 console
+> scripts this package declares. With the bound, pip fails instead and lists which versions it
+> skipped and why. To run the code on `main`, use `uv sync` in this directory rather than `pip`.
 
 ___
 **Note:** 


### PR DESCRIPTION
Fixes the silent half of #1300.

## What changed

`vesuvius/README.md` — the documented install command gains a lower bound, plus a short note
explaining why it is there. One file, +8/−1.

```diff
-$ pip install vesuvius
+$ pip install "vesuvius>=0.2.0"
```

## Why

`vesuvius/pyproject.toml` requires `>=3.14,<3.15` and `.python-version` pins `3.14`. Every
published 0.2.x wheel caps at `Requires-Python <3.14`. No published release satisfies the
project's own Python requirement, so on Python 3.14 pip skips all of 0.2.x and falls back to
`0.1.10` (2024-12-13), the last release that carries no upper bound. It prints
`Successfully installed vesuvius-0.1.10` and exits 0.

The user then runs the README's second line, `vesuvius.accept_terms --yes`, and that *also*
succeeds — `0.1.10` happens to ship exactly that one console script. Both documented steps
pass. What the user actually has is a build from before the 0.2 API providing 1 of the 12
console scripts this package declares, so the first real failure surfaces somewhere unrelated,
with nothing pointing back at the install.

The bound turns that into a pip error that names every skipped version and its
`Requires-Python`. It stays correct once a 3.14-compatible release is published, and it
prevents a 0.1.x fallback if a future Python bump reopens the same gap.

## How verified

pip 26.2.1. Resolution checked with `--dry-run --no-deps`; the `0.1.10` install was also done
for real in a throwaway venv to read its entry points.

| Python | Command | Result |
|---|---|---|
| 3.14.6 | `pip install vesuvius` | `Would install vesuvius-0.1.10` — exit 0 |
| 3.14.6 | `pip install "vesuvius>=0.2.0"` | exit 1, lists all five skipped 0.2.x versions with their `Requires-Python` |
| 3.11.15 | `pip install vesuvius` | `Would install vesuvius-0.2.4` — exit 0 |
| 3.11.15 | `pip install "vesuvius>=0.2.0"` | `Would install vesuvius-0.2.4` — exit 0, unchanged |

The last row is the no-regression check: on a supported Python the bound resolves to the same
version as before, so nothing changes for users who are not hitting the gap.

Entry points on the stale build:

```
$ pip install --no-deps vesuvius        # on Python 3.14 -> 0.1.10
$ python -c "import importlib.metadata as m; print([e.name for e in m.distribution('vesuvius').entry_points])"
['vesuvius.accept_terms']
```

against 12 entries in `[project.scripts]`.

## Risks / limitations

- Docs-only; no code path changes. Per `AGENTS.md` §1.7 the smoke step for this change *is* the
  install command, which is what the table above runs.
- Measured on Windows, but the mechanism is platform-independent: both releases ship a single
  `py3-none-any` wheel, so `Requires-Python` is the only filter pip applies here, and it keys
  off the interpreter version rather than the OS.
- The bound does not make `main` installable on 3.14 — it makes the failure legible. Installing
  `main` needs `uv`, because `volume-cartographer` is declared as a uv path source in
  `[tool.uv.sources]` and is not on PyPI; `pip install -e vesuvius/` ends in
  `No matching distribution found for volume-cartographer`. Publishing a 3.14-compatible wheel
  is the part I cannot contribute.
- I chose `>=0.2.0` rather than `>=0.2.4` as the least restrictive bound that still excludes the
  pre-0.2 API. Happy to change it if you would rather pin the exact current release.
