### PR TITLE
vc_obj2tifxyz: fail instead of writing an empty tifxyz

### DIFF
--- a/volume-cartographer/apps/src/vc_obj2tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_obj2tifxyz.cpp
@@ -313,10 +313,19 @@ public:
         std::cout << "Valid grid points: " << valid_count << " / " << (grid_size[0] * grid_size[1]) 
                   << " (" << (100.0f * valid_count / (grid_size[0] * grid_size[1])) << "%)" << std::endl;
         
-        // Scale is currently in OBJ units. Convert to micrometers now.
         if (valid_count == 0) {
-            std::cerr << "Warning: no valid grid points were rasterized." << std::endl;
+            delete points;
+            std::cerr << "Error: no valid grid points were rasterized; refusing to write an empty tifxyz." << std::endl;
+            const cv::Vec2f uv_range = uv_max - uv_min;
+            if (uv_range[0] <= 1.5f && uv_range[1] <= 1.5f) {
+                std::cerr << "UVs span only " << uv_range[0] << " x " << uv_range[1]
+                          << " — they look normalised to [0,1]. Pass a stretch_factor"
+                          << " (e.g. 800) so the grid has usable resolution." << std::endl;
+            }
+            return nullptr;
         }
+
+        // Scale is currently in OBJ units. Convert to micrometers now.
         const bool src_scale_mode = (src_scale[0] > 0.f && src_scale[1] > 0.f);
         if (src_scale_mode) {
             // Scale was adopted verbatim from the source tifxyz; do not rescale.
@@ -523,7 +532,8 @@ int main(int argc, char *argv[])
         std::cout << "Converts an OBJ file to tifxyz format" << std::endl;
         std::cout << std::endl;
         std::cout << "Parameters:" << std::endl;
-        std::cout << "  stretch_factor: UV scaling factor (default: 1.0)" << std::endl;
+        std::cout << "  stretch_factor: UV scaling factor (default: 1.0). UVs normalised to [0,1]" << std::endl;
+        std::cout << "                  need an explicit value (e.g. 800) or no grid points survive." << std::endl;
         std::cout << "  mesh_units    : micrometers per OBJ unit (default: 1.0)" << std::endl;
         std::cout << "Flags:" << std::endl;
         std::cout << "  --uv-metric         : UVs are metric (default; UV units == OBJ units unless --uv-to-obj is set)" << std::endl;
@@ -539,7 +549,7 @@ int main(int argc, char *argv[])
         std::cout << std::endl;
         std::cout << "Note: Scale factors are automatically calculated from the mesh grid structure." << std::endl;
         std::cout << "Examples:" << std::endl;
-        std::cout << "  " << argv[0] << " mesh.obj outdir                       (legacy behavior)" << std::endl;
+        std::cout << "  " << argv[0] << " mesh.obj outdir                       (UV-metric mode, default)" << std::endl;
         std::cout << "  " << argv[0] << " mesh.obj outdir 800 1.0 --uv-metric  (UV is metric, OBJ units == UV units)" << std::endl;
         std::cout << "  " << argv[0] << " mesh.obj outdir --uv-metric --uv-to-obj=0.001" << std::endl;
         return EXIT_SUCCESS;


### PR DESCRIPTION
With default arguments, any OBJ whose UVs are normalised to [0,1] — the format of all published segments under `paths/` — rasterizes 0 valid grid points, yet the tool wrote a 2×2 grid of `-1` sentinels, reported "Successfully converted", and exited 0. Anything scripting the tool saw success while getting an empty, valid-looking output directory.

- `createQuadSurface()` now returns `nullptr` when no grid point was rasterized; `main()` already turns that into `EXIT_FAILURE`, and nothing is written.
- - When the UV span suggests normalised coordinates (at most 1.5 on both axes), the error tells the user to pass a `stretch_factor` (e.g. 800).
- - `--help` no longer labels the plain invocation "(legacy behavior)" — the actual default is UV-metric mode — and the `stretch_factor` description now documents the normalised-UV pitfall.
## Verification

Built with `ghcr.io/scrollprize/vc3d-deps/linux:ubuntu-26.04`. Repro input: a triangle with normalised UVs whose UV-bbox corners are not attained by any vertex (which is how real segment OBJs end up at 0/4 — the extremes of u and v come from different vertices).

Before (unmodified main):

```
UV-metric mode: grid 2 x 2  scale(OBJ units): 1, 1
Valid grid points: 0 / 4 (0%)
Warning: no valid grid points were rasterized.
Successfully converted to tifxyz format
```

exit 0, and the output directory contains x/y/z.tif full of `-1` sentinels.

After:

```
UV-metric mode: grid 2 x 2  scale(OBJ units): 1, 1
Valid grid points: 0 / 4 (0%)
Error: no valid grid points were rasterized; refusing to write an empty tifxyz.
UVs span only 1 x 1 — they look normalised to [0,1]. Pass a stretch_factor (e.g. 800) so the grid has usable resolution.
Failed to create quad surface
```

exit 1, nothing written.

Counter-test — the same OBJ with `stretch_factor 800` converts as before: grid 801×801, 240200 valid points, exit 0.

Fixes #1320