### PR TITLE
test_command_line_tool_runner: abort the test slot when a check fails

### DIFF
--- a/volume-cartographer/apps/VC3D/test/test_command_line_tool_runner.cpp
+++ b/volume-cartographer/apps/VC3D/test/test_command_line_tool_runner.cpp
@@ -39,12 +39,15 @@ bool startHelper(CommandLineToolRunner& runner,
         helperProgram(), helperArguments(mode, outputPath), mode, options);
 }
 
-void expectSingleCompletion(QSignalSpy& finished)
-{
-    QTRY_COMPARE_WITH_TIMEOUT(finished.count(), 1, 3000);
-    QTest::qWait(100);
-    QCOMPARE(finished.count(), 1);
-}
+// QTest check macros return from the enclosing function only; as a macro this
+// aborts the calling test slot on failure instead of letting it run on into
+// accessors that index an empty spy.
+#define EXPECT_SINGLE_COMPLETION(finished)                        \
+    do {                                                          \
+        QTRY_COMPARE_WITH_TIMEOUT((finished).count(), 1, 3000);   \
+        QTest::qWait(100);                                        \
+        QCOMPARE((finished).count(), 1);                          \
+    } while (false)
 
 bool completionSucceeded(const QSignalSpy& finished, int index = 0)
 {
@@ -109,7 +112,7 @@ private slots:
         QSignalSpy finished(&runner, &CommandLineToolRunner::toolFinished);
 
         QVERIFY(startHelper(runner, "success"));
-        expectSingleCompletion(finished);
+        EXPECT_SINGLE_COMPLETION(finished);
 
         QVERIFY(completionSucceeded(finished));
         QVERIFY(!runner.isRunning());
@@ -121,7 +124,7 @@ private slots:
         QSignalSpy finished(&runner, &CommandLineToolRunner::toolFinished);
 
         QVERIFY(startHelper(runner, "crash"));
-        expectSingleCompletion(finished);
+        EXPECT_SINGLE_COMPLETION(finished);
 
         QVERIFY(!completionSucceeded(finished));
         QVERIFY(completionMessage(finished).contains("crash", Qt::CaseInsensitive));
@@ -144,7 +147,7 @@ private slots:
         QVERIFY(runner.executeCustomCommand(
             invalidProgram.fileName(), {}, "failed start",
             CommandLineToolRunner::ExecutionOptions::silent()));
-        expectSingleCompletion(finished);
+        EXPECT_SINGLE_COMPLETION(finished);
 
         QVERIFY(!completionSucceeded(finished));
         QVERIFY(completionMessage(finished).contains(
@@ -160,7 +163,7 @@ private slots:
         QVERIFY(startHelper(runner, "wait"));
         QTRY_VERIFY_WITH_TIMEOUT(runner.isRunning(), 1000);
         runner.cancel();
-        expectSingleCompletion(finished);
+        EXPECT_SINGLE_COMPLETION(finished);
 
         QVERIFY(!completionSucceeded(finished));
         QVERIFY(!runner.isRunning());
@@ -182,7 +185,7 @@ private slots:
             "onProcessError",
             Qt::DirectConnection,
             Q_ARG(QProcess::ProcessError, QProcess::ReadError)));
-        expectSingleCompletion(finished);
+        EXPECT_SINGLE_COMPLETION(finished);
 
         QVERIFY(!completionSucceeded(finished));
         QVERIFY(completionMessage(finished).contains(


### PR DESCRIPTION
`expectSingleCompletion()` used QTest check macros inside a helper function; on failure they return from the helper only, so the test slot carried on into `completionSucceeded()`, which indexes an empty `QSignalSpy` — out of bounds, so the binary segfaulted instead of reporting a clean failure, taking the remaining tests with it (as observed in #1318).

The helper is now a macro, so a failed check returns from the calling test slot itself: the failure is reported cleanly and the rest of the suite still runs, with the same diagnostics as before.

## Verification

Built with `ghcr.io/scrollprize/vc3d-deps/linux:ubuntu-26.04`, run with `QT_QPA_PLATFORM=offscreen`, injecting a forced failure (a slot calling the helper with nothing started) into a scratch copy.

Before (helper as a function): FAIL! reported, then `Received signal 11 (SIGSEGV)` — the remaining tests never ran.

After (helper as a macro), same forced failure: clean FAIL!, all other tests still run (`Totals: 9 passed, 1 failed`), non-zero exit.

The unmodified suite passes: `Totals: 9 passed, 0 failed, 0 skipped, 0 blacklisted`.

Fixes #1318