### PR TITLE
tifxyz format doc: fix the reference implementation pointers

### DIFF
--- a/lasagna/tifxyz_format.md
+++ b/lasagna/tifxyz_format.md
@@ -143,6 +143,6 @@ A compatible reader should:
 
 ## 8. Reference implementation pointers
 
-- Writer populates `meta.json.format = "tifxyz"` & `meta.json.scale = [sx, sy]`: [`core/src/QuadSurface.cpp:729`](core/src/QuadSurface.cpp:729)
-- Reader loads `x/y/z.tif`, invalidates `Z <= 0`, then applies optional `mask.tif`: [`core/src/QuadSurface.cpp:848`](core/src/QuadSurface.cpp:848)
+- Writer populates `meta.json.format = "tifxyz"` & `meta.json.scale = [sx, sy]`: `QuadSurface::save` in [`volume-cartographer/core/src/QuadSurface.cpp`](../volume-cartographer/core/src/QuadSurface.cpp)
+- Reader loads `x/y/z.tif`, invalidates `Z <= 0`, then applies optional `mask.tif`: `load_quad_from_tifxyz` in the same file
 


### PR DESCRIPTION
Trimmed per review: #1391 covers the scale semantics, so this now only fixes the reference pointers in section 8, which #1391 leaves as is.

The links were broken in two ways: the paths are relative to the repo root while the doc lives in `lasagna/`, so they 404 on GitHub, and the line numbers predate refactors (the writer is around line 2030 now, not 729). Switched to function names (`QuadSurface::save`, `load_quad_from_tifxyz`) instead of line anchors so they don't go stale again.
