### PR TITLE
predict: let a failed inference surface its own error

### DIFF
--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -1099,14 +1099,9 @@ class Inferer():
         if self.verbose: print("Inference complete.")
 
     def infer(self):
-        try:
-            self._run_inference()
-            main_output_path = os.path.join(self.output_dir, f"logits_part_{self.part_id}.zarr")
-            return main_output_path, self.coords_store_path
-        except Exception as e:
-            print(f"An error occurred during inference: {e}")
-            import traceback
-            traceback.print_exc() 
+        self._run_inference()
+        main_output_path = os.path.join(self.output_dir, f"logits_part_{self.part_id}.zarr")
+        return main_output_path, self.coords_store_path
 
 
 def _parse_bbox_arg(value):

--- a/vesuvius/tests/models/run/test_inference_error_propagation.py
+++ b/vesuvius/tests/models/run/test_inference_error_propagation.py
@@ -1,0 +1,29 @@
+"""A failed inference must surface its original error, not a follow-up symptom.
+
+Inferer.infer() used to catch every exception, print it, and fall through to an
+implicit None return. main() then failed unpacking that None ("cannot unpack
+non-iterable NoneType object"), reporting a traceback pointing at the wrong
+stage — and callers that checked the returned path instead of unpacking
+(structure_tensor.create_st) fell through with no error at all. See issue #1360.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vesuvius.models.run.inference import Inferer
+
+
+class _BrokenInferer(Inferer):
+    def __init__(self):
+        self.output_dir = "unused"
+        self.part_id = 0
+        self.coords_store_path = None
+
+    def _run_inference(self):
+        raise RuntimeError("store creation failed")
+
+
+def test_infer_propagates_run_inference_error() -> None:
+    with pytest.raises(RuntimeError, match="store creation failed"):
+        _BrokenInferer().infer()


### PR DESCRIPTION
Inferer.infer() caught every exception, printed it, and fell through to an implicit None return. vesuvius.predict then crashed unpacking that None — the final error the user saw was 'cannot unpack non-iterable NoneType object', a symptom pointing at the wrong stage — and structure_tensor.create_st, which checks the returned path instead of unpacking, fell through with no error and exit 0.

infer() now propagates; both CLI callers already catch at their own level, print the original error, and return 1.

Verified in the vc3d-deps container (zarr 3.2.1, torch CPU): the new regression test plus tests/data/test_open_zarr_format.py pass (7 passed), and a failing vesuvius.predict run exits 1 with the underlying error as the last line.

Fixes the remaining live half of #1360 (the zarr.Blosc and zarr_format=2 store-creation halves are already fixed on main; blending.main already returns 1).

Refs #1360