### PR TITLE
tracer: record the effective RNG seed in each trace's meta.json

### DIFF
--- a/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
+++ b/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
@@ -602,6 +602,8 @@ int main(int argc, char *argv[])
     meta_params["vc_gsfs_params"] = params;
     meta_params["vc_gsfs_mode"] = mode;
     meta_params["vc_gsfs_version"] = "dev";
+    meta_params["vc_gsfs_rng_seed"] = static_cast<uint64_t>(growpatch_rng_base_seed());
+    meta_params["vc_gsfs_omp_max_threads"] = omp_get_max_threads();
     add_target_context(meta_params, vol_path);
     if (mode == "expansion")
         meta_params["seed_overlap"] = count_overlap;

--- a/volume-cartographer/core/include/vc/tracer/Tracer.hpp
+++ b/volume-cartographer/core/include/vc/tracer/Tracer.hpp
@@ -29,3 +29,8 @@ struct DirectionField
 QuadSurface *grow_surf_from_surfs(QuadSurface *seed, const std::vector<QuadSurface*> &surfs_v, const utils::Json &params, float voxelsize = 1.0);
 QuadSurface *grow_surf_from_surfs(QuadSurface *seed, const std::vector<QuadSurface*> &surfs_v, const utils::Json &params, float voxelsize, SurfacePatchIndex* surface_patch_index);
 QuadSurface *tracer(Volume& volume, float scale, int level, cv::Vec3f origin, const utils::Json &params, const std::string &cache_root = "", float voxelsize = 1.0, const std::vector<DirectionField> &direction_fields = {}, QuadSurface* resume_surf = nullptr, const std::filesystem::path& tgt_path = "", const utils::Json& meta_params = {}, const PointCollections &corrections = PointCollections(), const cv::Mat* allowed_growth_mask = nullptr);
+
+// Effective base seed of the tracer's RNGs: VC_GROWPATCH_RNG_SEED when set,
+// otherwise drawn once per process. Stable for the process lifetime; with a
+// single OpenMP thread the trace is fully determined by it.
+uint32_t growpatch_rng_base_seed();

--- a/volume-cartographer/core/src/GrowPatch.cpp
+++ b/volume-cartographer/core/src/GrowPatch.cpp
@@ -21,6 +21,8 @@
 #include "vc/core/util/NormalGridVolume.hpp"
 #include "vc/core/util/GridStore.hpp"
 #include "vc/core/util/Umbilicus.hpp"
+
+#include <atomic>
 #include "vc/tracer/CostFunctions.hpp"
 #include "vc/core/util/HashFunctions.hpp"
 
@@ -96,14 +98,30 @@ std::optional<uint32_t> environment_seed()
     return cached;
 }
 
+} // anonymous namespace
+
+// Base seed for every RNG in this translation unit: the VC_GROWPATCH_RNG_SEED
+// environment value when set, otherwise drawn once per process so a trace can
+// record the seed that produced it (issue #1317). Thread RNGs derive from it
+// by thread ordinal, so with a single thread the stream is fully determined by
+// this value.
+uint32_t growpatch_rng_base_seed()
+{
+    static const uint32_t seed = [] {
+        if (const auto env = environment_seed()) {
+            return *env;
+        }
+        return static_cast<uint32_t>(std::random_device{}());
+    }();
+    return seed;
+}
+
+namespace {
+
 std::mt19937& thread_rng()
 {
-    static thread_local std::mt19937 rng = [] {
-        if (const auto seed = environment_seed()) {
-            return std::mt19937(*seed);
-        }
-        return std::mt19937(std::random_device{}());
-    }();
+    static std::atomic<uint32_t> thread_ordinal{0};
+    static thread_local std::mt19937 rng(growpatch_rng_base_seed() + thread_ordinal.fetch_add(1));
     return rng;
 }
 

--- a/volume-cartographer/docs/tracing.md
+++ b/volume-cartographer/docs/tracing.md
@@ -1,6 +1,36 @@
 # Tracing Documentation
 (a starting point)
 
+## Reproducibility
+
+By default a trace is not reproducible: run-to-run variance can exceed the
+effect of most tracer changes being benchmarked (see issue #1317). Two levers
+together make `vc_grow_seg_from_seed` deterministic per platform:
+
+```bash
+OMP_NUM_THREADS=1 VC_GROWPATCH_RNG_SEED=42 vc_grow_seg_from_seed ...
+```
+
+- `VC_GROWPATCH_RNG_SEED` fixes the base seed of the tracer's RNGs. Unset, a
+  base seed is drawn once per process instead.
+- A single thread is required because work distribution across OpenMP threads
+  is scheduling-dependent. `OMP_NUM_THREADS=1` or `"thread_limit": 1` in the
+  params JSON both work. Expect roughly 2x wall time versus unbounded threads
+  (measured in #1317), which is why this is a debugging/benchmarking mode
+  rather than the default.
+
+Every trace records what it used in its `meta.json`:
+
+- `vc_gsfs_rng_seed` — the effective base seed, whether it came from the
+  environment or was drawn at startup. Re-running with
+  `VC_GROWPATCH_RNG_SEED=<that value>` and one thread reproduces the trace on
+  the same platform/build.
+- `vc_gsfs_omp_max_threads` — the OpenMP thread count in effect.
+
+Scope: this covers `seed` mode with an explicit seed point. The seed-location
+picking in `random_seed` and `expansion` modes uses `rand()` seeded from the
+clock and is not covered by `VC_GROWPATCH_RNG_SEED`.
+
 ## apps/src/vc_grow_seg_from_seed.cpp
 
 - starting point for patch tracing - the seeding logic is here (and might need improvements/debugging)


### PR DESCRIPTION
Tracing is not reproducible by default, and the two levers that make it reproducible (VC_GROWPATCH_RNG_SEED + a single OpenMP thread) appeared nowhere outside a single line of core/src/GrowPatch.cpp. Anyone benchmarking a tracer change is measuring against run-to-run noise, and a bad trace cannot be reproduced for debugging.

- The tracer now draws one process-wide base seed (the environment value when set, random_device otherwise), exposed as growpatch_rng_base_seed(); per-thread RNGs derive from it by thread ordinal. Single-thread runs with the env seed remain byte-identical to the previous behaviour (thread 0 seeds with exactly the base value).
- vc_grow_seg_from_seed records vc_gsfs_rng_seed and vc_gsfs_omp_max_threads in the trace's meta.json, so every segment carries what is needed to reproduce it even when the user did not ask for determinism.
- docs/tracing.md documents the recipe, its ~2x wall-time cost, the new meta fields, and the scope limit (random_seed/expansion seed picking uses rand() and is not covered).

Verified in the vc3d-deps container: with VC_GROWPATCH_RNG_SEED=42 the base seed is 42 and stable within the process; unset, it is drawn once per process and differs across processes. vc_grow_seg_from_seed and vc_tracer build clean.

Fixes #1317