### PR TITLE
switch rest of quadsurf rendering to use same path as spiral did

### DIFF
--- a/volume-cartographer/apps/VC3D/MenuActionController.cpp
+++ b/volume-cartographer/apps/VC3D/MenuActionController.cpp
@@ -1255,13 +1255,11 @@ void MenuActionController::showSettingsDialog()
         settings.value(vc3d::settings::viewer::AXIS_OVERLAY_OPACITY,
                        vc3d::settings::viewer::AXIS_OVERLAY_OPACITY_DEFAULT).toInt());
 
-    // The spiral cache budgets live on the manager, not the window, and only the
-    // spiral workspace opts in -- so walk every live manager and let the ones
-    // that opted in re-read them. Byte capacities are adjustable in place, so
-    // this takes effect without reopening the workspace.
+    // Cache budgets are independent per workspace. Re-read them for every live
+    // manager so changes take effect without reopening either workspace.
     for (auto* manager : ViewerManager::allManagers()) {
-        if (manager && manager->surfaceCacheEnabled())
-            manager->applySpiralCacheSettings();
+        if (manager)
+            manager->applyViewerCacheSettings();
     }
 
     dialog->deleteLater();

--- a/volume-cartographer/apps/VC3D/SettingsDialog.cpp
+++ b/volume-cartographer/apps/VC3D/SettingsDialog.cpp
@@ -108,14 +108,15 @@ SettingsDialog::SettingsDialog(std::shared_ptr<VolumePkg> volumePackage,
 
     // Cache settings
     spinRamCacheSizeGB->setValue(settings.value(perf::RAM_CACHE_SIZE_GB, perf::RAM_CACHE_SIZE_GB_DEFAULT).toInt());
-    spinSpiralSurfaceCacheGB->setValue(
-        settings.value(spiral::SURFACE_CACHE_GB, spiral::SURFACE_CACHE_GB_DEFAULT).toInt());
-    spinSpiralOverlaySurfaceCacheGB->setValue(
-        settings.value(spiral::OVERLAY_SURFACE_CACHE_GB,
-                       spiral::OVERLAY_SURFACE_CACHE_GB_DEFAULT).toInt());
-    spinSpiralPlaneChunkCacheMB->setValue(
-        settings.value(spiral::PLANE_CHUNK_CACHE_MB,
-                       spiral::PLANE_CHUNK_CACHE_MB_DEFAULT).toInt());
+    spinViewerSurfaceCacheGB->setValue(
+        settings.value(viewer_cache::SURFACE_CACHE_GB,
+                       viewer_cache::SURFACE_CACHE_GB_DEFAULT).toInt());
+    spinViewerOverlaySurfaceCacheGB->setValue(
+        settings.value(viewer_cache::OVERLAY_SURFACE_CACHE_GB,
+                       viewer_cache::OVERLAY_SURFACE_CACHE_GB_DEFAULT).toInt());
+    spinViewerPlaneChunkCacheMB->setValue(
+        settings.value(viewer_cache::PLANE_CHUNK_CACHE_MB,
+                       viewer_cache::PLANE_CHUNK_CACHE_MB_DEFAULT).toInt());
     {
         const QString stored =
             settings.value(viewer::REMOTE_CACHE_DIR).toString();
@@ -335,10 +336,11 @@ void SettingsDialog::accept()
 
     // Cache settings
     settings.setValue(perf::RAM_CACHE_SIZE_GB, spinRamCacheSizeGB->value());
-    settings.setValue(spiral::SURFACE_CACHE_GB, spinSpiralSurfaceCacheGB->value());
-    settings.setValue(spiral::OVERLAY_SURFACE_CACHE_GB,
-                      spinSpiralOverlaySurfaceCacheGB->value());
-    settings.setValue(spiral::PLANE_CHUNK_CACHE_MB, spinSpiralPlaneChunkCacheMB->value());
+    settings.setValue(viewer_cache::SURFACE_CACHE_GB, spinViewerSurfaceCacheGB->value());
+    settings.setValue(viewer_cache::OVERLAY_SURFACE_CACHE_GB,
+                      spinViewerOverlaySurfaceCacheGB->value());
+    settings.setValue(viewer_cache::PLANE_CHUNK_CACHE_MB,
+                      spinViewerPlaneChunkCacheMB->value());
     settings.setValue(viewer::REMOTE_CACHE_DIR, edtRemoteCachePath->text());
     settings.setValue(perf::REMOTE_CACHE_COMPRESSION, chkCompressRemoteCache->isChecked());
     settings.setValue(perf::REMOTE_CACHE_QUANTIZATION,

--- a/volume-cartographer/apps/VC3D/SpiralWorkspace.cpp
+++ b/volume-cartographer/apps/VC3D/SpiralWorkspace.cpp
@@ -80,19 +80,13 @@ SpiralWorkspace::SpiralWorkspace(CState* mainState, QWidget* parent)
 {
     setObjectName(QStringLiteral("spiralWorkspaceWindow"));
     setDockOptions(QMainWindow::AnimatedDocks | QMainWindow::AllowNestedDocks | QMainWindow::AllowTabbedDocks);
-    // Share Main's process-wide decoded-chunk budget. Both workspaces use the
-    // single cache owned by their shared Volume.
+    // The state shares Main's process-wide default budget for non-viewer uses;
+    // ViewerManager gives this workspace independent bounded viewer caches.
     _state = new CState(
         _mainState ? _mainState->cacheSizeBytes() : 0,
         this,
         _mainState ? _mainState->decodedCacheBudget() : nullptr);
     _viewerManager = std::make_unique<ViewerManager>(_state, _state->pointCollection(), this);
-    // Spiral's plane panes get their own hard-capped decoded-chunk pool instead
-    // of sharing the Volume's, so browsing slices here can never displace the
-    // main workspace's working set, and the flattened pane renders from tiles of
-    // resampled surface space. Applied before the viewers exist so they pick up
-    // the policy on construction.
-    _viewerManager->applySpiralCacheSettings();
     // Spiral can trade some intersection detail for substantially cheaper
     // input-patch indexing without changing the main workspace preference.
     _viewerManager->setSurfacePatchSamplingStride(4, false);

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -275,31 +275,28 @@ namespace perf {
 }
 
 // -----------------------------------------------------------------------------
-// Spiral Workspace Settings
+// Viewer Cache Settings
 //
-// Spiral-only and independent of perf::RAM_CACHE_SIZE_GB, which keeps governing
-// the main workspace's shared decoded-chunk budget. All three apply without a
-// restart.
+// Each ViewerManager owns independent decoded-chunk and surface-tile caches, so
+// workspaces cannot evict one another. These settings apply without a restart.
 // -----------------------------------------------------------------------------
-namespace spiral {
-    // Budget for the flattened view's cache of resampled surface space, for the
-    // displayed (base) volume. 0 disables it, so the flattened view samples the
-    // volume every frame as it did before the cache existed.
-    constexpr auto SURFACE_CACHE_GB = "spiral/surface_cache_gb";
+namespace viewer_cache {
+    // Per-workspace budget for the flattened segmentation view's cache of
+    // resampled surface space. 0 selects the legacy direct-sampling path.
+    constexpr auto SURFACE_CACHE_GB = "viewer_cache/surface_cache_gb";
     constexpr int SURFACE_CACHE_GB_DEFAULT = 4;
 
-    // Same, for the overlay volume. Its own budget because overlay and base
-    // compete for nothing else. 0 disables it and leaves the overlay channel on
-    // its existing resident-only sampling path.
-    constexpr auto OVERLAY_SURFACE_CACHE_GB = "spiral/overlay_surface_cache_gb";
+    // Per-workspace budget for the overlay volume's surface-space cache. 0
+    // leaves the overlay channel on its legacy resident-only sampling path.
+    constexpr auto OVERLAY_SURFACE_CACHE_GB = "viewer_cache/overlay_surface_cache_gb";
     constexpr int OVERLAY_SURFACE_CACHE_GB_DEFAULT = 0;
 
-    // LRU cap for the private decoded-chunk pool behind the spiral slice panes.
+    // LRU cap for the private decoded-chunk pool behind a workspace's plane panes.
     // A floor rather than a ceiling: it is raised automatically when it cannot
     // hold one frame (otherwise a single render thrashes), and the status bar
     // reports the effective value. The surface-tile filler gets a pool of the
     // same size as an internal constant.
-    constexpr auto PLANE_CHUNK_CACHE_MB = "spiral/plane_chunk_cache_mb";
+    constexpr auto PLANE_CHUNK_CACHE_MB = "viewer_cache/plane_chunk_cache_mb";
     constexpr int PLANE_CHUNK_CACHE_MB_DEFAULT = 2048;
 }
 

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -289,7 +289,7 @@ namespace viewer_cache {
     // Per-workspace budget for the overlay volume's surface-space cache. 0
     // leaves the overlay channel on its legacy resident-only sampling path.
     constexpr auto OVERLAY_SURFACE_CACHE_GB = "viewer_cache/overlay_surface_cache_gb";
-    constexpr int OVERLAY_SURFACE_CACHE_GB_DEFAULT = 0;
+    constexpr int OVERLAY_SURFACE_CACHE_GB_DEFAULT = 2;
 
     // LRU cap for the private decoded-chunk pool behind a workspace's plane panes.
     // A floor rather than a ceiling: it is raised automatically when it cannot

--- a/volume-cartographer/apps/VC3D/VCSettings.ui
+++ b/volume-cartographer/apps/VC3D/VCSettings.ui
@@ -842,7 +842,7 @@
              <number>512</number>
             </property>
             <property name="value">
-             <number>0</number>
+             <number>2</number>
             </property>
             <property name="suffix">
              <string> GB</string>

--- a/volume-cartographer/apps/VC3D/VCSettings.ui
+++ b/volume-cartographer/apps/VC3D/VCSettings.ui
@@ -795,17 +795,17 @@
            </widget>
           </item>
           <item row="8" column="0">
-           <widget class="QLabel" name="labelSpiralSurfaceCache">
+           <widget class="QLabel" name="labelViewerSurfaceCache">
             <property name="text">
-             <string>Spiral surface cache (GB)</string>
+             <string>Viewer surface cache (GB)</string>
             </property>
             <property name="toolTip">
-             <string>RAM budget for the spiral flattened view's cache of resampled surface space. Independent of the RAM cache size above. 0 disables it and falls back to sampling the volume every frame.</string>
+             <string>Per-workspace RAM budget for the flattened segmentation view's cache of resampled surface space. Main and Spiral have independent caches. 0 disables tiled caching and falls back to sampling the volume every frame.</string>
             </property>
            </widget>
           </item>
           <item row="8" column="1">
-           <widget class="QSpinBox" name="spinSpiralSurfaceCacheGB">
+           <widget class="QSpinBox" name="spinViewerSurfaceCacheGB">
             <property name="minimum">
              <number>0</number>
             </property>
@@ -819,22 +819,22 @@
              <string> GB</string>
             </property>
             <property name="toolTip">
-             <string>RAM budget for the spiral flattened view's cache of resampled surface space. 0 disables it. Applies without restart.</string>
+             <string>Per-workspace RAM budget for the flattened segmentation view's surface tiles. 0 disables tiled caching. Applies without restart.</string>
             </property>
            </widget>
           </item>
           <item row="9" column="0">
-           <widget class="QLabel" name="labelSpiralOverlaySurfaceCache">
+           <widget class="QLabel" name="labelViewerOverlaySurfaceCache">
             <property name="text">
-             <string>Spiral overlay surface cache (GB)</string>
+             <string>Viewer overlay surface cache (GB)</string>
             </property>
             <property name="toolTip">
-             <string>Separate budget for the overlay volume's surface cache in the spiral flattened view. 0 disables it and leaves the overlay on its existing resident-only sampling path.</string>
+             <string>Per-workspace budget for the overlay volume's surface cache in the flattened segmentation view. 0 disables it and leaves the overlay on its existing resident-only sampling path.</string>
             </property>
            </widget>
           </item>
           <item row="9" column="1">
-           <widget class="QSpinBox" name="spinSpiralOverlaySurfaceCacheGB">
+           <widget class="QSpinBox" name="spinViewerOverlaySurfaceCacheGB">
             <property name="minimum">
              <number>0</number>
             </property>
@@ -848,22 +848,22 @@
              <string> GB</string>
             </property>
             <property name="toolTip">
-             <string>Separate budget for the overlay volume's surface cache in the spiral flattened view. 0 disables it. Applies without restart.</string>
+             <string>Per-workspace budget for overlay surface tiles in the flattened segmentation view. 0 disables it. Applies without restart.</string>
             </property>
            </widget>
           </item>
           <item row="10" column="0">
-           <widget class="QLabel" name="labelSpiralPlaneChunkCache">
+           <widget class="QLabel" name="labelViewerPlaneChunkCache">
             <property name="text">
-             <string>Spiral plane chunk cache (MB)</string>
+             <string>Viewer plane chunk cache (MB)</string>
             </property>
             <property name="toolTip">
-             <string>Hard cap on decoded chunks retained for the spiral slice panes. Private to the spiral workspace, so it can neither evict the main workspace's cache nor be evicted by it. This is a floor: it is raised automatically if it cannot hold one frame, and the status bar shows the effective value.</string>
+             <string>Per-workspace cap on decoded chunks retained for plane views. Main and Spiral have independent pools and cannot evict one another. This is a floor: it is raised automatically if it cannot hold one frame, and the status bar shows the effective value.</string>
             </property>
            </widget>
           </item>
           <item row="10" column="1">
-           <widget class="QSpinBox" name="spinSpiralPlaneChunkCacheMB">
+           <widget class="QSpinBox" name="spinViewerPlaneChunkCacheMB">
             <property name="minimum">
              <number>64</number>
             </property>
@@ -877,7 +877,7 @@
              <string> MB</string>
             </property>
             <property name="toolTip">
-             <string>Hard cap on decoded chunks retained for the spiral slice panes. A floor, raised automatically if it cannot hold one frame.</string>
+             <string>Per-workspace decoded-chunk cache for plane views. A floor, raised automatically if it cannot hold one frame. Applies without restart.</string>
             </property>
            </widget>
           </item>

--- a/volume-cartographer/apps/VC3D/ViewerManager.cpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.cpp
@@ -211,6 +211,11 @@ ViewerManager::ViewerManager(CState* state,
     _intersectionThickness = std::max(0.0f, storedThickness);
     _intersectionMaxSurfaces = viewer::INTERSECTION_MAX_SURFACES_DEFAULT;
 
+    // Every workspace uses the same policy but owns its pools and budgets.
+    // Apply it before any viewers are created so their first chunk source is
+    // already the private bounded one.
+    applyViewerCacheSettings();
+
     _surfacePatchIndexWatcher =
         new QFutureWatcher<std::shared_ptr<SurfacePatchIndex>>(this);
     connect(_surfacePatchIndexWatcher,
@@ -263,21 +268,21 @@ const std::vector<ViewerManager*>& ViewerManager::allManagers()
     return managerRegistry();
 }
 
-void ViewerManager::applySpiralCacheSettings()
+void ViewerManager::applyViewerCacheSettings()
 {
     using namespace vc3d::settings;
     QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
     constexpr std::size_t mib = 1024ULL * 1024ULL;
     constexpr std::size_t gib = 1024ULL * mib;
     const auto planeMb = std::max<qlonglong>(
-        0, settings.value(spiral::PLANE_CHUNK_CACHE_MB,
-                          spiral::PLANE_CHUNK_CACHE_MB_DEFAULT).toLongLong());
+        0, settings.value(viewer_cache::PLANE_CHUNK_CACHE_MB,
+                          viewer_cache::PLANE_CHUNK_CACHE_MB_DEFAULT).toLongLong());
     const auto surfaceGb = std::max<qlonglong>(
-        0, settings.value(spiral::SURFACE_CACHE_GB,
-                          spiral::SURFACE_CACHE_GB_DEFAULT).toLongLong());
+        0, settings.value(viewer_cache::SURFACE_CACHE_GB,
+                          viewer_cache::SURFACE_CACHE_GB_DEFAULT).toLongLong());
     const auto overlayGb = std::max<qlonglong>(
-        0, settings.value(spiral::OVERLAY_SURFACE_CACHE_GB,
-                          spiral::OVERLAY_SURFACE_CACHE_GB_DEFAULT).toLongLong());
+        0, settings.value(viewer_cache::OVERLAY_SURFACE_CACHE_GB,
+                          viewer_cache::OVERLAY_SURFACE_CACHE_GB_DEFAULT).toLongLong());
 
     if (_chunkCachePolicy == ChunkCachePolicy::PrivateBounded)
         setChunkCacheFloorBytes(ChunkCachePool::PlaneViews, std::size_t(planeMb) * mib);
@@ -404,7 +409,7 @@ std::shared_ptr<vc::render::ChunkCache> ViewerManager::chunkCacheFor(
         slot.cache = volume->createChunkCache(std::move(options));
         slot.builtCapacity = wanted;
     } catch (const std::exception& e) {
-        Logger()->warn("spiral private chunk cache unavailable: {}", e.what());
+        Logger()->warn("viewer private chunk cache unavailable: {}", e.what());
         slot.cache.reset();
         slot.budget.reset();
         slot.volume.reset();
@@ -415,7 +420,6 @@ std::shared_ptr<vc::render::ChunkCache> ViewerManager::chunkCacheFor(
 
 void ViewerManager::setSurfaceCacheBudgets(std::size_t baseBytes, std::size_t overlayBytes)
 {
-    _surfaceCacheEnabled = true;
     if (_surfaceCacheBudgetBytes == baseBytes &&
         _overlaySurfaceCacheBudgetBytes == overlayBytes) {
         return;
@@ -559,10 +563,8 @@ VolumeViewerBase* ViewerManager::initializeChunkedViewer(CChunkedVolumeViewer* c
     baseViewer->setOverlayWindow(_overlayWindowLow, _overlayWindowHigh);
     baseViewer->setOverlayMaxDisplayedResolution(_overlayMaxDisplayedResolution);
     baseViewer->setOverlayComposite(_overlayComposite);
-    if (_surfaceCacheEnabled) {
-        baseViewer->setSurfaceCacheBudgets(_surfaceCacheBudgetBytes,
-                                           _overlaySurfaceCacheBudgetBytes);
-    }
+    baseViewer->setSurfaceCacheBudgets(_surfaceCacheBudgetBytes,
+                                       _overlaySurfaceCacheBudgetBytes);
 
     if (_segmentationModule && role != ViewerRole::Annotation) {
         _segmentationModule->attachViewer(baseViewer);

--- a/volume-cartographer/apps/VC3D/ViewerManager.hpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.hpp
@@ -96,9 +96,7 @@ public:
 
     // --- Chunk-source policy ---
     //
-    // Where a viewer of this manager samples from. The default returns the
-    // Volume's shared cache, which is what every viewer used before this
-    // existed, so the main workspace is unaffected. PrivateBounded gives this
+    // Where a viewer of this manager samples from. PrivateBounded gives this
     // manager its own hard-capped pools that are not joined to the
     // process-wide decoded-byte budget: they can neither evict the shared
     // working set nor be evicted by it, and they die with the workspace.
@@ -108,11 +106,9 @@ public:
     // base-tile, and overlay-tile requests can supersede independently.
     enum class ChunkCachePool { PlaneViews, SurfaceTiles, OverlaySurfaceTiles };
 
-    // Opt this manager into the spiral cache policy and (re-)read all three
-    // spiral cache settings. Called once when the workspace is built and again
-    // whenever the settings dialog applies, so a budget change takes effect
-    // without reopening the workspace.
-    void applySpiralCacheSettings();
+    // Re-read all per-workspace viewer-cache settings. Called during manager
+    // construction and whenever the settings dialog applies.
+    void applyViewerCacheSettings();
     void setChunkCachePolicy(ChunkCachePolicy policy, std::size_t capacityBytes);
     ChunkCachePolicy chunkCachePolicy() const { return _chunkCachePolicy; }
     // The configured value is a *floor*: a setting that cannot hold one frame
@@ -136,12 +132,10 @@ public:
         const std::shared_ptr<Volume>& volume,
         ChunkCachePool pool = ChunkCachePool::PlaneViews);
 
-    // --- SurfaceCache budgets (spiral's flattened view) ---
+    // --- SurfaceCache budgets (flattened segmentation view) ---
     //
-    // Off unless a workspace opts in, so the main workspace never builds one.
     // Zero disables a channel and leaves it on the legacy render path.
     void setSurfaceCacheBudgets(std::size_t baseBytes, std::size_t overlayBytes);
-    bool surfaceCacheEnabled() const { return _surfaceCacheEnabled; }
     std::size_t surfaceCacheBudgetBytes() const { return _surfaceCacheBudgetBytes; }
     std::size_t overlaySurfaceCacheBudgetBytes() const { return _overlaySurfaceCacheBudgetBytes; }
 
@@ -382,7 +376,6 @@ private:
     int _intersectionMaxSurfaces{0};  // 0 = unlimited
 
     ChunkCachePolicy _chunkCachePolicy{ChunkCachePolicy::SharedVolumeCache};
-    bool _surfaceCacheEnabled{false};
     std::size_t _surfaceCacheBudgetBytes{0};
     std::size_t _overlaySurfaceCacheBudgetBytes{0};
     struct PrivateChunkPool {

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -1096,7 +1096,6 @@ void CChunkedVolumeViewer::dropOverlaySurfaceCache()
     _overlaySurfaceCache->shutdown();
     _overlaySurfaceCache.reset();
     _overlaySurfaceCacheVolume = nullptr;
-    _surfaceTileRenderQueued.store(false, std::memory_order_release);
     ++_surfaceCacheEpoch;
 }
 
@@ -1116,7 +1115,6 @@ void CChunkedVolumeViewer::dropSurfaceCaches()
     _surfaceCacheSurface = nullptr;
     _surfaceCacheGeometryEpoch = 0;
     _surfaceCacheOutOfBand = false;
-    _surfaceTileRenderQueued.store(false, std::memory_order_release);
     ++_surfaceCacheEpoch;
 }
 
@@ -1178,30 +1176,34 @@ void CChunkedVolumeViewer::ensureSurfaceCaches()
         ++_surfaceCacheEpoch;
         QPointer<CChunkedVolumeViewer> guard(this);
         std::weak_ptr<vc::render::SurfaceCache> cacheWeak = _surfaceCache;
-        _surfaceTileCbId = _surfaceCache->addTileReadyListener([guard, cacheWeak]() {
-            QMetaObject::invokeMethod(qApp, [guard, cacheWeak]() {
-                const auto source = cacheWeak.lock();
-                if (!guard || !source || guard->_surfaceCache != source ||
-                    guard->_surfaceTileRenderQueued.exchange(
-                        true, std::memory_order_acq_rel)) {
+        auto notificationQueued = std::make_shared<std::atomic_bool>(false);
+        _surfaceTileCbId = _surfaceCache->addTileReadyListener(
+            [guard, cacheWeak, notificationQueued]() {
+                // notifyTileReady() runs on fill workers. Gate here so a large tile
+                // publish burst posts only one event to Qt's UI queue.
+                if (notificationQueued->exchange(true, std::memory_order_acq_rel))
                     return;
-                }
-                QTimer::singleShot(kSurfaceTileRenderDebounceMs, guard,
-                                   [guard, cacheWeak]() {
+                QMetaObject::invokeMethod(qApp, [guard, cacheWeak, notificationQueued]() {
                     const auto source = cacheWeak.lock();
-                    if (!guard || !source || guard->_surfaceCache != source)
+                    if (!guard || !source || guard->_surfaceCache != source) {
+                        notificationQueued->store(false, std::memory_order_release);
                         return;
-                    guard->_surfaceTileRenderQueued.store(false,
-                                                          std::memory_order_release);
-                    if (guard->_closing)
-                        return;
-                    // One epoch represents the whole burst. The render reads
-                    // every tile resident at the time it starts.
-                    ++guard->_chunkContentEpoch;
-                    guard->submitRender("surface tile batch ready");
-                });
-            }, Qt::QueuedConnection);
-        });
+                    }
+                    QTimer::singleShot(kSurfaceTileRenderDebounceMs, guard,
+                                       [guard, cacheWeak, notificationQueued]() {
+                        notificationQueued->store(false, std::memory_order_release);
+                        const auto source = cacheWeak.lock();
+                        if (!guard || !source || guard->_surfaceCache != source)
+                            return;
+                        if (guard->_closing)
+                            return;
+                        // One epoch represents the whole burst. The render reads
+                        // every tile resident at the time it starts.
+                        ++guard->_chunkContentEpoch;
+                        guard->submitRender("surface tile batch ready");
+                    });
+                }, Qt::QueuedConnection);
+            });
     }
 
     // Overlay channel: its own instance with its own budget over the overlay
@@ -1246,28 +1248,31 @@ void CChunkedVolumeViewer::ensureSurfaceCaches()
 
     QPointer<CChunkedVolumeViewer> guard(this);
     std::weak_ptr<vc::render::SurfaceCache> cacheWeak = _overlaySurfaceCache;
-    _overlaySurfaceTileCbId = _overlaySurfaceCache->addTileReadyListener([guard, cacheWeak]() {
-        QMetaObject::invokeMethod(qApp, [guard, cacheWeak]() {
-            const auto source = cacheWeak.lock();
-            if (!guard || !source || guard->_overlaySurfaceCache != source ||
-                guard->_surfaceTileRenderQueued.exchange(
-                    true, std::memory_order_acq_rel)) {
+    auto notificationQueued = std::make_shared<std::atomic_bool>(false);
+    _overlaySurfaceTileCbId = _overlaySurfaceCache->addTileReadyListener(
+        [guard, cacheWeak, notificationQueued]() {
+            // Keep overlay tile bursts bounded to one queued UI notification too.
+            if (notificationQueued->exchange(true, std::memory_order_acq_rel))
                 return;
-            }
-            QTimer::singleShot(kSurfaceTileRenderDebounceMs, guard,
-                               [guard, cacheWeak]() {
+            QMetaObject::invokeMethod(qApp, [guard, cacheWeak, notificationQueued]() {
                 const auto source = cacheWeak.lock();
-                if (!guard || !source || guard->_overlaySurfaceCache != source)
+                if (!guard || !source || guard->_overlaySurfaceCache != source) {
+                    notificationQueued->store(false, std::memory_order_release);
                     return;
-                guard->_surfaceTileRenderQueued.store(false,
-                                                      std::memory_order_release);
-                if (guard->_closing)
-                    return;
-                ++guard->_chunkContentEpoch;
-                guard->submitRender("surface tile batch ready");
-            });
-        }, Qt::QueuedConnection);
-    });
+                }
+                QTimer::singleShot(kSurfaceTileRenderDebounceMs, guard,
+                                   [guard, cacheWeak, notificationQueued]() {
+                    notificationQueued->store(false, std::memory_order_release);
+                    const auto source = cacheWeak.lock();
+                    if (!guard || !source || guard->_overlaySurfaceCache != source)
+                        return;
+                    if (guard->_closing)
+                        return;
+                    ++guard->_chunkContentEpoch;
+                    guard->submitRender("surface tile batch ready");
+                });
+            }, Qt::QueuedConnection);
+        });
 }
 
 void CChunkedVolumeViewer::OnVolumeChanged(std::shared_ptr<Volume> vol)

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -1096,6 +1096,7 @@ void CChunkedVolumeViewer::dropOverlaySurfaceCache()
     _overlaySurfaceCache->shutdown();
     _overlaySurfaceCache.reset();
     _overlaySurfaceCacheVolume = nullptr;
+    _surfaceTileRenderQueued.store(false, std::memory_order_release);
     ++_surfaceCacheEpoch;
 }
 
@@ -1115,6 +1116,7 @@ void CChunkedVolumeViewer::dropSurfaceCaches()
     _surfaceCacheSurface = nullptr;
     _surfaceCacheGeometryEpoch = 0;
     _surfaceCacheOutOfBand = false;
+    _surfaceTileRenderQueued.store(false, std::memory_order_release);
     ++_surfaceCacheEpoch;
 }
 
@@ -1175,16 +1177,19 @@ void CChunkedVolumeViewer::ensureSurfaceCaches()
         _surfaceCacheGeometryEpoch = _surfaceGeometryEpoch;
         ++_surfaceCacheEpoch;
         QPointer<CChunkedVolumeViewer> guard(this);
-        _surfaceTileCbId = _surfaceCache->addTileReadyListener([guard]() {
-            if (!guard || guard->_surfaceTileRenderQueued.exchange(
-                              true, std::memory_order_acq_rel)) {
-                return;
-            }
-            QMetaObject::invokeMethod(qApp, [guard]() {
-                if (!guard)
+        std::weak_ptr<vc::render::SurfaceCache> cacheWeak = _surfaceCache;
+        _surfaceTileCbId = _surfaceCache->addTileReadyListener([guard, cacheWeak]() {
+            QMetaObject::invokeMethod(qApp, [guard, cacheWeak]() {
+                const auto source = cacheWeak.lock();
+                if (!guard || !source || guard->_surfaceCache != source ||
+                    guard->_surfaceTileRenderQueued.exchange(
+                        true, std::memory_order_acq_rel)) {
                     return;
-                QTimer::singleShot(kSurfaceTileRenderDebounceMs, guard, [guard]() {
-                    if (!guard)
+                }
+                QTimer::singleShot(kSurfaceTileRenderDebounceMs, guard,
+                                   [guard, cacheWeak]() {
+                    const auto source = cacheWeak.lock();
+                    if (!guard || !source || guard->_surfaceCache != source)
                         return;
                     guard->_surfaceTileRenderQueued.store(false,
                                                           std::memory_order_release);
@@ -1240,16 +1245,19 @@ void CChunkedVolumeViewer::ensureSurfaceCaches()
     ++_surfaceCacheEpoch;
 
     QPointer<CChunkedVolumeViewer> guard(this);
-    _overlaySurfaceTileCbId = _overlaySurfaceCache->addTileReadyListener([guard]() {
-        if (!guard || guard->_surfaceTileRenderQueued.exchange(
-                          true, std::memory_order_acq_rel)) {
-            return;
-        }
-        QMetaObject::invokeMethod(qApp, [guard]() {
-            if (!guard)
+    std::weak_ptr<vc::render::SurfaceCache> cacheWeak = _overlaySurfaceCache;
+    _overlaySurfaceTileCbId = _overlaySurfaceCache->addTileReadyListener([guard, cacheWeak]() {
+        QMetaObject::invokeMethod(qApp, [guard, cacheWeak]() {
+            const auto source = cacheWeak.lock();
+            if (!guard || !source || guard->_overlaySurfaceCache != source ||
+                guard->_surfaceTileRenderQueued.exchange(
+                    true, std::memory_order_acq_rel)) {
                 return;
-            QTimer::singleShot(kSurfaceTileRenderDebounceMs, guard, [guard]() {
-                if (!guard)
+            }
+            QTimer::singleShot(kSurfaceTileRenderDebounceMs, guard,
+                               [guard, cacheWeak]() {
+                const auto source = cacheWeak.lock();
+                if (!guard || !source || guard->_overlaySurfaceCache != source)
                     return;
                 guard->_surfaceTileRenderQueued.store(false,
                                                       std::memory_order_release);
@@ -1317,16 +1325,20 @@ void CChunkedVolumeViewer::invalidateVis()
         return;
     }
     _genCacheDirty = true;
+    // A full visual invalidation means cached samples from both channels are
+    // stale as well. Invalidate the shared geometry through the base last.
+    if (_overlaySurfaceCache)
+        _overlaySurfaceCache->invalidateAll();
+    if (_surfaceCache)
+        _surfaceCache->invalidateAll();
+    if (_surfName == "segmentation")
+        _surfaceEditInvalidationPending = true;
 }
 
 void CChunkedVolumeViewer::invalidateVisRegion(const std::string& name, const cv::Rect& changedCells)
 {
     if (changedCells.empty() || name != _surfName || _surfName != "segmentation") {
         invalidateVis();
-        if (_surfaceCache)
-            _surfaceCache->invalidateAll();
-        if (_overlaySurfaceCache)
-            _overlaySurfaceCache->invalidateAll();
         return;
     }
 
@@ -1339,6 +1351,7 @@ void CChunkedVolumeViewer::invalidateVisRegion(const std::string& name, const cv
         _surfaceCache->invalidateSurfaceRegion(changedCells);
 
     _genCacheDirty = true;
+    _surfaceEditInvalidationPending = true;
 }
 
 void CChunkedVolumeViewer::onSurfaceChanged(const std::string& name,
@@ -1351,6 +1364,10 @@ void CChunkedVolumeViewer::onSurfaceChanged(const std::string& name,
     const bool isCurrentSurface = (_surfName == name);
     const auto previousSurface = _surfWeak.lock();
     const bool isSameCurrentSurface = isCurrentSurface && previousSurface && previousSurface == surf;
+    const bool hadExplicitEditInvalidation =
+        isSameCurrentSurface && isEditUpdate && _surfaceEditInvalidationPending;
+    if (isCurrentSurface)
+        _surfaceEditInvalidationPending = false;
     const bool isIntersectionTarget =
         _intersectTgts.count(name) != 0 ||
         (_intersectTgts.count("visible_segmentation") != 0 &&
@@ -1386,6 +1403,15 @@ void CChunkedVolumeViewer::onSurfaceChanged(const std::string& name,
     _surfWeak = surf;
     if (isSameCurrentSurface && isEditUpdate) {
         _genCacheDirty = true;
+        // Tools with a known edit region invalidate it before sending this
+        // signal. Other same-object edits (brush/reset/etc.) need a conservative
+        // full tile invalidation so stale geometry is never sampled.
+        if (!hadExplicitEditInvalidation) {
+            if (_overlaySurfaceCache)
+                _overlaySurfaceCache->invalidateAll();
+            if (_surfaceCache)
+                _surfaceCache->invalidateAll();
+        }
         _zOffWorldDir = {0, 0, 0};
         updateContentBounds();
         updateFocusMarker();
@@ -1402,6 +1428,9 @@ void CChunkedVolumeViewer::onSurfaceChanged(const std::string& name,
     _zOffWorldDir = {0, 0, 0};
     invalidateIntersect(name);
     if (!surf) {
+        // Deselecting the active surface must release its memory immediately;
+        // returning to it later starts with a cold cache.
+        dropSurfaceCaches();
         clearIntersectionItems();
         _measurement = {};
         _scene->clear();
@@ -1547,8 +1576,10 @@ void CChunkedVolumeViewer::onSurfaceWillBeDeleted(const std::string&, const std:
         return;
     }
     auto current = _surfWeak.lock();
-    if (current && current == surf)
+    if (current && current == surf) {
         _surfWeak.reset();
+        dropSurfaceCaches();
+    }
 }
 
 void CChunkedVolumeViewer::onVolumeClosing()

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -464,6 +464,10 @@ private:
     bool _deferSegmentationIntersections = false;
     bool _deferredSegmentationIntersectionsDirty = false;
     bool _suppressNextSurfaceEditRender = false;
+    // An editing tool can invalidate all tiles or a precise region before it
+    // emits a same-object surfaceChanged signal. Consume that fact at the
+    // signal so regional invalidation is not widened to the whole surface.
+    bool _surfaceEditInvalidationPending = false;
     std::string _pendingRenderReason;
     std::string _pendingRenderCaller;
     std::string _pendingIntersectionReason;
@@ -496,9 +500,9 @@ private:
     bool _genCacheDirty = true;
 
     // --- SurfaceCache (flattened view only) ---
-    // Tiles of resampled surface space. Present only when a workspace set a
-    // non-zero budget and this viewer shows a QuadSurface segmentation; a null
-    // cache means the frame takes the pre-cache render path verbatim.
+    // Tiles of resampled surface space. Present only when the app-wide
+    // per-workspace budget is non-zero and this viewer shows a QuadSurface
+    // segmentation; a null cache means the legacy render path is used.
     std::shared_ptr<vc::render::SurfaceCache> _surfaceCache;
     std::shared_ptr<vc::render::SurfaceCache> _overlaySurfaceCache;
     std::shared_ptr<vc::render::SurfaceGeometryTileCache> _surfaceGeometryTiles;

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -517,9 +517,6 @@ private:
     std::uint64_t _surfaceViewGeneration = 0;
     std::uint64_t _surfaceTileCbId = 0;
     std::uint64_t _overlaySurfaceTileCbId = 0;
-    // Tile fills finish in bursts. Only one UI callback/render needs to
-    // represent all tiles that became resident during a short debounce window.
-    std::atomic_bool _surfaceTileRenderQueued{false};
     // Last frame fell outside the stored band and used the legacy path, so the
     // status bar can make that performance cliff legible.
     bool _surfaceCacheOutOfBand = false;


### PR DESCRIPTION
current rendering keeps entire chunks in cache for quadsurfaces , which makes the cache fill up very fast on large surfaces (extremely common with spiral outputs, even cut up ones) 

this loads + trims chunks into a smaller 32,128,128 tile for use on quadsurf only 

saves a fair bit of mem and is much faster than a full cache surf render w/ old method

also will enable the 3d viewer @pmh47 has in a dif branch