### PR TITLE
vc3d: prime an empty surface-patch index when the first surface arrives

### DIFF
--- a/volume-cartographer/apps/VC3D/ViewerManager.cpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.cpp
@@ -1942,7 +1942,24 @@ bool ViewerManager::updateSurfacePatchIndexForSurface(const SurfacePatchIndex::S
     }
 
     _surfacePatchIndexNeedsRebuild = true;
+    schedulePrimeSurfacePatchIndices();
     return true;
+}
+
+void ViewerManager::schedulePrimeSurfacePatchIndices()
+{
+    if (_surfacePatchIndexPrimeQueued) {
+        return;
+    }
+    _surfacePatchIndexPrimeQueued = true;
+    // One prime per event-loop turn, over the final surface set.
+    QMetaObject::invokeMethod(this, [this]() {
+        _surfacePatchIndexPrimeQueued = false;
+        if (_surfacePatchIndexNeedsRebuild
+            && !_shuttingDown.load(std::memory_order_relaxed)) {
+            primeSurfacePatchIndicesAsync();
+        }
+    }, Qt::QueuedConnection);
 }
 
 void ViewerManager::handleSurfaceChanged(std::string name, std::shared_ptr<Surface> surf, bool isEditUpdate)

--- a/volume-cartographer/apps/VC3D/ViewerManager.hpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.hpp
@@ -415,6 +415,9 @@ private:
     QString _surfacePatchIndexCacheKey;
     void invalidateSurfacePatchIndexCacheFor(const SurfacePatchIndex::SurfacePtr& surface);
     bool _surfacePatchIndexNeedsRebuild{true};
+    // A first surface entering an empty index has no other builder.
+    bool _surfacePatchIndexPrimeQueued{false};
+    void schedulePrimeSurfacePatchIndices();
     // Use string IDs for surface tracking to avoid dangling pointers in async operations
     std::unordered_set<std::string> _indexedSurfaceIds;
     std::vector<std::string> _pendingSurfacePatchIndexSurfaceIds;


### PR DESCRIPTION
A single-surface registration into an empty index only set _surfacePatchIndexNeedsRebuild and returned: the delta path needs a non-empty index, and nothing else was guaranteed to build one. Readers that call surfacePatchIndexIfReady() never build, so the index could stay empty indefinitely.

In the Spiral workspace this made the generated output surface fail to display whenever the profile had no local dataset path. With a mapping, installInputSurfaces() registered input surfaces through setSurfacesBatch(), whose bulk notification primed the index; with no mapping the batch was empty, so nothing primed it, the preview's own setSurface() hit the empty-index branch, and
installPreviewAliasWhenIndexed() timed out after 30s. Slices were unaffected, and the service saw nothing wrong.

Schedule one coalesced prime per event-loop turn instead. It only runs when the index is empty, so a warm index still takes the cheap single-surface delta path, and primeSurfacePatchIndicesAsync() already clears the rebuild flag when it launches and early-returns when the live index matches the current surface set.