### PR TITLE
Fix volume-only catalog imports

### DIFF
--- a/vesuvius/src/vesuvius/utils/catalog.py
+++ b/vesuvius/src/vesuvius/utils/catalog.py
@@ -7,8 +7,6 @@ import ssl
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-import aiohttp
-import nest_asyncio
 import requests
 import yaml
 
@@ -31,6 +29,8 @@ async def scrape_website(
 ) -> Tuple[CatalogTree, CatalogListing]:
     """Collect directory metadata and Zarr links from a remote listing."""
 
+    import aiohttp
+
     from vesuvius.data.paths import parser
 
     ssl_context = ssl.create_default_context()
@@ -50,6 +50,8 @@ async def scrape_website(
 
 async def collect_subfolders(base_url: str, ignore_list: List[str]) -> List[str]:
     """Return subfolder paths beneath ``base_url`` ignoring provided patterns."""
+
+    import aiohttp
 
     from vesuvius.data.paths import parser
 
@@ -91,6 +93,8 @@ def update_list(
 
     loop = _ensure_loop()
     if loop.is_running():
+        import nest_asyncio
+
         nest_asyncio.apply()
 
     tree, zarr_files = loop.run_until_complete(scrape_website(base_url, ignore_list))

--- a/vesuvius/tests/test_imports.py
+++ b/vesuvius/tests/test_imports.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 import subprocess
 import sys
@@ -22,6 +23,17 @@ def test_public_api_exports() -> None:
     assert hasattr(vesuvius, "utils")
     assert hasattr(vesuvius, "models")
     assert hasattr(vesuvius, "install")
+
+
+def test_list_files_imports_without_async_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "aiohttp", None)
+    monkeypatch.setitem(sys.modules, "nest_asyncio", None)
+
+    importlib.reload(catalog)
+
+    assert isinstance(catalog.list_files(), dict)
 
 
 def test_data_paths_lazy_exports() -> None:


### PR DESCRIPTION
Fixes #1329

`vesuvius.utils.catalog` imports `aiohttp` and `nest_asyncio` even when only `list_files()` is used, which breaks `volume-only` installs

Move those imports to the code paths that need them and add a regression test for `list_files()` without the optional dependencies
