### PR TITLE
Fix zarr_tasks input resolution: zarr 3 level creation and worker level paths

### DIFF
--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/base.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/base.py
@@ -241,6 +241,21 @@ class ZarrTask(ABC):
 
         return opened
 
+    def _get_input_path(self, level: Optional[str] = None) -> str:
+        """Path of the input array itself, with the OME-Zarr level resolved.
+
+        Workers receive paths and open them independently, so they need the path
+        of the array rather than of the pyramid root: opening the root yields a
+        Group, whose ``[slices]`` read fails, and the requested level would be
+        ignored either way.
+        """
+        opened = zarr.open(self.config.input_zarr, mode="r")
+
+        if isinstance(opened, zarr.Group):
+            return f"{self.config.input_zarr.rstrip('/')}/{level if level is not None else '0'}"
+
+        return self.config.input_zarr
+
     @classmethod
     def validate_args(cls, args: argparse.Namespace) -> None:
         """Validate parsed arguments.

--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/scale.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/scale.py
@@ -76,6 +76,7 @@ class ScaleTask(ZarrTask):
         super().__init__(config)
         self.config: ScaleConfig = config
         self._lvl0_path: str = ""
+        self._input_path: str = ""
         self._axes_names = ["z", "y", "x"]
         self._out_shape: Tuple[int, ...] = ()
         self._out_chunks: Tuple[int, ...] = ()
@@ -122,9 +123,9 @@ class ScaleTask(ZarrTask):
 
     def prepare(self) -> None:
         """Create output OME-Zarr structure with scaled shape."""
-        input_z = self._get_input_array(
-            str(self.config.level) if self.config.level is not None else "0"
-        )
+        level = str(self.config.level) if self.config.level is not None else "0"
+        input_z = self._get_input_array(level)
+        self._input_path = self._get_input_path(level)
 
         sf = self.config.scale_factor
         self._out_shape = tuple(max(1, int(round(d * sf))) for d in input_z.shape)
@@ -157,7 +158,7 @@ class ScaleTask(ZarrTask):
 
         for coords in out_chunk_coords:
             yield (
-                self.config.input_zarr,
+                self._input_path,
                 self._lvl0_path,
                 self.config.scale_factor,
                 coords,

--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/threshold.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/threshold.py
@@ -57,6 +57,7 @@ class ThresholdTask(ZarrTask):
         super().__init__(config)
         self.config: ThresholdConfig = config
         self._lvl0_path: str = ""
+        self._input_path: str = ""
         self._axes_names = ["z", "y", "x"]
 
     @classmethod
@@ -99,9 +100,9 @@ class ThresholdTask(ZarrTask):
 
     def prepare(self) -> None:
         """Create output OME-Zarr structure."""
-        input_z = self._get_input_array(
-            str(self.config.level) if self.config.level is not None else "0"
-        )
+        level = str(self.config.level) if self.config.level is not None else "0"
+        input_z = self._get_input_array(level)
+        self._input_path = self._get_input_path(level)
 
         print(f"Input array shape: {input_z.shape}")
         print(f"Input array chunks: {input_z.chunks}")
@@ -132,7 +133,7 @@ class ThresholdTask(ZarrTask):
 
         for coords in chunk_coords:
             yield (
-                self.config.input_zarr,
+                self._input_path,
                 self._lvl0_path,
                 self.config.threshold,
                 self.config.erase_blank,

--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/transpose.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/transpose.py
@@ -62,6 +62,7 @@ class TransposeTask(ZarrTask):
         super().__init__(config)
         self.config: TransposeConfig = config
         self._lvl0_path: str = ""
+        self._input_path: str = ""
         self._axes_names: List[str] = []
         self._out_shape: Tuple[int, ...] = ()
         self._out_chunks: Tuple[int, ...] = ()
@@ -110,9 +111,9 @@ class TransposeTask(ZarrTask):
 
     def prepare(self) -> None:
         """Create output OME-Zarr structure with transposed shape."""
-        input_z = self._get_input_array(
-            str(self.config.level) if self.config.level is not None else "0"
-        )
+        level = str(self.config.level) if self.config.level is not None else "0"
+        input_z = self._get_input_array(level)
+        self._input_path = self._get_input_path(level)
 
         # Parse transpose order string to permutation
         valid_axes = {"x": 2, "y": 1, "z": 0}
@@ -154,7 +155,7 @@ class TransposeTask(ZarrTask):
 
         for coords in out_chunk_coords:
             yield (
-                self.config.input_zarr,
+                self._input_path,
                 self._lvl0_path,
                 self._perm,
                 coords,

--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/utils.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/utils.py
@@ -112,16 +112,32 @@ def create_level_dataset(
     if overwrite and level_path.exists():
         shutil.rmtree(level_path)
 
-    store = zarr.NestedDirectoryStore(str(level_path))
+    if hasattr(zarr, "NestedDirectoryStore"):        # zarr 2.x
+        return zarr.open(
+            store=zarr.NestedDirectoryStore(str(level_path)),
+            shape=shape,
+            chunks=chunks,
+            dtype=dtype,
+            compressor=compressor,
+            mode="w",
+            write_empty_chunks=False,
+            fill_value=0,
+        )
+
+    # zarr 3 dropped NestedDirectoryStore; a v2 array with a "/" dimension
+    # separator is the same layout on disk, and empty chunks are skipped through
+    # the array config rather than a keyword.
     return zarr.open(
-        store=store,
+        str(level_path),
         shape=shape,
         chunks=chunks,
         dtype=dtype,
         compressor=compressor,
         mode="w",
-        write_empty_chunks=False,
         fill_value=0,
+        zarr_format=2,
+        dimension_separator="/",
+        config={"write_empty_chunks": False},
     )
 
 

--- a/vesuvius/tests/image_proc/run/zarr_tasks/test_zarr_tasks_input_level.py
+++ b/vesuvius/tests/image_proc/run/zarr_tasks/test_zarr_tasks_input_level.py
@@ -1,0 +1,108 @@
+"""Workers must receive the input *array* path, not the pyramid root.
+
+`prepare()` resolved the OME-Zarr level correctly, but `generate_work_items()`
+handed workers `config.input_zarr`. On any pyramid input -- including the output
+these tasks themselves write -- the worker's `zarr.open(path)` then returned a
+Group, and the `input_z[slices]` read raised
+`TypeError: sequence item 0: expected str instance, tuple found`, so every chunk
+failed and nothing was written. `--level N` was ignored for the same reason.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+zarr = pytest.importorskip("zarr")
+
+from vesuvius.image_proc.run.zarr_tasks.tasks.scale import ScaleConfig, ScaleTask
+from vesuvius.image_proc.run.zarr_tasks.tasks.threshold import (
+    ThresholdConfig,
+    ThresholdTask,
+)
+from vesuvius.image_proc.run.zarr_tasks.tasks.transpose import (
+    TransposeConfig,
+    TransposeTask,
+)
+
+
+@pytest.fixture
+def pyramid(tmp_path):
+    """A two-level OME-Zarr group, the v2 layout these tasks read and write."""
+    root = tmp_path / "input.zarr"
+    group = zarr.open_group(str(root), mode="w", zarr_format=2)
+    level0 = group.create_array("0", shape=(8, 8, 8), chunks=(4, 4, 4), dtype="u1")
+    level0[:] = 200
+    level1 = group.create_array("1", shape=(4, 4, 4), chunks=(4, 4, 4), dtype="u1")
+    level1[:] = 100
+    return str(root)
+
+
+@pytest.fixture
+def bare_array(tmp_path):
+    """A plain array input, which must keep working unchanged."""
+    path = tmp_path / "plain.zarr"
+    arr = zarr.open_array(str(path), mode="w", shape=(8, 8, 8), chunks=(4, 4, 4),
+                          dtype="u1", zarr_format=2)
+    arr[:] = 200
+    return str(path)
+
+
+def _threshold_task(input_path, tmp_path, level=None):
+    config = ThresholdConfig(input_zarr=input_path,
+                             output_zarr=str(tmp_path / "out.zarr"),
+                             num_workers=1, level=level)
+    task = ThresholdTask(config)
+    task.prepare()
+    return task
+
+
+def test_work_items_carry_an_array_path(pyramid, tmp_path):
+    task = _threshold_task(pyramid, tmp_path)
+    input_path = next(iter(task.generate_work_items()))[0]
+
+    opened = zarr.open(input_path, mode="r")
+    assert not isinstance(opened, zarr.Group)
+    # the read the worker performs must succeed on that path
+    assert opened[(slice(0, 4), slice(0, 4), slice(0, 4))].shape == (4, 4, 4)
+
+
+def test_processing_a_chunk_writes_the_expected_values(pyramid, tmp_path):
+    task = _threshold_task(pyramid, tmp_path)
+    item = next(iter(task.generate_work_items()))
+
+    task.process_item(item)
+
+    written = zarr.open(str(tmp_path / "out.zarr" / "0"), mode="r")
+    assert np.all(written[(slice(0, 4), slice(0, 4), slice(0, 4))] == 255)
+
+
+def test_requested_level_reaches_the_worker(pyramid, tmp_path):
+    task = _threshold_task(pyramid, tmp_path, level=1)
+    input_path = next(iter(task.generate_work_items()))[0]
+
+    assert input_path.endswith("/1")
+    assert zarr.open(input_path, mode="r").shape == (4, 4, 4)
+
+
+def test_bare_array_input_is_passed_through(bare_array, tmp_path):
+    task = _threshold_task(bare_array, tmp_path)
+    input_path = next(iter(task.generate_work_items()))[0]
+
+    assert input_path == bare_array
+    assert zarr.open(input_path, mode="r").shape == (8, 8, 8)
+
+
+@pytest.mark.parametrize("task_cls, config_cls, extra", [
+    (ScaleTask, ScaleConfig, {}),
+    (TransposeTask, TransposeConfig, {}),
+])
+def test_sibling_tasks_resolve_the_level_too(task_cls, config_cls, extra,
+                                             pyramid, tmp_path):
+    config = config_cls(input_zarr=pyramid, output_zarr=str(tmp_path / "out.zarr"),
+                        num_workers=1, **extra)
+    task = task_cls(config)
+    task.prepare()
+
+    input_path = next(iter(task.generate_work_items()))[0]
+    assert not isinstance(zarr.open(input_path, mode="r"), zarr.Group)

--- a/vesuvius/tests/image_proc/run/zarr_tasks/test_zarr_tasks_input_level.py
+++ b/vesuvius/tests/image_proc/run/zarr_tasks/test_zarr_tasks_input_level.py
@@ -10,10 +10,25 @@ failed and nothing was written. `--level N` was ignored for the same reason.
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
 
 zarr = pytest.importorskip("zarr")
+
+
+def _write_array(path, shape, chunks, value):
+    """Create a filled zarr v2 array, on either zarr generation.
+
+    zarr 2 writes v2 and has no ``zarr_format`` argument; zarr 3 defaults to v3,
+    which these tasks cannot consume (they read ``Array.compressor``).
+    """
+    kwargs = {} if zarr.__version__.startswith("2.") else {"zarr_format": 2}
+    array = zarr.open_array(str(path), mode="w", shape=shape, chunks=chunks,
+                            dtype="u1", **kwargs)
+    array[:] = value
+    return array
 
 from vesuvius.image_proc.run.zarr_tasks.tasks.scale import ScaleConfig, ScaleTask
 from vesuvius.image_proc.run.zarr_tasks.tasks.threshold import (
@@ -30,11 +45,11 @@ from vesuvius.image_proc.run.zarr_tasks.tasks.transpose import (
 def pyramid(tmp_path):
     """A two-level OME-Zarr group, the v2 layout these tasks read and write."""
     root = tmp_path / "input.zarr"
-    group = zarr.open_group(str(root), mode="w", zarr_format=2)
-    level0 = group.create_array("0", shape=(8, 8, 8), chunks=(4, 4, 4), dtype="u1")
-    level0[:] = 200
-    level1 = group.create_array("1", shape=(4, 4, 4), chunks=(4, 4, 4), dtype="u1")
-    level1[:] = 100
+    root.mkdir()
+    # the layout create_level_dataset writes: a .zgroup beside the level arrays
+    (root / ".zgroup").write_text(json.dumps({"zarr_format": 2}))
+    _write_array(root / "0", (8, 8, 8), (4, 4, 4), 200)
+    _write_array(root / "1", (4, 4, 4), (4, 4, 4), 100)
     return str(root)
 
 
@@ -42,9 +57,7 @@ def pyramid(tmp_path):
 def bare_array(tmp_path):
     """A plain array input, which must keep working unchanged."""
     path = tmp_path / "plain.zarr"
-    arr = zarr.open_array(str(path), mode="w", shape=(8, 8, 8), chunks=(4, 4, 4),
-                          dtype="u1", zarr_format=2)
-    arr[:] = 200
+    _write_array(path, (8, 8, 8), (4, 4, 4), 200)
     return str(path)
 
 


### PR DESCRIPTION
Two defects that stop `vesuvius.zarr_tasks threshold | scale | transpose` from producing output. Found while auditing published prediction volumes; both reproduce from a clean checkout with zarr 3.2.1 installed (`zarr>=2.18.7,<4` in pyproject).

**1. `create_level_dataset` uses a zarr-2-only API.** `utils.py` calls `zarr.NestedDirectoryStore`, which zarr 3 removed:

```
AttributeError: module 'zarr' has no attribute 'NestedDirectoryStore'   # utils.py:115
```

`prepare()` calls it before any work item is generated, so on a zarr 3 install every one of these tasks dies immediately. Fixed by keeping the zarr 2 path and, on zarr 3, opening a v2 array with `dimension_separator="/"` — the same layout on disk — with `write_empty_chunks` moved from the removed keyword to the array `config`.

**2. Workers receive the pyramid root instead of the resolved level.** `prepare()` resolves the level correctly via `_get_input_array(level)`, but `generate_work_items()` yields `self.config.input_zarr`, and the worker does:

```python
input_z = zarr.open(input_path, mode="r")
chunk_data = input_z[slices]
```

On an OME-Zarr input — including the pyramid these tasks themselves emit, so chaining two of them hits it — `zarr.open` returns a Group and the read raises `TypeError: sequence item 0: expected str instance, tuple found`. Every chunk fails, and `--level N` is silently ignored. `recompress.py` and `zero_range.py` already resolve the path (`f"{input_zarr}/{level}"`); this adds `_get_input_path()` next to `_get_input_array()` in the base class and uses it in the three tasks that were missing it, so bare-array inputs keep passing through unchanged.

Tests: a new suite builds a two-level v2 pyramid and checks that a work item carries an array path, that processing a chunk writes the expected values, that `--level` reaches the worker, that a bare array input is untouched, and that scale and transpose resolve the level too. Against current `main` all six fail (the first four on the `NestedDirectoryStore` AttributeError, the rest on the Group read); with this change all six pass.