### PR TITLE
finalize_outputs: quantize multiclass output on chunk-independent scales

### DIFF
--- a/vesuvius/src/vesuvius/models/run/finalize_outputs.py
+++ b/vesuvius/src/vesuvius/models/run/finalize_outputs.py
@@ -100,32 +100,29 @@ def apply_finalization(logits_np, num_classes, config: FinalizeConfig):
                 fg_prob = softmax[1:2]
                 output_data = fg_prob
     else:  # multiclass
-        argmax = np.argmax(logits_np, axis=0).astype(np.float32)
+        # Quantize the two parts on fixed, chunk-independent scales so a byte means the same
+        # thing in every chunk: the class index is written raw and the softmax probabilities
+        # use the same [0, 1] -> [0, 255] scale as the binary path. The previous code min-max
+        # rescaled the concatenated [softmax, argmax] array, so the largest class index present
+        # in a chunk set the scale. That made the same class land on different bytes in
+        # different chunks and stored a probability of 1.0 as something other than 255 (#1432).
+        argmax = np.argmax(logits_np, axis=0).astype(np.uint8)
         argmax = argmax[np.newaxis, ...]
         if threshold is not None:
             # In multiclass the CLI only allows the bare-flag form (arrives as 0.5); emit argmax only.
-            output_data = argmax
+            output_np = argmax
         else:
             exp_logits = np.exp(logits_np - np.max(logits_np, axis=0, keepdims=True))
             softmax = exp_logits / np.sum(exp_logits, axis=0, keepdims=True)
-            output_data = np.concatenate([softmax, argmax], axis=0)
-
-    output_np = output_data
+            softmax_u8 = np.clip(softmax * 255.0, 0, 255).astype(np.uint8)
+            output_np = np.concatenate([softmax_u8, argmax], axis=0)
 
     if mode == "binary":
-        output_np = np.clip(output_np * 255.0, 0, 255).astype(np.uint8)
+        output_np = np.clip(output_data * 255.0, 0, 255).astype(np.uint8)
     else:
-        # Scale to uint8 range [0, 255]
-        min_val = output_np.min()
-        max_val = output_np.max()
-        if min_val < max_val:
-            output_np = ((output_np - min_val) / (max_val - min_val) * 255).astype(np.uint8)
-        else:
-            return None, True
-
-        # Final check: if the processed data is homogeneous, don't write it
-        first_processed_value = output_np.flat[0]
-        if np.all(output_np == first_processed_value):
+        # Empty chunks are already handled by the is_empty guard above; skip a finalized chunk
+        # only when every byte is identical, matching the previous behavior.
+        if np.all(output_np == output_np.flat[0]):
             return None, True
 
     return output_np, False

--- a/vesuvius/tests/models/run/test_finalize_multiclass_scale.py
+++ b/vesuvius/tests/models/run/test_finalize_multiclass_scale.py
@@ -1,0 +1,97 @@
+"""Multiclass finalization must quantize on fixed, chunk-independent scales.
+
+`apply_finalization` writes a multiclass volume documented as
+`[softmax_c0...softmax_cN, argmax]`. It used to min-max rescale that whole array into
+uint8, but the array concatenates softmax probabilities in [0, 1] with an argmax channel
+holding class indices in [0, C-1]. The maximum of the array is therefore the largest class
+index that happens to appear in the chunk. That value set the scale. Two things broke:
+
+* the same class landed on a different byte in different chunks (class 3 alone in a chunk
+  became 255, class 1 alone in another chunk also became 255), so class indices were not
+  recoverable and were discontinuous at every chunk boundary; and
+* a softmax probability of 1.0 was stored as 85 in a chunk whose largest class index was 3
+  and as 255 in a chunk whose largest was 1, so the probabilities were not comparable
+  either.
+
+The fix writes the class index raw and puts the probabilities on the same [0, 1] -> [0, 255]
+scale the binary path already uses, so a byte means the same thing in every chunk. These
+tests pin both halves and fail on the old min-max code. Reported as #1432.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vesuvius.models.run.finalize_outputs import apply_finalization, FinalizeConfig
+
+
+# --- helpers -----------------------------------------------------------------------
+
+NUM_CLASSES = 4
+
+
+def chunk_dominated_by(class_idx):
+    """A (C, 1, 1, 2) logits chunk: voxel 0 is class_idx, voxel 1 is class 0.
+
+    A large logit makes that class the argmax and drives its softmax to ~1.0.
+    """
+    logits = np.zeros((NUM_CLASSES, 1, 1, 2), dtype=np.float32)
+    logits[class_idx, 0, 0, 0] = 20.0
+    logits[0, 0, 0, 1] = 20.0
+    return logits
+
+
+def finalize(logits, **cfg_kwargs):
+    cfg = FinalizeConfig(mode="multiclass", **cfg_kwargs)
+    out, is_empty = apply_finalization(logits, NUM_CLASSES, cfg)
+    assert not is_empty
+    return out
+
+
+# --- the class index must survive, unchanged, in every chunk -----------------------
+
+def test_argmax_channel_holds_the_raw_class_index():
+    # Last channel is the argmax. Different chunks contain different top classes.
+    out_a = finalize(chunk_dominated_by(3))  # classes {0, 3}
+    out_b = finalize(chunk_dominated_by(1))  # classes {0, 1}
+    assert out_a[-1].ravel().tolist() == [3, 0]
+    assert out_b[-1].ravel().tolist() == [1, 0]
+
+
+def test_two_classes_do_not_collapse_to_the_same_byte():
+    out_a = finalize(chunk_dominated_by(3))
+    out_b = finalize(chunk_dominated_by(1))
+    class3_byte = out_a[-1, 0, 0, 0]
+    class1_byte = out_b[-1, 0, 0, 0]
+    assert class3_byte != class1_byte  # min-max stored both as 255
+
+
+# --- a probability means the same thing in every chunk -----------------------------
+
+def test_probability_of_one_is_255_regardless_of_the_chunk():
+    out_a = finalize(chunk_dominated_by(3))
+    out_b = finalize(chunk_dominated_by(1))
+    # Softmax for the dominant class at voxel 0 is ~1.0 in both chunks.
+    assert int(out_a[3, 0, 0, 0]) == 255
+    assert int(out_b[1, 0, 0, 0]) == 255
+
+
+# --- the threshold (argmax-only) path keeps class indices too ----------------------
+
+def test_threshold_multiclass_emits_raw_argmax():
+    # A multiclass threshold arrives as 0.5 and emits argmax only (one channel).
+    out = finalize(chunk_dominated_by(3), threshold=0.5)
+    assert out.shape[0] == 1
+    assert out[0].ravel().tolist() == [3, 0]
+
+
+# --- the refactor must not disturb the binary path ---------------------------------
+
+def test_binary_probabilities_use_the_fixed_scale():
+    logits = np.zeros((2, 1, 1, 2), dtype=np.float32)
+    logits[1, 0, 0, 0] = 20.0   # foreground prob ~1.0
+    logits[0, 0, 0, 1] = 20.0   # foreground prob ~0.0
+    out, is_empty = apply_finalization(logits, 2, FinalizeConfig(mode="binary"))
+    assert not is_empty
+    assert int(out[0, 0, 0, 0]) == 255
+    assert int(out[0, 0, 0, 1]) == 0


### PR DESCRIPTION
## Motivation

`vesuvius.finalize_outputs --mode multiclass` writes a volume documented as `[softmax_c0...softmax_cN, argmax]`, but the uint8 conversion rescales the whole array by a factor that depends on the contents of each chunk, so neither the class indices nor the probabilities survive.

In `apply_finalization` (`models/run/finalize_outputs.py`), the multiclass branch concatenates the softmax probabilities (in `[0, 1]`) with the argmax channel (class indices in `[0, C-1]`), then min-max rescales the concatenation into uint8:

```python
output_np = np.concatenate([softmax, argmax], axis=0)
...
min_val = output_np.min()
max_val = output_np.max()
if min_val < max_val:
    output_np = ((output_np - min_val) / (max_val - min_val) * 255).astype(np.uint8)
```

`max_val` is the largest class index present in that chunk, so the scale factor changes from chunk to chunk. The `--threshold` path (argmax only) is rescaled the same way, so class indices are not recoverable there either. Reported in #1432.

## Reproduced

I do not have a GPU here to run a full multiclass `predict`, so I drove the real `apply_finalization` (a pure function, no I/O) on two chunks whose argmax holds different classes. `chunk A` contains classes {0, 3}, `chunk B` contains {0, 1}; each has a voxel whose softmax is ~1.0.

Before, on `main` at b4ceb53:

```
A classes {0,3}: argmax bytes = [255, 0]   softmax~1.0 stored as 85
B classes {0,1}: argmax bytes = [255, 0]   softmax~1.0 stored as 255
```

So class 3 and class 1 both become 255 (indistinguishable). A probability of 1.0 is 85 in one chunk and 255 in the next. After this change, same input:

```
A classes {0,3}: argmax bytes = [3, 0]     softmax~1.0 stored as 255
B classes {0,1}: argmax bytes = [1, 0]     softmax~1.0 stored as 255
```

Class indices are raw and distinct; a probability of 1.0 is 255 in every chunk.

## Fix

Quantize the two parts on fixed, chunk-independent scales rather than min-max rescaling the concatenation:

- the argmax channel is written raw (`astype(np.uint8)`), so a byte is the class index
- the softmax probabilities use the same `[0, 1] -> [0, 255]` scale the binary path already uses (`clip(softmax * 255)`)

The threshold (argmax-only) path emits the raw class index too. The binary path is untouched. No public surface or output-shape change: multiclass still writes `num_classes + 1` channels (`[softmax_c0...softmax_cN, argmax]`) or one argmax channel under `--threshold`.

This does change the byte values existing multiclass artifacts carry. That is the point of the fix (the old bytes are the per-chunk-scaled ones), but I am flagging it since anything that read the old multiclass output was reading a scale that shifted at every chunk boundary.

## Tests

`vesuvius/tests/models/run/test_finalize_multiclass_scale.py` pins both halves on `apply_finalization`:

- the argmax channel holds the raw class index; two different classes do not collapse to the same byte across chunks
- a softmax probability of 1.0 is 255 regardless of the chunk
- the `--threshold` multiclass path emits the raw argmax
- a binary-path sanity check that the refactor left it on the fixed `* 255` scale

The four multiclass cases fail on the pre-fix code (the argmax assertions come back 255):

```
FAILED ... test_argmax_channel_holds_the_raw_class_index
FAILED ... test_two_classes_do_not_collapse_to_the_same_byte
FAILED ... test_probability_of_one_is_255_regardless_of_the_chunk
FAILED ... test_threshold_multiclass_emits_raw_argmax
4 failed, 1 passed
```

## Verification

From `vesuvius/` on Python 3.14.5, numpy 2.4.6, zarr 3.3.0:

```
python -m pytest tests/                exit 0   883 passed, 4 skipped, 3 deselected
python -m pytest tests/models/run/     exit 0   52 passed
```

The suite's `pytest.ini` deselects the `slow` and `network` marks.

## AI assistance

AI (Claude, Anthropic) was used in developing this change. The design, review and verification were done by the author. Verified locally before submitting: the full `vesuvius` test suite (883 passed) and the new regression tests, on Python 3.14.5 with numpy 2.4.6 and zarr 3.3.0.
