### PR TITLE
Resolve the active volume's Lasagna dataset before starting the service

### DIFF
--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_lasagna.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_lasagna.cpp
@@ -37,6 +37,7 @@
 #include "LineAnnotationController.hpp"
 #include "LineAnnotationDialog.hpp"
 #include "MenuActionController.hpp"
+#include "OpenDataLasagna.hpp"
 #include "OpenDataManifest.hpp"
 #include "OpenDataSampleProject.hpp"
 #include "OpenDataSegmentCache.hpp"
@@ -118,8 +119,26 @@ QJsonObject AgentBridgeServer::handleLasagnaEnsureService(const QJsonValue& para
 
     // Internal mode: ensureServiceRunning() blocks until the process is up (or
     // fails) and returns synchronously -- no deferral needed.
+    //
+    // The data directory is resolved the same way every UI call site does
+    // (CWindow's resolvedLasagnaForState): via the active project's volume
+    // package and current volume ID. Previously this call site passed no
+    // directory at all, so ensureServiceRunning() always failed with "No
+    // Lasagna data directory was provided" regardless of what was open or
+    // selected -- the resolution step below was simply missing here.
     const QString pythonPath = p.value("pythonPath").toString();
-    if (!mgr.ensureServiceRunning(pythonPath)) {
+    QString dataDirectory;
+    CState* state = _window ? _window->_state : nullptr;
+    std::shared_ptr<VolumePkg> vpkg = state ? state->vpkg() : nullptr;
+    if (vpkg) {
+        const auto resolved = vc3d::opendata::resolveLasagnaForVolume(
+            *vpkg, state->currentVolumeId());
+        if (resolved && !resolved->manifestPath.empty()) {
+            dataDirectory = QString::fromStdString(
+                resolved->manifestPath.parent_path().string());
+        }
+    }
+    if (!mgr.ensureServiceRunning(pythonPath, dataDirectory)) {
         QJsonObject data;
         data["detail"] = mgr.lastError();
         throw AgentBridgeError{-32005, "Failed to start lasagna service", data};


### PR DESCRIPTION
Fixes #1437.

`lasagna.ensure_service` over the agent bridge fails with `No Lasagna data directory was provided`, regardless of which volume or project is open. Reproduced with a catalog-opened PHercParis4 project, the correct volume selected, workspace switched to `lasagna`, and a segment loaded and active.

Every UI call site resolves the directory first — `CWindow.cpp:5310-5335`, via `resolvedLasagnaForState` and `vc3d::opendata::resolveLasagnaForVolume`. The agent-bridge handler doesn't: `AgentBridgeHandlers_lasagna.cpp:122` calls the two-argument `ensureServiceRunning(pythonPath, dataDirectory)` with one argument, so `dataDirectory` is always empty and `startService` fails at `LasagnaServiceManager.cpp:690-697`. `rpc.describe` confirms the RPC exposes only `pythonPath`/`host`/`port`, so there's no way to pass it manually either.

Resolves the active volume's Lasagna dataset before starting the service, mirroring the UI path. The same `state`/`vpkg` accessors are already used four other places in this file.

Found while driving the Spiral workspace's Lasagna service for PHercParis4 through the agent bridge. This one is in `apps/VC3D`, so I couldn't compile it here — no Qt build environment on this machine. Write-up done with AI assistance (Claude); the error text is from real runs.
