### PR TITLE
line annotation: subdivide strip columns to the densest span step

### DIFF
--- a/volume-cartographer/apps/src/vc_lasagna_line_probe.cpp
+++ b/volume-cartographer/apps/src/vc_lasagna_line_probe.cpp
@@ -1409,9 +1409,18 @@ void writeReinitDebugObjOutput(
                            outputDir / "continuation_candidates.obj");
 }
 
-int scaledControlColumn(int sourceIndex, int renderScale, int cols)
+int scaledControlColumn(int sourceIndex,
+                        int renderScale,
+                        int cols,
+                        const vc::lasagna::LineStripPositionMap& positionMap)
 {
-    const double scaled = (static_cast<double>(sourceIndex) + 0.5) *
+    // The strip grid is subdivided per segment, so a point index is not a
+    // grid column; convert through the builder's position map first.
+    const double gridColumn = positionMap.valid()
+        ? positionMap.originalPositionToStripGridColumn(
+              static_cast<double>(sourceIndex))
+        : static_cast<double>(sourceIndex);
+    const double scaled = (gridColumn + 0.5) *
                           static_cast<double>(std::max(1, renderScale)) -
                           0.5;
     return std::clamp(static_cast<int>(std::lround(scaled)), 0, std::max(0, cols - 1));
@@ -1419,7 +1428,8 @@ int scaledControlColumn(int sourceIndex, int renderScale, int cols)
 
 cv::Mat makeStripOverlay(const cv::Mat& grayscale,
                          const std::vector<int>& fixedIndices,
-                         int renderScale)
+                         int renderScale,
+                         const vc::lasagna::LineStripPositionMap& positionMap)
 {
     cv::Mat image8;
     if (grayscale.depth() == CV_8U) {
@@ -1442,7 +1452,7 @@ cv::Mat makeStripOverlay(const cv::Mat& grayscale,
         if (index < 0) {
             continue;
         }
-        const int col = scaledControlColumn(index, renderScale, overlay.cols);
+        const int col = scaledControlColumn(index, renderScale, overlay.cols, positionMap);
         cv::line(overlay,
                  cv::Point(col, 0),
                  cv::Point(col, std::max(0, overlay.rows - 1)),
@@ -1462,6 +1472,7 @@ cv::Mat makeStripOverlay(const cv::Mat& grayscale,
 struct RenderedStrips {
     cv::Mat lineSurface;
     cv::Mat lineSideSlice;
+    vc::lasagna::LineStripPositionMap stripPositionMap;
 };
 
 RenderedStrips renderLineViewStrips(const vc::lasagna::LineModel& line,
@@ -1476,6 +1487,7 @@ RenderedStrips renderLineViewStrips(const vc::lasagna::LineModel& line,
     return {
         renderSurfaceTexture(*surfaces.lineSurface, textureVolume, textureLevel, renderScale),
         renderSurfaceTexture(*surfaces.lineSideSlice, textureVolume, textureLevel, renderScale),
+        surfaces.stripPositionMap,
     };
 }
 
@@ -1490,10 +1502,12 @@ void writeStripImages(const vc::lasagna::LineModel& line,
     const RenderedStrips strips = renderLineViewStrips(line, textureVolume, textureLevel, renderScale);
     writeTif(outputDir / "line_surface.tif", strips.lineSurface);
     writeTif(outputDir / "line_surface_overlay.tif",
-             makeStripOverlay(strips.lineSurface, fixedIndices, renderScale));
+             makeStripOverlay(strips.lineSurface, fixedIndices, renderScale,
+                              strips.stripPositionMap));
     writeTif(outputDir / "side_slice.tif", strips.lineSideSlice);
     writeTif(outputDir / "side_slice_overlay.tif",
-             makeStripOverlay(strips.lineSideSlice, fixedIndices, renderScale));
+             makeStripOverlay(strips.lineSideSlice, fixedIndices, renderScale,
+                              strips.stripPositionMap));
 }
 
 void writeLineViewObjOutput(const vc::lasagna::LineModel& line,

--- a/volume-cartographer/core/include/vc/lasagna/LineViewBuilder.hpp
+++ b/volume-cartographer/core/include/vc/lasagna/LineViewBuilder.hpp
@@ -12,10 +12,14 @@ class QuadSurface;
 namespace vc::lasagna {
 
 struct LineViewConfig {
-    // Derived ribbons retain every control-point bend and subdivide each
-    // control-point segment as closely as possible to this spacing. This is a
-    // view parameter in level-0/base-volume voxels, independent of stored point
-    // or optimizer spacing.
+    // Upper bound on the ribbon column spacing, in level-0/base-volume voxels,
+    // independent of stored point or optimizer spacing. Derived ribbons retain
+    // every control-point bend and subdivide each control-point segment as
+    // closely as possible to the effective spacing: the densest original
+    // segment, clamped to this bound (and floored so pathological inputs
+    // cannot explode the column count). Matching the densest segment keeps
+    // strip columns near-uniform in arclength, so spans interpolated at
+    // coarser steps no longer render squeezed next to native-trace spans.
     double targetSpacingBaseVoxels = 50.0;
     // Non-positive values retain the legacy automatic strip height: cross-row
     // spacing matches the median optimized control-point step.

--- a/volume-cartographer/core/src/lasagna/LineViewBuilder.cpp
+++ b/volume-cartographer/core/src/lasagna/LineViewBuilder.cpp
@@ -143,6 +143,31 @@ LineStripPositionMap buildPositionMap(const std::vector<SegmentNormalSample>& sa
         throw std::invalid_argument("Cannot build line annotation views for a zero-length LineModel");
     }
 
+    // The ribbon draws one column per grid entry, so the strip is only
+    // distortion-free when columns are near-uniform in arclength. Spans
+    // interpolated at coarser steps (cspline "short span" and lasagna
+    // fallbacks, ~32 vx) would otherwise render squeezed next to
+    // native-trace spans (~4-8 vx). Subdivide toward the densest original
+    // segment, keeping the configured target as the upper bound and a floor
+    // that caps the total column count on pathological inputs. Original
+    // points always remain grid supports, so bends survive and integer
+    // original positions keep landing exactly on columns.
+    double smallestStep = std::numeric_limits<double>::infinity();
+    for (size_t i = 1; i < samples.size(); ++i) {
+        const double segmentLength =
+            map.originalArclengths[i] - map.originalArclengths[i - 1];
+        if (segmentLength > kEpsilon) {
+            smallestStep = std::min(smallestStep, segmentLength);
+        }
+    }
+    constexpr double kMaxStripGridColumns = 60000.0;
+    const double spacingFloor =
+        std::max(1.0, map.totalArclength / kMaxStripGridColumns);
+    const double effectiveSpacing = std::isfinite(smallestStep)
+        ? std::clamp(smallestStep, std::min(spacingFloor, targetSpacingBaseVoxels),
+                     targetSpacingBaseVoxels)
+        : targetSpacingBaseVoxels;
+
     map.stripGridArclengths.push_back(0.0);
     for (size_t i = 1; i < samples.size(); ++i) {
         const double segmentStart = map.originalArclengths[i - 1];
@@ -152,14 +177,14 @@ LineStripPositionMap buildPositionMap(const std::vector<SegmentNormalSample>& sa
             continue;
         }
 
-        const double idealIntervals = segmentLength / targetSpacingBaseVoxels;
+        const double idealIntervals = segmentLength / effectiveSpacing;
         const size_t lowerIntervals = std::max<size_t>(
             1, static_cast<size_t>(std::floor(idealIntervals)));
         const size_t upperIntervals = lowerIntervals + 1;
         const double lowerError = std::abs(
-            segmentLength / static_cast<double>(lowerIntervals) - targetSpacingBaseVoxels);
+            segmentLength / static_cast<double>(lowerIntervals) - effectiveSpacing);
         const double upperError = std::abs(
-            segmentLength / static_cast<double>(upperIntervals) - targetSpacingBaseVoxels);
+            segmentLength / static_cast<double>(upperIntervals) - effectiveSpacing);
         const size_t intervalCount = upperError < lowerError
             ? upperIntervals
             : lowerIntervals;

--- a/volume-cartographer/core/test/test_lasagna_line_view_surfaces.cpp
+++ b/volume-cartographer/core/test/test_lasagna_line_view_surfaces.cpp
@@ -427,14 +427,17 @@ TEST_CASE("LineViewBuilder resamples uneven control-point segments and maps posi
 
     const auto views = vc::lasagna::buildLineViewSurfaces(line, config);
     const auto points = views.lineSurface->rawPoints();
-    REQUIRE(points.cols == 4);
-    CHECK(views.stripPositionMap.stripGridSpacingBaseVoxels == doctest::Approx(40.0));
-    CHECK(views.lineSurface->scale()[0] == doctest::Approx(1.0 / 40.0));
+    // The effective spacing matches the densest segment (15), so the 105-long
+    // segment subdivides into 7 uniform intervals instead of 2.
+    REQUIRE(points.cols == 9);
+    CHECK(views.stripPositionMap.stripGridSpacingBaseVoxels == doctest::Approx(15.0));
+    CHECK(views.lineSurface->scale()[0] == doctest::Approx(1.0 / 15.0));
     CHECK(views.lineSurface->scale()[1] == doctest::Approx(1.0 / 10.0));
     checkVec(points(2, 0), {0.0, 0.0, 0.0});
     checkVec(points(2, 1), {15.0, 0.0, 0.0});
-    checkVec(points(2, 2), {67.5, 0.0, 0.0});
-    checkVec(points(2, 3), {120.0, 0.0, 0.0});
+    checkVec(points(2, 2), {30.0, 0.0, 0.0});
+    checkVec(points(2, 5), {75.0, 0.0, 0.0});
+    checkVec(points(2, 8), {120.0, 0.0, 0.0});
 
     CHECK(views.stripPositionMap.originalPositionToStripGridColumn(1.0) ==
           doctest::Approx(1.0));
@@ -457,14 +460,14 @@ TEST_CASE("LineViewBuilder preserves reversed uneven arclength orientation")
 
     const auto views = vc::lasagna::buildLineViewSurfaces(line, config);
     const auto points = views.lineSurface->rawPoints();
-    REQUIRE(points.cols == 4);
+    REQUIRE(points.cols == 9);
     checkVec(points(points.rows / 2, 0), {120.0, 0.0, 0.0});
-    checkVec(points(points.rows / 2, 1), {67.5, 0.0, 0.0});
-    checkVec(points(points.rows / 2, 2), {15.0, 0.0, 0.0});
-    checkVec(points(points.rows / 2, 3), {0.0, 0.0, 0.0});
+    checkVec(points(points.rows / 2, 1), {105.0, 0.0, 0.0});
+    checkVec(points(points.rows / 2, 7), {15.0, 0.0, 0.0});
+    checkVec(points(points.rows / 2, 8), {0.0, 0.0, 0.0});
     CHECK(views.stripPositionMap.originalPositionToStripGridColumn(1.0) ==
-          doctest::Approx(2.0));
-    CHECK(views.stripPositionMap.stripGridColumnToOriginalPosition(2.0) ==
+          doctest::Approx(7.0));
+    CHECK(views.stripPositionMap.stripGridColumnToOriginalPosition(7.0) ==
           doctest::Approx(1.0));
 }
 
@@ -508,6 +511,47 @@ TEST_CASE("LineViewBuilder chooses closest spacing independently per segment")
           doctest::Approx(2.0));
     CHECK(views.stripPositionMap.stripGridColumnToOriginalPosition(2.0) ==
           doctest::Approx(1.0));
+}
+
+TEST_CASE("LineViewBuilder renders mixed-density spans at uniform column pitch")
+{
+    // The scrunch fixture: native-trace spans sample every ~4 vx while a
+    // cspline/lasagna span samples every ~32 vx. The effective spacing locks
+    // to the densest segment, so the sparse spans subdivide to the same pitch
+    // and every adjacent column pair sits the same arclength apart.
+    auto line = simpleLine();
+    line.segmentSamples.clear();
+    line.points = {
+        {{0.0, 0.0, 0.0}, line.points[0].sampledNormal, true},
+        {{4.0, 0.0, 0.0}, line.points[0].sampledNormal, true},
+        {{8.0, 0.0, 0.0}, line.points[0].sampledNormal, true},
+        {{12.0, 0.0, 0.0}, line.points[0].sampledNormal, true},
+        {{44.0, 0.0, 0.0}, line.points[0].sampledNormal, true},
+        {{76.0, 0.0, 0.0}, line.points[0].sampledNormal, true},
+    };
+    vc::lasagna::LineViewConfig config;
+    config.targetSpacingBaseVoxels = 50.0;
+
+    const auto views = vc::lasagna::buildLineViewSurfaces(line, config);
+    const auto points = views.lineSurface->rawPoints();
+    // 3 segments of 4 vx (one interval each) + 2 segments of 32 vx
+    // (eight 4 vx intervals each) = 20 columns.
+    REQUIRE(points.cols == 20);
+    CHECK(views.stripPositionMap.stripGridSpacingBaseVoxels == doctest::Approx(4.0));
+    for (int col = 1; col < points.cols; ++col) {
+        const cv::Vec3f step = points(points.rows / 2, col) -
+                               points(points.rows / 2, col - 1);
+        CHECK(cv::norm(step) == doctest::Approx(4.0));
+    }
+    // Original points stay grid supports: the sparse-span boundary at
+    // original position 4 (x = 44) lands exactly on column 11.
+    CHECK(views.stripPositionMap.originalPositionToStripGridColumn(4.0) ==
+          doctest::Approx(11.0));
+    CHECK(views.stripPositionMap.stripGridColumnToOriginalPosition(11.0) ==
+          doctest::Approx(4.0));
+    // Cut-view outputs stay per original line point.
+    CHECK(views.lineUpVectors.size() == line.points.size());
+    CHECK(views.lineZSlices.size() == line.points.size());
 }
 
 TEST_CASE("LineViewBuilder mapping canonicalizes duplicate control points")


### PR DESCRIPTION
## Problem

The line-annotation strip ribbon draws one column per grid entry, but dense-line spans are sampled at very different physical steps depending on how they were interpolated: native-trace spans every ~4–8 base voxels, cspline "short span" (< 100 vx gaps under a Global goal) and lasagna-fallback spans every ~32 voxels. Strip-x was therefore physically non-uniform — a small-gap span occupied 4–8× fewer columns per physical distance than its trace neighbors, so the strip image squished there and the flanking control-point markers visually "scrunched" together right after placement. The 3D geometry was always correct.

#1453 introduced exactly the right machinery for this — `LineStripPositionMap`, threaded through markers, clicks, camera framing, context menus and both strip paths, with correct mean-pitch scale metadata — but its subdivision only splits segments *longer* than `targetSpacingBaseVoxels` (50 vx), so the 4-vs-32 density mismatch inside a mixed line still rendered scrunched.

## Fix (one knob, on top of #1453)

Derive the per-segment subdivision target from the **densest original segment** instead of using the configured spacing directly:

- `targetSpacingBaseVoxels` becomes the upper bound; the effective spacing is `clamp(smallest positive segment, floor, target)`, where the floor caps the total column count on pathological inputs (near-coincident points).
- Everything else is #1453's design, untouched: original points remain grid supports (bends survive; integer line positions land exactly on columns, so the marker fast path stays exact), the position map stays the single source of truth, cut views / `lineUpVectors` / `lineZSlices` stay per original line point, and already-uniform lines produce byte-identical output.
- Mixed-density lines now subdivide their sparse spans down to the trace pitch and render at uniform column width — markers sit where they were placed.

Also threads the position map through `vc_lasagna_line_probe`'s strip overlays, which still assumed column == point index; with subdivision now common on mixed lines its markers would land visibly off.

## Tests

New: mixed-density fixture (4 vx trace steps + 32 vx spans) asserting every adjacent column pair is exactly the trace pitch apart, supports stay on columns, and cut-view outputs stay per line point. Updated: the two uneven-arclength cases from #1453 now expect subdivision at the densest step (15 vx fixtures); the bend-preservation, per-segment-spacing (target-capped), duplicate-point, and validation cases pass unchanged. Suites: 35 / 22 / 74 pass; `VC3D` and `vc_lasagna_line_probe` build and link.

## Notes

- Arrow-pan speed stays in linePosition/sec; on-screen px/sec varies across span types (it now reflects true physical length — previously the same non-uniformity showed as geometric squish).
- The overview bar stays index-uniform (schematic).
- Strip column count grows on mixed lines (a 32 vx span gains ~8× columns); the floor bounds the worst case.

## Provenance

Supersedes this PR's earlier standalone implementation (uniform arc-length resample + its own mapping type), which was developed against the #1422/#1423/#1428 stack before #1453 landed the equivalent — and better-integrated — `LineStripPositionMap` machinery on main. Reworked to a minimal delta on top of #1453 rather than carrying a parallel system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyKY5TNYyYYjhzvMkMvgZU
