### PR TITLE
Fix downsampled vector-field writes landing on the wrong grid

### DIFF
--- a/vesuvius/src/vesuvius/structure_tensor/vf_format.py
+++ b/vesuvius/src/vesuvius/structure_tensor/vf_format.py
@@ -2,6 +2,11 @@
 from __future__ import annotations
 import numpy as np
 import zarr
+
+# zarr 3 removed create_dataset/write_empty_chunks and defaults new groups to v3;
+# this writer keeps producing the v2 layout zarr 2 wrote, on either generation.
+_ZARR_V3 = int(zarr.__version__.split(".", 1)[0]) >= 3
+_V2_GROUP_KWARGS = {"zarr_format": 2} if _ZARR_V3 else {}
 from numcodecs import Blosc
 from typing import Optional, Tuple
 
@@ -63,7 +68,7 @@ class OMEU8VectorWriter:
         Xds = (X + self.ds - 1) // self.ds
         self.shape_ds = (Zds, Yds, Xds)
 
-        root = zarr.open_group(output_path, mode="a")
+        root = zarr.open_group(output_path, mode="a", **_V2_GROUP_KWARGS)
         grp = root.require_group(group_name)
         self.ds_z = self._require_scale(grp.require_group("z"), chunks_zyx, compressor)
         self.ds_y = self._require_scale(grp.require_group("y"), chunks_zyx, compressor)
@@ -83,6 +88,17 @@ class OMEU8VectorWriter:
                     f"expected {self.shape_ds}"
                 )
             return ds
+        if _ZARR_V3:
+            # zarr 3 dropped create_dataset/write_empty_chunks; a v2 array keeps the
+            # on-disk layout identical to what zarr 2 writes here.
+            return g.create_array(
+                self.scale_name,
+                shape=self.shape_ds,
+                chunks=chunks,
+                dtype=np.uint8,
+                compressors=compressor,
+                config={"write_empty_chunks": False},
+            )
         return g.create_dataset(
             self.scale_name,
             shape=self.shape_ds,
@@ -93,8 +109,21 @@ class OMEU8VectorWriter:
         )
 
     def _down_bounds(self, z0, z1, y0, y1, x0, x1):
+        """Destination slice for a block, on the *global* downsample grid.
+
+        The kept samples are the multiples of ``ds`` inside ``[a, b)``, and there
+        are ``ceil(b/ds) - ceil(a/ds)`` of them. Flooring instead counted the
+        multiples of ``ds`` in ``[0, b)`` minus those in ``[0, a)`` measured from
+        each block's own origin, which only matches when every block boundary is
+        itself a multiple of ``ds``.
+        """
         s = self.ds
-        return (z0 // s, z1 // s, y0 // s, y1 // s, x0 // s, x1 // s)
+        return tuple(-(-v // s) for v in (z0, z1, y0, y1, x0, x1))
+
+    def _stride_offsets(self, z0, y0, x0):
+        """Offsets into a block that put its first kept sample on the global grid."""
+        s = self.ds
+        return tuple((-(-v // s)) * s - v for v in (z0, y0, x0))
 
     def write_block(
         self,
@@ -108,8 +137,10 @@ class OMEU8VectorWriter:
         Dz, Dy, Dx, _ = directions_block_zyx.shape
         assert Dz == (z1 - z0) and Dy == (y1 - y0) and Dx == (x1 - x0)
 
-        # nearest-neighbour DS for now (consistent with // indexing)
-        dsub = directions_block_zyx[::self.ds, ::self.ds, ::self.ds, :] if self.ds > 1 else directions_block_zyx
+        # nearest-neighbour DS, sampled on the global grid so blocks tile exactly
+        s = self.ds
+        oz, oy, ox = self._stride_offsets(z0, y0, x0)
+        dsub = directions_block_zyx[oz::s, oy::s, ox::s, :] if s > 1 else directions_block_zyx
         z_u8 = encode_dir_to_u8(dsub[..., 0])
         y_u8 = encode_dir_to_u8(dsub[..., 1])
         x_u8 = encode_dir_to_u8(dsub[..., 2])
@@ -122,7 +153,7 @@ class OMEU8VectorWriter:
         if self.ds_conf is not None:
             if confidence_block is None:
                 raise ValueError("make_confidence=True but confidence_block=None")
-            csub = confidence_block[::self.ds, ::self.ds, ::self.ds] if self.ds > 1 else confidence_block
+            csub = confidence_block[oz::s, oy::s, ox::s] if s > 1 else confidence_block
             self.ds_conf[z0d:z1d, y0d:y1d, x0d:x1d] = encode_conf_to_u8(csub)
 
     def close(self):

--- a/vesuvius/tests/structure_tensor/test_vf_writer_downsample.py
+++ b/vesuvius/tests/structure_tensor/test_vf_writer_downsample.py
@@ -1,0 +1,107 @@
+"""Downsampled vector-field writes must tile the global grid.
+
+`write_block` sampled each block from its own origin (`block[::ds]`) but wrote to
+`[z0 // ds : z1 // ds]`, which counts multiples of `ds` from the volume origin.
+The two agree only when every block boundary is a multiple of `ds`, and
+`create_vf` partitions by a chunk size the user picks independently of
+`--downsample`. On a volume whose size is not a multiple of `ds` the final block
+raised `ValueError: could not broadcast input array ...`, and when the lengths
+happened to match the samples were written shifted by up to `ds - 1` voxels.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+zarr = pytest.importorskip("zarr")
+
+from vesuvius.structure_tensor.vf_format import OMEU8VectorWriter, encode_dir_to_u8
+
+
+def _blocks(shape, chunk):
+    """The partition create_vf feeds the writer."""
+    Z, Y, X = shape
+    cz, cy, cx = chunk
+    for z0 in range(0, Z, cz):
+        for y0 in range(0, Y, cy):
+            for x0 in range(0, X, cx):
+                yield z0, min(z0 + cz, Z), y0, min(y0 + cy, Y), x0, min(x0 + cx, X)
+
+
+def _write_ramp(path, shape, chunk, downsample):
+    """Write a field whose z component encodes the global z of each voxel."""
+    writer = OMEU8VectorWriter(
+        output_path=str(path),
+        group_name="vector_field",
+        vol_shape_zyx=shape,
+        chunks_zyx=(min(64, shape[0]), min(64, shape[1]), min(64, shape[2])),
+        downsample=downsample,
+    )
+    for z0, z1, y0, y1, x0, x1 in _blocks(shape, chunk):
+        block = np.zeros((z1 - z0, y1 - y0, x1 - x0, 3), dtype=np.float32)
+        zs = np.arange(z0, z1, dtype=np.float32) / max(shape[0] - 1, 1)  # -> [0, 1]
+        block[..., 0] = zs[:, None, None]
+        writer.write_block(z0=z0, z1=z1, y0=y0, y1=y1, x0=x0, x1=x1,
+                           directions_block_zyx=block)
+    return writer
+
+
+@pytest.mark.parametrize("shape, chunk, downsample", [
+    ((600, 8, 8), (250, 8, 8), 4),     # chunk not a multiple of ds
+    ((1001, 8, 8), (256, 8, 8), 2),    # volume not a multiple of ds
+    ((100, 8, 8), (32, 8, 8), 3),      # neither is
+    ((512, 8, 8), (256, 8, 8), 4),     # both are: was already fine
+])
+def test_every_block_writes(tmp_path, shape, chunk, downsample):
+    _write_ramp(tmp_path / "vf.zarr", shape, chunk, downsample)
+
+
+def test_samples_land_on_their_global_positions(tmp_path):
+    shape, chunk, ds = (600, 8, 8), (250, 8, 8), 4
+    writer = _write_ramp(tmp_path / "vf.zarr", shape, chunk, ds)
+
+    written = np.asarray(writer.ds_z[:, 0, 0])
+    expected = encode_dir_to_u8(
+        np.arange(0, shape[0], ds, dtype=np.float32) / (shape[0] - 1))
+
+    assert written.shape == expected.shape
+    np.testing.assert_array_equal(written, expected)
+
+
+def test_downsampled_array_is_fully_covered(tmp_path):
+    """No row may be left at its fill value once every block has been written."""
+    shape, chunk, ds = (1001, 8, 8), (256, 8, 8), 2
+    writer = _write_ramp(tmp_path / "vf.zarr", shape, chunk, ds)
+
+    written = np.asarray(writer.ds_z[:, 0, 0])
+    assert written.shape[0] == -(-shape[0] // ds)
+    assert written[-1] != 0            # the last row was written, not left empty
+
+
+def test_downsample_one_is_the_identity(tmp_path):
+    shape, chunk = (64, 8, 8), (32, 8, 8)
+    writer = _write_ramp(tmp_path / "vf.zarr", shape, chunk, 1)
+
+    written = np.asarray(writer.ds_z[:, 0, 0])
+    expected = encode_dir_to_u8(np.arange(shape[0], dtype=np.float32) / (shape[0] - 1))
+    np.testing.assert_array_equal(written, expected)
+
+
+def test_confidence_follows_the_same_grid(tmp_path):
+    shape, chunk, ds = (600, 8, 8), (250, 8, 8), 4
+    writer = OMEU8VectorWriter(
+        output_path=str(tmp_path / "vf.zarr"), group_name="vector_field",
+        vol_shape_zyx=shape,
+        chunks_zyx=(64, 8, 8), downsample=ds, make_confidence=True)
+
+    for z0, z1, y0, y1, x0, x1 in _blocks(shape, chunk):
+        d = np.zeros((z1 - z0, y1 - y0, x1 - x0, 3), dtype=np.float32)
+        conf = np.full((z1 - z0, y1 - y0, x1 - x0),
+                       (z0 // 250 + 1) / 4.0, dtype=np.float32)
+        writer.write_block(z0=z0, z1=z1, y0=y0, y1=y1, x0=x0, x1=x1,
+                           directions_block_zyx=d, confidence_block=conf)
+
+    conf_written = np.asarray(writer.ds_conf[:, 0, 0])
+    assert conf_written.shape[0] == -(-shape[0] // ds)
+    assert len(set(conf_written.tolist())) == 3      # one level per source block


### PR DESCRIPTION
`compute_vf --downsample N` (N > 1) either crashes or writes the field on the wrong grid, and on a zarr 3 install the writer cannot be constructed at all.

**Grid alignment.** `write_block` takes its samples from each block's own origin but writes them where the global grid says:

```python
dsub = directions_block_zyx[::self.ds, ::self.ds, ::self.ds, :]
...
z0d, z1d, ... = self._down_bounds(z0, z1, ...)      # (z0 // s, z1 // s, ...)
self.ds_z[z0d:z1d, y0d:y1d, x0d:x1d] = z_u8
```

`create_vf` partitions the volume by a chunk size the user picks independently of `--downsample`, so block boundaries are generally not multiples of `ds`. Simulating the real bound arithmetic:

```
Z=600  chunk=250 ds=4  ->  block [0:250)    src=63  dst=[0:62)      ValueError
                           block [250:500)  src=63  dst=[62:125)    lengths agree, but samples
                                                                    z=250,254,... land at indices
                                                                    meaning z=248,252,... (2-voxel shift)
Z=1001 chunk=256 ds=2  ->  block [768:1001) src=117 dst=[384:500)   ValueError, and row 500 of a
                                                                    501-row array is never written
```

With the shipped default `--chunk-size 256,256,256`, every `ds > 1` fails on the final block of any volume whose size is not a multiple of `ds`. `ds = 1` (the default) is unaffected.

The count of multiples of `s` in `[a, b)` is `ceil(b/s) - ceil(a/s)`, so `_down_bounds` now uses ceiling division and `write_block` offsets each block's stride to the first multiple of `s` at or after its origin. Lengths then match by construction and `ceil(Z/ds)` rows are covered exactly.

**zarr 3.** `_require_scale` calls `g.create_dataset(..., write_empty_chunks=False)`; zarr 3 removed both, so the writer raises `AttributeError` before writing anything, while `pyproject.toml` allows `zarr>=2.18.7,<4`. It now creates a v2 array through `create_array` on zarr 3 — identical layout on disk — and keeps the zarr 2 path unchanged. (Same class as #1431; the wider inventory is #1448.)

Tests cover four partitions (chunk not a multiple of ds, volume not a multiple, neither, both), that samples land on their global positions, that the last row is written, that `ds=1` is the identity, and that confidence follows the same grid. Against current `main` all eight fail — six with the broadcast `ValueError` under zarr 2, all eight with the `AttributeError` under zarr 3. With this change they pass on 2.18.7 and 3.2.1.