### PR TITLE
Fix 2x2 eigenvector branch returning the wrong eigenvector

### DIFF
--- a/vesuvius/src/vesuvius/image_proc/geometry/structure_tensor.py
+++ b/vesuvius/src/vesuvius/image_proc/geometry/structure_tensor.py
@@ -171,12 +171,12 @@ def _eigendecompose_2d_torch(
     # Eigenvectors
     v1x = torch.where(
         torch.abs(Jyx) > torch.abs(lam1 - Jxx),
-        -(lam1 - Jxx),
+        Jyx,
         -Jyx,
     )
     v1y = torch.where(
         torch.abs(Jyx) > torch.abs(lam1 - Jxx),
-        Jyx,
+        lam1 - Jxx,
         Jxx - lam1,
     )
     norm = torch.sqrt(v1x * v1x + v1y * v1y).clamp_min(1e-12)
@@ -215,12 +215,12 @@ def _eigendecompose_2d_numpy(
 
     v1x = np.where(
         np.abs(Jyx) > np.abs(lam1 - Jxx),
-        -(lam1 - Jxx),
+        Jyx,
         -Jyx,
     )
     v1y = np.where(
         np.abs(Jyx) > np.abs(lam1 - Jxx),
-        Jyx,
+        lam1 - Jxx,
         Jxx - lam1,
     )
     norm = np.sqrt(v1x * v1x + v1y * v1y) + 1e-12

--- a/vesuvius/src/vesuvius/models/training/auxiliary_tasks/aux_inplane_direction.py
+++ b/vesuvius/src/vesuvius/models/training/auxiliary_tasks/aux_inplane_direction.py
@@ -70,8 +70,8 @@ def _eigh2x2(a11, a12, a22):
     l2 = tr / 2 + tmp
     # eigenvectors for l1
     # Solve (A - lI)v = 0; pick vector orthogonal to [a12, l1 - a11]
-    v1x = np.where(np.abs(a12) > np.abs(l1 - a11), - (l1 - a11), -a12)
-    v1y = np.where(np.abs(a12) > np.abs(l1 - a11), a12, (a11 - l1))
+    v1x = np.where(np.abs(a12) > np.abs(l1 - a11), a12, -a12)
+    v1y = np.where(np.abs(a12) > np.abs(l1 - a11), l1 - a11, (a11 - l1))
     norm = np.sqrt(v1x * v1x + v1y * v1y) + 1e-12
     v1x /= norm
     v1y /= norm


### PR DESCRIPTION
The 2x2 eigenvector branch returns the vector belonging to the *other* eigenvalue whenever it is taken, so in-plane direction targets come out rotated by 90 degrees on about half of all pixels.

```python
v1x = np.where(np.abs(a12) > np.abs(l1 - a11), - (l1 - a11), -a12)
v1y = np.where(np.abs(a12) > np.abs(l1 - a11),   a12,        (a11 - l1))
```

The `else` outputs `(-a12, a11 - l1)`, a correct eigenvector for `l1`. The `if` outputs `(a11 - l1, a12)` — exactly orthogonal to it, i.e. the eigenvector of `l2`. `v2` is derived from `v1`, so both are swapped. Checking the residual `A v - l1 v` on random symmetric matrices: 271 of 500 wrong on `main`, 0 of 500 with this change. For a gradient at 60 degrees the returned tangent is 60 degrees instead of 150.

Since the condition reduces to `|u_y| > |u_x|` for a rank-1 structure tensor, the flip is pixel-by-pixel rather than global — `InplaneDirectionTrainer` regresses to a target field that is shredded rather than uniformly rotated.

Two lines per site, swapping the branch outputs. The same code is duplicated in `image_proc/geometry/structure_tensor.py` (torch and numpy paths), fixed there too — happy to split that out if you'd rather take them separately.