### PR TITLE
Fix validation IoU/Dice reading ~0 for single-channel heads

### DIFF
--- a/vesuvius/src/vesuvius/models/evaluation/iou_dice.py
+++ b/vesuvius/src/vesuvius/models/evaluation/iou_dice.py
@@ -64,25 +64,37 @@ def compute_iou_dice(pred: torch.Tensor,
         else:
             mask_np = np.asarray(mask)
 
+    def _binarize(scores: np.ndarray) -> np.ndarray:
+        """Single-channel heads emit a score per voxel, not a class id.
+
+        Squeezing one straight into the class comparisons below tests
+        ``score == 1`` on continuous values, which is essentially never true --
+        a perfect prediction then scores 0. Threshold instead: at 0 for logits
+        (the shipped configs use ``activation: "none"``), at 0.5 once an
+        activation has been applied.
+        """
+        cutoff = 0.0 if (scores.min() < 0.0 or scores.max() > 1.0) else 0.5
+        return (scores > cutoff).astype(np.int64)
+
     # Handle different input shapes for predictions
     if pred_np.ndim == 5:  # (batch, channels, depth, height, width)
         if pred_np.shape[1] > 1:  # Multi-channel, need argmax
             pred_np = np.argmax(pred_np, axis=1)
-        else:  # Single channel, just squeeze
-            pred_np = pred_np.squeeze(1)
+        else:  # Single channel: a score volume, threshold it
+            pred_np = _binarize(pred_np.squeeze(1))
     elif pred_np.ndim == 4:  # Could be (batch, depth, height, width) or (batch, channels, height, width)
         # Check if second dimension is channels (usually small) or spatial dimension
         if pred_np.shape[1] <= 10:  # Likely channels dimension
             if pred_np.shape[1] > 1:
                 pred_np = np.argmax(pred_np, axis=1)
             else:
-                pred_np = pred_np.squeeze(1)
+                pred_np = _binarize(pred_np.squeeze(1))
         # Otherwise assume it's already (batch, depth, height, width) or (batch, height, width)
     elif pred_np.ndim == 3 and pred_np.shape[0] <= 10:  # (channels, height, width)
         if pred_np.shape[0] > 1:
             pred_np = np.argmax(pred_np, axis=0)
         else:
-            pred_np = pred_np.squeeze(0)
+            pred_np = _binarize(pred_np.squeeze(0))
     
     # Handle different input shapes for ground truth (and align mask if provided)
     if gt_np.ndim == 3:  # (depth, height, width) or (height, width)


### PR DESCRIPTION
A single-channel head emits a score per voxel. `compute_iou_dice` squeezes that channel away and then runs the class comparisons `pred == c` on it, so it is asking whether a raw logit equals exactly 0 or exactly 1. It essentially never does, and every metric comes out at the smoothing floor.

Same perfect prediction, three ways of handing it over (8³ volume, foreground cube):

```
                        mean_dice   dice_class_1
1 channel, raw logits      0.0000        0.0000     <- what training passes
1 channel, probabilities   0.5000        1.0000     <- background class still wrong
2 channels (argmax)        1.0000        1.0000
```

Raw logits are the shipped path: `ps256_medial.yaml`, `ps192_medial.yaml`, `ps128_dicece.yaml` and friends declare `activation: "none"` and no `out_channels`, and the head width is auto-detected as 1 from the float labels the loader produces, so `vesuvius.train` reports a validation Dice/IoU of ~0 for those configs no matter how well the model does.

The fix thresholds the score volume instead of comparing it to class ids — at 0 for logits, at 0.5 once an activation has been applied. After it, the same three inputs all read 1.0000, and a prediction that finds half the foreground reads `dice_class_1` 0.6667 rather than 0.

`connected_components.py` and `voi.py` squeeze single-channel predictions the same way; I left them out to keep this reviewable, happy to follow up with the same change (`voi.py` additionally picks its binarisation from `pred_vol.max() <= 1`, which flips with the batch).