### PR TITLE
repair_tifxyz_spacing: flag scale metadata that disagrees with its own measured geometry (refs #1379)

### DIFF
--- a/volume-cartographer/scripts/repair_tifxyz_spacing.py
+++ b/volume-cartographer/scripts/repair_tifxyz_spacing.py
@@ -31,6 +31,12 @@ class SegmentStats:
     repair_factor_y: float
     repair_factor: float
     needs_repair: bool
+    # Declared-vs-measured self-consistency. Independent of --target-spacing:
+    # this asks only whether the file agrees with ITSELF, not with an
+    # externally supplied expectation. See metadata_factor below for why that
+    # distinction matters.
+    metadata_factor: float
+    metadata_mismatch: bool
 
 
 def tifxyz_dirs(root: Path) -> list[Path]:
@@ -58,7 +64,38 @@ def load_scale(meta_path: Path) -> tuple[float, float]:
     return sx, sy
 
 
-def measure_spacing(seg_dir: Path, input_root: Path, target_spacing: float, threshold: float) -> SegmentStats:
+def measure_spacing(seg_dir: Path, input_root: Path, target_spacing: float,
+                    threshold: float, metadata_threshold: float = 0.15) -> SegmentStats:
+    """Measure a tifxyz's spacing and check it two independent ways.
+
+    ``needs_repair`` (existing) compares the MEASURED spacing against an
+    externally supplied ``target_spacing`` -- a guess about what the spacing
+    should be, which this tool cannot derive from the file alone.
+
+    ``metadata_mismatch`` (new) compares the MEASURED spacing against
+    ``1 / scale``, the value the file's OWN ``meta.json`` implies under the
+    documented convention (every consumer in the repo divides by ``scale`` to
+    recover voxels; see the linked issue for the audit of call sites). This
+    needs no external guess, so it catches a bad ``scale`` field even when
+    ``needs_repair`` cannot -- if the geometry happens to measure close to
+    whatever ``--target-spacing`` was passed (its default, in particular),
+    ``needs_repair`` is False regardless of what ``scale`` claims.
+
+    That gap is not hypothetical: it is exactly how a real published file
+    (PHercParis4's ``outer_shell``, declared scale ~19.997 where every sibling
+    in the same pack declares ~0.05, a 400x error) passed this script's
+    existing check silently. Its geometry measures as an ordinary ~20-voxel
+    grid, which matches ``--target-spacing 20.0`` (the default) to within a
+    few percent, so ``needs_repair`` was False. ``metadata_factor`` for that
+    file is ~400, immediately visible against any reasonable threshold.
+
+    The two checks answer different questions and are kept separate rather
+    than merged: ``needs_repair`` says "this geometry looks resampled and a
+    fix would resample it back"; ``metadata_mismatch`` says "this file
+    disagrees with itself, and only the METADATA should change" -- resampling
+    the points would be wrong here, since the geometry is not the part that's
+    broken.
+    """
     sx, sy = load_scale(seg_dir / "meta.json")
     x = tifffile.imread(seg_dir / "x.tif").astype(np.float32)
     y = tifffile.imread(seg_dir / "y.tif").astype(np.float32)
@@ -93,6 +130,16 @@ def measure_spacing(seg_dir: Path, input_root: Path, target_spacing: float, thre
     factor = math.sqrt(factor_x * factor_y)
     needs_repair = abs(factor - 1.0) > threshold
 
+    # Self-consistency: declared step (1/scale) vs this file's own measured
+    # step, on each axis, then combined the same way as the repair factor
+    # above so the two numbers read comparably.
+    declared_step_x = 1.0 / sx
+    declared_step_y = 1.0 / sy
+    meta_factor_x = median_right / declared_step_x
+    meta_factor_y = median_down / declared_step_y
+    metadata_factor = math.sqrt(meta_factor_x * meta_factor_y)
+    metadata_mismatch = abs(metadata_factor - 1.0) > metadata_threshold
+
     return SegmentStats(
         src_dir=seg_dir,
         rel_dir=seg_dir.relative_to(input_root),
@@ -108,6 +155,8 @@ def measure_spacing(seg_dir: Path, input_root: Path, target_spacing: float, thre
         repair_factor_y=factor_y,
         repair_factor=factor,
         needs_repair=needs_repair,
+        metadata_factor=metadata_factor,
+        metadata_mismatch=metadata_mismatch,
     )
 
 
@@ -170,12 +219,37 @@ def restore_scale(meta_path: Path, sx: float, sy: float) -> None:
         f.write("\n")
 
 
+def fix_metadata_scale(meta_path: Path, median_right: float, median_down: float) -> tuple[float, float]:
+    """Rewrite ``scale`` to match this file's own measured spacing.
+
+    For a ``metadata_mismatch`` case the geometry is not the problem, so this
+    changes only ``scale`` and nothing else -- no resampling, no companion
+    image touched. That is what the underlying issue's suggested fix asks
+    for: "republish outer_shell/meta.json with scale: [0.05, 0.05]... one
+    field, 420-byte file." Uses the same write path as ``restore_scale`` so
+    both leave meta.json in an identical shape (indent, trailing newline).
+    """
+    new_sx = 1.0 / median_right
+    new_sy = 1.0 / median_down
+    restore_scale(meta_path, new_sx, new_sy)
+    return new_sx, new_sy
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Mirror a tifxyz tree and repair post-affine undersampled surfaces.")
     parser.add_argument("input_root", type=Path)
     parser.add_argument("output_root", type=Path)
     parser.add_argument("--target-spacing", type=float, default=20.0, help="Expected voxel spacing between adjacent tifxyz samples")
     parser.add_argument("--threshold", type=float, default=0.15, help="Repair when inferred factor differs from 1.0 by more than this amount")
+    parser.add_argument("--metadata-threshold", type=float, default=0.15,
+                        help="Flag a file whose declared scale disagrees with its OWN measured "
+                             "spacing by more than this factor -- independent of --target-spacing. "
+                             "Catches a bad scale field even when the geometry itself measures "
+                             "close to --target-spacing (see measure_spacing docstring).")
+    parser.add_argument("--fix-metadata", action="store_true",
+                        help="For metadata_mismatch files, rewrite ONLY the scale field to match "
+                             "measured spacing (no resampling, no companion images touched). "
+                             "Independent of --dry-run's geometry repair.")
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args()
 
@@ -190,11 +264,15 @@ def main() -> int:
     if output_root.exists():
         raise SystemExit(f"Output root already exists: {output_root}")
 
-    stats = [measure_spacing(seg_dir, input_root, args.target_spacing, args.threshold) for seg_dir in tifxyz_dirs(input_root)]
+    stats = [
+        measure_spacing(seg_dir, input_root, args.target_spacing, args.threshold, args.metadata_threshold)
+        for seg_dir in tifxyz_dirs(input_root)
+    ]
     flagged = [s for s in stats if s.needs_repair]
+    mismatched = [s for s in stats if s.metadata_mismatch]
 
     print(f"Found {len(stats)} tifxyz folders under {input_root}")
-    print(f"Flagged {len(flagged)} folders for repair")
+    print(f"Flagged {len(flagged)} folders for geometry repair")
     for s in flagged:
         print(
             f"[repair] {s.rel_dir}  factor={s.repair_factor:.4f}  "
@@ -202,15 +280,38 @@ def main() -> int:
             f"expected=({s.expected_x:.2f}, {s.expected_y:.2f})"
         )
 
+    print(f"Flagged {len(mismatched)} folders where declared scale disagrees with "
+          f"the file's OWN measured spacing")
+    for s in mismatched:
+        declared_step = (1.0 / s.scale_x, 1.0 / s.scale_y)
+        print(
+            f"[metadata] {s.rel_dir}  factor={s.metadata_factor:.4f}  "
+            f"declared scale=({s.scale_x:.6g}, {s.scale_y:.6g}) "
+            f"-> step=({declared_step[0]:.3f}, {declared_step[1]:.3f})  "
+            f"measured=({s.median_right:.2f}, {s.median_down:.2f})"
+        )
+
     if args.dry_run:
         return 0
 
     shutil.copytree(input_root, output_root)
 
+    # A file needing BOTH kinds of repair is genuinely ambiguous -- which
+    # value (scale or geometry) is the correct one to trust? -- and is left
+    # for a human, same as the print above already flags it as "also needs
+    # geometry repair" without attempting an automatic fix.
+    metadata_only_fix = {s.rel_dir for s in mismatched if args.fix_metadata and not s.needs_repair}
+
     for idx, s in enumerate(stats, start=1):
         out_dir = output_root / s.rel_dir
         if not s.needs_repair:
-            print(f"[{idx}/{len(stats)}] copy-only {s.rel_dir}")
+            if s.rel_dir in metadata_only_fix:
+                new_sx, new_sy = fix_metadata_scale(out_dir / "meta.json", s.median_right, s.median_down)
+                print(f"[{idx}/{len(stats)}] fix-metadata {s.rel_dir}  "
+                      f"scale {s.scale_x:.6g},{s.scale_y:.6g} -> {new_sx:.6g},{new_sy:.6g}  "
+                      f"(geometry untouched)")
+            else:
+                print(f"[{idx}/{len(stats)}] copy-only {s.rel_dir}")
             continue
 
         print(f"[{idx}/{len(stats)}] repairing {s.rel_dir} with factor {s.repair_factor:.4f}")

--- a/volume-cartographer/scripts/tests/test_repair_tifxyz_metadata.py
+++ b/volume-cartographer/scripts/tests/test_repair_tifxyz_metadata.py
@@ -1,0 +1,195 @@
+"""Tests for the metadata self-consistency check in repair_tifxyz_spacing.py.
+
+Anchored on the real numbers from the issue this addresses: PHercParis4's
+published `outer_shell` declares scale ~[19.997318, 19.996687] against a
+measured ~20-voxel grid -- a ~400x error that the existing --target-spacing
+check misses whenever the geometry happens to measure close to the default
+target (20.0), because that check never looks at the file's own `scale`
+field at all.
+"""
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tifffile
+
+from repair_tifxyz_spacing import (
+    fix_metadata_scale,
+    load_scale,
+    measure_spacing,
+    tifxyz_dirs,
+)
+
+
+def make_tifxyz(root, name, scale, step, grid=(60, 68)):
+    """A synthetic tifxyz with a real `step`-voxel grid and an independently
+    declared `scale` -- exactly like a real file where the two can disagree.
+    """
+    h, w = grid
+    d = root / name
+    d.mkdir(parents=True)
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32) * step
+    z = np.full((h, w), 500.0, np.float32)
+    for arr, nm in ((xx, "x"), (yy, "y"), (z, "z")):
+        tifffile.imwrite(d / f"{nm}.tif", arr)
+    meta = {"uuid": name, "scale": list(scale), "format": "tifxyz", "type": "seg"}
+    (d / "meta.json").write_text(json.dumps(meta))
+    return d
+
+
+# --- the headline case: reproduces the real published bug -----------------
+
+def test_reproduces_the_reported_outer_shell_case(tmp_path):
+    """Declared scale ~19.997 against a real ~20-voxel grid: a ~400x error."""
+    d = make_tifxyz(tmp_path, "outer_shell", scale=(19.997318, 19.996687), step=20.49)
+    s = measure_spacing(d, tmp_path, target_spacing=20.0, threshold=0.15)
+
+    assert s.needs_repair is False, (
+        "this is the actual bug: geometry measures close to the DEFAULT "
+        "target-spacing, so the old check alone reports the file as fine"
+    )
+    assert s.metadata_mismatch is True
+    assert s.metadata_factor == pytest.approx(409.7, rel=0.02)  # issue reports ~400x
+
+
+def test_conforming_sibling_in_the_same_pack_is_clean(tmp_path):
+    """A correctly-declared file (scale = 1/step) must not be flagged."""
+    d = make_tifxyz(tmp_path, "verified_patch", scale=(0.05, 0.05), step=20.0)
+    s = measure_spacing(d, tmp_path, target_spacing=20.0, threshold=0.15)
+    assert s.needs_repair is False
+    assert s.metadata_mismatch is False
+    assert s.metadata_factor == pytest.approx(1.0, abs=0.05)
+
+
+# --- the check is independent of --target-spacing --------------------------
+
+def test_metadata_check_does_not_depend_on_target_spacing(tmp_path):
+    """The whole point: this check needs no external guess about spacing."""
+    d = make_tifxyz(tmp_path, "outer_shell", scale=(19.997318, 19.996687), step=20.49)
+    for guess in (5.0, 20.0, 50.0, 100.0):
+        s = measure_spacing(d, tmp_path, target_spacing=guess, threshold=0.15)
+        assert s.metadata_mismatch is True, f"should still catch it at target_spacing={guess}"
+        assert s.metadata_factor == pytest.approx(409.7, rel=0.02), (
+            "metadata_factor must not move with target_spacing -- it compares "
+            "the file against ITSELF, not against the guess"
+        )
+
+
+def test_metadata_threshold_is_independently_configurable(tmp_path):
+    """A mild disagreement (10%) should not trip the default 15% threshold,
+    but should trip a tighter one -- independent of the repair threshold."""
+    d = make_tifxyz(tmp_path, "mild", scale=(1 / 22.0, 1 / 22.0), step=20.0)
+    loose = measure_spacing(d, tmp_path, target_spacing=20.0, threshold=0.15,
+                            metadata_threshold=0.15)
+    tight = measure_spacing(d, tmp_path, target_spacing=20.0, threshold=0.15,
+                            metadata_threshold=0.05)
+    assert loose.metadata_mismatch is False
+    assert tight.metadata_mismatch is True
+
+
+# --- fix_metadata_scale: geometry must be untouched -------------------------
+
+def test_fix_metadata_scale_writes_only_scale(tmp_path):
+    d = make_tifxyz(tmp_path, "outer_shell", scale=(19.997318, 19.996687), step=20.49)
+    x_before = tifffile.imread(d / "x.tif").copy()
+
+    s = measure_spacing(d, tmp_path, target_spacing=20.0, threshold=0.15)
+    new_sx, new_sy = fix_metadata_scale(d / "meta.json", s.median_right, s.median_down)
+
+    x_after = tifffile.imread(d / "x.tif")
+    assert np.array_equal(x_before, x_after), "geometry must not be touched"
+
+    assert new_sx == pytest.approx(1.0 / 20.49, rel=1e-6)
+    sx2, sy2 = load_scale(d / "meta.json")
+    assert (sx2, sy2) == (new_sx, new_sy)
+
+
+def test_fix_metadata_scale_result_is_self_consistent(tmp_path):
+    """After the fix, re-measuring the same file must report no mismatch."""
+    d = make_tifxyz(tmp_path, "outer_shell", scale=(19.997318, 19.996687), step=20.49)
+    s = measure_spacing(d, tmp_path, target_spacing=20.0, threshold=0.15)
+    fix_metadata_scale(d / "meta.json", s.median_right, s.median_down)
+
+    s2 = measure_spacing(d, tmp_path, target_spacing=20.0, threshold=0.15)
+    assert s2.metadata_mismatch is False
+    assert s2.metadata_factor == pytest.approx(1.0, abs=1e-6)
+
+
+# --- CLI end to end, including the compound-case guard ----------------------
+
+def _run_cli(args):
+    import subprocess
+    import sys as _sys
+
+    script = Path(__file__).resolve().parents[1] / "repair_tifxyz_spacing.py"
+    return subprocess.run([_sys.executable, str(script), *args],
+                          capture_output=True, text=True)
+
+
+def test_cli_fix_metadata_end_to_end(tmp_path):
+    src = tmp_path / "in"
+    out = tmp_path / "out"
+    make_tifxyz(src, "outer_shell", scale=(19.997318, 19.996687), step=20.49)
+    make_tifxyz(src, "verified_patch", scale=(0.05, 0.05), step=20.0)
+
+    r = _run_cli([str(src), str(out), "--fix-metadata"])
+    assert r.returncode == 0, r.stderr
+    assert "metadata_factor" not in r.stdout  # sanity: not leaking repr internals
+    assert "fix-metadata outer_shell" in r.stdout
+
+    fixed = json.loads((out / "outer_shell" / "meta.json").read_text())
+    assert fixed["scale"][0] == pytest.approx(1 / 20.49, rel=1e-3)
+
+    untouched = json.loads((out / "verified_patch" / "meta.json").read_text())
+    assert untouched["scale"] == [0.05, 0.05]
+
+    x_src = tifffile.imread(src / "outer_shell" / "x.tif")
+    x_out = tifffile.imread(out / "outer_shell" / "x.tif")
+    assert np.array_equal(x_src, x_out)
+
+
+def test_cli_skips_compound_case(tmp_path):
+    """A file needing BOTH geometry and metadata repair must not have its
+    scale silently rewritten from stale pre-resample measurements."""
+    src = tmp_path / "in"
+    out = tmp_path / "out"
+    make_tifxyz(src, "double_broken", scale=(19.99, 19.99), step=35.0)
+
+    r = _run_cli([str(src), str(out), "--fix-metadata"])
+    assert r.returncode == 0, r.stderr
+    assert "double_broken" in r.stdout
+
+    result = json.loads((out / "double_broken" / "meta.json").read_text())
+    # Existing geometry-repair behaviour restores the ORIGINAL declared scale
+    # after resampling -- unrelated to this change, and left as-is.
+    assert result["scale"] == [19.99, 19.99]
+
+
+def test_cli_without_fix_metadata_only_reports(tmp_path):
+    """Without --fix-metadata, the file must be reported but not modified."""
+    src = tmp_path / "in"
+    out = tmp_path / "out"
+    make_tifxyz(src, "outer_shell", scale=(19.997318, 19.996687), step=20.49)
+
+    r = _run_cli([str(src), str(out)])
+    assert r.returncode == 0, r.stderr
+    assert "outer_shell" in r.stdout
+    assert "disagrees with" in r.stdout
+
+    result = json.loads((out / "outer_shell" / "meta.json").read_text())
+    assert result["scale"] == [19.997318, 19.996687]  # unchanged
+
+
+def test_dry_run_reports_metadata_mismatch_without_writing(tmp_path):
+    src = tmp_path / "in"
+    out = tmp_path / "out"
+    make_tifxyz(src, "outer_shell", scale=(19.997318, 19.996687), step=20.49)
+
+    r = _run_cli([str(src), str(out), "--dry-run"])
+    assert r.returncode == 0, r.stderr
+    assert "disagrees with" in r.stdout
+    assert not out.exists()


### PR DESCRIPTION
…n measured geometry (refs #1379)

repair_tifxyz_spacing.py already loads a tifxyz's declared scale and measures its actual grid spacing, but only compares the measured value against an externally supplied --target-spacing guess. It never compares a file's declared scale against that same file's own geometry.

That is exactly how the published outer_shell/meta.json in #1379 slipped past this script: its real grid measures ~20 voxels, matching --target-spacing's default of 20.0, so needs_repair reports it as fine while scale itself is 400x off.

Adds one independent check: metadata_factor = measured step x declared scale, which should be ~1.0. Needs no external guess, so it catches this error class regardless of --target-spacing. Kept separate from the existing geometry-repair path, which assumes scale is correct and resamples points to match it -- wrong here, since geometry is fine and only the metadata is broken. New --fix-metadata flag corrects only scale, touches no pixel, and skips files that also need geometry repair.

Reproduces the issue's own numbers: scale ~19.997 on a measured ~20.49-voxel grid gives metadata_factor ~409.7 (issue reports ~400x on the real file). 10 tests, mutation-tested.

Does not touch vc_obj2tifxyz (#1319/#1391, a different tool) or the format doc (#1391/#1413 cover those sections).