### PR TITLE
Apply the #1455 threshold fix to the remaining metrics

### DIFF
--- a/vesuvius/src/vesuvius/models/evaluation/base_metric.py
+++ b/vesuvius/src/vesuvius/models/evaluation/base_metric.py
@@ -36,3 +36,17 @@ class BaseMetric(ABC):
     
     def reset(self):
         self.results = []
+
+
+def binarize_scores(scores):
+    """Turn a single-channel score volume into class ids.
+
+    Single-channel heads emit a score per voxel rather than a class id, so
+    comparing one to the class ids 0/1 is essentially never true. Threshold
+    instead: at 0 for logits (the shipped configs use ``activation: "none"``),
+    at 0.5 once an activation has been applied.
+    """
+    import numpy as np
+
+    cutoff = 0.0 if (scores.min() < 0.0 or scores.max() > 1.0) else 0.5
+    return (scores > cutoff).astype(np.int64)

--- a/vesuvius/src/vesuvius/models/evaluation/connected_components.py
+++ b/vesuvius/src/vesuvius/models/evaluation/connected_components.py
@@ -2,7 +2,7 @@ import numpy as np
 import cc3d
 import torch
 from typing import Dict, Optional
-from .base_metric import BaseMetric
+from .base_metric import BaseMetric, binarize_scores
 
 
 class ConnectedComponentsMetric(BaseMetric):
@@ -68,15 +68,15 @@ def get_connected_components_difference(
     if pred_np.ndim == 5:  # (batch, channels, depth, height, width)
         if pred_np.shape[1] > 1:  # Multi-channel, need argmax
             pred_np = np.argmax(pred_np, axis=1)
-        else:  # Single channel, just squeeze
-            pred_np = pred_np.squeeze(1)
+        else:  # Single channel: a score volume, threshold it
+            pred_np = binarize_scores(pred_np.squeeze(1))
     elif pred_np.ndim == 4:  # Could be (batch, depth, height, width) or (batch, channels, height, width)
         # Check if second dimension is channels (usually small) or spatial dimension
         if pred_np.shape[1] <= 10:  # Likely channels dimension
             if pred_np.shape[1] > 1:
                 pred_np = np.argmax(pred_np, axis=1)
             else:
-                pred_np = pred_np.squeeze(1)
+                pred_np = binarize_scores(pred_np.squeeze(1))
         # Otherwise assume it's already (batch, depth, height, width)
     
     # Handle different input shapes for ground truth (and align mask)

--- a/vesuvius/src/vesuvius/models/evaluation/voi.py
+++ b/vesuvius/src/vesuvius/models/evaluation/voi.py
@@ -4,7 +4,7 @@ import torch
 from typing import Dict, Optional, Tuple
 from skimage.metrics import variation_of_information
 
-from .base_metric import BaseMetric
+from .base_metric import BaseMetric, binarize_scores
 
 
 class VOIMetric(BaseMetric):
@@ -232,7 +232,10 @@ def compute_voi(
 
         # Create binary masks (foreground = class 1 for binary, or nonzero for multi-class)
         # Apply valid mask by setting invalid regions to 0
-        pred_bin = ((pred_vol == 1) & valid) if pred_vol.max() <= 1 else ((pred_vol > 0) & valid)
+        # A single-channel head emits scores; picking the comparison from the
+        # data ("== 1" when nothing exceeds 1) makes probability outputs select
+        # no voxels at all, and flips with the batch. Threshold explicitly.
+        pred_bin = (binarize_scores(pred_vol) > 0) & valid
         gt_bin = ((gt_vol == 1) & valid) if gt_vol.max() <= 1 else ((gt_vol > 0) & valid)
 
         result = _compute_voi_3d(


### PR DESCRIPTION
Follow-up to #1455, which fixed this in `iou_dice.py`: the other two metrics squeeze single-channel predictions the same way, so they are equally blind on the shipped config path.

**`connected_components.py`** (lines 72, 79, 86). Comparing a score volume to class ids never matches, so `num_cc_pred` is always 0 and the reported difference is just the ground-truth component count — the same number whatever the model predicts:

```
                          total
perfect prediction         3.0
all-background (worst)     3.0     <- identical
after this change:
perfect (logits)           0.0
perfect (probabilities)    0.0
all-background (worst)     2.0
```

**`voi.py`** (line 235) picks its binarisation from the data:

```python
pred_bin = ((pred_vol == 1) & valid) if pred_vol.max() <= 1 else ((pred_vol > 0) & valid)
```

For a head with an activation the scores are in [0, 1], so the `== 1` branch is taken and selects **no voxels at all** — checked on an 8³ example, a perfect sigmoid prediction contributes 0 of 64 foreground voxels. Raw logits happen to take the other branch and work by accident, and a batch whose logits all fall inside [0, 1] would silently switch behaviour.

The thresholding rule from #1455 now lives in `base_metric.py` as `binarize_scores` and both call sites use it; `iou_dice.py` keeps its own copy, happy to switch it over in the same PR if you'd rather have one definition.

(One thing I did **not** include: `_bbox3d` asserts `ndim == 3` and `VOIMetric` is attached to every target, which looks like it would break a 2D `patch_size`, but I could not reproduce a crash from the metric entry point, so I left it alone.)