### PR TITLE
Preserve tifxyz provenance metadata through flatten and trim (fixes #1321)

### DIFF
--- a/volume-cartographer/apps/src/vc_tifxyz_trim.cpp
+++ b/volume-cartographer/apps/src/vc_tifxyz_trim.cpp
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <string>
 #include "vc/core/util/MemMap.hpp"
 #include <vector>
@@ -170,7 +171,51 @@ int main(int argc, char* argv[])
     }
 
     Json meta = Json::parse_file(src / "meta.json");
-    if (meta.contains("bbox")) meta.erase("bbox");
+    // Recompute bbox from the TRIMMED points rather than dropping it. The old
+    // grid's bbox is wrong for the new extent, but a MISSING bbox is worse
+    // than a stale one: nothing downstream expects the field to be absent
+    // (QuadSurface::save() always writes one -- see core/src/QuadSurface.cpp,
+    // where bbox is recomputed from the saved points immediately before
+    // meta.json is written), so this keeps that convention instead of
+    // introducing a segment that violates it. `trimmed` (the already-cropped
+    // points, above) is exactly what QuadSurface::save() would see if this
+    // trimmed grid were loaded and re-saved, so bbox is computed the same
+    // way: min/max XYZ over valid points, skipping the -1,-1,-1 sentinel.
+    {
+        cv::Vec3f lo(std::numeric_limits<float>::max(),
+                    std::numeric_limits<float>::max(),
+                    std::numeric_limits<float>::max());
+        cv::Vec3f hi(-std::numeric_limits<float>::max(),
+                    -std::numeric_limits<float>::max(),
+                    -std::numeric_limits<float>::max());
+        bool any = false;
+        for (int r = 0; r < trimmed.rows; ++r) {
+            const cv::Vec3f* row = trimmed[r];
+            for (int c = 0; c < trimmed.cols; ++c) {
+                if (row[c][0] == -1.f) continue;
+                any = true;
+                for (int k = 0; k < 3; ++k) {
+                    lo[k] = std::min(lo[k], row[c][k]);
+                    hi[k] = std::max(hi[k], row[c][k]);
+                }
+            }
+        }
+        Json bbox = Json::array();
+        if (any) {
+            Json loJ = Json::array(); loJ.push_back(lo[0]); loJ.push_back(lo[1]); loJ.push_back(lo[2]);
+            Json hiJ = Json::array(); hiJ.push_back(hi[0]); hiJ.push_back(hi[1]); hiJ.push_back(hi[2]);
+            bbox.push_back(std::move(loJ));
+            bbox.push_back(std::move(hiJ));
+        } else {
+            // Unreachable in practice: r1/c1 < 0 above already exits when
+            // there are no valid cells at all, so `trimmed` always has at
+            // least one. Kept as a defensive fallback rather than assuming.
+            Json sentinel = Json::array(); sentinel.push_back(-1); sentinel.push_back(-1); sentinel.push_back(-1);
+            bbox.push_back(sentinel);
+            bbox.push_back(sentinel);
+        }
+        meta["bbox"] = std::move(bbox);
+    }
     {
         std::ofstream out(stage / "meta.json");
         out << meta.dump(4) << std::endl;

--- a/volume-cartographer/core/src/ABFFlattening.cpp
+++ b/volume-cartographer/core/src/ABFFlattening.cpp
@@ -2405,6 +2405,18 @@ QuadSurface* abfFlattenToNewSurface(const QuadSurface& surface, const ABFConfig&
 
     QuadSurface* result = new QuadSurface(outPoints, outScale);
 
+    // Preserve provenance metadata from the input. This constructor only
+    // sets points/scale -- meta (Surface's public utils::Json member) is left
+    // at its default, and save() only ever SETS bbox/type/uuid/format/scale
+    // on whatever meta already is rather than rebuilding it from scratch. So
+    // without this copy, every other key on the source's meta.json (anything
+    // beyond those five computed fields -- provenance, custom pipeline keys,
+    // whatever the source segment carried) is silently absent from the
+    // flattened output's meta.json. save()'s five computed keys correctly
+    // overwrite the corresponding ones copied here, since they describe the
+    // NEW (flattened) surface, not the source.
+    result->meta = surface.meta;
+
     // Step 7: Optionally rotate to place highest Z values at top (row 0)
     if (config.rotateHighZToTop) {
         result->orientZUp();


### PR DESCRIPTION
Ran into #1321 while looking through recent issues and ended up building
and verifying a fix for both halves. Apologies if you'd already started
on this yourself — happy to adjust, split, or step back if you'd rather
take a different approach.