### PR TITLE
structure_tensor: confidence channel invariant to --swap-eigenvectors

### DIFF
--- a/vesuvius/src/vesuvius/structure_tensor/create_st.py
+++ b/vesuvius/src/vesuvius/structure_tensor/create_st.py
@@ -781,7 +781,20 @@ def _finalize_structure_tensor_torch(
             nx[oz0:oz1, oy0:oy1, ox0:ox1] = _quantize_dir_u8(v_np[2, 2, slz, sly, slx])
 
             # Confidence (default: Fractional Anisotropy)
-            l1, l2, l3 = w_np[0], w_np[1], w_np[2]
+            # Sort ascending here rather than trusting eigvals_block's slot
+            # order directly. torch.linalg.eigh guarantees ascending order,
+            # but swap_eigenvectors (above) exchanges slots 0 and 1 -- on
+            # purpose, to relabel which spatial direction is "first" vs
+            # "second" in the vector outputs -- and that swap also moves the
+            # eigenVALUES sitting in those slots. linearity/planarity/max_lp
+            # assume l1<=l2<=l3 (smallest to largest); reading w_np[0..2]
+            # directly after a swap breaks that assumption and silently
+            # corrupts the confidence channel (verified: on eigenvalues
+            # [2,4,6], swap_eigenvectors=True changes linearity 0.333->0.667
+            # and planarity 0.333->-0.333, while fa is unaffected since it
+            # is symmetric in the three eigenvalues -- the invariant this
+            # sorting step now makes true of every choice, not just fa).
+            l1, l2, l3 = np.sort(w_np, axis=0)
             eps = 1e-12
             if confidence_metric == "linearity":
                 conf = (l3 - l2) / (np.abs(l3) + eps)

--- a/vesuvius/tests/structure_tensor/test_structure_tensor.py
+++ b/vesuvius/tests/structure_tensor/test_structure_tensor.py
@@ -343,6 +343,74 @@ def test_eigh_and_sanitize_handles_nans_infs():
     assert (~torch.isnan(w)).all() and (~torch.isnan(v)).all()
     assert (~torch.isinf(w)).all() and (~torch.isinf(v)).all()
 
+
+@pytest.mark.parametrize("metric", ["linearity", "planarity", "max_lp"])
+def test_confidence_invariant_to_swap_eigenvectors(tmp_path, metric):
+    """swap_eigenvectors relabels which spatial direction is "first" vs
+    "second" -- it must not change the scalar confidence/anisotropy channel,
+    which describes the SHAPE of the eigenvalue spectrum, not which vector
+    is called what.
+
+    Reproduces a real bug: the confidence block read w_np[0], w_np[1],
+    w_np[2] directly, assuming ascending order (which torch.linalg.eigh
+    guarantees). swap_eigenvectors exchanges slots 0 and 1 -- correctly, for
+    the vector outputs -- but that same swapped array fed the confidence
+    formulas too, breaking the ascending assumption those formulas depend
+    on. Concretely, on eigenvalues [1, 2, 3] this changed "linearity" from
+    0.333 to 0.667 and "planarity" from 0.333 to -0.333 (silently floored to
+    0 by the uint8 quantizer, since confidence is clipped to [0, 1] before
+    quantizing -- the negative number itself never survives to disk, only
+    its effect on the byte does). "fa" (fractional anisotropy, the default
+    metric) is untouched by this bug, since it happens to be symmetric in
+    the three eigenvalues -- which is exactly why testing only the default
+    metric would not have caught it.
+
+    Placed here (not near the existing swap test further down) because a
+    second stray `\'\'\'` later in this file currently disables everything
+    from test_eigenanalysis_chunk_defaults_and_shapes through
+    test_swap_eigenvectors_flag -- separate, pre-existing issue, out of
+    scope here. This test is independent of that and needs to run on
+    current main regardless of when that gets fixed.
+    """
+    Z, Y, X = 2, 2, 2
+    st = np.zeros((6, Z, Y, X), dtype=np.float32)
+    # diag(J) = [Jzz, Jyy, Jxx] = [3, 2, 1] -> eigenvalues [1, 2, 3] (diagonal
+    # matrix, so eigenvalues are just the diagonal entries, trivially sorted).
+    st[0] = 3.0; st[3] = 2.0; st[5] = 1.0
+    zarr_path = os.path.join(tmp_path, "st_conf.zarr")
+    root = zarr.open_group(zarr_path, mode="w")
+    root.create_dataset("structure_tensor", data=st, chunks=(1, Z, Y, X), dtype="f4")
+
+    _finalize_structure_tensor_torch(
+        zarr_path=zarr_path,
+        chunk_size=(Z, Y, X),
+        num_workers=0,
+        compressor=None,
+        verbose=False,
+        swap_eigenvectors=False,
+        ome_out=True,
+        confidence_metric=metric,
+    )
+    conf_no = zarr.open_group(zarr_path, mode="r")["confidence"]["0"][...]
+
+    _finalize_structure_tensor_torch(
+        zarr_path=zarr_path,
+        chunk_size=(Z, Y, X),
+        num_workers=0,
+        compressor=None,
+        verbose=False,
+        swap_eigenvectors=True,
+        ome_out=True,
+        confidence_metric=metric,
+    )
+    conf_sw = zarr.open_group(zarr_path, mode="r")["confidence"]["0"][...]
+
+    assert np.array_equal(conf_no, conf_sw), (
+        f"{metric}: confidence channel changed under swap_eigenvectors "
+        f"(no-swap={conf_no.flatten()}, swap={conf_sw.flatten()}) -- "
+        f"confidence must not depend on which vector is labeled first/second"
+    )
+
 '''
 def test_eigenanalysis_chunk_defaults_and_shapes(tmp_path):
     """


### PR DESCRIPTION
torch.linalg.eigh guarantees ascending eigenvalues. --swap-eigenvectors exchanges eigenpair slots 0 and 1 -- correct for relabeling which spatial direction is 'first' vs 'second' in the vector outputs -- but the confidence formulas (linearity/planarity/max_lp) read the same swapped array directly as l1,l2,l3 = w_np[0],w_np[1],w_np[2], assuming ascending order. The swap breaks that assumption for those three metrics.

Verified on eigenvalues [1,2,3]: linearity 0.333->0.667, planarity 0.333->-0.333, max_lp 0.333->0.667. fa (the default metric) is unaffected since it's symmetric in the three eigenvalues -- exactly why the existing swap test, which only checks the raw eigenvalues array, never caught this.

The negative planarity value doesn't survive to disk as a visible negative number: _quantize_unit_u8 clips to [0,1] before casting to uint8, so it silently floors to 0 -- reads as 'no planar structure here' rather than an obviously wrong value.

Fix: sort the eigenvalues immediately before the confidence computation, decoupled from whatever the swap did to slot ordering for the vector outputs.

3 new parametrized tests assert the confidence channel is byte-identical with and without swap_eigenvectors. Mutation-tested: reverting the fix makes all three fail. All 17 tests in the file pass. Verified against zarr 2.18.7, matching what this file currently requires; test placed in a live position since two pre-existing stray triple-quotes elsewhere in this file currently disable several other tests (out of scope here, matches #1394's stated scope).