### PR TITLE
prediction_grid: guarantee fair model comparison across coverage gaps

### DIFF
--- a/vesuvius/src/vesuvius/image_proc/run/prediction_grid.py
+++ b/vesuvius/src/vesuvius/image_proc/run/prediction_grid.py
@@ -760,6 +760,22 @@ def _collect_aggregated_model_stats(eval_root: Path, images_dir: Path,
 
     Returns (models_stats_list, num_images_considered), where models_stats_list is a list of (model_name, stats_means).
     The stats_means dict contains means of the five keys used in ranking when available.
+
+    Each model's mean for a given metric is computed over the SAME set of
+    images as every other model being compared, per metric -- not over
+    however many images that individual model happens to have a stats.json
+    for. Comparing means computed over different, non-identical image
+    subsets is an apples-to-oranges comparison: a model evaluated only on
+    an easier partial subset (e.g. from a crashed or partial eval run, or
+    simply evaluated before later, harder images were added to the test
+    set -- both realistic, common situations, not contrived edge cases)
+    would otherwise show artificially better numbers than a model honestly
+    evaluated on the full, harder set, with nothing in the tool's output to
+    reveal that the comparison wasn't fair. Verified: constructing exactly
+    this scenario (one model evaluated on only the easier half of a test
+    set, one evaluated on all of it including harder images it still
+    handled reasonably) had the partially-evaluated model chosen as "best"
+    under the previous per-model-coverage aggregation.
     """
     # Determine models
     model_dirs = [d for d in sorted(eval_root.iterdir()) if d.is_dir()]
@@ -781,14 +797,9 @@ def _collect_aggregated_model_stats(eval_root: Path, images_dir: Path,
     ]
     all_keys = keys_min + keys_max
 
-    # Accumulators per model
-    sums: Dict[str, Dict[str, float]] = {}
-    counts: Dict[str, Dict[str, int]] = {}
-
-    for md in model_dirs:
-        sums[md.name] = {k: 0.0 for k in all_keys}
-        counts[md.name] = {k: 0 for k in all_keys}
-
+    # First pass: load each model's raw per-image values without aggregating,
+    # so the common (fair) image set can be determined before any averaging.
+    raw: Dict[str, Dict[str, Dict[str, float]]] = {md.name: {} for md in model_dirs}
     for stem in stems:
         for md in model_dirs:
             stats_path = md / stem / "stats.json"
@@ -802,7 +813,7 @@ def _collect_aggregated_model_stats(eval_root: Path, images_dir: Path,
                     continue
             except Exception:
                 continue
-            # Accumulate available numeric values
+            entry: Dict[str, float] = {}
             for k in all_keys:
                 v = data.get(k, None)
                 try:
@@ -811,24 +822,47 @@ def _collect_aggregated_model_stats(eval_root: Path, images_dir: Path,
                     continue
                 if not np.isfinite(vf):
                     continue
-                sums[md.name][k] += vf
-                counts[md.name][k] += 1
+                entry[k] = vf
+            if entry:
+                raw[md.name][stem] = entry
 
-    # Compute means
-    models_stats: List[Tuple[str, Dict[str, float]]] = []
-    for md in model_dirs:
-        name = md.name
-        means: Dict[str, float] = {}
-        for k in all_keys:
-            c = counts[name][k]
-            if c > 0:
-                means[k] = sums[name][k] / c
-            else:
-                # Missing stays absent; ranking safety functions will treat missing as worst
-                pass
-        models_stats.append((name, means))
+    # Second pass: for each metric independently, average every model's
+    # value over the exact same set of images -- the images where ALL
+    # models being compared have a valid value for that metric.
+    means: Dict[str, Dict[str, float]] = {md.name: {} for md in model_dirs}
+    common_counts: List[int] = []
+    coverage_warnings: List[str] = []
+    for k in all_keys:
+        common_stems = [
+            stem for stem in stems
+            if all(k in raw[md.name].get(stem, {}) for md in model_dirs)
+        ]
+        common_counts.append(len(common_stems))
+        if not common_stems:
+            continue
+        for md in model_dirs:
+            own_count = sum(1 for stem in stems if k in raw[md.name].get(stem, {}))
+            if own_count > len(common_stems):
+                coverage_warnings.append(
+                    f"{md.name}: {own_count} images have '{k}', but only "
+                    f"{len(common_stems)} are shared by every compared model "
+                    f"-- averaging over the shared {len(common_stems)} only"
+                )
+            vals = [raw[md.name][stem][k] for stem in common_stems]
+            means[md.name][k] = sum(vals) / len(vals)
 
-    return models_stats, len(stems)
+    if coverage_warnings:
+        print("Warning: models have unequal stats coverage; restricting each "
+              "metric's comparison to the images every compared model has "
+              "in common, to avoid an unfair comparison:")
+        for w in coverage_warnings:
+            print(f"  {w}")
+
+    models_stats: List[Tuple[str, Dict[str, float]]] = [
+        (md.name, means[md.name]) for md in model_dirs
+    ]
+    num_images_considered = min(common_counts) if common_counts else 0
+    return models_stats, num_images_considered
 
 
 def _print_overall_ranking(eval_root: Path, images_dir: Path, only_models: Optional[Sequence[str]] = None,

--- a/vesuvius/tests/image_proc/run/test_prediction_grid_ranking.py
+++ b/vesuvius/tests/image_proc/run/test_prediction_grid_ranking.py
@@ -1,0 +1,148 @@
+"""Tests for _collect_aggregated_model_stats' cross-model fairness guarantee.
+
+Covers a real bug: means were previously computed per model over however
+many images that model happened to have a stats.json for, with no
+guarantee different models were compared on the same images. A model
+evaluated on only an easier partial subset of the test set (a realistic
+situation -- a crashed/partial eval run, or evaluated before harder images
+were added to the test set) could show artificially better numbers than a
+model honestly evaluated on the full, harder set, with nothing in the
+tool's output revealing the comparison wasn't fair.
+"""
+import json
+
+import pytest
+
+from vesuvius.image_proc.run.prediction_grid import (
+    _choose_best_model,
+    _collect_aggregated_model_stats,
+)
+
+
+def _write_stats(model_dir, stem, *, cc, bp, hd, pr, rc):
+    d = model_dir / stem
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "stats.json").write_text(json.dumps({
+        "connected_components_difference_class_1": cc,
+        "branch_points_absdiff_class_1": bp,
+        "hausdorff_distance_95_class_1": hd,
+        "precision_class_1": pr,
+        "recall_class_1": rc,
+    }))
+
+
+def _make_images(images_dir, n):
+    images_dir.mkdir(exist_ok=True)
+    for i in range(n):
+        (images_dir / f"img{i:02d}.tif").touch()
+
+
+def test_equal_coverage_is_unaffected(tmp_path):
+    """No-regression check: when every model has stats for every image,
+    behaviour is unchanged from a plain per-model mean."""
+    eval_root = tmp_path / "eval"
+    images_dir = tmp_path / "images"
+    eval_root.mkdir()
+    _make_images(images_dir, 10)
+
+    model_a = eval_root / "model_A"
+    model_b = eval_root / "model_B"
+    for i in range(10):
+        _write_stats(model_a, f"img{i:02d}", cc=1, bp=1, hd=2, pr=0.95, rc=0.95)
+        _write_stats(model_b, f"img{i:02d}", cc=5, bp=5, hd=10, pr=0.70, rc=0.65)
+
+    models_stats, num_images = _collect_aggregated_model_stats(eval_root, images_dir)
+    assert num_images == 10
+
+    means = dict(models_stats)
+    assert means["model_A"]["connected_components_difference_class_1"] == pytest.approx(1.0)
+    assert means["model_B"]["connected_components_difference_class_1"] == pytest.approx(5.0)
+    assert _choose_best_model(models_stats) == "model_A"
+
+
+def test_partial_coverage_does_not_unfairly_favor_the_less_evaluated_model(tmp_path, capsys):
+    """Reproduces the real bug directly: model_A is only evaluated on the
+    easier half of the test set (all great scores); model_B is evaluated
+    on the full set, matching model_A exactly on the easy half and scoring
+    worse (but reasonably) on the harder half it actually attempted.
+
+    Both models' means must be computed over the SAME (shared) image set,
+    so a model's apparent superiority can never come purely from having
+    skipped the harder images -- on the shared 10-image subset here, both
+    models are in fact numerically identical, so neither has genuine cause
+    to be preferred and both should therefore win or lose only via a
+    stable tie-break, never via unequal coverage.
+    """
+    eval_root = tmp_path / "eval"
+    images_dir = tmp_path / "images"
+    eval_root.mkdir()
+    _make_images(images_dir, 20)
+
+    model_a = eval_root / "model_A_partial_eval"
+    model_b = eval_root / "model_B_full_eval"
+    for i in range(10):
+        _write_stats(model_a, f"img{i:02d}", cc=1, bp=1, hd=2, pr=0.95, rc=0.95)
+        _write_stats(model_b, f"img{i:02d}", cc=1, bp=1, hd=2, pr=0.95, rc=0.95)
+    for i in range(10, 20):
+        # model_A never attempted these; model_B did, and did fine but not
+        # perfectly. Under the old per-model-coverage aggregation, this drags
+        # model_B's mean down while model_A's stays at its easy-subset value.
+        _write_stats(model_b, f"img{i:02d}", cc=3, bp=3, hd=6, pr=0.85, rc=0.85)
+
+    models_stats, num_images = _collect_aggregated_model_stats(eval_root, images_dir)
+    means = dict(models_stats)
+
+    assert num_images == 10, "must be restricted to the 10 images both models share"
+    assert means["model_A_partial_eval"] == means["model_B_full_eval"], (
+        "on the shared 10 images the two models are numerically identical -- "
+        "model_A's mean must not differ just because it has no data at all "
+        "for the other 10 images"
+    )
+
+    captured = capsys.readouterr()
+    assert "model_B_full_eval" in captured.out
+    assert "unequal stats coverage" in captured.out.lower() or "unfair" in captured.out.lower()
+
+
+def test_genuinely_better_full_coverage_model_still_wins(tmp_path):
+    """If the fully-evaluated model is ALSO genuinely better on the shared
+    subset (not just equal), it must still win -- this fix restricts the
+    comparison to fair ground, it must not penalize full evaluation."""
+    eval_root = tmp_path / "eval"
+    images_dir = tmp_path / "images"
+    eval_root.mkdir()
+    _make_images(images_dir, 20)
+
+    model_a = eval_root / "model_A_partial_eval"
+    model_b = eval_root / "model_B_full_eval"
+    for i in range(10):
+        _write_stats(model_a, f"img{i:02d}", cc=5, bp=5, hd=10, pr=0.70, rc=0.65)
+        _write_stats(model_b, f"img{i:02d}", cc=1, bp=1, hd=2, pr=0.95, rc=0.95)
+    for i in range(10, 20):
+        _write_stats(model_b, f"img{i:02d}", cc=3, bp=3, hd=6, pr=0.85, rc=0.85)
+
+    models_stats, _ = _collect_aggregated_model_stats(eval_root, images_dir)
+    assert _choose_best_model(models_stats) == "model_B_full_eval"
+
+
+def test_no_shared_images_leaves_metric_absent_for_all_models(tmp_path):
+    """If two models share zero images for a metric, no model can be fairly
+    scored on it -- it must be dropped for everyone rather than silently
+    falling back to per-model averages."""
+    eval_root = tmp_path / "eval"
+    images_dir = tmp_path / "images"
+    eval_root.mkdir()
+    _make_images(images_dir, 4)
+
+    model_a = eval_root / "model_A"
+    model_b = eval_root / "model_B"
+    _write_stats(model_a, "img00", cc=1, bp=1, hd=2, pr=0.9, rc=0.9)
+    _write_stats(model_a, "img01", cc=1, bp=1, hd=2, pr=0.9, rc=0.9)
+    _write_stats(model_b, "img02", cc=1, bp=1, hd=2, pr=0.9, rc=0.9)
+    _write_stats(model_b, "img03", cc=1, bp=1, hd=2, pr=0.9, rc=0.9)
+
+    models_stats, num_images = _collect_aggregated_model_stats(eval_root, images_dir)
+    means = dict(models_stats)
+    assert num_images == 0
+    assert means["model_A"] == {}
+    assert means["model_B"] == {}


### PR DESCRIPTION
_choose_best_model/_rank_models pick which trained model is 'best' -- that is the whole purpose of this tool. _collect_aggregated_model_stats computed each model's mean per metric over however many images that specific model happened to have a stats.json for, with no requirement that different models were compared on the same images.

That's a realistic, not contrived, failure mode: a crashed or partial eval run, or a model evaluated before harder images were later added to the test set, both leave a model with stats.json only for a partial, easier subset. Its mean then looks better than a model honestly evaluated on the full set -- purely from selection bias in which images have stats, not genuine model quality -- with nothing in the tool's output revealing the comparison wasn't fair.

Verified: constructed a 20-image scenario where model_A was evaluated on only the easier half (all great scores) and model_B was evaluated on all 20, matching model_A exactly on the easy half and scoring reasonably, not badly, on the harder half it actually attempted. Under the old per-model-coverage aggregation, model_A -- the LESS evaluated model -- was chosen as best.

Fix: for each metric independently, restrict the mean to the images where every compared model has a valid value for that metric. When coverage genuinely differs, the tool now prints an explicit warning naming which models had excluded extra coverage and why, and num_images_considered, previously just the total candidate pool size, now reflects the actual number of images the comparison was based on.

No behaviour change when all models have equal coverage, confirmed with a dedicated no-regression test. If a genuinely better model also has more coverage, it still wins -- the fix restricts the comparison to fair ground, it does not penalize full evaluation, confirmed.

4 new tests (this file had 0% test coverage, confirmed via real coverage measurement). Mutation-tested: reverting the fix reproduces 2 concrete failures, 20 vs 10 images considered in the main reproduction, 4 vs 0 in a zero-overlap edge case. Verified on three independent fresh clones of main, and confirmed this fix coexists cleanly with the separate voxelize_objs fix in the same directory.