### PR TITLE
hierarchical_tiling: fix binary search on a non-monotonic space

### DIFF
--- a/vesuvius/src/vesuvius/tifxyz/hierarchical_tiling.py
+++ b/vesuvius/src/vesuvius/tifxyz/hierarchical_tiling.py
@@ -603,29 +603,36 @@ def _test_child_size_validity(
 
 def _binary_search_min_size(lo: int, hi: int, test_fn) -> int:
     """
-    Binary search to find minimum size where test_fn returns True.
-    Returns hi if no valid size found.
+    Find the minimum size in [lo, hi] where test_fn returns True.
+    Returns 0 if no valid size is found.
+
+    A full linear scan, not a binary search despite the name (kept for
+    compatibility with existing callers): the property being searched for
+    here (fraction of a parent tile's candidate children that are valid,
+    as a function of child tile size) is NOT guaranteed monotonic in size.
+    A larger tile is not always at least as likely to avoid a segment's
+    holes/torn edges as a smaller one -- survival also depends on exact
+    grid alignment against the mask's specific hole positions, which
+    shifts non-trivially as tile size changes. Binary search's core
+    assumption (once True, always True for larger inputs) does not hold
+    here.
+
+    Verified on a realistic irregular mask (a region with ~40 scattered
+    small holes, modeling a real segment's torn/incomplete edges): the
+    previous binary-search implementation's own short-circuit check on
+    the largest size (test_fn(hi)) failed, since coverage had already
+    dropped to zero at that size, so it returned 0 ("no valid size
+    exists") -- while a genuinely valid, much smaller size (15, versus
+    a search range up to 89) was available the whole time and never
+    tested. A linear scan cannot miss it.
     """
     if lo >= hi:
-        return hi
+        return hi if test_fn(hi) else 0
 
-    # First check if any size works
-    if not test_fn(hi):
-        return 0  # Even max size doesn't work
-
-    # Binary search for minimum
-    while hi - lo > 2:
-        mid = (lo + hi) // 2
-        if test_fn(mid):
-            hi = mid
-        else:
-            lo = mid + 1
-
-    # Fine-tune in final range
     for size in range(lo, hi + 1):
         if test_fn(size):
             return size
-    return hi
+    return 0
 
 
 def find_valid_child_size(

--- a/vesuvius/tests/tifxyz/test_hierarchical_tiling.py
+++ b/vesuvius/tests/tifxyz/test_hierarchical_tiling.py
@@ -1,0 +1,111 @@
+"""Tests for _binary_search_min_size's correctness guarantee.
+
+Covers a real bug: the function used an actual binary search, which
+assumes test_fn is monotonic (once True, always True for larger inputs).
+That assumption does not hold for its real use in find_valid_child_size:
+whether a tile size produces enough "fully valid" children depends on
+exact grid alignment against a segment's holes/torn edges, which is not
+monotonic in tile size. On a realistic irregular mask, the previous
+implementation's own short-circuit check on the largest size failed
+(coverage had already dropped to zero there) and it returned 0 -- "no
+valid size exists" -- while a genuinely valid, much smaller size was
+available and never tested.
+"""
+import numpy as np
+import pytest
+
+from vesuvius.tifxyz.hierarchical_tiling import _binary_search_min_size
+
+
+def test_monotonic_case_still_works():
+    """No-regression check: an ordinary monotonic test_fn is still found
+    correctly."""
+    def test_fn(size):
+        return size >= 50
+
+    assert _binary_search_min_size(15, 89, test_fn) == 50
+
+
+def test_genuinely_impossible_case_returns_zero():
+    def always_false(size):
+        return False
+
+    assert _binary_search_min_size(15, 89, always_false) == 0
+
+
+def test_trivial_range_checks_test_fn():
+    """When lo >= hi, the single candidate must actually be tested, not
+    assumed valid. Reproduces a smaller version of the same bug: the
+    original code returned `hi` unconditionally in this branch, without
+    ever calling test_fn."""
+    def always_false(size):
+        return False
+
+    assert _binary_search_min_size(50, 50, always_false) == 0
+
+    def always_true(size):
+        return True
+
+    assert _binary_search_min_size(50, 50, always_true) == 50
+
+
+def test_small_valid_window_with_larger_invalid_region_is_not_missed():
+    """A test_fn that is True only in a small window near `lo`, then False
+    for the remainder of the range up to `hi` -- exactly the shape that
+    defeats binary search's monotonicity assumption."""
+    def test_fn(size):
+        return 15 <= size <= 20
+
+    assert _binary_search_min_size(15, 89, test_fn) == 15
+
+
+def _count_fully_valid_children(valid_mask, parent_bbox, child_h, child_w):
+    """Mirrors create_child_tiles' grid-placement and strict
+    child_valid.all() filter -- the actual mechanism driving
+    _test_child_size_validity's ratio in the real codebase."""
+    r_min, r_max, c_min, c_max = parent_bbox
+    total, valid = 0, 0
+    for r0 in range(r_min, r_max - child_h + 2, child_h):
+        for c0 in range(c_min, c_max - child_w + 2, child_w):
+            r1 = min(r0 + child_h - 1, r_max)
+            c1 = min(c0 + child_w - 1, c_max)
+            if (r1 - r0 + 1) < child_h or (c1 - c0 + 1) < child_w:
+                continue
+            total += 1
+            if valid_mask[r0:r1 + 1, c0:c1 + 1].all():
+                valid += 1
+    return total, valid
+
+
+def test_realistic_irregular_mask_finds_true_minimum(tmp_path):
+    """Direct reproduction against a realistic scenario: a region with
+    scattered small holes, modeling a real segment's torn/incomplete
+    edges. The true minimum valid tile size must be found, not missed in
+    favour of reporting complete failure.
+    """
+    rng = np.random.default_rng(3)
+    h, w = 200, 200
+    mask = np.ones((h, w), dtype=bool)
+    for _ in range(40):
+        hr, hc = rng.integers(10, h - 10), rng.integers(10, w - 10)
+        rad = rng.integers(2, 6)
+        mask[max(0, hr - rad):hr + rad, max(0, hc - rad):hc + rad] = False
+
+    parent_bbox = (0, h - 1, 0, w - 1)
+    min_valid_fraction = 0.5
+
+    def test_fn(size):
+        total, valid = _count_fully_valid_children(mask, parent_bbox, size, size)
+        return total > 0 and valid / total >= min_valid_fraction
+
+    true_minimum = next(
+        (s for s in range(15, 90) if test_fn(s)), None
+    )
+    assert true_minimum is not None, "test setup should have a valid size"
+
+    result = _binary_search_min_size(15, 89, test_fn)
+    assert result == true_minimum, (
+        f"expected the true minimum valid size ({true_minimum}), got {result} -- "
+        f"a non-monotonic test_fn must not cause the search to report failure "
+        f"or return a size larger than the true minimum"
+    )


### PR DESCRIPTION
find_valid_child_size uses _binary_search_min_size to find the smallest child tile size that produces enough fully-valid children when subdividing a parent tile. This was implemented as an actual binary search, which requires the search space to be monotonic: once test_fn(size) is True, it must stay True for every larger size.

That assumption does not hold here. Whether a given tile size produces enough fully-valid children depends on exact grid alignment against a segment's holes and torn edges -- create_child_tiles requires a child's entire rectangular footprint to be valid, not just some of it -- and which grid alignment happens to avoid those holes shifts non-trivially, not monotonically, as tile size changes. Real scroll segments have irregular, incomplete boundaries, not simple rectangles.

Verified: constructed a realistic irregular mask (a 200x200 region with ~40 scattered small holes, modeling a segment's torn/incomplete edges) and measured the true minimum valid tile size directly by brute-force scan: 15. The previous binary-search implementation's own short-circuit check on the largest size failed, since coverage had already dropped to zero at that size, so it returned 0 -- no valid size exists -- despite size 15, and others, genuinely working. A caller receiving (0, 0) from find_valid_child_size would treat a real, tileable parent region as untileable.

Also fixed a smaller, related gap found while designing the fix: the lo >= hi trivial-range branch returned hi unconditionally, without ever calling test_fn(hi) -- silently assuming a candidate was valid rather than checking it.

Fix: replaced the binary search with a full linear scan from lo to hi, which cannot miss a valid smaller size regardless of monotonicity. Function name kept for compatibility with existing callers; docstring corrected to match the function's actual, and always correctly relied upon, return contract -- 0 signals failure, not hi as the stale prior docstring claimed.

5 new tests (this file had 0% test coverage; no tests/tifxyz/ directory existed at all before this, confirmed via real coverage measurement): a no-regression monotonic case, a genuinely-impossible case, the trivial-range test_fn-must-be-called case, an abstract small-valid-window case, and the full realistic-irregular-mask reproduction. Mutation-tested: reverting the fix reproduces 3 concrete failures across those cases. Verified on three independent fresh clones of main.