### PR TITLE
ink_detection: exclude reader padding from robust flat normalization

### DIFF
--- a/vesuvius/src/vesuvius/ink_detection/inference/infer.py
+++ b/vesuvius/src/vesuvius/ink_detection/inference/infer.py
@@ -518,7 +518,21 @@ class FlatBlockDataset(Dataset):
         # maps an all-zero patch to nonzero values.
         nonempty = int(patch_HWZ.any())
         patch_ZYX = np.moveaxis(patch_HWZ, -1, 0)
-        patch_ZYX = normalize_flat_patch(patch_ZYX, self.preprocessing)
+        if self.preprocessing == "tifxyz_robust":
+            # Match training: normalize source voxels without reader padding.
+            depth_start = self.reader.output_depth_start
+            depth_stop = depth_start + self.reader.layer_indices.size
+            valid = (
+                slice(depth_start, depth_stop),
+                slice(0, block.valid_h),
+                slice(0, block.valid_w),
+            )
+            patch_ZYX = np.ascontiguousarray(patch_ZYX, dtype=np.float32)
+            patch_ZYX[valid] = normalize_flat_patch(
+                patch_ZYX[valid], self.preprocessing
+            )
+        else:
+            patch_ZYX = normalize_flat_patch(patch_ZYX, self.preprocessing)
         image_CZYX = torch.from_numpy(patch_ZYX).unsqueeze(0)
         metadata = torch.tensor(
             [block.y0, block.x0, block.valid_h, block.valid_w, nonempty],

--- a/vesuvius/tests/ink_detection/test_flat_inference.py
+++ b/vesuvius/tests/ink_detection/test_flat_inference.py
@@ -16,7 +16,9 @@ import zarr
 
 from vesuvius.ink_detection.config import InkConfig, NormalizationConfig
 from vesuvius.ink_detection.inference.infer import (
+    Block,
     ChunkAccumulator,
+    FlatBlockDataset,
     FlatPatchReader,
     choose_pyramid_array,
     compute_chunk_contribution_counts,
@@ -199,6 +201,45 @@ def test_flat_axes_layers_reverse_and_short_depth_padding(tmp_path):
         output_depth=6,
         direction="reverse",
     ).tolist() == [5, 4, 3, 2, 1, 0]
+
+
+def test_flat_robust_normalization_excludes_reader_padding(tmp_path):
+    input_path = tmp_path / "short-source.zarr"
+    values_ZYX = np.arange(100, 136, dtype=np.uint8).reshape(3, 3, 4)
+    source = zarr.open(
+        input_path,
+        mode="w",
+        shape=values_ZYX.shape,
+        chunks=values_ZYX.shape,
+        dtype="u1",
+        zarr_format=2,
+    )
+    source[:] = values_ZYX
+    reader = FlatPatchReader(
+        input_path=input_path,
+        resolution="0",
+        depth_axis_first=True,
+        height=3,
+        width=4,
+        layer_indices=np.arange(3),
+        output_depth=5,
+        preprocessing="tifxyz_robust",
+    )
+    dataset = FlatBlockDataset(
+        reader=reader,
+        blocks=[Block(y0=0, x0=0, valid_h=3, valid_w=4)],
+        patch_size=5,
+        preprocessing="tifxyz_robust",
+    )
+
+    image_CZYX, metadata = dataset[0]
+    expected = np.zeros((1, 5, 5, 5), dtype=np.float32)
+    expected[0, 1:4, :3, :4] = normalize_flat_patch(
+        values_ZYX.copy(), "tifxyz_robust"
+    )
+
+    np.testing.assert_array_equal(image_CZYX.numpy(), expected)
+    np.testing.assert_array_equal(metadata.numpy(), [0, 0, 3, 4, 1])
 
 
 def test_blocks_occupancy_blend_accumulation_and_truncating_tiles():


### PR DESCRIPTION
## Motivation

Closes #1481.

I reviewed the PHerc0139 replay and the two-file diff. This fix keeps padding at zero so flat inference matches training.

Flat ink training applies robust-MAD normalization only to source-backed voxels and leaves `read_bbox_with_padding()` padding at zero. Flat inference currently pads first and normalizes the complete tensor. On short-depth or spatial-boundary inputs, that changes the statistics, shifts real CT values, and turns zero padding nonzero before the model sees the tensor. The shipped aligned-21 hybrid recipe uses this preprocessing path.

The issue analysis and core change were proposed by @make-agi-quick; their contribution is retained with a commit co-author trailer.

## Change

- normalize only the source-backed Z/Y/X region for `tifxyz_robust`
- leave reader-inserted padding at zero, matching training
- keep `divide_255` behavior unchanged
- add a regression covering centered depth padding and bottom/right spatial padding together

## Real-scroll before/after

The validation replays Villa's actual `FlatPatchReader` and `FlatBlockDataset` on three source slices from this public PHerc0139 CT volume:

- source: `s3://vesuvius-challenge-open-data/PHerc0139/volumes/20250728140407-9.362um-1.2m-113keV-masked.zarr`
- L0 cube: `z04352_y03072_x02560.tif`, SHA-256 `d4bd2dfaf5ee1518560e15ac767b76ea836bf43e0a96a8be92445e5082e73dc3`
- replay: local Z `[62:65]` centered into a five-slice model input; 128 x 128 spatial extent
- reference: normalize the real source first, then place it in a zero-padded tensor, matching training

![Before and after terminal replay on public PHerc0139 CT](https://raw.githubusercontent.com/TAUIL-Abd-Elilah/villa/264cb782f13fdaa0c8901dba10715ada65bd399e/pr-evidence/1483/pr1483_real_scroll_before_after.png)

The left panel is the script failing on current main; the right panel is the same script passing on this PR.

[Reproducer](https://github.com/TAUIL-Abd-Elilah/villa/blob/264cb782f13fdaa0c8901dba10715ada65bd399e/pr-evidence/1483/verify_pr1483_real_scroll.py) | [Exact transcript](https://github.com/TAUIL-Abd-Elilah/villa/blob/264cb782f13fdaa0c8901dba10715ada65bd399e/pr-evidence/1483/pr1483_real_scroll_before_after.txt) | [Evidence notes](https://github.com/TAUIL-Abd-Elilah/villa/blob/264cb782f13fdaa0c8901dba10715ada65bd399e/pr-evidence/1483/README.md)

| Measurement | Current main | This PR |
|---|---:|---:|
| Process exit | 1 (fail) | 0 (pass) |
| Real-voxel MAE vs training input | 0.811289 | 0.000000 |
| Real-voxel max abs error | 3.352918 | 0.000000 |
| Nonzero padded voxels | 32,768 / 32,768 | 0 / 32,768 |

This is a deterministic input-preprocessing parity check on real scroll CT. It is not an ink-accuracy or model-quality claim.

## Tests

The [full upstream Python matrix](https://github.com/ScrollPrize/villa/actions/runs/32003446670) passes on both Zarr 2.18.7 and 3.2.1.

```text
python -m pytest -q \
  tests/ink_detection/test_flat_inference.py \
  tests/ink_detection/test_data_foundation.py \
  tests/ink_detection/test_inference_boundaries.py \
  tests/ink_detection/test_numerical_foundation.py \
  -m 'not slow and not network'

60 passed
```

## LLM assistance

Codex assisted with implementation, validation, and PR preparation.
