### PR TITLE
augmentation: fix SheetCompressionTransform (inverted warp + 2 more defects)

### DIFF
--- a/vesuvius/src/vesuvius/models/augmentation/transforms/spatial/sheet_compression.py
+++ b/vesuvius/src/vesuvius/models/augmentation/transforms/spatial/sheet_compression.py
@@ -30,6 +30,8 @@ class SheetCompressionTransform(BasicTransform):
         compression_axes: Candidate axes to compress (randomly selects one per sample)
     """
 
+    _is_spatial = True  # Skip per-transform padding restoration
+
     def __init__(
         self,
         compression_strength: RandomScalar = (0.1, 0.3),
@@ -104,11 +106,11 @@ class SheetCompressionTransform(BasicTransform):
                     displacement = blur_dimension(displacement, spatial_smoothing, dim)
             displacement = displacement[0]
 
-        # Normalize displacement to grid_sample coordinates [-1, 1]
-        # grid_sample expects coordinates in [-1, 1], so we need to convert
-        # displacement is in voxel units, we need to normalize by half the dimension size
+        # Normalize displacement to grid_sample coordinates [-1, 1].
+        # With align_corners=True, one voxel step spans 2/(dim-1) in grid
+        # coordinates, so voxel-unit displacement converts by that factor.
         dim_size = spatial_shape[chosen_axis]
-        displacement_normalized = displacement / (dim_size / 2.0)
+        displacement_normalized = displacement * (2.0 / max(dim_size - 1.0, 1.0))
 
         return {
             'apply': True,
@@ -138,8 +140,11 @@ class SheetCompressionTransform(BasicTransform):
         grid_axis_map = {0: 2, 1: 1, 2: 0}
         grid_idx = grid_axis_map[axis]
 
-        # Subtract displacement (positive displacement = sample from earlier position = compression)
-        grid[..., grid_idx] = grid[..., grid_idx] - displacement
+        # Add displacement: output[x] = input[x + d(x)] with d monotonically
+        # non-decreasing along the axis pulls content toward smaller indices,
+        # so accumulated gap width shrinks (local scale ds/dx = 1 + s*gap > 1).
+        # (Subtracting instead stretches the volume and *widens* gaps.)
+        grid[..., grid_idx] = grid[..., grid_idx] + displacement
 
         return grid.unsqueeze(0)  # (1, D, H, W, 3)
 


### PR DESCRIPTION
## Motivation

I was running an augmentation ablation for wishlist issue #191 — four models on
Dataset059, baseline vs `SheetCompressionTransform` — and the results made no
sense until we instrumented the transform itself. It turns out it does the
opposite of its name, and the ablation had unknowingly tested a stretch-and-crop.

## Three defects, each verified by direct measurement

**1. The displacement sign is inverted.** `grid - displacement` samples
`input[x − d(x)]`; with `d = cumsum(gap_weight)·strength` monotonically
non-decreasing along the axis, features can only move apart (the map is
order-preserving with local scale `1/(1 − s·gap) > 1`). Driving the real class
over a 16-sheet phantom (sheet thickness 3, period 10):

| strength | adjacent-sheet spacing ratio (main) | spacing ratio (this PR) |
|---|---|---|
| 0.10 | 1.071 (widened) | **0.940 (compressed)** |
| 0.20 | 1.150 | **0.883** |
| 0.35 | 1.286 | **0.817** |

The inverted version also never samples the far `~s·gap_fraction` of the axis
(far-end displacement 36.7 vox = 22.9% at s=0.35), silently deleting content:
3 of 16 phantom sheets lost at s=0.35, and on real Dataset059 crops every
deleted label component sat at axis positions 148–159 of 160. After the fix,
16/16 sheets survive at every strength and zero merge events occur (the label
path stays alignment-consistent in both directions; nearest-neighbour warp).

**2. Missing `_is_spatial = True`.** Every other spatial transform in the
package sets it (`rot90.py`, `transpose.py`, `spatial.py`, `mirroring.py`);
without it `basic_transform.py:58` restores padding from the **un-warped**
`padding_mask`, overwriting warped voxels with `PADDING_VALUE` at stale
locations.

**3. Voxel→grid normalization is off by `(dim−1)/dim`.** Displacement is
divided by `dim/2`, but with `align_corners=True` one voxel spans `2/(dim−1)`
in grid coordinates. Sub-percent at 160³, ~3% at 32³; fixed for correctness.

## Verification

Reproduction/verification script (drives the installed class, CPU, analytic
derivation + phantom measurements): happy to attach or PR it into a tests dir —
it asserts spacing ratio < 1 post-fix, 0 merges, full sheet retention, and the
grid_sample convention itself via a ramp test.

Also for context: in our 4-run ablation the broken transform did *not* corrupt
image/label alignment (image and label lose far-edge content identically), so
models trained with it were augmented with a mislabeled stretch — a possible
silent confound for anyone who has used this transform expecting compression.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
