### PR TITLE
Fail fast when ZarrDataset cannot generate auxiliary targets

### DIFF
--- a/vesuvius/docs/data_formatting.md
+++ b/vesuvius/docs/data_formatting.md
@@ -120,7 +120,7 @@ Label files must exist for each task (e.g., `fragment01_ink.tif` and `fragment01
 
 ### Auxiliary Targets
 
-The trainer can synthesize auxiliary regression targets on the fly. Declare them under `auxiliary_tasks` and reference the source classification task:
+The auxiliary trainer APIs can consume derived regression targets, but the current `ZarrDataset` does not generate them. Declaring them under `auxiliary_tasks` therefore fails at dataset startup with an actionable error until a dataset implementation provides those tensors:
 
 ```yaml
 auxiliary_tasks:
@@ -133,7 +133,7 @@ auxiliary_tasks:
         weight: 1.0
 ```
 
-During training the dataset computes distance transforms from the `ink` labels; you do not need to save additional volumes unless you want complete control over the tensors.
+Do not use this configuration with `ZarrDataset` yet; adding on-the-fly generation requires explicit distance-transform, dimensionality, padding, and augmentation semantics.
 
 ## Dataset Parameters Worth Tuning
 
@@ -177,4 +177,4 @@ Watch the log for messages about missing targets, unlabeled patches, or normaliz
 | Binary segmentation | One label file per volume with `{0, 1}` values | `out_channels: 1`, `activation: sigmoid` | Any positive voxel counts as foreground |
 | Multi-class segmentation | Single label map with integer class IDs | `out_channels: N`, `activation: softmax`, CE/Dice losses | Provide sequential integers `[0, N-1]` |
 | Multi-task | Separate label file per target | Multiple entries in `dataset_config.targets` | Targets share the same image volume |
-| Auxiliary regression | Primary label only | Configure under `auxiliary_tasks` | Auxiliary tensors are derived automatically |
+| Auxiliary regression | Dataset-specific | Configure under `auxiliary_tasks` only when the dataset provides tensors | `ZarrDataset` currently fails closed |

--- a/vesuvius/docs/training_flow.md
+++ b/vesuvius/docs/training_flow.md
@@ -338,7 +338,7 @@ Auxiliary tasks let you add side objectives that are derived from a primary “s
   - `loss_weight`: Optional overall weight for the task.
   - `out_channels`: Optional for `distance_transform` (defaults to 1); for `surface_normals` it is set automatically based on dimensionality (2 for 2D, 3 for 3D).
 
-Example (excerpt):
+Example (excerpt; auxiliary targets are currently rejected by `ZarrDataset` with a clear startup error until derived-target generation is implemented):
 
 ```yaml
 dataset_config:
@@ -415,7 +415,7 @@ auxiliary_tasks:
 
 How it works in code:
 - Config injection: `ConfigManager` reads `auxiliary_tasks` and calls a small factory to append derived targets into `mgr.targets` with `auxiliary_task: true` and a reference to `source_target`.
-- Dataset loading: Datasets only load label volumes for primary targets. Auxiliary targets do not require separate label files and are not looked up on disk.
+- Dataset loading: `ZarrDataset` currently loads label volumes only for primary targets. It fails fast when `auxiliary_task: true` targets are configured because it does not yet generate their derived tensors; this prevents a configuration from silently training zero-loss auxiliary heads.
 - Loss computation: During training, losses are computed per key present in the batch label dict. The helper `compute_auxiliary_loss` passes `source_pred=outputs[source_target]` to losses that accept it. This enables:
   - Self-consistency/regularization losses that don’t need explicit GT (e.g., `NormalSmoothnessLoss` using only predicted normals with optional masking from `source_pred`).
   - Losses that need derived GT (e.g., `SignedDistanceLoss`, cosine loss on normals) use the dataset-provided tensors for aux targets.
@@ -423,11 +423,11 @@ How it works in code:
   - For deep supervision, auxiliary targets default to `ds_interpolation: linear`, mapping to bilinear (2D) or trilinear (3D) in downsampling to preserve regression continuity.
 
 Important notes and current behavior:
-- The dataset now auto-generates ground-truth tensors for `distance_transform` (signed DT) and `surface_normals` per patch from the `source_target` labels, so related losses work out of the box.
-- Auxiliary losses that are self-supervised or use only predictions (e.g., `NormalSmoothnessLoss`) also work and can be masked using `source_pred` passed through `compute_auxiliary_loss`.
-- If you prefer, you can still precompute and store auxiliary labels on disk using the same naming convention; the dataset will ignore them unless you wire them explicitly.
+- `ZarrDataset` does not currently generate `distance_transform` or `surface_normals` tensors. Configuring them raises a clear `ValueError` during dataset startup instead of allowing the model to run with missing targets and zero auxiliary loss.
+- The auxiliary trainer implementations remain available for dataset implementations that provide the required tensors.
+- Adding on-the-fly auxiliary-target generation is a separate feature; it must define dimensionality, padding, augmentation, and numerical semantics before being enabled here.
 
-This design allows mixing fully supervised targets with auxiliary/self-supervised regularizers and keeps disk I/O simple by deriving common auxiliary targets on the fly.
+This fail-closed behavior keeps a documented training configuration from silently becoming a different experiment.
 
 4. **Mixed Precision Training**:
    - GradScaler for CUDA devices

--- a/vesuvius/src/vesuvius/models/datasets/zarr_dataset.py
+++ b/vesuvius/src/vesuvius/models/datasets/zarr_dataset.py
@@ -99,6 +99,18 @@ class ZarrDataset(Dataset):
         self.data_path = Path(mgr.data_path)
         self.patch_size = tuple(mgr.train_patch_size)
         self.targets = getattr(mgr, 'targets', {})
+        self.auxiliary_target_names = [
+            name for name, info in self.targets.items()
+            if info.get("auxiliary_task", False)
+        ]
+        if self.auxiliary_target_names:
+            names = ", ".join(self.auxiliary_target_names)
+            raise ValueError(
+                "ZarrDataset cannot generate auxiliary targets yet: "
+                f"{names}. Remove auxiliary_tasks from this config or use a "
+                "dataset implementation that provides those tensors; refusing "
+                "to start prevents silently training zero-loss auxiliary heads."
+            )
         self.target_names = [
             name for name, info in self.targets.items()
             if not info.get("auxiliary_task", False)

--- a/vesuvius/tests/models/datasets/test_zarr_dataset_auxiliary.py
+++ b/vesuvius/tests/models/datasets/test_zarr_dataset_auxiliary.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+import pytest
+
+from vesuvius.models.datasets.zarr_dataset import ZarrDataset
+
+
+def test_zarr_dataset_rejects_unsupported_auxiliary_targets(tmp_path):
+    mgr = SimpleNamespace(
+        data_path=tmp_path,
+        train_patch_size=(8, 8, 8),
+        targets={
+            "ink": {"auxiliary_task": False},
+            "distance_transform": {
+                "auxiliary_task": True,
+                "task_type": "distance_transform",
+                "source_target": "ink",
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="cannot generate auxiliary targets"):
+        ZarrDataset(mgr, is_training=False)


### PR DESCRIPTION
## Summary

`ZarrDataset` currently filters `auxiliary_task` targets out of `target_names`, while the Zarr path does not generate the derived tensors documented for `distance_transform` and `surface_normals`. This lets auxiliary heads train for 50 epochs with a reported loss of `0.0000` and no supervision.

This PR makes that unsupported combination fail at dataset startup with an actionable error instead of silently running the wrong experiment.

## Why this is relevant

I hit this while inspecting the auxiliary-task ablation workflow on real Vesuvius scroll data. The before/after run used the public ScrollPrize 0500p2 image and ink-label TIFFs, converted losslessly to local Zarr for the dataset path:

- Before: `target_names=['ink']`; `distance_transform` was absent from the sample.
- After: startup raises `ValueError: ZarrDataset cannot generate auxiliary targets yet: distance_transform`.

The terminal evidence is preserved locally at `/private/tmp/villa-1490-evidence/before-baseline.txt` and `/private/tmp/villa-1490-evidence/after-patched.txt`.

## Changes

- Reject unsupported auxiliary targets in `ZarrDataset.__init__`.
- Correct the training and data-formatting docs so they no longer claim ZarrDataset auto-generates these tensors.
- Add a regression test for the fail-fast behavior.

## Validation

- `pytest tests/models/datasets/test_zarr_dataset_auxiliary.py tests/models/datasets -q -k 'not dispatcher_is_case_insensitive'`
- Result: `16 passed, 4 deselected`
- `git diff --check`
- CPU-only; no GPU or cloud compute used.

## Scope

This PR intentionally does not invent signed-distance-transform or surface-normal semantics. Implementing those generators needs explicit decisions about dimensionality, padding, augmentation, and numerical conventions; until then, refusing to start is safer than silently training dead heads.

All code and the design decision were reviewed and owned by me; AI assistance was used for repository exploration and test scaffolding.

Closes #1490
