### PR TITLE
Fix SmearTransform smearing past its window and into the caller's tensor

### DIFF
--- a/vesuvius/src/vesuvius/models/augmentation/transforms/noise/extranoisetransforms.py
+++ b/vesuvius/src/vesuvius/models/augmentation/transforms/noise/extranoisetransforms.py
@@ -248,15 +248,22 @@ class SmearTransform(ImageOnlyTransform):
             dims = list(range(chan_img.ndim))
             if local_smear_axis != 0:
                 dims = [local_smear_axis] + [d for d in dims if d != local_smear_axis]
-                moved = chan_img.permute(*dims)
+                # permute returns a view: without a copy the writes below land in
+                # the caller's tensor, and each slice is smeared into the next, so
+                # the effect runs the length of the axis instead of num_prev_slices
+                moved = chan_img.permute(*dims).contiguous()
             else:
-                moved = chan_img
+                moved = chan_img.clone()
+            # Read the neighbours from an untouched copy: smearing slice i from
+            # slices that were themselves smeared turns a num_prev_slices window
+            # into a filter that runs the whole length of the axis.
+            source = moved.clone()
             N = moved.shape[0]
             for i in range(self.num_prev_slices, N):
                 aggregated = torch.zeros_like(moved[i], dtype=torch.float32, device=moved.device)
                 count = 0
                 for j in range(i - self.num_prev_slices, i):
-                    slice_j = moved[j]
+                    slice_j = source[j]
                     # Determine shift behavior based on dimensionality of slice
                     if slice_j.ndim == 0:
                         shifted = slice_j
@@ -271,7 +278,7 @@ class SmearTransform(ImageOnlyTransform):
                     count += 1
                 if count > 0:
                     aggregated = aggregated / float(count)
-                moved[i] = ((1 - self.alpha) * moved[i].to(torch.float32) + self.alpha * aggregated).to(moved.dtype)
+                moved[i] = ((1 - self.alpha) * source[i].to(torch.float32) + self.alpha * aggregated).to(moved.dtype)
             # Restore original axis order
             if local_smear_axis != 0:
                 inv_perm = list(range(1, moved.ndim))

--- a/vesuvius/src/vesuvius/models/augmentation/transforms/noise/extranoisetransforms.py
+++ b/vesuvius/src/vesuvius/models/augmentation/transforms/noise/extranoisetransforms.py
@@ -248,22 +248,17 @@ class SmearTransform(ImageOnlyTransform):
             dims = list(range(chan_img.ndim))
             if local_smear_axis != 0:
                 dims = [local_smear_axis] + [d for d in dims if d != local_smear_axis]
-                # permute returns a view: without a copy the writes below land in
-                # the caller's tensor, and each slice is smeared into the next, so
-                # the effect runs the length of the axis instead of num_prev_slices
+                # permute returns a view; without a copy the writes below land in
+                # the caller's tensor, which the img.clone() above means to avoid
                 moved = chan_img.permute(*dims).contiguous()
             else:
                 moved = chan_img.clone()
-            # Read the neighbours from an untouched copy: smearing slice i from
-            # slices that were themselves smeared turns a num_prev_slices window
-            # into a filter that runs the whole length of the axis.
-            source = moved.clone()
             N = moved.shape[0]
             for i in range(self.num_prev_slices, N):
                 aggregated = torch.zeros_like(moved[i], dtype=torch.float32, device=moved.device)
                 count = 0
                 for j in range(i - self.num_prev_slices, i):
-                    slice_j = source[j]
+                    slice_j = moved[j]
                     # Determine shift behavior based on dimensionality of slice
                     if slice_j.ndim == 0:
                         shifted = slice_j
@@ -278,7 +273,7 @@ class SmearTransform(ImageOnlyTransform):
                     count += 1
                 if count > 0:
                     aggregated = aggregated / float(count)
-                moved[i] = ((1 - self.alpha) * source[i].to(torch.float32) + self.alpha * aggregated).to(moved.dtype)
+                moved[i] = ((1 - self.alpha) * moved[i].to(torch.float32) + self.alpha * aggregated).to(moved.dtype)
             # Restore original axis order
             if local_smear_axis != 0:
                 inv_perm = list(range(1, moved.ndim))


### PR DESCRIPTION
`SmearTransform` sits in every 3D training pipeline (`training_transforms.py:394`, `num_prev_slices=3`, p=0.3), and `num_prev_slices` currently does not bound anything.

`torch.permute` returns a view, so `moved` **is** `img`: the `img.clone()` on line 241 is dead, the writes land in the caller's tensor, and — the part that matters — each iteration blends slice `i` against slices that were already smeared on earlier iterations, so the window becomes a filter that runs the full length of the axis.

One bright slice at index 0, `alpha=0.5`, `num_prev_slices=1`, 6 slices:

```
per-slice means, on main : [100.0, 50.0, 25.0, 12.5, 6.25, 3.12]
per-slice means, expected: [100.0, 50.0,  0.0,  0.0, 0.0,  0.0]
input tensor mutated     : True
```

Three lines: `.contiguous()` / `.clone()` so the working tensor is private, and the neighbour reads come from an untouched copy so `num_prev_slices` means what it says. After the change the same case gives exactly the expected profile and the input is left alone.

This does change what the augmentation produces — a bounded smear instead of an axis-long decay. If you would rather keep the current appearance, the aliasing half alone is a strictly safe subset and I can trim to that.