### PR TITLE
Preserve YAML training schedules when CLI flags are omitted

### DIFF
--- a/vesuvius/src/vesuvius/models/training/cli.py
+++ b/vesuvius/src/vesuvius/models/training/cli.py
@@ -13,6 +13,22 @@ from vesuvius.models.datasets.intensity_properties import load_intensity_props_f
 from vesuvius.models.utilities.cli_utils import update_config_from_args
 
 
+def _add_training_control_args(group):
+    """Add schedule controls whose omitted values must remain config-owned."""
+    group.add_argument("--max-epoch", type=int, default=None,
+                       help="Maximum number of epochs (overrides YAML when set)")
+    group.add_argument("--max-steps-per-epoch", type=int, default=None,
+                       help="Max training steps per epoch (use all data if unset; overrides YAML when set)")
+    group.add_argument("--max-val-steps-per-epoch", type=int, default=None,
+                       help="Max validation steps per epoch (use all data if unset; overrides YAML when set)")
+    group.add_argument("--full-epoch", action="store_true",
+                       help="Iterate over entire train/val set per epoch (overrides max-steps)")
+    group.add_argument("--early-stopping-patience", type=int, default=0,
+                       help="Epochs to wait for val loss improvement (0 disables)")
+    group.add_argument("--val-every-n", dest="val_every_n", type=int, default=None,
+                       help="Perform validation every N epochs (1=every epoch; overrides YAML when set)")
+
+
 def _maybe_set_spawn_start_method(argv):
     # s3fs/fsspec can misbehave with fork; force spawn if s3/config is present.
     if not argv:
@@ -104,20 +120,9 @@ def main(argv=None):
                            help="Type of pooling in encoder ('conv' = strided conv)")
 
     # Training Control
-    grp_train.add_argument("--max-epoch", type=int, default=1000,
-                           help="Maximum number of epochs")
-    grp_train.add_argument("--max-steps-per-epoch", type=int, default=250,
-                           help="Max training steps per epoch (use all data if unset)")
-    grp_train.add_argument("--max-val-steps-per-epoch", type=int, default=50,
-                           help="Max validation steps per epoch (use all data if unset)")
-    grp_train.add_argument("--full-epoch", action="store_true",
-                           help="Iterate over entire train/val set per epoch (overrides max-steps)")
-    grp_train.add_argument("--early-stopping-patience", type=int, default=0,
-                           help="Epochs to wait for val loss improvement (0 disables)")
+    _add_training_control_args(grp_train)
     grp_train.add_argument("--ddp", action="store_true",
                            help="Enable DistributedDataParallel (use with torchrun)")
-    grp_train.add_argument("--val-every-n", dest="val_every_n", type=int, default=1,
-                           help="Perform validation every N epochs (1=every epoch)")
     grp_train.add_argument("--gpus", type=str, default=None,
                            help="Comma-separated GPU device IDs to use, e.g. '0,1,3'. With DDP, length must equal WORLD_SIZE")
     grp_train.add_argument("--nproc-per-node", type=int, default=None,

--- a/vesuvius/tests/models/training/test_cli_schedule_defaults.py
+++ b/vesuvius/tests/models/training/test_cli_schedule_defaults.py
@@ -1,0 +1,25 @@
+import argparse
+
+from vesuvius.models.training.cli import _add_training_control_args
+
+
+def test_schedule_flags_leave_yaml_values_owned_when_omitted():
+    parser = argparse.ArgumentParser()
+    _add_training_control_args(parser)
+
+    defaults = parser.parse_args([])
+    assert defaults.max_epoch is None
+    assert defaults.max_steps_per_epoch is None
+    assert defaults.max_val_steps_per_epoch is None
+    assert defaults.val_every_n is None
+
+    explicit = parser.parse_args([
+        "--max-epoch", "50",
+        "--max-steps-per-epoch", "150",
+        "--max-val-steps-per-epoch", "20",
+        "--val-every-n", "5",
+    ])
+    assert explicit.max_epoch == 50
+    assert explicit.max_steps_per_epoch == 150
+    assert explicit.max_val_steps_per_epoch == 20
+    assert explicit.val_every_n == 5


### PR DESCRIPTION
## Summary

vesuvius.train schedule flags currently default to 1000, 250, 50, and 1 in argparse, so omitted CLI flags silently override YAML tr_config values. This PR changes those four defaults to None; explicit flags still override YAML and --full-epoch keeps its existing precedence.

## Real-data validation

Using real ScrollPrize 0500p2 data and a YAML schedule of 50/150/20/5, baseline CLI resolution was 1000/250/50/1; patched resolution was 50/150/20/5. The trainer was stubbed after CLI/config resolution, so no training or GPU work ran. Evidence: /private/tmp/villa-1489-before-real.txt and /private/tmp/villa-1489-after-real.txt.

## Tests

19 focused/configuration tests passed; git diff --check passed; CPU-only.

All code and design were reviewed and owned by me; AI assistance was used for repository exploration and test scaffolding.

Closes #1489