### PR TITLE
Stop CLI defaults from silently overriding the config's training horizon

### DIFF
--- a/vesuvius/src/vesuvius/models/training/cli.py
+++ b/vesuvius/src/vesuvius/models/training/cli.py
@@ -104,11 +104,11 @@ def main(argv=None):
                            help="Type of pooling in encoder ('conv' = strided conv)")
 
     # Training Control
-    grp_train.add_argument("--max-epoch", type=int, default=1000,
+    grp_train.add_argument("--max-epoch", type=int, default=None,
                            help="Maximum number of epochs")
-    grp_train.add_argument("--max-steps-per-epoch", type=int, default=250,
+    grp_train.add_argument("--max-steps-per-epoch", type=int, default=None,
                            help="Max training steps per epoch (use all data if unset)")
-    grp_train.add_argument("--max-val-steps-per-epoch", type=int, default=50,
+    grp_train.add_argument("--max-val-steps-per-epoch", type=int, default=None,
                            help="Max validation steps per epoch (use all data if unset)")
     grp_train.add_argument("--full-epoch", action="store_true",
                            help="Iterate over entire train/val set per epoch (overrides max-steps)")


### PR DESCRIPTION
`cli_utils.apply_cli_overrides` guards each override with `if args.X is not None`, but these three flags carry non-`None` argparse defaults, so the default is always present and always wins over the YAML.

```python
grp_train.add_argument("--max-epoch", type=int, default=1000, ...)
grp_train.add_argument("--max-steps-per-epoch", type=int, default=250,
                       help="Max training steps per epoch (use all data if unset)")
grp_train.add_argument("--max-val-steps-per-epoch", type=int, default=50, ...)
```

```
flag omitted, today : args.max_epoch = 1000  -> mgr.max_epoch := 1000, tr_config value discarded
flag omitted, after : args.max_epoch = None  -> the config value stands
```

`finetune/finetune_lejepa.yaml` declares `max_epoch: 100` and silently runs 1000. The "use all data if unset" in the help text describes a state that cannot currently be reached, and `ConfigManager` already holds defaults for all three (`config_manager.py:173-176`), so dropping the argparse defaults changes nothing for anyone passing the flags explicitly.

Scope kept to the three flags whose value the config also supplies. `--seed`, `--grad-clip`, `--amp-dtype` and `--early-stopping-patience` have the same shape but I did not touch them, since I could not confirm a config-side default for each — happy to extend if you want them covered.

(Related: #1495 fixes the other half of the `max_epoch` story, where the per-iteration schedulers read it as a step count.)