### PR TITLE
Fix ZarrDataset calling a method that does not exist

### DIFF
--- a/vesuvius/src/vesuvius/models/datasets/zarr_dataset.py
+++ b/vesuvius/src/vesuvius/models/datasets/zarr_dataset.py
@@ -494,7 +494,13 @@ class ZarrDataset(Dataset):
             if self.skip_patch_validation:
                 self._enumerate_all_patches()
             else:
-                self._find_valid_patches()
+                # Same path _build_patch_index takes when there is no mapping:
+                # a validated cache if one exists, otherwise plain enumeration.
+                cache_data = self._try_load_cache()
+                if cache_data is not None:
+                    self._load_from_cache(cache_data)
+                else:
+                    self._enumerate_all_patches()
             return
 
         logger.info(f"Loading patches from mapping file: {len(samples)} samples")


### PR DESCRIPTION
`_load_from_mapping` falls back to `self._find_valid_patches()` when the mapping file is unusable, and `ZarrDataset` has no such method — an AST walk of the class (methods called on `self` minus methods defined, minus `Dataset` members) leaves exactly `_find_valid_patches`.

```python
if not sample_shape or not samples:
    logger.warning("Invalid mapping file, falling back to standard validation")
    if self.skip_patch_validation:
        self._enumerate_all_patches()
    else:
        self._find_valid_patches()      # AttributeError
    return
```

Trigger: `data_path/samples_mapping.json` exists but carries an empty `layout.sample_shape` or an empty `samples` list, with `skip_patch_validation` at its default `False` — the dataset raises `AttributeError` at construction instead of taking the fallback the message promises.

The fix mirrors what `_build_patch_index` already does when there is no mapping at all: a validated cache if one exists, otherwise plain enumeration.