### PR TITLE
Fix DDP all-gather in the dice losses collapsing the class axis

### DIFF
--- a/vesuvius/src/vesuvius/models/training/loss/nnunet_losses.py
+++ b/vesuvius/src/vesuvius/models/training/loss/nnunet_losses.py
@@ -19,18 +19,17 @@ class AllGatherGrad(torch.autograd.Function):
             # Gather tensors from all ranks
             x_list = [torch.zeros_like(x) for _ in range(world_size)]
             torch.distributed.all_gather(x_list, x)
-            return torch.cat(x_list, dim=0)
+            # stack, not cat: the callers sum over dim 0 to reduce the world
+            # axis, so it has to be a new axis rather than the existing one
+            return torch.stack(x_list, dim=0)
         else:
             return x
 
     @staticmethod
     def backward(ctx, grad_output):
         if torch.distributed.is_available() and torch.distributed.is_initialized():
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
-            # Return only the gradient for this rank
-            grad_per_rank = grad_output.shape[0] // world_size
-            return grad_output[rank * grad_per_rank:(rank + 1) * grad_per_rank]
+            # forward stacked along a new dim 0, so this rank's slice is one index
+            return grad_output[torch.distributed.get_rank()]
         else:
             return grad_output
 


### PR DESCRIPTION
`AllGatherGrad` in the loss module concatenates along dim 0 where it needs to stack, so the world axis the callers sum away does not exist and they collapse the class axis instead.

Every consumer assumes a new leading axis:

```python
intersect = AllGatherGrad.apply(intersect).sum(0)   # meant to reduce the world axis
...
intersect = intersect.sum(0)                        # meant to reduce the batch axis
```

With `cat`, `(B, C)` becomes `(W*B, C)`, the first `sum(0)` already eats the batch axis and the second turns the per-class dice into a single scalar. `SoftDiceLoss` starts from `(C,)`, so the same path leaves a 0-dim tensor and `dc[1:]` raises.

Single-rank gloo group, where `ddp=True` must be numerically identical to `ddp=False`:

```
                                      before          after
MemoryEfficientSoftDiceLoss ddp=False  -0.3451745510   -0.3451745510
MemoryEfficientSoftDiceLoss ddp=True   -0.3454795182   -0.3451745510
SoftDiceLoss ddp=True                  IndexError      -0.3451745510
```

Both are reachable from a loss config — `batch_dice` and `ddp` are keys in `losses.py:1093/1122/1150`.

This repo already carries the correct implementation at `utils/models/ddp_allgather.py:38` (`torch.stack(gathered_tensor, dim=0)`, backward indexing by rank); this change brings the loss-module copy in line with it. `skeleton_recall.py:55-60` gathers the same way and is fixed by the same change.