### PR TITLE
data: Cube(cache=True) raises IsADirectoryError on every published cube

### DIFF
--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -1295,8 +1295,11 @@ class Cube:
                 array, _ = nrrd.read(url)
             else:
                 if self.cache:
-                    # Extract the relevant path after "instance-labels"
-                    path_after_finished_cubes = url.split('instance-labels/')[1]
+                    # Extract the relevant path after the last "instance-labels".
+                    # The published URLs contain it twice, under
+                    # volumetric-instance-labels/instance-labels/, so splitting on the
+                    # first occurrence yields the empty string between the two.
+                    path_after_finished_cubes = url.rsplit('instance-labels/', 1)[-1]
                     # Extract the directory structure and the filename
                     dir_structure, filename = os.path.split(path_after_finished_cubes)
 


### PR DESCRIPTION
## Show us what you made

**In one sentence:** `Cube(..., cache=True)` downloads and caches a published annotated-instance cube instead of raising `IsADirectoryError`.

**One real example:** Starting with the call written in `docs/accessing_data.md:140`, I ran it unchanged, and it produced a `(256, 256, 256)` volume and mask with the two `.nrrd` files landing under `<cache_dir>/02256_02512_04816/`.

**Before:**

```
$ python -c "from vesuvius.data.volume import Cube; Cube(scroll_id=1, energy=54, resolution=7.91, z=2256, y=2512, x=4816, cache=True)"
  File ".../vesuvius/data/volume.py", line 1315, in load_data
    array, _ = nrrd.read(temp_file_path)
  File ".../nrrd/reader.py", line 524, in read
    with open(filename, 'rb') as fh:
IsADirectoryError: [Errno 21] Is a directory: '/Users/…/vesuvius/annotated-instances/'
```

**After this PR:**

```
volume (256, 256, 256) uint8   mask (256, 256, 256) int32
reread from cache, identical: True
file: /tmp/vcube3/02256_02512_04816/02256_02512_04816_volume.nrrd
file: /tmp/vcube3/02256_02512_04816/02256_02512_04816_mask.nrrd
```

**Proof:** the two blocks above, same call, same machine, only this commit in between. The second `Cube(...)` construction is served from the cache and `np.array_equal` against the first is `True`.

**Why / where this is useful:** the cube URLs are `.../volumetric-instance-labels/instance-labels/<cube>/<cube>_volume.nrrd`, so the token appears twice and `url.split('instance-labels/')[1]` is the empty string between them. `os.path.split('')` returns `('', '')`, the temp path collapses to the cache directory itself, and `nrrd.read` is handed a directory. That is every entry in `cubes.yaml`, so anyone following the caching example in the docs hits it on the first call. `cache=False` is the default and is unaffected, which is why `example3_cubes_bootstrap.ipynb` never caught it.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Tested against `origin/main` @ `702d9055`, Python 3.14.6, `pip install -e vesuvius`, macOS, network only. One line plus a comment; `rsplit(..., 1)[-1]` also keeps working for any URL where the token appears once.

Found with agent assistance; the diagnosis and the before/after above are mine.
