### PR TITLE
data: Volume cannot open a published OME-Zarr group over https (keys() is empty on S3 REST)

### DIFF
--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -424,6 +424,17 @@ class Volume:
                         first_key = key
                         break
                 if first_key is None:
+                    # HTTP-backed stores may allow direct key access without directory
+                    # listing, so probe the canonical level before treating the group
+                    # as empty. Same reason as choose_pyramid_array() in
+                    # ink_detection/inference/infer.py.
+                    try:
+                        candidate = self.data['0']
+                    except (KeyError, FileNotFoundError):
+                        candidate = None
+                    if isinstance(candidate, zarr.Array):
+                        first_key = '0'
+                if first_key is None:
                     raise ValueError(f"No arrays found in zarr Group at {self.path}")
                 first_array = self.data[first_key]
                 if hasattr(first_array.dtype, 'numpy_dtype'):
@@ -602,7 +613,18 @@ class Volume:
             return 1
         n = getattr(self, "_num_levels_memo", None)
         if n is None:
-            n = self._num_levels_memo = len(self.data)
+            n = len(self.data)
+            if n == 0:
+                # An HTTP-backed group reports length 0 because the store cannot
+                # list a directory, not because the levels are missing. Count them
+                # by probing instead, so a remote multiscale is not read as empty.
+                while True:
+                    try:
+                        self.data[str(n)]
+                    except (KeyError, FileNotFoundError):
+                        break
+                    n += 1
+            self._num_levels_memo = n
         return n
 
     def _level(self, idx: int = 0):


### PR DESCRIPTION
## Show us what you made

**In one sentence:** `Volume`, `VCDataset` and therefore `vesuvius.predict --input_dir <https URL>` can open a published surface volume over https instead of reporting the group as empty.

**One real example:** Starting with `PHerc0172/segments/20251107110950-w064_.../surface-volumes/7.91um-53keV-volume-20241024131838.zarr` addressed by its https URL, I built a `Volume` and a `VCDataset`, and it produced level 0 at `(33, 13420, 14940)`, all six pyramid levels at the shapes the raw zarr reports, and 97394 patch positions.

**Before:**

```
$ python -c "from vesuvius import VCDataset; VCDataset(input_path='https://…131838.zarr', patch_size=(32,128,128))"
  File ".../vesuvius/data/volume.py", line 427, in _init_from_zarr_path
    raise ValueError(f"No arrays found in zarr Group at {self.path}")
ValueError: No arrays found in zarr Group at https://…/7.91um-53keV-volume-20241024131838.zarr
```

while the arrays are plainly there:

```
group type Group   keys(): []
direct g['0'] -> (33, 13420, 14940) uint8
```

**After this PR:**

```
Volume shape(0) (33, 13420, 14940)
levels counted: 6
shape(0) = (33, 13420, 14940)   raw zarr: (33, 13420, 14940)
shape(3) = (33, 1678, 1868)     raw zarr: (33, 1678, 1868)
shape(5) = (33, 420, 467)       raw zarr: (33, 420, 467)
level-3 read identical to raw zarr: True
VCDataset: 97394 patches
```

**Proof:** the blocks above, same URL, same machine, only this commit in between. Reads are compared against `zarr.open(url)[level]` on the same coordinates and are byte-identical. Unchanged paths still work: `Volume("Scroll1")` → `(14376, 7888, 8096)`, `Volume(type="segment", segment_id=20230827161847, scroll_id=1)` → `(65, 9163, 5048)`.

**Why / where this is useful:** the S3 REST endpoint serves keys but not directory listings, so `Group.keys()` is empty and `len(group)` is 0 for every published volume read over https, even though every level is fetchable by name. `Volume` raises on the first, and after that `_num_levels` returns 0 and each read fails with `Invalid subvolume index: 0. Available: 0 to -1`. Anyone pointing the documented `--input_dir` at a bucket URL gets this. The `s3://` spelling works, but only with `anon=True`.

This is the same situation `choose_pyramid_array()` in `ink_detection/inference/infer.py:312` already handles, with the comment *"HTTP-backed stores may allow direct key access without directory listing"*, so the same URL opens there and fails here. This PR applies that probe in `Volume`.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Tested against `origin/main` @ `702d9055`, Python 3.14.6, zarr 3.3.0, `pip install -e vesuvius`, macOS, CPU. Two sites in one file, both guarded so nothing changes for stores that do list.

One thing left alone, worth knowing: `data/zarr_chunk_index.py:477` warns *"No parseable chunk files found … falling back to lazy empty-patch detection"* on the same input, because the occupancy index is listing-based too. So `--skip_empty_patches`, which is predict's default, silently degrades over https even with this fix. That felt like a separate change.

Found with agent assistance; the diagnosis and the before/after above are mine.
