### PR TITLE
docs: the --input_dir example prints a URL that Volume cannot open

### DIFF
--- a/vesuvius/docs/inference.md
+++ b/vesuvius/docs/inference.md
@@ -27,7 +27,8 @@ vesuvius.predict \
 | Argument | Description |
 |----------|-------------|
 | `--model_path` (required) | Path to a model directory, a `.pth` checkpoint, or `hf://` repository.
-| `--input_dir` (required) | Volume input: Zarr root, TIFF stack, or a directory understood by the `Volume` helper.
+| `--input_dir` (required) | Volume input: Zarr root, TIFF stack, or a directory understood by the `Volume` helper. For open data use the `s3://` access root the catalog publishes, together with `--input_anon`.
+| `--input_anon` | Read the input bucket anonymously. Required for `s3://vesuvius-challenge-open-data/...`, which is public but unsigned.
 | `--output_dir` (required) | Destination folder for logits (`logits_part_{id}.zarr`) and coordinates.
 | `--input_format` | Force `zarr`, `tiff`, or `volume` detection. Usually optional.
 | `--tta_type` / `--disable_tta` | Choose `rotation` (default) or `mirroring`, or disable test-time augmentation.
@@ -68,7 +69,7 @@ and either bound may be omitted to reach the volume edge:
 
 ```bash
 vesuvius.predict --model_path hf://scrollprize/surface_recto \
-    --input_dir https://vesuvius-challenge-open-data.s3.amazonaws.com/PHercParis4/volumes/<volume>.zarr \
+    --input_dir s3://vesuvius-challenge-open-data/PHercParis4/volumes/<volume>.zarr --input_anon \
     --output_dir /tmp/logits \
     --bbox "2000:2200,1000:1200,1000:1200"
 


### PR DESCRIPTION
## Summary

The only `--input_dir` example in `vesuvius/docs/inference.md` used an HTTPS
bucket URL that cannot enumerate its Zarr group. Following the documentation
therefore produced `ValueError: No arrays found` even though the arrays existed.

This docs-only fix uses the anonymous `s3://` access root published by the
catalog and documents `--input_anon`.

## Evidence

On the same public PHercParis4 volume:

| documented input | result |
|---|---|
| HTTPS bucket REST URL | group appears empty; `No arrays found` |
| catalog `s3://` root + `--input_anon` | opens shape `(4071, 2264, 2264)`, six levels |

The cause is specific to the bucket REST host: fsspec's HTTP filesystem cannot
list it, although direct child access works. The other published HTTPS roots
that serve listings are unchanged.

This supersedes #1506. That PR attempted loader-side probing, but the supported
anonymous S3 path already worked; the incorrect documentation was the defect.

## Limit

This PR does not repair the separate Atlas copy button, which still emitted the
same HTTPS form when the PR was prepared.

## Agentic-use disclosure

Agentic AI assisted the original investigation. OpenAI Codex was used
agentically for the later audit and documentation.
