### PR TITLE
data: Cube(cache=True) and activate_caching() raise IsADirectoryError

### DIFF
--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -1295,13 +1295,17 @@ class Cube:
                 array, _ = nrrd.read(url)
             else:
                 if self.cache:
-                    # Extract the relevant path after "instance-labels"
-                    path_after_finished_cubes = url.split('instance-labels/')[1]
-                    # Extract the directory structure and the filename
-                    dir_structure, filename = os.path.split(path_after_finished_cubes)
+                    # The cube's own coordinates give the cache layout, so the URL does
+                    # not have to be parsed. It used to be split on 'instance-labels/',
+                    # which appears twice in the published URLs
+                    # (volumetric-instance-labels/instance-labels/), so the piece taken
+                    # was the empty string between the two occurrences.
+                    filename = os.path.basename(url)
 
                     # Create the full directory path in the temp_dir
-                    full_temp_dir_path = os.path.join(self.cache_dir, dir_structure)
+                    full_temp_dir_path = os.path.join(
+                        self.cache_dir, f'{self.z:05d}_{self.y:05d}_{self.x:05d}'
+                    )
 
                     # Make sure the directory structure exists
                     os.makedirs(full_temp_dir_path, exist_ok=True)


### PR DESCRIPTION
## Summary

The documented `Cube(..., cache=True)` path raised `IsADirectoryError` instead
of caching a cube. The URL contains `instance-labels/` twice, so splitting on
that token produced an empty basename and passed the cache directory itself to
`nrrd.read`.

The fix builds the existing cache layout from the cube's stored `z/y/x`
coordinates rather than parsing the URL.

## Evidence

On the published cube `02256_02512_04816`:

| | before | after |
|---|---|---|
| `Cube(cache=True)` | `IsADirectoryError` | volume and mask `(256, 256, 256)` |
| second construction | fails before caching | served from cache, arrays byte-identical |
| `activate_caching()` | same directory error | same coordinate-based cache path |

The default `cache=False` path and the AWS branch are unchanged. Existing cache
directories retain the layout the old code intended.

This supersedes #1505. Its `rsplit` change still depended on URL shape and made
the zero-token case a directory named after the full URL; using coordinates
removes that ambiguity.

## Limit

The public-data before/after was reproduced manually. The merged PR does not
contain a dedicated automated regression for this exact URL shape.

## Agentic-use disclosure

Agentic AI assisted the original investigation. OpenAI Codex was used
agentically for the later audit and documentation.
