### PR TITLE
cmake(macos): search frameworks last in the Homebrew LLVM preset

### DIFF
--- a/volume-cartographer/CMakePresets.json
+++ b/volume-cartographer/CMakePresets.json
@@ -177,7 +177,7 @@
     {
       "name": "macos-homebrew-llvm",
       "displayName": "macOS Homebrew LLVM",
-      "description": "Native macOS build using Homebrew LLVM/Clang, lld, and Homebrew binutils. The only Apple-toolchain pieces in the loop are SDKROOT (system headers/frameworks) and libSystem, because there is no Homebrew alternative for those.",
+      "description": "Native macOS build using Homebrew LLVM/Clang, lld, and Homebrew binutils. The only Apple-toolchain pieces in the loop are SDKROOT (system headers/frameworks) and libSystem, because there is no Homebrew alternative for those. CMAKE_FIND_FRAMEWORK=LAST because CMake's macOS default searches /Library/Frameworks ahead of the Homebrew prefix: any third-party framework that vendors a common C library wins the header search while the library still resolves to Homebrew.",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build-macos",
       "cacheVariables": {
@@ -202,6 +202,7 @@
         "CMAKE_SHARED_LINKER_FLAGS_INIT": "-fuse-ld=lld",
         "CMAKE_MODULE_LINKER_FLAGS_INIT": "-fuse-ld=lld",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3",
+        "CMAKE_FIND_FRAMEWORK": "LAST",
         "VC_TESTING": "OFF"
       }
     }


### PR DESCRIPTION
## Show us what you made

**In one sentence:** on a Mac carrying any third-party framework that vendors `tiff.h`, `core/src/Tiff.cpp` stops with two compile errors; this preset line makes `find_package(TIFF)` take Homebrew's headers and the file compiles.

**One real example:** I took the project's own compile command for `core/src/Tiff.cpp` out of `build-macos/compile_commands.json` and ran it twice, changing only the include search order.

**Before:** with the framework directory ahead of the Homebrew prefix, which is what `CMAKE_FIND_FRAMEWORK=FIRST` produces:

```
/Library/Frameworks/Mono.framework/Headers/tiff.h:77:23: error: typedef redefinition with
different types ('long' vs 'int64_t' (aka 'long long'))
/Library/Frameworks/Mono.framework/Headers/tiff.h:78:23: error: typedef redefinition with
different types ('unsigned long' vs 'uint64_t' (aka 'unsigned long long'))
2 errors generated.
```

**After this PR:** the same command, same file, zero errors.

**Proof:** the two runs above differ only in the include path. On this machine `/Library/Frameworks/Mono.framework/Headers/tiff.h` is dated 2021 and still declares the pre-4.3 global `int64`/`uint64` typedefs, while `/opt/homebrew/include` is libtiff 4.7.2 and does not. `Tiff.cpp` includes `<tiffio.h>` and `<opencv2/imgcodecs.hpp>`, so the two definitions meet in that translation unit. Reduced to three lines, `#include <opencv2/core/hal/interface.h>` followed by `#include <tiff.h>` reproduces it exactly and clears with the Homebrew include.

**Why / where this is useful:** anyone building VC3D from source on a Mac that has such a framework installed. Mono is one; `ls /Library/Frameworks/*.framework/Headers/tiff.h` is the check. CI cannot see it, because the hosted macOS runners carry no such framework, so the macOS job is green either way.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Motivation: I build VC3D from source on this Mac to open segments and render surface volumes for the ink-map work in #1372, and this is where that build stops.

`find_library(TIFF_LIBRARY tiff)` finds no `tiff.framework`, so it falls through to Homebrew regardless, which is why CMake reports `TIFF_FOUND` and the mismatch survives configure.

Host: M4, macOS 26.6, Homebrew LLVM, libtiff 4.7.2, OpenCV 5.

Scope I did not measure: I verified the failing and passing compile of `Tiff.cpp` specifically, not a full `build_macos.sh` run, and I have not measured whether the flag moves any other dependency in this preset. `find_package` calls that resolve through package config or a Homebrew prefix are unaffected by the framework search order; a dependency that exists only as a framework still resolves, since `LAST` reorders rather than excludes.

This supersedes my #1337, which described the same change as a silent header/library mismatch and as hardening. It is neither: the compiler stops, and that PR carried no error output and did not follow the template.

Agent-assisted; the reproduction above is mine.
