### PR TITLE
scripts(macos): add --tests and --check to build_macos.sh

### DIFF
--- a/volume-cartographer/scripts/build_macos.sh
+++ b/volume-cartographer/scripts/build_macos.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  scripts/build_macos.sh [--install-deps] [--ccache|--sccache] [--build-dir DIR] [--jobs N]
+  scripts/build_macos.sh [--install-deps] [--ccache|--sccache] [--build-dir DIR]
+                         [--jobs N] [--tests] [--check]
 
 Build VC3D natively on macOS with Homebrew LLVM/Clang.
 
@@ -14,6 +15,9 @@ Options:
   --sccache        Enable sccache (installed when combined with --install-deps).
   --build-dir DIR  Override the default build directory: build-macos
   --jobs N         Parallel build jobs. Defaults to the host CPU count.
+  --tests          Configure with VC_TESTING=ON so the unit tests are built.
+  --check          Implies --tests, then runs the check-core and check-specialized
+                   targets.
 USAGE
 }
 
@@ -31,6 +35,8 @@ install_deps=0
 use_ccache=0
 use_sccache=0
 build_dir="build-macos"
+build_tests=0
+run_check=0
 jobs="$(sysctl -n hw.ncpu 2>/dev/null || echo 8)"
 
 while [[ $# -gt 0 ]]; do
@@ -50,6 +56,15 @@ while [[ $# -gt 0 ]]; do
     --build-dir)
       build_dir="${2:?missing value for --build-dir}"
       shift 2
+      ;;
+    --tests)
+      build_tests=1
+      shift
+      ;;
+    --check)
+      build_tests=1
+      run_check=1
+      shift
       ;;
     --jobs)
       jobs="${2:?missing value for --jobs}"
@@ -201,6 +216,10 @@ done
 # Accelerate.framework — see openblas note in required_formulae above.
 extra_cmake_args+=("-DBLA_VENDOR=OpenBLAS")
 
+if (( build_tests )); then
+  extra_cmake_args+=("-DVC_TESTING=ON")
+fi
+
 # PaStiX enables Fortran at configure time even with PASTIX_WITH_FORTRAN=OFF.
 # Use LLVM's flang (from the Homebrew flang keg) so the toolchain stays
 # clang/flang + lld end-to-end; gfortran would inherit our -fuse-ld=lld
@@ -220,6 +239,10 @@ cmake --preset macos-homebrew-llvm \
   "${extra_cmake_args[@]}"
 
 cmake --build "$build_dir" -j "$jobs"
+
+if (( run_check )); then
+  cmake --build "$build_dir" -j "$jobs" --target check-core check-specialized
+fi
 
 if (( use_ccache )); then
   ccache --show-stats


### PR DESCRIPTION
## Show us what you made

**In one sentence:** `build_macos.sh` can build and run the C++ test suite, so a change to `core/` can be checked on a Mac before it is pushed.

**One real example:** on a clean `main`, I ran `scripts/build_macos.sh --check` and it produced 132 passing `vc-core` tests and 18 passing `vc-specialized` tests, Qt widget tests included.

**Before:**

```
$ scripts/build_macos.sh --tests
Unknown argument: --tests
Usage:
  scripts/build_macos.sh [--install-deps] [--ccache|--sccache] [--build-dir DIR] [--jobs N]
```

The preset the script uses pins `"VC_TESTING": "OFF"`, and the script passes no override, so the test targets do not exist in the tree. Both `ctest` jobs in `vc3d-ci.yml` are `ubuntu-24.04`; the macOS job compiles only. So the only route to a test build on macOS was to stop using the documented script and rebuild its environment by hand, which is `HOMEBREW_PREFIX` (the preset's compiler paths are `$env{HOMEBREW_PREFIX}/opt/llvm/...`, so `cmake --preset` alone does not configure), `SDKROOT`, lld and llvm on `PATH`, `CMAKE_Fortran_COMPILER`, `BLA_VENDOR`, `Eigen3_DIR`, `nlohmann_json_DIR` and the keg `PKG_CONFIG_PATH`.

**After this PR:**

```
$ scripts/build_macos.sh --check
...
100% tests passed, 0 tests failed out of 132     (vc-core, 46.2 s)
100% tests passed, 0 tests failed out of 18      (vc-specialized, 15.2 s)
```

**Proof:** same commit, same machine, same command apart from the flag. `--tests` appends one `-DVC_TESTING=ON` to the configure the script already runs; a command-line `-D` outranks the preset's cache entry, so the existing build directory is reused and the next plain `build_macos.sh` run puts it back to `OFF` on its own. I checked that directly: the tree's `CMakeCache.txt` went from `VC_TESTING:BOOL=OFF` to `ON`, and `check-core`, `check-core-offline` and `check-specialized` appeared as targets. `--check` then builds those targets, which is what #1339 made functional.

**Why / where this is useful:** anyone changing `vc_core` or the VC3D widgets on a Mac. Today that change reaches a test run only after it is pushed and a Linux runner picks it up.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Motivation: I build VC3D from source on this Mac for the ink-map work in #1372, and after touching `core/` I wanted to run the suite locally before pushing. There was no supported way to do it.

This adds nothing to CI and asks for no runner: `vc3d-ci` still calls `build_macos.sh --sccache` and stays a compile gate. It is two flags on the developer script the README points at.

This supersedes my #1338, which did the same thing in 57 lines instead of 24 because it built into a separate `build-macos-tests` directory. I argued that flipping `VC_TESTING` in place would silently produce a differently defined library. That was wrong, and checking it is what made me withdraw it: CMake reconfigures and rebuilds correctly in both directions, and `VC_TESTING` is `PRIVATE` to `vc_fiber_tracer` with additive guards, so a `--tests` tree is not an instrumented VC3D. The second directory only cost a full rebuild.

Host: M4, macOS 26.6, Homebrew LLVM. Agent-assisted; the run above and the decision to drop the second build tree are mine.
