### PR TITLE
Temporarily disable render Valgrind gate

### DIFF
--- a/.github/workflows/vc3d-ci.yml
+++ b/.github/workflows/vc3d-ci.yml
@@ -194,7 +194,9 @@ jobs:
   render-benchmark:
     name: Synthetic rendering regression (GCC Release / Valgrind replay)
     needs: changes
-    if: needs.changes.outputs.test_core == 'true'
+    # Temporarily disabled while the renderer regression and parallel replay
+    # stability are repaired. The aggregate CI job accepts this job as skipped.
+    if: ${{ false }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     container:


### PR DESCRIPTION
## Summary

Temporarily skip the synthetic rendering Valgrind CI job while the renderer regression and parallel replay instability are repaired.

The job remains in the workflow dependency graph, and aggregate CI already accepts a skipped result. The benchmark sources, model, reference data, and local CMake targets remain unchanged.

## Reason

The gate currently fails on `main` and varies materially between identical runs, blocking unrelated pull requests while the benchmark is investigated.

## Validation

- Parsed `.github/workflows/vc3d-ci.yml` as YAML
- Ran `git diff --check`
