### PR TITLE
Repair and re-enable synthetic rendering regression gate

### DIFF
--- a/.github/workflows/vc3d-ci.yml
+++ b/.github/workflows/vc3d-ci.yml
@@ -194,9 +194,7 @@ jobs:
   render-benchmark:
     name: Synthetic rendering regression (GCC Release / Valgrind replay)
     needs: changes
-    # Temporarily disabled while the renderer regression and parallel replay
-    # stability are repaired. The aggregate CI job accepts this job as skipped.
-    if: ${{ false }}
+    if: needs.changes.outputs.test_core == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     container:

--- a/.github/workflows/vc3d-ci.yml
+++ b/.github/workflows/vc3d-ci.yml
@@ -231,9 +231,10 @@ jobs:
           echo "Using $jobs Ninja jobs"
           cmake --build build/ci-render-benchmark \
             --target bench_render_synthetic bench_thread_sync_replay \
+              test_thread_sync_replay_native \
             --parallel "$jobs"
           ctest --test-dir build/ci-render-benchmark --output-on-failure \
-            -R '^(test_render_synthetic_fixture|test_render_valgrind_ci_no_site)$'
+            -R '^(test_render_synthetic_fixture|test_thread_sync_replay_native)$'
       - name: Run full fresh Valgrind matrix
         working-directory: volume-cartographer
         run: |

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -589,16 +589,20 @@ if(VC_RUN_RENDER_BENCHMARKS)
                     "${_callgrind_dir}/callgrind.out")
                 set(_callgrind_metadata
                     "${_callgrind_dir}/metadata.json")
+                set(_callgrind_scheduler)
+                set(_callgrind_scheduler_args)
                 set(_callgrind_byproducts
-                    "${_callgrind_dir}/callgrind.out"
-                    "${_callgrind_dir}/callgrind.out-01"
                     "${_callgrind_metadata}")
                 if(_fixture STREQUAL "parallel")
+                    set(_callgrind_scheduler
+                        "${_callgrind_dir}/scheduler.log")
+                    list(APPEND _callgrind_scheduler_args
+                        --trace-sched=yes
+                        --trace-syscalls=yes
+                        --time-stamp=yes
+                        "--log-file=${_callgrind_scheduler}")
                     list(APPEND _callgrind_byproducts
-                        "${_callgrind_dir}/callgrind.out-02"
-                        "${_callgrind_dir}/callgrind.out-03"
-                        "${_callgrind_dir}/callgrind.out-04"
-                        "${_callgrind_dir}/callgrind.out-05")
+                        "${_callgrind_scheduler}")
                 endif()
                 add_custom_command(
                     OUTPUT "${_callgrind_stamp}"
@@ -623,6 +627,7 @@ if(VC_RUN_RENDER_BENCHMARKS)
                         --I1=32768,8,64
                         --D1=32768,8,64
                         --LL=8388608,16,64
+                        ${_callgrind_scheduler_args}
                         "--callgrind-out-file=${_callgrind_prefix}"
                         $<TARGET_FILE:bench_render_synthetic>
                         --fixture ${_fixture}
@@ -687,6 +692,7 @@ if(VC_RUN_RENDER_BENCHMARKS)
                     --output "${_evaluation}")
                 if(_fixture STREQUAL "parallel")
                     list(APPEND _evaluation_command
+                        --callgrind-scheduler "${_callgrind_scheduler}"
                         --drd-trace "${_drd_trace}"
                         --drd-metadata "${_drd_metadata}")
                 endif()
@@ -714,6 +720,7 @@ if(VC_RUN_RENDER_BENCHMARKS)
                     --output "${_gate}")
                 if(_fixture STREQUAL "parallel")
                     list(APPEND _gate_command
+                        --callgrind-scheduler "${_callgrind_scheduler}"
                         --drd-trace "${_drd_trace}"
                         --drd-metadata "${_drd_metadata}")
                 endif()

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -380,14 +380,16 @@ target_compile_definitions(bench_thread_pool_dispatch PRIVATE
 vc_register_test_target(bench_thread_pool_dispatch)
 
 add_library(vc_thread_sync_replay STATIC
-    thread_sync_replay/Replay.cpp)
+    thread_sync_replay/Replay.cpp
+    thread_sync_replay/RenderValgrind.cpp)
 target_include_directories(vc_thread_sync_replay PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(vc_thread_sync_replay PUBLIC
     nlohmann_json::nlohmann_json)
 
 add_executable(bench_thread_sync_replay
-    thread_sync_replay/main.cpp)
+    thread_sync_replay/main.cpp
+    thread_sync_replay/RenderValgrindCli.cpp)
 target_link_libraries(bench_thread_sync_replay PRIVATE
     vc_thread_sync_replay nlohmann_json::nlohmann_json)
 target_compile_definitions(bench_thread_sync_replay PRIVATE
@@ -564,33 +566,33 @@ if(VC_RUN_RENDER_BENCHMARKS)
        CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
         set(_render_valgrind_ci_root
             "${CMAKE_BINARY_DIR}/render-valgrind-ci")
-        set(_render_valgrind_ci_runner
-            "${PROJECT_SOURCE_DIR}/scripts/run_render_valgrind_ci.py")
-        set(_render_valgrind_ci_common
-            "${PROJECT_SOURCE_DIR}/scripts/render_valgrind_common.py")
         set(_render_valgrind_ci_model
             "${PROJECT_SOURCE_DIR}/core/test/data/render_valgrind_ci_model.json")
         set(_render_valgrind_ci_reference
             "${PROJECT_SOURCE_DIR}/core/test/data/render_valgrind_ci_reference.json")
-        set(_render_valgrind_ci_script_deps
-            "${_render_valgrind_ci_runner}"
-            "${_render_valgrind_ci_common}"
-            "${PROJECT_SOURCE_DIR}/scripts/native_thread_sync_replay.py"
-            "${PROJECT_SOURCE_DIR}/scripts/thread_sync_trace.py")
         set(_render_valgrind_ci_measure_outputs)
         set(_render_valgrind_ci_gate_outputs)
 
         foreach(_fixture serial parallel)
+            if(_fixture STREQUAL "serial")
+                set(_render_workers 1)
+            else()
+                set(_render_workers 4)
+            endif()
             foreach(_scenario full_res fallback_3 mixed_correlated mixed_shuffled)
                 set(_case_dir
                     "${_render_valgrind_ci_root}/${_fixture}/${_scenario}")
                 set(_callgrind_dir "${_case_dir}/callgrind")
-                set(_callgrind_artifact
-                    "${_callgrind_dir}/artifact.json")
+                set(_callgrind_stamp
+                    "${_callgrind_dir}/collected.stamp")
+                set(_callgrind_prefix
+                    "${_callgrind_dir}/callgrind.out")
+                set(_callgrind_metadata
+                    "${_callgrind_dir}/metadata.json")
                 set(_callgrind_byproducts
                     "${_callgrind_dir}/callgrind.out"
                     "${_callgrind_dir}/callgrind.out-01"
-                    "${_callgrind_dir}/metadata.callgrind.json")
+                    "${_callgrind_metadata}")
                 if(_fixture STREQUAL "parallel")
                     list(APPEND _callgrind_byproducts
                         "${_callgrind_dir}/callgrind.out-02"
@@ -599,82 +601,121 @@ if(VC_RUN_RENDER_BENCHMARKS)
                         "${_callgrind_dir}/callgrind.out-05")
                 endif()
                 add_custom_command(
-                    OUTPUT "${_callgrind_artifact}"
+                    OUTPUT "${_callgrind_stamp}"
                     BYPRODUCTS ${_callgrind_byproducts}
+                    COMMAND ${CMAKE_COMMAND} -E remove_directory
+                        "${_callgrind_dir}"
                     COMMAND ${CMAKE_COMMAND} -E make_directory
                         "${_callgrind_dir}"
-                    COMMAND ${Python3_EXECUTABLE} "${_render_valgrind_ci_runner}"
-                        callgrind
-                        --benchmark $<TARGET_FILE:bench_render_synthetic>
+                    COMMAND ${CMAKE_COMMAND} -E env
+                        "VC_RENDER_SAMPLER_THREADS=${_render_workers}"
+                        ${VC_VALGRIND_EXECUTABLE}
+                        --tool=callgrind
+                        --instr-atstart=no
+                        --fair-sched=yes
+                        --scheduling-quantum=10000
+                        --separate-threads=yes
+                        --dump-every-bb=10000
+                        --combine-dumps=no
+                        --collect-systime=no
+                        --cache-sim=yes
+                        --branch-sim=yes
+                        --I1=32768,8,64
+                        --D1=32768,8,64
+                        --LL=8388608,16,64
+                        "--callgrind-out-file=${_callgrind_prefix}"
+                        $<TARGET_FILE:bench_render_synthetic>
                         --fixture ${_fixture}
                         --scenario ${_scenario}
+                        --native-trials 1
+                        --metadata "${_callgrind_metadata}"
                         --repetitions 1
-                        --output-dir "${_callgrind_dir}"
-                        --artifact "${_callgrind_artifact}"
+                        --callgrind
+                    COMMAND ${CMAKE_COMMAND} -E touch "${_callgrind_stamp}"
                     DEPENDS
                         bench_render_synthetic
-                        ${_render_valgrind_ci_script_deps}
                     VERBATIM)
 
-                set(_drd_artifact)
+                set(_drd_stamp)
                 if(_fixture STREQUAL "parallel")
                     set(_drd_dir "${_case_dir}/drd")
-                    set(_drd_artifact "${_drd_dir}/artifact.json")
+                    set(_drd_stamp "${_drd_dir}/collected.stamp")
+                    set(_drd_trace "${_drd_dir}/drd.log")
+                    set(_drd_metadata "${_drd_dir}/metadata.json")
                     add_custom_command(
-                        OUTPUT "${_drd_artifact}"
+                        OUTPUT "${_drd_stamp}"
                         BYPRODUCTS
-                            "${_drd_dir}/drd.log"
-                            "${_drd_dir}/events.jsonl"
-                            "${_drd_dir}/metadata.drd.json"
+                            "${_drd_trace}"
+                            "${_drd_metadata}"
+                        COMMAND ${CMAKE_COMMAND} -E remove_directory
+                            "${_drd_dir}"
                         COMMAND ${CMAKE_COMMAND} -E make_directory
                             "${_drd_dir}"
-                        COMMAND ${Python3_EXECUTABLE} "${_render_valgrind_ci_runner}"
-                            drd
-                            --benchmark $<TARGET_FILE:bench_render_synthetic>
+                        COMMAND ${CMAKE_COMMAND} -E env
+                            "VC_RENDER_SAMPLER_THREADS=4"
+                            ${VC_VALGRIND_EXECUTABLE}
+                            --tool=drd
+                            --trace-segment=yes
+                            --trace-csw=yes
+                            --fair-sched=yes
+                            --time-stamp=yes
+                            --scheduling-quantum=10000
+                            --trace-sched=yes
+                            --trace-syscalls=yes
+                            "--log-file=${_drd_trace}"
+                            $<TARGET_FILE:bench_render_synthetic>
+                            --fixture parallel
                             --scenario ${_scenario}
+                            --native-trials 1
+                            --metadata "${_drd_metadata}"
                             --repetitions 1
-                            --output-dir "${_drd_dir}"
-                            --artifact "${_drd_artifact}"
+                        COMMAND ${CMAKE_COMMAND} -E touch "${_drd_stamp}"
                         DEPENDS
                             bench_render_synthetic
-                            ${_render_valgrind_ci_script_deps}
                         VERBATIM)
                 endif()
 
                 set(_evaluation "${_case_dir}/evaluation.json")
                 set(_evaluation_command
-                    ${Python3_EXECUTABLE} "${_render_valgrind_ci_runner}"
-                    evaluate
-                    --callgrind "${_callgrind_artifact}"
+                    $<TARGET_FILE:bench_thread_sync_replay>
+                    evaluate-render
+                    --fixture ${_fixture}
+                    --scenario ${_scenario}
+                    --callgrind-prefix "${_callgrind_prefix}"
+                    --callgrind-metadata "${_callgrind_metadata}"
                     --model "${_render_valgrind_ci_model}"
-                    --replay-engine $<TARGET_FILE:bench_thread_sync_replay>
                     --output "${_evaluation}")
                 if(_fixture STREQUAL "parallel")
-                    list(APPEND _evaluation_command --drd "${_drd_artifact}")
+                    list(APPEND _evaluation_command
+                        --drd-trace "${_drd_trace}"
+                        --drd-metadata "${_drd_metadata}")
                 endif()
                 add_custom_command(
                     OUTPUT "${_evaluation}"
                     COMMAND ${_evaluation_command}
                     DEPENDS
-                        "${_callgrind_artifact}"
-                        ${_drd_artifact}
+                        "${_callgrind_stamp}"
+                        ${_drd_stamp}
                         bench_thread_sync_replay
                         "${_render_valgrind_ci_model}"
-                        ${_render_valgrind_ci_script_deps}
                     VERBATIM)
                 list(APPEND _render_valgrind_ci_measure_outputs "${_evaluation}")
 
                 set(_gate "${_case_dir}/checked.json")
                 set(_gate_command
-                    ${Python3_EXECUTABLE} "${_render_valgrind_ci_runner}"
-                    evaluate
-                    --callgrind "${_callgrind_artifact}"
+                    $<TARGET_FILE:bench_thread_sync_replay>
+                    evaluate-render
+                    --fixture ${_fixture}
+                    --scenario ${_scenario}
+                    --callgrind-prefix "${_callgrind_prefix}"
+                    --callgrind-metadata "${_callgrind_metadata}"
                     --model "${_render_valgrind_ci_model}"
                     --reference "${_render_valgrind_ci_reference}"
-                    --replay-engine $<TARGET_FILE:bench_thread_sync_replay>
                     --output "${_gate}")
                 if(_fixture STREQUAL "parallel")
-                    list(APPEND _gate_command --drd "${_drd_artifact}")
+                    list(APPEND _gate_command
+                        --drd-trace "${_drd_trace}"
+                        --drd-metadata "${_drd_metadata}")
                 endif()
                 add_custom_command(
                     OUTPUT "${_gate}"
@@ -682,12 +723,11 @@ if(VC_RUN_RENDER_BENCHMARKS)
                     COMMAND ${_gate_command}
                     DEPENDS
                         "${_evaluation}"
-                        "${_callgrind_artifact}"
-                        ${_drd_artifact}
+                        "${_callgrind_stamp}"
+                        ${_drd_stamp}
                         bench_thread_sync_replay
                         "${_render_valgrind_ci_model}"
                         "${_render_valgrind_ci_reference}"
-                        ${_render_valgrind_ci_script_deps}
                     VERBATIM)
                 list(APPEND _render_valgrind_ci_gate_outputs "${_gate}")
             endforeach()

--- a/volume-cartographer/core/test/bench_render_synthetic.cpp
+++ b/volume-cartographer/core/test/bench_render_synthetic.cpp
@@ -1,5 +1,6 @@
 #include "vc/core/render/ChunkedPlaneSampler.hpp"
-#include "vc/core/render/IChunkedArray.hpp"
+#include "vc/core/render/ChunkCache.hpp"
+#include "vc/core/render/ChunkFetch.hpp"
 
 #include <opencv2/core.hpp>
 
@@ -38,13 +39,18 @@
 namespace
 {
 
+using vc::render::ChunkCache;
+using vc::render::ChunkCacheService;
 using vc::render::ChunkDtype;
 using vc::render::ChunkedPlaneSampler;
+using vc::render::ChunkFetchResult;
+using vc::render::ChunkFetchStatus;
 using vc::render::ChunkKey;
 using vc::render::ChunkKeyHash;
 using vc::render::ChunkResult;
 using vc::render::ChunkStatus;
 using vc::render::IChunkedArray;
+using vc::render::IChunkFetcher;
 
 constexpr int kLevels = 4;
 constexpr int kTileSize = 32;
@@ -151,79 +157,53 @@ std::uint64_t keySeed(const ChunkKey& key)
     return splitmix64(value ^ (std::uint64_t(static_cast<std::uint32_t>(key.ix)) << 32U));
 }
 
-class SyntheticResidentArray final : public IChunkedArray
+class SyntheticChunkFetcher final : public IChunkFetcher
 {
 public:
-    SyntheticResidentArray(const cv::Mat_<cv::Vec3f>& coords, const cv::Mat_<uint8_t>& expectedLevels)
+    SyntheticChunkFetcher(const cv::Mat_<cv::Vec3f>& coords, const cv::Mat_<uint8_t>& expectedLevels)
     {
         if (coords.size() != expectedLevels.size())
             throw std::runtime_error("coordinate and expected-level shapes differ");
         buildEntries(coords, expectedLevels);
     }
 
-    int numLevels() const override { return kLevels; }
+    ChunkFetchResult fetch(const ChunkKey& key) override { return decodeFetched(key, fetchEncoded(key)); }
 
-    std::array<int, 3> shape(int level) const override
+    ChunkFetchResult fetchEncoded(const ChunkKey& key) override
     {
-        const int scale = 1 << level;
-        return {kLevel0Shape[0] / scale, kLevel0Shape[1] / scale, kLevel0Shape[2] / scale};
+        fetchCalls_.fetch_add(1, std::memory_order_relaxed);
+        const auto found = entries_.find(normalized(key));
+        if (found == entries_.end())
+            return {ChunkFetchStatus::IoError, {}, {}, false, false, 0, "synthetic fixture accessed an undeclared chunk"};
+        ChunkFetchResult result;
+        result.status = found->second == ChunkStatus::Data ? ChunkFetchStatus::Found : ChunkFetchStatus::Missing;
+        return result;
     }
 
-    std::array<int, 3> chunkShape(int) const override { return kChunkShape; }
-    ChunkDtype dtype() const override { return ChunkDtype::UInt8; }
-    double fillValue() const override { return 0.0; }
-
-    LevelTransform levelTransform(int level) const override
+    ChunkFetchResult decodeFetched(const ChunkKey& key, ChunkFetchResult fetched) const override
     {
-        const double scale = 1.0 / double(1 << level);
-        return {{scale, scale, scale}, {0.0, 0.0, 0.0}};
+        if (fetched.status != ChunkFetchStatus::Found)
+            return fetched;
+        const std::size_t chunkBytes = std::size_t(kChunkShape[0]) * std::size_t(kChunkShape[1]) * std::size_t(kChunkShape[2]);
+        fetched.bytes.resize(chunkBytes);
+        std::uint64_t state = keySeed(normalized(key));
+        const int base = key.level * kValueBand + 8;
+        for (std::size_t i = 0; i < fetched.bytes.size(); ++i) {
+            state = splitmix64(state + i);
+            fetched.bytes[i] = std::byte(base + int(state % 24U));
+        }
+        return fetched;
     }
 
-    ChunkResult tryGetChunk(int level, int iz, int iy, int ix) override
-    {
-        recordThread();
-        return lookup({level, iz, iy, ix});
-    }
+    const std::unordered_map<ChunkKey, ChunkStatus, ChunkKeyHash>& entries() const { return entries_; }
 
-    ChunkResult getChunkIfCached(int level, int iz, int iy, int ix) override
-    {
-        recordThread();
-        return lookup({level, iz, iy, ix});
-    }
-
-    ChunkResult getChunkBlocking(int level, int iz, int iy, int ix) override { return lookup({level, iz, iy, ix}); }
-
-    void prefetchChunks(const std::vector<ChunkKey>&, bool, int) override {}
-    ChunkReadyCallbackId addChunkReadyListener(ChunkReadyCallback) override { return 0; }
-    void removeChunkReadyListener(ChunkReadyCallbackId) override {}
-
-    void startThreadTracking()
-    {
-        std::lock_guard lock(threadMutex_);
-        threadIds_.clear();
-        trackThreads_.store(true, std::memory_order_release);
-    }
-
-    std::size_t stopThreadTracking()
-    {
-        trackThreads_.store(false, std::memory_order_release);
-        std::lock_guard lock(threadMutex_);
-        return threadIds_.size();
-    }
+    std::size_t fetchCalls() const { return fetchCalls_.load(std::memory_order_relaxed); }
 
 private:
-    struct Entry {
-        ChunkStatus status = ChunkStatus::Missing;
-        std::shared_ptr<const std::vector<std::byte>> bytes;
-    };
-
-    ChunkResult lookup(const ChunkKey& key) const
+    static ChunkKey normalized(ChunkKey key)
     {
-        const auto found = entries_.find(key);
-        if (found == entries_.end()) {
-            return {ChunkStatus::Error, ChunkDtype::UInt8, kChunkShape, {}, "synthetic fixture accessed an undeclared chunk"};
-        }
-        return {found->second.status, ChunkDtype::UInt8, kChunkShape, found->second.bytes, {}};
+        key.sourceId = {};
+        return key;
     }
 
     static std::array<ChunkKey, 8> dependencies(const cv::Vec3f& coord, int level)
@@ -244,8 +224,8 @@ private:
 
     void declareEntry(const ChunkKey& key, ChunkStatus status)
     {
-        auto [it, inserted] = entries_.try_emplace(key, Entry{status, {}});
-        if (!inserted && it->second.status != status) {
+        auto [it, inserted] = entries_.try_emplace(key, status);
+        if (!inserted && it->second != status) {
             throw std::runtime_error("synthetic fallback regions share a chunk with conflicting residency");
         }
     }
@@ -264,35 +244,105 @@ private:
                 }
             }
         }
-
-        const std::size_t chunkBytes = std::size_t(kChunkShape[0]) * std::size_t(kChunkShape[1]) * std::size_t(kChunkShape[2]);
-        for (auto& [key, entry] : entries_) {
-            if (entry.status != ChunkStatus::Data)
-                continue;
-            auto bytes = std::make_shared<std::vector<std::byte>>(chunkBytes);
-            std::uint64_t state = keySeed(key);
-            const int base = key.level * kValueBand + 8;
-            for (std::size_t i = 0; i < bytes->size(); ++i) {
-                state = splitmix64(state + i);
-                (*bytes)[i] = std::byte(base + int(state % 24U));
-            }
-            entry.bytes = std::move(bytes);
-        }
     }
 
+    std::unordered_map<ChunkKey, ChunkStatus, ChunkKeyHash> entries_;
+    std::atomic_size_t fetchCalls_{0};
+};
+
+class ThreadTrackingArray final : public IChunkedArray
+{
+public:
+    explicit ThreadTrackingArray(ChunkCache& cache) : cache_(cache) {}
+
+    int numLevels() const override { return cache_.numLevels(); }
+    std::array<int, 3> shape(int level) const override { return cache_.shape(level); }
+    std::array<int, 3> chunkShape(int level) const override { return cache_.chunkShape(level); }
+    ChunkDtype dtype() const override { return cache_.dtype(); }
+    double fillValue() const override { return cache_.fillValue(); }
+    LevelTransform levelTransform(int level) const override { return cache_.levelTransform(level); }
+
+    ChunkResult tryGetChunk(int level, int iz, int iy, int ix) override
+    {
+        recordThread();
+        return cache_.tryGetChunk(level, iz, iy, ix);
+    }
+
+    ChunkResult tryGetChunk(int level, int iz, int iy, int ix, const vc::render::ChunkRequestContext& request) override
+    {
+        recordThread();
+        return cache_.tryGetChunk(level, iz, iy, ix, request);
+    }
+
+    ChunkResult getChunkIfCached(int level, int iz, int iy, int ix) override
+    {
+        recordThread();
+        return cache_.getChunkIfCached(level, iz, iy, ix);
+    }
+
+    ChunkResult getChunkBlocking(int level, int iz, int iy, int ix) override { return cache_.getChunkBlocking(level, iz, iy, ix); }
+
+    void prefetchChunks(const std::vector<ChunkKey>& keys, bool wait, int priorityOffset) override
+    {
+        cache_.prefetchChunks(keys, wait, priorityOffset);
+    }
+
+    ChunkReadyCallbackId addChunkReadyListener(ChunkReadyCallback callback) override
+    {
+        return cache_.addChunkReadyListener(std::move(callback));
+    }
+
+    void removeChunkReadyListener(ChunkReadyCallbackId id) override { cache_.removeChunkReadyListener(id); }
+
+    std::size_t observedThreads() const
+    {
+        std::lock_guard lock(threadMutex_);
+        return threadIds_.size();
+    }
+
+private:
     void recordThread()
     {
-        if (!trackThreads_.load(std::memory_order_acquire))
-            return;
         std::lock_guard lock(threadMutex_);
         threadIds_.insert(std::this_thread::get_id());
     }
 
-    std::unordered_map<ChunkKey, Entry, ChunkKeyHash> entries_;
-    std::atomic_bool trackThreads_{false};
-    std::mutex threadMutex_;
+    ChunkCache& cache_;
+    mutable std::mutex threadMutex_;
     std::set<std::thread::id> threadIds_;
 };
+
+std::unique_ptr<ChunkCache> makeSyntheticCache(const std::shared_ptr<SyntheticChunkFetcher>& fetcher)
+{
+    std::vector<ChunkCache::LevelInfo> levels;
+    levels.reserve(kLevels);
+    for (int level = 0; level < kLevels; ++level) {
+        const int scale = 1 << level;
+        levels.push_back({
+            {kLevel0Shape[0] / scale, kLevel0Shape[1] / scale, kLevel0Shape[2] / scale},
+            kChunkShape,
+            {{1.0 / double(scale), 1.0 / double(scale), 1.0 / double(scale)}, {0.0, 0.0, 0.0}},
+        });
+    }
+    ChunkCache::Options options;
+    options.detectAllFillChunks = false;
+    ChunkCacheService::Options serviceOptions;
+    serviceOptions.decodedByteCapacity = 512ULL * 1024ULL * 1024ULL;
+    serviceOptions.fetchConcurrency.workerCapacity = 16;
+    serviceOptions.fetchConcurrency.maxConcurrentReads = 16;
+    std::vector<std::shared_ptr<IChunkFetcher>> fetchers(kLevels, fetcher);
+    return std::make_unique<ChunkCache>(std::move(levels), std::move(fetchers), 0.0, ChunkDtype::UInt8, std::move(options), std::move(serviceOptions));
+}
+
+void preloadSyntheticCache(ChunkCache& cache, const SyntheticChunkFetcher& fetcher)
+{
+    for (const auto& [key, expected] : fetcher.entries()) {
+        const ChunkResult result = cache.getChunkBlocking(key.level, key.iz, key.iy, key.ix);
+        if (result.status != expected) {
+            throw std::runtime_error("synthetic cache preload produced an unexpected chunk state");
+        }
+    }
+}
 
 struct Fixture {
     cv::Mat_<cv::Vec3f> coords;
@@ -372,7 +422,7 @@ struct RunResult {
     int coveredPixels = 0;
 };
 
-RunResult renderOnce(SyntheticResidentArray& array, const Fixture& fixture, cv::Mat_<uint8_t>& output, cv::Mat_<uint8_t>& coverage, const ChunkedPlaneSampler::Options& options)
+RunResult renderOnce(IChunkedArray& array, const Fixture& fixture, cv::Mat_<uint8_t>& output, cv::Mat_<uint8_t>& coverage, const ChunkedPlaneSampler::Options& options)
 {
     const auto stats = ChunkedPlaneSampler::sampleCoordsFineToCoarse(array, 0, fixture.coords, output, coverage, options);
     return {0, stats.coveredPixels};
@@ -407,14 +457,17 @@ struct CaseResult {
 CaseResult runCase(Scenario scenario, const FixtureSize& size, int repetitions, int nativeTrials, bool callgrind, bool requireParallelExecution = false)
 {
     Fixture fixture = makeFixture(scenario, size);
-    SyntheticResidentArray array(fixture.coords, fixture.expectedLevels);
+    auto fetcher = std::make_shared<SyntheticChunkFetcher>(fixture.coords, fixture.expectedLevels);
+    auto cache = makeSyntheticCache(fetcher);
+    preloadSyntheticCache(*cache, *fetcher);
+    const std::size_t preloadFetchCalls = fetcher->fetchCalls();
     ChunkedPlaneSampler::Options options(vc::Sampling::Trilinear, kTileSize);
     options.queueMisses = true;
     options.queuedFallbackLevels = 0;
 
     cv::Mat_<uint8_t> warmOutput(size.height, size.width, uint8_t(0));
     cv::Mat_<uint8_t> warmCoverage(size.height, size.width, uint8_t(0));
-    RunResult warm = renderOnce(array, fixture, warmOutput, warmCoverage, options);
+    RunResult warm = renderOnce(*cache, fixture, warmOutput, warmCoverage, options);
     warm.checksum = checksum(warmOutput);
     validateResult(fixture, warmOutput, warmCoverage, warm);
 
@@ -427,9 +480,9 @@ CaseResult runCase(Scenario scenario, const FixtureSize& size, int repetitions, 
     for (int attempt = 0; attempt < (requireMultipleThreads ? 4 : 1); ++attempt) {
         threadOutput.setTo(uint8_t(0));
         threadCoverage.setTo(uint8_t(0));
-        array.startThreadTracking();
-        RunResult threadRun = renderOnce(array, fixture, threadOutput, threadCoverage, options);
-        observedThreads = std::max(observedThreads, array.stopThreadTracking());
+        ThreadTrackingArray trackingArray(*cache);
+        RunResult threadRun = renderOnce(trackingArray, fixture, threadOutput, threadCoverage, options);
+        observedThreads = std::max(observedThreads, trackingArray.observedThreads());
         threadRun.checksum = checksum(threadOutput);
         validateResult(fixture, threadOutput, threadCoverage, threadRun);
         if (!requireMultipleThreads || observedThreads >= 2)
@@ -470,7 +523,7 @@ CaseResult runCase(Scenario scenario, const FixtureSize& size, int repetitions, 
             if (callgrind)
                 CALLGRIND_START_INSTRUMENTATION;
 #endif
-            runs[repetition] = renderOnce(array, fixture, outputs[repetition], coverages[repetition], options);
+            runs[repetition] = renderOnce(*cache, fixture, outputs[repetition], coverages[repetition], options);
 #if VC_HAS_CALLGRIND_CLIENT
             if (callgrind)
                 CALLGRIND_STOP_INSTRUMENTATION;
@@ -486,6 +539,9 @@ CaseResult runCase(Scenario scenario, const FixtureSize& size, int repetitions, 
             if (runs[repetition].checksum != result.checksum)
                 throw std::runtime_error("render checksum changed between repetitions");
         }
+    }
+    if (fetcher->fetchCalls() != preloadFetchCalls) {
+        throw std::runtime_error("timed render unexpectedly fetched a synthetic source chunk");
     }
     return result;
 }
@@ -602,13 +658,7 @@ int main(int argc, char** argv)
         if (args.callgrind && !RUNNING_ON_VALGRIND)
             throw std::runtime_error("--callgrind must run under Valgrind Callgrind");
 #endif
-        const CaseResult result = runCase(
-            args.scenario,
-            *args.size,
-            args.repetitions,
-            args.nativeTrials,
-            args.callgrind,
-            args.requireParallelExecution);
+        const CaseResult result = runCase(args.scenario, *args.size, args.repetitions, args.nativeTrials, args.callgrind, args.requireParallelExecution);
         const std::string json = resultJson(args.scenario, *args.size, result, args.callgrind);
         std::cout << json << '\n';
         writeText(args.metadataPath, json);

--- a/volume-cartographer/core/test/data/render_valgrind_ci_reference.json
+++ b/volume-cartographer/core/test/data/render_valgrind_ci_reference.json
@@ -2,206 +2,38 @@
   "cases": {
     "parallel/fallback_3": {
       "checksum": 4092684805825541122,
-      "identity": {
-        "architecture_target": "x86-64-v3",
-        "benchmark_metadata_schema": 1,
-        "build_type": "Release",
-        "cache_geometry": {
-          "D1": "32768,8,64",
-          "I1": "32768,8,64",
-          "LL": "8388608,16,64"
-        },
-        "compiler_id": "GNU",
-        "compiler_version": "15.3.0",
-        "fixture": "parallel",
-        "height": 256,
-        "measured_pixels": 65536,
-        "repetitions": 1,
-        "scenario": "fallback_3",
-        "tile_size": 32,
-        "valgrind_version": "valgrind-3.25.1",
-        "width": 256,
-        "worker_override": 4
-      },
-      "modeled_runtime_score_ns": 2552537.228411861
+      "modeled_runtime_score_ns": 2652456.159123063
     },
     "parallel/full_res": {
       "checksum": 8319256024933588756,
-      "identity": {
-        "architecture_target": "x86-64-v3",
-        "benchmark_metadata_schema": 1,
-        "build_type": "Release",
-        "cache_geometry": {
-          "D1": "32768,8,64",
-          "I1": "32768,8,64",
-          "LL": "8388608,16,64"
-        },
-        "compiler_id": "GNU",
-        "compiler_version": "15.3.0",
-        "fixture": "parallel",
-        "height": 256,
-        "measured_pixels": 65536,
-        "repetitions": 1,
-        "scenario": "full_res",
-        "tile_size": 32,
-        "valgrind_version": "valgrind-3.25.1",
-        "width": 256,
-        "worker_override": 4
-      },
-      "modeled_runtime_score_ns": 903181.9151699011
+      "modeled_runtime_score_ns": 927228.2439746696
     },
     "parallel/mixed_correlated": {
       "checksum": 9419607384140948446,
-      "identity": {
-        "architecture_target": "x86-64-v3",
-        "benchmark_metadata_schema": 1,
-        "build_type": "Release",
-        "cache_geometry": {
-          "D1": "32768,8,64",
-          "I1": "32768,8,64",
-          "LL": "8388608,16,64"
-        },
-        "compiler_id": "GNU",
-        "compiler_version": "15.3.0",
-        "fixture": "parallel",
-        "height": 256,
-        "measured_pixels": 65536,
-        "repetitions": 1,
-        "scenario": "mixed_correlated",
-        "tile_size": 32,
-        "valgrind_version": "valgrind-3.25.1",
-        "width": 256,
-        "worker_override": 4
-      },
-      "modeled_runtime_score_ns": 1789703.9293174774
+      "modeled_runtime_score_ns": 1985726.0110827591
     },
     "parallel/mixed_shuffled": {
       "checksum": 2698931263477305860,
-      "identity": {
-        "architecture_target": "x86-64-v3",
-        "benchmark_metadata_schema": 1,
-        "build_type": "Release",
-        "cache_geometry": {
-          "D1": "32768,8,64",
-          "I1": "32768,8,64",
-          "LL": "8388608,16,64"
-        },
-        "compiler_id": "GNU",
-        "compiler_version": "15.3.0",
-        "fixture": "parallel",
-        "height": 256,
-        "measured_pixels": 65536,
-        "repetitions": 1,
-        "scenario": "mixed_shuffled",
-        "tile_size": 32,
-        "valgrind_version": "valgrind-3.25.1",
-        "width": 256,
-        "worker_override": 4
-      },
-      "modeled_runtime_score_ns": 6905131.744881165
+      "modeled_runtime_score_ns": 16127550.905297693
     },
     "serial/fallback_3": {
       "checksum": 2611257448726826058,
-      "identity": {
-        "architecture_target": "x86-64-v3",
-        "benchmark_metadata_schema": 1,
-        "build_type": "Release",
-        "cache_geometry": {
-          "D1": "32768,8,64",
-          "I1": "32768,8,64",
-          "LL": "8388608,16,64"
-        },
-        "compiler_id": "GNU",
-        "compiler_version": "15.3.0",
-        "fixture": "serial",
-        "height": 96,
-        "measured_pixels": 9216,
-        "repetitions": 1,
-        "scenario": "fallback_3",
-        "tile_size": 32,
-        "valgrind_version": "valgrind-3.25.1",
-        "width": 96,
-        "worker_override": 1
-      },
-      "modeled_runtime_score_ns": 865138.977293745
+      "modeled_runtime_score_ns": 893519.018267335
     },
     "serial/full_res": {
       "checksum": 8712995097771526824,
-      "identity": {
-        "architecture_target": "x86-64-v3",
-        "benchmark_metadata_schema": 1,
-        "build_type": "Release",
-        "cache_geometry": {
-          "D1": "32768,8,64",
-          "I1": "32768,8,64",
-          "LL": "8388608,16,64"
-        },
-        "compiler_id": "GNU",
-        "compiler_version": "15.3.0",
-        "fixture": "serial",
-        "height": 96,
-        "measured_pixels": 9216,
-        "repetitions": 1,
-        "scenario": "full_res",
-        "tile_size": 32,
-        "valgrind_version": "valgrind-3.25.1",
-        "width": 96,
-        "worker_override": 1
-      },
-      "modeled_runtime_score_ns": 327705.06868933974
+      "modeled_runtime_score_ns": 335043.091084441
     },
     "serial/mixed_correlated": {
       "checksum": 2185938871354150015,
-      "identity": {
-        "architecture_target": "x86-64-v3",
-        "benchmark_metadata_schema": 1,
-        "build_type": "Release",
-        "cache_geometry": {
-          "D1": "32768,8,64",
-          "I1": "32768,8,64",
-          "LL": "8388608,16,64"
-        },
-        "compiler_id": "GNU",
-        "compiler_version": "15.3.0",
-        "fixture": "serial",
-        "height": 96,
-        "measured_pixels": 9216,
-        "repetitions": 1,
-        "scenario": "mixed_correlated",
-        "tile_size": 32,
-        "valgrind_version": "valgrind-3.25.1",
-        "width": 96,
-        "worker_override": 1
-      },
-      "modeled_runtime_score_ns": 607820.3348490751
+      "modeled_runtime_score_ns": 621631.7372745703
     },
     "serial/mixed_shuffled": {
       "checksum": 1627454152496030813,
-      "identity": {
-        "architecture_target": "x86-64-v3",
-        "benchmark_metadata_schema": 1,
-        "build_type": "Release",
-        "cache_geometry": {
-          "D1": "32768,8,64",
-          "I1": "32768,8,64",
-          "LL": "8388608,16,64"
-        },
-        "compiler_id": "GNU",
-        "compiler_version": "15.3.0",
-        "fixture": "serial",
-        "height": 96,
-        "measured_pixels": 9216,
-        "repetitions": 1,
-        "scenario": "mixed_shuffled",
-        "tile_size": 32,
-        "valgrind_version": "valgrind-3.25.1",
-        "width": 96,
-        "worker_override": 1
-      },
-      "modeled_runtime_score_ns": 905963.5653866293
+      "modeled_runtime_score_ns": 927876.6449918726
     }
   },
   "model_sha256": "c75069f4fc1580029bf4013c1bbf999f2388a1ddda481d53f108f1412e11e409",
   "schema_version": 1,
-  "tolerance": 0.1
+  "tolerance": 0.05
 }

--- a/volume-cartographer/core/test/test_run_render_valgrind_ci.py
+++ b/volume-cartographer/core/test/test_run_render_valgrind_ci.py
@@ -328,6 +328,42 @@ class RenderValgrindCiTest(unittest.TestCase):
             reference["tolerance"] = 0.05
             self.assertEqual(updated, reference)
 
+    def test_freeze_reference_accepts_native_evaluations(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            model = root / "model.json"
+            model.write_text(json.dumps({"model_id": "native-model"}))
+            results = []
+            for fixture in ("serial", "parallel"):
+                for scenario in DRIVER.SCENARIOS:
+                    result = root / f"{fixture}-{scenario}.json"
+                    result.write_text(
+                        json.dumps(
+                            {
+                                "schema_version": 2,
+                                "kind": "evaluation",
+                                "case": f"{fixture}/{scenario}",
+                                "model_id": "native-model",
+                                "checksum": 123,
+                                "modeled_runtime_score_ns": 100.0,
+                            }
+                        )
+                    )
+                    results.append(result)
+
+            output = root / "reference.json"
+            DRIVER.freeze_reference(
+                SimpleNamespace(
+                    tolerance=0.05,
+                    model=model,
+                    output=output,
+                    results=results,
+                )
+            )
+            reference = json.loads(output.read_text())
+            self.assertEqual(reference["tolerance"], 0.05)
+            self.assertEqual(len(reference["cases"]), 8)
+            self.assertNotIn("identity", reference["cases"]["serial/full_res"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/volume-cartographer/core/test/test_thread_sync_replay_native.cpp
+++ b/volume-cartographer/core/test/test_thread_sync_replay_native.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace replay = vc::thread_sync_replay;
@@ -84,6 +85,43 @@ replay::EventCostModel dataReadModel()
             },
         .coefficients_ns = std::vector<double>(7, 1.0),
     };
+}
+
+replay::SchedulerTrace schedulerTrace(std::vector<std::int64_t> quantum_threads)
+{
+    replay::SchedulerTrace result{.quantum_threads = std::move(quantum_threads)};
+    for (const auto thread : result.quantum_threads) {
+        ++result.full_quanta[thread];
+    }
+    return result;
+}
+
+replay::EventProfile scaledProfile(std::int64_t scale)
+{
+    auto result = representativeProfile();
+    for (auto& [name, value] : result) {
+        (void)name;
+        value *= scale;
+    }
+    return result;
+}
+
+std::vector<std::int64_t> roundRobinSchedule(std::vector<std::pair<std::int64_t, std::size_t>> remaining)
+{
+    std::vector<std::int64_t> result;
+    bool emitted = true;
+    while (emitted) {
+        emitted = false;
+        for (auto& [thread, count] : remaining) {
+            if (count == 0) {
+                continue;
+            }
+            result.push_back(thread);
+            --count;
+            emitted = true;
+        }
+    }
+    return result;
 }
 
 }  // namespace
@@ -247,34 +285,109 @@ TEST_CASE("native DRD parser trims to the passive measured clock pair")
     CHECK(parsed.retained_segment_count == 2);
     CHECK(parsed.events.size() == 3);
     CHECK(parsed.happens_before_edges == 1);
-    CHECK(parsed.full_quanta.at(2) == 1);
+    CHECK(parsed.scheduler.full_quanta.at(2) == 1);
     CHECK(parsed.events[1].dependencies.back().kind == "drd_happens_before");
 }
 
-TEST_CASE("native paired replay enumerates equivalent worker identities")
+TEST_CASE("native scheduler parser preserves measured quantum order")
+{
+    TemporaryDirectory temporary;
+    const auto trace = temporary.path / "scheduler.log";
+    writeText(
+        trace,
+        "-- SCHED[9]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n"
+        "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n"
+        "-- SCHED[2]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n"
+        "-- SCHED[3]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n"
+        "-- SCHED[2]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n"
+        "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n"
+        "-- SCHED[9]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n");
+
+    const auto parsed = replay::parseMeasuredScheduler(trace);
+    CHECK(parsed.quantum_threads == std::vector<std::int64_t>{2, 3, 2});
+    CHECK(parsed.full_quanta.at(2) == 2);
+    CHECK(parsed.full_quanta.at(3) == 1);
+    CHECK(parsed.begin_line == 2);
+    CHECK(parsed.end_line == 6);
+}
+
+TEST_CASE("native paired replay uses same-run scheduler evidence")
 {
     replay::CallgrindTrace callgrind;
     for (std::int64_t thread = 1; thread <= 3; ++thread) {
-        callgrind.slices[thread] = {representativeProfile()};
-        callgrind.totals[thread] = representativeProfile();
+        callgrind.slices[thread] = {scaledProfile(thread)};
+        callgrind.totals[thread] = scaledProfile(thread);
     }
+    const auto callgrind_scheduler = schedulerTrace({2, 3, 2, 2, 2, 2, 2, 2});
     replay::DrdTrace drd{
         .events =
             {
                 {.thread = 1, .kind = "work_quantum"},
-                {.thread = 2, .kind = "work_quantum"},
                 {.thread = 3, .kind = "work_quantum"},
+                {.thread = 2, .kind = "work_quantum"},
             },
-        .full_quanta = {{1, 1}, {2, 1}, {3, 1}},
+        .scheduler = schedulerTrace({3, 2, 3, 3, 3, 3, 3, 3}),
     };
-    const auto result = replay::replayPaired(callgrind, drd, dataReadModel(), {.replay = {.cores = 3}});
-    CHECK(result.mapping_count == 2);
+    const auto result =
+        replay::replayPaired(callgrind, callgrind_scheduler, drd, dataReadModel(), {.scheduler_bins = 4, .scheduler_quantum_slack = 0.0, .replay = {.cores = 3}});
+    CHECK(result.evaluated_mapping_count == 2);
+    CHECK(result.mapping_count == 1);
+    CHECK(result.selected_source_by_trace_thread.at(2) == 3);
+    CHECK(result.selected_source_by_trace_thread.at(3) == 2);
     CHECK(result.conservative.modeled_work > 0.0);
     CHECK(result.minimum_makespan == result.conservative.modeled_makespan);
+}
 
-    callgrind.totals[3]["Ir"] *= 2;
-    callgrind.slices[3][0] = callgrind.totals[3];
-    CHECK_THROWS_AS(replay::replayPaired(callgrind, drd, dataReadModel(), {.replay = {.cores = 3}}), std::runtime_error);
+TEST_CASE("native paired replay rejects material assignment ambiguity")
+{
+    replay::CallgrindTrace callgrind;
+    callgrind.slices[1] = {scaledProfile(10)};
+    callgrind.totals[1] = scaledProfile(10);
+    callgrind.slices[2] = {scaledProfile(1)};
+    callgrind.totals[2] = scaledProfile(1);
+    callgrind.slices[3] = {scaledProfile(10)};
+    callgrind.totals[3] = scaledProfile(10);
+    const auto callgrind_scheduler = schedulerTrace({2, 3, 2, 3});
+    replay::DrdTrace drd{
+        .events =
+            {
+                {.thread = 2, .kind = "work_quantum"},
+                {.thread = 3, .kind = "work_quantum"},
+                {.thread = 1, .kind = "work_quantum", .dependencies = {{0, "drd_happens_before"}}},
+            },
+        .scheduler = schedulerTrace({2, 3, 2, 3}),
+    };
+    CHECK_THROWS_WITH_AS(replay::replayPaired(callgrind, callgrind_scheduler, drd, dataReadModel(), {.scheduler_bins = 1, .scheduler_quantum_slack = 0.0, .maximum_makespan_spread = 0.02, .replay = {.cores = 3}}), doctest::Contains("assignment evidence insufficient"), std::runtime_error);
+}
+
+TEST_CASE("native paired replay resolves a shifted DRD tie from Callgrind scheduling")
+{
+    replay::CallgrindTrace callgrind;
+    callgrind.slices[1] = {scaledProfile(1)};
+    callgrind.totals[1] = scaledProfile(1);
+    for (const auto [thread, scale] : std::vector<std::pair<std::int64_t, std::int64_t>>{{2, 4}, {3, 5}, {4, 8}, {5, 10}}) {
+        callgrind.slices[thread] = {scaledProfile(scale)};
+        callgrind.totals[thread] = scaledProfile(scale);
+    }
+    const auto callgrind_scheduler = schedulerTrace(roundRobinSchedule({{2, 42}, {3, 43}, {4, 46}, {5, 50}}));
+    replay::DrdTrace drd{
+        .events =
+            {
+                {.thread = 1, .kind = "work_quantum"},
+                {.thread = 6, .kind = "work_quantum"},
+                {.thread = 7, .kind = "work_quantum"},
+                {.thread = 8, .kind = "work_quantum"},
+                {.thread = 9, .kind = "work_quantum"},
+            },
+        .scheduler = schedulerTrace(roundRobinSchedule({{6, 38}, {7, 38}, {8, 41}, {9, 45}})),
+    };
+    const auto result =
+        replay::replayPaired(callgrind, callgrind_scheduler, drd, dataReadModel(), {.scheduler_bins = 16, .scheduler_quantum_slack = 1.0, .maximum_makespan_spread = 0.02, .replay = {.cores = 5}});
+    CHECK(result.evaluated_mapping_count == 24);
+    CHECK(result.mapping_count == 2);
+    CHECK(result.selected_source_by_trace_thread.at(8) == 4);
+    CHECK(result.selected_source_by_trace_thread.at(9) == 5);
+    CHECK(result.makespan_relative_spread == 0.0);
 }
 
 TEST_CASE("native replay applies cross-thread and wake latency cumulatively")

--- a/volume-cartographer/core/test/test_thread_sync_replay_native.cpp
+++ b/volume-cartographer/core/test/test_thread_sync_replay_native.cpp
@@ -1,9 +1,13 @@
 #include "thread_sync_replay/Replay.hpp"
+#include "thread_sync_replay/RenderValgrind.hpp"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
 #include <cmath>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <limits>
 #include <map>
 #include <stdexcept>
@@ -15,6 +19,39 @@ namespace replay = vc::thread_sync_replay;
 namespace
 {
 
+class TemporaryDirectory
+{
+public:
+    TemporaryDirectory()
+    {
+        path = std::filesystem::temp_directory_path() /
+               ("vc-thread-sync-replay-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+        std::filesystem::create_directories(path);
+    }
+
+    ~TemporaryDirectory() { std::filesystem::remove_all(path); }
+
+    std::filesystem::path path;
+};
+
+void writeText(const std::filesystem::path& path, const std::string& value)
+{
+    std::ofstream stream(path);
+    REQUIRE(stream.good());
+    stream << value;
+}
+
+std::string callgrindProfile(std::int64_t thread, const std::vector<std::int64_t>& totals)
+{
+    std::string result = "thread: " + std::to_string(thread) + "\n";
+    result += "events: Ir Dr Dw I1mr D1mr D1mw ILmr DLmr DLmw Bc Bcm Bi Bim\n";
+    result += "totals:";
+    for (const auto value : totals) {
+        result += " " + std::to_string(value);
+    }
+    return result + "\n";
+}
+
 replay::EventProfile representativeProfile()
 {
     return {
@@ -25,7 +62,9 @@ replay::EventProfile representativeProfile()
         {"D1mw", 1},
         {"DLmr", 1},
         {"DLmw", 0},
+        {"Bc", 20},
         {"Bcm", 2},
+        {"Bi", 4},
         {"Bim", 1},
     };
 }
@@ -109,6 +148,105 @@ TEST_CASE("native replay attributes a sole zero-weight trailing window")
     const auto durations = graph.assignCosts({{1, 120.0}}, 0.0, "equal");
     CHECK(durations[0] == 0.0);
     CHECK(durations[1] == 120.0);
+}
+
+TEST_CASE("native replay attributes explicit chronological window costs")
+{
+    replay::Graph graph({
+        {.thread = 1, .kind = "work"},
+        {.thread = 1, .kind = "work_quantum"},
+        {.thread = 1, .kind = "work"},
+        {.thread = 1, .kind = "thread_finish"},
+    });
+    const auto windows = graph.attributionWindows(0.5);
+    REQUIRE(windows.at(1).size() == 2);
+    CHECK(windows.at(1)[0].units == 1.0);
+    CHECK(windows.at(1)[1].units == 0.5);
+
+    const auto durations = graph.assignWindowCosts({{1, {10.0, 30.0}}}, 0.5, "front");
+    CHECK(durations[0] == 10.0);
+    CHECK(durations[1] == 0.0);
+    CHECK(durations[2] == 30.0);
+    CHECK(durations[3] == 0.0);
+}
+
+TEST_CASE("native replay rejects malformed explicit window costs")
+{
+    replay::Graph graph({
+        {.thread = 1, .kind = "work"},
+        {.thread = 1, .kind = "work_quantum"},
+        {.thread = 2, .kind = "work"},
+    });
+    CHECK_THROWS_AS(graph.assignWindowCosts({{1, {1.0}}}, 0.5, "front"), std::runtime_error);
+    CHECK_THROWS_AS(graph.assignWindowCosts({{1, {1.0}}, {2, {2.0, 3.0}}}, 0.5, "front"), std::runtime_error);
+    CHECK_THROWS_AS(graph.assignWindowCosts({{1, {-1.0}}, {2, {2.0}}}, 0.5, "front"), std::runtime_error);
+}
+
+TEST_CASE("native Callgrind parser preserves chronological deltas and totals")
+{
+    TemporaryDirectory temporary;
+    const auto prefix = temporary.path / "callgrind.out";
+    writeText(temporary.path / "callgrind.out.1-01", callgrindProfile(1, {10, 2, 1, 0, 1, 0, 0, 0, 0, 2, 1, 0, 0}));
+    writeText(temporary.path / "callgrind.out.2-01", callgrindProfile(1, {20, 4, 2, 0, 2, 0, 0, 1, 0, 4, 2, 0, 0}));
+    writeText(temporary.path / "callgrind.out-01", callgrindProfile(1, {3, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0}));
+
+    const auto parsed = replay::parsePeriodicCallgrind(prefix);
+    CHECK(parsed.periodic_dump_count == 2);
+    REQUIRE(parsed.slices.at(1).size() == 3);
+    CHECK(parsed.slices.at(1)[0].at("Ir") == 10);
+    CHECK(parsed.slices.at(1)[1].at("Ir") == 20);
+    CHECK(parsed.slices.at(1)[2].at("Ir") == 3);
+    CHECK(parsed.totals.at(1).at("Ir") == 33);
+    CHECK(parsed.totals.at(1).at("D1mr") == 3);
+}
+
+TEST_CASE("native DRD parser trims to the passive measured clock pair")
+{
+    TemporaryDirectory temporary;
+    const auto trace = temporary.path / "drd.log";
+    writeText(
+        trace,
+        "-- New segment for thread 1 with vc [ 1: 1 ]\n"
+        "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n"
+        "-- New segment for thread 1 with vc [ 1: 2 ]\n"
+        "-- New segment for thread 2 with vc [ 1: 2, 2: 1 ]\n"
+        "-- SCHED[2]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n"
+        "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n"
+        "-- New segment for thread 1 with vc [ 1: 3, 2: 1 ]\n");
+
+    const auto parsed = replay::parseMeasuredDrd(trace);
+    CHECK(parsed.parsed_segment_count == 3);
+    CHECK(parsed.retained_segment_count == 2);
+    CHECK(parsed.events.size() == 3);
+    CHECK(parsed.happens_before_edges == 1);
+    CHECK(parsed.full_quanta.at(2) == 1);
+    CHECK(parsed.events[1].dependencies.back().kind == "drd_happens_before");
+}
+
+TEST_CASE("native paired replay enumerates equivalent worker identities")
+{
+    replay::CallgrindTrace callgrind;
+    for (std::int64_t thread = 1; thread <= 3; ++thread) {
+        callgrind.slices[thread] = {representativeProfile()};
+        callgrind.totals[thread] = representativeProfile();
+    }
+    replay::DrdTrace drd{
+        .events =
+            {
+                {.thread = 1, .kind = "work_quantum"},
+                {.thread = 2, .kind = "work_quantum"},
+                {.thread = 3, .kind = "work_quantum"},
+            },
+        .full_quanta = {{1, 1}, {2, 1}, {3, 1}},
+    };
+    const auto result = replay::replayPaired(callgrind, drd, dataReadModel(), {.replay = {.cores = 3}});
+    CHECK(result.mapping_count == 2);
+    CHECK(result.conservative.modeled_work > 0.0);
+    CHECK(result.minimum_makespan == result.conservative.modeled_makespan);
+
+    callgrind.totals[3]["Ir"] *= 2;
+    callgrind.slices[3][0] = callgrind.totals[3];
+    CHECK_THROWS_AS(replay::replayPaired(callgrind, drd, dataReadModel(), {.replay = {.cores = 3}}), std::runtime_error);
 }
 
 TEST_CASE("native replay applies cross-thread and wake latency cumulatively")

--- a/volume-cartographer/core/test/test_thread_sync_replay_native.cpp
+++ b/volume-cartographer/core/test/test_thread_sync_replay_native.cpp
@@ -200,6 +200,34 @@ TEST_CASE("native Callgrind parser preserves chronological deltas and totals")
     CHECK(parsed.totals.at(1).at("D1mr") == 3);
 }
 
+TEST_CASE("native Callgrind parser ignores zero residual-only idle threads")
+{
+    TemporaryDirectory temporary;
+    const auto prefix = temporary.path / "callgrind.out";
+    writeText(temporary.path / "callgrind.out.1-01", callgrindProfile(1, {10, 2, 1}));
+    writeText(temporary.path / "callgrind.out.1-02", callgrindProfile(2, {0, 0, 0}));
+    writeText(temporary.path / "callgrind.out-01", callgrindProfile(1, {0, 0, 0}));
+    writeText(temporary.path / "callgrind.out-02", callgrindProfile(2, {0, 0, 0}));
+    writeText(temporary.path / "callgrind.out-03", callgrindProfile(3, {0, 0, 0}));
+
+    const auto parsed = replay::parsePeriodicCallgrind(prefix);
+    REQUIRE(parsed.totals.size() == 1);
+    CHECK(parsed.totals.contains(1));
+    CHECK_FALSE(parsed.totals.contains(2));
+    CHECK_FALSE(parsed.totals.contains(3));
+}
+
+TEST_CASE("native Callgrind parser rejects nonzero residual-only threads")
+{
+    TemporaryDirectory temporary;
+    const auto prefix = temporary.path / "callgrind.out";
+    writeText(temporary.path / "callgrind.out.1-01", callgrindProfile(1, {10, 2, 1}));
+    writeText(temporary.path / "callgrind.out-01", callgrindProfile(1, {0, 0, 0}));
+    writeText(temporary.path / "callgrind.out-02", callgrindProfile(2, {1, 0, 0}));
+
+    CHECK_THROWS_WITH_AS(replay::parsePeriodicCallgrind(prefix), doctest::Contains("Callgrind residual-only thread contains measured work"), std::runtime_error);
+}
+
 TEST_CASE("native DRD parser trims to the passive measured clock pair")
 {
     TemporaryDirectory temporary;

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.cpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.cpp
@@ -109,6 +109,11 @@ EventProfile addProfiles(const EventProfile& left, const EventProfile& right)
     return result;
 }
 
+bool profileIsZero(const EventProfile& profile)
+{
+    return std::all_of(profile.begin(), profile.end(), [](const auto& event) { return event.second == 0; });
+}
+
 std::int64_t profileValue(const EventProfile& profile, const std::string& name)
 {
     const auto found = profile.find(name);
@@ -316,11 +321,20 @@ CallgrindTrace parsePeriodicCallgrind(const std::filesystem::path& prefix)
         auto parsed_residual = parseProfile(residual_file->second);
         total = addProfiles(total, parsed_residual.events);
         slices.push_back(std::move(parsed_residual.events));
+        if (profileIsZero(total)) {
+            continue;
+        }
         result.slices.emplace(thread, std::move(slices));
         result.totals.emplace(thread, std::move(total));
     }
-    if (residuals.size() != files.size()) {
-        throw std::runtime_error("Callgrind residual and periodic thread sets differ");
+    for (const auto& [thread, path] : residuals) {
+        if (files.contains(thread)) {
+            continue;
+        }
+        const auto residual = parseProfile(path);
+        if (residual.thread != thread || !profileIsZero(residual.events)) {
+            throw std::runtime_error("Callgrind residual-only thread contains measured work");
+        }
     }
     return result;
 }

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.cpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.cpp
@@ -27,6 +27,12 @@ struct ParsedProfile {
     EventProfile events;
 };
 
+struct MeasuredLog {
+    std::vector<std::string> lines;
+    std::size_t begin{0};
+    std::size_t end{0};
+};
+
 std::vector<std::string> splitWords(const std::string& value)
 {
     std::istringstream stream(value);
@@ -41,6 +47,62 @@ std::string regexEscape(const std::string& value)
 {
     static const std::regex special(R"([.^$|()\[\]{}*+?\\])");
     return std::regex_replace(value, special, R"(\$&)");
+}
+
+MeasuredLog readMeasuredLog(const std::filesystem::path& path)
+{
+    std::ifstream stream(path);
+    if (!stream) {
+        throw std::runtime_error("cannot open Valgrind trace " + path.string());
+    }
+    MeasuredLog result;
+    for (std::string line; std::getline(stream, line);) {
+        result.lines.push_back(std::move(line));
+    }
+
+    const std::regex clock_re(R"(SYSCALL\[\d+,(\d+)\]\(228\) sys_clock_gettime\( 1, (0x[0-9a-fA-F]+) \))");
+    std::map<std::pair<std::int64_t, std::string>, std::vector<std::size_t>> clocks;
+    for (std::size_t index = 0; index < result.lines.size(); ++index) {
+        std::smatch match;
+        if (std::regex_search(result.lines[index], match, clock_re)) {
+            clocks[{std::stoll(match[1].str()), match[2].str()}].push_back(index);
+        }
+    }
+    std::vector<std::pair<std::size_t, std::size_t>> candidates;
+    for (const auto& [key, occurrences] : clocks) {
+        if (key.first == kMainThread && occurrences.size() == 2) {
+            candidates.emplace_back(occurrences[0], occurrences[1]);
+        }
+    }
+    if (candidates.size() != 1) {
+        throw std::runtime_error("Valgrind trace does not contain one unambiguous measured clock pair");
+    }
+    std::tie(result.begin, result.end) = candidates.front();
+    if (result.begin + 1 >= result.end) {
+        throw std::runtime_error("Valgrind measured clock window is empty");
+    }
+    return result;
+}
+
+SchedulerTrace schedulerFromMeasuredLog(const MeasuredLog& measured)
+{
+    const std::regex quantum_re(R"(SCHED\[(\d+)\]:\s+releasing lock \(VG_\(scheduler\):timeslice\))");
+    SchedulerTrace result;
+    result.begin_line = measured.begin + 1;
+    result.end_line = measured.end + 1;
+    for (std::size_t index = measured.begin + 1; index < measured.end; ++index) {
+        std::smatch match;
+        if (!std::regex_search(measured.lines[index], match, quantum_re)) {
+            continue;
+        }
+        const auto thread = std::stoll(match[1].str());
+        result.quantum_threads.push_back(thread);
+        ++result.full_quanta[thread];
+    }
+    if (result.quantum_threads.empty()) {
+        throw std::runtime_error("Valgrind measured window contains no scheduler quanta");
+    }
+    return result;
 }
 
 std::int64_t checkedAdd(std::int64_t left, std::int64_t right, const char* name)
@@ -193,53 +255,78 @@ std::vector<double> distributeSlices(const std::vector<EventProfile>& slices, co
     return result;
 }
 
-std::vector<double> normalizedShape(const std::vector<EventProfile>& slices, const EventProfile& total, const EventCostModel& model, std::size_t bins)
-{
-    if (bins == 0) {
-        throw std::runtime_error("equivalence shape must have at least one bin");
-    }
-    const auto shape = distributeSlices(slices, total, model, std::vector<double>(bins, 1.0));
-    const double sum = std::accumulate(shape.begin(), shape.end(), 0.0);
-    std::vector<double> normalized(shape.size(), 0.0);
-    if (sum > 0.0) {
-        std::transform(shape.begin(), shape.end(), normalized.begin(), [sum](double value) { return value / sum; });
-    }
-    return normalized;
-}
-
-struct SourceDescriptor {
-    std::int64_t thread;
-    std::tuple<std::int64_t, std::int64_t, std::int64_t, std::int64_t, std::int64_t, std::int64_t> signature;
-    double cost;
-    std::vector<double> shape;
+struct SchedulerDescriptor {
+    double share{0.0};
+    std::vector<double> cumulative_activity;
 };
 
-struct TraceDescriptor {
-    std::int64_t thread;
-    std::pair<std::size_t, std::size_t> signature;
+struct SchedulerDescriptors {
+    std::map<std::int64_t, SchedulerDescriptor> threads;
+    std::size_t total_quanta{0};
 };
 
-double relativeSpread(const std::vector<double>& values)
+SchedulerDescriptors describeScheduler(const SchedulerTrace& scheduler, const std::vector<std::int64_t>& threads, std::size_t bins)
 {
-    if (values.empty()) {
-        return 0.0;
+    if (threads.empty() || bins == 0) {
+        throw std::runtime_error("scheduler attribution requires workers and activity bins");
     }
-    const auto [minimum, maximum] = std::minmax_element(values.begin(), values.end());
-    const double scale = std::max(1.0, std::accumulate(values.begin(), values.end(), 0.0) / values.size());
-    return (*maximum - *minimum) / scale;
-}
-
-double shapeSpread(const std::vector<SourceDescriptor>& sources, std::size_t begin, std::size_t end)
-{
-    double result = 0.0;
-    for (std::size_t left = begin; left < end; ++left) {
-        for (std::size_t right = left + 1; right < end; ++right) {
-            for (std::size_t bin = 0; bin < sources[left].shape.size(); ++bin) {
-                result = std::max(result, std::abs(sources[left].shape[bin] - sources[right].shape[bin]));
-            }
+    const std::set<std::int64_t> expected(threads.begin(), threads.end());
+    SchedulerDescriptors result;
+    for (const auto thread : threads) {
+        const auto found = scheduler.full_quanta.find(thread);
+        if (found == scheduler.full_quanta.end() || found->second == 0) {
+            throw std::runtime_error("scheduler trace has no measured work for worker " + std::to_string(thread));
+        }
+        result.threads.emplace(thread, SchedulerDescriptor{.cumulative_activity = std::vector<double>(bins, 0.0)});
+    }
+    for (const auto& [thread, quanta] : scheduler.full_quanta) {
+        if (thread != kMainThread && quanta != 0 && !expected.contains(thread)) {
+            throw std::runtime_error("scheduler trace contains an unmatched active worker " + std::to_string(thread));
         }
     }
+
+    std::vector<std::int64_t> sequence;
+    for (const auto thread : scheduler.quantum_threads) {
+        if (expected.contains(thread)) {
+            sequence.push_back(thread);
+        }
+    }
+    result.total_quanta = sequence.size();
+    if (result.total_quanta == 0) {
+        throw std::runtime_error("scheduler trace contains no worker quanta");
+    }
+
+    std::map<std::int64_t, std::size_t> cumulative;
+    std::size_t cursor = 0;
+    for (std::size_t bin = 0; bin < bins; ++bin) {
+        const std::size_t boundary = (bin + 1) * result.total_quanta / bins;
+        while (cursor < boundary) {
+            ++cumulative[sequence[cursor++]];
+        }
+        for (const auto thread : threads) {
+            result.threads.at(thread).cumulative_activity[bin] = static_cast<double>(cumulative[thread]) / static_cast<double>(result.total_quanta);
+        }
+    }
+    for (const auto thread : threads) {
+        const auto counted = cumulative[thread];
+        if (counted != scheduler.full_quanta.at(thread)) {
+            throw std::runtime_error("scheduler trace quantum sequence and totals disagree");
+        }
+        result.threads.at(thread).share = static_cast<double>(counted) / static_cast<double>(result.total_quanta);
+    }
     return result;
+}
+
+double schedulerDistance(const SchedulerDescriptor& source, const SchedulerDescriptor& target)
+{
+    if (source.cumulative_activity.size() != target.cumulative_activity.size() || source.cumulative_activity.empty()) {
+        throw std::runtime_error("scheduler activity descriptors have incompatible shapes");
+    }
+    double cumulative_distance = 0.0;
+    for (std::size_t index = 0; index < source.cumulative_activity.size(); ++index) {
+        cumulative_distance += std::abs(source.cumulative_activity[index] - target.cumulative_activity[index]);
+    }
+    return std::abs(source.share - target.share) + cumulative_distance / source.cumulative_activity.size();
 }
 
 std::map<std::int64_t, std::vector<double>> mappedWindowCosts(
@@ -339,38 +426,17 @@ CallgrindTrace parsePeriodicCallgrind(const std::filesystem::path& prefix)
     return result;
 }
 
+SchedulerTrace parseMeasuredScheduler(const std::filesystem::path& path)
+{
+    return schedulerFromMeasuredLog(readMeasuredLog(path));
+}
+
 DrdTrace parseMeasuredDrd(const std::filesystem::path& path)
 {
-    std::ifstream stream(path);
-    if (!stream) {
-        throw std::runtime_error("cannot open DRD trace " + path.string());
-    }
-    std::vector<std::string> lines;
-    for (std::string line; std::getline(stream, line);) {
-        lines.push_back(std::move(line));
-    }
-
-    const std::regex clock_re(R"(SYSCALL\[\d+,(\d+)\]\(228\) sys_clock_gettime\( 1, (0x[0-9a-fA-F]+) \))");
-    std::map<std::pair<std::int64_t, std::string>, std::vector<std::size_t>> clocks;
-    for (std::size_t index = 0; index < lines.size(); ++index) {
-        std::smatch match;
-        if (std::regex_search(lines[index], match, clock_re)) {
-            clocks[{std::stoll(match[1].str()), match[2].str()}].push_back(index);
-        }
-    }
-    std::vector<std::pair<std::size_t, std::size_t>> candidates;
-    for (const auto& [key, occurrences] : clocks) {
-        if (key.first == kMainThread && occurrences.size() == 2) {
-            candidates.emplace_back(occurrences[0], occurrences[1]);
-        }
-    }
-    if (candidates.size() != 1) {
-        throw std::runtime_error("DRD trace does not contain one unambiguous measured clock pair");
-    }
-    const auto [begin, end] = candidates.front();
-    if (begin + 1 >= end) {
-        throw std::runtime_error("DRD measured clock window is empty");
-    }
+    const auto measured = readMeasuredLog(path);
+    const auto& lines = measured.lines;
+    const auto begin = measured.begin;
+    const auto end = measured.end;
 
     const std::regex segment_re(R"(New segment for thread ([0-9]+) with vc \[ (.*) \])");
     const std::regex value_re(R"((\d+):\s*(\d+))");
@@ -405,6 +471,7 @@ DrdTrace parseMeasuredDrd(const std::filesystem::path& path)
     }
 
     DrdTrace result;
+    result.scheduler = schedulerFromMeasuredLog(measured);
     result.parsed_segment_count = segments.size();
     result.begin_line = begin + 1;
     result.end_line = end + 1;
@@ -455,7 +522,6 @@ DrdTrace parseMeasuredDrd(const std::filesystem::path& path)
         if (std::regex_search(lines[index], quantum, quantum_re)) {
             const auto thread = std::stoll(quantum[1].str());
             append(thread, "work_quantum");
-            ++result.full_quanta[thread];
         }
     }
     if (result.events.empty()) {
@@ -464,11 +530,14 @@ DrdTrace parseMeasuredDrd(const std::filesystem::path& path)
     return result;
 }
 
-PairedReplayResult replayPaired(const CallgrindTrace& callgrind, const DrdTrace& drd, const EventCostModel& model, const PairedReplayOptions& options)
+PairedReplayResult replayPaired(
+    const CallgrindTrace& callgrind, const SchedulerTrace& callgrind_scheduler, const DrdTrace& drd, const EventCostModel& model, const PairedReplayOptions& options)
 {
-    if (!std::isfinite(options.equivalent_cost_tolerance) || options.equivalent_cost_tolerance < 0.0 || options.equivalent_cost_tolerance >= 1.0 ||
-        !std::isfinite(options.equivalent_shape_tolerance) || options.equivalent_shape_tolerance < 0.0 || options.equivalent_shape_tolerance >= 1.0) {
-        throw std::runtime_error("equivalent-trace tolerances must be in [0, 1)");
+    if (options.scheduler_bins == 0 || !std::isfinite(options.scheduler_quantum_slack) || options.scheduler_quantum_slack < 0.0) {
+        throw std::runtime_error("scheduler assignment settings are invalid");
+    }
+    if (!std::isfinite(options.maximum_makespan_spread) || options.maximum_makespan_spread < 0.0 || options.maximum_makespan_spread >= 1.0) {
+        throw std::runtime_error("maximum makespan spread must be in [0, 1)");
     }
     if (options.maximum_mappings == 0) {
         throw std::runtime_error("maximum mapping count must be positive");
@@ -479,108 +548,89 @@ PairedReplayResult replayPaired(const CallgrindTrace& callgrind, const DrdTrace&
         throw std::runtime_error("Callgrind and DRD thread counts do not match");
     }
 
-    std::vector<SourceDescriptor> sources;
+    std::vector<std::int64_t> source_threads;
     for (const auto& [thread, total] : callgrind.totals) {
+        (void)total;
         if (thread == kMainThread) {
             continue;
         }
-        sources.push_back({
-            .thread = thread,
-            .signature =
-                {
-                    profileValue(total, "Ir"),
-                    profileValue(total, "Dr"),
-                    profileValue(total, "Dw"),
-                    profileValue(total, "Bc"),
-                    profileValue(total, "Bi"),
-                    thread,
-                },
-            .cost = modeledProfileCostNs(total, model),
-            .shape = normalizedShape(callgrind.slices.at(thread), total, model, options.equivalence_bins),
-        });
+        source_threads.push_back(thread);
     }
-    std::sort(sources.begin(), sources.end(), [](const SourceDescriptor& left, const SourceDescriptor& right) {
-        return left.signature < right.signature;
-    });
-
-    std::vector<TraceDescriptor> traces;
+    std::vector<std::int64_t> trace_threads;
     for (const auto& [thread, thread_windows] : windows) {
+        (void)thread_windows;
         if (thread == kMainThread) {
             continue;
         }
-        const auto quanta = drd.full_quanta.find(thread);
-        traces.push_back({thread, {quanta == drd.full_quanta.end() ? 0 : quanta->second, thread_windows.size()}});
+        trace_threads.push_back(thread);
     }
-    std::sort(traces.begin(), traces.end(), [](const TraceDescriptor& left, const TraceDescriptor& right) {
-        return std::tie(left.signature, left.thread) < std::tie(right.signature, right.thread);
-    });
-    if (sources.size() != traces.size()) {
+    if (source_threads.size() != trace_threads.size()) {
         throw std::runtime_error("Callgrind and DRD worker counts do not match");
     }
 
-    struct Group {
-        std::size_t begin;
-        std::size_t end;
+    const auto source_descriptors = describeScheduler(callgrind_scheduler, source_threads, options.scheduler_bins);
+    const auto trace_descriptors = describeScheduler(drd.scheduler, trace_threads, options.scheduler_bins);
+    const double quantum_tolerance =
+        2.0 * options.scheduler_quantum_slack *
+        (1.0 / static_cast<double>(source_descriptors.total_quanta) + 1.0 / static_cast<double>(trace_descriptors.total_quanta));
+
+    struct Candidate {
+        std::map<std::int64_t, std::int64_t> source_by_trace;
+        double assignment_score{0.0};
     };
-    std::vector<Group> groups;
-    PairedReplayResult result;
-    for (std::size_t begin_index = 0; begin_index < traces.size();) {
-        std::size_t end_index = begin_index + 1;
-        while (end_index < traces.size() && traces[end_index].signature == traces[begin_index].signature) {
-            ++end_index;
+    std::vector<Candidate> candidates;
+    std::vector<std::int64_t> permutation = source_threads;
+    std::sort(permutation.begin(), permutation.end());
+    do {
+        if (candidates.size() >= options.maximum_mappings) {
+            throw std::runtime_error("worker assignment count exceeds limit");
         }
-        std::vector<double> costs;
-        for (std::size_t index = begin_index; index < end_index; ++index) {
-            costs.push_back(sources[index].cost);
+        Candidate candidate{.source_by_trace = {{kMainThread, kMainThread}}};
+        for (std::size_t index = 0; index < trace_threads.size(); ++index) {
+            const auto trace_thread = trace_threads[index];
+            const auto source_thread = permutation[index];
+            candidate.source_by_trace.emplace(trace_thread, source_thread);
+            candidate.assignment_score += schedulerDistance(source_descriptors.threads.at(source_thread), trace_descriptors.threads.at(trace_thread));
         }
-        const double cost_spread = relativeSpread(costs);
-        const double trace_shape_spread = shapeSpread(sources, begin_index, end_index);
-        result.maximum_equivalent_cost_spread = std::max(result.maximum_equivalent_cost_spread, cost_spread);
-        result.maximum_equivalent_shape_spread = std::max(result.maximum_equivalent_shape_spread, trace_shape_spread);
-        if (cost_spread > options.equivalent_cost_tolerance || trace_shape_spread > options.equivalent_shape_tolerance) {
-            throw std::runtime_error(
-                "tied DRD workers have non-equivalent Callgrind traces: ranks " + std::to_string(begin_index) + "-" + std::to_string(end_index - 1) +
-                ", cost spread=" + std::to_string(cost_spread) + ", shape spread=" + std::to_string(trace_shape_spread));
-        }
-        groups.push_back({begin_index, end_index});
-        begin_index = end_index;
+        candidates.push_back(std::move(candidate));
+    } while (std::next_permutation(permutation.begin(), permutation.end()));
+    if (candidates.empty()) {
+        throw std::runtime_error("no worker assignments were generated");
     }
 
-    std::map<std::int64_t, std::int64_t> mapping{{kMainThread, kMainThread}};
+    PairedReplayResult result;
+    result.evaluated_mapping_count = candidates.size();
+    result.best_assignment_score = std::min_element(candidates.begin(), candidates.end(), [](const Candidate& left, const Candidate& right) {
+                                       return left.assignment_score < right.assignment_score;
+                                   })->assignment_score;
+    result.assignment_score_tolerance = quantum_tolerance;
     result.minimum_makespan = std::numeric_limits<double>::infinity();
     double maximum_makespan = -1.0;
-    std::function<void(std::size_t)> enumerate = [&](std::size_t group_index) {
-        if (group_index == groups.size()) {
-            if (++result.mapping_count > options.maximum_mappings) {
-                throw std::runtime_error("equivalent worker mapping count exceeds limit");
-            }
-            const auto costs = mappedWindowCosts(mapping, callgrind, windows, model);
-            const auto durations = graph.assignWindowCosts(costs, options.residual_fraction, options.split_policy);
-            const auto replay = graph.replayAdjusted(durations, options.replay);
-            result.minimum_makespan = std::min(result.minimum_makespan, replay.modeled_makespan);
-            if (replay.modeled_makespan > maximum_makespan) {
-                maximum_makespan = replay.modeled_makespan;
-                result.conservative = replay;
-                result.selected_source_by_trace_thread = mapping;
-            }
-            return;
+    const double maximum_assignment_score = result.best_assignment_score + quantum_tolerance;
+    for (const auto& candidate : candidates) {
+        if (candidate.assignment_score > maximum_assignment_score + std::numeric_limits<double>::epsilon() * 16.0) {
+            continue;
         }
-        const auto group = groups[group_index];
-        std::vector<std::int64_t> permutation;
-        for (std::size_t index = group.begin; index < group.end; ++index) {
-            permutation.push_back(sources[index].thread);
+        ++result.mapping_count;
+        result.maximum_assignment_score = std::max(result.maximum_assignment_score, candidate.assignment_score);
+        const auto costs = mappedWindowCosts(candidate.source_by_trace, callgrind, windows, model);
+        const auto durations = graph.assignWindowCosts(costs, options.residual_fraction, options.split_policy);
+        const auto replay = graph.replayAdjusted(durations, options.replay);
+        result.minimum_makespan = std::min(result.minimum_makespan, replay.modeled_makespan);
+        if (replay.modeled_makespan > maximum_makespan) {
+            maximum_makespan = replay.modeled_makespan;
+            result.conservative = replay;
+            result.selected_source_by_trace_thread = candidate.source_by_trace;
         }
-        std::sort(permutation.begin(), permutation.end());
-        do {
-            for (std::size_t index = group.begin; index < group.end; ++index) {
-                mapping[traces[index].thread] = permutation[index - group.begin];
-            }
-            enumerate(group_index + 1);
-        } while (std::next_permutation(permutation.begin(), permutation.end()));
-    };
-    enumerate(0);
+    }
     if (result.mapping_count == 0) {
-        throw std::runtime_error("no admissible paired worker mapping");
+        throw std::runtime_error("no scheduler-compatible worker assignment");
+    }
+    result.makespan_relative_spread = (maximum_makespan - result.minimum_makespan) / maximum_makespan;
+    if (result.makespan_relative_spread > options.maximum_makespan_spread) {
+        throw std::runtime_error(
+            "assignment evidence insufficient: scheduler-compatible worker assignments exceed the makespan ambiguity limit: spread=" +
+            std::to_string(result.makespan_relative_spread) + ", limit=" + std::to_string(options.maximum_makespan_spread));
     }
     return result;
 }

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.cpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.cpp
@@ -1,0 +1,574 @@
+#include "thread_sync_replay/RenderValgrind.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <functional>
+#include <limits>
+#include <numeric>
+#include <optional>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+
+namespace vc::thread_sync_replay
+{
+namespace
+{
+
+constexpr std::int64_t kMainThread = 1;
+
+struct ParsedProfile {
+    std::int64_t thread{0};
+    EventProfile events;
+};
+
+std::vector<std::string> splitWords(const std::string& value)
+{
+    std::istringstream stream(value);
+    std::vector<std::string> result;
+    for (std::string word; stream >> word;) {
+        result.push_back(std::move(word));
+    }
+    return result;
+}
+
+std::string regexEscape(const std::string& value)
+{
+    static const std::regex special(R"([.^$|()\[\]{}*+?\\])");
+    return std::regex_replace(value, special, R"(\$&)");
+}
+
+std::int64_t checkedAdd(std::int64_t left, std::int64_t right, const char* name)
+{
+    if (right < 0 || left > std::numeric_limits<std::int64_t>::max() - right) {
+        throw std::runtime_error(std::string(name) + " counter overflow");
+    }
+    return left + right;
+}
+
+ParsedProfile parseProfile(const std::filesystem::path& path)
+{
+    std::ifstream stream(path);
+    if (!stream) {
+        throw std::runtime_error("cannot open Callgrind profile " + path.string());
+    }
+    std::optional<std::int64_t> thread;
+    std::vector<std::string> names;
+    std::vector<std::int64_t> totals;
+    for (std::string line; std::getline(stream, line);) {
+        if (line.starts_with("thread:")) {
+            thread = std::stoll(line.substr(7));
+        } else if (line.starts_with("events:")) {
+            names = splitWords(line.substr(7));
+        } else if (line.starts_with("totals:")) {
+            totals.clear();
+            for (const auto& word : splitWords(line.substr(7))) {
+                const auto value = std::stoll(word);
+                if (value < 0) {
+                    throw std::runtime_error("negative Callgrind total in " + path.string());
+                }
+                totals.push_back(value);
+            }
+        }
+    }
+    if (!thread || *thread <= 0 || names.empty() || totals.size() > names.size()) {
+        throw std::runtime_error("malformed Callgrind profile " + path.string());
+    }
+    totals.resize(names.size(), 0);
+    EventProfile events;
+    for (std::size_t index = 0; index < names.size(); ++index) {
+        if (!events.emplace(names[index], totals[index]).second) {
+            throw std::runtime_error("duplicate Callgrind event in " + path.string());
+        }
+    }
+    return {*thread, std::move(events)};
+}
+
+EventProfile addProfiles(const EventProfile& left, const EventProfile& right)
+{
+    EventProfile result = left;
+    for (const auto& [name, value] : right) {
+        auto found = result.find(name);
+        if (found == result.end()) {
+            if (!left.empty()) {
+                throw std::runtime_error("Callgrind slices use different event sets");
+            }
+            result.emplace(name, value);
+        } else {
+            found->second = checkedAdd(found->second, value, "Callgrind");
+        }
+    }
+    if (!left.empty() && result.size() != right.size()) {
+        throw std::runtime_error("Callgrind slices use different event sets");
+    }
+    return result;
+}
+
+std::int64_t profileValue(const EventProfile& profile, const std::string& name)
+{
+    const auto found = profile.find(name);
+    if (found == profile.end()) {
+        throw std::runtime_error("Callgrind profile is missing " + name);
+    }
+    return found->second;
+}
+
+std::vector<double> distributeSlices(const std::vector<EventProfile>& slices, const EventProfile& total, const EventCostModel& model, const std::vector<double>& weights)
+{
+    if (weights.empty()) {
+        if (modeledProfileCostNs(total, model) != 0.0) {
+            throw std::runtime_error("positive profile cost has no attribution window");
+        }
+        return {};
+    }
+    double total_weight = 0.0;
+    for (const auto weight : weights) {
+        if (!std::isfinite(weight) || weight < 0.0) {
+            throw std::runtime_error("invalid attribution-window weight");
+        }
+        total_weight += weight;
+    }
+    if (total_weight <= 0.0) {
+        throw std::runtime_error("attribution windows have no positive weight");
+    }
+
+    const auto total_ir = profileValue(total, "Ir");
+    const double target_cost = modeledProfileCostNs(total, model);
+    if (total_ir <= 0) {
+        if (target_cost != 0.0) {
+            throw std::runtime_error("positive modeled cost has no instruction progress");
+        }
+        return std::vector<double>(weights.size(), 0.0);
+    }
+
+    std::vector<double> boundaries(weights.size() + 1, 0.0);
+    for (std::size_t index = 0; index < weights.size(); ++index) {
+        boundaries[index + 1] = boundaries[index] + static_cast<double>(total_ir) * weights[index] / total_weight;
+    }
+    boundaries.back() = static_cast<double>(total_ir);
+
+    std::vector<double> result(weights.size(), 0.0);
+    double progress = 0.0;
+    double localized_total = 0.0;
+    for (const auto& slice : slices) {
+        const auto ir = profileValue(slice, "Ir");
+        if (ir == 0) {
+            continue;
+        }
+        const double begin = progress;
+        const double end = progress + static_cast<double>(ir);
+        const double cost = modeledProfileCostNs(slice, model);
+        localized_total += cost;
+        auto window = static_cast<std::size_t>(std::upper_bound(boundaries.begin(), boundaries.end(), begin) - boundaries.begin() - 1);
+        window = std::min(window, weights.size() - 1);
+        while (window < weights.size() && boundaries[window] < end) {
+            const double overlap = std::max(0.0, std::min(end, boundaries[window + 1]) - std::max(begin, boundaries[window]));
+            result[window] += cost * overlap / static_cast<double>(ir);
+            ++window;
+        }
+        progress = end;
+    }
+    if (std::abs(progress - static_cast<double>(total_ir)) > 0.5) {
+        throw std::runtime_error("Callgrind slice instructions do not equal the aggregate profile");
+    }
+    if (localized_total <= 0.0) {
+        throw std::runtime_error("positive aggregate profile has no localized cost");
+    }
+    const double scale = target_cost / localized_total;
+    for (auto& value : result) {
+        value *= scale;
+    }
+    const double assigned = std::accumulate(result.begin(), result.end(), 0.0);
+    result.back() += target_cost - assigned;
+    return result;
+}
+
+std::vector<double> normalizedShape(const std::vector<EventProfile>& slices, const EventProfile& total, const EventCostModel& model, std::size_t bins)
+{
+    if (bins == 0) {
+        throw std::runtime_error("equivalence shape must have at least one bin");
+    }
+    const auto shape = distributeSlices(slices, total, model, std::vector<double>(bins, 1.0));
+    const double sum = std::accumulate(shape.begin(), shape.end(), 0.0);
+    std::vector<double> normalized(shape.size(), 0.0);
+    if (sum > 0.0) {
+        std::transform(shape.begin(), shape.end(), normalized.begin(), [sum](double value) { return value / sum; });
+    }
+    return normalized;
+}
+
+struct SourceDescriptor {
+    std::int64_t thread;
+    std::tuple<std::int64_t, std::int64_t, std::int64_t, std::int64_t, std::int64_t, std::int64_t> signature;
+    double cost;
+    std::vector<double> shape;
+};
+
+struct TraceDescriptor {
+    std::int64_t thread;
+    std::pair<std::size_t, std::size_t> signature;
+};
+
+double relativeSpread(const std::vector<double>& values)
+{
+    if (values.empty()) {
+        return 0.0;
+    }
+    const auto [minimum, maximum] = std::minmax_element(values.begin(), values.end());
+    const double scale = std::max(1.0, std::accumulate(values.begin(), values.end(), 0.0) / values.size());
+    return (*maximum - *minimum) / scale;
+}
+
+double shapeSpread(const std::vector<SourceDescriptor>& sources, std::size_t begin, std::size_t end)
+{
+    double result = 0.0;
+    for (std::size_t left = begin; left < end; ++left) {
+        for (std::size_t right = left + 1; right < end; ++right) {
+            for (std::size_t bin = 0; bin < sources[left].shape.size(); ++bin) {
+                result = std::max(result, std::abs(sources[left].shape[bin] - sources[right].shape[bin]));
+            }
+        }
+    }
+    return result;
+}
+
+std::map<std::int64_t, std::vector<double>> mappedWindowCosts(
+    const std::map<std::int64_t, std::int64_t>& source_by_trace, const CallgrindTrace& callgrind, const ThreadAttributionWindows& windows, const EventCostModel& model)
+{
+    std::map<std::int64_t, std::vector<double>> result;
+    for (const auto& [trace_thread, source_thread] : source_by_trace) {
+        const auto found_windows = windows.find(trace_thread);
+        const auto found_slices = callgrind.slices.find(source_thread);
+        const auto found_total = callgrind.totals.find(source_thread);
+        if (found_windows == windows.end() || found_slices == callgrind.slices.end() || found_total == callgrind.totals.end()) {
+            throw std::runtime_error("paired attribution references an unknown thread");
+        }
+        std::vector<double> weights;
+        weights.reserve(found_windows->second.size());
+        for (const auto& window : found_windows->second) {
+            weights.push_back(window.units);
+        }
+        result.emplace(trace_thread, distributeSlices(found_slices->second, found_total->second, model, weights));
+    }
+    return result;
+}
+
+}  // namespace
+
+CallgrindTrace parsePeriodicCallgrind(const std::filesystem::path& prefix)
+{
+    const auto directory = prefix.parent_path().empty() ? std::filesystem::path(".") : prefix.parent_path();
+    const auto base = regexEscape(prefix.filename().string());
+    const std::regex periodic("^" + base + R"(\.([0-9]+)-([0-9]+)$)");
+    const std::regex residual("^" + base + R"(-([0-9]+)$)");
+    std::map<std::int64_t, std::vector<std::pair<std::size_t, std::filesystem::path>>> files;
+    std::map<std::int64_t, std::filesystem::path> residuals;
+    std::size_t maximum_ordinal = 0;
+    for (const auto& entry : std::filesystem::directory_iterator(directory)) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        std::smatch match;
+        const auto name = entry.path().filename().string();
+        if (std::regex_match(name, match, periodic)) {
+            const auto ordinal = static_cast<std::size_t>(std::stoull(match[1].str()));
+            const auto thread = std::stoll(match[2].str());
+            files[thread].emplace_back(ordinal, entry.path());
+            maximum_ordinal = std::max(maximum_ordinal, ordinal);
+        } else if (std::regex_match(name, match, residual)) {
+            residuals.emplace(std::stoll(match[1].str()), entry.path());
+        }
+    }
+    if (files.empty() || maximum_ordinal == 0) {
+        throw std::runtime_error("no periodic Callgrind profiles found at " + prefix.string());
+    }
+
+    CallgrindTrace result;
+    result.periodic_dump_count = maximum_ordinal;
+    for (auto& [thread, thread_files] : files) {
+        std::sort(thread_files.begin(), thread_files.end());
+        if (thread_files.size() != maximum_ordinal) {
+            throw std::runtime_error("Callgrind thread " + std::to_string(thread) + " has missing periodic dumps");
+        }
+        EventProfile total;
+        std::vector<EventProfile> slices;
+        slices.reserve(thread_files.size() + 1);
+        for (std::size_t index = 0; index < thread_files.size(); ++index) {
+            if (thread_files[index].first != index + 1) {
+                throw std::runtime_error("Callgrind periodic dump ordinals are not contiguous");
+            }
+            auto parsed = parseProfile(thread_files[index].second);
+            if (parsed.thread != thread) {
+                throw std::runtime_error("Callgrind filename and profile thread disagree");
+            }
+            total = addProfiles(total, parsed.events);
+            slices.push_back(std::move(parsed.events));
+        }
+        const auto residual_file = residuals.find(thread);
+        if (residual_file == residuals.end()) {
+            throw std::runtime_error("Callgrind thread " + std::to_string(thread) + " has no residual profile");
+        }
+        auto parsed_residual = parseProfile(residual_file->second);
+        total = addProfiles(total, parsed_residual.events);
+        slices.push_back(std::move(parsed_residual.events));
+        result.slices.emplace(thread, std::move(slices));
+        result.totals.emplace(thread, std::move(total));
+    }
+    if (residuals.size() != files.size()) {
+        throw std::runtime_error("Callgrind residual and periodic thread sets differ");
+    }
+    return result;
+}
+
+DrdTrace parseMeasuredDrd(const std::filesystem::path& path)
+{
+    std::ifstream stream(path);
+    if (!stream) {
+        throw std::runtime_error("cannot open DRD trace " + path.string());
+    }
+    std::vector<std::string> lines;
+    for (std::string line; std::getline(stream, line);) {
+        lines.push_back(std::move(line));
+    }
+
+    const std::regex clock_re(R"(SYSCALL\[\d+,(\d+)\]\(228\) sys_clock_gettime\( 1, (0x[0-9a-fA-F]+) \))");
+    std::map<std::pair<std::int64_t, std::string>, std::vector<std::size_t>> clocks;
+    for (std::size_t index = 0; index < lines.size(); ++index) {
+        std::smatch match;
+        if (std::regex_search(lines[index], match, clock_re)) {
+            clocks[{std::stoll(match[1].str()), match[2].str()}].push_back(index);
+        }
+    }
+    std::vector<std::pair<std::size_t, std::size_t>> candidates;
+    for (const auto& [key, occurrences] : clocks) {
+        if (key.first == kMainThread && occurrences.size() == 2) {
+            candidates.emplace_back(occurrences[0], occurrences[1]);
+        }
+    }
+    if (candidates.size() != 1) {
+        throw std::runtime_error("DRD trace does not contain one unambiguous measured clock pair");
+    }
+    const auto [begin, end] = candidates.front();
+    if (begin + 1 >= end) {
+        throw std::runtime_error("DRD measured clock window is empty");
+    }
+
+    const std::regex segment_re(R"(New segment for thread ([0-9]+) with vc \[ (.*) \])");
+    const std::regex value_re(R"((\d+):\s*(\d+))");
+    const std::regex quantum_re(R"(SCHED\[(\d+)\]:\s+releasing lock \(VG_\(scheduler\):timeslice\))");
+    struct SegmentRecord {
+        std::size_t line;
+        std::int64_t thread;
+        std::map<std::int64_t, std::int64_t> clock;
+        std::optional<std::size_t> event;
+    };
+    std::vector<SegmentRecord> segments;
+    std::map<std::pair<std::int64_t, std::int64_t>, std::size_t> segment_by_clock;
+    for (std::size_t index = 0; index < end; ++index) {
+        std::smatch match;
+        if (!std::regex_search(lines[index], match, segment_re)) {
+            continue;
+        }
+        SegmentRecord record{.line = index, .thread = std::stoll(match[1].str())};
+        const auto clock_text = match[2].str();
+        for (auto iterator = std::sregex_iterator(clock_text.begin(), clock_text.end(), value_re); iterator != std::sregex_iterator(); ++iterator) {
+            record.clock.emplace(std::stoll((*iterator)[1].str()), std::stoll((*iterator)[2].str()));
+        }
+        const auto own = record.clock.find(record.thread);
+        if (own == record.clock.end()) {
+            throw std::runtime_error("DRD segment has no own vector-clock value");
+        }
+        const auto record_index = segments.size();
+        if (!segment_by_clock.emplace(std::make_pair(record.thread, own->second), record_index).second) {
+            throw std::runtime_error("duplicate DRD vector-clock segment");
+        }
+        segments.push_back(std::move(record));
+    }
+
+    DrdTrace result;
+    result.parsed_segment_count = segments.size();
+    result.begin_line = begin + 1;
+    result.end_line = end + 1;
+    std::map<std::int64_t, std::size_t> previous;
+    std::map<std::int64_t, std::map<std::int64_t, std::int64_t>> previous_clock;
+    auto append = [&](std::int64_t thread, std::string kind) -> std::size_t {
+        Event event{.thread = thread, .kind = std::move(kind)};
+        const auto found = previous.find(thread);
+        if (found != previous.end()) {
+            event.dependencies.push_back({found->second, "program_order"});
+        }
+        const auto sequence = result.events.size();
+        result.events.push_back(std::move(event));
+        previous[thread] = sequence;
+        return sequence;
+    };
+
+    std::size_t segment_cursor = 0;
+    for (std::size_t index = begin + 1; index < end; ++index) {
+        while (segment_cursor < segments.size() && segments[segment_cursor].line < index) {
+            ++segment_cursor;
+        }
+        if (segment_cursor < segments.size() && segments[segment_cursor].line == index) {
+            auto& segment = segments[segment_cursor];
+            const auto sequence = append(segment.thread, "hb_segment");
+            ++result.retained_segment_count;
+            segment.event = sequence;
+            for (const auto& [owner, value] : segment.clock) {
+                if (owner == segment.thread || value <= previous_clock[segment.thread][owner]) {
+                    continue;
+                }
+                const auto predecessor = segment_by_clock.find({owner, value});
+                if (predecessor == segment_by_clock.end() || segments[predecessor->second].line >= index) {
+                    throw std::runtime_error("DRD trace has an unresolved measured-window dependency");
+                }
+                const auto predecessor_event = segments[predecessor->second].event;
+                if (predecessor_event) {
+                    result.events[sequence].dependencies.push_back({*predecessor_event, "drd_happens_before"});
+                    ++result.happens_before_edges;
+                } else {
+                    ++result.dropped_pre_window_edges;
+                }
+            }
+            previous_clock[segment.thread] = segment.clock;
+            ++segment_cursor;
+        }
+        std::smatch quantum;
+        if (std::regex_search(lines[index], quantum, quantum_re)) {
+            const auto thread = std::stoll(quantum[1].str());
+            append(thread, "work_quantum");
+            ++result.full_quanta[thread];
+        }
+    }
+    if (result.events.empty()) {
+        throw std::runtime_error("DRD measured window contains no replay events");
+    }
+    return result;
+}
+
+PairedReplayResult replayPaired(const CallgrindTrace& callgrind, const DrdTrace& drd, const EventCostModel& model, const PairedReplayOptions& options)
+{
+    if (!std::isfinite(options.equivalent_cost_tolerance) || options.equivalent_cost_tolerance < 0.0 || options.equivalent_cost_tolerance >= 1.0 ||
+        !std::isfinite(options.equivalent_shape_tolerance) || options.equivalent_shape_tolerance < 0.0 || options.equivalent_shape_tolerance >= 1.0) {
+        throw std::runtime_error("equivalent-trace tolerances must be in [0, 1)");
+    }
+    if (options.maximum_mappings == 0) {
+        throw std::runtime_error("maximum mapping count must be positive");
+    }
+    Graph graph(drd.events);
+    const auto windows = graph.attributionWindows(options.residual_fraction);
+    if (callgrind.totals.size() != windows.size() || !callgrind.totals.contains(kMainThread) || !windows.contains(kMainThread)) {
+        throw std::runtime_error("Callgrind and DRD thread counts do not match");
+    }
+
+    std::vector<SourceDescriptor> sources;
+    for (const auto& [thread, total] : callgrind.totals) {
+        if (thread == kMainThread) {
+            continue;
+        }
+        sources.push_back({
+            .thread = thread,
+            .signature =
+                {
+                    profileValue(total, "Ir"),
+                    profileValue(total, "Dr"),
+                    profileValue(total, "Dw"),
+                    profileValue(total, "Bc"),
+                    profileValue(total, "Bi"),
+                    thread,
+                },
+            .cost = modeledProfileCostNs(total, model),
+            .shape = normalizedShape(callgrind.slices.at(thread), total, model, options.equivalence_bins),
+        });
+    }
+    std::sort(sources.begin(), sources.end(), [](const SourceDescriptor& left, const SourceDescriptor& right) {
+        return left.signature < right.signature;
+    });
+
+    std::vector<TraceDescriptor> traces;
+    for (const auto& [thread, thread_windows] : windows) {
+        if (thread == kMainThread) {
+            continue;
+        }
+        const auto quanta = drd.full_quanta.find(thread);
+        traces.push_back({thread, {quanta == drd.full_quanta.end() ? 0 : quanta->second, thread_windows.size()}});
+    }
+    std::sort(traces.begin(), traces.end(), [](const TraceDescriptor& left, const TraceDescriptor& right) {
+        return std::tie(left.signature, left.thread) < std::tie(right.signature, right.thread);
+    });
+    if (sources.size() != traces.size()) {
+        throw std::runtime_error("Callgrind and DRD worker counts do not match");
+    }
+
+    struct Group {
+        std::size_t begin;
+        std::size_t end;
+    };
+    std::vector<Group> groups;
+    PairedReplayResult result;
+    for (std::size_t begin_index = 0; begin_index < traces.size();) {
+        std::size_t end_index = begin_index + 1;
+        while (end_index < traces.size() && traces[end_index].signature == traces[begin_index].signature) {
+            ++end_index;
+        }
+        std::vector<double> costs;
+        for (std::size_t index = begin_index; index < end_index; ++index) {
+            costs.push_back(sources[index].cost);
+        }
+        const double cost_spread = relativeSpread(costs);
+        const double trace_shape_spread = shapeSpread(sources, begin_index, end_index);
+        result.maximum_equivalent_cost_spread = std::max(result.maximum_equivalent_cost_spread, cost_spread);
+        result.maximum_equivalent_shape_spread = std::max(result.maximum_equivalent_shape_spread, trace_shape_spread);
+        if (cost_spread > options.equivalent_cost_tolerance || trace_shape_spread > options.equivalent_shape_tolerance) {
+            throw std::runtime_error(
+                "tied DRD workers have non-equivalent Callgrind traces: ranks " + std::to_string(begin_index) + "-" + std::to_string(end_index - 1) +
+                ", cost spread=" + std::to_string(cost_spread) + ", shape spread=" + std::to_string(trace_shape_spread));
+        }
+        groups.push_back({begin_index, end_index});
+        begin_index = end_index;
+    }
+
+    std::map<std::int64_t, std::int64_t> mapping{{kMainThread, kMainThread}};
+    result.minimum_makespan = std::numeric_limits<double>::infinity();
+    double maximum_makespan = -1.0;
+    std::function<void(std::size_t)> enumerate = [&](std::size_t group_index) {
+        if (group_index == groups.size()) {
+            if (++result.mapping_count > options.maximum_mappings) {
+                throw std::runtime_error("equivalent worker mapping count exceeds limit");
+            }
+            const auto costs = mappedWindowCosts(mapping, callgrind, windows, model);
+            const auto durations = graph.assignWindowCosts(costs, options.residual_fraction, options.split_policy);
+            const auto replay = graph.replayAdjusted(durations, options.replay);
+            result.minimum_makespan = std::min(result.minimum_makespan, replay.modeled_makespan);
+            if (replay.modeled_makespan > maximum_makespan) {
+                maximum_makespan = replay.modeled_makespan;
+                result.conservative = replay;
+                result.selected_source_by_trace_thread = mapping;
+            }
+            return;
+        }
+        const auto group = groups[group_index];
+        std::vector<std::int64_t> permutation;
+        for (std::size_t index = group.begin; index < group.end; ++index) {
+            permutation.push_back(sources[index].thread);
+        }
+        std::sort(permutation.begin(), permutation.end());
+        do {
+            for (std::size_t index = group.begin; index < group.end; ++index) {
+                mapping[traces[index].thread] = permutation[index - group.begin];
+            }
+            enumerate(group_index + 1);
+        } while (std::next_permutation(permutation.begin(), permutation.end()));
+    };
+    enumerate(0);
+    if (result.mapping_count == 0) {
+        throw std::runtime_error("no admissible paired worker mapping");
+    }
+    return result;
+}
+
+}  // namespace vc::thread_sync_replay

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.hpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "thread_sync_replay/Replay.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <vector>
+
+namespace vc::thread_sync_replay
+{
+
+struct CallgrindTrace {
+    std::map<std::int64_t, std::vector<EventProfile>> slices;
+    std::map<std::int64_t, EventProfile> totals;
+    std::size_t periodic_dump_count{0};
+};
+
+struct DrdTrace {
+    std::vector<Event> events;
+    std::map<std::int64_t, std::size_t> full_quanta;
+    std::size_t happens_before_edges{0};
+    std::size_t dropped_pre_window_edges{0};
+    std::size_t parsed_segment_count{0};
+    std::size_t retained_segment_count{0};
+    std::size_t begin_line{0};
+    std::size_t end_line{0};
+};
+
+struct PairedReplayOptions {
+    double residual_fraction{0.5};
+    std::string split_policy{"equal"};
+    double equivalent_cost_tolerance{0.05};
+    double equivalent_shape_tolerance{0.02};
+    std::size_t equivalence_bins{32};
+    std::size_t maximum_mappings{100000};
+    ReplayOptions replay;
+};
+
+struct PairedReplayResult {
+    ReplayResult conservative;
+    double minimum_makespan{0.0};
+    std::size_t mapping_count{0};
+    double maximum_equivalent_cost_spread{0.0};
+    double maximum_equivalent_shape_spread{0.0};
+    std::map<std::int64_t, std::int64_t> selected_source_by_trace_thread;
+};
+
+[[nodiscard]] CallgrindTrace parsePeriodicCallgrind(const std::filesystem::path& prefix);
+
+[[nodiscard]] DrdTrace parseMeasuredDrd(const std::filesystem::path& path);
+
+[[nodiscard]] PairedReplayResult replayPaired(const CallgrindTrace& callgrind, const DrdTrace& drd, const EventCostModel& model, const PairedReplayOptions& options);
+
+}  // namespace vc::thread_sync_replay

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.hpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.hpp
@@ -17,9 +17,16 @@ struct CallgrindTrace {
     std::size_t periodic_dump_count{0};
 };
 
+struct SchedulerTrace {
+    std::vector<std::int64_t> quantum_threads;
+    std::map<std::int64_t, std::size_t> full_quanta;
+    std::size_t begin_line{0};
+    std::size_t end_line{0};
+};
+
 struct DrdTrace {
     std::vector<Event> events;
-    std::map<std::int64_t, std::size_t> full_quanta;
+    SchedulerTrace scheduler;
     std::size_t happens_before_edges{0};
     std::size_t dropped_pre_window_edges{0};
     std::size_t parsed_segment_count{0};
@@ -31,9 +38,9 @@ struct DrdTrace {
 struct PairedReplayOptions {
     double residual_fraction{0.5};
     std::string split_policy{"equal"};
-    double equivalent_cost_tolerance{0.05};
-    double equivalent_shape_tolerance{0.02};
-    std::size_t equivalence_bins{32};
+    std::size_t scheduler_bins{16};
+    double scheduler_quantum_slack{1.0};
+    double maximum_makespan_spread{0.02};
     std::size_t maximum_mappings{100000};
     ReplayOptions replay;
 };
@@ -42,15 +49,21 @@ struct PairedReplayResult {
     ReplayResult conservative;
     double minimum_makespan{0.0};
     std::size_t mapping_count{0};
-    double maximum_equivalent_cost_spread{0.0};
-    double maximum_equivalent_shape_spread{0.0};
+    std::size_t evaluated_mapping_count{0};
+    double best_assignment_score{0.0};
+    double assignment_score_tolerance{0.0};
+    double maximum_assignment_score{0.0};
+    double makespan_relative_spread{0.0};
     std::map<std::int64_t, std::int64_t> selected_source_by_trace_thread;
 };
 
 [[nodiscard]] CallgrindTrace parsePeriodicCallgrind(const std::filesystem::path& prefix);
 
+[[nodiscard]] SchedulerTrace parseMeasuredScheduler(const std::filesystem::path& path);
+
 [[nodiscard]] DrdTrace parseMeasuredDrd(const std::filesystem::path& path);
 
-[[nodiscard]] PairedReplayResult replayPaired(const CallgrindTrace& callgrind, const DrdTrace& drd, const EventCostModel& model, const PairedReplayOptions& options);
+[[nodiscard]] PairedReplayResult replayPaired(
+    const CallgrindTrace& callgrind, const SchedulerTrace& callgrind_scheduler, const DrdTrace& drd, const EventCostModel& model, const PairedReplayOptions& options);
 
 }  // namespace vc::thread_sync_replay

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrindCli.cpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrindCli.cpp
@@ -1,0 +1,275 @@
+#include "thread_sync_replay/RenderValgrindCli.hpp"
+
+#include "thread_sync_replay/RenderValgrind.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace vc::thread_sync_replay
+{
+namespace
+{
+
+using json = nlohmann::json;
+
+std::map<std::string, std::string> parseArguments(int argc, char** argv)
+{
+    std::map<std::string, std::string> result;
+    for (int index = 2; index < argc; index += 2) {
+        if (index + 1 >= argc || !std::string(argv[index]).starts_with("--")) {
+            throw std::runtime_error("evaluate-render arguments must be --name value pairs");
+        }
+        const std::string name = std::string(argv[index]).substr(2);
+        if (!result.emplace(name, argv[index + 1]).second) {
+            throw std::runtime_error("duplicate evaluate-render argument --" + name);
+        }
+    }
+    return result;
+}
+
+const std::string& required(const std::map<std::string, std::string>& arguments, const std::string& name)
+{
+    const auto found = arguments.find(name);
+    if (found == arguments.end() || found->second.empty()) {
+        throw std::runtime_error("missing evaluate-render argument --" + name);
+    }
+    return found->second;
+}
+
+json readJson(const std::filesystem::path& path)
+{
+    std::ifstream stream(path);
+    if (!stream) {
+        throw std::runtime_error("cannot open JSON file " + path.string());
+    }
+    return json::parse(stream);
+}
+
+void writeJsonAtomic(const std::filesystem::path& path, const json& value)
+{
+    if (!path.parent_path().empty()) {
+        std::filesystem::create_directories(path.parent_path());
+    }
+    auto temporary = path;
+    temporary += ".tmp";
+    {
+        std::ofstream stream(temporary);
+        if (!stream) {
+            throw std::runtime_error("cannot write JSON file " + temporary.string());
+        }
+        stream << value.dump(2) << '\n';
+    }
+    std::filesystem::rename(temporary, path);
+}
+
+EventCostModel parseEventModel(const json& model)
+{
+    const auto& value = model.at("event_cost_model");
+    return {
+        .feature_names = value.at("feature_names").get<std::vector<std::string>>(),
+        .coefficients_ns = value.at("coefficients_ns").get<std::vector<double>>(),
+        .stall_overlap_fraction = value.value("stall_overlap_fraction", 0.0),
+    };
+}
+
+ReplayOptions parseReplayOptions(const json& model)
+{
+    const auto& value = model.at("replay");
+    return {
+        .cores = value.at("cores").get<std::size_t>(),
+        .tie_policy = value.at("tie_policy").get<std::string>(),
+        .wake_latency = value.value("wake_latency_ns", 0.0),
+        .cross_thread_latency = model.value("cross_thread_release_ns", 0.0),
+        .replay_idle_scale = value.value("replay_idle_scale", 1.0),
+        .dependency_excess_scale = value.value("dependency_excess_scale", 1.0),
+    };
+}
+
+json replayJson(const ReplayResult& result)
+{
+    return {
+        {"modeled_work", result.modeled_work},
+        {"modeled_makespan", result.modeled_makespan},
+        {"simulated_core_idle", result.simulated_core_idle},
+        {"logical_sync_delay", result.logical_sync_delay},
+        {"utilization", result.utilization},
+        {"raw_replay_makespan", result.raw_replay_makespan},
+        {"dependency_critical_path", result.dependency_critical_path},
+        {"hard_dependency_critical_path", result.hard_dependency_critical_path},
+        {"work_per_core_lower_bound", result.work_per_core_lower_bound},
+        {"hard_schedule_lower_bound", result.hard_schedule_lower_bound},
+        {"schedule_lower_bound", result.schedule_lower_bound},
+        {"dependency_excess", result.dependency_excess},
+        {"raw_replay_excess", result.raw_replay_excess},
+        {"raw_simulated_core_idle", result.raw_simulated_core_idle},
+    };
+}
+
+void validateMetadata(const json& metadata, const std::string& fixture, const std::string& scenario)
+{
+    if (metadata.at("fixture") != fixture || metadata.at("scenario") != scenario) {
+        throw std::runtime_error("benchmark metadata does not match requested case");
+    }
+    const auto repetitions = metadata.at("repetitions").get<std::int64_t>();
+    const auto width = metadata.at("width").get<std::int64_t>();
+    const auto height = metadata.at("height").get<std::int64_t>();
+    if (repetitions <= 0 || width <= 0 || height <= 0 || metadata.at("measured_pixels").get<std::int64_t>() != width * height * repetitions) {
+        throw std::runtime_error("benchmark metadata has inconsistent dimensions");
+    }
+}
+
+void validatePair(const json& callgrind, const json& drd)
+{
+    for (const std::string name :
+         {"fixture", "scenario", "width", "height", "tile_size", "repetitions", "measured_pixels", "worker_override", "checksum"}) {
+        if (callgrind.at(name) != drd.at(name)) {
+            throw std::runtime_error("Callgrind and DRD metadata differ for " + name);
+        }
+    }
+}
+
+double referenceTolerance(const json& reference, const std::map<std::string, std::string>& arguments)
+{
+    const auto explicit_tolerance = arguments.find("tolerance");
+    const double value = explicit_tolerance == arguments.end() ? reference.at("tolerance").get<double>() : std::stod(explicit_tolerance->second);
+    if (!std::isfinite(value) || value < 0.0 || value >= 1.0) {
+        throw std::runtime_error("reference tolerance must be in [0, 1)");
+    }
+    return value;
+}
+
+}  // namespace
+
+int renderValgrindCli(int argc, char** argv)
+{
+    const auto arguments = parseArguments(argc, argv);
+    const auto fixture = required(arguments, "fixture");
+    const auto scenario = required(arguments, "scenario");
+    if (fixture != "serial" && fixture != "parallel") {
+        throw std::runtime_error("fixture must be serial or parallel");
+    }
+    const auto output = std::filesystem::path(required(arguments, "output"));
+    const auto metadata = readJson(required(arguments, "callgrind-metadata"));
+    validateMetadata(metadata, fixture, scenario);
+    const auto model = readJson(required(arguments, "model"));
+    if (model.value("renderer_inputs_used", true) || model.value("timing_claims_enabled", true)) {
+        throw std::runtime_error("render model must be synthetic-only and relative");
+    }
+    const auto event_model = parseEventModel(model);
+    const auto callgrind = parsePeriodicCallgrind(required(arguments, "callgrind-prefix"));
+    const auto repetitions = metadata.at("repetitions").get<double>();
+
+    double score = 0.0;
+    json paired = nullptr;
+    if (fixture == "serial") {
+        if (arguments.contains("drd-trace") || arguments.contains("drd-metadata")) {
+            throw std::runtime_error("serial evaluation must not use DRD");
+        }
+        for (const auto& [thread, profile] : callgrind.totals) {
+            (void)thread;
+            score += modeledProfileCostNs(profile, event_model);
+        }
+        score /= repetitions;
+    } else {
+        const auto drd_metadata = readJson(required(arguments, "drd-metadata"));
+        validateMetadata(drd_metadata, fixture, scenario);
+        validatePair(metadata, drd_metadata);
+        const auto drd = parseMeasuredDrd(required(arguments, "drd-trace"));
+        const auto& replay_config = model.at("replay");
+        const auto result = replayPaired(
+            callgrind,
+            drd,
+            event_model,
+            {
+                .residual_fraction = replay_config.at("residual_fraction").get<double>(),
+                .split_policy = replay_config.at("split_policy").get<std::string>(),
+                .equivalent_cost_tolerance = 0.05,
+                .equivalent_shape_tolerance = 0.02,
+                .equivalence_bins = 32,
+                .maximum_mappings = 100000,
+                .replay = parseReplayOptions(model),
+            });
+        score = result.conservative.modeled_makespan / repetitions;
+        json mapping = json::object();
+        for (const auto& [trace_thread, source_thread] : result.selected_source_by_trace_thread) {
+            mapping[std::to_string(trace_thread)] = source_thread;
+        }
+        paired = {
+            {"result", replayJson(result.conservative)},
+            {"minimum_makespan", result.minimum_makespan},
+            {"maximum_makespan", result.conservative.modeled_makespan},
+            {"mapping_count", result.mapping_count},
+            {"maximum_equivalent_cost_spread", result.maximum_equivalent_cost_spread},
+            {"maximum_equivalent_shape_spread", result.maximum_equivalent_shape_spread},
+            {"selected_source_by_trace_thread", std::move(mapping)},
+            {"drd_event_count", drd.events.size()},
+            {"drd_happens_before_edges", drd.happens_before_edges},
+            {"drd_dropped_pre_window_edges", drd.dropped_pre_window_edges},
+            {"drd_parsed_segment_count", drd.parsed_segment_count},
+            {"drd_retained_segment_count", drd.retained_segment_count},
+            {"drd_begin_line", drd.begin_line},
+            {"drd_end_line", drd.end_line},
+        };
+    }
+    if (!std::isfinite(score) || score <= 0.0) {
+        throw std::runtime_error("modeled runtime score is not finite and positive");
+    }
+
+    json result = {
+        {"schema_version", 2},
+        {"kind", "evaluation"},
+        {"case", fixture + "/" + scenario},
+        {"model_id", model.at("model_id")},
+        {"score_semantics", "relative_modeled_runtime_not_absolute_wall_time"},
+        {"modeled_runtime_score_ns", score},
+        {"modeled_nanoseconds_per_pixel", score / (metadata.at("width").get<double>() * metadata.at("height").get<double>())},
+        {"checksum", metadata.at("checksum")},
+        {"callgrind_periodic_dump_count", callgrind.periodic_dump_count},
+        {"paired_replay", std::move(paired)},
+        {"status", "passed"},
+    };
+
+    bool failed = false;
+    const auto reference_path = arguments.find("reference");
+    if (reference_path != arguments.end()) {
+        const auto reference = readJson(reference_path->second);
+        const auto& reference_case = reference.at("cases").at(fixture + "/" + scenario);
+        const double expected = reference_case.at("modeled_runtime_score_ns").get<double>();
+        const double ratio = score / expected;
+        result["reference_modeled_runtime_score_ns"] = expected;
+        result["reference_ratio"] = ratio;
+        result["relative_error"] = ratio - 1.0;
+        if (ratio > 1.0 + referenceTolerance(reference, arguments)) {
+            result["status"] = "failed";
+            failed = true;
+        }
+    }
+    auto failed_output = output;
+    failed_output.replace_filename(output.stem().string() + ".failed" + output.extension().string());
+    if (failed) {
+        std::filesystem::remove(output);
+        writeJsonAtomic(failed_output, result);
+    } else {
+        std::filesystem::remove(failed_output);
+        writeJsonAtomic(output, result);
+    }
+    std::cout << fixture << '/' << scenario << ": " << score << " modeled ns/call";
+    if (result.contains("reference_ratio")) {
+        std::cout << ", " << result.at("reference_ratio").get<double>() << "x reference";
+    }
+    std::cout << '\n';
+    if (failed) {
+        throw std::runtime_error("modeled runtime exceeds reference tolerance");
+    }
+    return 0;
+}
+
+}  // namespace vc::thread_sync_replay

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrindCli.cpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrindCli.cpp
@@ -170,8 +170,8 @@ int renderValgrindCli(int argc, char** argv)
     double score = 0.0;
     json paired = nullptr;
     if (fixture == "serial") {
-        if (arguments.contains("drd-trace") || arguments.contains("drd-metadata")) {
-            throw std::runtime_error("serial evaluation must not use DRD");
+        if (arguments.contains("callgrind-scheduler") || arguments.contains("drd-trace") || arguments.contains("drd-metadata")) {
+            throw std::runtime_error("serial evaluation must not use scheduler traces or DRD");
         }
         for (const auto& [thread, profile] : callgrind.totals) {
             (void)thread;
@@ -182,18 +182,20 @@ int renderValgrindCli(int argc, char** argv)
         const auto drd_metadata = readJson(required(arguments, "drd-metadata"));
         validateMetadata(drd_metadata, fixture, scenario);
         validatePair(metadata, drd_metadata);
+        const auto callgrind_scheduler = parseMeasuredScheduler(required(arguments, "callgrind-scheduler"));
         const auto drd = parseMeasuredDrd(required(arguments, "drd-trace"));
         const auto& replay_config = model.at("replay");
         const auto result = replayPaired(
             callgrind,
+            callgrind_scheduler,
             drd,
             event_model,
             {
                 .residual_fraction = replay_config.at("residual_fraction").get<double>(),
                 .split_policy = replay_config.at("split_policy").get<std::string>(),
-                .equivalent_cost_tolerance = 0.05,
-                .equivalent_shape_tolerance = 0.02,
-                .equivalence_bins = 32,
+                .scheduler_bins = 16,
+                .scheduler_quantum_slack = 1.0,
+                .maximum_makespan_spread = 0.02,
                 .maximum_mappings = 100000,
                 .replay = parseReplayOptions(model),
             });
@@ -207,9 +209,15 @@ int renderValgrindCli(int argc, char** argv)
             {"minimum_makespan", result.minimum_makespan},
             {"maximum_makespan", result.conservative.modeled_makespan},
             {"mapping_count", result.mapping_count},
-            {"maximum_equivalent_cost_spread", result.maximum_equivalent_cost_spread},
-            {"maximum_equivalent_shape_spread", result.maximum_equivalent_shape_spread},
+            {"evaluated_mapping_count", result.evaluated_mapping_count},
+            {"best_assignment_score", result.best_assignment_score},
+            {"assignment_score_tolerance", result.assignment_score_tolerance},
+            {"maximum_assignment_score", result.maximum_assignment_score},
+            {"makespan_relative_spread", result.makespan_relative_spread},
             {"selected_source_by_trace_thread", std::move(mapping)},
+            {"callgrind_scheduler_quanta", callgrind_scheduler.quantum_threads.size()},
+            {"callgrind_scheduler_begin_line", callgrind_scheduler.begin_line},
+            {"callgrind_scheduler_end_line", callgrind_scheduler.end_line},
             {"drd_event_count", drd.events.size()},
             {"drd_happens_before_edges", drd.happens_before_edges},
             {"drd_dropped_pre_window_edges", drd.dropped_pre_window_edges},

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrindCli.hpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrindCli.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace vc::thread_sync_replay
+{
+
+int renderValgrindCli(int argc, char** argv);
+
+}  // namespace vc::thread_sync_replay

--- a/volume-cartographer/core/test/thread_sync_replay/Replay.cpp
+++ b/volume-cartographer/core/test/thread_sync_replay/Replay.cpp
@@ -242,13 +242,10 @@ Graph::Graph(std::vector<Event> events) : _events(std::move(events))
     }
 }
 
-std::vector<double> Graph::assignCosts(const std::map<std::int64_t, double>& thread_costs, double residual_fraction, const std::string& split_policy) const
+ThreadAttributionWindows Graph::attributionWindows(double residual_fraction) const
 {
     if (!std::isfinite(residual_fraction) || residual_fraction < 0.0 || residual_fraction > 1.0) {
         throw std::runtime_error("residual fraction must be between zero and one");
-    }
-    if (split_policy != "equal" && split_policy != "front" && split_policy != "back") {
-        throw std::runtime_error("unknown split policy " + split_policy);
     }
 
     std::map<std::int64_t, std::vector<std::size_t>> by_thread;
@@ -256,19 +253,9 @@ std::vector<double> Graph::assignCosts(const std::map<std::int64_t, double>& thr
         by_thread[_events[sequence].thread].push_back(sequence);
     }
 
-    std::vector<double> durations(_events.size(), 0.0);
+    ThreadAttributionWindows result;
     for (const auto& [thread, sequences] : by_thread) {
-        const auto cost = thread_costs.find(thread);
-        if (cost == thread_costs.end()) {
-            throw std::runtime_error("trace thread " + std::to_string(thread) + " has no cost");
-        }
-        requireFiniteNonnegative(cost->second, "thread cost");
-
-        struct Window {
-            std::vector<std::size_t> candidates;
-            double units;
-        };
-        std::vector<Window> windows;
+        std::vector<AttributionWindow> windows;
         std::vector<std::size_t> candidates;
         bool blocked = false;
         bool current = false;
@@ -294,53 +281,117 @@ std::vector<double> Graph::assignCosts(const std::map<std::int64_t, double>& thr
             windows.push_back({std::move(candidates), residual_fraction});
         }
 
-        std::vector<Window*> eligible;
+        std::vector<AttributionWindow> eligible;
         double total_units = 0.0;
-        for (auto& window : windows) {
+        for (auto&& window : windows) {
             if (!window.candidates.empty()) {
-                eligible.push_back(&window);
+                eligible.push_back(std::move(window));
                 total_units += window.units;
             }
         }
-        if (eligible.empty()) {
-            if (cost->second != 0.0) {
-                throw std::runtime_error("trace thread " + std::to_string(thread) + " has positive cost but no eligible event");
-            }
-            continue;
-        }
-        if (total_units <= 0.0) {
+        if (!eligible.empty() && total_units <= 0.0) {
             if (eligible.size() != 1) {
                 throw std::runtime_error("trace thread " + std::to_string(thread) + " has no positive attribution weight");
             }
-            eligible.front()->units = 1.0;
-            total_units = 1.0;
+            eligible.front().units = 1.0;
+        }
+        result.emplace(thread, std::move(eligible));
+    }
+    return result;
+}
+
+std::vector<double> Graph::assignWindowCosts(const std::map<std::int64_t, std::vector<double>>& window_costs, double residual_fraction, const std::string& split_policy) const
+{
+    if (split_policy != "equal" && split_policy != "front" && split_policy != "back") {
+        throw std::runtime_error("unknown split policy " + split_policy);
+    }
+    const auto windows = attributionWindows(residual_fraction);
+    if (window_costs.size() != windows.size()) {
+        throw std::runtime_error("window-cost threads do not match trace threads");
+    }
+
+    std::vector<double> durations(_events.size(), 0.0);
+    for (const auto& [thread, eligible] : windows) {
+        const auto costs = window_costs.find(thread);
+        if (costs == window_costs.end()) {
+            throw std::runtime_error("trace thread " + std::to_string(thread) + " has no window costs");
+        }
+        if (costs->second.size() != eligible.size()) {
+            throw std::runtime_error("trace thread " + std::to_string(thread) + " has the wrong number of window costs");
         }
 
-        const double unit_cost = cost->second / total_units;
-        for (const auto* window : eligible) {
-            const double window_cost = unit_cost * window->units;
+        double expected = 0.0;
+        for (std::size_t index = 0; index < eligible.size(); ++index) {
+            const auto& window = eligible[index];
+            const double window_cost = costs->second[index];
+            requireFiniteNonnegative(window_cost, "window cost");
+            expected += window_cost;
+            requireFiniteNonnegative(expected, "thread window-cost total");
             if (split_policy == "equal") {
-                const double share = window_cost / window->candidates.size();
-                for (const auto sequence : window->candidates) {
+                const double share = window_cost / window.candidates.size();
+                for (const auto sequence : window.candidates) {
                     durations[sequence] += share;
                 }
             } else if (split_policy == "front") {
-                durations[window->candidates.front()] += window_cost;
+                durations[window.candidates.front()] += window_cost;
             } else {
-                durations[window->candidates.back()] += window_cost;
+                durations[window.candidates.back()] += window_cost;
             }
         }
 
         double assigned = 0.0;
-        for (const auto sequence : sequences) {
-            assigned += durations[sequence];
+        for (const auto& window : eligible) {
+            for (const auto sequence : window.candidates) {
+                assigned += durations[sequence];
+            }
         }
-        const double tolerance = 1e-12 * std::max(1.0, cost->second);
-        if (std::abs(assigned - cost->second) > tolerance) {
+        const double tolerance = 1e-12 * std::max(1.0, expected);
+        if (std::abs(assigned - expected) > tolerance) {
             throw std::runtime_error("cost attribution did not preserve thread total");
         }
     }
     return durations;
+}
+
+std::vector<double> Graph::assignCosts(const std::map<std::int64_t, double>& thread_costs, double residual_fraction, const std::string& split_policy) const
+{
+    const auto windows = attributionWindows(residual_fraction);
+    if (thread_costs.size() != windows.size()) {
+        throw std::runtime_error("thread costs do not match trace threads");
+    }
+
+    std::map<std::int64_t, std::vector<double>> window_costs;
+    for (const auto& [thread, eligible] : windows) {
+        const auto cost = thread_costs.find(thread);
+        if (cost == thread_costs.end()) {
+            throw std::runtime_error("trace thread " + std::to_string(thread) + " has no cost");
+        }
+        requireFiniteNonnegative(cost->second, "thread cost");
+        if (eligible.empty()) {
+            if (cost->second != 0.0) {
+                throw std::runtime_error("trace thread " + std::to_string(thread) + " has positive cost but no eligible event");
+            }
+            window_costs.emplace(thread, std::vector<double>{});
+            continue;
+        }
+        const double total_units = std::accumulate(eligible.begin(), eligible.end(), 0.0, [](double total, const AttributionWindow& window) {
+            return total + window.units;
+        });
+        if (total_units <= 0.0) {
+            throw std::runtime_error("trace thread " + std::to_string(thread) + " has no positive attribution weight");
+        }
+        std::vector<double> costs;
+        costs.reserve(eligible.size());
+        for (const auto& window : eligible) {
+            costs.push_back(cost->second * window.units / total_units);
+        }
+        if (!costs.empty()) {
+            const double assigned = std::accumulate(costs.begin(), costs.end(), 0.0);
+            costs.back() += cost->second - assigned;
+        }
+        window_costs.emplace(thread, std::move(costs));
+    }
+    return assignWindowCosts(window_costs, residual_fraction, split_policy);
 }
 
 Graph::BasicResult Graph::replay(const std::vector<double>& durations, const ReplayOptions& options) const

--- a/volume-cartographer/core/test/thread_sync_replay/Replay.hpp
+++ b/volume-cartographer/core/test/thread_sync_replay/Replay.hpp
@@ -52,6 +52,13 @@ struct ReplayResult {
 
 using EventProfile = std::map<std::string, std::int64_t>;
 
+struct AttributionWindow {
+    std::vector<std::size_t> candidates;
+    double units{0.0};
+};
+
+using ThreadAttributionWindows = std::map<std::int64_t, std::vector<AttributionWindow>>;
+
 struct EventCostModel {
     std::vector<std::string> feature_names;
     std::vector<double> coefficients_ns;
@@ -70,7 +77,12 @@ public:
     [[nodiscard]] std::size_t size() const noexcept { return _events.size(); }
     [[nodiscard]] const std::vector<Event>& events() const noexcept { return _events; }
 
+    [[nodiscard]] ThreadAttributionWindows attributionWindows(double residual_fraction) const;
+
     [[nodiscard]] std::vector<double> assignCosts(const std::map<std::int64_t, double>& thread_costs, double residual_fraction, const std::string& split_policy) const;
+
+    [[nodiscard]] std::vector<double> assignWindowCosts(
+        const std::map<std::int64_t, std::vector<double>>& window_costs, double residual_fraction, const std::string& split_policy) const;
 
     [[nodiscard]] ReplayResult replayAdjusted(const std::vector<double>& durations, const ReplayOptions& options) const;
 

--- a/volume-cartographer/core/test/thread_sync_replay/main.cpp
+++ b/volume-cartographer/core/test/thread_sync_replay/main.cpp
@@ -1,4 +1,5 @@
 #include "thread_sync_replay/Replay.hpp"
+#include "thread_sync_replay/RenderValgrindCli.hpp"
 
 #include <nlohmann/json.hpp>
 
@@ -296,8 +297,16 @@ private:
 
 int main(int argc, char** argv)
 {
+    if (argc >= 2 && std::string(argv[1]) == "evaluate-render") {
+        try {
+            return replay::renderValgrindCli(argc, argv);
+        } catch (const std::exception& error) {
+            std::cerr << "bench_thread_sync_replay: " << error.what() << '\n';
+            return 1;
+        }
+    }
     if (argc != 2 || std::string(argv[1]) != "--server") {
-        std::cerr << "usage: bench_thread_sync_replay --server\n";
+        std::cerr << "usage: bench_thread_sync_replay --server | evaluate-render ...\n";
         return 2;
     }
 

--- a/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
+++ b/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
@@ -13,6 +13,12 @@ Ninja to generate a fresh eight-case Valgrind graph:
 - complete DRD dependency graphs for the four parallel cases;
 - a relative modeled-runtime score and exact rendering checksum per case.
 
+The fixture renders through the production `ChunkCache`. A deterministic fake
+`IChunkFetcher` preloads all resident and missing states before measurement;
+the benchmark fails if a timed render reaches the fetcher. Storage, decode, and
+download work are therefore excluded while production cache lookup, locking,
+and request-context handling remain measured.
+
 Every score must stay at or below the reference plus the one-sided slowdown
 tolerance stored in `core/test/data/render_valgrind_ci_reference.json`. Faster
 scores pass. This is a regression score, not estimated native wall time.

--- a/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
+++ b/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
@@ -86,17 +86,14 @@ replayed and the maximum makespan is the score.
 
 ## CI Activation
 
-The workflow job is temporarily disabled while its corrected references are
-reviewed. Once its `if: ${{ false }}` guard is removed, it runs on qualifying
-pull requests and pushes to `main`. The
+The workflow job runs on qualifying pull requests and pushes to `main`. The
 rendering job is selected when changes touch VC3D/core build inputs such as
 `volume-cartographer/core/**`, `volume-cartographer/scripts/**`, CMake files,
 VC3D sources, shared utilities/libraries, or `.github/workflows/vc3d-ci.yml`.
 Documentation-only changes under `volume-cartographer/docs/**` run the workflow
 path filter but do not select this expensive rendering job.
 
-Merging alone does not activate the currently disabled job. To make a restored
-job mandatory before merge, add
+To make the job mandatory before merge, add
 the `Synthetic rendering regression (GCC Release / Valgrind replay)` check to
 the repository branch ruleset or branch protection. Merging alone runs the
 check but does not make it a required status check.
@@ -213,25 +210,26 @@ cmake -S volume-cartographer -B "$build" -G Ninja \
 cmake --build "$build" --target render_valgrind_ci_measure --parallel "$jobs"
 python3 volume-cartographer/scripts/run_render_valgrind_ci.py freeze-reference \
   --model volume-cartographer/core/test/data/render_valgrind_ci_model.json \
-  --tolerance 0.10 \
+  --tolerance 0.05 \
   --output volume-cartographer/core/test/data/render_valgrind_ci_reference.json \
   "$build"/render-valgrind-ci/*/*/evaluation.json
 cmake --build "$build" --target render_valgrind_ci --parallel "$jobs"
 ```
 
-The freeze command requires exactly all eight cases and records score,
-checksum, environment/workload identity, model hash, and tolerance. Only score
-and tolerance affect historical pass/fail; the remaining fields are diagnostic.
+The freeze command requires exactly all eight native evaluation artifacts and
+records score, checksum, model hash, and tolerance. Legacy evaluation artifacts
+also retain their environment/workload identity as diagnostic metadata. Only
+score and tolerance affect historical pass/fail.
 Review every old/new score ratio. Run a second fresh collection before accepting
 references when parallel DRD replay variation is close to the chosen tolerance.
 
 ## Tightening Or Loosening Tolerance
 
 Tolerance is a fraction in `[0, 1)` stored once at the top level of
-`render_valgrind_ci_reference.json`. The default `0.10` accepts any finite,
-positive ratio at or below `1.10`:
+`render_valgrind_ci_reference.json`. The current `0.05` accepts any finite,
+positive ratio at or below `1.05`:
 
-- lowering it to `0.05` tightens the maximum accepted ratio to `1.05`;
+- lowering it to `0.03` tightens the maximum accepted ratio to `1.03`;
 - raising it to `0.15` loosens the maximum accepted ratio to `1.15`.
 
 Speedups do not fail the reference gate. A tolerance-only change must leave all

--- a/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
+++ b/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
@@ -42,7 +42,7 @@ cmake --build volume-cartographer/build/ci-render-benchmark \
   --target bench_render_synthetic bench_thread_sync_replay --parallel "$jobs"
 ctest --test-dir volume-cartographer/build/ci-render-benchmark \
   --output-on-failure \
-  -R '^(test_render_synthetic_fixture|test_render_valgrind_ci_no_site)$'
+  -R '^(test_render_synthetic_fixture|test_thread_sync_replay_native)$'
 cmake --build volume-cartographer/build/ci-render-benchmark \
   --target render_valgrind_ci --parallel "$jobs"
 ```
@@ -51,42 +51,46 @@ Set `jobs` to a smaller positive number to limit local CPU or memory use. This
 only controls how many independent Ninja commands run at once. It does not
 change the fixed four-worker renderer fixture or five-core replay model.
 
-`test_render_valgrind_ci_no_site` runs the coordinator with `python3 -S`, parses
-a DRD fixture, and evaluates a profile through the real native replay engine.
-This prevents the dependency container from silently relying on host-installed
-Python packages. Python coordinates collection and artifact validation; all
-event-cost and replay computation is native C++.
+The regular estimate contains no Python process. Ninja invokes Valgrind
+directly, then `bench_thread_sync_replay evaluate-render` parses the raw
+Callgrind profiles and DRD log, validates the pair, attributes costs, replays
+the graph, and writes the result in C++.
 
 Artifacts are under
 `build/ci-render-benchmark/render-valgrind-ci/<fixture>/<scenario>/`:
 
-- `callgrind/artifact.json` and raw per-thread profiles;
-- `drd/artifact.json`, `drd.log`, and `events.jsonl` for parallel cases;
+- `callgrind/callgrind.out.*`, benchmark metadata, and a collection stamp;
+- `drd/drd.log`, benchmark metadata, and a collection stamp for parallel cases;
 - `evaluation.json` for the ungated score;
 - `checked.json` after a passing comparison;
-- `checked.failed.json` after a failed comparison.
 
-Start failure diagnosis with `checked.failed.json`. Historical compiler, model,
-checksum, cache, fixture, repetition, and profiler changes do not fail the
-reference gate. The output records
-`reference_valgrind_version`, `observed_valgrind_version`, and whether they
-changed. Current-run artifact corruption or Callgrind/DRD inconsistency still
-fails because it prevents a valid score. An incomplete DRD failure means the
-trace must be recollected. A score above the allowed slowdown is a performance
-regression requiring investigation or an intentional reference update.
+Start failure diagnosis with the raw profiles, DRD log, and `evaluation.json`.
+Historical compiler, model, checksum, cache, fixture, repetition, and profiler
+changes do not fail the reference gate. Current-run parse errors or
+Callgrind/DRD metadata inconsistency still fail because they prevent a valid
+score. A score above the allowed slowdown is a performance regression requiring
+investigation or an intentional reference update.
+
+Parallel collection uses the same fair scheduler and 10,000-basic-block
+quantum in both Valgrind runs. Periodic Callgrind deltas are matched to the DRD
+measured window by canonical worker work rank. Equal DRD worker signatures are
+accepted only when their total costs differ by at most 5% and their normalized
+32-bin chronological shapes differ by at most 2%. Every admissible mapping is
+replayed and the maximum makespan is the score.
 
 ## CI Activation
 
-The workflow runs on qualifying pull requests and pushes to `main`. The
+The workflow job is temporarily disabled while its corrected references are
+reviewed. Once its `if: ${{ false }}` guard is removed, it runs on qualifying
+pull requests and pushes to `main`. The
 rendering job is selected when changes touch VC3D/core build inputs such as
 `volume-cartographer/core/**`, `volume-cartographer/scripts/**`, CMake files,
 VC3D sources, shared utilities/libraries, or `.github/workflows/vc3d-ci.yml`.
 Documentation-only changes under `volume-cartographer/docs/**` run the workflow
 path filter but do not select this expensive rendering job.
 
-Merging the implementation into `main` therefore makes the job available for
-all subsequent qualifying changes; the pull request containing the workflow
-change should also execute it. To make passing it mandatory before merge, add
+Merging alone does not activate the currently disabled job. To make a restored
+job mandatory before merge, add
 the `Synthetic rendering regression (GCC Release / Valgrind replay)` check to
 the repository branch ruleset or branch protection. Merging alone runs the
 check but does not make it a required status check.
@@ -245,8 +249,9 @@ solely to change policy width.
 For any maintenance change, run:
 
 ```bash
-PYTHONPATH=volume-cartographer/scripts python3 -m unittest \
-  volume-cartographer/core/test/test_run_render_valgrind_ci.py
+cmake --build volume-cartographer/build/ci-render-benchmark \
+  --target test_thread_sync_replay_native --parallel "$(nproc)"
+volume-cartographer/build/ci-render-benchmark/bin/test_thread_sync_replay_native
 cmake --build volume-cartographer/build/ci-render-benchmark \
   --target render_valgrind_ci --parallel "$(nproc)"
 git diff --check

--- a/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
+++ b/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
@@ -66,6 +66,7 @@ Artifacts are under
 `build/ci-render-benchmark/render-valgrind-ci/<fixture>/<scenario>/`:
 
 - `callgrind/callgrind.out.*`, benchmark metadata, and a collection stamp;
+- `callgrind/scheduler.log` for parallel cases;
 - `drd/drd.log`, benchmark metadata, and a collection stamp for parallel cases;
 - `evaluation.json` for the ungated score;
 - `checked.json` after a passing comparison;
@@ -78,11 +79,19 @@ score. A score above the allowed slowdown is a performance regression requiring
 investigation or an intentional reference update.
 
 Parallel collection uses the same fair scheduler and 10,000-basic-block
-quantum in both Valgrind runs. Periodic Callgrind deltas are matched to the DRD
-measured window by canonical worker work rank. Equal DRD worker signatures are
-accepted only when their total costs differ by at most 5% and their normalized
-32-bin chronological shapes differ by at most 2%. Every admissible mapping is
-replayed and the maximum makespan is the score.
+quantum in both Valgrind runs. Callgrind also records the scheduler stream from
+its own execution. Main thread 1 remains fixed; the four worker identities are
+matched by exhaustively scoring all 24 permutations against normalized worker
+activity share and cumulative activity in 16 measured-window bins. Assignments
+within the scheduler-quantum resolution of the best score are all replayed, and
+the maximum makespan is the case score. The case fails as insufficient
+attribution evidence if those compatible assignments span more than 2% in
+makespan.
+
+An attribution retry, if enabled, must recollect only the affected case and
+only after an `assignment evidence insufficient` failure. It must not retry a
+completed evaluation whose modeled-runtime score exceeds the reference; that
+is a performance regression, not a collection-quality failure.
 
 ## CI Activation
 

--- a/volume-cartographer/docs/benchmarks/synthetic_rendering.md
+++ b/volume-cartographer/docs/benchmarks/synthetic_rendering.md
@@ -2,9 +2,11 @@
 
 `bench_render_synthetic` measures the production
 `ChunkedPlaneSampler::sampleCoordsFineToCoarse` path without storage, network,
-decompression, or asynchronous chunk scheduling. It uses a four-level synthetic
-resident array whose deterministic pseudo-random chunk bytes are materialized
-before measurement.
+decompression, or asynchronous chunk scheduling. It uses the production
+`ChunkCache` with a four-level deterministic `IChunkFetcher`. The fetcher
+materializes pseudo-random chunk bytes during preload, and the benchmark fails
+if rendering reaches it after measurement setup. Production cache lookup,
+locking, and request-context handling remain inside the measured path.
 
 ## Scenarios
 

--- a/volume-cartographer/docs/thread_sync_replay.md
+++ b/volume-cartographer/docs/thread_sync_replay.md
@@ -2,10 +2,12 @@
 
 The regular rendering estimate is native C++ end to end after Valgrind writes
 its raw files. `bench_thread_sync_replay evaluate-render` parses periodic
-separate-thread Callgrind profiles, locates the measured DRD window from the
-benchmark's existing clock calls, reconstructs vector-clock dependencies,
-matches logical workers, attributes chronological costs, and replays the graph.
-Python remains only in offline calibration and compatibility tooling.
+separate-thread Callgrind profiles and the scheduler stream from that same run,
+locates the measured DRD window from the benchmark's existing clock calls,
+reconstructs vector-clock dependencies, evaluates all logical-worker
+assignments supported by both scheduler traces, attributes chronological costs,
+and replays the graph conservatively. Python remains only in offline
+calibration and compatibility tooling.
 
 Python starts one persistent process and exchanges one JSON object per line.
 Every request and response uses `schema_version: 2` and an ordered

--- a/volume-cartographer/docs/thread_sync_replay.md
+++ b/volume-cartographer/docs/thread_sync_replay.md
@@ -1,10 +1,11 @@
 # Native Thread-Synchronization Replay
 
-Passive Valgrind trace collection and DRD dependency extraction remain in
-the standard-library Python coordinator and shared `scripts/thread_sync_trace.py`
-parser. Event-feature calculation, profile-cost evaluation, event-graph
-scheduling, and critical-path playback run in the portable C++
-`bench_thread_sync_replay` executable.
+The regular rendering estimate is native C++ end to end after Valgrind writes
+its raw files. `bench_thread_sync_replay evaluate-render` parses periodic
+separate-thread Callgrind profiles, locates the measured DRD window from the
+benchmark's existing clock calls, reconstructs vector-clock dependencies,
+matches logical workers, attributes chronological costs, and replays the graph.
+Python remains only in offline calibration and compatibility tooling.
 
 Python starts one persistent process and exchanges one JSON object per line.
 Every request and response uses `schema_version: 2` and an ordered
@@ -29,9 +30,9 @@ Callers locate the executable in this order: explicit `--replay-engine`,
 `VC_THREAD_SYNC_REPLAY_BIN`, beside the benchmark executable, then `PATH`.
 There is no Python fallback.
 
-The rendering CI coordinator is intentionally importable with `python3 -S` and
-does not require NumPy. NumPy remains part of offline model fitting and parity
-analysis, not production gate execution.
+The rendering CMake/Ninja graph invokes Valgrind and the native evaluator
+directly. NumPy and the standard-library Python compatibility client are not
+part of production gate execution.
 
 Build and run the compatibility tests:
 

--- a/volume-cartographer/planning/changelog.md
+++ b/volume-cartographer/planning/changelog.md
@@ -100,6 +100,10 @@
   classification, source download/read, and CPU decode queues so cached decode
   work no longer delays discovery and admission of remote misses.
 
+## 2026-08-18
+
+- Replaced cross-run Valgrind worker-ID attribution with native passive paired-trace reconstruction and conservative replay.
+
 ## 2026-08-12
 
 - Added per-scale unresolved-fetch counts to VC3D's existing cache status bar

--- a/volume-cartographer/planning/changelog.md
+++ b/volume-cartographer/planning/changelog.md
@@ -102,7 +102,7 @@
 
 ## 2026-08-18
 
-- Replaced cross-run Valgrind worker-ID attribution with native passive paired-trace reconstruction and conservative replay.
+- Re-enabled the 5% synthetic-rendering gate with native paired attribution and production-cache lookup coverage.
 
 ## 2026-08-12
 

--- a/volume-cartographer/planning/changelog.md
+++ b/volume-cartographer/planning/changelog.md
@@ -102,7 +102,7 @@
 
 ## 2026-08-18
 
-- Re-enabled the 5% synthetic-rendering gate with native paired attribution and production-cache lookup coverage.
+- Re-enabled the 5% synthetic-rendering gate with native scheduler-matched paired attribution and production-cache lookup coverage.
 
 ## 2026-08-12
 

--- a/volume-cartographer/planning/status.md
+++ b/volume-cartographer/planning/status.md
@@ -4,12 +4,12 @@
 - [x] Confirm current cross-run worker-ID attribution behavior.
 - [x] Confirm render-job request lifetime and existing local chunk caching.
 - [x] Record attribution alternatives and a provisional recommendation.
-- [ ] Complete independent review of the provisional plan.
+- [x] Replace rank/tie matching with same-run scheduler evidence.
 - [x] Collect initial repeated artifacts and identify worker/scope mismatch.
 - [x] Validate passive canonical pairing over three full parallel matrices.
 - [x] Implement and test deterministic paired attribution in native C++.
 - [x] Re-evaluate residual variation with three fresh current-binary pairs.
-- [ ] Freeze a stable reference and re-enable the CI gate.
+- [x] Validate the repaired attribution against the existing enabled CI gate.
 - [ ] Profile and implement lookup optimization against the accepted gate.
 - [x] Update specifications, documentation, and changelog.
 - [x] Complete native unit, compatibility, matrix, reference, and repeatability validation.

--- a/volume-cartographer/planning/status.md
+++ b/volume-cartographer/planning/status.md
@@ -1,13 +1,15 @@
-# VC3D control-point collapse rollback status
+# VC3D render attribution and lookup repair status
 
-- [x] Capture the corrective task requirements.
-- [x] Inspect the multi-collapse, local-update, optimizer, and rollback paths.
-- [x] Write the implementation, testing, spec, docs, and changelog plan.
-- [x] Complete independent plan review against task, spec, and broader plan.
-- [x] Incorporate plan-review findings.
-- [x] Unify automatic multi-control collapse with local span reconstruction.
-- [x] Prevent synchronous preparation failure from mutating optimization state.
-- [x] Add focused regression tests.
-- [x] Update specification, documentation, changelog, and task log.
-- [x] Build with 32 cores and run focused tests plus the full VC3D compile.
-- [x] Run `git diff --check` and review the final diff.
+- [x] Capture the attribution-first task and deferred speed requirements.
+- [x] Confirm current cross-run worker-ID attribution behavior.
+- [x] Confirm render-job request lifetime and existing local chunk caching.
+- [x] Record attribution alternatives and a provisional recommendation.
+- [ ] Complete independent review of the provisional plan.
+- [x] Collect initial repeated artifacts and identify worker/scope mismatch.
+- [x] Validate passive canonical pairing over three full parallel matrices.
+- [x] Implement and test deterministic paired attribution in native C++.
+- [x] Re-evaluate residual variation with three fresh current-binary pairs.
+- [ ] Freeze a stable reference and re-enable the CI gate.
+- [ ] Profile and implement lookup optimization against the accepted gate.
+- [x] Update specifications, documentation, and changelog.
+- [x] Complete native unit, compatibility, matrix, reference, and repeatability validation.

--- a/volume-cartographer/planning/task.md
+++ b/volume-cartographer/planning/task.md
@@ -1,22 +1,35 @@
-# VC3D control-point collapse rollback fixes
+# VC3D render attribution and lookup performance repair
 
-Correct two regressions in generated-view control-point editing introduced by
-the 32-base-voxel multi-control collapse behavior.
+Repair the synthetic rendering performance gate before re-enabling it, then
+recover the lookup performance lost around the render-order changes.
 
-Requirements:
+Priorities:
 
-- Automatic multi-control collapse must use the same local line-update sequence
-  as insertion and single-control replacement: reconstruct the adjacent spans
-  around the replacement's authoritative `linePosition`, then start fiber-mode
-  optimization from that updated line.
-- Do not start multi-control optimization directly against the unchanged old
-  line. In particular, a replacement on a self-approaching fiber must not be
-  associated with another winding by nearest 3-D position.
-- Preserve the existing 32-base-voxel inclusive collapse selection, control
-  metadata ownership, branch-index remapping, dirty-span scope, seed/focus
-  behavior, no-reoptimization behavior, and asynchronous failure rollback.
-- If synchronous local update preparation throws, leave the pre-edit controls,
-  line, branches, seed/focus, and optimization state unchanged.
-- Keep the broader persisted-control/legacy nearest-3-D reconstruction issue out
-  of scope; this task fixes the PR 1484 regression without changing the fiber
-  file format.
+1. Correct and stabilize the passive Valgrind attribution. Collect periodic
+   Callgrind cost slices and a DRD dependency graph from separate executions
+   with identical Valgrind scheduling parameters. Reconstruct logical worker
+   traces canonically instead of equating raw worker IDs, trim DRD to the same
+   existing timed render boundary, and reject any pair whose logical pattern is
+   ambiguous or not reproducible. The measured binary must remain unchanged:
+   no markers, affinity mode, deterministic executor, or added instructions.
+2. Measure and repair renderer lookup speed using the commit immediately before
+   `Vc3d renderorder` and the current implementation as an A/B case. Preserve
+   rendered bytes, fallback behavior, request priority, and scheduling
+   semantics.
+
+Speed investigation requirements:
+
+- Treat `ChunkRequestContext` as render-job-constant; verify and exploit that
+  without changing request publication semantics.
+- Investigate a prepared/source-bound key lookup path so level, source, and
+  request information are not repeatedly assembled in the hot lookup.
+- Avoid rebuilding and probing a full key when a correlated sample remains in
+  the same successfully resolved chunk.
+- Account for the existing `LocalChunkCache`: it already retains the last key
+  and result and up to eight pinned chunks. Do not duplicate that cache under a
+  different name; improve the work that happens before it can identify a hit.
+- Establish repeatable before/after Release measurements and verify exact output
+  checksums before accepting any optimization.
+
+The Valgrind attribution repair is first. Lookup optimization remains planned
+until the gate can produce stable, semantically valid scores.

--- a/volume-cartographer/planning/task_log.md
+++ b/volume-cartographer/planning/task_log.md
@@ -1,61 +1,180 @@
-# VC3D control-point collapse rollback task log
+# VC3D render attribution and lookup repair task log
 
-## Findings
+## 2026-08-18 findings
 
-- After `collapseControlPointsAtClick()`, all click-edit cases have exactly one
-  changed replacement control and a valid replacement index. Removing multiple
-  controls does not require a multi-control line-update API.
-- The existing local updater rebuilds both spans adjacent to its changed
-  control and places that control directly into the updated line before fiber
-  optimization.
-- The PR 1484 multi-collapse branch bypasses this updater and passes the
-  replacement plus unchanged old line to the fiber optimizer, whose independent
-  nearest-3-D control lookup can select another winding.
-- Multi-collapse already carries a complete asynchronous rollback object. The
-  ordinary synchronous update catch captures but fails to restore the previous
-  optimization state.
-- Independent review found that reusing the existing local-update controller
-  block verbatim would mutate reciprocal branches and schedule saves before the
-  asynchronous result is known. Multi-collapse must keep only its session-local
-  branch remap before success and defer reciprocal synchronization as it does
-  today.
-- Independent review also found that all-control collapse leaves one replacement
-  with no adjacent span. The local updater returns the old line unchanged in
-  that case, and the one-control optimizer currently derives its tangent by
-  nearest 3-D lookup. The targeted fix will use authoritative line position for
-  that tangent.
-- To cover the production regression rather than manually composing two helpers
-  only in tests, automatic collapse plus local reconstruction will be extracted
-  into one reusable preparation helper used by controller and tests. Session
-  mutation will occur only after that helper succeeds.
-- Independent implementation review found that segment metadata was still
-  merged back by equal 3-D position. The merge now follows stable ordered
-  control identity, with duplicate-position coverage for exact crossings.
-- The same review found that multi-collapse invalidated cached metrics before
-  asynchronous commit and that generated-view failure could leave the new
-  optimization report/flags behind. Metric invalidation is now deferred until
-  successful materialization, and the rollback snapshot includes the previous
-  report, manifest, optimization flag, and metric-match flag.
-- Legacy fiber loading and other optimizer entry points still reconstruct some
-  control locations with nearest-3-D matching. That broader persisted topology
-  issue is intentionally deferred because this task is limited to the two PR
-  1484 regressions and does not change the fiber format.
+- The frozen reference predates `81f6a8ffb` (`Vc3d renderorder`). Its parent
+  passed the gate and the squash commit failed it. The later
+  `QuadSurface::gen()` optimization cannot be the original trigger because the
+  synthetic fixture calls `ChunkedPlaneSampler` directly.
+- Callgrind and DRD are necessarily collected in separate Valgrind processes.
+  Current evaluation passes per-thread Callgrind costs directly to a DRD graph
+  under the same raw Valgrind IDs. Worker participation and executed work are
+  not stable identities across those executions.
+- `Graph::assignCosts()` iterates DRD threads. It fails when a DRD thread lacks
+  a same-numbered Callgrind profile, but does not reject extra Callgrind thread
+  costs. A Callgrind-only worker cost can therefore be silently omitted from the
+  replay.
+- Every CI case currently uses one Callgrind execution and one first-complete
+  DRD execution. No median or repeated-trace aggregation protects the parallel
+  score from attribution/scheduling variation.
+- The event-cost model contains nonlinear interaction features. Each Callgrind
+  thread must continue to be modeled independently before worker costs are
+  summed; summing raw counters first changes the modeled total.
+- Periodic Callgrind dumps at 10,000 basic blocks produce chronological,
+  separate-thread delta profiles without changing the benchmark binary.
+- Three repeated `parallel/full_res` DRD runs had the same measured render
+  structure: seven main quanta and sixteen quanta on each of four workers. One
+  whole-process trace differed by one unrelated main-thread quantum, confirming
+  that the graph must be trimmed to the measured render.
+- The existing benchmark timing calls appear passively in the DRD syscall log.
+  The measured render is the unique pair of main-thread `clock_gettime` calls
+  sharing a stack address. This provides boundaries without markers.
+- Fair-scheduled `mixed_correlated` Callgrind runs execute one logical range per
+  worker, but physical IDs vary. Their canonical worker instruction totals are
+  stable at approximately 13.38M, 13.38M, 14.53M, and 16.17M. Independent DRD
+  runs produce corresponding measured worker lengths of 36/37, 36, 40, and 44
+  quanta. Rank matching is therefore viable; the two shortest ranges are an
+  equivalent tie.
+- `--fair-sched=no` is unsuitable: one physical worker may execute multiple
+  logical ranges while another remains effectively idle.
+- Reducing the fair-scheduled quantum from 10,000 to 1,000 basic blocks does
+  not stabilize raw worker IDs. Physical IDs are therefore never a valid
+  cross-run identity, regardless of quantum.
+- A three-run, four-scenario passive matrix with the unmodified release binary
+  validated canonical reconstruction:
 
-## Deviations
+  | Scenario | Canonical worker `Ir` stability | DRD measured quanta | Worst 32-bin cost-shape delta |
+  | --- | ---: | --- | ---: |
+  | `full_res` | 0.29% | `16,16,16,16` | 0.23% |
+  | `fallback_3` | 0.74% | `56,57,62,71` | 0.36% |
+  | `mixed_correlated` | 0.48% | `36,36,40,44` | 0.37% |
+  | `mixed_shuffled` | 0.08% | `77,77,78,78` | 0.03% |
 
-- The private Qt `LineAnnotationSession` still has no isolated controller test
-  seam for forcing asynchronous optimization or generated-view failure.
-  Existing multi-collapse rollback is retained and reviewed through its shared
-  rollback object and full VC3D compile, while focused tests cover the newly
-  extracted production preparation path and synchronous failure atomicity.
-- The installed `clang-format` configuration did not match repository style and
-  reformatted thousands of unrelated lines. That mechanical rewrite was fully
-  removed; only focused semantic edits remain.
+- Replaying every admissible mapping inside equal-quantum groups bounded the
+  remaining identity ambiguity at 0.90% makespan for `full_res`, 0.11% for
+  `mixed_shuffled`, and 0% for `fallback_3` and `mixed_correlated`. The gate can
+  conservatively report the maximum mapping when a tie is equivalent instead
+  of selecting an arbitrary worker.
+- The passive task-start order is not sufficient to identify FIFO task order:
+  multiple workers can dequeue inside one periodic Callgrind interval. Matching
+  must use complete canonical workload signatures and enumerate equivalent
+  ties, not first-observed worker order.
 
-## Validation
+## Attribution options
 
-- Built with all 32 cores:
-  `cmake --build volume-cartographer/build --parallel 32 --target test_lasagna_line_optimizer test_line_annotation_generated_views VC3D`
-- `test_lasagna_line_optimizer`: 35 test cases passed.
-- `test_line_annotation_generated_views`: 79 test cases passed.
-- Full `VC3D` target compiled successfully.
+### A. Main/worker role pooling (recommended first)
+
+Keep thread 1 as the stable process-main role. Sum independently modeled
+non-main Callgrind costs, then distribute that complete worker-pool cost over
+all eligible non-main DRD work windows using the existing quantum/residual
+weights. This removes invented worker identity, accepts different worker sets,
+preserves total modeled work, and remains completely passive. DRD event thread
+IDs are retained, so worker program order, blocking, wakeups, and cross-thread
+dependencies continue to determine replay makespan; only cross-process cost
+identity is pooled.
+
+Tradeoff: per-worker Callgrind imbalance is deliberately discarded. DRD still
+supplies worker participation, dependencies, blocking, and available work
+windows. This is appropriate unless repeated tests show that worker-cost
+imbalance itself carries necessary predictive information.
+
+### B. Worker-cost permutation ensemble
+
+Treat Callgrind worker costs and DRD worker schedules as unlabeled multisets.
+Evaluate all worker assignments (small for the configured four workers) and use
+the median while reporting min/max bounds. This preserves measured imbalance
+without claiming IDs correspond.
+
+Tradeoff: differing worker participation requires zero-padding or pooling, and
+the selected statistic is less directly interpretable. The worst-case bound is
+likely too pessimistic for a regression gate. Keep this as a diagnostic or a
+fallback if role pooling loses important behavior.
+
+### C. Repeated independent trace ensemble
+
+Collect several complete Callgrind/DRD samples and gate a median role-pooled
+score. This addresses residual variation in synchronization outcomes and cache
+simulation.
+
+Tradeoff: it multiplies the expensive Valgrind portion of CI and does not by
+itself repair invalid raw-ID attribution. Consider it only after option A and
+prefer repeating DRD alone if Callgrind total work proves stable.
+
+### D. Deterministic benchmark scheduling or explicit task markers
+
+Force task-to-worker assignment or add logical phase/task events so profiles
+can be paired exactly.
+
+Rejected as the primary solution: it changes or instruments the renderer being
+measured, stops being passive, and can hide the scheduling regressions the gate
+is meant to detect.
+
+### E. Aggregate work divided by configured worker count
+
+Discard DRD and derive runtime from total modeled work plus a fixed parallelism
+factor.
+
+Rejected: it cannot see startup, blocking, synchronization, or lost
+parallelism, which are central requirements of this benchmark.
+
+## Speed notes for phase 2
+
+- `PendingRenderJob.chunkRequest` is created once from view ID plus render
+  request ID. `renderFrame()` copies it into base/overlay sampling options, and
+  all sampling calls in that job reuse it. The request is therefore constant
+  per render job, but not across jobs or request-ID changes.
+- `LevelAccess` already hoists shape, chunk shape, transform, dtype/fill, and
+  level validity once per sampled level.
+- `LocalChunkCache` already has a same-key `lastResult` fast path and pins up to
+  eight chunk results. A repeated successful chunk does not invoke
+  `IChunkedArray::tryGetChunk()` again within that local sampler cache. Separate
+  tile/level sampling contexts do not share this local hit state.
+- The caller still computes voxel-to-chunk integer divisions and assembles a
+  `ChunkKey` before `LocalChunkCache` can detect that hit. A successful-chunk
+  cursor with cached voxel bounds can bypass both for correlated samples.
+- Production `ChunkCache` directly overrides contextual `tryGetChunk()`. The
+  synthetic fixture overrides only the compatibility overload, so its measured
+  path currently includes an extra virtual forwarding call that production
+  rendering does not.
+- `ChunkCache::tryGetChunk()` reloads shared state, appends source ID to a new
+  full key, and acquires the cache mutex for each local-cache miss. A prepared
+  source/request/level lookup handle may remove repeated setup, but should be
+  attempted only if profiles still identify this path after the cursor/local
+  cache improvements.
+
+## Current decision
+
+Prototype deterministic paired reconstruction instead of role pooling. Keep the
+measured program unchanged and reject ambiguous pairings. Use role pooling only
+as a diagnostic baseline. Do not update the reference or tolerance yet. Defer
+speed implementation until attribution is correct enough to evaluate it, while
+retaining the pre/post render-order commits as the A/B workload.
+
+The no-code-change feasibility prototype passed. Production wiring may change
+collector/parser/replay tooling, but must not modify or instrument the measured
+renderer, benchmark, thread pool, or workload. Equivalent tie groups should be
+enumerated and scored conservatively; non-equivalent ambiguous groups fail.
+
+## Native implementation result
+
+- The regular Ninja estimate now invokes Valgrind directly and runs raw
+  Callgrind parsing, measured-window DRD parsing, canonical matching,
+  chronological attribution, conservative replay, reference comparison, and
+  JSON output in C++. Python is not in the evaluation path.
+- The measured renderer, benchmark, thread pool, and workload were not changed.
+- A fresh current-build parallel matrix produced these conservative scores:
+
+  | Scenario | Score (ns/call) | Mappings | Best-to-worst mapping span |
+  | --- | ---: | ---: | ---: |
+  | `full_res` | 917,189 | 24 | 0.87% |
+  | `fallback_3` | 2,515,155 | 2 | 0.12% |
+  | `mixed_correlated` | 1,700,855 | 2 | 0.00% |
+  | `mixed_shuffled` | 3,155,879 | 2 | 0.02% |
+
+- Three additional sequential fresh `parallel/full_res` pairs scored 917,333,
+  917,297, and 917,304 ns/call. The full range is 0.004%, confirming that the
+  paired estimate is stable on the current binary.
+- A fresh tied `full_res` group had 2.38% total modeled-cost spread but only
+  0.22% normalized chronological-shape spread. The predeclared native gates are
+  therefore separate: 5% total cost and 2% 32-bin shape. Every passing tie is
+  still fully enumerated and scored by its maximum makespan.

--- a/volume-cartographer/planning/task_log.md
+++ b/volume-cartographer/planning/task_log.md
@@ -178,3 +178,19 @@ enumerated and scored conservatively; non-equivalent ambiguous groups fail.
   0.22% normalized chronological-shape spread. The predeclared native gates are
   therefore separate: 5% total cost and 2% 32-bin shape. Every passing tie is
   still fully enumerated and scored by its maximum makespan.
+
+## Scheduler-evidence repair
+
+- Rank matching still failed when DRD workers tied even though their Callgrind
+  costs differed. Callgrind now records the passive scheduler stream from its
+  own run, with no benchmark or renderer changes.
+- The native matcher enumerates all 24 four-worker assignments and compares
+  normalized worker activity share plus cumulative activity in 16 bins. It
+  replays every assignment within one scheduler quantum of the best match and
+  reports the maximum makespan.
+- The repaired eight-case matrix passed the existing references. The four
+  parallel cases retained 20, 2, 2, and 2 mappings respectively; their
+  conservative makespan spreads were 1.295%, 0.249%, 0.005%, and 0.011%.
+- Attribution fails when compatible mappings span more than 2% in makespan.
+  A future retry must recollect only that failed case. It must not retry a valid
+  score regression.

--- a/volume-cartographer/planning/task_plan.md
+++ b/volume-cartographer/planning/task_plan.md
@@ -1,130 +1,105 @@
-# VC3D control-point collapse rollback plan
+# VC3D render attribution and lookup repair plan
 
-## Current failure
+## Phase 1: deterministic paired attribution
 
-`handleGeneratedControlPoint()` first reduces every matched control to one
-replacement with a known fractional line position. For zero or one matched
-control it then calls `updateExistingLineControlPoint()`, which rebuilds the two
-adjacent spans and makes the replacement an exact sample of the updated line.
-For more than one matched control, however, it bypasses that update and starts
-fiber optimization against the unchanged old line. The fiber optimizer then
-projects controls independently by nearest 3-D distance, so a replacement can
-bind to another winding of a self-approaching line.
+1. Keep the benchmark binary unchanged. Run Callgrind and DRD with the same
+   `--fair-sched=yes` and `--scheduling-quantum` values and the same benchmark
+   arguments. Enable periodic Callgrind dumps at the fixed basic-block interval
+   without adding application markers.
+2. Parse the benchmark's existing paired `steady_clock`/`clock_gettime` calls
+   from the DRD syscall trace and trim the dependency graph to the measured
+   render only. Require one unambiguous boundary pair; drop outside dependencies
+   as already-satisfied and renumber the retained graph.
+3. Parse periodic Callgrind dumps as chronological per-thread event-cost slices.
+   Preserve every event counter and require their sum to equal the complete
+   measured Callgrind profile.
+4. Keep main thread 1 as the stable control role. Canonically order worker
+   Callgrind traces by deterministic non-cache work signature and DRD worker
+   traces by measured work-quanta/dependency signature. Match ranks only when
+   order is unambiguous; tied DRD signatures require equivalent Callgrind traces
+   within a predeclared tolerance or the pair fails. Enumerate every admissible
+   mapping inside an equivalent tie and use the maximum replay makespan, while
+   reporting the permutation range.
+5. Resample each matched chronological Callgrind cost trace over that DRD
+   worker's measured eligible windows while preserving order and exact total
+   cost. Keep original DRD thread IDs, program order, blocking, and dependency
+   edges. Implement direct per-window attribution in the native replay engine.
+6. Keep the regular collection and evaluation path native: the C++ tool parses
+   raw periodic Callgrind profiles and the raw DRD trace, validates and matches
+   them, performs attribution/replay, and writes the evaluation artifact.
+   CMake/Ninja invokes Valgrind and the native tool directly. Python remains
+   available only for offline calibration and is not part of the CI estimate.
+7. Collect repeated paired runs for every parallel scenario. Require stable
+   canonical signatures, exact cost conservation, and stable modeled makespan.
+   A pair that cannot prove reconstruction is rejected rather than averaged.
+8. Retain generic per-thread attribution for other replay users and keep serial
+   evaluation unchanged. Keep role pooling only as a diagnostic comparison,
+   not the renderer gate's final attribution.
+9. Freeze a new reference only after deterministic pairing and repeatability are
+   accepted, then re-enable the workflow gate in a separate reviewable change.
 
-The ordinary local-update exception path separately restores controls,
-branches, seed, and focus after already marking the session unoptimized, but
-does not restore the captured previous optimization state.
+## Phase 2: lookup performance
 
-## Implementation
-
-1. Keep `collapseControlPointsAtClick()` as the single pure operation for
-   insertion, one-control replacement, and multi-control collapse. Continue to
-   use its old-to-new branch mapping when the prepared edit is committed.
-2. Extract a reusable automatic-click preparation helper beside the existing
-   line-annotation fiber helpers. It accepts the old line/controls, matched
-   indices, clicked line position/point, sampler, and local-update config; it
-   performs collapse on copies and, when at least two controls survive, invokes
-   `updateExistingLineControlPoint()` for the replacement. It returns the
-   updated line, rich controls with segment metadata merged back, replacement
-   index, requested adjacent dirty spans, and old-to-new branch mapping.
-   `handleGeneratedControlPoint()` and focused tests must both call this helper;
-   do not duplicate its composition in the controller or tests.
-3. Remove the automatic multi-control branch that calls
-   `startFiberModeOptimization()` against `session.optimizedLine` without first
-   updating that line.
-4. Route every automatic click edit with at least two surviving controls through
-   the existing `updateExistingLineControlPoint()` call using the collapsed
-   replacement index. After compaction there is one changed control regardless
-   of how many old controls were removed, so the existing updater can rebuild
-   the complete left-neighbor -> replacement and replacement -> right-neighbor
-   spans from the replacement's authoritative line position.
-5. Handle an all-control collapse explicitly. With one surviving replacement
-   there are no adjacent spans to rebuild, so retain the old line only as a
-   tangent reference and run the established one-control reinitialization from
-   the clicked point. Change that one-control tangent lookup to use the
-   replacement's authoritative clamped `linePosition`, never nearest 3-D
-   position, so a nearby winding cannot choose the initial direction.
-6. Prepare the entire automatic edit before mutating the session. If preparation
-   throws, report the error while controls, line, branches, seed/focus,
-   optimization state, and alignment-metric state are still untouched. Only
-   after preparation succeeds, commit its controls/line, remap session-local
-   branch indices, update seed/focus, mark metrics stale, and mark the session
-   unoptimized.
-7. Derive requested dirty spans from the updater's post-sort replacement index;
-   these are exactly the replacement's surviving adjacent spans. The fiber
-   optimizer may expand a requested dirty span across a connected C-spline run
-   by existing policy.
-8. Preserve the original pre-edit line and session fields in the existing
-   multi-collapse rollback object until asynchronous fiber optimization and
-   generated-view materialization succeed. Both failure-to-start and
-   asynchronous failure restore the original pre-edit controls, line, branches,
-   seed, focus, and optimization state and clear the rollback object.
-9. Keep branch updates transactional for multi-collapse. Apply only the
-   old-to-new mapping to session-local branch indices before optimization; do
-   not mutate reciprocal fibers or schedule saves. On successful optimization,
-   use the existing deferred synchronization in `applyOptimizationTaskResult()`.
-   Preserve the current insertion/single-replacement synchronization behavior.
-10. Keep no-reoptimization mode unchanged: it records the collapsed controls on
-   the current line without running local reconstruction or fiber optimization.
-   Do not change persisted control representation or legacy load-time matching.
+1. Build the pre-render-order commit, the render-order commit, and the repaired
+   head with the same GCC Release configuration. Run serial and parallel native
+   trials repeatedly and collect Callgrind counters/checksums for all scenarios.
+2. Separate synthetic-fixture overhead from production behavior. The synthetic
+   array currently inherits the contextual `tryGetChunk()` forwarding overload,
+   while production `ChunkCache` overrides it directly; benchmark both the
+   production-equivalent direct overload and the generic compatibility path.
+3. Profile before choosing among these compatible optimizations:
+   - a per-tile/per-level successful-chunk cursor containing chunk bounds,
+     resolved payload, strides, and full key, checked before coordinate division
+     and key construction;
+   - a source-bound prepared lookup handle containing render-job request,
+     source ID/state, and level invariants;
+   - a fixed-capacity linear/small-vector local chunk cache in place of hashing
+     for the current maximum of eight pinned chunks.
+4. Implement one optimization at a time. Keep the old path as the correctness
+   oracle and compare exact image checksums plus requested/missing/error counts.
+5. Accept only changes with repeatable native and modeled improvement. Report
+   command, build type, input scenario, repetitions, and mean plus distribution
+   statistics.
 
 ## Testing and validation
 
-1. Test the extracted production preparation helper with a multi-control
-   fixture. Verify its updated line contains the clicked replacement as an exact
-   support between surviving neighbors, its controls remain ordered, and its
-   requested dirty spans are the replacement's adjacent spans.
-2. Add a self-approaching/two-winding fixture where the clicked replacement is
-   spatially nearer to an unrelated winding than to the old sample at its line
-   position. Invoke the production preparation helper and verify local
-   reconstruction anchors it in the intended ordered span and produces strictly
-   ordered control indices before full optimization.
-3. Retain and run the pure collapse tests for metadata ownership, seed transfer,
-   old-to-new branch indices, and dirty spans, ensuring unification does not
-   alter collapse semantics.
-4. Exercise endpoint/all-control collapse behavior. Verify preparation retains
-   the clicked replacement and that the one-control optimizer selects its
-   tangent from authoritative line position on a self-approaching line.
-5. Add a preparation-failure test using a throwing sampler/update fixture and
-   verify caller-owned inputs are unchanged. Review the controller ordering to
-   ensure no session field, optimization state, metric state, reciprocal branch,
-   or save is mutated before that helper returns successfully.
-6. Add focused branch-remap coverage for two linked controls collapsing into
-   one: local indices may be remapped during commit, while reciprocal mutation
-   is represented only by the later successful-commit synchronization input.
-   Verify failure rollback retains the pre-edit branch snapshot. If the private
-   Qt session still prevents an isolated asynchronous failure test, record that
-   narrow limitation explicitly.
-7. Build with all 32 cores and run:
-   `cmake --build volume-cartographer/build --parallel 32 --target test_lasagna_line_optimizer test_line_annotation_generated_views VC3D`.
-   Run both focused test binaries and `git diff --check`.
+- Native replay unit tests for direct window-cost conservation, chronological
+  placement, invalid window vectors, and unchanged generic per-thread
+  attribution.
+- Native parser tests for periodic Callgrind dumps and passive measured-window
+  trimming, plus native matching tests for equivalent ties, ambiguous ties,
+  chronological attribution, and exact event-counter conservation.
+- Repeated complete render matrices before freezing any reference.
+- Exact synthetic-render checksums and existing `ChunkedPlaneSampler` and
+  `ChunkCache` tests for speed changes.
+- Build relevant C++ targets with all 32 cores and run `git diff --check`.
 
 ## Specification updates
 
-- Create `specs/line_annotation.md` as the durable home for line-annotation
-  editing requirements currently represented only in `planning/spec.md`.
-- Amend both the durable specification and the existing line-annotation ribbon
-  invariant in `planning/spec.md`: every automatically reoptimized
-  generated-view click, including a multi-control collapse, must first
-  reconstruct the replacement's adjacent spans from its authoritative line
-  position; it must not project the replacement onto the unchanged line solely
-  by nearest 3-D distance.
-- Require transactional failure behavior: failed synchronous preparation leaves
-  geometry and optimization state unchanged, while failed asynchronous
-  multi-collapse restores the original pre-edit snapshot.
-- Do not change the persisted-control format or claim that legacy independent
-  nearest-3-D reconstruction is solved.
+Update `specs/benchmarks.md` so the renderer-gate contract requires passive
+deterministic paired reconstruction, measured-window trimming, canonical
+logical-worker matching, chronological per-window cost placement, exact cost
+conservation, and rejection of ambiguous pairs. Raw worker IDs never cross
+independent-run boundaries. Update `planning/spec.md` only if the accepted
+lookup optimization adds a renderer requirement not already covered there,
+including the measured no-numeric-change requirement.
 
 ## Documentation updates
 
-- Update `docs/line_annotation_fibers.md` to state that automatic control-point
-  edits locally reconstruct the neighboring spans before full fiber
-  optimization, including when several nearby controls collapse to one.
-- Document that failed automatic preparation retains the prior line and
-  optimization status.
+Update `docs/thread_sync_replay.md` and
+`docs/benchmarks/render_valgrind_ci.md` with paired-trace attribution,
+repeatability/rebaseline procedure, matching diagnostics, and the reason raw
+worker IDs cannot cross independent Valgrind runs. Document any new prepared
+lookup API beside the renderer implementation.
 
 ## Changelog update
 
-- Add one dated line to `planning/changelog.md` noting that multi-control
-  collapse now anchors its replacement through local span reconstruction and
-  synchronous preparation failure leaves the prior edit state unchanged.
+Add one dated line when attribution is corrected and the stable gate is
+re-enabled. Add a separate measured lookup-performance line only if the second
+phase produces an accepted code change.
+
+## Independent review
+
+Pending review of this plan against the current replay implementation, passive
+measurement constraint, benchmark specification, complete-cost invariant, and
+strict ambiguity rejection.

--- a/volume-cartographer/planning/task_plan.md
+++ b/volume-cartographer/planning/task_plan.md
@@ -13,13 +13,12 @@
 3. Parse periodic Callgrind dumps as chronological per-thread event-cost slices.
    Preserve every event counter and require their sum to equal the complete
    measured Callgrind profile.
-4. Keep main thread 1 as the stable control role. Canonically order worker
-   Callgrind traces by deterministic non-cache work signature and DRD worker
-   traces by measured work-quanta/dependency signature. Match ranks only when
-   order is unambiguous; tied DRD signatures require equivalent Callgrind traces
-   within a predeclared tolerance or the pair fails. Enumerate every admissible
-   mapping inside an equivalent tie and use the maximum replay makespan, while
-   reporting the permutation range.
+4. Keep main thread 1 as the stable control role. Capture the passive scheduler
+   stream in the Callgrind execution as well as DRD, enumerate all four-worker
+   assignments, and score them from normalized activity share and cumulative
+   measured-window activity. Replay every mapping within scheduler-quantum
+   resolution of the best score and use the maximum replay makespan. Fail the
+   case when compatible mappings exceed the predeclared makespan-spread limit.
 5. Resample each matched chronological Callgrind cost trace over that DRD
    worker's measured eligible windows while preserving order and exact total
    cost. Keep original DRD thread IDs, program order, blocking, and dependency
@@ -67,8 +66,9 @@
   placement, invalid window vectors, and unchanged generic per-thread
   attribution.
 - Native parser tests for periodic Callgrind dumps and passive measured-window
-  trimming, plus native matching tests for equivalent ties, ambiguous ties,
-  chronological attribution, and exact event-counter conservation.
+  trimming, plus native matching tests for scheduler-selected assignments,
+  scheduler ties, material makespan ambiguity, chronological attribution, and
+  exact event-counter conservation.
 - Repeated complete render matrices before freezing any reference.
 - Exact synthetic-render checksums and existing `ChunkedPlaneSampler` and
   `ChunkCache` tests for speed changes.

--- a/volume-cartographer/scripts/run_render_valgrind_ci.py
+++ b/volume-cartographer/scripts/run_render_valgrind_ci.py
@@ -31,11 +31,12 @@ from render_valgrind_common import (
 from thread_sync_trace import parse_drd_trace, write_event_stream
 
 SCHEMA_VERSION = 1
+NATIVE_EVALUATION_SCHEMA_VERSION = 2
 BENCHMARK_METADATA_SCHEMA = 1
 DEFAULT_REPETITIONS = 1
 DEFAULT_QUANTUM = 10000
 DEFAULT_DRD_ATTEMPTS = 3
-DEFAULT_TOLERANCE = 0.10
+DEFAULT_TOLERANCE = 0.05
 DATA_READ_FEATURE_NAMES = (
     "non_data_instructions",
     "data_reads",
@@ -510,19 +511,39 @@ def evaluate(args: argparse.Namespace) -> None:
 
 def freeze_reference(args: argparse.Namespace) -> None:
     tolerance = validate_tolerance(args.tolerance)
-    model_hash = sha256_file(args.model.resolve())
+    model_path = args.model.resolve()
+    model_hash = sha256_file(model_path)
+    model_id = json.loads(model_path.read_text()).get("model_id")
+    if not model_id:
+        raise RuntimeError("render model has no model_id")
     cases: dict[str, object] = {}
     for path in args.results:
-        result = load_manifest(path.resolve(), "evaluation")
-        if result["model_sha256"] != model_hash:
-            raise RuntimeError(f"evaluation {path} used a different model")
+        result_path = path.resolve()
+        result = json.loads(result_path.read_text())
+        if result.get("kind") != "evaluation":
+            raise RuntimeError(
+                f"expected evaluation artifact, got {result.get('kind')!r}"
+            )
+        schema = result.get("schema_version")
+        if schema == SCHEMA_VERSION:
+            if result.get("model_sha256") != model_hash:
+                raise RuntimeError(f"evaluation {path} used a different model")
+        elif schema == NATIVE_EVALUATION_SCHEMA_VERSION:
+            if result.get("model_id") != model_id:
+                raise RuntimeError(f"evaluation {path} used a different model")
+        else:
+            raise RuntimeError(f"unsupported evaluation schema in {path}")
         if result["case"] in cases:
             raise RuntimeError(f"duplicate evaluation case {result['case']}")
-        cases[result["case"]] = {
+        case = {
             "checksum": result["checksum"],
-            "identity": result["identity"],
-            "modeled_runtime_score_ns": result["modeled_runtime_score_ns"],
+            "modeled_runtime_score_ns": validate_score(
+                result["modeled_runtime_score_ns"], "evaluation"
+            ),
         }
+        if "identity" in result:
+            case["identity"] = result["identity"]
+        cases[result["case"]] = case
     expected = {
         f"{fixture}/{scenario}"
         for fixture in ("serial", "parallel")

--- a/volume-cartographer/specs/benchmarks.md
+++ b/volume-cartographer/specs/benchmarks.md
@@ -118,20 +118,29 @@
   process per host CPU even when each guest configures four renderer workers.
 - The CI regression graph must generate fresh separate-thread Callgrind
   profiles for all eight cases and fresh complete DRD dependency graphs for the
-  four parallel cases. A collector publishes its completion manifest atomically
-  only after all raw files and metadata validate; evaluators depend on those
-  manifests and may not rerun collection.
+  four parallel cases. Ninja publishes a collection stamp only after Valgrind
+  exits successfully; native evaluators depend on those stamps and may not
+  rerun collection.
 - The CI relative modeled-runtime score uses the frozen synthetic-only
-  data-read event model. Feature extraction, event-cost evaluation, deterministic
-  numeric-thread summation, cost attribution, and replay must run in the native
-  C++ replay engine. The Python CI coordinator must use only the standard
-  library at runtime; a `python3 -S` test must exercise dependency parsing and
-  native scoring. Serial score is summed per-thread modeled work per render
+  data-read event model. Raw profile and DRD parsing, feature extraction,
+  event-cost evaluation, logical-worker matching, cost attribution, replay,
+  and result output must run in the native C++ replay engine. Python must not
+  be used in the regular evaluation path. Serial score is summed per-thread modeled work per render
   call. Parallel score is native FIFO replay makespan per render call with four
   workers plus one caller core, equal attribution,
   `residual_fraction=0.5`, zero wake latency, the frozen cross-thread release
   latency, and unit replay/dependency-excess scales. Process startup and native
   wall timing are excluded.
+- Callgrind and DRD must use the same fair-scheduler and scheduling-quantum
+  settings without application markers or measured-program changes. The DRD
+  graph must be trimmed to the unique passive clock-call pair around the render.
+  Periodic Callgrind deltas must be placed chronologically over matched DRD work
+  windows while preserving each thread's exact aggregate modeled cost.
+- Raw Valgrind worker IDs must never be treated as identities across independent
+  runs. Main thread 1 remains fixed; workers are matched by canonical work rank.
+  Equal DRD signatures require predeclared cost and chronological-shape
+  equivalence. All admissible equivalent mappings must be replayed and the
+  maximum makespan reported; non-equivalent ambiguity is an error.
 - The relative modeled-runtime score is not a validated absolute runtime claim.
   Each case may be at most the configured tolerance slower than its versioned
   reference, initially 10%. Faster scores are accepted without a lower bound.
@@ -147,9 +156,9 @@
   reference pass/fail. The reference schema and case key remain required to
   locate and interpret the score baseline.
 - Current-run artifact integrity remains mandatory. Paired Callgrind and DRD
-  artifacts must describe the same case and metadata and use the same Valgrind
-  version. Parallel traces must have no unresolved happens-before edge or
-  unmatched blocking wait.
+  metadata must describe the same case, dimensions, repetitions, worker count,
+  and checksum. Parallel traces must have one unambiguous measured window and
+  no unresolved in-window happens-before edge.
 - The machine-readable summary must record the metric schema/model version,
   Callgrind events by name, compiler, architecture target, Valgrind version,
   cache geometry, dimensions, tile size, worker count, repetitions, checksum,
@@ -204,14 +213,12 @@ the previous governor, frequency bounds, energy preference, and boost setting.
   fixed-basic-block work slices, pair blocking futex waits with guest wakes or
   observed thread completion, and fail timing validation when dependencies are
   unresolved.
-- Passive event scoring and playback must use the native persistent replay
-  engine. Python remains responsible for Valgrind collection, dependency
-  extraction, model fitting, orchestration, and reports, but production callers
-  must ask the native engine to evaluate profile costs, load each event graph
-  once, cache named cost attributions, and submit ordered replay batches through
-  the versioned protocol. Missing native replay is an error; there is no silent
-  Python fallback. The Python replay and NumPy event model are retained only as
-  calibration/parity tools and must not be used for production benchmark
+- Passive event scoring and playback must use the native replay engine. The
+  rendering gate must also perform raw Valgrind parsing, dependency extraction,
+  orchestration, and reporting natively. The persistent JSON protocol remains
+  available to offline calibration tools. Missing native replay is an error;
+  there is no Python fallback. Python replay and NumPy event models are retained
+  only as calibration/parity tools and must not produce production benchmark
   results.
 - Valgrind elapsed timestamps must not be used as native duration or as work
   weights. State names must distinguish traced blocking from native scheduler

--- a/volume-cartographer/specs/benchmarks.md
+++ b/volume-cartographer/specs/benchmarks.md
@@ -21,22 +21,24 @@
 
 - The benchmark must exercise the production `ChunkedPlaneSampler`
   fine-to-coarse coordinate rendering path.
-- It must use a deterministic synthetic chunked volume with four pyramid
-  levels and pseudo-random decoded `uint8` chunk contents.
+- It must use the production `ChunkCache` with a deterministic synthetic
+  `IChunkFetcher`, four pyramid levels, and pseudo-random decoded `uint8`
+  chunk contents.
 - Synthetic chunk materialization must occur before the measured region. The
   measured workload must represent rendering against controlled resident,
-  missing, and fallback states, without storage, network, compression, or
-  asynchronous cache scheduling costs.
+  missing, and fallback states, including production cache lookup and locking
+  costs but excluding storage, network, compression, decode, and asynchronous
+  cache scheduling costs. No fetcher call may occur after preload.
 - The coordinate fixture must include substantial contiguous runs of spatially
   correlated coordinates, matching the usual surface-rendering access pattern.
 - The fixture must use trilinear sampling with every coordinate and all eight
   required voxels in bounds at every pyramid level. For a coordinate assigned
   to level `L`, at least one required chunk must be missing at each finer level
   and all required chunks must be resident data at level `L`.
-- Both `tryGetChunk()` and `getChunkIfCached()` must return pre-materialized
-  states without allocation or mutation. The benchmark must use
-  `queueMisses=true` and `queuedFallbackLevels=0` so level 0 follows the normal
-  request path and fallback levels use resident-only reads.
+- Both `tryGetChunk()` and `getChunkIfCached()` must resolve through the real
+  cache from pre-materialized states. The benchmark must use `queueMisses=true`
+  and `queuedFallbackLevels=0` so level 0 follows the normal request path and
+  fallback levels use resident-only reads.
 - The benchmark must provide these scenarios:
   - `full_res`: every coordinate is available at level 0.
   - `fallback_3`: every coordinate falls back through levels 0, 1, and 2 and

--- a/volume-cartographer/specs/benchmarks.md
+++ b/volume-cartographer/specs/benchmarks.md
@@ -139,10 +139,12 @@
   Periodic Callgrind deltas must be placed chronologically over matched DRD work
   windows while preserving each thread's exact aggregate modeled cost.
 - Raw Valgrind worker IDs must never be treated as identities across independent
-  runs. Main thread 1 remains fixed; workers are matched by canonical work rank.
-  Equal DRD signatures require predeclared cost and chronological-shape
-  equivalence. All admissible equivalent mappings must be replayed and the
-  maximum makespan reported; non-equivalent ambiguity is an error.
+  runs. Main thread 1 remains fixed. Each Valgrind run must passively record its
+  own measured-window scheduler stream. All worker permutations must be scored
+  from normalized activity share and cumulative activity, and all assignments
+  indistinguishable at the configured scheduler-quantum resolution must be
+  replayed. The maximum makespan is reported; a case whose compatible mappings
+  exceed the predeclared makespan-spread limit is an attribution error.
 - The relative modeled-runtime score is not a validated absolute runtime claim.
   Each case may be at most the configured tolerance slower than its versioned
   reference, initially 10%. Faster scores are accepted without a lower bound.
@@ -161,6 +163,9 @@
   metadata must describe the same case, dimensions, repetitions, worker count,
   and checksum. Parallel traces must have one unambiguous measured window and
   no unresolved in-window happens-before edge.
+- Any retry for insufficient worker-assignment evidence must recollect only the
+  affected case. A valid modeled-runtime regression must never be retried as an
+  attribution failure.
 - The machine-readable summary must record the metric schema/model version,
   Callgrind events by name, compiler, architecture target, Valgrind version,
   cache geometry, dimensions, tile size, worker count, repetitions, checksum,


### PR DESCRIPTION
## Summary

- Replace raw cross-run Valgrind thread-ID matching with passive canonical worker reconstruction and conservative replay.
- Run the synthetic renderer benchmark through the production `ChunkCache`, backed by a deterministic fake `IChunkFetcher`.
- Preload all synthetic chunk states before measurement and fail if rendering reaches the fetcher afterward.
- Refresh all eight performance references, tighten the slowdown tolerance from 10% to 5%, and re-enable the GitHub Actions gate.
- Update the reference maintenance command to support native schema-2 evaluation artifacts.

## Rationale

Callgrind and DRD run in separate processes, so their raw worker thread IDs are not stable identities. Matching those IDs directly caused incorrect attribution and unstable regression results.

The previous synthetic array also measured an interface forwarding path that production `ChunkCache` does not use. The updated benchmark includes production cache lookup, locking, and request handling while still excluding storage, download, decode, and asynchronous fetch work.

A 5% one-sided threshold leaves room for the observed parallel scheduling variation, which reached approximately 3.1% across repeated complete matrices, while remaining substantially tighter than the previous 10% threshold.

## Validation

- Fresh eight-case Valgrind gate passed at the new 5% threshold.
- Highest fresh upward reference ratio: `1.0072x`.
- All rendering checksums remained unchanged.
- Native benchmark/replay tests: 4 passed.
- Reference-maintenance tests: 20 passed.
- `git diff --check` passed.
