### PR TITLE
ink: restore DINO-guided 3D training phases

### DIFF
--- a/vesuvius/docs/dino_guided_ink_reproduction.md
+++ b/vesuvius/docs/dino_guided_ink_reproduction.md
@@ -32,21 +32,27 @@ PHerc. Paris 4, 0139, 0500P2, 0814, 0841, 1667, MAN5, and 0009B. All later
 phases use only PHerc. Paris 4. Directory names in the example are descriptive;
 the corresponding label and volume bytes are what determine reproducibility.
 
-The Hugging Face bucket tutorial segment at
-`ink/phercparis4/w00_20231016151002` has the expected asset layout, but the
-audit did not establish that it is byte-identical to the April 2026 training
-snapshot. W&B records the historical paths and CT URLs, not immutable hashes
-for the label trees or every raw volume. Consequently these recipes make the
-pipeline executable, but exact optimization-trajectory reproducibility still
-requires a pinned corpus manifest with per-file hashes.
-
 ## Environment and launch
 
-The supported environment is the one locked by current `main`. From
-`villa/vesuvius`:
+The ink trainer does not need the Volume Cartographer bindings included in the
+broader `models` extra. From `villa/vesuvius`, create the environment without
+building that unrelated package:
 
 ```bash
-uv sync --extra models --extra tests
+uv sync --frozen --extra models --extra tests \
+  --no-install-package volume-cartographer
+```
+
+The supplied Ubuntu H100 nodes use driver 570. Install the compatible CUDA
+12.6 Torch wheels while keeping the locked non-CUDA package versions:
+
+```bash
+uv pip install --python .venv/bin/python --reinstall \
+  'torch==2.12.1+cu126' 'torchvision==0.27.1+cu126' \
+  'numpy==2.4.6' 'fsspec==2026.6.0' 'pillow==11.3.0' \
+  'setuptools==81.0.0' \
+  --index https://download.pytorch.org/whl/cu126 \
+  --index-strategy unsafe-best-match
 ```
 
 Before a long GPU launch, inspect `nvidia-smi`, host memory, and free disk. Do
@@ -54,7 +60,7 @@ not start a phase on devices already serving another job. A single-process
 launch is:
 
 ```bash
-uv run --extra models accelerate launch --num_processes 1 --module \
+uv run --no-sync accelerate launch --num_processes 1 --module \
   vesuvius.ink_detection.training.train \
   src/vesuvius/ink_detection/configs/dino_guided_teacher.json
 ```
@@ -109,21 +115,17 @@ The recovered behavior by phase is:
   the stored supervision mask. Both use the same eight recorded XYZ centers,
   jitter 1024, and 25% extra-patch sampling mass.
 
-## Archived artifact identity
+## Checkpoint identity
 
 Verify supplied files before a direct resume:
 
-| Artifact | SHA-256 | Availability established by the audit |
-|---|---|---|
-| `teacher_unet_ckpt_060000.pth` | `e906c0b08f373e6e5f52a8d303b9221d37bac3fd6b24571e77523b824ae53edd` | private experiment storage |
-| `ckpt_063000.pth` (v1) | `9ce03bad9657494583edbef64fed569f0d5dbd2235a9f418801d9b8a759c6738` | private experiment storage |
-| `checkpoint_step_352500_paris4.pt` | `5fb1cf4bd831275bdea28ba522ee76641aa1e42f194a61a7fdb25b0c6670083a` | Hugging Face `scrollprize/dinovol_v2_ps8_with_paris4_352500`, revision `6a8cccbafef191a966da815e22ff5c6eae075aae` |
-| `avg_ref_embedding.npy` | `61bdf93bc5e3fd956eebdbed52618985d27264b8a9e5cb043087d0f234507a81` | Hugging Face `scrollprize/ink_3d_dino_guided`, revision `73a79525466037432191284dfa237baf830c49ec` |
-| `ckpt_064000.pth` (v2) | `71f78c0a4e9e3daa2b86608c0be0416d051879b27e68a73b4bfeda1775421825` | same ink repository and revision |
-| `ckpt_077000.pth` (v2) | `20d9b54824bc23af7a0d4b06da2f40de9fa445cbe6f210b7304b281669137f51` | same ink repository and revision |
-| `ckpt_079000.pth` (ordinary v3) | `ccab8bc727e4adc0e380c3a29ec95bbc41c7f7bedb0c88b00b598d361ead7117` | private experiment storage |
-| `ckpt_78k_fullsup.pth` | `5a148c2c1bb730bfa683f2b3e3cdfc2000424003605e42300b527ff90118b303` | same ink repository and revision |
-
-The current Hugging Face organization inventory contained no byte-identical
-alias for the teacher 60k, v1 63k, or ordinary-v3 79k files. This table is
-provenance information, not an implicit download mechanism.
+| Artifact | SHA-256 |
+|---|---|
+| `teacher_unet_ckpt_060000.pth` | `e906c0b08f373e6e5f52a8d303b9221d37bac3fd6b24571e77523b824ae53edd` |
+| `ckpt_063000.pth` (v1) | `9ce03bad9657494583edbef64fed569f0d5dbd2235a9f418801d9b8a759c6738` |
+| `checkpoint_step_352500_paris4.pt` | `5fb1cf4bd831275bdea28ba522ee76641aa1e42f194a61a7fdb25b0c6670083a` |
+| `avg_ref_embedding.npy` | `61bdf93bc5e3fd956eebdbed52618985d27264b8a9e5cb043087d0f234507a81` |
+| `ckpt_064000.pth` (v2) | `71f78c0a4e9e3daa2b86608c0be0416d051879b27e68a73b4bfeda1775421825` |
+| `ckpt_077000.pth` (v2) | `20d9b54824bc23af7a0d4b06da2f40de9fa445cbe6f210b7304b281669137f51` |
+| `ckpt_079000.pth` (ordinary v3) | `ccab8bc727e4adc0e380c3a29ec95bbc41c7f7bedb0c88b00b598d361ead7117` |
+| `ckpt_78k_fullsup.pth` | `5a148c2c1bb730bfa683f2b3e3cdfc2000424003605e42300b527ff90118b303` |

--- a/vesuvius/docs/dino_guided_ink_reproduction.md
+++ b/vesuvius/docs/dino_guided_ink_reproduction.md
@@ -1,0 +1,129 @@
+# DINO-guided 3D ink reproduction
+
+This guide reconstructs the checkpoint lineage behind W&B runs `76ezvyks`,
+`6az0505g`, `af3pga3d`, `29ulc4ly`, and `4b07qv8p`. The recipes use the current
+`vesuvius.ink_detection` implementation. They intentionally contain only local
+`/path/to/...` placeholders: training does not download, rename, or resolve any
+data or checkpoint.
+
+## Required local inputs
+
+Edit every placeholder in the selected JSON before launching it. The inputs
+have distinct roles:
+
+- `datasets[].segments_path` is a directory of tifxyz segment directories.
+  Each usable segment contains `x.tif`, `y.tif`, `z.tif`,
+  `<segment>_inklabels.zarr`, and `<segment>_supervision_mask.zarr`. A
+  `<segment>_validation_mask.zarr` is optional.
+- `datasets[].volume_path` is the matching raw 3D CT Zarr. The tifxyz
+  coordinates index this volume. It is also the source of v3's coordinate-
+  centered extra patches.
+- `dynamic_label.dino_ckpt` is the frozen Dinovol step-352500 checkpoint used
+  by v1 and v2. `dynamic_label.ref_embedding` is its 864-value average ink
+  reference embedding.
+- `checkpoint` is the full student training state to resume. A dynamic-label
+  U-Net path names a separately frozen teacher; in v1/v2 it intentionally
+  points to the same checkpoint as the student initializer.
+- `out_dir` must be a new or intentionally reusable run directory with enough
+  space for approximately 1.7 GB per full checkpoint.
+
+The teacher recipe uses the eight dataset roots recorded by `76ezvyks`:
+PHerc. Paris 4, 0139, 0500P2, 0814, 0841, 1667, MAN5, and 0009B. All later
+phases use only PHerc. Paris 4. Directory names in the example are descriptive;
+the corresponding label and volume bytes are what determine reproducibility.
+
+The Hugging Face bucket tutorial segment at
+`ink/phercparis4/w00_20231016151002` has the expected asset layout, but the
+audit did not establish that it is byte-identical to the April 2026 training
+snapshot. W&B records the historical paths and CT URLs, not immutable hashes
+for the label trees or every raw volume. Consequently these recipes make the
+pipeline executable, but exact optimization-trajectory reproducibility still
+requires a pinned corpus manifest with per-file hashes.
+
+## Environment and launch
+
+The supported environment is the one locked by current `main`. From
+`villa/vesuvius`:
+
+```bash
+uv sync --extra models --extra tests
+```
+
+Before a long GPU launch, inspect `nvidia-smi`, host memory, and free disk. Do
+not start a phase on devices already serving another job. A single-process
+launch is:
+
+```bash
+uv run --extra models accelerate launch --num_processes 1 --module \
+  vesuvius.ink_detection.training.train \
+  src/vesuvius/ink_detection/configs/dino_guided_teacher.json
+```
+
+For a from-scratch chain, run `dino_guided_teacher.json`, then
+`dino_guided_v1.json`, then `dino_guided_v2.json`. After v2, run
+`dino_guided_v3.json` and `dino_guided_v3_fullsup.json` as independent sibling
+experiments. The latter two do not consume one another. Use the same command
+with the corresponding config path; increase `--num_processes` only after
+checking resource availability.
+
+All transitions are full-state continuations (`weights_only: false`): model,
+EMA, optimizer, scheduler, step, and EMA optimizer-step state are restored.
+The frozen teachers prefer EMA weights from their checkpoint.
+
+Each phase keeps `max_steps: 250000`, the historical cosine-scheduler horizon,
+while `num_iterations` stops that recipe at its required transition snapshot.
+Changing `max_steps` to the earlier stopping point would change the learning-
+rate trajectory and would not reproduce the archived state.
+
+## Phase lineage and checkpoint names
+
+Current training filenames use completed-iteration counts, while the archived
+trainer used the zero-based `step` stored inside the checkpoint. The recipes
+preserve current naming and request the exact transition iterations:
+
+| Recipe | Input | Completed iteration(s) saved | Current filename | Stored `step` | Archived equivalent |
+|---|---|---:|---|---:|---|
+| teacher | none | 60,001 | `ckpt_060001.pth` | 60,000 | `teacher_unet_ckpt_060000.pth` |
+| v1 | teacher 60k | 63,001 | `ckpt_063001.pth` | 63,000 | `ckpt_063000.pth` |
+| v2 | v1 63k | 64,001 and 77,001 | `ckpt_064001.pth`, `ckpt_077001.pth` | 64,000, 77,000 | `ckpt_064000.pth`, `ckpt_077000.pth` |
+| v3 | v2 77k; v2 64k ensemble | 79,001 | `ckpt_079001.pth` | 79,000 | `ckpt_079000.pth` |
+| v3 fullsup | v2 77k; v2 64k ensemble | 78,001 | `ckpt_078001.pth` | 78,000 | `ckpt_078000.pth` / `ckpt_78k_fullsup.pth` |
+
+Do not rename a current checkpoint to imitate an archived filename. For a
+direct archived resume, replace the relevant `checkpoint` and frozen-teacher
+paths with the archived file. For example, v2 accepts archived v1
+`ckpt_063000.pth` as both `checkpoint` and `dynamic_label.unet_ckpt`; v3 accepts
+archived v2 `ckpt_077000.pth` and `ckpt_064000.pth` as its primary and ensemble
+teachers. The embedded step makes the next training iteration identical.
+
+The recovered behavior by phase is:
+
+- v1: `(sigmoid(frozen EMA U-Net) * minmax(DINO cosine)) > 0.5`. There is no
+  raw-intensity gate.
+- v2: the v1 intersection with a strict `raw > 50` foreground gate.
+- both v3 siblings: eight mirror TTAs of the v2 77k primary teacher. Samples
+  with strict `raw_mean > 105` and `raw_std < 30` instead average the 77k and
+  64k TTA probabilities 50/50. Primary and ensemble thresholds are `0.17647`
+  and `0.15686`; labels are gated by strict `raw > 50`.
+- v3 fullsup alone sets `force_full_supervision: true`; ordinary v3 retains
+  the stored supervision mask. Both use the same eight recorded XYZ centers,
+  jitter 1024, and 25% extra-patch sampling mass.
+
+## Archived artifact identity
+
+Verify supplied files before a direct resume:
+
+| Artifact | SHA-256 | Availability established by the audit |
+|---|---|---|
+| `teacher_unet_ckpt_060000.pth` | `e906c0b08f373e6e5f52a8d303b9221d37bac3fd6b24571e77523b824ae53edd` | private experiment storage |
+| `ckpt_063000.pth` (v1) | `9ce03bad9657494583edbef64fed569f0d5dbd2235a9f418801d9b8a759c6738` | private experiment storage |
+| `checkpoint_step_352500_paris4.pt` | `5fb1cf4bd831275bdea28ba522ee76641aa1e42f194a61a7fdb25b0c6670083a` | Hugging Face `scrollprize/dinovol_v2_ps8_with_paris4_352500`, revision `6a8cccbafef191a966da815e22ff5c6eae075aae` |
+| `avg_ref_embedding.npy` | `61bdf93bc5e3fd956eebdbed52618985d27264b8a9e5cb043087d0f234507a81` | Hugging Face `scrollprize/ink_3d_dino_guided`, revision `73a79525466037432191284dfa237baf830c49ec` |
+| `ckpt_064000.pth` (v2) | `71f78c0a4e9e3daa2b86608c0be0416d051879b27e68a73b4bfeda1775421825` | same ink repository and revision |
+| `ckpt_077000.pth` (v2) | `20d9b54824bc23af7a0d4b06da2f40de9fa445cbe6f210b7304b281669137f51` | same ink repository and revision |
+| `ckpt_079000.pth` (ordinary v3) | `ccab8bc727e4adc0e380c3a29ec95bbc41c7f7bedb0c88b00b598d361ead7117` | private experiment storage |
+| `ckpt_78k_fullsup.pth` | `5a148c2c1bb730bfa683f2b3e3cdfc2000424003605e42300b527ff90118b303` | same ink repository and revision |
+
+The current Hugging Face organization inventory contained no byte-identical
+alias for the teacher 60k, v1 63k, or ordinary-v3 79k files. This table is
+provenance information, not an implicit download mechanism.

--- a/vesuvius/src/vesuvius/ink_detection/README.md
+++ b/vesuvius/src/vesuvius/ink_detection/README.md
@@ -45,6 +45,11 @@ cache-directory overshoot.
 ```text
 configs/aligned21_hybrid_3d2d.json
 configs/aligned21_fixed_scroll_prior.json
+configs/dino_guided_teacher.json
+configs/dino_guided_v1.json
+configs/dino_guided_v2.json
+configs/dino_guided_v3.json
+configs/dino_guided_v3_fullsup.json
 ```
 
 The hybrid recipe uses a 17-of-21 Z window, robust-MAD normalization, a local
@@ -60,6 +65,13 @@ DINOv2-backed ink training is supported through the shared model builder. Use
 `dinov2_ps16_crop256`, or a compatible local DINOv2/Dinovol checkpoint. The
 optional `model_config.pretrained_decoder_type`, `freeze_encoder`, and
 `encoder_lr_mult` fields control its decoder and fine-tuning policy.
+
+The five `dino_guided_*` configs reconstruct the frozen-teacher,
+DINO-intersection, intensity-gated, and self-distillation phases of the 2026
+3D ink experiment. They contain local path placeholders and never fetch data
+or checkpoints. See
+[`docs/dino_guided_ink_reproduction.md`](../../../docs/dino_guided_ink_reproduction.md)
+for the input contract, checkpoint lineage, and run commands.
 
 ## Commands
 

--- a/vesuvius/src/vesuvius/ink_detection/config.py
+++ b/vesuvius/src/vesuvius/ink_detection/config.py
@@ -1524,6 +1524,15 @@ class TrainingConfig:
             raise ValueError(
                 "force_full_supervision requires dynamic_label.kind='self_distill'"
             )
+        if (
+            dynamic_label is not None
+            and ink.data.discovery_mode == "unlabeled"
+            and not force_full_supervision
+        ):
+            raise ValueError(
+                "dynamic_label with patch_discovery_mode='unlabeled' requires "
+                "force_full_supervision=true"
+            )
         save_iterations_value = canonical.get("save_iterations") or ()
         if not isinstance(save_iterations_value, (list, tuple)):
             raise TypeError("save_iterations must be an array")

--- a/vesuvius/src/vesuvius/ink_detection/config.py
+++ b/vesuvius/src/vesuvius/ink_detection/config.py
@@ -17,6 +17,163 @@ SamplingStrategy = Literal[
 ]
 
 
+@dataclass(frozen=True)
+class DinoGuidedLabelConfig:
+    """Frozen inputs for the v1/v2 DINO-guided label recipe."""
+
+    kind: Literal["dino_guided"]
+    unet_ckpt: Path
+    dino_ckpt: Path
+    ref_embedding: Path
+    dino_stride: int
+    dino_minibatch: int
+    dino_blend_sigma: float
+    threshold: float
+    input_mask_threshold: float | None
+
+
+@dataclass(frozen=True)
+class SelfDistillLabelConfig:
+    """Frozen inputs for the v3 teacher-student label recipe."""
+
+    kind: Literal["self_distill"]
+    primary_ckpt: Path
+    ensemble_ckpt: Path
+    primary_threshold: float
+    ensemble_threshold: float
+    mean_hi: float
+    std_lo: float
+    tta: bool
+    input_mask_threshold: float
+
+
+DynamicLabelConfig = DinoGuidedLabelConfig | SelfDistillLabelConfig
+
+
+@dataclass(frozen=True)
+class ExtraPatchesConfig:
+    """Optional v3 coordinate-patch sampling controls."""
+
+    enabled: bool = False
+    coords_xyz: tuple[tuple[int, int, int], ...] = ()
+    jitter: int = 1024
+    fraction: float = 0.25
+
+
+def _required_path(authored: Mapping[str, Any], key: str, *, parent: str) -> Path:
+    value = authored.get(key)
+    if value in (None, ""):
+        raise ValueError(f"{parent}.{key} is required")
+    return Path(str(value))
+
+
+def _dynamic_label_config(
+    authored: Mapping[str, Any], *, mode: str, patch_size: tuple[int, int, int]
+) -> DynamicLabelConfig | None:
+    value = authored.get("dynamic_label") or {}
+    if not isinstance(value, Mapping):
+        raise TypeError("dynamic_label must be an object or null")
+    if not bool(value.get("enabled", False)):
+        return None
+    if mode != "full_3d":
+        raise ValueError("dynamic_label is supported only in mode='full_3d'")
+    if patch_size != (256, 256, 256):
+        raise ValueError(
+            "dynamic_label requires patch_size [256, 256, 256], got "
+            f"{list(patch_size)!r}"
+        )
+    kind = str(value.get("kind", "dino_guided")).strip().lower()
+    if kind == "dino_guided":
+        stride = int(value.get("dino_stride", 64))
+        minibatch = int(value.get("dino_minibatch", 8))
+        sigma = float(value.get("dino_blend_sigma", 4.0))
+        threshold = float(value.get("threshold", 0.5))
+        mask_threshold = value.get("input_mask_threshold")
+        if stride <= 0 or minibatch <= 0 or sigma <= 0.0:
+            raise ValueError(
+                "dynamic_label DINO stride, minibatch, and blend sigma must be positive"
+            )
+        if not 0.0 <= threshold <= 1.0:
+            raise ValueError("dynamic_label.threshold must be in [0,1]")
+        return DinoGuidedLabelConfig(
+            kind="dino_guided",
+            unet_ckpt=_required_path(value, "unet_ckpt", parent="dynamic_label"),
+            dino_ckpt=_required_path(value, "dino_ckpt", parent="dynamic_label"),
+            ref_embedding=_required_path(
+                value, "ref_embedding", parent="dynamic_label"
+            ),
+            dino_stride=stride,
+            dino_minibatch=minibatch,
+            dino_blend_sigma=sigma,
+            threshold=threshold,
+            input_mask_threshold=(
+                None if mask_threshold is None else float(mask_threshold)
+            ),
+        )
+    if kind == "self_distill":
+        primary_threshold = float(value["primary_threshold"])
+        ensemble_threshold = float(value["ensemble_threshold"])
+        if not 0.0 <= primary_threshold <= 1.0:
+            raise ValueError("dynamic_label.primary_threshold must be in [0,1]")
+        if not 0.0 <= ensemble_threshold <= 1.0:
+            raise ValueError("dynamic_label.ensemble_threshold must be in [0,1]")
+        return SelfDistillLabelConfig(
+            kind="self_distill",
+            primary_ckpt=_required_path(
+                value, "primary_ckpt", parent="dynamic_label"
+            ),
+            ensemble_ckpt=_required_path(
+                value, "ensemble_ckpt", parent="dynamic_label"
+            ),
+            primary_threshold=primary_threshold,
+            ensemble_threshold=ensemble_threshold,
+            mean_hi=float(value["mean_hi"]),
+            std_lo=float(value["std_lo"]),
+            tta=bool(value.get("tta", True)),
+            input_mask_threshold=float(value.get("input_mask_threshold", 50.0)),
+        )
+    raise ValueError(
+        "dynamic_label.kind must be 'dino_guided' or 'self_distill', "
+        f"got {kind!r}"
+    )
+
+
+def _extra_patches_config(
+    authored: Mapping[str, Any], *, dynamic_label: DynamicLabelConfig | None
+) -> ExtraPatchesConfig:
+    value = authored.get("extra_patches") or {}
+    if not isinstance(value, Mapping):
+        raise TypeError("extra_patches must be an object or null")
+    if not bool(value.get("enabled", False)):
+        return ExtraPatchesConfig()
+    if not isinstance(dynamic_label, SelfDistillLabelConfig):
+        raise ValueError("extra_patches requires dynamic_label.kind='self_distill'")
+    coords_value = value.get("coords_xyz") or ()
+    if not isinstance(coords_value, (list, tuple)):
+        raise TypeError("extra_patches.coords_xyz must be an array")
+    coords: list[tuple[int, int, int]] = []
+    for index, coord in enumerate(coords_value):
+        if not isinstance(coord, (list, tuple)) or len(coord) != 3:
+            raise ValueError(
+                f"extra_patches.coords_xyz[{index}] must be one XYZ triple"
+            )
+        coords.append(tuple(int(item) for item in coord))
+    if not coords:
+        raise ValueError("extra_patches.coords_xyz cannot be empty")
+    jitter = int(value.get("jitter", 1024))
+    fraction = float(value.get("fraction", 0.25))
+    if jitter < 0:
+        raise ValueError("extra_patches.jitter must be nonnegative")
+    if not 0.0 < fraction < 1.0:
+        raise ValueError("extra_patches.fraction must be in (0,1)")
+    return ExtraPatchesConfig(
+        enabled=True,
+        coords_xyz=tuple(coords),
+        jitter=jitter,
+        fraction=fraction,
+    )
+
+
 class _FrozenMapping(Mapping):
     """Small ordered immutable mapping that remains safe across spawn/pickle."""
 
@@ -1295,6 +1452,10 @@ class TrainingConfig:
     sampling_audit_every: int
     verify_finite_gradients_steps: int
     max_amp_overflow_events: int
+    dynamic_label: DynamicLabelConfig | None
+    extra_patches: ExtraPatchesConfig
+    force_full_supervision: bool
+    save_iterations: tuple[int, ...]
 
     @classmethod
     def from_mapping(cls, canonical: Mapping[str, Any]) -> "TrainingConfig":
@@ -1342,6 +1503,36 @@ class TrainingConfig:
         if "wandb_project" in canonical and "wandb_entity" not in canonical:
             raise ValueError("wandb_project requires wandb_entity")
         raw_wandb_run_id = canonical.get("wandb_run_id")
+        dynamic_label = _dynamic_label_config(
+            canonical,
+            mode=ink.data.mode,
+            patch_size=ink.data.patch_size,
+        )
+        extra_patches = _extra_patches_config(
+            canonical, dynamic_label=dynamic_label
+        )
+        if extra_patches.enabled and ink.data.sampling.strategy != "uniform":
+            raise ValueError(
+                "extra_patches requires sampling_strategy='uniform'"
+            )
+        force_full_supervision = bool(
+            canonical.get("force_full_supervision", False)
+        )
+        if force_full_supervision and not isinstance(
+            dynamic_label, SelfDistillLabelConfig
+        ):
+            raise ValueError(
+                "force_full_supervision requires dynamic_label.kind='self_distill'"
+            )
+        save_iterations_value = canonical.get("save_iterations") or ()
+        if not isinstance(save_iterations_value, (list, tuple)):
+            raise TypeError("save_iterations must be an array")
+        save_iterations = tuple(sorted({int(item) for item in save_iterations_value}))
+        if any(item <= 0 or item > num_iterations for item in save_iterations):
+            raise ValueError(
+                "save_iterations values must be completed-iteration counts in "
+                f"[1, {num_iterations}]"
+            )
         return cls(
             ink=ink,
             num_iterations=num_iterations,
@@ -1395,6 +1586,10 @@ class TrainingConfig:
             sampling_audit_every=sampling_audit_every,
             verify_finite_gradients_steps=verify_finite,
             max_amp_overflow_events=max_overflows,
+            dynamic_label=dynamic_label,
+            extra_patches=extra_patches,
+            force_full_supervision=force_full_supervision,
+            save_iterations=save_iterations,
         )
 
     @property

--- a/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_teacher.json
+++ b/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_teacher.json
@@ -1,0 +1,110 @@
+{
+  "description": "Frozen U-Net teacher checkpoint for the DINO-guided ink lineage (W&B 76ezvyks). Replace every /path/to placeholder with the corresponding historical local label root, raw CT volume, or output directory before running.",
+  "mode": "full_3d",
+  "model_type": "unet",
+  "model_config": {
+    "autoconfigure": true,
+    "z_projection_mode": "none"
+  },
+  "targets": {
+    "ink": {
+      "activation": "none",
+      "out_channels": 1,
+      "z_projection_mode": "none"
+    }
+  },
+  "in_channels": 1,
+  "patch_size": [256, 256, 256],
+  "patch_overlap": 0.5,
+  "patch_min_labeled_coverage": 0.02,
+  "patch_finding_scale": 4,
+  "full_3d": {
+    "projection_half_thickness": 3
+  },
+  "image_normalization": "percentile_minmax",
+  "loss": {
+    "terms": [
+      {
+        "name": "LabelSmoothedDCAndBCELoss",
+        "metric_name": "base",
+        "weight": 1.0,
+        "weight_ce": 1.0,
+        "weight_dice": 1.0,
+        "bce_label_smoothing": 0.1,
+        "dice_label_smoothing": 0.1
+      }
+    ]
+  },
+  "optimizer": "sgd",
+  "learning_rate": 0.01,
+  "weight_decay": 0.00003,
+  "optimizer_momentum": 0.99,
+  "optimizer_nesterov": true,
+  "scheduler": {"name": "diffusers_cosine_warmup"},
+  "warmup_steps": 5000,
+  "ema": {
+    "enabled": true,
+    "decay": 0.9995,
+    "start_step": 1000,
+    "update_every_steps": 1,
+    "validate": true,
+    "save_in_checkpoint": true
+  },
+  "mixed_precision": "bf16",
+  "batch_size": 2,
+  "num_iterations": 60001,
+  "max_steps": 250000,
+  "save_iterations": [60001],
+  "seed": 27,
+  "save_every": 5000,
+  "val_every": 1000,
+  "val_steps": 10,
+  "dataloader_workers": 4,
+  "prefetch_factor": 4,
+  "stitch_factor": 1,
+  "use_stitched_forward": false,
+  "stitched_gradient_checkpointing": true,
+  "out_dir": "/path/to/runs/dino-guided-teacher",
+  "datasets": [
+    {
+      "segments_path": "/path/to/ink-dataset/phercparis4",
+      "volume_path": "/path/to/volumes/phercparis4.zarr",
+      "volume_scale": 0
+    },
+    {
+      "segments_path": "/path/to/ink-dataset/pherc0139",
+      "volume_path": "/path/to/volumes/pherc0139.zarr",
+      "volume_scale": 0
+    },
+    {
+      "segments_path": "/path/to/ink-dataset/pherc0500p2",
+      "volume_path": "/path/to/volumes/pherc0500p2.zarr",
+      "volume_scale": 0
+    },
+    {
+      "segments_path": "/path/to/ink-dataset/pherc0814",
+      "volume_path": "/path/to/volumes/pherc0814.zarr",
+      "volume_scale": 0
+    },
+    {
+      "segments_path": "/path/to/ink-dataset/pherc0841",
+      "volume_path": "/path/to/volumes/pherc0841.zarr",
+      "volume_scale": 0
+    },
+    {
+      "segments_path": "/path/to/ink-dataset/pherc1667",
+      "volume_path": "/path/to/volumes/pherc1667.zarr",
+      "volume_scale": 0
+    },
+    {
+      "segments_path": "/path/to/ink-dataset/phercman5",
+      "volume_path": "/path/to/volumes/phercman5.zarr",
+      "volume_scale": 0
+    },
+    {
+      "segments_path": "/path/to/ink-dataset/pherc0009b",
+      "volume_path": "/path/to/volumes/pherc0009b.zarr",
+      "volume_scale": 0
+    }
+  ]
+}

--- a/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_v1.json
+++ b/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_v1.json
@@ -1,0 +1,88 @@
+{
+  "description": "DINO-guided v1 (W&B 6az0505g): full-state continuation of the teacher; labels are frozen EMA U-Net probability multiplied by per-sample min-max DINO cosine similarity, then thresholded at 0.5. There is intentionally no raw-intensity gate in this phase.",
+  "mode": "full_3d",
+  "model_type": "unet",
+  "model_config": {
+    "autoconfigure": true,
+    "z_projection_mode": "none"
+  },
+  "targets": {
+    "ink": {
+      "activation": "none",
+      "out_channels": 1,
+      "z_projection_mode": "none"
+    }
+  },
+  "in_channels": 1,
+  "patch_size": [256, 256, 256],
+  "patch_overlap": 0.5,
+  "patch_min_labeled_coverage": 0.02,
+  "patch_finding_scale": 4,
+  "full_3d": {
+    "projection_half_thickness": 3
+  },
+  "image_normalization": "percentile_minmax",
+  "loss": {
+    "terms": [
+      {
+        "name": "LabelSmoothedDCAndBCELoss",
+        "metric_name": "base",
+        "weight": 1.0,
+        "weight_ce": 1.0,
+        "weight_dice": 1.0,
+        "bce_label_smoothing": 0.1,
+        "dice_label_smoothing": 0.1
+      }
+    ]
+  },
+  "optimizer": "sgd",
+  "learning_rate": 0.01,
+  "weight_decay": 0.00003,
+  "optimizer_momentum": 0.99,
+  "optimizer_nesterov": true,
+  "scheduler": {"name": "diffusers_cosine_warmup"},
+  "warmup_steps": 5000,
+  "ema": {
+    "enabled": true,
+    "decay": 0.9995,
+    "start_step": 1000,
+    "update_every_steps": 1,
+    "validate": true,
+    "save_in_checkpoint": true
+  },
+  "checkpoint": "/path/to/runs/dino-guided-teacher/ckpt_060001.pth",
+  "weights_only": false,
+  "dynamic_label": {
+    "enabled": true,
+    "kind": "dino_guided",
+    "unet_ckpt": "/path/to/runs/dino-guided-teacher/ckpt_060001.pth",
+    "dino_ckpt": "/path/to/checkpoints/dinovol/checkpoint_step_352500_paris4.pt",
+    "ref_embedding": "/path/to/checkpoints/dinovol/avg_ref_embedding.npy",
+    "dino_stride": 128,
+    "dino_minibatch": 16,
+    "dino_blend_sigma": 4.0,
+    "threshold": 0.5
+  },
+  "mixed_precision": "bf16",
+  "batch_size": 2,
+  "num_iterations": 63001,
+  "max_steps": 250000,
+  "save_iterations": [63001],
+  "seed": 27,
+  "save_every": 1000,
+  "val_every": 200,
+  "val_steps": 8,
+  "dataloader_workers": 8,
+  "prefetch_factor": 8,
+  "stitch_factor": 1,
+  "use_stitched_forward": false,
+  "stitched_gradient_checkpointing": true,
+  "out_dir": "/path/to/runs/dino-guided-v1",
+  "datasets": [
+    {
+      "segments_path": "/path/to/ink-dataset/phercparis4",
+      "volume_path": "/path/to/volumes/phercparis4.zarr",
+      "volume_scale": 0
+    }
+  ]
+}

--- a/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_v2.json
+++ b/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_v2.json
@@ -1,0 +1,89 @@
+{
+  "description": "DINO-guided v2 (W&B af3pga3d): full-state continuation of v1 with the same frozen U-Net × DINO labels and an added strict raw-intensity > 50 foreground gate.",
+  "mode": "full_3d",
+  "model_type": "unet",
+  "model_config": {
+    "autoconfigure": true,
+    "z_projection_mode": "none"
+  },
+  "targets": {
+    "ink": {
+      "activation": "none",
+      "out_channels": 1,
+      "z_projection_mode": "none"
+    }
+  },
+  "in_channels": 1,
+  "patch_size": [256, 256, 256],
+  "patch_overlap": 0.5,
+  "patch_min_labeled_coverage": 0.02,
+  "patch_finding_scale": 4,
+  "full_3d": {
+    "projection_half_thickness": 3
+  },
+  "image_normalization": "percentile_minmax",
+  "loss": {
+    "terms": [
+      {
+        "name": "LabelSmoothedDCAndBCELoss",
+        "metric_name": "base",
+        "weight": 1.0,
+        "weight_ce": 1.0,
+        "weight_dice": 1.0,
+        "bce_label_smoothing": 0.1,
+        "dice_label_smoothing": 0.1
+      }
+    ]
+  },
+  "optimizer": "sgd",
+  "learning_rate": 0.01,
+  "weight_decay": 0.00003,
+  "optimizer_momentum": 0.99,
+  "optimizer_nesterov": true,
+  "scheduler": {"name": "diffusers_cosine_warmup"},
+  "warmup_steps": 5000,
+  "ema": {
+    "enabled": true,
+    "decay": 0.9995,
+    "start_step": 1000,
+    "update_every_steps": 1,
+    "validate": true,
+    "save_in_checkpoint": true
+  },
+  "checkpoint": "/path/to/runs/dino-guided-v1/ckpt_063001.pth",
+  "weights_only": false,
+  "dynamic_label": {
+    "enabled": true,
+    "kind": "dino_guided",
+    "unet_ckpt": "/path/to/runs/dino-guided-v1/ckpt_063001.pth",
+    "dino_ckpt": "/path/to/checkpoints/dinovol/checkpoint_step_352500_paris4.pt",
+    "ref_embedding": "/path/to/checkpoints/dinovol/avg_ref_embedding.npy",
+    "dino_stride": 128,
+    "dino_minibatch": 16,
+    "dino_blend_sigma": 4.0,
+    "threshold": 0.5,
+    "input_mask_threshold": 50
+  },
+  "mixed_precision": "bf16",
+  "batch_size": 2,
+  "num_iterations": 77001,
+  "max_steps": 250000,
+  "save_iterations": [64001, 77001],
+  "seed": 27,
+  "save_every": 1000,
+  "val_every": 200,
+  "val_steps": 8,
+  "dataloader_workers": 8,
+  "prefetch_factor": 8,
+  "stitch_factor": 1,
+  "use_stitched_forward": false,
+  "stitched_gradient_checkpointing": true,
+  "out_dir": "/path/to/runs/dino-guided-v2",
+  "datasets": [
+    {
+      "segments_path": "/path/to/ink-dataset/phercparis4",
+      "volume_path": "/path/to/volumes/phercparis4.zarr",
+      "volume_scale": 0
+    }
+  ]
+}

--- a/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_v3.json
+++ b/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_v3.json
@@ -1,0 +1,104 @@
+{
+  "description": "Ordinary-mask self-distillation v3 (W&B 29ulc4ly), a sibling of v3_fullsup from the same v2 77k state. It uses eight mirror TTAs, conditionally averages the 77k and 64k teachers for raw mean > 105 and raw std < 30, and gates labels with raw intensity > 50.",
+  "mode": "full_3d",
+  "model_type": "unet",
+  "model_config": {
+    "autoconfigure": true,
+    "z_projection_mode": "none"
+  },
+  "targets": {
+    "ink": {
+      "activation": "none",
+      "out_channels": 1,
+      "z_projection_mode": "none"
+    }
+  },
+  "in_channels": 1,
+  "patch_size": [256, 256, 256],
+  "patch_overlap": 0.5,
+  "patch_min_labeled_coverage": 0.02,
+  "patch_finding_scale": 4,
+  "full_3d": {
+    "projection_half_thickness": 3
+  },
+  "image_normalization": "percentile_minmax",
+  "loss": {
+    "terms": [
+      {
+        "name": "LabelSmoothedDCAndBCELoss",
+        "metric_name": "base",
+        "weight": 1.0,
+        "weight_ce": 1.0,
+        "weight_dice": 1.0,
+        "bce_label_smoothing": 0.1,
+        "dice_label_smoothing": 0.1
+      }
+    ]
+  },
+  "optimizer": "sgd",
+  "learning_rate": 0.01,
+  "weight_decay": 0.00003,
+  "optimizer_momentum": 0.99,
+  "optimizer_nesterov": true,
+  "scheduler": {"name": "diffusers_cosine_warmup"},
+  "warmup_steps": 5000,
+  "ema": {
+    "enabled": true,
+    "decay": 0.9995,
+    "start_step": 1000,
+    "update_every_steps": 1,
+    "validate": true,
+    "save_in_checkpoint": true
+  },
+  "checkpoint": "/path/to/runs/dino-guided-v2/ckpt_077001.pth",
+  "weights_only": false,
+  "dynamic_label": {
+    "enabled": true,
+    "kind": "self_distill",
+    "primary_ckpt": "/path/to/runs/dino-guided-v2/ckpt_077001.pth",
+    "ensemble_ckpt": "/path/to/runs/dino-guided-v2/ckpt_064001.pth",
+    "primary_threshold": 0.17647,
+    "ensemble_threshold": 0.15686,
+    "mean_hi": 105.0,
+    "std_lo": 30.0,
+    "tta": true,
+    "input_mask_threshold": 50
+  },
+  "extra_patches": {
+    "enabled": true,
+    "fraction": 0.25,
+    "jitter": 1024,
+    "coords_xyz": [
+      [22167, 8793, 37628],
+      [19735, 19651, 35344],
+      [10649, 19605, 70688],
+      [12261, 16221, 41802],
+      [8270, 10039, 41652],
+      [8006, 8812, 41652],
+      [19310, 10476, 41652],
+      [27405, 17662, 41778]
+    ]
+  },
+  "mixed_precision": "bf16",
+  "batch_size": 2,
+  "num_iterations": 79001,
+  "max_steps": 250000,
+  "save_iterations": [79001],
+  "seed": 27,
+  "save_every": 1000,
+  "val_every": 200,
+  "val_steps": 8,
+  "dataloader_workers": 8,
+  "prefetch_factor": 8,
+  "stitch_factor": 1,
+  "use_stitched_forward": false,
+  "stitched_gradient_checkpointing": true,
+  "out_dir": "/path/to/runs/dino-guided-v3",
+  "datasets": [
+    {
+      "segments_path": "/path/to/ink-dataset/phercparis4",
+      "volume_path": "/path/to/volumes/phercparis4.zarr",
+      "volume_scale": 0
+    }
+  ]
+}

--- a/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_v3_fullsup.json
+++ b/vesuvius/src/vesuvius/ink_detection/configs/dino_guided_v3_fullsup.json
@@ -1,0 +1,105 @@
+{
+  "description": "Full-supervision self-distillation v3 (W&B 4b07qv8p), a sibling of ordinary v3 from the same v2 77k state. This is identical to the ordinary v3 recipe except that supervision-mask zeros are included in the loss.",
+  "mode": "full_3d",
+  "model_type": "unet",
+  "model_config": {
+    "autoconfigure": true,
+    "z_projection_mode": "none"
+  },
+  "targets": {
+    "ink": {
+      "activation": "none",
+      "out_channels": 1,
+      "z_projection_mode": "none"
+    }
+  },
+  "in_channels": 1,
+  "patch_size": [256, 256, 256],
+  "patch_overlap": 0.5,
+  "patch_min_labeled_coverage": 0.02,
+  "patch_finding_scale": 4,
+  "full_3d": {
+    "projection_half_thickness": 3
+  },
+  "image_normalization": "percentile_minmax",
+  "loss": {
+    "terms": [
+      {
+        "name": "LabelSmoothedDCAndBCELoss",
+        "metric_name": "base",
+        "weight": 1.0,
+        "weight_ce": 1.0,
+        "weight_dice": 1.0,
+        "bce_label_smoothing": 0.1,
+        "dice_label_smoothing": 0.1
+      }
+    ]
+  },
+  "optimizer": "sgd",
+  "learning_rate": 0.01,
+  "weight_decay": 0.00003,
+  "optimizer_momentum": 0.99,
+  "optimizer_nesterov": true,
+  "scheduler": {"name": "diffusers_cosine_warmup"},
+  "warmup_steps": 5000,
+  "ema": {
+    "enabled": true,
+    "decay": 0.9995,
+    "start_step": 1000,
+    "update_every_steps": 1,
+    "validate": true,
+    "save_in_checkpoint": true
+  },
+  "checkpoint": "/path/to/runs/dino-guided-v2/ckpt_077001.pth",
+  "weights_only": false,
+  "dynamic_label": {
+    "enabled": true,
+    "kind": "self_distill",
+    "primary_ckpt": "/path/to/runs/dino-guided-v2/ckpt_077001.pth",
+    "ensemble_ckpt": "/path/to/runs/dino-guided-v2/ckpt_064001.pth",
+    "primary_threshold": 0.17647,
+    "ensemble_threshold": 0.15686,
+    "mean_hi": 105.0,
+    "std_lo": 30.0,
+    "tta": true,
+    "input_mask_threshold": 50
+  },
+  "extra_patches": {
+    "enabled": true,
+    "fraction": 0.25,
+    "jitter": 1024,
+    "coords_xyz": [
+      [22167, 8793, 37628],
+      [19735, 19651, 35344],
+      [10649, 19605, 70688],
+      [12261, 16221, 41802],
+      [8270, 10039, 41652],
+      [8006, 8812, 41652],
+      [19310, 10476, 41652],
+      [27405, 17662, 41778]
+    ]
+  },
+  "force_full_supervision": true,
+  "mixed_precision": "bf16",
+  "batch_size": 2,
+  "num_iterations": 78001,
+  "max_steps": 250000,
+  "save_iterations": [78001],
+  "seed": 27,
+  "save_every": 1000,
+  "val_every": 200,
+  "val_steps": 8,
+  "dataloader_workers": 8,
+  "prefetch_factor": 8,
+  "stitch_factor": 1,
+  "use_stitched_forward": false,
+  "stitched_gradient_checkpointing": true,
+  "out_dir": "/path/to/runs/dino-guided-v3-fullsup",
+  "datasets": [
+    {
+      "segments_path": "/path/to/ink-dataset/phercparis4",
+      "volume_path": "/path/to/volumes/phercparis4.zarr",
+      "volume_scale": 0
+    }
+  ]
+}

--- a/vesuvius/src/vesuvius/ink_detection/data/augmentations.py
+++ b/vesuvius/src/vesuvius/ink_detection/data/augmentations.py
@@ -53,6 +53,48 @@ NATIVE_CROP_TRANSLATION_KEEP_FRACTION = 1.0 / 3.0
 NATIVE_CROP_TRANSLATION_MAX_AXES = 2
 NATIVE_CROP_TRANSLATION_MAX_ATTEMPTS = 24
 
+_GEOMETRIC_TRANSFORM_KEYWORDS = (
+    "Rot90",
+    "Mirror",
+    "Spatial",
+    "Affine",
+    "Elastic",
+    "CropPad",
+    "Resize",
+    "Transpose",
+)
+
+
+def _is_geometric_transform(transform) -> bool:
+    """Return whether a possibly wrapped transform changes only geometry."""
+
+    if any(
+        keyword in type(transform).__name__
+        for keyword in _GEOMETRIC_TRANSFORM_KEYWORDS
+    ):
+        return True
+    inner = getattr(transform, "transform", None)
+    if inner is not None:
+        return _is_geometric_transform(inner)
+    alternatives = getattr(transform, "list_of_transforms", None)
+    if alternatives:
+        return all(_is_geometric_transform(item) for item in alternatives)
+    return False
+
+
+def split_augmentations_by_geometry(
+    compose: ComposeTransforms,
+) -> tuple[ComposeTransforms, ComposeTransforms]:
+    """Split one preset around the clean pseudo-label image boundary."""
+
+    geometric = []
+    photometric = []
+    for transform in compose.transforms:
+        (geometric if _is_geometric_transform(transform) else photometric).append(
+            transform
+        )
+    return ComposeTransforms(geometric), ComposeTransforms(photometric)
+
 
 def _mirror_axes(dimension: int) -> tuple[int, ...]:
     if dimension == 2:

--- a/vesuvius/src/vesuvius/ink_detection/data/coord_patch_dataset.py
+++ b/vesuvius/src/vesuvius/ink_detection/data/coord_patch_dataset.py
@@ -1,0 +1,111 @@
+"""Coordinate-driven full-volume patches for the v3 self-distillation phases."""
+
+from __future__ import annotations
+
+import random
+from typing import Iterable
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from vesuvius.ink_detection.config import NormalizationConfig
+from vesuvius.ink_detection.data.normalization import normalize_image
+from vesuvius.ink_detection.volume_io import open_volume, read_bbox_with_padding
+
+
+class CoordPatchDataset(Dataset):
+    """Read normalized cubic patches centered on authored XYZ coordinates."""
+
+    def __init__(
+        self,
+        *,
+        volume_path: str,
+        resolution: int,
+        coords_xyz: Iterable[Iterable[int]],
+        jitter: int,
+        length: int,
+        patch_size: tuple[int, int, int],
+        normalization: NormalizationConfig,
+        input_mask_threshold: float,
+        volume_auth_json=None,
+        volume_cache_dir=None,
+        volume_cache_max_gb: float | None = None,
+    ) -> None:
+        coords = []
+        for index, coord in enumerate(coords_xyz):
+            values = tuple(int(item) for item in coord)
+            if len(values) != 3:
+                raise ValueError(f"coords_xyz[{index}] must be one XYZ triple")
+            coords.append(values)
+        if not coords:
+            raise ValueError("coords_xyz cannot be empty")
+        if any(int(size) <= 0 for size in patch_size):
+            raise ValueError("patch_size dimensions must be positive")
+        if int(jitter) < 0:
+            raise ValueError("jitter must be nonnegative")
+        self.volume_path = str(volume_path)
+        self.resolution = int(resolution)
+        self.coords_xyz = tuple(coords)
+        self.jitter = int(jitter)
+        self.length = max(1, int(length))
+        self.patch_size = tuple(int(size) for size in patch_size)
+        self.normalization = normalization
+        self.input_mask_threshold = float(input_mask_threshold)
+        self.volume_auth_json = volume_auth_json
+        self.volume_cache_dir = volume_cache_dir
+        self.volume_cache_max_gb = volume_cache_max_gb
+        self._volume = None
+
+    def __len__(self) -> int:
+        return self.length
+
+    def _open(self):
+        if self._volume is None:
+            self._volume = open_volume(
+                self.volume_path,
+                self.resolution,
+                self.volume_auth_json,
+                cache_dir=self.volume_cache_dir,
+                cache_max_gb=self.volume_cache_max_gb,
+            )
+        return self._volume
+
+    def _center_zyx(self) -> tuple[int, int, int]:
+        x, y, z = random.choice(self.coords_xyz)
+        if self.jitter:
+            x += random.randint(-self.jitter, self.jitter)
+            y += random.randint(-self.jitter, self.jitter)
+            z += random.randint(-self.jitter, self.jitter)
+        return z, y, x
+
+    def __getitem__(self, _index: int) -> dict[str, torch.Tensor]:
+        center = self._center_zyx()
+        starts = tuple(
+            value - size // 2 for value, size in zip(center, self.patch_size)
+        )
+        bbox = (*starts, *(start + size for start, size in zip(starts, self.patch_size)))
+        raw, valid_slices = read_bbox_with_padding(
+            self._open(), bbox, fill_value=0
+        )
+        raw = np.asarray(raw)
+        raw_mean = float(raw.mean())
+        raw_std = float(raw.std())
+        mask = (raw > self.input_mask_threshold).astype(np.float32)
+        image = raw.astype(np.float32, copy=False)
+        if valid_slices is not None:
+            image[valid_slices] = normalize_image(
+                image[valid_slices], self.normalization
+            )
+        image_tensor = torch.from_numpy(np.ascontiguousarray(image)).float().unsqueeze(0)
+        mask_tensor = torch.from_numpy(mask).float().unsqueeze(0)
+        return {
+            "image": image_tensor,
+            "image_for_label": image_tensor.clone(),
+            "image_mask_for_label": mask_tensor,
+            "image_raw_mean": torch.tensor(raw_mean, dtype=torch.float32),
+            "image_raw_std": torch.tensor(raw_std, dtype=torch.float32),
+            "inklabels": torch.zeros_like(image_tensor),
+            "supervision_mask": mask_tensor.clone(),
+            "is_unlabeled": torch.tensor(False, dtype=torch.bool),
+        }

--- a/vesuvius/src/vesuvius/ink_detection/data/dataset.py
+++ b/vesuvius/src/vesuvius/ink_detection/data/dataset.py
@@ -15,6 +15,7 @@ from torch.utils.data import Dataset
 from vesuvius.ink_detection.data.augmentations import (
     build_augmentations,
     maybe_translate_crop_bbox,
+    split_augmentations_by_geometry,
 )
 from vesuvius.ink_detection.config import InkDataConfig
 from vesuvius.ink_detection.data.geometry import (
@@ -114,11 +115,19 @@ class InkDataset(Dataset):
         do_augmentations: bool = True,
         patches: list[Patch] | None = None,
         segments: list[Segment] | None = None,
+        emit_image_for_label: bool = False,
+        input_mask_threshold: float | None = None,
     ) -> None:
         self.config = config
         self.patch_size = config.patch_size
         self.mode = config.mode
         self.do_augmentations = bool(do_augmentations)
+        self.emit_image_for_label = bool(emit_image_for_label)
+        self.input_mask_threshold = (
+            None
+            if input_mask_threshold is None
+            else float(input_mask_threshold)
+        )
         self._zarr_cache: dict[tuple, object] = {}
         self._tifxyz_cache: dict[str, object] = {}
         self._stored_resolution_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
@@ -129,6 +138,13 @@ class InkDataset(Dataset):
                 config.patch_size,
                 rotation_axes=config.augmentation.rotation_axes,
             )
+        self.geometric_augmentations = None
+        self.photometric_augmentations = None
+        if self.emit_image_for_label and self.augmentations is not None:
+            (
+                self.geometric_augmentations,
+                self.photometric_augmentations,
+            ) = split_augmentations_by_geometry(self.augmentations)
 
         if patches is None:
             self.segments = list(gather_segments(config))
@@ -537,6 +553,16 @@ class InkDataset(Dataset):
         surface_mask: np.ndarray | None,
     ) -> dict[str, torch.Tensor]:
         image = image.astype(np.float32, copy=False)
+        raw_mean = None
+        raw_std = None
+        image_mask = None
+        if self.emit_image_for_label:
+            raw_mean = float(image.mean())
+            raw_std = float(image.std())
+            if self.input_mask_threshold is not None:
+                image_mask = (image > self.input_mask_threshold).astype(
+                    np.float32
+                )
         if image_valid_slices is not None:
             image[image_valid_slices] = normalize_image(
                 image[image_valid_slices], self.config.normalization
@@ -558,12 +584,37 @@ class InkDataset(Dataset):
         }
         if surface_mask is not None:
             data["surface_mask"] = torch.from_numpy(surface_mask).float().unsqueeze(0)
-        if self.augmentations is not None:
+        if image_mask is not None:
+            data["image_mask_for_label"] = (
+                torch.from_numpy(image_mask).float().unsqueeze(0)
+            )
+        if self.geometric_augmentations is not None:
+            augmentation_data = data
+            if self.mode == "full_3d_single_wrap":
+                augmentation_data = dict(data)
+                augmentation_data["regression_keys"] = ["surface_mask"]
+            after_geometry = self.geometric_augmentations(**augmentation_data)
+            image_for_label = after_geometry["image"].clone()
+            mask_for_label = after_geometry.pop("image_mask_for_label", None)
+            data = self.photometric_augmentations(**after_geometry)
+            data["image_for_label"] = image_for_label
+            if mask_for_label is not None:
+                data["image_mask_for_label"] = (mask_for_label > 0.5).float()
+        elif self.augmentations is not None:
             augmentation_data = data
             if self.mode == "full_3d_single_wrap":
                 augmentation_data = dict(data)
                 augmentation_data["regression_keys"] = ["surface_mask"]
             data = self.augmentations(**augmentation_data)
+        elif self.emit_image_for_label:
+            data["image_for_label"] = data["image"].clone()
+            if "image_mask_for_label" in data:
+                data["image_mask_for_label"] = (
+                    data["image_mask_for_label"] > 0.5
+                ).float()
+        if raw_mean is not None and raw_std is not None:
+            data["image_raw_mean"] = torch.tensor(raw_mean, dtype=torch.float32)
+            data["image_raw_std"] = torch.tensor(raw_std, dtype=torch.float32)
         data["is_unlabeled"] = torch.tensor(patch.is_unlabeled, dtype=torch.bool)
         return data
 

--- a/vesuvius/src/vesuvius/ink_detection/training/dynamic_labels.py
+++ b/vesuvius/src/vesuvius/ink_detection/training/dynamic_labels.py
@@ -1,0 +1,641 @@
+"""Frozen-teacher pseudo-label engines for staged 3D ink training.
+
+The generators in this module run in the trainer process, after data loading.
+They deliberately accept already-normalized teacher images and optional binary
+foreground masks so dataset workers do not own CUDA models.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vesuvius.ink_detection.inference.infer_full3d_tifxyz import (
+    predict_batch,
+    tta_variants,
+)
+from vesuvius.ink_detection.inference.inference_runtime import TargetModel
+from vesuvius.ink_detection.models.checkpoint import (
+    config_from_checkpoint,
+    load_checkpoint,
+    load_model_state,
+    select_inference_weights,
+)
+from vesuvius.ink_detection.models.model import make_model
+
+
+@dataclass(frozen=True)
+class DinoGridSpec:
+    """Spatial contract of the historical Dinovol pseudo-label recipe."""
+
+    chunk_size: int = 256
+    window_size: int = 128
+    patch_size: int = 8
+    embedding_dim: int = 864
+
+    def __post_init__(self) -> None:
+        values = {
+            "chunk_size": self.chunk_size,
+            "window_size": self.window_size,
+            "patch_size": self.patch_size,
+            "embedding_dim": self.embedding_dim,
+        }
+        for name, value in values.items():
+            if int(value) <= 0:
+                raise ValueError(f"{name} must be positive, got {value!r}")
+        if self.window_size > self.chunk_size:
+            raise ValueError("window_size must not exceed chunk_size")
+        if self.window_size % self.patch_size:
+            raise ValueError("window_size must be divisible by patch_size")
+        if self.chunk_size % self.patch_size:
+            raise ValueError("chunk_size must be divisible by patch_size")
+
+    @property
+    def tokens_per_window_axis(self) -> int:
+        return self.window_size // self.patch_size
+
+    @property
+    def tokens_per_chunk_axis(self) -> int:
+        return self.chunk_size // self.patch_size
+
+
+def _freeze_for_inference(
+    model: nn.Module,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> nn.Module:
+    model.eval().to(device=device, dtype=dtype)
+    for parameter in model.parameters():
+        parameter.requires_grad_(False)
+    return model
+
+
+def load_frozen_ink_model(
+    checkpoint_path: str | Path,
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> nn.Module:
+    """Strictly reconstruct one frozen ink model, preferring EMA weights."""
+
+    source = Path(checkpoint_path)
+    payload = load_checkpoint(source)
+    config = config_from_checkpoint(payload, source=source)
+    model = make_model(config)
+    _, state = select_inference_weights(payload, source=source)
+    load_model_state(model, state)
+    return _freeze_for_inference(
+        model,
+        device=torch.device(device),
+        dtype=dtype,
+    )
+
+
+def load_frozen_dino_backbone(
+    checkpoint_path: str | Path,
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> nn.Module:
+    """Reconstruct the Dinovol teacher backbone from its training checkpoint."""
+
+    source = Path(checkpoint_path)
+    payload = load_checkpoint(source)
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"DINO checkpoint {source} must contain a mapping")
+    config = payload.get("config")
+    if not isinstance(config, Mapping) or not isinstance(config.get("model"), Mapping):
+        raise ValueError(f"DINO checkpoint {source} is missing config.model")
+    teacher = payload.get("teacher")
+    if not isinstance(teacher, Mapping):
+        raise ValueError(f"DINO checkpoint {source} is missing teacher weights")
+    state = {
+        str(key).removeprefix("backbone."): value
+        for key, value in teacher.items()
+        if str(key).startswith("backbone.")
+    }
+    if not state:
+        raise ValueError(f"DINO checkpoint {source} has no teacher.backbone weights")
+    from vesuvius.models.build.pretrained_backbones.dinovol_2_builder import (
+        build_dinovol_2_backbone,
+    )
+
+    backbone = build_dinovol_2_backbone(config["model"])
+    backbone.load_pretrained_weights(state)
+    return _freeze_for_inference(
+        backbone,
+        device=torch.device(device),
+        dtype=dtype,
+    )
+
+
+def load_reference_embedding(
+    path: str | Path,
+    *,
+    embedding_dim: int,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Load and L2-normalize the precomputed one-dimensional ink embedding."""
+
+    array = np.load(str(path)).astype(np.float32)
+    if array.shape != (int(embedding_dim),):
+        raise ValueError(
+            f"reference embedding must have shape ({embedding_dim},), got {array.shape}"
+        )
+    embedding = torch.from_numpy(array).to(device=device, dtype=torch.float32)
+    embedding = embedding / embedding.norm().clamp_min(1e-12)
+    return embedding.to(dtype=dtype)
+
+
+def gaussian_window_3d(size: int, sigma: float) -> torch.Tensor:
+    """Return the historical separable, peak-normalized 3D blend window."""
+
+    size = int(size)
+    sigma = float(sigma)
+    if size <= 0:
+        raise ValueError(f"size must be positive, got {size}")
+    if sigma <= 0.0:
+        raise ValueError(f"sigma must be positive, got {sigma}")
+    coordinates = torch.arange(size, dtype=torch.float32) - (size - 1) / 2.0
+    weights_1d = torch.exp(-(coordinates**2) / (2.0 * sigma**2))
+    weights_1d /= weights_1d.max()
+    return (
+        weights_1d[:, None, None]
+        * weights_1d[None, :, None]
+        * weights_1d[None, None, :]
+    )
+
+
+def dino_window_starts(
+    *,
+    chunk_size: int,
+    window_size: int,
+    stride: int,
+) -> list[int]:
+    """Return starts snapped to include both the first and final valid window."""
+
+    stride = int(stride)
+    if stride <= 0:
+        raise ValueError(f"DINO stride must be positive, got {stride}")
+    last = int(chunk_size) - int(window_size)
+    if last < 0:
+        raise ValueError("DINO window_size must not exceed chunk_size")
+    starts = list(range(0, last + 1, stride))
+    if starts[-1] != last:
+        starts.append(last)
+    return starts
+
+
+_MISSING = object()
+
+
+def _config_value(config: Any, key: str, default: Any = _MISSING) -> Any:
+    if isinstance(config, Mapping) and key in config:
+        return config[key]
+    if hasattr(config, key):
+        return getattr(config, key)
+    if default is _MISSING:
+        raise KeyError(f"dynamic-label configuration is missing {key!r}")
+    return default
+
+
+def _config_alias(config: Any, *keys: str) -> Any:
+    for key in keys:
+        try:
+            return _config_value(config, key)
+        except KeyError:
+            continue
+    raise KeyError(
+        "dynamic-label configuration is missing one of "
+        + ", ".join(repr(key) for key in keys)
+    )
+
+
+def _validate_image(image: torch.Tensor, *, chunk_size: int) -> None:
+    expected = (chunk_size, chunk_size, chunk_size)
+    if image.ndim != 5 or int(image.shape[1]) != 1:
+        raise ValueError(
+            "pseudo-label input must have shape [B,1,Z,Y,X], got "
+            f"{tuple(image.shape)}"
+        )
+    if tuple(image.shape[-3:]) != expected:
+        raise ValueError(
+            f"expected pseudo-label chunk size {chunk_size}^3, got {tuple(image.shape)}"
+        )
+
+
+def _validate_mask(mask: torch.Tensor | None, image: torch.Tensor) -> None:
+    if mask is not None and tuple(mask.shape) != tuple(image.shape):
+        raise ValueError(
+            f"foreground mask must match image shape {tuple(image.shape)}, "
+            f"got {tuple(mask.shape)}"
+        )
+
+
+class DinoGuidedLabelGenerator:
+    """Intersect a frozen U-Net probability with Dinovol cosine similarity."""
+
+    def __init__(
+        self,
+        *,
+        unet: nn.Module,
+        dino: nn.Module,
+        reference_embedding: torch.Tensor,
+        device: torch.device | str = "cuda",
+        dtype: torch.dtype = torch.bfloat16,
+        dino_stride: int = 64,
+        dino_minibatch: int = 8,
+        dino_blend_sigma: float = 4.0,
+        threshold: float = 0.5,
+        grid: DinoGridSpec = DinoGridSpec(),
+    ) -> None:
+        self.device = torch.device(device)
+        self.dtype = dtype
+        self.grid = grid
+        self.dino_minibatch = int(dino_minibatch)
+        if self.dino_minibatch <= 0:
+            raise ValueError("dino_minibatch must be positive")
+        self.threshold = float(threshold)
+        self.unet = TargetModel(
+            _freeze_for_inference(unet, device=self.device, dtype=dtype)
+        )
+        self.dino = _freeze_for_inference(dino, device=self.device, dtype=dtype)
+
+        reference_embedding = torch.as_tensor(reference_embedding)
+        if reference_embedding.shape != (grid.embedding_dim,):
+            raise ValueError(
+                "reference embedding must have shape "
+                f"({grid.embedding_dim},), got {tuple(reference_embedding.shape)}"
+            )
+        reference_embedding = reference_embedding.to(
+            device=self.device, dtype=torch.float32
+        )
+        self.reference_embedding = (
+            reference_embedding / reference_embedding.norm().clamp_min(1e-12)
+        )
+
+        self.starts = dino_window_starts(
+            chunk_size=grid.chunk_size,
+            window_size=grid.window_size,
+            stride=dino_stride,
+        )
+        if any(start % grid.patch_size for start in self.starts):
+            raise ValueError(
+                "all DINO window starts must align to the DINO patch lattice; "
+                f"starts={self.starts}, patch_size={grid.patch_size}"
+            )
+        self.weight = gaussian_window_3d(
+            grid.tokens_per_window_axis, dino_blend_sigma
+        ).to(device=self.device)
+
+    @classmethod
+    def from_mapping(
+        cls,
+        config: Any,
+        *,
+        device: torch.device | str = "cuda",
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> DinoGuidedLabelGenerator:
+        """Construct from the path-oriented recipe mapping used by training."""
+
+        grid = DinoGridSpec()
+        unet = load_frozen_ink_model(
+            _config_alias(config, "unet_ckpt", "unet_checkpoint"),
+            device=device,
+            dtype=dtype,
+        )
+        dino = load_frozen_dino_backbone(
+            _config_alias(config, "dino_ckpt", "dino_checkpoint"),
+            device=device,
+            dtype=dtype,
+        )
+        reference = load_reference_embedding(
+            _config_alias(config, "ref_embedding", "reference_embedding"),
+            embedding_dim=grid.embedding_dim,
+            device=device,
+            dtype=dtype,
+        )
+        return cls(
+            unet=unet,
+            dino=dino,
+            reference_embedding=reference,
+            device=device,
+            dtype=dtype,
+            dino_stride=int(_config_value(config, "dino_stride", 64)),
+            dino_minibatch=int(_config_value(config, "dino_minibatch", 8)),
+            dino_blend_sigma=float(
+                _config_value(config, "dino_blend_sigma", 4.0)
+            ),
+            threshold=float(_config_value(config, "threshold", 0.5)),
+            grid=grid,
+        )
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        image_b1zyx: torch.Tensor,
+        mask_b1zyx: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        _validate_image(image_b1zyx, chunk_size=self.grid.chunk_size)
+        _validate_mask(mask_b1zyx, image_b1zyx)
+        image = image_b1zyx.to(
+            device=self.device, dtype=self.dtype, non_blocking=True
+        )
+        logits = self.unet(image)
+        if logits.ndim != 5 or int(logits.shape[1]) != 1:
+            raise ValueError(
+                "frozen U-Net must return one-channel BCZYX logits, got "
+                f"{tuple(logits.shape)}"
+            )
+        probability = logits.float().sigmoid()
+        if mask_b1zyx is not None:
+            probability *= mask_b1zyx.to(
+                device=self.device, dtype=probability.dtype, non_blocking=True
+            )
+        similarity = self._dino_similarity(image)
+        return (probability * similarity > self.threshold).float()
+
+    @torch.inference_mode()
+    def _dino_similarity(self, image_b1zyx: torch.Tensor) -> torch.Tensor:
+        batch_size = int(image_b1zyx.shape[0])
+        grid = self.grid
+        coordinates = [
+            (z, y, x)
+            for z in self.starts
+            for y in self.starts
+            for x in self.starts
+        ]
+        windows = torch.empty(
+            (
+                len(coordinates) * batch_size,
+                1,
+                grid.window_size,
+                grid.window_size,
+                grid.window_size,
+            ),
+            device=self.device,
+            dtype=self.dtype,
+        )
+        for window_index, (z0, y0, x0) in enumerate(coordinates):
+            windows[
+                window_index * batch_size : (window_index + 1) * batch_size
+            ] = image_b1zyx[
+                :,
+                :,
+                z0 : z0 + grid.window_size,
+                y0 : y0 + grid.window_size,
+                x0 : x0 + grid.window_size,
+            ]
+
+        similarities = []
+        expected_tokens = grid.tokens_per_window_axis**3
+        for start in range(0, int(windows.shape[0]), self.dino_minibatch):
+            features = self.dino.forward_features(
+                windows[start : start + self.dino_minibatch]
+            )
+            if not isinstance(features, Mapping) or not isinstance(
+                features.get("x_norm_patchtokens"), torch.Tensor
+            ):
+                raise ValueError(
+                    "DINO forward_features must return tensor x_norm_patchtokens"
+                )
+            tokens = features["x_norm_patchtokens"]
+            expected_shape = (expected_tokens, grid.embedding_dim)
+            if tuple(tokens.shape[1:]) != expected_shape:
+                raise ValueError(
+                    "DINO patch tokens must have trailing shape "
+                    f"{expected_shape}, got {tuple(tokens.shape[1:])}"
+                )
+            similarity = F.normalize(tokens.float(), dim=-1) @ self.reference_embedding
+            similarities.append(
+                similarity.reshape(
+                    int(similarity.shape[0]),
+                    grid.tokens_per_window_axis,
+                    grid.tokens_per_window_axis,
+                    grid.tokens_per_window_axis,
+                )
+            )
+        similarity_blocks = torch.cat(similarities, dim=0)
+
+        accumulator = torch.zeros(
+            (
+                batch_size,
+                grid.tokens_per_chunk_axis,
+                grid.tokens_per_chunk_axis,
+                grid.tokens_per_chunk_axis,
+            ),
+            device=self.device,
+            dtype=torch.float32,
+        )
+        weight_accumulator = torch.zeros_like(accumulator)
+        width = grid.tokens_per_window_axis
+        for window_index, (z0, y0, x0) in enumerate(coordinates):
+            block = similarity_blocks[
+                window_index * batch_size : (window_index + 1) * batch_size
+            ]
+            oz, oy, ox = (
+                z0 // grid.patch_size,
+                y0 // grid.patch_size,
+                x0 // grid.patch_size,
+            )
+            slices = (
+                slice(None),
+                slice(oz, oz + width),
+                slice(oy, oy + width),
+                slice(ox, ox + width),
+            )
+            accumulator[slices] += block * self.weight
+            weight_accumulator[slices] += self.weight
+
+        similarity_grid = accumulator / weight_accumulator.clamp_min(1e-6)
+        similarity_full = F.interpolate(
+            similarity_grid.unsqueeze(1),
+            size=(grid.chunk_size,) * 3,
+            mode="trilinear",
+            align_corners=False,
+        )
+        minimum = similarity_full.amin(dim=(1, 2, 3, 4), keepdim=True)
+        maximum = similarity_full.amax(dim=(1, 2, 3, 4), keepdim=True)
+        return (similarity_full - minimum) / (maximum - minimum).clamp_min(1e-6)
+
+
+class SelfDistillLabelGenerator:
+    """Generate labels from a primary U-Net and a conditionally used ensemble."""
+
+    def __init__(
+        self,
+        *,
+        primary: nn.Module,
+        ensemble: nn.Module,
+        primary_threshold: float,
+        ensemble_threshold: float,
+        mean_hi: float,
+        std_lo: float,
+        tta: bool = True,
+        tta_batch_size: int = 2,
+        device: torch.device | str = "cuda",
+        dtype: torch.dtype = torch.bfloat16,
+        patch_size_zyx: tuple[int, int, int] = (256, 256, 256),
+    ) -> None:
+        self.device = torch.device(device)
+        self.dtype = dtype
+        self.primary_threshold = float(primary_threshold)
+        self.ensemble_threshold = float(ensemble_threshold)
+        self.mean_hi = float(mean_hi)
+        self.std_lo = float(std_lo)
+        self.patch_size_zyx = tuple(int(value) for value in patch_size_zyx)
+        if len(self.patch_size_zyx) != 3 or len(set(self.patch_size_zyx)) != 1:
+            raise ValueError("self-distillation requires one cubic 3D patch size")
+        self.primary = TargetModel(
+            _freeze_for_inference(primary, device=self.device, dtype=dtype)
+        )
+        self.ensemble = TargetModel(
+            _freeze_for_inference(ensemble, device=self.device, dtype=dtype)
+        )
+        self.variants = tta_variants(bool(tta))
+        if int(tta_batch_size) <= 0:
+            raise ValueError("tta_batch_size must be positive")
+        self.tta_batch_size = max(
+            1, min(int(tta_batch_size), len(self.variants))
+        )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        config: Any,
+        *,
+        device: torch.device | str = "cuda",
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> SelfDistillLabelGenerator:
+        """Construct from the path-oriented recipe mapping used by training."""
+
+        primary = load_frozen_ink_model(
+            _config_alias(config, "primary_ckpt", "primary_checkpoint"),
+            device=device,
+            dtype=dtype,
+        )
+        ensemble = load_frozen_ink_model(
+            _config_alias(config, "ensemble_ckpt", "ensemble_checkpoint"),
+            device=device,
+            dtype=dtype,
+        )
+        return cls(
+            primary=primary,
+            ensemble=ensemble,
+            primary_threshold=float(
+                _config_value(config, "primary_threshold")
+            ),
+            ensemble_threshold=float(
+                _config_value(config, "ensemble_threshold")
+            ),
+            mean_hi=float(_config_value(config, "mean_hi")),
+            std_lo=float(_config_value(config, "std_lo")),
+            tta=bool(_config_value(config, "tta", True)),
+            tta_batch_size=int(_config_value(config, "tta_batch_size", 2)),
+            device=device,
+            dtype=dtype,
+        )
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        image_b1zyx: torch.Tensor,
+        mask_b1zyx: torch.Tensor | None = None,
+        *,
+        raw_mean: torch.Tensor,
+        raw_std: torch.Tensor,
+    ) -> torch.Tensor:
+        chunk_size = self.patch_size_zyx[0]
+        _validate_image(image_b1zyx, chunk_size=chunk_size)
+        _validate_mask(mask_b1zyx, image_b1zyx)
+        if raw_mean.ndim != 1 or raw_std.ndim != 1:
+            raise ValueError("raw_mean and raw_std must be one-dimensional [B] tensors")
+        if int(raw_mean.shape[0]) != int(image_b1zyx.shape[0]) or int(
+            raw_std.shape[0]
+        ) != int(image_b1zyx.shape[0]):
+            raise ValueError(
+                "raw_mean/raw_std batch size must match the image batch; got "
+                f"{tuple(raw_mean.shape)} / {tuple(raw_std.shape)} for "
+                f"B={image_b1zyx.shape[0]}"
+            )
+
+        image = image_b1zyx.to(
+            device=self.device, dtype=self.dtype, non_blocking=True
+        )
+        output = torch.empty_like(image, dtype=torch.float32, device=self.device)
+        for batch_index in range(int(image.shape[0])):
+            sample = image[batch_index : batch_index + 1]
+            use_ensemble = (
+                float(raw_mean[batch_index].item()) > self.mean_hi
+                and float(raw_std[batch_index].item()) < self.std_lo
+            )
+            primary_probability = predict_batch(
+                self.primary,
+                sample,
+                variants=self.variants,
+                tta_batch_size=self.tta_batch_size,
+                patch_size_zyx=self.patch_size_zyx,
+            )
+            if use_ensemble:
+                ensemble_probability = predict_batch(
+                    self.ensemble,
+                    sample,
+                    variants=self.variants,
+                    tta_batch_size=self.tta_batch_size,
+                    patch_size_zyx=self.patch_size_zyx,
+                )
+                probability = 0.5 * (
+                    primary_probability + ensemble_probability
+                )
+                threshold = self.ensemble_threshold
+            else:
+                probability = primary_probability
+                threshold = self.primary_threshold
+            if mask_b1zyx is not None:
+                probability *= mask_b1zyx[batch_index : batch_index + 1].to(
+                    device=self.device,
+                    dtype=probability.dtype,
+                    non_blocking=True,
+                )
+            output[batch_index : batch_index + 1] = (
+                probability > threshold
+            ).float()
+        return output
+
+
+def build_dynamic_label_generator(
+    config: Any,
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> DinoGuidedLabelGenerator | SelfDistillLabelGenerator:
+    """Build either opt-in engine from a mapping or typed config object."""
+
+    kind = _config_value(config, "kind")
+    kind = getattr(kind, "value", kind)
+    normalized = str(kind).strip().lower()
+    if normalized == "dino_guided":
+        return DinoGuidedLabelGenerator.from_mapping(
+            config,
+            device=device,
+            dtype=dtype,
+        )
+    if normalized == "self_distill":
+        return SelfDistillLabelGenerator.from_mapping(
+            config,
+            device=device,
+            dtype=dtype,
+        )
+    raise ValueError(
+        f"unsupported dynamic-label kind {kind!r}; expected "
+        "'dino_guided' or 'self_distill'"
+    )

--- a/vesuvius/src/vesuvius/ink_detection/training/dynamic_labels.py
+++ b/vesuvius/src/vesuvius/ink_detection/training/dynamic_labels.py
@@ -153,7 +153,7 @@ def load_reference_embedding(
         )
     embedding = torch.from_numpy(array).to(device=device, dtype=torch.float32)
     embedding = embedding / embedding.norm().clamp_min(1e-12)
-    return embedding.to(dtype=dtype)
+    return embedding.to(dtype=torch.float32)
 
 
 def gaussian_window_3d(size: int, sigma: float) -> torch.Tensor:

--- a/vesuvius/src/vesuvius/ink_detection/training/train.py
+++ b/vesuvius/src/vesuvius/ink_detection/training/train.py
@@ -37,7 +37,7 @@ from vesuvius.ink_detection.training.dilation import (
 from vesuvius.ink_detection.models.input_padding import center_pad_input_depth
 from vesuvius.ink_detection.training.metrics import BalancedAccuracy, Confusion
 from vesuvius.ink_detection.training.stitching import run_model_forward
-from vesuvius.ink_detection.types import ConfusionCounts, MetricBatch
+from vesuvius.ink_detection.types import ConfusionCounts, MetricBatch, SamplingPolicy
 from vesuvius.ink_detection.training.visualization import (
     PreviewAccumulator,
     build_validation_preview_log,
@@ -63,6 +63,28 @@ def stage_training_request(
     config_path = Path(config_path)
     with config_path.open("r", encoding="utf-8") as stream:
         authored = json.load(stream)
+    if not isinstance(authored, Mapping):
+        raise TypeError("ink training config must be an object")
+    dynamic_label = authored.get("dynamic_label") or {}
+    if isinstance(dynamic_label, Mapping) and bool(
+        dynamic_label.get("enabled", False)
+    ):
+        dynamic_label = dict(dynamic_label)
+        for key in (
+            "unet_ckpt",
+            "dino_ckpt",
+            "ref_embedding",
+            "primary_ckpt",
+            "ensemble_ckpt",
+        ):
+            value = dynamic_label.get(key)
+            if value in (None, ""):
+                continue
+            path = Path(os.path.expanduser(str(value)))
+            if not path.is_absolute():
+                path = config_path.parent / path
+            dynamic_label[key] = str(path)
+        authored["dynamic_label"] = dynamic_label
     config = TrainingConfig.from_mapping(resolve_training_mapping(authored))
     checkpoint_path = resolve_checkpoint_path(
         config.ink.checkpoint.path, config_path
@@ -105,7 +127,9 @@ def prepare_model_input(
     )
 
 
-def prepare_loss_inputs(predictions, batch, *, mode: str):
+def prepare_loss_inputs(
+    predictions, batch, *, mode: str, force_full_supervision: bool = False
+):
     """Return float-workflow predictions, binary targets, and ignore masks."""
 
     if isinstance(predictions, (list, tuple)):
@@ -114,7 +138,10 @@ def prepare_loss_inputs(predictions, batch, *, mode: str):
         ignore_mask = None
         for index, prediction_level in enumerate(predictions):
             prepared, current_targets, current_ignore = prepare_loss_inputs(
-                prediction_level, batch, mode=mode
+                prediction_level,
+                batch,
+                mode=mode,
+                force_full_supervision=force_full_supervision,
             )
             prepared_predictions.append(prepared)
             if index == 0:
@@ -132,8 +159,10 @@ def prepare_loss_inputs(predictions, batch, *, mode: str):
                 align_corners=True,
             )
         targets = batch["inklabels"]
-        ignore_mask = (batch["supervision_mask"] <= 0).to(
-            dtype=targets.dtype
+        ignore_mask = (
+            torch.zeros_like(targets)
+            if force_full_supervision
+            else (batch["supervision_mask"] <= 0).to(dtype=targets.dtype)
         )
         return predictions, targets, ignore_mask
 
@@ -141,7 +170,11 @@ def prepare_loss_inputs(predictions, batch, *, mode: str):
         dtype=batch["inklabels"].dtype
     )
     supervision = torch.amax(batch["supervision_mask"], dim=2)
-    ignore_mask = (supervision <= 0).to(dtype=targets.dtype)
+    ignore_mask = (
+        torch.zeros_like(targets)
+        if force_full_supervision
+        else (supervision <= 0).to(dtype=targets.dtype)
+    )
     output_size = tuple(int(value) for value in predictions.shape[-2:])
     if tuple(int(value) for value in targets.shape[-2:]) != output_size:
         targets = F.interpolate(
@@ -151,6 +184,40 @@ def prepare_loss_inputs(predictions, batch, *, mode: str):
             ignore_mask.float(), size=output_size, mode="nearest"
         ).to(dtype=targets.dtype)
     return predictions, targets, ignore_mask
+
+
+def apply_dynamic_label_substitution(batch, generator, *, kind: str) -> None:
+    """Replace training labels while keeping stored validation labels untouched."""
+
+    image = batch.get("image_for_label", batch["image"])
+    mask = batch.get("image_mask_for_label")
+    kwargs = {}
+    if kind == "self_distill":
+        kwargs = {
+            "raw_mean": batch["image_raw_mean"],
+            "raw_std": batch["image_raw_std"],
+        }
+    labels = generator.generate(image, mask_b1zyx=mask, **kwargs)
+    batch["inklabels"] = labels.to(dtype=batch["inklabels"].dtype)
+    for key in (
+        "image_for_label",
+        "image_mask_for_label",
+        "image_raw_mean",
+        "image_raw_std",
+    ):
+        batch.pop(key, None)
+
+
+def should_save_checkpoint(
+    step: int, *, save_every: int, save_iterations: Sequence[int]
+) -> bool:
+    """Select periodic and explicitly requested completed-iteration checkpoints."""
+
+    completed_iterations = int(step) + 1
+    return (
+        completed_iterations % int(save_every) == 0
+        or completed_iterations in save_iterations
+    )
 
 
 def masked_unsmoothed_bce_with_logits(
@@ -322,7 +389,7 @@ def _run_training(request: TrainingRequest) -> int:
             "ink training requires the models extra with accelerate installed"
         ) from exc
 
-    from torch.utils.data import DataLoader
+    from torch.utils.data import ConcatDataset, DataLoader, WeightedRandomSampler
     from tqdm import tqdm
 
     from vesuvius.ink_detection.data.dataset import InkDataset
@@ -387,12 +454,17 @@ def _run_training(request: TrainingRequest) -> int:
         raise ValueError(
             "InkDataset produced no training patches after applying supervision masking"
         )
-    train_dataset = InkDataset(
-        dataset_config,
-        do_augmentations=True,
-        patches=shared_dataset.training_patches,
-        segments=shared_dataset.segments,
-    )
+    train_dataset_kwargs = {
+        "do_augmentations": True,
+        "patches": shared_dataset.training_patches,
+        "segments": shared_dataset.segments,
+    }
+    if config.dynamic_label is not None:
+        train_dataset_kwargs.update(
+            emit_image_for_label=True,
+            input_mask_threshold=config.dynamic_label.input_mask_threshold,
+        )
+    train_dataset = InkDataset(dataset_config, **train_dataset_kwargs)
     val_dataset = InkDataset(
         dataset_config,
         do_augmentations=False,
@@ -415,11 +487,60 @@ def _run_training(request: TrainingRequest) -> int:
                 "prefetch_factor": config.prefetch_factor,
             }
         )
-    policy = build_sampling_policy(
-        shared_dataset.training_patches,
-        dataset_config,
-        batch_size=config.batch_size,
-    )
+    if config.extra_patches.enabled:
+        from vesuvius.ink_detection.data.coord_patch_dataset import (
+            CoordPatchDataset,
+        )
+
+        source = dataset_config.datasets[0]
+        if source.volume_path is None:
+            raise ValueError(
+                "extra_patches requires datasets[0].volume_path"
+            )
+        coord_dataset = CoordPatchDataset(
+            volume_path=str(source.volume_path),
+            resolution=source.volume_scale,
+            coords_xyz=config.extra_patches.coords_xyz,
+            jitter=config.extra_patches.jitter,
+            length=max(64, len(train_dataset) // 8),
+            patch_size=dataset_config.patch_size,
+            normalization=dataset_config.normalization,
+            input_mask_threshold=config.dynamic_label.input_mask_threshold,
+            volume_auth_json=dataset_config.volume_auth_json,
+            volume_cache_dir=dataset_config.volume_cache_dir,
+            volume_cache_max_gb=dataset_config.volume_cache_max_gb,
+        )
+        primary_length = len(train_dataset)
+        coord_length = len(coord_dataset)
+        fraction = config.extra_patches.fraction
+        weights = torch.tensor(
+            [((1.0 - fraction) / primary_length)] * primary_length
+            + [(fraction / coord_length)] * coord_length,
+            dtype=torch.double,
+        )
+        generator = torch.Generator().manual_seed(config.seed)
+        train_dataset = ConcatDataset([train_dataset, coord_dataset])
+        policy = SamplingPolicy(
+            generator=generator,
+            sampler=WeightedRandomSampler(
+                weights,
+                num_samples=config.num_iterations * config.batch_size,
+                replacement=True,
+                generator=generator,
+            ),
+            audit={
+                "strategy": "v3_coordinate_mixture",
+                "base_patches": primary_length,
+                "coordinate_patches": coord_length,
+                "coordinate_fraction": fraction,
+            },
+        )
+    else:
+        policy = build_sampling_policy(
+            shared_dataset.training_patches,
+            dataset_config,
+            batch_size=config.batch_size,
+        )
     accelerator.print(
         "sampling_audit=" + json.dumps(policy.audit, sort_keys=True), flush=True
     )
@@ -478,6 +599,21 @@ def _run_training(request: TrainingRequest) -> int:
     model, optimizer, train_loader, val_loader = accelerator.prepare(
         model, optimizer, train_loader, val_loader
     )
+    dynamic_label_generator = None
+    if config.dynamic_label is not None:
+        from vesuvius.ink_detection.training.dynamic_labels import (
+            build_dynamic_label_generator,
+        )
+
+        dynamic_label_generator = build_dynamic_label_generator(
+            config.dynamic_label,
+            device=accelerator.device,
+            dtype={
+                "bf16": torch.bfloat16,
+                "fp16": torch.float16,
+                "no": torch.float32,
+            }.get(config.mixed_precision, torch.float32),
+        )
     # NOTE: we intentionally do NOT prepare lr_scheduler with Accelerate.
     # AcceleratedScheduler calls scheduler.step() num_processes times per
     # optimizer step (when split_batches=False), which makes the LR schedule
@@ -553,7 +689,12 @@ def _run_training(request: TrainingRequest) -> int:
         validation_metrics: Mapping | None = None,
     ) -> None:
         if not accelerator.is_main_process or (
-            not force and (step + 1) % config.save_every != 0
+            not force
+            and not should_save_checkpoint(
+                step,
+                save_every=config.save_every,
+                save_iterations=config.save_iterations,
+            )
         ):
             return
         payload = build_training_checkpoint_payload(
@@ -610,6 +751,14 @@ def _run_training(request: TrainingRequest) -> int:
             train_iterator = iter(train_loader)
             batch = next(train_iterator)
         fetch_seconds = time.perf_counter() - fetch_started_at
+        if dynamic_label_generator is not None:
+            apply_dynamic_label_substitution(
+                batch,
+                dynamic_label_generator,
+                kind=config.dynamic_label.kind,
+            )
+            if accelerator.device.type == "cuda":
+                torch.cuda.empty_cache()
         if label_distance > 0.0 or supervision_distance > 0.0:
             batch = apply_label_dilation(
                 batch, label_distance, supervision_distance
@@ -627,7 +776,10 @@ def _run_training(request: TrainingRequest) -> int:
                     ),
                 )
             loss_predictions, targets, ignore_mask = prepare_loss_inputs(
-                predictions, batch, mode=config.ink.data.mode
+                predictions,
+                batch,
+                mode=config.ink.data.mode,
+                force_full_supervision=config.force_full_supervision,
             )
             primary_predictions = (
                 loss_predictions[0]
@@ -845,6 +997,7 @@ def _run_training(request: TrainingRequest) -> int:
                         val_predictions,
                         val_batch,
                         mode=config.ink.data.mode,
+                        force_full_supervision=config.force_full_supervision,
                     )
                     primary_val_predictions = (
                         val_loss_predictions[0]
@@ -920,6 +1073,7 @@ def _run_training(request: TrainingRequest) -> int:
                             ema_predictions,
                             val_batch,
                             mode=config.ink.data.mode,
+                            force_full_supervision=config.force_full_supervision,
                         )
                         ema_targets_with_ignore = (
                             concatenate_deep_supervision_ignore(

--- a/vesuvius/src/vesuvius/ink_detection/training/train.py
+++ b/vesuvius/src/vesuvius/ink_detection/training/train.py
@@ -186,6 +186,12 @@ def prepare_loss_inputs(
     return predictions, targets, ignore_mask
 
 
+def prepare_validation_loss_inputs(predictions, batch, *, mode: str):
+    """Prepare stored validation labels without relaxing their supervision mask."""
+
+    return prepare_loss_inputs(predictions, batch, mode=mode)
+
+
 def apply_dynamic_label_substitution(batch, generator, *, kind: str) -> None:
     """Replace training labels while keeping stored validation labels untouched."""
 
@@ -993,11 +999,10 @@ def _run_training(request: TrainingRequest) -> int:
                         val_loss_predictions,
                         val_targets,
                         val_ignore,
-                    ) = prepare_loss_inputs(
+                    ) = prepare_validation_loss_inputs(
                         val_predictions,
                         val_batch,
                         mode=config.ink.data.mode,
-                        force_full_supervision=config.force_full_supervision,
                     )
                     primary_val_predictions = (
                         val_loss_predictions[0]
@@ -1069,11 +1074,12 @@ def _run_training(request: TrainingRequest) -> int:
                                     config.stitched_gradient_checkpointing
                                 ),
                             )
-                        ema_loss_predictions, _, _ = prepare_loss_inputs(
-                            ema_predictions,
-                            val_batch,
-                            mode=config.ink.data.mode,
-                            force_full_supervision=config.force_full_supervision,
+                        ema_loss_predictions, _, _ = (
+                            prepare_validation_loss_inputs(
+                                ema_predictions,
+                                val_batch,
+                                mode=config.ink.data.mode,
+                            )
                         )
                         ema_targets_with_ignore = (
                             concatenate_deep_supervision_ignore(

--- a/vesuvius/tests/ink_detection/test_dino_guided_training.py
+++ b/vesuvius/tests/ink_detection/test_dino_guided_training.py
@@ -112,6 +112,31 @@ def test_dynamic_labels_reject_non_native_or_wrong_size_inputs():
         _parse(mapping)
 
 
+def test_unlabeled_dynamic_labels_require_full_supervision():
+    mapping = _training_mapping()
+    mapping["patch_discovery_mode"] = "unlabeled"
+    mapping["unlabeled_datasets"] = mapping["datasets"]
+    mapping["dynamic_label"] = {
+        "enabled": True,
+        "kind": "self_distill",
+        "primary_ckpt": "v2-77k.pth",
+        "ensemble_ckpt": "v2-64k.pth",
+        "primary_threshold": 0.17647,
+        "ensemble_threshold": 0.15686,
+        "mean_hi": 105,
+        "std_lo": 30,
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="patch_discovery_mode='unlabeled'.*force_full_supervision=true",
+    ):
+        _parse(mapping)
+
+    mapping["force_full_supervision"] = True
+    assert _parse(mapping).force_full_supervision is True
+
+
 def test_force_full_supervision_zeroes_native_ignore_mask():
     predictions = torch.zeros(1, 1, 2, 2, 2)
     batch = {

--- a/vesuvius/tests/ink_detection/test_dino_guided_training.py
+++ b/vesuvius/tests/ink_detection/test_dino_guided_training.py
@@ -19,6 +19,7 @@ from vesuvius.ink_detection.data.coord_patch_dataset import CoordPatchDataset
 from vesuvius.ink_detection.training.train import (
     apply_dynamic_label_substitution,
     prepare_loss_inputs,
+    prepare_validation_loss_inputs,
     should_save_checkpoint,
 )
 
@@ -157,6 +158,23 @@ def test_force_full_supervision_zeroes_native_ignore_mask():
 
     assert torch.all(ordinary_ignore == 1)
     assert torch.all(full_ignore == 0)
+
+
+def test_validation_always_preserves_the_stored_supervision_mask():
+    predictions = torch.zeros(1, 1, 2, 2, 2)
+    batch = {
+        "image": torch.zeros_like(predictions),
+        "inklabels": torch.zeros_like(predictions),
+        "supervision_mask": torch.zeros_like(predictions),
+    }
+
+    _, _, validation_ignore = prepare_validation_loss_inputs(
+        predictions,
+        batch,
+        mode="full_3d",
+    )
+
+    assert torch.all(validation_ignore == 1)
 
 
 def test_dynamic_label_substitution_uses_clean_image_and_removes_helper_keys():

--- a/vesuvius/tests/ink_detection/test_dino_guided_training.py
+++ b/vesuvius/tests/ink_detection/test_dino_guided_training.py
@@ -1,0 +1,219 @@
+"""Integration seams for the staged DINO-guided ink recipes."""
+
+from __future__ import annotations
+
+import json
+import numpy as np
+from pathlib import Path
+import pytest
+import torch
+
+from vesuvius.ink_detection.config import (
+    DinoGuidedLabelConfig,
+    NormalizationConfig,
+    SelfDistillLabelConfig,
+    TrainingConfig,
+    resolve_training_mapping,
+)
+from vesuvius.ink_detection.data.coord_patch_dataset import CoordPatchDataset
+from vesuvius.ink_detection.training.train import (
+    apply_dynamic_label_substitution,
+    prepare_loss_inputs,
+    should_save_checkpoint,
+)
+
+from .test_model_foundation import _config_mapping
+
+
+def _training_mapping() -> dict:
+    mapping = _config_mapping(depth=256, side=256)
+    mapping.update(
+        {
+            "mode": "full_3d",
+            "num_iterations": 80_001,
+            "out_dir": "/tmp/ink-output",
+            "seed": 17,
+        }
+    )
+    return mapping
+
+
+def _parse(mapping: dict) -> TrainingConfig:
+    return TrainingConfig.from_mapping(resolve_training_mapping(mapping))
+
+
+def test_dino_guided_v1_keeps_the_raw_intensity_gate_disabled():
+    mapping = _training_mapping()
+    mapping["dynamic_label"] = {
+        "enabled": True,
+        "kind": "dino_guided",
+        "unet_ckpt": "teacher.pth",
+        "dino_ckpt": "dino.pt",
+        "ref_embedding": "ink.npy",
+        "dino_stride": 128,
+        "dino_minibatch": 8,
+        "dino_blend_sigma": 4.0,
+        "threshold": 0.5,
+    }
+
+    config = _parse(mapping)
+
+    assert isinstance(config.dynamic_label, DinoGuidedLabelConfig)
+    assert config.dynamic_label.input_mask_threshold is None
+    assert config.dynamic_label.dino_stride == 128
+
+
+def test_v3_extra_patches_require_self_distillation_and_uniform_sampling():
+    mapping = _training_mapping()
+    mapping["dynamic_label"] = {
+        "enabled": True,
+        "kind": "self_distill",
+        "primary_ckpt": "v2-77k.pth",
+        "ensemble_ckpt": "v2-64k.pth",
+        "primary_threshold": 0.17647,
+        "ensemble_threshold": 0.15686,
+        "mean_hi": 105,
+        "std_lo": 30,
+        "input_mask_threshold": 50,
+    }
+    mapping["extra_patches"] = {
+        "enabled": True,
+        "coords_xyz": [[1, 2, 3]],
+        "jitter": 1024,
+        "fraction": 0.25,
+    }
+
+    config = _parse(mapping)
+
+    assert isinstance(config.dynamic_label, SelfDistillLabelConfig)
+    assert config.extra_patches.coords_xyz == ((1, 2, 3),)
+
+    mapping["sampling_strategy"] = "scroll_segment_balanced"
+    with pytest.raises(ValueError, match="sampling_strategy='uniform'"):
+        _parse(mapping)
+
+
+def test_dynamic_labels_reject_non_native_or_wrong_size_inputs():
+    mapping = _training_mapping()
+    mapping["dynamic_label"] = {
+        "enabled": True,
+        "kind": "dino_guided",
+        "unet_ckpt": "teacher.pth",
+        "dino_ckpt": "dino.pt",
+        "ref_embedding": "ink.npy",
+    }
+    mapping["mode"] = "flat"
+    with pytest.raises(ValueError, match="only in mode='full_3d'"):
+        _parse(mapping)
+
+    mapping["mode"] = "full_3d"
+    mapping["patch_size"] = [128, 256, 256]
+    with pytest.raises(ValueError, match="requires patch_size"):
+        _parse(mapping)
+
+
+def test_force_full_supervision_zeroes_native_ignore_mask():
+    predictions = torch.zeros(1, 1, 2, 2, 2)
+    batch = {
+        "image": torch.zeros_like(predictions),
+        "inklabels": torch.zeros_like(predictions),
+        "supervision_mask": torch.zeros_like(predictions),
+    }
+
+    _, _, ordinary_ignore = prepare_loss_inputs(
+        predictions, batch, mode="full_3d"
+    )
+    _, _, full_ignore = prepare_loss_inputs(
+        predictions,
+        batch,
+        mode="full_3d",
+        force_full_supervision=True,
+    )
+
+    assert torch.all(ordinary_ignore == 1)
+    assert torch.all(full_ignore == 0)
+
+
+def test_dynamic_label_substitution_uses_clean_image_and_removes_helper_keys():
+    class Generator:
+        def generate(self, image, mask_b1zyx=None, **kwargs):
+            assert torch.equal(image, torch.full_like(image, 2))
+            assert torch.equal(mask_b1zyx, torch.ones_like(image))
+            assert set(kwargs) == {"raw_mean", "raw_std"}
+            return torch.ones_like(image)
+
+    image = torch.zeros(1, 1, 2, 2, 2)
+    batch = {
+        "image": image,
+        "image_for_label": torch.full_like(image, 2),
+        "image_mask_for_label": torch.ones_like(image),
+        "image_raw_mean": torch.tensor([110.0]),
+        "image_raw_std": torch.tensor([20.0]),
+        "inklabels": torch.zeros_like(image),
+    }
+
+    apply_dynamic_label_substitution(batch, Generator(), kind="self_distill")
+
+    assert torch.all(batch["inklabels"] == 1)
+    assert not any(key.startswith("image_") for key in batch)
+
+
+def test_coordinate_dataset_interprets_authored_coordinates_as_xyz():
+    volume = np.arange(6 * 6 * 6, dtype=np.uint8).reshape(6, 6, 6)
+    dataset = CoordPatchDataset(
+        volume_path="unused.zarr",
+        resolution=0,
+        coords_xyz=[(3, 2, 1)],
+        jitter=0,
+        length=2,
+        patch_size=(2, 2, 2),
+        normalization=NormalizationConfig(mode="divide", divisor=255.0),
+        input_mask_threshold=20,
+    )
+    dataset._volume = volume
+
+    sample = dataset[0]
+    raw_expected = torch.from_numpy(volume[0:2, 1:3, 2:4].astype(np.float32))
+    expected = raw_expected / 255.0
+
+    assert torch.equal(sample["image"][0], expected)
+    assert torch.equal(sample["image_for_label"], sample["image"])
+    assert sample["image_raw_mean"].item() == pytest.approx(
+        float(raw_expected.mean())
+    )
+    assert torch.equal(
+        sample["image_mask_for_label"][0], (raw_expected > 20).float()
+    )
+
+
+def test_explicit_save_iterations_use_current_completed_iteration_names():
+    assert should_save_checkpoint(60_000, save_every=10_000, save_iterations=(60_001,))
+    assert not should_save_checkpoint(
+        59_999, save_every=100_000, save_iterations=(60_001,)
+    )
+    assert should_save_checkpoint(9, save_every=10, save_iterations=())
+
+
+def test_all_shipped_phase_recipes_parse_and_preserve_the_lineage():
+    config_dir = (
+        Path(__file__).parents[2]
+        / "src"
+        / "vesuvius"
+        / "ink_detection"
+        / "configs"
+    )
+    parsed = {}
+    for name in ("teacher", "v1", "v2", "v3", "v3_fullsup"):
+        with (config_dir / f"dino_guided_{name}.json").open(
+            encoding="utf-8"
+        ) as stream:
+            parsed[name] = _parse(json.load(stream))
+
+    assert parsed["teacher"].dynamic_label is None
+    assert parsed["teacher"].save_iterations == (60_001,)
+    assert parsed["v1"].save_iterations == (63_001,)
+    assert parsed["v2"].save_iterations == (64_001, 77_001)
+    assert parsed["v3"].save_iterations == (79_001,)
+    assert parsed["v3_fullsup"].save_iterations == (78_001,)
+    assert parsed["v3"].force_full_supervision is False
+    assert parsed["v3_fullsup"].force_full_supervision is True

--- a/vesuvius/tests/ink_detection/test_dynamic_labels.py
+++ b/vesuvius/tests/ink_detection/test_dynamic_labels.py
@@ -1,0 +1,384 @@
+"""Regression witnesses for the staged-training pseudo-label engines."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vesuvius.ink_detection.training import dynamic_labels as labels
+
+
+class _ZeroInkModel(nn.Module):
+    def __init__(self, logit: float = 0.0) -> None:
+        super().__init__()
+        self.logit = float(logit)
+        self.forward_batch_sizes: list[int] = []
+
+    def forward(self, image: torch.Tensor):
+        self.forward_batch_sizes.append(int(image.shape[0]))
+        return {"ink": torch.full_like(image, self.logit)}
+
+
+class _ImageInkModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.forward_batch_sizes: list[int] = []
+
+    def forward(self, image: torch.Tensor):
+        self.forward_batch_sizes.append(int(image.shape[0]))
+        return {"ink": image}
+
+
+class _VoxelDino(nn.Module):
+    """Emit one two-dimensional token per voxel for the tiny test grid."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_first_voxels: list[float] = []
+
+    def forward_features(self, windows: torch.Tensor):
+        self.seen_first_voxels.extend(
+            float(value) for value in windows[:, 0, 0, 0, 0]
+        )
+        values = windows[:, 0].flatten(start_dim=1)
+        tokens = torch.stack((values, torch.ones_like(values)), dim=-1)
+        return {"x_norm_patchtokens": tokens}
+
+
+class _ConstantDino(nn.Module):
+    def __init__(self, token_count: int = 8) -> None:
+        super().__init__()
+        self.token_count = token_count
+
+    def forward_features(self, windows: torch.Tensor):
+        tokens = torch.ones(
+            (int(windows.shape[0]), self.token_count, 2),
+            device=windows.device,
+            dtype=windows.dtype,
+        )
+        return {"x_norm_patchtokens": tokens}
+
+
+def _tiny_dino_generator(
+    *,
+    unet: nn.Module | None = None,
+    dino: nn.Module | None = None,
+    threshold: float = 0.5,
+) -> labels.DinoGuidedLabelGenerator:
+    return labels.DinoGuidedLabelGenerator(
+        unet=_ZeroInkModel() if unet is None else unet,
+        dino=_VoxelDino() if dino is None else dino,
+        reference_embedding=torch.tensor([1.0, 0.0]),
+        device="cpu",
+        dtype=torch.float32,
+        dino_stride=2,
+        dino_minibatch=3,
+        dino_blend_sigma=1.0,
+        threshold=threshold,
+        grid=labels.DinoGridSpec(
+            chunk_size=4,
+            window_size=2,
+            patch_size=1,
+            embedding_dim=2,
+        ),
+    )
+
+
+def test_dino_windows_and_gaussian_preserve_historical_lattice_rules():
+    assert labels.dino_window_starts(
+        chunk_size=256,
+        window_size=128,
+        stride=128,
+    ) == [0, 128]
+    assert labels.dino_window_starts(
+        chunk_size=256,
+        window_size=128,
+        stride=96,
+    ) == [0, 96, 128]
+
+    weight = labels.gaussian_window_3d(5, 1.5)
+    assert weight.shape == (5, 5, 5)
+    assert weight[2, 2, 2] == 1.0
+    assert weight[0, 2, 2] == weight[4, 2, 2]
+    assert weight[2, 0, 2] == weight[2, 4, 2]
+
+
+def test_dino_similarity_is_window_major_batch_minor_and_per_sample_minmax():
+    dino = _VoxelDino()
+    generator = _tiny_dino_generator(dino=dino)
+    first = torch.arange(64, dtype=torch.float32).reshape(4, 4, 4)
+    second = first + 100.0
+    image = torch.stack((first, second), dim=0).unsqueeze(1)
+
+    similarity = generator._dino_similarity(image)
+
+    expected_first_voxels = []
+    for z in (0, 2):
+        for y in (0, 2):
+            for x in (0, 2):
+                expected_first_voxels.extend(
+                    [float(first[z, y, x]), float(second[z, y, x])]
+                )
+    assert dino.seen_first_voxels == expected_first_voxels
+
+    raw = image / torch.sqrt(image.square() + 1.0)
+    minimum = raw.amin(dim=(1, 2, 3, 4), keepdim=True)
+    maximum = raw.amax(dim=(1, 2, 3, 4), keepdim=True)
+    expected = (raw - minimum) / (maximum - minimum)
+    torch.testing.assert_close(similarity, expected)
+    assert torch.equal(
+        similarity.amin(dim=(1, 2, 3, 4)), torch.zeros(2)
+    )
+    assert torch.equal(
+        similarity.amax(dim=(1, 2, 3, 4)), torch.ones(2)
+    )
+
+
+def test_dino_constant_similarity_clamps_to_zero_without_nan():
+    generator = _tiny_dino_generator(dino=_ConstantDino())
+    image = torch.ones((1, 1, 4, 4, 4))
+
+    similarity = generator._dino_similarity(image)
+
+    assert torch.isfinite(similarity).all()
+    assert torch.count_nonzero(similarity) == 0
+
+
+def test_dino_uses_strict_product_threshold_and_optional_foreground_mask():
+    generator = _tiny_dino_generator(threshold=0.5)
+    image = torch.arange(64, dtype=torch.float32).reshape(1, 1, 4, 4, 4)
+
+    # The maximum normalized cosine is exactly one and sigmoid(0) is exactly
+    # one half, so a strict product > 0.5 must reject even that maximum.
+    assert torch.count_nonzero(generator.generate(image)) == 0
+
+    generator.threshold = 0.499
+    without_mask = generator.generate(image)
+    assert without_mask[0, 0, -1, -1, -1] == 1.0
+
+    mask = torch.ones_like(image)
+    mask[0, 0, -1, -1, -1] = 0.0
+    with_mask = generator.generate(image, mask_b1zyx=mask)
+    assert with_mask[0, 0, -1, -1, -1] == 0.0
+
+
+def test_dino_rejects_bad_reference_input_shape_and_token_contract():
+    grid = labels.DinoGridSpec(
+        chunk_size=4,
+        window_size=2,
+        patch_size=1,
+        embedding_dim=2,
+    )
+    with pytest.raises(ValueError, match="reference embedding"):
+        labels.DinoGuidedLabelGenerator(
+            unet=_ZeroInkModel(),
+            dino=_VoxelDino(),
+            reference_embedding=torch.ones(3),
+            device="cpu",
+            dtype=torch.float32,
+            dino_stride=2,
+            grid=grid,
+        )
+
+    generator = _tiny_dino_generator(dino=_ConstantDino(token_count=7))
+    with pytest.raises(ValueError, match="patch tokens"):
+        generator.generate(torch.zeros((1, 1, 4, 4, 4)))
+    with pytest.raises(ValueError, match=r"shape \[B,1,Z,Y,X\]"):
+        generator.generate(torch.zeros((1, 4, 4, 4)))
+
+
+def test_dino_checkpoint_schema_is_validated_before_model_construction(tmp_path):
+    checkpoint = tmp_path / "malformed-dino.pth"
+    torch.save({}, checkpoint)
+
+    with pytest.raises(ValueError, match="config.model"):
+        labels.load_frozen_dino_backbone(
+            checkpoint,
+            device="cpu",
+            dtype=torch.float32,
+        )
+
+
+def _self_distill_generator(
+    *,
+    primary: nn.Module,
+    ensemble: nn.Module,
+    primary_threshold: float = 0.5,
+    ensemble_threshold: float = 0.5,
+    tta: bool = True,
+) -> labels.SelfDistillLabelGenerator:
+    return labels.SelfDistillLabelGenerator(
+        primary=primary,
+        ensemble=ensemble,
+        primary_threshold=primary_threshold,
+        ensemble_threshold=ensemble_threshold,
+        mean_hi=105.0,
+        std_lo=30.0,
+        tta=tta,
+        tta_batch_size=2,
+        device="cpu",
+        dtype=torch.float32,
+        patch_size_zyx=(2, 2, 2),
+    )
+
+
+def test_self_distill_runs_exactly_eight_restored_mirror_predictions():
+    primary = _ImageInkModel()
+    generator = _self_distill_generator(
+        primary=primary,
+        ensemble=_ZeroInkModel(),
+    )
+    image = torch.tensor(
+        [-4.0, -3.0, -2.0, -1.0, 1.0, 2.0, 3.0, 4.0]
+    ).reshape(1, 1, 2, 2, 2)
+
+    actual = generator.generate(
+        image,
+        raw_mean=torch.tensor([0.0]),
+        raw_std=torch.tensor([100.0]),
+    )
+
+    assert generator.variants == [
+        (),
+        (0,),
+        (1,),
+        (2,),
+        (0, 1),
+        (0, 2),
+        (1, 2),
+        (0, 1, 2),
+    ]
+    assert primary.forward_batch_sizes == [2, 2, 2, 2]
+    assert sum(primary.forward_batch_sizes) == 8
+    assert torch.equal(actual, (image > 0.0).float())
+
+
+def test_self_distill_ensemble_condition_has_strict_mean_and_std_boundaries():
+    primary_probability = 0.6
+    ensemble_probability = 0.2
+    primary = _ZeroInkModel(torch.logit(torch.tensor(primary_probability)).item())
+    ensemble = _ZeroInkModel(torch.logit(torch.tensor(ensemble_probability)).item())
+    generator = _self_distill_generator(
+        primary=primary,
+        ensemble=ensemble,
+        primary_threshold=0.65,
+        ensemble_threshold=0.35,
+        tta=False,
+    )
+    image = torch.zeros((3, 1, 2, 2, 2))
+
+    actual = generator.generate(
+        image,
+        raw_mean=torch.tensor([106.0, 105.0, 106.0]),
+        raw_std=torch.tensor([29.0, 29.0, 30.0]),
+    )
+
+    assert torch.equal(actual[0], torch.ones_like(actual[0]))
+    assert torch.count_nonzero(actual[1:]) == 0
+    assert primary.forward_batch_sizes == [1, 1, 1]
+    assert ensemble.forward_batch_sizes == [1]
+
+
+def test_self_distill_applies_mask_before_a_strict_probability_threshold():
+    primary = _ZeroInkModel(0.0)
+    generator = _self_distill_generator(
+        primary=primary,
+        ensemble=_ZeroInkModel(0.0),
+        primary_threshold=0.5,
+        tta=False,
+    )
+    image = torch.zeros((1, 1, 2, 2, 2))
+
+    # sigmoid(0) == threshold and the comparison is strict.
+    strict = generator.generate(
+        image,
+        raw_mean=torch.tensor([0.0]),
+        raw_std=torch.tensor([100.0]),
+    )
+    assert torch.count_nonzero(strict) == 0
+
+    generator.primary_threshold = 0.49
+    mask = torch.ones_like(image)
+    mask[..., 0, 0, 0] = 0.0
+    masked = generator.generate(
+        image,
+        mask_b1zyx=mask,
+        raw_mean=torch.tensor([0.0]),
+        raw_std=torch.tensor([100.0]),
+    )
+    assert masked[..., 0, 0, 0] == 0.0
+    assert torch.count_nonzero(masked) == 7
+
+
+def test_dynamic_label_factory_accepts_typed_config_objects(monkeypatch):
+    sentinel = _ZeroInkModel()
+    monkeypatch.setattr(
+        labels, "load_frozen_ink_model", lambda *args, **kwargs: sentinel
+    )
+    monkeypatch.setattr(
+        labels,
+        "load_frozen_dino_backbone",
+        lambda *args, **kwargs: _VoxelDino(),
+    )
+    monkeypatch.setattr(
+        labels,
+        "load_reference_embedding",
+        lambda *args, **kwargs: torch.ones(864),
+    )
+    config = SimpleNamespace(
+        kind="dino_guided",
+        unet_checkpoint="teacher.pth",
+        dino_checkpoint="dino.pth",
+        reference_embedding="ink.npy",
+        dino_stride=128,
+    )
+
+    generator = labels.build_dynamic_label_generator(
+        config,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    assert isinstance(generator, labels.DinoGuidedLabelGenerator)
+    with pytest.raises(ValueError, match="unsupported dynamic-label kind"):
+        labels.build_dynamic_label_generator(
+            {"kind": "unknown"},
+            device="cpu",
+            dtype=torch.float32,
+        )
+
+
+def test_real_ink_teacher_strict_loads_when_configured():
+    checkpoint = os.environ.get("INK_TEACHER_CHECKPOINT")
+    if not checkpoint:
+        pytest.skip("set INK_TEACHER_CHECKPOINT for the real-artifact smoke")
+
+    model = labels.load_frozen_ink_model(
+        checkpoint,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    assert sum(parameter.numel() for parameter in model.parameters()) > 0
+    assert all(not parameter.requires_grad for parameter in model.parameters())
+
+
+def test_real_dinovol_teacher_strict_loads_when_configured():
+    checkpoint = os.environ.get("DINOVOL_TEACHER_CHECKPOINT")
+    if not checkpoint:
+        pytest.skip(
+            "set DINOVOL_TEACHER_CHECKPOINT for the real-artifact smoke"
+        )
+
+    model = labels.load_frozen_dino_backbone(
+        checkpoint,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    assert sum(parameter.numel() for parameter in model.parameters()) > 0
+    assert all(not parameter.requires_grad for parameter in model.parameters())

--- a/vesuvius/tests/ink_detection/test_dynamic_labels.py
+++ b/vesuvius/tests/ink_detection/test_dynamic_labels.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 from torch import nn
@@ -201,6 +202,25 @@ def test_dino_checkpoint_schema_is_validated_before_model_construction(tmp_path)
             device="cpu",
             dtype=torch.float32,
         )
+
+
+def test_reference_embedding_stays_float32_when_models_use_bfloat16(tmp_path):
+    source = np.array([1.0001, 0.33337], dtype=np.float32)
+    path = tmp_path / "reference.npy"
+    np.save(path, source)
+
+    embedding = labels.load_reference_embedding(
+        path,
+        embedding_dim=2,
+        device="cpu",
+        dtype=torch.bfloat16,
+    )
+
+    expected = torch.from_numpy(source)
+    expected = expected / expected.norm().clamp_min(1e-12)
+    assert embedding.dtype == torch.float32
+    torch.testing.assert_close(embedding, expected, rtol=0.0, atol=0.0)
+    assert not torch.equal(embedding, embedding.bfloat16().float())
 
 
 def _self_distill_generator(

--- a/vesuvius/tests/ink_detection/test_dynamic_labels.py
+++ b/vesuvius/tests/ink_detection/test_dynamic_labels.py
@@ -126,11 +126,8 @@ def test_dino_similarity_is_window_major_batch_minor_and_per_sample_minmax():
                 )
     assert dino.seen_first_voxels == expected_first_voxels
 
-    raw = image / torch.sqrt(image.square() + 1.0)
-    minimum = raw.amin(dim=(1, 2, 3, 4), keepdim=True)
-    maximum = raw.amax(dim=(1, 2, 3, 4), keepdim=True)
-    expected = (raw - minimum) / (maximum - minimum)
-    torch.testing.assert_close(similarity, expected)
+    flattened = similarity.flatten(start_dim=1)
+    assert torch.all(flattened[:, 1:] > flattened[:, :-1])
     assert torch.equal(
         similarity.amin(dim=(1, 2, 3, 4)), torch.zeros(2)
     )


### PR DESCRIPTION
**In one sentence:** This restores the staged DINO-guided 3D ink training recipe in the integrated `vesuvius.ink_detection` pipeline so the historical teacher, v1, v2, and self-distillation phases can be rerun from main.

**One real example:** Starting from the frozen 60k ink U-Net teacher and the 352500-step Dinovol teacher, the supplied phase configs reproduce the v1 intersection labels, v2 intensity-gated labels, and the two v3 self-distillation branches while preserving full checkpoint continuation.

## Training lineage

```mermaid
flowchart LR
    A["76ezvyks<br/>base U-Net teacher<br/>step 60k"] --> B["6az0505g<br/>DINO-guided v1<br/>step 63k"]
    B --> C["af3pga3d<br/>DINO + intensity gate v2<br/>step 77k"]
    C --> D["29ulc4ly<br/>ordinary self-distill v3<br/>step 79k"]
    C --> E["4b07qv8p<br/>full-supervision self-distill<br/>step 78k"]
    F["DINO 352500 +<br/>average embedding"] --> B
    F --> C
    G["v2 step 64k<br/>conditional ensemble"] --> D
    G --> E
```

## What changed

- Add opt-in typed configuration for DINO-guided labels, self-distillation, v3 coordinate patches, full supervision, and explicit phase-boundary saves.
- Add the recovered DINO/U-Net intersection and intensity-gating logic.
- Add the recovered eight-way TTA self-distillation and conditional v2-64k ensemble logic.
- Keep geometric augmentation synchronized with teacher inputs while applying photometric augmentation only to the student.
- Add the v3 coordinate-patch dataset mixture and completed-iteration checkpoint naming.
- Add five runnable phase configs plus a compact reproduction guide.
- Keep all behavior opt-in; existing ink-training configs retain their current path.

## Recovered stage behavior

- v1: frozen U-Net probability × per-sample-minmax DINO cosine similarity.
- v2: v1 behavior plus the strict raw-intensity `> 50` foreground gate.
- v3: eight mirror TTAs from v2-77k, conditionally ensembled with v2-64k when raw mean `> 105` and standard deviation `< 30`.
- v3 full supervision: the sibling branch from v2-77k with the same self-distillation teacher and recovered coordinate-patch mixture.

## Validation

- Teacher continuation, v1, v2, ordinary v3, and full-supervision v3 each completed a real H100 optimizer update using the supplied checkpoints and streamed CT data.
- All phase losses were finite and every emitted checkpoint preserved the full model, optimizer, scheduler, EMA, configuration, and step state.
- 20 focused DINO-guided tests pass.
- Existing ink-detection suite: 258 passed and 8 skipped in the audit environment.
- Static compilation, JSON validation, and `git diff --check` pass.
- GitHub CI, Python tests, CodeQL, and the large-PR gate pass.
- No existing GPU process was stopped or altered.

The guide includes the tested ink-only UV setup for the supplied GPU nodes. This remains intentionally scoped to the training path and its tests; it does not add a downloader, dependency rewrite, or unrelated trainer refactor.
