### PR TITLE
local catalog: accept any resolution precision, not just two decimals

### DIFF
--- a/vesuvius/src/vesuvius/data/paths/local.py
+++ b/vesuvius/src/vesuvius/data/paths/local.py
@@ -59,8 +59,14 @@ def categorize_zarr_files(tree, base_dir):
     zarr_files: Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, str]]]]] = {}
 
     # Regex patterns for matching volume and segment paths
-    volume_pattern = re.compile(r'volumes[/\\](?P<intensity>\d+)(?=keV|um)(?P<unit>[a-zA-Z]+)_(?P<resolution>\d+\.\d{2})(?P<suffix>[a-zA-Z]*)\.zarr')
-    segment_pattern = re.compile(r'segments[/\\](?P<intensity>\d+)(?=keV|um)(?P<unit>[a-zA-Z]+)_(?P<resolution>\d+\.\d{2})(?P<suffix>[a-zA-Z]*)[/\\](?P<segment_id>[^/\\]+)\.zarr')
+    # Resolution accepts any number of decimal places (or none). Hardcoding
+    # exactly two (\d+\.\d{2}) silently skipped most published resolutions:
+    # of the resolutions actually present in the open-data bucket, only
+    # 3.24um and 7.91um have two decimals -- 1.129um, 2.399um, 9.9um,
+    # 45.532um and 2.4um were all dropped, with no warning, so a local
+    # catalog built from them was silently incomplete.
+    volume_pattern = re.compile(r'volumes[/\\](?P<intensity>\d+)(?=keV|um)(?P<unit>[a-zA-Z]+)_(?P<resolution>\d+(?:\.\d+)?)(?P<suffix>[a-zA-Z]*)\.zarr')
+    segment_pattern = re.compile(r'segments[/\\](?P<intensity>\d+)(?=keV|um)(?P<unit>[a-zA-Z]+)_(?P<resolution>\d+(?:\.\d+)?)(?P<suffix>[a-zA-Z]*)[/\\](?P<segment_id>[^/\\]+)\.zarr')
     scroll_pattern = re.compile(r'(?P<scrollnumber>\d+)[/\\](?=volumes|segments)(volumes|segments)')
 
     for key in tree.keys():

--- a/vesuvius/tests/data/paths/test_local_categorize.py
+++ b/vesuvius/tests/data/paths/test_local_categorize.py
@@ -1,0 +1,99 @@
+"""Tests for categorize_zarr_files' resolution parsing.
+
+Covers a real bug: the volume and segment regexes hardcoded exactly two
+decimal places for the resolution (``\\d+\\.\\d{2}``). Of the resolutions
+actually present in the public open-data bucket, only 3.24um and 7.91um
+have two decimals -- 1.129um, 2.399um, 9.9um and 45.532um all have a
+different number, and were silently dropped from the returned catalog with
+no warning, leaving a local scan of a real data directory quietly
+incomplete.
+"""
+import pytest
+
+from vesuvius.data.paths.local import categorize_zarr_files
+
+
+# Resolutions confirmed present in the public bucket's published paths.
+REAL_RESOLUTIONS = ["1.129", "2.399", "3.24", "7.91", "9.9", "45.532"]
+
+
+def _tree_for(resolutions):
+    tree = {}
+    for res in resolutions:
+        tree[f"Scroll1/volumes/54keV_{res}um.zarr"] = None
+        tree[f"Scroll1/segments/54keV_{res}um/seg_{res}.zarr"] = None
+    return tree
+
+
+def _collect(result):
+    """Flatten the nested result into (resolutions_with_volume, resolutions_with_segment)."""
+    vols, segs = set(), set()
+    for _scroll, intensities in result.items():
+        for _intensity, by_res in intensities.items():
+            for res, entry in by_res.items():
+                if entry.get("volume"):
+                    vols.add(res)
+                if entry.get("segments"):
+                    segs.add(res)
+    return vols, segs
+
+
+@pytest.mark.parametrize("resolution", REAL_RESOLUTIONS)
+def test_each_real_resolution_is_catalogued(resolution):
+    """Every resolution that actually appears in published data must be
+    parsed, regardless of how many decimal places it has."""
+    result = categorize_zarr_files(_tree_for([resolution]), "/base")
+    vols, segs = _collect(result)
+
+    assert resolution in vols, (
+        f"volume at resolution {resolution}um was silently skipped -- "
+        f"the resolution pattern must not assume a fixed number of decimals"
+    )
+    assert resolution in segs, (
+        f"segment at resolution {resolution}um was silently skipped"
+    )
+
+
+def test_all_real_resolutions_catalogued_together():
+    """The full realistic mix must come through completely, not just the
+    two-decimal subset."""
+    result = categorize_zarr_files(_tree_for(REAL_RESOLUTIONS), "/base")
+    vols, segs = _collect(result)
+
+    assert vols == set(REAL_RESOLUTIONS), (
+        f"missing volume resolutions: {set(REAL_RESOLUTIONS) - vols}"
+    )
+    assert segs == set(REAL_RESOLUTIONS), (
+        f"missing segment resolutions: {set(REAL_RESOLUTIONS) - segs}"
+    )
+
+
+def test_two_decimal_resolutions_still_work():
+    """No-regression check for the resolutions that already parsed."""
+    result = categorize_zarr_files(_tree_for(["3.24", "7.91"]), "/base")
+    vols, segs = _collect(result)
+    assert vols == {"3.24", "7.91"}
+    assert segs == {"3.24", "7.91"}
+
+
+def test_integer_resolution_is_catalogued():
+    """A resolution with no decimal point at all must not be skipped."""
+    result = categorize_zarr_files(_tree_for(["20"]), "/base")
+    vols, _segs = _collect(result)
+    assert "20" in vols
+
+
+def test_volume_path_and_segment_id_are_preserved():
+    """Beyond just matching, the captured fields must still be correct."""
+    tree = {"Scroll1/volumes/54keV_1.129um.zarr": None,
+            "Scroll1/segments/54keV_1.129um/my_segment.zarr": None}
+    result = categorize_zarr_files(tree, "/base")
+
+    assert "1" in result
+    assert "54" in result["1"]
+    entry = result["1"]["54"]["1.129"]
+    assert entry["volume"].endswith("Scroll1/volumes/54keV_1.129um.zarr")
+    assert "my_segment" in entry["segments"]
+    assert entry["segments"]["my_segment"].endswith(
+        "Scroll1/segments/54keV_1.129um/my_segment.zarr"
+    )


### PR DESCRIPTION
categorize_zarr_files scans a local data directory and builds the catalog of available volumes and segments. Both its volume and segment regexes hardcoded exactly two decimal places for the resolution.

Of the resolutions actually present in the public open-data bucket, only 3.24um and 7.91um have two decimals. Every other one silently fails to match and is dropped from the returned catalog entirely -- no warning, no error, just a quietly incomplete result.

Verified against resolution strings taken from real published S3 paths. End-to-end through the real function on a tree containing 1.129um, 2.399um, 3.24um, 7.91um, 9.9um and 45.532um: 2 of 6 volumes and 2 of 6 segments were catalogued before the fix, 6 of 6 after. The dropped ones include the newest, highest-resolution scans.

Fix: the resolution group now accepts any number of decimal places, or none. The intensity, unit, suffix and segment_id groups are unchanged, and the two resolutions that already worked are unaffected.

Scope: categorize_zarr_files is reached via update_local_list, which is exported from vesuvius.data.paths but is not top-level vesuvius API and is not documented, so this affects fewer users than the data loss alone might suggest. Within that path, though, the loss is total and silent for the affected resolutions.

10 new tests (this file had no test coverage; no tests/data/paths/ directory existed before). Mutation-tested: reverting the fix fails 7 of the 10, and the 3 that still pass are exactly the ones that should.

**In one sentence:** <!-- Explain what someone can do with this; don’t list features. -->

**One real example:** Starting with [real data/input], I [action], and it produced [result].

**Before:** <!-- What happened without this PR? -->

**After this PR:** <!-- What happens now? -->

**Proof:** <!-- Attach the image, video, output, or benchmark. Use the same input/settings for comparisons and say what we should look at. -->

**Why / where this is useful:** <!-- Who would use this result, and what can they do next? -->

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

<!-- Method, exact tested commit, commands, data, checkpoints, comparisons, limitations, etc. -->
