### PR TITLE
Vc3d open access invalid creds

### DIFF
--- a/volume-cartographer/apps/VC3D/OpenDataLasagna.cpp
+++ b/volume-cartographer/apps/VC3D/OpenDataLasagna.cpp
@@ -214,6 +214,7 @@ std::vector<std::string> entryTags(const OpenDataLasagnaInfo& info)
 {
     std::vector<std::string> tags{
         "open-data",
+        std::string(vc::project::kAnonymousRemoteAuthTag),
         std::string(kOpenDataLasagnaEntryTag),
         std::string(kOpenDataSampleIdTagPrefix) + info.sampleId,
         "vc-open-data-volume-id:" + info.volumeId,
@@ -454,13 +455,21 @@ std::filesystem::path prepareOpenDataLasagna(
                 const auto manifest = finalDir /
                     marker.value("manifest_file", std::string{});
                 if (std::filesystem::is_regular_file(manifest)) {
-                    validatePrepared(info, manifest);
+                    bool markerChanged = false;
+                    if (!marker.value("anonymous", false)) {
+                        marker["anonymous"] = true;
+                        markerChanged = true;
+                    }
                     if (marker.value("source_coordinate_level", -1) !=
                         info.sourceCoordinateLevel) {
                         marker["source_coordinate_level"] =
                             info.sourceCoordinateLevel;
+                        markerChanged = true;
+                    }
+                    if (markerChanged) {
                         detail::writeStringAtomic(markerPath, marker.dump(2));
                     }
+                    validatePrepared(info, manifest);
                     return manifest;
                 }
             }
@@ -477,10 +486,12 @@ std::filesystem::path prepareOpenDataLasagna(
         cacheOptions.cacheRoot = cacheRoot;
         cacheOptions.destination =
             (finalDir / relativeName).lexically_relative(cacheRoot);
+        cacheOptions.discoverAwsCredentials = false;
         const auto cached = vc::core::util::cacheRemoteFile(
             manifestUrl, cacheOptions);
         nlohmann::json marker{
             {"version", 1},
+            {"anonymous", true},
             {"artifact_url", info.artifactUrl},
             {"sample_id", info.sampleId},
             {"volume_id", info.volumeId},
@@ -494,9 +505,15 @@ std::filesystem::path prepareOpenDataLasagna(
             marker["source_to_base"] = *info.sourceToBase;
         if (info.baseShapeZYX)
             marker["base_shape_zyx"] = *info.baseShapeZYX;
-        validatePrepared(info, cached.path);
         detail::writeStringAtomic(
             finalDir / vc::lasagna::kLasagnaRemoteMarker, marker.dump(2));
+        try {
+            validatePrepared(info, cached.path);
+        } catch (...) {
+            std::error_code ec;
+            std::filesystem::remove(markerPath, ec);
+            throw;
+        }
         return cached.path;
     } catch (const std::exception& e) {
         if (errorOut) *errorOut = e.what();

--- a/volume-cartographer/apps/VC3D/OpenDataSampleProject.cpp
+++ b/volume-cartographer/apps/VC3D/OpenDataSampleProject.cpp
@@ -109,6 +109,11 @@ std::vector<std::string> volumeTags(const OpenDataSample& sample,
         }
     };
 
+    // Every origin admitted by the Open Data manifest is public-read. Persist
+    // the transport policy with the entry so cached catalog projects and
+    // deferred resolution never consult ambient AWS credentials.
+    addUnique(std::string(vc::project::kAnonymousRemoteAuthTag));
+
     if (jsonStringEqualsInsensitive(artifact.properties, "representation", "normal3d") ||
         jsonStringEqualsInsensitive(volume.properties, "representation", "normal3d") ||
         containsInsensitive(artifact.type, "normal3d") ||
@@ -743,6 +748,7 @@ OpenDataSampleProjectResult attachOpenDataSampleVolumes(
 
         auto tags = coordinateTags(
             sample, volume, level, effectiveVoxelSize, candidate.sourceUrl);
+        tags.push_back(std::string(vc::project::kAnonymousRemoteAuthTag));
         tags.push_back(std::string(kOpenDataSampleIdTagPrefix) + sample.id);
         tags.push_back("vc-open-data-volume-id:" + volume.id);
         const auto lasagna = lasagnaArtifacts(sample.id, volume);

--- a/volume-cartographer/apps/VC3D/VolumeAttachmentController.cpp
+++ b/volume-cartographer/apps/VC3D/VolumeAttachmentController.cpp
@@ -203,11 +203,16 @@ bool VolumeAttachmentController::start(
             try {
                 const std::string location = request.location.toStdString();
                 if (vc::project::isLocationRemote(location)) {
+                    const bool anonymous = std::find(
+                        request.tags.begin(), request.tags.end(),
+                        vc::project::kAnonymousRemoteAuthTag) !=
+                        request.tags.end();
                     result.volume = Volume::NewFromUrl(
                         location,
                         request.remoteCacheRoot.toStdString(),
-                        request.auth,
-                        vc::project::volumeMetadataFromEntryTags(request.tags));
+                        anonymous ? vc::HttpAuth{} : request.auth,
+                        vc::project::volumeMetadataFromEntryTags(request.tags),
+                        !anonymous);
                 } else {
                     result.volume = Volume::New(std::filesystem::path(location));
                 }

--- a/volume-cartographer/core/include/vc/core/render/ZarrChunkFetcher.hpp
+++ b/volume-cartographer/core/include/vc/core/render/ZarrChunkFetcher.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace utils {
@@ -62,6 +63,15 @@ OpenedChunkedZarr openHttpZarrPyramid(
 OpenedRemoteChunkedZarr openRemoteZarrPyramid(
     const std::string& url,
     RemoteZarrOpenOptions options = {});
+
+// S3 deliberately returns AccessDenied rather than NotFound for a missing key
+// when the caller lacks ListBucket. Optional discovery probes must therefore
+// accept a generic 403 while preserving explicit credential failures so the
+// anonymous retry policy can still run. Exposed for deterministic tests.
+bool isOptionalRemoteMetadataMiss(
+    long status,
+    std::string_view key,
+    std::string_view responseBody = {});
 
 // Enforce the supported contiguous dyadic VC pyramid contract and make
 // physical level baseScaleLevel logical level zero. Exposed for deterministic

--- a/volume-cartographer/core/include/vc/core/types/Volume.hpp
+++ b/volume-cartographer/core/include/vc/core/types/Volume.hpp
@@ -82,14 +82,16 @@ public:
                                        const ZarrCreateOptions& options);
 
     // Create a Volume backed by a remote zarr store over HTTP.
-    // If auth is provided, it is used as-is; otherwise credentials are read
-    // from environment variables. When cacheRoot is non-empty, remote chunks
-    // are persisted under a volume-specific subdirectory of that root.
+    // If auth is provided, it is used as-is. Otherwise credentials are read
+    // from the ambient AWS configuration only when discoverAwsCredentials is
+    // true; false forces an anonymous request. When cacheRoot is non-empty,
+    // remote chunks are persisted under a volume-specific subdirectory.
     static std::shared_ptr<Volume> NewFromUrl(
         const std::string& url,
         const std::filesystem::path& cacheRoot = {},
         const vc::HttpAuth& auth = {},
-        const utils::Json& metadata = {});
+        const utils::Json& metadata = {},
+        bool discoverAwsCredentials = true);
 
     // Construct a normal 3D Volume from a caller-prepared chunk source. The
     // source factory is invoked again when a cache is recreated. It must return

--- a/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
+++ b/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
@@ -21,6 +21,8 @@ class QuadSurface;
 namespace vc::project {
 
 inline constexpr std::string_view kFiberLasagnaTag = "vc-lasagna-fiber";
+inline constexpr std::string_view kAnonymousRemoteAuthTag =
+    "vc-remote-auth:anonymous";
 
 struct Entry {
     std::string location;
@@ -28,6 +30,7 @@ struct Entry {
 };
 
 [[nodiscard]] bool hasEntryTag(const Entry& entry, std::string_view tag);
+[[nodiscard]] bool usesAnonymousRemoteAuth(const Entry& entry);
 [[nodiscard]] bool isFiberLasagnaEntry(const Entry& entry);
 
 enum class Category { Volumes, Segments, NormalGrids };

--- a/volume-cartographer/core/include/vc/core/util/RemoteFileCache.hpp
+++ b/volume-cartographer/core/include/vc/core/util/RemoteFileCache.hpp
@@ -31,6 +31,9 @@ struct RemoteFileCacheOptions {
     RemoteFileCachePolicy policy = RemoteFileCachePolicy::CacheFirst;
     RemoteFileCacheAccounting accounting = RemoteFileCacheAccounting::Unmanaged;
     vc::HttpAuth auth;
+    // When false and auth is empty, S3 requests are always anonymous and the
+    // machine's ambient AWS configuration is not consulted.
+    bool discoverAwsCredentials = true;
     RemoteFileFetcher fetcher;
 };
 

--- a/volume-cartographer/core/include/vc/lasagna/Dataset.hpp
+++ b/volume-cartographer/core/include/vc/lasagna/Dataset.hpp
@@ -21,6 +21,8 @@ struct LasagnaDatasetOpenOptions {
     vc::HttpAuth remoteAuth;
     vc::core::util::RemoteFileCachePolicy cachePolicy = vc::core::util::RemoteFileCachePolicy::CacheFirst;
     vc::core::util::RemoteFileFetcher remoteFileFetcher;
+    // False forces anonymous S3 access for both the manifest and its groups.
+    bool discoverAwsCredentials = true;
 };
 
 struct MaterializedLasagnaManifest {

--- a/volume-cartographer/core/include/vc/lasagna/Manifest.hpp
+++ b/volume-cartographer/core/include/vc/lasagna/Manifest.hpp
@@ -36,6 +36,7 @@ struct LasagnaChannelGroup {
     std::string remoteZarrKey;
     std::filesystem::path remoteCacheRoot;
     vc::HttpAuth remoteAuth;
+    bool discoverAwsCredentials = true;
     int scaledown = 0;
     std::vector<std::string> channels;
 
@@ -68,6 +69,9 @@ struct LasagnaDatasetManifest {
     // Original marker or manifest origin used to form readable project paths.
     std::string remoteSourceBaseLocation;
     std::filesystem::path remoteCacheRoot;
+    // A cached public catalog marker sets this false so later group opens do
+    // not accidentally inherit invalid credentials from the host machine.
+    bool discoverAwsCredentials = true;
 
     // Backward-compatible summary for old callers: a Lasagna dataset's
     // normal source is its manifest when nx/ny channels are present.

--- a/volume-cartographer/core/include/vc/lasagna/ProjectVolumes.hpp
+++ b/volume-cartographer/core/include/vc/lasagna/ProjectVolumes.hpp
@@ -16,6 +16,10 @@ namespace vc::lasagna
 inline constexpr std::string_view kLasagnaVolumeManifestTagPrefix = "vc-lasagna-manifest:";
 inline constexpr std::string_view kLasagnaVolumeGroupTagPrefix = "vc-lasagna-group:";
 
+[[nodiscard]] std::vector<std::string> lasagnaProjectVolumeTags(
+    const LasagnaChannelGroup& group,
+    std::string_view manifestLocation);
+
 struct PreparedLasagnaProjectVolume {
     std::string location;
     std::vector<std::string> tags;

--- a/volume-cartographer/core/src/RemoteFileCache.cpp
+++ b/volume-cartographer/core/src/RemoteFileCache.cpp
@@ -137,7 +137,9 @@ struct RemoteClientDetails {
     std::string region;
 };
 
-RemoteClientDetails makeRemoteClientDetails(const vc::ResolvedUrl& endpoint, const vc::HttpAuth& explicitAuth)
+RemoteClientDetails makeRemoteClientDetails(const vc::ResolvedUrl& endpoint,
+                                            const vc::HttpAuth& explicitAuth,
+                                            bool discoverAwsCredentials)
 {
     RemoteClientDetails details;
     details.config.transfer_timeout = std::chrono::seconds{60};
@@ -145,7 +147,8 @@ RemoteClientDetails makeRemoteClientDetails(const vc::ResolvedUrl& endpoint, con
     details.config.max_retries = 2;
     details.config.aws_auth = explicitAuth;
     details.isS3 = endpoint.useAwsSigv4;
-    if (details.isS3 && details.config.aws_auth.empty())
+    if (details.isS3 && details.config.aws_auth.empty() &&
+        discoverAwsCredentials)
         details.config.aws_auth = vc::loadAwsCredentials();
     if (details.isS3 && details.config.aws_auth.region.empty())
         details.config.aws_auth.region = endpoint.awsRegion;
@@ -232,10 +235,14 @@ std::string fetchFailureMessage(const std::string& sourceLocation, const vc::Res
     return message;
 }
 
-void defaultFetch(const std::string& sourceLocation, const std::filesystem::path& temporaryPath, const vc::HttpAuth& explicitAuth)
+void defaultFetch(const std::string& sourceLocation,
+                  const std::filesystem::path& temporaryPath,
+                  const vc::HttpAuth& explicitAuth,
+                  bool discoverAwsCredentials)
 {
     const auto endpoint = vc::resolveRemoteUrl(sourceLocation);
-    auto details = makeRemoteClientDetails(endpoint, explicitAuth);
+    auto details = makeRemoteClientDetails(
+        endpoint, explicitAuth, discoverAwsCredentials);
     utils::HttpClient client(std::move(details.config));
     const auto response = client.get(endpoint.httpsUrl);
     if (!response.ok())
@@ -380,7 +387,8 @@ RemoteFileCacheResult cacheRemoteFile(const std::string& sourceLocation, const R
             if (options.fetcher)
                 options.fetcher(sourceLocation, tmp);
             else
-                defaultFetch(sourceLocation, tmp, options.auth);
+                defaultFetch(sourceLocation, tmp, options.auth,
+                             options.discoverAwsCredentials);
             if (!std::filesystem::is_regular_file(tmp))
                 throw std::runtime_error("remote file fetcher did not create its temporary file");
             temporarySidecar = writeTemporarySidecar(payload, tmp, source, options.accounting);

--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -1325,10 +1325,12 @@ std::shared_ptr<Volume> Volume::NewFromUrl(
     const std::string& url,
     const std::filesystem::path& cacheRoot,
     const vc::HttpAuth& authIn,
-    const utils::Json& metadata)
+    const utils::Json& metadata,
+    bool discoverAwsCredentials)
 {
     vc::render::RemoteZarrOpenOptions openOptions;
     openOptions.auth = authIn;
+    openOptions.discoverAwsCredentials = discoverAwsCredentials;
     auto remoteOpen = vc::render::openRemoteZarrPyramid(url, std::move(openOptions));
     auto opened = std::move(remoteOpen.opened);
     auto auth = std::move(remoteOpen.auth);

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -50,6 +50,11 @@ bool hasEntryTag(const Entry& entry, std::string_view tag)
     return std::find(entry.tags.begin(), entry.tags.end(), tag) != entry.tags.end();
 }
 
+bool usesAnonymousRemoteAuth(const Entry& entry)
+{
+    return hasEntryTag(entry, kAnonymousRemoteAuthTag);
+}
+
 bool isFiberLasagnaEntry(const Entry& entry)
 {
     return hasEntryTag(entry, kFiberLasagnaTag);
@@ -878,13 +883,16 @@ bool VolumePkg::reconcileVolumeEntryTags(
                 !samePersistedVolumeIdentity(volume->remoteLocator(), entry.location))
                 continue;
             try {
+                const bool anonymous =
+                    vc::project::usesAnonymousRemoteAuth(entry);
                 auto refreshed = Volume::NewFromUrl(
                     entry.location,
                     opts_.remoteCacheRoot.empty()
                         ? volume->remoteCacheRoot()
                         : opts_.remoteCacheRoot,
-                    volume->remoteAuth(),
-                    vc::project::volumeMetadataFromEntryTags(entry.tags));
+                    anonymous ? vc::HttpAuth{} : volume->remoteAuth(),
+                    vc::project::volumeMetadataFromEntryTags(entry.tags),
+                    !anonymous);
                 const auto oldId = it->first;
                 const auto newId = refreshed->id();
                 if (newId != oldId && loadedVolumes_.count(newId) != 0) {
@@ -935,12 +943,15 @@ bool VolumePkg::mergeVolumeEntryTags(const std::string& location, const std::vec
                 auto metadata = vc::project::volumeMetadataFromEntryTags(e.tags);
                 if (!metadata.empty()) {
                     try {
+                        const bool anonymous =
+                            vc::project::usesAnonymousRemoteAuth(e);
                         auto refreshed = Volume::NewFromUrl(
                             e.location,
                             opts_.remoteCacheRoot.empty()
                                 ? volume->remoteCacheRoot()
                                 : opts_.remoteCacheRoot,
-                            volume->remoteAuth(), metadata);
+                            anonymous ? vc::HttpAuth{} : volume->remoteAuth(),
+                            metadata, !anonymous);
                         const auto refreshedId = refreshed->id();
                         if (refreshedId != id && loadedVolumes_.count(refreshedId) == 0) {
                             loadedVolumes_.erase(it);
@@ -1908,7 +1919,8 @@ void VolumePkg::resolveAll()
                 remoteResults[i] = {
                     Volume::NewFromUrl(
                         entry.location, remoteCacheRoot, {},
-                        vc::project::volumeMetadataFromEntryTags(entry.tags)),
+                        vc::project::volumeMetadataFromEntryTags(entry.tags),
+                        !vc::project::usesAnonymousRemoteAuth(entry)),
                     {}};
             } catch (const std::exception& ex) {
                 remoteResults[i] = {nullptr, ex.what()};
@@ -2019,7 +2031,8 @@ void VolumePkg::resolveVolumeEntry(const vc::project::Entry& e)
                 e.location,
                 opts_.remoteCacheRoot,
                 {},
-                vc::project::volumeMetadataFromEntryTags(e.tags));
+                vc::project::volumeMetadataFromEntryTags(e.tags),
+                !vc::project::usesAnonymousRemoteAuth(e));
             const auto id = v->id();
             if (loadedVolumes_.count(id) > 0) {
                 Logger()->warn("Duplicate remote volume id '{}' from '{}', skipping", id, e.location);

--- a/volume-cartographer/core/src/lasagna/Dataset.cpp
+++ b/volume-cartographer/core/src/lasagna/Dataset.cpp
@@ -65,13 +65,16 @@ namespace {
     return resolved;
 }
 
-[[nodiscard]] utils::HttpClient makeRemoteClient(const vc::ResolvedUrl& endpoint, const vc::HttpAuth& explicitAuth)
+[[nodiscard]] utils::HttpClient makeRemoteClient(
+    const vc::ResolvedUrl& endpoint,
+    const vc::HttpAuth& explicitAuth,
+    bool discoverAwsCredentials)
 {
     utils::HttpClient::Config config;
     config.transfer_timeout = std::chrono::seconds{60};
     config.aws_auth = explicitAuth;
     if (endpoint.useAwsSigv4) {
-        if (config.aws_auth.empty())
+        if (config.aws_auth.empty() && discoverAwsCredentials)
             config.aws_auth = utils::AwsAuth::load();
         if (!endpoint.awsRegion.empty())
             config.aws_auth.region = endpoint.awsRegion;
@@ -114,7 +117,12 @@ namespace {
     return normalized.generic_string();
 }
 
-void applyRemoteGroup(LasagnaChannelGroup& group, std::string remoteBaseUrl, std::string remoteKey, std::filesystem::path remoteCacheRoot, const vc::HttpAuth& remoteAuth)
+void applyRemoteGroup(LasagnaChannelGroup& group,
+                      std::string remoteBaseUrl,
+                      std::string remoteKey,
+                      std::filesystem::path remoteCacheRoot,
+                      const vc::HttpAuth& remoteAuth,
+                      bool discoverAwsCredentials)
 {
     if (remoteCacheRoot.empty()) {
         throw std::runtime_error("Remote Lasagna group requires a remote cache directory: " + group.relativeZarrKey);
@@ -124,6 +132,7 @@ void applyRemoteGroup(LasagnaChannelGroup& group, std::string remoteBaseUrl, std
     group.remoteZarrKey = std::move(remoteKey);
     group.remoteCacheRoot = std::move(remoteCacheRoot);
     group.remoteAuth = remoteAuth;
+    group.discoverAwsCredentials = discoverAwsCredentials;
 }
 
 void resolveGroupLocations(
@@ -138,12 +147,18 @@ void resolveGroupLocations(
         manifest.remoteCacheRoot.empty()
             ? optionRemoteCacheRoot
             : manifest.remoteCacheRoot;
+    const bool discoverAwsCredentials =
+        manifest.discoverAwsCredentials && options.discoverAwsCredentials;
+    const vc::HttpAuth remoteAuth = discoverAwsCredentials
+        ? options.remoteAuth
+        : vc::HttpAuth{};
 
     for (auto& group : manifest.groups) {
         group.sourceLocation.clear();
         group.remoteZarrBaseUrl.clear();
         group.remoteZarrKey.clear();
         group.remoteCacheRoot.clear();
+        group.discoverAwsCredentials = true;
 
         if (isRemoteLocation(group.relativeZarrKey)) {
             const auto endpoint = resolveRemoteEndpoint(group.relativeZarrKey);
@@ -156,7 +171,8 @@ void resolveGroupLocations(
                 vc::core::util::remoteFileCachePath(group.relativeZarrKey);
             group.sourceLocation = vc::core::util::remoteFileCacheSource(
                 group.relativeZarrKey);
-            applyRemoteGroup(group, endpoint.httpsUrl, {}, cacheRoot, options.remoteAuth);
+            applyRemoteGroup(group, endpoint.httpsUrl, {}, cacheRoot,
+                             remoteAuth, discoverAwsCredentials);
             continue;
         }
 
@@ -175,7 +191,8 @@ void resolveGroupLocations(
                     : manifest.remoteSourceBaseLocation,
                 key);
             applyRemoteGroup(group, manifest.remoteBaseUrl, key,
-                             manifest.remoteCacheRoot, options.remoteAuth);
+                             manifest.remoteCacheRoot, remoteAuth,
+                             discoverAwsCredentials);
             continue;
         }
 
@@ -193,14 +210,15 @@ class PersistentHttpStore final : public utils::Store {
 public:
     PersistentHttpStore(std::string baseUrl,
                         std::filesystem::path cacheRoot,
-                        vc::HttpAuth remoteAuth)
+                        vc::HttpAuth remoteAuth,
+                        bool discoverAwsCredentials)
         : cacheRoot_(std::move(cacheRoot)),
           budget_(vc::render::PersistentZarrCacheBudget::findForPath(cacheRoot_))
     {
         const auto endpoint = resolveRemoteEndpoint(baseUrl);
         baseUrl_ = endpoint.httpsUrl;
         client_ = std::make_unique<utils::HttpClient>(
-            makeRemoteClient(endpoint, remoteAuth));
+            makeRemoteClient(endpoint, remoteAuth, discoverAwsCredentials));
     }
 
     bool exists(const std::string& key) const override
@@ -489,6 +507,8 @@ void loadRemoteMarker(LasagnaDatasetManifest& manifest)
     manifest.remoteSourceBaseLocation =
         vc::core::util::remoteFileCacheSource(url);
     manifest.remoteCacheRoot = manifest.baseDirectory;
+    manifest.discoverAwsCredentials =
+        !marker.value("anonymous", false);
 }
 
 } // namespace
@@ -524,7 +544,10 @@ MaterializedLasagnaManifest materializeLasagnaManifest(const std::string& manife
     cacheOptions.cacheRoot = root;
     cacheOptions.destination = manifestPath.lexically_relative(root);
     cacheOptions.policy = options.cachePolicy;
-    cacheOptions.auth = options.remoteAuth;
+    cacheOptions.auth = options.discoverAwsCredentials
+        ? options.remoteAuth
+        : vc::HttpAuth{};
+    cacheOptions.discoverAwsCredentials = options.discoverAwsCredentials;
     cacheOptions.fetcher = options.remoteFileFetcher;
     const auto cached = vc::core::util::cacheRemoteFile(manifestLocation, cacheOptions);
     std::clog << "Lasagna manifest cache "
@@ -642,7 +665,8 @@ utils::ZarrArray openLasagnaChannelArray(
     auto registry = vc::buildZarrCodecRegistry(dtypeSize);
     if (group.isRemote()) {
         auto store = std::make_shared<PersistentHttpStore>(
-            group.remoteZarrBaseUrl, group.remoteCacheRoot, group.remoteAuth);
+            group.remoteZarrBaseUrl, group.remoteCacheRoot, group.remoteAuth,
+            group.discoverAwsCredentials);
         return utils::ZarrArray::open(
             std::move(store), group.remoteZarrKey, std::move(registry));
     }

--- a/volume-cartographer/core/src/lasagna/ProjectVolumes.cpp
+++ b/volume-cartographer/core/src/lasagna/ProjectVolumes.cpp
@@ -1,6 +1,7 @@
 #include "vc/lasagna/ProjectVolumes.hpp"
 
 #include "vc/core/types/Volume.hpp"
+#include "vc/core/types/VolumePkg.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -91,13 +92,33 @@ std::shared_ptr<Volume> openRegularVolumeForGroup(
 {
     const std::string location = attachmentLocationForGroup(group);
     if (group.isRemote()) {
-        return Volume::NewFromUrl(location, group.remoteCacheRoot,
-                                  group.remoteAuth);
+        const auto auth = group.discoverAwsCredentials
+            ? group.remoteAuth
+            : vc::HttpAuth{};
+        return Volume::NewFromUrl(
+            location, group.remoteCacheRoot, auth, {},
+            group.discoverAwsCredentials);
     }
     return Volume::New(std::filesystem::path(location));
 }
 
 }  // namespace
+
+std::vector<std::string> lasagnaProjectVolumeTags(
+    const LasagnaChannelGroup& group,
+    std::string_view manifestLocation)
+{
+    std::vector<std::string> tags;
+    addUniqueTag(
+        tags, std::string(kLasagnaVolumeManifestTagPrefix) +
+                  std::string(manifestLocation));
+    addUniqueTag(tags, std::string(kLasagnaVolumeGroupTagPrefix) + group.name);
+    if (group.isRemote() && !group.discoverAwsCredentials) {
+        addUniqueTag(
+            tags, std::string(vc::project::kAnonymousRemoteAuthTag));
+    }
+    return tags;
+}
 
 std::vector<PreparedLasagnaProjectVolume> prepareLasagnaProjectVolumes(
     const LasagnaDataset& dataset,
@@ -118,20 +139,14 @@ std::vector<PreparedLasagnaProjectVolume> prepareLasagnaProjectVolumes(
                 return candidate.location == location;
             });
 
-        const std::string manifestTag =
-            std::string(kLasagnaVolumeManifestTagPrefix) + manifestLocation;
-        const std::string groupTag =
-            std::string(kLasagnaVolumeGroupTagPrefix) + group.name;
+        auto tags = lasagnaProjectVolumeTags(group, manifestLocation);
 
         if (existing != prepared.end()) {
-            addUniqueTag(existing->tags, manifestTag);
-            addUniqueTag(existing->tags, groupTag);
+            for (auto& tag : tags)
+                addUniqueTag(existing->tags, std::move(tag));
             continue;
         }
 
-        std::vector<std::string> tags;
-        addUniqueTag(tags, manifestTag);
-        addUniqueTag(tags, groupTag);
         prepared.push_back({
             location,
             std::move(tags),

--- a/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
+++ b/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
@@ -91,6 +91,7 @@ class ClassifyingHttpStore final : public utils::Store {
 public:
     explicit ClassifyingHttpStore(std::string baseUrl, vc::HttpAuth auth = {})
         : baseUrl_(stripTrailingSlash(std::move(baseUrl)))
+        , authenticated_(!auth.empty())
         , client_(makeClient(std::move(auth)))
     {
     }
@@ -102,7 +103,8 @@ public:
             return true;
         if (response.not_found())
             return false;
-        if (response.status_code == 403 && isOptionalMetadataProbe(key))
+        if (response.status_code == 403 && isOptionalMetadataProbe(key) &&
+            !authenticated_)
             return false;
         throw HttpStatusError(response.status_code, key, response.error_message);
     }
@@ -124,7 +126,8 @@ public:
         }
         if (response.not_found())
             return std::nullopt;
-        if (response.status_code == 403 && isOptionalMetadataProbe(key))
+        if (response.status_code == 403 && isOptionalMetadataProbe(key) &&
+            !authenticated_)
             return std::nullopt;
         throw HttpStatusError(response.status_code, key, response.error_message);
     }
@@ -194,6 +197,7 @@ private:
     }
 
     std::string baseUrl_;
+    bool authenticated_ = false;
     utils::HttpClient client_;
     mutable std::mutex metadataMutex_;
     mutable std::unordered_map<std::string, std::vector<std::byte>> metadata_;

--- a/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
+++ b/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
@@ -55,12 +55,40 @@ bool hasSuffix(std::string_view value, std::string_view suffix)
            value.substr(value.size() - suffix.size()) == suffix;
 }
 
-bool isOptionalMetadataProbe(const std::string& key)
+bool isOptionalMetadataProbe(std::string_view key)
 {
     return key == ".zgroup" || key == ".zarray" || key == ".zattrs" ||
            key == ".zmetadata" || key == "zarr.json" ||
            hasSuffix(key, "/.zgroup") || hasSuffix(key, "/.zarray") ||
            hasSuffix(key, "/.zattrs") || hasSuffix(key, "/zarr.json");
+}
+
+bool hasExplicitAwsCredentialError(std::string_view detail)
+{
+    constexpr std::array<std::string_view, 10> markers{
+        "ExpiredToken",
+        "InvalidAccessKeyId",
+        "InvalidClientTokenId",
+        "InvalidSignatureException",
+        "InvalidToken",
+        "RequestExpired",
+        "RequestTimeTooSkewed",
+        "SignatureDoesNotMatch",
+        "TokenRefreshRequired",
+        "UnrecognizedClientException",
+    };
+    return std::any_of(markers.begin(), markers.end(), [&](const auto marker) {
+        return detail.find(marker) != std::string_view::npos;
+    });
+}
+
+std::string responseErrorDetail(const utils::HttpResponse& response)
+{
+    if (!response.error_message.empty())
+        return response.error_message;
+    constexpr std::size_t kMaxDetailLength = 1024;
+    const auto body = response.body_string();
+    return std::string(body.substr(0, kMaxDetailLength));
 }
 
 bool isZarrMetadataKey(std::string_view key)
@@ -91,7 +119,6 @@ class ClassifyingHttpStore final : public utils::Store {
 public:
     explicit ClassifyingHttpStore(std::string baseUrl, vc::HttpAuth auth = {})
         : baseUrl_(stripTrailingSlash(std::move(baseUrl)))
-        , authenticated_(!auth.empty())
         , client_(makeClient(std::move(auth)))
     {
     }
@@ -103,10 +130,11 @@ public:
             return true;
         if (response.not_found())
             return false;
-        if (response.status_code == 403 && isOptionalMetadataProbe(key) &&
-            !authenticated_)
+        if (isOptionalRemoteMetadataMiss(
+                response.status_code, key, response.body_string()))
             return false;
-        throw HttpStatusError(response.status_code, key, response.error_message);
+        throw HttpStatusError(
+            response.status_code, key, responseErrorDetail(response));
     }
 
     std::vector<std::byte> get(const std::string& key) const override
@@ -126,10 +154,11 @@ public:
         }
         if (response.not_found())
             return std::nullopt;
-        if (response.status_code == 403 && isOptionalMetadataProbe(key) &&
-            !authenticated_)
+        if (isOptionalRemoteMetadataMiss(
+                response.status_code, key, response.body_string()))
             return std::nullopt;
-        throw HttpStatusError(response.status_code, key, response.error_message);
+        throw HttpStatusError(
+            response.status_code, key, responseErrorDetail(response));
     }
 
     std::optional<std::vector<std::byte>>
@@ -140,7 +169,8 @@ public:
             return std::move(response.body);
         if (response.not_found())
             return std::nullopt;
-        throw HttpStatusError(response.status_code, key, response.error_message);
+        throw HttpStatusError(
+            response.status_code, key, responseErrorDetail(response));
     }
 
     void set(const std::string&, std::span<const std::byte>) override
@@ -197,7 +227,6 @@ private:
     }
 
     std::string baseUrl_;
-    bool authenticated_ = false;
     utils::HttpClient client_;
     mutable std::mutex metadataMutex_;
     mutable std::unordered_map<std::string, std::vector<std::byte>> metadata_;
@@ -792,6 +821,15 @@ void addRemoteLevelFromKey(
 }
 
 } // namespace
+
+bool isOptionalRemoteMetadataMiss(
+    long status,
+    std::string_view key,
+    std::string_view responseBody)
+{
+    return status == 403 && isOptionalMetadataProbe(key) &&
+           !hasExplicitAwsCredentialError(responseBody);
+}
 
 std::vector<std::pair<int, std::string>> remoteLevelKeysFromZattrs(
     const std::shared_ptr<utils::Store>& store,

--- a/volume-cartographer/core/test/test_lasagna_manifest.cpp
+++ b/volume-cartographer/core/test/test_lasagna_manifest.cpp
@@ -174,6 +174,7 @@ TEST_CASE("LasagnaDataset resolves marker-backed remote relative groups")
         std::ofstream out(dir / vc::lasagna::kLasagnaRemoteMarker);
         out << R"({
           "artifact_url":"s3://bucket/path/artifact/",
+          "anonymous":true,
           "manifest_file":"dataset.lasagna.json"
         })";
     }
@@ -188,6 +189,8 @@ TEST_CASE("LasagnaDataset resolves marker-backed remote relative groups")
     CHECK(group.remoteCacheRoot == dir);
     CHECK(group.sourceLocation ==
           "s3://bucket/path/artifact/pred.zarr");
+    CHECK_FALSE(dataset.manifest().discoverAwsCredentials);
+    CHECK_FALSE(group.discoverAwsCredentials);
 
     fs::remove_all(dir);
 }

--- a/volume-cartographer/core/test/test_lasagna_project_volumes.cpp
+++ b/volume-cartographer/core/test/test_lasagna_project_volumes.cpp
@@ -158,6 +158,26 @@ TEST_CASE("Lasagna project preparation deduplicates shared source zarrs")
     fs::remove_all(dir);
 }
 
+TEST_CASE("Lasagna project volume tags preserve anonymous remote authentication")
+{
+    vc::lasagna::LasagnaChannelGroup group;
+    group.name = "pred";
+    group.remoteZarrBaseUrl =
+        "https://bucket.s3.us-east-1.amazonaws.com/artifact/pred.zarr";
+    group.discoverAwsCredentials = false;
+
+    const auto tags = vc::lasagna::lasagnaProjectVolumeTags(
+        group, "s3://bucket/artifact/dataset.lasagna.json");
+    CHECK(std::find(tags.begin(), tags.end(),
+                    vc::project::kAnonymousRemoteAuthTag) != tags.end());
+
+    group.discoverAwsCredentials = true;
+    const auto signedTags = vc::lasagna::lasagnaProjectVolumeTags(
+        group, "s3://bucket/artifact/dataset.lasagna.json");
+    CHECK(std::find(signedTags.begin(), signedTags.end(),
+                    vc::project::kAnonymousRemoteAuthTag) == signedTags.end());
+}
+
 TEST_CASE("Lasagna project preparation keeps numeric scale group ids unique")
 {
     const auto dir = temporaryDirectory();

--- a/volume-cartographer/core/test/test_open_data_manifest.cpp
+++ b/volume-cartographer/core/test/test_open_data_manifest.cpp
@@ -458,6 +458,8 @@ TEST_CASE("Open-data Lasagna alone requests its declared rebased source view")
           "http://127.0.0.1:9/source.zarr");
     CHECK(pkg->volumeEntries()[1].location ==
           "http://127.0.0.1:9/source.zarr#vc-base-scale=2");
+    CHECK(vc::project::usesAnonymousRemoteAuth(pkg->volumeEntries()[0]));
+    CHECK(vc::project::usesAnonymousRemoteAuth(pkg->volumeEntries()[1]));
     CHECK(std::find(pkg->volumeEntries()[1].tags.begin(),
                     pkg->volumeEntries()[1].tags.end(),
                     "vc-open-data-coordinate-space:sample/high-resolution@L2") !=
@@ -972,6 +974,9 @@ TEST_CASE("OpenDataSampleProject attaches all supported zarr artifacts for a cat
     CHECK(pkg->volumeEntries()[0].location == "http://127.0.0.1:9/base.zarr");
     CHECK(pkg->volumeEntries()[1].location == "http://127.0.0.1:9/surface.zarr");
     CHECK(pkg->volumeEntries()[2].location == "http://127.0.0.1:9/ink.zarr");
+    for (const auto& entry : pkg->volumeEntries()) {
+        CHECK(vc::project::usesAnonymousRemoteAuth(entry));
+    }
 
     CHECK(std::find(pkg->volumeEntries()[1].tags.begin(),
                     pkg->volumeEntries()[1].tags.end(),

--- a/volume-cartographer/core/test/test_volume_live_s3.cpp
+++ b/volume-cartographer/core/test/test_volume_live_s3.cpp
@@ -47,6 +47,28 @@ TEST_CASE("Volume::NewFromUrl: opens the PHerc 0172 zarr")
     CHECK_FALSE(v->id().empty());
 }
 
+TEST_CASE("Volume::NewFromUrl: invalid credentials fall back to anonymous public S3")
+{
+    vc::HttpAuth invalid;
+    invalid.access_key = "INVALIDACCESSKEY";
+    invalid.secret_key = "INVALIDSECRET";
+    invalid.session_token = "INVALIDSESSIONTOKEN";
+    invalid.region = "us-east-1";
+
+    try {
+        const auto volume = Volume::NewFromUrl(kVolumeUrl, {}, invalid);
+        REQUIRE(volume != nullptr);
+        CHECK(volume->isRemote());
+        CHECK(volume->remoteAuth().empty());
+    } catch (const std::exception& e) {
+        if (requireNetwork()) {
+            FAIL("invalid-credential anonymous fallback failed: " << e.what());
+        }
+        MESSAGE("Skipping invalid-credential fallback (network unavailable?): "
+                << e.what());
+    }
+}
+
 TEST_CASE("Volume: shape and pyramid metadata match the upstream .zarray files")
 {
     auto v = openOrSkip();

--- a/volume-cartographer/core/test/test_zarr_chunk_fetcher.cpp
+++ b/volume-cartographer/core/test/test_zarr_chunk_fetcher.cpp
@@ -229,6 +229,22 @@ TEST_CASE("openLocalZarrPyramid: missing dir throws")
     CHECK_THROWS(openLocalZarrPyramid("/__no__/__where__"));
 }
 
+TEST_CASE("optional remote metadata probes accept least-privilege S3 403s")
+{
+    CHECK(vc::render::isOptionalRemoteMetadataMiss(
+        403, ".zgroup", "<Code>AccessDenied</Code>"));
+    CHECK(vc::render::isOptionalRemoteMetadataMiss(
+        403, "1/.zarray"));
+    CHECK_FALSE(vc::render::isOptionalRemoteMetadataMiss(
+        403, "1/0.0.0", "<Code>AccessDenied</Code>"));
+    CHECK_FALSE(vc::render::isOptionalRemoteMetadataMiss(
+        403, ".zgroup", "<Code>InvalidAccessKeyId</Code>"));
+    CHECK_FALSE(vc::render::isOptionalRemoteMetadataMiss(
+        403, ".zattrs", "<Code>ExpiredToken</Code>"));
+    CHECK_FALSE(vc::render::isOptionalRemoteMetadataMiss(
+        404, ".zgroup"));
+}
+
 TEST_CASE("createChunkCache wraps openLocalZarrPyramid result")
 {
     auto d = tmpDir("cc_wrap");


### PR DESCRIPTION
vc3d would pass aws creds to every request (even open access) and if these were invalid/expired it would fail to read from open data even if the req did not require creds 