### PR TITLE
Add a mypy import gate config for internal vesuvius.* imports

### DIFF
--- a/vesuvius/mypy-imports.ini
+++ b/vesuvius/mypy-imports.ini
@@ -1,0 +1,253 @@
+# mypy configuration for the vesuvius package.
+#
+# The point of this config is one specific trap: `ignore_missing_imports = True`
+# is unavoidable here (torch, zarr, numba, cupy and ~75 others ship no stubs),
+# but setting it GLOBALLY also silences unresolved *internal* imports -- which is
+# how several `vesuvius.*` imports of modules that do not exist reached main.
+#
+# So: ignore_missing_imports stays FALSE globally, and is enabled per-module for
+# third-party packages only. Broken internal imports are then reported.
+
+[mypy]
+ignore_missing_imports = False
+follow_imports = silent
+# Only the import-resolution checks are enabled; this is an import gate, not a
+# type-correctness gate. Turning on full type checking here would bury the signal.
+disable_error_code = attr-defined, name-defined, var-annotated, assignment, arg-type, return-value, index, operator, misc, call-overload, union-attr, override, valid-type, has-type, call-arg, list-item, dict-item, typeddict-item, comparison-overlap, no-redef, func-returns-value, abstract, type-var, str-bytes-safe, unused-ignore, truthy-function, str-unpack, exit-return, annotation-unchecked
+
+[mypy-PIL.*]
+ignore_missing_imports = True
+
+[mypy-SimpleITK.*]
+ignore_missing_imports = True
+
+[mypy-accelerate.*]
+ignore_missing_imports = True
+
+[mypy-acvl_utils.*]
+ignore_missing_imports = True
+
+[mypy-aiohttp.*]
+ignore_missing_imports = True
+
+[mypy-alphashape.*]
+ignore_missing_imports = True
+
+[mypy-batchgenerators.*]
+ignore_missing_imports = True
+
+[mypy-batchviewer.*]
+ignore_missing_imports = True
+
+[mypy-betti_matching.*]
+ignore_missing_imports = True
+
+[mypy-botocore.*]
+ignore_missing_imports = True
+
+[mypy-cachetools.*]
+ignore_missing_imports = True
+
+[mypy-cc3d.*]
+ignore_missing_imports = True
+
+[mypy-click.*]
+ignore_missing_imports = True
+
+[mypy-create_vf.*]
+ignore_missing_imports = True
+
+[mypy-cripser.*]
+ignore_missing_imports = True
+
+[mypy-cucim.*]
+ignore_missing_imports = True
+
+[mypy-cupy.*]
+ignore_missing_imports = True
+
+[mypy-cupyx.*]
+ignore_missing_imports = True
+
+[mypy-cv2.*]
+ignore_missing_imports = True
+
+[mypy-dask.*]
+ignore_missing_imports = True
+
+[mypy-detect_holes.*]
+ignore_missing_imports = True
+
+[mypy-diffusers.*]
+ignore_missing_imports = True
+
+[mypy-edt.*]
+ignore_missing_imports = True
+
+[mypy-einops.*]
+ignore_missing_imports = True
+
+[mypy-fastremap.*]
+ignore_missing_imports = True
+
+[mypy-fft_conv_pytorch.*]
+ignore_missing_imports = True
+
+[mypy-fit_data.*]
+ignore_missing_imports = True
+
+[mypy-fix_holes.*]
+ignore_missing_imports = True
+
+[mypy-flash_attn.*]
+ignore_missing_imports = True
+
+[mypy-fsspec.*]
+ignore_missing_imports = True
+
+[mypy-fvcore.*]
+ignore_missing_imports = True
+
+[mypy-google.*]
+ignore_missing_imports = True
+
+[mypy-hiddenlayer.*]
+ignore_missing_imports = True
+
+[mypy-huggingface_hub.*]
+ignore_missing_imports = True
+
+[mypy-inference_provenance.*]
+ignore_missing_imports = True
+
+[mypy-lasagna.*]
+ignore_missing_imports = True
+
+[mypy-lasagna_volume.*]
+ignore_missing_imports = True
+
+[mypy-live_omezarr_cache.*]
+ignore_missing_imports = True
+
+[mypy-lxml.*]
+ignore_missing_imports = True
+
+[mypy-magicgui.*]
+ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-monai.*]
+ignore_missing_imports = True
+
+[mypy-napari.*]
+ignore_missing_imports = True
+
+[mypy-nest_asyncio.*]
+ignore_missing_imports = True
+
+[mypy-nnunetv2.*]
+ignore_missing_imports = True
+
+[mypy-normal_encoding.*]
+ignore_missing_imports = True
+
+[mypy-nrrd.*]
+ignore_missing_imports = True
+
+[mypy-numba.*]
+ignore_missing_imports = True
+
+[mypy-numcodecs.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True
+
+[mypy-pybind11.*]
+ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True
+
+[mypy-pytorch_optimizer.*]
+ignore_missing_imports = True
+
+[mypy-qtpy.*]
+ignore_missing_imports = True
+
+[mypy-requests.*]
+ignore_missing_imports = True
+
+[mypy-sample_spiral.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
+[mypy-shapely.*]
+ignore_missing_imports = True
+
+[mypy-skimage.*]
+ignore_missing_imports = True
+
+[mypy-sklearn.*]
+ignore_missing_imports = True
+
+[mypy-smooth_vf.*]
+ignore_missing_imports = True
+
+[mypy-tifffile.*]
+ignore_missing_imports = True
+
+[mypy-tiled_predict3d.*]
+ignore_missing_imports = True
+
+[mypy-timm.*]
+ignore_missing_imports = True
+
+[mypy-torch.*]
+ignore_missing_imports = True
+
+[mypy-torchvision.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True
+
+[mypy-transforms.*]
+ignore_missing_imports = True
+
+[mypy-trimesh.*]
+ignore_missing_imports = True
+
+[mypy-umbilicus.*]
+ignore_missing_imports = True
+
+[mypy-vc.*]
+ignore_missing_imports = True
+
+[mypy-vc3d_fiber_format.*]
+ignore_missing_imports = True
+
+[mypy-vf_format.*]
+ignore_missing_imports = True
+
+[mypy-vf_io.*]
+ignore_missing_imports = True
+
+[mypy-wandb.*]
+ignore_missing_imports = True
+
+[mypy-yaml.*]
+ignore_missing_imports = True
+
+[mypy-zarr.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Three files on main import vesuvius.* modules that do not exist:

  src/vesuvius/vesuvius.py:9
    from .setup.accept_terms import get_installation_path
    (the directory is install/, not setup/)
  src/vesuvius/image_proc/run/stack_composite_tifs.py:23
    vesuvius.image_proc.run.workflow
  src/vesuvius/neural_tracing/trace_service.py:150,217
    vesuvius.neural_tracing.inference.infer_global_extrap

None is guarded, and none of the missing symbols is defined anywhere in the repository. The test suite cannot catch these because importing the affected modules requires cupy, a GPU, or the full torch+zarr+numba stack.

mypy does not catch them either, for a specific reason worth fixing: ignore_missing_imports = True is effectively mandatory here (79 distinct third-party top-level modules, most without stubs), but set globally it also silences unresolved internal imports. The setting that makes mypy usable in this repo is the one that hides this bug class.

mypy-imports.ini keeps ignore_missing_imports false globally and enables it per module for third-party packages only. Type-correctness error codes are disabled, so this is an import gate rather than a typing gate.

Result: 3 errors across 449 source files, no false positives. Verified in both directions: with the three modules stubbed in, the same command reports success on 453 files, so the gate goes green once the imports resolve and will not block unrelated work.

A CI workflow to run this is proposed in the PR description rather than included here.

This does not fix the three imports; each needs a maintainer decision about whether to restore, repoint, or delete the caller.

**In one sentence:** <!-- Explain what someone can do with this; don’t list features. -->

**One real example:** Starting with [real data/input], I [action], and it produced [result].

**Before:** <!-- What happened without this PR? -->

**After this PR:** <!-- What happens now? -->

**Proof:** <!-- Attach the image, video, output, or benchmark. Use the same input/settings for comparisons and say what we should look at. -->

**Why / where this is useful:** <!-- Who would use this result, and what can they do next? -->

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

<!-- Method, exact tested commit, commands, data, checkpoints, comparisons, limitations, etc. -->
