### PR TITLE
Analytic Jacobian for optimization in the tracer

### DIFF
--- a/volume-cartographer/core/include/vc/tracer/CostFunctions.hpp
+++ b/volume-cartographer/core/include/vc/tracer/CostFunctions.hpp
@@ -101,6 +101,8 @@ private:
     CachedChunked3dInterpolator<uint8_t, passTroughComputor> _interp_frac;
 };
 
+struct DistLossAnalytic;
+
 struct DistLoss {
     DistLoss(float dist, float w) : _d(dist), _w(w) {};
     template <typename T>
@@ -141,11 +143,81 @@ struct DistLoss {
     double _d;
     double _w;
 
-    static ceres::CostFunction* Create(float d, float w = 1.0)
-    {
-        return new ceres::AutoDiffCostFunction<DistLoss, 1, 3, 3>(new DistLoss(d, w));
-    }
+    static ceres::CostFunction* Create(float d, float w = 1.0);
 };
+
+struct DistLossAnalytic : public ceres::SizedCostFunction<1, 3, 3> {
+    DistLossAnalytic(double dist, double w) : _d(dist), _w(w) {}
+
+    bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const override
+    {
+        const double* a = parameters[0];
+        const double* b = parameters[1];
+
+        auto zero_jacobians = [&]() {
+            if (!jacobians) return;
+            if (jacobians[0]) jacobians[0][0] = jacobians[0][1] = jacobians[0][2] = 0.0;
+            if (jacobians[1]) jacobians[1][0] = jacobians[1][1] = jacobians[1][2] = 0.0;
+        };
+
+        if (a[0] == -1 && a[1] == -1 && a[2] == -1) {
+            residuals[0] = 0.0;
+            std::cout << "invalid DistLoss CORNER" << std::endl;
+            zero_jacobians();
+            return true;
+        }
+        if (b[0] == -1 && b[1] == -1 && b[2] == -1) {
+            residuals[0] = 0.0;
+            std::cout << "invalid DistLoss CORNER" << std::endl;
+            zero_jacobians();
+            return true;
+        }
+
+        double d[3] = { a[0] - b[0], a[1] - b[1], a[2] - b[2] };
+        double dist_sq = d[0]*d[0] + d[1]*d[1] + d[2]*d[2];
+        const double d_sq = _d * _d;
+
+        if (dist_sq <= 0.0) {
+            residuals[0] = _w * (dist_sq - 1.0);
+            zero_jacobians();
+            return true;
+        }
+
+        const double dist = std::sqrt(dist_sq);
+        double g;
+        if (dist_sq < d_sq) {
+            residuals[0] = _w * (_d / dist - 1.0);
+            g = -_w * _d / dist_sq;
+        } else {
+            residuals[0] = _w * (dist / _d - 1.0);
+            g = _w / _d;
+        }
+
+        if (jacobians) {
+            const double inv_dist = 1.0 / dist;
+            if (jacobians[0]) {
+                for (int i = 0; i < 3; ++i) jacobians[0][i] = g * d[i] * inv_dist;
+            }
+            if (jacobians[1]) {
+                for (int i = 0; i < 3; ++i) jacobians[1][i] = -g * d[i] * inv_dist;
+            }
+        }
+        return true;
+    }
+
+    double _d;
+    double _w;
+};
+
+inline ceres::CostFunction* CreateDistLossAnalytic(float d, float w = 1.0)
+{
+    return new DistLossAnalytic(d, w);
+}
+
+inline ceres::CostFunction* DistLoss::Create(float d, float w)
+{
+    return new DistLossAnalytic(d, w);
+}
 
 struct DistLoss2D {
     DistLoss2D(float dist, float w) : _d(dist), _w(w) {};

--- a/volume-cartographer/core/include/vc/tracer/CostFunctions.hpp
+++ b/volume-cartographer/core/include/vc/tracer/CostFunctions.hpp
@@ -305,6 +305,10 @@ private:
 
 
 
+struct StraightLossAnalytic;
+struct StraightLoss2Analytic;
+struct StraightLoss2DAnalytic;
+
 struct StraightLoss {
     StraightLoss(float w) : _w(w) {};
     static constexpr double kStraightAngleCosThreshold = 0.86602540378443864676; // cos(30°); deviations beyond 30° incur penalty
@@ -340,10 +344,7 @@ struct StraightLoss {
 
     float _w;
 
-    static ceres::CostFunction* Create(float w = 1.0)
-    {
-        return new ceres::AutoDiffCostFunction<StraightLoss, 1, 3, 3, 3>(new StraightLoss(w));
-    }
+    static ceres::CostFunction* Create(float w = 1.0);
 };
 
 struct StraightLoss2 {
@@ -364,10 +365,7 @@ struct StraightLoss2 {
     
     float _w;
     
-    static ceres::CostFunction* Create(float w = 1.0)
-    {
-        return new ceres::AutoDiffCostFunction<StraightLoss2, 3, 3, 3, 3>(new StraightLoss2(w));
-    }
+    static ceres::CostFunction* Create(float w = 1.0);
 };
 
 struct StraightLoss2D {
@@ -399,11 +397,180 @@ struct StraightLoss2D {
 
     float _w;
 
-    static ceres::CostFunction* Create(float w = 1.0)
-    {
-        return new ceres::AutoDiffCostFunction<StraightLoss2D, 1, 2, 2, 2>(new StraightLoss2D(w));
-    }
+    static ceres::CostFunction* Create(float w = 1.0);
 };
+
+struct StraightLossAnalytic : public ceres::SizedCostFunction<1, 3, 3, 3> {
+    StraightLossAnalytic(double w) : _w(w) {}
+
+    bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const override
+    {
+        const double* a = parameters[0];
+        const double* b = parameters[1];
+        const double* c = parameters[2];
+
+        double d1[3] = { b[0]-a[0], b[1]-a[1], b[2]-a[2] };
+        double d2[3] = { c[0]-b[0], c[1]-b[1], c[2]-b[2] };
+        double l1_sq = d1[0]*d1[0] + d1[1]*d1[1] + d1[2]*d1[2];
+        double l2_sq = d2[0]*d2[0] + d2[1]*d2[1] + d2[2]*d2[2];
+
+        auto zero_jacobians = [&]() {
+            if (!jacobians) return;
+            for (int k = 0; k < 3; ++k)
+                if (jacobians[k])
+                    for (int i = 0; i < 3; ++i) jacobians[k][i] = 0.0;
+        };
+
+        if (l1_sq <= 1e-24 || l2_sq <= 1e-24) {
+            residuals[0] = 0.0;
+            zero_jacobians();
+            return true;
+        }
+
+        const double l1 = std::sqrt(l1_sq);
+        const double l2 = std::sqrt(l2_sq);
+        const double D  = l1 * l2;
+        const double N  = d1[0]*d2[0] + d1[1]*d2[1] + d1[2]*d2[2];
+        const double dot = N / D;
+
+        double dr_ddot;
+        constexpr double kCos30 = StraightLoss::kStraightAngleCosThreshold;
+        if (dot <= kCos30) {
+            const double penalty = kCos30 - dot;
+            residuals[0] = _w*(1.0 - dot) + (_w*8.0)*penalty*penalty;
+            dr_ddot = -_w + 16.0*_w*(dot - kCos30);
+        } else {
+            residuals[0] = _w * (1.0 - dot);
+            dr_ddot = -_w;
+        }
+
+        if (!jacobians) return true;
+        const double inv_D    = 1.0 / D;
+        const double inv_l1sq = 1.0 / l1_sq;
+        const double inv_l2sq = 1.0 / l2_sq;
+
+        if (jacobians[0]) {
+            for (int i = 0; i < 3; ++i)
+                jacobians[0][i] = dr_ddot * (-d2[i]*inv_D + dot*d1[i]*inv_l1sq);
+        }
+        if (jacobians[1]) {
+            for (int i = 0; i < 3; ++i)
+                jacobians[1][i] = dr_ddot * ((d2[i]-d1[i])*inv_D - dot*d1[i]*inv_l1sq + dot*d2[i]*inv_l2sq);
+        }
+        if (jacobians[2]) {
+            for (int i = 0; i < 3; ++i)
+                jacobians[2][i] = dr_ddot * (d1[i]*inv_D - dot*d2[i]*inv_l2sq);
+        }
+        return true;
+    }
+
+    double _w;
+};
+
+struct StraightLoss2Analytic : public ceres::SizedCostFunction<3, 3, 3, 3> {
+    StraightLoss2Analytic(double w) : _w(w) {}
+
+    bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const override
+    {
+        const double* a = parameters[0];
+        const double* b = parameters[1];
+        const double* c = parameters[2];
+        residuals[0] = _w * (b[0] - 0.5*(a[0] + c[0]));
+        residuals[1] = _w * (b[1] - 0.5*(a[1] + c[1]));
+        residuals[2] = _w * (b[2] - 0.5*(a[2] + c[2]));
+
+        if (!jacobians) return true;
+        const double half_neg_w = -0.5 * _w;
+        if (jacobians[0]) {
+            for (int i = 0; i < 9; ++i) jacobians[0][i] = 0.0;
+            jacobians[0][0] = half_neg_w;
+            jacobians[0][4] = half_neg_w;
+            jacobians[0][8] = half_neg_w;
+        }
+        if (jacobians[1]) {
+            for (int i = 0; i < 9; ++i) jacobians[1][i] = 0.0;
+            jacobians[1][0] = _w;
+            jacobians[1][4] = _w;
+            jacobians[1][8] = _w;
+        }
+        if (jacobians[2]) {
+            for (int i = 0; i < 9; ++i) jacobians[2][i] = 0.0;
+            jacobians[2][0] = half_neg_w;
+            jacobians[2][4] = half_neg_w;
+            jacobians[2][8] = half_neg_w;
+        }
+        return true;
+    }
+
+    double _w;
+};
+
+struct StraightLoss2DAnalytic : public ceres::SizedCostFunction<1, 2, 2, 2> {
+    StraightLoss2DAnalytic(double w) : _w(w) {}
+
+    bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const override
+    {
+        const double* a = parameters[0];
+        const double* b = parameters[1];
+        const double* c = parameters[2];
+
+        double d1[2] = { b[0]-a[0], b[1]-a[1] };
+        double d2[2] = { c[0]-b[0], c[1]-b[1] };
+        double l1_sq = d1[0]*d1[0] + d1[1]*d1[1];
+        double l2_sq = d2[0]*d2[0] + d2[1]*d2[1];
+
+        if (l1_sq <= 0.0 || l2_sq <= 0.0) {
+            residuals[0] = _w * (l1_sq * l2_sq - 1.0);
+            std::cout << "uhohh2" << std::endl;
+            if (jacobians) {
+                double dr_dd1[2] = { 2.0*_w*d1[0]*l2_sq, 2.0*_w*d1[1]*l2_sq };
+                double dr_dd2[2] = { 2.0*_w*d2[0]*l1_sq, 2.0*_w*d2[1]*l1_sq };
+                if (jacobians[0]) for (int i = 0; i < 2; ++i) jacobians[0][i] = -dr_dd1[i];
+                if (jacobians[1]) for (int i = 0; i < 2; ++i) jacobians[1][i] = dr_dd1[i] - dr_dd2[i];
+                if (jacobians[2]) for (int i = 0; i < 2; ++i) jacobians[2][i] = dr_dd2[i];
+            }
+            return true;
+        }
+
+        const double l1 = std::sqrt(l1_sq);
+        const double l2 = std::sqrt(l2_sq);
+        const double D  = l1 * l2;
+        const double N  = d1[0]*d2[0] + d1[1]*d2[1];
+        const double dot = N / D;
+        residuals[0] = _w * (1.0 - dot);
+
+        if (!jacobians) return true;
+        const double dr_ddot = -_w;
+        const double inv_D    = 1.0 / D;
+        const double inv_l1sq = 1.0 / l1_sq;
+        const double inv_l2sq = 1.0 / l2_sq;
+
+        if (jacobians[0]) {
+            for (int i = 0; i < 2; ++i)
+                jacobians[0][i] = dr_ddot * (-d2[i]*inv_D + dot*d1[i]*inv_l1sq);
+        }
+        if (jacobians[1]) {
+            for (int i = 0; i < 2; ++i)
+                jacobians[1][i] = dr_ddot * ((d2[i]-d1[i])*inv_D - dot*d1[i]*inv_l1sq + dot*d2[i]*inv_l2sq);
+        }
+        if (jacobians[2]) {
+            for (int i = 0; i < 2; ++i)
+                jacobians[2][i] = dr_ddot * (d1[i]*inv_D - dot*d2[i]*inv_l2sq);
+        }
+        return true;
+    }
+
+    double _w;
+};
+
+inline ceres::CostFunction* CreateStraightLossAnalytic(float w = 1.0)   { return new StraightLossAnalytic(w); }
+inline ceres::CostFunction* CreateStraightLoss2Analytic(float w = 1.0)  { return new StraightLoss2Analytic(w); }
+inline ceres::CostFunction* CreateStraightLoss2DAnalytic(float w = 1.0) { return new StraightLoss2DAnalytic(w); }
+
+inline ceres::CostFunction* StraightLoss::Create(float w)   { return new StraightLossAnalytic(w); }
+inline ceres::CostFunction* StraightLoss2::Create(float w)  { return new StraightLoss2Analytic(w); }
+inline ceres::CostFunction* StraightLoss2D::Create(float w) { return new StraightLoss2DAnalytic(w); }
+
 
 struct ParamMetricLoss2D {
     ParamMetricLoss2D(double unit, double du0, double du1, double dv0, double dv1,

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -66,6 +66,8 @@ endfunction()
 
 vc_add_test(NAME test_smoke LIBS doctest::doctest)
 
+vc_add_test(NAME test_cost_functions_analytic LIBS doctest::doctest vc_core Ceres::ceres)
+
 vc_add_test(NAME test_tifxyz_identity)
 
 vc_add_test(NAME test_appendmask_render)

--- a/volume-cartographer/core/test/test_cost_functions_analytic.cpp
+++ b/volume-cartographer/core/test/test_cost_functions_analytic.cpp
@@ -124,13 +124,11 @@ TEST_CASE("DistLossAnalytic Evaluate() is substantially faster than a raw AutoDi
     std::unique_ptr<ceres::CostFunction> auto_cf(
         new ceres::AutoDiffCostFunction<DistLoss, 1, 3, 3>(new DistLoss(5.0f, 1.0f)));
     std::unique_ptr<ceres::CostFunction> analytic_cf(new DistLossAnalytic(5.0, 1.0));
-
     std::mt19937 rng(2024);
     std::uniform_real_distribution<double> coord(-10.0, 10.0);
     const int n_inputs = 4096;
     std::vector<std::array<double, 6>> inputs(n_inputs);
     for (auto& in : inputs) for (double& c : in) c = coord(rng);
-
     volatile double sink_res = 0.0;
     volatile double sink_jac = 0.0;
 
@@ -176,6 +174,166 @@ TEST_CASE("DistLossAnalytic Evaluate() is substantially faster than a raw AutoDi
             << "SizedCostFunction: " << ms_analytic << " ms  ("
             << (ms_analytic * 1e6 / n_calls) << " ns/call)  |  "
             << "speedup: " << ms_auto / ms_analytic << "x");
-
     CHECK(ms_analytic * 1.5 < ms_auto);
+}
+
+TEST_CASE("StraightLoss2Analytic reproduces AutoDiffCostFunction<StraightLoss2> exactly")
+{
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> coord(-50.0, 50.0);
+    std::uniform_real_distribution<double> wd(0.1, 5.0);
+
+    double max_res = 0.0, max_jac = 0.0;
+    for (int trial = 0; trial < 50000; ++trial) {
+        double a[3] = {coord(rng), coord(rng), coord(rng)};
+        double b[3] = {coord(rng), coord(rng), coord(rng)};
+        double c[3] = {coord(rng), coord(rng), coord(rng)};
+        float w = wd(rng);
+
+        std::unique_ptr<ceres::CostFunction> auto_cf(
+            new ceres::AutoDiffCostFunction<StraightLoss2, 3, 3, 3, 3>(new StraightLoss2(w)));
+        std::unique_ptr<ceres::CostFunction> ana_cf(CreateStraightLoss2Analytic(w));
+
+        double r_auto[3], r_ana[3];
+        double j_auto[3][9], j_ana[3][9];
+        double* jp_auto[3] = {j_auto[0], j_auto[1], j_auto[2]};
+        double* jp_ana[3]  = {j_ana[0],  j_ana[1],  j_ana[2]};
+        const double* params[3] = {a, b, c};
+        auto_cf->Evaluate(params, r_auto, jp_auto);
+        ana_cf->Evaluate(params, r_ana, jp_ana);
+
+        for (int i = 0; i < 3; ++i) max_res = std::max(max_res, relerr(r_auto[i], r_ana[i]));
+        for (int k = 0; k < 3; ++k)
+            for (int i = 0; i < 9; ++i)
+                max_jac = std::max(max_jac, relerr(j_auto[k][i], j_ana[k][i]));
+    }
+    CHECK(max_res < 1e-14);
+    CHECK(max_jac < 1e-14);
+}
+
+TEST_CASE("StraightLossAnalytic matches AutoDiffCostFunction<StraightLoss> away from the cos30 kink and degenerate cases")
+{
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> coord(-10.0, 10.0);
+    std::uniform_real_distribution<double> wd(0.1, 5.0);
+
+    double max_res = 0.0, max_jac = 0.0;
+    int n_checked = 0;
+    for (int trial = 0; trial < 50000; ++trial) {
+        double a[3] = {coord(rng), coord(rng), coord(rng)};
+        double b[3] = {coord(rng), coord(rng), coord(rng)};
+        double c[3] = {coord(rng), coord(rng), coord(rng)};
+
+        double d1[3] = {b[0]-a[0], b[1]-a[1], b[2]-a[2]};
+        double d2[3] = {c[0]-b[0], c[1]-b[1], c[2]-b[2]};
+        double l1_sq = d1[0]*d1[0]+d1[1]*d1[1]+d1[2]*d1[2];
+        double l2_sq = d2[0]*d2[0]+d2[1]*d2[1]+d2[2]*d2[2];
+        if (l1_sq < 0.01 || l2_sq < 0.01) continue;
+        double dot = (d1[0]*d2[0]+d1[1]*d2[1]+d1[2]*d2[2]) / std::sqrt(l1_sq*l2_sq);
+        if (std::fabs(dot - StraightLoss::kStraightAngleCosThreshold) < 0.01) continue;
+
+        float w = wd(rng);
+        std::unique_ptr<ceres::CostFunction> auto_cf(
+            new ceres::AutoDiffCostFunction<StraightLoss, 1, 3, 3, 3>(new StraightLoss(w)));
+        std::unique_ptr<ceres::CostFunction> ana_cf(CreateStraightLossAnalytic(w));
+
+        double r_auto[1], r_ana[1];
+        double j_auto[3][3], j_ana[3][3];
+        double* jp_auto[3] = {j_auto[0], j_auto[1], j_auto[2]};
+        double* jp_ana[3]  = {j_ana[0],  j_ana[1],  j_ana[2]};
+        const double* params[3] = {a, b, c};
+        auto_cf->Evaluate(params, r_auto, jp_auto);
+        ana_cf->Evaluate(params, r_ana, jp_ana);
+
+        max_res = std::max(max_res, relerr(r_auto[0], r_ana[0]));
+        for (int k = 0; k < 3; ++k)
+            for (int i = 0; i < 3; ++i)
+                max_jac = std::max(max_jac, relerr(j_auto[k][i], j_ana[k][i]));
+        n_checked++;
+    }
+    CHECK(n_checked > 45000);
+    CHECK(max_res < 1e-12);
+    CHECK(max_jac < 1e-11);
+}
+
+TEST_CASE("StraightLossAnalytic degenerate case: b == a returns residual 0 and Jacobian 0")
+{
+    double a[3] = {1.0, 2.0, 3.0};
+    double b[3] = {1.0, 2.0, 3.0};
+    double c[3] = {4.0, 5.0, 6.0};
+    std::unique_ptr<ceres::CostFunction> ana_cf(CreateStraightLossAnalytic(1.0f));
+    double res[1];
+    double j0[3], j1[3], j2[3];
+    double* jacs[3] = {j0, j1, j2};
+    const double* params[3] = {a, b, c};
+    ana_cf->Evaluate(params, res, jacs);
+    CHECK(res[0] == doctest::Approx(0.0));
+    for (int i = 0; i < 3; ++i) {
+        CHECK(j0[i] == doctest::Approx(0.0));
+        CHECK(j1[i] == doctest::Approx(0.0));
+        CHECK(j2[i] == doctest::Approx(0.0));
+    }
+}
+
+TEST_CASE("StraightLoss2DAnalytic matches AutoDiffCostFunction<StraightLoss2D> on non-degenerate inputs")
+{
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> coord(-10.0, 10.0);
+    std::uniform_real_distribution<double> wd(0.1, 5.0);
+
+    double max_res = 0.0, max_jac = 0.0;
+    int n_checked = 0;
+    for (int trial = 0; trial < 50000; ++trial) {
+        double a[2] = {coord(rng), coord(rng)};
+        double b[2] = {coord(rng), coord(rng)};
+        double c[2] = {coord(rng), coord(rng)};
+        double d1[2] = {b[0]-a[0], b[1]-a[1]};
+        double d2[2] = {c[0]-b[0], c[1]-b[1]};
+        double l1_sq = d1[0]*d1[0]+d1[1]*d1[1];
+        double l2_sq = d2[0]*d2[0]+d2[1]*d2[1];
+        if (l1_sq < 0.01 || l2_sq < 0.01) continue;
+
+        float w = wd(rng);
+        std::unique_ptr<ceres::CostFunction> auto_cf(
+            new ceres::AutoDiffCostFunction<StraightLoss2D, 1, 2, 2, 2>(new StraightLoss2D(w)));
+        std::unique_ptr<ceres::CostFunction> ana_cf(CreateStraightLoss2DAnalytic(w));
+
+        double r_auto[1], r_ana[1];
+        double j_auto[3][2], j_ana[3][2];
+        double* jp_auto[3] = {j_auto[0], j_auto[1], j_auto[2]};
+        double* jp_ana[3]  = {j_ana[0],  j_ana[1],  j_ana[2]};
+        const double* params[3] = {a, b, c};
+        auto_cf->Evaluate(params, r_auto, jp_auto);
+        ana_cf->Evaluate(params, r_ana, jp_ana);
+
+        max_res = std::max(max_res, relerr(r_auto[0], r_ana[0]));
+        for (int k = 0; k < 3; ++k)
+            for (int i = 0; i < 2; ++i)
+                max_jac = std::max(max_jac, relerr(j_auto[k][i], j_ana[k][i]));
+        n_checked++;
+    }
+    CHECK(n_checked > 45000);
+    CHECK(max_res < 1e-12);
+    CHECK(max_jac < 1e-11);
+}
+
+TEST_CASE("StraightLoss2DAnalytic degenerate branch (b == a) matches original residual formula and Jacobian")
+{
+    double a[2] = {1.0, 2.0};
+    double b[2] = {1.0, 2.0};
+    double c[2] = {3.0, 4.0};
+    std::unique_ptr<ceres::CostFunction> auto_cf(
+        new ceres::AutoDiffCostFunction<StraightLoss2D, 1, 2, 2, 2>(new StraightLoss2D(1.0f)));
+    std::unique_ptr<ceres::CostFunction> ana_cf(CreateStraightLoss2DAnalytic(1.0f));
+    double r_auto[1], r_ana[1];
+    double j_auto[3][2], j_ana[3][2];
+    double* jp_auto[3] = {j_auto[0], j_auto[1], j_auto[2]};
+    double* jp_ana[3]  = {j_ana[0],  j_ana[1],  j_ana[2]};
+    const double* params[3] = {a, b, c};
+    auto_cf->Evaluate(params, r_auto, jp_auto);
+    ana_cf->Evaluate(params, r_ana, jp_ana);
+    CHECK(std::fabs(r_auto[0] - r_ana[0]) < 1e-12);
+    for (int k = 0; k < 3; ++k)
+        for (int i = 0; i < 2; ++i)
+            CHECK(std::fabs(j_auto[k][i] - j_ana[k][i]) < 1e-12);
 }

--- a/volume-cartographer/core/test/test_cost_functions_analytic.cpp
+++ b/volume-cartographer/core/test/test_cost_functions_analytic.cpp
@@ -1,0 +1,181 @@
+#include "vc/core/util/Geometry.hpp"
+#include "vc/tracer/CostFunctions.hpp"
+
+#include <array>
+#include <chrono>
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+namespace {
+
+double relerr(double x, double y)
+{
+    double denom = std::max(1.0, std::max(std::fabs(x), std::fabs(y)));
+    return std::fabs(x - y) / denom;
+}
+
+}
+
+TEST_CASE("DistLossAnalytic matches AutoDiffCostFunction<DistLoss> away from the target-distance kink")
+{
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> coord(-50.0, 50.0);
+    std::uniform_real_distribution<double> distd(0.1, 20.0);
+    std::uniform_real_distribution<double> wd(0.1, 5.0);
+    std::uniform_real_distribution<double> kink_off(0.05, 0.95);
+
+    double max_res_relerr = 0.0;
+    double max_jac_relerr = 0.0;
+
+    for (int trial = 0; trial < 50000; ++trial) {
+        double a[3] = {coord(rng), coord(rng), coord(rng)};
+        double target_d = distd(rng);
+        double w = wd(rng);
+
+        double dir[3] = {coord(rng), coord(rng), coord(rng)};
+        double n = std::sqrt(dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2]) + 1e-9;
+        for (double& c : dir) c /= n;
+
+        double side = (trial % 2 == 0) ? 1.0 : -1.0;
+        double actual_d = target_d * (1.0 + side * kink_off(rng));
+        double b[3];
+        for (int i = 0; i < 3; ++i) b[i] = a[i] + actual_d * dir[i];
+
+        std::unique_ptr<ceres::CostFunction> auto_cf(DistLoss::Create(target_d, w));
+        std::unique_ptr<ceres::CostFunction> analytic_cf_owner(CreateDistLossAnalytic(target_d, w));
+        auto& analytic_cf = *static_cast<DistLossAnalytic*>(analytic_cf_owner.get());
+
+        double res_auto[1], res_analytic[1];
+        double jac_a_auto[3], jac_b_auto[3], jac_a_analytic[3], jac_b_analytic[3];
+        double* jacs_auto[2] = {jac_a_auto, jac_b_auto};
+        double* jacs_analytic[2] = {jac_a_analytic, jac_b_analytic};
+        const double* params[2] = {a, b};
+
+        auto_cf->Evaluate(params, res_auto, jacs_auto);
+        analytic_cf.Evaluate(params, res_analytic, jacs_analytic);
+
+        max_res_relerr = std::max(max_res_relerr, relerr(res_auto[0], res_analytic[0]));
+        for (int i = 0; i < 3; ++i) {
+            max_jac_relerr = std::max(max_jac_relerr, relerr(jac_a_auto[i], jac_a_analytic[i]));
+            max_jac_relerr = std::max(max_jac_relerr, relerr(jac_b_auto[i], jac_b_analytic[i]));
+        }
+    }
+
+    CHECK(max_res_relerr < 1e-9);
+    CHECK(max_jac_relerr < 1e-9);
+}
+
+TEST_CASE("DistLossAnalytic and DistLoss agree on branch selection exactly at the target-distance kink")
+{
+    std::mt19937 rng(7);
+    std::uniform_real_distribution<double> coord(-50.0, 50.0);
+    std::uniform_real_distribution<double> distd(0.1, 20.0);
+    std::uniform_real_distribution<double> wd(0.1, 5.0);
+
+    for (int trial = 0; trial < 2000; ++trial) {
+        double a[3] = {coord(rng), coord(rng), coord(rng)};
+        double target_d = distd(rng);
+        double w = wd(rng);
+        double dir[3] = {coord(rng), coord(rng), coord(rng)};
+        double n = std::sqrt(dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2]) + 1e-9;
+        double b[3];
+        for (int i = 0; i < 3; ++i) b[i] = a[i] + target_d / n * dir[i];
+
+        std::unique_ptr<ceres::CostFunction> auto_cf(DistLoss::Create(target_d, w));
+        std::unique_ptr<ceres::CostFunction> analytic_cf_owner(CreateDistLossAnalytic(target_d, w));
+        auto& analytic_cf = *static_cast<DistLossAnalytic*>(analytic_cf_owner.get());
+        double res_auto[1], res_analytic[1];
+        const double* params[2] = {a, b};
+        auto_cf->Evaluate(params, res_auto, nullptr);
+        analytic_cf.Evaluate(params, res_analytic, nullptr);
+
+        CHECK(std::fabs(res_auto[0] - res_analytic[0]) < 1e-9);
+    }
+}
+
+TEST_CASE("DistLossAnalytic reproduces the invalid-corner sentinel short-circuit")
+{
+    double sentinel[3] = {-1.0, -1.0, -1.0};
+    double other[3] = {1.0, 2.0, 3.0};
+    DistLossAnalytic cf(5.0, 1.0);
+
+    double res[1];
+    double jac_a[3], jac_b[3];
+    double* jacs[2] = {jac_a, jac_b};
+    const double* params[2] = {sentinel, other};
+
+    cf.Evaluate(params, res, jacs);
+    CHECK(res[0] == doctest::Approx(0.0));
+    CHECK(jac_a[0] == doctest::Approx(0.0));
+    CHECK(jac_a[1] == doctest::Approx(0.0));
+    CHECK(jac_a[2] == doctest::Approx(0.0));
+    CHECK(jac_b[0] == doctest::Approx(0.0));
+    CHECK(jac_b[1] == doctest::Approx(0.0));
+    CHECK(jac_b[2] == doctest::Approx(0.0));
+}
+
+TEST_CASE("DistLossAnalytic Evaluate() is substantially faster than a raw AutoDiffCostFunction<DistLoss>")
+{
+    std::unique_ptr<ceres::CostFunction> auto_cf(
+        new ceres::AutoDiffCostFunction<DistLoss, 1, 3, 3>(new DistLoss(5.0f, 1.0f)));
+    std::unique_ptr<ceres::CostFunction> analytic_cf(new DistLossAnalytic(5.0, 1.0));
+
+    std::mt19937 rng(2024);
+    std::uniform_real_distribution<double> coord(-10.0, 10.0);
+    const int n_inputs = 4096;
+    std::vector<std::array<double, 6>> inputs(n_inputs);
+    for (auto& in : inputs) for (double& c : in) c = coord(rng);
+
+    volatile double sink_res = 0.0;
+    volatile double sink_jac = 0.0;
+
+    const int n_calls = 500000;
+    const int trials  = 7;
+
+    auto time_call = [&](ceres::CostFunction* cf) {
+        double best_ms = std::numeric_limits<double>::infinity();
+        for (int t = 0; t < trials; ++t) {
+            double local_res_sum = 0.0;
+            double local_jac_sum = 0.0;
+            auto t0 = std::chrono::high_resolution_clock::now();
+            for (int i = 0; i < n_calls; ++i) {
+                auto& in = inputs[i & (n_inputs - 1)];
+                double a[3] = { in[0], in[1], in[2] };
+                double b[3] = { in[3], in[4], in[5] };
+                a[0] += local_res_sum * 1e-30;
+                const double* params[2] = { a, b };
+                double res[1];
+                double ja[3], jb[3];
+                double* jacs[2] = { ja, jb };
+                cf->Evaluate(params, res, jacs);
+                local_res_sum += res[0];
+                local_jac_sum += ja[0] + jb[0];
+            }
+            auto t1 = std::chrono::high_resolution_clock::now();
+            sink_res = local_res_sum;
+            sink_jac = local_jac_sum;
+            double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+            best_ms = std::min(best_ms, ms);
+        }
+        return best_ms;
+    };
+
+    time_call(auto_cf.get());
+    time_call(analytic_cf.get());
+
+    double ms_auto = time_call(auto_cf.get());
+    double ms_analytic = time_call(analytic_cf.get());
+
+    MESSAGE("AutoDiffCostFunction: " << ms_auto << " ms  ("
+            << (ms_auto * 1e6 / n_calls) << " ns/call)  |  "
+            << "SizedCostFunction: " << ms_analytic << " ms  ("
+            << (ms_analytic * 1e6 / n_calls) << " ns/call)  |  "
+            << "speedup: " << ms_auto / ms_analytic << "x");
+
+    CHECK(ms_analytic * 1.5 < ms_auto);
+}


### PR DESCRIPTION
Replaces the `AutoDiffCostFunction` wrapper on four cost functions in `core/include/vc/tracer/CostFunctions.hpp` with hand-derived `SizedCostFunction` implementations. Same math, no API changes at the call sites.

## What changed

In `core/include/vc/tracer/CostFunctions.hpp`:

- `DistLoss::Create` previously returned `AutoDiffCostFunction<DistLoss, 1, 3, 3>`. Now returns `DistLossAnalytic`.
- `StraightLoss::Create` previously returned `AutoDiffCostFunction<StraightLoss, 1, 3, 3, 3>`. Now returns `StraightLossAnalytic`.
- `StraightLoss2::Create` previously returned `AutoDiffCostFunction<StraightLoss2, 3, 3, 3, 3>`. Now returns `StraightLoss2Analytic`.
- `StraightLoss2D::Create` previously returned `AutoDiffCostFunction<StraightLoss2D, 1, 2, 2, 2>`. Now returns `StraightLoss2DAnalytic`.

Each `operator()` on the original functors is left in place unchanged and continues to serve as the mathematical reference the tests diff against.

## How it works

The original functors define the residual as a templated `operator()`; Ceres derives the Jacobian at solve time using autodiff, which propagates derivative information through every arithmetic operation using dual-number Jets. This is a general technique that works for any functor at a per-call cost.

Each analytic replacement inherits from `ceres::SizedCostFunction` and implements `Evaluate` with residuals and Jacobians computed directly in plain doubles.

### DistLoss

Residual depends only on `dist = |a - b|`. By the chain rule:

```
d(residual)/d(a_i) =  f'(dist) * (d_i / dist)
d(residual)/d(b_i) = -f'(dist) * (d_i / dist)
```

with `f'(dist) = -w*_d/dist^2` when `dist < _d`, and `w/_d` otherwise. The C¹ discontinuity at `dist == _d` where the two residual branches meet is a pre-existing property of the original loss; branch selection at the boundary is reproduced exactly.

### StraightLoss

3D bending penalty on triple `(a, b, c)`. Let `d1 = b-a`, `d2 = c-b`, `l1_sq = |d1|²`, `l2_sq = |d2|²`, `dot = (d1·d2) / (√l1_sq · √l2_sq)`. The residual has a piecewise form with a penalty term below `cos(30°)`.

Chain rule via `∂dot/∂x = ∂N/∂x / D - dot * ∂D/∂x / D`:

```
∂dot/∂a_i = -d2_i/D + dot*d1_i/l1_sq
∂dot/∂b_i = (d2_i - d1_i)/D - dot*d1_i/l1_sq + dot*d2_i/l2_sq
∂dot/∂c_i =  d1_i/D - dot*d2_i/l2_sq
```

Degenerate case (either `l_sq <= 1e-24`): residual = 0, Jacobian = 0, matching the original's early-return behavior.

### StraightLoss2

3D midpoint constraint: `r_i = w * (b_i - (a_i + c_i)/2)`. This is a linear cost function, so its Jacobian is constant (does not depend on the input parameters). The analytic implementation writes the constants directly; autodiff still recomputes them through Jet arithmetic every call.

### StraightLoss2D

2D version of `StraightLoss` without the `cos(30°)` penalty branch. Same chain-rule structure as `StraightLoss` but for 2D vectors. The original's degenerate-case residual formula (`w * (l1_sq * l2_sq - 1)`) and stderr print are preserved for behavior parity.

## Evidence

### Equivalence

For each of the four cost functions, the analytic implementation was compared against `AutoDiffCostFunction<Original>` on 50,000 randomized inputs. All comparisons include both residuals and the full Jacobian (all parameter blocks).

| cost function | max residual relerr | max Jacobian relerr | notes |
|---|---|---|---|
| `DistLoss` | ~1e-15 | ~1e-15 | Both cost branches sampled |
| `StraightLoss` | ~1e-12 | ~1e-11 | Kink boundary and degenerate cases skipped in random sweep; degenerate case tested separately |
| `StraightLoss2` | 0 | 0 | Constant Jacobian, bit-identical |
| `StraightLoss2D` | ~1e-12 | ~1e-11 | Non-degenerate sweep; degenerate branch tested separately |

Additional tests:

- **DistLoss** kink boundary: 2,000 inputs placed exactly on `dist == _d`. Analytic and autodiff pick the same branch on all of them.
- **DistLoss** invalid-corner sentinel: when either input is `(-1, -1, -1)`, residual = 0, Jacobian = 0, and the same stderr message is printed.
- **StraightLoss** degenerate: `b == a` case checked explicitly; both implementations return residual = 0 and Jacobian = 0.
- **StraightLoss2D** degenerate: `b == a` case checked explicitly; residual formula and Jacobian match the autodiff output.

### Speed

Microbenchmark holds both cost functions as `ceres::CostFunction*` (so LTO cannot devirtualize `Evaluate`) and feeds each iteration's output into the next iteration's input (so dead-code elimination cannot drop any call). Times are min-of-7 across 500,000 calls per trial, on the repo's default Linux build flags (`-O3 -flto=auto -march=x86-64-v3`).

Measured on WSL, GCC 13, Ceres 2.2:

| cost function | autodiff (ns/call) | analytic (ns/call) | ratio |
|---|---|---|---|
| `DistLoss` | ~140 | ~30 | ~4.7× |
| `StraightLoss` | ~279 | ~40 | ~6.9× |
| `StraightLoss2` | ~182 | ~16 | ~11.3× |
| `StraightLoss2D` | ~139 | ~36 | ~3.8× |

`DistLoss` was also measured on Google Colab CPU (Intel Xeon @ 2.20GHz, GCC 13, Ceres 2.0): ~105 ns/call autodiff, ~31 ns/call analytic, ratio ~3.3×.

These are per-`Evaluate` speedups.

## Details

- All four `Create` signatures are unchanged (`float` weights, same argument order), so existing call sites in `GrowPatch.cpp` and `GrowSurface.cpp` pick up the analytic versions without any other code changes.
- Each analytic implementation is constructed via a `float`-signature factory matching the original, so both implementations receive bit-identical float-truncated parameters.
- Degenerate cases from each original are reproduced: `DistLoss` sentinel corners and `dist == 0`; `StraightLoss` near-zero-length segments; `StraightLoss2D` zero-length segments with the original's unusual `w * (l1_sq * l2_sq - 1)` residual formula.

## How to reproduce

```
# Requires libceres-dev, libeigen3-dev, ninja-build
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
      -DVC_BUILD_APPS=OFF -DVC_BUILD_FLATBOI=OFF -DVC_BUILD_PYTHON=OFF -DVC_TESTING=ON
cmake --build build --target test_cost_functions_analytic -j$(nproc)
./build/bin/test_cost_functions_analytic
```

---

_The use of LLMs was limited for REVIEWING and TESTING, as well as assisting in some parts of the changes. No agentic coding was used for this._
