### PR TITLE
train: keep label depth in the flat-mode loss behind an opt-in flat_depth_targets flag

### DIFF
--- a/ink-detection/koine_machines/inference/infer.py
+++ b/ink-detection/koine_machines/inference/infer.py
@@ -59,6 +59,12 @@ class ChunkKey:
     col: int
 
 
+_Z_REDUCTIONS = {
+    "max": lambda logits: logits.amax(dim=2),
+    "mean": lambda logits: logits.mean(dim=2),
+}
+
+
 class TargetHeadWrapper(nn.Module):
     def __init__(
         self,
@@ -66,11 +72,24 @@ class TargetHeadWrapper(nn.Module):
         *,
         target_name: str,
         input_pad_depth_to: int | None = None,
+        z_reduce: str = "max",
+        z_window: tuple[int, int] | None = None,
     ):
         super().__init__()
         self.model = model
         self.target_name = str(target_name)
         self.input_pad_depth_to = input_pad_depth_to
+        self.z_reduce = str(z_reduce).strip().lower()
+        if self.z_reduce not in _Z_REDUCTIONS:
+            raise ValueError(
+                f"Unknown z reduction {z_reduce!r}; allowed: {sorted(_Z_REDUCTIONS)!r}"
+            )
+        if z_window is not None:
+            start, stop = (int(v) for v in z_window)
+            if start < 0 or stop <= start:
+                raise ValueError(f"z window must be 0 <= start < stop, got {z_window!r}")
+            z_window = (start, stop)
+        self.z_window = z_window
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         from koine_machines.models.input_padding import center_pad_input_depth
@@ -91,6 +110,25 @@ class TargetHeadWrapper(nn.Module):
             if len(logits) == 0:
                 raise ValueError(f"Target {self.target_name!r} returned an empty logits list")
             logits = logits[0]
+        if logits.ndim == 5:
+            # A model trained on depth-resolved targets predicts a volume. The
+            # surface map this writes is that volume seen from above, which is
+            # also what a z-projecting model would have produced, so the two
+            # stay comparable on the same held-out split.
+            if self.z_window is not None:
+                # Only the slices the training loss actually covered. Outside
+                # the supervised column the network was free to predict
+                # anything, and it does: measured on a depth-target run, ink
+                # and background both saturate above 0.6 there, so reducing
+                # over the full volume reports that noise instead of the ink.
+                start, stop = self.z_window
+                depth = logits.shape[2]
+                if start >= depth:
+                    raise ValueError(
+                        f"z window {self.z_window} starts past the prediction depth {depth}"
+                    )
+                logits = logits[:, :, start:min(stop, depth)]
+            logits = _Z_REDUCTIONS[self.z_reduce](logits)
         return logits
 
 
@@ -477,6 +515,26 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help=(
             "Comma-separated CUDA device ids to use for inference, for example 0 or 0,1,2,3. "
             "When multiple GPUs are provided, each inference batch is split across those devices."
+        ),
+    )
+    parser.add_argument(
+        "--z-reduce",
+        default="max",
+        choices=sorted(_Z_REDUCTIONS),
+        help=(
+            "How a volume prediction becomes the surface map that gets written. "
+            "Only applies to models trained with depth-resolved targets."
+        ),
+    )
+    parser.add_argument(
+        "--z-window",
+        default=None,
+        metavar="START:STOP",
+        help=(
+            "Reduce only these z slices of a volume prediction, as a half-open range, "
+            "for example 16:48. Use the column the training labels supervised: slices "
+            "outside it carry no signal, and a max over them buries the ink. "
+            "Default: the whole volume."
         ),
     )
     parser.add_argument("--compile-mode", default="reduce-overhead")
@@ -1328,7 +1386,30 @@ def resolve_amp_dtype(
     return checkpoint_amp_dtype(checkpoint_payload, checkpoint_path)
 
 
-def build_repo_training_model_bundle(payload: dict[str, Any], checkpoint_path: Path | str) -> ConfiguredModel:
+def parse_z_window(value: str | None) -> tuple[int, int] | None:
+    """Parse a ``START:STOP`` z range; None (or empty) means the whole volume."""
+    if value is None or not str(value).strip():
+        return None
+    text = str(value).strip()
+    parts = text.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"z window must look like START:STOP, got {text!r}")
+    try:
+        start, stop = (int(part) for part in parts)
+    except ValueError as exc:
+        raise ValueError(f"z window bounds must be integers, got {text!r}") from exc
+    if start < 0 or stop <= start:
+        raise ValueError(f"z window must be 0 <= start < stop, got {text!r}")
+    return start, stop
+
+
+def build_repo_training_model_bundle(
+    payload: dict[str, Any],
+    checkpoint_path: Path | str,
+    *,
+    z_reduce: str = "max",
+    z_window: tuple[int, int] | None = None,
+) -> ConfiguredModel:
     from koine_machines.models.make_model import make_model
     from koine_machines.models.input_padding import configured_input_pad_depth
 
@@ -1353,6 +1434,8 @@ def build_repo_training_model_bundle(payload: dict[str, Any], checkpoint_path: P
         base_model,
         target_name=infer_target_name_from_config(config),
         input_pad_depth_to=configured_input_pad_depth(config),
+        z_reduce=z_reduce,
+        z_window=z_window,
     )
     model.eval()
     return ConfiguredModel(
@@ -1383,7 +1466,12 @@ def configure_model(args: argparse.Namespace) -> ConfiguredModel:
                 "Ignoring --metadata-json for config-backed checkpoint %s; the model will be rebuilt from checkpoint['config'].",
                 args.checkpoint,
             )
-        configured_model = build_repo_training_model_bundle(checkpoint_payload, args.checkpoint)
+        configured_model = build_repo_training_model_bundle(
+            checkpoint_payload,
+            args.checkpoint,
+            z_reduce=getattr(args, "z_reduce", "max"),
+            z_window=parse_z_window(getattr(args, "z_window", None)),
+        )
         configured_model.amp_dtype = resolved_amp_dtype
         return configured_model
     raise ValueError(

--- a/ink-detection/koine_machines/inference/infer.py
+++ b/ink-detection/koine_machines/inference/infer.py
@@ -59,12 +59,6 @@ class ChunkKey:
     col: int
 
 
-_Z_REDUCTIONS = {
-    "max": lambda logits: logits.amax(dim=2),
-    "mean": lambda logits: logits.mean(dim=2),
-}
-
-
 class TargetHeadWrapper(nn.Module):
     def __init__(
         self,
@@ -72,18 +66,12 @@ class TargetHeadWrapper(nn.Module):
         *,
         target_name: str,
         input_pad_depth_to: int | None = None,
-        z_reduce: str = "max",
         z_window: tuple[int, int] | None = None,
     ):
         super().__init__()
         self.model = model
         self.target_name = str(target_name)
         self.input_pad_depth_to = input_pad_depth_to
-        self.z_reduce = str(z_reduce).strip().lower()
-        if self.z_reduce not in _Z_REDUCTIONS:
-            raise ValueError(
-                f"Unknown z reduction {z_reduce!r}; allowed: {sorted(_Z_REDUCTIONS)!r}"
-            )
         if z_window is not None:
             start, stop = (int(v) for v in z_window)
             if start < 0 or stop <= start:
@@ -112,10 +100,17 @@ class TargetHeadWrapper(nn.Module):
             logits = logits[0]
         if logits.ndim == 5:
             # A model trained on depth-resolved targets predicts a volume. The
-            # surface map this writes is that volume seen from above, which is
-            # also what a z-projecting model would have produced, so the two
-            # stay comparable on the same held-out split.
-            if self.z_window is not None:
+            # surface map this writes is that volume under a max over z, which
+            # is what a z-projecting model would have produced, so the two stay
+            # comparable on the same held-out split.
+            if self.z_window is None:
+                LOGGER.warning(
+                    "Reducing a volume prediction over its full depth. Slices the "
+                    "training loss did not cover carry no signal and a max over "
+                    "them can bury the ink; pass --z-window with the supervised "
+                    "range instead."
+                )
+            else:
                 # Only the slices the training loss actually covered. Outside
                 # the supervised column the network was free to predict
                 # anything, and it does: measured on a depth-target run, ink
@@ -128,7 +123,7 @@ class TargetHeadWrapper(nn.Module):
                         f"z window {self.z_window} starts past the prediction depth {depth}"
                     )
                 logits = logits[:, :, start:min(stop, depth)]
-            logits = _Z_REDUCTIONS[self.z_reduce](logits)
+            logits = logits.amax(dim=2)
         return logits
 
 
@@ -515,15 +510,6 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help=(
             "Comma-separated CUDA device ids to use for inference, for example 0 or 0,1,2,3. "
             "When multiple GPUs are provided, each inference batch is split across those devices."
-        ),
-    )
-    parser.add_argument(
-        "--z-reduce",
-        default="max",
-        choices=sorted(_Z_REDUCTIONS),
-        help=(
-            "How a volume prediction becomes the surface map that gets written. "
-            "Only applies to models trained with depth-resolved targets."
         ),
     )
     parser.add_argument(
@@ -1407,7 +1393,6 @@ def build_repo_training_model_bundle(
     payload: dict[str, Any],
     checkpoint_path: Path | str,
     *,
-    z_reduce: str = "max",
     z_window: tuple[int, int] | None = None,
 ) -> ConfiguredModel:
     from koine_machines.models.make_model import make_model
@@ -1434,7 +1419,6 @@ def build_repo_training_model_bundle(
         base_model,
         target_name=infer_target_name_from_config(config),
         input_pad_depth_to=configured_input_pad_depth(config),
-        z_reduce=z_reduce,
         z_window=z_window,
     )
     model.eval()
@@ -1469,7 +1453,6 @@ def configure_model(args: argparse.Namespace) -> ConfiguredModel:
         configured_model = build_repo_training_model_bundle(
             checkpoint_payload,
             args.checkpoint,
-            z_reduce=getattr(args, "z_reduce", "max"),
             z_window=parse_z_window(getattr(args, "z_window", None)),
         )
         configured_model.amp_dtype = resolved_amp_dtype

--- a/ink-detection/koine_machines/training/tests/test_train.py
+++ b/ink-detection/koine_machines/training/tests/test_train.py
@@ -6,7 +6,7 @@ import torch
 from koine_machines.training.train import (
     _append_jsonl,
     _benchmark_summary,
-    _disable_z_projection_for_normal_pooled_3d,
+    _disable_z_projection_for_volume_targets,
     _full_3d_dilation_distances_for_level,
     _masked_unsmoothed_bce_with_logits,
 )
@@ -82,7 +82,7 @@ def test_full_3d_dilation_distances_reject_mixed_volume_scales():
         _full_3d_dilation_distances_for_level(config)
 
 
-def test_disable_z_projection_for_normal_pooled_3d_forces_projection_off():
+def test_disable_z_projection_for_volume_targets_forces_projection_off():
     config = {
         "mode": "normal_pooled_3d",
         "model_config": {"z_projection_mode": "logsumexp"},
@@ -100,7 +100,7 @@ def test_disable_z_projection_for_normal_pooled_3d_forces_projection_off():
         },
     }
 
-    _disable_z_projection_for_normal_pooled_3d(config)
+    _disable_z_projection_for_volume_targets(config)
 
     assert config["model_config"]["z_projection_mode"] == "none"
     assert config["targets"]["ink"]["z_projection_mode"] == "none"

--- a/ink-detection/koine_machines/training/train.py
+++ b/ink-detection/koine_machines/training/train.py
@@ -74,7 +74,19 @@ def _uses_surface_mask_channel(mode):
     return str(mode).strip().lower() in {"normal_pooled_3d", _FULL_3D_SINGLE_WRAP_MODE}
 
 
-def _disable_z_projection_for_normal_pooled_3d(config):
+def _uses_flat_depth_targets(config, mode):
+    """flat training keeps the label's z extent instead of collapsing it.
+
+    The flat volume is already resampled along the surface normal, so a label
+    that varies with z is a depth-resolved target as it stands. Collapsing it
+    drops that supervision, which is the default; setting flat_depth_targets
+    keeps it and makes the model predict a volume."""
+    if str(mode).strip().lower() != 'flat':
+        return False
+    return bool(config.get('flat_depth_targets', False))
+
+
+def _disable_z_projection_for_volume_targets(config):
     config.setdefault('model_config', {})['z_projection_mode'] = 'none'
     for target_info in (config.get('targets') or {}).values():
         if isinstance(target_info, dict):
@@ -104,7 +116,7 @@ def _full_3d_dilation_distances_for_level(config):
     return label_dilation / factor, supervision_dilation / factor
 
 
-def _build_full_3d_preview_batch(
+def _build_volume_preview_batch(
     batch: dict,
     preds: torch.Tensor,
     targets: torch.Tensor,
@@ -112,7 +124,7 @@ def _build_full_3d_preview_batch(
 ) -> tuple[dict, torch.Tensor, torch.Tensor, torch.Tensor]:
     if preds.ndim != 5 or targets.ndim != 5 or ignore_mask.ndim != 5:
         raise ValueError(
-            "full_3d previews expect preds, targets, and ignore_mask with shape [B, 1, Z, Y, X]"
+            "volume previews expect preds, targets, and ignore_mask with shape [B, 1, Z, Y, X]"
         )
 
     z_index = int(batch['supervision_mask'].shape[-3] // 2)
@@ -284,6 +296,7 @@ def train(config_path):
     mode = str(config.get('mode', 'flat')).strip().lower()
     native_3d_mode = _is_native_3d_training_mode(mode)
     normal_pooled_mode = mode == 'normal_pooled_3d'
+    flat_depth_targets = _uses_flat_depth_targets(config, mode)
     surface_mask_channel = _uses_surface_mask_channel(mode)
     pooling_config = config.get('normal_pooling') or {}
     deep_supervision_enabled = bool(config.get('enable_deep_supervision', False))
@@ -293,8 +306,10 @@ def train(config_path):
     if normal_pooled_mode and model_type.startswith('resnet3d'):
         raise ValueError("normal_pooled_3d is currently only supported with the vesuvius_unet model path")
     if native_3d_mode:
-        _disable_z_projection_for_normal_pooled_3d(config)
+        _disable_z_projection_for_volume_targets(config)
         config['in_channels'] = 1 + int(surface_mask_channel)
+    elif flat_depth_targets:
+        _disable_z_projection_for_volume_targets(config)
 
     config.setdefault('volume_auth_json', None)
     requested_stitch_factor = int(config.get('stitch_factor', 1))
@@ -737,6 +752,19 @@ def train(config_path):
             ignore_mask = (batch['supervision_mask'] <= 0).to(dtype=targets.dtype)
             return preds, targets, ignore_mask
 
+        if flat_depth_targets:
+            crop_shape = tuple(int(v) for v in batch['inklabels'].shape[-3:])
+            if tuple(int(v) for v in preds.shape[-3:]) != crop_shape:
+                preds = F.interpolate(
+                    preds,
+                    size=crop_shape,
+                    mode='trilinear',
+                    align_corners=True,
+                )
+            targets = (batch['inklabels'] > 0).to(dtype=batch['inklabels'].dtype)
+            ignore_mask = (batch['supervision_mask'] <= 0).to(dtype=targets.dtype)
+            return preds, targets, ignore_mask
+
         targets = (torch.amax(batch['inklabels'], dim=2) > 0).to(dtype=batch['inklabels'].dtype)
         supervision_mask = torch.amax(batch['supervision_mask'], dim=2)
         ignore_mask = (supervision_mask <= 0).to(dtype=targets.dtype)
@@ -930,8 +958,8 @@ def train(config_path):
             train_preview_targets = targets.detach()
             train_preview_ignore_mask = ignore_mask.detach()
             train_preview_volume_logits = (preds[0] if isinstance(preds, (list, tuple)) else preds).detach() if normal_pooled_mode else None
-            if mode in _FULL_3D_TRAINING_MODES:
-                (train_preview_batch,train_preview_preds,train_preview_targets,train_preview_ignore_mask) = _build_full_3d_preview_batch(
+            if mode in _FULL_3D_TRAINING_MODES or flat_depth_targets:
+                (train_preview_batch,train_preview_preds,train_preview_targets,train_preview_ignore_mask) = _build_volume_preview_batch(
                     batch,
                     train_preview_preds,
                     train_preview_targets,
@@ -1069,13 +1097,13 @@ def train(config_path):
                         val_preview_targets = val_targets.detach()
                         val_preview_ignore = val_ignore_mask.detach()
                         val_preview_volume_logits = preview_volume_preds.detach() if normal_pooled_mode else None
-                        if mode in _FULL_3D_TRAINING_MODES:
+                        if mode in _FULL_3D_TRAINING_MODES or flat_depth_targets:
                             (
                                 val_preview_batch,
                                 val_preview_preds,
                                 val_preview_targets,
                                 val_preview_ignore,
-                            ) = _build_full_3d_preview_batch(
+                            ) = _build_volume_preview_batch(
                                 val_batch,
                                 val_preview_preds,
                                 val_preview_targets,


### PR DESCRIPTION
Reopening #1434, which was closed by review — both asks are addressed here, and the
reply is on that thread. `--z-reduce mean` is gone; the description now follows
`CONTRIBUTING.md`.

## Motivation

Testing the premise of #192 — that more accurate 3D ink labels train better models — on
PHercParis4 `w00_20231016151002` and `w02_20231031143852`, I hit a wall in the pipeline
itself. In `flat` mode the label never reaches the loss with its depth intact:

    targets = (torch.amax(batch['inklabels'], dim=2) > 0).to(dtype=batch['inklabels'].dtype)
    supervision_mask = torch.amax(batch['supervision_mask'], dim=2)

Every label voxel is max-pooled into one plane first, so a depth-resolved label and the
published single-plane label produce **byte-identical targets**. The experiment #192 asks
for is not expressible in flat mode at all. `full_3d` does keep depth, but it wants the
native scroll volume and builds its own band by projecting the flat annotation to a
constant half-thickness, so it answers a different question.

## The half that is easy to get wrong

Training on a depth-resolved label changes what inference must do with the prediction.
The loss only constrains the supervised z column; outside it the network is free, and it
saturates. A max down the full axis reports that noise instead of the ink:

![z-window before/after](https://raw.githubusercontent.com/khj1222/vesuvius-challenge/main/docs/images/w00_z_window_before_after.png)

Same checkpoint, same held-out region, only the volume→surface collapse differs:
**F1 0.499 → 0.814**. The tell is the threshold — scored over the whole volume, every
fold's best threshold pinned to 254, the top of the uint8 range. A full-segment
prediction TIFF written without the window is degraded the same way, so this is not just
a scoring detail.

## Change — opt-in, default path untouched

Everything is behind `flat_depth_targets: true`; without the key nothing changes.

* z projection is disabled for model and targets the way the native 3D modes already do
  it, and the model emits `[B, 1, Z, Y, X]`.
* The loss runs volume-to-volume, with `supervision_mask` as the ignore mask.
* Train previews reuse the `full_3d` central-slice reduction.
* `infer` gains `--z-window START:STOP` to collapse a volume prediction back to the
  ordinary 2D TIFF over the supervised slices, and warns when it is reduced over the full
  depth. Default (no window) reproduces existing behaviour.

## Verification on real scroll data

| check | result |
|---|---|
| a constant 8-voxel band trained through this path vs the 2D baseline, same 3 folds | 0.8478 vs 0.8472 mean F1 — within the 0.03 noise floor, so the depth path is calibrated, not just plumbed |
| the same on a second segment (`w02`) | 0.8263 vs its own 2D baseline 0.8235 |
| `--z-window` across the full 3-fold arm | 0.5046 → 0.8098 mean F1 |
| default-off path | a config without the key takes the existing `amax` branch, unchanged |
| unit tests | 7 passed; projection-gating tests extended to cover the flag |
| shapes / throughput | output `(1, 1, 64, 256, 256)`, ~3.6 it/s, unchanged from 2D targets |

15 training runs, ~30 GPU-hours, two segments. The full write-up and raw numbers are in
#192.

## Changed since the first round

`--z-reduce mean` is gone. It rested on one ad-hoc checkpoint comparison and never
entered the matrix, so there was no evidence to offer for it — `max` over the supervised
window is what the runs actually validate.

## Why this matters to me

I did not set out to add a flag. I wanted an answer to #192 — whether more accurate
3D ink labels actually train better models — and found that in `flat` mode the question
cannot be asked at all: the label is max-pooled into a plane before the loss, so a
depth-resolved label and the published one produce identical targets. Nothing errors and
nothing warns; the experiment just quietly measures nothing, which is a bad way for a
codebase to say "not supported".

My own answer came out negative — the measured band lost to a constant one, on two
segments — and I am still submitting the gate, because the wall is not about my band.
Anyone who tries a label-depth idea here hits it, and they hit it silently. The
`--z-window` half is the same lesson: the first time I scored a depth-target run I got
F1 0.53 and assumed the labels had failed, when the actual fault was reducing the
prediction over slices the loss never constrained. That cost me a scoring round, and it
belongs in the tool rather than in my notes.

Whether it belongs in villa is your call. It is config-gated and default-off, so my
argument is only that the flat path should be able to express the experiment the issue
asks for. If you would rather keep flat mode simple, I would find that a reasonable
answer — I would just ask that it be said on #192, so the next person does not spend a
month rediscovering it.

On process, per CONTRIBUTING: the code was written with an LLM assistant. I read the
diff, ran the tests, and every number above comes from runs on my own hardware —
15 training runs on PHercParis4 `w00` and `w02`, scored with a held-out split I built
for the July round.