### PR TITLE
Use same-run Callgrind replay for render CI

### DIFF
--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -641,45 +641,6 @@ if(VC_RUN_RENDER_BENCHMARKS)
                         bench_render_synthetic
                     VERBATIM)
 
-                set(_drd_stamp)
-                if(_fixture STREQUAL "parallel")
-                    set(_drd_dir "${_case_dir}/drd")
-                    set(_drd_stamp "${_drd_dir}/collected.stamp")
-                    set(_drd_trace "${_drd_dir}/drd.log")
-                    set(_drd_metadata "${_drd_dir}/metadata.json")
-                    add_custom_command(
-                        OUTPUT "${_drd_stamp}"
-                        BYPRODUCTS
-                            "${_drd_trace}"
-                            "${_drd_metadata}"
-                        COMMAND ${CMAKE_COMMAND} -E remove_directory
-                            "${_drd_dir}"
-                        COMMAND ${CMAKE_COMMAND} -E make_directory
-                            "${_drd_dir}"
-                        COMMAND ${CMAKE_COMMAND} -E env
-                            "VC_RENDER_SAMPLER_THREADS=4"
-                            ${VC_VALGRIND_EXECUTABLE}
-                            --tool=drd
-                            --trace-segment=yes
-                            --trace-csw=yes
-                            --fair-sched=yes
-                            --time-stamp=yes
-                            --scheduling-quantum=10000
-                            --trace-sched=yes
-                            --trace-syscalls=yes
-                            "--log-file=${_drd_trace}"
-                            $<TARGET_FILE:bench_render_synthetic>
-                            --fixture parallel
-                            --scenario ${_scenario}
-                            --native-trials 1
-                            --metadata "${_drd_metadata}"
-                            --repetitions 1
-                        COMMAND ${CMAKE_COMMAND} -E touch "${_drd_stamp}"
-                        DEPENDS
-                            bench_render_synthetic
-                        VERBATIM)
-                endif()
-
                 set(_evaluation "${_case_dir}/evaluation.json")
                 set(_evaluation_command
                     $<TARGET_FILE:bench_thread_sync_replay>
@@ -692,16 +653,13 @@ if(VC_RUN_RENDER_BENCHMARKS)
                     --output "${_evaluation}")
                 if(_fixture STREQUAL "parallel")
                     list(APPEND _evaluation_command
-                        --callgrind-scheduler "${_callgrind_scheduler}"
-                        --drd-trace "${_drd_trace}"
-                        --drd-metadata "${_drd_metadata}")
+                        --callgrind-scheduler "${_callgrind_scheduler}")
                 endif()
                 add_custom_command(
                     OUTPUT "${_evaluation}"
                     COMMAND ${_evaluation_command}
                     DEPENDS
                         "${_callgrind_stamp}"
-                        ${_drd_stamp}
                         bench_thread_sync_replay
                         "${_render_valgrind_ci_model}"
                     VERBATIM)
@@ -720,9 +678,7 @@ if(VC_RUN_RENDER_BENCHMARKS)
                     --output "${_gate}")
                 if(_fixture STREQUAL "parallel")
                     list(APPEND _gate_command
-                        --callgrind-scheduler "${_callgrind_scheduler}"
-                        --drd-trace "${_drd_trace}"
-                        --drd-metadata "${_drd_metadata}")
+                        --callgrind-scheduler "${_callgrind_scheduler}")
                 endif()
                 add_custom_command(
                     OUTPUT "${_gate}"
@@ -731,7 +687,6 @@ if(VC_RUN_RENDER_BENCHMARKS)
                     DEPENDS
                         "${_evaluation}"
                         "${_callgrind_stamp}"
-                        ${_drd_stamp}
                         bench_thread_sync_replay
                         "${_render_valgrind_ci_model}"
                         "${_render_valgrind_ci_reference}"

--- a/volume-cartographer/core/test/data/render_valgrind_ci_reference.json
+++ b/volume-cartographer/core/test/data/render_valgrind_ci_reference.json
@@ -2,35 +2,35 @@
   "cases": {
     "parallel/fallback_3": {
       "checksum": 4092684805825541122,
-      "modeled_runtime_score_ns": 2652456.159123063
+      "modeled_runtime_score_ns": 2605277.8967071185
     },
     "parallel/full_res": {
       "checksum": 8319256024933588756,
-      "modeled_runtime_score_ns": 927228.2439746696
+      "modeled_runtime_score_ns": 896747.1151190569
     },
     "parallel/mixed_correlated": {
       "checksum": 9419607384140948446,
-      "modeled_runtime_score_ns": 1985726.0110827591
+      "modeled_runtime_score_ns": 1708503.75388749
     },
     "parallel/mixed_shuffled": {
       "checksum": 2698931263477305860,
-      "modeled_runtime_score_ns": 16127550.905297693
+      "modeled_runtime_score_ns": 8961775.524007399
     },
     "serial/fallback_3": {
       "checksum": 2611257448726826058,
-      "modeled_runtime_score_ns": 893519.018267335
+      "modeled_runtime_score_ns": 893407.7850907209
     },
     "serial/full_res": {
       "checksum": 8712995097771526824,
-      "modeled_runtime_score_ns": 335043.091084441
+      "modeled_runtime_score_ns": 334923.4415747905
     },
     "serial/mixed_correlated": {
       "checksum": 2185938871354150015,
-      "modeled_runtime_score_ns": 621631.7372745703
+      "modeled_runtime_score_ns": 621331.3474646086
     },
     "serial/mixed_shuffled": {
       "checksum": 1627454152496030813,
-      "modeled_runtime_score_ns": 927876.6449918726
+      "modeled_runtime_score_ns": 927652.3631373289
     }
   },
   "model_sha256": "c75069f4fc1580029bf4013c1bbf999f2388a1ddda481d53f108f1412e11e409",

--- a/volume-cartographer/core/test/test_render_valgrind_ci_no_site.py
+++ b/volume-cartographer/core/test/test_render_valgrind_ci_no_site.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import math
 import sys
-import tempfile
 from pathlib import Path
 
 SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
@@ -14,24 +13,12 @@ sys.path.insert(0, str(SCRIPTS))
 
 import run_render_valgrind_ci  # noqa: F401
 from native_thread_sync_replay import NativeReplayEngine
-from thread_sync_trace import parse_drd_trace
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--replay-engine", type=Path, required=True)
     args = parser.parse_args()
-
-    with tempfile.TemporaryDirectory() as directory:
-        trace = Path(directory) / "drd.log"
-        trace.write_text(
-            "New segment for thread 1 with vc [1: 1]\n"
-            "SCHED[1]: entering VG_(scheduler)\n"
-            "SCHED[1]: exiting VG_(scheduler)\n"
-        )
-        parsed = parse_drd_trace(trace)
-        if not parsed.events or parsed.unresolved_happens_before != 0:
-            raise RuntimeError("dependency-free DRD parser smoke failed")
 
     profiles = {
         1: {

--- a/volume-cartographer/core/test/test_run_render_valgrind_ci.py
+++ b/volume-cartographer/core/test/test_run_render_valgrind_ci.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import copy
 import importlib.util
 import json
 import sys
@@ -8,7 +7,6 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
@@ -19,181 +17,14 @@ SPEC.loader.exec_module(DRIVER)
 
 
 class RenderValgrindCiTest(unittest.TestCase):
-    def setUp(self):
-        self.identity = {
-            "compiler_id": "GNU",
-            "compiler_version": "14.2",
-            "build_type": "Release",
-            "architecture_target": "x86-64-v3",
-            "fixture": "serial",
-            "scenario": "full_res",
-            "width": 96,
-            "height": 96,
-            "tile_size": 32,
-            "repetitions": 1,
-            "measured_pixels": 9216,
-            "worker_override": 1,
-            "valgrind_version": "valgrind-3.22.0",
-            "cache_geometry": DRIVER.CACHE_GEOMETRY,
-            "benchmark_metadata_schema": 1,
-        }
-        self.result = {
-            "case": "serial/full_res",
-            "model_sha256": "model-hash",
-            "identity": self.identity,
-            "checksum": 123,
-            "modeled_runtime_score_ns": 100.0,
-        }
-        self.reference = {
-            "schema_version": 1,
-            "model_sha256": "model-hash",
-            "tolerance": 0.10,
-            "cases": {
-                "serial/full_res": {
-                    "identity": self.identity,
-                    "checksum": 123,
-                    "modeled_runtime_score_ns": 100.0,
-                }
-            },
-        }
-
-    def test_callgrind_command_uses_separate_profiles_and_fixed_cache(self):
-        command = DRIVER.callgrind_command(
-            Path("bench"),
-            "parallel",
-            "fallback_3",
-            Path("metadata.json"),
-            Path("callgrind.out"),
-            1,
-            separate_threads=True,
-        )
-        self.assertIn("--separate-threads=yes", command)
-        self.assertIn("--fair-sched=yes", command)
-        self.assertIn(f"--D1={DRIVER.CACHE_GEOMETRY['D1']}", command)
-        self.assertEqual(command[-1], "--callgrind")
-
-    def test_drd_command_collects_vector_clocks_and_scheduler_events(self):
-        command = DRIVER.drd_command(
-            Path("bench"),
-            "mixed_correlated",
-            Path("metadata.json"),
-            Path("drd.log"),
-            1,
-            10000,
-        )
-        self.assertIn("--tool=drd", command)
-        self.assertIn("--trace-segment=yes", command)
-        self.assertIn("--trace-sched=yes", command)
-        self.assertIn("--scheduling-quantum=10000", command)
-        self.assertNotIn("--callgrind", command)
-
-    def test_reference_gate_accepts_improvements_and_upper_tolerance_bound(self):
-        for score in (0.01, 50.0, 90.0, 110.0):
-            result = copy.deepcopy(self.result)
-            result["modeled_runtime_score_ns"] = score
-            DRIVER.check_reference(result, self.reference, 0.10)
-
-    def test_reference_tolerance_is_authoritative_by_default(self):
-        self.reference["tolerance"] = 0.05
-        self.result["modeled_runtime_score_ns"] = 105.1
-        with self.assertRaisesRegex(RuntimeError, "required"):
-            DRIVER.check_reference(self.result, self.reference)
-        self.result["modeled_runtime_score_ns"] = 105.0
-        DRIVER.check_reference(self.result, self.reference)
-
-    def test_explicit_diagnostic_tolerance_can_override_reference(self):
-        self.reference["tolerance"] = 0.05
-        self.result["modeled_runtime_score_ns"] = 106.0
-        DRIVER.check_reference(self.result, self.reference, 0.10)
-
     def test_invalid_tolerances_are_rejected(self):
         for tolerance in (-0.01, 1.0, float("inf"), float("nan")):
             with self.subTest(tolerance=tolerance):
                 with self.assertRaisesRegex(RuntimeError, "tolerance"):
                     DRIVER.validate_tolerance(tolerance)
 
-    def test_reference_gate_rejects_above_upper_bound(self):
-        self.result["modeled_runtime_score_ns"] = 110.1
-        with self.assertRaisesRegex(RuntimeError, "required"):
-            DRIVER.check_reference(self.result, self.reference, 0.10)
-
-    def test_reference_gate_ignores_all_non_performance_changes(self):
-        result = copy.deepcopy(self.result)
-        reference = copy.deepcopy(self.reference)
-        result["model_sha256"] = "different-model"
-        result["checksum"] = 999
-        result["identity"] = {
-            "compiler_id": "DifferentCompiler",
-            "fixture": "changed-fixture",
-            "valgrind_version": "changed-profiler",
-        }
-        reference["model_sha256"] = "historical-model"
-        reference["cases"]["serial/full_res"]["checksum"] = 456
-        reference["cases"]["serial/full_res"]["identity"] = {
-            "compiler_id": "HistoricalCompiler",
-            "fixture": "historical-fixture",
-            "valgrind_version": "historical-profiler",
-        }
-        DRIVER.check_reference(result, reference, 0.10)
-
-    def test_reference_gate_accepts_valgrind_change_and_records_versions(self):
-        result = copy.deepcopy(self.result)
-        reference = copy.deepcopy(self.reference)
-        result["identity"]["valgrind_version"] = "valgrind-3.26.0"
-        DRIVER.check_reference(result, reference, 0.10)
-        self.assertEqual(result["reference_valgrind_version"], "valgrind-3.22.0")
-        self.assertEqual(result["observed_valgrind_version"], "valgrind-3.26.0")
-        self.assertTrue(result["valgrind_version_changed"])
-
-    def test_reference_gate_keeps_valgrind_diagnostics_on_score_failure(self):
-        result = copy.deepcopy(self.result)
-        reference = copy.deepcopy(self.reference)
-        result["identity"]["valgrind_version"] = "valgrind-3.26.0"
-        result["modeled_runtime_score_ns"] = 110.1
-        with self.assertRaisesRegex(RuntimeError, "required"):
-            DRIVER.check_reference(result, reference, 0.10)
-        self.assertEqual(result["reference_valgrind_version"], "valgrind-3.22.0")
-        self.assertEqual(result["observed_valgrind_version"], "valgrind-3.26.0")
-        self.assertTrue(result["valgrind_version_changed"])
-
-    def test_reference_gate_does_not_require_identity_metadata(self):
-        result = copy.deepcopy(self.result)
-        reference = copy.deepcopy(self.reference)
-        result.pop("identity")
-        reference["cases"]["serial/full_res"].pop("identity")
-        DRIVER.check_reference(result, reference, 0.10)
-        self.assertIsNone(result["reference_valgrind_version"])
-        self.assertIsNone(result["observed_valgrind_version"])
-        self.assertFalse(result["valgrind_version_changed"])
-
-    def test_pair_requires_matching_valgrind_versions(self):
-        callgrind = {
-            "case": "parallel/full_res",
-            "metadata": {},
-            "valgrind_version": "valgrind-3.25.1",
-        }
-        drd = {
-            "case": "parallel/full_res",
-            "metadata": {},
-            "valgrind_version": "valgrind-3.26.0",
-            "trace": {
-                "unmatched_futex_waits": 0,
-                "unresolved_happens_before": 0,
-            },
-        }
-        with (
-            mock.patch.object(DRIVER, "_verify_manifest_files"),
-            self.assertRaisesRegex(RuntimeError, "different Valgrind versions"),
-        ):
-            DRIVER._validate_pair(callgrind, drd)
-
-    def test_reference_gate_rejects_missing_case(self):
-        self.result["case"] = "serial/new_case"
-        with self.assertRaisesRegex(RuntimeError, "reference has no case"):
-            DRIVER.check_reference(self.result, self.reference, 0.10)
-
-    def test_reference_gate_rejects_invalid_scores(self):
-        invalid = (
+    def test_invalid_scores_are_rejected(self):
+        for score in (
             float("nan"),
             float("inf"),
             float("-inf"),
@@ -201,75 +32,10 @@ class RenderValgrindCiTest(unittest.TestCase):
             -1.0,
             "not-a-score",
             None,
-        )
-        for source in ("observed", "reference"):
-            for score in invalid:
-                with self.subTest(source=source, score=score):
-                    result = copy.deepcopy(self.result)
-                    reference = copy.deepcopy(self.reference)
-                    if source == "observed":
-                        result["modeled_runtime_score_ns"] = score
-                    else:
-                        reference["cases"]["serial/full_res"][
-                            "modeled_runtime_score_ns"
-                        ] = score
-                    with self.assertRaisesRegex(RuntimeError, "finite and positive"):
-                        DRIVER.check_reference(result, reference, 0.10)
-
-    def test_trace_completeness_requires_all_dependencies(self):
-        complete = SimpleNamespace(
-            unmatched_waits=0, unresolved_happens_before=0, events=[object()]
-        )
-        self.assertTrue(DRIVER._trace_is_complete(complete))
-        complete.unmatched_waits = 1
-        self.assertFalse(DRIVER._trace_is_complete(complete))
-        complete.unmatched_waits = 0
-        complete.unresolved_happens_before = 1
-        self.assertFalse(DRIVER._trace_is_complete(complete))
-
-    def test_serial_score_is_normalized_by_repetitions(self):
-        callgrind = {
-            "profiles": {
-                "1": {
-                    "Ir": 80,
-                    "Dr": 20,
-                    "Dw": 10,
-                    "D1mr": 2,
-                    "D1mw": 1,
-                    "DLmr": 1,
-                    "DLmw": 0,
-                    "Bcm": 2,
-                    "Bim": 1,
-                }
-            },
-            "metadata": {"repetitions": 2},
-        }
-        event_model = {
-            "feature_names": [
-                "non_data_instructions",
-                "data_reads",
-                "data_writes",
-                "l1_data_misses",
-                "last_level_data_misses",
-                "branch_misses",
-                "branch_weighted_l1_misses",
-            ],
-            "coefficients_ns": [1.0] * 7,
-            "stall_overlap_fraction": 0.0,
-        }
-        expected_features = 50 + 20 + 10 + 3 + 1 + 3 + (3 * 3 / 80)
-        engine = mock.MagicMock()
-        engine.__enter__.return_value = engine
-        engine.model_profile_costs.return_value = (
-            {1: expected_features},
-            expected_features,
-        )
-        with mock.patch.object(DRIVER, "NativeReplayEngine", return_value=engine):
-            score, replay = DRIVER.estimate_score(
-                callgrind, None, {"event_cost_model": event_model}, Path("unused")
-            )
-        self.assertAlmostEqual(score, expected_features / 2)
-        self.assertIsNone(replay)
+        ):
+            with self.subTest(score=score):
+                with self.assertRaisesRegex(RuntimeError, "finite and positive"):
+                    DRIVER.validate_score(score, "test")
 
     def test_atomic_json_is_complete(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -310,25 +76,30 @@ class RenderValgrindCiTest(unittest.TestCase):
             self.assertFalse(model["timing_claims_enabled"])
 
     def test_set_tolerance_preserves_all_reference_cases(self):
-        reference = copy.deepcopy(self.reference)
+        reference = {
+            "schema_version": 1,
+            "model_sha256": "model-hash",
+            "tolerance": 0.10,
+            "cases": {},
+        }
         for fixture in ("serial", "parallel"):
             for scenario in DRIVER.SCENARIOS:
                 reference["cases"][f"{fixture}/{scenario}"] = {
-                    "identity": {"fixture": fixture, "scenario": scenario},
                     "checksum": 123,
                     "modeled_runtime_score_ns": 100.0,
                 }
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "reference.json"
             path.write_text(json.dumps(reference))
-            args = SimpleNamespace(reference=path, output=None, tolerance=0.05)
-            DRIVER.set_tolerance(args)
+            DRIVER.set_tolerance(
+                SimpleNamespace(reference=path, output=None, tolerance=0.05)
+            )
             updated = json.loads(path.read_text())
             self.assertEqual(updated["tolerance"], 0.05)
             reference["tolerance"] = 0.05
             self.assertEqual(updated, reference)
 
-    def test_freeze_reference_accepts_native_evaluations(self):
+    def test_freeze_reference_accepts_callgrind_only_native_evaluations(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             model = root / "model.json"
@@ -340,7 +111,7 @@ class RenderValgrindCiTest(unittest.TestCase):
                     result.write_text(
                         json.dumps(
                             {
-                                "schema_version": 2,
+                                "schema_version": 3,
                                 "kind": "evaluation",
                                 "case": f"{fixture}/{scenario}",
                                 "model_id": "native-model",
@@ -363,7 +134,7 @@ class RenderValgrindCiTest(unittest.TestCase):
             reference = json.loads(output.read_text())
             self.assertEqual(reference["tolerance"], 0.05)
             self.assertEqual(len(reference["cases"]), 8)
-            self.assertNotIn("identity", reference["cases"]["serial/full_res"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/volume-cartographer/core/test/test_thread_sync_replay_native.cpp
+++ b/volume-cartographer/core/test/test_thread_sync_replay_native.cpp
@@ -87,39 +87,12 @@ replay::EventCostModel dataReadModel()
     };
 }
 
-replay::SchedulerTrace schedulerTrace(std::vector<std::int64_t> quantum_threads)
-{
-    replay::SchedulerTrace result{.quantum_threads = std::move(quantum_threads)};
-    for (const auto thread : result.quantum_threads) {
-        ++result.full_quanta[thread];
-    }
-    return result;
-}
-
 replay::EventProfile scaledProfile(std::int64_t scale)
 {
     auto result = representativeProfile();
     for (auto& [name, value] : result) {
         (void)name;
         value *= scale;
-    }
-    return result;
-}
-
-std::vector<std::int64_t> roundRobinSchedule(std::vector<std::pair<std::int64_t, std::size_t>> remaining)
-{
-    std::vector<std::int64_t> result;
-    bool emitted = true;
-    while (emitted) {
-        emitted = false;
-        for (auto& [thread, count] : remaining) {
-            if (count == 0) {
-                continue;
-            }
-            result.push_back(thread);
-            --count;
-            emitted = true;
-        }
     }
     return result;
 }
@@ -266,30 +239,38 @@ TEST_CASE("native Callgrind parser rejects nonzero residual-only threads")
     CHECK_THROWS_WITH_AS(replay::parsePeriodicCallgrind(prefix), doctest::Contains("Callgrind residual-only thread contains measured work"), std::runtime_error);
 }
 
-TEST_CASE("native DRD parser trims to the passive measured clock pair")
+TEST_CASE("native Callgrind synchronization parser pairs measured futex wakeups")
 {
     TemporaryDirectory temporary;
-    const auto trace = temporary.path / "drd.log";
+    const auto trace = temporary.path / "scheduler.log";
     writeText(
         trace,
-        "-- New segment for thread 1 with vc [ 1: 1 ]\n"
+        "SYSCALL[2,2](202) sys_futex ( 0xbbb, 393, 0, 0x0, 0x0 ) --> [async] ...\n"
         "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n"
-        "-- New segment for thread 1 with vc [ 1: 2 ]\n"
-        "-- New segment for thread 2 with vc [ 1: 2, 2: 1 ]\n"
+        "SYSCALL[2,1](202) sys_futex ( 0xbbb, 129, 1, 0x0, 0x0 ) --> [async] ...\n"
+        "SYSCALL[2,1](202) ... [async] --> Success(0x1)\n"
+        "SYSCALL[2,2](202) ... [async] --> Success(0x0)\n"
         "-- SCHED[2]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n"
+        "SYSCALL[2,2](202) sys_futex ( 0xccc, 393, 0, 0x0, 0x0 ) --> [async] ...\n"
         "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n"
-        "-- New segment for thread 1 with vc [ 1: 3, 2: 1 ]\n");
+        "-- SCHED[9]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n");
 
-    const auto parsed = replay::parseMeasuredDrd(trace);
-    CHECK(parsed.parsed_segment_count == 3);
-    CHECK(parsed.retained_segment_count == 2);
-    CHECK(parsed.events.size() == 3);
-    CHECK(parsed.happens_before_edges == 1);
+    const auto parsed = replay::parseMeasuredCallgrindSync(trace);
+    REQUIRE(parsed.events.size() == 4);
+    CHECK(parsed.parsed_futex_calls == 2);
+    CHECK(parsed.blocking_futex_waits == 1);
+    CHECK(parsed.futex_happens_before_edges == 1);
+    CHECK(parsed.dropped_pre_window_edges == 0);
     CHECK(parsed.scheduler.full_quanta.at(2) == 1);
-    CHECK(parsed.events[1].dependencies.back().kind == "drd_happens_before");
+    CHECK(parsed.events[0].kind == "futex_wake");
+    CHECK(parsed.events[1].kind == "futex_resume");
+    CHECK(parsed.events[1].dependencies.back().kind == "futex_wake");
+    CHECK(parsed.events[2].kind == "work_quantum");
+    CHECK(parsed.events[3].kind == "futex_wait");
+    CHECK(parsed.events[3].blocked);
 }
 
-TEST_CASE("native scheduler parser preserves measured quantum order")
+TEST_CASE("native Callgrind synchronization parser preserves measured quantum order")
 {
     TemporaryDirectory temporary;
     const auto trace = temporary.path / "scheduler.log";
@@ -303,91 +284,85 @@ TEST_CASE("native scheduler parser preserves measured quantum order")
         "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n"
         "-- SCHED[9]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n");
 
-    const auto parsed = replay::parseMeasuredScheduler(trace);
-    CHECK(parsed.quantum_threads == std::vector<std::int64_t>{2, 3, 2});
-    CHECK(parsed.full_quanta.at(2) == 2);
-    CHECK(parsed.full_quanta.at(3) == 1);
-    CHECK(parsed.begin_line == 2);
-    CHECK(parsed.end_line == 6);
+    const auto parsed = replay::parseMeasuredCallgrindSync(trace);
+    CHECK(parsed.scheduler.quantum_threads == std::vector<std::int64_t>{2, 3, 2});
+    CHECK(parsed.scheduler.full_quanta.at(2) == 2);
+    CHECK(parsed.scheduler.full_quanta.at(3) == 1);
+    CHECK(parsed.scheduler.begin_line == 2);
+    CHECK(parsed.scheduler.end_line == 6);
 }
 
-TEST_CASE("native paired replay uses same-run scheduler evidence")
+TEST_CASE("native Callgrind synchronization parser ignores nonblocking futex waits")
+{
+    TemporaryDirectory temporary;
+    const auto trace = temporary.path / "scheduler.log";
+    writeText(
+        trace,
+        "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n"
+        "SYSCALL[2,2](202) sys_futex ( 0xbbb, 393, 0, 0x0, 0x0 ) --> [async] ...\n"
+        "SYSCALL[2,2](202) ... [async] --> Failure(0xb)\n"
+        "-- SCHED[2]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n"
+        "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n");
+
+    const auto parsed = replay::parseMeasuredCallgrindSync(trace);
+    REQUIRE(parsed.events.size() == 2);
+    CHECK(parsed.events[0].kind == "futex_wait");
+    CHECK_FALSE(parsed.events[0].blocked);
+    CHECK(parsed.blocking_futex_waits == 0);
+    CHECK(parsed.futex_happens_before_edges == 0);
+}
+
+TEST_CASE("native Callgrind synchronization parser rejects an unmatched measured wakeup")
+{
+    TemporaryDirectory temporary;
+    const auto trace = temporary.path / "scheduler.log";
+    writeText(
+        trace,
+        "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n"
+        "SYSCALL[2,2](202) sys_futex ( 0xbbb, 393, 0, 0x0, 0x0 ) --> [async] ...\n"
+        "SYSCALL[2,2](202) ... [async] --> Success(0x0)\n"
+        "-- SCHED[2]: releasing lock (VG_(scheduler):timeslice) -> VgTs_Yielding\n"
+        "SYSCALL[2,1](228) sys_clock_gettime( 1, 0xaaa )[sync] --> Success(0x0)\n");
+
+    CHECK_THROWS_WITH_AS(replay::parseMeasuredCallgrindSync(trace), doctest::Contains("no matching wake"), std::runtime_error);
+}
+
+TEST_CASE("native Callgrind replay attributes costs directly to same-run threads")
 {
     replay::CallgrindTrace callgrind;
     for (std::int64_t thread = 1; thread <= 3; ++thread) {
         callgrind.slices[thread] = {scaledProfile(thread)};
         callgrind.totals[thread] = scaledProfile(thread);
     }
-    const auto callgrind_scheduler = schedulerTrace({2, 3, 2, 2, 2, 2, 2, 2});
-    replay::DrdTrace drd{
+    replay::CallgrindSyncTrace sync{
         .events =
             {
                 {.thread = 1, .kind = "work_quantum"},
-                {.thread = 3, .kind = "work_quantum"},
-                {.thread = 2, .kind = "work_quantum"},
-            },
-        .scheduler = schedulerTrace({3, 2, 3, 3, 3, 3, 3, 3}),
-    };
-    const auto result =
-        replay::replayPaired(callgrind, callgrind_scheduler, drd, dataReadModel(), {.scheduler_bins = 4, .scheduler_quantum_slack = 0.0, .replay = {.cores = 3}});
-    CHECK(result.evaluated_mapping_count == 2);
-    CHECK(result.mapping_count == 1);
-    CHECK(result.selected_source_by_trace_thread.at(2) == 3);
-    CHECK(result.selected_source_by_trace_thread.at(3) == 2);
-    CHECK(result.conservative.modeled_work > 0.0);
-    CHECK(result.minimum_makespan == result.conservative.modeled_makespan);
-}
-
-TEST_CASE("native paired replay rejects material assignment ambiguity")
-{
-    replay::CallgrindTrace callgrind;
-    callgrind.slices[1] = {scaledProfile(10)};
-    callgrind.totals[1] = scaledProfile(10);
-    callgrind.slices[2] = {scaledProfile(1)};
-    callgrind.totals[2] = scaledProfile(1);
-    callgrind.slices[3] = {scaledProfile(10)};
-    callgrind.totals[3] = scaledProfile(10);
-    const auto callgrind_scheduler = schedulerTrace({2, 3, 2, 3});
-    replay::DrdTrace drd{
-        .events =
-            {
                 {.thread = 2, .kind = "work_quantum"},
                 {.thread = 3, .kind = "work_quantum"},
-                {.thread = 1, .kind = "work_quantum", .dependencies = {{0, "drd_happens_before"}}},
             },
-        .scheduler = schedulerTrace({2, 3, 2, 3}),
     };
-    CHECK_THROWS_WITH_AS(replay::replayPaired(callgrind, callgrind_scheduler, drd, dataReadModel(), {.scheduler_bins = 1, .scheduler_quantum_slack = 0.0, .maximum_makespan_spread = 0.02, .replay = {.cores = 3}}), doctest::Contains("assignment evidence insufficient"), std::runtime_error);
+    const auto result = replay::replayCallgrind(callgrind, sync, dataReadModel(), {.replay = {.cores = 3}});
+    const double expected = replay::modeledProfileCostNs(scaledProfile(1), dataReadModel()) +
+                            replay::modeledProfileCostNs(scaledProfile(2), dataReadModel()) +
+                            replay::modeledProfileCostNs(scaledProfile(3), dataReadModel());
+    CHECK(result.modeled_work == doctest::Approx(expected));
 }
 
-TEST_CASE("native paired replay resolves a shifted DRD tie from Callgrind scheduling")
+TEST_CASE("native Callgrind replay retains short threads without a full quantum")
 {
     replay::CallgrindTrace callgrind;
     callgrind.slices[1] = {scaledProfile(1)};
     callgrind.totals[1] = scaledProfile(1);
-    for (const auto [thread, scale] : std::vector<std::pair<std::int64_t, std::int64_t>>{{2, 4}, {3, 5}, {4, 8}, {5, 10}}) {
-        callgrind.slices[thread] = {scaledProfile(scale)};
-        callgrind.totals[thread] = scaledProfile(scale);
-    }
-    const auto callgrind_scheduler = schedulerTrace(roundRobinSchedule({{2, 42}, {3, 43}, {4, 46}, {5, 50}}));
-    replay::DrdTrace drd{
-        .events =
-            {
-                {.thread = 1, .kind = "work_quantum"},
-                {.thread = 6, .kind = "work_quantum"},
-                {.thread = 7, .kind = "work_quantum"},
-                {.thread = 8, .kind = "work_quantum"},
-                {.thread = 9, .kind = "work_quantum"},
-            },
-        .scheduler = schedulerTrace(roundRobinSchedule({{6, 38}, {7, 38}, {8, 41}, {9, 45}})),
+    callgrind.slices[2] = {scaledProfile(2)};
+    callgrind.totals[2] = scaledProfile(2);
+    replay::CallgrindSyncTrace sync{
+        .events = {{.thread = 1, .kind = "work_quantum"}},
     };
-    const auto result =
-        replay::replayPaired(callgrind, callgrind_scheduler, drd, dataReadModel(), {.scheduler_bins = 16, .scheduler_quantum_slack = 1.0, .maximum_makespan_spread = 0.02, .replay = {.cores = 5}});
-    CHECK(result.evaluated_mapping_count == 24);
-    CHECK(result.mapping_count == 2);
-    CHECK(result.selected_source_by_trace_thread.at(8) == 4);
-    CHECK(result.selected_source_by_trace_thread.at(9) == 5);
-    CHECK(result.makespan_relative_spread == 0.0);
+    const auto result = replay::replayCallgrind(callgrind, sync, dataReadModel(), {.replay = {.cores = 2}});
+    CHECK(
+        result.modeled_work ==
+        doctest::Approx(replay::modeledProfileCostNs(scaledProfile(1), dataReadModel()) + replay::modeledProfileCostNs(scaledProfile(2), dataReadModel())));
 }
 
 TEST_CASE("native replay applies cross-thread and wake latency cumulatively")

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.cpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.cpp
@@ -3,12 +3,10 @@
 #include <algorithm>
 #include <cmath>
 #include <fstream>
-#include <functional>
 #include <limits>
 #include <numeric>
 #include <optional>
 #include <regex>
-#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -255,97 +253,28 @@ std::vector<double> distributeSlices(const std::vector<EventProfile>& slices, co
     return result;
 }
 
-struct SchedulerDescriptor {
-    double share{0.0};
-    std::vector<double> cumulative_activity;
-};
-
-struct SchedulerDescriptors {
-    std::map<std::int64_t, SchedulerDescriptor> threads;
-    std::size_t total_quanta{0};
-};
-
-SchedulerDescriptors describeScheduler(const SchedulerTrace& scheduler, const std::vector<std::int64_t>& threads, std::size_t bins)
-{
-    if (threads.empty() || bins == 0) {
-        throw std::runtime_error("scheduler attribution requires workers and activity bins");
-    }
-    const std::set<std::int64_t> expected(threads.begin(), threads.end());
-    SchedulerDescriptors result;
-    for (const auto thread : threads) {
-        const auto found = scheduler.full_quanta.find(thread);
-        if (found == scheduler.full_quanta.end() || found->second == 0) {
-            throw std::runtime_error("scheduler trace has no measured work for worker " + std::to_string(thread));
-        }
-        result.threads.emplace(thread, SchedulerDescriptor{.cumulative_activity = std::vector<double>(bins, 0.0)});
-    }
-    for (const auto& [thread, quanta] : scheduler.full_quanta) {
-        if (thread != kMainThread && quanta != 0 && !expected.contains(thread)) {
-            throw std::runtime_error("scheduler trace contains an unmatched active worker " + std::to_string(thread));
-        }
-    }
-
-    std::vector<std::int64_t> sequence;
-    for (const auto thread : scheduler.quantum_threads) {
-        if (expected.contains(thread)) {
-            sequence.push_back(thread);
-        }
-    }
-    result.total_quanta = sequence.size();
-    if (result.total_quanta == 0) {
-        throw std::runtime_error("scheduler trace contains no worker quanta");
-    }
-
-    std::map<std::int64_t, std::size_t> cumulative;
-    std::size_t cursor = 0;
-    for (std::size_t bin = 0; bin < bins; ++bin) {
-        const std::size_t boundary = (bin + 1) * result.total_quanta / bins;
-        while (cursor < boundary) {
-            ++cumulative[sequence[cursor++]];
-        }
-        for (const auto thread : threads) {
-            result.threads.at(thread).cumulative_activity[bin] = static_cast<double>(cumulative[thread]) / static_cast<double>(result.total_quanta);
-        }
-    }
-    for (const auto thread : threads) {
-        const auto counted = cumulative[thread];
-        if (counted != scheduler.full_quanta.at(thread)) {
-            throw std::runtime_error("scheduler trace quantum sequence and totals disagree");
-        }
-        result.threads.at(thread).share = static_cast<double>(counted) / static_cast<double>(result.total_quanta);
-    }
-    return result;
-}
-
-double schedulerDistance(const SchedulerDescriptor& source, const SchedulerDescriptor& target)
-{
-    if (source.cumulative_activity.size() != target.cumulative_activity.size() || source.cumulative_activity.empty()) {
-        throw std::runtime_error("scheduler activity descriptors have incompatible shapes");
-    }
-    double cumulative_distance = 0.0;
-    for (std::size_t index = 0; index < source.cumulative_activity.size(); ++index) {
-        cumulative_distance += std::abs(source.cumulative_activity[index] - target.cumulative_activity[index]);
-    }
-    return std::abs(source.share - target.share) + cumulative_distance / source.cumulative_activity.size();
-}
-
-std::map<std::int64_t, std::vector<double>> mappedWindowCosts(
-    const std::map<std::int64_t, std::int64_t>& source_by_trace, const CallgrindTrace& callgrind, const ThreadAttributionWindows& windows, const EventCostModel& model)
+std::map<std::int64_t, std::vector<double>> directWindowCosts(const CallgrindTrace& callgrind, const ThreadAttributionWindows& windows, const EventCostModel& model)
 {
     std::map<std::int64_t, std::vector<double>> result;
-    for (const auto& [trace_thread, source_thread] : source_by_trace) {
-        const auto found_windows = windows.find(trace_thread);
-        const auto found_slices = callgrind.slices.find(source_thread);
-        const auto found_total = callgrind.totals.find(source_thread);
-        if (found_windows == windows.end() || found_slices == callgrind.slices.end() || found_total == callgrind.totals.end()) {
-            throw std::runtime_error("paired attribution references an unknown thread");
+    for (const auto& [thread, thread_windows] : windows) {
+        const auto found_slices = callgrind.slices.find(thread);
+        const auto found_total = callgrind.totals.find(thread);
+        if (found_slices == callgrind.slices.end() || found_total == callgrind.totals.end()) {
+            result.emplace(thread, std::vector<double>(thread_windows.size(), 0.0));
+            continue;
         }
         std::vector<double> weights;
-        weights.reserve(found_windows->second.size());
-        for (const auto& window : found_windows->second) {
+        weights.reserve(thread_windows.size());
+        for (const auto& window : thread_windows) {
             weights.push_back(window.units);
         }
-        result.emplace(trace_thread, distributeSlices(found_slices->second, found_total->second, model, weights));
+        result.emplace(thread, distributeSlices(found_slices->second, found_total->second, model, weights));
+    }
+    for (const auto& [thread, total] : callgrind.totals) {
+        (void)total;
+        if (!windows.contains(thread)) {
+            throw std::runtime_error("Callgrind thread " + std::to_string(thread) + " has measured cost but no scheduler event");
+        }
     }
     return result;
 }
@@ -426,59 +355,168 @@ CallgrindTrace parsePeriodicCallgrind(const std::filesystem::path& prefix)
     return result;
 }
 
-SchedulerTrace parseMeasuredScheduler(const std::filesystem::path& path)
-{
-    return schedulerFromMeasuredLog(readMeasuredLog(path));
-}
-
-DrdTrace parseMeasuredDrd(const std::filesystem::path& path)
+CallgrindSyncTrace parseMeasuredCallgrindSync(const std::filesystem::path& path)
 {
     const auto measured = readMeasuredLog(path);
     const auto& lines = measured.lines;
     const auto begin = measured.begin;
     const auto end = measured.end;
 
-    const std::regex segment_re(R"(New segment for thread ([0-9]+) with vc \[ (.*) \])");
-    const std::regex value_re(R"((\d+):\s*(\d+))");
-    const std::regex quantum_re(R"(SCHED\[(\d+)\]:\s+releasing lock \(VG_\(scheduler\):timeslice\))");
-    struct SegmentRecord {
-        std::size_t line;
-        std::int64_t thread;
-        std::map<std::int64_t, std::int64_t> clock;
-        std::optional<std::size_t> event;
+    struct FutexCall {
+        std::int64_t thread{0};
+        std::string address;
+        std::uint64_t operation{0};
+        std::size_t start_line{0};
+        std::size_t completion_line{0};
+        bool complete{false};
+        bool success{false};
+        std::uint64_t result{0};
     };
-    std::vector<SegmentRecord> segments;
-    std::map<std::pair<std::int64_t, std::int64_t>, std::size_t> segment_by_clock;
-    for (std::size_t index = 0; index < end; ++index) {
+    const std::regex start_re(R"(SYSCALL\[\d+,(\d+)\]\(202\) sys_futex \(\s*(0x[0-9a-fA-F]+),\s*([0-9]+),\s*([0-9]+).+\)\s*--> )");
+    const std::regex completion_re(R"(SYSCALL\[\d+,(\d+)\]\(202\) \.\.\. \[async\] --> (Success|Failure)\((0x[0-9a-fA-F]+)\))");
+    const std::regex result_re(R"(--> (Success|Failure)\((0x[0-9a-fA-F]+)\))");
+    const std::regex quantum_re(R"(SCHED\[(\d+)\]:\s+releasing lock \(VG_\(scheduler\):timeslice\))");
+    std::vector<FutexCall> calls;
+    std::map<std::int64_t, std::size_t> pending;
+    for (std::size_t index = 0; index < lines.size(); ++index) {
         std::smatch match;
-        if (!std::regex_search(lines[index], match, segment_re)) {
+        if (std::regex_search(lines[index], match, start_re)) {
+            FutexCall call{
+                .thread = std::stoll(match[1].str()),
+                .address = match[2].str(),
+                .operation = std::stoull(match[3].str()),
+                .start_line = index,
+                .completion_line = index,
+            };
+            std::smatch immediate;
+            if (std::regex_search(lines[index], immediate, result_re)) {
+                call.complete = true;
+                call.success = immediate[1].str() == "Success";
+                call.result = std::stoull(immediate[2].str(), nullptr, 0);
+            }
+            const auto call_index = calls.size();
+            calls.push_back(std::move(call));
+            if (!calls.back().complete && !pending.emplace(calls.back().thread, call_index).second) {
+                throw std::runtime_error("Callgrind scheduler trace has overlapping futex syscalls for one thread");
+            }
             continue;
         }
-        SegmentRecord record{.line = index, .thread = std::stoll(match[1].str())};
-        const auto clock_text = match[2].str();
-        for (auto iterator = std::sregex_iterator(clock_text.begin(), clock_text.end(), value_re); iterator != std::sregex_iterator(); ++iterator) {
-            record.clock.emplace(std::stoll((*iterator)[1].str()), std::stoll((*iterator)[2].str()));
+        if (!std::regex_search(lines[index], match, completion_re)) {
+            continue;
         }
-        const auto own = record.clock.find(record.thread);
-        if (own == record.clock.end()) {
-            throw std::runtime_error("DRD segment has no own vector-clock value");
+        const auto thread = std::stoll(match[1].str());
+        const auto found = pending.find(thread);
+        if (found == pending.end()) {
+            continue;
         }
-        const auto record_index = segments.size();
-        if (!segment_by_clock.emplace(std::make_pair(record.thread, own->second), record_index).second) {
-            throw std::runtime_error("duplicate DRD vector-clock segment");
-        }
-        segments.push_back(std::move(record));
+        auto& call = calls[found->second];
+        call.complete = true;
+        call.completion_line = index;
+        call.success = match[2].str() == "Success";
+        call.result = std::stoull(match[3].str(), nullptr, 0);
+        pending.erase(found);
     }
 
-    DrdTrace result;
+    const auto command = [](const FutexCall& call) { return call.operation & 0x7fU; };
+    const auto is_wait = [&](const FutexCall& call) { return command(call) == 0U || command(call) == 9U; };
+    const auto is_wake = [&](const FutexCall& call) { return command(call) == 1U || command(call) == 10U; };
+    const auto wait_blocks = [](const FutexCall& call) {
+        constexpr std::uint64_t eagain = 11;
+        return !call.complete || call.success || call.result != eagain;
+    };
+    const auto in_window = [&](std::size_t line) { return line > begin && line < end; };
+
+    std::vector<std::uint64_t> wake_capacity(calls.size(), 0);
+    for (std::size_t index = 0; index < calls.size(); ++index) {
+        const auto& call = calls[index];
+        if (in_window(call.start_line) && !is_wait(call) && !is_wake(call)) {
+            throw std::runtime_error("Callgrind measured window contains unsupported futex operation " + std::to_string(command(call)));
+        }
+        if (is_wake(call) && call.complete && call.success) {
+            wake_capacity[index] = call.result;
+        }
+    }
+
+    std::vector<std::size_t> successful_waits;
+    for (std::size_t index = 0; index < calls.size(); ++index) {
+        if (is_wait(calls[index]) && calls[index].complete && calls[index].success) {
+            successful_waits.push_back(index);
+        }
+    }
+    std::sort(successful_waits.begin(), successful_waits.end(), [&](std::size_t left, std::size_t right) {
+        return calls[left].completion_line < calls[right].completion_line;
+    });
+
+    std::map<std::size_t, std::size_t> wake_by_wait;
+    std::size_t dropped_pre_window_edges = 0;
+    for (const auto wait_index : successful_waits) {
+        const auto& wait = calls[wait_index];
+        std::optional<std::size_t> selected;
+        for (std::size_t wake_index = 0; wake_index < calls.size(); ++wake_index) {
+            const auto& wake = calls[wake_index];
+            if (!is_wake(wake) || wake.address != wait.address || wake_capacity[wake_index] == 0 || wake.start_line < wait.start_line ||
+                wake.start_line > wait.completion_line) {
+                continue;
+            }
+            selected = wake_index;
+            break;
+        }
+        if (!selected) {
+            if (in_window(wait.completion_line) && wait.start_line <= begin) {
+                ++dropped_pre_window_edges;
+                continue;
+            }
+            if (in_window(wait.completion_line)) {
+                throw std::runtime_error("Callgrind measured futex wait has no matching wake");
+            }
+            continue;
+        }
+        --wake_capacity[*selected];
+        if (in_window(wait.completion_line)) {
+            wake_by_wait.emplace(wait_index, *selected);
+        }
+    }
+
+    enum class ActionKind {
+        FutexStart,
+        FutexResume,
+        WorkQuantum,
+    };
+    struct Action {
+        std::size_t line{0};
+        ActionKind kind{ActionKind::FutexStart};
+        std::int64_t thread{0};
+        std::size_t call{0};
+    };
+    std::vector<Action> actions;
+    for (std::size_t index = 0; index < calls.size(); ++index) {
+        const auto& call = calls[index];
+        if (in_window(call.start_line) && (is_wait(call) || is_wake(call))) {
+            actions.push_back({call.start_line, ActionKind::FutexStart, call.thread, index});
+        }
+        if (is_wait(call) && call.complete && wait_blocks(call) && in_window(call.completion_line)) {
+            actions.push_back({call.completion_line, ActionKind::FutexResume, call.thread, index});
+        }
+    }
+    for (std::size_t index = begin + 1; index < end; ++index) {
+        std::smatch match;
+        if (std::regex_search(lines[index], match, quantum_re)) {
+            actions.push_back({index, ActionKind::WorkQuantum, std::stoll(match[1].str()), 0});
+        }
+    }
+    std::stable_sort(actions.begin(), actions.end(), [](const Action& left, const Action& right) {
+        return std::tie(left.line, left.kind) < std::tie(right.line, right.kind);
+    });
+
+    CallgrindSyncTrace result;
     result.scheduler = schedulerFromMeasuredLog(measured);
-    result.parsed_segment_count = segments.size();
+    result.dropped_pre_window_edges = dropped_pre_window_edges;
     result.begin_line = begin + 1;
     result.end_line = end + 1;
     std::map<std::int64_t, std::size_t> previous;
-    std::map<std::int64_t, std::map<std::int64_t, std::int64_t>> previous_clock;
-    auto append = [&](std::int64_t thread, std::string kind) -> std::size_t {
-        Event event{.thread = thread, .kind = std::move(kind)};
+    std::map<std::size_t, std::size_t> wake_event;
+    const auto append = [&](std::int64_t thread, std::string kind, bool blocked = false) {
+        Event event{.thread = thread, .kind = std::move(kind), .blocked = blocked};
         const auto found = previous.find(thread);
         if (found != previous.end()) {
             event.dependencies.push_back({found->second, "program_order"});
@@ -488,151 +526,75 @@ DrdTrace parseMeasuredDrd(const std::filesystem::path& path)
         previous[thread] = sequence;
         return sequence;
     };
-
-    std::size_t segment_cursor = 0;
-    for (std::size_t index = begin + 1; index < end; ++index) {
-        while (segment_cursor < segments.size() && segments[segment_cursor].line < index) {
-            ++segment_cursor;
+    for (const auto& action : actions) {
+        if (action.kind == ActionKind::WorkQuantum) {
+            append(action.thread, "work_quantum");
+            continue;
         }
-        if (segment_cursor < segments.size() && segments[segment_cursor].line == index) {
-            auto& segment = segments[segment_cursor];
-            const auto sequence = append(segment.thread, "hb_segment");
-            ++result.retained_segment_count;
-            segment.event = sequence;
-            for (const auto& [owner, value] : segment.clock) {
-                if (owner == segment.thread || value <= previous_clock[segment.thread][owner]) {
-                    continue;
+        const auto& call = calls[action.call];
+        if (action.kind == ActionKind::FutexStart) {
+            ++result.parsed_futex_calls;
+            if (is_wait(call)) {
+                const bool blocked = wait_blocks(call);
+                append(call.thread, "futex_wait", blocked);
+                if (blocked) {
+                    ++result.blocking_futex_waits;
                 }
-                const auto predecessor = segment_by_clock.find({owner, value});
-                if (predecessor == segment_by_clock.end() || segments[predecessor->second].line >= index) {
-                    throw std::runtime_error("DRD trace has an unresolved measured-window dependency");
-                }
-                const auto predecessor_event = segments[predecessor->second].event;
-                if (predecessor_event) {
-                    result.events[sequence].dependencies.push_back({*predecessor_event, "drd_happens_before"});
-                    ++result.happens_before_edges;
-                } else {
-                    ++result.dropped_pre_window_edges;
-                }
+            } else {
+                wake_event.emplace(action.call, append(call.thread, "futex_wake"));
             }
-            previous_clock[segment.thread] = segment.clock;
-            ++segment_cursor;
+            continue;
         }
-        std::smatch quantum;
-        if (std::regex_search(lines[index], quantum, quantum_re)) {
-            const auto thread = std::stoll(quantum[1].str());
-            append(thread, "work_quantum");
+
+        const auto sequence = append(call.thread, "futex_resume");
+        const auto matching_wake = wake_by_wait.find(action.call);
+        if (matching_wake == wake_by_wait.end()) {
+            continue;
         }
+        const auto source = wake_event.find(matching_wake->second);
+        if (source == wake_event.end()) {
+            ++result.dropped_pre_window_edges;
+            continue;
+        }
+        result.events[sequence].dependencies.push_back({source->second, "futex_wake"});
+        ++result.futex_happens_before_edges;
     }
     if (result.events.empty()) {
-        throw std::runtime_error("DRD measured window contains no replay events");
+        throw std::runtime_error("Callgrind measured window contains no replay events");
     }
     return result;
 }
 
-PairedReplayResult replayPaired(
-    const CallgrindTrace& callgrind, const SchedulerTrace& callgrind_scheduler, const DrdTrace& drd, const EventCostModel& model, const PairedReplayOptions& options)
+ReplayResult replayCallgrind(const CallgrindTrace& callgrind, const CallgrindSyncTrace& sync, const EventCostModel& model, const CallgrindReplayOptions& options)
 {
-    if (options.scheduler_bins == 0 || !std::isfinite(options.scheduler_quantum_slack) || options.scheduler_quantum_slack < 0.0) {
-        throw std::runtime_error("scheduler assignment settings are invalid");
-    }
-    if (!std::isfinite(options.maximum_makespan_spread) || options.maximum_makespan_spread < 0.0 || options.maximum_makespan_spread >= 1.0) {
-        throw std::runtime_error("maximum makespan spread must be in [0, 1)");
-    }
-    if (options.maximum_mappings == 0) {
-        throw std::runtime_error("maximum mapping count must be positive");
-    }
-    Graph graph(drd.events);
-    const auto windows = graph.attributionWindows(options.residual_fraction);
-    if (callgrind.totals.size() != windows.size() || !callgrind.totals.contains(kMainThread) || !windows.contains(kMainThread)) {
-        throw std::runtime_error("Callgrind and DRD thread counts do not match");
+    std::vector<Event> events = sync.events;
+    std::map<std::int64_t, std::size_t> previous;
+    for (std::size_t sequence = 0; sequence < events.size(); ++sequence) {
+        previous[events[sequence].thread] = sequence;
     }
 
-    std::vector<std::int64_t> source_threads;
+    Graph initial(events);
+    const auto initial_windows = initial.attributionWindows(options.residual_fraction);
     for (const auto& [thread, total] : callgrind.totals) {
         (void)total;
-        if (thread == kMainThread) {
+        const auto found = initial_windows.find(thread);
+        if (found != initial_windows.end() && !found->second.empty()) {
             continue;
         }
-        source_threads.push_back(thread);
-    }
-    std::vector<std::int64_t> trace_threads;
-    for (const auto& [thread, thread_windows] : windows) {
-        (void)thread_windows;
-        if (thread == kMainThread) {
-            continue;
+        Event residual{.thread = thread, .kind = "work_residual"};
+        const auto predecessor = previous.find(thread);
+        if (predecessor != previous.end()) {
+            residual.dependencies.push_back({predecessor->second, "program_order"});
         }
-        trace_threads.push_back(thread);
-    }
-    if (source_threads.size() != trace_threads.size()) {
-        throw std::runtime_error("Callgrind and DRD worker counts do not match");
+        previous[thread] = events.size();
+        events.push_back(std::move(residual));
     }
 
-    const auto source_descriptors = describeScheduler(callgrind_scheduler, source_threads, options.scheduler_bins);
-    const auto trace_descriptors = describeScheduler(drd.scheduler, trace_threads, options.scheduler_bins);
-    const double quantum_tolerance =
-        2.0 * options.scheduler_quantum_slack *
-        (1.0 / static_cast<double>(source_descriptors.total_quanta) + 1.0 / static_cast<double>(trace_descriptors.total_quanta));
-
-    struct Candidate {
-        std::map<std::int64_t, std::int64_t> source_by_trace;
-        double assignment_score{0.0};
-    };
-    std::vector<Candidate> candidates;
-    std::vector<std::int64_t> permutation = source_threads;
-    std::sort(permutation.begin(), permutation.end());
-    do {
-        if (candidates.size() >= options.maximum_mappings) {
-            throw std::runtime_error("worker assignment count exceeds limit");
-        }
-        Candidate candidate{.source_by_trace = {{kMainThread, kMainThread}}};
-        for (std::size_t index = 0; index < trace_threads.size(); ++index) {
-            const auto trace_thread = trace_threads[index];
-            const auto source_thread = permutation[index];
-            candidate.source_by_trace.emplace(trace_thread, source_thread);
-            candidate.assignment_score += schedulerDistance(source_descriptors.threads.at(source_thread), trace_descriptors.threads.at(trace_thread));
-        }
-        candidates.push_back(std::move(candidate));
-    } while (std::next_permutation(permutation.begin(), permutation.end()));
-    if (candidates.empty()) {
-        throw std::runtime_error("no worker assignments were generated");
-    }
-
-    PairedReplayResult result;
-    result.evaluated_mapping_count = candidates.size();
-    result.best_assignment_score = std::min_element(candidates.begin(), candidates.end(), [](const Candidate& left, const Candidate& right) {
-                                       return left.assignment_score < right.assignment_score;
-                                   })->assignment_score;
-    result.assignment_score_tolerance = quantum_tolerance;
-    result.minimum_makespan = std::numeric_limits<double>::infinity();
-    double maximum_makespan = -1.0;
-    const double maximum_assignment_score = result.best_assignment_score + quantum_tolerance;
-    for (const auto& candidate : candidates) {
-        if (candidate.assignment_score > maximum_assignment_score + std::numeric_limits<double>::epsilon() * 16.0) {
-            continue;
-        }
-        ++result.mapping_count;
-        result.maximum_assignment_score = std::max(result.maximum_assignment_score, candidate.assignment_score);
-        const auto costs = mappedWindowCosts(candidate.source_by_trace, callgrind, windows, model);
-        const auto durations = graph.assignWindowCosts(costs, options.residual_fraction, options.split_policy);
-        const auto replay = graph.replayAdjusted(durations, options.replay);
-        result.minimum_makespan = std::min(result.minimum_makespan, replay.modeled_makespan);
-        if (replay.modeled_makespan > maximum_makespan) {
-            maximum_makespan = replay.modeled_makespan;
-            result.conservative = replay;
-            result.selected_source_by_trace_thread = candidate.source_by_trace;
-        }
-    }
-    if (result.mapping_count == 0) {
-        throw std::runtime_error("no scheduler-compatible worker assignment");
-    }
-    result.makespan_relative_spread = (maximum_makespan - result.minimum_makespan) / maximum_makespan;
-    if (result.makespan_relative_spread > options.maximum_makespan_spread) {
-        throw std::runtime_error(
-            "assignment evidence insufficient: scheduler-compatible worker assignments exceed the makespan ambiguity limit: spread=" +
-            std::to_string(result.makespan_relative_spread) + ", limit=" + std::to_string(options.maximum_makespan_spread));
-    }
-    return result;
+    Graph graph(std::move(events));
+    const auto windows = graph.attributionWindows(options.residual_fraction);
+    const auto costs = directWindowCosts(callgrind, windows, model);
+    const auto durations = graph.assignWindowCosts(costs, options.residual_fraction, options.split_policy);
+    return graph.replayAdjusted(durations, options.replay);
 }
 
 }  // namespace vc::thread_sync_replay

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.hpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrind.hpp
@@ -24,46 +24,28 @@ struct SchedulerTrace {
     std::size_t end_line{0};
 };
 
-struct DrdTrace {
+struct CallgrindSyncTrace {
     std::vector<Event> events;
     SchedulerTrace scheduler;
-    std::size_t happens_before_edges{0};
+    std::size_t futex_happens_before_edges{0};
     std::size_t dropped_pre_window_edges{0};
-    std::size_t parsed_segment_count{0};
-    std::size_t retained_segment_count{0};
+    std::size_t parsed_futex_calls{0};
+    std::size_t blocking_futex_waits{0};
     std::size_t begin_line{0};
     std::size_t end_line{0};
 };
 
-struct PairedReplayOptions {
+struct CallgrindReplayOptions {
     double residual_fraction{0.5};
     std::string split_policy{"equal"};
-    std::size_t scheduler_bins{16};
-    double scheduler_quantum_slack{1.0};
-    double maximum_makespan_spread{0.02};
-    std::size_t maximum_mappings{100000};
     ReplayOptions replay;
-};
-
-struct PairedReplayResult {
-    ReplayResult conservative;
-    double minimum_makespan{0.0};
-    std::size_t mapping_count{0};
-    std::size_t evaluated_mapping_count{0};
-    double best_assignment_score{0.0};
-    double assignment_score_tolerance{0.0};
-    double maximum_assignment_score{0.0};
-    double makespan_relative_spread{0.0};
-    std::map<std::int64_t, std::int64_t> selected_source_by_trace_thread;
 };
 
 [[nodiscard]] CallgrindTrace parsePeriodicCallgrind(const std::filesystem::path& prefix);
 
-[[nodiscard]] SchedulerTrace parseMeasuredScheduler(const std::filesystem::path& path);
+[[nodiscard]] CallgrindSyncTrace parseMeasuredCallgrindSync(const std::filesystem::path& path);
 
-[[nodiscard]] DrdTrace parseMeasuredDrd(const std::filesystem::path& path);
-
-[[nodiscard]] PairedReplayResult replayPaired(
-    const CallgrindTrace& callgrind, const SchedulerTrace& callgrind_scheduler, const DrdTrace& drd, const EventCostModel& model, const PairedReplayOptions& options);
+[[nodiscard]] ReplayResult replayCallgrind(
+    const CallgrindTrace& callgrind, const CallgrindSyncTrace& sync, const EventCostModel& model, const CallgrindReplayOptions& options);
 
 }  // namespace vc::thread_sync_replay

--- a/volume-cartographer/core/test/thread_sync_replay/RenderValgrindCli.cpp
+++ b/volume-cartographer/core/test/thread_sync_replay/RenderValgrindCli.cpp
@@ -126,16 +126,6 @@ void validateMetadata(const json& metadata, const std::string& fixture, const st
     }
 }
 
-void validatePair(const json& callgrind, const json& drd)
-{
-    for (const std::string name :
-         {"fixture", "scenario", "width", "height", "tile_size", "repetitions", "measured_pixels", "worker_override", "checksum"}) {
-        if (callgrind.at(name) != drd.at(name)) {
-            throw std::runtime_error("Callgrind and DRD metadata differ for " + name);
-        }
-    }
-}
-
 double referenceTolerance(const json& reference, const std::map<std::string, std::string>& arguments)
 {
     const auto explicit_tolerance = arguments.find("tolerance");
@@ -168,10 +158,10 @@ int renderValgrindCli(int argc, char** argv)
     const auto repetitions = metadata.at("repetitions").get<double>();
 
     double score = 0.0;
-    json paired = nullptr;
+    json replay = nullptr;
     if (fixture == "serial") {
-        if (arguments.contains("callgrind-scheduler") || arguments.contains("drd-trace") || arguments.contains("drd-metadata")) {
-            throw std::runtime_error("serial evaluation must not use scheduler traces or DRD");
+        if (arguments.contains("callgrind-scheduler")) {
+            throw std::runtime_error("serial evaluation must not use a scheduler trace");
         }
         for (const auto& [thread, profile] : callgrind.totals) {
             (void)thread;
@@ -179,52 +169,28 @@ int renderValgrindCli(int argc, char** argv)
         }
         score /= repetitions;
     } else {
-        const auto drd_metadata = readJson(required(arguments, "drd-metadata"));
-        validateMetadata(drd_metadata, fixture, scenario);
-        validatePair(metadata, drd_metadata);
-        const auto callgrind_scheduler = parseMeasuredScheduler(required(arguments, "callgrind-scheduler"));
-        const auto drd = parseMeasuredDrd(required(arguments, "drd-trace"));
+        const auto sync = parseMeasuredCallgrindSync(required(arguments, "callgrind-scheduler"));
         const auto& replay_config = model.at("replay");
-        const auto result = replayPaired(
+        const auto result = replayCallgrind(
             callgrind,
-            callgrind_scheduler,
-            drd,
+            sync,
             event_model,
             {
                 .residual_fraction = replay_config.at("residual_fraction").get<double>(),
                 .split_policy = replay_config.at("split_policy").get<std::string>(),
-                .scheduler_bins = 16,
-                .scheduler_quantum_slack = 1.0,
-                .maximum_makespan_spread = 0.02,
-                .maximum_mappings = 100000,
                 .replay = parseReplayOptions(model),
             });
-        score = result.conservative.modeled_makespan / repetitions;
-        json mapping = json::object();
-        for (const auto& [trace_thread, source_thread] : result.selected_source_by_trace_thread) {
-            mapping[std::to_string(trace_thread)] = source_thread;
-        }
-        paired = {
-            {"result", replayJson(result.conservative)},
-            {"minimum_makespan", result.minimum_makespan},
-            {"maximum_makespan", result.conservative.modeled_makespan},
-            {"mapping_count", result.mapping_count},
-            {"evaluated_mapping_count", result.evaluated_mapping_count},
-            {"best_assignment_score", result.best_assignment_score},
-            {"assignment_score_tolerance", result.assignment_score_tolerance},
-            {"maximum_assignment_score", result.maximum_assignment_score},
-            {"makespan_relative_spread", result.makespan_relative_spread},
-            {"selected_source_by_trace_thread", std::move(mapping)},
-            {"callgrind_scheduler_quanta", callgrind_scheduler.quantum_threads.size()},
-            {"callgrind_scheduler_begin_line", callgrind_scheduler.begin_line},
-            {"callgrind_scheduler_end_line", callgrind_scheduler.end_line},
-            {"drd_event_count", drd.events.size()},
-            {"drd_happens_before_edges", drd.happens_before_edges},
-            {"drd_dropped_pre_window_edges", drd.dropped_pre_window_edges},
-            {"drd_parsed_segment_count", drd.parsed_segment_count},
-            {"drd_retained_segment_count", drd.retained_segment_count},
-            {"drd_begin_line", drd.begin_line},
-            {"drd_end_line", drd.end_line},
+        score = result.modeled_makespan / repetitions;
+        replay = {
+            {"result", replayJson(result)},
+            {"event_count", sync.events.size()},
+            {"futex_happens_before_edges", sync.futex_happens_before_edges},
+            {"dropped_pre_window_edges", sync.dropped_pre_window_edges},
+            {"parsed_futex_calls", sync.parsed_futex_calls},
+            {"blocking_futex_waits", sync.blocking_futex_waits},
+            {"scheduler_quanta", sync.scheduler.quantum_threads.size()},
+            {"scheduler_begin_line", sync.scheduler.begin_line},
+            {"scheduler_end_line", sync.scheduler.end_line},
         };
     }
     if (!std::isfinite(score) || score <= 0.0) {
@@ -232,7 +198,7 @@ int renderValgrindCli(int argc, char** argv)
     }
 
     json result = {
-        {"schema_version", 2},
+        {"schema_version", 3},
         {"kind", "evaluation"},
         {"case", fixture + "/" + scenario},
         {"model_id", model.at("model_id")},
@@ -241,7 +207,7 @@ int renderValgrindCli(int argc, char** argv)
         {"modeled_nanoseconds_per_pixel", score / (metadata.at("width").get<double>() * metadata.at("height").get<double>())},
         {"checksum", metadata.at("checksum")},
         {"callgrind_periodic_dump_count", callgrind.periodic_dump_count},
-        {"paired_replay", std::move(paired)},
+        {"callgrind_replay", std::move(replay)},
         {"status", "passed"},
     };
 

--- a/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
+++ b/volume-cartographer/docs/benchmarks/render_valgrind_ci.md
@@ -9,8 +9,8 @@ Ninja to generate a fresh eight-case Valgrind graph:
 
 - serial and four-worker parallel fixtures;
 - `full_res`, `fallback_3`, `mixed_correlated`, and `mixed_shuffled`;
-- separate-thread Callgrind profiles for all eight cases;
-- complete DRD dependency graphs for the four parallel cases;
+- periodic separate-thread Callgrind profiles for all eight cases;
+- scheduler and futex traces from each parallel case's same Callgrind run;
 - a relative modeled-runtime score and exact rendering checksum per case.
 
 The fixture renders through the production `ChunkCache`. A deterministic fake
@@ -59,39 +59,31 @@ change the fixed four-worker renderer fixture or five-core replay model.
 
 The regular estimate contains no Python process. Ninja invokes Valgrind
 directly, then `bench_thread_sync_replay evaluate-render` parses the raw
-Callgrind profiles and DRD log, validates the pair, attributes costs, replays
-the graph, and writes the result in C++.
+Callgrind profiles and scheduler log, attributes costs to their originating
+threads, replays the synchronization graph, and writes the result in C++.
 
 Artifacts are under
 `build/ci-render-benchmark/render-valgrind-ci/<fixture>/<scenario>/`:
 
 - `callgrind/callgrind.out.*`, benchmark metadata, and a collection stamp;
 - `callgrind/scheduler.log` for parallel cases;
-- `drd/drd.log`, benchmark metadata, and a collection stamp for parallel cases;
 - `evaluation.json` for the ungated score;
 - `checked.json` after a passing comparison;
 
-Start failure diagnosis with the raw profiles, DRD log, and `evaluation.json`.
+Start failure diagnosis with the raw profiles, scheduler log, and
+`evaluation.json`.
 Historical compiler, model, checksum, cache, fixture, repetition, and profiler
 changes do not fail the reference gate. Current-run parse errors or
-Callgrind/DRD metadata inconsistency still fail because they prevent a valid
-score. A score above the allowed slowdown is a performance regression requiring
+incomplete futex dependencies still fail because they prevent a valid score. A
+score above the allowed slowdown is a performance regression requiring
 investigation or an intentional reference update.
 
-Parallel collection uses the same fair scheduler and 10,000-basic-block
-quantum in both Valgrind runs. Callgrind also records the scheduler stream from
-its own execution. Main thread 1 remains fixed; the four worker identities are
-matched by exhaustively scoring all 24 permutations against normalized worker
-activity share and cumulative activity in 16 measured-window bins. Assignments
-within the scheduler-quantum resolution of the best score are all replayed, and
-the maximum makespan is the case score. The case fails as insufficient
-attribution evidence if those compatible assignments span more than 2% in
-makespan.
-
-An attribution retry, if enabled, must recollect only the affected case and
-only after an `assignment evidence insufficient` failure. It must not retry a
-completed evaluation whose modeled-runtime score exceeds the reference; that
-is a performance regression, not a collection-quality failure.
+Parallel collection uses Callgrind's fair scheduler and a fixed
+10,000-basic-block quantum. Periodic event-counter deltas, scheduler quanta,
+and futex wait/wake operations all come from that one execution. Successful
+waits are linked to wakes on the same futex address, and each thread's profile
+is applied directly to that thread's replay windows. There is no cross-run
+worker assignment or second profiler trace.
 
 ## CI Activation
 
@@ -115,7 +107,7 @@ naturally bounded by available graph work.
 
 Model calibration, case references, and tolerance are independent controls:
 
-- **Recalibrate** only when changing how Callgrind/DRD events map to the score.
+- **Recalibrate** only when changing how Callgrind events map to the score.
 - **Refresh references** when an understood code or toolchain change shifts the
   expected score while the model remains valid.
 - **Change tolerance** when intentionally changing regression sensitivity.
@@ -203,8 +195,8 @@ baseline. Never use renderer observations to fit these coefficients.
 
 Use this when the model remains unchanged but an understood implementation,
 compiler, or Valgrind change alters expected scores. Use a new build directory
-to guarantee fresh Callgrind and DRD collection, and match the intended CI
-toolchain exactly:
+to guarantee fresh Callgrind collection, and match the intended CI toolchain
+exactly:
 
 ```bash
 build=volume-cartographer/build/render-reference-$(date +%Y%m%d-%H%M%S)
@@ -229,8 +221,8 @@ The freeze command requires exactly all eight native evaluation artifacts and
 records score, checksum, model hash, and tolerance. Legacy evaluation artifacts
 also retain their environment/workload identity as diagnostic metadata. Only
 score and tolerance affect historical pass/fail.
-Review every old/new score ratio. Run a second fresh collection before accepting
-references when parallel DRD replay variation is close to the chosen tolerance.
+Review every old/new score ratio. Run a second fresh collection before
+accepting references when a parallel score is close to the chosen tolerance.
 
 ## Tightening Or Loosening Tolerance
 

--- a/volume-cartographer/docs/benchmarks/synthetic_rendering.md
+++ b/volume-cartographer/docs/benchmarks/synthetic_rendering.md
@@ -938,9 +938,9 @@ native difference between correlated and shuffled memory access.
 
 The CI gate uses `scripts/run_render_valgrind_ci.py` and writes under
 `build/ci-render-benchmark/render-valgrind-ci/<fixture>/<scenario>/`. Every case
-has a separate-thread Callgrind artifact. Parallel cases additionally have a
-DRD trace/event artifact. Collection manifests are written atomically after
-validation, and each raw file is hashed before evaluation.
+has one separate-thread Callgrind execution. Parallel cases use the scheduler
+and futex stream from that same execution. Collection manifests are written
+atomically after validation, and each raw file is hashed before evaluation.
 
 The frozen model is `core/test/data/render_valgrind_ci_model.json`. It uses the
 seven synthetic-only data-read event coefficients. Serial score is total
@@ -964,18 +964,19 @@ modeled-runtime score only. It must not be described as estimated native wall
 time. Each candidate score must fall in `[0.90, 1.10]` times the checked
 reference.
 
-The gate rejects model hashes, checksums, incomplete DRD dependencies, compiler,
-cache geometry, architecture, fixture shape, repetition count, and worker count
-that differ from the reference. It records reference and observed Valgrind
-versions but does not reject a version change by itself; material profiler
-effects remain subject to the modeled-score tolerance. CI retains the complete
-`render-valgrind-ci/` tree even on failure.
+Historical model hashes, checksums, compiler, cache geometry, architecture,
+fixture shape, repetition count, worker count, and Valgrind version are
+diagnostic and do not fail comparison with the reference. Current-run metadata,
+the measured window, and successful futex dependencies must still be internally
+valid. Material profiler effects remain subject to the modeled-score tolerance.
+CI retains the complete `render-valgrind-ci/` tree even on failure.
 
-The CI runtime does not import NumPy. Its standard-library Python coordinator
-collects and validates artifacts, while the versioned C++ replay engine computes
-event features, per-thread modeled costs, serial totals, cost attribution, and
-parallel replay. The `test_render_valgrind_ci_no_site` CTest runs this boundary
-under `python3 -S`.
+The regular estimate does not run Python. Ninja invokes Callgrind directly, and
+the versioned C++ replay engine parses its periodic profiles and scheduler log,
+computes event features and per-thread modeled costs, then performs serial
+aggregation or parallel replay. Python remains a maintenance tool for freezing
+models and references. The `test_render_valgrind_ci_no_site` CTest verifies that
+maintenance boundary under `python3 -S`.
 
 The 2026-08-07 GCC 15.3.0/Valgrind 3.25.1 reference collection took 15.73 s on
 the four-core calibration host. A second fresh collection and gate took 16.38

--- a/volume-cartographer/planning/changelog.md
+++ b/volume-cartographer/planning/changelog.md
@@ -100,6 +100,10 @@
   classification, source download/read, and CPU decode queues so cached decode
   work no longer delays discovery and admission of remote misses.
 
+## 2026-08-19
+
+- Replaced paired Callgrind/DRD render scoring with same-run Callgrind scheduler and futex replay.
+
 ## 2026-08-18
 
 - Re-enabled the 5% synthetic-rendering gate with native scheduler-matched paired attribution and production-cache lookup coverage.

--- a/volume-cartographer/scripts/render_valgrind_common.py
+++ b/volume-cartographer/scripts/render_valgrind_common.py
@@ -160,33 +160,3 @@ def callgrind_command(
         ]
     )
     return command
-
-
-def drd_command(
-    benchmark: Path,
-    scenario: str,
-    metadata: Path,
-    trace: Path,
-    repetitions: int,
-    quantum: int,
-) -> list[str]:
-    return [
-        "valgrind",
-        "--tool=drd",
-        "--trace-segment=yes",
-        "--trace-csw=yes",
-        "--fair-sched=yes",
-        "--time-stamp=yes",
-        f"--scheduling-quantum={quantum}",
-        "--trace-sched=yes",
-        "--trace-syscalls=yes",
-        f"--log-file={trace}",
-        *renderer_command(
-            benchmark,
-            "parallel",
-            scenario,
-            metadata,
-            repetitions,
-            callgrind=False,
-        ),
-    ]

--- a/volume-cartographer/scripts/run_render_valgrind_ci.py
+++ b/volume-cartographer/scripts/run_render_valgrind_ci.py
@@ -1,41 +1,20 @@
 #!/usr/bin/env python3
-"""Collect and gate the complete synthetic-renderer Valgrind CI matrix."""
+"""Maintain the C++ synthetic-renderer Callgrind performance gate."""
 
 from __future__ import annotations
 
 import argparse
-import glob
 import hashlib
 import json
 import math
 import os
-import subprocess
 import sys
 from pathlib import Path
 
-from native_thread_sync_replay import (
-    NativeReplayEngine,
-    attribution_request,
-    replay_request,
-)
-from render_valgrind_common import (
-    CACHE_GEOMETRY,
-    SCENARIOS,
-    callgrind_command,
-    drd_command,
-    load_renderer_metadata,
-    parse_thread_profiles,
-    require_supported_host,
-    valgrind_version,
-)
-from thread_sync_trace import parse_drd_trace, write_event_stream
+from render_valgrind_common import SCENARIOS
 
 SCHEMA_VERSION = 1
-NATIVE_EVALUATION_SCHEMA_VERSION = 2
-BENCHMARK_METADATA_SCHEMA = 1
-DEFAULT_REPETITIONS = 1
-DEFAULT_QUANTUM = 10000
-DEFAULT_DRD_ATTEMPTS = 3
+NATIVE_EVALUATION_SCHEMA_VERSIONS = {2, 3}
 DEFAULT_TOLERANCE = 0.05
 DATA_READ_FEATURE_NAMES = (
     "non_data_instructions",
@@ -56,22 +35,6 @@ REPLAY_CONFIGURATION = {
     "replay_idle_scale": 1.0,
     "dependency_excess_scale": 1.0,
 }
-IDENTITY_FIELDS = (
-    "compiler_id",
-    "compiler_version",
-    "build_type",
-    "architecture_target",
-)
-WORKLOAD_FIELDS = (
-    "fixture",
-    "scenario",
-    "width",
-    "height",
-    "tile_size",
-    "repetitions",
-    "measured_pixels",
-    "worker_override",
-)
 
 
 def sha256_file(path: Path) -> str:
@@ -90,308 +53,6 @@ def write_json_atomic(path: Path, value: object) -> None:
         temporary.replace(path)
     finally:
         temporary.unlink(missing_ok=True)
-
-
-def load_manifest(path: Path, kind: str) -> dict[str, object]:
-    value = json.loads(path.read_text())
-    if value.get("schema_version") != SCHEMA_VERSION:
-        raise RuntimeError(f"unsupported artifact schema in {path}")
-    if value.get("kind") != kind:
-        raise RuntimeError(f"expected {kind} artifact, got {value.get('kind')!r}")
-    return value
-
-
-def _workers(fixture: str) -> int:
-    return 1 if fixture == "serial" else int(REPLAY_CONFIGURATION["workers"])
-
-
-def _environment(fixture: str) -> dict[str, str]:
-    environment = os.environ.copy()
-    environment["VC_RENDER_SAMPLER_THREADS"] = str(_workers(fixture))
-    return environment
-
-
-def _validate_metadata(
-    metadata: dict[str, object], fixture: str, scenario: str, repetitions: int
-) -> None:
-    expected = {
-        "fixture": fixture,
-        "scenario": scenario,
-        "repetitions": repetitions,
-        "worker_override": _workers(fixture),
-    }
-    for name, value in expected.items():
-        if metadata.get(name) != value:
-            raise RuntimeError(
-                f"benchmark metadata {name} changed: {metadata.get(name)!r} != {value!r}"
-            )
-    expected_pixels = int(metadata["width"]) * int(metadata["height"]) * repetitions
-    if metadata["measured_pixels"] != expected_pixels:
-        raise RuntimeError("benchmark measured-pixel count is inconsistent")
-    observed = int(metadata["observed_threads"])
-    if fixture == "serial" and observed != 1:
-        raise RuntimeError("serial fixture executed on multiple threads")
-    if fixture == "parallel" and observed <= 1:
-        raise RuntimeError("parallel fixture did not execute on multiple threads")
-
-
-def collect_callgrind(args: argparse.Namespace) -> None:
-    output_dir = args.output_dir.resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    prefix = output_dir / "callgrind.out"
-    metadata_path = output_dir / "metadata.callgrind.json"
-    for stale in glob.glob(f"{prefix}*"):
-        Path(stale).unlink()
-    metadata_path.unlink(missing_ok=True)
-    args.artifact.unlink(missing_ok=True)
-
-    command = callgrind_command(
-        args.benchmark.resolve(),
-        args.fixture,
-        args.scenario,
-        metadata_path,
-        prefix,
-        args.repetitions,
-        separate_threads=True,
-    )
-    completed = subprocess.run(
-        command,
-        check=True,
-        text=True,
-        capture_output=True,
-        env=_environment(args.fixture),
-    )
-    metadata = load_renderer_metadata(metadata_path)
-    _validate_metadata(metadata, args.fixture, args.scenario, args.repetitions)
-    profiles = parse_thread_profiles(prefix)
-    profile_paths = sorted(Path(name).resolve() for name in glob.glob(f"{prefix}-*"))
-    manifest = {
-        "schema_version": SCHEMA_VERSION,
-        "benchmark_metadata_schema": BENCHMARK_METADATA_SCHEMA,
-        "kind": "callgrind",
-        "case": f"{args.fixture}/{args.scenario}",
-        "valgrind_version": valgrind_version(),
-        "cache_geometry": CACHE_GEOMETRY,
-        "metadata": metadata,
-        "metadata_path": str(metadata_path),
-        "metadata_sha256": sha256_file(metadata_path),
-        "profile_prefix": str(prefix),
-        "profiles": {
-            str(thread): events for thread, events in sorted(profiles.items())
-        },
-        "profile_files": [
-            {"path": str(path), "sha256": sha256_file(path)} for path in profile_paths
-        ],
-        "command": command,
-        "stdout": completed.stdout.strip(),
-    }
-    write_json_atomic(args.artifact.resolve(), manifest)
-    print(f"{manifest['case']}: collected {len(profiles)} Callgrind profiles")
-
-
-def _trace_is_complete(parsed: object) -> bool:
-    return (
-        parsed.unmatched_waits == 0
-        and parsed.unresolved_happens_before == 0
-        and bool(parsed.events)
-    )
-
-
-def collect_drd(args: argparse.Namespace) -> None:
-    output_dir = args.output_dir.resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    trace_path = output_dir / "drd.log"
-    event_path = output_dir / "events.jsonl"
-    metadata_path = output_dir / "metadata.drd.json"
-    args.artifact.unlink(missing_ok=True)
-    selected = None
-    command: list[str] = []
-    stdout = ""
-    for attempt in range(1, args.attempts + 1):
-        trace_path.unlink(missing_ok=True)
-        event_path.unlink(missing_ok=True)
-        metadata_path.unlink(missing_ok=True)
-        command = drd_command(
-            args.benchmark.resolve(),
-            args.scenario,
-            metadata_path,
-            trace_path,
-            args.repetitions,
-            args.quantum,
-        )
-        completed = subprocess.run(
-            command,
-            check=True,
-            text=True,
-            capture_output=True,
-            env=_environment("parallel"),
-        )
-        stdout = completed.stdout.strip()
-        parsed = parse_drd_trace(trace_path)
-        if _trace_is_complete(parsed):
-            selected = (attempt, parsed)
-            break
-    if selected is None:
-        raise RuntimeError(
-            f"DRD trace remained incomplete after {args.attempts} attempts"
-        )
-    attempt, parsed = selected
-    metadata = load_renderer_metadata(metadata_path)
-    _validate_metadata(metadata, "parallel", args.scenario, args.repetitions)
-    write_event_stream(event_path, parsed.events)
-    manifest = {
-        "schema_version": SCHEMA_VERSION,
-        "benchmark_metadata_schema": BENCHMARK_METADATA_SCHEMA,
-        "kind": "drd",
-        "case": f"parallel/{args.scenario}",
-        "valgrind_version": valgrind_version(),
-        "metadata": metadata,
-        "metadata_path": str(metadata_path),
-        "metadata_sha256": sha256_file(metadata_path),
-        "trace_path": str(trace_path),
-        "trace_sha256": sha256_file(trace_path),
-        "event_path": str(event_path),
-        "event_sha256": sha256_file(event_path),
-        "attempt": attempt,
-        "trace": {
-            "events": len(parsed.events),
-            "blocking_futex_waits": parsed.blocking_waits,
-            "matched_futex_waits": parsed.matched_waits,
-            "unmatched_futex_waits": parsed.unmatched_waits,
-            "happens_before_edges": parsed.happens_before_edges,
-            "unresolved_happens_before": parsed.unresolved_happens_before,
-            "scheduler_quantum_basic_blocks": args.quantum,
-        },
-        "command": command,
-        "stdout": stdout,
-    }
-    write_json_atomic(args.artifact.resolve(), manifest)
-    print(
-        f"{manifest['case']}: collected complete DRD graph ({len(parsed.events)} events)"
-    )
-
-
-def load_model(path: Path) -> dict[str, object]:
-    model = json.loads(path.read_text())
-    if model.get("schema_version") != SCHEMA_VERSION:
-        raise RuntimeError("unsupported modeled-runtime score model schema")
-    if model.get("renderer_inputs_used") is not False:
-        raise RuntimeError("modeled-runtime score model is not synthetic-only")
-    if model.get("timing_claims_enabled") is not False:
-        raise RuntimeError(
-            "relative score model must not enable absolute timing claims"
-        )
-    if model.get("replay") != REPLAY_CONFIGURATION:
-        raise RuntimeError("modeled-runtime replay configuration changed")
-    return model
-
-
-def _verify_manifest_files(manifest: dict[str, object]) -> None:
-    metadata_path = Path(str(manifest["metadata_path"]))
-    if sha256_file(metadata_path) != manifest["metadata_sha256"]:
-        raise RuntimeError("benchmark metadata changed after collection")
-    if manifest["kind"] == "callgrind":
-        for profile in manifest["profile_files"]:
-            if sha256_file(Path(str(profile["path"]))) != profile["sha256"]:
-                raise RuntimeError("Callgrind profile changed after collection")
-        parsed = {
-            str(thread): events
-            for thread, events in sorted(
-                parse_thread_profiles(Path(str(manifest["profile_prefix"]))).items()
-            )
-        }
-        if parsed != manifest["profiles"]:
-            raise RuntimeError("Callgrind manifest does not match its raw profiles")
-    else:
-        for key in ("trace", "event"):
-            if (
-                sha256_file(Path(str(manifest[f"{key}_path"])))
-                != manifest[f"{key}_sha256"]
-            ):
-                raise RuntimeError(f"DRD {key} changed after collection")
-
-
-def _validate_pair(callgrind: dict[str, object], drd: dict[str, object] | None) -> None:
-    _verify_manifest_files(callgrind)
-    if drd is None:
-        return
-    _verify_manifest_files(drd)
-    if callgrind["case"] != drd["case"]:
-        raise RuntimeError("Callgrind and DRD artifacts describe different cases")
-    if drd["trace"]["unmatched_futex_waits"] != 0:
-        raise RuntimeError("DRD trace has unmatched blocking waits")
-    if drd["trace"]["unresolved_happens_before"] != 0:
-        raise RuntimeError("DRD trace has unresolved happens-before dependencies")
-    for name in (*IDENTITY_FIELDS, *WORKLOAD_FIELDS, "checksum"):
-        if callgrind["metadata"].get(name) != drd["metadata"].get(name):
-            raise RuntimeError(f"Callgrind/DRD metadata mismatch for {name}")
-    if callgrind["valgrind_version"] != drd["valgrind_version"]:
-        raise RuntimeError("Callgrind and DRD used different Valgrind versions")
-
-
-def estimate_score(
-    callgrind: dict[str, object],
-    drd: dict[str, object] | None,
-    model: dict[str, object],
-    replay_engine: Path,
-) -> tuple[float, dict[str, object] | None]:
-    profiles = {
-        int(thread): {str(name): int(value) for name, value in events.items()}
-        for thread, events in callgrind["profiles"].items()
-    }
-    repetitions = int(callgrind["metadata"]["repetitions"])
-    with NativeReplayEngine(replay_engine.resolve()) as engine:
-        costs, total_cost = engine.model_profile_costs(
-            profiles, model["event_cost_model"]
-        )
-        if drd is None:
-            return total_cost / repetitions, None
-        replay = model["replay"]
-        event_count = engine.load_graph("renderer", Path(str(drd["event_path"])))
-        if event_count != int(drd["trace"]["events"]):
-            raise RuntimeError("native replay loaded a different DRD event count")
-        engine.register_attributions(
-            "renderer",
-            [
-                attribution_request(
-                    "modeled-runtime",
-                    costs,
-                    float(replay["residual_fraction"]),
-                    str(replay["split_policy"]),
-                )
-            ],
-        )
-        result = engine.replay_batch(
-            "renderer",
-            [
-                replay_request(
-                    "parallel",
-                    "modeled-runtime",
-                    int(replay["cores"]),
-                    str(replay["tie_policy"]),
-                    float(replay["wake_latency_ns"]),
-                    float(model["cross_thread_release_ns"]),
-                    float(replay["replay_idle_scale"]),
-                    float(replay["dependency_excess_scale"]),
-                )
-            ],
-        )["parallel"]
-        engine_info = engine.info()
-    return float(result["modeled_makespan"]) / repetitions, {
-        "result": result,
-        "engine": engine_info,
-    }
-
-
-def _case_identity(manifest: dict[str, object]) -> dict[str, object]:
-    metadata = manifest["metadata"]
-    return {
-        **{name: metadata[name] for name in IDENTITY_FIELDS},
-        **{name: metadata[name] for name in WORKLOAD_FIELDS},
-        "valgrind_version": manifest["valgrind_version"],
-        "cache_geometry": manifest["cache_geometry"],
-        "benchmark_metadata_schema": manifest["benchmark_metadata_schema"],
-    }
 
 
 def validate_tolerance(value: object) -> float:
@@ -415,100 +76,6 @@ def validate_score(value: object, source: str) -> float:
     return score
 
 
-def check_reference(
-    result: dict[str, object],
-    reference: dict[str, object],
-    tolerance: float | None = None,
-) -> None:
-    if reference.get("schema_version") != SCHEMA_VERSION:
-        raise RuntimeError("unsupported modeled-runtime reference schema")
-    reference_tolerance = validate_tolerance(reference.get("tolerance", -1.0))
-    if tolerance is None:
-        tolerance = reference_tolerance
-    else:
-        tolerance = validate_tolerance(tolerance)
-    case = reference.get("cases", {}).get(result["case"])
-    if case is None:
-        raise RuntimeError(f"reference has no case {result['case']}")
-    reference_identity = case.get("identity", {})
-    observed_identity = result.get("identity", {})
-    reference_version = (
-        reference_identity.get("valgrind_version")
-        if isinstance(reference_identity, dict)
-        else None
-    )
-    observed_version = (
-        observed_identity.get("valgrind_version")
-        if isinstance(observed_identity, dict)
-        else None
-    )
-    result["reference_valgrind_version"] = reference_version
-    result["observed_valgrind_version"] = observed_version
-    result["valgrind_version_changed"] = reference_version != observed_version
-    observed = validate_score(result["modeled_runtime_score_ns"], "observed")
-    expected = validate_score(case["modeled_runtime_score_ns"], "reference")
-    ratio = observed / expected
-    result["reference_modeled_runtime_score_ns"] = expected
-    result["reference_ratio"] = ratio
-    result["relative_error"] = ratio - 1.0
-    if ratio > 1.0 + tolerance:
-        raise RuntimeError(
-            f"modeled-runtime score for {result['case']} is {ratio:.3f}x reference; "
-            f"required <= {1.0 + tolerance:.2f}x"
-        )
-
-
-def evaluate(args: argparse.Namespace) -> None:
-    output_path = args.output.resolve()
-    failed_path = output_path.with_suffix(".failed.json")
-    output_path.unlink(missing_ok=True)
-    failed_path.unlink(missing_ok=True)
-    callgrind = load_manifest(args.callgrind.resolve(), "callgrind")
-    fixture = str(callgrind["metadata"]["fixture"])
-    drd = load_manifest(args.drd.resolve(), "drd") if args.drd else None
-    if fixture == "parallel" and drd is None:
-        raise RuntimeError("parallel evaluation requires a DRD artifact")
-    if fixture == "serial" and drd is not None:
-        raise RuntimeError("serial evaluation must not use a DRD artifact")
-    _validate_pair(callgrind, drd)
-    model = load_model(args.model.resolve())
-    score, replay = estimate_score(callgrind, drd, model, args.replay_engine.resolve())
-    result = {
-        "schema_version": SCHEMA_VERSION,
-        "kind": "evaluation",
-        "case": callgrind["case"],
-        "model_id": model["model_id"],
-        "model_sha256": sha256_file(args.model.resolve()),
-        "score_semantics": "relative_modeled_runtime_not_absolute_wall_time",
-        "modeled_runtime_score_ns": score,
-        "modeled_nanoseconds_per_pixel": score
-        / (int(callgrind["metadata"]["width"]) * int(callgrind["metadata"]["height"])),
-        "checksum": callgrind["metadata"]["checksum"],
-        "identity": _case_identity(callgrind),
-        "replay": replay,
-    }
-    failure = None
-    if args.reference:
-        try:
-            check_reference(
-                result, json.loads(args.reference.read_text()), args.tolerance
-            )
-        except RuntimeError as error:
-            failure = error
-    result["status"] = "failed" if failure else "passed"
-    write_json_atomic(failed_path if failure else output_path, result)
-    print(
-        f"{result['case']}: {score:.3f} modeled ns/call"
-        + (
-            f", {result['reference_ratio']:.3f}x reference"
-            if "reference_ratio" in result
-            else ""
-        )
-    )
-    if failure:
-        raise failure
-
-
 def freeze_reference(args: argparse.Namespace) -> None:
     tolerance = validate_tolerance(args.tolerance)
     model_path = args.model.resolve()
@@ -518,8 +85,7 @@ def freeze_reference(args: argparse.Namespace) -> None:
         raise RuntimeError("render model has no model_id")
     cases: dict[str, object] = {}
     for path in args.results:
-        result_path = path.resolve()
-        result = json.loads(result_path.read_text())
+        result = json.loads(path.resolve().read_text())
         if result.get("kind") != "evaluation":
             raise RuntimeError(
                 f"expected evaluation artifact, got {result.get('kind')!r}"
@@ -528,7 +94,7 @@ def freeze_reference(args: argparse.Namespace) -> None:
         if schema == SCHEMA_VERSION:
             if result.get("model_sha256") != model_hash:
                 raise RuntimeError(f"evaluation {path} used a different model")
-        elif schema == NATIVE_EVALUATION_SCHEMA_VERSION:
+        elif schema in NATIVE_EVALUATION_SCHEMA_VERSIONS:
             if result.get("model_id") != model_id:
                 raise RuntimeError(f"evaluation {path} used a different model")
         else:
@@ -544,6 +110,7 @@ def freeze_reference(args: argparse.Namespace) -> None:
         if "identity" in result:
             case["identity"] = result["identity"]
         cases[result["case"]] = case
+
     expected = {
         f"{fixture}/{scenario}"
         for fixture in ("serial", "parallel")
@@ -618,35 +185,6 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    callgrind = subparsers.add_parser("callgrind")
-    callgrind.add_argument("--benchmark", required=True, type=Path)
-    callgrind.add_argument("--fixture", required=True, choices=("serial", "parallel"))
-    callgrind.add_argument("--scenario", required=True, choices=SCENARIOS)
-    callgrind.add_argument("--output-dir", required=True, type=Path)
-    callgrind.add_argument("--artifact", required=True, type=Path)
-    callgrind.add_argument("--repetitions", type=int, default=DEFAULT_REPETITIONS)
-    callgrind.set_defaults(function=collect_callgrind)
-
-    drd = subparsers.add_parser("drd")
-    drd.add_argument("--benchmark", required=True, type=Path)
-    drd.add_argument("--scenario", required=True, choices=SCENARIOS)
-    drd.add_argument("--output-dir", required=True, type=Path)
-    drd.add_argument("--artifact", required=True, type=Path)
-    drd.add_argument("--repetitions", type=int, default=DEFAULT_REPETITIONS)
-    drd.add_argument("--quantum", type=int, default=DEFAULT_QUANTUM)
-    drd.add_argument("--attempts", type=int, default=DEFAULT_DRD_ATTEMPTS)
-    drd.set_defaults(function=collect_drd)
-
-    evaluation = subparsers.add_parser("evaluate")
-    evaluation.add_argument("--callgrind", required=True, type=Path)
-    evaluation.add_argument("--drd", type=Path)
-    evaluation.add_argument("--model", required=True, type=Path)
-    evaluation.add_argument("--reference", type=Path)
-    evaluation.add_argument("--replay-engine", required=True, type=Path)
-    evaluation.add_argument("--output", required=True, type=Path)
-    evaluation.add_argument("--tolerance", type=float)
-    evaluation.set_defaults(function=evaluate)
-
     freeze = subparsers.add_parser("freeze-reference")
     freeze.add_argument("--model", required=True, type=Path)
     freeze.add_argument("--output", required=True, type=Path)
@@ -671,11 +209,6 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    require_supported_host()
-    if getattr(args, "repetitions", 1) <= 0:
-        raise RuntimeError("repetitions must be positive")
-    if getattr(args, "attempts", 1) <= 0:
-        raise RuntimeError("DRD attempts must be positive")
     args.function(args)
     return 0
 
@@ -683,6 +216,6 @@ def main() -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
-    except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+    except (OSError, RuntimeError, ValueError) as error:
         print(f"run_render_valgrind_ci.py: {error}", file=sys.stderr)
         raise SystemExit(1)

--- a/volume-cartographer/specs/benchmarks.md
+++ b/volume-cartographer/specs/benchmarks.md
@@ -118,33 +118,32 @@
   instrumented guest is serialized by Valgrind, CI uses the runner's available
   logical CPU count as Ninja concurrency and may run one independent Valgrind
   process per host CPU even when each guest configures four renderer workers.
-- The CI regression graph must generate fresh separate-thread Callgrind
-  profiles for all eight cases and fresh complete DRD dependency graphs for the
-  four parallel cases. Ninja publishes a collection stamp only after Valgrind
-  exits successfully; native evaluators depend on those stamps and may not
-  rerun collection.
+- The CI regression graph must run Callgrind exactly once for each of the eight
+  cases. Every run generates fresh separate-thread periodic profiles; each
+  parallel run also records the scheduler and futex stream from that same
+  execution. Ninja publishes a collection stamp only after Valgrind exits
+  successfully; native evaluators depend on those stamps and may not rerun
+  collection.
 - The CI relative modeled-runtime score uses the frozen synthetic-only
-  data-read event model. Raw profile and DRD parsing, feature extraction,
-  event-cost evaluation, logical-worker matching, cost attribution, replay,
-  and result output must run in the native C++ replay engine. Python must not
-  be used in the regular evaluation path. Serial score is summed per-thread modeled work per render
-  call. Parallel score is native FIFO replay makespan per render call with four
-  workers plus one caller core, equal attribution,
+  data-read event model. Raw profile and scheduler/futex parsing, feature
+  extraction, event-cost evaluation, direct per-thread cost attribution,
+  replay, and result output must run in the native C++ replay engine. Python
+  must not be used in the regular evaluation path. Serial score is summed
+  per-thread modeled work per render call. Parallel score is native FIFO replay
+  makespan per render call with four workers plus one caller core,
   `residual_fraction=0.5`, zero wake latency, the frozen cross-thread release
   latency, and unit replay/dependency-excess scales. Process startup and native
   wall timing are excluded.
-- Callgrind and DRD must use the same fair-scheduler and scheduling-quantum
-  settings without application markers or measured-program changes. The DRD
-  graph must be trimmed to the unique passive clock-call pair around the render.
-  Periodic Callgrind deltas must be placed chronologically over matched DRD work
-  windows while preserving each thread's exact aggregate modeled cost.
-- Raw Valgrind worker IDs must never be treated as identities across independent
-  runs. Main thread 1 remains fixed. Each Valgrind run must passively record its
-  own measured-window scheduler stream. All worker permutations must be scored
-  from normalized activity share and cumulative activity, and all assignments
-  indistinguishable at the configured scheduler-quantum resolution must be
-  replayed. The maximum makespan is reported; a case whose compatible mappings
-  exceed the predeclared makespan-spread limit is an attribution error.
+- Callgrind must use the fair scheduler and fixed scheduling quantum without
+  application markers or measured-program changes. The synchronization graph
+  must be trimmed to the unique passive clock-call pair around the render.
+  Periodic Callgrind deltas must be placed chronologically over that same run's
+  scheduler work windows while preserving each thread's exact aggregate
+  modeled cost.
+- Callgrind worker IDs identify both costs and scheduler/futex events because
+  they come from the same process. Costs must be attributed directly to the
+  originating thread; no cross-run matching, worker permutation, or inferred
+  identity assignment is permitted.
 - The relative modeled-runtime score is not a validated absolute runtime claim.
   Each case may be at most the configured tolerance slower than its versioned
   reference, initially 10%. Faster scores are accepted without a lower bound.
@@ -159,13 +158,12 @@
   worker count, and profiler version are diagnostic-only and must not affect
   reference pass/fail. The reference schema and case key remain required to
   locate and interpret the score baseline.
-- Current-run artifact integrity remains mandatory. Paired Callgrind and DRD
-  metadata must describe the same case, dimensions, repetitions, worker count,
-  and checksum. Parallel traces must have one unambiguous measured window and
-  no unresolved in-window happens-before edge.
-- Any retry for insufficient worker-assignment evidence must recollect only the
-  affected case. A valid modeled-runtime regression must never be retried as an
-  attribution failure.
+- Current-run artifact integrity remains mandatory. Callgrind metadata must
+  describe the requested case, dimensions, repetitions, worker count, and
+  checksum. Parallel traces must have one unambiguous measured window and no
+  unresolved successful in-window futex wait.
+- Collection or attribution failures are hard errors. A valid modeled-runtime
+  regression must never be retried as an attribution failure.
 - The machine-readable summary must record the metric schema/model version,
   Callgrind events by name, compiler, architecture target, Valgrind version,
   cache geometry, dimensions, tile size, worker count, repetitions, checksum,
@@ -213,9 +211,9 @@ the previous governor, frequency bounds, energy preference, and boost setting.
   threshold protocol.
 - Passive synchronization extraction must not require application markers or
   alter the benchmark binary. On Linux amd64 the dispatch fixture may use
-  Valgrind's core scheduler and syscall debug streams. Renderer replay must use
-  DRD vector clocks so nonblocking userspace synchronization is represented in
-  addition to scheduler quanta and futex syscalls.
+  Valgrind's core scheduler and syscall debug streams. The rendering gate must
+  derive costs, scheduler quanta, and futex dependencies from one Callgrind
+  execution so thread identities are exact.
 - A passive event stream must preserve thread IDs and global order, represent
   fixed-basic-block work slices, pair blocking futex waits with guest wakes or
   observed thread completion, and fail timing validation when dependencies are
@@ -230,19 +228,19 @@ the previous governor, frequency bounds, energy preference, and boost setting.
 - Valgrind elapsed timestamps must not be used as native duration or as work
   weights. State names must distinguish traced blocking from native scheduler
   state; simulated core idle is never an observed native metric.
-- Callgrind work weights and native timing must cover the same explicit
-  measured loop. The passive DRD dependency graph may span the process, but
-  allocation, fixture construction, verification, and teardown must not be
-  assigned measured work. Partial scheduler quanta and scheduler tie-breaking
-  must be reported as sensitivity ranges.
+- Callgrind work weights and synchronization events must cover the same
+  explicit measured loop. Allocation, fixture construction, verification, and
+  teardown must not be assigned measured work. Partial scheduler quanta and
+  scheduler tie-breaking must be reported as sensitivity ranges.
 - Native renderer replay must reserve one CPU for the submitting caller:
   `parallel_cores = workers + 1`. The one-CCD domain therefore ends at seven
   workers on CPUs 0--7. Comparing `workers` threads on only `workers` CPUs is a
   saturated diagnostic and must not be used as renderer validation.
 - Renderer validation may not fit an effective-parallelism, contention, or
   worker-count coefficient. Valgrind supplies work events, scheduler slices,
-  and DRD happens-before edges; native data validates the result but does not
-  alter it. Every frozen case must remain within 20% median speedup error.
+  and futex happens-before edges from one execution; native data validates the
+  result but does not alter it. Every frozen case must remain within 20% median
+  speedup error.
 - Renderer diagnostics may motivate a generic synthetic hypothesis, but they
   may not choose its formula, bounds, coefficients, fit cases, holdouts, or
   acceptance thresholds. Existing renderer cases used to motivate a hypothesis
@@ -285,7 +283,7 @@ the previous governor, frequency bounds, energy preference, and boost setting.
   `0 <= dependency_excess_scale <= 1`:
 
   ```text
-  hard_cp = critical path excluding inferred DRD happens-before edges
+  hard_cp = critical path excluding inferred cross-thread release edges
   hard_lower = max(total_event_work / core_count, hard_cp)
   full_lower = max(hard_lower, full_dependency_critical_path)
   dependency_excess = full_lower - hard_lower
@@ -296,7 +294,7 @@ the previous governor, frequency bounds, energy preference, and boost setting.
   ```
 
   Hard critical-path edges include per-thread program order and thread
-  lifecycle. The full path additionally includes inferred DRD vector-clock
+  lifecycle. The full path additionally includes inferred cross-thread release
   edges and the separately calibrated cross-thread release latency. Scale one
   must reproduce current FIFO replay exactly. Scale zero may remove only
   inferred dependency excess and must preserve hard task imbalance, program


### PR DESCRIPTION
**In one sentence:** The VC3D render performance gate now derives costs and synchronization from one Callgrind execution per case, eliminating cross-run DRD attribution noise.

**One real example:** Running the eight-case `render_valgrind_ci` target now produces each parallel score from periodic profiles, scheduler quanta, and futex events captured in the same Callgrind process, without creating a DRD artifact.

**Before:** Parallel cases combined independent Callgrind and DRD executions, requiring heuristic worker matching that could vary between otherwise identical CI runs and cause false regressions.

**After this PR:** Parallel costs are attributed directly to same-process thread IDs and replayed from Callgrind's scheduler and futex trace. DRD collection, cross-run assignment, and assignment retries are removed from the render gate.

**Proof:** Two fresh eight-case gate runs passed against the refreshed 5% reference. Seven cases varied by at most 1.1%; `parallel/full_res` varied by 9.1% because the executions observed different numbers of blocking futex waits. The focused native and Python boundary tests all pass.

**Why / where this is useful:** This makes the synthetic rendering regression gate more reliable, removes four Valgrind executions from the CI matrix, and attributes work to exact thread identities without modifying production renderer code.

## Details

- Parses periodic Callgrind profiles and the same run's scheduler/futex log in C++.
- Pairs successful futex waits and wakes and rejects unresolved measured waits.
- Keeps Python only for model and reference maintenance.
- Updates the evaluation schema, tests, benchmark specification, documentation, and stored references.
- Does not change renderer output, production rendering logic, or numerical behavior.

Validation:

```bash
cmake --build volume-cartographer/build/ci-render-benchmark \
  --target test_thread_sync_replay_native bench_thread_sync_replay --parallel 32

ctest --test-dir volume-cartographer/build/ci-render-benchmark \
  --output-on-failure \
  -R '^(test_render_synthetic_fixture|test_thread_sync_replay_native|test_render_valgrind_ci_driver|test_render_valgrind_ci_no_site)$'

cmake --build volume-cartographer/build/ci-render-benchmark \
  --target render_valgrind_ci --parallel 32
```