### PR TITLE
Register Open Data placeholder segments despite missing tif payload

### DIFF
--- a/volume-cartographer/core/src/Segmentation.cpp
+++ b/volume-cartographer/core/src/Segmentation.cpp
@@ -118,7 +118,11 @@ bool Segmentation::canLoadSurface() const
     for (const auto* band : {"x.tif", "y.tif", "z.tif"}) {
         std::error_code ec;
         if (!std::filesystem::exists(path_ / band, ec) || ec) {
-            return false;
+            // Open Data placeholders carry catalog-origin.json instead of a
+            // payload; they must register so the fetch/materialize path can
+            // run, and app code guards geometry access for them.
+            std::error_code originEc;
+            return std::filesystem::exists(path_ / "catalog-origin.json", originEc) && !originEc;
         }
     }
     return true;

--- a/volume-cartographer/core/src/Segmentation.cpp
+++ b/volume-cartographer/core/src/Segmentation.cpp
@@ -7,6 +7,8 @@
 #include <system_error>
 
 static const std::filesystem::path METADATA_FILE = "meta.json";
+static constexpr const char* OPEN_DATA_LAZY_PLACEHOLDER_KEY =
+    "vc_open_data_lazy_placeholder";
 
 Segmentation::Segmentation(std::filesystem::path path)
     : path_(std::move(path))
@@ -106,6 +108,15 @@ bool Segmentation::canLoadSurface() const
         return false;
     }
 
+    // Catalog placeholders intentionally contain only metadata until the user
+    // selects one. QuadSurface can construct their lightweight tree-row model
+    // from scale/tiff_dimensions without touching the absent TIFF payload.
+    if (metadata_.contains(OPEN_DATA_LAZY_PLACEHOLDER_KEY) &&
+        metadata_[OPEN_DATA_LAZY_PLACEHOLDER_KEY].is_boolean() &&
+        metadata_[OPEN_DATA_LAZY_PLACEHOLDER_KEY].get_bool()) {
+        return true;
+    }
+
     // loadSurface() only reads meta.json; the x/y/z.tif payload is read lazily
     // by QuadSurface::ensureLoaded() on first geometry access. That access
     // typically happens deep inside a Qt slot (focus marker, intersections,
@@ -118,11 +129,7 @@ bool Segmentation::canLoadSurface() const
     for (const auto* band : {"x.tif", "y.tif", "z.tif"}) {
         std::error_code ec;
         if (!std::filesystem::exists(path_ / band, ec) || ec) {
-            // Open Data placeholders carry catalog-origin.json instead of a
-            // payload; they must register so the fetch/materialize path can
-            // run, and app code guards geometry access for them.
-            std::error_code originEc;
-            return std::filesystem::exists(path_ / "catalog-origin.json", originEc) && !originEc;
+            return false;
         }
     }
     return true;

--- a/volume-cartographer/core/test/test_segmentation.cpp
+++ b/volume-cartographer/core/test/test_segmentation.cpp
@@ -151,6 +151,14 @@ TEST_CASE("Segmentation: canLoadSurface requires the tifxyz payload")
     CHECK_FALSE(seg.canLoadSurface());
     CHECK(seg.loadSurface() == nullptr);
 
+    SUBCASE("catalog provenance alone is not a lazy placeholder")
+    {
+        std::ofstream(t.dir / "catalog-origin.json") << "{}";
+        Segmentation catalogSegment(t.dir);
+        CHECK_FALSE(catalogSegment.canLoadSurface());
+        CHECK(catalogSegment.loadSurface() == nullptr);
+    }
+
     SUBCASE("a partial payload is still not loadable")
     {
         std::ofstream(t.dir / "x.tif") << "stub";
@@ -165,6 +173,26 @@ TEST_CASE("Segmentation: canLoadSurface requires the tifxyz payload")
         Segmentation complete(t.dir);
         CHECK(complete.canLoadSurface());
     }
+}
+
+TEST_CASE("Segmentation: canLoadSurface allows open-data lazy placeholders")
+{
+    TmpSeg t;
+    writeMeta(t.dir, R"({
+        "type":"seg",
+        "uuid":"placeholder",
+        "name":"lazy",
+        "format":"tifxyz",
+        "scale":[1.0,1.0],
+        "tiff_dimensions":[16,8],
+        "vc_open_data_lazy_placeholder":true
+    })");
+
+    Segmentation seg(t.dir);
+    CHECK(seg.canLoadSurface());
+    CHECK(seg.loadSurface() != nullptr);
+    CHECK(seg.getSurface() != nullptr);
+    CHECK_FALSE(fs::exists(t.dir / "x.tif"));
 }
 
 TEST_CASE("Segmentation: loadSurface returns nullptr when not tifxyz")


### PR DESCRIPTION
PR #1225 made Segmentation::canLoadSurface() require x/y/z.tif on disk to stop partial segment directories from aborting the app deep in lazy loading. But Open Data catalog segments are intentionally payload-less placeholders (meta.json + catalog-origin.json, tifs materialized on fetch), so the check rejected every catalog segment at registration: the surface panel showed 0 segments for any open-data sample and the fetch path was unreachable. Exempt directories carrying catalog-origin.json; genuinely truncated local segments are still refused.

**One real example:** Loading Paris4 or 0139 from Open Data.

**Before:** no segments appear in VC3D

**After this PR:** Correct segments appear

- [X] I personally verified that the example and proof above were produced by this PR on the stated data.

