### PR TITLE
Bound remote prefetch by render timeout

### DIFF
--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -556,10 +556,21 @@ static std::vector<vc::render::ChunkKey> collectPrefetchKeysForRows(
 
 static bool prefetchChunkKeys(
     vc::render::IChunkedArray* cache,
-    const std::vector<vc::render::ChunkKey>& keys)
+    const std::vector<vc::render::ChunkKey>& keys,
+    int timeoutMinutes)
 {
     if (!cache || keys.empty()) return true;
-    cache->prefetchChunks(keys, true);
+    if (timeoutMinutes <= 0) {
+        cache->prefetchChunks(keys, true);
+        if (!g_logFile) std::fprintf(stderr, "\n");
+        return true;
+    }
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::minutes(timeoutMinutes);
+    if (!cache->prefetchChunksUntil(keys, deadline)) {
+        std::fprintf(stderr, "Error: remote prefetch exceeded --timeout budget\n");
+        return false;
+    }
     if (!g_logFile) std::fprintf(stderr, "\n");
     return true;
 }
@@ -1728,7 +1739,9 @@ int main(int argc, char *argv[])
                       prefetchKeys.size(),
                       rowStart,
                       rowEnd > rowStart ? rowEnd - 1 : rowStart);
-            if (!prefetchChunkKeys(chunk_cache, prefetchKeys)) {
+            const int renderTimeout = parsed["timeout"].as<int>();
+            const int prefetchTimeout = renderTimeout > 1 ? renderTimeout - 1 : renderTimeout;
+            if (!prefetchChunkKeys(chunk_cache, prefetchKeys, prefetchTimeout)) {
                 return false;
             }
         }

--- a/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
+++ b/volume-cartographer/core/include/vc/core/render/ChunkCache.hpp
@@ -245,6 +245,9 @@ public:
                         bool wait,
                         int priorityOffset,
                         const ChunkRequestContext& request) override;
+    bool prefetchChunksUntil(const std::vector<ChunkKey>& keys,
+                             std::chrono::steady_clock::time_point deadline,
+                             int priorityOffset = 0) override;
     void replaceViewDemand(const ChunkRequestContext& request,
                            const std::array<float, 2>& focus,
                            std::vector<ChunkViewportSample> samples) override;

--- a/volume-cartographer/core/include/vc/core/render/IChunkedArray.hpp
+++ b/volume-cartographer/core/include/vc/core/render/IChunkedArray.hpp
@@ -3,12 +3,14 @@
 #include "vc/core/render/ChunkFetch.hpp"
 
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace vc::render {
@@ -106,6 +108,28 @@ public:
     {
         (void)request;
         prefetchChunks(keys, wait, priorityOffset);
+    }
+    virtual bool prefetchChunksUntil(const std::vector<ChunkKey>& keys,
+                                     std::chrono::steady_clock::time_point deadline,
+                                     int priorityOffset = 0)
+    {
+        prefetchChunks(keys, false, priorityOffset);
+        while (std::chrono::steady_clock::now() < deadline) {
+            bool pending = false;
+            for (const auto& key : keys) {
+                const auto result = getChunkIfCached(key.level, key.iz, key.iy, key.ix);
+                if (result.status == ChunkStatus::MissQueued) {
+                    pending = true;
+                    break;
+                }
+                if (result.status == ChunkStatus::Error)
+                    return false;
+            }
+            if (!pending)
+                return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        return false;
     }
 
     // Atomically replaces one view's located demand for this source. Building

--- a/volume-cartographer/core/src/render/ChunkCache.cpp
+++ b/volume-cartographer/core/src/render/ChunkCache.cpp
@@ -1723,6 +1723,54 @@ void ChunkCache::prefetchChunks(const std::vector<ChunkKey>& keys,
     });
 }
 
+bool ChunkCache::prefetchChunksUntil(const std::vector<ChunkKey>& keys,
+                                     std::chrono::steady_clock::time_point deadline,
+                                     int priorityOffset)
+{
+    auto state = state_;
+    std::unique_lock lock(state->mutex_);
+    std::vector<ChunkKey> remoteStarts;
+    for (auto key : keys) {
+        if (std::chrono::steady_clock::now() >= deadline)
+            return false;
+        key = sourceKey(*state, key);
+        if (!isValidKey(*state, key))
+            continue;
+        auto [it, inserted] = state->entries_.emplace(key, Entry{});
+        if (inserted) {
+            if (addRequestDemandLocked(*state, key, it->second, {})) {
+                if (queueFetchLocked(state, key, state->generation_, priorityOffset))
+                    remoteStarts.push_back(key);
+            } else {
+                state->entries_.erase(it);
+            }
+        } else if (it->second.status == EntryStatus::InFlight) {
+            if (addRequestDemandLocked(*state, key, it->second, {})) {
+                it->second.basePriority = std::min(
+                    it->second.basePriority,
+                    fetchBasePriority(*state, key, priorityOffset));
+                reprioritizeEntryLocked(*state, key, it->second);
+            }
+        }
+    }
+    lock.unlock();
+    for (const auto& key : remoteStarts) {
+        if (std::chrono::steady_clock::now() >= deadline)
+            return false;
+        notifyRemoteFetchListeners(state, key, true);
+    }
+    lock.lock();
+    return state->cv_.wait_until(lock, deadline, [&] {
+        for (auto key : keys) {
+            key = sourceKey(*state, key);
+            auto it = state->entries_.find(key);
+            if (it != state->entries_.end() && it->second.status == EntryStatus::InFlight)
+                return false;
+        }
+        return true;
+    });
+}
+
 IChunkedArray::ChunkReadyCallbackId ChunkCache::addChunkReadyListener(ChunkReadyCallback cb)
 {
     auto state = state_;

--- a/volume-cartographer/core/test/test_chunk_cache.cpp
+++ b/volume-cartographer/core/test/test_chunk_cache.cpp
@@ -874,6 +874,19 @@ TEST_CASE("ChunkCacheService deduplicates an in-flight fetch across handles")
     CHECK(fetcher->fetchCalls.load() == 1);
 }
 
+TEST_CASE("ChunkCache: timed prefetch returns while a fetch is unresolved")
+{
+    auto fetcher = std::make_shared<BlockingFetcher>();
+    auto cache = makeServiceCache(makeService(), "timed-prefetch", fetcher);
+    const std::vector<ChunkKey> keys{{0, 0, 0, 0}};
+
+    const bool resolved = cache->prefetchChunksUntil(
+        keys, std::chrono::steady_clock::now() + std::chrono::milliseconds(50));
+    CHECK_FALSE(resolved);
+    fetcher->release();
+    CHECK(waitForResolved(*cache, 0, 0, 0, 0).status == ChunkStatus::Data);
+}
+
 TEST_CASE("ChunkCacheService rejects stale publication after source invalidation")
 {
     auto service = makeService();


### PR DESCRIPTION
## Summary

`vc_render_tifxyz --prefetch-remote` could remain blocked in synchronous
prefetch work until an external watchdog terminated the process, leaving
placeholder TIFFs behind. This change adds a deadline-aware prefetch path and
makes the renderer return an explicit error when the reproduced prefetch path
exhausts its `--timeout` budget.

## What changed

- Add `IChunkedArray::prefetchChunksUntil(...)` with a deadline-based default
  implementation.
- Implement the bounded wait in `ChunkCache` using the existing scheduler and
  condition variable.
- Reserve one minute of `--timeout` for the renderer watchdog, while preserving
  existing unlimited behavior when `--timeout=0`.
- Add a regression test proving an unresolved fetch returns at its deadline.

## Real-scroll evidence

On PHerc1203, the reproduced three-minute command planned 556,053 remote
chunks. Before the change this path reached the external watchdog while
leaving invalid placeholder TIFFs. On a fresh current-main Linux build with
this change it returned after 130 seconds:

```text
Error: remote prefetch exceeded --timeout budget
renderer_rc=1
```

The output remained invalid placeholder data and was rejected; no render,
unwrapping, ink, or letter result is claimed.

The run wrote 62 placeholder files of 134 bytes each; they were rejected as
invalid. The empty cache and output sizes are reported as failure evidence, not
scientific artifacts.

## Verification

- Current-main Linux `vc_render_tifxyz` build: passed (`85/85` build steps).
- Focused `test_chunk_cache`: passed (`1/1`, 1.31 seconds).
- Fresh PHerc1203 failure path: explicit error, renderer exit 1 after 130
  seconds; outer watchdog not reached.
- GitHub CI: relevant compile, test, scan, and gate jobs pass; the Vercel
  authorization status is unrelated to this C++ change.

## Scope and limitation

This bounds the reproduced renderer failure path. It does not claim that every
possible scheduler or transport operation is cancellable, and it does not turn
an incomplete remote fetch into a scientific output. Its purpose is to fail
explicitly before invalid TIFF stacks enter downstream geometry or ink
analysis.

The verified configuration uses `--timeout 3`, which reserves one minute
between the prefetch deadline and the renderer watchdog. A one-minute timeout
can race the watchdog and is not included in the claim.
