### PR TITLE
vesuvius: harden the ink-detection disk cache against concurrent access

### DIFF
--- a/vesuvius/src/vesuvius/ink_detection/volume_io.py
+++ b/vesuvius/src/vesuvius/ink_detection/volume_io.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,8 @@ import zarr
 
 from vesuvius.data.utils import open_zarr as open_vesuvius_zarr
 
+
+LOGGER = logging.getLogger(__name__)
 
 _PUBLIC_S3_VOLUME_SUBSTRING = "vesuvius-challenge-open-data"
 ZARR_V3 = int(zarr.__version__.split(".", 1)[0]) >= 3
@@ -49,8 +52,72 @@ def _evict_to_watermark(
             path.unlink()
         except FileNotFoundError:
             pass
+        except OSError:
+            # Windows refuses to unlink a file that another process still holds
+            # open, so a sibling DataLoader worker reading this entry turns the
+            # sweep into a PermissionError. The entry survives and therefore
+            # still occupies its bytes: skip it without crediting the budget and
+            # evict a different one instead.
+            continue
         total -= size
     return total
+
+
+def _best_effort_cache_store(cache_path: Path) -> Any:
+    """Build the cache-side store, tolerating mutations the OS refuses.
+
+    The disk cache is an optimization, never a source of truth, so a failed
+    cache write or eviction must not abort the read that triggered it. That
+    distinction only becomes visible on Windows: zarr commits each cache entry
+    with ``os.replace`` and drops entries with ``unlink``, and Windows denies
+    both while another process holds the target open. Several DataLoader
+    workers sharing one ``cache_dir`` collide on exactly the same keys, so the
+    failure is routine rather than exotic -- four concurrent readers of one
+    volume fail roughly half the time. POSIX ``rename(2)``/``unlink(2)`` permit
+    both operations, which is why the cache looks reliable on Linux and macOS.
+
+    Losing the write costs one refetch; raising costs the whole run.
+    """
+    from zarr.storage import LocalStore
+
+    class _BestEffortCacheStore(LocalStore):
+        async def get(
+            self,
+            key: str,
+            prototype: Any = None,
+            byte_range: Any = None,
+        ) -> Any:
+            try:
+                return await super().get(key, prototype, byte_range)
+            except OSError as error:
+                # LocalStore.get already reports an unreadable entry as a miss
+                # for FileNotFoundError and friends; on Windows a sibling
+                # process committing the same key denies the read instead, which
+                # means exactly the same thing here.
+                LOGGER.debug("treating unreadable cache entry %s as a miss: %s", key, error)
+                return None
+
+        async def _set(self, key: str, value: Any, exclusive: bool = False) -> None:
+            try:
+                await super()._set(key, value, exclusive=exclusive)
+            except FileExistsError:
+                raise
+            except OSError as error:
+                LOGGER.debug("skipped caching %s: %s", key, error)
+
+        async def delete(self, key: str) -> None:
+            try:
+                await super().delete(key)
+            except OSError as error:
+                LOGGER.debug("skipped evicting %s: %s", key, error)
+
+        async def delete_dir(self, prefix: str) -> None:
+            try:
+                await super().delete_dir(prefix)
+            except OSError as error:
+                LOGGER.debug("skipped evicting %s: %s", prefix, error)
+
+    return _BestEffortCacheStore(cache_path)
 
 
 def load_volume_auth(auth_json_path: str | Path | None) -> tuple[str, str] | None:
@@ -137,7 +204,7 @@ def open_volume_root(
             source_store = LocalStore(path_text, read_only=True)
         store = CacheStore(
             store=source_store,
-            cache_store=LocalStore(cache_path),
+            cache_store=_best_effort_cache_store(cache_path),
             max_size=maximum_bytes,
         )
         return zarr.open(store=store, mode="r")

--- a/vesuvius/tests/ink_detection/test_volume_io.py
+++ b/vesuvius/tests/ink_detection/test_volume_io.py
@@ -139,7 +139,11 @@ def test_open_sweep_prunes_oldest_recursively_and_leaves_under_budget(
     for timestamp, path in enumerate(over_files, start=1):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(bytes([timestamp]) * 4)
-        os.utime(path, ns=(timestamp, timestamp))
+        # NTFS stores timestamps at 100 ns resolution, so 1 ns spacing collapses
+        # every file to st_mtime_ns == 0 on Windows and destroys the LRU ordering
+        # this test relies on. Space the stamps a second apart to stay portable.
+        stamp_ns = timestamp * 1_000_000_000
+        os.utime(path, ns=(stamp_ns, stamp_ns))
 
     opened = open_volume_root(
         "over.zarr",
@@ -157,7 +161,11 @@ def test_open_sweep_prunes_oldest_recursively_and_leaves_under_budget(
     for timestamp, (path, size) in enumerate(zip(under_files, (4, 6)), start=20):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(b"x" * size)
-        os.utime(path, ns=(timestamp, timestamp))
+        # NTFS stores timestamps at 100 ns resolution, so 1 ns spacing collapses
+        # every file to st_mtime_ns == 0 on Windows and destroys the LRU ordering
+        # this test relies on. Space the stamps a second apart to stay portable.
+        stamp_ns = timestamp * 1_000_000_000
+        os.utime(path, ns=(stamp_ns, stamp_ns))
     before = [(path.read_bytes(), path.stat().st_mtime_ns) for path in under_files]
 
     open_volume_root(
@@ -168,6 +176,77 @@ def test_open_sweep_prunes_oldest_recursively_and_leaves_under_budget(
 
     after = [(path.read_bytes(), path.stat().st_mtime_ns) for path in under_files]
     assert after == before
+
+
+@pytest.mark.skipif(not _ZARR_V3, reason="volume disk cache requires Zarr 3")
+def test_cache_write_denied_by_os_still_serves_correct_data(tmp_path, monkeypatch):
+    from zarr.storage import _local
+
+    source_path = tmp_path / "volume.zarr"
+    expected = np.arange(6 * 7 * 8, dtype=np.uint16).reshape(6, 7, 8) * 11 + 2
+    _write_pyramid(source_path, expected)
+
+    def denied(*args, **kwargs):
+        raise PermissionError(13, "Access is denied")
+
+    monkeypatch.setattr(_local, "_put", denied)
+
+    volume = open_volume(source_path, 0, cache_dir=tmp_path / "cache")
+    assert np.asarray(volume[:]).tobytes() == expected.tobytes()
+
+
+@pytest.mark.skipif(not _ZARR_V3, reason="volume disk cache requires Zarr 3")
+def test_cache_read_denied_by_os_falls_back_to_source(tmp_path, monkeypatch):
+    from zarr.storage import _local
+
+    source_path = tmp_path / "volume.zarr"
+    cache_dir = tmp_path / "cache"
+    expected = np.arange(5 * 6 * 7, dtype=np.uint16).reshape(5, 6, 7) * 19 + 1
+    _write_pyramid(source_path, expected)
+
+    primed = open_volume(source_path, 0, cache_dir=cache_dir)
+    assert np.asarray(primed[:]).tobytes() == expected.tobytes()
+
+    real_get = _local._get
+
+    def denied_under_cache(path, prototype, byte_range=None):
+        if cache_dir in Path(path).parents:
+            raise PermissionError(13, "Permission denied")
+        return real_get(path, prototype, byte_range)
+
+    monkeypatch.setattr(_local, "_get", denied_under_cache)
+
+    volume = open_volume(source_path, 0, cache_dir=cache_dir)
+    assert np.asarray(volume[:]).tobytes() == expected.tobytes()
+
+
+def test_eviction_skips_entries_the_os_refuses_to_delete(tmp_path, monkeypatch):
+    target = disk_cache_subdir("locked.zarr", tmp_path / "cache")
+    files = [target / "zarr.json", target / "c" / "0", target / "c" / "1"]
+    for timestamp, path in enumerate(files, start=1):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"x" * 4)
+        stamp_ns = timestamp * 1_000_000_000
+        os.utime(path, ns=(stamp_ns, stamp_ns))
+
+    real_unlink = Path.unlink
+
+    def maybe_denied(self, *args, **kwargs):
+        if self.name == "zarr.json":
+            raise PermissionError(13, "Access is denied")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", maybe_denied)
+
+    remaining = volume_io._evict_to_watermark(volume_io._cache_snapshot(target), 12)
+
+    # The undeletable oldest entry survives, so it must keep counting against
+    # the budget; the sweep evicts the next-oldest instead of crediting bytes
+    # that are still on disk.
+    assert files[0].exists()
+    assert not files[1].exists()
+    assert files[2].exists()
+    assert remaining == 8
 
 
 @pytest.mark.skipif(not _ZARR_V3, reason="volume disk cache requires Zarr 3")


### PR DESCRIPTION
## What breaks

The shared volume disk cache (`ink_detection/volume_io.py` — the `LocalStore`-backed `CacheStore` reached via the documented `volume_cache_dir` config field and `infer_full3d_tifxyz.py --cache-dir`) breaks when several processes populate the same cache directory concurrently — e.g. a `DataLoader` with `num_workers > 0`. On Windows 11 the existing test `test_shared_cache_multiprocess_reads_are_not_torn` fails **7 of 12 runs** with `PermissionError`; it passes in isolation, which is why it reads as a flake.

Three distinct surfaces, found by fixing them one at a time:

1. **Cache-entry commit** — zarr's `_atomic_write` finalizes entries with `os.replace`; Windows (`MoveFileEx(MOVEFILE_REPLACE_EXISTING)`) refuses while another process holds the destination open, where POSIX `rename(2)` permits it. Upstream report: zarr-developers/zarr-python#3522 (open, unfixed as of zarr 3.2.1).
2. **Cache read** — a concurrent commit can deny the reader's `open` as well (only visible after fixing 1).
3. **Eviction** — `_evict_to_watermark` caught only `FileNotFoundError` on `unlink()` (Windows raises `PermissionError` for in-use entries) **and decremented the size budget even when the file stayed on disk**, under-evicting. This accounting bug is OS-independent.

## The fix

A `_BestEffortCacheStore` wrapper on the **cache-side** `LocalStore` only. A cache is an optimization, never a source of truth: a refused cache mutation degrades to a no-op (logged at `debug`), and an unreadable entry reports as a miss — extending `LocalStore.get`'s own miss semantics for `FileNotFoundError`; `CacheStore` already refetches from source on `None`. No platform branches anywhere; the source store is untouched.

Named trade-off: cache writes also swallow e.g. `ENOSPC`, so a full disk becomes slow refetches instead of a crash — intended for a cache, and visible at debug level.

The eviction sweep now skips undeletable entries without crediting their bytes and evicts the next-oldest instead.

## Verification

- The racing test: 58% failure → **12/12 consecutive passes** (Windows 11, Python 3.14, CPU torch, `volume-only` extra).
- **Three new deterministic regression tests** force each `PermissionError` surface via monkeypatching — verified to fail against the unfixed code, on any OS, so Linux CI gets a stable signal a 58% race never gave it.
- Also fixes an NTFS portability bug in the LRU eviction test: `os.utime` with 1–3 ns timestamps collapses to `st_mtime_ns == 0` on NTFS (100 ns resolution), destroying the LRU ordering the test relies on; stamps are now spaced 1 s apart.
- Suite on Windows (volume-only extra): 47 passed / 2 failed → **52 passed / 0 failed** (the 59 collection errors from absent heavy optional deps are unchanged).

## Packaging companion

`cucim-cu13` (declared in the `models` and `all` extras) publishes manylinux wheels only, so `uv sync --extra all` cannot resolve on Windows or macOS without a marker. This PR adds `; sys_platform == 'linux'` at both declaration sites. `test_dependency_wiring` splits requirement names on `;` and is unaffected.

This also moves toward the note in `test-vesuvius.yml` — *"Extend this list once the build scripts for macOS and Windows are confirmed"* — the `volume-only` extra now installs and passes its tests cleanly on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLMDCz18xaYUSMXemJ8r1y
