### PR TITLE
community projects: add sheet-topo-bench

### DIFF
--- a/scrollprize.org/docs/20_community_projects.md
+++ b/scrollprize.org/docs/20_community_projects.md
@@ -194,6 +194,8 @@ For state-of-the-art updates join our [Discord server](https://discord.com/invit
 
 - [spiralcheck](https://github.com/Nicodol/spiralcheck) by Nicolas Dolegieviez. Held-out evaluation for whole-scroll spiral fits: scores a finished run from its output meshes alone (CPU-only, no checkpoint, producer-agnostic) against verified patches withheld from that fit, and measures geometrically how much of the withheld evidence actually sits within touching distance of the fit's real inputs — on PHerc. Paris 4, 54.8% of a naive name-level split leaked that way, which no hash-level check can see. Also ships ground-truth-free winding-order checks around the umbilicus, a planted-defect matrix with computed null-control bounds, and `spiralcheck demo`, which runs the whole pipeline on a synthetic scroll with planted defects and needs no data.
 
+- [sheet-topo-bench](https://github.com/tonclap/sheet-topo-bench) by tonclap. A benchmark for topological errors (sheet switch / merger) of scroll surfaces - open problems #3/#4: an error injector with self-generating ground truth, a no-GPU detector (frozen v1 AP 0.65 on two held-out sets; a learned CPU re-ranking examined once on a fresh held-out generation - AP 0.70/0.89, paired gain +0.11/+0.25 significant - against naive baselines <= 0.006), an ERL-for-sheets metric (mm of sheet traced before a topological error), three real-error corpora with three validated prediction-free channels, an address list of verified real 2026 tracing errors, published negative results, and `verify.py`, which recomputes every README number from the shipped runs offline.
+
 ### 📦 Materials
 
 #### 🌟 Highlighted


### PR DESCRIPTION
**In one sentence:** Adds [sheet-topo-bench](https://github.com/tonclap/sheet-topo-bench) — a benchmark for topological errors (sheet switch / merger) of scroll surfaces, open problems #3/#4 — to the community-projects catalogue.

**One real example:** Clone the repo, `pip install -r requirements-verify.txt`, `python verify.py` — it reproduces every README number from the shipped PHerc. Paris 4 / PHerc0139 runs offline: 15/15 regenerated tables, 74/74 bound literals, exit 0, seconds.

**Before:** No benchmark for sheet switch/merger errors in the catalogue.

**After this PR:** Two lines in Segmentation → Tools listing one: error injector with self-generating ground truth, no-GPU detector baseline, ERL-for-sheets metric, three real-error corpora, an address list of verified real 2026 tracing errors, published negative results.

**Proof:** `verify.py` ends with "all numbers verified against the shipped runs" (checked on CPython 3.10/3.11/3.14 in bare venvs, 2026-08-20).

**Why / where this is useful:** Anyone tuning a tracing pipeline can score their detector against the same frozen protocol and reuse the real-error corpora.

The research design was chosen after literature review in similar scientific areas. The method is borrowed from connectomics, which hit the same silent merge/split failures on thin structures and answered by measuring first — ERL and merge/split benchmarks came before the fixes.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Docs-only change (+2 lines). The package is AI-assisted work under human direction — `AI_DISCLOSURE.md` in the repo.
