### PR TITLE
Remove the unused entries in view menu.

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -3347,8 +3347,6 @@ void CWindow::populateDockToggleMenu(QMenu* menu) const
     addDock(menu, ui.dockWidgetSegmentation);
     addDock(menu, ui.dockWidgetDistanceTransform);
     addDock(menu, ui.dockWidgetViewerControls);
-    addDock(menu, ui.dockWidgetNormalVis);
-    addDock(menu, ui.dockWidgetView);
     addDock(menu, ui.dockWidgetOverlay);
     addDock(menu, _inkDetectionDock);
     addDock(menu, _transformsDock);


### PR DESCRIPTION
Remove the unused entries in view menu. Clicking on the "View" and "Normal Vis" entries under the View menu did nothing, because those panels' controls have been folded into "Viewer Controls".

**Proof:** <!-- Attach the image, video, output, or benchmark. Use the same input/settings for comparisons and say what we should look at. -->
<img width="421" height="517" alt="image" src="https://github.com/user-attachments/assets/3635b82d-3e5a-413a-97d6-5c4960389949" />

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.