### PR TITLE
Unblock catalog-streamed Lasagna new-model fits

### DIFF
--- a/lasagna/cli_data.py
+++ b/lasagna/cli_data.py
@@ -11,6 +11,7 @@ import fit_data
 @dataclass(frozen=True)
 class DataConfig:
 	input: str
+	init_shell_dir: str | None                           # optional fit-service path for shell-dir-crop init
 	device: str
 	downscale: float
 	crop: tuple[int, int, int, int, int, int] | None  # (x, y, z, w, h, d) fullres
@@ -30,6 +31,8 @@ class DataConfig:
 def add_args(p: argparse.ArgumentParser) -> None:
 	g = p.add_argument_group("data")
 	g.add_argument("--input", default=None)
+	g.add_argument("--init-shell-dir", default=None,
+		help="Shell directory for shell-dir-crop init; overrides init_shell_dir in the input manifest")
 	g.add_argument("--device", default="cuda")
 	g.add_argument("--downscale", type=float, default=4.0)
 	g.add_argument("--crop", type=int, nargs=6, default=None,
@@ -81,6 +84,11 @@ def from_args(args: argparse.Namespace) -> DataConfig:
 		winding_volume = str(winding_volume)
 	return DataConfig(
 		input=str(args.input),
+		init_shell_dir=(
+			str(args.init_shell_dir).strip()
+			if getattr(args, "init_shell_dir", None) not in (None, "")
+			else None
+		),
 		device=str(args.device),
 		downscale=float(args.downscale),
 		crop=crop,

--- a/lasagna/fit.py
+++ b/lasagna/fit.py
@@ -923,13 +923,25 @@ def _apply_cylinder_prepare_model_step(mdl: "model.Model3D", model_step: float |
 		mdl.cyl_shell_current_height_step = step
 
 
-def _require_manifest_init_shell_dir(prep_params: dict) -> str:
-	value = prep_params.get("init_shell_dir", None)
+def _require_init_shell_dir(
+	prep_params: dict, *, override: str | None = None
+) -> str:
+	value = (
+		override
+		if isinstance(override, str) and override.strip()
+		else prep_params.get("init_shell_dir", None)
+	)
 	if value is None:
-		raise ValueError("shell-dir-crop init requires .lasagna.json key 'init_shell_dir'")
+		raise ValueError(
+			"shell-dir-crop init requires --init-shell-dir or "
+			".lasagna.json key 'init_shell_dir'"
+		)
 	if not isinstance(value, str) or not value.strip():
-		raise ValueError("shell-dir-crop init requires non-empty string .lasagna.json key 'init_shell_dir'")
-	return str(value)
+		raise ValueError(
+			"shell-dir-crop init requires a non-empty --init-shell-dir or "
+			".lasagna.json key 'init_shell_dir'"
+		)
+	return value.strip()
 
 
 def _parse_corr_points(obj: dict, device: torch.device) -> fit_data.CorrPoints3D | None:
@@ -1537,7 +1549,10 @@ def main(argv: list[str] | None = None, *, lifecycle_fn=None) -> int:
 	if init_mode == "shell-dir-crop" and model_init != "seed":
 		raise ValueError("init-mode=shell-dir-crop requires args.model-init=seed")
 	if init_mode == "shell-dir-crop" and "init_shell_dir" in cfg:
-		raise ValueError("do not set top-level config key 'init_shell_dir'; shell-dir-crop reads it from --input .lasagna.json")
+		raise ValueError(
+			"do not set top-level config key 'init_shell_dir'; put 'init-shell-dir' "
+			"under 'args' or pass --init-shell-dir"
+		)
 
 	# Probe preprocessed data for scaledown and volume extent (in base/VC3D coords)
 	_t = _stage_start("probe_preprocessed_data")
@@ -1664,7 +1679,8 @@ def main(argv: list[str] | None = None, *, lifecycle_fn=None) -> int:
 		if corr_points_3d_for_roi is None or corr_points_3d_for_roi.points_xyz_winda.shape[0] <= 0:
 			raise ValueError("corr-point-roi requires nonempty corr_points")
 		from init_shell_index import InitShellIndex
-		init_shell_dir = _require_manifest_init_shell_dir(prep_params)
+		init_shell_dir = _require_init_shell_dir(
+			prep_params, override=data_cfg.init_shell_dir)
 		corr_point_roi_shell_index = InitShellIndex.from_directory(init_shell_dir)
 		if device.type == "cuda":
 			corr_point_roi_normal_data = fit_data.load_3d_streaming(
@@ -1848,7 +1864,8 @@ def main(argv: list[str] | None = None, *, lifecycle_fn=None) -> int:
 				shell_quality_analysis,
 				trim_shell_surface_rows_by_quality,
 			)
-			init_shell_dir = _require_manifest_init_shell_dir(prep_params)
+			init_shell_dir = _require_init_shell_dir(
+				prep_params, override=data_cfg.init_shell_dir)
 			if corr_point_roi_init is not None:
 				shell_index = corr_point_roi_shell_index if corr_point_roi_shell_index is not None else InitShellIndex.from_directory(init_shell_dir)
 				closest = corr_point_roi_init.closest

--- a/lasagna/fit_data.py
+++ b/lasagna/fit_data.py
@@ -4,18 +4,130 @@ import math
 import json
 import os
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 import zarr
 
-from lasagna_volume import LasagnaVolume
+from lasagna_volume import ChannelGroup, LasagnaVolume
 
 # --- Chunk sampling statistics ---
 CHUNK_STATS_ENABLED = False
 _CHUNK_SIZE = 32
+
+
+@dataclass(frozen=True)
+class StreamingZarrSource:
+	"""A complete local Zarr array or the authoritative remote catalog array."""
+
+	zarr_path: str
+	remote: bool = False
+
+
+def _safe_relative_zarr_key(raw_path: str) -> tuple[str, ...]:
+	"""Return a catalog-safe relative Zarr key without normalizing traversal."""
+
+	value = str(raw_path).strip()
+	posix = PurePosixPath(value.replace("\\", "/"))
+	windows = PureWindowsPath(value)
+	parts = posix.parts
+	if (not value or posix.is_absolute() or windows.is_absolute() or windows.drive
+			or not parts or any(part in ("", ".", "..") for part in parts)):
+		raise ValueError(f"catalog remote Zarr path must be a safe relative path: {raw_path!r}")
+	return tuple(parts)
+
+
+def _read_validated_lasagna_remote_marker(vol: LasagnaVolume) -> str:
+	"""Return the authoritative artifact URL from VC3D's adjacent marker."""
+
+	marker_path = vol.path.parent / "lasagna-remote.json"
+	try:
+		marker = json.loads(marker_path.read_text(encoding="utf-8"))
+	except FileNotFoundError as exc:
+		raise ValueError(
+			"VC3D split Lasagna cache has metadata outside the chunk tree but "
+			"no adjacent lasagna-remote.json marker; refusing to treat partial "
+			"local chunks as a complete Zarr store"
+		) from exc
+	except json.JSONDecodeError as exc:
+		raise ValueError(f"invalid VC3D lasagna-remote.json: {marker_path}") from exc
+	if not isinstance(marker, dict):
+		raise ValueError(f"VC3D lasagna-remote.json must be an object: {marker_path}")
+	manifest_file = marker.get("manifest_file")
+	if not isinstance(manifest_file, str) or not manifest_file.strip():
+		raise ValueError("VC3D lasagna-remote.json has no manifest_file")
+	if (vol.path.parent / manifest_file).resolve() != vol.path.resolve():
+		raise ValueError("VC3D lasagna-remote.json does not identify the opened manifest")
+	artifact_url = marker.get("artifact_url")
+	if not isinstance(artifact_url, str) or not artifact_url.strip():
+		raise ValueError("VC3D lasagna-remote.json has no artifact_url")
+	url = artifact_url.strip().rstrip("/")
+	parsed_url = urlsplit(url)
+	if parsed_url.scheme not in {"http", "https", "s3"} or not parsed_url.netloc:
+		raise ValueError("VC3D lasagna-remote.json artifact_url must use http, https, or s3")
+	return url
+
+
+def _join_remote_artifact_url(artifact_url: str, key_parts: tuple[str, ...]) -> str:
+	"""Append a relative Zarr key before any query or fragment component."""
+
+	parsed = urlsplit(artifact_url)
+	encoded_key = "/".join(quote(part, safe="-._~") for part in key_parts)
+	path = parsed.path.rstrip("/") + "/" + encoded_key
+	return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, parsed.fragment))
+
+
+def resolve_streaming_zarr_source(
+	vol: LasagnaVolume, group: ChannelGroup
+) -> StreamingZarrSource:
+	"""Resolve a group without ever accepting VC3D's incomplete sparse cache.
+
+	VC3D deliberately keeps Zarr metadata under ``.lasagna-zarr-metadata`` while
+	chunk objects live in the visible sibling tree.  Opening that visible tree
+	locally would turn every not-yet-cached chunk into Zarr's fill value.  For a
+	split cache, use the marker's authoritative remote artifact instead.
+	"""
+
+	group_path = str(group.zarr_path)
+	marker_path = vol.path.parent / "lasagna-remote.json"
+	if marker_path.is_file():
+		# A VC3D marker means the artifact is authoritative.  A copied .zarray
+		# beside incomplete cached chunks would otherwise make Zarr return fills.
+		key_parts = _safe_relative_zarr_key(group_path)
+		artifact_url = _read_validated_lasagna_remote_marker(vol)
+		return StreamingZarrSource(
+			_join_remote_artifact_url(artifact_url, key_parts),
+			remote=True,
+		)
+
+	local_path = vol.path.parent / group_path
+	if any((local_path / name).is_file() for name in (".zarray", "zarr.json")):
+		return StreamingZarrSource(str(local_path), remote=False)
+
+	key_parts = _safe_relative_zarr_key(group_path)
+	metadata_root = vol.path.parent / ".lasagna-zarr-metadata" / Path(*key_parts)
+	has_split_metadata = any(
+		(metadata_root / name).is_file() for name in (".zarray", "zarr.json")
+	)
+	if not has_split_metadata:
+		# Preserve the normal local-Zarr failure when this is not a VC3D catalog cache.
+		return StreamingZarrSource(str(local_path), remote=False)
+
+	artifact_url = _read_validated_lasagna_remote_marker(vol)
+	return StreamingZarrSource(
+		_join_remote_artifact_url(artifact_url, key_parts),
+		remote=True,
+	)
+
+
+def _probe_tensorstore_zarr_shape(zarr_path: str, *, remote: bool) -> tuple[int, ...]:
+	"""Open only remote metadata so load_3d_streaming can validate its shape."""
+
+	from sparse_tensorstore_cache import probe_zarr_shape
+	return probe_zarr_shape(zarr_path, remote=remote)
 
 
 def _dilate26(t: torch.Tensor) -> torch.Tensor:
@@ -1284,11 +1396,20 @@ def load_3d_streaming(
 		if not channels:
 			continue
 
-		zarr_path = str(vol.path.parent / group.zarr_path)
-		zsrc = zarr.open(zarr_path, mode="r")
-		if not isinstance(zsrc, zarr.Array):
-			raise ValueError(f"expected zarr.Array at {zarr_path}, got {type(zsrc)}")
-		shape = tuple(int(v) for v in zsrc.shape)
+		source = resolve_streaming_zarr_source(vol, group)
+		zarr_path = source.zarr_path
+		if source.remote:
+			if _backend != "tensorstore":
+				raise ValueError(
+					"VC3D catalog split-cache fallback requires "
+					"sparse_prefetch_backend='tensorstore'"
+				)
+			shape = _probe_tensorstore_zarr_shape(zarr_path, remote=True)
+		else:
+			zsrc = zarr.open(zarr_path, mode="r")
+			if not isinstance(zsrc, zarr.Array):
+				raise ValueError(f"expected zarr.Array at {zarr_path}, got {type(zsrc)}")
+			shape = tuple(int(v) for v in zsrc.shape)
 		Z, Y, X, is_3d = _validate_group_zarr_shape(
 			vol=vol,
 			group_name=group_name,
@@ -1308,6 +1429,7 @@ def load_3d_streaming(
 			cache = TensorStoreSparseChunkGroupCache(
 				channels=channels,
 				zarr_path=zarr_path,
+				remote=source.remote,
 				vol_shape_zyx=(Z, Y, X),
 				channel_indices=channel_indices,
 				is_3d_zarr=is_3d,

--- a/lasagna/sparse_tensorstore_cache.py
+++ b/lasagna/sparse_tensorstore_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import time
+from urllib.parse import urlsplit, urlunsplit
 
 import numpy as np
 import tensorstore as ts
@@ -16,6 +17,37 @@ def _fmt_mib(value: int | float) -> str:
     return f"{float(value) / 1024.0 ** 2:.1f}MiB"
 
 
+def zarr_kvstore_spec(zarr_path: str, *, remote: bool) -> dict[str, str]:
+    """Build the TensorStore kvstore for a local array or catalog artifact."""
+
+    if not remote:
+        return {"driver": "file", "path": str(zarr_path)}
+    parsed = urlsplit(str(zarr_path))
+    if parsed.scheme in {"http", "https"} and parsed.netloc:
+        base_url = urlunsplit((
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path.rstrip("/") + "/",
+            parsed.query,
+            "",
+        ))
+        return {"driver": "http", "base_url": base_url}
+    if parsed.scheme == "s3" and parsed.netloc:
+        return {"driver": "s3", "bucket": parsed.netloc, "path": parsed.path.lstrip("/")}
+    raise ValueError(f"unsupported remote Zarr URL: {zarr_path!r}")
+
+
+def _zarr_spec(zarr_path: str, *, remote: bool) -> dict[str, object]:
+    return {"driver": "zarr", "kvstore": zarr_kvstore_spec(zarr_path, remote=remote)}
+
+
+def probe_zarr_shape(zarr_path: str, *, remote: bool) -> tuple[int, ...]:
+    """Read only Zarr metadata to validate a remote streaming source."""
+
+    store = ts.open(_zarr_spec(zarr_path, remote=remote), open=True, read=True).result()
+    return tuple(int(value) for value in store.shape)
+
+
 class TensorStoreSparseChunkGroupCache:
     """PyTorch-facing sparse cache using TensorStore for parallel chunk reads."""
 
@@ -24,6 +56,7 @@ class TensorStoreSparseChunkGroupCache:
         *,
         channels: list[str],
         zarr_path: str,
+        remote: bool = False,
         vol_shape_zyx: tuple[int, int, int],
         channel_indices: dict[str, int],
         is_3d_zarr: bool,
@@ -34,6 +67,7 @@ class TensorStoreSparseChunkGroupCache:
     ) -> None:
         self.channels = channels
         self.zarr_path = zarr_path
+        self.remote = bool(remote)
         self.n_channels = len(channels)
         self.vol_shape_zyx = tuple(int(v) for v in vol_shape_zyx)
         self.channel_indices = channel_indices
@@ -61,10 +95,7 @@ class TensorStoreSparseChunkGroupCache:
             "data_copy_concurrency": {"limit": int(data_copy_threads)},
         })
         self._store = ts.open(
-            {
-                "driver": "zarr",
-                "kvstore": {"driver": "file", "path": str(zarr_path)},
-            },
+            _zarr_spec(zarr_path, remote=self.remote),
             context=self._context,
             open=True,
             read=True,

--- a/lasagna/tests/test_fit_data_manifest_lazy.py
+++ b/lasagna/tests/test_fit_data_manifest_lazy.py
@@ -9,6 +9,7 @@ import torch
 import zarr
 
 import fit_data
+import sparse_tensorstore_cache
 from lasagna_volume import ChannelGroup, LasagnaVolume
 
 
@@ -69,6 +70,15 @@ class _FakeSparseChunkGroupCache:
 		self.channel_indices = dict(channel_indices)
 		self.is_3d_zarr = bool(is_3d_zarr)
 		self.chunk_table = torch.zeros(1, dtype=torch.int64, device=device)
+
+
+class _FakeTensorStoreSparseChunkGroupCache(_FakeSparseChunkGroupCache):
+	created: list[tuple[str, bool]] = []
+
+	def __init__(self, *, zarr_path: str, remote: bool = False, **kwargs) -> None:
+		super().__init__(zarr_path=zarr_path, **kwargs)
+		self.remote = bool(remote)
+		type(self).created.append((zarr_path, self.remote))
 
 
 class FitDataManifestLazyTests(unittest.TestCase):
@@ -271,6 +281,190 @@ class FitDataManifestLazyTests(unittest.TestCase):
 			self.assertIsNone(data.umbilicus_points)
 			self.assertIsNone(data.umbilicus_xy_lookup)
 			self.assertEqual(set(data.channel_spacing or {}), {"grad_mag", "nx", "ny"})
+
+	def test_streaming_source_keeps_complete_local_zarr(self) -> None:
+		with tempfile.TemporaryDirectory() as td:
+			root = Path(td)
+			_write_u8_zarr(root / "surface.zarr", (3, 4, 5, 6))
+			manifest = _write_manifest(root, groups=_surface_group())
+			vol = LasagnaVolume.load(manifest)
+
+			source = fit_data.resolve_streaming_zarr_source(vol, vol.groups["surface"])
+
+			self.assertFalse(source.remote)
+			self.assertEqual(Path(source.zarr_path), root / "surface.zarr")
+
+	def test_streaming_source_uses_validated_remote_marker_for_vc3d_split_cache(self) -> None:
+		with tempfile.TemporaryDirectory() as td:
+			root = Path(td)
+			manifest = _write_manifest(
+				root,
+				groups=_surface_group("surface.ome.zarr/4"),
+				base_shape=(4, 5, 6),
+				umbilicus_json=None,
+			)
+			mirror = root / ".lasagna-zarr-metadata" / "surface.ome.zarr" / "4"
+			mirror.mkdir(parents=True)
+			(mirror / ".zarray").write_text('{"shape":[3,4,5,6]}', encoding="utf-8")
+			(root / "lasagna-remote.json").write_text(
+				json.dumps({
+					"artifact_url": "https://example.test/artifacts/lasagna/",
+					"manifest_file": manifest.name,
+				}) + "\n",
+				encoding="utf-8",
+			)
+			vol = LasagnaVolume.load(manifest)
+
+			source = fit_data.resolve_streaming_zarr_source(vol, vol.groups["surface"])
+
+			self.assertTrue(source.remote)
+			self.assertEqual(source.zarr_path, "https://example.test/artifacts/lasagna/surface.ome.zarr/4")
+
+	def test_catalog_marker_stays_remote_when_metadata_was_copied_into_partial_cache(self) -> None:
+		with tempfile.TemporaryDirectory() as td:
+			root = Path(td)
+			manifest = _write_manifest(root, groups=_surface_group("surface.ome.zarr/4"))
+			partial = root / "surface.ome.zarr" / "4"
+			partial.mkdir(parents=True)
+			(partial / ".zarray").write_text('{"shape":[3,4,5,6]}', encoding="utf-8")
+			(partial / "0.0.0").write_bytes(b"one cached chunk")
+			(root / "lasagna-remote.json").write_text(
+				json.dumps({
+					"artifact_url": "https://example.test/artifacts/lasagna",
+					"manifest_file": manifest.name,
+				}) + "\n",
+				encoding="utf-8",
+			)
+			vol = LasagnaVolume.load(manifest)
+
+			source = fit_data.resolve_streaming_zarr_source(vol, vol.groups["surface"])
+
+			self.assertTrue(source.remote)
+			self.assertEqual(source.zarr_path, "https://example.test/artifacts/lasagna/surface.ome.zarr/4")
+
+	def test_remote_artifact_join_preserves_query_and_fragment(self) -> None:
+		self.assertEqual(
+			fit_data._join_remote_artifact_url(
+				"https://example.test/artifacts/lasagna/?token=a%2Fb#anchor",
+				("surface.ome.zarr", "4"),
+			),
+			"https://example.test/artifacts/lasagna/surface.ome.zarr/4?token=a%2Fb#anchor",
+		)
+
+	def test_load_streaming_split_cache_uses_remote_tensorstore_not_partial_local_store(self) -> None:
+		with tempfile.TemporaryDirectory() as td:
+			root = Path(td)
+			manifest = _write_manifest(
+				root,
+				groups=_surface_group("surface.ome.zarr/4"),
+				base_shape=(4, 5, 6),
+				umbilicus_json=None,
+			)
+			mirror = root / ".lasagna-zarr-metadata" / "surface.ome.zarr" / "4"
+			mirror.mkdir(parents=True)
+			(mirror / ".zarray").write_text('{"shape":[3,4,5,6]}', encoding="utf-8")
+			(root / "surface.ome.zarr" / "4").mkdir(parents=True)
+			(root / "lasagna-remote.json").write_text(
+				json.dumps({
+					"artifact_url": "https://example.test/artifacts/lasagna",
+					"manifest_file": manifest.name,
+				}) + "\n",
+				encoding="utf-8",
+			)
+			_FakeTensorStoreSparseChunkGroupCache.created.clear()
+			with (
+				mock.patch.object(
+					fit_data, "_probe_tensorstore_zarr_shape", return_value=(3, 4, 5, 6)
+				),
+				mock.patch(
+					"sparse_tensorstore_cache.TensorStoreSparseChunkGroupCache",
+					_FakeTensorStoreSparseChunkGroupCache,
+				),
+				mock.patch.object(fit_data.zarr, "open", side_effect=AssertionError("partial local store opened")),
+			):
+				data = fit_data.load_3d_streaming(
+					path=str(manifest), device=torch.device("cpu"), sparse_prefetch_backend="tensorstore"
+				)
+
+			self.assertEqual(data.size, (4, 5, 6))
+			self.assertEqual(
+				_FakeTensorStoreSparseChunkGroupCache.created,
+				[("https://example.test/artifacts/lasagna/surface.ome.zarr/4", True)],
+			)
+
+	def test_streaming_source_rejects_split_cache_without_valid_marker(self) -> None:
+		with tempfile.TemporaryDirectory() as td:
+			root = Path(td)
+			manifest = _write_manifest(root, groups=_surface_group("surface.ome.zarr/4"))
+			mirror = root / ".lasagna-zarr-metadata" / "surface.ome.zarr" / "4"
+			mirror.mkdir(parents=True)
+			(mirror / ".zarray").write_text("{}", encoding="utf-8")
+			(root / "lasagna-remote.json").write_text(
+				json.dumps({"artifact_url": "https://example.test/a", "manifest_file": "other.lasagna.json"}),
+				encoding="utf-8",
+			)
+			vol = LasagnaVolume.load(manifest)
+
+			with self.assertRaisesRegex(ValueError, "does not identify the opened manifest"):
+				fit_data.resolve_streaming_zarr_source(vol, vol.groups["surface"])
+
+	def test_streaming_source_rejects_split_cache_without_marker(self) -> None:
+		with tempfile.TemporaryDirectory() as td:
+			root = Path(td)
+			manifest = _write_manifest(root, groups=_surface_group("surface.ome.zarr/4"))
+			mirror = root / ".lasagna-zarr-metadata" / "surface.ome.zarr" / "4"
+			mirror.mkdir(parents=True)
+			(mirror / ".zarray").write_text("{}", encoding="utf-8")
+			vol = LasagnaVolume.load(manifest)
+
+			with self.assertRaisesRegex(ValueError, "no adjacent lasagna-remote.json"):
+				fit_data.resolve_streaming_zarr_source(vol, vol.groups["surface"])
+
+	def test_streaming_source_rejects_unsafe_remote_group_path(self) -> None:
+		with tempfile.TemporaryDirectory() as td:
+			root = Path(td)
+			manifest = _write_manifest(root, groups=_surface_group("../outside.zarr"))
+			(root / "lasagna-remote.json").write_text(
+				json.dumps({"artifact_url": "https://example.test/a", "manifest_file": manifest.name}),
+				encoding="utf-8",
+			)
+			vol = LasagnaVolume.load(manifest)
+
+			with self.assertRaisesRegex(ValueError, "safe relative path"):
+				fit_data.resolve_streaming_zarr_source(vol, vol.groups["surface"])
+
+	def test_tensorstore_kvstore_specs_cover_local_http_https_and_s3(self) -> None:
+		self.assertEqual(
+			sparse_tensorstore_cache.zarr_kvstore_spec("C:/data/a.zarr", remote=False),
+			{"driver": "file", "path": "C:/data/a.zarr"},
+		)
+		self.assertEqual(
+			sparse_tensorstore_cache.zarr_kvstore_spec(
+				"http://localhost/a.zarr/4", remote=True
+			),
+			{"driver": "http", "base_url": "http://localhost/a.zarr/4/"},
+		)
+		self.assertEqual(
+			sparse_tensorstore_cache.zarr_kvstore_spec(
+				"https://example.test/a.zarr/4", remote=True
+			),
+			{"driver": "http", "base_url": "https://example.test/a.zarr/4/"},
+		)
+		self.assertEqual(
+			sparse_tensorstore_cache.zarr_kvstore_spec(
+				"https://example.test/a.zarr/4?token=a%2Fb#ignored", remote=True
+			),
+			{
+				"driver": "http",
+				"base_url": "https://example.test/a.zarr/4/?token=a%2Fb",
+			},
+		)
+		self.assertEqual(
+			sparse_tensorstore_cache.zarr_kvstore_spec(
+				"s3://bucket/prefix/a.zarr/4", remote=True
+			),
+			{"driver": "s3", "bucket": "bucket", "path": "prefix/a.zarr/4"},
+		)
 
 	def test_load_3d_streaming_requires_umbilicus_when_requested(self) -> None:
 		with tempfile.TemporaryDirectory() as td:

--- a/lasagna/tests/test_init_shell_index.py
+++ b/lasagna/tests/test_init_shell_index.py
@@ -101,9 +101,20 @@ def _grid_center(xyz: torch.Tensor) -> torch.Tensor:
 class InitShellIndexErrorTest(unittest.TestCase):
 	def test_missing_manifest_init_shell_dir_key_errors(self) -> None:
 		with self.assertRaisesRegex(ValueError, "init_shell_dir"):
-			fit._require_manifest_init_shell_dir({})
+			fit._require_init_shell_dir({})
 		with self.assertRaisesRegex(ValueError, "init_shell_dir"):
-			fit._require_manifest_init_shell_dir({"init_shell_dir": ""})
+			fit._require_init_shell_dir({"init_shell_dir": ""})
+
+	def test_explicit_init_shell_dir_overrides_manifest_and_blank_falls_back(self) -> None:
+		params = {"init_shell_dir": "/manifest/shells"}
+		self.assertEqual(
+			fit._require_init_shell_dir(params, override=" /service/shells "),
+			"/service/shells",
+		)
+		self.assertEqual(
+			fit._require_init_shell_dir(params, override=""),
+			"/manifest/shells",
+		)
 
 	def test_manifest_init_shell_dir_resolves_relative_to_lasagna_json(self) -> None:
 		with tempfile.TemporaryDirectory() as td:
@@ -220,6 +231,18 @@ class InitShellCropTest(unittest.TestCase):
 		self.assertFalse(cfg.corr_point_roi)
 		self.assertEqual(cfg.corr_point_roi_init_margin, 80)
 		self.assertEqual(cfg.corr_point_roi_output_radius, 20)
+
+	def test_cli_data_accepts_init_shell_dir_override(self) -> None:
+		parser = argparse.ArgumentParser()
+		cli_data.add_args(parser)
+		args = parser.parse_args([
+			"--input", "/tmp/input.lasagna.json",
+			"--init-shell-dir", "/srv/pherc0332/init_shells",
+		])
+
+		cfg = cli_data.from_args(args)
+
+		self.assertEqual(cfg.init_shell_dir, "/srv/pherc0332/init_shells")
 
 	def test_cli_data_accepts_corr_point_roi_args(self) -> None:
 		parser = argparse.ArgumentParser()

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_lasagna.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_lasagna.cpp
@@ -202,6 +202,7 @@ QJsonObject AgentBridgeServer::handleLasagnaStartOptimization(const QJsonValue& 
 
     const QString configPath = p.value("configPath").toString();
     const QString atlasPath = p.value("atlasPath").toString();
+    const QString initShellDir = p.value("initShellDir").toString();
     std::optional<cv::Vec3i> seed;
     if (p.contains("seed")) {
         const cv::Vec3f v = jsonToVec3(p.value("seed"), "seed");
@@ -209,8 +210,8 @@ QJsonObject AgentBridgeServer::handleLasagnaStartOptimization(const QJsonValue& 
     }
 
     QString errorMessage;
-    const bool started =
-        panel->startOptimizationHeadless(state, mode, configPath, seed, atlasPath, &errorMessage);
+    const bool started = panel->startOptimizationHeadless(
+        state, mode, configPath, seed, atlasPath, initShellDir, &errorMessage);
     if (!started) {
         QJsonObject data;
         data["detail"] = errorMessage;

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_lasagna.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_lasagna.cpp
@@ -64,6 +64,7 @@ void AgentBridgeServer::registerLasagnaHandlers()
                 Params::optionalString(QStringLiteral("configPath")),
                 optionalVec3(QStringLiteral("seed")),
                 Params::optionalString(QStringLiteral("atlasPath")),
+                Params::optionalString(QStringLiteral("initShellDir")),
             },
             .errors = {-32602, -32000, -32004, -32005, -32007, -32009},
             .mcp = Mcp::snakeCase(

--- a/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
+++ b/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
@@ -1275,7 +1275,8 @@
         ],
         "paramRenames": {
           "atlasPath": "atlas_path",
-          "configPath": "config_path"
+          "configPath": "config_path",
+          "initShellDir": "init_shell_dir"
         },
         "tool": "vc3d_lasagna_start_optimization"
       },
@@ -1285,6 +1286,9 @@
             "type": "string"
           },
           "configPath": {
+            "type": "string"
+          },
+          "initShellDir": {
             "type": "string"
           },
           "mode": {

--- a/volume-cartographer/apps/VC3D/segmentation/panels/SegmentationLasagnaPanel.cpp
+++ b/volume-cartographer/apps/VC3D/segmentation/panels/SegmentationLasagnaPanel.cpp
@@ -1889,7 +1889,7 @@ void SegmentationLasagnaPanel::repeatLastLasagnaAction()
 bool SegmentationLasagnaPanel::repeatLastLasagnaActionHeadless(CState* state, QString* errorMessage)
 {
     return startOptimizationHeadless(state, _lastLasagnaMode, QString(), std::nullopt,
-                                      QString(), errorMessage);
+                                      QString(), QString(), errorMessage);
 }
 
 void SegmentationLasagnaPanel::startOptimization(CState* state, QStatusBar* statusBar)
@@ -1949,6 +1949,7 @@ bool SegmentationLasagnaPanel::startOptimizationHeadless(CState* state,
                                                          const QString& configPath,
                                                          std::optional<cv::Vec3i> seed,
                                                          const QString& atlasPath,
+                                                         const QString& initShellDir,
                                                          QString* errorMessage)
 {
     auto fail = [errorMessage](const QString& msg) {
@@ -2021,7 +2022,7 @@ bool SegmentationLasagnaPanel::startOptimizationHeadless(CState* state,
     } else {
         result = startOptimizationWithOverrides(
             state, nullptr, static_cast<int>(mode), resolvedConfig,
-            hasSeed, seedX, seedY, seedZ, Presentation::Silent);
+            hasSeed, seedX, seedY, seedZ, Presentation::Silent, initShellDir);
     }
 
     if (!result.submitted) {
@@ -2350,7 +2351,8 @@ SegmentationLasagnaPanel::startOptimizationWithOverrides(
     int seedX,
     int seedY,
     int seedZ,
-    Presentation presentation)
+    Presentation presentation,
+    const QString& initShellDirOverride)
 {
     auto showStatus = [statusBar](const QString& msg, int timeout) {
         if (statusBar) {
@@ -2629,6 +2631,9 @@ SegmentationLasagnaPanel::startOptimizationWithOverrides(
     args[QStringLiteral("model-w-unit")] = nmWUnit;
     args[QStringLiteral("model-h")] = nmH;
     args[QStringLiteral("depth")] = nmN;
+    if (!initShellDirOverride.trimmed().isEmpty()) {
+        args[QStringLiteral("init-shell-dir")] = initShellDirOverride.trimmed();
+    }
     config[QStringLiteral("args")] = args;
 
     std::cerr << "[lasagna] request settings:"

--- a/volume-cartographer/apps/VC3D/segmentation/panels/SegmentationLasagnaPanel.hpp
+++ b/volume-cartographer/apps/VC3D/segmentation/panels/SegmentationLasagnaPanel.hpp
@@ -84,11 +84,13 @@ public:
     ///   configPath: empty => selectedLasagnaConfigPathForMode(mode)
     ///   seed:       nullopt => panel seed / focus (no seed override)
     ///   atlasPath:  empty => panel selection; applied via setSelectedAtlasPath
+    ///   initShellDir: path visible to the fit-service host; empty => manifest
     bool startOptimizationHeadless(CState* state,
                                    LasagnaMode mode,
                                    const QString& configPath,
                                    std::optional<cv::Vec3i> seed,
                                    const QString& atlasPath,
+                                   const QString& initShellDir,
                                    QString* errorMessage = nullptr);
     /// Repeats the last action without entering the interactive signal chain.
     bool repeatLastLasagnaActionHeadless(CState* state, QString* errorMessage = nullptr);
@@ -172,7 +174,8 @@ private:
         int seedX,
         int seedY,
         int seedZ,
-        Presentation presentation = Presentation::Interactive);
+        Presentation presentation = Presentation::Interactive,
+        const QString& initShellDirOverride = QString());
 
     // -- Sections --
     CollapsibleSettingsGroup* _connectionGroup{nullptr};

--- a/volume-cartographer/core/test/test_segmentation_lasagna_panel_ui.cpp
+++ b/volume-cartographer/core/test/test_segmentation_lasagna_panel_ui.cpp
@@ -567,6 +567,23 @@ int main(int argc, char** argv)
     require(panel._compactAtlasConfigCombo->count() == panel._atlasConfigCombo->count(),
             "Compact atlas config combo should mirror the full atlas config combo");
     panel.setLasagnaDataInputPath(QStringLiteral("/data/atlas_input.lasagna.json"));
+    QString headlessError;
+    require(panel.startOptimizationHeadless(
+                &state,
+                SegmentationLasagnaPanel::LasagnaMode::NewModel,
+                configPath,
+                cv::Vec3i{4, 5, 6},
+                QString(),
+                QStringLiteral("/service/pherc0332/init_shells"),
+                &headlessError),
+            "Headless New Model launch should accept an init-shell directory override");
+    QJsonObject shellOverrideConfig =
+        g_lastLasagnaOptimizationRequest[QStringLiteral("job_spec")].toObject()
+            [QStringLiteral("config")].toObject();
+    require(shellOverrideConfig[QStringLiteral("args")].toObject()
+                [QStringLiteral("init-shell-dir")].toString() ==
+                QStringLiteral("/service/pherc0332/init_shells"),
+            "Headless New Model launch should forward initShellDir to fit args");
     const QString outputPathsDir = volpkgRoot + QStringLiteral("/paths");
     require(QDir().mkpath(outputPathsDir + QStringLiteral("/my_sheet_v001.tifxyz")),
             "Failed to create atlas output collision directory");

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_bridge.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_bridge.py
@@ -234,6 +234,16 @@ class ToolLayerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["kind"], "lasagna.optimize")
         self.assertNotIn("state", result)
 
+    async def test_vc3d_lasagna_start_optimization_forwards_init_shell_dir(self) -> None:
+        await vc3d_lasagna_start_optimization(
+            mode="new_model",
+            init_shell_dir="/service/pherc0332/init_shells",
+        )
+        self.assertEqual(
+            self.fake_server.received_requests[-1]["params"]["initShellDir"],
+            "/service/pherc0332/init_shells",
+        )
+
     async def test_vc3d_lasagna_start_optimization_wait_returns_terminal_status(self) -> None:
         result = await vc3d_lasagna_start_optimization(mode="reoptimize", wait=True)
         self.assertEqual(result["jobId"], "job-2")

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/lasagna.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/lasagna.py
@@ -84,6 +84,7 @@ async def vc3d_lasagna_start_optimization(
     config_path: Optional[str] = None,
     seed: Optional[_Vec3] = None,
     atlas_path: Optional[str] = None,
+    init_shell_dir: Optional[str] = None,
     wait: bool = False,
     ctx: Optional[Context] = None,
 ) -> dict[str, Any]:
@@ -99,6 +100,9 @@ async def vc3d_lasagna_start_optimization(
     integers.
     atlas_path: required for mode "atlas" unless the panel already has an atlas
     selected; missing fails -32007 (data.kind:"atlas"). Ignored for other modes.
+    init_shell_dir: shell directory visible to the fit-service host. For
+    new_model shell-dir-crop initialization this overrides init_shell_dir in
+    the input manifest.
     wait: if true (MCP-server-side only, not part of the underlying RPC), block
     until the job finishes (30-minute cap) and return the terminal job.status
     inline instead of just the jobId; on timeout the jobId is returned with an
@@ -119,6 +123,7 @@ async def vc3d_lasagna_start_optimization(
                 "configPath": config_path,
                 "seed": seed,
                 "atlasPath": atlas_path,
+                "initShellDir": init_shell_dir,
             }
         ),
     )


### PR DESCRIPTION
**In one sentence:** A catalog-attached `new_model` job can now accept a fit-service-visible shell directory and safely stream channels from the catalog when VC3D has split Zarr metadata from cached chunks.

**One real example:** With the unchanged public PHerc0332 manifest, I passed a local init-shell directory, built a 25×43 initial mesh, opened all three required prediction groups, and read `grad_mag[1050,579,374] = 228` from the public artifact.

**Before:** `load_3d_streaming` opened the manifest-sibling chunk directory as a complete Zarr store and failed with `PathNotFoundError: nothing found at path ''`.

**After this PR:** A valid adjacent `lasagna-remote.json` marker selects the authoritative HTTP/S3 artifact, while normal marker-free local Zarr inputs keep their existing behavior. `initShellDir` is also carried from the agent bridge/MCP call to fit.py as `--init-shell-dir`.

**Proof:**

![Before: local split-cache open fails](https://raw.githubusercontent.com/TAUIL-Abd-Elilah/vesuvius-repro/25d99b7/evidence/villa-1540/before.png)

![After: remote groups open and a real PHerc0332 voxel is read](https://raw.githubusercontent.com/TAUIL-Abd-Elilah/vesuvius-repro/25d99b7/evidence/villa-1540/after.png)

```text
BEFORE=PathNotFoundError: nothing found at path ''
[fit] shell-dir-crop selected shell_0001.tifxyz ... crop=25x43
[fit_data] load_3d_streaming ... groups=['grad_mag', 'nx', 'ny'] sparse_prefetch=tensorstore
AFTER_SIZE=(2100, 986, 986)
REAL_SCROLL_READ=PHerc0332 grad_mag[1050,579,374]=228
REMOTE_SOURCE=True
```

**Independent end-to-end replay on this branch** (`@Bullo27`, through the
agent bridge, unchanged public manifest):

```text
stage 0: 1000/1000  loss 0.1526
stage 1: 1000/1000  loss 0.1384
stage 2:  500/500   loss 0.1376
remote reads: 174 chunks/channel while only 6 chunks were cached locally
wall time: 206 s; peak GPU memory: 0.02 GiB
output: new_model_v002.tifxyz (24 x 42 grid; 0.1357 cm²)
```

[Full independent replay](https://github.com/ScrollPrize/villa/pull/1572#issuecomment-5384415862)
The 2,500-step replay used a synthetic shell only to seed a mesh through a real PHerc0332 material point. It demonstrates that the catalog workflow runs and exports; it does not establish resulting surface quality.

Same public artifact and manifest on both sides:
`PHerc0332/representations/predictions/lasagna/20251211183505-lasagna-20260419180421-L2/PHerc0332-20251211183505-lasagna-20260724.lasagna.json`

**Why / where this is useful:** It removes the two blockers that prevented `shell-dir-crop` new-model jobs from reaching optimization on catalog-attached samples.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Tested commit: `2363183da`

- 24 manifest/streaming resolver tests pass.
- 25 init-shell tests pass.
- MCP descriptor/contract tests pass.
- Real PHerc0332 metadata opened for `cos`, `grad_mag`, `nx`, and `ny`; the real voxel above was read through TensorStore.
- Full replay record: https://github.com/TAUIL-Abd-Elilah/vesuvius-repro/tree/25d99b7/evidence/villa-1540
- A full local fit reached stage-0 prefetch, then stopped because this Windows host lacks Ninja/CUDA toolkit for the existing JIT extension.

This addresses the `shell-dir-crop` and split-store blockers in #1540. `cylinder_seed` remains blocked by the missing published `umbilicus_json`.

Thanks @Bullo27 for the exact reproducer, reference run, and split-cache diagnosis.
