### PR TITLE
spiral: fit a 4,000-slice window on a 16 GB host

### DIFF
--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -1928,7 +1928,10 @@ class FitContext:
                     or track_sampling_config['crossing_mode'] == 'track_walk'):
                 track_crossing_cache = load_track_crossing_cache(self.tracks_dbm_path)
                 if track_crossing_cache is not None:
-                    track_graph = TrackGraph(track_crossing_cache)
+                    # Training restricts and remaps the exact-crossing CSR;
+                    # it never traverses the duplicate rustworkx topology.
+                    track_graph = TrackGraph(
+                        track_crossing_cache, build_topology=False)
                     print(
                         f'built TrackGraph: {len(track_graph)} tracks, '
                         f'{track_graph.edge_count} crossings in '

--- a/spiral-fitting/pack_resident_pools.py
+++ b/spiral-fitting/pack_resident_pools.py
@@ -29,18 +29,49 @@ from __future__ import annotations
 
 import argparse
 import glob
+import itertools
 import json
 import os
 import sys
 import threading
 import time
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
 
 RESPOOL_FORMAT_VERSION = 2
+
+# Chunk reads in flight per worker thread. Enough to keep every thread busy
+# across one write, small enough that the decoded bricks waiting to be written
+# stay a bounded cost rather than a function of how many chunks the store has.
+READS_IN_FLIGHT_PER_THREAD = 4
+
+
+def map_bounded(executor, function, items, max_in_flight):
+    """Like ``executor.map``, but with a bounded number of pending results.
+
+    ``Executor.map`` submits every task before yielding anything and holds each
+    finished result until the consumer reaches it, so a reader that outruns the
+    writer accumulates the whole input in memory. Packing a lasagna store that
+    way peaked at 26.2 GB and was killed; the only workaround was --io-threads 1,
+    which serialises the reads to make the pile-up small. Keeping a sliding
+    window of submissions instead bounds the resident results directly, so the
+    thread count goes back to being a throughput knob.
+
+    (``chunksize`` does not help here: ThreadPoolExecutor uses the base
+    ``Executor.map``, which ignores it.)
+    """
+    items = iter(items)
+    pending = deque(
+        executor.submit(function, item)
+        for item in itertools.islice(items, max(1, max_in_flight)))
+    while pending:
+        result = pending.popleft().result()
+        for item in itertools.islice(items, 1):
+            pending.append(executor.submit(function, item))
+        yield result
 
 
 def sidecar_path(zarr_path: str, group: str, *, pair: bool = False) -> str:
@@ -354,8 +385,9 @@ def pack_arrays(
             f.write(bytes(brick_voxels))  # row 0: reserved all-zero brick
         with ThreadPoolExecutor(io_threads) as executor:
             done = 0
-            for key, keep_idx, channel_bricks in executor.map(
-                    read_chunk, keys, chunksize=4):
+            for key, keep_idx, channel_bricks in map_bounded(
+                    executor, read_chunk, keys,
+                    io_threads * READS_IN_FLIGHT_PER_THREAD):
                 base = np.multiply(key, sub)
                 for sz, sy, sx in sub_grid[keep_idx]:
                     coords.append((base[0] + sz, base[1] + sy, base[2] + sx))

--- a/spiral-fitting/tests/test_compact_in_place.py
+++ b/spiral-fitting/tests/test_compact_in_place.py
@@ -1,0 +1,108 @@
+"""In-place compaction must not corrupt, and must refuse what it cannot own.
+
+Dropping the unkept rows with ``rows[keep]`` allocates a second array the size
+of the survivors, so both exist at once: 2.16 GB beside 2.16 GB on the 2 um
+store at three thousand slices, inside a peak a 16 GB machine cannot clear.
+Moving the survivors down inside the original removes the duplicate.
+
+The reason this is safe is narrow, so it is worth pinning: the write position
+trails the read position only because compaction preserves order and produces a
+prefix. Anything that breaks either property silently corrupts data, and the
+two guards -- a read-only array, and a view into someone else's buffer -- both
+exist because the packed track store is a read-only memmap that reaches this
+code as a copy by accident of dtype.
+"""
+import unittest
+
+import numpy as np
+
+from tracks import _compact_rows_in_place
+
+
+class CompactInPlaceTests(unittest.TestCase):
+
+    def reference(self, rows, keep):
+        return rows[keep].copy()
+
+    def test_matches_fancy_indexing(self):
+        rng = np.random.default_rng(0)
+        for n in (1, 2, 17, 1000, 5000):
+            rows = rng.integers(-2**20, 2**20, size=(n, 3)).astype(np.float32)
+            keep = rng.random(n) > 0.35
+            want = self.reference(rows, keep)
+            got = _compact_rows_in_place(rows.copy(), keep)
+            np.testing.assert_array_equal(got, want, err_msg=f'n={n}')
+
+    def test_crosses_block_boundaries(self):
+        # The default block is millions of rows, so nothing in a unit test
+        # would ever span one. A small block exercises the case where the write
+        # position has fallen behind the read position by more than a block.
+        rng = np.random.default_rng(1)
+        rows = rng.integers(0, 1000, size=(997, 3)).astype(np.float32)
+        keep = rng.random(997) > 0.5
+        want = self.reference(rows, keep)
+        for block in (1, 2, 7, 64, 512):
+            got = _compact_rows_in_place(rows.copy(), keep, block=block)
+            np.testing.assert_array_equal(got, want, err_msg=f'block={block}')
+
+    def test_keeps_order(self):
+        rows = np.arange(300, dtype=np.float32).reshape(100, 3)
+        keep = np.zeros(100, dtype=bool)
+        keep[[0, 1, 50, 98, 99]] = True
+        got = _compact_rows_in_place(rows.copy(), keep, block=8)
+        np.testing.assert_array_equal(got[:, 0], [0, 3, 150, 294, 297])
+
+    def test_all_kept_returns_the_input(self):
+        rows = np.ones((10, 3), dtype=np.float32)
+        got = _compact_rows_in_place(rows, np.ones(10, dtype=bool))
+        self.assertIs(got.base if got.base is not None else got, rows)
+
+    def test_none_kept(self):
+        rows = np.ones((10, 3), dtype=np.float32)
+        got = _compact_rows_in_place(rows, np.zeros(10, dtype=bool))
+        self.assertEqual(got.shape, (0, 3))
+
+    def test_refuses_a_read_only_array(self):
+        """The packed store's coordinates are a read-only memmap.
+
+        They arrive as a writable copy only because the store is int32 and the
+        caller asks for float32. If that ever lines up, this must not write
+        through to the file.
+        """
+        rows = np.ones((100, 3), dtype=np.float32)
+        rows.flags.writeable = False
+        keep = np.zeros(100, dtype=bool)
+        keep[:60] = True
+        got = _compact_rows_in_place(rows, keep)
+        self.assertEqual(got.shape, (60, 3))
+        self.assertTrue(rows.flags.writeable is False)
+
+    def test_refuses_a_view(self):
+        """Writing through a view rewrites whatever it is a window onto."""
+        backing = np.arange(600, dtype=np.float32).reshape(200, 3)
+        rows = backing[50:150]
+        untouched = backing.copy()
+        keep = np.zeros(100, dtype=bool)
+        keep[::2] = True
+        got = _compact_rows_in_place(rows, keep)
+        np.testing.assert_array_equal(got, untouched[50:150][keep])
+        np.testing.assert_array_equal(backing, untouched)
+
+    def test_prefers_the_copy_when_most_rows_are_dropped(self):
+        """Below half survival the stranded tail costs more than the copy."""
+        rows = np.arange(3000, dtype=np.float32).reshape(1000, 3)
+        keep = np.zeros(1000, dtype=bool)
+        keep[:100] = True
+        original = rows.copy()
+        got = _compact_rows_in_place(rows, keep)
+        np.testing.assert_array_equal(got, original[keep])
+        np.testing.assert_array_equal(rows, original, 'input was mutated')
+
+    def test_mask_length_must_match(self):
+        rows = np.ones((10, 3), dtype=np.float32)
+        with self.assertRaises(ValueError):
+            _compact_rows_in_place(rows, np.ones(9, dtype=bool))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/spiral-fitting/tests/test_pack_bounded_map.py
+++ b/spiral-fitting/tests/test_pack_bounded_map.py
@@ -1,0 +1,111 @@
+"""Packing must not hold the whole store in memory.
+
+read_chunk decodes bricks and the caller writes them to disk one chunk at a
+time. Executor.map submits every task up front and keeps each finished result
+until the consumer reaches it, so a reader that outruns the writer accumulates
+results without bound: packing a lasagna store that way peaked at 26.2 GB and
+was killed, and the only way through was --io-threads 1, which throttles the
+reads until the pile-up is small.
+
+These tests pin the bound and the ordering, and the control shows the bound is
+not something Executor.map provides on its own.
+"""
+import itertools
+import threading
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+from pack_resident_pools import map_bounded
+
+
+class ResidentResultTracker:
+    """Counts results produced but not yet consumed."""
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.live = 0
+        self.peak = 0
+
+    def produce(self, item):
+        with self.lock:
+            self.live += 1
+            self.peak = max(self.peak, self.live)
+        # Long enough that several workers overlap one consumer step.
+        time.sleep(0.001)
+        return item
+
+    def consume(self):
+        with self.lock:
+            self.live -= 1
+
+
+class BoundedMapTests(unittest.TestCase):
+    ITEMS = 400
+    THREADS = 8
+    IN_FLIGHT = 16
+
+    def drain(self, iterator, tracker):
+        seen = []
+        for value in iterator:
+            tracker.consume()
+            seen.append(value)
+            time.sleep(0.002)      # a writer is slower than a reader
+        return seen
+
+    def test_resident_results_stay_within_the_window(self):
+        tracker = ResidentResultTracker()
+        with ThreadPoolExecutor(self.THREADS) as executor:
+            seen = self.drain(
+                map_bounded(executor, tracker.produce,
+                            range(self.ITEMS), self.IN_FLIGHT),
+                tracker)
+
+        self.assertEqual(seen, list(range(self.ITEMS)), 'order must be kept')
+        # The window admits one extra: the replacement is submitted before the
+        # result is yielded, so between those two statements W+1 tasks have run
+        # while the consumer has taken W. Asserting W alone fails about once in
+        # forty runs on eight threads and roughly half the time on thirty-two,
+        # which would read as a flaky bound rather than as an off-by-one here.
+        self.assertLessEqual(
+            tracker.peak, self.IN_FLIGHT + 1,
+            f'{tracker.peak} results were resident at once for a window of '
+            f'{self.IN_FLIGHT}')
+
+    def test_executor_map_does_not_bound_them(self):
+        """The control: without the window the whole input piles up."""
+        tracker = ResidentResultTracker()
+        with ThreadPoolExecutor(self.THREADS) as executor:
+            self.drain(
+                executor.map(tracker.produce, range(self.ITEMS), chunksize=4),
+                tracker)
+
+        self.assertGreater(
+            tracker.peak, self.IN_FLIGHT * 4,
+            'Executor.map was expected to run far ahead of the consumer; if it '
+            'no longer does, this regression test needs rethinking')
+
+    def test_window_smaller_than_one_still_makes_progress(self):
+        with ThreadPoolExecutor(2) as executor:
+            self.assertEqual(
+                list(map_bounded(executor, lambda x: x * 2, range(5), 0)),
+                [0, 2, 4, 6, 8])
+
+    def test_empty_input(self):
+        with ThreadPoolExecutor(2) as executor:
+            self.assertEqual(
+                list(map_bounded(executor, lambda x: x, [], 4)), [])
+
+    def test_exceptions_reach_the_caller(self):
+        def boom(item):
+            if item == 3:
+                raise ValueError('boom')
+            return item
+
+        with ThreadPoolExecutor(2) as executor:
+            with self.assertRaises(ValueError):
+                list(map_bounded(executor, boom, range(10), 4))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/spiral-fitting/tests/test_packed_store_signature.py
+++ b/spiral-fitting/tests/test_packed_store_signature.py
@@ -1,0 +1,153 @@
+"""A published sidecar must survive being copied to another machine.
+
+The packed track store and the crossing cache both fingerprint their source
+DBM. That fingerprint used to include ``st_mtime_ns``, which is not a property
+of the bytes and is not preserved by copying or downloading, so every sidecar
+shipped with a dataset was refused on every machine except the one that wrote
+it. These tests pin the portable behaviour and the change detection it has to
+keep.
+
+Nothing here needs the native track-store extension: the writer and the
+signature check are pure Python, so the regression stays covered on machines
+that have not built the C++ side.
+"""
+import dbm
+import json
+import os
+import pickle
+from pathlib import Path
+import tempfile
+import unittest
+
+import numpy as np
+
+from build_track_crossings import build_cache
+from tracks import (
+    _packed_store_if_current,
+    _tracks_db_signature,
+    _tracks_db_content_signature,
+    load_track_crossing_cache,
+    track_store_path,
+    write_packed_track_store,
+)
+
+
+def line_track(length, *, z=10, y=10, axis=2, offset=0):
+    points = np.zeros((int(length) + 1, 3), dtype=np.int32)
+    points[:, 0] = z
+    points[:, 1] = y
+    points[:, axis] = np.arange(int(length) + 1, dtype=np.int32) + offset
+    return points
+
+
+class PackedStoreSignatureTests(unittest.TestCase):
+    def make_db(self, root, *, offset=0):
+        path = Path(root) / 'tracks.dbm'
+        with dbm.open(str(path), 'c') as database:
+            database[b'h:0'] = pickle.dumps(
+                [line_track(20, z=10, y=10, axis=2, offset=offset)])
+            database[b'vy:0'] = pickle.dumps(
+                [line_track(20, z=10, y=0, axis=1, offset=offset)])
+        return path
+
+    def backing_files(self, path):
+        logical = Path(str(path))
+        return [candidate
+                for candidate in (logical, *(Path(str(logical) + suffix)
+                                             for suffix in ('.db', '.dat',
+                                                            '.dir', '.pag')))
+                if candidate.is_file()]
+
+    def retouch(self, path):
+        """Give the DBM the modification time a fresh download would give it."""
+        for candidate in self.backing_files(path):
+            stat = candidate.stat()
+            os.utime(candidate, ns=(stat.st_atime_ns,
+                                    stat.st_mtime_ns + 5_000_000_000))
+
+    def test_store_survives_a_changed_modification_time(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            store = write_packed_track_store(path, show_progress=False)
+            self.assertEqual(store, track_store_path(path))
+
+            self.retouch(path)
+            self.assertIsNotNone(
+                _packed_store_if_current(path),
+                'a store must stay usable after the DBM is copied or '
+                'downloaded, which is the only thing a new mtime proves')
+
+    def test_store_is_rejected_when_the_contents_change(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            write_packed_track_store(path, show_progress=False)
+
+            # Same key count and same pickle lengths, different coordinates:
+            # the file size is unchanged, so only a content-derived signature
+            # can tell that this is no longer the packed DBM.
+            before = [candidate.stat().st_size
+                      for candidate in self.backing_files(path)]
+            self.make_db(temporary, offset=7)
+            after = [candidate.stat().st_size
+                     for candidate in self.backing_files(path)]
+            self.assertEqual(before, after, 'test needs an equal-size rewrite')
+
+            self.assertIsNone(_packed_store_if_current(path))
+
+    def test_legacy_store_is_accepted_on_name_and_size(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            store = write_packed_track_store(path, show_progress=False)
+
+            # A store written before the portable signature existed.
+            metadata_path = store / 'metadata.json'
+            metadata = json.loads(metadata_path.read_text(encoding='utf-8'))
+            metadata.pop('source_db_signature_content')
+            metadata_path.write_text(json.dumps(metadata), encoding='utf-8')
+
+            self.retouch(path)
+            self.assertIsNotNone(
+                _packed_store_if_current(path),
+                'the shipped 12 GiB store carries only the legacy signature, '
+                'so it has to be honoured on the fields that travel with it')
+
+    def test_legacy_store_still_rejected_when_the_size_changes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            store = write_packed_track_store(path, show_progress=False)
+            metadata_path = store / 'metadata.json'
+            metadata = json.loads(metadata_path.read_text(encoding='utf-8'))
+            metadata.pop('source_db_signature_content')
+            metadata_path.write_text(json.dumps(metadata), encoding='utf-8')
+
+            with dbm.open(str(path), 'c') as database:
+                database[b'h:1'] = pickle.dumps([line_track(400)])
+
+            self.assertIsNone(_packed_store_if_current(path))
+
+    def test_content_signature_ignores_only_the_timestamp(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            legacy_before = _tracks_db_signature(path)
+            content_before = _tracks_db_content_signature(path)
+
+            self.retouch(path)
+            self.assertNotEqual(legacy_before, _tracks_db_signature(path))
+            self.assertEqual(content_before, _tracks_db_content_signature(path))
+
+
+    def test_crossing_cache_survives_a_changed_modification_time(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            build_cache(path, show_progress=False)
+            self.assertIsNotNone(load_track_crossing_cache(path))
+
+            self.retouch(path)
+            self.assertIsNotNone(
+                load_track_crossing_cache(path),
+                'the crossing cache carries the same defect as the packed '
+                'store and has to be fixed with it')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/spiral-fitting/tests/test_streamed_track_exclusion.py
+++ b/spiral-fitting/tests/test_streamed_track_exclusion.py
@@ -1,0 +1,130 @@
+"""Streaming the exclusion must produce exactly what materialising produced.
+
+The streamed path exists to keep a second and third copy of the selected
+points from existing at once.  That is only worth anything if the bytes it
+produces are the same bytes, so every check here is an equality against the
+path it replaces -- including against the native compaction, which is what
+runs in production when the extension is installed.
+
+The cases are the ones a blocked gather gets wrong while still looking right
+on a uniform fixture:
+
+  * tracks of unequal length, so a block boundary lands mid-selection
+  * a selection that is not the identity and not sorted contiguously
+  * block sizes smaller than, equal to and larger than a single track
+  * a mask that removes the whole of some tracks and part of others
+"""
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
+from tracks import (                                  # noqa: E402
+    PackedTrackCollection,
+    _compact_blocked,
+    _compact_rows_in_place,
+)
+
+RNG = np.random.default_rng(20260822)
+
+
+def make_collection(track_count=97, rows=None):
+    lengths = RNG.integers(1, 40, size=track_count).astype(np.int64)
+    offsets = np.empty(track_count + 1, dtype=np.int64)
+    offsets[0] = 0
+    np.cumsum(lengths, out=offsets[1:])
+    total = int(offsets[-1])
+    coordinates = RNG.integers(0, 5000, size=(total, 3)).astype(np.float32)
+    return PackedTrackCollection(
+        coordinates, offsets,
+        source_ids=np.arange(track_count, dtype=np.uint64),
+        family_codes=np.zeros(track_count, dtype=np.int8),
+        arclengths=np.ones(track_count, dtype=np.float64),
+        tortuosities=np.ones(track_count, dtype=np.float64),
+        rows=rows)
+
+
+class StreamedExclusionTests(unittest.TestCase):
+
+    def gather(self, collection, block_points):
+        pieces = []
+        expected_begin = 0
+        for begin, block in collection.iter_selected_blocks(block_points):
+            self.assertEqual(begin, expected_begin,
+                             'blocks must arrive in materialised order')
+            pieces.append(np.array(block, copy=True))
+            expected_begin += len(block)
+        if not pieces:
+            return np.zeros((0, 3), dtype=np.float32)
+        return np.concatenate(pieces, axis=0)
+
+    def test_blocks_reproduce_materialize_for_the_identity(self):
+        collection = make_collection()
+        flat, offsets = collection.materialize()
+        flat = np.asarray(flat, dtype=np.float32)
+        np.testing.assert_array_equal(collection.selected_offsets,
+                                      np.asarray(offsets, dtype=np.int64))
+        for block_points in (1, 7, 64, 10_000):
+            with self.subTest(block_points=block_points):
+                np.testing.assert_array_equal(
+                    self.gather(collection, block_points), flat)
+
+    def test_blocks_reproduce_materialize_for_a_scattered_selection(self):
+        base = make_collection()
+        rows = RNG.permutation(len(base.source_ids))[:53].astype(np.int64)
+        collection = base.subset(np.arange(len(rows)))  # keeps the shape valid
+        collection = PackedTrackCollection(
+            base.coordinates, base.offsets, base.source_ids,
+            base.family_codes, base.arclengths, base.tortuosities, rows=rows)
+        flat, offsets = collection.materialize()
+        flat = np.asarray(flat, dtype=np.float32)
+        np.testing.assert_array_equal(collection.selected_offsets,
+                                      np.asarray(offsets, dtype=np.int64))
+        for block_points in (1, 3, 50, 1 << 20):
+            with self.subTest(block_points=block_points):
+                np.testing.assert_array_equal(
+                    self.gather(collection, block_points), flat)
+
+    def test_blocked_compaction_equals_boolean_indexing(self):
+        collection = make_collection()
+        flat = np.asarray(collection.materialize()[0], dtype=np.float32)
+        for fraction in (0.0, 0.13, 0.5, 0.87, 1.0):
+            keep = RNG.random(len(flat)) < fraction
+            with self.subTest(fraction=fraction):
+                for block_points in (1, 11, 4096):
+                    got = _compact_blocked(
+                        collection.iter_selected_blocks(block_points),
+                        keep, int(keep.sum()))
+                    np.testing.assert_array_equal(got, flat[keep])
+
+    def test_blocked_compaction_equals_the_in_place_path(self):
+        collection = make_collection()
+        flat = np.asarray(collection.materialize()[0], dtype=np.float32)
+        keep = RNG.random(len(flat)) < 0.8
+        reference = _compact_rows_in_place(np.array(flat, copy=True), keep)
+        got = _compact_blocked(collection.iter_selected_blocks(1024),
+                               keep, int(keep.sum()))
+        np.testing.assert_array_equal(got, reference)
+
+    def test_a_short_count_is_refused_rather_than_returned(self):
+        collection = make_collection()
+        keep = np.ones(int(collection.selected_offsets[-1]), dtype=bool)
+        with self.assertRaises(ValueError):
+            _compact_blocked(collection.iter_selected_blocks(64), keep,
+                             int(keep.sum()) - 1)
+
+    def test_empty_selection(self):
+        base = make_collection()
+        collection = PackedTrackCollection(
+            base.coordinates, base.offsets, base.source_ids,
+            base.family_codes, base.arclengths, base.tortuosities,
+            rows=np.zeros(0, dtype=np.int64))
+        self.assertEqual(list(collection.iter_selected_blocks()), [])
+        self.assertEqual(int(collection.selected_offsets[-1]), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/spiral-fitting/tests/test_track_crossing_cache.py
+++ b/spiral-fitting/tests/test_track_crossing_cache.py
@@ -60,7 +60,21 @@ class TrackCrossingCacheTests(unittest.TestCase):
             np.testing.assert_array_equal(
                 cache['offsets'][1:] - cache['offsets'][:-1], [1, 0, 1])
 
+    def require_native_crossings(self):
+        """Skip when the default crossing mode cannot run.
+
+        prepare_main_phase_tracks defaults to track_crossing_mode='track_walk'
+        (config.py), which raises without vc.track_crossings. That module comes
+        from the volume-cartographer package, which scripts/spiral does not
+        depend on, so `uv sync` here -- the install CONTRIBUTING.md describes --
+        produces an environment without it. Skip as the native kernel tests
+        already do, rather than reporting a failure the checkout did not cause.
+        """
+        if _load_native_track_crossings() is None:
+            self.skipTest('VC native crossing extension is not built')
+
     def test_fit_remaps_whole_db_cache_after_z_filtering(self):
+        self.require_native_crossings()
         with tempfile.TemporaryDirectory() as temporary:
             path = self.make_db(temporary)
             build_cache(path, show_progress=False)
@@ -96,6 +110,7 @@ class TrackCrossingCacheTests(unittest.TestCase):
                 sample['sampled_scroll'][sample['partner_cross_flat'][0]].numpy())
 
     def test_packed_store_loads_and_prepares_without_track_objects(self):
+        self.require_native_crossings()
         with tempfile.TemporaryDirectory() as temporary:
             path = self.make_db(temporary)
             build_cache(path, show_progress=False)
@@ -132,6 +147,7 @@ class TrackCrossingCacheTests(unittest.TestCase):
                 int(prepared['crossing_index_stats']['directed_crossings']), 2)
 
     def test_builder_limits_cache_to_half_open_z_range(self):
+        self.require_native_crossings()
         with tempfile.TemporaryDirectory() as temporary:
             path = self.make_db(temporary)
             build_cache(

--- a/spiral-fitting/tests/test_track_crossing_mmap_cache.py
+++ b/spiral-fitting/tests/test_track_crossing_mmap_cache.py
@@ -1,0 +1,125 @@
+"""The mmap crossing cache must load the same CSR the NPZ loads.
+
+The point of the directory form is that its arrays stay mmap-backed, so the
+kernel can reclaim them under pressure.  Two things therefore have to hold and
+neither is visible in the returned values alone:
+
+  * the arrays really are memory maps, not copies the loader made silently
+  * a conversion that was interrupted is not loadable, so a short cache can
+    never be mistaken for a complete one
+
+Both are checked here, along with equality against the NPZ the directory was
+converted from.
+"""
+import dbm
+import json
+import pickle
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from build_track_crossings import build_cache
+from tracks import (
+    load_track_crossing_cache,
+    track_crossing_cache_path,
+    track_crossing_mmap_cache_path,
+    write_track_crossing_mmap_cache,
+)
+
+
+def line_track(length, *, z=10, y=10, axis=2):
+    points = np.zeros((int(length) + 1, 3), dtype=np.int32)
+    points[:, 0] = z
+    points[:, 1] = y
+    points[:, axis] = np.arange(int(length) + 1, dtype=np.int32)
+    return points
+
+
+class TrackCrossingMmapCacheTests(unittest.TestCase):
+
+    def make_db(self, root):
+        path = Path(root) / 'tracks.dbm'
+        horizontal = line_track(20, z=10, y=10, axis=2)
+        vertical = line_track(20, z=10, y=0, axis=1)
+        vertical[:, 2] = 10
+        with dbm.open(str(path), 'c') as database:
+            database[b'h:0'] = pickle.dumps([horizontal])
+            database[b'vy:0'] = pickle.dumps([vertical])
+        return path
+
+    def test_directory_form_loads_the_same_csr(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            build_cache(path, show_progress=False)
+            from_npz = load_track_crossing_cache(path)
+            self.assertIsNotNone(from_npz)
+
+            destination = write_track_crossing_mmap_cache(path)
+            self.assertEqual(destination, track_crossing_mmap_cache_path(path))
+            from_dir = load_track_crossing_cache(path)
+            self.assertIsNotNone(from_dir)
+            self.assertEqual(set(from_npz), set(from_dir))
+            for name in from_npz:
+                np.testing.assert_array_equal(
+                    from_npz[name], from_dir[name], err_msg=name)
+                self.assertEqual(from_npz[name].dtype, from_dir[name].dtype,
+                                 msg=name)
+
+    def test_the_arrays_are_actually_mapped(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            build_cache(path, show_progress=False)
+            write_track_crossing_mmap_cache(path)
+            csr = load_track_crossing_cache(path)
+            for name, array in csr.items():
+                self.assertIsInstance(
+                    array, np.memmap,
+                    msg=f'{name} came back as a copy, so nothing was saved')
+
+    def test_a_partial_conversion_is_not_loadable(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            build_cache(path, show_progress=False)
+            write_track_crossing_mmap_cache(path)
+            (track_crossing_mmap_cache_path(path) / 'metadata.json').unlink()
+            self.assertIsNone(load_track_crossing_cache(path, warn=False))
+
+    def test_a_stale_directory_is_rejected_like_a_stale_npz(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            build_cache(path, show_progress=False)
+            destination = write_track_crossing_mmap_cache(path)
+            metadata_path = destination / 'metadata.json'
+            metadata = json.loads(metadata_path.read_text(encoding='utf-8'))
+            # Corrupt every signature the metadata carries, not just the one
+            # this branch happens to write.  A tree that also records a content
+            # signature would otherwise accept the directory on the field the
+            # test left intact, and the test would pass by not testing.
+            signatures = [k for k in metadata if 'signature' in k]
+            self.assertTrue(signatures, 'no signature field to invalidate')
+            for key in signatures:
+                metadata[key] = [['tracks.dbm', 1, 1]]
+            metadata_path.write_text(json.dumps(metadata), encoding='utf-8')
+            self.assertIsNone(load_track_crossing_cache(path, warn=False))
+
+    def test_conversion_refuses_to_overwrite(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            build_cache(path, show_progress=False)
+            write_track_crossing_mmap_cache(path)
+            with self.assertRaises(FileExistsError):
+                write_track_crossing_mmap_cache(path)
+
+    def test_the_npz_still_loads_when_no_directory_exists(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.make_db(temporary)
+            build_cache(path, show_progress=False)
+            self.assertTrue(track_crossing_cache_path(path).is_file())
+            self.assertFalse(track_crossing_mmap_cache_path(path).exists())
+            self.assertIsNotNone(load_track_crossing_cache(path))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/spiral-fitting/tests/test_track_graph_lightweight.py
+++ b/spiral-fitting/tests/test_track_graph_lightweight.py
@@ -1,0 +1,62 @@
+"""The fitter's CSR-only TrackGraph must match the full topology wrapper."""
+import unittest
+
+import numpy as np
+
+from track_graph import TrackGraph
+
+
+def crossing_cache():
+    # Two undirected edges: 0--1 and 1--2, stored as symmetric CSR records.
+    return {
+        "source_ids": np.array([10, 20, 30], dtype=np.uint64),
+        "offsets": np.array([0, 1, 3, 4], dtype=np.int64),
+        "partners": np.array([1, 0, 2, 1], dtype=np.int32),
+        "self_local": np.array([1, 2, 1, 2], dtype=np.int32),
+        "partner_local": np.array([2, 1, 2, 1], dtype=np.int32),
+        "positions": np.array([1.0, 2.0, 3.0, 4.0]),
+        "clearances": np.array([0.1, 0.1, 0.2, 0.2]),
+    }
+
+
+class LightweightTrackGraphTests(unittest.TestCase):
+
+    def setUp(self):
+        self.full = TrackGraph(crossing_cache())
+        self.light = TrackGraph(crossing_cache(), build_topology=False)
+
+    def assert_csr_equal(self, left, right):
+        self.assertEqual(set(left), set(right))
+        for name in left:
+            np.testing.assert_array_equal(left[name], right[name], err_msg=name)
+
+    def test_counts_do_not_require_duplicate_topology(self):
+        self.assertIsNone(self.light.graph)
+        self.assertEqual(len(self.light), len(self.full))
+        self.assertEqual(self.light.edge_count, self.full.edge_count)
+
+    def test_restricted_csr_is_bitwise_identical(self):
+        selected = np.array([10, 20], dtype=np.uint64)
+        self.assert_csr_equal(
+            self.light.restricted_csr(selected),
+            self.full.restricted_csr(selected))
+
+    def test_clipped_csr_is_bitwise_identical(self):
+        selected = np.array([10, 20, 30], dtype=np.uint64)
+        input_offsets = np.array([0, 3, 6, 9], dtype=np.int64)
+        surviving = np.array([0, 1, 2], dtype=np.int64)
+        point_map = np.arange(9, dtype=np.int32)
+        output_offsets = input_offsets.copy()
+        self.assert_csr_equal(
+            self.light.clipped_csr(
+                selected, input_offsets, surviving, point_map, output_offsets),
+            self.full.clipped_csr(
+                selected, input_offsets, surviving, point_map, output_offsets))
+
+    def test_traversal_fails_explicitly(self):
+        with self.assertRaisesRegex(RuntimeError, "without traversal topology"):
+            self.light.gated_random_walk(0, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spiral-fitting/track_graph.py
+++ b/spiral-fitting/track_graph.py
@@ -19,7 +19,7 @@ class TrackGraph:
 
     def __init__(
             self, crossing_cache, *, track_chunk_size=250_000,
-            node_chunk_size=1_000_000):
+            node_chunk_size=1_000_000, build_topology=True):
         self.source_ids = np.asarray(
             crossing_cache["source_ids"], dtype=np.uint64)
         self.offsets = np.asarray(
@@ -37,6 +37,17 @@ class TrackGraph:
         self._validate()
 
         started = time.perf_counter()
+        self.graph = None
+        if not build_topology:
+            # Fitting only restricts and remaps the packed CSR above; it never
+            # traverses the graph.  Materialising the same tracks and crossings
+            # a second time as rustworkx nodes and edges costs several GiB of
+            # anonymous memory that nothing on that path reads.  Leave the
+            # arrays authoritative and let traversal clients opt in, which is
+            # the historical default.
+            self.build_seconds = time.perf_counter() - started
+            return
+
         self.graph = rx.PyGraph(multigraph=True)
         for begin in range(0, len(self.source_ids), node_chunk_size):
             count = min(node_chunk_size, len(self.source_ids) - begin)
@@ -91,7 +102,8 @@ class TrackGraph:
             raise ValueError("crossing local indices must be non-negative")
 
     def __len__(self):
-        return self.graph.num_nodes()
+        return (len(self.source_ids) if self.graph is None
+                else self.graph.num_nodes())
 
     def __getitem__(self, name):
         if name not in {
@@ -102,7 +114,14 @@ class TrackGraph:
 
     @property
     def edge_count(self):
-        return self.graph.num_edges()
+        return (len(self.partners) // 2 if self.graph is None
+                else self.graph.num_edges())
+
+    def _require_topology(self):
+        if self.graph is None:
+            raise RuntimeError(
+                'this TrackGraph was built without traversal topology; '
+                'construct it with build_topology=True to walk it')
 
     def node_for_source_id(self, source_id):
         """Return the graph node for one stable track source ID."""
@@ -116,7 +135,7 @@ class TrackGraph:
         """Return the directed CSR record for track -> partner."""
         track = int(track)
         partner = int(partner)
-        if not self.graph.has_node(track):
+        if track < 0 or track >= len(self.source_ids):
             raise IndexError(f"track graph has no node {track}")
         begin = int(self.offsets[track])
         end = int(self.offsets[track + 1])
@@ -129,6 +148,7 @@ class TrackGraph:
     def _bounded_path_to_root(
             self, current, root, remaining_new_tracks, forbidden):
         """Return one simple path suffix to root, or None."""
+        self._require_topology()
         for neighbor in self.graph.neighbors(current):
             neighbor = int(neighbor)
             if neighbor == root:
@@ -238,6 +258,7 @@ class TrackGraph:
         steps = int(steps)
         if steps < 0:
             raise ValueError("walk steps must be non-negative")
+        self._require_topology()
         if not self.graph.has_node(original):
             raise IndexError(f"track graph has no node {original}")
         rng = np.random.default_rng() if rng is None else rng
@@ -269,6 +290,7 @@ class TrackGraph:
         if max_tracks > 4:
             raise ValueError(
                 "short-cycle queries support at most four tracks")
+        self._require_topology()
         if not self.graph.has_node(node):
             raise IndexError(f"track graph has no node {node}")
         root_neighbors = sorted(set(self.graph.neighbors(node)))

--- a/spiral-fitting/tracks.py
+++ b/spiral-fitting/tracks.py
@@ -71,7 +71,17 @@ class PackedTrackCollection:
     def __init__(
             self, coordinates, offsets, source_ids, family_codes,
             arclengths, tortuosities, *, store_path=None, rows=None):
-        self.coordinates = np.asarray(coordinates, dtype=np.float32)
+        # The store keeps coordinates as int32 and the native loader maps the
+        # file, so they arrive as reclaimable file pages.  Converting the whole
+        # ROI to float32 here turns 2.01 GiB of them into anonymous memory
+        # before anyone has asked for a single point -- on a swapless host that
+        # is the one kind of page that cannot be given back.  Keep what the
+        # store gave us and convert where the points are used; `coordinates`
+        # still hands out the float32 array, but only if something wants it.
+        self._coordinates_raw = np.asarray(coordinates)
+        self._coordinates_f32 = (
+            self._coordinates_raw
+            if self._coordinates_raw.dtype == np.float32 else None)
         self.offsets = np.asarray(offsets, dtype=np.int64)
         self.source_ids = np.asarray(source_ids, dtype=np.uint64)
         self.family_codes = np.asarray(family_codes, dtype=np.int8)
@@ -87,6 +97,28 @@ class PackedTrackCollection:
                 or self.tortuosities.shape != self.source_ids.shape):
             raise ValueError('packed track metadata arrays are not parallel')
 
+    @property
+    def coordinates(self):
+        """Every point as float32, materialising the conversion on first use.
+
+        Callers that only need some of the points should take them through
+        `points_at` or `iter_selected_blocks`, which convert a gather or a
+        block at a time and leave the store's own pages file-backed.
+        """
+        if self._coordinates_f32 is None:
+            self._coordinates_f32 = np.asarray(
+                self._coordinates_raw, dtype=np.float32)
+        return self._coordinates_f32
+
+    @property
+    def point_count(self):
+        """How many points the store holds, without converting any of them."""
+        return len(self._coordinates_raw)
+
+    def points_at(self, index):
+        """Gather these point indices as float32, converting only the gather."""
+        return np.asarray(self._coordinates_raw[index], dtype=np.float32)
+
     def __len__(self):
         return len(self.rows)
 
@@ -94,12 +126,13 @@ class PackedTrackCollection:
         if isinstance(index, slice):
             return self.subset(np.arange(len(self), dtype=np.int64)[index])
         row = int(self.rows[index])
-        return self.coordinates[self.offsets[row]:self.offsets[row + 1]]
+        return self.points_at(
+            slice(int(self.offsets[row]), int(self.offsets[row + 1])))
 
     def subset(self, indices):
         indices = np.asarray(indices, dtype=np.int64)
         return PackedTrackCollection(
-            self.coordinates, self.offsets, self.source_ids,
+            self._coordinates_raw, self.offsets, self.source_ids,
             self.family_codes, self.arclengths, self.tortuosities,
             store_path=self.store_path, rows=self.rows[indices])
 
@@ -169,7 +202,7 @@ class PackedTrackCollection:
             index = (np.arange(taken, dtype=np.int64)
                      - np.repeat(local, block_lengths)
                      + np.repeat(starts[first:last], block_lengths))
-            yield int(cumulative[first]), self.coordinates[index]
+            yield int(cumulative[first]), self.points_at(index)
 
     def materialize(self, workers=None):
         identity = (len(self.rows) == len(self.source_ids)
@@ -527,7 +560,7 @@ def _load_packed_track_collection(path, z_lo=None, z_hi=None, warn=True):
             result['tortuosities'], store_path=store)
         print(
             f'loaded packed track store {store}: {len(collection)} tracks, '
-            f'{len(collection.coordinates)} points in ROI')
+            f'{collection.point_count} points in ROI')
         return collection
     except (OSError, RuntimeError, ValueError, KeyError, json.JSONDecodeError) as error:
         if warn:
@@ -837,7 +870,7 @@ def filter_tracks_to_outer_shell(
             begin = tracks.offsets[rows]
             end = tracks.offsets[rows + 1] - 1
             endpoints = np.stack((
-                tracks.coordinates[begin], tracks.coordinates[end]), axis=1)
+                tracks.points_at(begin), tracks.points_at(end)), axis=1)
             with torch.no_grad():
                 target_radius, radius, _confidence, _valid = shell_envelope.lookup(
                     torch.from_numpy(endpoints.reshape(-1, 3)))

--- a/spiral-fitting/tracks.py
+++ b/spiral-fitting/tracks.py
@@ -2226,6 +2226,63 @@ def _build_anchor_kdtree(anchor_zyx):
     return cKDTree(np.ascontiguousarray(anchor_np, dtype=np.float32))
 
 
+def _compact_rows_in_place(rows, keep, block=1 << 22):
+    """Drop the unkept rows of `rows`, reusing its own storage.
+
+    ``rows[keep]`` allocates a second array as large as the survivors, so for a
+    moment both exist: on the 2 um store at three thousand slices that is
+    2.16 GB standing beside 2.16 GB, inside a peak of 14.5 GiB that a 16 GB
+    machine cannot clear. Compacting in place removes the duplicate; the caller
+    keeps a view of the surviving prefix and the tail is released with the
+    original.
+
+    Safe because the write position never overtakes the read position. Entering
+    a block at ``lo``, ``write`` counts survivors before ``lo`` and so is at
+    most ``lo``; the block contributes ``n <= hi - lo`` rows; therefore
+    ``write + n <= hi``. Nothing is overwritten before it has been read. This
+    holds only for order-preserving compaction into a prefix, which is what a
+    boolean mask does and is why the assertion below is worth keeping.
+
+    Returns the view. The caller must not keep using the full array.
+    """
+    if rows.shape[0] != keep.shape[0]:
+        raise ValueError(
+            f'mask length {keep.shape[0]} does not match {rows.shape[0]} rows')
+    # Refuse anything this must not write through. The packed store's
+    # coordinates are a read-only int32 memmap and reach the caller as a fresh
+    # float32 array only because the conversion copies; were the store ever
+    # written as float32 that conversion would become a no-op and this would be
+    # asked to rewrite the file on disk. A view into someone else's buffer is
+    # the same hazard without the file. Fall back to the copy instead.
+    if not rows.flags.writeable or rows.base is not None:
+        return rows[keep]
+    total = int(np.count_nonzero(keep))
+    if total == rows.shape[0]:
+        return rows
+    # Compacting in place keeps the whole original allocation alive behind the
+    # returned view, so it trades a lower peak for a larger resident tail. That
+    # is the right trade only while most rows survive; below half, the copy is
+    # smaller than the tail it would strand.
+    if total * 2 < rows.shape[0]:
+        return rows[keep]
+    write = 0
+    for lo in range(0, rows.shape[0], block):
+        hi = min(lo + block, rows.shape[0])
+        sub = keep[lo:hi]
+        n = int(np.count_nonzero(sub))
+        if n == 0:
+            continue
+        if write + n > hi:                       # cannot happen; see above
+            raise AssertionError(
+                f'in-place compaction would overwrite unread rows: '
+                f'write {write} + {n} > {hi}')
+        rows[write:write + n] = rows[lo:hi][sub]
+        write += n
+    if write != total:
+        raise AssertionError(f'compacted {write} rows, expected {total}')
+    return rows[:total]
+
+
 def _track_points_far_from_anchors_mask(track_zyx, anchor_tree, threshold,
                                         progress=None):
     if isinstance(track_zyx, torch.Tensor):
@@ -2606,7 +2663,11 @@ def prepare_main_phase_tracks(
     keep_np &= surviving_points
     del surviving_points
     lengths_new = new_lengths[surviving].astype(np.int64)
-    compact_zyx_np = flat_zyx_np[keep_np]
+    # In place: the fancy-indexed copy stood beside the original until the del
+    # below, and on the 2 um store at three thousand slices each is 2.16 GB
+    # inside a 14.5 GiB peak. Compaction preserves order and writes a prefix,
+    # so the survivors can be moved down within the array they came from.
+    compact_zyx_np = _compact_rows_in_place(flat_zyx_np, keep_np)
     crossing_csr_override = None
     if track_graph is not None:
         if int(keep_np.sum()) >= np.iinfo(np.int32).max:

--- a/spiral-fitting/tracks.py
+++ b/spiral-fitting/tracks.py
@@ -1,5 +1,6 @@
 import colorsys
 import dbm
+import hashlib
 import importlib
 import itertools
 import json
@@ -37,6 +38,8 @@ TRACK_CROSSING_CACHE_VERSION = 1
 TRACK_CROSSING_CACHE_SUFFIX = '.crossings.npz'
 TRACK_STORE_SUFFIX = '.vctracks'
 TRACK_STORE_VERSION = 1
+# Window read at the head, middle and tail of a DBM to fingerprint its contents.
+TRACK_STORE_PROBE_BYTES = 1 << 20
 TRACK_STORE_MAGIC = b'VCTRK01\0'
 
 
@@ -226,6 +229,67 @@ def _tracks_db_signature(path):
     return sorted(result)
 
 
+def _file_content_probe(path, size):
+    """Digest a bounded sample of a file: its size plus head, middle and tail."""
+    digest = hashlib.blake2b(digest_size=16)
+    digest.update(int(size).to_bytes(8, 'little'))
+    offsets = sorted({0,
+                      max(0, size // 2 - TRACK_STORE_PROBE_BYTES // 2),
+                      max(0, size - TRACK_STORE_PROBE_BYTES)})
+    with open(path, 'rb') as stream:
+        for offset in offsets:
+            stream.seek(offset)
+            digest.update(stream.read(TRACK_STORE_PROBE_BYTES))
+    return digest.hexdigest()
+
+
+def _tracks_db_content_signature(path):
+    """Fingerprint a logical DBM using only properties of its contents.
+
+    Same shape as :func:`_tracks_db_signature`, with the modification time
+    replaced by a bounded content probe. Reading three 1 MiB windows costs a
+    few milliseconds even on a 12 GiB DBM, and unlike a timestamp it survives
+    being copied or downloaded.
+    """
+    result = []
+    for name, size, _ in _tracks_db_signature(path):
+        candidate = Path(normalize_tracks_dbm_path(path)).with_name(name)
+        result.append((name, size, _file_content_probe(candidate, size)))
+    return sorted(result)
+
+
+def _tracks_db_signature_matches(path, metadata, signature_key):
+    """Does a sidecar's recorded signature still describe this DBM?
+
+    Returns ``(ok, note)``; a non-empty ``note`` is worth printing even when
+    ``ok``.
+
+    The signature originally recorded ``st_mtime_ns``. A modification time is
+    not a property of the bytes and is not preserved by copying or downloading,
+    so a sidecar published alongside a dataset is rejected on every machine
+    except the one that wrote it -- the dataset's own 12 GiB packed store is
+    refused by every downloader for exactly this reason. The portable content
+    signature is authoritative when present; a legacy signature is honoured on
+    the fields it can actually attest to, which are the name and the size.
+    """
+    recorded = metadata.get(signature_key + '_content')
+    if recorded is not None:
+        expected = [list(item) for item in _tracks_db_content_signature(path)]
+        return recorded == expected, ''
+    legacy = metadata.get(signature_key)
+    if legacy is None:
+        return False, ''
+    expected = [list(item) for item in _tracks_db_signature(path)]
+    if legacy == expected:
+        return True, ''
+    if [list(item[:2]) for item in legacy] == [item[:2] for item in expected]:
+        return True, (
+            'sidecar predates the portable signature and records a different '
+            'modification time than the local DBM; accepted on name and size, '
+            'which are unchanged. Repack to record a content signature.')
+    return False, ''
+
+
 def track_store_path(path):
     """Return the conventional packed-store directory beside a tracks DBM."""
     return Path(normalize_tracks_dbm_path(path) + TRACK_STORE_SUFFIX)
@@ -345,6 +409,11 @@ def write_packed_track_store(
             os.fsync(stream.fileno())
         metadata = {
             'version': TRACK_STORE_VERSION,
+            # Both are written: the content signature is the one that travels
+            # with the store, the legacy timestamp signature keeps older
+            # readers working against a newly written store.
+            'source_db_signature_content':
+                [list(item) for item in _tracks_db_content_signature(logical)],
             'source_db_signature': [list(item) for item in _tracks_db_signature(logical)],
             'track_count': track_count,
             'point_count': point_count,
@@ -383,9 +452,12 @@ def _load_packed_track_collection(path, z_lo=None, z_hi=None, warn=True):
             metadata = json.load(stream)
         if metadata.get('version') != TRACK_STORE_VERSION:
             raise ValueError('unsupported packed track-store version')
-        expected = [list(item) for item in _tracks_db_signature(path)]
-        if metadata.get('source_db_signature') != expected:
+        current, note = _tracks_db_signature_matches(
+            path, metadata, 'source_db_signature')
+        if not current:
             raise ValueError('source DBM changed after the packed store was written')
+        if note and warn:
+            print(f'NOTE: packed track store {store}: {note}')
         result = native.load(
             os.fspath(store),
             z_minimum=-(1 << 63) if z_lo is None else int(z_lo),
@@ -416,8 +488,9 @@ def _packed_store_if_current(path):
             metadata = json.load(stream)
         if metadata.get('version') != TRACK_STORE_VERSION:
             return None
-        expected = [list(item) for item in _tracks_db_signature(path)]
-        if metadata.get('source_db_signature') != expected:
+        current, _ = _tracks_db_signature_matches(
+            path, metadata, 'source_db_signature')
+        if not current:
             return None
         return store
     except (OSError, ValueError, KeyError, json.JSONDecodeError):
@@ -1762,6 +1835,8 @@ def write_track_crossing_cache(
                  else source_signature)
     metadata = {
         'version': TRACK_CROSSING_CACHE_VERSION,
+        'db_signature_content':
+            [list(item) for item in _tracks_db_content_signature(path)],
         'db_signature': [list(item) for item in signature],
         'angle_degrees': 30.0,
         'tangent_radius_voxels': 12.0,
@@ -1809,9 +1884,12 @@ def load_track_crossing_cache(path, warn=True, expected_z_range=None):
             if metadata.get('version') != TRACK_CROSSING_CACHE_VERSION:
                 raise ValueError(
                     f"unsupported version {metadata.get('version')!r}")
-            expected_signature = [list(item) for item in _tracks_db_signature(path)]
-            if metadata.get('db_signature') != expected_signature:
+            current, note = _tracks_db_signature_matches(
+                path, metadata, 'db_signature')
+            if not current:
                 raise ValueError('tracks DBM has changed since the cache was built')
+            if note and warn:
+                print(f'NOTE: crossing cache {cache_path}: {note}')
             if (expected_z_range is not None
                     and metadata.get('z_range', [None, None])
                     != list(expected_z_range)):

--- a/spiral-fitting/tracks.py
+++ b/spiral-fitting/tracks.py
@@ -123,6 +123,54 @@ class PackedTrackCollection:
     def selected_lengths(self):
         return self.offsets[self.rows + 1] - self.offsets[self.rows]
 
+    @property
+    def selected_offsets(self):
+        """Where each selected track starts once materialised, without
+        materialising anything: the lengths are already in `offsets`."""
+        out = np.empty(len(self.rows) + 1, dtype=np.int64)
+        out[0] = 0
+        np.cumsum(self.selected_lengths, out=out[1:])
+        return out
+
+    def iter_selected_blocks(self, block_points=1 << 22):
+        """Yield ``(begin, coordinates)`` over the selected points in
+        materialised order, holding one block at a time.
+
+        This is what materialize() returns, produced in pieces.  The caller
+        that only needs to look at every point once, or to write a filtered
+        copy of them, never has to have all of them at once: on the 2 um store
+        at three thousand slices the whole selection is 1.98 GiB and a block is
+        48 MiB.  Blocks break on track boundaries, so a consumer that needs
+        whole tracks still gets them.
+        """
+        lengths = self.selected_lengths
+        if len(lengths) == 0:
+            return
+        starts = self.offsets[self.rows]
+        cumulative = self.selected_offsets
+        total = int(cumulative[-1])
+        block_points = max(1, int(block_points))
+        # Block boundaries at track granularity, found once rather than by
+        # walking tracks in Python.
+        cuts = np.unique(np.concatenate((
+            [0],
+            np.searchsorted(cumulative, np.arange(block_points, total,
+                                                  block_points)),
+            [len(lengths)])))
+        for first, last in zip(cuts[:-1], cuts[1:]):
+            if last <= first:
+                continue
+            block_lengths = lengths[first:last]
+            taken = int(block_lengths.sum())
+            local = np.empty(len(block_lengths), dtype=np.int64)
+            local[0] = 0
+            if len(block_lengths) > 1:
+                np.cumsum(block_lengths[:-1], out=local[1:])
+            index = (np.arange(taken, dtype=np.int64)
+                     - np.repeat(local, block_lengths)
+                     + np.repeat(starts[first:last], block_lengths))
+            yield int(cumulative[first]), self.coordinates[index]
+
     def materialize(self, workers=None):
         identity = (len(self.rows) == len(self.source_ids)
                     and np.array_equal(
@@ -2381,6 +2429,63 @@ def _track_points_far_from_anchors_mask(track_zyx, anchor_tree, threshold,
     return keep
 
 
+def _mask_far_from_anchors_blocked(
+        blocks, total_points, anchor_tree, threshold, progress=None):
+    """The exclusion mask, built from blocks instead of from one array.
+
+    Same question as _track_points_far_from_anchors_mask and the same answer,
+    but the points arrive a block at a time, so nothing the size of the whole
+    selection has to exist.  Only the one-byte mask is resident.
+    """
+    keep = np.empty(total_points, dtype=bool)
+    if threshold <= 0 or anchor_tree is None:
+        keep[:] = True
+        return keep
+    reporter = progress_or_null(progress)
+    reporter.begin('loading', 'Excluding track points near patches',
+                   step=0, total_steps=total_points, unit='points')
+    bar = tqdm(total=total_points, desc='excluding track points',
+               unit='point', unit_scale=True, disable=progress is not None)
+    seen = 0
+    try:
+        for begin, block in blocks:
+            block = np.ascontiguousarray(block, dtype=np.float32)
+            distance, _ = anchor_tree.query(
+                block, k=1, distance_upper_bound=float(threshold), workers=-1)
+            keep[begin:begin + len(block)] = np.isinf(distance)
+            seen = begin + len(block)
+            bar.update(len(block))
+            reporter.update(seen)
+    finally:
+        bar.close()
+    if seen != total_points:
+        raise ValueError(
+            f'the blocks covered {seen} points, not {total_points}')
+    return keep
+
+
+def _compact_blocked(blocks, keep, out_points):
+    """Write the surviving points straight out of the blocks.
+
+    The pair (mask, blocks) already says what the answer is; building the full
+    selection first and then compacting it means two arrays of that size exist
+    at once, which is the peak this avoids.  One allocation, the size of the
+    result, filled a block at a time.
+    """
+    out = np.empty((out_points, 3), dtype=np.float32)
+    written = 0
+    for begin, block in blocks:
+        selected = keep[begin:begin + len(block)]
+        count = int(np.count_nonzero(selected))
+        if count:
+            np.compress(selected, block, axis=0, out=out[written:written + count])
+        written += count
+    if written != out_points:
+        raise ValueError(
+            f'compaction wrote {written} points, expected {out_points}')
+    return out
+
+
 def prepare_main_phase_tracks(
         tracks, anchor_scroll_zyxs, exclusion_radius, device, anchor_tree=None,
         sampling_config=None, track_families=None, track_source_ids=None,
@@ -2688,7 +2793,21 @@ def prepare_main_phase_tracks(
         return finish_prepared(
             flat_zyx_np, lengths_new, surviving, surviving_tracks)
 
-    if packed_input:
+    # A packed store can answer the exclusion question a block at a time, and
+    # then write the survivors straight out.  Materialising the selection first
+    # puts a second copy of every selected point beside the store's own, and
+    # compacting that copy puts a third beside it: measured on the 2 um store
+    # at three thousand slices, 2.01 + 1.98 + 1.75 GiB inside a 14.3 GiB peak.
+    # Streaming needs one array the size of the result and one block.
+    streamed = (packed_input and exclusion_radius > 0
+                and anchor_tree is not None)
+    flat_zyx_np = None
+    if streamed:
+        input_offsets = working_tracks.selected_offsets
+        keep_np = _mask_far_from_anchors_blocked(
+            working_tracks.iter_selected_blocks(), int(input_offsets[-1]),
+            anchor_tree, exclusion_radius, progress=progress)
+    elif packed_input:
         flat_zyx_np, packed_offsets = working_tracks.materialize()
         flat_zyx_np = np.asarray(flat_zyx_np, dtype=np.float32)
         input_offsets = np.asarray(packed_offsets, dtype=np.int64)
@@ -2701,8 +2820,9 @@ def prepare_main_phase_tracks(
         np.cumsum(input_lengths, out=input_offsets[1:])
         flat_zyx_np = np.concatenate(
             [t.astype(np.float32) for t in working_tracks], axis=0)
-    keep_np = _track_points_far_from_anchors_mask(
-        flat_zyx_np, anchor_tree, exclusion_radius, progress=progress)
+    if not streamed:
+        keep_np = _track_points_far_from_anchors_mask(
+            flat_zyx_np, anchor_tree, exclusion_radius, progress=progress)
     num_tracks_orig = len(working_tracks)
     # Points are already grouped by track.  Segment reduction replaces the old
     # int64 track-id-per-point array (7.3 GiB for the 2um store).
@@ -2723,7 +2843,12 @@ def prepare_main_phase_tracks(
     # below, and on the 2 um store at three thousand slices each is 2.16 GB
     # inside a 14.5 GiB peak. Compaction preserves order and writes a prefix,
     # so the survivors can be moved down within the array they came from.
-    compact_zyx_np = _compact_rows_in_place(flat_zyx_np, keep_np)
+    if streamed:
+        compact_zyx_np = _compact_blocked(
+            working_tracks.iter_selected_blocks(), keep_np,
+            int(lengths_new.sum()))
+    else:
+        compact_zyx_np = _compact_rows_in_place(flat_zyx_np, keep_np)
     crossing_csr_override = None
     if track_graph is not None:
         if int(keep_np.sum()) >= np.iinfo(np.int32).max:

--- a/spiral-fitting/tracks.py
+++ b/spiral-fitting/tracks.py
@@ -36,6 +36,10 @@ from sample_spiral import (
 
 TRACK_CROSSING_CACHE_VERSION = 1
 TRACK_CROSSING_CACHE_SUFFIX = '.crossings.npz'
+TRACK_CROSSING_MMAP_SUFFIX = '.mmap'
+_TRACK_CROSSING_CSR_ARRAYS = (
+    'source_ids', 'offsets', 'partners', 'self_local',
+    'partner_local', 'positions', 'clearances')
 TRACK_STORE_SUFFIX = '.vctracks'
 TRACK_STORE_VERSION = 1
 # Window read at the head, middle and tail of a DBM to fingerprint its contents.
@@ -202,6 +206,11 @@ def normalize_tracks_dbm_path(path):
 def track_crossing_cache_path(path):
     """Return the conventional exact-crossing sidecar path for a tracks DBM."""
     return Path(normalize_tracks_dbm_path(path) + TRACK_CROSSING_CACHE_SUFFIX)
+
+
+def track_crossing_mmap_cache_path(path):
+    """Directory form of the crossing cache whose arrays can stay mmap-backed."""
+    return Path(str(track_crossing_cache_path(path)) + TRACK_CROSSING_MMAP_SUFFIX)
 
 
 def _tracks_db_signature(path):
@@ -1868,6 +1877,46 @@ def write_track_crossing_cache(
     return destination
 
 
+def write_track_crossing_mmap_cache(path, destination=None):
+    """Convert the adjacent NPZ crossing cache to an atomic mmap directory.
+
+    ``np.load`` cannot memory-map an array inside an NPZ, even one ``np.savez``
+    stored uncompressed, so loading the cache makes every byte of it anonymous.
+    A production crossing CSR is about 3 GiB; held beside the ROI coordinates
+    on a 16 GB, swap-free host that is the difference between a fit that runs
+    and one the kernel kills before the first optimisation step.  Separate NPY
+    files preserve the exact dtypes and bytes and let the kernel reclaim the
+    pages as clean cache.
+
+    The metadata file is written last.  It is the sentinel the loader keys on,
+    so a conversion killed part way through leaves a directory nothing will
+    load rather than a short one something might.
+    """
+    source = track_crossing_cache_path(path)
+    destination = (track_crossing_mmap_cache_path(path)
+                   if destination is None else Path(destination))
+    if destination.exists():
+        raise FileExistsError(destination)
+    temporary = destination.with_name(destination.name + f'.tmp-{os.getpid()}')
+    temporary.mkdir(parents=True)
+    try:
+        with np.load(source, allow_pickle=False) as stored:
+            metadata = json.loads(str(stored['metadata'].item()))
+            for name in _TRACK_CROSSING_CSR_ARRAYS:
+                np.save(temporary / f'{name}.npy', stored[name],
+                        allow_pickle=False)
+        with (temporary / 'metadata.json').open('w', encoding='utf-8') as stream:
+            json.dump(metadata, stream, indent=2, sort_keys=True)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, destination)
+        temporary = None
+        return destination
+    finally:
+        if temporary is not None and temporary.exists():
+            shutil.rmtree(temporary, ignore_errors=True)
+
+
 def load_track_crossing_cache(path, warn=True, expected_z_range=None):
     """Load a valid adjacent CSR sidecar, or return ``None`` on a safe miss."""
     try:
@@ -1876,39 +1925,46 @@ def load_track_crossing_cache(path, warn=True, expected_z_range=None):
         if warn:
             print(f'WARNING: cannot resolve tracks DBM for crossing cache: {error}')
         return None
-    if not cache_path.is_file():
+    mmap_path = track_crossing_mmap_cache_path(path)
+    if not mmap_path.is_dir() and not cache_path.is_file():
         return None
+    loaded_path = mmap_path if mmap_path.is_dir() else cache_path
     try:
-        with np.load(cache_path, allow_pickle=False) as stored:
-            metadata = json.loads(str(stored['metadata'].item()))
-            if metadata.get('version') != TRACK_CROSSING_CACHE_VERSION:
-                raise ValueError(
-                    f"unsupported version {metadata.get('version')!r}")
-            current, note = _tracks_db_signature_matches(
-                path, metadata, 'db_signature')
-            if not current:
-                raise ValueError('tracks DBM has changed since the cache was built')
-            if note and warn:
-                print(f'NOTE: crossing cache {cache_path}: {note}')
-            if (expected_z_range is not None
-                    and metadata.get('z_range', [None, None])
-                    != list(expected_z_range)):
-                raise ValueError(
-                    'crossing cache was built for a different z range')
+        if mmap_path.is_dir():
+            with (mmap_path / 'metadata.json').open('r', encoding='utf-8') as fh:
+                metadata = json.load(fh)
             csr = {
-                name: stored[name]
-                for name in (
-                    'source_ids', 'offsets', 'partners', 'self_local',
-                    'partner_local', 'positions', 'clearances')
+                name: np.load(mmap_path / f'{name}.npy', mmap_mode='r',
+                              allow_pickle=False)
+                for name in _TRACK_CROSSING_CSR_ARRAYS
             }
+        else:
+            with np.load(cache_path, allow_pickle=False) as stored:
+                metadata = json.loads(str(stored['metadata'].item()))
+                csr = {name: stored[name]
+                       for name in _TRACK_CROSSING_CSR_ARRAYS}
+        if metadata.get('version') != TRACK_CROSSING_CACHE_VERSION:
+            raise ValueError(
+                f"unsupported version {metadata.get('version')!r}")
+        current, note = _tracks_db_signature_matches(
+            path, metadata, 'db_signature')
+        if not current:
+            raise ValueError('tracks DBM has changed since the cache was built')
+        if note and warn:
+            print(f'NOTE: crossing cache {loaded_path}: {note}')
+        if (expected_z_range is not None
+                and metadata.get('z_range', [None, None])
+                != list(expected_z_range)):
+            raise ValueError(
+                'crossing cache was built for a different z range')
         _validate_crossing_partner_csr(csr, require_sorted_source_ids=True)
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         if warn:
             print(f'WARNING: ignoring invalid track crossing cache '
-                  f'{cache_path}: {error}')
+                  f'{loaded_path}: {error}')
         return None
     print(
-        f'loaded track crossing cache {cache_path}: '
+        f'loaded track crossing cache {loaded_path}: '
         f'{len(csr["source_ids"])} tracks, {len(csr["partners"])} directed records'
     )
     return csr


### PR DESCRIPTION
**In one sentence:** On a 16 GB host with no swap, a 4,000-slice spiral fit goes from killed by the kernel to finished.

**One real example:** Starting with the PHercParis4 lasagna inputs, z 4000-8000, 40 steps, seed 1, on an RTX 4080 Laptop under WSL2 capped at 16 GB with swap off, I ran the fit. Without this branch it was killed by signal 9 during "Excluding track points near patches" at 6:37 with a peak RSS of 15.62 GB, at the host's limit. With this branch the same command finished at 9:36 with exit 0: 5,529,849 of 6,044,103 tracks survive exclusion, 18,447,442 directed crossings, 208,504,823 points retained, step-0 loss 6946.0, final mesh windings [10, 130).

**Before:** The same window on the tree without the last four commits of this branch is killed before the first optimisation step, exit 137. That tree already carries the first four commits; none of them changes the fit's memory. Packing is a separate step, the fingerprint and the test skip allocate nothing, and in-place compaction takes the copy fallback on the packed path. For this measurement it is main.

**After this PR:** It finishes. Peak anonymous memory 10.49 GiB, file-backed 9.42 GiB, peak VmRSS 13.89 GiB. The arrays did not get smaller; the bulk moved to pages the kernel can reclaim. Two independent runs read 10.46 and 10.49.

**Proof:** Two terminal captures.

- `A1_stock_OOM.png`: `Command terminated by signal 9`, `SENTINEL_EXIT=137`, `Maximum resident set size 15620352 kB`.
- `A1_fixed_OK.png`: same command, same data, `SENTINEL_EXIT=0`, the track, crossing and point counts above.

Both runs use the same dataset root, the same config overrides, seed and step count; each log records `SOURCE_COMMIT` and `SOURCE_DIRTY_FILES=0`. The capture prints the exact command, streams the fit's own log, then prints the exit code and peak RSS.

Before:

![stock run, killed by signal 9, exit 137](https://raw.githubusercontent.com/7jycwjmbfn-eng/villa/pr-assets/shots_2026-08-22/A1_stock_OOM.png)

After:

![this branch, exit 0, RssAnon peak 10.49 GiB](https://raw.githubusercontent.com/7jycwjmbfn-eng/villa/pr-assets/shots_2026-08-22/A1_fixed_OK.png)

**Why / where this is useful:**

I wanted to see how far I could push spiral fitting on an ordinary laptop. RAM and GPUs are expensive, and telling people to just buy more hardware isn't much of a solution. All I can do is try to lower the hardware bar a little.

My machine has 32 GB of system RAM and an RTX 4080 Laptop GPU with 12 GB of VRAM. I run the fit inside WSL2, capped at 16 GB of RAM with swap disabled, to roughly mimic a 16 GB laptop. Under those constraints, the stock implementation got killed before it reached the first optimization step on a 4,000-slice window.

The changes on this branch came directly from those failures. Most of them fix a spot where the fit actually ran out of memory on my machine; the rest clear things I hit on the way there: a shipped sidecar that was refused on every machine except the one that wrote it, and tests that failed on a fresh checkout.

This doesn't mean the default 13,000-slice range now fits in 16 GB. It doesn't. Even at 4,000 slices, peak memory is still 13.9 GiB out of the 15.6 GiB available to WSL2, so the full range remains well beyond this memory tier. The host still has to hold most of the working set. The savings come from memory that never needed to stay resident for the whole fit.

There's still more to do. I'm working on render-side fetching separately, and closing the remaining gap to the full 13,000-slice range is next.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Eight focused commits:

- **39ee1121f:** fingerprints packed track stores by size plus bounded BLAKE2b content probes, so copied or downloaded sidecars are not rejected only because their timestamps changed. Both signatures are written for compatibility.
- **97279485a:** applies the existing native-extension skip guard to three crossing tests. A fresh `uv sync` checkout goes from 3 failed / 7 passed / 3 skipped to 17 passed / 7 skipped in that file.
- **bf47a9865:** replaces unbounded `Executor.map` submission with a sliding window. The 36.9 GiB pool packed in 642 s at 232.8 MiB peak RSS, with `--verify 2000` clean.
- **140ba36ee:** compacts surviving points in place when the caller owns a writable array and survival is high enough. Unsafe cases retain the copy fallback.
- **967ad2970:** adds `build_topology=False` so fitting can use the packed CSR without materialising an unused rustworkx graph. At 3,000 slices, peak RssAnon fell from 14.19 to 12.84 GiB with the same counts and step-0 loss.
- **1b1713bb7:** stores the crossing cache as NPY files so its arrays can remain mmap-backed; the loader still accepts the previous NPZ format. Together with the topology change, the 4,000-slice run completed at 13.26 GiB peak RssAnon.
- **cb976840d:** streams selected track points in blocks and writes survivors directly into one output array. Regression tests compare it with the previous path across track layouts, block sizes and survival fractions.
- **189d82e07:** keeps packed int32 coordinates file-backed and converts them to float32 on first bulk access. This and streamed exclusion reduced peak RssAnon from 13.26 to 10.49 GiB.

**Limits.**

- The default 13,000-slice range is not demonstrated at this memory tier.
- Measurements use RssAnon/RssFile high-water marks and `time -v` peak RSS; they are not sampling-profiler results.
- The installed `vc.spiral_sampling` extension was built for f75e4c29e, so each measurement applies this branch's patches to that tree. The patched lines do not touch the extension.
- The kernel dmesg entry was not captured. The OOM evidence is signal 9, exit 137 and peak RSS at the host limit.
- With the same environment and files, upstream main reports 6 failed / 8 passed / 3 skipped; this branch reports 3 failed / 44 passed / 6 skipped. The three remaining failures reproduce on main.
