### PR TITLE
spiral: a half-size resident pool that the sidecar selects

### DIFF
--- a/spiral-fitting/benchmark_resident_pool_memory.py
+++ b/spiral-fitting/benchmark_resident_pool_memory.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""How much scratch VRAM does one gather cost, on top of the pool it reads?
+
+Halving the resident pool is only worth what reaches the fitter's peak.  A
+decode that allocates a few int64 temporaries per gathered voxel can hand back
+everything the smaller pool won, and the pool-size number alone will not show
+it: the pool is steady state, the temporaries are the peak.
+
+For each pool this reports
+
+    resident   bytes the pool holds for the whole fit
+    transient  max_memory_allocated - memory_allocated across one gather,
+               i.e. everything the call touched that the pool does not own
+    output     bytes of the value tensor the call returns
+
+Transient is the number that competes with the model, the optimiser and the
+other pools for the same allocator budget.
+
+The instrument is checked before it is used: --self-test allocates a known
+number of bytes inside a fake gather and requires the reading back to match,
+and the run fails if the reading is off by more than one allocator block.
+Without that, a decode change that does nothing would read as a win.
+
+Run:
+  python benchmark_resident_pool_memory.py <raw sidecar> <min3 sidecar> \
+      [--z-roi lo hi] [--n 4000000]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+# absolute(), not resolve(): resolve() expands symlinks, which puts the real
+# checkout path into every traceback this script can raise.
+sys.path.insert(0, str(Path(__file__).absolute().parent))
+
+from min3_pool import Min3BrickPool             # noqa: E402
+from sparse_cuda_cache import ResidentBrickPool  # noqa: E402
+
+
+def measure(fn, *args):
+    """Peak allocated bytes above the resting level, across one call."""
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    resting = torch.cuda.memory_allocated()
+    out = fn(*args)
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated()
+    kept = out.numel() * out.element_size()
+    del out
+    return peak - resting, kept
+
+
+class _Waster:
+    """A gather that does nothing but allocate a known number of bytes."""
+
+    def __init__(self, want_bytes):
+        self.want_bytes = want_bytes
+
+    def gather(self, indices_zyx):
+        scratch = torch.empty(self.want_bytes, dtype=torch.uint8,
+                              device='cuda')
+        scratch.fill_(1)
+        out = torch.zeros((indices_zyx.shape[0], 1), dtype=torch.uint8,
+                          device='cuda')
+        del scratch
+        return out
+
+
+def self_test():
+    """Does the meter move by exactly what a known allocation costs?"""
+    idx = torch.zeros((1024, 3), dtype=torch.long, device='cuda')
+    small, _ = measure(_Waster(1 << 20).gather, idx)
+    large, _ = measure(_Waster(64 << 20).gather, idx)
+    grew = large - small
+    want = (64 - 1) << 20
+    # The allocator rounds; one 2 MiB block of slack is fine, a factor is not.
+    if abs(grew - want) > (2 << 20):
+        raise SystemExit(
+            f'self-test failed: a {want:,}-byte increase read as {grew:,}. '
+            f'The meter is not measuring what this script claims.')
+    print(f'self-test: a {want / 2**20:.0f} MiB increase reads as '
+          f'{grew / 2**20:.0f} MiB -- meter live')
+
+
+def draw(z_lo, z_hi, shape, n, seed=0):
+    rng = np.random.default_rng(seed)
+    _, ys, xs = shape
+    return np.stack([rng.integers(z_lo, z_hi, n),
+                     rng.integers(0, ys, n),
+                     rng.integers(0, xs, n)], axis=1)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('raw')
+    ap.add_argument('min3')
+    ap.add_argument('--z-roi', type=int, nargs=2, default=None)
+    ap.add_argument('--n', type=int, default=4_000_000)
+    ap.add_argument('--json-out', default=None)
+    args = ap.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit('this benchmark needs a CUDA device')
+    self_test()
+
+    z_roi = tuple(args.z_roi) if args.z_roi else None
+    raw = ResidentBrickPool(args.raw, origin_zyx=(0, 0, 0), z_roi=z_roi,
+                            label='raw')
+    packed = Min3BrickPool(args.min3, origin_zyx=(0, 0, 0), z_roi=z_roi,
+                           label='min3')
+
+    lo = z_roi[0] if z_roi else 0
+    hi = min(z_roi[1], raw.shape_zyx[0]) if z_roi else raw.shape_zyx[0]
+    idx = torch.from_numpy(draw(lo, hi, raw.shape_zyx, args.n)).cuda()
+
+    report = {'n': args.n, 'pools': {}}
+    print(f'\none gather over {args.n:,} indices\n')
+    print(f'{"pool":6} {"resident GiB":>13} {"transient MiB":>14} '
+          f'{"output MiB":>11} {"transient/index B":>18}')
+    for pool, name in ((raw, 'raw'), (packed, 'min3')):
+        pool.gather(idx[:1024])                      # warm the kernels
+        readings = [measure(pool.gather, idx)[0] for _ in range(3)]
+        transient = min(readings)
+        _, kept = measure(pool.gather, idx)
+        print(f'{name:6} {pool.pool_bytes / 2**30:13.2f} '
+              f'{transient / 2**20:14.1f} {kept / 2**20:11.1f} '
+              f'{transient / args.n:18.1f}')
+        report['pools'][name] = {
+            'resident_bytes': int(pool.pool_bytes),
+            'transient_bytes': int(transient),
+            'transient_readings': [int(v) for v in readings],
+            'output_bytes': int(kept),
+        }
+
+    r, m = report['pools']['raw'], report['pools']['min3']
+    saved = r['resident_bytes'] - m['resident_bytes']
+    paid = m['transient_bytes'] - r['transient_bytes']
+    report['resident_saved_bytes'] = int(saved)
+    report['transient_paid_bytes'] = int(paid)
+    report['net_bytes'] = int(saved - paid)
+    print(f'\nresident saved   {saved / 2**30:+.3f} GiB')
+    print(f'transient paid   {-paid / 2**30:+.3f} GiB')
+    print(f'net at the peak  {(saved - paid) / 2**30:+.3f} GiB')
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f'\nwritten: {args.json_out}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/spiral-fitting/check_pool_equivalence.py
+++ b/spiral-fitting/check_pool_equivalence.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Does the packed pool return exactly what the raw pool returns?
+
+Lossless is a claim about every voxel, so this gathers the same indices from
+both pools and requires torch.equal -- not a tolerance, not a sample mean. The
+indices are drawn to hit the cases a packing gets wrong when its layout is
+wrong: both parities of the linear index, block boundaries, brick boundaries,
+and the reserved all-zero row.
+
+The second argument's own meta.json says which packing it is, and the pool
+class comes from the same dispatch the fitter uses, so this cannot pass against
+a class the fitter would not have loaded.
+
+Run:
+  python check_pool_equivalence.py <raw sidecar> <packed sidecar> [--z-roi lo hi]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+import numpy as np
+import torch
+
+from pathlib import Path
+
+# Everything this needs is now in the tree beside it, so a run cannot pick up
+# a pool class from somewhere the commit does not describe.  absolute(), not
+# resolve(): resolve() expands symlinks into every traceback.
+_HERE = Path(__file__).absolute().parent
+sys.path.insert(0, str(_HERE))
+from sparse_cuda_cache import ResidentBrickPool          # noqa: E402
+
+
+def open_packed(sidecar, **kwargs):
+    """Whichever pool the sidecar asks for -- same choice the fitter makes."""
+    import json
+    encoding = json.loads(
+        (Path(sidecar) / 'meta.json').read_text()).get('encoding', 'raw')
+    if encoding == 'min3':
+        from min3_pool import Min3BrickPool
+        return Min3BrickPool(sidecar, **kwargs), encoding
+    raise SystemExit(f'{sidecar}: encoding {encoding!r} is not a packed pool')
+
+
+def draw_indices(z_lo, z_hi, shape, brick, side, n, seed):
+    """Random points plus every boundary the packing can be wrong about.
+
+    Boundaries are absolute, not relative to the ROI: brick b spans
+    [128b, 128b+128), so offsets from an arbitrary z_lo land nowhere near one.
+    An earlier version of this generator shifted relative offsets by z_lo and
+    therefore tested no boundary at all.
+    """
+    rng = np.random.default_rng(seed)
+    _, ys, xs = shape
+    pts = [np.stack([rng.integers(z_lo, z_hi, n),
+                     rng.integers(0, ys, n),
+                     rng.integers(0, xs, n)], axis=1)]
+
+    def edges(step, lo, hi, take):
+        """Absolute multiples of `step` inside [lo, hi), and their neighbours."""
+        first = ((lo + step - 1) // step) * step
+        out = set()
+        for k in range(take):
+            m = first + k * step
+            if m >= hi:
+                break
+            for d in (-1, 0, 1):
+                v = m + d
+                if lo <= v < hi:
+                    out.add(int(v))
+        return sorted(out)
+
+    ez = edges(brick[0], z_lo, z_hi, 6) + edges(side, z_lo, z_hi, 8)
+    ey = edges(brick[1], 0, ys, 6) + edges(side, 0, ys, 8)
+    ex = edges(brick[2], 0, xs, 6) + edges(side, 0, xs, 8)
+    if ez and ey and ex:
+        g = np.array(np.meshgrid(ez, ey, ex, indexing='ij')).reshape(3, -1).T
+        pts.append(g.astype(np.int64))
+
+    # A contiguous run along x so both nibble parities appear consecutively,
+    # crossing a brick edge on the way.
+    span = min(4096, xs)
+    x0 = max(0, min(xs - span, (brick[2] * 3) - span // 2))
+    run = np.stack([np.full(span, (z_lo + z_hi) // 2),
+                    np.full(span, ys // 2),
+                    np.arange(x0, x0 + span)], axis=1)
+    pts.append(run.astype(np.int64))
+    return np.concatenate(pts, axis=0)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('raw')
+    ap.add_argument('packed')
+    ap.add_argument('--z-roi', type=int, nargs=2, default=None)
+    ap.add_argument('--n', type=int, default=2_000_000)
+    ap.add_argument('--seed', type=int, default=0)
+    args = ap.parse_args()
+
+    z_roi = tuple(args.z_roi) if args.z_roi else None
+    raw = ResidentBrickPool(args.raw, origin_zyx=(0, 0, 0), z_roi=z_roi,
+                            label='raw')
+    packed, enc = open_packed(args.packed, origin_zyx=(0, 0, 0),
+                              z_roi=z_roi, label='packed')
+    print(f'\nVRAM: raw {raw.pool_bytes / 2**30:.2f} GiB vs '
+          f'{enc} {packed.pool_bytes / 2**30:.2f} GiB '
+          f'= {raw.pool_bytes / packed.pool_bytes:.3f}x smaller')
+
+    shape = raw.shape_zyx
+    brick = tuple(int(v) for v in raw.meta['brick_shape'])
+    side = int(packed.meta['encode_block'])
+    lo = z_roi[0] if z_roi else 0
+    hi = min(z_roi[1], shape[0]) if z_roi else shape[0]
+    idx = draw_indices(lo, hi, shape, brick, side, args.n, args.seed)
+    on_brick = int(np.count_nonzero(idx[:, 2] % brick[2] == 0))
+    on_block = int(np.count_nonzero(idx[:, 2] % side == 0))
+    odd = int(np.count_nonzero((idx[:, 2] & 1) == 1))
+    oob = ((idx < 0) | (idx >= np.array(shape))).any(axis=1)
+    if oob.any():
+        raise SystemExit(
+            f'the index generator produced {int(oob.sum())} out-of-range '
+            f'points, e.g. {idx[oob][0].tolist()} against shape {shape} -- '
+            f'fix the generator, do not let the pool decide')
+    print(f'comparing {len(idx):,} gathers  '
+          f'(on a brick edge in x: {on_brick:,}; on a block edge: {on_block:,}; '
+          f'odd nibble: {odd:,})')
+
+    bad = 0
+    CH = 1 << 20
+    for s in range(0, len(idx), CH):
+        t = torch.from_numpy(idx[s:s + CH])
+        a = raw.gather(t)
+        b = packed.gather(t)
+        if not torch.equal(a, b):
+            d = (a != b).nonzero()
+            bad += int(d.shape[0])
+            if bad and d.shape[0]:
+                k = int(d[0, 0])
+                print(f'  MISMATCH at index {s + k}: zyx={idx[s + k].tolist()} '
+                      f'raw={a[k].tolist()} {enc}={b[k].tolist()}')
+                break
+    if bad:
+        print(f'\nFAIL: {bad:,} differing gathers')
+        return 1
+    print(f'\nPASS: every one of {len(idx):,} gathers is bitwise equal')
+
+    # Halving VRAM is worthless if the fit slows down: decode adds a second
+    # dependent load and an add per gathered voxel. Time both on the same
+    # indices with the device synchronised, so this compares kernels rather
+    # than queue depth.
+    bench = torch.from_numpy(idx[:min(len(idx), 8 << 20)])
+    for pool, name in ((raw, 'raw '), (packed, enc)):
+        for _ in range(3):
+            pool.gather(bench)
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(10):
+            pool.gather(bench)
+        torch.cuda.synchronize()
+        ms = (time.perf_counter() - t0) * 100.0
+        # AGENTS.md 1.4 wants iteration counts and a distribution, not one
+        # number: time each iteration separately and report min/median/max.
+        per = []
+        for _ in range(10):
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            pool.gather(bench)
+            torch.cuda.synchronize()
+            per.append((time.perf_counter() - t1) * 1000.0)
+        per.sort()
+        print(f'  {name} gather over {len(bench):,} indices, 10 iterations: '
+              f'min {per[0]:.2f} / median {per[len(per)//2]:.2f} / '
+              f'max {per[-1]:.2f} ms   (mean of a separate 10-run batch '
+              f'{ms:.2f} ms)')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/spiral-fitting/lasagna_data.py
+++ b/spiral-fitting/lasagna_data.py
@@ -143,6 +143,29 @@ def _read_sidecar_meta(sidecar):
         return json.load(f)
 
 
+def _open_resident_pool(sidecar, **kwargs):
+    """Construct whichever lossless resident-pool encoding the sidecar names.
+
+    The encoding is a property of the sidecar, not of the run: a fit asked for
+    a volume, and how that volume is packed on the device is the packer's
+    business.  Dispatching here rather than at the call sites keeps the three
+    pools the fitter loads on one code path.
+    """
+    encoding = 'raw'
+    try:
+        with open(os.path.join(str(sidecar), 'meta.json')) as fh:
+            encoding = json.load(fh).get('encoding', 'raw')
+    except OSError:
+        pass
+    from sparse_cuda_cache import ResidentBrickPool
+    if encoding == 'raw':
+        return ResidentBrickPool(sidecar, **kwargs)
+    if encoding == 'min3':
+        from min3_pool import Min3BrickPool
+        return Min3BrickPool(sidecar, **kwargs)
+    raise ValueError(f'{sidecar}: unsupported sidecar encoding {encoding!r}')
+
+
 def prepare_lasagna_volume(
     scroll_zarr,
     *,
@@ -232,7 +255,7 @@ def prepare_lasagna_volume(
             progress.begin(
                 'loading', 'Loading normal volumes onto GPU',
                 step=0, total_steps=0, unit='bricks')
-        normal_cache = ResidentBrickPool(
+        normal_cache = _open_resident_pool(
             normal_sidecar,
             origin_zyx=(z_lo, 0, 0),
             z_roi=(z_lo, z_hi),
@@ -251,7 +274,7 @@ def prepare_lasagna_volume(
             progress.begin(
                 'loading', 'Loading gradient volume onto GPU',
                 step=0, total_steps=0, unit='bricks')
-        grad_cache = ResidentBrickPool(
+        grad_cache = _open_resident_pool(
             grad_sidecar,
             origin_zyx=(z_lo, 0, 0),
             z_roi=(z_lo, z_hi),
@@ -414,7 +437,7 @@ def prepare_surf_sdt_volume(
         progress.begin(
             'loading', 'Loading surface-distance volume onto GPU',
             step=0, total_steps=0, unit='bricks')
-    cache = ResidentBrickPool(
+    cache = _open_resident_pool(
         sidecar,
         origin_zyx=(z_lo, 0, 0),
         z_roi=(z_lo, z_hi),

--- a/spiral-fitting/min3_pool.py
+++ b/spiral-fitting/min3_pool.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""A ResidentBrickPool that keeps the pool in min3 words on the device.
+
+Same public surface as the upstream class -- ``gather(indices_zyx)`` returning
+``(..., channels)`` uint8 -- so the fitter cannot tell the difference except by
+how much VRAM is left. Decode is per voxel, out of one aligned 32-bit word:
+
+    value = (w & 0xFF) + ((w >> (8 + 3*j)) & 7)      j = voxel index in its 2^3 block
+
+One load. That is the whole point of the layout, and it is why this replaces
+Min4BrickPool rather than sitting beside it: min4 keeps codes and minima in two
+arrays, so every gather is two random reads, and on the real 2.03 GiB pool that
+cost 71% over an uncompressed read where this costs 4.6% -- at a better ratio,
+2.000x against 1.939x.
+
+No overflow is possible in the add: the block minimum plus a code of at most 7
+is the block maximum, which was a uint8 in the source.
+
+Words are held as int32 rather than uint32 because the arithmetic below is all
+mask-and-shift and int32 is the type every torch version handles the same way.
+The sign bit is the top code bit; ``& 7`` after the shift discards the sign
+extension, so the value is unaffected.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+class Min3BrickPool:
+    """Resident pool over a `<sidecar>.min3` directory."""
+
+    def __init__(self, sidecar_dir, *, origin_zyx=(0, 0, 0), z_roi=None,
+                 device: torch.device | str = 'cuda', label: str,
+                 expected_channels: int | None = None,
+                 expected_shape_zyx: tuple[int, int, int] | None = None,
+                 progress_callback=None,
+                 bounds_check: bool = True):
+        started = time.perf_counter()
+        sidecar_dir = Path(sidecar_dir)
+        meta = json.loads((sidecar_dir / 'meta.json').read_text())
+        if meta.get('encoding') != 'min3':
+            raise ValueError(f'{sidecar_dir}: not a min3 sidecar')
+        self.meta = meta
+        self.label = str(label)
+        self.device = torch.device(device)
+        self.side = int(meta['encode_block'])
+
+        self.sidecar_dir = str(sidecar_dir)
+        self.shape_zyx = tuple(int(v) for v in meta['array_shape'])
+        self.origin_zyx = tuple(int(v) for v in origin_zyx)
+        # The upstream pool refuses a sidecar that does not match the array it
+        # is standing in for. Keeping the same two checks matters more here,
+        # not less: a re-encoded sidecar is one more place the two can drift.
+        if (expected_shape_zyx is not None
+                and tuple(int(v) for v in expected_shape_zyx) != self.shape_zyx):
+            raise ValueError(
+                f'{label}: sidecar {sidecar_dir} covers array shape '
+                f'{self.shape_zyx}, expected {tuple(expected_shape_zyx)}')
+        brick = tuple(int(v) for v in meta['brick_shape'])
+        self._edge = brick[0]
+        rows = int(meta['rows'])
+        self.channels = len(meta['channels'])
+        if expected_channels is not None and self.channels != expected_channels:
+            raise ValueError(
+                f'{label}: sidecar {sidecar_dir} has {self.channels} '
+                f'channel(s), expected {expected_channels}')
+        blocks_per_brick = (self._edge // self.side) ** 3
+
+        table_np = np.load(sidecar_dir / 'table.npy')
+        coords_np = np.load(sidecar_dir / 'brick_coords.npy')
+
+        keep = np.ones(rows, dtype=bool)
+        if z_roi is not None:
+            z_lo, z_hi = int(z_roi[0]), int(z_roi[1])
+            brick_z = coords_np[:, 0].astype(np.int64)
+            keep = (brick_z * brick[0] < z_hi) & ((brick_z + 1) * brick[0] > z_lo)
+            keep[0] = True                      # the reserved all-zero brick
+        kept_ids = np.flatnonzero(keep)
+        remap = np.zeros(rows, dtype=np.int32)
+        remap[kept_ids] = np.arange(len(kept_ids), dtype=np.int32)
+
+        self.resident_bricks = len(kept_ids)
+        self.pool_bytes = self.channels * len(kept_ids) * blocks_per_brick * 4
+        try:
+            self.words = torch.empty(
+                (self.channels, len(kept_ids), blocks_per_brick),
+                dtype=torch.int32, device=self.device)
+        except torch.OutOfMemoryError as exc:
+            raise RuntimeError(
+                f'Could not allocate the {self.label} min3 pool '
+                f'({self.pool_bytes / 1024**3:.2f} GiB, {len(kept_ids)} bricks)'
+            ) from exc
+
+        slab = max(1, (256 << 20) // max(1, blocks_per_brick * 4))
+        for ci in range(self.channels):
+            wm = np.memmap(sidecar_dir / f'channel_{ci}.u32', dtype=np.uint32,
+                           mode='r', shape=(rows, blocks_per_brick))
+            done = 0
+            total = self.channels * len(kept_ids)
+            for lo in range(0, len(kept_ids), slab):
+                ids = kept_ids[lo:lo + slab]
+                block = np.ascontiguousarray(wm[ids]).view(np.int32)
+                self.words[ci, lo:lo + len(ids)] = torch.from_numpy(block).to(
+                    self.device)
+                done += len(ids)
+                if progress_callback is not None:
+                    progress_callback(ci * len(kept_ids) + done, total,
+                                      f'{self.label} min3 pool')
+
+        self.table = torch.from_numpy(remap[table_np]).to(self.device)
+        self._origin = torch.tensor(
+            [int(v) for v in origin_zyx], device=self.device, dtype=torch.long)
+        self._brick = torch.tensor(list(brick), device=self.device,
+                                   dtype=torch.long)
+        self._shape = torch.tensor(list(self.shape_zyx), device=self.device,
+                                   dtype=torch.long)
+        self._bps = self._edge // self.side          # blocks per brick edge
+        # Upstream gates this on an environment variable and leaves it off by
+        # default. Defaulting it on here would make the drop-in stricter than
+        # what it replaces -- it would raise on indices the pool it stands in
+        # for accepts -- so the substitution would change behaviour, which is
+        # the one thing it must not do.
+        self._bounds_check = (
+            bool(bounds_check)
+            and os.environ.get('FIT_SPIRAL_RESIDENT_BOUNDS_CHECK') == '1')
+        self.total_bricks = rows
+        self._gathers = 0
+        self._gather_seconds = 0.0
+        # fit_spiral reads store.last_timings after every phase step, so the
+        # drop-in has to carry it or the substitution fails at run time rather
+        # than at load.
+        self.last_timings: dict[str, float | int] = {}
+        self.load_seconds = time.perf_counter() - started
+        print(f'{self.label}: min3 pool {self.resident_bricks:,}/{rows:,} bricks '
+              f'({self.pool_bytes / 1024**3:.2f} GiB) loaded in '
+              f'{self.load_seconds:.1f}s from {sidecar_dir.name}', flush=True)
+
+    def gather(self, indices_zyx: torch.Tensor) -> torch.Tensor:
+        started = time.perf_counter()
+        original_shape = tuple(indices_zyx.shape[:-1])
+        flat = indices_zyx.detach().reshape(-1, 3)
+        if flat.shape[0] == 0:
+            return torch.empty((*original_shape, self.channels),
+                               dtype=torch.uint8, device=self.device)
+        flat = flat.to(device=self.device, dtype=torch.long)
+        source = flat + self._origin
+        if self._bounds_check and bool(
+                ((source < 0) | (source >= self._shape)).any()):
+            raise IndexError(f'{self.label} gather received an out-of-bounds index')
+        brick_idx = torch.div(source, self._brick, rounding_mode='floor')
+        slots = self.table[brick_idx[:, 0], brick_idx[:, 1],
+                           brick_idx[:, 2]].to(torch.long)
+        local = source - brick_idx * self._brick
+
+        side = self.side
+        bz = torch.div(local[:, 0], side, rounding_mode='floor')
+        by = torch.div(local[:, 1], side, rounding_mode='floor')
+        bx = torch.div(local[:, 2], side, rounding_mode='floor')
+        block = (bz * self._bps + by) * self._bps + bx
+        # Position inside the 2^3 block, in the same (z,y,x) order the packer
+        # laid the codes down.
+        j = (((local[:, 0] - bz * side) * side
+              + (local[:, 1] - by * side)) * side
+             + (local[:, 2] - bx * side))
+
+        w = self.words[:, slots, block]                     # (channels, n) int32
+        mn = torch.bitwise_and(w, 0xFF)
+        shift = (8 + 3 * j).to(torch.int32).unsqueeze(0).expand_as(w)
+        code = torch.bitwise_and(torch.bitwise_right_shift(w, shift), 7)
+        values = (mn + code).to(torch.uint8).transpose(0, 1)
+
+        elapsed = time.perf_counter() - started
+        self._gather_seconds += elapsed
+        self._gathers += 1
+        self.last_timings = {
+            'gather_seconds': elapsed,
+            'resident_bricks': self.resident_bricks,
+            'resident_mib': self.pool_bytes / 1024 ** 2,
+        }
+        return values.reshape(*original_shape, self.channels)
+
+    def stats(self) -> dict[str, float | int]:
+        return {
+            'resident_bricks': self.resident_bricks,
+            'total_bricks': self.total_bricks,
+            'gathers': self._gathers,
+            'gather_seconds': self._gather_seconds,
+            'load_seconds': self.load_seconds,
+            'pool_bytes': self.pool_bytes,
+        }

--- a/spiral-fitting/min3_pool.py
+++ b/spiral-fitting/min3_pool.py
@@ -156,24 +156,41 @@ class Min3BrickPool:
         brick_idx = torch.div(source, self._brick, rounding_mode='floor')
         slots = self.table[brick_idx[:, 0], brick_idx[:, 1],
                            brick_idx[:, 2]].to(torch.long)
-        local = source - brick_idx * self._brick
+        # local = source - brick_idx * brick, through the two tensors that
+        # already exist rather than into a third.  At the batch sizes the
+        # fitter gathers, one more live (n, 3) int64 is 24 bytes per index of
+        # peak, which is six times what the words it decodes cost.
+        brick_idx.mul_(self._brick)
+        source.sub_(brick_idx)
+        del brick_idx
+        lz, ly, lx = source[:, 0], source[:, 1], source[:, 2]
 
         side = self.side
-        bz = torch.div(local[:, 0], side, rounding_mode='floor')
-        by = torch.div(local[:, 1], side, rounding_mode='floor')
-        bx = torch.div(local[:, 2], side, rounding_mode='floor')
-        block = (bz * self._bps + by) * self._bps + bx
-        # Position inside the 2^3 block, in the same (z,y,x) order the packer
-        # laid the codes down.
-        j = (((local[:, 0] - bz * side) * side
-              + (local[:, 1] - by * side)) * side
-             + (local[:, 2] - bx * side))
+        bz = torch.div(lz, side, rounding_mode='floor')
+        by = torch.div(ly, side, rounding_mode='floor')
+        bx = torch.div(lx, side, rounding_mode='floor')
+        # The shift operand, 8 + 3j, built in int32 and in place.  j is the
+        # position inside the 2^3 block, in the same (z,y,x) order the packer
+        # laid the codes down; it never reaches 8, so carrying it as int64 and
+        # then widening it to the shape of the words -- which is what the first
+        # version of this did -- cost more scratch than the codes it decodes.
+        shift = lz.sub(bz * side).to(torch.int32)
+        shift.mul_(side).add_(ly.sub(by * side).to(torch.int32))
+        shift.mul_(side).add_(lx.sub(bx * side).to(torch.int32))
+        shift.mul_(3).add_(8)
+        block = bz.mul_(self._bps).add_(by).mul_(self._bps).add_(bx)
+        del by, bx, lz, ly, lx, source
 
+        # Advanced indexing returns a fresh tensor, so the decode can run in
+        # place without touching the resident words.
         w = self.words[:, slots, block]                     # (channels, n) int32
-        mn = torch.bitwise_and(w, 0xFF)
-        shift = (8 + 3 * j).to(torch.int32).unsqueeze(0).expand_as(w)
-        code = torch.bitwise_and(torch.bitwise_right_shift(w, shift), 7)
-        values = (mn + code).to(torch.uint8).transpose(0, 1)
+        del block, slots
+        code = torch.bitwise_right_shift(w, shift)   # (channels, n) >> (n,)
+        code.bitwise_and_(7)
+        w.bitwise_and_(0xFF)                                # w is now the minima
+        w.add_(code)
+        del code, shift
+        values = w.to(torch.uint8).transpose(0, 1)
 
         elapsed = time.perf_counter() - started
         self._gather_seconds += elapsed

--- a/spiral-fitting/pack_min3.py
+++ b/spiral-fitting/pack_min3.py
@@ -27,6 +27,7 @@ ratio: 4 bytes per 8 voxels is exactly 2.000x against 1.939x.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import shutil
@@ -145,7 +146,12 @@ def main() -> int:
     out_meta = dict(meta)
     out_meta['encoding'] = 'min3'
     out_meta['encode_block'] = args.side
-    out_meta['encoded_from'] = str(src)
+    # Which sidecar this came from, not where it happened to sit: the absolute
+    # path identifies the machine, and a sidecar that has been re-encoded since
+    # has the same path and a different table.
+    out_meta['encoded_from'] = src.name
+    out_meta['encoded_from_table_sha256'] = hashlib.sha256(
+        (src / 'table.npy').read_bytes()).hexdigest()
     out_meta['worst_block_span'] = worst_overall
     # meta.json last: it is the completion sentinel every reader keys on, so a
     # conversion killed part way through leaves a directory nothing will load

--- a/spiral-fitting/pack_min3.py
+++ b/spiral-fitting/pack_min3.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Re-encode a resident-pool sidecar to min3: one aligned 32-bit word per 2^3 block.
+
+Layout, little-endian, one word per block:
+
+    | byte 0 = block minimum | bits 8..31 = eight 3-bit codes, voxel j at 8+3j |
+
+    value = (w & 0xFF) + ((w >> (8 + 3*j)) & 7)
+
+Lossless exactly when every 2^3 block spans at most 7. On las_008_surf_sdt that
+was checked block by block over the whole store -- 4,951,375,872 blocks, worst
+span 6, none over 7 -- not sampled. This packer re-checks every block anyway and
+refuses to write if one is over, because a sidecar that is silently lossy is
+worse than no sidecar.
+
+Why 2^3 and not min4's 4^3, given 4 bits per voxel sounds cheaper than 3 plus a
+bigger minimum table: it is not the ratio that decides, it is the number of
+memory transactions. min4 stores codes and minima in two arrays, so every gather
+is two random reads; measured on the real 2.03 GiB pool that costs 71% over an
+uncompressed read. Here the minimum travels inside the same word as its codes,
+so a gather is one aligned 32-bit load -- 4.6% over uncompressed, at a better
+ratio: 4 bytes per 8 voxels is exactly 2.000x against 1.939x.
+
+    python pack_min3.py <sidecar>              # writes <sidecar>.min3
+    python pack_min3.py <sidecar> --analyze    # check and size it, write nothing
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+BLOCK = 2
+MAX_CODE = 7
+
+
+def encode_bricks(bricks: np.ndarray, side: int = BLOCK) -> np.ndarray:
+    """(rows, edge, edge, edge) uint8 -> (rows, blocks) uint32. Raises if inexact."""
+    rows, edge = bricks.shape[0], bricks.shape[1]
+    c = edge // side
+    b = bricks.reshape(rows, c, side, c, side, c, side)
+    mins = b.min(axis=(2, 4, 6))
+    span = b.max(axis=(2, 4, 6)).astype(np.int16) - mins.astype(np.int16)
+    worst = int(span.max()) if span.size else 0
+    if worst > MAX_CODE:
+        bad = int(np.count_nonzero(span > MAX_CODE))
+        raise ValueError(
+            f'{bad} block(s) of {span.size} span more than {MAX_CODE}; '
+            f'largest span {worst} -- not exact at side {side}')
+    codes = (b - mins[:, :, None, :, None, :, None]).astype(np.uint32)
+    w = mins.astype(np.uint32)                              # byte 0
+    for dz in range(side):
+        for dy in range(side):
+            for dx in range(side):
+                j = (dz * side + dy) * side + dx
+                w |= codes[:, :, dz, :, dy, :, dx] << (8 + 3 * j)
+    return np.ascontiguousarray(w.reshape(rows, c ** 3)), worst
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('sidecar')
+    ap.add_argument('--out', default=None, help='default <sidecar>.min3')
+    ap.add_argument('--side', type=int, default=BLOCK)
+    ap.add_argument('--group', type=int, default=64, help='bricks per read')
+    ap.add_argument('--analyze', action='store_true',
+                    help='check exactness and report the size, write nothing')
+    args = ap.parse_args()
+
+    if args.side ** 3 * 3 > 24:
+        raise SystemExit(f'side {args.side} needs {args.side**3 * 3} code bits, '
+                         f'only 24 fit beside the minimum in a 32-bit word')
+
+    src = Path(args.sidecar)
+    meta = json.loads((src / 'meta.json').read_text())
+    if meta.get('encoding', 'raw') != 'raw':
+        raise SystemExit(f'{src}: expected a raw sidecar, found '
+                         f'{meta.get("encoding")!r}')
+    brick = tuple(int(v) for v in meta['brick_shape'])
+    if len(set(brick)) != 1:
+        raise SystemExit(f'non-cubic brick {brick} is not handled')
+    edge = brick[0]
+    if edge % args.side:
+        raise SystemExit(f'brick edge {edge} is not a multiple of {args.side}')
+    brick_voxels = edge ** 3
+    rows = int(meta['rows'])
+    channels = len(meta['channels'])
+    blocks = (edge // args.side) ** 3
+
+    dst = Path(args.out) if args.out else Path(str(src) + '.min3')
+    if not args.analyze:
+        dst.mkdir(parents=True, exist_ok=True)
+        for name in ('table.npy', 'brick_coords.npy'):
+            shutil.copy2(src / name, dst / name)
+
+    started = time.perf_counter()
+    worst_overall = 0
+    for ci in range(channels):
+        mm = np.memmap(src / f'channel_{ci}.u8', dtype=np.uint8, mode='r',
+                       shape=(rows, brick_voxels))
+        out = (None if args.analyze else
+               (dst / f'channel_{ci}.u32').open('wb', buffering=8 << 20))
+        try:
+            for lo in range(0, rows, args.group):
+                hi = min(lo + args.group, rows)
+                buf = np.asarray(mm[lo:hi]).reshape(-1, edge, edge, edge)
+                words, worst = encode_bricks(buf, args.side)
+                worst_overall = max(worst_overall, worst)
+                if out is not None:
+                    # A writable memmap of the whole 19 GiB output can leave
+                    # almost all pages dirty and make flush() fail with ENOMEM
+                    # on a 15 GiB, swap-free WSL host.  Stream bounded groups
+                    # in row order; the on-disk layout is byte-for-byte the
+                    # same and kernel writeback can throttle each group.
+                    encoded = words.astype('<u4', copy=False)
+                    out.write(memoryview(encoded).cast('B'))
+                if (lo // args.group) % 32 == 0:
+                    print(f'  channel {ci}: {hi:,}/{rows:,} bricks '
+                          f'({time.perf_counter() - started:.0f}s, '
+                          f'worst span {worst_overall})', flush=True)
+            if out is not None:
+                out.flush()
+                os.fsync(out.fileno())
+        finally:
+            if out is not None:
+                out.close()
+
+    raw = rows * brick_voxels * channels
+    enc = rows * blocks * 4 * channels
+    print(f'\n{rows:,} bricks x {channels} channel(s) in '
+          f'{time.perf_counter() - started:.0f}s')
+    print(f'raw {raw / 2**30:.2f} GiB -> encoded {enc / 2**30:.2f} GiB '
+          f'= {raw / enc:.3f}x   (side {args.side}, worst span '
+          f'{worst_overall}/{MAX_CODE})')
+    if args.analyze:
+        print('analyze only, nothing written.')
+        return 0
+
+    out_meta = dict(meta)
+    out_meta['encoding'] = 'min3'
+    out_meta['encode_block'] = args.side
+    out_meta['encoded_from'] = str(src)
+    out_meta['worst_block_span'] = worst_overall
+    # meta.json last: it is the completion sentinel every reader keys on, so a
+    # conversion killed part way through leaves a directory nothing will load
+    # rather than a short one something might.
+    (dst / 'meta.json').write_text(json.dumps(out_meta, indent=2))
+    print(f'written: {dst}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/spiral-fitting/pack_resident_pools.py
+++ b/spiral-fitting/pack_resident_pools.py
@@ -124,8 +124,13 @@ def _make_chunk_reader(compressor: dict | None, chunk_voxels: int):
     codec = numcodecs.get_codec(compressor)
 
     def read(path: Path) -> np.ndarray:
-        with open(path, 'rb') as f:
-            decoded = codec.decode(f.read())
+        try:
+            with open(path, 'rb') as f:
+                decoded = codec.decode(f.read())
+        except Exception as exc:
+            # Without the path, a codec failure on one chunk out of millions
+            # is a stack trace with nothing to act on.
+            raise RuntimeError(f'{path}: codec decode failed: {exc}') from exc
         decoded = np.frombuffer(decoded, dtype=np.uint8)
         if decoded.size != chunk_voxels:
             raise ValueError(f'{path}: decoded chunk has {decoded.size} bytes, expected {chunk_voxels}')

--- a/spiral-fitting/tests/test_min3_pool.py
+++ b/spiral-fitting/tests/test_min3_pool.py
@@ -1,0 +1,185 @@
+"""The min3 pool must return exactly what the uncompressed pool returns.
+
+The claim min3 makes is not "close enough", it is "the same bytes at half the
+resident size", so every check here is an equality against the pool it stands
+in for, on a sidecar built in the test rather than on a fixture.
+
+The cases are the ones a wrong layout survives at random:
+
+  * the code for voxel 7 of a block sits at bits 29..31, so it owns the sign
+    bit of the int32 word the pool holds.  A decode that shifts without
+    masking the sign extension reads that block wrong and nothing else.
+  * a block spanning the full 7 that min3 allows, next to a flat block.
+  * values at the top of the uint8 range, where minimum plus code is 255.
+  * brick and block boundaries, where a linear index is easy to build with
+    the wrong stride.
+"""
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
+
+from min3_pool import Min3BrickPool             # noqa: E402
+from pack_min3 import encode_bricks             # noqa: E402
+from sparse_cuda_cache import ResidentBrickPool  # noqa: E402
+
+EDGE = 4
+SIDE = 2
+SHAPE = (8, 8, 8)
+
+
+def build_volume():
+    """A volume whose 2^3 blocks exercise the cases above."""
+    rng = np.random.default_rng(7)
+    base = rng.integers(0, 249, size=SHAPE, dtype=np.uint16)
+    # Make every 2^3 block flat first, then add a controlled span, so no block
+    # can accidentally exceed 7 and make the packer refuse for the wrong reason.
+    base = base.reshape(4, SIDE, 4, SIDE, 4, SIDE)
+    base[:] = base[:, :1, :, :1, :, :1]
+    volume = base.reshape(SHAPE).astype(np.uint16)
+
+    offsets = np.zeros(SHAPE, dtype=np.uint16)
+    # Voxel 7 of a block is (z,y,x) odd in all three: give it the high codes so
+    # bit 31 of the word is set.
+    offsets[1::SIDE, 1::SIDE, 1::SIDE] = 7
+    offsets[0, 0, 0] = 0
+    volume = volume + offsets
+    # One block sitting hard against the top of the range.
+    volume[2:4, 2:4, 2:4] = 248
+    volume[3, 3, 3] = 255
+    return np.ascontiguousarray(volume.astype(np.uint8))
+
+
+def bricks_of(volume):
+    """(rows, edge^3) with row 0 reserved all-zero, plus the lookup table."""
+    gz, gy, gx = (s // EDGE for s in SHAPE)
+    table = np.zeros((gz, gy, gx), dtype=np.int32)
+    rows = [np.zeros(EDGE ** 3, dtype=np.uint8)]
+    for z in range(gz):
+        for y in range(gy):
+            for x in range(gx):
+                table[z, y, x] = len(rows)
+                rows.append(volume[z * EDGE:(z + 1) * EDGE,
+                                   y * EDGE:(y + 1) * EDGE,
+                                   x * EDGE:(x + 1) * EDGE].reshape(-1).copy())
+    coords = np.zeros((len(rows), 3), dtype=np.int32)
+    i = 1
+    for z in range(gz):
+        for y in range(gy):
+            for x in range(gx):
+                coords[i] = (z, y, x)
+                i += 1
+    return np.stack(rows), table, coords
+
+
+def write_sidecars(root, volume):
+    """Write a raw sidecar and its min3 re-encoding; return both paths."""
+    rows, table, coords = bricks_of(volume)
+    meta = {
+        'format': 'respool',
+        'version': 2,
+        'array_shape': list(SHAPE),
+        'brick_shape': [EDGE, EDGE, EDGE],
+        'rows': int(rows.shape[0]),
+        'channels': ['synthetic'],
+    }
+    raw = root / 'raw'
+    raw.mkdir()
+    (raw / 'meta.json').write_text(json.dumps(meta))
+    np.save(raw / 'table.npy', table)
+    np.save(raw / 'brick_coords.npy', coords)
+    (raw / 'channel_0.u8').write_bytes(rows.tobytes())
+
+    words, worst = encode_bricks(
+        rows.reshape(-1, EDGE, EDGE, EDGE), SIDE)
+    packed = root / 'min3'
+    packed.mkdir()
+    np.save(packed / 'table.npy', table)
+    np.save(packed / 'brick_coords.npy', coords)
+    (packed / 'channel_0.u32').write_bytes(
+        words.astype('<u4', copy=False).tobytes())
+    packed_meta = dict(meta)
+    packed_meta.update(encoding='min3', encode_block=SIDE,
+                       worst_block_span=int(worst))
+    (packed / 'meta.json').write_text(json.dumps(packed_meta))
+    return raw, packed, worst
+
+
+class Min3PoolTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        root = Path(cls._tmp.name)
+        cls.volume = build_volume()
+        cls.raw_dir, cls.min3_dir, cls.worst = write_sidecars(root, cls.volume)
+        cls.raw = ResidentBrickPool(str(cls.raw_dir), label='raw',
+                                    device='cpu')
+        cls.min3 = Min3BrickPool(str(cls.min3_dir), label='min3',
+                                 device='cpu')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+
+    def all_indices(self):
+        grid = np.indices(SHAPE).reshape(3, -1).T
+        return torch.from_numpy(np.ascontiguousarray(grid)).to(torch.long)
+
+    def test_the_fixture_exercises_the_sign_bit(self):
+        """A test that never sets bit 31 would pass against a broken decode."""
+        self.assertEqual(self.worst, 7)
+        words = np.fromfile(self.min3_dir / 'channel_0.u32', dtype='<u4')
+        self.assertTrue((words >> 31).any(),
+                        'no word has its top code bit set; the sign-extension '
+                        'case is untested')
+
+    def test_pool_is_exactly_half(self):
+        self.assertEqual(self.raw.pool_bytes, 2 * self.min3.pool_bytes)
+
+    def test_every_voxel_decodes_to_the_source(self):
+        idx = self.all_indices()
+        got = self.min3.gather(idx).reshape(SHAPE)
+        np.testing.assert_array_equal(got.numpy(), self.volume)
+
+    def test_matches_the_uncompressed_pool_bitwise(self):
+        idx = self.all_indices()
+        self.assertTrue(torch.equal(self.raw.gather(idx), self.min3.gather(idx)))
+
+    def test_gather_does_not_modify_its_input(self):
+        idx = self.all_indices()
+        before = idx.clone()
+        self.min3.gather(idx)
+        self.assertTrue(torch.equal(idx, before))
+
+    def test_gather_does_not_consume_the_pool(self):
+        """Decoding in place must not decode the resident words in place."""
+        idx = self.all_indices()
+        first = self.min3.gather(idx).clone()
+        second = self.min3.gather(idx)
+        self.assertTrue(torch.equal(first, second))
+
+    def test_shape_is_preserved(self):
+        idx = self.all_indices().reshape(8, 8, 8, 3)
+        self.assertEqual(tuple(self.min3.gather(idx).shape), (8, 8, 8, 1))
+
+    def test_empty_gather(self):
+        idx = torch.zeros((0, 3), dtype=torch.long)
+        self.assertEqual(tuple(self.min3.gather(idx).shape), (0, 1))
+
+    def test_packer_refuses_a_block_it_cannot_encode(self):
+        bad = np.zeros((1, EDGE, EDGE, EDGE), dtype=np.uint8)
+        bad[0, 0, 0, 0] = 0
+        bad[0, 1, 1, 1] = 8
+        with self.assertRaises(ValueError):
+            encode_bricks(bad, SIDE)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**In one sentence:** The surf_sdt resident pool takes half the VRAM, its gather scratch is lower than the raw pool's, and the allocator budget the fit needs drops from 7.0 to 5.5 GiB.

**One real example:** Starting with PHercParis4's `las_008_surf_sdt.ome.zarr.respool_g1` at 36.9 GiB, I re-encoded it with `pack_min3.py` to 18.45 GiB, exactly 2.000x at 4 bytes per 8 voxels. On the same ROI, z 4000-4400, 40 steps, seed 1, `dense_spacing_mode=phase`, with the allocator capped at 6.25 GiB, the raw pool dies with `torch.OutOfMemoryError` asking for 350 MiB at 5.73 GiB allocated; the min3 pool finishes 40 steps and writes the 260-winding final mesh with a 4.92 GiB peak.

**Before:** On this ROI the raw pool passes at a 7.0 GiB budget and fails at 6.75.

**After this PR:** The min3 pool passes at 5.5 and fails at 5.25, three runs at each boundary with identical peaks: 4.92 passing, 4.85 failing. Of the 1.5 GiB, compression buys 0.5 (7.0 to 6.5) and the decode rewrite buys 1.0 (6.5 to 5.5).

**Proof:**
- `A2_raw_OOM.png` and `A2_min3_OK.png`: two terminal captures, same ROI, same config, same 6.25 GiB cap, differing only in which encoding the SDT sidecar points at. The tree for these runs also carries the host-memory patches from the companion PR. Those patches affect host memory. The 4.92 GiB min3 peak matches the runs made with the min3 commits alone.

Raw pool at 6.25 GiB:

![raw pool, CUDA OOM at 6.25 GiB](https://raw.githubusercontent.com/7jycwjmbfn-eng/villa/pr-assets/shots_2026-08-22/A2_raw_OOM.png)

min3 pool at 6.25 GiB:

![min3 pool, finishes at 6.25 GiB, peak 4.92 GiB](https://raw.githubusercontent.com/7jycwjmbfn-eng/villa/pr-assets/shots_2026-08-22/A2_min3_OK.png)

- The full budget sweep, raw / min3 before the rewrite / min3 after, 5.0 to 7.5 GiB in 0.25 steps, is in `runs/min3_caps_2026-08-22/RESULT.md`.
- Lossless: 2,031,312 real gathers through the fitter's own dispatch compare `torch.equal` to the uncompressed pool, brick and block boundaries included. `tests/test_min3_pool.py` builds a sidecar inside the test and covers voxel 7 of each 2x2x2 block, whose code owns the sign bit of the int32 word; four deliberate decode mutations each turn it red.

**Why / where this is useful:**

Same machine, a 12 GB card; many more people have 8 GB or 6 GB. The resident pool occupies steady-state memory; gather scratch pushes VRAM to its peak. My first min3 version halved the pool and then gave more than half of that saving back as gather scratch. After the rewrite, its scratch is lower than the uncompressed pool's. This PR and the host-memory PR hit two different hardware walls, so I kept them separate.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Three focused commits:

- **0483f7ebe:** moves the existing min3 pool and packer into the repository so run behaviour is determined by the checkout. The layout stores one minimum and eight 3-bit codes in each aligned 32-bit word. The full surf_sdt group-1 census found a worst block span of 6; the packer rejects spans above 7.
- **7f220e8be:** reduces gather scratch by reusing coordinate tensors, building the shift operand as int32 at shape `(n,)`, and decoding in place on the gathered words. On 4,000,000 indices, scratch fell from 144.4 to 76.1 bytes per index and gather overhead fell from +24% to +4.9% over the raw pool.
- **a2f0737f7:** dispatches the resident-pool class from the sidecar encoding, records portable source metadata, and includes the failing chunk path in decode errors.

**Limits.**

- The 2.000x ratio applies to surf_sdt group 1. Other tested stores exceed this encoding's span limit.
- The budget floor uses PyTorch's allocator cap. CUDA context memory, non-PyTorch allocations and small-card fragmentation remain outside the measurement.
- The sweep ROI has zero tracks after filtering. It validates the phase/SDT path for 40 steps; track-dense behaviour and fit quality remain untested.
- The lossless claim covers the gather layer. Full-fit output equivalence was not evaluated because repeated fits already produce different outputs.
- The min3 tests pass, 9 passed; the full suite's failure set matches clean main.
