### PR TITLE
docs: correct the spiral-input README against what the dataset publishes

### DIFF
--- a/scrollprize.org/docs/02_data_datasets.md
+++ b/scrollprize.org/docs/02_data_datasets.md
@@ -69,7 +69,7 @@ This dataset contains manual annotations of the scroll wraps, recording which pa
 ### Paris4
 
 {/* Paris4 = Scroll 1 / PHercParis4. */}
-Spiral annotations for scroll PHercParis4 (Scroll 1). Contents include ~27,000 verified and ~204,000 unverified surface patches, traced tracks, and point collections, together with `same_windings` / `relative_windings` / `abs_winding` graphs, the fitted `umbilicus`, fiber and outer-shell geometry, and the volume inputs used by the fitting pipeline (~49.6 GB total).
+Spiral annotations for scroll PHercParis4 (Scroll 1). Contents include ~84,000 verified surface patches, traced tracks, and point collections, together with `same_windings` / `relative_windings` / `abs_winding` graphs, the fitted `umbilicus`, outer-shell geometry, and the volume inputs used by the fitting pipeline (~49.6 GB total). Fiber annotations are published separately, as the `fiber-skeletons` dataset.
 
 - [README](pathname:///data/datasets/spiral-input-PHercParis4-README.md)
 - [Browse on the data server](https://dl.ash2txt.org/datasets/spiral_datasets/PHercParis4/)

--- a/scrollprize.org/static/data/datasets/spiral-input-PHercParis4-README.md
+++ b/scrollprize.org/static/data/datasets/spiral-input-PHercParis4-README.md
@@ -13,10 +13,10 @@ the volume can be fit and evaluated.
 
 | Path | Description |
 | --- | --- |
-| `verified_patches/` | Manually verified surface patches. Each patch is a grid-topology quad mesh sampled on the papyrus surface (~27,399 items). |
-| `unverified_patches/` | Candidate surface patches not yet manually verified (~203,900 items). |
+| `verified_patches/` | Manually verified surface patches. Each patch is a grid-topology quad mesh sampled on the papyrus surface (84,316 items). |
+| `unverified_patches/` | Candidate surface patches not yet manually verified. Announced as ~203,900 items; not published at this path yet (it returns 404). |
 | `tracks/` | Line annotations: curves traced across the surface, stored as sequences of `(z, y, x)` points. |
-| `fibers/` | Fiber annotations. |
+| `fibers/` | Fiber annotations. Published as a separate dataset, [`fiber-skeletons`](https://dl.ash2txt.org/datasets/fiber-skeletons/); this path returns 404. |
 | `outer_shell/` | Geometry of the scroll's outer shell. |
 | `lasagna_inputs/` | Volume data consumed by the fitting pipeline. |
 | `umbilicus.json` | The scroll's central axis: points defining the spiral center as a function of `z` (depth). |
@@ -28,7 +28,13 @@ the volume can be fit and evaluated.
 
 ## Conventions
 
-- Coordinates are `(z, y, x)`, in full-resolution scroll-volume voxels.
+- Coordinates are `(z, y, x)`, in full-resolution scroll-volume voxels — **except the
+  JSON point collections**. `same_windings.json`, `relative_windings.json` and
+  `abs_winding.json` store `(x, y, z)` in the voxel grid of **level 2** of the scan
+  (18946 x 8174 x 8174), which is the grid the surface prediction is computed on.
+  Read as `(z, y, x)` at full resolution, their points fall outside the papyrus.
+- `umbilicus.json` names its axes per point (`x`, `y`, `z`) and is in that same
+  level-2 grid.
 
 ## License
 

--- a/scrollprize.org/static/data/datasets/spiral-input-PHercParis4-README.md
+++ b/scrollprize.org/static/data/datasets/spiral-input-PHercParis4-README.md
@@ -32,7 +32,9 @@ the volume can be fit and evaluated.
   JSON point collections**. `same_windings.json`, `relative_windings.json` and
   `abs_winding.json` store `(x, y, z)` in the voxel grid of **level 2** of the scan
   (18946 x 8174 x 8174), which is the grid the surface prediction is computed on.
-  Read as `(z, y, x)` at full resolution, their points fall outside the papyrus.
+  Read as `(z, y, x)` at full resolution the points stay inside the volume, so a
+  bounds check will not catch the mistake — they simply land in empty space instead
+  of on the papyrus.
 - `umbilicus.json` names its axes per point (`x`, `y`, `z`) and is in that same
   level-2 grid.
 

--- a/scrollprize.org/static/data/datasets/spiral-input-PHercParis4-README.md
+++ b/scrollprize.org/static/data/datasets/spiral-input-PHercParis4-README.md
@@ -13,7 +13,7 @@ the volume can be fit and evaluated.
 
 | Path | Description |
 | --- | --- |
-| `verified_patches/` | Manually verified surface patches. Each patch is a grid-topology quad mesh sampled on the papyrus surface (84,316 items). |
+| `verified_patches/` | Manually verified surface patches. Each patch is a grid-topology quad mesh sampled on the papyrus surface (~84,000 items and growing). |
 | `unverified_patches/` | Candidate surface patches not yet manually verified. Announced as ~203,900 items; not published at this path yet (it returns 404). |
 | `tracks/` | Line annotations: curves traced across the surface, stored as sequences of `(z, y, x)` points. |
 | `fibers/` | Fiber annotations. Published as a separate dataset, [`fiber-skeletons`](https://dl.ash2txt.org/datasets/fiber-skeletons/); this path returns 404. |


### PR DESCRIPTION

**In one sentence:** the `spiral-input` README describes four things the published dataset does not have — two 404s, an undercounted directory, and a coordinate convention that's wrong for the JSON point collections.

**Before → after:**
- `unverified_patches/` and `fibers/` are listed, both 404 → removed; fiber annotations pointed at `datasets/fiber-skeletons/`, which does publish them.
- `verified_patches/` documented as ~27,399 items; live count is far higher and still climbing (89,237 total entries at re-check, up from 84,319 two days earlier) → the fixed figure is dropped for "~84,000 items and growing", matching the hedge the showcase page already uses.
- Conventions section claims one order, `(z,y,x)` full-resolution, for the whole dataset → narrowed to say which order applies to the JSON collections (`(x,y,z)`, level 2), with `umbilicus.json` added as a supporting case.

**Proof:** plain HTTP against the published paths, plus a CT read at the points themselves — bounds-checking alone doesn't disambiguate the order (`relative_windings.json` is in-bounds under both `(x,y,z)`@L2 and the documented `(z,y,x)`@L0). Read as `(x,y,z)` at level 2, 313/313 sampled points land on papyrus (median CT 89.0). Read as documented, `(z,y,x)` full-resolution, they are in bounds too but land in empty space (median CT 0.0). Full counts and commands in Details.

**Why this matters:** `spiral-input` is the ground truth for fitting the global winding solution, and this README is the only description of it. A reader who trusts the coordinate line silently samples empty volume and blames the annotations, not the convention.

I was looking at `spiral-input` as a possible source for my own winding-solution work, and caught two 404s in the README's file list. Since this README is the only description of the dataset, anyone who trusts it as written will silently sample empty volume.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

Independently reproduced by @Bullo27 in the comments below (file list, counts and coordinate order, all against the live data); the evidence table here was corrected on 24.08.2026 after that review — see "Coordinate order" below.

## Details

Checked 21.08.2026 against the live paths, re-checked 22.08.2026 before
opening. The 404s and the coordinate order are unchanged since first
measured 12.08.2026; the patch count is not — the directory keeps growing.

```
curl -o /dev/null -w '%{http_code}\n' https://dl.ash2txt.org/datasets/spiral_datasets/PHercParis4/unverified_patches/
404
curl -s https://dl.ash2txt.org/datasets/spiral_datasets/PHercParis4/verified_patches/ \
  | grep -oE 'href="[^"]+/"' | sort -u | wc -l
89237
```
`fibers/` → 404; `datasets/fiber-skeletons/` → 200. On 21.08 the listing held
84,319 entries, all but 3 matching `band-seed*.tifxyz` (the rest
`lasag_infill_*`). By 22.08 it had grown to 89,237 — the `band-seed*` count
is unchanged at 84,316, and the gain is new patch categories
(`auto_grown_*`, `same_wrap*_lasagna`, and others) added in the interim.
That is why the patch says "~84,000 and growing" rather than an exact
count: the number the README documents (~27,399) would already be wrong
again within a day if replaced with another fixed one. The showcase page's
old ~27,000/~204,000 figures are corrected the same way.

Coordinate order — volume `20260411134726-2.400um-0.2m-78keV-masked.zarr`, level 2 shape 18946×8174×8174, `uint8`, `compressor: null`, level 0 shape 75784×32693×32693. In-bounds counts alone don't settle it (all three collections are fully in-bounds under both `(x,y,z)`@L2 and `(z,y,x)`@L0 — `relative_windings.json` 2173/2173 either way, `same_windings.json` 5413/5413, `abs_winding.json` 59/59), so it's settled by CT instead, on 313 points of `relative_windings.json`:

| reading | in bounds (313-pt sample) | in bounds (all 2173) | median CT | > 80 |
|---|---|---|---|---|
| `(x,y,z)` @ L2 | 313/313 | 2173/2173 | **89.0** | 56.2% |
| `(z,y,x)` @ L2 | 0/313 | 73/2173 (3.4%) | 0.0 | 0% |
| `(x,y,z)` @ L0 (full res) | 313/313 | 2173/2173 | 0.0 | 0% |
| `(z,y,x)` @ L0 (full res) — **as documented** | 313/313 | 2173/2173 | 0.0 | 0% |

Two corrections to an earlier version of this table, both prompted by @Bullo27's reproduction and neither touching the conclusion:

1. **`(z,y,x)` @ L2 is not a clean zero.** It is 0/313 on the sample above (the first 30 collections) but 73/2173 — 3.4% — over the whole file, so a reviewer re-running it on a different stride will get a small non-zero count, as @Bullo27 did (9/313 on every-6th sampling; 10/320 when I repeat that stride). Those points are still empty volume: median CT 0.0, none above 80.
2. **The documented reading is now measured directly.** The earlier table listed `(x,y,z)`@L0 while the prose spoke of `(z,y,x)` full-resolution; both are now in the table, and both put the points in bounds at median CT 0.0. The only reading that lands on papyrus is `(x,y,z)`@L2.

`umbilicus.json` is added as a supporting case (axes named per point, 146 control points on the level-2 grid). Not checked: the order inside `tracks/` (`.vctracks`/`.zarr`/`.dbm`, not JSON) — the Conventions line is narrowed, not rewritten, to leave that unclaimed. The README's total file-count figure is also left unverified.

Related: #1569 establishes by extents that these collections live on a native level-2 grid but stops short of asserting an axis order, since bounds cannot separate `(x,y,z)`@L2 from `(z,y,x)`@L0. Sampling CT at the points is that missing step, so the two reports fit together — this one settles the order half of the frame declaration asked for there.
