### PR TITLE
Guard console_scripts against stale module paths; exit non-zero on a failed batch

### DIFF
--- a/vesuvius/src/vesuvius/image_proc/run/edt_frangi_label.py
+++ b/vesuvius/src/vesuvius/image_proc/run/edt_frangi_label.py
@@ -3,6 +3,7 @@ import os
 import glob
 import argparse
 import multiprocessing
+import sys
 
 import numpy as np
 import tifffile
@@ -96,6 +97,10 @@ def main():
         print(f"{len(failures)} files failed:")
         for fail in failures:
             print(f"File: {fail[0]}, Error: {fail[2]}")
+        # Exit non-zero so a caller can tell a failed batch from a clean one:
+        # per-file errors are swallowed by process_file(), so the exit code is
+        # the only signal a script driving this command ever sees.
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/vesuvius/tests/test_console_scripts.py
+++ b/vesuvius/tests/test_console_scripts.py
@@ -1,0 +1,37 @@
+"""Every console_script target must resolve to a module that exists on disk.
+
+Entry points are resolved only when the command is invoked, so a path left
+stale by a file move survives the build, the install and the rest of the test
+suite -- the command simply fails with ModuleNotFoundError for whoever runs
+it. Two entry points were stale for about ten months for exactly this reason
+and were fixed in #1447; this test is the regression guard for that class.
+
+The check reads pyproject.toml and the source tree only. It deliberately
+imports nothing from vesuvius, so it still runs when a package's optional
+dependencies are absent.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_console_scripts_resolve_to_real_modules() -> None:
+    root = Path(__file__).resolve().parents[1]
+    with (root / "pyproject.toml").open("rb") as handle:
+        scripts = tomllib.load(handle)["project"]["scripts"]
+
+    src = root / "src"
+    missing = []
+    for name, target in sorted(scripts.items()):
+        module = target.split(":", 1)[0]
+        relative = Path(*module.split("."))
+        if not (src / relative.with_suffix(".py")).is_file() and not (
+            src / relative / "__init__.py"
+        ).is_file():
+            missing.append(f"{name} -> {module}")
+
+    assert not missing, "console_scripts pointing at missing modules: " + ", ".join(
+        missing
+    )


### PR DESCRIPTION
**In one sentence:** `pytest` now catches a `console_scripts` entry pointing at a module that no longer exists, instead of the command failing for whoever runs it months later.

**Before → after:**
- Entry points resolve only when invoked, so `vesuvius.voxelize_obj` and `vesuvius.refine_labels` pointed at moved modules through build, install and the whole test suite with no red signal — #1447 fixed the paths, but nothing stops the next move from breaking them again → new test resolves every `console_scripts` target against the source tree.
- `vesuvius.refine_labels` on a folder where every file fails exits **0** (`process_file()` swallows per-file errors) → a batch with any failure exits **1**; an empty or clean run still exits 0.

**Proof:**

```
$ pytest tests/test_console_scripts.py                     # on main: passes
1 passed in 0.08s

$ pytest tests/test_console_scripts.py                     # pyproject.toml reverted to pre-#1447
E  AssertionError: console_scripts pointing at missing modules:
E    vesuvius.refine_labels -> vesuvius.image_proc.edt_frangi_label,
E    vesuvius.voxelize_obj  -> vesuvius.image_proc.voxelize_objs
1 failed in 0.40s

$ python edt_frangi_label.py in/ out/ --num_workers 1      # 2 unreadable .tif, before this PR
exit code: 0
$ python edt_frangi_label.py in/ out/ --num_workers 1      # same input, this PR
exit code: 1
$ python edt_frangi_label.py empty/ out/ --num_workers 1   # this PR, nothing to do
exit code: 0
```

**Why this matters:** a driving script can't currently tell a wholly failed batch from a clean one. The paths broke silently for ~10 months without a test catching it; the regression guard is the part that outlives this PR.

This is the tail end of my earlier #1388. #1447 landed a fix for the module paths before my own PR did, but it didn't add a regression test or touch the exit code, so this PR narrows down to exactly what's left rather than reopening the whole thing.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Tested against `97621bc`. Python 3.14.7, pytest 9.1.1. Thanks to @axiosdevs for landing the paths in #1447 — this only adds what was left over.

- Test resolves each `pyproject.toml` target to a `.py`/`__init__.py` under `src/` without importing it, so it stays green without optional deps installed (~0.1s). Standalone file, not added to `tests/test_imports.py`, because that module imports `vesuvius` at collection time and wouldn't collect without the package installed.
- `sys.exit(1)` fires on *any* failed file, not only a wholly failed batch — say if you'd rather have partial failures stay at 0 or gate it behind a flag. Empty input still exits 0, unchanged.
- The `edt_frangi_label` runs above used stubbed `vesuvius.image_proc` imports (the changed branch of `main()` doesn't touch them); the test run itself is unstubbed.
