### PR TITLE
VC3D: allow catalog fiber atlases with local shells

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -222,6 +222,22 @@ resolvedLasagnaForState(const CState* state)
         *state->vpkg(), state->currentVolumeId());
 }
 
+bool stateLasagnaHasPredDt(const CState* state)
+{
+    try {
+        const auto resolved = resolvedLasagnaForState(state);
+        if (!resolved || resolved->manifestPath.empty() ||
+            !std::filesystem::exists(resolved->manifestPath)) {
+            return false;
+        }
+        const auto manifest = vc::lasagna::LasagnaDatasetManifest::parseFile(
+            resolved->manifestPath);
+        return manifest.groupForChannel("pred_dt") != nullptr;
+    } catch (...) {
+        return false;
+    }
+}
+
 enum class SurfaceOverlayItemKind {
     Folder,
     Surface,
@@ -2065,7 +2081,8 @@ QDockWidget* createAtlasOverviewDock(QWidget* parent)
     auto* rankSnap = new QPushButton(QObject::tr("Rank via Fit-Service"), content);
     rankSnap->setObjectName(QStringLiteral("atlasRankSnapButton"));
     rankSnap->setToolTip(QObject::tr(
-        "Run atlas pred-snap ranking through the Lasagna fit-service job queue."));
+        "Run atlas pred-snap ranking through the Lasagna fit-service job queue. "
+        "Requires a selected Lasagna dataset with a pred_dt channel."));
     rankSnap->setEnabled(false);
     actions->addWidget(rankSnap);
 
@@ -2100,6 +2117,8 @@ QDockWidget* createAtlasFiberDock(QWidget* parent)
 
     auto* optimize = new QPushButton(QObject::tr("Optimize snap cands"), content);
     optimize->setObjectName(QStringLiteral("atlasOptimizeSnapCandidatesButton"));
+    optimize->setToolTip(QObject::tr(
+        "Requires a selected Lasagna dataset with a pred_dt channel."));
     optimize->setEnabled(false);
     layout->addWidget(optimize);
 
@@ -4925,19 +4944,9 @@ void CWindow::updateAtlasFiberDocks()
     auto* optimize = _atlasWorkspaceFiberDock->widget()->findChild<QPushButton*>(
         QStringLiteral("atlasOptimizeSnapCandidatesButton"));
     auto updateOptimizeEnabled = [&]() {
-        bool hasManifest = false;
-        if (_state && _state->vpkg()) {
-            try {
-                const auto resolved = resolvedLasagnaForState(_state);
-                hasManifest = resolved && !resolved->manifestPath.empty() &&
-                              std::filesystem::exists(resolved->manifestPath);
-            } catch (...) {
-                hasManifest = false;
-            }
-        }
         if (optimize) {
             optimize->setEnabled(_currentAtlasDir.has_value() &&
-                                 hasManifest &&
+                                 stateLasagnaHasPredDt(_state) &&
                                  LasagnaServiceManager::instance().isRunning());
         }
     };
@@ -5099,6 +5108,7 @@ void CWindow::updateAtlasSearchDocks()
     }
     const bool hasSnapshots = !snapshots.empty();
     const bool atlasUsable = _currentAtlasDir.has_value() && atlasLoadError.isEmpty();
+    const bool predSnapAvailable = stateLasagnaHasPredDt(_state);
     const QString atlasName = _currentAtlasDir
         ? QString::fromStdString(_currentAtlasName.empty()
               ? _currentAtlasDir->filename().string()
@@ -5144,7 +5154,7 @@ void CWindow::updateAtlasSearchDocks()
             continue;
         }
         if (auto* rankSnap = dock->widget()->findChild<QPushButton*>(QStringLiteral("atlasRankSnapButton"))) {
-            rankSnap->setEnabled(atlasUsable);
+            rankSnap->setEnabled(atlasUsable && predSnapAvailable);
         }
         if (auto* remap = dock->widget()->findChild<QPushButton*>(QStringLiteral("atlasRemapButton"))) {
             remap->setEnabled(atlasUsable);
@@ -5312,6 +5322,14 @@ bool CWindow::optimizeAtlasSnapCandidatesHeadless(QString* errorMessage,
     }
     const std::filesystem::path manifestPath = resolvedLasagna->manifestPath;
     const double workingToBaseScale = resolvedLasagna->workingToBaseScale;
+    try {
+        const auto manifest = vc::lasagna::LasagnaDatasetManifest::parseFile(manifestPath);
+        if (manifest.groupForChannel("pred_dt") == nullptr) {
+            return fail(tr("The selected Lasagna dataset has no pred_dt channel."));
+        }
+    } catch (const std::exception& ex) {
+        return fail(QString::fromStdString(ex.what()));
+    }
 
     auto& manager = LasagnaServiceManager::instance();
     if (manager.isExternal()) {
@@ -6716,8 +6734,7 @@ void CWindow::loadAndDisplayAtlas(const std::filesystem::path& atlasDir)
     }
     const auto resolvedLasagna = resolvedLasagnaForState(_state);
     if (!resolvedLasagna || resolvedLasagna->manifestPath.empty()) {
-        throw std::runtime_error(
-            "No Lasagna dataset matches the active volume; atlas pred-snap attachments are required");
+        throw std::runtime_error("No Lasagna dataset matches the active volume");
     }
     const std::filesystem::path manifestPath = resolvedLasagna->manifestPath;
     if (!std::filesystem::exists(manifestPath)) {
@@ -6733,8 +6750,10 @@ void CWindow::loadAndDisplayAtlas(const std::filesystem::path& atlasDir)
             vc::lasagna::LasagnaDatasetOpenOptions{
                 resolvedLasagna->workingToBaseScale});
     vc::lasagna::LasagnaNormalSampler sampler(dataset);
-    (void)vc::atlas::ensureAtlasPredSnapAttachments(atlasDir, volpkgRoot, sampler);
-    atlas = vc::atlas::Atlas::load(atlasDir, volpkgRoot);
+    if (sampler.hasPredDtChannel()) {
+        (void)vc::atlas::ensureAtlasPredSnapAttachments(atlasDir, volpkgRoot, sampler);
+        atlas = vc::atlas::Atlas::load(atlasDir, volpkgRoot);
+    }
     _currentAtlasDir = atlasDir;
     _currentAtlasName = atlas.metadata.name;
     if (_lineAnnotationController) {
@@ -6869,10 +6888,6 @@ void CWindow::displayAtlasFromDirectory(const std::filesystem::path& atlasDir)
                         vc::lasagna::LasagnaDatasetOpenOptions{
                             resolvedLasagna->workingToBaseScale});
                 vc::lasagna::LasagnaNormalSampler sampler(dataset);
-                if (!sampler.hasPredDtChannel()) {
-                    throw std::runtime_error(
-                        "Selected Lasagna dataset has no pred_dt channel; atlas pred-snap attachments are required");
-                }
                 vc::atlas::rebuildAtlasFromSourceFibers(atlasDir, volpkgRoot, sampler);
                 displayAtlasFromDirectory(atlasDir);
             } catch (const std::exception& rebuildEx) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -3574,14 +3574,16 @@ void LineAnnotationController::createAtlasFromFiber(uint64_t fiberId)
     }
 }
 
-bool LineAnnotationController::createAtlasFromFiberHeadless(uint64_t fiberId,
-                                                            QString* errorMessage,
-                                                            fs::path* atlasDirOut)
+bool LineAnnotationController::createAtlasFromFiberHeadless(
+    uint64_t fiberId,
+    QString* errorMessage,
+    fs::path* atlasDirOut,
+    const std::optional<fs::path>& initShellDirOverride)
 {
     // Do not emit atlasCreated: it is connected to the interactive display
     // path. Direct callers display the returned directory themselves.
     try {
-        const fs::path atlasDir = createAtlasFromFiberCore(fiberId);
+        const fs::path atlasDir = createAtlasFromFiberCore(fiberId, initShellDirOverride);
         if (atlasDirOut) {
             *atlasDirOut = atlasDir;
         }
@@ -3594,7 +3596,9 @@ bool LineAnnotationController::createAtlasFromFiberHeadless(uint64_t fiberId,
     }
 }
 
-fs::path LineAnnotationController::createAtlasFromFiberCore(uint64_t fiberId)
+fs::path LineAnnotationController::createAtlasFromFiberCore(
+    uint64_t fiberId,
+    const std::optional<fs::path>& initShellDirOverride)
 {
     auto vpkg = _state ? _state->vpkg() : nullptr;
     if (!vpkg) {
@@ -3627,8 +3631,8 @@ fs::path LineAnnotationController::createAtlasFromFiberCore(uint64_t fiberId)
     vc::lasagna::LasagnaDataset dataset = vc::lasagna::LasagnaDataset::open(
         manifestPath, {resolvedLasagna->second});
     vc::lasagna::LasagnaNormalSampler sampler(dataset);
-    const fs::path initShellDir =
-        vc::atlas::initShellDirectoryFromManifest(dataset.manifest());
+    const fs::path initShellDir = vc::atlas::resolveInitShellDirectory(
+        dataset.manifest(), initShellDirOverride);
     atlasDebug("selected_manifest=" + manifestPath.string());
     atlasDebug("resolved_init_shell_dir=" + initShellDir.string());
 

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -244,8 +244,11 @@ public:
                               int* importedCount = nullptr, int* skippedCount = nullptr);
     // Creates an atlas without dialogs. It does not emit atlasCreated because
     // that signal is connected to the interactive display path.
-    bool createAtlasFromFiberHeadless(uint64_t fiberId, QString* errorMessage = nullptr,
-                                      std::filesystem::path* atlasDirOut = nullptr);
+    bool createAtlasFromFiberHeadless(
+        uint64_t fiberId,
+        QString* errorMessage = nullptr,
+        std::filesystem::path* atlasDirOut = nullptr,
+        const std::optional<std::filesystem::path>& initShellDirOverride = std::nullopt);
     // Most recently opened live line-annotation workspace, or nullptr.
     [[nodiscard]] LineAnnotationDialog* mostRecentLineAnnotationDialog() const;
     // Short-lived presentation guard for direct operations. Sessions created
@@ -785,7 +788,9 @@ private:
     // Shared core of createAtlasFromFiber / createAtlasFromFiberHeadless.
     // Returns the created atlas directory; throws std::exception on failure.
     // Does not emit atlasCreated (callers decide).
-    std::filesystem::path createAtlasFromFiberCore(uint64_t fiberId);
+    std::filesystem::path createAtlasFromFiberCore(
+        uint64_t fiberId,
+        const std::optional<std::filesystem::path>& initShellDirOverride = std::nullopt);
     // Shared per-pane finalize+save loop of saveOpenFibers /
     // saveOpenFibersHeadless (no waiting).
     void saveOpenFibersCore();

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_fiber.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_fiber.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <filesystem>
 #include <limits>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_set>
@@ -463,12 +464,38 @@ QJsonObject AgentBridgeServer::handleFiberCreateAtlas(const QJsonValue& params)
     const uint64_t fiberId = jsonToFiberId(p.value("fiberId"), "fiberId");
     requireKnownFiber(ctrl, fiberId);
 
+    std::optional<std::filesystem::path> initShellDir;
+    if (p.contains("initShellDir")) {
+        const QString value = p.value("initShellDir").toString();
+        if (value.isEmpty()) {
+            QJsonObject data;
+            data["param"] = "initShellDir";
+            throw AgentBridgeError{-32602, "initShellDir must be a non-empty string", data};
+        }
+        initShellDir = std::filesystem::path(value.toStdString());
+        if (initShellDir->is_relative()) {
+            QJsonObject data;
+            data["param"] = "initShellDir";
+            throw AgentBridgeError{-32602, "initShellDir must be an absolute path", data};
+        }
+        std::error_code ec;
+        if (!std::filesystem::is_directory(*initShellDir, ec)) {
+            QJsonObject data;
+            data["kind"] = "path";
+            data["path"] = value;
+            throw AgentBridgeError{
+                -32007,
+                "Init shell directory does not exist or is not a directory",
+                data};
+        }
+    }
+
     // createAtlasFromFiber is synchronous, but its error and rebuild dialogs are
     // unsafe for remote calls. Run the dialog-free split and display the result
     // through displayAtlasFromDirectoryHeadless.
     QString err;
     std::filesystem::path atlasDir;
-    if (!ctrl->createAtlasFromFiberHeadless(fiberId, &err, &atlasDir)) {
+    if (!ctrl->createAtlasFromFiberHeadless(fiberId, &err, &atlasDir, initShellDir)) {
         QJsonObject data;
         data["detail"] = err;
         throw AgentBridgeError{-32005, "Atlas creation failed", data};

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_fiber.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_fiber.cpp
@@ -139,6 +139,7 @@ void AgentBridgeServer::registerFiberHandlers()
             .name = QStringLiteral("fiber.create_atlas"),
             .params = {
                 fiberId(QStringLiteral("fiberId")),
+                Params::optionalString(QStringLiteral("initShellDir")),
             },
             .errors = {-32602, -32000, -32010, -32007, -32005},
             .mcp = Mcp::snakeCase(QStringLiteral("vc3d_fiber_create_atlas")),

--- a/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
+++ b/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
@@ -439,7 +439,7 @@ is the sole bridge method without an MCP tool.
 | `vc3d_drag` | `canvas.drag` |
 | `vc3d_enable_editing` | `segmentation.enable_editing` | Turn segmentation editing mode on/off for the active segment. |
 | `vc3d_fetch_segment` | `segments.fetch` | Download ("materialize") an open-data placeholder segment so it can be activated/edited. Sync if already materialized; else a `"catalog"` job (`wait` defaults true). |
-| `vc3d_fiber_create_atlas` | `fiber.create_atlas` |
+| `vc3d_fiber_create_atlas` | `fiber.create_atlas` | Accepts an optional absolute `init_shell_dir` override containing wrapped `shell_*.tifxyz` surfaces; atlases can display without `pred_dt`, while pred-snap operations still require it. |
 | `vc3d_fiber_delete` | `fiber.delete` |
 | `vc3d_fiber_export` | `fiber.export` |
 | `vc3d_fiber_import` | `fiber.import` |

--- a/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
+++ b/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
@@ -606,7 +606,8 @@
       ],
       "mcp": {
         "paramRenames": {
-          "fiberId": "fiber_id"
+          "fiberId": "fiber_id",
+          "initShellDir": "init_shell_dir"
         },
         "tool": "vc3d_fiber_create_atlas"
       },
@@ -617,6 +618,9 @@
               "string",
               "integer"
             ]
+          },
+          "initShellDir": {
+            "type": "string"
           }
         },
         "required": [

--- a/volume-cartographer/core/include/vc/atlas/Atlas.hpp
+++ b/volume-cartographer/core/include/vc/atlas/Atlas.hpp
@@ -340,6 +340,9 @@ std::filesystem::path uniqueAtlasDirectory(const std::filesystem::path& volpkgRo
                                            const std::string& baseName);
 std::filesystem::path initShellDirectoryFromManifest(
     const vc::lasagna::LasagnaDatasetManifest& manifest);
+std::filesystem::path resolveInitShellDirectory(
+    const vc::lasagna::LasagnaDatasetManifest& manifest,
+    const std::optional<std::filesystem::path>& overrideDir = std::nullopt);
 std::vector<SurfaceCandidate> loadInitShellCandidates(
     const std::filesystem::path& initShellDir);
 

--- a/volume-cartographer/core/src/Atlas.cpp
+++ b/volume-cartographer/core/src/Atlas.cpp
@@ -3801,6 +3801,20 @@ fs::path initShellDirectoryFromManifest(const vc::lasagna::LasagnaDatasetManifes
     return *manifest.initShellDir;
 }
 
+fs::path resolveInitShellDirectory(
+    const vc::lasagna::LasagnaDatasetManifest& manifest,
+    const std::optional<fs::path>& overrideDir)
+{
+    if (!overrideDir.has_value()) {
+        return initShellDirectoryFromManifest(manifest);
+    }
+    if (!fs::is_directory(*overrideDir)) {
+        throw std::runtime_error("Atlas init shell override does not exist or is not a directory: " +
+                                 overrideDir->string());
+    }
+    return *overrideDir;
+}
+
 std::vector<SurfaceCandidate> loadInitShellCandidates(const fs::path& initShellDir)
 {
     if (!fs::is_directory(initShellDir)) {

--- a/volume-cartographer/core/test/test_atlas.cpp
+++ b/volume-cartographer/core/test/test_atlas.cpp
@@ -2873,6 +2873,26 @@ TEST_CASE("Atlas manifest init_shell_dir resolves relative to lasagna manifest")
     CHECK(*manifest.initShellDir == fs::absolute(root / "init_shells").lexically_normal());
 }
 
+TEST_CASE("Atlas init shell override takes precedence over the manifest")
+{
+    const fs::path root = tempRoot("vc_atlas_init_shell_override");
+    const fs::path manifestDir = root / "manifest_shells";
+    const fs::path overrideDir = root / "local_shells";
+    fs::create_directories(manifestDir);
+    fs::create_directories(overrideDir);
+    const auto manifest = vc::lasagna::LasagnaDatasetManifest::parseText(
+        R"({"version":1,"init_shell_dir":"manifest_shells"})",
+        root / "dataset.lasagna.json");
+
+    CHECK(vc::atlas::resolveInitShellDirectory(manifest) ==
+          fs::absolute(manifestDir).lexically_normal());
+    CHECK(vc::atlas::resolveInitShellDirectory(manifest, overrideDir) == overrideDir);
+    CHECK_THROWS_WITH_AS(
+        vc::atlas::resolveInitShellDirectory(manifest, root / "missing_shells"),
+        doctest::Contains("Atlas init shell override does not exist or is not a directory"),
+        std::runtime_error);
+}
+
 TEST_CASE("Atlas init shell loading accepts only shell tifxyz directories")
 {
     const fs::path root = tempRoot("vc_atlas_init_shell_candidates");

--- a/volume-cartographer/tools/vc3d-mcp/tests/tools/test_fiber.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/tools/test_fiber.py
@@ -1,0 +1,32 @@
+"""Focused tests for the fiber MCP wrappers."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from vc3d_mcp.tools import fiber
+
+
+class FiberToolsTest(unittest.IsolatedAsyncioTestCase):
+    async def test_create_atlas_passes_init_shell_override(self) -> None:
+        call = mock.AsyncMock(return_value={"atlasDir": "/tmp/atlas", "displayed": True})
+        with mock.patch.object(fiber, "_call", call):
+            result = await fiber.vc3d_fiber_create_atlas("17", "/tmp/init_shells")
+
+        self.assertTrue(result["displayed"])
+        call.assert_awaited_once_with(
+            "fiber.create_atlas",
+            {"fiberId": "17", "initShellDir": "/tmp/init_shells"},
+        )
+
+    async def test_create_atlas_omits_unspecified_override(self) -> None:
+        call = mock.AsyncMock(return_value={"atlasDir": "/tmp/atlas", "displayed": True})
+        with mock.patch.object(fiber, "_call", call):
+            await fiber.vc3d_fiber_create_atlas("17")
+
+        call.assert_awaited_once_with("fiber.create_atlas", {"fiberId": "17"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/fiber.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/fiber.py
@@ -140,18 +140,28 @@ async def vc3d_fiber_set_tag(fiber_id: str, tag: str, enabled: bool) -> dict[str
 
 
 @mcp.tool()
-async def vc3d_fiber_create_atlas(fiber_id: str) -> dict[str, Any]:
+async def vc3d_fiber_create_atlas(
+    fiber_id: str,
+    init_shell_dir: Optional[str] = None,
+) -> dict[str, Any]:
     """Create a single-fiber atlas from a saved fiber and display it
     (dialog-free). SYNCHRONOUS and potentially slow (heavy geometry work on
     the app thread) -- allow a generous client timeout. Requires a
     manifest-backed Lasagna dataset resolvable for the currently selected
     volume (a "lasagna"-kind representation, NOT a "normal_grids" store or the
-    vc3d_lasagna_* fit service), AND that dataset's manifest must provide
-    init_shell_dir -- a dataset can resolve for tracing yet still fail atlas
-    creation if that atlas-only field is absent. Returns {"atlasDir",
-    "displayed"} (plus displayDetail when display failed but creation
-    succeeded)."""
-    return await _call("fiber.create_atlas", {"fiberId": fiber_id})
+    vc3d_lasagna_* fit service). init_shell_dir optionally supplies an absolute
+    path on the VC3D host to a directory containing explicitly wrapped
+    shell_*.tifxyz surfaces and overrides the manifest's init_shell_dir; this
+    is required for published catalog manifests that omit the local producer
+    path. The fiber seed must intersect real material on one of those shells.
+    Display does not require pred_dt, but pred-snap features remain unavailable
+    when that channel is absent. Returns
+    {"atlasDir", "displayed"} (plus displayDetail when display failed but
+    creation succeeded)."""
+    return await _call(
+        "fiber.create_atlas",
+        _strip_none({"fiberId": fiber_id, "initShellDir": init_shell_dir}),
+    )
 
 
 @mcp.tool()


### PR DESCRIPTION
**In one sentence:** Catalog-streamed Lasagna datasets can now create, display, and remap fiber atlases using a local shell without editing the published manifest.

**One real example:** On the unchanged public PHerc0332 catalog manifest, the issue reporter passed a local wrapped shell to `fiber.create_atlas`; it returned a complete displayed atlas, then `atlas.open` and `atlas.remap` both succeeded without `pred_dt`.

**Before:** Atlas creation stopped with `Lasagna manifest is missing init_shell_dir`. Hand-injecting that field reached creation, but display then stopped because the published dataset has no `pred_dt`.

**After this PR:** An absolute `initShellDir` can be supplied without changing the manifest. Display and remap work without `pred_dt`; snap ranking remains unavailable and rejects immediately with a clear error.

**Proof:** Independent PHerc0332 replay, including the unchanged-manifest check, negative control, complete artifact, display/remap, snap guard, and 151/151 tests: https://github.com/ScrollPrize/villa/pull/1577#issuecomment-5385808699

All code-relevant GitHub checks pass on Linux, Windows, and macOS: https://github.com/ScrollPrize/villa/actions/runs/32636827471

**Why / where this is useful:** This unblocks the catalog workflow after fitting a fiber: users can create and inspect its atlas directly against streamed scroll data.

## Details

Fixes #1530. Tested commit: `ec5cf5f3b63a77ba2ffe6e2d3ff49bcaafef2539`.

The existing manifest fallback is unchanged. An explicit shell override must be absolute and exist. Pred-snap attachments are optional only for display/remap; ranking still requires `pred_dt` and its GUI controls stay disabled when that channel is absent.

The real-scroll replay above was run independently by @Bullo27 against this exact commit.
