### PR TITLE
Add quantitative pair reports to vc_seg_add_overlap

### DIFF
--- a/volume-cartographer/apps/src/vc_seg_add_overlap.cpp
+++ b/volume-cartographer/apps/src/vc_seg_add_overlap.cpp
@@ -1,6 +1,8 @@
 #include "vc/core/util/QuadSurface.hpp"
 #include "vc/core/util/SurfacePatchIndex.hpp"
 
+#include "vc_seg_add_overlap_metrics.hpp"
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -8,6 +10,7 @@
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -32,6 +35,7 @@ constexpr float kOverlapTolerance = 2.0f;
 struct TargetInfo {
     std::string key;
     std::string id;
+    std::string relativePath;
     fs::path path;
 };
 
@@ -39,7 +43,10 @@ struct SourceScanResult {
     fs::path sourcePath;
     std::string sourceKey;
     std::string sourceId;
+    std::string sourceRelativePath;
     std::vector<std::pair<std::string, std::string>> hits;
+    std::map<std::string, size_t> matchedPointsByTarget;
+    size_t validPoints = 0;
     size_t queriedPoints = 0;
 };
 
@@ -48,6 +55,7 @@ struct Config {
     fs::path sourceRoot;
     size_t requestedWorkers = 0;
     size_t pointStride = 1;
+    fs::path reportPath;
     bool help = false;
 };
 
@@ -62,6 +70,60 @@ std::string canonical_key(const fs::path& path)
         p = path;
     }
     return p.lexically_normal().generic_string();
+}
+
+std::string relative_report_path(const fs::path& path, const fs::path& root)
+{
+    std::error_code ec;
+    fs::path relative = fs::relative(path, root, ec);
+    if (ec) {
+        return path.filename().generic_string();
+    }
+    const std::string value = relative.lexically_normal().generic_string();
+    return value.empty() ? "." : value;
+}
+
+void validate_report_path(const fs::path& reportPath,
+                          const std::vector<fs::path>& targetDirs,
+                          const std::vector<fs::path>& sourceDirs)
+{
+    if (reportPath.empty()) {
+        return;
+    }
+
+    fs::path parent = reportPath.parent_path();
+    if (parent.empty()) {
+        parent = fs::current_path();
+    }
+    std::error_code ec;
+    if (!fs::is_directory(parent, ec) || ec) {
+        throw std::runtime_error(
+            "Report parent is not a directory: " + parent.string());
+    }
+
+    const std::string reportKey = canonical_key(reportPath);
+    auto rejectAlias = [&](const fs::path& dir) {
+        for (const char* name : {
+                 "meta.json", "x.tif", "y.tif", "z.tif", "overlapping.json"}) {
+            const fs::path dataPath = dir / name;
+            std::error_code equivalentEc;
+            const bool equivalent = fs::exists(reportPath, equivalentEc) &&
+                !equivalentEc &&
+                fs::equivalent(reportPath, dataPath, equivalentEc) &&
+                !equivalentEc;
+            if (canonical_key(dataPath) == reportKey || equivalent) {
+                throw std::runtime_error(
+                    "Report path would overwrite surface data: " +
+                    reportPath.string());
+            }
+        }
+    };
+    for (const fs::path& dir : targetDirs) {
+        rejectAlias(dir);
+    }
+    for (const fs::path& dir : sourceDirs) {
+        rejectAlias(dir);
+    }
 }
 
 bool is_tifxyz_dir(const fs::path& dir)
@@ -109,7 +171,19 @@ std::vector<fs::path> discover_tifxyz_dirs(const fs::path& root)
         }
     }
     std::sort(dirs.begin(), dirs.end());
-    return dirs;
+
+    // A collection can contain directory symlinks to the same segment. Loading
+    // both would count one target twice in the report (and could make coverage
+    // exceed 1), so retain the first deterministic path for each real segment.
+    std::unordered_set<std::string> seen;
+    std::vector<fs::path> uniqueDirs;
+    uniqueDirs.reserve(dirs.size());
+    for (const fs::path& dir : dirs) {
+        if (seen.insert(canonical_key(dir)).second) {
+            uniqueDirs.push_back(dir);
+        }
+    }
+    return uniqueDirs;
 }
 
 std::vector<SurfacePatchIndex::SurfacePtr>
@@ -136,11 +210,15 @@ void print_usage(const char* argv0)
               << "options:\n"
               << "   --workers N        source-scan workers; default is min(source count, hardware concurrency)\n"
               << "   --point-stride N   check one out of every N valid source points; default is 1\n"
+              << "   --report-json PATH write a deterministic directed-pair proximity report\n"
               << "   --help             show this help\n";
 }
 
 size_t parse_positive_size(const std::string& name, const std::string& value)
 {
+    if (value.empty() || value.find_first_not_of("0123456789") != std::string::npos) {
+        throw std::runtime_error("Invalid " + name + " value: " + value);
+    }
     try {
         size_t parsedChars = 0;
         const unsigned long long parsed = std::stoull(value, &parsedChars);
@@ -181,6 +259,8 @@ Config parse_args(int argc, char* argv[])
             cfg.requestedWorkers = parse_positive_size("workers", require_value(i, arg));
         } else if (arg == "--point-stride") {
             cfg.pointStride = parse_positive_size("point-stride", require_value(i, arg));
+        } else if (arg == "--report-json") {
+            cfg.reportPath = require_value(i, arg);
         } else if (!arg.empty() && arg[0] == '-') {
             throw std::runtime_error("Unknown argument: " + arg);
         } else {
@@ -297,6 +377,7 @@ int main(int argc, char *argv[])
             std::cerr << "No tifxyz segments found in source: " << cfg.sourceRoot << std::endl;
             return EXIT_FAILURE;
         }
+        validate_report_path(cfg.reportPath, targetDirs, sourceDirs);
 
         std::cout << "Target tifxyz segments: " << targetDirs.size() << std::endl;
         std::cout << "Source tifxyz segments: " << sourceDirs.size() << std::endl;
@@ -310,7 +391,14 @@ int main(int argc, char *argv[])
         for (const auto& surface : targetSurfaces) {
             const std::string key = canonical_key(surface->path);
             targetByPath.emplace(key, surface);
-            targetInfoBySurface.emplace(surface.get(), TargetInfo{key, surface->id, surface->path});
+            targetInfoBySurface.emplace(
+                surface.get(),
+                TargetInfo{
+                    key,
+                    surface->id,
+                    relative_report_path(surface->path, cfg.targetRoot),
+                    surface->path,
+                });
         }
 
         std::unordered_map<std::string, fs::path> sourcePathByKey;
@@ -326,6 +414,11 @@ int main(int argc, char *argv[])
         index.rebuild(targetSurfaces);
         const double buildSeconds = std::chrono::duration<double>(
             std::chrono::steady_clock::now() - buildStart).count();
+        if (!cfg.reportPath.empty() &&
+            index.surfaceCount() != targetSurfaces.size()) {
+            throw std::runtime_error(
+                "Cannot report coverage: one or more target surfaces could not be indexed");
+        }
         std::cout << "SurfacePatchIndex built: surfaces=" << index.surfaceCount()
                   << " patches=" << index.patchCount()
                   << " seconds=" << buildSeconds << std::endl;
@@ -376,6 +469,8 @@ int main(int argc, char *argv[])
                         result.sourcePath = source.path;
                         result.sourceKey = canonical_key(source.path);
                         result.sourceId = source.id;
+                        result.sourceRelativePath =
+                            relative_report_path(source.path, cfg.sourceRoot);
 
                         std::unordered_set<SurfacePatchIndex::SurfacePtr> excludedTargetSurfaces;
                         excludedTargetSurfaces.reserve(32);
@@ -383,6 +478,8 @@ int main(int argc, char *argv[])
                             selfIt != targetByPath.end()) {
                             excludedTargetSurfaces.insert(selfIt->second);
                         }
+                        std::unordered_set<std::string> seenTargetKeys;
+                        seenTargetKeys.reserve(32);
                         size_t progressPointBatch = 0;
                         size_t validPointIndex = 0;
                         for (const auto& pointRef : source.validPoints()) {
@@ -416,17 +513,23 @@ int main(int argc, char *argv[])
                                 if (target.key == result.sourceKey) {
                                     continue;
                                 }
-                                if (!excludedTargetSurfaces.insert(hitSurface).second) {
-                                    continue;
-                                }
 
-                                result.hits.emplace_back(target.key, target.id);
-                                discoveredPairs.fetch_add(1, std::memory_order_relaxed);
+                                if (!cfg.reportPath.empty()) {
+                                    ++result.matchedPointsByTarget[target.key];
+                                }
+                                if (seenTargetKeys.insert(target.key).second) {
+                                    result.hits.emplace_back(target.key, target.id);
+                                    discoveredPairs.fetch_add(1, std::memory_order_relaxed);
+                                    if (cfg.reportPath.empty()) {
+                                        excludedTargetSurfaces.insert(hitSurface);
+                                    }
+                                }
                             }
                         }
                         if (progressPointBatch > 0) {
                             queriedPoints.fetch_add(progressPointBatch, std::memory_order_relaxed);
                         }
+                        result.validPoints = validPointIndex;
 
                         scanResults[sourceIndex] = std::move(result);
                     } catch (const std::exception& e) {
@@ -506,6 +609,61 @@ int main(int argc, char *argv[])
                           << sourceIt->second.filename().string()
                           << " (" << overlaps.size() << " overlaps)" << std::endl;
             }
+        }
+
+        if (!cfg.reportPath.empty()) {
+            std::vector<vc_seg_overlap::SurfaceInfo> reportTargets;
+            reportTargets.reserve(targetSurfaces.size());
+            for (const auto& target : targetSurfaces) {
+                const auto infoIt = targetInfoBySurface.find(target.get());
+                if (infoIt == targetInfoBySurface.end()) {
+                    continue;
+                }
+                reportTargets.push_back({
+                    infoIt->second.key,
+                    infoIt->second.id,
+                    infoIt->second.relativePath,
+                });
+            }
+
+            std::vector<vc_seg_overlap::SourceMatches> reportSources;
+            reportSources.reserve(scanResults.size());
+            for (const SourceScanResult& result : scanResults) {
+                if (result.sourceKey.empty()) {
+                    continue;
+                }
+                reportSources.push_back({
+                    {
+                        result.sourceKey,
+                        result.sourceId,
+                        result.sourceRelativePath,
+                    },
+                    result.validPoints,
+                    result.queriedPoints,
+                    result.matchedPointsByTarget,
+                });
+            }
+
+            const Json report = vc_seg_overlap::buildReport(
+                std::move(reportSources), std::move(reportTargets),
+                cfg.pointStride, kOverlapTolerance);
+            std::ofstream out(cfg.reportPath);
+            if (!out) {
+                throw std::runtime_error(
+                    "Failed to create report: " + cfg.reportPath.string());
+            }
+            out << report.dump(2) << '\n';
+            out.flush();
+            if (!out) {
+                throw std::runtime_error(
+                    "Failed to write report: " + cfg.reportPath.string());
+            }
+            out.close();
+            if (out.fail()) {
+                throw std::runtime_error(
+                    "Failed to finish report: " + cfg.reportPath.string());
+            }
+            std::cout << "Pair report written to " << cfg.reportPath << std::endl;
         }
 
         std::cout << "Queried source points: " << queriedPoints.load() << std::endl;

--- a/volume-cartographer/apps/src/vc_seg_add_overlap_metrics.hpp
+++ b/volume-cartographer/apps/src/vc_seg_add_overlap_metrics.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "utils/Json.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace vc_seg_overlap {
+
+struct SurfaceInfo {
+    std::string key;
+    std::string id;
+    std::string relativePath;
+};
+
+struct SourceMatches {
+    SurfaceInfo source;
+    std::size_t validPoints = 0;
+    std::size_t sampledPoints = 0;
+    std::map<std::string, std::size_t> matchedPointsByTarget;
+};
+
+inline utils::Json buildReport(std::vector<SourceMatches> sources,
+                               std::vector<SurfaceInfo> targets,
+                               std::size_t pointStride,
+                               float tolerance)
+{
+    auto byPath = [](const auto& a, const auto& b) {
+        return std::tie(a.relativePath, a.key) <
+               std::tie(b.relativePath, b.key);
+    };
+    std::sort(targets.begin(), targets.end(), byPath);
+    std::sort(sources.begin(), sources.end(), [](const SourceMatches& a,
+                                                 const SourceMatches& b) {
+        return std::tie(a.source.relativePath, a.source.key) <
+               std::tie(b.source.relativePath, b.source.key);
+    });
+
+    utils::Json report = utils::Json::object();
+    report["tool"] = "vc_seg_add_overlap";
+    report["schema_version"] = 1;
+    utils::Json metric = utils::Json::object();
+    metric["name"] = "directed_source_point_surface_coverage";
+    metric["definition"] = "matched_source_points / queried_source_points";
+    metric["distance"] = "euclidean point-to-target-triangle";
+    metric["comparison"] = "<=";
+    metric["coordinate_units"] = "tifxyz coordinate units; usually voxels";
+    report["metric"] = std::move(metric);
+    utils::Json parameters = utils::Json::object();
+    parameters["tolerance"] = tolerance;
+    parameters["point_stride"] = static_cast<std::uint64_t>(pointStride);
+    parameters["target_index_sampling_stride"] = 1;
+    report["parameters"] = std::move(parameters);
+    report["source_count"] = static_cast<std::uint64_t>(sources.size());
+    report["target_count"] = static_cast<std::uint64_t>(targets.size());
+    report["self_pairs_excluded"] = true;
+    report["zero_match_pairs_omitted"] = true;
+
+    utils::Json targetRows = utils::Json::array();
+    for (const SurfaceInfo& target : targets) {
+        utils::Json row = utils::Json::object();
+        row["target_id"] = target.id;
+        row["target_path"] = target.relativePath;
+        targetRows.push_back(std::move(row));
+    }
+    report["targets"] = std::move(targetRows);
+
+    utils::Json sourceRows = utils::Json::array();
+    std::uint64_t overlapPairs = 0;
+    for (const SourceMatches& source : sources) {
+        if (source.sampledPoints > source.validPoints) {
+            throw std::invalid_argument(
+                "queried source points cannot exceed valid source points");
+        }
+        for (const auto& [targetKey, matched] :
+             source.matchedPointsByTarget) {
+            (void)targetKey;
+            if (matched > source.sampledPoints) {
+                throw std::invalid_argument(
+                    "matched source points cannot exceed queried source points");
+            }
+        }
+
+        utils::Json sourceRow = utils::Json::object();
+        sourceRow["source_id"] = source.source.id;
+        sourceRow["source_path"] = source.source.relativePath;
+        sourceRow["valid_source_points"] =
+            static_cast<std::uint64_t>(source.validPoints);
+        sourceRow["queried_source_points"] =
+            static_cast<std::uint64_t>(source.sampledPoints);
+        utils::Json hits = utils::Json::array();
+        for (const SurfaceInfo& target : targets) {
+            if (source.source.key == target.key) {
+                continue;
+            }
+
+            const auto hitIt = source.matchedPointsByTarget.find(target.key);
+            if (hitIt == source.matchedPointsByTarget.end() || hitIt->second == 0) {
+                continue;
+            }
+            const std::size_t matched = hitIt->second;
+            const double fraction = source.sampledPoints == 0
+                ? 0.0
+                : static_cast<double>(matched) /
+                      static_cast<double>(source.sampledPoints);
+
+            utils::Json pair = utils::Json::object();
+            pair["target_id"] = target.id;
+            pair["target_path"] = target.relativePath;
+            pair["matched_source_points"] = static_cast<std::uint64_t>(matched);
+            pair["source_coverage_fraction"] = fraction;
+            hits.push_back(std::move(pair));
+            ++overlapPairs;
+        }
+        sourceRow["hits"] = std::move(hits);
+        sourceRows.push_back(std::move(sourceRow));
+    }
+    report["directed_overlap_pair_count"] = overlapPairs;
+    report["sources"] = std::move(sourceRows);
+    return report;
+}
+
+} // namespace vc_seg_overlap

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -848,6 +848,8 @@ vc_add_test(NAME test_atlas LIBS doctest::doctest vc_atlas)
 # with the command-line tool so the tested code is the shipped code).
 vc_add_test(NAME test_tifxyz_selfcross LIBS doctest::doctest opencv_core)
 
+vc_add_test(NAME test_seg_add_overlap_metrics)
+
 # End-to-end CLI contract for the same tool: exit codes, report
 # serialization, collection envelope. Needs the binary, so it only exists
 # in configurations that build the apps -- the test shards configure with
@@ -858,6 +860,13 @@ if(TARGET vc_tifxyz_selfcross)
         LIBS doctest::doctest vc_core opencv_core opencv_imgcodecs
         DEFS VC_SELFCROSS_BIN="$<TARGET_FILE:vc_tifxyz_selfcross>")
     add_dependencies(test_tifxyz_selfcross_cli vc_tifxyz_selfcross)
+endif()
+
+if(TARGET vc_seg_add_overlap)
+    vc_add_test(NAME test_seg_add_overlap_cli
+        LIBS doctest::doctest vc_core opencv_core opencv_imgcodecs
+        DEFS VC_SEG_ADD_OVERLAP_BIN="$<TARGET_FILE:vc_seg_add_overlap>")
+    add_dependencies(test_seg_add_overlap_cli vc_seg_add_overlap)
 endif()
 
 vc_add_test(NAME test_fiber_intersections LIBS doctest::doctest vc_atlas)

--- a/volume-cartographer/core/test/test_seg_add_overlap_cli.cpp
+++ b/volume-cartographer/core/test/test_seg_add_overlap_cli.cpp
@@ -1,0 +1,257 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "vc_test.hpp"
+
+#include "utils/Json.hpp"
+
+#include <opencv2/core/mat.hpp>
+#include <opencv2/imgcodecs.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+TEST_CASE("cli tests are POSIX-only") {}
+#else
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+void write_tifxyz(const fs::path& dir, const std::string& id, float z)
+{
+    constexpr int rows = 8;
+    constexpr int cols = 8;
+    cv::Mat x(rows, cols, CV_32F);
+    cv::Mat y(rows, cols, CV_32F);
+    cv::Mat zs(rows, cols, CV_32F, cv::Scalar(z));
+    for (int v = 0; v < rows; ++v) {
+        for (int u = 0; u < cols; ++u) {
+            x.at<float>(v, u) = 4.f * u;
+            y.at<float>(v, u) = 4.f * v;
+        }
+    }
+    fs::create_directories(dir);
+    REQUIRE(cv::imwrite((dir / "x.tif").string(), x));
+    REQUIRE(cv::imwrite((dir / "y.tif").string(), y));
+    REQUIRE(cv::imwrite((dir / "z.tif").string(), zs));
+    std::ofstream meta(dir / "meta.json");
+    meta << "{\"format\":\"tifxyz\",\"type\":\"seg\","
+            "\"scale\":[1.0,1.0],\"uuid\":\""
+         << id
+         << "\",\"bbox\":[[0.0,0.0," << z
+         << "],[28.0,28.0," << z << "]]}\n";
+    REQUIRE(meta.good());
+}
+
+std::string sh(const std::string& value)
+{
+    std::string quoted = "'";
+    for (char c : value) {
+        quoted += c == '\'' ? "'\\''" : std::string(1, c);
+    }
+    return quoted + "'";
+}
+
+int run_cli(const std::vector<std::string>& args)
+{
+    std::string command = sh(VC_SEG_ADD_OVERLAP_BIN);
+    for (const std::string& arg : args) {
+        command += " " + sh(arg);
+    }
+    command += " >/dev/null 2>&1";
+    const int status = std::system(command.c_str());
+    REQUIRE(status != -1);
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -2;
+}
+
+std::string read_file(const fs::path& path)
+{
+    std::ifstream in(path, std::ios::binary);
+    REQUIRE(in.good());
+    std::ostringstream contents;
+    contents << in.rdbuf();
+    return contents.str();
+}
+
+void write_collection_fixture(const fs::path& root)
+{
+    write_tifxyz(root / "sources" / "source-a", "source-a", 10.f);
+    write_tifxyz(root / "sources" / "source-b", "source-b", 30.f);
+    write_tifxyz(root / "targets" / "duplicate", "duplicate", 10.f);
+    write_tifxyz(root / "targets" / "near", "near", 11.5f);
+    write_tifxyz(root / "targets" / "far", "far", 13.f);
+}
+
+struct TempDir {
+    fs::path path;
+    TempDir()
+    {
+        path = fs::temp_directory_path() /
+               ("vc_seg_add_overlap_cli_" + std::to_string(::getpid()));
+        fs::create_directories(path);
+    }
+    ~TempDir()
+    {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+} // namespace
+
+TEST_CASE("report measures duplicate and within-tolerance coverage")
+{
+    TempDir tmp;
+    const fs::path source = tmp.path / "source";
+    const fs::path targets = tmp.path / "targets";
+    write_tifxyz(source, "source", 10.f);
+    write_tifxyz(targets / "duplicate", "duplicate", 10.f);
+    write_tifxyz(targets / "near", "near", 11.5f);
+    write_tifxyz(targets / "far", "far", 13.f);
+
+    const fs::path reportPath = tmp.path / "report.json";
+    REQUIRE(run_cli({
+        "--target", targets.string(),
+        "--source", source.string(),
+        "--workers", "1",
+        "--point-stride", "2",
+        "--report-json", reportPath.string(),
+    }) == 0);
+
+    const utils::Json report = utils::Json::parse_file(reportPath);
+    CHECK(report["metric"]["name"].get_string() ==
+          "directed_source_point_surface_coverage");
+    CHECK(report["parameters"]["tolerance"].get_float() == 2.0);
+    CHECK(report["parameters"]["point_stride"].get_int() == 2);
+    CHECK(report["target_count"].get_int() == 3);
+    CHECK(report["directed_overlap_pair_count"].get_int() == 2);
+
+    const utils::Json& row = report["sources"][size_t(0)];
+    CHECK(row["source_path"].get_string() == ".");
+    CHECK(row["valid_source_points"].get_int() == 64);
+    CHECK(row["queried_source_points"].get_int() == 32);
+    REQUIRE(row["hits"].size() == 2);
+    CHECK(row["hits"][size_t(0)]["target_path"].get_string() == "duplicate");
+    CHECK(row["hits"][size_t(0)]["matched_source_points"].get_int() == 32);
+    CHECK(row["hits"][size_t(0)]["source_coverage_fraction"].get_float() == 1.0);
+    CHECK(row["hits"][size_t(1)]["target_path"].get_string() == "near");
+    CHECK(row["hits"][size_t(1)]["matched_source_points"].get_int() == 32);
+    CHECK(row["hits"][size_t(1)]["source_coverage_fraction"].get_float() == 1.0);
+
+    const utils::Json sourceOverlap =
+        utils::Json::parse_file(source / "overlapping.json");
+    CHECK(sourceOverlap["overlapping"].size() == 2);
+    CHECK(!fs::exists(targets / "far" / "overlapping.json"));
+}
+
+TEST_CASE("report refuses missing parents and surface-data aliases")
+{
+    TempDir tmp;
+    const fs::path source = tmp.path / "source";
+    const fs::path target = tmp.path / "target";
+    write_tifxyz(source, "source", 10.f);
+    write_tifxyz(target, "target", 10.f);
+
+    CHECK(run_cli({
+        "--target", target.string(),
+        "--source", source.string(),
+        "--report-json", (tmp.path / "missing" / "report.json").string(),
+    }) == 1);
+    CHECK(run_cli({
+        "--target", target.string(),
+        "--source", source.string(),
+        "--report-json", (source / "meta.json").string(),
+    }) == 1);
+
+    const fs::path hardlink = tmp.path / "hardlink.json";
+    fs::create_hard_link(source / "meta.json", hardlink);
+    CHECK(run_cli({
+        "--target", target.string(),
+        "--source", source.string(),
+        "--report-json", hardlink.string(),
+    }) == 1);
+}
+
+TEST_CASE("numeric options reject signs")
+{
+    CHECK(run_cli({"--target", ".", "--source", ".",
+                   "--point-stride", "-1"}) == 1);
+    CHECK(run_cli({"--target", ".", "--source", ".",
+                   "--workers", "+2"}) == 1);
+}
+
+TEST_CASE("canonical target aliases are counted once")
+{
+    TempDir tmp;
+    const fs::path source = tmp.path / "source";
+    const fs::path targets = tmp.path / "targets";
+    write_tifxyz(source, "source", 10.f);
+    write_tifxyz(targets / "real", "target", 10.f);
+    fs::create_directory_symlink(targets / "real", targets / "alias");
+
+    const fs::path reportPath = tmp.path / "report.json";
+    REQUIRE(run_cli({
+        "--target", targets.string(),
+        "--source", source.string(),
+        "--report-json", reportPath.string(),
+    }) == 0);
+
+    const utils::Json report = utils::Json::parse_file(reportPath);
+    CHECK(report["target_count"].get_int() == 1);
+    CHECK(report["directed_overlap_pair_count"].get_int() == 1);
+    const utils::Json& row = report["sources"][size_t(0)];
+    REQUIRE(row["hits"].size() == 1);
+    CHECK(row["hits"][size_t(0)]["source_coverage_fraction"].get_float() == 1.0);
+}
+
+TEST_CASE("report mode preserves legacy output and is worker deterministic")
+{
+    TempDir tmp;
+    const fs::path baseline = tmp.path / "baseline";
+    const fs::path reportOne = tmp.path / "report-one";
+    const fs::path reportTwo = tmp.path / "report-two";
+    write_collection_fixture(baseline);
+    write_collection_fixture(reportOne);
+    write_collection_fixture(reportTwo);
+
+    REQUIRE(run_cli({
+        "--target", (baseline / "targets").string(),
+        "--source", (baseline / "sources").string(),
+        "--workers", "1",
+    }) == 0);
+    REQUIRE(run_cli({
+        "--target", (reportOne / "targets").string(),
+        "--source", (reportOne / "sources").string(),
+        "--workers", "1",
+        "--report-json", (reportOne / "report.json").string(),
+    }) == 0);
+    REQUIRE(run_cli({
+        "--target", (reportTwo / "targets").string(),
+        "--source", (reportTwo / "sources").string(),
+        "--workers", "2",
+        "--report-json", (reportTwo / "report.json").string(),
+    }) == 0);
+
+    for (const fs::path& relative : {
+             fs::path("sources/source-a/overlapping.json"),
+             fs::path("targets/near/overlapping.json"),
+             fs::path("targets/duplicate/overlapping.json")}) {
+        const std::string expected = read_file(baseline / relative);
+        CHECK(read_file(reportOne / relative) == expected);
+        CHECK(read_file(reportTwo / relative) == expected);
+    }
+    CHECK(!fs::exists(baseline / "sources/source-b/overlapping.json"));
+    CHECK(!fs::exists(reportOne / "sources/source-b/overlapping.json"));
+    CHECK(!fs::exists(reportTwo / "sources/source-b/overlapping.json"));
+    CHECK(read_file(reportOne / "report.json") ==
+          read_file(reportTwo / "report.json"));
+}
+
+#endif

--- a/volume-cartographer/core/test/test_seg_add_overlap_metrics.cpp
+++ b/volume-cartographer/core/test/test_seg_add_overlap_metrics.cpp
@@ -1,0 +1,96 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "vc_test.hpp"
+
+#include "../../apps/src/vc_seg_add_overlap_metrics.hpp"
+
+#include <cmath>
+
+using vc_seg_overlap::SourceMatches;
+using vc_seg_overlap::SurfaceInfo;
+
+TEST_CASE("pair report is directional, sparse, and deterministic")
+{
+    std::vector<SurfaceInfo> targets{
+        {"/z", "z", "z"},
+        {"/b", "b", "b"},
+        {"/a", "a", "a"},
+    };
+    std::vector<SourceMatches> sources{
+        {{"/b", "b", "b"}, 6, 4, {{"/a", 3}, {"/z", 1}}},
+        {{"/a", "a", "a"}, 2, 2, {{"/b", 2}}},
+    };
+
+    const utils::Json report = vc_seg_overlap::buildReport(
+        std::move(sources), std::move(targets), 2, 2.0f);
+
+    CHECK(report["schema_version"].get_int() == 1);
+    CHECK(report["parameters"]["point_stride"].get_int() == 2);
+    CHECK(report["source_count"].get_int() == 2);
+    CHECK(report["target_count"].get_int() == 3);
+    CHECK(report["directed_overlap_pair_count"].get_int() == 3);
+    CHECK(report["self_pairs_excluded"].get_bool());
+    CHECK(report["zero_match_pairs_omitted"].get_bool());
+
+    const utils::Json& targetRows = report["targets"];
+    REQUIRE(targetRows.size() == 3);
+    CHECK(targetRows[size_t(0)]["target_path"].get_string() == "a");
+    CHECK(targetRows[size_t(1)]["target_path"].get_string() == "b");
+    CHECK(targetRows[size_t(2)]["target_path"].get_string() == "z");
+
+    const utils::Json& sourceRows = report["sources"];
+    REQUIRE(sourceRows.size() == 2);
+
+    const utils::Json& a = sourceRows[size_t(0)];
+    CHECK(a["source_id"].get_string() == "a");
+    CHECK(a["source_path"].get_string() == "a");
+    CHECK(a["valid_source_points"].get_int() == 2);
+    CHECK(a["queried_source_points"].get_int() == 2);
+    REQUIRE(a["hits"].size() == 1);
+    CHECK(a["hits"][size_t(0)]["target_id"].get_string() == "b");
+    CHECK(a["hits"][size_t(0)]["target_path"].get_string() == "b");
+    CHECK(a["hits"][size_t(0)]["matched_source_points"].get_int() == 2);
+    CHECK(std::fabs(a["hits"][size_t(0)]["source_coverage_fraction"].get_float() - 1.0) < 1e-12);
+
+    const utils::Json& b = sourceRows[size_t(1)];
+    CHECK(b["source_id"].get_string() == "b");
+    CHECK(b["valid_source_points"].get_int() == 6);
+    CHECK(b["queried_source_points"].get_int() == 4);
+    REQUIRE(b["hits"].size() == 2);
+    CHECK(b["hits"][size_t(0)]["target_id"].get_string() == "a");
+    CHECK(std::fabs(b["hits"][size_t(0)]["source_coverage_fraction"].get_float() - 0.75) < 1e-12);
+    CHECK(b["hits"][size_t(1)]["target_id"].get_string() == "z");
+    CHECK(std::fabs(b["hits"][size_t(1)]["source_coverage_fraction"].get_float() - 0.25) < 1e-12);
+}
+
+TEST_CASE("an empty source produces no positive hits")
+{
+    const utils::Json report = vc_seg_overlap::buildReport(
+        {{{"/source", "source", "."}, 0, 0, {}}},
+        {{"/target", "target", "."}},
+        1,
+        2.0f);
+
+    const utils::Json& source = report["sources"][size_t(0)];
+    CHECK(source["valid_source_points"].get_int() == 0);
+    CHECK(source["queried_source_points"].get_int() == 0);
+    CHECK(source["hits"].size() == 0);
+}
+
+TEST_CASE("pair report rejects impossible point counts")
+{
+    CHECK_THROWS_AS(
+        vc_seg_overlap::buildReport(
+            {{{"/source", "source", "."}, 1, 2, {}}},
+            {{"/target", "target", "."}},
+            1,
+            2.0f),
+        std::invalid_argument);
+
+    CHECK_THROWS_AS(
+        vc_seg_overlap::buildReport(
+            {{{"/source", "source", "."}, 2, 2, {{"/target", 3}}}},
+            {{"/target", "target", "."}},
+            1,
+            2.0f),
+        std::invalid_argument);
+}


### PR DESCRIPTION
**In one sentence:** Adds an optional JSON report showing how much of each source surface lies within the existing overlap tolerance of each target.

**One real example:** On the pinned original PHerc0139 w044-w047 TIFXYZ files, w045->w046 measured 83.51% and w046->w045 measured 83.47%; the largest preregistered adjacent control was 2.31%.

The earlier #1547 figures use nearest-vertex distance; this report uses `vc_seg_add_overlap`'s existing point-to-triangle test, which also increases control coverage, so the percentages are not directly comparable.

**Before:** `vc_seg_add_overlap` only wrote a boolean-style overlap list. All six pairs in this four-window set were listed, so the unusual w045/w046 pair looked like an ordinary small contact.

**After this PR:** `--report-json PATH` writes matched and queried point counts plus directed coverage fractions while leaving the default output and `overlapping.json` behavior unchanged.

**Proof:** The thresholds were [posted before the run](https://github.com/ScrollPrize/villa/issues/1547#issuecomment-5386343015). The [immutable replay](https://github.com/TAUIL-Abd-Elilah/vesuvius-repro/tree/a2565599772605901ec515d75ba0cb7dd918f335/evidence/villa-1547) passed every gate: 36.07x positive/control separation, byte-identical reports with 1 and 4 workers, and byte-identical legacy output with and without the report.

![Directed PHerc0139 source-point coverage: the w045/w046 pair is about 83.5% in both directions; adjacent controls are at most 2.31%](https://raw.githubusercontent.com/TAUIL-Abd-Elilah/vesuvius-repro/a2565599772605901ec515d75ba0cb7dd918f335/evidence/villa-1547/coverage.svg)

All code-relevant GitHub checks pass: https://github.com/ScrollPrize/villa/actions/runs/32646992978

**Why / where this is useful:** It lets surface reviewers distinguish broad near-duplication from incidental contact before accepting data for downstream training or analysis.

## Details

- Uses the existing 2-unit point-to-target-triangle test and stride-1 target index.
- Counts every queried source point only when `--report-json` is requested; the default fast path is unchanged.
- Emits stable relative paths and deterministic output across worker counts.
- Omits zero-hit rows and states that zero and self pairs are excluded.
- Rejects output paths that alias source data and deduplicates canonical directory aliases.
- Adds focused metric and CLI tests for real output behavior, synthetic geometry, worker determinism, legacy compatibility, and invalid inputs.

Addresses #1547.
