### PR TITLE
Show a coordinate frame gizmo at the top right of each viewport.

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -8231,6 +8231,17 @@ void CWindow::CreateWidgets(void)
         chkAxisOverlays->setChecked(showOverlays);
         connect(chkAxisOverlays, &QCheckBox::toggled, this, &CWindow::onAxisOverlayVisibilityToggled);
     }
+    // Deliberately not persisted: the coordinate frame gizmo is on by default
+    // every session, matching the checkbox's designer state.
+    if (auto* chkCoordinateFrames = ui.chkCoordinateFrames) {
+        connect(chkCoordinateFrames, &QCheckBox::toggled, this, [](bool show) {
+            for (auto* manager : ViewerManager::allManagers()) {
+                if (manager) {
+                    manager->setShowCoordinateFrames(show);
+                }
+            }
+        });
+    }
     if (auto* btnResetRot = ui.btnResetAxisRotations) {
         connect(btnResetRot, &QPushButton::clicked, this, &CWindow::onResetAxisAlignedRotations);
     }

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -1052,6 +1052,19 @@
        </property>
       </widget>
      </item>
+     <item row="11" column="0" colspan="4">
+      <widget class="QCheckBox" name="chkCoordinateFrames">
+       <property name="text">
+        <string>Show coordinate frames</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Draw the X/Y/Z reference frame in the corner of the slice views</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </widget>
    </widget>

--- a/volume-cartographer/apps/VC3D/ViewerManager.cpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.cpp
@@ -370,6 +370,7 @@ VolumeViewerBase* ViewerManager::initializeChunkedViewer(CChunkedVolumeViewer* c
         bool showNormals = settings.value(viewer::SHOW_SURFACE_NORMALS, viewer::SHOW_SURFACE_NORMALS_DEFAULT).toBool();
         baseViewer->setShowSurfaceNormals(showNormals);
     }
+    chunkedViewer->setShowCoordinateFrame(_showCoordinateFrames);
 
     {
         using namespace vc3d::settings;
@@ -780,6 +781,16 @@ void ViewerManager::setShowSurfaceNormals(bool show)
     forEachBaseViewer([show](VolumeViewerBase* viewer) {
         if (viewer) {
             viewer->setShowSurfaceNormals(show);
+        }
+    });
+}
+
+void ViewerManager::setShowCoordinateFrames(bool show)
+{
+    _showCoordinateFrames = show;
+    forEachBaseViewer([show](VolumeViewerBase* viewer) {
+        if (auto* chunkedViewer = dynamic_cast<CChunkedVolumeViewer*>(viewer)) {
+            chunkedViewer->setShowCoordinateFrame(show);
         }
     });
 }

--- a/volume-cartographer/apps/VC3D/ViewerManager.hpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.hpp
@@ -202,6 +202,7 @@ public:
     // --- Fleet setters: apply a viewer preference to every viewer ---
     void setShowDirectionHints(bool show);
     void setShowSurfaceNormals(bool show);
+    void setShowCoordinateFrames(bool show);
     void setPlaneIntersectionLinesVisible(bool visible);
     void setSurfaceOverlaysEnabled(bool enabled);
     void setSurfaceOverlapThreshold(float threshold);
@@ -331,6 +332,7 @@ private:
     float _volumeWindowLow{0.0f};
     float _volumeWindowHigh{255.0f};
     bool _mirrorCursorToSegmentation{false};
+    bool _showCoordinateFrames{true};
     double _zScrollSensitivity{1.0};
     int _surfacePatchSamplingStride{1};
     std::atomic<bool> _shuttingDown{false};

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -41,6 +41,7 @@
 #include <QTimer>
 #include <QTransform>
 #include <QVBoxLayout>
+#include <QVector3D>
 #include <QtConcurrent/QtConcurrentRun>
 
 #include <algorithm>
@@ -1342,6 +1343,9 @@ void CChunkedVolumeViewer::onSurfaceChangedImpl(const std::string& name, const s
     }
 
     _surfWeak = surf;
+    // The edit paths below can return without submitting a render, so they never
+    // reach syncCameraTransform(); refresh the plane's frame here instead.
+    updateCoordinateFrame();
     if (isSameCurrentSurface && isEditUpdate) {
         _genCacheDirty = true;
         // A plane mutated in place (axis-aligned slice rotation/tilt, line
@@ -1686,6 +1690,32 @@ void CChunkedVolumeViewer::updateScalebarScale()
     _view->setVoxelSize(unitsPerScenePx, unitsPerScenePx, physical);
 }
 
+void CChunkedVolumeViewer::setShowCoordinateFrame(bool show)
+{
+    if (_closing || _showCoordinateFrame == show) {
+        return;
+    }
+    _showCoordinateFrame = show;
+    updateCoordinateFrame();
+    requestDirectPaint();
+}
+
+void CChunkedVolumeViewer::updateCoordinateFrame()
+{
+    if (!_view) {
+        return;
+    }
+    // Showing a world coordinates reference frame indicator in a quad surface
+    // view doesn't make sense. We could show a uv coordinates indicator instead.
+    PlaneSurface* plane = dynamic_cast<PlaneSurface*>(currentSurface());
+    if (!_showCoordinateFrame || !plane) {
+        _view->showCoordinateFrame(false);
+        return;
+    }
+
+    _view->setCoordinateFrame(plane);
+}
+
 void CChunkedVolumeViewer::resizeFramebuffer()
 {
     const QSize vpSize = _view->viewport()->size();
@@ -1766,6 +1796,7 @@ void CChunkedVolumeViewer::syncCameraTransform()
     _camSurfX = _surfacePtrX;
     _camSurfY = _surfacePtrY;
     _camScale = _scale;
+    updateCoordinateFrame();
     updateDisplayedFramebufferMapping();
     updateIntersectionPreviewTransform();
     refreshMeasurementOverlay();

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -141,6 +141,7 @@ public:
     bool isShowDirectionHints() const override { return _showDirectionHints; }
     void setShowSurfaceNormals(bool on) override { if (_closing) return; _showSurfaceNormals = on; emit overlaysUpdated(); }
     bool isShowSurfaceNormals() const override { return _showSurfaceNormals; }
+    void setShowCoordinateFrame(bool show);
     float normalArrowLengthScale() const override { return _normalArrowLengthScale; }
     int normalMaxArrows() const override { return _normalMaxArrows; }
     void setNormalArrowLengthScale(float scale) override { if (_closing) return; _normalArrowLengthScale = scale; emit overlaysUpdated(); }
@@ -352,6 +353,8 @@ private:
     void resizeFramebuffer();
     void recalcPyramidLevel();
     void updateScalebarScale();   // push µm/scene-px to the view's scalebar overlay
+    // Push the displayed plane's basis to the view's coordinate frame gizmo.
+    void updateCoordinateFrame();
     // Build/drop the base and overlay SurfaceCache to match the current
     // (volume, surface, geometry epoch) identity and the configured budgets.
     void ensureSurfaceCaches();
@@ -616,6 +619,7 @@ private:
     int _maxDisplayedResolution = 0;
     bool _showDirectionHints = true;
     bool _showSurfaceNormals = false;
+    bool _showCoordinateFrame = true;
     float _normalArrowLengthScale = 1.0f;
     int _normalMaxArrows = 32;
     bool _surfaceOverlayEnabled = false;

--- a/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.cpp
@@ -6,11 +6,20 @@
 #include <QKeyEvent>
 #include <QPainter>
 #include <QPaintEvent>
+#include <QPolygonF>
 #include <QScrollBar>
 #include <cmath>
 #include <algorithm>
+#include "vc/core/util/PlaneSurface.hpp"
 
 
+CVolumeViewerView::CVolumeViewerView(QWidget* parent) : QGraphicsView(parent)
+{
+    setMouseTracking(true);
+    if (viewport()) {
+        viewport()->setMouseTracking(true);
+    }
+};
 
 double CVolumeViewerView::chooseNiceLength(double nominal) const
 {
@@ -44,67 +53,106 @@ CVolumeViewerView::ScaleBarLabel CVolumeViewerView::formatScaleBarLength(double 
     return label;
 }
 
+void CVolumeViewerView::setCoordinateFrame(PlaneSurface* plane)
+{
+    if (!plane) {
+        return;
+    }
+    _showFrame = true;
+    cv::Matx33d M = plane->frame();
+    _frame[0] = cv::Vec3f(M(0,0), M(1,0), M(2,0));
+    _frame[1] = cv::Vec3f(M(0,1), M(1,1), M(2,1));
+    _frame[2] = cv::Vec3f(M(0,2), M(1,2), M(2,2));
+    update();
+}
+
+void CVolumeViewerView::showCoordinateFrame(bool visible)
+{
+    _showFrame = visible;
+    update();
+}
+
 void CVolumeViewerView::drawForeground(QPainter* p, const QRectF& sceneRect)
 {
     QGraphicsView::drawForeground(p, sceneRect);
-    if (property("vc_hide_scalebar").toBool()) {
-        drawTiltHandle(p);
+    drawCoordinateFrame(p);
+    drawTiltHandle(p);
+    drawScaleBar(p);
+}
+
+void CVolumeViewerView::drawCoordinateFrame(QPainter* p) const
+{
+    if (!_showFrame) {
         return;
     }
-    const double dpr = devicePixelRatioF();
-    const double m11 = transform().m11();
-    const int vpW = viewport()->width();
-    const int vpH = viewport()->height();
 
-    // Recompute cached scalebar only when inputs change
-    if (_cachedM11 != m11 || _cachedDpr != dpr || _cachedVpW != vpW ||
-        _cachedVpH != vpH || _cachedVx != m_vx ||
-        _cachedPhysicalUnits != m_physicalUnits || _scalebarCacheDirty) {
-        _cachedM11 = m11;
-        _cachedDpr = dpr;
-        _cachedVpW = vpW;
-        _cachedVpH = vpH;
-        _cachedVx = m_vx;
-        _cachedPhysicalUnits = m_physicalUnits;
-        _scalebarCacheDirty = false;
+    const double radius = 40.0;
+    const double head = 10.0;
+    const double margin = 10.0;
+    const QColor colors[3] = {QColor(230, 30, 30), QColor(30, 230, 30), QColor(30, 40, 220)};
+    const QString labels[3] = {QStringLiteral("X"), QStringLiteral("Y"), QStringLiteral("Z")};
+    
+    const QPointF center(viewport()->width() - margin - radius, margin + radius);
 
-        _cachedFont = p->font();
-        _cachedFont.setPointSizeF(12 * dpr);
-
-        double pxPerScene = m11 * dpr;
-        double pxPerUm = pxPerScene / m_vx;
-        double wPx = vpW * dpr;
-        double wUm = wPx / pxPerUm;
-        double barUm = chooseNiceLength(wUm / 4.0);
-        _cachedBarPx = barUm * pxPerUm;
-
-        _cachedBarLabel = m_physicalUnits
-            ? formatScaleBarLength(barUm).text
-            : QString::number(barUm) + QStringLiteral(" vx");
-    }
+    // Sort by depth, furthest first. Higher z coord = further into the screen.
+    std::array<int, 3> order{0, 1, 2};
+    std::sort(order.begin(), order.end(), [this](int a, int b) {
+        return _frame[a][2] > _frame[b][2];
+    });
 
     p->save();
     p->resetTransform();
     p->setRenderHint(QPainter::Antialiasing);
-    p->setPen(QPen(Qt::red, 2));
-    p->setFont(_cachedFont);
 
-    constexpr int M = 10;
-    int bottom = static_cast<int>(vpH * dpr) - M;
-    p->drawLine(M, bottom, static_cast<int>(M + _cachedBarPx), bottom);
-    p->drawText(M, bottom - 5, _cachedBarLabel);
-    p->restore();
+    for (int i : order) {
+        const QPointF dir = QPointF(_frame[i][0], _frame[i][1]);
+        const QPointF tip(center.x() + dir.x() * radius, center.y() + dir.y() * radius);
+        const double length = std::hypot(tip.x() - center.x(), tip.y() - center.y());
+        const QColor& color = colors[i];
 
-    drawTiltHandle(p);
-}
+        if (length < 2.0) {
+            if (_frame[i][2] > 0.5) {
+                // into the screen
+                p->setPen(QPen(color, 1.0));
+                p->setBrush(Qt::NoBrush);
+            } else {
+                // out of the screen
+                p->setPen(Qt::NoPen);
+                p->setBrush(color);
+            }
+            p->drawEllipse(center, head/2, head/2);
+            p->setPen(color);
+            p->drawText(QPointF(center.x() + 5.0, center.y() - 5.0), labels[i]);
+            continue;
+        }
 
-CVolumeViewerView::CVolumeViewerView(QWidget* parent) : QGraphicsView(parent)
-{
-    setMouseTracking(true);
-    if (viewport()) {
-        viewport()->setMouseTracking(true);
+        const double ux = (tip.x() - center.x()) / length;
+        const double uy = (tip.y() - center.y()) / length;
+
+        p->setPen(QPen(color, 1.6, Qt::SolidLine, Qt::RoundCap));
+        p->setBrush(Qt::NoBrush);
+        p->drawLine(center, tip);
+
+        QPolygonF arrow;
+        arrow << tip
+              << QPointF(tip.x() - ux * head - uy * head * 0.45,
+                         tip.y() - uy * head + ux * head * 0.45)
+              << QPointF(tip.x() - ux * head + uy * head * 0.45,
+                         tip.y() - uy * head - ux * head * 0.45);
+        if (_frame[i][2] > 0.01) {
+            // into the screen
+            p->setPen(QPen(color, 1.0));
+            p->setBrush(Qt::NoBrush);
+        } else {
+            // out of the screen
+            p->setPen(Qt::NoPen);
+            p->setBrush(color);
+        }
+        p->drawPolygon(arrow);
     }
-};
+
+    p->restore();
+}
 
 void CVolumeViewerView::setTiltHandle(TiltHandleMode mode, QPointF tilt)
 {
@@ -214,6 +262,55 @@ void CVolumeViewerView::drawTiltHandle(QPainter* p) const
     p->setPen(QPen(QColor(40, 28, 0), 1.0));
     p->setBrush(QColor(255, 214, 42));
     p->drawEllipse(dot, 4.0, 4.0);
+    p->restore();
+}
+
+void CVolumeViewerView::drawScaleBar(QPainter* p) const
+{
+    if (property("vc_hide_scalebar").toBool()) {
+        return;
+    }
+    const double m11 = transform().m11();
+    const int vpW = viewport()->width();
+    const int vpH = viewport()->height();
+
+    // Recompute cached scalebar only when inputs change
+    if (_cachedM11 != m11 || _cachedVpW != vpW ||
+        _cachedVpH != vpH || _cachedVx != m_vx ||
+        _cachedPhysicalUnits != m_physicalUnits || _scalebarCacheDirty) {
+        _cachedM11 = m11;
+        _cachedVpW = vpW;
+        _cachedVpH = vpH;
+        _cachedVx = m_vx;
+        _cachedPhysicalUnits = m_physicalUnits;
+        _scalebarCacheDirty = false;
+
+        _cachedFont = p->font();
+        _cachedFont.setPointSizeF(12);
+
+        // Logical pixels, to match the painter after resetTransform().
+        double pxPerScene = m11;
+        double pxPerUm = pxPerScene / m_vx;
+        double wPx = vpW;
+        double wUm = wPx / pxPerUm;
+        double barUm = chooseNiceLength(wUm / 4.0);
+        _cachedBarPx = barUm * pxPerUm;
+
+        _cachedBarLabel = m_physicalUnits
+            ? formatScaleBarLength(barUm).text
+            : QString::number(barUm) + QStringLiteral(" vx");
+    }
+
+    p->save();
+    p->resetTransform();
+    p->setRenderHint(QPainter::Antialiasing);
+    p->setPen(QPen(Qt::red, 2));
+    p->setFont(_cachedFont);
+
+    constexpr int M = 10;
+    int bottom = vpH - M;
+    p->drawLine(M, bottom, static_cast<int>(M + _cachedBarPx), bottom);
+    p->drawText(M, bottom - 5, _cachedBarLabel);
     p->restore();
 }
 

--- a/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.hpp
@@ -1,20 +1,20 @@
 #pragma once
 
+#include <array>
+
 #include <QGraphicsView>
 #include <QPointF>
 #include <QString>
+#include <QVector3D>
+
+#include <opencv2/core.hpp>
+#include "vc/core/util/PlaneSurface.hpp"
 
 class CVolumeViewerView : public QGraphicsView
 {
     Q_OBJECT
     
 public:
-    struct ScaleBarLabel {
-        double displayLength = 0.0;
-        QString unit;
-        QString text;
-    };
-
     CVolumeViewerView(QWidget* parent = 0);
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
@@ -37,10 +37,21 @@ public:
         m_physicalUnits = physical;
         update();
     }
-    static ScaleBarLabel formatScaleBarLength(double barUm);
+
     void setMiddleButtonPanEnabled(bool enabled) { _middleButtonPanEnabled = enabled; }
     bool middleButtonPanEnabled() const { return _middleButtonPanEnabled; }
     void setScrollPanDisabled(bool disabled) { _scrollPanDisabled = disabled; }
+    
+    void showCoordinateFrame(bool visible);
+    void setCoordinateFrame(PlaneSurface* plane);
+
+    struct ScaleBarLabel {
+        double displayLength = 0.0;
+        QString unit;
+        QString text;
+    };
+    static ScaleBarLabel formatScaleBarLength(double barUm);
+    
     enum class TiltHandleMode {
         Hidden,
         Square,
@@ -98,7 +109,9 @@ private:
     QRectF tiltHandleRect() const;
     bool pointInTiltHandle(const QPointF& viewportPos) const;
     QPointF tiltFromHandlePos(const QPointF& viewportPos) const;
+    void drawCoordinateFrame(QPainter* painter) const;
     void drawTiltHandle(QPainter* painter) const;
+    void drawScaleBar(QPainter* painter) const;
     bool pointInSceneWidget(const QPointF& viewportPos) const;
 
     // µm (or voxels, when !m_physicalUnits) per scene-unit (pixel)
@@ -113,7 +126,6 @@ private:
     mutable double _cachedBarPx = 0;
     mutable QString _cachedBarLabel;
     mutable double _cachedM11 = 0;
-    mutable double _cachedDpr = 0;
     mutable int _cachedVpW = 0;
     mutable int _cachedVpH = 0;
     mutable bool _cachedPhysicalUnits = true;
@@ -121,4 +133,7 @@ private:
 
     TiltHandleMode _tiltHandleMode = TiltHandleMode::Hidden;
     QPointF _tiltHandleValue{0.0, 0.0};
+    
+    bool _showFrame = false;
+    cv::Vec3f _frame[3];
 };

--- a/volume-cartographer/core/include/vc/core/util/PlaneSurface.hpp
+++ b/volume-cartographer/core/include/vc/core/util/PlaneSurface.hpp
@@ -25,6 +25,7 @@ public:
     void gen(cv::Mat_<cv::Vec3f> *coords, cv::Mat_<cv::Vec3f> *normals, cv::Size size, const cv::Vec3f &ptr, float scale, const cv::Vec3f &offset) const override;
 
     float pointDist(cv::Vec3f wp);
+    cv::Matx33d frame();
     cv::Vec3f project(cv::Vec3f wp, float render_scale = 1.0, float coord_scale = 1.0);
     void setNormal(cv::Vec3f normal);
     void setOrigin(cv::Vec3f origin);

--- a/volume-cartographer/core/src/PlaneSurface.cpp
+++ b/volume-cartographer/core/src/PlaneSurface.cpp
@@ -3,6 +3,7 @@
 #include "vc/core/util/Geometry.hpp"
 
 #include <opencv2/calib3d.hpp>
+#include <opencv2/core/mat.hpp>
 #include "utils/Json.hpp"
 
 #include <cmath>
@@ -22,7 +23,8 @@ static cv::Vec3f internal_loc(const cv::Vec3f &nominal, const cv::Vec3f &interna
     return internal + cv::Vec3f(nominal[0]*scale[0], nominal[1]*scale[1], nominal[2]);
 }
 
-//given origin and normal, return the normalized vector v which describes a point : origin + v which lies in the plane and maximizes v.x at the cost of v.y,v.z
+// given origin and normal, return the normalized vector v which describes a point : origin + v
+// which lies in the plane and maximizes v.x at the cost of v.y,v.z
 static cv::Vec3f vx_from_orig_norm(const cv::Vec3f &o, const cv::Vec3f &n)
 {
     //impossible
@@ -210,6 +212,10 @@ void PlaneSurface::update()
 
     _M = transf({0,0,3,3});
     _T = transf({3,0,1,3});
+}
+
+cv::Matx33d PlaneSurface::frame() {
+    return _M;
 }
 
 cv::Vec3f PlaneSurface::project(cv::Vec3f wp, float render_scale, float coord_scale)


### PR DESCRIPTION
<img width="1381" height="890" alt="image" src="https://github.com/user-attachments/assets/7b830682-5374-4c52-8a49-b17f9914f6cf" />

New gizmo to show world coordinate frame. Matches how the coords printed on the statsbar increase. Derived directly from the plane's _M transform.

The scale bar also wasn't showing for me and getting rid of that dpr code fixed it.

I changed the negative handle of the plane slicing overlay controller to draw in black, which is ugly, but I wanted to make it asymetrical, to see what's going on. Probably shouldn't belong in this PR.