### PR TITLE
ink_detection: report a prepared input whose scale does not match its recipe

### DIFF
--- a/vesuvius/src/vesuvius/ink_detection/inference/infer.py
+++ b/vesuvius/src/vesuvius/ink_detection/inference/infer.py
@@ -38,6 +38,8 @@ from vesuvius.ink_detection.inference.inference_runtime import (
 from vesuvius.ink_detection.models.model import make_model
 from vesuvius.ink_detection.volume_io import (
     ZARR_V3,
+    InputScaleRefused,
+    check_flat_input_scale,
     open_volume,
     open_volume_root,
     select_volume_level,
@@ -964,6 +966,13 @@ def infer_single_zarr(
     """Run one direction over one surface-volume input and replace a TIFF."""
 
     root = open_volume_root(input_zarr)
+    mismatch = check_flat_input_scale(
+        root,
+        source=str(input_zarr),
+        strict=bool(getattr(args, "strict_input_scale", False)),
+    )
+    if mismatch is not None:
+        LOGGER.warning("%s", mismatch)
     resolution = "0" if hasattr(root, "shape") else str(args.resolution)
     volume = select_volume_level(root, resolution, source=str(input_zarr))
     depth_first, depth, height, width, chunk_h, chunk_w = _volume_axes(volume)
@@ -1239,14 +1248,21 @@ def infer_folder(
                 )
                 skipped_count += 1
                 continue
-            infer_single_zarr(
-                args=args,
-                input_zarr=input_zarr,
-                configured_model=configured_model,
-                device=device,
-                output_tiff=prediction_dir / f"{name_prefix}{date}.tif",
-                layer_direction=direction,
-            )
+            try:
+                infer_single_zarr(
+                    args=args,
+                    input_zarr=input_zarr,
+                    configured_model=configured_model,
+                    device=device,
+                    output_tiff=prediction_dir / f"{name_prefix}{date}.tif",
+                    layer_direction=direction,
+                )
+            except InputScaleRefused as exc:
+                # Same convention as the missing-input case above: one bad segment is
+                # skipped and recorded, it does not abort the rest of the folder.
+                LOGGER.warning("Skipping %s: %s", segment_dir, exc)
+                skipped_count += 1
+                continue
             ran_count += 1
     LOGGER.info(
         "Folder run complete. segments_ran=%d segments_skipped=%d",
@@ -1336,6 +1352,14 @@ def parse_args(argv: Sequence[str] | None = None):
         "--amp-dtype",
         choices=("auto", "default", "fp16", "bf16"),
         default="auto",
+    )
+    parser.add_argument(
+        "--strict-input-scale",
+        action="store_true",
+        help=(
+            "refuse to run when a prepared input's scale does not match what its "
+            "recipe trains at, instead of reporting it and continuing"
+        ),
     )
     parser.add_argument("--tta-mirror", action="store_true")
     parser.add_argument("--tta-batch-size", type=int)

--- a/vesuvius/src/vesuvius/ink_detection/inference/infer.py
+++ b/vesuvius/src/vesuvius/ink_detection/inference/infer.py
@@ -1239,14 +1239,7 @@ def infer_folder(
             LOGGER.warning("Skipping %s: %s", segment_dir, exc)
             skipped_count += 1
             continue
-        try:
-            report_input_scale(args, input_zarr)
-        except InputScaleRefused as exc:
-            # Same level and same convention as the missing-input case above: one bad
-            # segment is skipped and recorded, and the rest of the folder still runs.
-            LOGGER.warning("Skipping %s: %s", segment_dir, exc)
-            skipped_count += 1
-            continue
+        scale_reported = False
         for direction in resolve_run_directions(args.direction):
             name_prefix = (
                 f"{prefix}{segment_dir.name}_{checkpoint_stem}_{direction}_"
@@ -1266,6 +1259,19 @@ def infer_folder(
                 )
                 skipped_count += 1
                 continue
+            if not scale_reported:
+                # Once per input rather than once per direction, and only once some
+                # direction is actually going to run: a segment whose predictions all
+                # exist is skipped without opening its store at all. On a refusal the
+                # whole segment is skipped and recorded, which is the level the
+                # missing-input case above uses.
+                try:
+                    report_input_scale(args, input_zarr)
+                except InputScaleRefused as exc:
+                    LOGGER.warning("Skipping %s: %s", segment_dir, exc)
+                    skipped_count += 1
+                    break
+                scale_reported = True
             infer_single_zarr(
                 args=args,
                 input_zarr=input_zarr,

--- a/vesuvius/src/vesuvius/ink_detection/inference/infer.py
+++ b/vesuvius/src/vesuvius/ink_detection/inference/infer.py
@@ -966,13 +966,6 @@ def infer_single_zarr(
     """Run one direction over one surface-volume input and replace a TIFF."""
 
     root = open_volume_root(input_zarr)
-    mismatch = check_flat_input_scale(
-        root,
-        source=str(input_zarr),
-        strict=bool(getattr(args, "strict_input_scale", False)),
-    )
-    if mismatch is not None:
-        LOGGER.warning("%s", mismatch)
     resolution = "0" if hasattr(root, "shape") else str(args.resolution)
     volume = select_volume_level(root, resolution, source=str(input_zarr))
     depth_first, depth, height, width, chunk_h, chunk_w = _volume_axes(volume)
@@ -1156,6 +1149,23 @@ def resolve_run_directions(direction: str) -> tuple[str, ...]:
     return ("forward", "reverse") if direction == "both" else (direction,)
 
 
+def report_input_scale(args, input_zarr) -> None:
+    """Compare a prepared input's recorded scale with its recipe's, once per input.
+
+    Called before the direction loop rather than inside `infer_single_zarr`, which runs
+    once per direction: the finding describes the input, not the traversal, and
+    `--direction both` would otherwise report it twice.
+    """
+
+    mismatch = check_flat_input_scale(
+        open_volume_root(input_zarr),
+        source=str(input_zarr),
+        strict=bool(getattr(args, "strict_input_scale", False)),
+    )
+    if mismatch is not None:
+        LOGGER.warning("%s", mismatch)
+
+
 def resolve_single_output_path(
     output_tiff: Path,
     *,
@@ -1229,6 +1239,14 @@ def infer_folder(
             LOGGER.warning("Skipping %s: %s", segment_dir, exc)
             skipped_count += 1
             continue
+        try:
+            report_input_scale(args, input_zarr)
+        except InputScaleRefused as exc:
+            # Same level and same convention as the missing-input case above: one bad
+            # segment is skipped and recorded, and the rest of the folder still runs.
+            LOGGER.warning("Skipping %s: %s", segment_dir, exc)
+            skipped_count += 1
+            continue
         for direction in resolve_run_directions(args.direction):
             name_prefix = (
                 f"{prefix}{segment_dir.name}_{checkpoint_stem}_{direction}_"
@@ -1248,21 +1266,14 @@ def infer_folder(
                 )
                 skipped_count += 1
                 continue
-            try:
-                infer_single_zarr(
-                    args=args,
-                    input_zarr=input_zarr,
-                    configured_model=configured_model,
-                    device=device,
-                    output_tiff=prediction_dir / f"{name_prefix}{date}.tif",
-                    layer_direction=direction,
-                )
-            except InputScaleRefused as exc:
-                # Same convention as the missing-input case above: one bad segment is
-                # skipped and recorded, it does not abort the rest of the folder.
-                LOGGER.warning("Skipping %s: %s", segment_dir, exc)
-                skipped_count += 1
-                continue
+            infer_single_zarr(
+                args=args,
+                input_zarr=input_zarr,
+                configured_model=configured_model,
+                device=device,
+                output_tiff=prediction_dir / f"{name_prefix}{date}.tif",
+                layer_direction=direction,
+            )
             ran_count += 1
     LOGGER.info(
         "Folder run complete. segments_ran=%d segments_skipped=%d",
@@ -1404,6 +1415,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.folder is not None:
         infer_folder(args, configured, device=device)
     else:
+        try:
+            report_input_scale(args, args.input_zarr)
+        except InputScaleRefused as exc:
+            LOGGER.error("%s", exc)
+            return 1
         for direction in resolve_run_directions(args.direction):
             infer_single_zarr(
                 args=args,

--- a/vesuvius/src/vesuvius/ink_detection/volume_io.py
+++ b/vesuvius/src/vesuvius/ink_detection/volume_io.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 import aiohttp
 import numpy as np
@@ -244,3 +244,240 @@ def read_bbox_with_padding(
     )
     output[destination] = crop
     return output, destination
+
+
+# `prepare_9um_isotropic_input` stamps `format`, `source` and `source_level` on every
+# input it writes, unconditionally: the tag names the recipe, and `source`/`source_level`
+# say which store the input came from and at which pyramid level. Nothing downstream
+# currently reads any of it.
+#
+# The tag does not name a single scale. The shipped recipe is trained on two documented
+# representation families: 2.399 um renders pooled at level 2, and native 9.362 um
+# renders used at level 0. Both are legitimate inputs, so both are accepted.
+FLAT_INPUT_RECIPES = {
+    # format tag -> (in-plane micrometres the recipe trains at, level the tag names)
+    "level2-zmean4-21slice-v1": ((9.596, 9.362), "2"),
+}
+FLAT_INPUT_SCALE_TOLERANCE = 0.02
+
+
+class InputScaleRefused(ValueError):
+    """Raised by `check_flat_input_scale(strict=True)`; a folder run skips and records it."""
+
+# Mirrors the order `Volume::normalize()` uses when a store records its scale outside
+# OME metadata: a numeric `voxelsize`, then the alternative spellings, then the beamline
+# `samplePixelSize`, which is recorded in millimetres.
+_VOXEL_SIZE_KEYS = (
+    "voxelsize",
+    "voxel_size_um",
+    "voxelSizeUm",
+    "pixel_size_um",
+    "pixelSizeUm",
+    "resolution_um",
+)
+_NESTED_METADATA_KEYS = ("scan", "volume", "properties", "metadata")
+_SAMPLE_PIXEL_SIZE_PATH = ("scan", "tomo", "acquisition", "detector")
+
+
+def _positive_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if value > 0 else None
+
+
+def _number_from_object(obj, keys):
+    if not isinstance(obj, dict):
+        return None
+    for key in keys:
+        found = _positive_number(obj.get(key))
+        if found is not None:
+            return found
+    return None
+
+
+def inplane_um_from_ome(attrs, level):
+    """In-plane micrometres for one pyramid level of an OME-Zarr store.
+
+    Rendered surface volumes record this directly - axes in micrometre and a scale per
+    dataset - so the level an input was built from names its own in-plane sampling.
+    """
+
+    multiscales = attrs.get("multiscales")
+    if not isinstance(multiscales, list) or not multiscales:
+        return None
+    entry = multiscales[0]
+    if not isinstance(entry, dict):
+        return None
+    axes = entry.get("axes")
+    if not isinstance(axes, list):
+        return None
+    names = [str(axis.get("name")) for axis in axes if isinstance(axis, dict)]
+    units = {
+        str(axis.get("name")): str(axis.get("unit", ""))
+        for axis in axes
+        if isinstance(axis, dict)
+    }
+    if any(units.get(name) not in ("micrometer", "micrometre") for name in ("y", "x")):
+        return None
+    for dataset in entry.get("datasets") or ():
+        if not isinstance(dataset, dict) or str(dataset.get("path")) != str(level):
+            continue
+        for transform in dataset.get("coordinateTransformations") or ():
+            if not isinstance(transform, dict) or transform.get("type") != "scale":
+                continue
+            scale = transform.get("scale")
+            if not isinstance(scale, list) or len(scale) != len(names):
+                continue
+            values = [
+                _positive_number(scale[index])
+                for index, name in enumerate(names)
+                if name in ("y", "x")
+            ]
+            if len(values) == 2 and all(values) and values[0] == values[1]:
+                return values[0]
+    return None
+
+
+def voxel_size_um_from_document(document):
+    """Scale from a store's metadata document, in the order `Volume::normalize()` uses."""
+
+    if not isinstance(document, dict):
+        return None
+    merged = dict(document)
+    scan = merged.get("scan")
+    if isinstance(scan, dict):
+        merged.update(scan)
+    found = _number_from_object(merged, _VOXEL_SIZE_KEYS)
+    if found is not None:
+        return found
+    for key in _NESTED_METADATA_KEYS:
+        found = _number_from_object(merged.get(key), _VOXEL_SIZE_KEYS)
+        if found is not None:
+            return found
+    current = document
+    for key in _SAMPLE_PIXEL_SIZE_PATH:
+        if not isinstance(current, dict) or key not in current:
+            current = None
+            break
+        current = current[key]
+    millimetres = _number_from_object(current, ("samplePixelSize",))
+    return None if millimetres is None else millimetres * 1000.0
+
+
+def resolve_source_inplane_um(source, level, *, attrs_reader=None):
+    """In-plane micrometres of `source` at `level`, with the reason when unknown.
+
+    Only the store's metadata is read, never its arrays. "unreachable" is kept distinct
+    from "records no scale" so a source that cannot be opened is never reported as a
+    scale error.
+    """
+
+    if not source:
+        return None, "no source recorded"
+    reader = attrs_reader
+    if reader is None:
+
+        def reader(path):
+            return dict(zarr.open(path, mode="r").attrs)
+
+    try:
+        attrs = reader(source)
+    except Exception as exc:  # unreachable source, stale path, no permission
+        return None, f"source unreachable ({type(exc).__name__})"
+    if not isinstance(attrs, Mapping):
+        return None, "source metadata unreadable"
+    found = inplane_um_from_ome(attrs, level)
+    if found is None:
+        found = voxel_size_um_from_document(dict(attrs))
+        if found is not None and str(level).isdigit():
+            found *= 2 ** int(level)
+    if found is None:
+        return None, "source records no scale"
+    return found, "ok"
+
+
+def describe_flat_input_scale_mismatch(root, *, source, attrs_reader=None):
+    """Compare a prepared input's actual in-plane scale with what its recipe trains at.
+
+    Returns a description, or None when the input is consistent or carries no recipe tag
+    to check. Inputs without a known `format` tag - published surface volumes, or inputs
+    prepared by other means - are left alone.
+    """
+
+    attrs = getattr(root, "attrs", None)
+    if attrs is None:
+        return None
+    try:
+        recorded = dict(attrs)
+    except Exception:
+        return None
+
+    tag = recorded.get("format")
+    recipe = None if tag is None else FLAT_INPUT_RECIPES.get(str(tag))
+    if recipe is None:
+        return None
+    trained_scales, expected_level = recipe
+
+    source_level = recorded.get("source_level")
+    if source_level is None:
+        return (
+            f"{source}: input declares format {str(tag)!r}, which is prepared from "
+            f"pyramid level {expected_level}, but records no source_level, so the scale "
+            "it was built at cannot be checked"
+        )
+    recorded_level = str(source_level)
+    recorded_source = str(recorded.get("source") or "")
+    actual_um, reason = resolve_source_inplane_um(
+        recorded_source, recorded_level, attrs_reader=attrs_reader
+    )
+    if actual_um is not None:
+        nearest = min(trained_scales, key=lambda um: abs(actual_um - um) / um)
+        if abs(actual_um - nearest) / nearest <= FLAT_INPUT_SCALE_TOLERANCE:
+            return None
+        trained = " or ".join(f"{um:g}" for um in trained_scales)
+        return (
+            f"{source}: input is {actual_um:g} um in-plane; this recipe trains at "
+            f"{trained} um (nearest {nearest:g}, factor {actual_um / nearest:.3g}). "
+            f"Prepared from {recorded_source} at level {recorded_level}."
+        )
+
+    # The source could not be consulted. The tag and the recorded level still have to
+    # agree with each other, and that comparison needs nothing but the input itself.
+    if recorded_level == expected_level:
+        return None
+    message = (
+        f"{source}: input declares format {str(tag)!r}, which is prepared from pyramid "
+        f"level {expected_level}, but records source_level {recorded_level!r}"
+    )
+    if recorded_level.isdigit():
+        ratio = 2.0 ** (int(expected_level) - int(recorded_level))
+        message += (
+            f"; its in-plane sampling is {ratio:g}x finer than that format implies"
+            if ratio > 1
+            else f"; its in-plane sampling is {1 / ratio:g}x coarser than that format implies"
+        )
+    return (
+        f"{message} (absolute scale not checked: {reason}; a native "
+        f"{min(trained_scales):g} um render prepared at level 0 is legitimate and would "
+        "be reported here)"
+    )
+
+
+def check_flat_input_scale(root, *, source, strict=False, attrs_reader=None):
+    """Report a prepared input whose scale does not match its recipe.
+
+    Reporting rather than refusing is the default: an input prepared by other means is a
+    legitimate thing to hand this code, and a message carrying the numbers is enough to
+    act on. `strict` turns the same finding into a refusal.
+    """
+
+    message = describe_flat_input_scale_mismatch(
+        root, source=source, attrs_reader=attrs_reader
+    )
+    if message is not None and strict:
+        raise InputScaleRefused(
+            message
+            + " Re-prepare the input at the level this recipe expects, or drop "
+            "--strict-input-scale to continue with a warning."
+        )
+    return message

--- a/vesuvius/tests/ink_detection/test_volume_io.py
+++ b/vesuvius/tests/ink_detection/test_volume_io.py
@@ -423,3 +423,207 @@ def test_missing_node_error_has_zarr2_fallback(monkeypatch):
     assert isinstance(
         volume_io._missing_node_error("missing"), CompatiblePathError
     )
+
+
+RECIPE_TAG = "level2-zmean4-21slice-v1"
+
+
+def _prepared_root(tmp_path, attrs, name="input.zarr"):
+    """A prepared input is a group carrying the stamp `prepare_9um` writes."""
+
+    root = zarr.open_group(str(tmp_path / name), mode="w")
+    root.attrs.update(attrs)
+    return root
+
+
+def _ome_attrs(scales):
+    """Minimal OME metadata of a rendered surface volume: micrometre axes per level."""
+
+    return {
+        "multiscales": [
+            {
+                "axes": [
+                    {"name": "z", "type": "space", "unit": "micrometer"},
+                    {"name": "y", "type": "space", "unit": "micrometer"},
+                    {"name": "x", "type": "space", "unit": "micrometer"},
+                ],
+                "datasets": [
+                    {
+                        "path": str(level),
+                        "coordinateTransformations": [
+                            {"type": "scale", "scale": [scales[0], um, um]},
+                            {"type": "translation", "translation": [0.0, 0.0, 0.0]},
+                        ],
+                    }
+                    for level, um in enumerate(scales)
+                ],
+            }
+        ]
+    }
+
+
+def test_input_at_the_scale_the_recipe_trains_at_is_silent(tmp_path):
+    root = _prepared_root(
+        tmp_path,
+        {"format": RECIPE_TAG, "source_level": "2", "source": "render.zarr"},
+    )
+    reader = lambda path: _ome_attrs([2.399, 4.798, 9.596])
+    assert (
+        volume_io.check_flat_input_scale(
+            root, source="input.zarr", attrs_reader=reader
+        )
+        is None
+    )
+
+
+def test_input_prepared_at_the_wrong_level_reports_the_numbers(tmp_path):
+    root = _prepared_root(
+        tmp_path,
+        {"format": RECIPE_TAG, "source_level": "0", "source": "render.zarr"},
+    )
+    reader = lambda path: _ome_attrs([2.399, 4.798, 9.596])
+    message = volume_io.check_flat_input_scale(
+        root, source="input.zarr", attrs_reader=reader
+    )
+    assert message is not None
+    assert "2.399 um in-plane" in message
+    assert "9.596 or 9.362 um" in message
+    assert "nearest 9.362" in message  # nearest in relative distance
+    assert "factor 0.256" in message
+
+
+def test_strict_refuses_what_the_default_reports(tmp_path):
+    root = _prepared_root(
+        tmp_path,
+        {"format": RECIPE_TAG, "source_level": "0", "source": "render.zarr"},
+    )
+    reader = lambda path: _ome_attrs([2.399, 4.798, 9.596])
+    with pytest.raises(ValueError, match="factor 0.25"):
+        volume_io.check_flat_input_scale(
+            root, source="input.zarr", strict=True, attrs_reader=reader
+        )
+
+
+def test_unreachable_source_falls_back_and_never_raises(tmp_path):
+    root = _prepared_root(
+        tmp_path,
+        {"format": RECIPE_TAG, "source_level": "0", "source": "gone.zarr"},
+    )
+
+    def reader(path):
+        raise FileNotFoundError(path)
+
+    message = volume_io.check_flat_input_scale(
+        root, source="input.zarr", attrs_reader=reader
+    )
+    assert message is not None
+    assert "absolute scale not checked" in message
+    assert "source unreachable" in message
+
+
+def test_unreachable_source_at_the_expected_level_is_silent(tmp_path):
+    # Nothing is known about the scale and nothing is inconsistent: say nothing.
+    root = _prepared_root(
+        tmp_path,
+        {"format": RECIPE_TAG, "source_level": "2", "source": "gone.zarr"},
+    )
+
+    def reader(path):
+        raise FileNotFoundError(path)
+
+    assert (
+        volume_io.check_flat_input_scale(
+            root, source="input.zarr", attrs_reader=reader
+        )
+        is None
+    )
+
+
+def test_input_with_no_attrs_at_all_is_left_alone(tmp_path):
+    # What anyone preparing inputs by other means will hand this code.
+    root = _prepared_root(tmp_path, {})
+    assert volume_io.check_flat_input_scale(root, source="input.zarr") is None
+
+
+def test_bare_array_without_attrs_is_left_alone(tmp_path):
+    array = zarr.open_array(
+        str(tmp_path / "bare.zarr"), mode="w", shape=(21, 8, 8), dtype="uint8"
+    )
+    assert volume_io.check_flat_input_scale(array, source="bare.zarr") is None
+
+
+def test_input_without_known_format_tag_is_left_alone(tmp_path):
+    root = _prepared_root(tmp_path, _ome_attrs([2.399, 4.798, 9.596]))
+    assert volume_io.check_flat_input_scale(root, source="input.zarr") is None
+
+
+def test_missing_source_level_is_reported(tmp_path):
+    root = _prepared_root(tmp_path, {"format": RECIPE_TAG, "source": "render.zarr"})
+    message = volume_io.check_flat_input_scale(root, source="input.zarr")
+    assert message is not None and "records no source_level" in message
+
+
+def test_source_recording_only_a_voxel_size_is_scaled_by_level(tmp_path):
+    # A store that records its scale outside OME metadata, as Volume::normalize reads it.
+    root = _prepared_root(
+        tmp_path,
+        {"format": RECIPE_TAG, "source_level": "2", "source": "volume.zarr"},
+    )
+    reader = lambda path: {"voxelsize": 2.399}
+    assert (
+        volume_io.check_flat_input_scale(
+            root, source="input.zarr", attrs_reader=reader
+        )
+        is None
+    )
+
+
+def test_sample_pixel_size_is_read_in_millimetres(tmp_path):
+    doc = {"scan": {"tomo": {"acquisition": {"detector": {"samplePixelSize": 0.002399}}}}}
+    assert volume_io.voxel_size_um_from_document(doc) == pytest.approx(2.399)
+
+
+def test_native_nine_micron_render_at_level_zero_is_silent(tmp_path):
+    """The recipe's second documented family: a 9.362 um render used at level 0.
+
+    prepare_9um stamps the same tag whatever `--level` it was run with, so this input
+    carries a level-2 tag with source_level 0 and is still correct.
+    """
+
+    root = _prepared_root(
+        tmp_path,
+        {"format": RECIPE_TAG, "source_level": "0", "source": "native9.zarr"},
+    )
+    reader = lambda path: _ome_attrs([9.362])
+    assert (
+        volume_io.check_flat_input_scale(
+            root, source="input.zarr", attrs_reader=reader
+        )
+        is None
+    )
+
+
+def test_native_nine_micron_recorded_as_voxel_size_is_silent(tmp_path):
+    root = _prepared_root(
+        tmp_path,
+        {"format": RECIPE_TAG, "source_level": "0", "source": "native9.zarr"},
+    )
+    reader = lambda path: {"voxelsize": 9.362}
+    assert (
+        volume_io.check_flat_input_scale(
+            root, source="input.zarr", attrs_reader=reader
+        )
+        is None
+    )
+
+
+def test_refusal_uses_a_dedicated_exception(tmp_path):
+    root = _prepared_root(
+        tmp_path,
+        {"format": RECIPE_TAG, "source_level": "0", "source": "render.zarr"},
+    )
+    reader = lambda path: _ome_attrs([2.399, 4.798, 9.596])
+    with pytest.raises(volume_io.InputScaleRefused):
+        volume_io.check_flat_input_scale(
+            root, source="input.zarr", strict=True, attrs_reader=reader
+        )


### PR DESCRIPTION
**In one sentence:** ink inference can now tell whether the input it was handed was prepared at a scale the recipe trains at, using metadata `prepare_9um_isotropic_input` already writes.

**One real example:** Starting from a 2.399 µm rendered surface volume for PHerc0139 `w035`, I prepared the model input with `--level 0` instead of the documented `--level 2`, ran the shipped `aligned21_hybrid_3d2d` recipe, and scored the output against the published ink labels. The input was four times finer in-plane than the scale the recipe trains at, **and no stage of the pipeline said so**. Holding the depth orientation correct and changing only `--level`, that mistake costs **AUC 0.637 / 0.641 against 0.949 / 0.955** (two seeds).

**Before:** nothing downstream reads the provenance. `prepare_9um_isotropic_input` records `format`, `source`, `source_level`, `source_shape_zyx`, `source_z_slice` and `z_pool` on its output group, but across the repository `source_level` appears only in that writer, in the test asserting it was written, and in two unrelated files. Inference never looks at any of it, so an input at the wrong in-plane scale is indistinguishable from a correct one at run time.

**After this PR:** inference resolves the in-plane micrometres of the recorded source at the recorded level, compares them with the scales the recipe trains at, and reports the numbers on a mismatch:

```
w035_9um.zarr: input is 2.399 um in-plane; this recipe trains at 9.596 or 9.362 um
(nearest 9.362, factor 0.256). Prepared from ink_ctrl2/w035_sv.zarr at level 0.
```

**Proof.** Both inputs were produced by `prepare_9um_isotropic_input` from the same source volume and window, differing only in `--level`:

| input | in-plane | check |
|---|---|---|
| `--level 2` | 9.596 µm | silent |
| `--level 0` | 2.399 µm | reports the mismatch |
| published surface volume (not produced by this preparer) | — | silent, no recipe tag |

The silence on the first is a passing check, not a skipped one.

**What the mistake costs.** The scale fault in this incident was accompanied by a second one — the render traversed the surface normal in the opposite order to the labels — so the two were varied independently. Two seeds, same window and labels, AUC over the whole crop:

| | depth order as rendered | depth order reversed |
|---|---|---|
| `--level 0` (2.399 µm) | 0.555 / 0.538 | **0.637 / 0.641** |
| `--level 2` (9.596 µm) | 0.511 / 0.530 | **0.949 / 0.955** |

Published surface volume, for reference: 0.979. AUC is computed exactly, as the rank statistic over every pixel of the window against the binary published labels; a threshold-sweep approximation gives figures around 0.01 lower on the same rasters, so the method matters when reproducing these. Restricting the same computation to the annotated region moves every figure in the same direction and does not change the comparison — 0.645 / 0.671 against 0.968 / 0.976 for the two reversed-order cells.

With the depth order correct, changing only `--level` costs **0.31 of AUC**, and the two seeds agree to the third digit in both cells.

Neither fault explains the failure alone. Correcting the depth order alone moves 0.555 to 0.637; correcting the scale alone moves 0.555 to 0.511, which is noise between two values at chance. Only both together reach 0.949. That interaction is why the original investigation could not diagnose either fault from results alone: fixing one and re-running still looks like failure.

**What to look at:** the check reads only metadata that was already on disk during the incident. It adds no new keys, defines no new format, requires no change to how inputs are produced, and never reads an array — from the source store it reads the metadata document only.

Regression, whole `ink_detection` suite, same environment and command, measured on this branch and on the commit it is rebased onto:

| | failed | passed | skipped | collection errors |
|---|---|---|---|---|
| without this PR | 2 | 20 | 1 | 16 |
| with this PR | 2 | 34 | 1 | 16 |

The fourteen additional passes are exactly this PR's tests. The two failures are the same two before and after — this PR neither fixes nor touches them — and the 16 collection errors are optional dependencies missing in the test environment, identical in both runs.

**Why / where this is useful:** anyone running the shipped ink recipe on their own renders. The failure it catches is silent by construction — the model returns a confident, plausible, wrong map, and a negative result is indistinguishable from a misconfigured one.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

### Motivation

A pre-registered ink protocol on PHerc. MAN5 — criterion fixed before any data, thirteen jobs, displaced negative controls, and a blind read by a human — returned a clean negative and was about to be reported as a null. The pre-registration had also prescribed a positive control on a segment with published labels, and that step had not been run. Running it returned a clean negative there too, on documented letters.

Working out why took longer than it should have, because there was more than one fault and they hid each other, as the table above shows. Correcting it then introduced a third of the same family: the corrected input was made by resampling the existing one in place while keeping its attributes, so the file went on describing data it no longer contained — and this check reports it, correctly, for that reason.

Every defence in that protocol sits downstream of all three, and each behaved exactly as it would have in front of a real null. This PR addresses the one of the three for which the repository does not already have an answer. The depth convention is documented — `--flip-normals`, and `--direction both` when a segment's orientation is unknown — and we had not read it.

### How the scale is resolved

`source_level` alone is not a scale, so the check consults the store named in `source`:

1. **OME metadata first.** A rendered surface volume records micrometre axes and a scale per dataset, so the level the input was built from names its own in-plane sampling directly — `9.596` at level 2, `2.399` at level 0, for a 2.399 µm render.
2. **Otherwise a recorded voxel size**, read in the order `Volume::normalize()` uses: a numeric `voxelsize`, then the alternative spellings (`voxel_size_um`, `voxelSizeUm`, `pixel_size_um`, `pixelSizeUm`, `resolution_um`), then the beamline `samplePixelSize`, which is recorded in millimetres. That figure is then scaled by the pyramid level.

Only metadata is read, never an array.

**The recipe trains at two scales, not one, so the check accepts either.** `aligned21_fixed_scroll_prior.json` — described in the docs as the readable contract behind the recipe's `datasets` block — declares 29 representations in two source families: 24 `public_2p4_level2_zmean4` (2.399 µm renders pooled at level 2, so 9.596 µm) and 5 `native_9p362_level0` (native 9.362 µm renders used at level 0). The tutorial states the same split. `0139:w035` appears in both, the same physical segment at two scales. The check therefore accepts an input within 2% of either figure, and reports which one it was nearest to. The two acceptance windows overlap, and the nearest wrong pyramid level is 50% away, so nothing legitimate falls between them and nothing wrong falls inside.

If the source cannot be opened, or records no scale, that outcome is kept **distinct from a scale error**: the check falls back to comparing the recipe tag with the recorded level — which needs nothing but the input itself — and says in the message that the absolute scale was not checked, naming the reason, and noting that a native 9.362 µm render prepared at level 0 is legitimate and would be reported by that fallback.

### Default behaviour

**The check reports by default**; `--strict-input-scale` turns the same finding into a refusal.

Reporting is the right default for a check that lives in someone else's inference path. A refusal's blast radius falls on users whose inputs were prepared by another route, or whose recorded `source` has since moved — and a message carrying the actual numbers is enough to act on. The incident above would have been stopped just as effectively by the warning as by a refusal, because the numbers are in it. If maintainers prefer refusal as the default, inverting the flag is a one-line change.

In a folder run, a refusal skips that segment and records it — `LOGGER.warning` plus `skipped_count`, the same convention the loop twenty lines above already uses for a segment whose input zarr is missing — rather than aborting the remaining segments. The refusal uses a dedicated `InputScaleRefused(ValueError)` so that the loop catches this case and not unrelated errors.

### Limits and relationships

- **The recipe tag is a constant, so the tag-vs-level fallback can mis-report the native family.** `prepare_9um_isotropic_input` writes `format: FORMAT_TAG` unconditionally, with no branch on the level, so every input it produces claims the level-2 recipe — including one correctly prepared at level 0 from a native 9.362 µm render. When the source can be consulted this is irrelevant, because the absolute scale settles it; when it cannot, the fallback reports such an input, and says so in its own message.
- **`source` is recorded as it was typed, so a relative path stops resolving elsewhere.** `prepare_9um_isotropic_input` stores the input path verbatim; when that is relative, a consumer run from a different working directory cannot open it. The check then reports `absolute scale not checked: source unreachable`, which is correct but weaker than it needs to be. We hit this on the first run of the check against our own incident artefacts.
- **The check trusts the recorded provenance.** If an array is resampled or rewritten after preparation while its attributes are preserved, the metadata describes the old data and the check reports on the stale record. This is not hypothetical: it happened to one of our own corrected inputs, which we resampled in place and which the check therefore reports.
- **Only one recipe tag is known** (`level2-zmean4-21slice-v1`). A new recipe needs one line in the mapping; an unknown tag is not an error and is skipped untouched.
- **A source that cannot be consulted degrades the check, it does not fail it.** A public-catalogue sweep found stores returning `NoSuchKey`, so "unreachable" had to be a distinct outcome rather than a crash or a false alarm.
- The check does not validate the surface against its CT volume. That is #1463, and it should run first.
- It does not check depth orientation. The tutorial already documents `--flip-normals` for reproducing the published renders' orientation, and `--direction both` for the case where a segment's orientation is unknown; we did not read that before losing the experiment above, and there is nothing to add to it.
- **Precedent rather than neighbourhood:** #1483 fixed a training/inference divergence in this same path — inference doing something different from training — and was merged. This is that shape again, with the pyramid level as the diverging variable. #1229 fixed the same class one stage upstream, scale metadata describing the wrong level. #1541 (open) makes voxel-size discovery robust to nested remote metadata; this change is independent of it and does not depend on it landing.

### Agentic disclosure

Investigation, implementation, testing and drafting used Claude Code and OpenAI Codex under my direction. Every number above comes from runs on public data.
