### PR TITLE
Scroll 3 is catalogued under 54 keV but its only volume is the 53 keV…

### DIFF
--- a/vesuvius/src/vesuvius/install/configs/scrolls.yaml
+++ b/vesuvius/src/vesuvius/install/configs/scrolls.yaml
@@ -27,7 +27,7 @@
 
 # Scroll 4 - tested 03/24/25
 "4":
-  "54":
+  "53":
     "7.91":
       volume: "https://dl.ash2txt.org/full-scrolls/Scroll4/PHerc1667.volpkg/volumes_zarr/20231117161658.zarr/"
 

--- a/vesuvius/src/vesuvius/install/configs/scrolls.yaml
+++ b/vesuvius/src/vesuvius/install/configs/scrolls.yaml
@@ -21,7 +21,7 @@
 
 # Scroll 3 -  tested 03/24/25
 "3":
-  "54":
+  "53":
     "7.91":
       volume: "https://dl.ash2txt.org/full-scrolls/Scroll3/PHerc332.volpkg/volumes_zarr_standardized/53keV_7.91um_Scroll3.zarr/"
 


### PR DESCRIPTION
**In one sentence:** You can now open Scroll 3 with the energy its data actually has.

**One real example:** Starting with Scroll 3 (PHerc332) on `dl.ash2txt.org`, I called
`Volume(type="scroll", scroll_id=3, energy=53, resolution=7.91)` and it produced a
`ValueError` — even though the only volume the server publishes for that scroll is
`53keV_7.91um_Scroll3.zarr`.

**Before:**

```
>>> from vesuvius import Volume
>>> v = Volume(type="scroll", scroll_id=3, energy=53, resolution=7.91)
Error reading or parsing config file .../configs/scrolls.yaml: URL not found in config
for scroll=3, energy=53, resolution=7.91
ValueError: URL not found in config for scroll=3, energy=53, resolution=7.91
```

And the inverse, which is the part that worries me more — asking for an energy that does not
exist succeeds and silently hands back the 53 keV volume:

```
>>> v = Volume(type="scroll", scroll_id=3, energy=54, resolution=7.91)
>>> v.shape()
(9778, 3550, 3400)          # this is 53keV_7.91um_Scroll3.zarr
```

**After this PR:**

```
>>> v = Volume(type="scroll", scroll_id=3, energy=53, resolution=7.91)
>>> v.shape()
(9778, 3550, 3400)
>>> patch = v[5000, 1700:1764, 1700:1764]
>>> patch.shape, patch.dtype, patch.min(), patch.max(), round(float(patch.mean()), 1)
((64, 64), dtype('uint8'), 0, 216, 49.9)
```

**Proof:** the two blocks above are the same call before and after the one-line change, on the
same machine and the same remote volume. The directory listing at
`https://dl.ash2txt.org/full-scrolls/Scroll3/PHerc332.volpkg/volumes_zarr_standardized/`
contains exactly one entry, `53keV_7.91um_Scroll3.zarr` — there is no 54 keV volume to point at.
Scroll 5, whose volume is also a 53 keV scan, is already keyed `"53"` in the same file.

I also re-checked the four scrolls I did not touch, and they open unchanged:

```
scroll 1 @ 54keV -> (14376, 7888, 8096)
scroll 2 @ 54keV -> (14428, 10112, 11984)
scroll 4 @ 54keV -> (11174, 3340, 3440)
scroll 5 @ 53keV -> (21000, 6700, 9100)
```

**Why / where this is useful:** anyone selecting scroll volumes by energy — comparing scans
across scrolls, or scripting over `list_files()` — currently has to ask for the wrong number to
get Scroll 3, and gets no warning that the volume they received was scanned at a different
energy from the one they requested.

- [x] I personally verified that the example and proof above were produced by this PR on the
      stated data.

## Details

Tested commit: `de3c249`. One-line change in
`vesuvius/src/vesuvius/install/configs/scrolls.yaml`: the Scroll 3 block's energy key goes from
`"54"` to `"53"`. No URL is edited and no other scroll is touched — the diff is +1/-1.

Environment: Windows 11, Python 3.14.5, minimal install (`uv pip install -e .` plus
`nest-asyncio`, which `list_files()` needs and is not in the base dependencies — that part is
already tracked in #1329, so it is not included here).