### PR TITLE
ink_detection: make cache_max_gb bound the cache directory, not each process

### DIFF
--- a/vesuvius/docs/ink_detection.md
+++ b/vesuvius/docs/ink_detection.md
@@ -90,13 +90,19 @@ not totals across the cache root.
 
 When a volume opens with a budget, the code scans that volume's cache
 subdirectory once. An over-budget directory is pruned oldest-mtime-first to at
-most 90% of the budget; an at- or under-budget directory is left alone. Zarr's
-CacheStore then applies a process-local steady-state LRU. Multiple workers may
-share the directory safely because LocalStore installs complete values
-atomically, but independent process accounting means the directory can briefly
-overshoot its budget before a later open-time sweep. Every process constructs
-its own source store after it starts; a remote fsspec store is never inherited
-as the active transport across a fork.
+most 90% of the budget; an at- or under-budget directory is left alone. The
+files that survive the scan are then registered, oldest first, in the LRU that
+Zarr's CacheStore builds for this process. Zarr starts that LRU empty in every
+new process and never scans the cache directory itself, so without the seed a
+re-open would spend a second full budget on top of whatever the sweep retained;
+with it, one budget bounds the directory across sequential runs, and reusing a
+file inherited from an earlier run refreshes its LRU position instead of
+leaving it ranked by its original mtime. Multiple workers may share the
+directory safely because LocalStore installs complete values atomically, but
+each worker still enforces the budget against its own view, so a directory
+written by several simultaneous processes can overshoot until the next
+open-time sweep. Every process constructs its own source store after it starts;
+a remote fsspec store is never inherited as the active transport across a fork.
 
 ## Shipped aligned-corpus configs
 

--- a/vesuvius/src/vesuvius/ink_detection/README.md
+++ b/vesuvius/src/vesuvius/ink_detection/README.md
@@ -36,9 +36,10 @@ Paste volume paths in their correct local, `s3://`, or `https://` form; the
 package does not rewrite URLs. The optional compressed-chunk disk cache requires
 Zarr 3; uncached reads support Zarr 2.18.7 and Zarr 3. Its budget is per volume:
 an over-budget volume subdirectory is swept oldest-first to 90% when opened,
-then Zarr CacheStore applies a process-local LRU. Concurrent workers use atomic
-LocalStore installs, but their independent accounting can cause a brief shared
-cache-directory overshoot.
+and the files that survive the sweep are registered in this process's Zarr
+CacheStore LRU so the budget bounds the directory rather than each process.
+Concurrent workers use atomic LocalStore installs, but their independent
+accounting can still cause a shared cache-directory overshoot while they run.
 
 ## Shipped configs
 

--- a/vesuvius/src/vesuvius/ink_detection/volume_io.py
+++ b/vesuvius/src/vesuvius/ink_detection/volume_io.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import time
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -39,9 +41,15 @@ def _cache_snapshot(cache_dir: Path) -> list[tuple[int, int, Path]]:
 
 def _evict_to_watermark(
     snapshot: list[tuple[int, int, Path]], max_bytes: int
-) -> int:
+) -> list[tuple[int, int, Path]]:
+    """Delete oldest entries until the snapshot fits under the watermark.
+
+    Returns the entries that survived, still sorted oldest-mtime-first, so the
+    caller can hand exactly the retained set to ``_seed_cache_store_lru``.
+    """
     total = sum(size for _, size, _ in snapshot)
     target_bytes = 0.9 * max_bytes
+    evicted = 0
     for _, size, path in snapshot:
         if total <= target_bytes:
             break
@@ -50,7 +58,63 @@ def _evict_to_watermark(
         except FileNotFoundError:
             pass
         total -= size
-    return total
+        evicted += 1
+    return snapshot[evicted:]
+
+
+def _seed_cache_store_lru(
+    store: Any, cache_path: Path, snapshot: list[tuple[int, int, Path]]
+) -> bool:
+    """Register already-cached files in a fresh CacheStore's LRU accounting.
+
+    ``CacheStore`` builds its LRU bookkeeping in memory and starts it empty in
+    every new process: it never scans ``cache_store`` on construction, so files
+    left by an earlier run are invisible to it. It therefore writes a full
+    ``max_size`` of new data on top of whatever the open-time sweep retained,
+    and a hit on a pre-existing file neither counts toward the budget nor
+    refreshes that file's LRU position. Seeding the accounting from the files
+    that are actually on disk makes ``max_size`` a true bound on the cache
+    directory rather than a per-process allowance, and lets reuse of an
+    inherited entry keep it alive.
+
+    The alternative of shrinking ``max_size`` to the remaining headroom is
+    worse: the sweep leaves 90% of the budget in place, so headroom collapses
+    to 10% (or to 0 when the directory is already at budget), and a
+    ``max_size`` below one chunk makes ``CacheStore`` write every value to disk
+    and then decline to track it -- an unbounded, never-evicted cache. Evicting
+    far enough to free a whole budget would instead throw away the cross-run
+    reuse the disk cache exists to provide.
+
+    This reaches into ``CacheStore._state`` because zarr exposes no public seam
+    for pre-populating the LRU (``cache_info()`` is read-only). The proper
+    home for this is ``CacheStore.__init__``; until it lands upstream, the
+    access is guarded and reported rather than assumed.
+
+    Returns True when the accounting was seeded.
+    """
+    state = getattr(store, "_state", None)
+    required = ("cache_order", "key_sizes", "key_insert_times", "current_size")
+    if state is None or not all(hasattr(state, name) for name in required):
+        return False
+    monotonic_now = time.monotonic()
+    wall_now = time.time()
+    total = 0
+    for mtime_ns, size, path in snapshot:
+        try:
+            key = path.relative_to(cache_path).as_posix()
+        except ValueError:
+            continue
+        # snapshot is oldest-first, so insertion order is already LRU order.
+        state.cache_order[key] = None
+        state.key_sizes[key] = size
+        # Age entries by mtime so a finite max_age_seconds would still expire
+        # them; with the "infinity" default this value is never read.
+        state.key_insert_times[key] = monotonic_now - max(
+            0.0, wall_now - mtime_ns / 1e9
+        )
+        total += size
+    state.current_size = total
+    return True
 
 
 def load_volume_auth(auth_json_path: str | Path | None) -> tuple[str, str] | None:
@@ -121,10 +185,13 @@ def open_volume_root(
             raise ValueError("cache_max_gb must be nonnegative or None")
         cache_path = disk_cache_subdir(path_text, Path(cache_dir))
         cache_path.mkdir(parents=True, exist_ok=True)
+        retained: list[tuple[int, int, Path]] = []
         if maximum_bytes is not None:
             snapshot = _cache_snapshot(cache_path)
             if sum(size for _, size, _ in snapshot) > maximum_bytes:
-                _evict_to_watermark(snapshot, maximum_bytes)
+                retained = _evict_to_watermark(snapshot, maximum_bytes)
+            else:
+                retained = snapshot
         if is_remote:
             remote_options = dict(storage_options)
             remote_options["skip_instance_cache"] = True
@@ -140,6 +207,20 @@ def open_volume_root(
             cache_store=LocalStore(cache_path),
             max_size=maximum_bytes,
         )
+        # Seed before the first read: zarr.open() itself fetches metadata
+        # through this store, and those writes must be charged against the
+        # bytes already on disk rather than against an empty budget.
+        if maximum_bytes is not None and not _seed_cache_store_lru(
+            store, cache_path, retained
+        ):
+            warnings.warn(
+                "installed zarr CacheStore exposes no LRU state to seed "
+                f"(zarr {zarr.__version__}); the volume cache budget of "
+                f"{maximum_bytes} bytes is enforced only by the open-time "
+                "sweep, so this process may grow the cache directory past it",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         return zarr.open(store=store, mode="r")
 
     if is_remote and ZARR_V3:

--- a/vesuvius/tests/ink_detection/test_volume_io.py
+++ b/vesuvius/tests/ink_detection/test_volume_io.py
@@ -171,6 +171,118 @@ def test_open_sweep_prunes_oldest_recursively_and_leaves_under_budget(
 
 
 @pytest.mark.skipif(not _ZARR_V3, reason="volume disk cache requires Zarr 3")
+def test_reopening_reuses_one_budget_instead_of_granting_a_new_one(tmp_path):
+    chunk_bytes = 16 * 16 * 16
+    chunk_count = 40
+    shape = (16, 16, 16 * chunk_count)
+    expected = (
+        np.arange(chunk_bytes * chunk_count, dtype=np.int64)
+        .astype(np.uint8)
+        .reshape(shape)
+    )
+    source_path = tmp_path / "volume.zarr"
+    source = zarr.open_group(source_path, mode="w")
+    # Uncompressed chunks make every cached file exactly chunk_bytes long, so
+    # the budget below holds exactly half of this volume.
+    source.create_array(
+        "0",
+        shape=shape,
+        chunks=(16, 16, 16),
+        dtype="uint8",
+        compressors=None,
+    )
+    source["0"][:] = expected
+
+    budget_bytes = chunk_bytes * (chunk_count // 2)
+    cache_root = tmp_path / "cache"
+    cache_path = disk_cache_subdir(str(source_path), cache_root)
+
+    for _ in range(3):
+        # Each open builds a new CacheStore whose in-memory LRU starts empty,
+        # which is exactly what a second training or inference process sees.
+        root = open_volume_root(
+            source_path,
+            cache_dir=cache_root,
+            cache_max_gb=budget_bytes / 1e9,
+        )
+        assert np.asarray(root["0"][:]).tobytes() == expected.tobytes()
+        on_disk = sum(
+            size for _, size, _ in volume_io._cache_snapshot(cache_path)
+        )
+        assert 0 < on_disk <= budget_bytes
+        # Every cached file is a tracked full-key entry, so the store's own
+        # accounting can only exceed the directory (current_size also covers
+        # CacheStore's in-memory byte-range entries, which never reach disk).
+        # Sandwiching the directory under it is what makes max_size a real
+        # bound; before the seed, on_disk ran to twice current_size.
+        assert on_disk <= root.store.cache_info()["current_size"] <= budget_bytes
+
+
+@pytest.mark.skipif(not _ZARR_V3, reason="volume disk cache requires Zarr 3")
+def test_seeded_entries_evict_oldest_first_and_survive_reuse(tmp_path):
+    from zarr.experimental.cache_store import CacheStore
+    from zarr.storage import LocalStore, MemoryStore
+
+    cache_path = tmp_path / "cache"
+    files = [cache_path / "c" / "1", cache_path / "c" / "0"]
+    # Whole seconds, not raw nanoseconds: NTFS keeps 100 ns granularity and
+    # anchors at 1601, so sub-microsecond mtimes near the epoch collapse to 0
+    # and the intended age ordering disappears.
+    for timestamp, path in enumerate(files, start=1):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"x" * 4)
+        os.utime(path, ns=(timestamp * 10**9, timestamp * 10**9))
+
+    source = MemoryStore()
+    store = CacheStore(
+        store=source,
+        cache_store=LocalStore(cache_path),
+        max_size=10,
+    )
+    assert volume_io._seed_cache_store_lru(
+        store, cache_path, volume_io._cache_snapshot(cache_path)
+    )
+    assert store.cache_info()["current_size"] == 8
+
+    async def scenario():
+        from zarr.core.buffer.core import default_buffer_prototype
+
+        prototype = default_buffer_prototype()
+        # Reading the older seeded entry must promote it, so the newer one is
+        # what the next admission evicts. "c/1" is the older file here, so an
+        # order taken from paths instead of mtimes would evict the wrong one.
+        assert (await store.get("c/1", prototype)).to_bytes() == b"x" * 4
+        await source.set("c/2", prototype.buffer.from_bytes(b"y" * 4))
+        assert (await store.get("c/2", prototype)).to_bytes() == b"y" * 4
+
+    asyncio.run(scenario())
+
+    assert files[0].exists()
+    assert not files[1].exists()
+    assert store.cache_info()["current_size"] == 8
+    assert sum(size for _, size, _ in volume_io._cache_snapshot(cache_path)) == 8
+
+
+@pytest.mark.skipif(not _ZARR_V3, reason="volume disk cache requires Zarr 3")
+def test_unseedable_cache_store_is_reported_not_silently_overfilled(
+    tmp_path, monkeypatch
+):
+    class Stateless:
+        pass
+
+    assert not volume_io._seed_cache_store_lru(Stateless(), tmp_path, [])
+
+    monkeypatch.setattr(volume_io.zarr, "open", lambda *, store, mode: store)
+    monkeypatch.setattr(
+        volume_io, "_seed_cache_store_lru", lambda *args, **kwargs: False
+    )
+    with pytest.warns(RuntimeWarning, match="enforced only by the open-time"):
+        open_volume_root(
+            "unseedable.zarr", cache_dir=tmp_path / "cache", cache_max_gb=1e-6
+        )
+
+
+@pytest.mark.skipif(not _ZARR_V3, reason="volume disk cache requires Zarr 3")
 def test_shared_cache_multiprocess_reads_are_not_torn(tmp_path):
     source_path = tmp_path / "source.zarr"
     cache_dir = tmp_path / "cache"


### PR DESCRIPTION
Fixes #1586.
**In one sentence:** Makes `cache_max_gb` bound the ink-detection cache *directory* instead of granting each process its own full budget, so the number in your config is the number on disk.

**One real example:** Starting with the 5,979,366,890-byte cache directory a real PHerc1203 `auto_grown` render had just produced under a `--cache-max-gb 4` budget, I re-ran the same render with this PR applied, and it produced a **3,999,538,943-byte** directory in a single open — the render exited 0 and the surface volume was intact (shape `(21, 4639, 5359)`, mid-slice mean 77.04 DN, 65.6% non-zero).

**Before:** The budget is enforced twice, by two accountants who cannot see each other's books. `open_volume_root` sweeps the cache directory to 0.9 × budget from its own filesystem snapshot, then hands the *same* budget to zarr's `CacheStore`, whose LRU ledger is in-memory and starts empty in every process. The retained 90% is invisible to the store that is supposed to enforce the budget, so the process spends a further full `max_size` on top of it before its first eviction. Steady state ≈ **1.9× the requested budget**, re-established by every process that reuses the directory. Reading an inherited chunk does not even register it, because `_update_access_order` no-ops on keys it has never seen.

**After this PR:** The sweep hands the files it retained to the `CacheStore` this process just built, registering them oldest-first in that store's LRU before the first read goes through it. `max_size` stays at the full `cache_max_gb` and means what the docs already say it means: a bound on the directory, not an allowance per process. Reuse of an inherited chunk promotes it properly, so eviction follows actual access rather than original download order. The patched opener also **recovers** a directory that is already over budget, rather than merely preventing the next overshoot.

**Proof:** Three measurements on this fix's before/after boundary. **Sources are labelled — they are not the same machine or the same data.**

| # | source | data | budget | before (on disk) | vs budget | after | vs budget |
|---|---|---|---|---|---|---|---|
| 1 | **RunPod pod**, Ubuntu 22.04, `/workspace` 20 GB — *real data* | one `auto_grown` PHerc1203 segment render, `s3://vesuvius-challenge-open-data/PHerc1203/volumes/20250820131727-9.362um-1.2m-113keV-masked.zarr` | 4,000,000,000 B | pass 1: 3,999,538,943 B / 1,907 files<br>pass 2: **5,979,366,890 B / 2,854 files** | 1.00×<br>**1.49×** | same dir, same render, same budget: **5,979,366,890 B → 3,999,538,943 B / 1,907 files** in a single open | **1.00×** |
| 2 | **workstation**, same volume over anonymous S3 — *also real data* | same PHerc1203 volume, level 0, papyrus-bearing region, 3 bbox reads | 30,000,000 B | 29,360,128 B / 14 files at open → **58,720,256 B / 28 files** after the reads | **1.96× (first warm re-open)** | 29,360,128 B / 14 files at open → 29,360,128 B / 14 files after the reads | **0.98×** |
| 3 | **local synthetic**, no network | 40-chunk uncompressed `LocalStore` volume in a temp dir, 4 sequential re-opens | 81,920 B | pass 1: 81,920 B<br>pass 2: 163,840 B<br>pass 3-4: 155,648 B | 1.00×<br>**2.00×**<br>**1.90× (steady)** | 81,920 B on every pass | 1.00× |

Rows 1 and 2 are both real scroll data at budget scales three orders of magnitude apart — 4 GB on the pod that actually filled, 30 MB on a workstation where the arithmetic is small enough to read at a glance. They agree on the mechanism and bracket the effect. Row 3 removes the network and makes the chunk sizes exact; it is what the regression test in this PR asserts.

Row 2 is the cleanest apples-to-apples — **same starting directory, same reads, same budget**: `main` takes 29,360,128 B to 58,720,256 B, the patched opener leaves it at 29,360,128 B. Crop means are identical across both (`114.8 / 109.0 / 104.5`), so only the eviction schedule differs. Voxel data is unchanged in all three; row 3's harness asserts byte-equality against the source on every pass.

**Why / where this is useful:** Anyone rendering or inferring off an S3-backed scroll volume with `--cache-dir` turned on — which the docs recommend for exactly this workload — currently has to provision twice the disk they asked for, and a long render that dies at 90% costs far more than a smaller cache does.

It also makes both documented numbers honest. `vesuvius/docs/ink_detection.md:488` puts `--cache-max-gb 100` in the copy-paste example (~190 GB on this mechanism), and `scrollprize.org/docs/07_tutorial5.md:327` ships `"volume_cache_max_gb": 120`, with line 349 describing it as "an on-disk LRU cache (capped at `volume_cache_max_gb`)". On `main` that cap is per process against an empty ledger, so following the tutorial on a 128 GB disk occupies ~228 GB and fails. With this PR the documented sentence becomes true and neither example needs its number changed, which is why I left them alone.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

### Mechanism

| file:line (`37e300d3`) | code | effect |
|---|---|---|
| `volume_io.py:117-119` | `maximum_bytes = int(float(cache_max_gb) * 1e9)` | the budget, in bytes |
| `volume_io.py:124-127` | `snapshot = _cache_snapshot(cache_path)` … `_evict_to_watermark(snapshot, maximum_bytes)` | sweeps the directory to 0.9 × budget at open |
| `volume_io.py:138-142` | `CacheStore(store=…, cache_store=LocalStore(cache_path), max_size=maximum_bytes)` | the same budget handed to zarr's `CacheStore` |
| `zarr/experimental/cache_store.py:125` | `self._state = _CacheState()` | LRU ledger starts empty in every process; never scans `cache_store` |
| `zarr/experimental/cache_store.py:196-226` | `_track_entry` | only keys written by this process enter the ledger |
| `zarr/experimental/cache_store.py:228-232` | `if entry_key in self._state.cache_order:` | a hit on an inherited file is unrankable |
| `zarr/experimental/cache_store.py:155-167` | `_accommodate_value` | eviction only considers this process's own keys |

### The change

- `_evict_to_watermark` returns the surviving snapshot entries instead of a byte total (no caller used the total).
- New `_seed_cache_store_lru(store, cache_path, snapshot)` fills `cache_order`, `key_sizes`, `key_insert_times` and `current_size` from those entries, mapping each path back to its store key with `path.relative_to(cache_path).as_posix()` (`LocalStore` stores key `k` at `root / k`, `zarr/storage/_local.py:213`).
- `open_volume_root` seeds **before** `zarr.open()`, because `zarr.open()` itself fetches metadata through the store and those writes must be charged against the bytes already on disk.

| file | change |
|---|---|
| `vesuvius/src/vesuvius/ink_detection/volume_io.py` | `+84 / -3`: `_evict_to_watermark` returns survivors; new `_seed_cache_store_lru`; `open_volume_root` seeds and warns |
| `vesuvius/tests/ink_detection/test_volume_io.py` | `+112`: three regression tests |
| `vesuvius/docs/ink_detection.md` | the cache paragraph now describes the seed and is honest about the concurrent case |
| `vesuvius/src/vesuvius/ink_detection/README.md` | same, in short form |

No new dependencies, no public-flag changes, no change to `cache_max_gb` semantics other than making them true.

### Why this design, and not the headroom variant

The obvious alternative — keep the sweep and give `CacheStore` only `max(budget - retained, 0)` — makes the on-disk invariant true too, but buys it with two real regressions:

- **It shrinks the working set exactly when the cache is warm.** The sweep leaves 90% of the budget in place, so headroom collapses to 10% of the budget; to get usable headroom back you have to delete cache you were about to reuse (retaining half the budget means re-downloading up to 60 GB per process start at the tutorial's `120`). A warm start would get a *smaller* working set than a cold one, which is backwards.
- **At the bottom it silently disables eviction, not caching.** With `max_size` below one value, `_cache_miss` writes to the cache store at `zarr/experimental/cache_store.py:281` and *then* calls `_track_entry`, and unlike the byte-range branch at 286-293 the full-key branch does not roll back. Every chunk lands on disk, none is tracked, `evictions` stays 0, and the directory grows without limit. (Measured separately at a 1,000-byte budget: 165,678,289 B on disk after three reads, `evictions=0`, still climbing.) The headroom design walks toward that cliff by construction, since headroom shrinks as the cache fills.

Evicting far enough to free a whole budget avoids both, but throws away the cross-run reuse the disk cache exists to provide — the entire reason `--cache-dir` is worth turning on for an S3-backed render. Seeding keeps the full budget usable, keeps the warm cache, and fixes the LRU-promotion bug as a side effect.

### The part that is not villa's to fix

`_seed_cache_store_lru` writes to `CacheStore._state` because zarr exposes no public seam for pre-populating the LRU — `cache_info()` is read-only and `__init__` takes no starting state. The correct home for this is `CacheStore.__init__` scanning its `cache_store` (or accepting a seed callback); I have filed that upstream as zarr-developers/zarr-python#4282.

Until that lands the access is guarded rather than assumed: `_seed_cache_store_lru` returns `False` if the expected attributes are absent, and `open_volume_root` raises a `RuntimeWarning` naming the installed zarr version and the budget it can no longer enforce. It degrades to today's behaviour, loudly — never to a silently disabled or silently unbounded cache. If the upstream fix lands, this seed becomes a harmless no-op re-assert of values zarr already computed, and can be deleted.

**Known limitation, now stated honestly in the docs rather than as "brief":** several workers sharing one cache directory *at the same time* each enforce the budget against their own view, so a concurrent fleet can still overshoot until the next open-time sweep. This PR fixes the sequential case — the train-then-infer and render-then-rerun patterns that actually filled the disk.

### Test evidence

Run from the repo root with a Zarr-3 environment (these paths skip on Zarr 2, which cannot use the disk cache at all):

```
python -m pytest vesuvius/tests/ink_detection/test_volume_io.py -q
```

| test | asserts |
|---|---|
| `test_reopening_reuses_one_budget_instead_of_granting_a_new_one` | three sequential opens of a 40-chunk volume with a 20-chunk budget; after each, `0 < on_disk <= cache_info()["current_size"] <= budget`, i.e. the directory is bounded by the store's own ledger and the ledger by the budget. Reads are asserted byte-identical to the source on every pass |
| `test_seeded_entries_evict_oldest_first_and_survive_reuse` | seeded entries carry mtime order (the older file is the lexicographically *later* one, so a path-ordered seed would evict the wrong one); reading a seeded entry promotes it, and the next admission evicts the other |
| `test_unseedable_cache_store_is_reported_not_silently_overfilled` | the guard returns `False` on a store with no `_state`, and `open_volume_root` raises `RuntimeWarning` instead of proceeding quietly |

The three new tests against **unpatched** `volume_io.py`:

```
FAILED test_reopening_reuses_one_budget_instead_of_granting_a_new_one
E       assert 163840 <= 81920
FAILED test_seeded_entries_evict_oldest_first_and_survive_reuse
FAILED test_unseedable_cache_store_is_reported_not_silently_overfilled
3 failed, 13 deselected
```

With this PR:

```
3 passed, 13 deselected in 3.08s
```

Whole-file and neighbours, on this branch rebased onto `37e300d3`:

| suite | result |
|---|---|
| `vesuvius/tests/ink_detection/test_volume_io.py` | 13 passed, 2 failed, 1 skipped |
| `vesuvius/tests/data/test_chunk_cache.py` + `vesuvius/tests/neural_tracing/test_disk_cache_store.py` | 7 passed, 1 skipped |
| `test_data_foundation.py`, `test_dependency_wiring.py`, `test_flat_inference.py`, `test_native_full3d_inference.py` | 53 passed |

The 2 failures are **pre-existing and Windows-only artifacts of my measurement machine**, present identically before and after this change; villa targets Ubuntu/macOS (`AGENTS.md §1.5`):

- `test_open_sweep_prunes_oldest_recursively_and_leaves_under_budget` sets mtimes with `os.utime(path, ns=(1,1))`/`(2,2)`/`(3,3)`; NTFS keeps 100 ns granularity anchored at 1601, so all three collapse to `st_mtime_ns == 0` and the eviction order falls through to the path tiebreak. Fails deterministically.
- `test_shared_cache_multiprocess_reads_are_not_torn` fails with `PermissionError(13)`: Windows will not replace a file another process has open, which is what `LocalStore`'s `.partial` install does. This one is **flaky rather than deterministic** — it passed in 1 of 3 runs here.

The new tests avoid the first trap deliberately: they set mtimes at whole-second resolution, with a comment saying why.

> I hit this while screening PHerc1203 for First Letters on 20 GB pods, where a render that dies at 90% costs far more than a smaller cache does. I would rather the budget be honest than large.

---

*Disclosure: I used Claude (Anthropic) as a coding assistant to investigate this and draft the text and the patch. The pod runs, the measurements, the before/after numbers and the design decision were produced and checked in my own sessions against real scroll data, and I have reviewed and edited everything above.*
