### PR TITLE
Fix SAM2 Hydra config resolution

### DIFF
--- a/foundation/sam2-photogrammetry/segment.py
+++ b/foundation/sam2-photogrammetry/segment.py
@@ -230,7 +230,7 @@ def main():
     # Convert input paths to Path objects and then resolve them
     root_dir = Path(args.root_dir).resolve()
     sam2_checkpoint = Path(args.sam2_checkpoint).resolve()
-    model_cfg = Path(args.model_cfg).resolve()
+    model_cfg = args.model_cfg
     photo_t_checkpoint = Path(args.photo_t_checkpoint).resolve()
 
     # Select the device for computation


### PR DESCRIPTION
**In one sentence:** `segment.py` can now pass a package-relative SAM 2 configuration key to Hydra instead of turning it into an invalid absolute filesystem path.

**One real example:** Starting with local real photogrammetry input, I ran the same masking command before and after this change.

**Before:** The script resolved `--model_cfg` to an absolute path, and Hydra failed before inference with `MissingConfigException`.

**After this PR:** The script leaves the Hydra package key unchanged; the same command exits successfully and completes mask generation.

**Proof:** The failure was reproduced on the unmodified branch, then the one-line patch was applied and the full masking command was rerun successfully on the same local input and environment.

**Why / where this is useful:** Anyone passing the documented SAM 2.1 package-relative configuration key can run photogrammetry masking without maintaining a patched copy of `segment.py`.

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

- Change: one line in `foundation/sam2-photogrammetry/segment.py`
- The patch was tested before commit and push.
- Local test logs and dataset-specific measurements are intentionally not published in the PR.