### PR TITLE
Pin Scrollcase CAD dependencies

### DIFF
--- a/foundation/scrollcase/pyproject.toml
+++ b/foundation/scrollcase/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 dependencies = [
-    "build123d @ git+https://github.com/gumyr/build123d",
-    "bd_warehouse @ git+https://github.com/gumyr/bd_warehouse",
+    "build123d @ git+https://github.com/gumyr/build123d@30bbe96cfe0410e3c9cd3f1418ba9e227a546bce",
+    "bd_warehouse @ git+https://github.com/gumyr/bd_warehouse@97112a02d9538d57740a005a7802dd149d797568",
     "numpy",
     "trimesh",
     "ocp-vscode",

--- a/foundation/scrollcase/requirements.txt
+++ b/foundation/scrollcase/requirements.txt
@@ -4,4 +4,4 @@ ipykernel
 nbconvert
 tqdm
 meshlib==3.0.5.215
-git+https://github.com/gumyr/bd_warehouse
+git+https://github.com/gumyr/bd_warehouse@97112a02d9538d57740a005a7802dd149d797568


### PR DESCRIPTION
**In one sentence:** Scrollcase installations now resolve the CAD dependency revisions compatible with the current case design instead of moving Git branches.

**One real example:** Starting with local real reconstructed scroll meshes, I installed Scrollcase from its patched package metadata and ran the stock STL generator successfully.

**Before:** A fresh installation could resolve newer `build123d` and `bd_warehouse` revisions, causing case generation to fail with `BuildSketch doesn't have a Line object or operation`.

**After this PR:** Both editable and requirements-file installations retain the historical CAD revisions, and the unchanged generator completes normally.

**Proof:** A fresh Python 3.12 environment resolved the exact commits below after both `uv pip install -e .` and `uv pip install -r requirements.txt`. The stock generator then completed on the same local real inputs, and its STL and CSV outputs passed readability checks.

**Why / where this is useful:** Scrollcase users can install the project normally without manually preinstalling dependencies and using `--no-deps` to protect compatible versions.

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

The last Villa commit changing `case.py` is `a07edecef71216c5902428ce7b41b0ee7c8ff0ad` from 2025-07-09. The VCS pins below are the latest dependency commits that existed at that source timestamp:

| Dependency | Revision |
| --- | --- |
| `build123d` | `30bbe96cfe0410e3c9cd3f1418ba9e227a546bce` |
| `bd_warehouse` | `97112a02d9538d57740a005a7802dd149d797568` |
| `meshlib` | `3.0.5.215` |

`meshlib` was already pinned and remains unchanged. The moving `bd_warehouse` reference in `requirements.txt` is also pinned so the documented requirements installation cannot override the project metadata.

Tested before push:

```bash
uv venv --python 3.12 <test-env>
uv pip install --python <test-env>/bin/python -e .
uv pip install --python <test-env>/bin/python -r requirements.txt
<test-env>/bin/python scripts/stl_generator.py \
  --input <local-real-input> \
  --output <test-output>
```

Dataset-specific measurements and paths are intentionally not published in the PR.