### PR TITLE
Add foundation subproject index

### DIFF
--- a/foundation/README.md
+++ b/foundation/README.md
@@ -1,0 +1,16 @@
+# Foundation
+
+Small, mostly standalone projects that support the rest of the repository.
+
+## Subprojects
+
+- [comparison-website](comparison-website/) — Collects pairwise image preferences through a small FastAPI and Nginx app.
+- [datasets](datasets/) **(OLD)** — Scripts for generating and registering fiber, mesh, and volumetric-label datasets.
+- [kaggle-visualizer](kaggle-visualizer/) — Napari helper for browsing paired 3D TIFF volumes and binary labels.
+- [obj2nml](obj2nml/) **(OLD)** — Converts OBJ meshes into WebKnossos NML skeleton annotations.
+- [sam2-photogrammetry](sam2-photogrammetry/) — SAM 2 fine-tuned to mask scrolls and rulers in photogrammetry images.
+- [scanning](scanning/) — Small scripts for x-ray and scanning-parameter analysis.
+- [scroll-unwrap-pipeline](scroll-unwrap-pipeline/) — Renders scroll unwrap videos from wrap meshes, with optional ink overlays.
+- [scrollcase](scrollcase/) — Creates STL models of scroll cases for 3D printing.
+- [shift-optimizer](shift-optimizer/) — Assigns shifts to people for scan sessions at the synchrotron.
+- [volume-registration](volume-registration/) — Tool for finding transforms between fixed and moving Zarr volumes or meshes.


### PR DESCRIPTION
**In one sentence:** Add a concise index of the subprojects under `foundation/`.

**One real example:** Starting at `foundation/`, a reader can use the index to identify and open the project for a specific task, such as rendering unwrap videos or preparing scroll cases for 3D printing.

**Before:** `foundation/` has no overview of its contents, so its subprojects must be discovered by browsing the directory.

**After this PR:** `foundation/README.md` lists all 10 tracked subprojects with short descriptions and relative links.

**Proof:** All listed directories exist, and `git diff --check` passes.

**Why / where this is useful:** The index gives contributors a quick way to understand what each foundation project is for, while marking the older `datasets` and `obj2nml` projects explicitly.

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Documentation-only change. No runtime behavior or project files were modified.