### PR TITLE
Stabilize Scrollcase generation on Linux

### DIFF
--- a/foundation/scrollcase/scripts/stl_generator.py
+++ b/foundation/scrollcase/scripts/stl_generator.py
@@ -21,13 +21,13 @@ Usage:
 import argparse
 import csv
 import logging
+import multiprocessing
 import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
+from scrollcase import mesh, case
 from meshlib import mrmeshpy as mm
 from tqdm import tqdm
-
-from scrollcase import mesh, case
 
 
 def pad_scroll_name(scroll_number: str) -> str:
@@ -169,7 +169,11 @@ def main():
     scroll_summary = []
 
     # Process scrolls concurrently using ProcessPoolExecutor with a tqdm progress bar
-    with ProcessPoolExecutor() as executor:
+    worker_count = max(1, min(len(tasks), os.cpu_count() or 1))
+    with ProcessPoolExecutor(
+        max_workers=worker_count,
+        mp_context=multiprocessing.get_context("spawn"),
+    ) as executor:
         future_to_scroll = {
             executor.submit(process_scroll, padded, mesh_file, out_dir): padded
             for padded, mesh_file, out_dir in tasks

--- a/foundation/scrollcase/tests/test_stl_generator.py
+++ b/foundation/scrollcase/tests/test_stl_generator.py
@@ -1,0 +1,82 @@
+import csv
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "stl_generator.py"
+
+
+def load_stl_generator():
+    meshlib = types.ModuleType("meshlib")
+    meshlib.mrmeshpy = types.ModuleType("meshlib.mrmeshpy")
+
+    scrollcase = types.ModuleType("scrollcase")
+    scrollcase.mesh = types.ModuleType("scrollcase.mesh")
+    scrollcase.case = types.ModuleType("scrollcase.case")
+
+    tqdm = types.ModuleType("tqdm")
+    tqdm.tqdm = lambda iterable, **_kwargs: iterable
+
+    modules = {
+        "meshlib": meshlib,
+        "meshlib.mrmeshpy": meshlib.mrmeshpy,
+        "scrollcase": scrollcase,
+        "scrollcase.mesh": scrollcase.mesh,
+        "scrollcase.case": scrollcase.case,
+        "tqdm": tqdm,
+    }
+    with mock.patch.dict(sys.modules, modules):
+        spec = importlib.util.spec_from_file_location("stl_generator", SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+class StlGeneratorTests(unittest.TestCase):
+    def test_missing_meshes_write_header_only_summary(self):
+        module = load_stl_generator()
+
+        class ValidatingExecutor:
+            def __init__(self, max_workers, **_kwargs):
+                if max_workers <= 0:
+                    raise ValueError("max_workers must be greater than 0")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_root = Path(temp_dir) / "input"
+            output_root = Path(temp_dir) / "output"
+            (input_root / "4").mkdir(parents=True)
+            output_root.mkdir()
+
+            argv = [
+                "stl_generator.py",
+                "--input",
+                str(input_root),
+                "--output",
+                str(output_root),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(module, "ProcessPoolExecutor", ValidatingExecutor),
+            ):
+                module.main()
+
+            with (output_root / "scroll_summary.csv").open(newline="") as csvfile:
+                self.assertEqual(
+                    list(csv.reader(csvfile)),
+                    [["Scroll ID", "Height (mm)", "Diameter (mm)"]],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**In one sentence:** The Scrollcase batch generator now completes reliably on x86 Linux by loading OCP before MeshLib and using a bounded spawn-based worker pool.

**One real example:** Starting with the accepted PHercParis4 textured reconstruction, I generated scroll `0004`; the patched generator completed in 8.72 seconds and produced the scroll proxy, both case halves and one populated CSV row.

**Before:** The unmodified generator aborted with `free(): invalid pointer`; a second run on the accepted final PLY with spawn alone failed the same way, isolating the remaining allocator/import-order conflict.

**After this PR:** The full generator completes on the same final PLY, writes all three expected STLs plus the CSV row, and limits the pool to the number of actual scroll tasks.

**Proof:** The retained run logs record `free(): invalid pointer` before the fix and successful completion in 8.72 seconds afterward. QA found three readable, nonempty STLs; the scroll proxy is a watertight single component with extents 64.68×59.67×177.54 mm.

**Why / where this is useful:** Linux users generating fitted cases from reconstructed scroll meshes can run the batch script without the native allocator crash or dozens of unnecessary worker processes for a single scroll.

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

- Executed source revision: `a60235b67249918953b3d3c367d08d7da54ae459` plus this exact one-file change.
- PR base: current Villa `main` at preparation time, `e2442b77`; the target file was unchanged between those revisions.
- Environment: Ubuntu 24.04, x86_64, Python 3.12.3, `meshlib==3.0.5.215`, pinned Scrollcase CAD dependencies and `libxrender1`.
- Real-data command:

  ```bash
  .venv/bin/python scripts/stl_generator.py \
    --input /path/to/scrollcase-input \
    --output /path/to/scrollcase-output
  ```

- Validation:
  - retained two failed pre-fix logs and the successful full-generator log;
  - same final PLY still failed with spawn alone, then succeeded with the combined import-order/spawn change;
  - three expected STLs and one CSV row produced;
  - topology report and canonical assembly render reviewed;
  - `python3 -m unittest discover -s foundation/scrollcase/tests -p 'test_*.py' -v`;
  - `python3 -m py_compile foundation/scrollcase/scripts/stl_generator.py`;
  - `git diff --check`;
  - prepared file is byte-identical to the source used in the successful run.
- Limitation: the native failure was reproduced on the stated x86 Linux environment; other OS/architecture combinations were not rerun.
- Formatting note: `ruff` was not installed in the existing checkout; no dependency installation was performed while preparing the PR.
