### PR TITLE
spiral: merge_concat_runs bbox from valid vertices, in x,y,z order

### DIFF
--- a/spiral-fitting/merge_concat_runs.py
+++ b/spiral-fitting/merge_concat_runs.py
@@ -115,12 +115,17 @@ def save_tifxyz(pts, out_winding_dir, uuid, step_size, voxel_um, source):
         & valid_vertex[:-1, 1:] & valid_vertex[1:, 1:]
     )
     area_vx2 = int(vq.sum()) * step_size ** 2
-    # bbox over all cells incl. -1 sentinel, in [z,y,x]-low/high order (matches save_tifxyz)
-    lo = pts.min(axis=(0, 1))[::-1].tolist()
-    hi = pts.max(axis=(0, 1))[::-1].tolist()
+    # bbox over valid vertices only, in [x,y,z]-low/high order
+    # (matches spiral-fitting/tifxyz.py:save_tifxyz)
+    valid_pts = pts[valid_vertex]
+    bbox = (
+        [valid_pts.min(axis=0).tolist(), valid_pts.max(axis=0).tolist()]
+        if valid_vertex.any()
+        else [[-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]]
+    )
     meta = {
         "scale": [1.0 / step_size, 1.0 / step_size],
-        "bbox": [lo, hi],
+        "bbox": bbox,
         "area_vx2": area_vx2,
         "area_cm2": area_vx2 * voxel_um ** 2 / 1.0e8 if voxel_um else None,
         "format": "tifxyz",

--- a/spiral-fitting/tests/test_merge_concat_runs.py
+++ b/spiral-fitting/tests/test_merge_concat_runs.py
@@ -1,0 +1,53 @@
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+SPIRAL_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SPIRAL_DIR))
+
+from merge_concat_runs import save_tifxyz  # noqa: E402
+from tifxyz import save_tifxyz as save_tifxyz_canonical  # noqa: E402
+
+
+def grid():
+    """3x3 grid with x/y/z in distinct ranges, so an axis swap is visible."""
+    pts = np.zeros((3, 3, 3), np.float32)
+    pts[..., 0] = 100 + np.arange(3)[None, :]                          # x
+    pts[..., 1] = 200 + np.arange(3)[:, None]                          # y
+    pts[..., 2] = 300 + np.arange(3)[:, None] + np.arange(3)[None, :]  # z
+    return pts
+
+
+def written_bbox(out_dir):
+    return json.loads((Path(out_dir) / "meta.json").read_text())["bbox"]
+
+
+def test_bbox_masks_invalid_vertices_and_is_xyz_ordered(tmp_path):
+    pts = grid()
+    pts[0, 0] = -1.0
+    save_tifxyz(pts, tmp_path / "merged", "w000", 20.0, 7.91, "test")
+
+    valid = np.any(pts != -1, axis=-1)
+    assert written_bbox(tmp_path / "merged") == [
+        pts[valid].min(axis=0).tolist(),
+        pts[valid].max(axis=0).tolist(),
+    ]
+
+
+def test_bbox_matches_canonical_spiral_writer(tmp_path):
+    pts = grid()
+    pts[2, 2] = -1.0
+    save_tifxyz(pts, tmp_path / "merged", "w000", 20.0, 7.91, "test")
+    # the canonical writer takes z,y,x-ordered input
+    save_tifxyz_canonical(pts[..., ::-1], str(tmp_path), "ref", 20.0, 7.91, "test")
+
+    assert written_bbox(tmp_path / "merged") == written_bbox(tmp_path / "ref")
+
+
+def test_all_invalid_grid_falls_back_to_sentinel_bbox(tmp_path):
+    save_tifxyz(np.full((3, 3, 3), -1.0, np.float32), tmp_path / "merged",
+                "w000", 20.0, 7.91, "test")
+
+    assert written_bbox(tmp_path / "merged") == [[-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]]


### PR DESCRIPTION
**In one sentence:** merged spiral windings keep a usable meta.json bbox, so they stop vanishing from every bbox-based z filter.

**One real example:** Starting with three real PHercParis4 tifxyz surfaces laid out as two `concat` runs, I ran `python merge_concat_runs.py /tmp/runs --out /tmp/merged`, and the merged windings became selectable by z range again.

**Before:** every merged winding got `bbox` low `[-1, -1, -1]` (the invalid sentinel went into the min) and a high corner in `[z, y, x]` order. `list_tifxyz(z_range=(8000, 14000))` returned **0 of 3** windings, though all three really span z 8316 to 13502.

```
w000  written bbox [[-1.0, -1.0, -1.0], [10061.0, 4050.2, 4779.7]]
      true bbox [[4101.5, 3276.7, 8316.1], [4779.7, 4050.2, 10061.0]]   [BAD]
w001  written bbox [[-1.0, -1.0, -1.0], [11933.0, 4516.0, 5835.7]]
      true bbox [[3628.0, 2501.3, 9452.0], [5835.7, 4516.0, 11933.0]]   [BAD]
w002  written bbox [[-1.0, -1.0, -1.0], [13501.7, 4628.7, 4054.1]]
      true bbox [[3024.1, 2616.8, 10204.5], [4054.1, 4628.7, 13501.7]]   [BAD]

list_tifxyz(z_range=(8000, 14000)) over the merged output: 0 of 3 windings kept
```

**After this PR:** the same merge run, same inputs, same command:

```
w000  written bbox [[4101.5, 3276.7, 8316.1], [4779.7, 4050.2, 10061.0]]
      true bbox [[4101.5, 3276.7, 8316.1], [4779.7, 4050.2, 10061.0]]   [OK ]
w001  written bbox [[3628.0, 2501.3, 9452.0], [5835.7, 4516.0, 11933.0]]
      true bbox [[3628.0, 2501.3, 9452.0], [5835.7, 4516.0, 11933.0]]   [OK ]
w002  written bbox [[3024.1, 2616.8, 10204.5], [4054.1, 4628.7, 13501.7]]
      true bbox [[3024.1, 2616.8, 10204.5], [4054.1, 4628.7, 13501.7]]   [OK ]

list_tifxyz(z_range=(8000, 14000)) over the merged output: 3 of 3 windings kept
  kept w000: bbox z [8316.1, 10061.0]
  kept w001: bbox z [9452.0, 11933.0]
  kept w002: bbox z [10204.5, 13501.7]
```

**Proof:** the two blocks above are the same script over the same merged output directories, one produced by `main` at `c53c74a29` and one by this branch. "true bbox" is recomputed from the `x/y/z.tif` files that `save_tifxyz` itself just wrote, so the comparison needs nothing but the tool's own output. Full report in #1604.

**Why / where this is useful:** anyone merging per-winding `concat` surfaces across spiral-fit runs and then selecting them by z (rendering a band, feeding ink inference, VC3D bbox intersection, coverage tooling) currently gets an empty or wrong selection with no error. After this they get the windings they asked for.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Fixes #1604. Branch `fix-merge-concat-bbox`, single commit `bfea5205`, on top of `c53c74a29`.

`save_tifxyz` in `spiral-fitting/merge_concat_runs.py` took min/max over every grid cell including the `-1` invalid sentinel, and ran already x,y,z-ordered points through a `[::-1]` flip:

```python
# bbox over all cells incl. -1 sentinel, in [z,y,x]-low/high order (matches save_tifxyz)
lo = pts.min(axis=(0, 1))[::-1].tolist()
hi = pts.max(axis=(0, 1))[::-1].tolist()
```

The comment is wrong in both directions. `spiral-fitting/tifxyz.py:save_tifxyz`, the writer it says it mirrors, masks invalid vertices before min/max and writes `[x, y, z]`; its own input is z,y,x, so its flip lands on x,y,z. Feeding x,y,z through the same flip produces z,y,x. In practice every merged winding has at least one masked vertex, so every merged winding was affected.

The fix reuses `valid_vertex`, which is already computed two lines up for `area_vx2`, and keeps `tifxyz.py`'s sentinel fallback for an all-invalid grid. The misleading comment is corrected.

### Test

New `spiral-fitting/tests/test_merge_concat_runs.py`, written failing-first:

- `test_bbox_masks_invalid_vertices_and_is_xyz_ordered`: a grid with one `(-1,-1,-1)` vertex must produce the min/max of the valid vertices, in x,y,z order.
- `test_bbox_matches_canonical_spiral_writer`: the same grid through both writers must produce an identical bbox.
- `test_all_invalid_grid_falls_back_to_sentinel_bbox`: an all-invalid grid keeps the sentinel box.

```
$ python -m pytest tests/test_merge_concat_runs.py     # this branch
3 passed
$ python -m pytest tests/test_merge_concat_runs.py     # same file on main
2 failed, 1 passed
```

### How the example inputs were built

`merge_concat_runs.py` reads `<parent>/<run>/meshes/<name>/concat/<winding>/`. I filled that layout with three real surfaces from the public PHercParis4 spiral-input verified patches (`0000_low_band_final_sel_20260617_080606_1`, `0000_mid_band_final`, `0000_top_vt_strip_2`), each present twice: once at its native grid, once nearest-resampled to 85% of its theta width, which is the run-to-run width difference this script exists to reconcile. Every point in both copies is an exact coordinate from the published surfaces, so the "true bbox" numbers above are real scroll coordinates rather than interpolated ones.

Same family as #1272 and #1285: a bbox not derived from the valid points at save time. This is the Python merge writer's variant.
