### PR TITLE
vesuvius: tifxyz write_metadata recomputes the bbox from valid vertices

### DIFF
--- a/vesuvius/src/vesuvius/tifxyz/test_writer.py
+++ b/vesuvius/src/vesuvius/tifxyz/test_writer.py
@@ -1,0 +1,75 @@
+import json
+from pathlib import Path
+
+import numpy as np
+
+from vesuvius.tifxyz import read_tifxyz, write_tifxyz
+from vesuvius.tifxyz.types import Tifxyz
+from vesuvius.tifxyz.writer import TifxyzWriter
+
+
+def _fresh_surface() -> Tifxyz:
+    h, w = 4, 5
+    y_grid, x_grid = np.mgrid[:h, :w]
+    return Tifxyz(
+        _x=(10.0 + x_grid).astype(np.float32),
+        _y=(20.0 + y_grid).astype(np.float32),
+        _z=np.full((h, w), 30.0, dtype=np.float32),
+        uuid="segment",
+    )
+
+
+def _load_mutate(tmp_path: Path) -> Tifxyz:
+    """Write a surface, read it back, then edit its coordinates in place."""
+    write_tifxyz(tmp_path / "segment", _fresh_surface())
+    surface = read_tifxyz(tmp_path / "segment")
+    assert surface.bbox == (10.0, 20.0, 30.0, 14.0, 23.0, 30.0)
+    surface._x[:] += 100.0  # e.g. translate the surface after loading
+    return surface
+
+
+def test_write_metadata_recomputes_bbox_after_inplace_edit(tmp_path: Path) -> None:
+    surface = _load_mutate(tmp_path)
+
+    TifxyzWriter(tmp_path / "segment", overwrite=True).write_metadata(surface)
+
+    meta = json.loads((tmp_path / "segment" / "meta.json").read_text())
+    assert meta["bbox"] == [[110.0, 20.0, 30.0], [114.0, 23.0, 30.0]]
+
+
+def test_write_metadata_repairs_a_stale_stored_bbox(tmp_path: Path) -> None:
+    """A surface loaded with a wrong stored bbox is written out corrected."""
+    write_tifxyz(tmp_path / "segment", _fresh_surface())
+    meta_path = tmp_path / "segment" / "meta.json"
+    meta = json.loads(meta_path.read_text())
+    meta["bbox"] = [[-0.25, -0.25, -0.25], [14.0, 23.0, 30.0]]
+    meta_path.write_text(json.dumps(meta))
+
+    surface = read_tifxyz(tmp_path / "segment")
+    TifxyzWriter(tmp_path / "segment", overwrite=True).write_metadata(surface)
+
+    assert json.loads(meta_path.read_text())["bbox"] == [
+        [10.0, 20.0, 30.0], [14.0, 23.0, 30.0]
+    ]
+
+
+def test_write_metadata_opt_out_keeps_stored_bbox(tmp_path: Path) -> None:
+    surface = _load_mutate(tmp_path)
+
+    TifxyzWriter(tmp_path / "segment", overwrite=True).write_metadata(
+        surface, recompute_bbox=False
+    )
+
+    meta = json.loads((tmp_path / "segment" / "meta.json").read_text())
+    assert meta["bbox"] == [[10.0, 20.0, 30.0], [14.0, 23.0, 30.0]]
+
+
+def test_explicit_bbox_argument_still_wins(tmp_path: Path) -> None:
+    surface = _load_mutate(tmp_path)
+
+    TifxyzWriter(tmp_path / "segment", overwrite=True).write_metadata(
+        surface, bbox=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+    )
+
+    meta = json.loads((tmp_path / "segment" / "meta.json").read_text())
+    assert meta["bbox"] == [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]

--- a/vesuvius/src/vesuvius/tifxyz/writer.py
+++ b/vesuvius/src/vesuvius/tifxyz/writer.py
@@ -156,6 +156,8 @@ class TifxyzWriter:
         self,
         surface: Tifxyz,
         bbox: Optional[tuple] = None,
+        *,
+        recompute_bbox: bool = True,
     ) -> None:
         """Write meta.json.
 
@@ -164,7 +166,13 @@ class TifxyzWriter:
         surface : Tifxyz
             Surface to get metadata from.
         bbox : Optional[tuple]
-            Override bounding box. If None, uses surface.bbox.
+            Override bounding box. If None, the bbox is derived from the
+            surface's valid vertices, or taken verbatim from surface.bbox
+            when recompute_bbox is False.
+        recompute_bbox : bool
+            If True (default) and no bbox override is given, recompute the
+            bbox from the current coordinate arrays, so edits made after
+            loading are reflected. If False, carry surface.bbox as-is.
         """
         # Build metadata dict in C++ format
         meta_dict = {
@@ -177,7 +185,14 @@ class TifxyzWriter:
         }
 
         # Add bbox
-        use_bbox = bbox if bbox is not None else surface.bbox
+        if bbox is not None:
+            use_bbox = bbox
+        elif recompute_bbox:
+            use_bbox = compute_grid_bounds(
+                surface._x, surface._y, surface._z, surface._valid_mask
+            )
+        else:
+            use_bbox = surface.bbox
         if use_bbox is not None:
             # bbox format: [[min_x, min_y, min_z], [max_x, max_y, max_z]]
             meta_dict["bbox"] = [


### PR DESCRIPTION
**In one sentence:** `TifxyzWriter.write_metadata()` writes the bbox of the surface you hand it, so the Python tifxyz API can finally correct a wrong stored bbox instead of copying it back to disk.

**One real example:** Starting with `same_wrap002204_lasagna`, one of the PHercParis4 verified patches with a stale meta.json bbox reported in #1272, I called `read_tifxyz()` and then `TifxyzWriter(...).write_metadata(surface)`, and the patch's meta.json came out with the bbox of its actual vertices.

**Before:** the rewrite was a no-op. The poisoned box went straight back to disk, and a z-range query still selected the patch nowhere near where it lives.

```
patch same_wrap002204_lasagna  (164x173 grid, 24,272 invalid vertices)
  stored meta.json bbox              [[-0.2, -0.2, -0.2], [3412.2, 2957.0, 13247.7]]
  bbox of its valid vertices         [[2800.9, 2240.5, 12565.3], [3412.2, 2957.0, 13247.7]]

after read_tifxyz() -> TifxyzWriter.write_metadata():
  meta.json bbox                     [[-0.2, -0.2, -0.2], [3412.2, 2957.0, 13247.7]]
  repaired: False

list_tifxyz(z_range=(1000, 2000)): 1 of 1 patch selected (the patch really spans z [12565.3, 13247.7], so the right answer is 0)

after translating x by +100 in memory and calling write_metadata():
  meta.json bbox                     [[-0.2, -0.2, -0.2], [3412.2, 2957.0, 13247.7]]
  x_min reflects the edit: False
```

**After this PR:** same patch, same calls.

```
patch same_wrap002204_lasagna  (164x173 grid, 24,272 invalid vertices)
  stored meta.json bbox              [[-0.2, -0.2, -0.2], [3412.2, 2957.0, 13247.7]]
  bbox of its valid vertices         [[2800.9, 2240.5, 12565.3], [3412.2, 2957.0, 13247.7]]

after read_tifxyz() -> TifxyzWriter.write_metadata():
  meta.json bbox                     [[2800.9, 2240.5, 12565.3], [3412.2, 2957.0, 13247.7]]
  repaired: True

list_tifxyz(z_range=(1000, 2000)): 0 of 1 patch selected (the patch really spans z [12565.3, 13247.7], so the right answer is 0)

after translating x by +100 in memory and calling write_metadata():
  meta.json bbox                     [[2900.9, 2240.5, 12565.3], [3512.2, 2957.0, 13247.7]]
  x_min reflects the edit: True
```

**Proof:** the two blocks are the same script on a copy of the same published patch, run against `main` at `c53c74a29` and against this branch. The recomputed box also matches, to the decimal, what my out-of-tree audit tool derives for this patch by replaying VC3D's loader validity rules, which is an independent check that the recomputation is the right box and not just a different one.

**Why / where this is useful:** anyone using the `vesuvius.tifxyz` Python API to edit surfaces (translate, crop, repair coordinates, or repair a stale box like the 106 patches in #1272) and then persist the metadata. Today that silently writes the pre-edit box, and downstream z filtering acts on it.

**Details of the failure mode:** `write_metadata()` carried `surface.bbox` verbatim, which is whatever meta.json said at load time:

```python
use_bbox = bbox if bbox is not None else surface.bbox
```

The full `write()` path already recomputes via `compute_grid_bounds`, so only the direct-metadata path leaked stale values.

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Branch `fix-tifxyz-write-metadata-bbox`, single commit `2514dfb9`, on top of `c53c74a29`.

`write_metadata()` now derives the bbox from the current coordinate arrays and validity mask by default, with an opt-out:

```python
def write_metadata(self, surface, bbox=None, *, recompute_bbox=True):
    ...
    if bbox is not None:
        use_bbox = bbox                      # explicit override still wins
    elif recompute_bbox:
        use_bbox = compute_grid_bounds(      # default: derive from valid vertices
            surface._x, surface._y, surface._z, surface._valid_mask
        )
    else:
        use_bbox = surface.bbox              # opt-out: carry the stored value
```

`write()` passes an explicit bbox, so its behaviour is unchanged. `recompute_bbox=False` restores the old carry-verbatim behaviour for callers that deliberately preserve a stored box.

### Test

New `vesuvius/src/vesuvius/tifxyz/test_writer.py` (pytest style, next to the existing in-package `test_labels.py`), written failing-first:

- `test_write_metadata_recomputes_bbox_after_inplace_edit`: load, mutate coordinates, `write_metadata()`, meta.json must reflect the edit.
- `test_write_metadata_repairs_a_stale_stored_bbox`: a surface loaded with a wrong stored box is written out corrected. This is the #1272 repair path in miniature.
- `test_write_metadata_opt_out_keeps_stored_bbox`: `recompute_bbox=False` carries the loaded box verbatim.
- `test_explicit_bbox_argument_still_wins`: an explicit `bbox=` overrides both paths, covering the `write()` call site.

```
$ PYTHONPATH=src python -m pytest src/vesuvius/tifxyz/test_writer.py   # this branch
4 passed
$ PYTHONPATH=src python -m pytest src/vesuvius/tifxyz/test_writer.py   # same file on main
3 failed, 1 passed
$ PYTHONPATH=src python -m pytest src/vesuvius/tifxyz/                 # this branch, whole package
13 passed
```

Refs #1272 and companion to #1605: together they make every Python tifxyz metadata path derive its bbox from the vertices actually present. The C++ side was handled in #1285.
