### PR TITLE
spiral: a dataset with tracks and no outer_shell/ should not crash the headless fit

### DIFF
--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -1516,7 +1516,14 @@ class FitContext:
         # Patch loading and ROI filtering
         # ==========================================================================
 
-        filter_tracks_by_shell = bool(self.tracks_dbm_path) and bool(self.shell_path)
+        # The conventional layout resolves an outer_shell path without probing
+        # for it, so a dataset that ships tracks but no outer_shell/ still gets
+        # a shell path here. Only filter tracks by a shell that actually exists;
+        # a shell the losses genuinely require is still loaded (and still fails
+        # loudly) through outer_shell_required().
+        filter_tracks_by_shell = (
+            bool(self.tracks_dbm_path) and bool(self.shell_path)
+            and os.path.isdir(self.shell_path))
         shell_patch = None
         if self.outer_shell_required() or filter_tracks_by_shell:
             if not self.shell_path:

--- a/spiral-fitting/tests/test_optional_outer_shell.py
+++ b/spiral-fitting/tests/test_optional_outer_shell.py
@@ -1,0 +1,99 @@
+"""A dataset that ships tracks but no outer_shell/ must still load.
+
+The conventional layout resolves an outer_shell path without probing for it,
+so before this guard load_host_inputs() opened that path for track filtering
+even when no loss required the shell, and the fit died on the missing
+outer_shell/meta.json.
+"""
+import dbm
+import json
+import pickle
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+SPIRAL_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SPIRAL_DIR))
+
+from config import Config, FitConfig  # noqa: E402
+from fit_session import ScrollSpec, SpiralInputPaths  # noqa: E402
+from fit_spiral import FitContext  # noqa: E402
+
+Z_BEGIN, Z_END = 1000, 2000
+
+
+def tracks_only_dataset(root: Path) -> SpiralInputPaths:
+    """A dataset root with umbilicus + tracks and deliberately no outer_shell."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "umbilicus.json").write_text(json.dumps({
+        "control_points": [
+            {"x": 3000, "y": 3000, "z": z, "score": 100}
+            for z in range(0, 4001, 500)
+        ]
+    }))
+
+    (root / "tracks").mkdir()
+    dbm_path = root / "tracks" / "surf.dbm"
+    track = np.stack([
+        np.arange(Z_BEGIN + 100, Z_BEGIN + 132),
+        np.full(32, 3200),
+        np.arange(3300, 3332),
+    ], axis=-1).astype(np.int32)
+    with dbm.open(str(dbm_path), "c") as db:
+        db[f"h:{Z_BEGIN}"] = pickle.dumps([track])
+
+    assert not (root / "outer_shell").exists()
+    return SpiralInputPaths(
+        dataset_root=str(root),
+        umbilicus=str(root / "umbilicus.json"),
+        tracks_dbm=str(dbm_path),
+        # exactly what conventional_input_paths() hands over: a path that was
+        # composed from the dataset root, never probed for
+        outer_shell=str(root / "outer_shell"),
+    )
+
+
+def tracks_only_config() -> dict:
+    return Config({
+        "z_begin": Z_BEGIN,
+        "z_end": Z_END,
+        "loss_weight_shell_outer": 0.0,
+        "input_use_verified_patches": False,
+        "input_use_unverified_patches": False,
+        "input_use_fibers": False,
+        "input_use_normals": False,
+        "input_use_surf_sdt": False,
+        "input_use_gradient_magnitude": False,
+        "input_use_winding_inference": False,
+    }).as_dict()
+
+
+def make_context(config, paths):
+    return FitContext(
+        FitConfig(config),
+        scroll=ScrollSpec(name="test", voxel_size_um=1.0,
+                          spiral_outward_sense="CW"),
+        paths=paths,
+    )
+
+
+def test_absent_outer_shell_does_not_block_track_loading(tmp_path):
+    context = make_context(tracks_only_config(), tracks_only_dataset(tmp_path / "ds"))
+
+    context.load_host_inputs()
+
+    assert context.filter_tracks_by_shell is False
+    assert context.shell_patch is None
+    assert len(context.tracks) == 1
+
+
+def test_a_required_outer_shell_still_fails_when_it_is_missing(tmp_path):
+    config = tracks_only_config()
+    config["loss_weight_shell_outer"] = 1.0  # shell losses want the shell
+    context = make_context(config, tracks_only_dataset(tmp_path / "ds"))
+
+    assert context.outer_shell_required()
+    with pytest.raises(FileNotFoundError):
+        context.load_host_inputs()


### PR DESCRIPTION
**In one sentence:** a spiral dataset that ships tracks but no `outer_shell/` runs instead of dying during input loading.

**One real example:** Starting with a dataset root holding real public PHercParis4 inputs (`umbilicus.json`, two verified patches, a tracks DBM) and no `outer_shell/`, I ran `python fit_spiral.py --dataset <root>` with the shell losses off, and loading completed instead of raising `FileNotFoundError`.

**Before:** on `main` at `c53c74a29`, with `loss_weight_shell_outer = 0` so nothing asks for a shell:

```
$ FIT_SPIRAL_CONFIG_OVERRIDES='{"loss_weight_shell_outer": 0.0, ...}' python fit_spiral.py --dataset /tmp/ds
...
  File "spiral-fitting/fit_spiral.py", line 4611, in run
    self.load_host_inputs()
  File "spiral-fitting/fit_spiral.py", line 1527, in load_host_inputs
    shell_patch = load_tifxyz(self.shell_path)
  File "spiral-fitting/tifxyz.py", line 362, in load_tifxyz
    with open(f'{path}/meta.json', 'r') as meta_json:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/ds/outer_shell/meta.json'
```

There is no way around it short of patching the file: `outer_shell/` is never listed as an input for this run, no loss reads it, and the CLI has no flag that skips it while keeping the tracks. Setting `input_use_outer_shell: false` avoids the crash but is not a fix, since it is meant to disable shell supervision, not to work around a loader that opens a file it was told not to use.

**After this PR:** same dataset, same command, loading runs to the end:

```
skipping all verified/unverified patch loading
 loaded 0 patches
 loaded 0 unverified patches
fiber links: 0 resolved
pcls: 0 cross-patch, 0 unattached
loading tracks from /tmp/ds/tracks/2um_ds2_ps256_surf_v2.dbm
loaded 6 tracks within z-roi [4000, 17000)
fitting 0 patches
```

and with the two patches enabled as well:

```
loading tracks from /tmp/ds/tracks/2um_ds2_ps256_surf_v2.dbm
loaded 6 tracks within z-roi [4000, 17000)
fitting 2 patches
```

**Proof:** the two blocks are the same command against the same dataset root, one on `main` at `c53c74a29` and one on this branch (dataset root and checkout paths shortened in both transcripts). My box has no CUDA and no built `vc_spiral` extension, so the "after" run stops later at `Torch not compiled with CUDA enabled` in `build_device_state()`. That is my hardware, not the fix: on `main` it never gets that far, because host input loading dies first.

**Why / where this is useful:** anyone fitting a dataset assembled from tracks alone, which is the normal shape when you have a track store for a scroll but no outer shell for it yet. Today that layout simply cannot be run headless without editing `fit_spiral.py`.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Branch `fix-fit-spiral-optional-outer-shell`, single commit `f7c57789`, on top of `c53c74a29`.

`conventional_input_paths()` composes an `outer_shell` path from the dataset root and, as its docstring says, deliberately performs no existence probing. So `context.shell_path` is a non-empty string for every conventional dataset, whether or not the directory exists. `load_host_inputs()` then derived the track filter from that string alone (`spiral-fitting/fit_spiral.py:1519`):

```python
filter_tracks_by_shell = bool(self.tracks_dbm_path) and bool(self.shell_path)
shell_patch = None
if self.outer_shell_required() or filter_tracks_by_shell:
    ...
    shell_patch = load_tifxyz(self.shell_path)
```

`outer_shell_required()` is the fit-input catalog's answer to "does anything need the shell", and it is correct: with shell losses off and `dense_spacing_mode != "winding_model"` it returns False. `filter_tracks_by_shell` bypasses it, so the presence of tracks alone is enough to open the shell.

The change is to require the directory to be there:

```python
filter_tracks_by_shell = (
    bool(self.tracks_dbm_path) and bool(self.shell_path)
    and os.path.isdir(self.shell_path))
```

Nothing else moves. A shell that the losses or the winding model genuinely require is still loaded through `outer_shell_required()`, and still fails loudly if it is missing. Only the "we have tracks, so let us also open the shell to trim them" path becomes conditional on the shell existing. When it does exist, behaviour is identical.

### Test

New `spiral-fitting/tests/test_optional_outer_shell.py`, written failing-first, building a dataset root with a umbilicus, a one-track DBM and no `outer_shell/`:

- `test_absent_outer_shell_does_not_block_track_loading`: `load_host_inputs()` completes, `filter_tracks_by_shell` is False, `shell_patch` is None, and the track is loaded.
- `test_a_required_outer_shell_still_fails_when_it_is_missing`: with shell losses on, `outer_shell_required()` is True and loading still raises `FileNotFoundError`, so the guard cannot hide a shell someone actually needs.

```
$ python -m pytest tests/test_optional_outer_shell.py    # this branch
2 passed
$ python -m pytest tests/test_optional_outer_shell.py    # same file on main
1 failed, 1 passed

$ python -m pytest tests/test_input_toggles.py tests/test_input_catalog.py \
                   tests/test_config.py tests/test_spiral_helpers.py \
                   tests/test_optional_outer_shell.py
49 passed
```

The tests that exercise the surrounding input plumbing are the four above; the rest of the suite needs CUDA or the native `vc_spiral` extension, which this machine does not have, so I could not run it.
