### PR TITLE
scripts: expand the aligned-21 contract into a runnable (optionally h…

### DIFF
--- a/ink-detection/scripts/make_holdout_config.py
+++ b/ink-detection/scripts/make_holdout_config.py
@@ -12,9 +12,10 @@ This script does that join by locating each representation under the roots you
 give it. Holding scrolls or segments out turns the same recipe into a
 generalisation probe: nothing on the held-out scroll is ever sampled, so its
 whole supervision mask stays honest held-out ground truth. Per-scroll batch
-quotas are renormalised over the survivors, because ``FixedScrollPriorSampler``
-rejects a batch whose quotas do not sum to ``batch_size``, and rejects quota keys
-that do not exactly match the scrolls the patches came from.
+quotas are renormalised over the survivors, because
+``FixedScrollPriorStratifiedBatchSampler`` rejects a batch whose quotas do not sum
+to ``batch_size``, rejects a non-positive quota, and rejects quota keys that do not
+exactly match the scrolls the patches came from.
 """
 
 from __future__ import annotations
@@ -78,6 +79,12 @@ def renormalise(quotas: dict, keep: set, batch_size: int) -> dict:
     live = {scroll: value for scroll, value in quotas.items() if scroll in keep}
     if not live:
         sys.exit("error: every scroll was excluded")
+    if batch_size < len(live):
+        # Every survivor is floored to one slot below, because the sampler rejects a
+        # zero quota outright, so a smaller batch than the scroll count has no answer.
+        sys.exit(f"error: batch_size {batch_size} cannot cover {len(live)} scrolls; "
+                 "FixedScrollPriorStratifiedBatchSampler needs at least one slot per "
+                 "scroll")
     total = sum(live.values())
     exact = {scroll: batch_size * value / total for scroll, value in live.items()}
     out = {scroll: max(1, int(value)) for scroll, value in exact.items()}
@@ -174,6 +181,10 @@ def main() -> int:
     batch_size = args.batch_size or int(recipe["batch_size"])
     seed = args.seed if args.seed is not None else int(recipe["seed"])
     surviving = {entry["sampling_scroll"] for entry in groups.values()}
+    if not surviving:
+        # Only reachable under --allow-missing: without it the locate failure above exits.
+        sys.exit(f"error: none of the {len(kept)} representations could be located under "
+                 f"{args.labels_root} and {args.volumes_root}")
     quotas = renormalise(contract["target_batch_counts"], surviving, batch_size)
     held_out = sorted({rep["segment"] for rep in dropped})
 

--- a/ink-detection/scripts/make_holdout_config.py
+++ b/ink-detection/scripts/make_holdout_config.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Expand the aligned-21 sampling contract into a runnable training config.
+
+``configs/aligned21_hybrid_3d2d.json`` ships one ``datasets`` entry with
+``/path/to/...`` placeholders, and the 29 representations it is meant to train
+on live separately in ``configs/aligned21_fixed_scroll_prior.json``. Joining the
+two by hand means writing 29 entries, each with its own label directory and
+surface-volume path, and keeping ``fixed_scroll_prior.target_batch_counts``
+consistent with whatever subset you kept.
+
+This script does that join by locating each representation under the roots you
+give it. Holding scrolls or segments out turns the same recipe into a
+generalisation probe: nothing on the held-out scroll is ever sampled, so its
+whole supervision mask stays honest held-out ground truth. Per-scroll batch
+quotas are renormalised over the survivors, because ``FixedScrollPriorSampler``
+rejects a batch whose quotas do not sum to ``batch_size``, and rejects quota keys
+that do not exactly match the scrolls the patches came from.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "configs"
+DEFAULT_RECIPE = CONFIG_DIR / "aligned21_hybrid_3d2d.json"
+DEFAULT_CONTRACT = CONFIG_DIR / "aligned21_fixed_scroll_prior.json"
+
+
+def as_posix(path: Path) -> str:
+    return str(path.resolve()).replace("\\", "/")
+
+
+def walk_dirs(root: Path):
+    """Yield directories under root without descending into Zarr stores."""
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = [entry for entry in current.iterdir() if entry.is_dir()]
+        except OSError:
+            continue
+        for entry in entries:
+            yield entry
+            if entry.suffix != ".zarr":
+                stack.append(entry)
+
+
+def find_label_dir(labels_root: Path, segment: str) -> Path | None:
+    """A segment's label directory is named after it and holds its inklabels."""
+    for candidate in walk_dirs(labels_root):
+        if candidate.name == segment and (candidate / f"{segment}_inklabels.zarr").exists():
+            return candidate
+    return None
+
+
+def find_volume(volumes_root: Path, segment: str) -> Path | None:
+    """Accept either <segment>.zarr or <segment>/<one>.zarr."""
+    holder = None
+    for candidate in walk_dirs(volumes_root):
+        if candidate.suffix == ".zarr" and candidate.stem == segment:
+            return candidate
+        if candidate.name == segment and candidate.suffix != ".zarr":
+            holder = candidate
+    if holder is None:
+        return None
+    stores = sorted(store for store in holder.iterdir() if store.suffix == ".zarr")
+    if len(stores) != 1:
+        sys.exit(f"error: expected exactly one *.zarr under {holder}, found {len(stores)}")
+    return stores[0]
+
+
+def renormalise(quotas: dict, keep: set, batch_size: int) -> dict:
+    """Spread the recipe's quotas over the surviving scrolls, summing to batch_size."""
+    live = {scroll: value for scroll, value in quotas.items() if scroll in keep}
+    if not live:
+        sys.exit("error: every scroll was excluded")
+    total = sum(live.values())
+    exact = {scroll: batch_size * value / total for scroll, value in live.items()}
+    out = {scroll: max(1, int(value)) for scroll, value in exact.items()}
+    # Largest-remainder top-up so the quotas land exactly on batch_size.
+    order = sorted(live, key=lambda s: exact[s] - int(exact[s]), reverse=True)
+    index = 0
+    while sum(out.values()) < batch_size:
+        out[order[index % len(order)]] += 1
+        index += 1
+    while sum(out.values()) > batch_size:
+        victim = max((s for s in order if out[s] > 1), key=lambda s: out[s])
+        out[victim] -= 1
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--labels-root", type=Path, required=True,
+                        help="Directory the per-segment label folders live under.")
+    parser.add_argument("--volumes-root", type=Path, required=True,
+                        help="Directory the ~9 um surface volumes live under.")
+    parser.add_argument("--out", type=Path, required=True, help="Config path to write.")
+    parser.add_argument("--run-dir", type=Path, required=True, help="Training out_dir.")
+    parser.add_argument("--exclude-scroll", action="append", default=[], metavar="SCROLL",
+                        help="Hold out every representation of this scroll. Repeatable.")
+    parser.add_argument("--exclude-segment", action="append", default=[], metavar="SEGMENT",
+                        help="Hold out one representation by segment name. Repeatable.")
+    parser.add_argument("--recipe", type=Path, default=DEFAULT_RECIPE,
+                        help=f"Base training config. Default: {DEFAULT_RECIPE.name}")
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT,
+                        help=f"Sampling contract. Default: {DEFAULT_CONTRACT.name}")
+    parser.add_argument("--seed", type=int, default=None, help="Override seed and sampler seed.")
+    parser.add_argument("--batch-size", type=int, default=None)
+    parser.add_argument("--iterations", type=int, default=None)
+    parser.add_argument("--save-every", type=int, default=None)
+    parser.add_argument("--val-every", type=int, default=None)
+    parser.add_argument("--allow-missing", action="store_true",
+                        help="Write the config even if some inputs are not prepared yet.")
+    args = parser.parse_args()
+
+    recipe = json.loads(args.recipe.read_text())
+    contract = json.loads(args.contract.read_text())
+
+    excluded_scrolls = set(args.exclude_scroll)
+    excluded_segments = set(args.exclude_segment)
+    known_scrolls = {rep["scroll"] for rep in contract["representations"]}
+    unknown = excluded_scrolls - known_scrolls
+    if unknown:
+        sys.exit(f"error: unknown scroll(s) {sorted(unknown)}; known: {sorted(known_scrolls)}")
+    known_segments = {rep["segment"] for rep in contract["representations"]}
+    unknown = excluded_segments - known_segments
+    if unknown:
+        sys.exit(f"error: unknown segment(s) {sorted(unknown)}")
+
+    kept, dropped = [], []
+    for rep in contract["representations"]:
+        if rep["scroll"] in excluded_scrolls or rep["segment"] in excluded_segments:
+            dropped.append(rep)
+        else:
+            kept.append(rep)
+    if not kept:
+        sys.exit("error: the exclusions removed every representation")
+
+    groups = OrderedDict()
+    missing = []
+    for rep in kept:
+        segment = rep["segment"]
+        labels = find_label_dir(args.labels_root, segment)
+        volume = find_volume(args.volumes_root, segment)
+        if labels is None:
+            missing.append(f"labels for {segment} under {args.labels_root}")
+            continue
+        if volume is None:
+            missing.append(f"surface volume for {segment} under {args.volumes_root}")
+            continue
+        entry = groups.setdefault((labels.parent, rep["scroll"]), {
+            "segments_path": as_posix(labels.parent),
+            "segments": [],
+            "surface_volume_paths": {},
+            "volume_scale": 0,
+            "sampling_scroll": rep["scroll"],
+            "sampling_physical_segment_keys": {},
+            "sampling_representation_keys": {},
+        })
+        entry["segments"].append(segment)
+        entry["surface_volume_paths"][segment] = as_posix(volume)
+        entry["sampling_physical_segment_keys"][segment] = rep["physical_segment_key"]
+        entry["sampling_representation_keys"][segment] = rep["representation_key"]
+
+    if missing and not args.allow_missing:
+        sys.exit("error: could not locate:\n  " + "\n  ".join(sorted(set(missing))))
+
+    batch_size = args.batch_size or int(recipe["batch_size"])
+    seed = args.seed if args.seed is not None else int(recipe["seed"])
+    surviving = {entry["sampling_scroll"] for entry in groups.values()}
+    quotas = renormalise(contract["target_batch_counts"], surviving, batch_size)
+    held_out = sorted({rep["segment"] for rep in dropped})
+
+    config = dict(recipe)
+    config["batch_size"] = batch_size
+    config["seed"] = seed
+    config["fixed_scroll_prior"] = {"seed": seed, "target_batch_counts": quotas}
+    config["out_dir"] = as_posix(args.run_dir)
+    config["datasets"] = list(groups.values())
+    for key, value in (("num_iterations", args.iterations),
+                       ("save_every", args.save_every),
+                       ("val_every", args.val_every)):
+        if value is not None:
+            config[key] = value
+    arm = f"held out {sorted(excluded_scrolls) or held_out}" if dropped else "no held-out representations"
+    kept_count = sum(len(entry["segments"]) for entry in groups.values())
+    config["description"] = (f"{recipe['description'].split('.')[0]}. Arm: {arm}; "
+                             f"{kept_count} representations, quotas {quotas}.")
+    config["held_out_representations"] = held_out
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(config, indent=2) + "\n")
+    print(f"wrote {args.out}")
+    print(f"  representations : {kept_count} kept, {len(dropped)} held out")
+    if dropped:
+        print(f"  held out        : {', '.join(held_out)}")
+    print(f"  quotas          : {quotas} (batch {batch_size})")
+    print(f"  dataset entries : {len(groups)}")
+    if missing:
+        print(f"  WARNING         : {len(set(missing))} input(s) not located")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**In one sentence:** Turn the published aligned-21 recipe into a config you can actually run,
and optionally hold a scroll or a segment out of it so the same recipe measures how well the
model transfers to data it never saw.

**One real example:** Starting with the released `ink_9um` labels and surface volumes, I ran

```bash
python scripts/make_holdout_config.py \
  --labels-root  /data/ink_9um/labels \
  --volumes-root /data/ink_9um/surface-volumes \
  --exclude-scroll 0139 \
  --seed 42 \
  --out configs/loso_no0139_s42.json \
  --run-dir runs/loso_no0139_s42
```

and it produced a 15-representation training config with quotas
`{'1667': 40, 'Paris4': 20, '0814': 4}` — byte-identical to the config I had previously
written by hand and trained on.

**Before:** `configs/aligned21_hybrid_3d2d.json` ships a single `datasets` entry whose paths
are `/path/to/aligned-21slice-data`, and the 29 representations it is meant to train on live
in a different file, `configs/aligned21_fixed_scroll_prior.json`. To run the recipe you join
the two by hand: 29 entries, each carrying its own `segments_path`, `surface_volume_paths`,
`sampling_physical_segment_keys` and `sampling_representation_keys`. To hold anything out you
also have to fix `fixed_scroll_prior.target_batch_counts` yourself. Drop a scroll without
renormalising and training stops at startup with
`fixed scroll quotas sum to 51, expected batch_size=64`, or, if the sums happen to work out,
with `fixed scroll quota keys must exactly match patch scrolls`. The sampler is right to
refuse; what is left to the user is finding a valid integer split that sums to `batch_size`,
once per arm.

**After this PR:** one command. Exclusions are `--exclude-scroll` / `--exclude-segment`, both
repeatable, and the quotas are renormalised over the survivors by largest remainder so they
still sum to `batch_size`.

**Proof:** the script regenerates the configs behind measurements I have already published,
from the contract rather than from my copies. Four arms, same seed, compared key by key
against the configs the checkpoints were actually trained with:

| arm | flags | representations | renormalised quotas | vs. the config I trained |
|---|---|---|---|---|
| leave-0139-out | `--exclude-scroll 0139` | 15 | `{1667: 40, Paris4: 20, 0814: 4}` | **identical** |
| leave-1667-out | `--exclude-scroll 1667` | 23 | `{0139: 44, Paris4: 17, 0814: 3}` | **identical** |
| leave-Paris4-out | `--exclude-scroll Paris4` | 21 | `{0139: 35, 1667: 27, 0814: 2}` | **identical** |
| two segments, both families | `--exclude-segment pherc0139-w035 --exclude-segment w035 --exclude-segment pherc0139-w039 --exclude-segment w039` | 25 | `{0139: 29, 1667: 22, Paris4: 11, 0814: 2}` | differs only in `dataloader_workers`, which I had lowered from 12 to 6 by hand |

With no exclusions it emits all 29 representations and reproduces the released quotas
`{0139: 29, 1667: 22, Paris4: 11, 0814: 2}` unchanged, which is the renormaliser's no-op case.

Failure modes are loud rather than silent: an unknown scroll prints the valid ones
(`error: unknown scroll(s) ['0247']; known: ['0139', '0814', '1667', 'Paris4']`), and a
representation whose labels or surface volume cannot be located is listed by name instead of
being written into a config that dies later in patch finding.

**Why / where this is useful:** anyone who wants to run the published recipe at all, and
anyone measuring cross-scroll generalisation — open problem #7. Holding a scroll out makes its
entire supervision mask honest held-out ground truth, so it can be scored directly. The three
leave-one-scroll-out arms above are what I used to get the first numbers on that problem, and
the point of upstreaming the generator is that the next person can re-run or disagree with
them without reconstructing the config by hand.

- [x] I personally verified that the example and proof above were produced by this PR on the
      stated data.

## Details

- Tested at `c61cc9f`, branched from `3ea17f5` (`merge-ink-pipelines` tip).
- Representations are located by exact directory name under the two roots, so a layout with
  `aligned/<segment>.zarr` and `native/<segment>/<one>.zarr` both work without flags. The walk
  does not descend into `.zarr` stores, so it stays fast on a full corpus (0.14 s over 29
  representations here).
- `--recipe` and `--contract` default to the two files in `configs/` next to the script and can
  be pointed elsewhere.
- Not covered: the script does not verify that a located surface volume is at the scale the
  recipe trains at. #1580 is adding exactly that check on the inference side, and it belongs
  there rather than here.
- No changes to any existing file.

**Why this matters to me:** I wanted to see whether the publicly released ink_9um model could
generalize to scrolls it had never seen before. The recipe was available, but it did not run
as-is, so before I could even get to that question, I had to manually define 29 dataset
entries. I then repeated the joins and quota calculations for each arm across three
leave-one-scroll-out splits and one two-segment holdout. At that point, it made more sense to
keep the setup in the repository than in my notes.
