### PR TITLE
spiral: build the native helpers with MSVC

### DIFF
--- a/spiral-fitting/cpp/CMakeLists.txt
+++ b/spiral-fitting/cpp/CMakeLists.txt
@@ -23,7 +23,15 @@ function(vc_spiral_module target source output_name)
         LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/vc_spiral"
     )
     target_compile_features(${target} PRIVATE cxx_std_23)
-    if(OpenMP_CXX_FOUND)
+    if(MSVC)
+        # No OpenMP here: MSVC's 2.0 mode rejects the atomic capture and
+        # min/max constructs these kernels use, and /openmp:llvm links a
+        # second OpenMP runtime beside the libiomp5md that torch's Windows
+        # wheels load, which aborts at import (OMP Error #15). The kernels
+        # build serial, the documented no-OpenMP fallback.
+        # MSVC's <cmath> only defines M_PI behind this macro.
+        target_compile_definitions(${target} PRIVATE _USE_MATH_DEFINES)
+    elseif(OpenMP_CXX_FOUND)
         target_link_libraries(${target} PRIVATE OpenMP::OpenMP_CXX)
     endif()
     install(TARGETS ${target}

--- a/spiral-fitting/cpp/track_store.cpp
+++ b/spiral-fitting/cpp/track_store.cpp
@@ -12,10 +12,16 @@
 #include <utility>
 #include <vector>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#else
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -55,6 +61,42 @@ public:
 
     explicit Mapping(const fs::path& path)
     {
+#ifdef _WIN32
+        file_ = ::CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                              nullptr, OPEN_EXISTING,
+                              FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
+                              nullptr);
+        if (file_ == INVALID_HANDLE_VALUE)
+            throw std::system_error(
+                static_cast<int>(::GetLastError()), std::system_category(),
+                "cannot open " + path.string());
+        LARGE_INTEGER file_size{};
+        if (!::GetFileSizeEx(file_, &file_size)) {
+            const int error = static_cast<int>(::GetLastError());
+            ::CloseHandle(file_);
+            file_ = INVALID_HANDLE_VALUE;
+            throw std::system_error(
+                error, std::system_category(), "cannot stat " + path.string());
+        }
+        size_ = static_cast<size_t>(file_size.QuadPart);
+        if (size_ != 0) {
+            mapping_ = ::CreateFileMappingW(file_, nullptr, PAGE_READONLY,
+                                            0, 0, nullptr);
+            if (mapping_ != nullptr)
+                data_ = ::MapViewOfFile(mapping_, FILE_MAP_READ, 0, 0, 0);
+            if (data_ == nullptr) {
+                const int error = static_cast<int>(::GetLastError());
+                if (mapping_ != nullptr)
+                    ::CloseHandle(mapping_);
+                mapping_ = nullptr;
+                ::CloseHandle(file_);
+                file_ = INVALID_HANDLE_VALUE;
+                throw std::system_error(
+                    error, std::system_category(),
+                    "cannot map " + path.string());
+            }
+        }
+#else
         descriptor_ = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
         if (descriptor_ < 0)
             throw std::system_error(
@@ -82,11 +124,31 @@ public:
             ::madvise(data_, size_, MADV_SEQUENTIAL);
 #endif
         }
+#endif
     }
 
     Mapping(const Mapping&) = delete;
     Mapping& operator=(const Mapping&) = delete;
 
+#ifdef _WIN32
+    Mapping(Mapping&& other) noexcept
+        : file_(std::exchange(other.file_, INVALID_HANDLE_VALUE)),
+          mapping_(std::exchange(other.mapping_, nullptr)),
+          data_(std::exchange(other.data_, nullptr)),
+          size_(std::exchange(other.size_, 0))
+    {
+    }
+
+    ~Mapping()
+    {
+        if (data_ != nullptr)
+            ::UnmapViewOfFile(data_);
+        if (mapping_ != nullptr)
+            ::CloseHandle(mapping_);
+        if (file_ != INVALID_HANDLE_VALUE)
+            ::CloseHandle(file_);
+    }
+#else
     Mapping(Mapping&& other) noexcept
         : descriptor_(std::exchange(other.descriptor_, -1)),
           data_(std::exchange(other.data_, nullptr)),
@@ -101,6 +163,7 @@ public:
         if (descriptor_ >= 0)
             ::close(descriptor_);
     }
+#endif
 
     const void* data() const { return data_; }
     size_t size() const { return size_; }
@@ -118,7 +181,12 @@ public:
     }
 
 private:
+#ifdef _WIN32
+    HANDLE file_ = INVALID_HANDLE_VALUE;
+    HANDLE mapping_ = nullptr;
+#else
     int descriptor_ = -1;
+#endif
     void* data_ = nullptr;
     size_t size_ = 0;
 };


### PR DESCRIPTION
**In one sentence:** `uv sync` in spiral-fitting cannot build the vc_spiral native helpers with MSVC: OpenMP constructs its default mode rejects, a missing `M_PI`, and a POSIX-only mmap.

**One real example:** Windows 11, VS 2022 (MSVC 14.34), Python 3.14, villa @ c53c74a. I was setting up a fit of the PHercParis4 lasagna inputs on an RTX 4080 Laptop when `uv sync` failed with:

```
track_crossings.cpp(1020,9): error C7660: '#pragma omp atomic update': requires '-openmp:llvm'
spiral_sampling.cpp(1027,77): error C2065: 'M_PI': undeclared identifier
track_store.cpp(16,10): fatal error C1083: Cannot open include file: 'sys/mman.h'
```

With this branch the same `uv sync` builds all four modules, `import vc_spiral.track_store` succeeds next to torch, and a real fit (z 5000-5400, 40 steps) runs to `checkpoint_fitted.ckpt` with exit 0.

**What changed:**
- The kernels build serial under MSVC. Its 2.0-mode OpenMP rejects the atomic capture/update and min/max constructs these kernels use, and building with `/openmp:llvm` instead loads a second OpenMP runtime beside the `libiomp5md.dll` that torch's Windows wheels ship, which aborts at import (`OMP: Error #15`). Serial is the fallback the README already documents for toolchains without OpenMP.
- `_USE_MATH_DEFINES`, which MSVC's `<cmath>` needs before it defines `M_PI`.
- `Mapping` in track_store.cpp gets a Windows file-mapping branch (`CreateFileMappingW` / `MapViewOfFile`) with the same read-only, sequential-access semantics. Checked against the published PHercParis4 packed track store: 19,746,134 tracks / 1,014,441,480 points load with counts matching the store's metadata exactly.

No behavior change on any other platform: both hunks are `if(MSVC)` / `#ifdef _WIN32`.
