### PR TITLE
tracks: accept a packed-store-backed DBM path where no dbm backend reads the DBM

### DIFF
--- a/spiral-fitting/tracks.py
+++ b/spiral-fitting/tracks.py
@@ -193,6 +193,13 @@ def normalize_tracks_dbm_path(path):
         return text
     if text.endswith('.db') and dbm.whichdb(text[:-3]):
         return text[:-3]
+    # A packed sibling store serves every read without opening the DBM, so
+    # accept the logical path on its evidence alone: whichdb cannot identify
+    # a Berkeley DBM where the stdlib lacks dbm.gnu/dbm.ndbm (e.g. Windows).
+    if os.path.isdir(text + TRACK_STORE_SUFFIX):
+        return text
+    if text.endswith('.db') and os.path.isdir(text[:-3] + TRACK_STORE_SUFFIX):
+        return text[:-3]
     raise FileNotFoundError(f'not a readable DBM logical path: {path}')
 
 


### PR DESCRIPTION
**In one sentence:** `normalize_tracks_dbm_path` requires `dbm.whichdb` to identify the DBM even when the packed sibling store serves every read, so on Windows (the stdlib ships neither `dbm.gnu` nor `dbm.ndbm`) `fit_spiral.py` dies at track loading with the `.vctracks` store sitting right beside the DBM.

**One real example:** Windows 11, Python 3.14, villa @ c53c74a, fitting PHercParis4 (z 5000-5400) with the published tracks:

```
FileNotFoundError: not a readable DBM logical path: G:\...\tracks\2um_ds2_ps256_surf_v2.dbm
```

The backing `.db` is a Berkeley hash (magic `0x00061561`), which no stdlib dbm backend on Windows can identify or open. With this branch the same command loads `708,712 tracks, 24,329,815 points in ROI` from the packed store and the fit completes with exit 0.

**What changed:** when `whichdb` cannot identify the DBM, accept the logical path if the packed sibling store directory exists. Reads then go through the packed store exactly as they already did; the DBM itself is still never opened on that path. Hosts where `whichdb` works keep the current behavior.
