### PR TITLE
readme: make the entrypoint table match [project.scripts]

### DIFF
--- a/vesuvius/README.md
+++ b/vesuvius/README.md
@@ -5,7 +5,6 @@ From [Vesuvius Challenge](https://scrollprize.org), a Python library for :
 - Training 2d or 3d models on regression tasks
 - Inferring with models trained with the trainers provided in the package or with pretrained nnUNetv2 models
   - Inference can be performed on remote data (http, s3) stored as Zarr arrays
-- Rendering .obj segments with local or remote data
 - Voxelizing large .obj segmentations for use as 3d labels
 - Preprocessing labels of fiber-like structures
 - Interactive labeling and model training through a Napari based trainer
@@ -79,7 +78,7 @@ Additionally, the augmentations provided within this package are from another of
 
 Copying the modules directly into `vesuvius` was a choice of end-user friendliness, as we were using highly modified branches of both libraries, which created conflicts if an end user were to attempt to run any of our models.
 
-_**Detailed documentation for training and inference are located in [the docs folder](docs/docs)**_
+_**Detailed documentation for training and inference are located in [the docs folder](docs)**_
 ___
 
 
@@ -93,7 +92,7 @@ ___
 6. Infer on the same layer, or another by importing an image, selecting it in the inference widget, and hitting `Run Inference`
 
 
-![alt text](docs/docs/images/napari_trainer.png)
+![alt text](docs/images/napari_trainer.png)
 
 ___
 
@@ -109,7 +108,7 @@ The proofreader lives in [`segmentation/vc_proofreader`](../segmentation/vc_proo
 6. Skip patches or continue with `spacebar` or `next pair`
 7. Patches are saved in the output dir, and their locations in the .json progress file
 
-![alt text](docs/docs/images/proofreader.png)
+![alt text](docs/images/proofreader.png)
 
 ### Training with `vesuvius.train`
 
@@ -159,4 +158,4 @@ By default, the last 10 checkpoints are saved. This is not a smart way to do it,
 Training will run for 1,000 epochs by default, with 200 batches/epoch. This can be modified through the configuration file, which can be optionally provided to `vesuvius.train`, and some examples are provided in the [models folder](src/vesuvius/models/configuration/)
 
 ### Rendering and Flattening objs
-Documentation is provided in [the rendering folder](src/vesuvius/rendering/README.md)
+This code was retired with ThaumatoAnakalyptor (now under [`deprecated/`](../deprecated/thaumato-anakalyptor)). To render a segment into a surface volume, use `vc_render_tifxyz` from [volume-cartographer](../volume-cartographer).

--- a/vesuvius/README.md
+++ b/vesuvius/README.md
@@ -21,19 +21,22 @@ _this package is in active development_
 
 ### Entrypoints: 
 
-| Name                          | Script                             | Description                                                                                                                                                                                               |
-| ----------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `vesuvius.predict`            | `models.run.inference`             | outputs logits from a pretrained nnUNet-v2 model or one trained within the Vesuvius training framework; currently only works on Zarr data and can be fully distributed with `--num_parts` and `--part_id` |
-| `vesuvius.blend_logits`       | `models.run.blending`              | blends the logits from `vesuvius.predict` using Gaussian blending                                                                                                                                         |
-| `vesuvius.finalize_outputs`   | `models.run.finalize_outputs`      | performs softmax / argmax / none on the blended array and writes a final `uint8` volume                                                                                                                   |
-| `vesuvius.compute_st`         | `structure_tensor.run_create_st`   | computes structure tensors on input data and derives eigen-values/vectors                                                                                                                                 |
-| `vesuvius.napari_trainer`     | `napari_trainer.main_window`       | launches a Napari window for interactive training and inference                                                                                                                                           |
-| `vesuvius.proofreader`        | `utils.vc_proofreader.main`        | opens a Napari window that loads local / remote image-label arrays and extracts training patches                                                                                                          |
-| `vesuvius.voxelize_obj`       | `scripts.voxelize_objs`            | converts input `.obj` meshes to voxel grids and outputs `.tif` stacks                                                                                                                                     |
-| `vesuvius.refine_labels`      | `scripts.edt_frangi_label`         | refines surface or fibre labels with a custom Frangi-based filter                                                                                                                                         |
-| `vesuvius.render_obj`         | `rendering.mesh_to_surface`        | renders `.obj` meshes and outputs their surface-volume layers                                                                                                                                             |
-| `vesuvius.flatten_obj`        | `rendering.slim_uv`                | flattens an `.obj` mesh using `slim_uv`                                                                                                                                                                   |
-| `vesuvius.train`              | `models.run.train`                 | main entry point for training models                                                                                                                                                                      |
+| Name                            | Script                               | Description                                                                                                                                                                                               |
+| ------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `vesuvius.accept_terms`         | `install.accept_terms`               | accepts the data usage terms and conditions (required once before accessing the data)                                                                                                                     |
+| `vesuvius.predict`              | `models.run.inference`               | outputs logits from a pretrained nnUNet-v2 model or one trained within the Vesuvius training framework; currently only works on Zarr data and can be fully distributed with `--num_parts` and `--part_id` |
+| `vesuvius.blend_logits`         | `models.run.blending`                | blends the logits from `vesuvius.predict` using Gaussian blending                                                                                                                                         |
+| `vesuvius.blend_and_finalize`   | `models.run.blending`                | blends partial inference outputs and finalizes (softmax + `uint8`) in a single pass                                                                                                                       |
+| `vesuvius.finalize_outputs`     | `models.run.finalize_outputs`        | performs softmax / argmax / none on the blended array and writes a final `uint8` volume                                                                                                                   |
+| `vesuvius.compute_st`           | `structure_tensor.run_create_st`     | computes structure tensors on input data and derives eigen-values/vectors                                                                                                                                 |
+| `vesuvius.napari_trainer`       | `napari_trainer.main_window`         | launches a Napari window for interactive training and inference                                                                                                                                           |
+| `vesuvius.voxelize_obj`         | `image_proc.run.voxelize_objs`       | converts input `.obj` meshes to voxel grids and outputs `.tif` stacks                                                                                                                                     |
+| `vesuvius.refine_labels`        | `image_proc.run.edt_frangi_label`    | refines surface or fibre labels with a custom Frangi-based filter                                                                                                                                         |
+| `vesuvius.train`                | `models.training.train`              | main entry point for training models                                                                                                                                                                      |
+| `vesuvius.zarr_tasks`           | `image_proc.run.zarr_tasks`          | operates on zarr arrays with various tasks                                                                                                                                                                |
+| `vesuvius.find_patches`         | `models.preprocessing.patches.cli`   | generates per-volume patch caches for a dataset                                                                                                                                                           |
+
+> **Note:** the previously documented `vesuvius.render_obj` and `vesuvius.flatten_obj` entrypoints no longer exist — that code was retired with ThaumatoAnakalyptor (now under `deprecated/`). To render a segment into a surface volume, use `vc_render_tifxyz` from [volume-cartographer](../volume-cartographer). The proofreader still exists but is no longer part of this package: it lives at [`segmentation/vc_proofreader`](../segmentation/vc_proofreader) (see [Proofreading labels](#proofreading-labels) below).
 
 
 
@@ -96,8 +99,10 @@ ___
 
 ### Proofreading labels
 
-1. Update the config in `/utils/vc_proofreader/config.py` with the proper paths
-2. Run `vesuvius.proofreader`
+The proofreader lives in [`segmentation/vc_proofreader`](../segmentation/vc_proofreader) (it is not part of the `vesuvius` package).
+
+1. Write a config file (JSON, or a Python script defining a `config` dict) with the proper paths
+2. Run `python segmentation/vc_proofreader/main.py --config <your config>` from the repo root
 3. Select your desired patch size and min labeled percentage 
 4. Click `run` 
 5. Approve patches with `a` or by checking the box


### PR DESCRIPTION
**In one sentence:** The README's entrypoint table now matches what `pip install vesuvius` actually registers, so nobody else goes looking for `vesuvius.render_obj`, `vesuvius.flatten_obj`, or `vesuvius.proofreader` — commands that don't exist.

**One real example:** Following the README to find a rendering entrypoint, `python -c "import vesuvius.rendering"` fails with `ModuleNotFoundError` — the reporter of #1520 hit exactly this while trying to render a PHerc1203 segment for ink detection and ended up writing their own renderer.

**Before:** The table documented 3 commands that are not in `[project.scripts]` and whose modules don't exist in the tree (`render_obj`, `flatten_obj`, `proofreader`), listed 3 more with stale module paths (`voxelize_obj`, `refine_labels`, `train`), and omitted 4 registered commands entirely (`accept_terms`, `blend_and_finalize`, `zarr_tasks`, `find_patches`). The proofreading section pointed at `/utils/vc_proofreader/config.py`, which doesn't exist.

**After this PR:** The table lists exactly the 12 commands registered in `pyproject.toml` `[project.scripts]`, with their real module paths. A note explains where the removed rendering entrypoints went (retired with ThaumatoAnakalyptor, now under `deprecated/`; segment rendering is `vc_render_tifxyz` in volume-cartographer) — and, new finding while verifying #1520: **the proofreader is not actually gone** — it lives at `segmentation/vc_proofreader/`, so the proofreading section now points there with its real `--config` invocation (`main.py` takes a JSON file or a Python script defining a `config` dict).

**Proof:** Structural verification that every row in the new table resolves — each script target's module file exists and defines (or imports) the named function — and that the removed modules are really gone:

```
OK   vesuvius.accept_terms          vesuvius.install.accept_terms:main
OK   vesuvius.predict               vesuvius.models.run.inference:main
OK   vesuvius.blend_logits          vesuvius.models.run.blending:main
OK   vesuvius.blend_and_finalize   vesuvius.models.run.blending:blend_and_finalize_main
OK   vesuvius.finalize_outputs      vesuvius.models.run.finalize_outputs:main
OK   vesuvius.compute_st            vesuvius.structure_tensor.run_create_st:main
OK   vesuvius.napari_trainer        vesuvius.napari_trainer.main_window:main
OK   vesuvius.voxelize_obj          vesuvius.image_proc.run.voxelize_objs:main
OK   vesuvius.refine_labels         vesuvius.image_proc.run.edt_frangi_label:main
OK   vesuvius.train                 vesuvius.models.training.train:main
OK   vesuvius.zarr_tasks            vesuvius.image_proc.run.zarr_tasks.__main__:main
OK   vesuvius.find_patches          vesuvius.models.preprocessing.patches.cli:main
dead module dirs: False False
ALL TABLE ROWS VERIFIED
```

`vc_render_tifxyz` confirmed present at `volume-cartographer/apps/src/vc_render_tifxyz.cpp`; proofreader confirmed at `segmentation/vc_proofreader/main.py` with `--config` argparse.

**Why / where this is useful:** The entrypoint table is the first thing a new contributor reads to learn what the package can do. Three of its rows sent people (including the #1520 reporter, mid-First-Letters work) hunting for tools that don't exist; the missing rows hid tools that do.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

Fixes #1520

## Details

- Doc-only change to `vesuvius/README.md`: entrypoint table rebuilt from `pyproject.toml` `[project.scripts]` (the source of truth), a note for the removed/relocated tools, and the "Proofreading labels" steps updated to the real location and invocation.
- #1520 suggested either dropping the dead rows or re-pointing them; this does both where each applies: the rendering pair is genuinely gone (only copies are under `deprecated/thaumato-anakalyptor/`), while the proofreader survived the reorganization into `segmentation/`.
- Kept all original descriptions where they were still accurate; the two new descriptions come from the tools' own argparse `description` strings.

## From the submitter

Corrected documentation for vesuvius CLI tool. I checked the changes Claude showed me.

*Disclosure: Claude (Anthropic) verified the issue, researched where the tools moved, and drafted this change and text under my direction. I reviewed the diff before submitting.*
