### PR TITLE
ci(vc3d): restore smoke-tested runtime image publishing

### DIFF
--- a/.github/workflows/vc3d-publish-runtime.yml
+++ b/.github/workflows/vc3d-publish-runtime.yml
@@ -1,0 +1,181 @@
+name: Publish VC3D runtime image (ghcr.io)
+
+# Keep the documented :main and :edge C++ runtime images aligned with the
+# source users get from the default branch. The builder-image workflow remains
+# separate so source-only changes do not republish the CI dependency image.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'volume-cartographer/**'
+      - '.github/workflows/vc3d-publish-runtime.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/villa/volume-cartographer
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Prepare image name
+    runs-on: ubuntu-24.04
+    outputs:
+      registry_image: ${{ steps.image.outputs.registry_image }}
+    steps:
+      - name: Require the default branch
+        if: github.ref != 'refs/heads/main'
+        shell: bash
+        run: |
+          echo "Runtime tags may only be published from main; got $GITHUB_REF" >&2
+          exit 1
+      - name: Normalize registry image name
+        id: image
+        shell: bash
+        run: echo "registry_image=${REGISTRY_IMAGE,,}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build runtime (${{ matrix.platform }})
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            artifact: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: linux-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate image labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.prepare.outputs.registry_image }}
+      - name: Build and push runtime by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./volume-cartographer
+          file: ./volume-cartographer/Dockerfile
+          target: runtime
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=vc3d-runtime-${{ matrix.artifact }}
+          cache-to: type=gha,mode=max,scope=vc3d-runtime-${{ matrix.artifact }}
+          provenance: true
+          outputs: type=image,name=${{ needs.prepare.outputs.registry_image }},push-by-digest=true,name-canonical=true,push=true
+      - name: Smoke-test published digest
+        env:
+          REGISTRY_IMAGE: ${{ needs.prepare.outputs.registry_image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker pull "$REGISTRY_IMAGE@$DIGEST"
+          docker run --rm --entrypoint /bin/bash "$REGISTRY_IMAGE@$DIGEST" -lc '
+            set -euo pipefail
+            echo "architecture=$(uname -m)"
+            for binary in VC3D vc3d vc_render_tifxyz vc_grow_seg_from_seed \
+              vc_gen_normalgrids flatboi; do
+              test -x "/usr/local/bin/$binary"
+              echo "executable=$binary"
+            done
+
+            ldd_checked=0
+            while IFS= read -r -d "" binary; do
+              missing="$(ldd "$binary" 2>&1 | grep "not found" || true)"
+              if [[ -n "$missing" ]]; then
+                echo "missing shared libraries for $binary:" >&2
+                printf "%s\n" "$missing" >&2
+                exit 1
+              fi
+              ldd_checked=$((ldd_checked + 1))
+            done < <(find -L /usr/local/bin -maxdepth 1 -type f -perm /111 -print0)
+            echo "ldd_checked=$ldd_checked"
+
+            for binary in vc_render_tifxyz vc_grow_seg_from_seed \
+              vc_gen_normalgrids flatboi; do
+              "$binary" --help >/dev/null
+            done
+
+            set +e
+            QT_QPA_PLATFORM=offscreen HOME=/tmp timeout 8 VC3D \
+              >/tmp/vc3d-smoke.log 2>&1
+            rc=$?
+            set -e
+            tail -n 20 /tmp/vc3d-smoke.log
+            if [[ "$rc" -ne 124 ]]; then
+              echo "VC3D exited unexpectedly during the offscreen startup smoke (rc=$rc)" >&2
+              exit 1
+            fi
+            echo "runtime_smoke=ok"
+          '
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.artifact }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish multi-platform runtime tags
+    needs: [prepare, build]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Generate runtime tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.prepare.outputs.registry_image }}
+          tags: |
+            type=raw,value=main
+            type=raw,value=edge
+            type=raw,value=sha-${{ github.sha }}
+      - name: Create and inspect manifest list
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          REGISTRY_IMAGE: ${{ needs.prepare.outputs.registry_image }}
+        shell: bash
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "$REGISTRY_IMAGE@sha256:%s " *)
+          docker buildx imagetools inspect "$REGISTRY_IMAGE:edge"


### PR DESCRIPTION
**In one sentence:** After merge and a successful qualifying `main` run, users pulling the documented `:edge` or `:main` image will receive a current, smoke-tested VC3D/C++ runtime instead of the broken May 13 build.

**One real example:** The local amd64 evidence records one current-source generation with the public PHerc0813 m7 surface Zarr, remote-only normal-grid marker, and seed `(3968, 3970, 14878)`: it read the binary voxel as `255`, fetched the remote normal grids, generated `302.567159 vx²`, saved the TIFXYZ path, and exited 0.

**Before:** Both `:edge` and `:main` resolve to the same 2026-05-13 image (`1e3f4c02`), 285 commits behind the tested source. On this exact input that image read the voxel as `103` and crashed on remote metadata; the reporter's full eight-seed run also produced flat, zero-area surfaces.

**After this PR:** On each qualifying push to `main`, the workflow is configured to build native amd64 and arm64 runtime digests from the existing Dockerfile. Each digest must be pulled back and smoke-tested before the workflow can advance `main`, `edge`, and an immutable full-SHA tag.

**Proof:**

- Reporter failure and independent stale-image diagnosis: https://github.com/ScrollPrize/villa/issues/1588
- Reporter eight-seed before/after geometry: https://github.com/ScrollPrize/villa/issues/1588#issuecomment-5406053138
- Research-thread report that the current-source path unblocked surface growth: https://github.com/ScrollPrize/villa/issues/191#issuecomment-5406053252
- Local build/run and final implementation record: https://github.com/ScrollPrize/villa/issues/1588#issuecomment-5432544176
- Hash-bound local inputs, raw log, and two output metadata records: https://gist.github.com/TAUIL-Abd-Elilah/53c10e4d9aaf0967ed8ac19bc6426283 (revision `940863d17bedc712dfa4890efd3623c48ed5f580`)
- Independent smoke-gate replay and coverage review: https://github.com/ScrollPrize/villa/pull/1619#issuecomment-5432714620

```text
current-source build: 1244/1244 compile steps; 12/12 image steps; exit 0
amd64 image digest:    sha256:95cfa07a89d825fbba2f6a3064ca91c95b85d7d65ebd4f133b2328efe9860504
seed voxel:            255
remote normal grid:    loaded (marker was the only initial file)
generated surface:     302.567159 vx² / 0.000265 cm²
saved artifact:        auto_grown_20260826213017169
runtime exit:          0
```

**Why / where this is useful:** The README recommends this image because VC3D is expensive to build. The stale binary already cost a contributor three pod experiments and hid fixes needed for real PHerc0813 surface growth; restoring guarded publication prevents that failure from recurring for every later fix.

## Details

Fixes #1588.

Tested source: `6847063ffdb4da898ae8d1d494ebf7d71473f509`; workflow commit: `e3a318270`.

- Reuses `volume-cartographer/Dockerfile` and its existing `runtime` target; no application or image-content changes.
- Configures native `ubuntu-24.04` and `ubuntu-24.04-arm` runners, avoiding emulated multi-architecture builds.
- Pushes architecture images by digest, then re-pulls and tests that exact registry object.
- Checks the core tools plus the documented `vc_gen_normalgrids` and `flatboi`; scans every executable in `/usr/local/bin` for missing shared libraries; runs four representative CLI help paths; and requires VC3D to remain healthy for an eight-second offscreen startup.
- Publishes moving tags only after both architecture jobs pass. A failure may leave an untagged digest, but cannot update `main` or `edge`.
- Leaves the separate CI-builder workflow unchanged.

Scope is intentionally the existing C++ runtime. A broader prototype was rejected after verification showed that merely copying Spiral sources would omit its locked Python/CUDA/Lasagna environment and expose a partial service. Image slimming is also separate; the existing runtime target retains its build toolchain.

Local checks: `actionlint` 1.7.12 clean; Docker BuildKit `--check` clean; `git diff --check` clean. Arm64 execution is delegated to the workflow's native runner.

The eight-seed `68.1° → 20.5°` / `0 → 8.08–9.73 cm²` comparison is @flummoxjr's evidence; the local evidence reproduces only the one-generation constructor/runtime path above.

AI disclosure: Codex assisted with implementation and verification in my workspace. The local evidence records executed amd64 build and real-data commands; no arm64 workflow run is claimed. Limitations are stated above.
