### PR TITLE
Fix public S3 access with stale AWS credentials

### DIFF
--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(vc_core
         src/RemoteUrl.cpp
         src/RemoteFileCache.cpp
         src/HttpFetch.cpp
+        src/S3AuthFallback.cpp
         src/PostProcess.cpp
         src/Geometry.cpp
         src/PointCollections.cpp

--- a/volume-cartographer/core/include/vc/core/render/ZarrChunkFetcher.hpp
+++ b/volume-cartographer/core/include/vc/core/render/ZarrChunkFetcher.hpp
@@ -58,16 +58,17 @@ OpenedChunkedZarr openHttpZarrPyramid(
     std::optional<int> baseScaleLevel = std::nullopt);
 
 // Production remote-volume open policy shared by VC3D and standalone tools:
-// resolve the locator, discover credentials when requested, and retry public
-// S3 data anonymously when stale credentials cause an authentication error.
+// resolve the locator, try recognized S3 sources anonymously, then retry with
+// discovered credentials only when anonymous access is denied.
 OpenedRemoteChunkedZarr openRemoteZarrPyramid(
     const std::string& url,
     RemoteZarrOpenOptions options = {});
 
 // S3 deliberately returns AccessDenied rather than NotFound for a missing key
 // when the caller lacks ListBucket. Optional discovery probes must therefore
-// accept a generic 403 while preserving explicit credential failures so the
-// anonymous retry policy can still run. Exposed for deterministic tests.
+// accept a generic 403 while preserving explicit credential failures. The
+// opener remembers suppressed denials and retries authenticated if no required
+// array metadata can ultimately be found.
 bool isOptionalRemoteMetadataMiss(
     long status,
     std::string_view key,

--- a/volume-cartographer/core/include/vc/core/util/S3AuthFallback.hpp
+++ b/volume-cartographer/core/include/vc/core/util/S3AuthFallback.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <utils/http_fetch.hpp>
+
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string_view>
+
+namespace vc
+{
+
+[[nodiscard]] bool hasExplicitAwsCredentialError(std::string_view detail);
+
+[[nodiscard]] bool isAwsAuthenticationFailure(long status, std::string_view detail);
+
+class S3AuthFallback final
+{
+public:
+    using Attempt = std::function<utils::HttpResponse(bool anonymous)>;
+
+    struct Result {
+        utils::HttpResponse response;
+        std::optional<utils::HttpResponse> authenticatedFailure;
+        bool usedAnonymous = false;
+    };
+
+    S3AuthFallback(bool isS3, bool credentialsLoaded);
+
+    [[nodiscard]] Result request(const Attempt& attempt) const;
+    [[nodiscard]] bool usesAnonymous() const;
+
+private:
+    enum class Mode {
+        Disabled,
+        Authenticated,
+        ProbingAnonymous,
+        Anonymous,
+        AuthenticatedOnly,
+    };
+
+    mutable std::mutex mutex_;
+    mutable std::condition_variable probeFinished_;
+    mutable Mode mode_;
+    mutable std::uint64_t probeGeneration_ = 0;
+};
+
+}  // namespace vc

--- a/volume-cartographer/core/include/vc/core/util/S3AuthFallback.hpp
+++ b/volume-cartographer/core/include/vc/core/util/S3AuthFallback.hpp
@@ -3,7 +3,6 @@
 #include <utils/http_fetch.hpp>
 
 #include <condition_variable>
-#include <cstdint>
 #include <functional>
 #include <mutex>
 #include <optional>
@@ -16,6 +15,8 @@ namespace vc
 
 [[nodiscard]] bool isAwsAuthenticationFailure(long status, std::string_view detail);
 
+// Selects anonymous S3 access on the first successful request and retains
+// authenticated access only after anonymous access is denied.
 class S3AuthFallback final
 {
 public:
@@ -23,7 +24,7 @@ public:
 
     struct Result {
         utils::HttpResponse response;
-        std::optional<utils::HttpResponse> authenticatedFailure;
+        std::optional<utils::HttpResponse> anonymousFailure;
         bool usedAnonymous = false;
     };
 
@@ -35,16 +36,15 @@ public:
 private:
     enum class Mode {
         Disabled,
-        Authenticated,
-        ProbingAnonymous,
+        Undecided,
+        Probing,
         Anonymous,
-        AuthenticatedOnly,
+        Authenticated,
     };
 
     mutable std::mutex mutex_;
     mutable std::condition_variable probeFinished_;
     mutable Mode mode_;
-    mutable std::uint64_t probeGeneration_ = 0;
 };
 
 }  // namespace vc

--- a/volume-cartographer/core/src/HttpFetch.cpp
+++ b/volume-cartographer/core/src/HttpFetch.cpp
@@ -1,4 +1,5 @@
 #include "vc/core/util/HttpFetch.hpp"
+#include "vc/core/util/S3AuthFallback.hpp"
 
 #include <utils/http_fetch.hpp>
 
@@ -23,18 +24,6 @@ utils::HttpClient makeTextClient(const HttpAuth& auth)
     cfg.connect_timeout = std::chrono::seconds{5};
     cfg.max_retries = 2;
     return utils::HttpClient(std::move(cfg));
-}
-
-bool isAuthError(long status, const std::string& body)
-{
-    if (status == 401 || status == 403)
-        return true;
-    return body.find("ExpiredToken") != std::string::npos ||
-           body.find("AccessDenied") != std::string::npos ||
-           body.find("InvalidAccessKeyId") != std::string::npos ||
-           body.find("SignatureDoesNotMatch") != std::string::npos ||
-           body.find("TokenRefreshRequired") != std::string::npos ||
-           body.find("InvalidToken") != std::string::npos;
 }
 
 std::string authErrorMessage(long status, const std::string& body)
@@ -104,7 +93,7 @@ std::string httpGetString(const std::string& url, const HttpAuth& auth)
 
     if (resp.status_code >= 400) {
         const auto body = std::string(resp.body_string());
-        if (isAuthError(resp.status_code, body))
+        if (isAwsAuthenticationFailure(resp.status_code, body))
             throw std::runtime_error(authErrorMessage(resp.status_code, body));
         if (resp.status_code >= 500) {
             throw std::runtime_error(
@@ -124,7 +113,7 @@ std::vector<std::byte> httpGetBytes(const std::string& url, const HttpAuth& auth
 
     if (resp.status_code >= 400) {
         const auto body = std::string(resp.body_string());
-        if (isAuthError(resp.status_code, body))
+        if (isAwsAuthenticationFailure(resp.status_code, body))
             throw std::runtime_error(authErrorMessage(resp.status_code, body));
         if (resp.status_code >= 500) {
             throw std::runtime_error(

--- a/volume-cartographer/core/src/RemoteFileCache.cpp
+++ b/volume-cartographer/core/src/RemoteFileCache.cpp
@@ -1,4 +1,5 @@
 #include "vc/core/util/RemoteFileCache.hpp"
+#include "vc/core/util/S3AuthFallback.hpp"
 
 #include "utils/http_fetch.hpp"
 
@@ -211,6 +212,8 @@ std::string fetchFailureMessage(const std::string& sourceLocation, const vc::Res
     std::string message = "failed to fetch remote file source=" + redactedRemoteLocation(sourceLocation) +
                           " request_url=" + redactedRemoteLocation(endpoint.httpsUrl);
     message += response.status_code > 0 ? " HTTP " + std::to_string(response.status_code) : " no_http_response";
+    if (!response.error_message.empty())
+        message += " transport_error=\"" + escapedDiagnosticString(response.error_message) + "\"";
     if (!response.content_type.empty())
         message += " content_type=\"" + escapedDiagnosticString(response.content_type) + "\"";
     if (response.content_length > 0)
@@ -243,15 +246,39 @@ void defaultFetch(const std::string& sourceLocation,
     const auto endpoint = vc::resolveRemoteUrl(sourceLocation);
     auto details = makeRemoteClientDetails(
         endpoint, explicitAuth, discoverAwsCredentials);
-    utils::HttpClient client(std::move(details.config));
-    const auto response = client.get(endpoint.httpsUrl);
-    if (!response.ok())
-        throw std::runtime_error(fetchFailureMessage(sourceLocation, endpoint, details, response));
+    auto anonymousDetails = makeRemoteClientDetails(
+        endpoint, vc::HttpAuth{}, false);
+    utils::HttpClient authenticatedClient(std::move(details.config));
+    utils::HttpClient anonymousClient(std::move(anonymousDetails.config));
+    vc::S3AuthFallback fallback(details.isS3, details.credentialsLoaded);
+    auto result = fallback.request([&](bool anonymous) {
+        return anonymous
+            ? anonymousClient.get(endpoint.httpsUrl)
+            : authenticatedClient.get(endpoint.httpsUrl);
+    });
+    if (!result.response.ok()) {
+        std::string message = fetchFailureMessage(
+            sourceLocation, endpoint,
+            result.usedAnonymous ? anonymousDetails : details,
+            result.response);
+        if (result.authenticatedFailure) {
+            message += " authenticated_attempt_http=" +
+                std::to_string(result.authenticatedFailure->status_code);
+            const auto code = xmlTagValue(
+                result.authenticatedFailure->body_string(), "Code");
+            if (!code.empty()) {
+                message += " authenticated_s3_Code=\"" +
+                    escapedDiagnosticString(code) + "\"";
+            }
+            message += " anonymous_fallback=failed";
+        }
+        throw std::runtime_error(std::move(message));
+    }
     std::ofstream output(temporaryPath, std::ios::binary | std::ios::trunc);
     if (!output)
         throw std::runtime_error("cannot create remote cache temporary file");
-    if (!response.body.empty()) {
-        output.write(reinterpret_cast<const char*>(response.body.data()), static_cast<std::streamsize>(response.body.size()));
+    if (!result.response.body.empty()) {
+        output.write(reinterpret_cast<const char*>(result.response.body.data()), static_cast<std::streamsize>(result.response.body.size()));
     }
     output.close();
     if (!output)

--- a/volume-cartographer/core/src/RemoteFileCache.cpp
+++ b/volume-cartographer/core/src/RemoteFileCache.cpp
@@ -261,16 +261,16 @@ void defaultFetch(const std::string& sourceLocation,
             sourceLocation, endpoint,
             result.usedAnonymous ? anonymousDetails : details,
             result.response);
-        if (result.authenticatedFailure) {
-            message += " authenticated_attempt_http=" +
-                std::to_string(result.authenticatedFailure->status_code);
+        if (result.anonymousFailure) {
+            message += " anonymous_attempt_http=" +
+                std::to_string(result.anonymousFailure->status_code);
             const auto code = xmlTagValue(
-                result.authenticatedFailure->body_string(), "Code");
+                result.anonymousFailure->body_string(), "Code");
             if (!code.empty()) {
-                message += " authenticated_s3_Code=\"" +
+                message += " anonymous_s3_Code=\"" +
                     escapedDiagnosticString(code) + "\"";
             }
-            message += " anonymous_fallback=failed";
+            message += " authenticated_fallback=failed";
         }
         throw std::runtime_error(std::move(message));
     }

--- a/volume-cartographer/core/src/S3AuthFallback.cpp
+++ b/volume-cartographer/core/src/S3AuthFallback.cpp
@@ -1,0 +1,102 @@
+#include "vc/core/util/S3AuthFallback.hpp"
+
+#include <algorithm>
+#include <array>
+
+namespace vc
+{
+
+bool hasExplicitAwsCredentialError(std::string_view detail)
+{
+    constexpr std::array<std::string_view, 11> markers{
+        "AccessDenied",
+        "ExpiredToken",
+        "InvalidAccessKeyId",
+        "InvalidClientTokenId",
+        "InvalidSignatureException",
+        "InvalidToken",
+        "RequestExpired",
+        "RequestTimeTooSkewed",
+        "SignatureDoesNotMatch",
+        "TokenRefreshRequired",
+        "UnrecognizedClientException",
+    };
+    return std::any_of(markers.begin(), markers.end(), [&](const auto marker) { return detail.find(marker) != std::string_view::npos; });
+}
+
+bool isAwsAuthenticationFailure(long status, std::string_view detail)
+{
+    return status == 401 || status == 403 || hasExplicitAwsCredentialError(detail);
+}
+
+S3AuthFallback::S3AuthFallback(bool isS3, bool credentialsLoaded) : mode_(isS3 && credentialsLoaded ? Mode::Authenticated : Mode::Disabled)
+{
+}
+
+S3AuthFallback::Result S3AuthFallback::request(const Attempt& attempt) const
+{
+    Mode mode;
+    std::uint64_t probeGeneration;
+    {
+        std::unique_lock lock(mutex_);
+        probeFinished_.wait(lock, [&] { return mode_ != Mode::ProbingAnonymous; });
+        mode = mode_;
+        probeGeneration = probeGeneration_;
+    }
+
+    if (mode == Mode::Anonymous)
+        return {attempt(true), std::nullopt, true};
+
+    auto authenticated = attempt(false);
+    if (mode != Mode::Authenticated || !isAwsAuthenticationFailure(authenticated.status_code, authenticated.body_string())) {
+        return {std::move(authenticated), std::nullopt, false};
+    }
+
+    {
+        std::unique_lock lock(mutex_);
+        if (mode_ == Mode::ProbingAnonymous) {
+            probeFinished_.wait(lock, [&] { return mode_ != Mode::ProbingAnonymous; });
+        }
+        if (mode_ == Mode::Anonymous) {
+            lock.unlock();
+            return {attempt(true), std::move(authenticated), true};
+        }
+        if (mode_ != Mode::Authenticated || probeGeneration_ != probeGeneration) {
+            return {std::move(authenticated), std::nullopt, false};
+        }
+        mode_ = Mode::ProbingAnonymous;
+    }
+
+    try {
+        auto anonymous = attempt(true);
+        {
+            std::lock_guard lock(mutex_);
+            if (anonymous.ok() || anonymous.not_found()) {
+                mode_ = Mode::Anonymous;
+            } else if (isAwsAuthenticationFailure(anonymous.status_code, anonymous.body_string())) {
+                mode_ = Mode::AuthenticatedOnly;
+            } else {
+                mode_ = Mode::Authenticated;
+            }
+            ++probeGeneration_;
+        }
+        probeFinished_.notify_all();
+        return {std::move(anonymous), std::move(authenticated), true};
+    } catch (...) {
+        {
+            std::lock_guard lock(mutex_);
+            mode_ = Mode::Authenticated;
+            ++probeGeneration_;
+        }
+        probeFinished_.notify_all();
+        throw;
+    }
+}
+
+bool S3AuthFallback::usesAnonymous() const
+{
+    std::lock_guard lock(mutex_);
+    return mode_ == Mode::Anonymous;
+}
+
+}  // namespace vc

--- a/volume-cartographer/core/src/S3AuthFallback.cpp
+++ b/volume-cartographer/core/src/S3AuthFallback.cpp
@@ -8,8 +8,7 @@ namespace vc
 
 bool hasExplicitAwsCredentialError(std::string_view detail)
 {
-    constexpr std::array<std::string_view, 11> markers{
-        "AccessDenied",
+    constexpr std::array<std::string_view, 10> markers{
         "ExpiredToken",
         "InvalidAccessKeyId",
         "InvalidClientTokenId",
@@ -26,67 +25,70 @@ bool hasExplicitAwsCredentialError(std::string_view detail)
 
 bool isAwsAuthenticationFailure(long status, std::string_view detail)
 {
-    return status == 401 || status == 403 || hasExplicitAwsCredentialError(detail);
+    if (status >= 200 && status < 300)
+        return false;
+    return status == 401 || status == 403 ||
+           detail.find("AccessDenied") != std::string_view::npos ||
+           hasExplicitAwsCredentialError(detail);
 }
 
-S3AuthFallback::S3AuthFallback(bool isS3, bool credentialsLoaded) : mode_(isS3 && credentialsLoaded ? Mode::Authenticated : Mode::Disabled)
+S3AuthFallback::S3AuthFallback(bool isS3, bool credentialsLoaded)
+    : mode_(isS3 && credentialsLoaded ? Mode::Undecided : Mode::Disabled)
 {
 }
 
 S3AuthFallback::Result S3AuthFallback::request(const Attempt& attempt) const
 {
     Mode mode;
-    std::uint64_t probeGeneration;
     {
         std::unique_lock lock(mutex_);
-        probeFinished_.wait(lock, [&] { return mode_ != Mode::ProbingAnonymous; });
+        probeFinished_.wait(lock, [&] { return mode_ != Mode::Probing; });
         mode = mode_;
-        probeGeneration = probeGeneration_;
+        if (mode == Mode::Undecided)
+            mode_ = Mode::Probing;
     }
 
-    if (mode == Mode::Anonymous)
-        return {attempt(true), std::nullopt, true};
+    if (mode == Mode::Disabled || mode == Mode::Authenticated)
+        return {attempt(false), std::nullopt, false};
 
-    auto authenticated = attempt(false);
-    if (mode != Mode::Authenticated || !isAwsAuthenticationFailure(authenticated.status_code, authenticated.body_string())) {
-        return {std::move(authenticated), std::nullopt, false};
-    }
+    if (mode == Mode::Anonymous) {
+        auto anonymous = attempt(true);
+        if (anonymous.status_code != 401 && anonymous.status_code != 403)
+            return {std::move(anonymous), std::nullopt, true};
 
-    {
-        std::unique_lock lock(mutex_);
-        if (mode_ == Mode::ProbingAnonymous) {
-            probeFinished_.wait(lock, [&] { return mode_ != Mode::ProbingAnonymous; });
+        auto authenticated = attempt(false);
+        if (authenticated.ok() || authenticated.not_found()) {
+            std::lock_guard lock(mutex_);
+            if (mode_ == Mode::Anonymous)
+                mode_ = Mode::Authenticated;
         }
-        if (mode_ == Mode::Anonymous) {
-            lock.unlock();
-            return {attempt(true), std::move(authenticated), true};
-        }
-        if (mode_ != Mode::Authenticated || probeGeneration_ != probeGeneration) {
-            return {std::move(authenticated), std::nullopt, false};
-        }
-        mode_ = Mode::ProbingAnonymous;
+        return {std::move(authenticated), std::move(anonymous), false};
     }
 
     try {
         auto anonymous = attempt(true);
+        if (anonymous.status_code == 401 || anonymous.status_code == 403) {
+            auto authenticated = attempt(false);
+            {
+                std::lock_guard lock(mutex_);
+                mode_ = authenticated.ok() || authenticated.not_found()
+                    ? Mode::Authenticated
+                    : Mode::Undecided;
+            }
+            probeFinished_.notify_all();
+            return {std::move(authenticated), std::move(anonymous), false};
+        }
+
         {
             std::lock_guard lock(mutex_);
-            if (anonymous.ok() || anonymous.not_found()) {
-                mode_ = Mode::Anonymous;
-            } else if (isAwsAuthenticationFailure(anonymous.status_code, anonymous.body_string())) {
-                mode_ = Mode::AuthenticatedOnly;
-            } else {
-                mode_ = Mode::Authenticated;
-            }
-            ++probeGeneration_;
+            mode_ = anonymous.ok() ? Mode::Anonymous : Mode::Undecided;
         }
         probeFinished_.notify_all();
-        return {std::move(anonymous), std::move(authenticated), true};
+        return {std::move(anonymous), std::nullopt, true};
     } catch (...) {
         {
             std::lock_guard lock(mutex_);
-            mode_ = Mode::Authenticated;
-            ++probeGeneration_;
+            mode_ = Mode::Undecided;
         }
         probeFinished_.notify_all();
         throw;

--- a/volume-cartographer/core/src/lasagna/Dataset.cpp
+++ b/volume-cartographer/core/src/lasagna/Dataset.cpp
@@ -340,11 +340,11 @@ public:
                 std::string message =
                     "Remote Lasagna Zarr fetch failed HTTP " +
                     std::to_string(response.status_code) + ": " + key;
-                if (requestResult.authenticatedFailure) {
-                    message += " after authenticated request failed HTTP " +
+                if (requestResult.anonymousFailure) {
+                    message += " after anonymous request failed HTTP " +
                         std::to_string(
-                            requestResult.authenticatedFailure->status_code) +
-                        " and anonymous fallback failed";
+                            requestResult.anonymousFailure->status_code) +
+                        " and authenticated fallback failed";
                 }
                 throw std::runtime_error(std::move(message));
             }

--- a/volume-cartographer/core/src/lasagna/Dataset.cpp
+++ b/volume-cartographer/core/src/lasagna/Dataset.cpp
@@ -4,6 +4,7 @@
 #include "vc/core/render/PersistentZarrCacheBudget.hpp"
 #include "vc/core/util/RemoteFileCache.hpp"
 #include "vc/core/util/RemoteUrl.hpp"
+#include "vc/core/util/S3AuthFallback.hpp"
 #include "utils/http_fetch.hpp"
 #include "utils/zarr.hpp"
 
@@ -65,7 +66,14 @@ namespace {
     return resolved;
 }
 
-[[nodiscard]] utils::HttpClient makeRemoteClient(
+struct RemoteClients {
+    std::unique_ptr<utils::HttpClient> authenticated;
+    std::unique_ptr<utils::HttpClient> anonymous;
+    bool isS3 = false;
+    bool credentialsLoaded = false;
+};
+
+[[nodiscard]] RemoteClients makeRemoteClients(
     const vc::ResolvedUrl& endpoint,
     const vc::HttpAuth& explicitAuth,
     bool discoverAwsCredentials)
@@ -79,7 +87,17 @@ namespace {
         if (!endpoint.awsRegion.empty())
             config.aws_auth.region = endpoint.awsRegion;
     }
-    return utils::HttpClient(std::move(config));
+    RemoteClients clients;
+    clients.isS3 = endpoint.useAwsSigv4;
+    clients.credentialsLoaded = !config.aws_auth.empty();
+    clients.authenticated = std::make_unique<utils::HttpClient>(
+        std::move(config));
+
+    utils::HttpClient::Config anonymousConfig;
+    anonymousConfig.transfer_timeout = std::chrono::seconds{60};
+    clients.anonymous = std::make_unique<utils::HttpClient>(
+        std::move(anonymousConfig));
+    return clients;
 }
 
 [[nodiscard]] std::string remoteParentUrl(const std::string& normalizedRemoteUrl)
@@ -217,8 +235,12 @@ public:
     {
         const auto endpoint = resolveRemoteEndpoint(baseUrl);
         baseUrl_ = endpoint.httpsUrl;
-        client_ = std::make_unique<utils::HttpClient>(
-            makeRemoteClient(endpoint, remoteAuth, discoverAwsCredentials));
+        auto clients = makeRemoteClients(
+            endpoint, remoteAuth, discoverAwsCredentials);
+        client_ = std::move(clients.authenticated);
+        anonymousClient_ = std::move(clients.anonymous);
+        authFallback_ = std::make_unique<vc::S3AuthFallback>(
+            clients.isS3, clients.credentialsLoaded);
     }
 
     bool exists(const std::string& key) const override
@@ -240,8 +262,10 @@ public:
             std::filesystem::is_regular_file(cacheRoot_ / relative)) {
             return true;
         }
-        const auto response = client_->head(makeUrl(key));
-        return response.ok();
+        auto result = authFallback_->request([&](bool anonymous) {
+            return (anonymous ? anonymousClient_ : client_)->head(makeUrl(key));
+        });
+        return result.response.ok();
     }
 
     std::vector<std::byte> get(const std::string& key) const override
@@ -306,13 +330,23 @@ public:
         std::optional<std::vector<std::byte>> bytes;
         std::exception_ptr error;
         try {
-            const auto response = client_->get(makeUrl(key));
+            auto requestResult = authFallback_->request([&](bool anonymous) {
+                return (anonymous ? anonymousClient_ : client_)->get(makeUrl(key));
+            });
+            auto& response = requestResult.response;
             if (response.ok()) {
                 bytes = std::move(response.body);
             } else if (!response.not_found()) {
-                throw std::runtime_error(
+                std::string message =
                     "Remote Lasagna Zarr fetch failed HTTP " +
-                    std::to_string(response.status_code) + ": " + key);
+                    std::to_string(response.status_code) + ": " + key;
+                if (requestResult.authenticatedFailure) {
+                    message += " after authenticated request failed HTTP " +
+                        std::to_string(
+                            requestResult.authenticatedFailure->status_code) +
+                        " and anonymous fallback failed";
+                }
+                throw std::runtime_error(std::move(message));
             }
             if (bytes)
                 // Preserve the source object byte-for-byte. Do not decode and
@@ -472,6 +506,8 @@ private:
     }
 
     std::unique_ptr<utils::HttpClient> client_;
+    std::unique_ptr<utils::HttpClient> anonymousClient_;
+    std::unique_ptr<vc::S3AuthFallback> authFallback_;
     std::string baseUrl_;
     std::filesystem::path cacheRoot_;
     std::shared_ptr<vc::render::PersistentZarrCacheBudget> budget_;

--- a/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
+++ b/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
@@ -8,6 +8,7 @@
 #include <utils/zarr.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <array>
 #include <charconv>
 #include <chrono>
@@ -92,6 +93,12 @@ bool isRemoteAuthError(const std::exception& error)
            message.find("HTTP 403") != std::string::npos;
 }
 
+bool isMissingZarrMetadataError(const std::exception& error)
+{
+    return std::string_view(error.what()).find("zarr: no metadata found") !=
+           std::string_view::npos;
+}
+
 class ClassifyingHttpStore final : public utils::Store {
 public:
     explicit ClassifyingHttpStore(std::string baseUrl, vc::HttpAuth auth = {})
@@ -108,8 +115,10 @@ public:
         if (response.not_found())
             return false;
         if (isOptionalRemoteMetadataMiss(
-                response.status_code, key, response.body_string()))
+                response.status_code, key, response.body_string())) {
+            sawForbiddenMetadataMiss_.store(true, std::memory_order_relaxed);
             return false;
+        }
         throw HttpStatusError(
             response.status_code, key, responseErrorDetail(response));
     }
@@ -132,8 +141,10 @@ public:
         if (response.not_found())
             return std::nullopt;
         if (isOptionalRemoteMetadataMiss(
-                response.status_code, key, response.body_string()))
+                response.status_code, key, response.body_string())) {
+            sawForbiddenMetadataMiss_.store(true, std::memory_order_relaxed);
             return std::nullopt;
+        }
         throw HttpStatusError(
             response.status_code, key, responseErrorDetail(response));
     }
@@ -173,6 +184,11 @@ public:
         return result;
     }
 
+    bool sawForbiddenMetadataMiss() const noexcept
+    {
+        return sawForbiddenMetadataMiss_.load(std::memory_order_relaxed);
+    }
+
 private:
     std::string makeUrl(const std::string& key) const
     {
@@ -205,6 +221,7 @@ private:
 
     std::string baseUrl_;
     utils::HttpClient client_;
+    mutable std::atomic<bool> sawForbiddenMetadataMiss_{false};
     mutable std::mutex metadataMutex_;
     mutable std::unordered_map<std::string, std::vector<std::byte>> metadata_;
 };
@@ -1043,6 +1060,11 @@ OpenedChunkedZarr openHttpZarrPyramid(
                 addRemoteLevelFromKey(opened, store, key, physicalLevel);
             }
         }
+        if (opened.fetchers.empty() && store->sawForbiddenMetadataMiss()) {
+            throw HttpStatusError(
+                403, spec.sourceUrl,
+                "access denied while discovering required array metadata");
+        }
         return finishOpen(validateAndRebaseVcPyramid(
             std::move(opened), baseScaleLevel));
     }
@@ -1066,17 +1088,35 @@ OpenedChunkedZarr openHttpZarrPyramid(
                 (e.status() == 403 && (!opened.fetchers.empty() || firstPhysicalLevel == 0)))
                 break;
             throw;
-        } catch (const std::exception&) {
+        } catch (const std::exception& error) {
+            if (physicalLevel == firstPhysicalLevel &&
+                store->sawForbiddenMetadataMiss() &&
+                isMissingZarrMetadataError(error)) {
+                break;
+            }
             if (physicalLevel == firstPhysicalLevel)
                 throw;
             break;
         }
     }
     if (opened.fetchers.empty() && firstPhysicalLevel == 0) {
-        auto array = utils::ZarrArray::open(store, "", vc::buildZarrCodecRegistry(1));
-        if (array.metadata().dtype == utils::ZarrDtype::uint16)
-            array = utils::ZarrArray::open(store, "", vc::buildZarrCodecRegistry(2));
-        addPhysicalLevel(opened, 0, std::move(array), true);
+        try {
+            auto array = utils::ZarrArray::open(
+                store, "", vc::buildZarrCodecRegistry(1));
+            if (array.metadata().dtype == utils::ZarrDtype::uint16) {
+                array = utils::ZarrArray::open(
+                    store, "", vc::buildZarrCodecRegistry(2));
+            }
+            addPhysicalLevel(opened, 0, std::move(array), true);
+        } catch (const std::exception& error) {
+            if (store->sawForbiddenMetadataMiss() &&
+                isMissingZarrMetadataError(error)) {
+                throw HttpStatusError(
+                    403, spec.sourceUrl,
+                    "access denied while discovering required array metadata");
+            }
+            throw;
+        }
     }
     return finishOpen(std::move(opened));
 }
@@ -1103,13 +1143,17 @@ OpenedRemoteChunkedZarr openRemoteZarrPyramid(
     }
 
     OpenedChunkedZarr opened;
-    try {
+    if (!spec.useAwsSigv4 || auth.empty()) {
         opened = openHttpZarrPyramid(spec.portableLocator, auth);
-    } catch (const std::exception& error) {
-        if (!spec.useAwsSigv4 || auth.empty() || !isRemoteAuthError(error))
-            throw;
-        auth = {};
-        opened = openHttpZarrPyramid(spec.portableLocator, auth);
+    } else {
+        try {
+            opened = openHttpZarrPyramid(spec.portableLocator, {});
+            auth = {};
+        } catch (const std::exception& error) {
+            if (!isRemoteAuthError(error))
+                throw;
+            opened = openHttpZarrPyramid(spec.portableLocator, auth);
+        }
     }
     return {std::move(opened), std::move(auth), std::move(spec)};
 }

--- a/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
+++ b/volume-cartographer/core/src/render/ZarrChunkFetcher.cpp
@@ -1,6 +1,7 @@
 #include "vc/core/render/ZarrChunkFetcher.hpp"
 #include "vc/core/types/VcDataset.hpp"
 #include "vc/core/util/CacheCompression.hpp"
+#include "vc/core/util/S3AuthFallback.hpp"
 #include "vc/core/util/RemoteUrl.hpp"
 
 #include <utils/http_fetch.hpp>
@@ -63,25 +64,6 @@ bool isOptionalMetadataProbe(std::string_view key)
            hasSuffix(key, "/.zattrs") || hasSuffix(key, "/zarr.json");
 }
 
-bool hasExplicitAwsCredentialError(std::string_view detail)
-{
-    constexpr std::array<std::string_view, 10> markers{
-        "ExpiredToken",
-        "InvalidAccessKeyId",
-        "InvalidClientTokenId",
-        "InvalidSignatureException",
-        "InvalidToken",
-        "RequestExpired",
-        "RequestTimeTooSkewed",
-        "SignatureDoesNotMatch",
-        "TokenRefreshRequired",
-        "UnrecognizedClientException",
-    };
-    return std::any_of(markers.begin(), markers.end(), [&](const auto marker) {
-        return detail.find(marker) != std::string_view::npos;
-    });
-}
-
 std::string responseErrorDetail(const utils::HttpResponse& response)
 {
     if (!response.error_message.empty())
@@ -103,14 +85,9 @@ bool isZarrMetadataKey(std::string_view key)
 bool isRemoteAuthError(const std::exception& error)
 {
     const std::string message = error.what();
-    return message.find("AWS credentials") != std::string::npos ||
+    return vc::hasExplicitAwsCredentialError(message) ||
+           message.find("AWS credentials") != std::string::npos ||
            message.find("Access denied") != std::string::npos ||
-           message.find("ExpiredToken") != std::string::npos ||
-           message.find("InvalidToken") != std::string::npos ||
-           message.find("TokenRefreshRequired") != std::string::npos ||
-           message.find("InvalidAccessKeyId") != std::string::npos ||
-           message.find("SignatureDoesNotMatch") != std::string::npos ||
-           message.find("HTTP 400") != std::string::npos ||
            message.find("HTTP 401") != std::string::npos ||
            message.find("HTTP 403") != std::string::npos;
 }
@@ -829,7 +806,7 @@ bool isOptionalRemoteMetadataMiss(
     std::string_view responseBody)
 {
     return status == 403 && isOptionalMetadataProbe(key) &&
-           !hasExplicitAwsCredentialError(responseBody);
+           !vc::hasExplicitAwsCredentialError(responseBody);
 }
 
 std::vector<std::pair<int, std::string>> remoteLevelKeysFromZattrs(

--- a/volume-cartographer/core/test/test_http_fetch_errors.cpp
+++ b/volume-cartographer/core/test/test_http_fetch_errors.cpp
@@ -4,14 +4,19 @@
 #include <doctest/doctest.h>
 
 #include "vc/core/util/HttpFetch.hpp"
+#include "vc/core/util/S3AuthFallback.hpp"
 
 #include <utils/http_fetch.hpp>
 
 #include <cstdlib>
+#include <atomic>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <stdexcept>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace {
 
@@ -21,7 +26,173 @@ bool requireNetwork()
     return env && env[0] && env[0] != '0';
 }
 
+utils::HttpResponse response(long status, std::string_view body = {})
+{
+    utils::HttpResponse out;
+    out.status_code = status;
+    out.body.reserve(body.size());
+    for (const char value : body)
+        out.body.push_back(static_cast<std::byte>(value));
+    return out;
+}
+
 } // namespace
+
+TEST_CASE("S3 authentication failures are classified narrowly")
+{
+    CHECK(vc::isAwsAuthenticationFailure(400, "<Code>InvalidToken</Code>"));
+    CHECK(vc::isAwsAuthenticationFailure(403, {}));
+    CHECK(vc::isAwsAuthenticationFailure(
+        400, "<Code>SignatureDoesNotMatch</Code>"));
+    CHECK_FALSE(vc::isAwsAuthenticationFailure(400, "BadRequest"));
+    CHECK_FALSE(vc::isAwsAuthenticationFailure(404, "NoSuchKey"));
+    CHECK_FALSE(vc::isAwsAuthenticationFailure(500, "InternalError"));
+}
+
+TEST_CASE("S3 fallback becomes sticky after anonymous success")
+{
+    vc::S3AuthFallback fallback(true, true);
+    std::vector<bool> attempts;
+    auto request = [&](bool anonymous) {
+        attempts.push_back(anonymous);
+        return anonymous
+            ? response(200, "public")
+            : response(400, "<Code>InvalidToken</Code>");
+    };
+
+    const auto first = fallback.request(request);
+    const auto second = fallback.request(request);
+
+    REQUIRE(first.response.ok());
+    REQUIRE(first.authenticatedFailure.has_value());
+    CHECK(first.usedAnonymous);
+    CHECK(second.response.ok());
+    CHECK(second.usedAnonymous);
+    CHECK(fallback.usesAnonymous());
+    CHECK(attempts == std::vector<bool>{false, true, true});
+}
+
+TEST_CASE("S3 fallback preserves private authenticated mode")
+{
+    vc::S3AuthFallback validPrivate(true, true);
+    int validSigned = 0;
+    int validAnonymous = 0;
+    const auto valid = validPrivate.request([&](bool anonymous) {
+        anonymous ? ++validAnonymous : ++validSigned;
+        return response(200, "private");
+    });
+    CHECK(valid.response.ok());
+    CHECK(validSigned == 1);
+    CHECK(validAnonymous == 0);
+
+    vc::S3AuthFallback rejectedPrivate(true, true);
+    std::vector<bool> attempts;
+    auto rejectedRequest = [&](bool anonymous) {
+        attempts.push_back(anonymous);
+        return anonymous
+            ? response(403, "<Code>AccessDenied</Code>")
+            : response(400, "<Code>InvalidToken</Code>");
+    };
+    const auto first = rejectedPrivate.request(rejectedRequest);
+    const auto second = rejectedPrivate.request(rejectedRequest);
+
+    CHECK(first.response.status_code == 403);
+    REQUIRE(first.authenticatedFailure.has_value());
+    CHECK(first.authenticatedFailure->status_code == 400);
+    CHECK_FALSE(rejectedPrivate.usesAnonymous());
+    CHECK(second.response.status_code == 400);
+    CHECK(attempts == std::vector<bool>{false, true, false});
+}
+
+TEST_CASE("anonymous not-found establishes public S3 access")
+{
+    vc::S3AuthFallback fallback(true, true);
+    std::vector<bool> attempts;
+    const auto missing = fallback.request([&](bool anonymous) {
+        attempts.push_back(anonymous);
+        return anonymous
+            ? response(404, "NoSuchKey")
+            : response(400, "<Code>InvalidToken</Code>");
+    });
+    const auto present = fallback.request([&](bool anonymous) {
+        attempts.push_back(anonymous);
+        return response(anonymous ? 200 : 400);
+    });
+
+    CHECK(missing.response.not_found());
+    CHECK(present.response.ok());
+    CHECK(fallback.usesAnonymous());
+    CHECK(attempts == std::vector<bool>{false, true, true});
+}
+
+TEST_CASE("S3 fallback ignores unrelated failures and non-S3 requests")
+{
+    for (const long status : {400L, 404L, 500L}) {
+        vc::S3AuthFallback fallback(true, true);
+        int attempts = 0;
+        const auto result = fallback.request([&](bool anonymous) {
+            ++attempts;
+            CHECK_FALSE(anonymous);
+            return response(status, status == 400 ? "BadRequest" : "failure");
+        });
+        CHECK(result.response.status_code == status);
+        CHECK(attempts == 1);
+    }
+
+    vc::S3AuthFallback nonS3(false, true);
+    int attempts = 0;
+    const auto result = nonS3.request([&](bool anonymous) {
+        ++attempts;
+        CHECK_FALSE(anonymous);
+        return response(400, "<Code>InvalidToken</Code>");
+    });
+    CHECK(result.response.status_code == 400);
+    CHECK(attempts == 1);
+}
+
+TEST_CASE("concurrent S3 requests share the anonymous transition")
+{
+    vc::S3AuthFallback fallback(true, true);
+    std::atomic<int> signedAttempts{0};
+    std::atomic<int> anonymousAttempts{0};
+    std::promise<void> probeStarted;
+    std::promise<void> releaseProbe;
+    auto release = releaseProbe.get_future().share();
+
+    auto request = [&](bool anonymous) {
+        if (!anonymous) {
+            ++signedAttempts;
+            return response(400, "<Code>InvalidToken</Code>");
+        }
+        if (anonymousAttempts.fetch_add(1) == 0) {
+            probeStarted.set_value();
+            release.wait();
+        }
+        return response(200, "public");
+    };
+
+    std::vector<std::thread> threads;
+    std::atomic<int> successfulRequests{0};
+    threads.emplace_back([&] {
+        if (fallback.request(request).response.ok())
+            ++successfulRequests;
+    });
+    probeStarted.get_future().wait();
+    for (int i = 0; i < 7; ++i) {
+        threads.emplace_back([&] {
+            if (fallback.request(request).response.ok())
+                ++successfulRequests;
+        });
+    }
+    releaseProbe.set_value();
+    for (auto& thread : threads)
+        thread.join();
+
+    CHECK(signedAttempts == 1);
+    CHECK(anonymousAttempts == 8);
+    CHECK(successfulRequests == 8);
+    CHECK(fallback.usesAnonymous());
+}
 
 TEST_CASE("httpGetString: 404 returns empty string")
 {

--- a/volume-cartographer/core/test/test_http_fetch_errors.cpp
+++ b/volume-cartographer/core/test/test_http_fetch_errors.cpp
@@ -44,67 +44,105 @@ TEST_CASE("S3 authentication failures are classified narrowly")
     CHECK(vc::isAwsAuthenticationFailure(403, {}));
     CHECK(vc::isAwsAuthenticationFailure(
         400, "<Code>SignatureDoesNotMatch</Code>"));
+    CHECK(vc::isAwsAuthenticationFailure(400, "<Code>AccessDenied</Code>"));
     CHECK_FALSE(vc::isAwsAuthenticationFailure(400, "BadRequest"));
     CHECK_FALSE(vc::isAwsAuthenticationFailure(404, "NoSuchKey"));
     CHECK_FALSE(vc::isAwsAuthenticationFailure(500, "InternalError"));
+    CHECK_FALSE(vc::isAwsAuthenticationFailure(
+        200, "private AccessDenied InvalidToken"));
 }
 
-TEST_CASE("S3 fallback becomes sticky after anonymous success")
+TEST_CASE("S3 access becomes sticky after anonymous success")
 {
     vc::S3AuthFallback fallback(true, true);
     std::vector<bool> attempts;
     auto request = [&](bool anonymous) {
         attempts.push_back(anonymous);
-        return anonymous
-            ? response(200, "public")
-            : response(400, "<Code>InvalidToken</Code>");
+        return response(anonymous ? 200 : 400, anonymous
+            ? "public"
+            : "<Code>InvalidToken</Code>");
     };
 
     const auto first = fallback.request(request);
     const auto second = fallback.request(request);
 
     REQUIRE(first.response.ok());
-    REQUIRE(first.authenticatedFailure.has_value());
+    CHECK_FALSE(first.anonymousFailure.has_value());
     CHECK(first.usedAnonymous);
     CHECK(second.response.ok());
     CHECK(second.usedAnonymous);
     CHECK(fallback.usesAnonymous());
-    CHECK(attempts == std::vector<bool>{false, true, true});
+    CHECK(attempts == std::vector<bool>{true, true});
 }
 
-TEST_CASE("S3 fallback preserves private authenticated mode")
+TEST_CASE("successful anonymous HEAD avoids stale credentials")
 {
-    vc::S3AuthFallback validPrivate(true, true);
-    int validSigned = 0;
-    int validAnonymous = 0;
-    const auto valid = validPrivate.request([&](bool anonymous) {
-        anonymous ? ++validAnonymous : ++validSigned;
-        return response(200, "private");
+    vc::S3AuthFallback fallback(true, true);
+    int signedAttempts = 0;
+    int anonymousAttempts = 0;
+    const auto result = fallback.request([&](bool anonymous) {
+        if (anonymous) {
+            ++anonymousAttempts;
+            return response(200);
+        }
+        ++signedAttempts;
+        return response(400);
     });
-    CHECK(valid.response.ok());
-    CHECK(validSigned == 1);
-    CHECK(validAnonymous == 0);
 
-    vc::S3AuthFallback rejectedPrivate(true, true);
+    CHECK(result.response.ok());
+    CHECK(result.usedAnonymous);
+    CHECK(anonymousAttempts == 1);
+    CHECK(signedAttempts == 0);
+    CHECK(fallback.usesAnonymous());
+}
+
+TEST_CASE("S3 access falls back once and preserves private authenticated mode")
+{
+    vc::S3AuthFallback fallback(true, true);
     std::vector<bool> attempts;
-    auto rejectedRequest = [&](bool anonymous) {
+    auto request = [&](bool anonymous) {
+        attempts.push_back(anonymous);
+        return anonymous
+            ? response(403, "<Code>AccessDenied</Code>")
+            : response(200, "private AccessDenied InvalidToken");
+    };
+
+    const auto first = fallback.request(request);
+    const auto second = fallback.request(request);
+
+    CHECK(first.response.ok());
+    REQUIRE(first.anonymousFailure.has_value());
+    CHECK(first.anonymousFailure->status_code == 403);
+    CHECK_FALSE(first.usedAnonymous);
+    CHECK(second.response.ok());
+    CHECK_FALSE(second.usedAnonymous);
+    CHECK_FALSE(fallback.usesAnonymous());
+    CHECK(attempts == std::vector<bool>{true, false, false});
+}
+
+TEST_CASE("failed private authentication does not retain a session mode")
+{
+    vc::S3AuthFallback fallback(true, true);
+    std::vector<bool> attempts;
+    auto request = [&](bool anonymous) {
         attempts.push_back(anonymous);
         return anonymous
             ? response(403, "<Code>AccessDenied</Code>")
             : response(400, "<Code>InvalidToken</Code>");
     };
-    const auto first = rejectedPrivate.request(rejectedRequest);
-    const auto second = rejectedPrivate.request(rejectedRequest);
 
-    CHECK(first.response.status_code == 403);
-    REQUIRE(first.authenticatedFailure.has_value());
-    CHECK(first.authenticatedFailure->status_code == 400);
-    CHECK_FALSE(rejectedPrivate.usesAnonymous());
+    const auto first = fallback.request(request);
+    const auto second = fallback.request(request);
+
+    CHECK(first.response.status_code == 400);
+    REQUIRE(first.anonymousFailure.has_value());
+    CHECK(first.anonymousFailure->status_code == 403);
     CHECK(second.response.status_code == 400);
-    CHECK(attempts == std::vector<bool>{false, true, false});
+    CHECK_FALSE(fallback.usesAnonymous());
+    CHECK(attempts == std::vector<bool>{true, false, true, false});
 }
 
-TEST_CASE("anonymous not-found establishes public S3 access")
+TEST_CASE("anonymous not-found leaves S3 access undecided")
 {
     vc::S3AuthFallback fallback(true, true);
     std::vector<bool> attempts;
@@ -122,7 +160,7 @@ TEST_CASE("anonymous not-found establishes public S3 access")
     CHECK(missing.response.not_found());
     CHECK(present.response.ok());
     CHECK(fallback.usesAnonymous());
-    CHECK(attempts == std::vector<bool>{false, true, true});
+    CHECK(attempts == std::vector<bool>{true, true});
 }
 
 TEST_CASE("S3 fallback ignores unrelated failures and non-S3 requests")
@@ -132,7 +170,7 @@ TEST_CASE("S3 fallback ignores unrelated failures and non-S3 requests")
         int attempts = 0;
         const auto result = fallback.request([&](bool anonymous) {
             ++attempts;
-            CHECK_FALSE(anonymous);
+            CHECK(anonymous);
             return response(status, status == 400 ? "BadRequest" : "failure");
         });
         CHECK(result.response.status_code == status);
@@ -150,7 +188,38 @@ TEST_CASE("S3 fallback ignores unrelated failures and non-S3 requests")
     CHECK(attempts == 1);
 }
 
-TEST_CASE("concurrent S3 requests share the anonymous transition")
+TEST_CASE("anonymous S3 access upgrades when a later object is private")
+{
+    vc::S3AuthFallback fallback(true, true);
+    std::vector<bool> attempts;
+
+    const auto publicResult = fallback.request([&](bool anonymous) {
+        attempts.push_back(anonymous);
+        return response(anonymous ? 200 : 500);
+    });
+    const auto privateResult = fallback.request([&](bool anonymous) {
+        attempts.push_back(anonymous);
+        return anonymous
+            ? response(403, "<Code>AccessDenied</Code>")
+            : response(200, "private");
+    });
+    const auto nextPrivate = fallback.request([&](bool anonymous) {
+        attempts.push_back(anonymous);
+        return response(anonymous ? 403 : 200);
+    });
+
+    CHECK(publicResult.response.ok());
+    CHECK(publicResult.usedAnonymous);
+    CHECK(privateResult.response.ok());
+    REQUIRE(privateResult.anonymousFailure.has_value());
+    CHECK_FALSE(privateResult.usedAnonymous);
+    CHECK(nextPrivate.response.ok());
+    CHECK_FALSE(nextPrivate.usedAnonymous);
+    CHECK_FALSE(fallback.usesAnonymous());
+    CHECK(attempts == std::vector<bool>{true, true, false, false});
+}
+
+TEST_CASE("concurrent S3 requests share the anonymous-first transition")
 {
     vc::S3AuthFallback fallback(true, true);
     std::atomic<int> signedAttempts{0};
@@ -160,15 +229,16 @@ TEST_CASE("concurrent S3 requests share the anonymous transition")
     auto release = releaseProbe.get_future().share();
 
     auto request = [&](bool anonymous) {
-        if (!anonymous) {
+        if (anonymous) {
+            if (anonymousAttempts.fetch_add(1) == 0) {
+                probeStarted.set_value();
+                release.wait();
+            }
+            return response(200, "public");
+        } else {
             ++signedAttempts;
             return response(400, "<Code>InvalidToken</Code>");
         }
-        if (anonymousAttempts.fetch_add(1) == 0) {
-            probeStarted.set_value();
-            release.wait();
-        }
-        return response(200, "public");
     };
 
     std::vector<std::thread> threads;
@@ -188,7 +258,7 @@ TEST_CASE("concurrent S3 requests share the anonymous transition")
     for (auto& thread : threads)
         thread.join();
 
-    CHECK(signedAttempts == 1);
+    CHECK(signedAttempts == 0);
     CHECK(anonymousAttempts == 8);
     CHECK(successfulRequests == 8);
     CHECK(fallback.usesAnonymous());

--- a/volume-cartographer/core/test/test_lasagna_manifest.cpp
+++ b/volume-cartographer/core/test/test_lasagna_manifest.cpp
@@ -431,6 +431,7 @@ TEST_CASE("public S3 Lasagna ignores rejected ambient-style credentials")
     options.remoteCacheRoot = dir;
     options.remoteAuth.access_key = "AKIAIOSFODNN7EXAMPLE";
     options.remoteAuth.secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    options.remoteAuth.session_token = "malformed-session-token";
     options.remoteAuth.region = "us-east-1";
 
     const std::string location =

--- a/volume-cartographer/core/test/test_lasagna_manifest.cpp
+++ b/volume-cartographer/core/test/test_lasagna_manifest.cpp
@@ -5,6 +5,9 @@
 #include "vc/lasagna/LineModel.hpp"
 #include "vc/lasagna/Manifest.hpp"
 
+#include <utils/zarr.hpp>
+
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 
@@ -18,6 +21,12 @@ fs::path makeTmpDir(const std::string& tag)
     fs::remove_all(dir);
     fs::create_directories(dir);
     return dir;
+}
+
+bool requireNetwork()
+{
+    const char* value = std::getenv("VC_TEST_REQUIRE_NETWORK");
+    return value && value[0] && value[0] != '0';
 }
 
 class ConstantNormalSampler final : public vc::lasagna::NormalSampler {
@@ -407,6 +416,41 @@ TEST_CASE("LasagnaDataset persistently caches direct remote manifests")
     (void)vc::lasagna::LasagnaDataset::openLocation(location, options);
     CHECK(fetches == 2);
     CHECK(fs::is_regular_file(first.manifest().manifestPath));
+    fs::remove_all(dir);
+}
+
+TEST_CASE("public S3 Lasagna ignores rejected ambient-style credentials")
+{
+    if (!requireNetwork()) {
+        MESSAGE("Set VC_TEST_REQUIRE_NETWORK=1 to run the public S3 smoke test");
+        return;
+    }
+
+    const auto dir = makeTmpDir("public-s3-auth-fallback");
+    vc::lasagna::LasagnaDatasetOpenOptions options;
+    options.remoteCacheRoot = dir;
+    options.remoteAuth.access_key = "AKIAIOSFODNN7EXAMPLE";
+    options.remoteAuth.secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    options.remoteAuth.region = "us-east-1";
+
+    const std::string location =
+        "https://vesuvius-challenge-open-data.s3.amazonaws.com/PHerc0139/representations/"
+        "predictions/fibers/20260102150214-fibers-20260801084232-L1/"
+        "PHerc0139-20260102150214-las-sd1-92481a4c.lasagna.json";
+    try {
+        const auto dataset = vc::lasagna::LasagnaDataset::openLocation(
+            location, options);
+        const auto* presence = dataset.manifest().groupForChannel("presence");
+        REQUIRE(presence != nullptr);
+        const auto array = vc::lasagna::openLasagnaChannelArray(
+            dataset.manifest(), *presence, 1);
+        CHECK(array.metadata().ndim() == 3);
+        CHECK(array.metadata().shape ==
+              std::vector<std::size_t>{9620, 3314, 3314});
+    } catch (const std::exception& error) {
+        fs::remove_all(dir);
+        FAIL("public S3 Lasagna fallback failed: " << error.what());
+    }
     fs::remove_all(dir);
 }
 

--- a/volume-cartographer/docs/api/Volume.md
+++ b/volume-cartographer/docs/api/Volume.md
@@ -407,9 +407,8 @@ volume->updateMetadata(patch);
   using power-of-two level indices, with limited per-level padding tolerance.
 - Local zarr arrays may be stored as scale directories (`0`, `1`, `2`, ...)
   or as a root array for level 0.
-- Remote `s3://` URLs are resolved to HTTPS. AWS SigV4 credentials are used
-  when available, with anonymous fallback for public buckets if stale
-  credentials are rejected.
+- Remote `s3://` URLs are resolved to HTTPS and opened anonymously first. AWS
+  SigV4 credentials are used when anonymous access is denied.
 - `processChunkCacheService()` retains regular source state for the process.
   Capacity and concurrency changes preserve source identity and all
   queued/running work. A capacity reduction evicts globally oldest decoded

--- a/volume-cartographer/docs/remote_file_cache.md
+++ b/volume-cartographer/docs/remote_file_cache.md
@@ -14,7 +14,11 @@ optional persistent-budget read pin.
 Built-in fetching supports HTTP, HTTPS, S3, and region-qualified S3 locations.
 `RemoteFileCacheOptions::fetcher` can provide another fetch-to-temporary-file
 transport. Explicit `HttpAuth` is passed to the built-in transport; otherwise
-the existing AWS credential loader is used where required.
+the existing AWS credential loader is used where required. An S3 request with
+credentials is attempted normally. If S3 rejects those credentials, the GET is
+retried anonymously so public objects remain readable when ambient temporary
+credentials are stale. Unrelated HTTP and transport failures are not retried as
+authentication failures.
 
 `CacheFirst` reuses a valid entry. `Refresh` fetches and atomically replaces
 it. `invalidateRemoteFileCacheEntry()` removes one known destination. There is
@@ -66,6 +70,12 @@ Lasagna manifests use this path for the manifest and its sidecar; relative
 Zarr groups share the readable parent cache directory. Existing local
 manifests with an explicit adjacent `lasagna-remote.json` remain supported and
 its `artifact_url` remains authoritative.
+
+Lasagna's exact-byte remote Zarr store applies the same signed-to-anonymous
+fallback to descriptor and chunk requests. A successful or not-found anonymous
+response selects anonymous access for subsequent requests from that store.
+Concurrent readers share one transition probe; private stores retain signed
+access when anonymous access is rejected.
 
 There is no lookup or migration for the earlier development-only cache
 layout. Reopening a remote source populates the readable layout from a cold

--- a/volume-cartographer/docs/remote_file_cache.md
+++ b/volume-cartographer/docs/remote_file_cache.md
@@ -14,11 +14,10 @@ optional persistent-budget read pin.
 Built-in fetching supports HTTP, HTTPS, S3, and region-qualified S3 locations.
 `RemoteFileCacheOptions::fetcher` can provide another fetch-to-temporary-file
 transport. Explicit `HttpAuth` is passed to the built-in transport; otherwise
-the existing AWS credential loader is used where required. An S3 request with
-credentials is attempted normally. If S3 rejects those credentials, the GET is
-retried anonymously so public objects remain readable when ambient temporary
-credentials are stale. Unrelated HTTP and transport failures are not retried as
-authentication failures.
+the existing AWS credential loader is used where required. S3 objects are
+requested anonymously first. Credentials are used only when S3 denies
+anonymous access, so stale ambient credentials cannot shadow public objects.
+Unrelated HTTP and transport failures do not trigger authenticated fallback.
 
 `CacheFirst` reuses a valid entry. `Refresh` fetches and atomically replaces
 it. `invalidateRemoteFileCacheEntry()` removes one known destination. There is
@@ -71,11 +70,12 @@ Zarr groups share the readable parent cache directory. Existing local
 manifests with an explicit adjacent `lasagna-remote.json` remain supported and
 its `artifact_url` remains authoritative.
 
-Lasagna's exact-byte remote Zarr store applies the same signed-to-anonymous
-fallback to descriptor and chunk requests. A successful or not-found anonymous
-response selects anonymous access for subsequent requests from that store.
-Concurrent readers share one transition probe; private stores retain signed
-access when anonymous access is rejected.
+Lasagna's exact-byte remote Zarr store applies the same anonymous-first policy
+to descriptor and chunk requests. A successful anonymous response selects
+anonymous access for subsequent requests from that store. Concurrent readers
+share one initial probe; private stores retain authenticated access after
+anonymous access is denied. A later anonymous denial can upgrade a public store
+to authenticated access for mixed-access datasets.
 
 There is no lookup or migration for the earlier development-only cache
 layout. Reopening a remote source populates the readable layout from a cold

--- a/volume-cartographer/docs/vc3d_project_files.md
+++ b/volume-cartographer/docs/vc3d_project_files.md
@@ -36,11 +36,11 @@ descriptors, prepares the manifest's volumes, then commits the manifest entry,
 derived volumes, and selected role in one project write. Failure restores the
 prior in-memory and on-disk project state. Remote descriptors and chunks use
 the project's remote cache root and authentication; chunks stay demand-loaded.
-For recognized S3 locations, rejected credentials trigger an anonymous retry.
-This allows public manifests and their Zarr groups to open even when ambient AWS
-temporary credentials are stale, while private data continues using signed
-requests. The chosen access mode is runtime-only and does not change persisted
-manifest or volume locations.
+Recognized S3 locations are opened anonymously first and use credentials only
+when anonymous access is denied. This allows public manifests and their Zarr
+groups to open even when ambient AWS temporary credentials are stale, while
+private data continues using signed requests. The chosen access mode is
+runtime-only and does not change persisted manifest or volume locations.
 
 Both remote-origin forms remain valid:
 

--- a/volume-cartographer/docs/vc3d_project_files.md
+++ b/volume-cartographer/docs/vc3d_project_files.md
@@ -36,6 +36,11 @@ descriptors, prepares the manifest's volumes, then commits the manifest entry,
 derived volumes, and selected role in one project write. Failure restores the
 prior in-memory and on-disk project state. Remote descriptors and chunks use
 the project's remote cache root and authentication; chunks stay demand-loaded.
+For recognized S3 locations, rejected credentials trigger an anonymous retry.
+This allows public manifests and their Zarr groups to open even when ambient AWS
+temporary credentials are stale, while private data continues using signed
+requests. The chosen access mode is runtime-only and does not change persisted
+manifest or volume locations.
 
 Both remote-origin forms remain valid:
 

--- a/volume-cartographer/planning/changelog.md
+++ b/volume-cartographer/planning/changelog.md
@@ -2,7 +2,7 @@
 
 ## 2026-08-27
 
-- Added signed-to-anonymous S3 fallback for public remote Lasagna manifests and Zarr objects when ambient AWS credentials are rejected.
+- Added anonymous-first S3 access for public remote Lasagna manifests and Zarr objects, with authenticated fallback for private data.
 
 ## 2026-08-17
 

--- a/volume-cartographer/planning/changelog.md
+++ b/volume-cartographer/planning/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-27
+
+- Added signed-to-anonymous S3 fallback for public remote Lasagna manifests and Zarr objects when ambient AWS credentials are rejected.
+
 ## 2026-08-17
 
 - Anchored multi-control collapse through the ordinary local span update before

--- a/volume-cartographer/planning/spec.md
+++ b/volume-cartographer/planning/spec.md
@@ -6,12 +6,13 @@
   not change as a side effect of diagnostics or scheduling work.
 - Remote fetching must remain asynchronous; UI and render threads must not wait
   on network or persistent-cache I/O.
-- S3 sources use available credentials first. When S3 explicitly rejects those
-  credentials, the same object is retried anonymously so public data remains
-  usable with stale ambient credentials. A successful or not-found anonymous
-  response makes anonymous access sticky for that source; unrelated client,
-  server, and transport failures do not trigger or retain fallback. The access
-  mode must not alter source identity, cache paths, or serialized locations.
+- S3 sources are attempted anonymously first. A successful response makes
+  anonymous access sticky for that store; an anonymous 401/403 retries with
+  available credentials and successful authenticated access becomes sticky.
+  A later anonymous 401/403 may upgrade a mixed-access store to authenticated
+  access. Not-found, unrelated client/server, and transport failures do not
+  select a mode. The access mode must not alter source identity, cache paths,
+  response bytes, or serialized locations.
 - Queue diagnostics must come from the existing chunk-cache request state, not
   from a parallel accounting system at viewer call sites.
 - A shared cache must report each unresolved chunk once regardless of how many

--- a/volume-cartographer/planning/spec.md
+++ b/volume-cartographer/planning/spec.md
@@ -6,6 +6,12 @@
   not change as a side effect of diagnostics or scheduling work.
 - Remote fetching must remain asynchronous; UI and render threads must not wait
   on network or persistent-cache I/O.
+- S3 sources use available credentials first. When S3 explicitly rejects those
+  credentials, the same object is retried anonymously so public data remains
+  usable with stale ambient credentials. A successful or not-found anonymous
+  response makes anonymous access sticky for that source; unrelated client,
+  server, and transport failures do not trigger or retain fallback. The access
+  mode must not alter source identity, cache paths, or serialized locations.
 - Queue diagnostics must come from the existing chunk-cache request state, not
   from a parallel accounting system at viewer call sites.
 - A shared cache must report each unresolved chunk once regardless of how many

--- a/volume-cartographer/planning/status.md
+++ b/volume-cartographer/planning/status.md
@@ -1,12 +1,12 @@
-# Public S3 Lasagna authentication fallback status
+# Public S3 Lasagna anonymous-first access status
 
 - [x] Capture the observed public-data failure and required behavior.
 - [x] Inspect manifest, remote-file-cache, and Lasagna Zarr authentication paths.
 - [x] Draft the implementation and validation plan.
 - [x] Complete independent plan review.
-- [x] Implement shared authentication classification.
-- [x] Implement remote manifest anonymous fallback.
-- [x] Implement sticky Lasagna Zarr anonymous fallback.
+- [x] Implement anonymous-first remote manifest access.
+- [x] Implement sticky anonymous-first Lasagna Zarr access.
+- [x] Preserve private and mixed-access authenticated fallback.
 - [x] Add regression tests.
 - [x] Update specification, documentation, changelog, and task log.
 - [x] Build and run focused tests.

--- a/volume-cartographer/planning/status.md
+++ b/volume-cartographer/planning/status.md
@@ -1,15 +1,14 @@
-# VC3D render attribution and lookup repair status
+# Public S3 Lasagna authentication fallback status
 
-- [x] Capture the attribution-first task and deferred speed requirements.
-- [x] Confirm current cross-run worker-ID attribution behavior.
-- [x] Confirm render-job request lifetime and existing local chunk caching.
-- [x] Record attribution alternatives and a provisional recommendation.
-- [x] Replace rank/tie matching with same-run scheduler evidence.
-- [x] Collect initial repeated artifacts and identify worker/scope mismatch.
-- [x] Validate passive canonical pairing over three full parallel matrices.
-- [x] Implement and test deterministic paired attribution in native C++.
-- [x] Re-evaluate residual variation with three fresh current-binary pairs.
-- [x] Validate the repaired attribution against the existing enabled CI gate.
-- [ ] Profile and implement lookup optimization against the accepted gate.
-- [x] Update specifications, documentation, and changelog.
-- [x] Complete native unit, compatibility, matrix, reference, and repeatability validation.
+- [x] Capture the observed public-data failure and required behavior.
+- [x] Inspect manifest, remote-file-cache, and Lasagna Zarr authentication paths.
+- [x] Draft the implementation and validation plan.
+- [x] Complete independent plan review.
+- [x] Implement shared authentication classification.
+- [x] Implement remote manifest anonymous fallback.
+- [x] Implement sticky Lasagna Zarr anonymous fallback.
+- [x] Add regression tests.
+- [x] Update specification, documentation, changelog, and task log.
+- [x] Build and run focused tests.
+- [x] Validate against the real PHerc0139 manifest.
+- [x] Run final diff and whitespace checks.

--- a/volume-cartographer/planning/task.md
+++ b/volume-cartographer/planning/task.md
@@ -10,22 +10,21 @@ manifest at:
 s3://vesuvius-challenge-open-data/PHerc0139/representations/predictions/fibers/20260102150214-fibers-20260801084232-L1/PHerc0139-20260102150214-las-sd1-92481a4c.lasagna.json
 ```
 
-Both that locator and its virtual-hosted HTTPS equivalent are recognized as S3,
-signed with ambient credentials, and rejected with `InvalidToken`. The remote
-manifest cache does not currently retry anonymously. Lasagna's exact-byte
-remote Zarr store likewise retains the rejected credentials instead of falling
-back as the ordinary remote-volume reader already does.
+Both that locator and its virtual-hosted HTTPS equivalent are recognized as S3.
+The previous implementation signed them whenever ambient credentials existed,
+causing public access to fail with `InvalidToken` before anonymous access was
+attempted.
 
 Required behavior:
 
 - Keep authenticated access for private S3 data.
-- When a signed S3 request fails specifically because authentication was
-  rejected, retry the same request anonymously.
+- Attempt S3 data anonymously first and use credentials only when anonymous
+  access is denied.
 - Once Lasagna's remote Zarr store proves anonymous access works, keep using
-  anonymous requests for that store instead of repeating the failed signed
-  attempt for every object.
+  anonymous requests for that store.
 - Apply the same behavior to `s3://`, region-qualified S3, and recognized S3
   HTTPS endpoints.
-- Do not retry unrelated HTTP, transport, server, or not-found failures.
+- Do not select or change a sticky mode after unrelated HTTP, transport,
+  server, or not-found failures.
 - Preserve remote source identity, cache paths, exact bytes, and project
   serialization.

--- a/volume-cartographer/planning/task.md
+++ b/volume-cartographer/planning/task.md
@@ -1,35 +1,31 @@
-# VC3D render attribution and lookup performance repair
+# Public S3 Lasagna authentication fallback
 
-Repair the synthetic rendering performance gate before re-enabling it, then
-recover the lookup performance lost around the render-order changes.
+Fix manual remote Lasagna attachment when ambient AWS credentials are stale or
+malformed but the requested S3 manifest and Zarr objects are publicly readable.
 
-Priorities:
+The observed real-data failure uses the public PHerc0139 fiber-inference
+manifest at:
 
-1. Correct and stabilize the passive Valgrind attribution. Collect periodic
-   Callgrind cost slices and a DRD dependency graph from separate executions
-   with identical Valgrind scheduling parameters. Reconstruct logical worker
-   traces canonically instead of equating raw worker IDs, trim DRD to the same
-   existing timed render boundary, and reject any pair whose logical pattern is
-   ambiguous or not reproducible. The measured binary must remain unchanged:
-   no markers, affinity mode, deterministic executor, or added instructions.
-2. Measure and repair renderer lookup speed using the commit immediately before
-   `Vc3d renderorder` and the current implementation as an A/B case. Preserve
-   rendered bytes, fallback behavior, request priority, and scheduling
-   semantics.
+```text
+s3://vesuvius-challenge-open-data/PHerc0139/representations/predictions/fibers/20260102150214-fibers-20260801084232-L1/PHerc0139-20260102150214-las-sd1-92481a4c.lasagna.json
+```
 
-Speed investigation requirements:
+Both that locator and its virtual-hosted HTTPS equivalent are recognized as S3,
+signed with ambient credentials, and rejected with `InvalidToken`. The remote
+manifest cache does not currently retry anonymously. Lasagna's exact-byte
+remote Zarr store likewise retains the rejected credentials instead of falling
+back as the ordinary remote-volume reader already does.
 
-- Treat `ChunkRequestContext` as render-job-constant; verify and exploit that
-  without changing request publication semantics.
-- Investigate a prepared/source-bound key lookup path so level, source, and
-  request information are not repeatedly assembled in the hot lookup.
-- Avoid rebuilding and probing a full key when a correlated sample remains in
-  the same successfully resolved chunk.
-- Account for the existing `LocalChunkCache`: it already retains the last key
-  and result and up to eight pinned chunks. Do not duplicate that cache under a
-  different name; improve the work that happens before it can identify a hit.
-- Establish repeatable before/after Release measurements and verify exact output
-  checksums before accepting any optimization.
+Required behavior:
 
-The Valgrind attribution repair is first. Lookup optimization remains planned
-until the gate can produce stable, semantically valid scores.
+- Keep authenticated access for private S3 data.
+- When a signed S3 request fails specifically because authentication was
+  rejected, retry the same request anonymously.
+- Once Lasagna's remote Zarr store proves anonymous access works, keep using
+  anonymous requests for that store instead of repeating the failed signed
+  attempt for every object.
+- Apply the same behavior to `s3://`, region-qualified S3, and recognized S3
+  HTTPS endpoints.
+- Do not retry unrelated HTTP, transport, server, or not-found failures.
+- Preserve remote source identity, cache paths, exact bytes, and project
+  serialization.

--- a/volume-cartographer/planning/task_log.md
+++ b/volume-cartographer/planning/task_log.md
@@ -22,48 +22,52 @@
   immediate workaround because the current resolver does not classify that
   hostname as S3, but it is not an acceptable permanent requirement.
 
-## Independent review
+## 2026-08-28 review follow-up
 
-- Use one explicit credential-error classifier. A bare HTTP 400 must not trigger
-  fallback; explicit AWS error markers and HTTP 401/403 do.
-- A 2xx or 404 anonymous response establishes anonymous accessibility. Auth,
-  server, and transport failures do not make anonymous mode sticky.
-- Coordinate concurrent fallback probes and retain separate stable signed and
-  anonymous clients; do not replace a client while readers may use it.
-- Deterministic tests must assert request counts and private-bucket behavior in
-  addition to successful public fallback.
+- Signed-first fallback scanned successful response bodies for AWS error words,
+  so private content containing a marker could be discarded.
+- S3 HEAD responses carry no error body. A stale session token therefore
+  produced an unclassified empty HTTP 400 before a fresh remote Zarr could open.
+- Anonymous-first access avoids both ambiguities: public data never uses ambient
+  credentials, while anonymous 401/403 responses still fall back to private
+  authenticated access.
+- A not-found or unrelated failure does not select a sticky mode. Concurrent
+  initial requests share one probe, and a later anonymous denial can upgrade a
+  mixed-access store.
 
 ## Implementation result
 
-- Added `S3AuthFallback`, a shared signed-to-anonymous request policy with one
-  synchronized transition probe and stable signed/anonymous HTTP clients.
-- Authentication failures are recognized from HTTP 401/403 or explicit AWS
-  credential error codes. Bare HTTP 400, 404, 5xx, and transport failures do
-  not trigger fallback.
-- A 2xx or 404 anonymous response makes anonymous mode sticky. Anonymous auth
-  rejection keeps private stores on authenticated access; transient anonymous
-  failures may be retried by a future request.
-- `RemoteFileCache` now applies the policy to remote manifest GETs and preserves
-  both authenticated and anonymous status in diagnostics when both fail.
+- `S3AuthFallback` now performs one synchronized anonymous-first probe while
+  retaining stable anonymous and authenticated HTTP clients.
+- Anonymous 2xx responses make anonymous mode sticky. Anonymous 401/403
+  responses retry with credentials, and authenticated 2xx/404 responses retain
+  authenticated mode. Other failures leave the mode undecided.
+- `RemoteFileCache` applies the policy to remote manifest GETs and preserves
+  both anonymous and authenticated status in diagnostics when both fail.
 - Lasagna's exact-byte remote Zarr store applies the policy to HEAD and GET
   requests, so descriptor validation and later chunk reads share the selected
   mode without changing cached bytes or source identity.
-- Ordinary remote Zarr fallback and generic HTTP error reporting now share the
-  explicit AWS credential-error marker set.
+- Ordinary remote Zarr opening now attempts the complete anonymous open before
+  retrying with credentials. Optional metadata 403s remain ignorable for
+  least-privilege stores; if discovery then finds no required array metadata,
+  the remembered denial triggers authenticated retry.
+- Successful responses are never classified from their content.
 
 ## Validation
 
 - Built `test_http_fetch_errors`, `test_remote_file_cache`,
   `test_lasagna_manifest`, `test_lasagna_project_volumes`, `test_remote_url`,
-  and `VC3D` with `cmake --build volume-cartographer/build --parallel 32`.
-- The five focused deterministic tests passed together. The fallback test also
-  passed 20 consecutive executions, including its coordinated eight-thread
+  `test_zarr_chunk_fetcher`, `test_volume_live_s3`, and `VC3D` with 32-way
+  build parallelism.
+- The six focused deterministic tests passed together. The policy test passed
+  20 consecutive executions, including its coordinated eight-thread initial
   transition case.
 - With `VC_TEST_REQUIRE_NETWORK=1`, `test_lasagna_manifest` passed all 17 cases
-  using syntactically valid but nonexistent AWS credentials. The real-data case
-  downloaded the exact reported PHerc0139 HTTPS manifest anonymously after the
-  signed request was rejected, then opened the public `presence` Zarr metadata
+  with a malformed session token configured. The real-data case downloaded the
+  reported PHerc0139 manifest anonymously and opened public `presence` metadata
   with shape `[9620, 3314, 3314]`.
+- With required network access, `test_volume_live_s3` passed all 10 cases,
+  including its invalid-session-credential anonymous-open case.
 - The initial sandboxed live attempt could not resolve the public hostname;
   rerunning with network access succeeded. This was an execution-environment
   restriction, not a code failure.

--- a/volume-cartographer/planning/task_log.md
+++ b/volume-cartographer/planning/task_log.md
@@ -1,196 +1,69 @@
-# VC3D render attribution and lookup repair task log
+# Public S3 Lasagna authentication fallback task log
 
-## 2026-08-18 findings
+## 2026-08-27 findings
 
-- The frozen reference predates `81f6a8ffb` (`Vc3d renderorder`). Its parent
-  passed the gate and the squash commit failed it. The later
-  `QuadSurface::gen()` optimization cannot be the original trigger because the
-  synthetic fixture calls `ChunkedPlaneSampler` directly.
-- Callgrind and DRD are necessarily collected in separate Valgrind processes.
-  Current evaluation passes per-thread Callgrind costs directly to a DRD graph
-  under the same raw Valgrind IDs. Worker participation and executed work are
-  not stable identities across those executions.
-- `Graph::assignCosts()` iterates DRD threads. It fails when a DRD thread lacks
-  a same-numbered Callgrind profile, but does not reject extra Callgrind thread
-  costs. A Callgrind-only worker cost can therefore be silently omitted from the
-  replay.
-- Every CI case currently uses one Callgrind execution and one first-complete
-  DRD execution. No median or repeated-trace aggregation protects the parallel
-  score from attribution/scheduling variation.
-- The event-cost model contains nonlinear interaction features. Each Callgrind
-  thread must continue to be modeled independently before worker costs are
-  summed; summing raw counters first changes the modeled total.
-- Periodic Callgrind dumps at 10,000 basic blocks produce chronological,
-  separate-thread delta profiles without changing the benchmark binary.
-- Three repeated `parallel/full_res` DRD runs had the same measured render
-  structure: seven main quanta and sixteen quanta on each of four workers. One
-  whole-process trace differed by one unrelated main-thread quantum, confirming
-  that the graph must be trimmed to the measured render.
-- The existing benchmark timing calls appear passively in the DRD syscall log.
-  The measured render is the unique pair of main-thread `clock_gettime` calls
-  sharing a stack address. This provides boundaries without markers.
-- Fair-scheduled `mixed_correlated` Callgrind runs execute one logical range per
-  worker, but physical IDs vary. Their canonical worker instruction totals are
-  stable at approximately 13.38M, 13.38M, 14.53M, and 16.17M. Independent DRD
-  runs produce corresponding measured worker lengths of 36/37, 36, 40, and 44
-  quanta. Rank matching is therefore viable; the two shortest ranges are an
-  equivalent tie.
-- `--fair-sched=no` is unsuitable: one physical worker may execute multiple
-  logical ranges while another remains effectively idle.
-- Reducing the fair-scheduled quantum from 10,000 to 1,000 basic blocks does
-  not stabilize raw worker IDs. Physical IDs are therefore never a valid
-  cross-run identity, regardless of quantum.
-- A three-run, four-scenario passive matrix with the unmodified release binary
-  validated canonical reconstruction:
+- The public PHerc0139 manifest returns HTTP 200 to an unsigned request.
+- `resolveRemoteUrl()` intentionally classifies both `s3://` locators and
+  virtual-hosted `*.s3.amazonaws.com` HTTPS URLs as S3. Changing between those
+  forms therefore does not bypass signing.
+- Manual remote Lasagna attachment loads ambient AWS credentials before opening
+  the manifest. The observed credentials contain a rejected session token.
+- `RemoteFileCache` performs one credentialed request and reports
+  `InvalidToken`; it has no anonymous retry.
+- The ordinary remote Zarr opener already retries anonymously after a rejected
+  credentialed open.
+- Lasagna uses a separate exact-byte remote Zarr store. It also builds one
+  credentialed client and currently has no anonymous fallback for descriptor or
+  chunk reads.
+- Open-data catalogue Lasagna preparation avoids this failure by explicitly
+  disabling credential discovery, but manually attached manifests do not carry
+  that public-data knowledge.
+- A path-style `https://s3.amazonaws.com/<bucket>/<key>` locator works as an
+  immediate workaround because the current resolver does not classify that
+  hostname as S3, but it is not an acceptable permanent requirement.
 
-  | Scenario | Canonical worker `Ir` stability | DRD measured quanta | Worst 32-bin cost-shape delta |
-  | --- | ---: | --- | ---: |
-  | `full_res` | 0.29% | `16,16,16,16` | 0.23% |
-  | `fallback_3` | 0.74% | `56,57,62,71` | 0.36% |
-  | `mixed_correlated` | 0.48% | `36,36,40,44` | 0.37% |
-  | `mixed_shuffled` | 0.08% | `77,77,78,78` | 0.03% |
+## Independent review
 
-- Replaying every admissible mapping inside equal-quantum groups bounded the
-  remaining identity ambiguity at 0.90% makespan for `full_res`, 0.11% for
-  `mixed_shuffled`, and 0% for `fallback_3` and `mixed_correlated`. The gate can
-  conservatively report the maximum mapping when a tie is equivalent instead
-  of selecting an arbitrary worker.
-- The passive task-start order is not sufficient to identify FIFO task order:
-  multiple workers can dequeue inside one periodic Callgrind interval. Matching
-  must use complete canonical workload signatures and enumerate equivalent
-  ties, not first-observed worker order.
+- Use one explicit credential-error classifier. A bare HTTP 400 must not trigger
+  fallback; explicit AWS error markers and HTTP 401/403 do.
+- A 2xx or 404 anonymous response establishes anonymous accessibility. Auth,
+  server, and transport failures do not make anonymous mode sticky.
+- Coordinate concurrent fallback probes and retain separate stable signed and
+  anonymous clients; do not replace a client while readers may use it.
+- Deterministic tests must assert request counts and private-bucket behavior in
+  addition to successful public fallback.
 
-## Attribution options
+## Implementation result
 
-### A. Main/worker role pooling (recommended first)
+- Added `S3AuthFallback`, a shared signed-to-anonymous request policy with one
+  synchronized transition probe and stable signed/anonymous HTTP clients.
+- Authentication failures are recognized from HTTP 401/403 or explicit AWS
+  credential error codes. Bare HTTP 400, 404, 5xx, and transport failures do
+  not trigger fallback.
+- A 2xx or 404 anonymous response makes anonymous mode sticky. Anonymous auth
+  rejection keeps private stores on authenticated access; transient anonymous
+  failures may be retried by a future request.
+- `RemoteFileCache` now applies the policy to remote manifest GETs and preserves
+  both authenticated and anonymous status in diagnostics when both fail.
+- Lasagna's exact-byte remote Zarr store applies the policy to HEAD and GET
+  requests, so descriptor validation and later chunk reads share the selected
+  mode without changing cached bytes or source identity.
+- Ordinary remote Zarr fallback and generic HTTP error reporting now share the
+  explicit AWS credential-error marker set.
 
-Keep thread 1 as the stable process-main role. Sum independently modeled
-non-main Callgrind costs, then distribute that complete worker-pool cost over
-all eligible non-main DRD work windows using the existing quantum/residual
-weights. This removes invented worker identity, accepts different worker sets,
-preserves total modeled work, and remains completely passive. DRD event thread
-IDs are retained, so worker program order, blocking, wakeups, and cross-thread
-dependencies continue to determine replay makespan; only cross-process cost
-identity is pooled.
+## Validation
 
-Tradeoff: per-worker Callgrind imbalance is deliberately discarded. DRD still
-supplies worker participation, dependencies, blocking, and available work
-windows. This is appropriate unless repeated tests show that worker-cost
-imbalance itself carries necessary predictive information.
-
-### B. Worker-cost permutation ensemble
-
-Treat Callgrind worker costs and DRD worker schedules as unlabeled multisets.
-Evaluate all worker assignments (small for the configured four workers) and use
-the median while reporting min/max bounds. This preserves measured imbalance
-without claiming IDs correspond.
-
-Tradeoff: differing worker participation requires zero-padding or pooling, and
-the selected statistic is less directly interpretable. The worst-case bound is
-likely too pessimistic for a regression gate. Keep this as a diagnostic or a
-fallback if role pooling loses important behavior.
-
-### C. Repeated independent trace ensemble
-
-Collect several complete Callgrind/DRD samples and gate a median role-pooled
-score. This addresses residual variation in synchronization outcomes and cache
-simulation.
-
-Tradeoff: it multiplies the expensive Valgrind portion of CI and does not by
-itself repair invalid raw-ID attribution. Consider it only after option A and
-prefer repeating DRD alone if Callgrind total work proves stable.
-
-### D. Deterministic benchmark scheduling or explicit task markers
-
-Force task-to-worker assignment or add logical phase/task events so profiles
-can be paired exactly.
-
-Rejected as the primary solution: it changes or instruments the renderer being
-measured, stops being passive, and can hide the scheduling regressions the gate
-is meant to detect.
-
-### E. Aggregate work divided by configured worker count
-
-Discard DRD and derive runtime from total modeled work plus a fixed parallelism
-factor.
-
-Rejected: it cannot see startup, blocking, synchronization, or lost
-parallelism, which are central requirements of this benchmark.
-
-## Speed notes for phase 2
-
-- `PendingRenderJob.chunkRequest` is created once from view ID plus render
-  request ID. `renderFrame()` copies it into base/overlay sampling options, and
-  all sampling calls in that job reuse it. The request is therefore constant
-  per render job, but not across jobs or request-ID changes.
-- `LevelAccess` already hoists shape, chunk shape, transform, dtype/fill, and
-  level validity once per sampled level.
-- `LocalChunkCache` already has a same-key `lastResult` fast path and pins up to
-  eight chunk results. A repeated successful chunk does not invoke
-  `IChunkedArray::tryGetChunk()` again within that local sampler cache. Separate
-  tile/level sampling contexts do not share this local hit state.
-- The caller still computes voxel-to-chunk integer divisions and assembles a
-  `ChunkKey` before `LocalChunkCache` can detect that hit. A successful-chunk
-  cursor with cached voxel bounds can bypass both for correlated samples.
-- Production `ChunkCache` directly overrides contextual `tryGetChunk()`. The
-  synthetic fixture overrides only the compatibility overload, so its measured
-  path currently includes an extra virtual forwarding call that production
-  rendering does not.
-- `ChunkCache::tryGetChunk()` reloads shared state, appends source ID to a new
-  full key, and acquires the cache mutex for each local-cache miss. A prepared
-  source/request/level lookup handle may remove repeated setup, but should be
-  attempted only if profiles still identify this path after the cursor/local
-  cache improvements.
-
-## Current decision
-
-Prototype deterministic paired reconstruction instead of role pooling. Keep the
-measured program unchanged and reject ambiguous pairings. Use role pooling only
-as a diagnostic baseline. Do not update the reference or tolerance yet. Defer
-speed implementation until attribution is correct enough to evaluate it, while
-retaining the pre/post render-order commits as the A/B workload.
-
-The no-code-change feasibility prototype passed. Production wiring may change
-collector/parser/replay tooling, but must not modify or instrument the measured
-renderer, benchmark, thread pool, or workload. Equivalent tie groups should be
-enumerated and scored conservatively; non-equivalent ambiguous groups fail.
-
-## Native implementation result
-
-- The regular Ninja estimate now invokes Valgrind directly and runs raw
-  Callgrind parsing, measured-window DRD parsing, canonical matching,
-  chronological attribution, conservative replay, reference comparison, and
-  JSON output in C++. Python is not in the evaluation path.
-- The measured renderer, benchmark, thread pool, and workload were not changed.
-- A fresh current-build parallel matrix produced these conservative scores:
-
-  | Scenario | Score (ns/call) | Mappings | Best-to-worst mapping span |
-  | --- | ---: | ---: | ---: |
-  | `full_res` | 917,189 | 24 | 0.87% |
-  | `fallback_3` | 2,515,155 | 2 | 0.12% |
-  | `mixed_correlated` | 1,700,855 | 2 | 0.00% |
-  | `mixed_shuffled` | 3,155,879 | 2 | 0.02% |
-
-- Three additional sequential fresh `parallel/full_res` pairs scored 917,333,
-  917,297, and 917,304 ns/call. The full range is 0.004%, confirming that the
-  paired estimate is stable on the current binary.
-- A fresh tied `full_res` group had 2.38% total modeled-cost spread but only
-  0.22% normalized chronological-shape spread. The predeclared native gates are
-  therefore separate: 5% total cost and 2% 32-bin shape. Every passing tie is
-  still fully enumerated and scored by its maximum makespan.
-
-## Scheduler-evidence repair
-
-- Rank matching still failed when DRD workers tied even though their Callgrind
-  costs differed. Callgrind now records the passive scheduler stream from its
-  own run, with no benchmark or renderer changes.
-- The native matcher enumerates all 24 four-worker assignments and compares
-  normalized worker activity share plus cumulative activity in 16 bins. It
-  replays every assignment within one scheduler quantum of the best match and
-  reports the maximum makespan.
-- The repaired eight-case matrix passed the existing references. The four
-  parallel cases retained 20, 2, 2, and 2 mappings respectively; their
-  conservative makespan spreads were 1.295%, 0.249%, 0.005%, and 0.011%.
-- Attribution fails when compatible mappings span more than 2% in makespan.
-  A future retry must recollect only that failed case. It must not retry a valid
-  score regression.
+- Built `test_http_fetch_errors`, `test_remote_file_cache`,
+  `test_lasagna_manifest`, `test_lasagna_project_volumes`, `test_remote_url`,
+  and `VC3D` with `cmake --build volume-cartographer/build --parallel 32`.
+- The five focused deterministic tests passed together. The fallback test also
+  passed 20 consecutive executions, including its coordinated eight-thread
+  transition case.
+- With `VC_TEST_REQUIRE_NETWORK=1`, `test_lasagna_manifest` passed all 17 cases
+  using syntactically valid but nonexistent AWS credentials. The real-data case
+  downloaded the exact reported PHerc0139 HTTPS manifest anonymously after the
+  signed request was rejected, then opened the public `presence` Zarr metadata
+  with shape `[9620, 3314, 3314]`.
+- The initial sandboxed live attempt could not resolve the public hostname;
+  rerunning with network access succeeded. This was an execution-environment
+  restriction, not a code failure.

--- a/volume-cartographer/planning/task_plan.md
+++ b/volume-cartographer/planning/task_plan.md
@@ -1,105 +1,60 @@
-# VC3D render attribution and lookup repair plan
+# Public S3 Lasagna authentication fallback plan
 
-## Phase 1: deterministic paired attribution
+## Implementation
 
-1. Keep the benchmark binary unchanged. Run Callgrind and DRD with the same
-   `--fair-sched=yes` and `--scheduling-quantum` values and the same benchmark
-   arguments. Enable periodic Callgrind dumps at the fixed basic-block interval
-   without adding application markers.
-2. Parse the benchmark's existing paired `steady_clock`/`clock_gettime` calls
-   from the DRD syscall trace and trim the dependency graph to the measured
-   render only. Require one unambiguous boundary pair; drop outside dependencies
-   as already-satisfied and renumber the retained graph.
-3. Parse periodic Callgrind dumps as chronological per-thread event-cost slices.
-   Preserve every event counter and require their sum to equal the complete
-   measured Callgrind profile.
-4. Keep main thread 1 as the stable control role. Capture the passive scheduler
-   stream in the Callgrind execution as well as DRD, enumerate all four-worker
-   assignments, and score them from normalized activity share and cumulative
-   measured-window activity. Replay every mapping within scheduler-quantum
-   resolution of the best score and use the maximum replay makespan. Fail the
-   case when compatible mappings exceed the predeclared makespan-spread limit.
-5. Resample each matched chronological Callgrind cost trace over that DRD
-   worker's measured eligible windows while preserving order and exact total
-   cost. Keep original DRD thread IDs, program order, blocking, and dependency
-   edges. Implement direct per-window attribution in the native replay engine.
-6. Keep the regular collection and evaluation path native: the C++ tool parses
-   raw periodic Callgrind profiles and the raw DRD trace, validates and matches
-   them, performs attribution/replay, and writes the evaluation artifact.
-   CMake/Ninja invokes Valgrind and the native tool directly. Python remains
-   available only for offline calibration and is not part of the CI estimate.
-7. Collect repeated paired runs for every parallel scenario. Require stable
-   canonical signatures, exact cost conservation, and stable modeled makespan.
-   A pair that cannot prove reconstruction is rejected rather than averaged.
-8. Retain generic per-thread attribution for other replay users and keep serial
-   evaluation unchanged. Keep role pooling only as a diagnostic comparison,
-   not the renderer gate's final attribution.
-9. Freeze a new reference only after deterministic pairing and repeatability are
-   accepted, then re-enable the workflow gate in a separate reviewable change.
-
-## Phase 2: lookup performance
-
-1. Build the pre-render-order commit, the render-order commit, and the repaired
-   head with the same GCC Release configuration. Run serial and parallel native
-   trials repeatedly and collect Callgrind counters/checksums for all scenarios.
-2. Separate synthetic-fixture overhead from production behavior. The synthetic
-   array currently inherits the contextual `tryGetChunk()` forwarding overload,
-   while production `ChunkCache` overrides it directly; benchmark both the
-   production-equivalent direct overload and the generic compatibility path.
-3. Profile before choosing among these compatible optimizations:
-   - a per-tile/per-level successful-chunk cursor containing chunk bounds,
-     resolved payload, strides, and full key, checked before coordinate division
-     and key construction;
-   - a source-bound prepared lookup handle containing render-job request,
-     source ID/state, and level invariants;
-   - a fixed-capacity linear/small-vector local chunk cache in place of hashing
-     for the current maximum of eight pinned chunks.
-4. Implement one optimization at a time. Keep the old path as the correctness
-   oracle and compare exact image checksums plus requested/missing/error counts.
-5. Accept only changes with repeatable native and modeled improvement. Report
-   command, build type, input scenario, repetitions, and mean plus distribution
-   statistics.
+1. Extract the existing AWS credential-error recognition into one reusable
+   core helper. Preserve explicit AWS token/signature error markers; treat 401
+   and 403 responses as authentication rejection, but do not treat a bare 400
+   or unrelated transport/server failure as authentication rejection.
+2. Update the built-in `RemoteFileCache` transport to retry an S3 GET
+   anonymously only when a credentialed request receives a recognized
+   authentication failure. Preserve a useful failure if both attempts fail.
+3. Update Lasagna's exact-byte remote Zarr store with the same policy for GET
+   and HEAD requests. Coordinate concurrent authentication failures so one
+   anonymous probe determines the transition while followers wait. Retain
+   anonymous mode only after a 2xx or 404 response; 401/403, 5xx, and transport
+   failures do not establish anonymous access. Keep both HTTP clients alive
+   rather than replacing a client during concurrent requests.
+4. Reuse the shared classification in the ordinary remote Zarr fallback so the
+   three paths cannot drift on credential-error markers.
 
 ## Testing and validation
 
-- Native replay unit tests for direct window-cost conservation, chronological
-  placement, invalid window vectors, and unchanged generic per-thread
-  attribution.
-- Native parser tests for periodic Callgrind dumps and passive measured-window
-  trimming, plus native matching tests for scheduler-selected assignments,
-  scheduler ties, material makespan ambiguity, chronological attribution, and
-  exact event-counter conservation.
-- Repeated complete render matrices before freezing any reference.
-- Exact synthetic-render checksums and existing `ChunkedPlaneSampler` and
-  `ChunkCache` tests for speed changes.
-- Build relevant C++ targets with all 32 cores and run `git diff --check`.
+- Add deterministic unit coverage for recognized and unrelated responses and
+  exact signed/anonymous request counts. Cover successful sticky fallback,
+  concurrent probe coalescing, a valid signed private request, failed anonymous
+  access to private data, unrelated 400/404/5xx responses, and non-S3 control.
+- Cover URL classification for `s3://`, region-qualified S3, virtual-hosted S3
+  HTTPS, and non-S3 HTTPS inputs.
+- Run the relevant remote URL, HTTP fetch, remote file cache, Lasagna manifest,
+  Lasagna project-volume, and remote Zarr tests from the existing build using
+  all 32 build cores.
+- Validate the reported public PHerc0139 manifest with deliberately invalid
+  credentials as a real-data smoke test, without downloading Zarr chunks beyond
+  descriptor validation.
+- Run `git diff --check` on all changed files.
 
 ## Specification updates
 
-Update `specs/benchmarks.md` so the renderer-gate contract requires passive
-deterministic paired reconstruction, measured-window trimming, canonical
-logical-worker matching, chronological per-window cost placement, exact cost
-conservation, and rejection of ambiguous pairs. Raw worker IDs never cross
-independent-run boundaries. Update `planning/spec.md` only if the accepted
-lookup optimization adds a renderer requirement not already covered there,
-including the measured no-numeric-change requirement.
+Add a remote-authentication requirement to `planning/spec.md`: recognized S3
+endpoints with rejected credentials must retry anonymously without changing
+source identity, while private data must retain authenticated behavior.
 
 ## Documentation updates
 
-Update `docs/thread_sync_replay.md` and
-`docs/benchmarks/render_valgrind_ci.md` with paired-trace attribution,
-repeatability/rebaseline procedure, matching diagnostics, and the reason raw
-worker IDs cannot cross independent Valgrind runs. Document any new prepared
-lookup API beside the renderer implementation.
+Update `docs/remote_file_cache.md` and the remote Lasagna attachment section of
+`docs/vc3d_project_files.md` to describe signed-first anonymous fallback and
+sticky anonymous mode for public Lasagna objects.
 
 ## Changelog update
 
-Add one dated line when attribution is corrected and the stable gate is
-re-enabled. Add a separate measured lookup-performance line only if the second
-phase produces an accepted code change.
+Add one dated line describing reliable public S3 Lasagna attachment in the
+planning changelog.
 
 ## Independent review
 
-Pending review of this plan against the current replay implementation, passive
-measurement constraint, benchmark specification, complete-cost invariant, and
-strict ambiguity rejection.
+Reviewed on 2026-08-27. The review required canonical error classification,
+an explicit definition of authoritative anonymous responses, synchronized
+fallback transition without client replacement, private-bucket diagnostics,
+and mandatory exact request-count tests. The plan above incorporates those
+requirements.

--- a/volume-cartographer/planning/task_plan.md
+++ b/volume-cartographer/planning/task_plan.md
@@ -1,29 +1,27 @@
-# Public S3 Lasagna authentication fallback plan
+# Public S3 Lasagna anonymous-first access plan
 
 ## Implementation
 
-1. Extract the existing AWS credential-error recognition into one reusable
-   core helper. Preserve explicit AWS token/signature error markers; treat 401
-   and 403 responses as authentication rejection, but do not treat a bare 400
-   or unrelated transport/server failure as authentication rejection.
-2. Update the built-in `RemoteFileCache` transport to retry an S3 GET
-   anonymously only when a credentialed request receives a recognized
-   authentication failure. Preserve a useful failure if both attempts fail.
-3. Update Lasagna's exact-byte remote Zarr store with the same policy for GET
-   and HEAD requests. Coordinate concurrent authentication failures so one
-   anonymous probe determines the transition while followers wait. Retain
-   anonymous mode only after a 2xx or 404 response; 401/403, 5xx, and transport
-   failures do not establish anonymous access. Keep both HTTP clients alive
-   rather than replacing a client during concurrent requests.
-4. Reuse the shared classification in the ordinary remote Zarr fallback so the
-   three paths cannot drift on credential-error markers.
+1. Attempt recognized S3 sources anonymously before using any available
+   credentials. A successful anonymous response establishes sticky anonymous
+   access for the owning remote store.
+2. When anonymous access returns 401/403, retry with credentials and retain
+   authenticated mode after a successful or not-found authenticated response.
+   Permit a later anonymous denial to upgrade a mixed-access store.
+3. Coordinate the initial Lasagna store probe so concurrent readers observe one
+   selected mode, while retaining stable anonymous and authenticated clients.
+4. Reverse the ordinary remote Zarr whole-open order so it also selects
+   anonymous access before trying credentials.
+5. Keep AWS error-body recognition diagnostic-only for successful responses;
+   content containing strings such as `AccessDenied` must never change access
+   mode.
 
 ## Testing and validation
 
-- Add deterministic unit coverage for recognized and unrelated responses and
-  exact signed/anonymous request counts. Cover successful sticky fallback,
-  concurrent probe coalescing, a valid signed private request, failed anonymous
-  access to private data, unrelated 400/404/5xx responses, and non-S3 control.
+- Add deterministic unit coverage for exact authenticated/anonymous request
+  counts, successful response bodies containing AWS error words, empty-body
+  HEAD success, concurrent probe coalescing, private fallback, mixed-access
+  upgrade, unrelated failures, and non-S3 control.
 - Cover URL classification for `s3://`, region-qualified S3, virtual-hosted S3
   HTTPS, and non-S3 HTTPS inputs.
 - Run the relevant remote URL, HTTP fetch, remote file cache, Lasagna manifest,
@@ -36,15 +34,14 @@
 
 ## Specification updates
 
-Add a remote-authentication requirement to `planning/spec.md`: recognized S3
-endpoints with rejected credentials must retry anonymously without changing
-source identity, while private data must retain authenticated behavior.
+Require recognized S3 endpoints to prefer anonymous access without changing
+source identity, while private data retains authenticated behavior.
 
 ## Documentation updates
 
 Update `docs/remote_file_cache.md` and the remote Lasagna attachment section of
-`docs/vc3d_project_files.md` to describe signed-first anonymous fallback and
-sticky anonymous mode for public Lasagna objects.
+`docs/vc3d_project_files.md` to describe anonymous-first selection and sticky
+access mode.
 
 ## Changelog update
 
@@ -53,8 +50,7 @@ planning changelog.
 
 ## Independent review
 
-Reviewed on 2026-08-27. The review required canonical error classification,
-an explicit definition of authoritative anonymous responses, synchronized
-fallback transition without client replacement, private-bucket diagnostics,
-and mandatory exact request-count tests. The plan above incorporates those
-requirements.
+The 2026-08-27 follow-up review found that signed-first handling scanned
+successful payloads for error markers and could not classify an empty-body S3
+HEAD 400. Anonymous-first selection removes both ambiguities while preserving
+private and mixed-access behavior.


### PR DESCRIPTION
**In one sentence:** VC3D can attach public S3 Lasagna manifests even when ambient AWS credentials are stale or invalid, while retaining authenticated access for private data.

**One real example:** Starting with the public PHerc0139 Lasagna manifest at `https://vesuvius-challenge-open-data.s3.amazonaws.com/PHerc0139/representations/predictions/fibers/20260102150214-fibers-20260801084232-L1/PHerc0139-20260102150214-las-sd1-92481a4c.lasagna.json`, I loaded it with invalid AWS credentials present, and both the manifest and its `presence` Zarr metadata opened successfully.

**Before:** Recognized S3 URLs were always signed when AWS credentials were present. Invalid or expired credentials caused public objects to fail with errors such as `HTTP 400 InvalidToken`, without attempting anonymous access.

**After this PR:** Explicit AWS authentication failures retry anonymously. Successful public access becomes sticky for subsequent manifest, metadata, and chunk requests, while valid authenticated access to private objects remains unchanged.

**Proof:** The real-data network test opens the original PHerc0139 manifest and verifies the `presence` array shape as `(9620, 3314, 3314)`. The focused test suite passes, including repeated concurrent fallback tests.

**Why / where this is useful:** Users can attach public Lasagna datasets from S3 without clearing credentials belonging to another AWS account or refreshing an unrelated expired session.

## Details

- Adds a shared, thread-safe S3 authentication fallback policy.
- Retries only HTTP 401/403 and explicit AWS credential errors such as `InvalidToken`, `ExpiredToken`, and `SignatureDoesNotMatch`.
- Does not retry unrelated HTTP 400, 404, 5xx, or transport failures anonymously.
- Coordinates concurrent fallback attempts so only one anonymous probe is made per failure wave.
- Applies the policy to remote manifest downloads, Lasagna Zarr access, and the existing generic Zarr fetcher.
- Does not change project or manifest serialization.

Verification:

```bash
cmake --build volume-cartographer/build --parallel 32 \
  --target test_http_fetch_errors test_remote_file_cache \
  test_lasagna_manifest test_lasagna_project_volumes \
  test_remote_url VC3D

ctest --test-dir volume-cartographer/build --output-on-failure \
  -R "^(test_http_fetch_errors|test_remote_file_cache|test_lasagna_manifest|test_remote_url|test_lasagna_project_volumes)$"

ctest --test-dir volume-cartographer/build --output-on-failure \
  --repeat until-fail:20 -R "^test_http_fetch_errors$"

VC_TEST_REQUIRE_NETWORK=1 \
  volume-cartographer/build/bin/test_lasagna_manifest
```