### PR TITLE
spiral: report direct absolute-winding disagreements

### DIFF
--- a/spiral-fitting/find_inconsistent_windings.py
+++ b/spiral-fitting/find_inconsistent_windings.py
@@ -180,14 +180,31 @@ def build_fit_inputs(checkpoint, patches_dir, pcl_paths, filter_z_begin, filter_
     Returns (fit_config, scroll, paths, model_z_begin, model_z_end); the model
     z-range shapes the transform's flow field independently of the filtering
     z-range."""
-    from fit_session import PclInputSpec, ScrollSpec, SpiralInputPaths
+    from fit_session import (
+        PclInputSpec,
+        ScrollSpec,
+        SpiralInputPaths,
+        effective_pcl_role,
+    )
 
     cfg = fs.Config().as_dict()
     cfg.update(checkpoint['cfg'])
+    pcl_specs = tuple(PclInputSpec(path=str(path), role=None)
+                      for path in pcl_paths)
     # This tool IS the patch graph — a checkpoint trained supervision-free
     # (disable_patches, e.g. the 2026-07-17 normals-only baseline) must not
     # stop the loaders from reading the patches it wants to analyse.
     cfg['input_disable_patches'] = False
+    cfg['input_use_verified_patches'] = True
+    # --pcl and --fibers are explicit diagnostic inputs rather than requests
+    # to reproduce a checkpoint's training-input ablation. Enable only the
+    # supplied roles, leaving every unrelated checkpoint input unchanged.
+    # Role-less paths retain the historical basename convention.
+    for spec in pcl_specs:
+        role = effective_pcl_role(spec.role, spec.path)
+        cfg[f'input_use_pcl_{role.value}'] = True
+    if fibers_path:
+        cfg['input_use_fibers'] = True
     # We compute no shell losses; zero their weights so the context's
     # shell_losses_enabled() gate stops load_host_inputs() from loading the
     # shell (replacing the old fs.shell_losses_enabled = lambda: False
@@ -214,8 +231,7 @@ def build_fit_inputs(checkpoint, patches_dir, pcl_paths, filter_z_begin, filter_
     # unless a fibers dir is passed.
     paths = SpiralInputPaths(
         umbilicus=umbilicus_path,
-        pcls=tuple(PclInputSpec(path=str(path), role=None)
-                   for path in pcl_paths),
+        pcls=pcl_specs,
         fibers=fibers_path or '',
         verified_patches=patches_dir,
     )

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -4665,6 +4665,7 @@ class FitContext:
                 patches_dict=self.verified_patches,
                 patch_atlas=self.patch_atlas,
                 unattached_pcl_strips=self.unattached_pcl_strips,
+                cross_patch_pcls=self.cross_patch_pcls,
                 tracks=self.tracks,
                 unverified_patches_list=self.unverified_patches_list,
                 unverified_patches_dict=self.unverified_patches,

--- a/spiral-fitting/satisfaction_metrics.py
+++ b/spiral-fitting/satisfaction_metrics.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 
 from sample_spiral import (
+    get_theta,
     get_theta_and_radii,
     get_theta_crossing_step_adjustments,
     radius_from_unwrapped_shifted,
@@ -98,6 +99,207 @@ class PatchSatisfactionEvaluation:
                 output[selected_ij[:, 0], selected_ij[:, 1]] = packed[begin:end]
             outputs.append(output)
         return outputs
+
+
+def report_absolute_winding_diagnostic(
+        slice_to_spiral_transform, patch_ids, evaluation, cross_patch_pcls):
+    """Compare native patch targets with attached absolute-winding annotations.
+
+    Patch satisfaction deliberately derives its target from the evaluated patch.
+    That makes it useful for geometric residuals, but means it cannot by itself
+    distinguish a patch on the intended winding from the same patch translated by
+    a whole winding.  Absolute-winding point collections provide an external target
+    that can also be consumed by ``get_patch_abs_winding_loss``.  This helper
+    keeps the two signals separate and reports their disagreement; it never changes a
+    satisfaction count, a mesh selection, or a loss.
+
+    Only direct absolute anchors are used here.  Relative/fiber collections are
+    intentionally ignored: propagating them requires the valid-quad graph and
+    seam-aware BFS implemented by ``find_inconsistent_windings.py``.  Reporting a
+    direct anchor is still valuable, and avoids treating a relative annotation as
+    an absolute one when the full graph is unavailable in the final-output path.
+
+    An anchor is evaluated at the same clamped quad cell used by
+    ``losses._valid_patch_annotation``.  A missing/out-of-ROI/disconnected native
+    target, a non-finite annotation, or a non-integral absolute annotation is
+    reported as skipped rather than guessed.  This is deliberately conservative:
+    a missing comparison must not become a false sheet-switch warning.
+    """
+    patch_ids = list(patch_ids)
+    patch_index_by_id = {patch_id: index for index, patch_id in enumerate(patch_ids)}
+    skipped = {
+        'not_absolute': 0,
+        'missing_attachment': 0,
+        'unknown_patch': 0,
+        'nonfinite_annotation': 0,
+        'nonintegral_annotation': 0,
+        'missing_anchor_position': 0,
+        'outside_target_grid': 0,
+        'missing_native_target': 0,
+    }
+    candidates = []
+    absolute_anchor_candidates = 0
+
+    for pcl_position, pcl in enumerate(cross_patch_pcls or ()):
+        if not pcl.get('metadata', {}).get('winding_is_absolute', False):
+            # Count actual attached points, not a collection with no patch evidence.
+            skipped['not_absolute'] += sum(
+                len(points) for points in pcl.get('points_by_patch', {}).values())
+            continue
+        for attached_patch_id, points in pcl.get('points_by_patch', {}).items():
+            for point_position, point in enumerate(points):
+                absolute_anchor_candidates += 1
+                on_patch = point.get('on_patch')
+                if not on_patch:
+                    skipped['missing_attachment'] += 1
+                    continue
+                patch_id = on_patch.get('id', attached_patch_id)
+                patch_index = patch_index_by_id.get(patch_id)
+                if patch_index is None:
+                    skipped['unknown_patch'] += 1
+                    continue
+                try:
+                    annotation = float(point['winding_annotation'])
+                except (KeyError, TypeError, ValueError):
+                    skipped['nonfinite_annotation'] += 1
+                    continue
+                if not np.isfinite(annotation):
+                    skipped['nonfinite_annotation'] += 1
+                    continue
+                expected_winding = int(round(annotation))
+                if not np.isclose(annotation, expected_winding, rtol=0.0, atol=1e-3):
+                    skipped['nonintegral_annotation'] += 1
+                    continue
+                try:
+                    anchor_zyx = np.asarray(point['zyx'], dtype=np.float32)
+                except (KeyError, TypeError, ValueError):
+                    skipped['missing_anchor_position'] += 1
+                    continue
+                if anchor_zyx.shape != (3,) or not np.isfinite(anchor_zyx).all():
+                    skipped['missing_anchor_position'] += 1
+                    continue
+                try:
+                    ij = on_patch['ij']
+                    i_q, j_q = int(ij[0]), int(ij[1])
+                except (KeyError, TypeError, ValueError, IndexError):
+                    skipped['missing_attachment'] += 1
+                    continue
+                begin = int(evaluation.patch_offsets[patch_index].item())
+                end = int(evaluation.patch_offsets[patch_index + 1].item())
+                target_shape = tuple(evaluation.quad_shapes[patch_index].tolist())
+                if not target_shape or target_shape[0] <= 0 or target_shape[1] <= 0:
+                    skipped['outside_target_grid'] += 1
+                    continue
+                # This matches _valid_patch_annotation: annotations are attached to
+                # a retained quad cell, with grid-boundary positions clamped in.
+                i_q = min(max(i_q, 0), target_shape[0] - 1)
+                j_q = min(max(j_q, 0), target_shape[1] - 1)
+                local_ijs = evaluation.quad_ijs[begin:end].numpy()
+                match = np.flatnonzero(
+                    (local_ijs[:, 0] == i_q) & (local_ijs[:, 1] == j_q))
+                if match.size != 1:
+                    skipped['missing_native_target'] += 1
+                    continue
+                candidates.append({
+                    'patch_id': patch_id,
+                    'patch_index': patch_index,
+                    'quad_ij': [i_q, j_q],
+                    'packed_index': begin + int(match[0]),
+                    'annotation_winding_at_anchor': expected_winding,
+                    'anchor_zyx': anchor_zyx,
+                    'pcl_id': pcl.get('id', pcl_position),
+                    'pcl_name': pcl.get('name'),
+                    'source_file': pcl.get('source_file'),
+                    'point_id': point.get('id', point_position),
+                })
+
+    # Pull only anchor cells off the device.  Final reports can hold far more
+    # packed quads than annotations, so materialising dense target/satisfaction
+    # grids just for this diagnostic would make the report itself expensive.
+    if candidates:
+        packed_positions = [entry['packed_index'] for entry in candidates]
+        packed_indices = torch.as_tensor(
+            packed_positions, dtype=torch.int64,
+            device=evaluation.target_winding_indices.device)
+        native_targets = evaluation.target_winding_indices.index_select(
+            0, packed_indices).cpu().tolist()
+        theta_indices = torch.as_tensor(
+            packed_positions, dtype=torch.int64,
+            device=evaluation.center_theta.device)
+        cell_thetas = evaluation.center_theta.index_select(0, theta_indices)
+        anchor_zyxs = torch.as_tensor(
+            np.stack([entry['anchor_zyx'] for entry in candidates]),
+            dtype=torch.float32, device=cell_thetas.device)
+        with torch.no_grad():
+            anchor_spiral = slice_to_spiral_transform(anchor_zyxs)
+            anchor_thetas, _ = get_theta(anchor_spiral[..., 1:])
+        reference_delta = cell_thetas - anchor_thetas
+        reference_steps = (
+            (reference_delta > np.pi).to(torch.int32)
+            - (reference_delta < -np.pi).to(torch.int32)
+        ).cpu().tolist()
+        strict_profile = evaluation.profiles['strict']
+        quad_indices = torch.as_tensor(
+            packed_positions, dtype=torch.int64,
+            device=strict_profile.packed_satisfied_quads.device)
+        native_quad_satisfied = strict_profile.packed_satisfied_quads.index_select(
+            0, quad_indices).cpu().tolist()
+        patch_indices = torch.as_tensor(
+            [entry['patch_index'] for entry in candidates], dtype=torch.int64,
+            device=strict_profile.satisfied_patches.device)
+        native_patch_satisfied = strict_profile.satisfied_patches.index_select(
+            0, patch_indices).tolist()
+    else:
+        native_targets = []
+        reference_steps = []
+        native_quad_satisfied = []
+        native_patch_satisfied = []
+
+    comparisons = []
+    for entry, native_winding, reference_step, quad_satisfied, patch_satisfied in zip(
+            candidates, native_targets, reference_steps,
+            native_quad_satisfied, native_patch_satisfied):
+        native_winding = int(native_winding)
+        if native_winding < 0:
+            skipped['missing_native_target'] += 1
+            continue
+        annotation_winding = entry.pop('annotation_winding_at_anchor')
+        entry.pop('anchor_zyx')
+        # Match ThetaCrossingMap.adjustments_from_potentials for an annotation
+        # reference node and its attached patch cell.  A direct comparison to
+        # wind_a would create a false +/-1 warning across theta=0.
+        expected_at_cell = annotation_winding - int(reference_step)
+        comparisons.append({
+            **entry,
+            'annotation_winding_at_anchor': annotation_winding,
+            'anchor_to_cell_theta_reference_step': int(reference_step),
+            'annotation_derived_expected_winding_at_cell': expected_at_cell,
+            'native_self_derived_winding': native_winding,
+            'difference_windings': native_winding - expected_at_cell,
+            'native_anchor_quad_strict_satisfied': bool(quad_satisfied),
+            'native_patch_strict_satisfied': bool(patch_satisfied),
+        })
+
+    comparisons.sort(key=lambda entry: (
+        str(entry['patch_id']), str(entry['pcl_id']), str(entry['point_id'])))
+    disagreements = [entry for entry in comparisons if entry['difference_windings'] != 0]
+    return {
+        'kind': 'report_only_direct_absolute_winding_comparison',
+        'scope': (
+            'Direct anchors from metadata.winding_is_absolute only; relative and '
+            'fiber collections are intentionally not promoted to absolute evidence.'),
+        'effect_on_satisfaction': 'none',
+        'summary': {
+            'absolute_anchor_candidates': absolute_anchor_candidates,
+            'anchors_compared': len(comparisons),
+            'anchors_agreeing': len(comparisons) - len(disagreements),
+            'anchors_disagreeing': len(disagreements),
+            'disagreeing_and_native_patch_strict_satisfied': sum(
+                entry['native_patch_strict_satisfied'] for entry in disagreements),
+            'skipped': skipped,
+        },
+        'comparisons': comparisons,
+    }
 
 
 class _ListPatchAtlas:
@@ -831,6 +1033,7 @@ def save_overlay_and_print_satisfaction(
     run_tag=None,
     save_png_visualizations=False,
     progress=None,
+    cross_patch_pcls=(),
 ):
     if progress is not None:
         progress.begin(
@@ -876,6 +1079,16 @@ def save_overlay_and_print_satisfaction(
         'total_area': total_area,
         'satisfied_area_fraction': satisfied_area_ratio,
     }
+    absolute_winding_diagnostic = report_absolute_winding_diagnostic(
+        slice_to_spiral_transform, patches_dict.keys(),
+        patch_evaluation, cross_patch_pcls)
+    absolute_summary = absolute_winding_diagnostic['summary']
+    print(
+        'absolute_winding_diagnostic = '
+        f"{absolute_summary['anchors_disagreeing']}/"
+        f"{absolute_summary['anchors_compared']} direct anchors disagree "
+        f"({absolute_summary['disagreeing_and_native_patch_strict_satisfied']} "
+        'also native-patch-strict-satisfied)')
     unattached_pcl_per_point_satisfied = []
     unattached_pcl_fully_satisfied = torch.zeros(len(unattached_pcl_strips), dtype=torch.bool)
     if unattached_pcl_strips:
@@ -917,8 +1130,7 @@ def save_overlay_and_print_satisfaction(
                     'finalizing', 'Evaluating tracks',
                     detail=f'{len(tracks):,} tracks')
             track_satisfied_counts, track_total_counts = get_track_satisfied_counts_in_chunks(
-                slice_to_spiral_transform, dr_per_winding, tracks, metrics_config,
-            )
+                slice_to_spiral_transform, dr_per_winding, tracks, metrics_config)
             track_fully_satisfied = (track_satisfied_counts == track_total_counts)
             fully_satisfied_tracks = int(track_fully_satisfied.sum().item())
             num_valid_tracks = int(track_total_counts.numel())
@@ -1012,6 +1224,8 @@ def save_overlay_and_print_satisfaction(
         }, f, indent=2)
     with open(f'{out_path}/satisfaction_metrics_{suffix}.json', 'w') as f:
         json.dump({'summary': satisfaction_summary}, f, indent=2)
+    with open(f'{out_path}/absolute_winding_diagnostic_{suffix}.json', 'w') as f:
+        json.dump(absolute_winding_diagnostic, f, indent=2)
     need_overlay = (save_png_visualizations
                     and os.environ.get('FIT_SPIRAL_SKIP_SAVE_OVERLAY') != '1')
     need_mesh = os.environ.get('FIT_SPIRAL_SKIP_SAVE_MESH') != '1'

--- a/spiral-fitting/tests/test_absolute_winding_diagnostic.py
+++ b/spiral-fitting/tests/test_absolute_winding_diagnostic.py
@@ -1,0 +1,183 @@
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from satisfaction_metrics import (
+    _ListPatchAtlas,
+    evaluate_patch_satisfaction_packed,
+    report_absolute_winding_diagnostic,
+)
+
+
+class _IdentityTransform:
+    def __call__(self, points):
+        return points
+
+    def inv(self, points):
+        return points
+
+
+def _spiral_point(theta, winding, *, dr=10.0, radial_noise=0.0):
+    radius = (winding + theta / (2 * math.pi)) * dr + radial_noise
+    return torch.tensor(
+        [0.0, math.sin(theta) * radius, math.cos(theta) * radius],
+        dtype=torch.float32,
+    )
+
+
+def _one_quad_patch(theta, winding, *, radial_noise=0.0):
+    # The native evaluator scores the mean of four corners.  Repeating the
+    # analytic point keeps that mean exactly on the requested winding while
+    # retaining a normal one-quad patch layout.
+    point = _spiral_point(theta, winding, radial_noise=radial_noise)
+    return SimpleNamespace(
+        zyxs=point.repeat(2, 2, 1),
+        valid_quad_mask=torch.ones((1, 1), dtype=torch.bool),
+        area=1.0,
+    )
+
+
+def _evaluation(patches, device='cpu'):
+    device = torch.device(device)
+    return evaluate_patch_satisfaction_packed(
+        _IdentityTransform(), torch.tensor(10.0, device=device), patches,
+        _ListPatchAtlas(patches, device),
+        -1, 1, include_splicing=False)
+
+
+def _absolute_anchor(patch_id, winding, *, point_id=1, theta=0.2):
+    return {
+        'id': 10,
+        'name': 'absolute-anchor',
+        'source_file': 'abs_winding.json',
+        'metadata': {'winding_is_absolute': True},
+        'points_by_patch': {
+            patch_id: [{
+                'id': point_id,
+                'winding_annotation': float(winding),
+                'zyx': _spiral_point(theta, winding).numpy(),
+                'on_patch': {'id': patch_id, 'ij': [0.0, 0.0]},
+            }],
+        },
+    }
+
+
+def test_whole_winding_shift_stays_native_satisfied_but_direct_anchor_flags_it():
+    patches = [
+        _one_quad_patch(0.2, 40),
+        _one_quad_patch(0.2, 41),
+        _one_quad_patch(0.2, 42),
+        _one_quad_patch(0.2, 63),
+    ]
+    evaluation = _evaluation(patches)
+
+    # This is the native metric's blind spot: each exactly-on-winding patch
+    # passes even though three carry an absolute annotation for winding 40.
+    assert evaluation.profiles['strict'].satisfied_patches.tolist() == [True] * 4
+
+    report = report_absolute_winding_diagnostic(
+        _IdentityTransform(),
+        ['correct', 'shifted-one', 'shifted-two', 'shifted-twenty-three'], evaluation,
+        [
+            _absolute_anchor('correct', 40),
+            _absolute_anchor('shifted-one', 40),
+            _absolute_anchor('shifted-two', 40),
+            _absolute_anchor('shifted-twenty-three', 40),
+        ],
+    )
+
+    comparisons = {entry['patch_id']: entry for entry in report['comparisons']}
+    assert comparisons['correct']['difference_windings'] == 0
+    assert comparisons['shifted-one']['difference_windings'] == 1
+    assert comparisons['shifted-two']['difference_windings'] == 2
+    assert comparisons['shifted-twenty-three']['difference_windings'] == 23
+    assert all(entry['native_patch_strict_satisfied'] for entry in comparisons.values())
+    assert report['summary']['anchors_disagreeing'] == 3
+    assert report['summary']['disagreeing_and_native_patch_strict_satisfied'] == 3
+
+
+def test_direct_anchor_diagnostic_does_not_turn_uniform_radial_offset_into_a_switch():
+    # Two voxels are inside both default native tolerances for dr=10.  The
+    # expected absolute winding and native target still agree, so the diagnostic
+    # reports no sheet switch rather than treating ordinary surface scatter as one.
+    patches = [_one_quad_patch(0.2, 40, radial_noise=2.0)]
+    evaluation = _evaluation(patches)
+    assert evaluation.profiles['strict'].satisfied_patches.tolist() == [True]
+
+    report = report_absolute_winding_diagnostic(
+        _IdentityTransform(), ['offset-but-correct'], evaluation,
+        [_absolute_anchor('offset-but-correct', 40)],
+    )
+
+    assert report['summary']['anchors_compared'] == 1
+    assert report['summary']['anchors_disagreeing'] == 0
+    assert report['comparisons'][0]['difference_windings'] == 0
+
+
+def test_only_usable_absolute_anchors_are_compared():
+    patches = [_one_quad_patch(0.2, 40)]
+    evaluation = _evaluation(patches)
+    nonabsolute = _absolute_anchor('p', 9)
+    nonabsolute['metadata']['winding_is_absolute'] = False
+    nonintegral = _absolute_anchor('p', 40.25, point_id=2)
+    unknown_patch = _absolute_anchor('missing', 99, point_id=3)
+
+    report = report_absolute_winding_diagnostic(
+        _IdentityTransform(), ['p'], evaluation,
+        [nonabsolute, nonintegral, unknown_patch])
+
+    assert report['comparisons'] == []
+    assert report['summary']['anchors_compared'] == 0
+    assert report['summary']['skipped']['not_absolute'] == 1
+    assert report['summary']['skipped']['nonintegral_annotation'] == 1
+    assert report['summary']['skipped']['unknown_patch'] == 1
+
+
+def test_theta_seam_reference_step_does_not_create_false_disagreement():
+    anchor_theta = 2 * math.pi - 0.002
+    cell_theta = 0.002
+    patches = [_one_quad_patch(cell_theta, 41)]
+    evaluation = _evaluation(patches)
+    anchor = _absolute_anchor('seam', 40, theta=anchor_theta)
+
+    # The public loader's attachment tolerance is 2.5 voxels.  This synthetic
+    # real-shaped case lies within it while crossing theta=0.
+    distance = torch.linalg.norm(
+        torch.as_tensor(anchor['points_by_patch']['seam'][0]['zyx'])
+        - patches[0].zyxs[0, 0]).item()
+    assert distance < 2.5
+
+    report = report_absolute_winding_diagnostic(
+        _IdentityTransform(), ['seam'], evaluation, [anchor])
+    comparison = report['comparisons'][0]
+    assert comparison['anchor_to_cell_theta_reference_step'] == -1
+    assert comparison['annotation_derived_expected_winding_at_cell'] == 41
+    assert comparison['native_self_derived_winding'] == 41
+    assert comparison['difference_windings'] == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA is unavailable')
+def test_direct_anchor_diagnostic_indexes_cpu_profiles_from_cuda_evaluation():
+    patches = [_one_quad_patch(0.2, 41)]
+    evaluation = _evaluation(patches, device='cuda')
+
+    # Packed geometry stays on the model device, while profile results are
+    # deliberately returned on CPU for reporting.  Gather indices must follow
+    # each source tensor rather than the geometry device globally.
+    assert evaluation.target_winding_indices.is_cuda
+    assert evaluation.center_theta.is_cuda
+    assert evaluation.profiles['strict'].packed_satisfied_quads.device.type == 'cpu'
+    assert evaluation.profiles['strict'].satisfied_patches.device.type == 'cpu'
+
+    report = report_absolute_winding_diagnostic(
+        _IdentityTransform(), ['shifted'], evaluation,
+        [_absolute_anchor('shifted', 40)],
+    )
+
+    comparison = report['comparisons'][0]
+    assert comparison['difference_windings'] == 1
+    assert comparison['native_anchor_quad_strict_satisfied'] is True
+    assert comparison['native_patch_strict_satisfied'] is True

--- a/spiral-fitting/tests/test_find_inconsistent_windings_inputs.py
+++ b/spiral-fitting/tests/test_find_inconsistent_windings_inputs.py
@@ -1,0 +1,56 @@
+import fit_spiral as fs
+from find_inconsistent_windings import build_fit_inputs
+
+
+def test_explicit_diagnostic_inputs_override_checkpoint_source_ablation(tmp_path):
+    patches_dir = tmp_path / 'patches'
+    absolute_path = tmp_path / 'abs_winding.json'
+    relative_path = tmp_path / 'diagnostic_links.json'
+    fibers_path = tmp_path / 'fibers'
+    checkpoint = {
+        'cfg': {
+            'input_disable_patches': True,
+            'input_use_verified_patches': False,
+            'input_use_unverified_patches': False,
+            'input_use_tracks': False,
+            'input_use_fibers': False,
+            'input_use_pcl_absolute': False,
+            'input_use_pcl_relative': False,
+            'input_use_pcl_same_winding': False,
+            'input_use_pcl_drawn_control_points': False,
+        },
+        'z_begin': 100,
+        'z_end': 200,
+        'spiral_outward_sense': 'CW',
+    }
+
+    fit_config, scroll, paths, model_z_begin, model_z_end = build_fit_inputs(
+        checkpoint,
+        str(patches_dir),
+        (str(absolute_path), str(relative_path)),
+        110,
+        190,
+        str(tmp_path / 'umbilicus.json'),
+        str(fibers_path),
+    )
+    context = fs.FitContext(fit_config, scroll=scroll, paths=paths)
+
+    assert fit_config['input_disable_patches'] is False
+    assert fit_config['input_use_verified_patches'] is True
+    assert fit_config['input_use_pcl_absolute'] is True
+    assert fit_config['input_use_pcl_relative'] is True
+    assert fit_config['input_use_fibers'] is True
+    assert fit_config['input_use_unverified_patches'] is False
+    assert fit_config['input_use_tracks'] is False
+    assert fit_config['input_use_pcl_same_winding'] is False
+    assert fit_config['input_use_pcl_drawn_control_points'] is False
+
+    assert context.verified_patches_path == str(patches_dir)
+    assert context.fibers_path == str(fibers_path)
+    assert context.pcl_input_specs == [
+        (str(absolute_path), None),
+        (str(relative_path), None),
+    ]
+    assert context.unverified_patches_path is None
+    assert context.tracks_dbm_path is None
+    assert (model_z_begin, model_z_end) == (100, 200)


### PR DESCRIPTION
## Summary

Add a report-only direct absolute-winding check beside the existing periodic patch-satisfaction metrics, and make `find_inconsistent_windings --pcl` honor its explicit diagnostic inputs even when the source checkpoint disabled those inputs during fitting.

This addresses #1621 conservatively: it reports evidence of an integer-winding disagreement without changing loss, satisfaction decisions, or mesh selection.

This covers directly anchored patch cells only. It does **not** add the complementary track check: `get_track_satisfied_counts_in_chunks` still discards `mode_winding_per_track`, so that remaining path needs separate treatment.

## What changes

- compare each directly attached `metadata.winding_is_absolute` annotation with the native self-derived winding target at the same retained quad cell;
- handle both directions of the theta-zero seam using the same reference-step convention as `ThetaCrossingMap`;
- emit `absolute_winding_diagnostic_<suffix>.json` plus one summary log line;
- keep relative/fiber propagation out of this report rather than promoting indirect evidence to an absolute claim;
- honor explicit PCL/fiber arguments in `find_inconsistent_windings` even when a supervision-free checkpoint has those inputs disabled;
- preserve all existing satisfaction, splicing, and optimizer behavior.

## Real before/after validation

On two real PHercParis4 5,000-step checkpoints trained with PCL supervision disabled:

- before: explicit `--pcl` paths were silently filtered; `0 absolute`, `0 direct votes`;
- after: 6 absolute collections loaded and the one in-window direct anchor was compared;
- baseline: annotation-derived 37 versus native 45, difference +8;
- second fit: annotation-derived 37 versus native 43, difference +6.

Both anchor quads and both patches were already native-strict-unsatisfied, so this example validates the real diagnostic path but is not claimed as a previously accepted false negative. With one anchor, it also cannot distinguish a global integer gauge offset from a local switch.

The predeclared follow-up across all six existing checkpoints reproduced a
nonzero direct-cell disagreement every time: baseline `[+8, +7, +7]` and
cap-0.75 `[+6, +6, +5]` for seeds 17/23/101. Every whole-patch strict verdict
was false; the seed-101 cap-0.75 anchor quad was locally strict-true despite a
+5 disagreement. This remains one spatial anchor and is not a prevalence or
treatment-effect claim.

The predeclared dense-anchor follow-up then compared 49/50 in-window anchors
across four distinct patches on a fresh 5,000-step seed-17 fit. The raw
difference mode was +12 windings (46 anchors); after removing it, three anchors
on three patches had residuals -12, +1, and +3. None was native-strict-satisfied
at either its anchor quad or whole patch. This validates multi-anchor coverage
and finds localized candidates, but **does not** demonstrate the strongest case
of a silently accepted whole-winding error. Forty-six comparisons also come
from one collection on one patch, and the singleton second-collection residual
can reflect a collection convention difference.
Exact outputs, hashes, failed attempts, and limitations:
https://gist.github.com/TAUIL-Abd-Elilah/bceb2ae8923aa07d309e81dabe55ec31

Replication protocol and four additional reports:
https://gist.github.com/TAUIL-Abd-Elilah/3c53376761897c67695f75bfa663732e

## Verification

- 50 related tests passed in independent audit, including the actual CUDA path on an RTX 3090;
- whole-winding shifts of +1, +2, and +23 remain native-satisfied in the synthetic control but are separated by the report;
- ordinary 2-voxel radial scatter produces no disagreement;
- both theta-seam directions are covered;
- the loaded Windows native binding is pinned by SHA-256
  `32d9269d...617a327` (this PR does not change native code);
- `git diff --check` passes;
- the clean PR commit has the same tree as the audited and real-run evidence commit.

AI disclosure: Codex assisted with implementation and verification. Every real-data number above comes from retained command output, and the negative/limited findings are stated explicitly.

