### PR TITLE
spiral-fitting: document the default full-scroll fit window and its o…

### DIFF
--- a/spiral-fitting/README.md
+++ b/spiral-fitting/README.md
@@ -4,6 +4,26 @@ Code and helpers to fit a canonical Archimedean spiral to deformed scrolls.
 `spiral_service.py` hosts one persistent interactive fit session over HTTP for
 the VC3D Spiral workspace; `fit_spiral.py` is the underlying fitter.
 
+## A note on the default fit window
+
+If you don't set `z_begin`/`z_end`, `fit_spiral.py` defaults to the entire
+written region of the scroll (`config.py`'s `z_begin = 4000`, `z_end =
+17000` — the range inherited from the PHercParis4 production dataset, not
+something derived from the scroll you're fitting). This is not what the
+tutorial's first-run example uses, and for good reason: under a reduced
+config (patches disabled, `dense_spacing_mode: grad_mag`, zeroed
+shell-loss weights — a tutorial-style setup), a
+full-range PHerc0826 run reached real optimization, accelerated past
+0.9 it/s, and then died silently around 300 iterations with no traceback
+and an ETA that had climbed past 8 hours — not the GPU out-of-memory error
+a "~60 GB, will OOM" figure might lead you to expect (actual GPU memory
+use stayed under 8 GiB of a 32 GiB card throughout). Whatever kills the
+process at this scale is not confirmed (a host-RAM kill during the
+~8.4M-track preparation for the full window is the leading candidate). Set
+`z_begin`/`z_end` to a smaller window (the tutorial's own ~1,000-slice
+recommendation is a reasonable first run) regardless of your GPU's VRAM
+headroom.
+
 ## Sweep runner output
 
 `runners/run_sweep.py` prefixes each active fit's live `PROGRESS` and


### PR DESCRIPTION
**In one sentence:** Records what actually happens if you run `fit_spiral.py` without setting `z_begin`/`z_end`, which is not the failure the tutorial prepares you for.

**One real example:** On PHerc0826, under a reduced config (patches off, `dense_spacing_mode: grad_mag`, shell-loss weights zeroed), we left the z-range at its default and the run reached real optimization, accelerated past 0.9 it/s, and then died around 300 iterations — no traceback, no error, ETA by then over 8 hours. GPU memory never went above 8 GiB of a 32 GiB card.

**Before:** The README says nothing about the default window. The tutorial says to consider a small range because fitting all of Scroll 1 needs "around 60 GB" of GPU memory — which reads as "you're fine if you have enough VRAM." We had enough VRAM, so we ran it, and got a silent death instead of an OOM. A silent death is much harder to diagnose than the error you were told to expect.

**After this PR:** One paragraph noting that `config.py` defaults to `z_begin = 4000`, `z_end = 17000` (the range inherited from the PHercParis4 production dataset, not something derived from the scroll you're fitting), what we saw at that scale, and the honest state of the diagnosis — we don't know what kills the process; a host-RAM kill during the ~8.4M-track preparation is our leading candidate. The advice is to set a smaller window regardless of your card's VRAM.

**Proof:**

Deliberate run with no window override, PHerc0826, this project's reduced config (patches disabled, `dense_spacing_mode: grad_mag`, zeroed shell-loss/dense-spacing weights), real box, captured 2026-08-27 (`logs/d41_default_window_oom.log`):

```
scaled per-step counts by 1.368 for the 13000-slice z-range [4000, 17000) (reference 9500 slices):
  sample_count_tracks_per_step=65684
  ...
PROGRESS Optimizing — 1/30,000 iterations (0.0%) — 0.0 it/s — elapsed 2m 13s — ETA 1106h 48m
PROGRESS Optimizing — 113/30,000 iterations (0.4%) — 0.4 it/s — elapsed 4m 44s — ETA 20h 51m
PROGRESS Optimizing — 233/30,000 iterations (0.8%) — 0.7 it/s — elapsed 5m 15s — ETA 11h 09m
PROGRESS Optimizing — 313/30,000 iterations (1.0%) — 0.9 it/s — elapsed 5m 35s — ETA 8h 49m
/root/.local/share/uv/python/cpython-3.14.0-linux-x86_64-gnu/lib/python3.14/multiprocessing/resource_tracker.py:297: UserWarning: resource_tracker: There appear to be 2 leaked semaphore objects to clean up at shutdown: {'/mp-n4x9qydx', '/mp-0dh30lg4'}
  warnings.warn(
```
(Log ends there — no further output, no Python traceback, process gone.)

No `dmesg`/kernel-log access exists inside a RunPod pod to confirm the exact cause; a host-RAM kill during preparation of 8,384,681 tracks for the full 13,000-slice window is the leading candidate, not confirmed — the resource-tracker warning immediately before the log stops is consistent with an external process kill, not a Python exception.

**Why / where this is useful:** The existing guidance frames the risk as GPU memory, so someone on a big card reasonably skips it. One README paragraph turns a day of "why did my job vanish" into a non-event.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data. (The GPU-memory figure is observed-live from watching nvidia-smi during the run, not from a saved capture — see Limitations.)

## Details

**Method:** villa commit `6847063ffdb4da898ae8d1d494ebf7d71473f509` (2026-08-26 21:25 CEST). RunPod EU-RO-1, RTX PRO 4500 32GB (Blackwell, sm_120). `SCROLL=PHerc0826`, no `Z_BEGIN`/`Z_END` override (villa's own `config.py` default). Command: `fit_spiral.py` with our other config overrides (patches disabled, `dense_spacing_mode: grad_mag`, zeroed shell/spacing weights) but `z_begin`/`z_end` left unset.

**The added paragraph** (in `spiral-fitting/README.md`, placed right after the intro — see Files changed).

**Comparisons:** N/A (documentation-only change).

**Limitations:** The exact cause of the silent death (host-RAM OOM vs. something else) is not confirmed — this PR documents the observed symptom and its real cost (multi-hour ETA, no clean error) honestly as unconfirmed, not as a diagnosed root cause. Only tested against PHerc0826 and this project's specific reduced config; behavior under villa's own full default config (patches enabled, `dense_spacing_mode: phase`, nonzero shell weights) was not tested and may differ. The GPU-memory figure is an observed-live fact, not backed by a saved terminal capture — happy to re-run the deliberate default-window test with memory logging if that would help.

**Disclosure:** We're a two-person team and we worked with an LLM assistant on this, including the diagnosis and the patch. We directed the work, ran everything on real PHerc0826 data, and checked the evidence ourselves before opening this.