### PR TITLE
Normal grids: Avoid sqrt for computing norm squared.

### DIFF
--- a/volume-cartographer/apps/diffusion/support.cpp
+++ b/volume-cartographer/apps/diffusion/support.cpp
@@ -24,7 +24,8 @@ void populate_normal_grid(const SkeletonGraph& g, vc::core::util::GridStore& nor
 
         for (size_t i = 1; i < path.size(); ++i) {
             cv::Point current_point = path[i];
-            double dist_sq = cv::norm(current_point - last_point) * cv::norm(current_point - last_point);
+            auto v = current_point - last_point;
+            double dist_sq = v.ddot(v);
             if (dist_sq >= target_dist_sq) {
                 resampled_path.push_back(current_point);
                 last_point = current_point;
@@ -50,7 +51,8 @@ void populate_normal_grid(const std::vector<std::vector<cv::Point>>& traces, vc:
 
         for (size_t i = 1; i < trace.size(); ++i) {
             cv::Point current_point = trace[i];
-            double dist_sq = cv::norm(current_point - last_point) * cv::norm(current_point - last_point);
+            auto v = current_point - last_point;
+            double dist_sq = v.ddot(v);
             if (dist_sq >= target_dist_sq) {
                 resampled_path.push_back(current_point);
                 last_point = current_point;


### PR DESCRIPTION
Because $|v|^2 = v \cdot v$ , this is equivalent and avoids doing two square roots, which should be faster and more precise. Haven't tried it though, haven't had to generate normal grids yet, I was just skimming the code.