### PR TITLE
vc_sync: ash-* commands — bidirectional SFTP sync via rclone

### DIFF
--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -1092,3 +1092,328 @@ class TestClassifyFibers:
         assert vc_sync.unpublishable_reason({'tags': None})
         assert vc_sync.unpublishable_reason({'tags': 'unreviewed'})
         assert vc_sync.unpublishable_reason([1, 2, 3])
+
+
+# --- SFTP (ash) sync -------------------------------------------------------
+
+import subprocess
+
+
+def completed(returncode=0, stdout='', stderr=''):
+    return subprocess.CompletedProcess(args=[], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def sftp_manager(tmp_path, monkeypatch):
+    """An SftpSyncManager over a temp dir; rclone probing/obscuring stubbed
+    out so construction touches no network and needs no rclone binary."""
+    creds_file = tmp_path / 'creds.json'
+    creds_file.write_text(json.dumps(
+        {'host': 'ash.example.org', 'user': 'user1',
+         'pass': 'secret', 'port': 2022}))
+    os.chmod(creds_file, 0o600)
+    local = tmp_path / 'data'
+    local.mkdir()
+    (local / vc_sync.ASH_CONFIG_NAME).write_text(json.dumps({
+        'remote_path': '/srv/backup',
+        'creds_file': str(creds_file),
+        'last_updated': '2026-01-01T00:00:00',
+    }))
+    monkeypatch.setattr(vc_sync.S3SyncManager, '_detect_rclone',
+                        lambda self: True)
+    monkeypatch.setattr(vc_sync.SftpSyncManager, '_rclone_obscure',
+                        staticmethod(lambda password: 'obscured:' + password))
+    return vc_sync.SftpSyncManager(str(local))
+
+
+class TestSftpCredentials:
+    def write_creds(self, tmp_path, data):
+        path = tmp_path / 'creds.json'
+        path.write_text(json.dumps(data))
+        os.chmod(path, 0o600)
+        return str(path)
+
+    def test_valid_with_default_port(self, tmp_path):
+        path = self.write_creds(tmp_path, {'host': 'h', 'user': 'u', 'pass': 'p'})
+        creds = vc_sync.load_sftp_credentials(path)
+        assert creds == {'host': 'h', 'user': 'u', 'pass': 'p', 'port': 22,
+                         'known_hosts_file': 'none'}
+
+    def test_known_hosts_file_passthrough(self, tmp_path):
+        path = self.write_creds(tmp_path,
+                                {'host': 'h', 'user': 'u', 'pass': 'p',
+                                 'known_hosts_file': '~/.ssh/known_hosts'})
+        creds = vc_sync.load_sftp_credentials(path)
+        assert creds['known_hosts_file'] == '~/.ssh/known_hosts'
+
+    def test_explicit_port(self, tmp_path):
+        path = self.write_creds(tmp_path,
+                                {'host': 'h', 'user': 'u', 'pass': 'p', 'port': 2022})
+        assert vc_sync.load_sftp_credentials(path)['port'] == 2022
+
+    def test_missing_file_exits(self, tmp_path):
+        with pytest.raises(SystemExit):
+            vc_sync.load_sftp_credentials(str(tmp_path / 'nope.json'))
+
+    def test_missing_key_exits(self, tmp_path):
+        path = self.write_creds(tmp_path, {'host': 'h', 'user': 'u'})
+        with pytest.raises(SystemExit):
+            vc_sync.load_sftp_credentials(path)
+
+    def test_non_string_pass_exits(self, tmp_path):
+        path = self.write_creds(tmp_path,
+                                {'host': 'h', 'user': 'u', 'pass': 12345})
+        with pytest.raises(SystemExit):
+            vc_sync.load_sftp_credentials(path)
+
+    def test_non_int_port_exits(self, tmp_path):
+        path = self.write_creds(tmp_path,
+                                {'host': 'h', 'user': 'u', 'pass': 'p', 'port': '22'})
+        with pytest.raises(SystemExit):
+            vc_sync.load_sftp_credentials(path)
+
+
+class TestSftpManagerState:
+    def test_state_files_are_independent_of_s3_sync(self, sftp_manager):
+        assert sftp_manager.config_file.endswith(vc_sync.ASH_CONFIG_NAME)
+        assert sftp_manager.db_file.endswith(vc_sync.ASH_DB_NAME)
+        assert sftp_manager.BASE_DIR == vc_sync.ASH_BASE_DIR_NAME
+        assert sftp_manager.CONFLICT_DIR == vc_sync.ASH_CONFLICT_DIR_NAME
+        assert vc_sync.ASH_BASE_DIR_NAME != vc_sync.BASE_DIR_NAME
+
+    def test_ash_state_files_are_ignored_by_scans(self):
+        # Load-bearing: the ash sync's own state must never be synced,
+        # by either the S3 sync or the ash sync itself
+        for name in (vc_sync.ASH_CONFIG_NAME, vc_sync.ASH_DB_NAME):
+            assert S3SyncManager._is_ignored(name)
+        for dirname in (vc_sync.ASH_BASE_DIR_NAME, vc_sync.ASH_CONFLICT_DIR_NAME):
+            assert S3SyncManager._is_ignored(f'{dirname}/fibers/f1.json')
+
+    def test_rclone_remote_and_env(self, sftp_manager):
+        assert sftp_manager._rclone_remote() == ':sftp:/srv/backup'
+        env = sftp_manager._rclone_env()
+        assert env['RCLONE_SFTP_HOST'] == 'ash.example.org'
+        assert env['RCLONE_SFTP_USER'] == 'user1'
+        assert env['RCLONE_SFTP_PORT'] == '2022'
+        assert env['RCLONE_SFTP_PASS'] == 'obscured:secret'
+        assert env['RCLONE_SFTP_KNOWN_HOSTS_FILE'] == 'none'
+
+    def test_display_url(self, sftp_manager):
+        assert sftp_manager._get_s3_url('a/b.json') == (
+            'sftp://user1@ash.example.org:2022/srv/backup/a/b.json')
+
+    def test_no_versioning_and_no_history_base(self, sftp_manager):
+        assert sftp_manager._bucket_versioning_enabled() is False
+        assert sftp_manager._fetch_base_from_history(
+            'a.json', 'd41d8cd98f00b204e9800998ecf8427e') is None
+
+    def test_aws_cli_calls_are_a_bug(self, sftp_manager):
+        with pytest.raises(RuntimeError):
+            sftp_manager._run_aws_command(['aws', 's3', 'ls'])
+
+    def test_init_writes_config_roundtrip(self, tmp_path, monkeypatch):
+        creds_file = tmp_path / 'creds.json'
+        creds_file.write_text(json.dumps(
+            {'host': 'h', 'user': 'u', 'pass': 'p'}))
+        os.chmod(creds_file, 0o600)
+        monkeypatch.setattr(vc_sync.S3SyncManager, '_detect_rclone',
+                            lambda self: True)
+        monkeypatch.setattr(vc_sync.SftpSyncManager, '_rclone_obscure',
+                            staticmethod(lambda password: 'x'))
+        local = tmp_path / 'newdir'
+        first = vc_sync.SftpSyncManager(str(local), 'backup/scrolls/',
+                                        str(creds_file))
+        assert first.remote_path == 'backup/scrolls'  # trailing slash stripped
+        reloaded = vc_sync.SftpSyncManager(str(local))
+        assert reloaded.remote_path == 'backup/scrolls'
+        assert reloaded.creds_file == str(creds_file)
+
+
+class TestSftpRemoteChanged:
+    MD5_A = 'a' * 32
+    MD5_B = 'b' * 32
+
+    def test_size_change_wins(self, sftp_manager):
+        assert sftp_manager._remote_changed(
+            {'s3_size': 10, 's3_etag': self.MD5_A, 's3_mtime': 0.0},
+            {'s3_size': 11, 's3_etag': self.MD5_A, 's3_mtime': 0.0})
+
+    def test_matching_md5s_beat_mtime_drift(self, sftp_manager):
+        assert not sftp_manager._remote_changed(
+            {'s3_size': 10, 's3_etag': self.MD5_A, 's3_mtime': 0.0},
+            {'s3_size': 10, 's3_etag': self.MD5_A, 's3_mtime': 9999.0})
+
+    def test_differing_md5s_detected_despite_same_mtime(self, sftp_manager):
+        assert sftp_manager._remote_changed(
+            {'s3_size': 10, 's3_etag': self.MD5_A, 's3_mtime': 0.0},
+            {'s3_size': 10, 's3_etag': self.MD5_B, 's3_mtime': 0.0})
+
+    def test_mtime_fallback_without_hashes(self, sftp_manager):
+        tracked = {'s3_size': 10, 's3_etag': None, 's3_mtime': 100.0}
+        assert not sftp_manager._remote_changed(
+            tracked, {'s3_size': 10, 's3_etag': None, 's3_mtime': 101.0})
+        assert sftp_manager._remote_changed(
+            tracked, {'s3_size': 10, 's3_etag': None, 's3_mtime': 105.0})
+
+    def test_one_sided_hash_falls_back_to_mtime(self, sftp_manager):
+        # tracked before server-side hashing was available
+        tracked = {'s3_size': 10, 's3_etag': None, 's3_mtime': 100.0}
+        assert sftp_manager._remote_changed(
+            tracked, {'s3_size': 10, 's3_etag': self.MD5_A, 's3_mtime': 105.0})
+
+    def test_untracked_mtime_is_not_a_change(self, sftp_manager):
+        assert not sftp_manager._remote_changed(
+            {'s3_size': 10}, {'s3_size': 10, 's3_etag': None, 's3_mtime': 5.0})
+
+
+class TestSftpTimeParsing:
+    def test_nanosecond_rfc3339(self, sftp_manager):
+        ts = sftp_manager._parse_rclone_time('2026-08-27T10:00:00.123456789Z')
+        assert abs(ts - 1787824800.123456) < 0.001
+
+    def test_offset_and_no_fraction(self, sftp_manager):
+        assert (sftp_manager._parse_rclone_time('2026-08-27T12:00:00+02:00') ==
+                sftp_manager._parse_rclone_time('2026-08-27T10:00:00Z'))
+
+
+class TestSftpContentMatch:
+    MD5_A = 'a' * 32
+    MD5_B = 'b' * 32
+
+    def test_hash_match_is_proof(self, sftp_manager):
+        assert sftp_manager._content_matches_remote('f.json', self.MD5_A,
+                                                    self.MD5_A)
+
+    def test_hash_mismatch_is_proof_and_seeds_cache(self, sftp_manager):
+        assert not sftp_manager._content_matches_remote('f.json', self.MD5_A,
+                                                        self.MD5_B)
+        # The remote hash is now known without any download
+        assert sftp_manager._remote_md5('f.json') == self.MD5_B
+
+    def test_no_remote_hash_downloads(self, sftp_manager, monkeypatch):
+        monkeypatch.setattr(sftp_manager, '_remote_md5',
+                            lambda path: self.MD5_A)
+        assert sftp_manager._content_matches_remote('f.json', self.MD5_A, None)
+
+
+class TestSftpScanAndHashes:
+    def test_scan_parses_listing_applies_ignores_and_attaches_md5s(
+            self, sftp_manager, monkeypatch):
+        listing = [
+            {'Path': 'fibers/f1.json', 'Size': 100,
+             'ModTime': '2026-08-27T10:00:00.5Z'},
+            {'Path': '.hidden/skipme.json', 'Size': 5,
+             'ModTime': '2026-08-27T10:00:00Z'},
+            {'Path': 'layers_full/x.tif', 'Size': 5,
+             'ModTime': '2026-08-27T10:00:00Z'},
+            {'Path': 'volumes/big.tif', 'Size': 12345,
+             'ModTime': '2026-08-27T10:00:00Z'},
+        ]
+        md5 = 'c' * 32
+        calls = {}
+
+        def fake_capture(args, timeout=None):
+            assert args[0] == 'lsjson'
+            return completed(stdout=json.dumps(listing))
+
+        def fake_md5sums(paths):
+            calls['paths'] = paths
+            return {'fibers/f1.json': md5}
+
+        monkeypatch.setattr(sftp_manager, '_run_rclone_capture', fake_capture)
+        monkeypatch.setattr(sftp_manager, '_remote_md5sums', fake_md5sums)
+
+        files = sftp_manager.scan_s3_files()
+        assert sorted(files) == ['fibers/f1.json', 'volumes/big.tif']
+        assert files['fibers/f1.json']['s3_etag'] == md5
+        assert files['fibers/f1.json']['s3_size'] == 100
+        assert files['volumes/big.tif']['s3_etag'] is None
+        # Only hash-scoped files were sent for hashing
+        assert calls['paths'] == ['fibers/f1.json']
+
+    def test_scan_missing_remote_dir_is_empty(self, sftp_manager, monkeypatch):
+        monkeypatch.setattr(
+            sftp_manager, '_run_rclone_capture',
+            lambda args, timeout=None: completed(
+                returncode=3, stderr='2026/08/27 error: directory not found'))
+        assert sftp_manager.scan_s3_files() == {}
+
+    def test_md5sums_parses_and_skips_unsupported(self, sftp_manager,
+                                                  monkeypatch):
+        stdout = ('d41d8cd98f00b204e9800998ecf8427e  a.json\n'
+                  'UNSUPPORTED  b.json\n'
+                  '                                  c.json\n')
+        monkeypatch.setattr(sftp_manager, '_run_rclone_capture',
+                            lambda args, timeout=None: completed(stdout=stdout))
+        md5s = sftp_manager._remote_md5sums(['a.json', 'b.json', 'c.json'])
+        assert md5s == {'a.json': 'd41d8cd98f00b204e9800998ecf8427e'}
+        assert sftp_manager._remote_hashing_works is True
+
+    def test_md5sums_unsupported_server_disables_hashing(self, sftp_manager,
+                                                         monkeypatch):
+        ran = []
+        monkeypatch.setattr(
+            sftp_manager, '_run_rclone_capture',
+            lambda args, timeout=None: ran.append(args) or completed(stdout=''))
+        assert sftp_manager._remote_md5sums(['a.json']) == {}
+        assert sftp_manager._remote_hashing_works is False
+        # Later calls short-circuit instead of re-probing the server
+        assert sftp_manager._remote_md5sums(['b.json']) == {}
+        assert len(ran) == 1
+
+
+class TestSftpAnalyzeIntegration:
+    """analyze_changes over the SFTP manager: the md5-in-the-etag-slot and
+    mtime-fallback semantics drive the same engine decisions ETags do on S3."""
+
+    def test_remote_content_change_same_size_is_download(self, sftp_manager):
+        path = 'fibers/f1.json'
+        write_local(sftp_manager, path, '{"a": 1}')
+        info = local_info(sftp_manager, path)
+        track_row(sftp_manager, path, info['local_size'], info['local_mtime'],
+                  info['local_size'], 'a' * 32, local_md5=info['local_md5'])
+        remote = {path: {'path': path, 's3_size': info['local_size'],
+                         's3_mtime': 0.0, 's3_etag': 'b' * 32,
+                         'is_backup': False}}
+        actions = sftp_manager.analyze_changes({path: info}, remote)
+        assert actions[path][0] == SyncAction.DOWNLOAD
+
+    def test_unhashed_remote_mtime_change_is_download(self, sftp_manager):
+        path = 'volumes/meta.bin'
+        write_local(sftp_manager, path, 'binary')
+        info = local_info(sftp_manager, path)
+        with sqlite3.connect(sftp_manager.db_file) as conn:
+            conn.execute(
+                'INSERT OR REPLACE INTO files '
+                '(path, local_size, local_mtime, s3_size, s3_mtime, s3_etag) '
+                'VALUES (?, ?, ?, ?, ?, ?)',
+                (path, info['local_size'], info['local_mtime'],
+                 info['local_size'], 100.0, None))
+        remote = {path: {'path': path, 's3_size': info['local_size'],
+                         's3_mtime': 200.0, 's3_etag': None,
+                         'is_backup': False}}
+        actions = sftp_manager.analyze_changes({path: info}, remote)
+        assert actions[path][0] == SyncAction.DOWNLOAD
+
+    def test_both_changed_identical_content_converges(self, sftp_manager):
+        path = 'fibers/f1.json'
+        write_local(sftp_manager, path, '{"a": 2}')
+        info = local_info(sftp_manager, path)
+        track_row(sftp_manager, path, 1, 0.0, 1, 'a' * 32, local_md5='b' * 32)
+        remote = {path: {'path': path, 's3_size': info['local_size'],
+                         's3_mtime': 0.0, 's3_etag': info['local_md5'],
+                         'is_backup': False}}
+        actions = sftp_manager.analyze_changes({path: info}, remote)
+        assert actions[path][0] == SyncAction.SKIP
+
+    def test_both_changed_different_content_is_conflict(self, sftp_manager):
+        path = 'fibers/f1.json'
+        write_local(sftp_manager, path, '{"a": 2}')
+        info = local_info(sftp_manager, path)
+        track_row(sftp_manager, path, 1, 0.0, 1, 'a' * 32, local_md5='b' * 32)
+        remote = {path: {'path': path, 's3_size': info['local_size'],
+                         's3_mtime': 0.0, 's3_etag': 'c' * 32,
+                         'is_backup': False}}
+        actions = sftp_manager.analyze_changes({path: info}, remote)
+        assert actions[path][0] == SyncAction.CONFLICT

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -33,6 +33,39 @@ Usage:
     python s3_sync.py update <directory> [--sync-backups]
     python s3_sync.py reset <directory> [--sync-backups]
     python s3_sync.py hfsync <directory> [--dry-run]
+    python s3_sync.py ash-init <directory> <remote_path> [--creds=<file>]
+    python s3_sync.py ash-status <directory> [--verbose] [--sync-backups]
+    python s3_sync.py ash-sync <directory> [--dry-run] [--sync-backups]
+    python s3_sync.py ash-update <directory> [--sync-backups]
+    python s3_sync.py ash-reset <directory> [--sync-backups]
+
+SFTP sync (the ash-* commands):
+    The same interactive bidirectional sync, but against a folder on an SFTP
+    server, transferred through rclone's sftp backend (rclone is required —
+    there is no aws-CLI fallback). Tracking is fully independent of the S3
+    sync: ash-* commands use .ashsync.json / .ashsync.db / .ashsync-base /
+    .ashsync-conflicts, so one directory can sync to both S3 and the SFTP
+    server. SFTP has no ETags or object versioning, so remote change
+    detection uses one batched server-side `rclone md5sum` for
+    annotation-sized JSON files (mtime+size for everything else), and merge
+    bases come only from the local .ashsync-base shadow copies.
+
+    Credentials live in a JSON file OUTSIDE the sync tree (default
+    ~/.vc_ash_sftp.json, override at ash-init time with --creds). Keep it
+    chmod 600. Format:
+
+        {
+          "host": "ash.example.org",
+          "user": "myuser",
+          "pass": "my-password",
+          "port": 2022
+        }
+
+    "port" is optional (defaults to 22), as is "known_hosts_file" (a path
+    such as "~/.ssh/known_hosts" enables host-key pinning; the default
+    "none" skips validation, matching rclone's sftp default). The password
+    is handed to rclone obscured and via environment variables only — it
+    never appears on a command line.
 
 Hugging Face sync (hfsync):
     Pushes fiber JSONs carrying a given tag to a Hugging Face storage bucket.
@@ -53,6 +86,7 @@ Hugging Face sync (hfsync):
 """
 
 import os
+import re
 import sys
 import json
 import shlex
@@ -94,6 +128,14 @@ HASH_MAX_BYTES = 16 * 1024 * 1024
 # syncing — that exclusion is a load-bearing dependency.
 BASE_DIR_NAME = '.s3sync-base'          # last-synced copies (3-way merge base)
 CONFLICT_DIR_NAME = '.s3sync-conflicts'  # versions preserved before overwrite
+
+# The ash (SFTP) sync keeps fully independent tracking state, all
+# dot-prefixed for the same scan-exclusion reason.
+ASH_CONFIG_NAME = '.ashsync.json'
+ASH_DB_NAME = '.ashsync.db'
+ASH_BASE_DIR_NAME = '.ashsync-base'
+ASH_CONFLICT_DIR_NAME = '.ashsync-conflicts'
+ASH_DEFAULT_CREDS = '~/.vc_ash_sftp.json'
 
 # Tag the merge puts on fibers whose line it could not re-fit; mirrored here
 # so hfsync still recognizes them when fiber_merge is unavailable.
@@ -140,11 +182,19 @@ class S3SyncManager:
     RCLONE_TRANSFERS = 16
     RCLONE_CHECKERS = 32
 
+    # Per-remote identity: the SFTP subclass overrides these so its tracking
+    # state never collides with the S3 sync's in the same directory.
+    REMOTE_NAME = 'S3'
+    CONFIG_NAME = '.s3sync.json'
+    DB_NAME = '.s3sync.db'
+    BASE_DIR = BASE_DIR_NAME
+    CONFLICT_DIR = CONFLICT_DIR_NAME
+
     def __init__(self, local_dir, s3_bucket=None, s3_prefix=None,
                  aws_profile=None):
         self.local_dir = os.path.abspath(local_dir)
-        self.config_file = os.path.join(self.local_dir, '.s3sync.json')
-        self.db_file = os.path.join(self.local_dir, '.s3sync.db')
+        self.config_file = os.path.join(self.local_dir, self.CONFIG_NAME)
+        self.db_file = os.path.join(self.local_dir, self.DB_NAME)
 
         # Load or create config
         if os.path.exists(self.config_file):
@@ -161,6 +211,11 @@ class S3SyncManager:
             self.aws_profile = aws_profile
             self._save_config()
 
+        self._finish_init()
+
+    def _finish_init(self):
+        """Shared tail of construction (subclasses call this after their
+        own config handling)."""
         # Initialize database
         self._init_db()
 
@@ -407,6 +462,13 @@ class S3SyncManager:
             return True
         return self._remote_md5(path) == md5
 
+    def _remote_changed(self, tracked_info, remote_info):
+        """Whether the remote side changed since the tracked baseline.
+        S3: size + ETag (ETags change on every overwrite, so this catches
+        size-preserving edits). Subclasses without ETags override this."""
+        return (tracked_info.get('s3_size') != remote_info['s3_size'] or
+                tracked_info.get('s3_etag') != remote_info['s3_etag'])
+
     def _bucket_versioning_enabled(self):
         """Whether the target bucket keeps object versions (cached)."""
         if self._bucket_versioning is None:
@@ -420,6 +482,12 @@ class S3SyncManager:
                 self._bucket_versioning = False
         return self._bucket_versioning
 
+    def _fetch_remote_file(self, path, dst):
+        """Download one remote file to a local destination path (raises on
+        failure). The single remote-fetch primitive shared by hashing,
+        conflict stashing, and merge-base/remote-JSON fetches."""
+        self._run_aws_command(['aws', 's3', 'cp', self._get_s3_url(path), dst])
+
     def _remote_md5(self, path):
         """Definitive remote content hash: download the object to a temp
         file and hash it. Cached per run; returns None when the fetch
@@ -431,7 +499,7 @@ class S3SyncManager:
         tmp = self._merge_tmp_path(path, '.hashcheck')
         md5 = None
         try:
-            self._run_aws_command(['aws', 's3', 'cp', self._get_s3_url(path), tmp])
+            self._fetch_remote_file(path, tmp)
             md5 = self._file_md5(tmp)
         except Exception:
             md5 = None
@@ -448,7 +516,9 @@ class S3SyncManager:
     # annotation files. Scope matches _should_hash.
 
     def _shadow_path(self, path):
-        return os.path.join(self.local_dir, BASE_DIR_NAME, path)
+        # normpath: sync paths are '/'-keyed, so on Windows the raw join
+        # mixes separators and defeats _remove_shadow's prefix check
+        return os.path.normpath(os.path.join(self.local_dir, self.BASE_DIR, path))
 
     def _update_shadow(self, path):
         """Record the current local file as the last-synced (base) version."""
@@ -474,7 +544,7 @@ class S3SyncManager:
             os.remove(dst)
         except OSError:
             return
-        shadow_root = os.path.join(self.local_dir, BASE_DIR_NAME)
+        shadow_root = os.path.join(self.local_dir, self.BASE_DIR)
         dirpath = os.path.dirname(dst)
         while dirpath != shadow_root and dirpath.startswith(shadow_root + os.sep):
             try:
@@ -494,13 +564,13 @@ class S3SyncManager:
         """
         stamp = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
         stem, ext = os.path.splitext(os.path.basename(path))
-        dst = os.path.join(self.local_dir, CONFLICT_DIR_NAME,
+        dst = os.path.join(self.local_dir, self.CONFLICT_DIR,
                            os.path.dirname(path),
                            f"{stem}.conflict-{stamp}-{side}{ext}")
         try:
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             if source is None and side == 'remote':
-                self._run_aws_command(['aws', 's3', 'cp', self._get_s3_url(path), dst])
+                self._fetch_remote_file(path, dst)
             else:
                 shutil.copy2(source or os.path.join(self.local_dir, path), dst)
         except Exception as e:
@@ -626,7 +696,7 @@ class S3SyncManager:
         — the caller stashes/removes temp_path — or (None, None)."""
         tmp = self._merge_tmp_path(path, '.remote')
         try:
-            self._run_aws_command(['aws', 's3', 'cp', self._get_s3_url(path), tmp])
+            self._fetch_remote_file(path, tmp)
             with open(tmp) as f:
                 return json.load(f), tmp
         except Exception:
@@ -978,8 +1048,8 @@ class S3SyncManager:
             # Keep the real reason ("Both ..." prefix preserved for the
             # prompt's both-modified warning).
             manual_conflicts.append(
-                (path, "Both local and S3 modified since last sync; "
-                       f"auto-merge failed: {reason}"))
+                (path, f"Both local and {self.REMOTE_NAME} modified since "
+                       f"last sync; auto-merge failed: {reason}"))
             manual_paths.add(path)
 
         manual_paths = {p for p, _ in manual_conflicts} | set(delete_local_paths)
@@ -1288,8 +1358,9 @@ class S3SyncManager:
                     else:
                         actions[path] = (SyncAction.SKIP, "Backup file (in sync)")
                 elif s3_info and not local_info:
-                    # Backup exists on S3 but not locally - skip (never download backups)
-                    actions[path] = (SyncAction.SKIP, "Backup file (S3 only, not downloading)")
+                    # Backup exists remotely but not locally - skip (never download backups)
+                    actions[path] = (SyncAction.SKIP,
+                                     f"Backup file ({self.REMOTE_NAME} only, not downloading)")
                 continue
 
             # Regular file logic (non-backup)
@@ -1302,11 +1373,12 @@ class S3SyncManager:
                         # Surface delete-vs-edit explicitly; the perform
                         # phase stashes a conflict copy before deleting.
                         actions[path] = (SyncAction.DELETE_LOCAL,
-                                         "S3 file was deleted; local copy has "
-                                         "unsynced edits (conflict copy will "
-                                         "be saved)")
+                                         f"{self.REMOTE_NAME} file was deleted; "
+                                         "local copy has unsynced edits "
+                                         "(conflict copy will be saved)")
                     else:
-                        actions[path] = (SyncAction.DELETE_LOCAL, "S3 file was deleted")
+                        actions[path] = (SyncAction.DELETE_LOCAL,
+                                         f"{self.REMOTE_NAME} file was deleted")
                 else:
                     actions[path] = (SyncAction.UPLOAD, "New local file")
 
@@ -1315,7 +1387,7 @@ class S3SyncManager:
                 if tracked_info.get('local_size') is not None:
                     actions[path] = (SyncAction.DELETE_REMOTE, "Local file was deleted")
                 else:
-                    actions[path] = (SyncAction.DOWNLOAD, "New S3 file")
+                    actions[path] = (SyncAction.DOWNLOAD, f"New {self.REMOTE_NAME} file")
 
             # File exists in both places
             elif local_info and s3_info:
@@ -1341,8 +1413,7 @@ class S3SyncManager:
                             # current content as the tracked content.
                             md5_backfills.append((current_md5, path))
 
-                    s3_changed = (tracked_info.get('s3_size') != s3_info['s3_size'] or
-                                  tracked_info.get('s3_etag') != s3_info['s3_etag'])
+                    s3_changed = self._remote_changed(tracked_info, s3_info)
 
                     if local_changed and s3_changed:
                         if (current_md5 and
@@ -1355,11 +1426,13 @@ class S3SyncManager:
                             converged.append(path)
                         else:
                             actions[path] = (SyncAction.CONFLICT,
-                                             "Both local and S3 modified since last sync")
+                                             f"Both local and {self.REMOTE_NAME} "
+                                             "modified since last sync")
                     elif local_changed:
                         actions[path] = (SyncAction.UPLOAD, "Local file modified")
                     elif s3_changed:
-                        actions[path] = (SyncAction.DOWNLOAD, "S3 file modified")
+                        actions[path] = (SyncAction.DOWNLOAD,
+                                         f"{self.REMOTE_NAME} file modified")
                     else:
                         actions[path] = (SyncAction.SKIP, "Files are in sync")
                 else:
@@ -1448,7 +1521,7 @@ class S3SyncManager:
         if local_info and s3_info:
             print(f"  Local:  Size={local_info['local_size']:,} bytes, "
                   f"Modified={datetime.fromtimestamp(local_info['local_mtime'])}")
-            print(f"  S3:     Size={s3_info['s3_size']:,} bytes, "
+            print(f"  {self.REMOTE_NAME + ':':<7} Size={s3_info['s3_size']:,} bytes, "
                   f"Modified={datetime.fromtimestamp(s3_info['s3_mtime'])}")
 
             if "both" in reason.lower():
@@ -1476,8 +1549,8 @@ class S3SyncManager:
                     print("  (previous remote version remains available "
                           "through S3 bucket versioning)")
                 else:
-                    print("  ⚠️  Bucket versioning is NOT enabled: the "
-                          "previous remote version will be overwritten "
+                    print("  ⚠️  No remote version history is available: "
+                          "the previous remote version will be overwritten "
                           "without a preserved copy")
 
             return {'l': SyncAction.UPLOAD,
@@ -1882,7 +1955,7 @@ class S3SyncManager:
         if not paths:
             return 0
 
-        print(f"  Deleting {len(paths)} files from S3...")
+        print(f"  Deleting {len(paths)} files from {self.REMOTE_NAME}...")
         ok = self._run_rclone(['delete', self._rclone_remote()], paths)
         if not ok:
             print("  ⚠️  rclone reported errors during deletion; verifying what was deleted")
@@ -1899,7 +1972,8 @@ class S3SyncManager:
         with self._get_db() as conn:
             for path in paths:
                 if path in fresh_s3:
-                    print(f"  ❌ {path} is still present on S3; will retry on next sync")
+                    print(f"  ❌ {path} is still present on {self.REMOTE_NAME}; "
+                          f"will retry on next sync")
                     continue
                 conn.execute('DELETE FROM files WHERE path = ?', (path,))
                 deleted_paths.append(path)
@@ -1908,7 +1982,7 @@ class S3SyncManager:
         for path in deleted_paths:
             self._remove_shadow(path)
 
-        print(f"  ✓ Deleted {success_count}/{len(paths)} files from S3")
+        print(f"  ✓ Deleted {success_count}/{len(paths)} files from {self.REMOTE_NAME}")
         return success_count
 
     def _print_file_preview(self, files, title, max_files=50):
@@ -2004,7 +2078,8 @@ class S3SyncManager:
         self._print_file_preview(uploads, "Files to Upload")
         self._print_file_preview(downloads, "Files to Download")
         self._print_file_preview(deletes_local, "Files to Delete Locally")
-        self._print_file_preview(deletes_remote, "Files to Delete from S3")
+        self._print_file_preview(deletes_remote,
+                                 f"Files to Delete from {self.REMOTE_NAME}")
         self._print_file_preview(conflicts, "Conflicts to Resolve")
 
         # Flag suspect upload candidates (zero-byte files, unparseable JSON)
@@ -2177,9 +2252,9 @@ class S3SyncManager:
 
     def show_status(self, verbose=False, include_backups=False):
         """Show sync status"""
-        print(f"S3 Sync Status")
+        print(f"{self.REMOTE_NAME} Sync Status")
         print(f"Local directory: {self.local_dir}")
-        print(f"S3 location: s3://{self.s3_bucket}/{self.s3_prefix}/")
+        print(f"{self.REMOTE_NAME} location: {self._get_s3_url()}")
 
         if self.aws_profile:
             print(f"AWS Profile: {self.aws_profile}")
@@ -2213,7 +2288,8 @@ class S3SyncManager:
         print(f"\nSummary:")
         print(f"  Files to upload:     {action_counts.get(SyncAction.UPLOAD, 0)}")
         print(f"  Files to download:   {action_counts.get(SyncAction.DOWNLOAD, 0)}")
-        print(f"  Files to delete (S3): {action_counts.get(SyncAction.DELETE_REMOTE, 0)}")
+        print(f"  Files to delete ({self.REMOTE_NAME}): "
+              f"{action_counts.get(SyncAction.DELETE_REMOTE, 0)}")
         print(f"  Files to delete (local): {action_counts.get(SyncAction.DELETE_LOCAL, 0)}")
         print(f"  Conflicts:           {action_counts.get(SyncAction.CONFLICT, 0)}")
         if action_counts.get(SyncAction.CONFLICT) and fiber_merge is not None:
@@ -2237,6 +2313,378 @@ class S3SyncManager:
                     print(f"\n{action.value.replace('_', ' ').title()} ({len(files)} files):")
                     for path, reason in sorted(files):
                         print(f"  {path}: {reason}")
+
+
+def load_sftp_credentials(creds_file):
+    """Load SFTP credentials for the ash sync from a JSON file.
+
+    Required keys: host, user, pass. Optional: port (default 22) and
+    known_hosts_file (path for host-key pinning, e.g. ~/.ssh/known_hosts;
+    default "none" = no host-key validation, matching rclone's sftp
+    default). The file lives outside the sync tree (default
+    ~/.vc_ash_sftp.json) and should be chmod 600; permissive modes only
+    warn so a sync is never blocked on a permissions fix."""
+    path = os.path.expanduser(creds_file)
+    if not os.path.exists(path):
+        print(f"Error: SFTP credentials file not found: {path}")
+        print("Create it with (chmod 600) content like:")
+        print(json.dumps({'host': 'ash.example.org', 'user': 'myuser',
+                          'pass': 'my-password', 'port': 22}, indent=2))
+        sys.exit(1)
+
+    # POSIX only: Windows synthesizes st_mode, so the check would always
+    # fire there despite NTFS ACLs protecting the file
+    if os.name == 'posix':
+        try:
+            mode = os.stat(path).st_mode
+            if mode & 0o077:
+                print(f"⚠️  {path} is readable by other users — "
+                      f"consider: chmod 600 {path}")
+        except OSError:
+            pass
+
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Error: could not read SFTP credentials file {path}: {e}")
+        sys.exit(1)
+
+    missing = [key for key in ('host', 'user', 'pass')
+               if not isinstance(data.get(key), str) or not data.get(key)]
+    if missing:
+        print(f"Error: SFTP credentials file {path} is missing required "
+              f"string field(s): {', '.join(missing)}")
+        sys.exit(1)
+
+    port = data.get('port', 22)
+    if not isinstance(port, int):
+        print(f"Error: 'port' in {path} must be an integer, got {port!r}")
+        sys.exit(1)
+
+    known_hosts = data.get('known_hosts_file', 'none')
+    if not isinstance(known_hosts, str) or not known_hosts:
+        print(f"Error: 'known_hosts_file' in {path} must be a non-empty "
+              f"string (use \"none\" to disable host-key validation)")
+        sys.exit(1)
+
+    return {'host': data['host'], 'user': data['user'],
+            'pass': data['pass'], 'port': port,
+            'known_hosts_file': known_hosts}
+
+
+class SftpSyncManager(S3SyncManager):
+    """The same interactive sync engine against a folder on an SFTP server.
+
+    All remote I/O goes through rclone's sftp backend (rclone is REQUIRED;
+    there is no serial aws-CLI fallback). The tracking DB reuses the s3_*
+    column names for remote metadata, but lives in its own files so it never
+    collides with an S3 sync of the same directory.
+
+    SFTP has no ETags: the s3_etag slot instead carries a real content MD5
+    for hash-scoped (annotation-sized JSON) files, computed server-side in
+    one batched `rclone md5sum` per scan. Where that is unavailable, remote
+    change detection falls back to size + mtime (rclone preserves mtimes
+    over SFTP), and content verification downloads-and-hashes on demand.
+    There is no remote version history, so merge bases come only from the
+    local shadow copies."""
+
+    REMOTE_NAME = 'SFTP'
+    CONFIG_NAME = ASH_CONFIG_NAME
+    DB_NAME = ASH_DB_NAME
+    BASE_DIR = ASH_BASE_DIR_NAME
+    CONFLICT_DIR = ASH_CONFLICT_DIR_NAME
+
+    # SFTP servers commonly cap concurrent sessions (OpenSSH MaxSessions
+    # defaults to 10); stay comfortably below what the S3 path uses.
+    RCLONE_TRANSFERS = 8
+    RCLONE_CHECKERS = 8
+
+    # SFTP mtimes have 1-second granularity; mirror the local scan's
+    # tolerance with a margin for the round-trip through setstat.
+    MTIME_TOLERANCE = 2.0
+
+    def __init__(self, local_dir, remote_path=None, creds_file=None):
+        self.local_dir = os.path.abspath(local_dir)
+        self.config_file = os.path.join(self.local_dir, self.CONFIG_NAME)
+        self.db_file = os.path.join(self.local_dir, self.DB_NAME)
+        self.aws_profile = None  # unused; kept for shared engine paths
+
+        if os.path.exists(self.config_file):
+            self._load_config()
+        else:
+            if not remote_path:
+                raise ValueError("remote_path required for initialization")
+            os.makedirs(self.local_dir, exist_ok=True)
+            self.remote_path = remote_path.rstrip('/')
+            self.creds_file = creds_file or ASH_DEFAULT_CREDS
+            self._save_config()
+
+        self._creds = load_sftp_credentials(self.creds_file)
+
+        self._finish_init()
+
+        if not self.use_rclone:
+            print(f"Error: the SFTP sync requires rclone: "
+                  f"{self.rclone_unavailable_reason}")
+            sys.exit(1)
+
+        self._sftp_pass_obscured = self._rclone_obscure(self._creds['pass'])
+        # One-shot notice when the server can't hash (printed by
+        # _remote_md5sums); None = not probed yet.
+        self._remote_hashing_works = None
+
+    def _load_config(self):
+        with open(self.config_file, 'r') as f:
+            data = json.load(f)
+        self.remote_path = data['remote_path']
+        self.creds_file = data.get('creds_file') or ASH_DEFAULT_CREDS
+
+    def _save_config(self):
+        data = {
+            'local_dir': self.local_dir,
+            'remote_path': self.remote_path,
+            'creds_file': self.creds_file,
+            'last_updated': datetime.now().isoformat()
+        }
+        with open(self.config_file, 'w') as f:
+            json.dump(data, f, indent=2)
+
+    @staticmethod
+    def _rclone_obscure(password):
+        """rclone requires the sftp password in its obscured form; feed the
+        plaintext via stdin so it never appears in a process listing."""
+        try:
+            result = subprocess.run(['rclone', 'obscure', '-'],
+                                    input=password, capture_output=True,
+                                    text=True, timeout=30)
+        except (OSError, subprocess.TimeoutExpired) as e:
+            print(f"Error: 'rclone obscure' failed: {e}")
+            sys.exit(1)
+        if result.returncode != 0 or not result.stdout.strip():
+            print(f"Error: 'rclone obscure' failed: "
+                  f"{(result.stderr or '').strip()}")
+            sys.exit(1)
+        return result.stdout.strip()
+
+    def _run_aws_command(self, cmd):
+        raise RuntimeError(
+            f"BUG: aws CLI call {cmd[:3]}... reached the SFTP sync manager")
+
+    def _get_s3_url(self, relative_path=None):
+        """Display-only remote location (all transfers go through rclone)."""
+        base = (f"sftp://{self._creds['user']}@{self._creds['host']}:"
+                f"{self._creds['port']}/{self.remote_path.lstrip('/')}")
+        if relative_path:
+            return f"{base}/{relative_path}"
+        return f"{base}/"
+
+    def _rclone_remote(self):
+        """On-the-fly sftp remote; connection details travel as RCLONE_SFTP_*
+        env vars (see _rclone_env) so nothing sensitive is on the argv."""
+        return f":sftp:{self.remote_path}"
+
+    def _rclone_env(self):
+        env = os.environ.copy()
+        env['RCLONE_SFTP_HOST'] = self._creds['host']
+        env['RCLONE_SFTP_USER'] = self._creds['user']
+        env['RCLONE_SFTP_PORT'] = str(self._creds['port'])
+        env['RCLONE_SFTP_PASS'] = self._sftp_pass_obscured
+        # "none" (the default) matches rclone's no-validation default but
+        # silences the per-invocation host-key NOTICE; a real path enables
+        # host-key pinning.
+        env['RCLONE_SFTP_KNOWN_HOSTS_FILE'] = os.path.expanduser(
+            self._creds['known_hosts_file'])
+        return env
+
+    def _run_rclone_capture(self, args, timeout=None):
+        """Run one rclone command against the SFTP remote, capturing output.
+        Returns the CompletedProcess (never raises on non-zero exit)."""
+        cmd = ['rclone'] + args
+        extra_flags = os.environ.get('VC_SYNC_RCLONE_FLAGS')
+        if extra_flags:
+            cmd += shlex.split(extra_flags)
+        return subprocess.run(cmd, env=self._rclone_env(),
+                              capture_output=True, text=True, timeout=timeout)
+
+    def _fetch_remote_file(self, path, dst):
+        result = self._run_rclone_capture(
+            ['copyto', f"{self._rclone_remote()}/{path}", dst])
+        if result.returncode != 0:
+            detail_lines = (result.stderr or '').strip().splitlines()
+            detail = detail_lines[-1] if detail_lines else "unknown error"
+            raise RuntimeError(f"rclone copyto failed for {path}: {detail}")
+
+    def _bucket_versioning_enabled(self):
+        return False
+
+    def _fetch_base_from_history(self, path, etag):
+        # No version history on SFTP; merge bases come from shadow copies only
+        return None
+
+    def _content_matches_remote(self, path, md5, etag):
+        """Unlike an S3 ETag, the etag slot here carries a genuine content
+        MD5 whenever the server can hash, so a mismatch IS proof of
+        difference — no need to download and re-hash."""
+        if not md5:
+            return False
+        if etag:
+            # The etag IS the remote content hash: seed the cache so later
+            # _remote_md5 lookups (e.g. the could-not-verify distinction in
+            # analyze_changes) don't re-download the file.
+            self._remote_md5_cache.setdefault(path, etag)
+            return md5 == etag
+        return self._remote_md5(path) == md5
+
+    def _remote_changed(self, tracked_info, remote_info):
+        """Size first; then content MD5s when both sides carry one (they
+        live in the s3_etag slot); mtime as the last resort — an SFTP
+        overwrite that preserves size, mtime, and (where hashed) content is
+        indistinguishable from no change."""
+        if tracked_info.get('s3_size') != remote_info['s3_size']:
+            return True
+        tracked_md5 = tracked_info.get('s3_etag')
+        fresh_md5 = remote_info.get('s3_etag')
+        if tracked_md5 and fresh_md5:
+            return tracked_md5 != fresh_md5
+        tracked_mtime = tracked_info.get('s3_mtime')
+        remote_mtime = remote_info.get('s3_mtime')
+        return bool(tracked_mtime and remote_mtime and
+                    abs(tracked_mtime - remote_mtime) > self.MTIME_TOLERANCE)
+
+    @staticmethod
+    def _parse_rclone_time(timestamp_str):
+        """rclone lsjson ModTime → Unix timestamp. rclone emits RFC 3339
+        with up to nanosecond precision; fromisoformat only takes
+        microseconds, so trim the fraction."""
+        ts = timestamp_str.replace('Z', '+00:00')
+        ts = re.sub(r'\.(\d{6})\d+', r'.\1', ts)
+        return datetime.fromisoformat(ts).timestamp()
+
+    def _remote_md5sums(self, paths):
+        """{path: md5} for the given remote paths via ONE batched
+        `rclone md5sum` run (server-side hashing over a single SSH
+        connection). Returns {} when the server cannot hash — callers then
+        fall back to mtime comparison / on-demand download-and-hash."""
+        if not paths or self._remote_hashing_works is False:
+            return {}
+        with tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False,
+                                         dir=self.local_dir,
+                                         prefix='.ashsync-files-') as f:
+            f.write('\n'.join(paths) + '\n')
+            list_path = f.name
+        try:
+            result = self._run_rclone_capture(
+                ['md5sum', self._rclone_remote(),
+                 '--files-from', list_path,
+                 '--checkers', str(self.RCLONE_CHECKERS)])
+        finally:
+            try:
+                os.unlink(list_path)
+            except OSError:
+                pass
+
+        md5s = {}
+        for line in (result.stdout or '').splitlines():
+            # "<32-hex>  <path>"; unsupported hashes show up as empty or
+            # "UNSUPPORTED" and are simply not adopted
+            hash_part, sep, name = line.partition('  ')
+            if sep and re.fullmatch(r'[0-9a-f]{32}', hash_part):
+                md5s[name] = hash_part
+
+        if not md5s:
+            if self._remote_hashing_works is None:
+                self._remote_hashing_works = False
+                print("  ⚠️  Server-side MD5 hashing unavailable on the SFTP "
+                      "remote; falling back to size+mtime change detection "
+                      "(content is fetched to verify only where needed)")
+            return {}
+        self._remote_hashing_works = True
+        if result.returncode != 0:
+            # Partial output (e.g. one unreadable file) is still usable as
+            # positive evidence; missing entries just stay unhashed.
+            print("  ⚠️  rclone md5sum reported errors; "
+                  f"got hashes for {len(md5s)}/{len(paths)} file(s)")
+        return md5s
+
+    def _attach_remote_md5s(self, files):
+        """Fill the s3_etag slot with real content MD5s for hash-scoped
+        files in a remote listing (in place)."""
+        hash_paths = [path for path, info in files.items()
+                      if self._should_hash(path, info['s3_size'])]
+        for path, md5 in self._remote_md5sums(hash_paths).items():
+            if path in files:
+                files[path]['s3_etag'] = md5
+
+    def scan_s3_files(self, include_backups=False):
+        """Scan the remote SFTP folder (name kept for the shared engine)."""
+        print(f"Scanning SFTP: {self._get_s3_url()}")
+        result = self._run_rclone_capture(
+            ['lsjson', '-R', '--files-only', '--no-mimetype',
+             self._rclone_remote()])
+        if result.returncode != 0:
+            stderr = (result.stderr or '').strip()
+            if 'directory not found' in stderr.lower():
+                print("Remote folder does not exist yet "
+                      "(it will be created by the first upload)")
+                return {}
+            detail = stderr.splitlines()[-1] if stderr else "unknown error"
+            print(f"Error: could not list the SFTP remote: {detail}")
+            sys.exit(1)
+
+        files = {}
+        for entry in json.loads(result.stdout or '[]'):
+            relative_path = entry['Path']
+            if self._is_ignored(relative_path, include_backups):
+                continue
+            files[relative_path] = {
+                'path': relative_path,
+                's3_size': entry['Size'],
+                's3_mtime': self._parse_rclone_time(entry['ModTime']),
+                's3_etag': None,
+                'is_backup': is_backup_file(os.path.basename(relative_path))
+            }
+
+        self._attach_remote_md5s(files)
+
+        print(f"Found {len(files)} remote files")
+        return files
+
+    def _fetch_s3_info(self, paths, include_backups=False):
+        """Fresh remote metadata for post-transfer verification (see the
+        base method for the contract: absent paths are omitted, unverifiable
+        ones stay with unknown size)."""
+        if len(paths) > self.VERIFY_HEAD_MAX:
+            print("  Verifying against a fresh remote listing...")
+            return self.scan_s3_files(include_backups)
+
+        print(f"  Verifying {len(paths)} file(s) against the SFTP remote...")
+        info = {}
+        for path in paths:
+            result = self._run_rclone_capture(
+                ['lsjson', '--stat', '--no-mimetype',
+                 f"{self._rclone_remote()}/{path}"])
+            if result.returncode != 0:
+                stderr = (result.stderr or '').strip()
+                # 3/4 are rclone's directory/file-not-found exit codes
+                if (result.returncode in (3, 4) or
+                        'not found' in stderr.lower()):
+                    continue  # confirmed absent
+                print(f"  ⚠️  Could not verify {path}: {stderr}")
+                info[path] = {'path': path, 's3_size': None, 's3_mtime': None}
+                continue
+            entry = json.loads(result.stdout)
+            info[path] = {
+                'path': path,
+                's3_size': entry['Size'],
+                's3_mtime': self._parse_rclone_time(entry['ModTime']),
+                's3_etag': None,
+            }
+
+        verified = {path: meta for path, meta in info.items()
+                    if meta['s3_size'] is not None}
+        self._attach_remote_md5s(verified)
+        return info
 
 
 HFSYNC_CONFIG_NAME = '.hfsync.json'
@@ -2476,67 +2924,137 @@ def main():
     hfsync_parser.add_argument('--dry-run', action='store_true',
                                help='Show what would be synced without doing it')
 
+    # SFTP (ash) sync commands: same engine, independent tracking state
+    ash_init_parser = subparsers.add_parser(
+        'ash-init', help='Initialize SFTP sync configuration (rclone sftp backend)')
+    ash_init_parser.add_argument('directory', help='Local directory to sync')
+    ash_init_parser.add_argument('remote_path',
+                                 help='Folder on the SFTP server (leading / for '
+                                      'an absolute path, otherwise relative to '
+                                      'the login home)')
+    ash_init_parser.add_argument('--creds', default=None,
+                                 help=f'SFTP credentials JSON file '
+                                      f'(default: {ASH_DEFAULT_CREDS})')
+
+    ash_status_parser = subparsers.add_parser('ash-status', help='Show SFTP sync status')
+    ash_status_parser.add_argument('directory', help='Local directory')
+    ash_status_parser.add_argument('--verbose', '-v', action='store_true',
+                                   help='Show detailed file list')
+    ash_status_parser.add_argument('--sync-backups', action='store_true',
+                                   help='Include backups/ directories in sync')
+
+    ash_sync_parser = subparsers.add_parser(
+        'ash-sync', help='Perform interactive sync with the SFTP remote')
+    ash_sync_parser.add_argument('directory', help='Local directory')
+    ash_sync_parser.add_argument('--dry-run', action='store_true',
+                                 help='Show what would be synced without doing it')
+    ash_sync_parser.add_argument('--sync-backups', action='store_true',
+                                 help='Include backups/ directories in sync')
+    ash_sync_parser.add_argument('--no-auto-merge', action='store_true',
+                                 help='Disable the fiber-aware three-way merge for '
+                                      'conflicting annotation files')
+
+    ash_update_parser = subparsers.add_parser(
+        'ash-update',
+        help='Refresh SFTP sync tracking without hiding pending changes')
+    ash_update_parser.add_argument('directory', help='Local directory')
+    ash_update_parser.add_argument('--sync-backups', action='store_true',
+                                   help='Include backups/ directories in tracking')
+
+    ash_reset_parser = subparsers.add_parser(
+        'ash-reset',
+        help='Reset SFTP sync tracking (marks ALL files as synced, '
+             'discarding pending differences)')
+    ash_reset_parser.add_argument('directory', help='Local directory')
+    ash_reset_parser.add_argument('--sync-backups', action='store_true',
+                                  help='Include backups/ directories in reset')
+
     args = parser.parse_args()
 
     if not args.command:
         parser.print_help()
         sys.exit(1)
 
-    if args.command == 'init':
+    def run_init(manager, sync_cmd):
         # Initialize new sync configuration. No transfers happen here: files
-        # identical on both sides are recorded as in sync, and everything else
-        # (S3-only, local-only, size mismatches) is left for 'sync' to resolve.
-        manager = S3SyncManager(args.directory, args.s3_bucket, args.s3_prefix, args.profile)
+        # identical on both sides are recorded as in sync, and everything
+        # else (remote-only, local-only, size mismatches) is left for the
+        # sync command to resolve.
+        remote = manager.REMOTE_NAME
         print(f"Initialized sync configuration in {args.directory}")
-        print(f"S3 location: s3://{args.s3_bucket}/{args.s3_prefix}/")
+        print(f"{remote} location: {manager._get_s3_url()}")
 
         print("\nScanning initial state...")
         local_files = manager.scan_local_files(include_backups=False)
         s3_files = manager.scan_s3_files(include_backups=False)
 
-        manager._record_untracked_synced(local_files, s3_files)
+        try:
+            manager._record_untracked_synced(local_files, s3_files)
+        finally:
+            # Content verification may fetch remote copies into the run
+            # scratch dir; never leave them in the system tmp dir.
+            manager._cleanup_run_tmp()
 
-        s3_only = sum(1 for path in s3_files if path not in local_files)
+        remote_only = sum(1 for path in s3_files if path not in local_files)
         local_only = sum(1 for path in local_files if path not in s3_files)
-        if s3_only:
-            print(f"{s3_only} file(s) exist only on S3 and can be downloaded with 'sync'")
+        if remote_only:
+            print(f"{remote_only} file(s) exist only on {remote} and can be "
+                  f"downloaded with '{sync_cmd}'")
         if local_only:
-            print(f"{local_only} file(s) exist only locally and can be uploaded with 'sync'")
+            print(f"{local_only} file(s) exist only locally and can be "
+                  f"uploaded with '{sync_cmd}'")
 
         print("\n✓ Initialization complete!")
-        print("Use 'sync' to transfer differences and 'status' to see current sync state")
+        print(f"Use '{sync_cmd}' to transfer differences and "
+              f"'{sync_cmd.replace('sync', 'status')}' to see current sync state")
+
+    if args.command == 'init':
+        run_init(S3SyncManager(args.directory, args.s3_bucket,
+                               args.s3_prefix, args.profile), 'sync')
+
+    elif args.command == 'ash-init':
+        run_init(SftpSyncManager(args.directory, args.remote_path,
+                                 args.creds), 'ash-sync')
 
     elif args.command == 'hfsync':
         # Independent of the S3 sync configuration; gated only on .hfsync.json
         hf_sync(args.directory, args.dry_run)
 
     else:
+        # The ash-* commands are the same engine over the SFTP manager,
+        # with its own configuration/tracking files
+        is_ash = args.command.startswith('ash-')
+        command = args.command[len('ash-'):] if is_ash else args.command
+        manager_cls = SftpSyncManager if is_ash else S3SyncManager
+
         # Check for existing configuration
-        config_file = os.path.join(args.directory, '.s3sync.json')
+        config_file = os.path.join(args.directory, manager_cls.CONFIG_NAME)
 
         if not os.path.exists(config_file):
+            init_cmd = 'ash-init' if is_ash else 'init'
             print(f"Error: No sync configuration found in {args.directory}")
-            print("Run 'init' command first to set up sync configuration")
+            print(f"Run '{init_cmd}' command first to set up sync configuration")
             sys.exit(1)
 
-        manager = S3SyncManager(args.directory)
+        manager = manager_cls(args.directory)
 
         try:
-            if args.command == 'status':
+            if command == 'status':
                 manager.show_status(args.verbose, args.sync_backups)
 
-            elif args.command == 'sync':
+            elif command == 'sync':
                 manager.sync(args.dry_run, args.sync_backups,
                              auto_merge=not args.no_auto_merge)
 
-            elif args.command == 'update':
+            elif command == 'update':
                 manager.refresh_tracking(args.sync_backups)
 
-            elif args.command == 'reset':
+            elif command == 'reset':
                 print("Resetting sync tracking...")
                 print("This will mark ALL current files as synced, discarding any pending differences.")
-                print("Files that currently differ between local and S3 will also lose their "
-                      "merge base until the next successful sync.")
+                print(f"Files that currently differ between local and "
+                      f"{manager.REMOTE_NAME} will also lose their "
+                      f"merge base until the next successful sync.")
                 if not args.sync_backups:
                     print("Note: Excluding backups/ directories (use --sync-backups to include them)")
 


### PR DESCRIPTION
## What

Adds an SFTP counterpart to the S3 sync in `volume-cartographer/scripts/vc_sync.py`: new `ash-init` / `ash-sync` / `ash-status` / `ash-update` / `ash-reset` commands run the **same interactive bidirectional engine** (tracking DB, conflict detection + interactive resolution, fiber-aware three-way merge, conflict-copy stashing) against a folder on an SFTP server, with all remote I/O through rclone's sftp backend (rclone required; no aws-CLI fallback).

## Design

- **Independent state per remote**: the ash sync uses `.ashsync.json` / `.ashsync.db` / `.ashsync-base` / `.ashsync-conflicts`, all dot-prefixed (scan-excluded), so one directory can sync to both S3 and the SFTP server without the two ever touching each other's tracking.
- **Credentials outside the sync tree** in `~/.vc_ash_sftp.json` (`host`/`user`/`pass`, optional `port`, optional `known_hosts_file` for host-key pinning; overridable at `ash-init` with `--creds`). The password is obscured via `rclone obscure -` on stdin and reaches rclone only as `RCLONE_SFTP_*` environment variables — never on a command line. Same env-var mechanism the script already used for `RCLONE_S3_REGION`.
- **Change detection without ETags**: for hash-scoped (annotation-sized JSON) files, the tracked etag slot carries a genuine content MD5 computed by one batched server-side `rclone md5sum` per scan — so a remote edit that preserves size *and* mtime is still caught, and convergence/verification semantics match S3. Servers that can't hash degrade to size+mtime (2s tolerance) with on-demand download-and-hash.
- **No remote version history**: merge bases come from the local shadow copies only (`_fetch_base_from_history` returns None).
- **Base-class changes are hooks only**: `_fetch_remote_file`, `_remote_changed`, per-remote state-file name class attrs, and `REMOTE_NAME` in user-facing strings. S3 behavior is unchanged (for the S3 manager every parameterized string renders exactly as before).
- Two portability fixes for Windows annotator machines ride along: the creds-permissions warning is POSIX-only (Windows synthesizes `st_mode`), and shadow paths are normalized so `_remove_shadow`'s prefix check works with backslash paths.

## How to run

```
python3 vc_sync.py ash-init <dir> <remote_folder> [--creds FILE]
python3 vc_sync.py ash-status <dir> [--verbose]
python3 vc_sync.py ash-sync <dir> [--dry-run] [--sync-backups] [--no-auto-merge]
```

Credentials file format is documented in the module docstring.

## Verification

- `pytest volume-cartographer/scripts/tests/` — 183 passed (33 new: creds parsing, `_remote_changed` semantics, rclone time/listing/md5sum parsing, `analyze_changes` integration over the SFTP manager).
- End-to-end smoke test against a local `rclone serve sftp`: init, upload/download both ways, in-sync status, remote content-change detection via MD5 (same size), interactive conflict (local wins; remote copy stashed in `.ashsync-conflicts`), local-deletion → verified remote deletion.
- Verified against rclone v1.75: `lsjson --stat`, `md5sum --files-from`, `obscure -`, and `RCLONE_SFTP_*` env resolution for on-the-fly `:sftp:` remotes.

## Risks / limitations

- Remote empty directories left behind by remote deletions aren't pruned (S3 has no directories, so the engine never needed this).
- First scan of a large tree runs one server-side `md5sum` per remote JSON over a single SSH connection — noticeable once, cheap after.
- The `rclone serve sftp` test fixture caches hashes by size+mtime, so one adversarial case (spoofed same-size-same-mtime edit) can't be demonstrated against it — covered by unit test instead; real OpenSSH servers hash the actual bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)