### PR TITLE
vc_sync ash: leave RCLONE_SFTP_KNOWN_HOSTS_FILE unset by default

### DIFF
--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -1197,7 +1197,15 @@ class TestSftpManagerState:
         assert env['RCLONE_SFTP_USER'] == 'user1'
         assert env['RCLONE_SFTP_PORT'] == '2022'
         assert env['RCLONE_SFTP_PASS'] == 'obscured:secret'
-        assert env['RCLONE_SFTP_KNOWN_HOSTS_FILE'] == 'none'
+        # The "none" default must leave the variable UNSET: older rclone
+        # treats any value as a literal path and fails to open "none"
+        assert 'RCLONE_SFTP_KNOWN_HOSTS_FILE' not in env
+
+    def test_known_hosts_path_reaches_rclone_env(self, sftp_manager):
+        sftp_manager._creds['known_hosts_file'] = '~/.ssh/known_hosts'
+        env = sftp_manager._rclone_env()
+        assert env['RCLONE_SFTP_KNOWN_HOSTS_FILE'] == os.path.expanduser(
+            '~/.ssh/known_hosts')
 
     def test_display_url(self, sftp_manager):
         assert sftp_manager._get_s3_url('a/b.json') == (

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -2490,11 +2490,14 @@ class SftpSyncManager(S3SyncManager):
         env['RCLONE_SFTP_USER'] = self._creds['user']
         env['RCLONE_SFTP_PORT'] = str(self._creds['port'])
         env['RCLONE_SFTP_PASS'] = self._sftp_pass_obscured
-        # "none" (the default) matches rclone's no-validation default but
-        # silences the per-invocation host-key NOTICE; a real path enables
-        # host-key pinning.
-        env['RCLONE_SFTP_KNOWN_HOSTS_FILE'] = os.path.expanduser(
-            self._creds['known_hosts_file'])
+        # Only set when a real path is configured (host-key pinning).
+        # The "none" default must leave the variable UNSET: older rclone
+        # treats any value as a literal path and fails to open "none";
+        # unset simply means rclone's own default of no validation (newer
+        # rclone then prints a one-line NOTICE per invocation — harmless).
+        known_hosts = self._creds['known_hosts_file']
+        if known_hosts.lower() != 'none':
+            env['RCLONE_SFTP_KNOWN_HOSTS_FILE'] = os.path.expanduser(known_hosts)
         return env
 
     def _run_rclone_capture(self, args, timeout=None):


### PR DESCRIPTION
Follow-up to #1636, which merged before this fix landed on its branch.

Passing the `"none"` sentinel through `RCLONE_SFTP_KNOWN_HOSTS_FILE` breaks on rclone versions that treat `known_hosts_file` strictly as a path — the first real deployment hit:

```
Failed to create file system for ":sftp:0139_fibers": couldn't parse known_hosts_file: open none: no such file or directory
```

Unset means rclone's own no-validation default on every version, so the variable is now only set when the credentials file configures a real path for host-key pinning. Newer rclone prints a one-line host-key NOTICE per invocation in the default case — harmless.

Verification: full scripts suite passes (184, including a new test that the default leaves the variable unset and a real path reaches the rclone environment expanded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)