### PR TITLE
Make lasagna work with the mps torch backend, falling back to single precision.

### DIFF
--- a/lasagna/approval_inpaint.py
+++ b/lasagna/approval_inpaint.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Iterable
 
 import numpy as np
+from dtypes import numpy_float_hi
 import tifffile
 
 
@@ -167,7 +168,7 @@ def nearest_valid_index(xyz: np.ndarray, valid: np.ndarray, seed: tuple[float, f
 		raise ValueError(f"xyz must have shape (H, W, 3), got {xyz.shape}")
 	if valid.shape != xyz.shape[:2]:
 		raise ValueError(f"valid shape mismatch: {valid.shape} vs {xyz.shape[:2]}")
-	seed_np = np.asarray(seed, dtype=np.floathi)
+	seed_np = np.asarray(seed, dtype=numpy_float_hi)
 	if seed_np.shape != (3,) or not np.isfinite(seed_np).all():
 		raise ValueError(f"approval inpaint seed must contain three finite values, got {seed}")
 
@@ -181,7 +182,7 @@ def nearest_valid_index(xyz: np.ndarray, valid: np.ndarray, seed: tuple[float, f
 		mask = flat_valid[start:end]
 		if not bool(mask.any()):
 			continue
-		coords = flat_xyz[start:end][mask].astype(np.floathi, copy=False)
+		coords = flat_xyz[start:end][mask].astype(numpy_float_hi, copy=False)
 		d2 = np.sum((coords - seed_np.reshape(1, 3)) ** 2, axis=1)
 		local = int(np.argmin(d2))
 		if float(d2[local]) < best_d2:
@@ -431,10 +432,10 @@ def _sample_xyz_at_index_center(
 	fc = max(0.0, min(float(col) - c0, 1.0))
 	corners = [(r0, c0), (r1, c0), (r0, c1), (r1, c1)]
 	if all(bool(valid[r, c]) for r, c in corners):
-		p00 = xyz[r0, c0].astype(np.floathi)
-		p10 = xyz[r1, c0].astype(np.floathi)
-		p01 = xyz[r0, c1].astype(np.floathi)
-		p11 = xyz[r1, c1].astype(np.floathi)
+		p00 = xyz[r0, c0].astype(numpy_float_hi)
+		p10 = xyz[r1, c0].astype(numpy_float_hi)
+		p01 = xyz[r0, c1].astype(numpy_float_hi)
+		p11 = xyz[r1, c1].astype(numpy_float_hi)
 		p = (
 			(1.0 - fr) * (1.0 - fc) * p00
 			+ fr * (1.0 - fc) * p10
@@ -446,8 +447,8 @@ def _sample_xyz_at_index_center(
 	valid_rc = np.argwhere(valid)
 	if valid_rc.size == 0:
 		raise ValueError("approval inpaint source tifxyz contains no valid vertices")
-	d2 = (valid_rc[:, 0].astype(np.floathi) - float(row)) ** 2 + (
-		valid_rc[:, 1].astype(np.floathi) - float(col)
+	d2 = (valid_rc[:, 0].astype(numpy_float_hi) - float(row)) ** 2 + (
+		valid_rc[:, 1].astype(numpy_float_hi) - float(col)
 	) ** 2
 	rr, cc = (int(v) for v in valid_rc[int(np.argmin(d2))])
 	return float(xyz[rr, cc, 0]), float(xyz[rr, cc, 1]), float(xyz[rr, cc, 2])
@@ -577,8 +578,8 @@ def build_approval_inpaint(
 	if not coords:
 		raise ValueError("approval inpaint generated no valid skeleton correction points")
 
-	rows = np.asarray([p[0] for p in coords], dtype=np.floathi)
-	cols = np.asarray([p[1] for p in coords], dtype=np.floathi)
+	rows = np.asarray([p[0] for p in coords], dtype=numpy_float_hi)
+	cols = np.asarray([p[1] for p in coords], dtype=numpy_float_hi)
 	rmin = int(rows.min())
 	rmax = int(rows.max())
 	cmin = int(cols.min())
@@ -587,8 +588,8 @@ def build_approval_inpaint(
 	center_c = 0.5 * (float(cmin) + float(cmax))
 	new_seed = _sample_xyz_at_index_center(xyz, valid, center_r, center_c)
 
-	corr_xyz = np.asarray([xyz[r, c] for r, c in coords], dtype=np.floathi)
-	seed_xyz = np.asarray(new_seed, dtype=np.floathi)
+	corr_xyz = np.asarray([xyz[r, c] for r, c in coords], dtype=numpy_float_hi)
+	seed_xyz = np.asarray(new_seed, dtype=numpy_float_hi)
 	offsets = corr_xyz - seed_xyz.reshape(1, 3)
 	raw_w = 2.0 * float(np.max(np.abs(offsets[:, 0])))
 	raw_h = 2.0 * float(np.max(np.abs(offsets[:, 1])))

--- a/lasagna/approval_inpaint.py
+++ b/lasagna/approval_inpaint.py
@@ -167,7 +167,7 @@ def nearest_valid_index(xyz: np.ndarray, valid: np.ndarray, seed: tuple[float, f
 		raise ValueError(f"xyz must have shape (H, W, 3), got {xyz.shape}")
 	if valid.shape != xyz.shape[:2]:
 		raise ValueError(f"valid shape mismatch: {valid.shape} vs {xyz.shape[:2]}")
-	seed_np = np.asarray(seed, dtype=np.float64)
+	seed_np = np.asarray(seed, dtype=np.floathi)
 	if seed_np.shape != (3,) or not np.isfinite(seed_np).all():
 		raise ValueError(f"approval inpaint seed must contain three finite values, got {seed}")
 
@@ -181,7 +181,7 @@ def nearest_valid_index(xyz: np.ndarray, valid: np.ndarray, seed: tuple[float, f
 		mask = flat_valid[start:end]
 		if not bool(mask.any()):
 			continue
-		coords = flat_xyz[start:end][mask].astype(np.float64, copy=False)
+		coords = flat_xyz[start:end][mask].astype(np.floathi, copy=False)
 		d2 = np.sum((coords - seed_np.reshape(1, 3)) ** 2, axis=1)
 		local = int(np.argmin(d2))
 		if float(d2[local]) < best_d2:
@@ -431,10 +431,10 @@ def _sample_xyz_at_index_center(
 	fc = max(0.0, min(float(col) - c0, 1.0))
 	corners = [(r0, c0), (r1, c0), (r0, c1), (r1, c1)]
 	if all(bool(valid[r, c]) for r, c in corners):
-		p00 = xyz[r0, c0].astype(np.float64)
-		p10 = xyz[r1, c0].astype(np.float64)
-		p01 = xyz[r0, c1].astype(np.float64)
-		p11 = xyz[r1, c1].astype(np.float64)
+		p00 = xyz[r0, c0].astype(np.floathi)
+		p10 = xyz[r1, c0].astype(np.floathi)
+		p01 = xyz[r0, c1].astype(np.floathi)
+		p11 = xyz[r1, c1].astype(np.floathi)
 		p = (
 			(1.0 - fr) * (1.0 - fc) * p00
 			+ fr * (1.0 - fc) * p10
@@ -446,8 +446,8 @@ def _sample_xyz_at_index_center(
 	valid_rc = np.argwhere(valid)
 	if valid_rc.size == 0:
 		raise ValueError("approval inpaint source tifxyz contains no valid vertices")
-	d2 = (valid_rc[:, 0].astype(np.float64) - float(row)) ** 2 + (
-		valid_rc[:, 1].astype(np.float64) - float(col)
+	d2 = (valid_rc[:, 0].astype(np.floathi) - float(row)) ** 2 + (
+		valid_rc[:, 1].astype(np.floathi) - float(col)
 	) ** 2
 	rr, cc = (int(v) for v in valid_rc[int(np.argmin(d2))])
 	return float(xyz[rr, cc, 0]), float(xyz[rr, cc, 1]), float(xyz[rr, cc, 2])
@@ -577,8 +577,8 @@ def build_approval_inpaint(
 	if not coords:
 		raise ValueError("approval inpaint generated no valid skeleton correction points")
 
-	rows = np.asarray([p[0] for p in coords], dtype=np.float64)
-	cols = np.asarray([p[1] for p in coords], dtype=np.float64)
+	rows = np.asarray([p[0] for p in coords], dtype=np.floathi)
+	cols = np.asarray([p[1] for p in coords], dtype=np.floathi)
 	rmin = int(rows.min())
 	rmax = int(rows.max())
 	cmin = int(cols.min())
@@ -587,8 +587,8 @@ def build_approval_inpaint(
 	center_c = 0.5 * (float(cmin) + float(cmax))
 	new_seed = _sample_xyz_at_index_center(xyz, valid, center_r, center_c)
 
-	corr_xyz = np.asarray([xyz[r, c] for r, c in coords], dtype=np.float64)
-	seed_xyz = np.asarray(new_seed, dtype=np.float64)
+	corr_xyz = np.asarray([xyz[r, c] for r, c in coords], dtype=np.floathi)
+	seed_xyz = np.asarray(new_seed, dtype=np.floathi)
 	offsets = corr_xyz - seed_xyz.reshape(1, 3)
 	raw_w = 2.0 * float(np.max(np.abs(offsets[:, 0])))
 	raw_h = 2.0 * float(np.max(np.abs(offsets[:, 1])))

--- a/lasagna/cyl_sdf_volume.py
+++ b/lasagna/cyl_sdf_volume.py
@@ -115,9 +115,9 @@ def capped_shell_mesh(shell_xyz: torch.Tensor) -> tuple[torch.Tensor, torch.Tens
 	W = int(shell_xyz.shape[1])
 	if H < 2 or W < 3:
 		raise ValueError(f"capped shell mesh requires H>=2 and W>=3, got H={H} W={W}")
-	verts = shell_xyz.detach().to(device="cpu", dtype=torch.float64).contiguous().reshape(H * W, 3)
-	bottom_center = shell_xyz[0].detach().to(device="cpu", dtype=torch.float64).mean(dim=0, keepdim=True)
-	top_center = shell_xyz[-1].detach().to(device="cpu", dtype=torch.float64).mean(dim=0, keepdim=True)
+	verts = shell_xyz.detach().to(device="cpu", dtype=torch.floathi).contiguous().reshape(H * W, 3)
+	bottom_center = shell_xyz[0].detach().to(device="cpu", dtype=torch.floathi).mean(dim=0, keepdim=True)
+	top_center = shell_xyz[-1].detach().to(device="cpu", dtype=torch.floathi).mean(dim=0, keepdim=True)
 	verts = torch.cat([verts, bottom_center, top_center], dim=0)
 	bottom_i = H * W
 	top_i = H * W + 1
@@ -145,7 +145,7 @@ def default_shell_bbox(
 ) -> tuple[float, float, float, float, float, float]:
 	_ = max(1.0e-6, float(grid_step))
 	pad = CYL_OUTSIDE_BARRIER_DEPTH_MAX if padding is None else max(0.0, float(padding))
-	shell_cpu = shell_xyz.detach().to(device="cpu", dtype=torch.float64)
+	shell_cpu = shell_xyz.detach().to(device="cpu", dtype=torch.floathi)
 	lo = shell_cpu.reshape(-1, 3).amin(dim=0) - pad
 	hi = shell_cpu.reshape(-1, 3).amax(dim=0) + pad
 	return (
@@ -234,8 +234,8 @@ def build_previous_shell_violation_depth_volume(
 	volume_cpu, depth_max = ext.build_violation_depth_volume(
 		verts.contiguous(),
 		faces.contiguous(),
-		torch.tensor(origin, dtype=torch.float64),
-		torch.tensor((step, step, step), dtype=torch.float64),
+		torch.tensor(origin, dtype=torch.floathi),
+		torch.tensor((step, step, step), dtype=torch.floathi),
 		torch.tensor(shape, dtype=torch.int64),
 		float(depth_max),
 		mode,

--- a/lasagna/cyl_sdf_volume.py
+++ b/lasagna/cyl_sdf_volume.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import torch
+from dtypes import torch_float_hi
 
 
 DEFAULT_CYL_OUTSIDE_GRID_STEP = 64.0
@@ -115,9 +116,9 @@ def capped_shell_mesh(shell_xyz: torch.Tensor) -> tuple[torch.Tensor, torch.Tens
 	W = int(shell_xyz.shape[1])
 	if H < 2 or W < 3:
 		raise ValueError(f"capped shell mesh requires H>=2 and W>=3, got H={H} W={W}")
-	verts = shell_xyz.detach().to(device="cpu", dtype=torch.floathi).contiguous().reshape(H * W, 3)
-	bottom_center = shell_xyz[0].detach().to(device="cpu", dtype=torch.floathi).mean(dim=0, keepdim=True)
-	top_center = shell_xyz[-1].detach().to(device="cpu", dtype=torch.floathi).mean(dim=0, keepdim=True)
+	verts = shell_xyz.detach().to(device="cpu", dtype=torch_float_hi).contiguous().reshape(H * W, 3)
+	bottom_center = shell_xyz[0].detach().to(device="cpu", dtype=torch_float_hi).mean(dim=0, keepdim=True)
+	top_center = shell_xyz[-1].detach().to(device="cpu", dtype=torch_float_hi).mean(dim=0, keepdim=True)
 	verts = torch.cat([verts, bottom_center, top_center], dim=0)
 	bottom_i = H * W
 	top_i = H * W + 1
@@ -145,7 +146,7 @@ def default_shell_bbox(
 ) -> tuple[float, float, float, float, float, float]:
 	_ = max(1.0e-6, float(grid_step))
 	pad = CYL_OUTSIDE_BARRIER_DEPTH_MAX if padding is None else max(0.0, float(padding))
-	shell_cpu = shell_xyz.detach().to(device="cpu", dtype=torch.floathi)
+	shell_cpu = shell_xyz.detach().to(device="cpu", dtype=torch_float_hi)
 	lo = shell_cpu.reshape(-1, 3).amin(dim=0) - pad
 	hi = shell_cpu.reshape(-1, 3).amax(dim=0) + pad
 	return (
@@ -234,8 +235,8 @@ def build_previous_shell_violation_depth_volume(
 	volume_cpu, depth_max = ext.build_violation_depth_volume(
 		verts.contiguous(),
 		faces.contiguous(),
-		torch.tensor(origin, dtype=torch.floathi),
-		torch.tensor((step, step, step), dtype=torch.floathi),
+		torch.tensor(origin, dtype=torch_float_hi),
+		torch.tensor((step, step, step), dtype=torch_float_hi),
 		torch.tensor(shape, dtype=torch.int64),
 		float(depth_max),
 		mode,

--- a/lasagna/dtypes.py
+++ b/lasagna/dtypes.py
@@ -1,0 +1,13 @@
+# Set LASAGNA_MAX_PRECISION_FLOAT=64 to make lasagna use 64 bit precision where it did before.
+#
+# TODO: If float32 works well, replace float_hi with float32 and remove float_hi.
+# see: https://github.com/ScrollPrize/villa/pull/1639
+
+import os
+import torch
+import numpy as np
+
+
+_float_bits = os.environ.get("LASAGNA_MAX_PRECISION_FLOAT", "32")
+torch_float_hi = getattr(torch, "float" + _float_bits)
+numpy_float_hi = getattr(np, "float" + _float_bits)

--- a/lasagna/fit.py
+++ b/lasagna/fit.py
@@ -360,6 +360,16 @@ def _require_torch_device_available(device: torch.device) -> None:
 			f"{count} visible CUDA device(s)."
 		)
 
+def _set_device_floathi(device: torch.device):
+	import numpy as np
+	torch.floathi = torch.float64
+	np.floathi = np.float64
+	try:
+		torch.zeros(1, dtype=torch.float64, device=device)
+	except (RuntimeError, TypeError):
+		torch.floathi = torch.float32
+		np.floathi = np.float32
+
 
 def _grid_center(mdl: "model.Model3D") -> torch.Tensor:
 	"""Bilinear center of the model grid — matches (Hm-1)/2, (Wm-1)/2 in station loss."""
@@ -1304,6 +1314,7 @@ def _run_flatten_mode(
 		raise ValueError("model-init=flatten must not set --model-input")
 
 	device = torch.device(str(getattr(args, "device", "cuda")))
+	_set_device_floathi(device)
 	from tifxyz_io import load_tifxyz
 	xyz, valid, meta = load_tifxyz(str(ext0["path"]), device=device)
 	source_step = _flatten_source_step_from_tifxyz_meta(meta, model_cfg.mesh_step)
@@ -1521,6 +1532,7 @@ def main(argv: list[str] | None = None, *, lifecycle_fn=None) -> int:
 
 	device = torch.device(data_cfg.device)
 	_require_torch_device_available(device)
+	_set_device_floathi(device)
 	init_mode = str(model_cfg.init_mode).strip().lower()
 	self_map_init = _validate_self_map_init_args(
 		self_map_init=self_map_init,

--- a/lasagna/fit.py
+++ b/lasagna/fit.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import torch
 import torch.nn.functional as F
+from dtypes import torch_float_hi
 
 import cli_data
 import cli_json
@@ -359,16 +360,6 @@ def _require_torch_device_available(device: torch.device) -> None:
 			f"CUDA device {device} was requested, but PyTorch reports only "
 			f"{count} visible CUDA device(s)."
 		)
-
-def _set_device_floathi(device: torch.device):
-	import numpy as np
-	torch.floathi = torch.float64
-	np.floathi = np.float64
-	try:
-		torch.zeros(1, dtype=torch.float64, device=device)
-	except (RuntimeError, TypeError):
-		torch.floathi = torch.float32
-		np.floathi = np.float32
 
 
 def _grid_center(mdl: "model.Model3D") -> torch.Tensor:
@@ -1314,7 +1305,6 @@ def _run_flatten_mode(
 		raise ValueError("model-init=flatten must not set --model-input")
 
 	device = torch.device(str(getattr(args, "device", "cuda")))
-	_set_device_floathi(device)
 	from tifxyz_io import load_tifxyz
 	xyz, valid, meta = load_tifxyz(str(ext0["path"]), device=device)
 	source_step = _flatten_source_step_from_tifxyz_meta(meta, model_cfg.mesh_step)
@@ -1532,7 +1522,6 @@ def main(argv: list[str] | None = None, *, lifecycle_fn=None) -> int:
 
 	device = torch.device(data_cfg.device)
 	_require_torch_device_available(device)
-	_set_device_floathi(device)
 	init_mode = str(model_cfg.init_mode).strip().lower()
 	self_map_init = _validate_self_map_init_args(
 		self_map_init=self_map_init,

--- a/lasagna/fit2tifxyz.py
+++ b/lasagna/fit2tifxyz.py
@@ -300,11 +300,11 @@ def _mark_segment_vertices(
 	rmax = min(mask.shape[0] - 1, int(math.ceil(max(r0, r1) + eps)))
 	cmin = max(0, int(math.floor(min(c0, c1) - eps)))
 	cmax = min(mask.shape[1] - 1, int(math.ceil(max(c0, c1) + eps)))
-	seg = np.asarray([r1 - r0, c1 - c0], dtype=np.float64)
+	seg = np.asarray([r1 - r0, c1 - c0], dtype=np.floathi)
 	seg_len2 = float(np.dot(seg, seg))
 	for r in range(rmin, rmax + 1):
 		for c in range(cmin, cmax + 1):
-			v = np.asarray([float(r) - r0, float(c) - c0], dtype=np.float64)
+			v = np.asarray([float(r) - r0, float(c) - c0], dtype=np.floathi)
 			if seg_len2 <= eps:
 				dist2 = float(np.dot(v, v))
 			else:
@@ -384,7 +384,7 @@ def _mask_bbox(mask: np.ndarray) -> list[int] | None:
 def _points_bbox(points: list[tuple[float, float]]) -> list[float] | None:
 	if not points:
 		return None
-	arr = np.asarray(points, dtype=np.float64)
+	arr = np.asarray(points, dtype=np.floathi)
 	return [
 		round(float(np.min(arr[:, 0])), 3),
 		round(float(np.max(arr[:, 0])), 3),

--- a/lasagna/fit2tifxyz.py
+++ b/lasagna/fit2tifxyz.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
+from dtypes import numpy_float_hi
 import tifffile
 import torch
 
@@ -300,11 +301,11 @@ def _mark_segment_vertices(
 	rmax = min(mask.shape[0] - 1, int(math.ceil(max(r0, r1) + eps)))
 	cmin = max(0, int(math.floor(min(c0, c1) - eps)))
 	cmax = min(mask.shape[1] - 1, int(math.ceil(max(c0, c1) + eps)))
-	seg = np.asarray([r1 - r0, c1 - c0], dtype=np.floathi)
+	seg = np.asarray([r1 - r0, c1 - c0], dtype=numpy_float_hi)
 	seg_len2 = float(np.dot(seg, seg))
 	for r in range(rmin, rmax + 1):
 		for c in range(cmin, cmax + 1):
-			v = np.asarray([float(r) - r0, float(c) - c0], dtype=np.floathi)
+			v = np.asarray([float(r) - r0, float(c) - c0], dtype=numpy_float_hi)
 			if seg_len2 <= eps:
 				dist2 = float(np.dot(v, v))
 			else:
@@ -384,7 +385,7 @@ def _mask_bbox(mask: np.ndarray) -> list[int] | None:
 def _points_bbox(points: list[tuple[float, float]]) -> list[float] | None:
 	if not points:
 		return None
-	arr = np.asarray(points, dtype=np.floathi)
+	arr = np.asarray(points, dtype=numpy_float_hi)
 	return [
 		round(float(np.min(arr[:, 0])), 3),
 		round(float(np.max(arr[:, 0])), 3),

--- a/lasagna/fit_data.py
+++ b/lasagna/fit_data.py
@@ -828,15 +828,15 @@ def _load_umbilicus_lookup(
 			raise ValueError(f"umbilicus control point {i} has non-finite coordinates")
 		rows.append((x, y, z))
 
-	pts_np = np.asarray(rows, dtype=np.float64)
+	pts_np = np.asarray(rows, dtype=np.floathi)
 	order = np.argsort(pts_np[:, 2], kind="mergesort")
 	pts_np = pts_np[order]
 
 	z_vals = pts_np[:, 2]
 	uniq_z, inv = np.unique(z_vals, return_inverse=True)
 	if uniq_z.shape[0] != z_vals.shape[0]:
-		xy_sum = np.zeros((uniq_z.shape[0], 2), dtype=np.float64)
-		count = np.zeros((uniq_z.shape[0], 1), dtype=np.float64)
+		xy_sum = np.zeros((uniq_z.shape[0], 2), dtype=np.floathi)
+		count = np.zeros((uniq_z.shape[0], 1), dtype=np.floathi)
 		np.add.at(xy_sum, inv, pts_np[:, :2])
 		np.add.at(count, inv, 1.0)
 		xy_vals = xy_sum / np.maximum(count, 1.0)
@@ -848,7 +848,7 @@ def _load_umbilicus_lookup(
 	z0 = math.floor(float(z_vals[0]) / z_step) * z_step
 	z1 = math.ceil(float(z_vals[-1]) / z_step) * z_step
 	count = max(1, int(round((z1 - z0) / z_step)) + 1)
-	z_lookup = z0 + np.arange(count, dtype=np.float64) * z_step
+	z_lookup = z0 + np.arange(count, dtype=np.floathi) * z_step
 	x_lookup = np.interp(z_lookup, z_vals, pts_np[:, 0])
 	y_lookup = np.interp(z_lookup, z_vals, pts_np[:, 1])
 	lookup_np = np.stack([x_lookup, y_lookup], axis=1).astype(np.float32)

--- a/lasagna/fit_data.py
+++ b/lasagna/fit_data.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
+from dtypes import numpy_float_hi
 import torch
 import torch.nn.functional as F
 import zarr
@@ -828,15 +829,15 @@ def _load_umbilicus_lookup(
 			raise ValueError(f"umbilicus control point {i} has non-finite coordinates")
 		rows.append((x, y, z))
 
-	pts_np = np.asarray(rows, dtype=np.floathi)
+	pts_np = np.asarray(rows, dtype=numpy_float_hi)
 	order = np.argsort(pts_np[:, 2], kind="mergesort")
 	pts_np = pts_np[order]
 
 	z_vals = pts_np[:, 2]
 	uniq_z, inv = np.unique(z_vals, return_inverse=True)
 	if uniq_z.shape[0] != z_vals.shape[0]:
-		xy_sum = np.zeros((uniq_z.shape[0], 2), dtype=np.floathi)
-		count = np.zeros((uniq_z.shape[0], 1), dtype=np.floathi)
+		xy_sum = np.zeros((uniq_z.shape[0], 2), dtype=numpy_float_hi)
+		count = np.zeros((uniq_z.shape[0], 1), dtype=numpy_float_hi)
 		np.add.at(xy_sum, inv, pts_np[:, :2])
 		np.add.at(count, inv, 1.0)
 		xy_vals = xy_sum / np.maximum(count, 1.0)
@@ -848,7 +849,7 @@ def _load_umbilicus_lookup(
 	z0 = math.floor(float(z_vals[0]) / z_step) * z_step
 	z1 = math.ceil(float(z_vals[-1]) / z_step) * z_step
 	count = max(1, int(round((z1 - z0) / z_step)) + 1)
-	z_lookup = z0 + np.arange(count, dtype=np.floathi) * z_step
+	z_lookup = z0 + np.arange(count, dtype=numpy_float_hi) * z_step
 	x_lookup = np.interp(z_lookup, z_vals, pts_np[:, 0])
 	y_lookup = np.interp(z_lookup, z_vals, pts_np[:, 1])
 	lookup_np = np.stack([x_lookup, y_lookup], axis=1).astype(np.float32)

--- a/lasagna/init_shell_index.py
+++ b/lasagna/init_shell_index.py
@@ -413,7 +413,7 @@ class InitShellIndex:
 		shell_index: int | None = None,
 		anchor_hw: tuple[float, float] | None = None,
 	) -> ShellClosestPoint:
-		seed_np = np.asarray(seed, dtype=np.float64)
+		seed_np = np.asarray(seed, dtype=np.floathi)
 		if seed_np.shape != (3,) or not np.all(np.isfinite(seed_np)):
 			raise ValueError(f"seed must be three finite coordinates, got {seed}")
 		if shell_index is not None and (int(shell_index) < 0 or int(shell_index) >= len(self.surfaces)):
@@ -653,7 +653,7 @@ def crop_shell_surface(
 ) -> tuple[torch.Tensor, torch.Tensor, ShellCropInfo]:
 	if closest.shell_id != surface.shell_id:
 		raise ValueError(f"closest point shell_id {closest.shell_id!r} does not match surface {surface.shell_id!r}")
-	seed_np = np.asarray(seed, dtype=np.float64)
+	seed_np = np.asarray(seed, dtype=np.floathi)
 	if seed_np.shape != (3,) or not np.all(np.isfinite(seed_np)):
 		raise ValueError(f"seed must be three finite coordinates, got {seed}")
 	step = float(mesh_step)

--- a/lasagna/init_shell_index.py
+++ b/lasagna/init_shell_index.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import math
 
 import numpy as np
+from dtypes import numpy_float_hi
 import torch
 import tifffile
 
@@ -413,7 +414,7 @@ class InitShellIndex:
 		shell_index: int | None = None,
 		anchor_hw: tuple[float, float] | None = None,
 	) -> ShellClosestPoint:
-		seed_np = np.asarray(seed, dtype=np.floathi)
+		seed_np = np.asarray(seed, dtype=numpy_float_hi)
 		if seed_np.shape != (3,) or not np.all(np.isfinite(seed_np)):
 			raise ValueError(f"seed must be three finite coordinates, got {seed}")
 		if shell_index is not None and (int(shell_index) < 0 or int(shell_index) >= len(self.surfaces)):
@@ -653,7 +654,7 @@ def crop_shell_surface(
 ) -> tuple[torch.Tensor, torch.Tensor, ShellCropInfo]:
 	if closest.shell_id != surface.shell_id:
 		raise ValueError(f"closest point shell_id {closest.shell_id!r} does not match surface {surface.shell_id!r}")
-	seed_np = np.asarray(seed, dtype=np.floathi)
+	seed_np = np.asarray(seed, dtype=numpy_float_hi)
 	if seed_np.shape != (3,) or not np.all(np.isfinite(seed_np)):
 		raise ValueError(f"seed must be three finite coordinates, got {seed}")
 	step = float(mesh_step)

--- a/lasagna/labels_to_winding_volume.py
+++ b/lasagna/labels_to_winding_volume.py
@@ -244,7 +244,7 @@ def main(argv: list[str] | None = None) -> int:
     # -- Nearest CC + pairwise distances (using cached DTs) -----------------
     dist_1 = np.full(shape, np.inf, dtype=np.float32)  # nearest CC distance
     idx_1 = np.zeros(shape, dtype=np.int32)             # CC index of nearest (0-based)
-    avg_dist = np.zeros((N, N), dtype=np.float64)       # pairwise avg distances
+    avg_dist = np.zeros((N, N), dtype=np.floathi)       # pairwise avg distances
 
     for i in range(N):
         dt_i = dt_all[i]
@@ -267,7 +267,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # -- Greedy chain winding assignment ------------------------------------
     # total_avg[i] = mean distance from CC i to all other CCs
-    total_avg = np.zeros(N, dtype=np.float64)
+    total_avg = np.zeros(N, dtype=np.floathi)
     for i in range(N):
         vals = [avg_dist[i, j] for j in range(N) if i != j]
         total_avg[i] = np.mean(vals) if vals else 0.0

--- a/lasagna/labels_to_winding_volume.py
+++ b/lasagna/labels_to_winding_volume.py
@@ -18,6 +18,7 @@ import argparse
 from pathlib import Path
 
 import numpy as np
+from dtypes import numpy_float_hi
 import tifffile
 import zarr
 from scipy.ndimage import distance_transform_edt, gaussian_filter, maximum_filter
@@ -244,7 +245,7 @@ def main(argv: list[str] | None = None) -> int:
     # -- Nearest CC + pairwise distances (using cached DTs) -----------------
     dist_1 = np.full(shape, np.inf, dtype=np.float32)  # nearest CC distance
     idx_1 = np.zeros(shape, dtype=np.int32)             # CC index of nearest (0-based)
-    avg_dist = np.zeros((N, N), dtype=np.floathi)       # pairwise avg distances
+    avg_dist = np.zeros((N, N), dtype=numpy_float_hi)       # pairwise avg distances
 
     for i in range(N):
         dt_i = dt_all[i]
@@ -267,7 +268,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # -- Greedy chain winding assignment ------------------------------------
     # total_avg[i] = mean distance from CC i to all other CCs
-    total_avg = np.zeros(N, dtype=np.floathi)
+    total_avg = np.zeros(N, dtype=numpy_float_hi)
     for i in range(N):
         vals = [avg_dist[i, j] for j in range(N) if i != j]
         total_avg[i] = np.mean(vals) if vals else 0.0

--- a/lasagna/model.py
+++ b/lasagna/model.py
@@ -6,6 +6,7 @@ import math
 import torch
 from torch import nn
 import torch.nn.functional as F
+from dtypes import torch_float_hi, numpy_float_hi
 
 import fit_data
 
@@ -3154,8 +3155,8 @@ class Model3D(nn.Module):
 
 		device = uv_yx.device
 		dtype = uv_yx.dtype
-		uv = uv_yx.detach().cpu().numpy().astype(np.float64, copy=False)
-		xyz = source_xyz.detach().cpu().numpy().astype(np.float64, copy=False)
+		uv = uv_yx.detach().cpu().numpy().astype(numpy_float_hi, copy=False)
+		xyz = source_xyz.detach().cpu().numpy().astype(numpy_float_hi, copy=False)
 		cell_valid = source_cell_valid.detach().cpu().numpy().astype(bool, copy=False)
 		Hs, Ws = int(uv.shape[0]), int(uv.shape[1])
 		min_h, min_w = min_shape if min_shape is not None else Model3D._flatten_output_shape_for_source(
@@ -3263,20 +3264,20 @@ class Model3D(nn.Module):
 		# stays on CPU. Float64 keeps shared-edge and overlapping-cell tie behavior
 		# stable across CPU and CUDA.
 		use_cuda = bool(torch.device(device).type == "cuda")
-		tri0_s_cell = torch.as_tensor(q10 - q00, dtype=torch.floathi, device=device)
-		tri0_t_cell = torch.as_tensor(q01 - q00, dtype=torch.floathi, device=device)
-		tri1_u_cell = torch.as_tensor(q11 - q10, dtype=torch.floathi, device=device)
-		tri1_v_cell = torch.as_tensor(q01 - q10, dtype=torch.floathi, device=device)
-		q00_c = torch.as_tensor(q00, dtype=torch.floathi, device=device)
-		q10_c = torch.as_tensor(q10, dtype=torch.floathi, device=device)
-		x00_c = torch.as_tensor(x00, dtype=torch.floathi, device=device)
-		x10_c = torch.as_tensor(x10, dtype=torch.floathi, device=device)
-		x01_c = torch.as_tensor(x01, dtype=torch.floathi, device=device)
-		x11_c = torch.as_tensor(x11, dtype=torch.floathi, device=device)
-		rows_c = torch.as_tensor(rows.astype(np.floathi), device=device)
-		cols_c = torch.as_tensor(cols.astype(np.floathi), device=device)
+		tri0_s_cell = torch.as_tensor(q10 - q00, dtype=torch_float_hi, device=device)
+		tri0_t_cell = torch.as_tensor(q01 - q00, dtype=torch_float_hi, device=device)
+		tri1_u_cell = torch.as_tensor(q11 - q10, dtype=torch_float_hi, device=device)
+		tri1_v_cell = torch.as_tensor(q01 - q10, dtype=torch_float_hi, device=device)
+		q00_c = torch.as_tensor(q00, dtype=torch_float_hi, device=device)
+		q10_c = torch.as_tensor(q10, dtype=torch_float_hi, device=device)
+		x00_c = torch.as_tensor(x00, dtype=torch_float_hi, device=device)
+		x10_c = torch.as_tensor(x10, dtype=torch_float_hi, device=device)
+		x01_c = torch.as_tensor(x01, dtype=torch_float_hi, device=device)
+		x11_c = torch.as_tensor(x11, dtype=torch_float_hi, device=device)
+		rows_c = torch.as_tensor(rows.astype(numpy_float_hi), device=device)
+		cols_c = torch.as_tensor(cols.astype(numpy_float_hi), device=device)
 		if not use_tree:
-			centers_c = torch.as_tensor(centers, dtype=torch.floathi, device=device)
+			centers_c = torch.as_tensor(centers, dtype=torch_float_hi, device=device)
 
 		out_map_t = torch.zeros((out_h * out_w, 2), dtype=torch.float32, device=device)
 		out_xyz_t = torch.zeros((out_h * out_w, 3), dtype=torch.float32, device=device)
@@ -3294,7 +3295,7 @@ class Model3D(nn.Module):
 			flat_idx = np.arange(start, stop, dtype=np.int64)
 			oy = flat_idx // int(out_w)
 			ox = flat_idx - oy * int(out_w)
-			points = np.stack([lo[0] + oy.astype(np.floathi), lo[1] + ox.astype(np.floathi)], axis=-1)
+			points = np.stack([lo[0] + oy.astype(numpy_float_hi), lo[1] + ox.astype(numpy_float_hi)], axis=-1)
 			if use_tree:
 				_dist, cand = tree.query(points, k=k, workers=-1)
 				cand = np.asarray(cand, dtype=np.int64)
@@ -3302,11 +3303,11 @@ class Model3D(nn.Module):
 					cand = cand[:, None]
 				cand_t = torch.as_tensor(cand, dtype=torch.long, device=device)
 			else:
-				pts_bf = torch.as_tensor(points, dtype=torch.floathi, device=device)
+				pts_bf = torch.as_tensor(points, dtype=torch_float_hi, device=device)
 				d2 = ((pts_bf[:, None, :] - centers_c[None, :, :]) ** 2).sum(dim=-1)
 				cand_t = torch.topk(d2, min(k, int(centers_c.shape[0])), dim=1, largest=False).indices
 
-			pts_t = torch.as_tensor(points, dtype=torch.floathi, device=device)
+			pts_t = torch.as_tensor(points, dtype=torch_float_hi, device=device)
 
 			# Triangle 0: q00 + s*(q10-q00) + t*(q01-q00).
 			rhs0 = pts_t[:, None, :] - q00_c[cand_t]

--- a/lasagna/model.py
+++ b/lasagna/model.py
@@ -3263,20 +3263,20 @@ class Model3D(nn.Module):
 		# stays on CPU. Float64 keeps shared-edge and overlapping-cell tie behavior
 		# stable across CPU and CUDA.
 		use_cuda = bool(torch.device(device).type == "cuda")
-		tri0_s_cell = torch.as_tensor(q10 - q00, dtype=torch.float64, device=device)
-		tri0_t_cell = torch.as_tensor(q01 - q00, dtype=torch.float64, device=device)
-		tri1_u_cell = torch.as_tensor(q11 - q10, dtype=torch.float64, device=device)
-		tri1_v_cell = torch.as_tensor(q01 - q10, dtype=torch.float64, device=device)
-		q00_c = torch.as_tensor(q00, dtype=torch.float64, device=device)
-		q10_c = torch.as_tensor(q10, dtype=torch.float64, device=device)
-		x00_c = torch.as_tensor(x00, dtype=torch.float64, device=device)
-		x10_c = torch.as_tensor(x10, dtype=torch.float64, device=device)
-		x01_c = torch.as_tensor(x01, dtype=torch.float64, device=device)
-		x11_c = torch.as_tensor(x11, dtype=torch.float64, device=device)
-		rows_c = torch.as_tensor(rows.astype(np.float64), device=device)
-		cols_c = torch.as_tensor(cols.astype(np.float64), device=device)
+		tri0_s_cell = torch.as_tensor(q10 - q00, dtype=torch.floathi, device=device)
+		tri0_t_cell = torch.as_tensor(q01 - q00, dtype=torch.floathi, device=device)
+		tri1_u_cell = torch.as_tensor(q11 - q10, dtype=torch.floathi, device=device)
+		tri1_v_cell = torch.as_tensor(q01 - q10, dtype=torch.floathi, device=device)
+		q00_c = torch.as_tensor(q00, dtype=torch.floathi, device=device)
+		q10_c = torch.as_tensor(q10, dtype=torch.floathi, device=device)
+		x00_c = torch.as_tensor(x00, dtype=torch.floathi, device=device)
+		x10_c = torch.as_tensor(x10, dtype=torch.floathi, device=device)
+		x01_c = torch.as_tensor(x01, dtype=torch.floathi, device=device)
+		x11_c = torch.as_tensor(x11, dtype=torch.floathi, device=device)
+		rows_c = torch.as_tensor(rows.astype(np.floathi), device=device)
+		cols_c = torch.as_tensor(cols.astype(np.floathi), device=device)
 		if not use_tree:
-			centers_c = torch.as_tensor(centers, dtype=torch.float64, device=device)
+			centers_c = torch.as_tensor(centers, dtype=torch.floathi, device=device)
 
 		out_map_t = torch.zeros((out_h * out_w, 2), dtype=torch.float32, device=device)
 		out_xyz_t = torch.zeros((out_h * out_w, 3), dtype=torch.float32, device=device)
@@ -3294,7 +3294,7 @@ class Model3D(nn.Module):
 			flat_idx = np.arange(start, stop, dtype=np.int64)
 			oy = flat_idx // int(out_w)
 			ox = flat_idx - oy * int(out_w)
-			points = np.stack([lo[0] + oy.astype(np.float64), lo[1] + ox.astype(np.float64)], axis=-1)
+			points = np.stack([lo[0] + oy.astype(np.floathi), lo[1] + ox.astype(np.floathi)], axis=-1)
 			if use_tree:
 				_dist, cand = tree.query(points, k=k, workers=-1)
 				cand = np.asarray(cand, dtype=np.int64)
@@ -3302,11 +3302,11 @@ class Model3D(nn.Module):
 					cand = cand[:, None]
 				cand_t = torch.as_tensor(cand, dtype=torch.long, device=device)
 			else:
-				pts_bf = torch.as_tensor(points, dtype=torch.float64, device=device)
+				pts_bf = torch.as_tensor(points, dtype=torch.floathi, device=device)
 				d2 = ((pts_bf[:, None, :] - centers_c[None, :, :]) ** 2).sum(dim=-1)
 				cand_t = torch.topk(d2, min(k, int(centers_c.shape[0])), dim=1, largest=False).indices
 
-			pts_t = torch.as_tensor(points, dtype=torch.float64, device=device)
+			pts_t = torch.as_tensor(points, dtype=torch.floathi, device=device)
 
 			# Triangle 0: q00 + s*(q10-q00) + t*(q01-q00).
 			rhs0 = pts_t[:, None, :] - q00_c[cand_t]

--- a/lasagna/predict3d_holescan.py
+++ b/lasagna/predict3d_holescan.py
@@ -338,7 +338,7 @@ def _find_holes_in_counts(
 	max_low_density: float,
 ) -> list[HoleFinding]:
 	voxels_per_slice = max(1, (y1 - y0) * (x1 - x0))
-	density = counts.astype(np.float64) / float(voxels_per_slice)
+	density = counts.astype(np.floathi) / float(voxels_per_slice)
 	findings: list[HoleFinding] = []
 	for start, end in _iter_runs(density <= max_low_density):
 		before_med, after_med = _bracket_density(density, start, end, bracket_window)

--- a/lasagna/predict3d_holescan.py
+++ b/lasagna/predict3d_holescan.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Callable, Iterable
 
 import numpy as np
+from dtypes import numpy_float_hi
 from scipy import ndimage
 import tensorstore as ts
 import zarr
@@ -338,7 +339,7 @@ def _find_holes_in_counts(
 	max_low_density: float,
 ) -> list[HoleFinding]:
 	voxels_per_slice = max(1, (y1 - y0) * (x1 - x0))
-	density = counts.astype(np.floathi) / float(voxels_per_slice)
+	density = counts.astype(numpy_float_hi) / float(voxels_per_slice)
 	findings: list[HoleFinding] = []
 	for start, end in _iter_runs(density <= max_low_density):
 		before_med, after_med = _bracket_density(density, start, end, bracket_window)

--- a/lasagna/scripts/prefetch_training_cache.py
+++ b/lasagna/scripts/prefetch_training_cache.py
@@ -451,11 +451,11 @@ def main():
             corners_zyx = np.array([
                 [z, y, x]
                 for z in (z0, z1) for y in (y0, y1) for x in (x0, x1)
-            ], dtype=np.float64)
+            ], dtype=np.floathi)
             corners_vol = _apply_affine_zyx(patch.cache_to_volume, corners_zyx)
             aabb_center = (corners_vol.min(axis=0) + corners_vol.max(axis=0)) / 2.0
             label_min = np.round(
-                aabb_center - np.array((L, L, L), dtype=np.float64) / 2.0
+                aabb_center - np.array((L, L, L), dtype=np.floathi) / 2.0
             ).astype(np.int64)
         else:
             label_min = np.array([z0, y0, x0], dtype=np.int64)

--- a/lasagna/scripts/prefetch_training_cache.py
+++ b/lasagna/scripts/prefetch_training_cache.py
@@ -280,6 +280,7 @@ def main():
     if _LASAGNA_DIR not in sys.path:
         sys.path.insert(0, _LASAGNA_DIR)
 
+    from dtypes import numpy_float_hi
     from tifxyz_lasagna_dataset import TifxyzLasagnaDataset, _apply_affine_zyx
 
     patch_size = args.patch_size
@@ -451,11 +452,11 @@ def main():
             corners_zyx = np.array([
                 [z, y, x]
                 for z in (z0, z1) for y in (y0, y1) for x in (x0, x1)
-            ], dtype=np.floathi)
+            ], dtype=numpy_float_hi)
             corners_vol = _apply_affine_zyx(patch.cache_to_volume, corners_zyx)
             aabb_center = (corners_vol.min(axis=0) + corners_vol.max(axis=0)) / 2.0
             label_min = np.round(
-                aabb_center - np.array((L, L, L), dtype=np.floathi) / 2.0
+                aabb_center - np.array((L, L, L), dtype=numpy_float_hi) / 2.0
             ).astype(np.int64)
         else:
             label_min = np.array([z0, y0, x0], dtype=np.int64)

--- a/lasagna/tests/test_cyl_sdf_volume.py
+++ b/lasagna/tests/test_cyl_sdf_volume.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import torch
+from dtypes import torch_float_hi
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -33,7 +34,7 @@ class CylSdfVolumeTests(unittest.TestCase):
 		self.assertTrue(edges)
 		self.assertEqual(set(edges.values()), {2})
 
-		v = verts.to(dtype=torch.floathi)
+		v = verts.to(dtype=torch_float_hi)
 		f = faces.to(dtype=torch.long)
 		p0 = v[f[:, 0]]
 		p1 = v[f[:, 1]]

--- a/lasagna/tests/test_cyl_sdf_volume.py
+++ b/lasagna/tests/test_cyl_sdf_volume.py
@@ -33,7 +33,7 @@ class CylSdfVolumeTests(unittest.TestCase):
 		self.assertTrue(edges)
 		self.assertEqual(set(edges.values()), {2})
 
-		v = verts.to(dtype=torch.float64)
+		v = verts.to(dtype=torch.floathi)
 		f = faces.to(dtype=torch.long)
 		p0 = v[f[:, 0]]
 		p1 = v[f[:, 1]]

--- a/lasagna/tests/test_flatten_slim.py
+++ b/lasagna/tests/test_flatten_slim.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from dtypes import numpy_float_hi
 
 import numpy as np
 import torch
@@ -157,8 +158,8 @@ class FlattenSlimTest(unittest.TestCase):
 		self.assertLessEqual(s1.final_residual, s0.final_residual * 1.05)
 
 	def test_bilinear_quad_inversion_accepts_inside_and_rejects_outside(self) -> None:
-		points = np.asarray([[0.25, 0.75], [1.5, 0.5]], dtype=np.floathi)
-		quad = np.asarray([[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]], dtype=np.floathi)
+		points = np.asarray([[0.25, 0.75], [1.5, 0.5]], dtype=numpy_float_hi)
+		quad = np.asarray([[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]], dtype=numpy_float_hi)
 		quads = np.repeat(quad[None, :, :, :], 2, axis=0)
 
 		s, t, residual2 = flatten_slim.bilinear_inverse_points(points, quads)

--- a/lasagna/tests/test_flatten_slim.py
+++ b/lasagna/tests/test_flatten_slim.py
@@ -157,8 +157,8 @@ class FlattenSlimTest(unittest.TestCase):
 		self.assertLessEqual(s1.final_residual, s0.final_residual * 1.05)
 
 	def test_bilinear_quad_inversion_accepts_inside_and_rejects_outside(self) -> None:
-		points = np.asarray([[0.25, 0.75], [1.5, 0.5]], dtype=np.float64)
-		quad = np.asarray([[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]], dtype=np.float64)
+		points = np.asarray([[0.25, 0.75], [1.5, 0.5]], dtype=np.floathi)
+		quad = np.asarray([[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]], dtype=np.floathi)
 		quads = np.repeat(quad[None, :, :, :], 2, axis=0)
 
 		s, t, residual2 = flatten_slim.bilinear_inverse_points(points, quads)

--- a/lasagna/tests/test_preprocess_cos_omezarr.py
+++ b/lasagna/tests/test_preprocess_cos_omezarr.py
@@ -1280,7 +1280,7 @@ class PreprocessCosOmezarrTests(unittest.TestCase):
 			with self.assertRaisesRegex(ValueError, "float16 or float32"):
 				_CircularZBand(
 					name="bad", channel_count=1, z_size=1, y_size=1, x_size=1,
-					tmp_dir=td, prefix="unit_", dtype=np.floathi,
+					tmp_dir=td, prefix="unit_", dtype=np.float64,
 				)
 
 	def test_rolling_z_band_sparse_ranges_read_as_zero(self):

--- a/lasagna/tests/test_preprocess_cos_omezarr.py
+++ b/lasagna/tests/test_preprocess_cos_omezarr.py
@@ -1280,7 +1280,7 @@ class PreprocessCosOmezarrTests(unittest.TestCase):
 			with self.assertRaisesRegex(ValueError, "float16 or float32"):
 				_CircularZBand(
 					name="bad", channel_count=1, z_size=1, y_size=1, x_size=1,
-					tmp_dir=td, prefix="unit_", dtype=np.float64,
+					tmp_dir=td, prefix="unit_", dtype=np.floathi,
 				)
 
 	def test_rolling_z_band_sparse_ranges_read_as_zero(self):

--- a/lasagna/tifxyz_lasagna_dataset.py
+++ b/lasagna/tifxyz_lasagna_dataset.py
@@ -14,6 +14,7 @@ import warnings
 from pathlib import Path
 
 import numpy as np
+from dtypes import numpy_float_hi
 import torch
 from torch.utils.data import Dataset
 
@@ -52,17 +53,17 @@ TAG = "[tifxyz_lasagna_dataset]"
 def _parse_transform(dataset: dict) -> np.ndarray | None:
     """Parse inline 3×4 affine from dataset config, optionally inverting.
 
-    Returns (3, 4) float64 ndarray in XYZ order (matching transform.json
+    Returns a (3, 4) float ndarray in XYZ order (matching transform.json
     convention), or None if no transform is specified.
     """
     raw = dataset.get("transform")
     if raw is None:
         return None
-    m = np.array(raw, dtype=np.floathi)
+    m = np.array(raw, dtype=numpy_float_hi)
     if m.shape != (3, 4):
         raise ValueError(f"transform must be (3,4), got {m.shape}")
     if dataset.get("transform_invert", False):
-        m4 = np.eye(4, dtype=np.floathi)
+        m4 = np.eye(4, dtype=numpy_float_hi)
         m4[:3, :] = m
         m4 = np.linalg.inv(m4)
         m = m4[:3, :]
@@ -87,7 +88,7 @@ def _build_cache_to_volume_zyx(
     down = 1.0 / float(2 ** volume_scale)
 
     # Compose in 4×4 XYZ space
-    m4 = np.eye(4, dtype=np.floathi)
+    m4 = np.eye(4, dtype=numpy_float_hi)
     m4[:3, :] = transform_xyz
     # Pre-multiply by scale-up (acts on input): multiply columns 0-2 by up
     m4[:3, :3] *= up
@@ -102,7 +103,7 @@ def _build_cache_to_volume_zyx(
     # Column swap: input is (z, y, x) instead of (x, y, z)
     m4_zyx[:, 0], m4_zyx[:, 2] = m4_zyx[:, 2].copy(), m4_zyx[:, 0].copy()
 
-    return m4_zyx[:3, :].astype(np.floathi)
+    return m4_zyx[:3, :].astype(numpy_float_hi)
 
 
 def _apply_affine_zyx(affine_3x4: np.ndarray, zyx: np.ndarray) -> np.ndarray:
@@ -118,8 +119,8 @@ def _apply_affine_zyx(affine_3x4: np.ndarray, zyx: np.ndarray) -> np.ndarray:
     (..., 3) array — transformed points
     """
     shape = zyx.shape
-    pts = zyx.reshape(-1, 3).astype(np.floathi)
-    ones = np.ones((pts.shape[0], 1), dtype=np.floathi)
+    pts = zyx.reshape(-1, 3).astype(numpy_float_hi)
+    ones = np.ones((pts.shape[0], 1), dtype=numpy_float_hi)
     homo = np.hstack([pts, ones])  # (N, 4)
     out = (affine_3x4 @ homo.T).T  # (N, 3)
     return out.astype(np.float32).reshape(shape)
@@ -1038,13 +1039,13 @@ class TifxyzLasagnaDataset(Dataset):
                 for z in (z0, z1)
                 for y in (y0, y1)
                 for x in (x0, x1)
-            ], dtype=np.floathi)
+            ], dtype=numpy_float_hi)
             corners_vol = _apply_affine_zyx(patch.cache_to_volume, corners_zyx)
             aabb_min = corners_vol.min(axis=0)
             aabb_max = corners_vol.max(axis=0)
             aabb_center = (aabb_min + aabb_max) / 2.0
             label_min = np.round(
-                aabb_center - np.array(label_size, dtype=np.floathi) / 2.0
+                aabb_center - np.array(label_size, dtype=numpy_float_hi) / 2.0
             ).astype(np.int64)
         else:
             label_min = np.array([z0, y0, x0], dtype=np.int64)
@@ -1452,7 +1453,7 @@ class TifxyzLasagnaDataset(Dataset):
             (bbox[0] + bbox[1]) / 2.0,
             (bbox[2] + bbox[3]) / 2.0,
             (bbox[4] + bbox[5]) / 2.0,
-        ], dtype=np.floathi)
+        ], dtype=numpy_float_hi)
 
         sample = {
             "image": vol_crop_t,                        # (1, Z, Y, X)
@@ -1465,7 +1466,7 @@ class TifxyzLasagnaDataset(Dataset):
             "patch_info": {
                 "segment_uuid": str(patch.wraps[0]["segment"].uuid) if patch.wraps else "",
                 "world_bbox": patch.world_bbox,
-                "world_center": world_center,           # (3,) float64 — base-level voxels
+                "world_center": world_center,           # (3,) numpy_float_hi — base-level voxels
                 "world_min": min_corner,                # (3,) int64 — CT read origin
                 "scale": patch.scale,                   # zarr level
                 "idx": patch.dataset_local_idx,

--- a/lasagna/tifxyz_lasagna_dataset.py
+++ b/lasagna/tifxyz_lasagna_dataset.py
@@ -58,11 +58,11 @@ def _parse_transform(dataset: dict) -> np.ndarray | None:
     raw = dataset.get("transform")
     if raw is None:
         return None
-    m = np.array(raw, dtype=np.float64)
+    m = np.array(raw, dtype=np.floathi)
     if m.shape != (3, 4):
         raise ValueError(f"transform must be (3,4), got {m.shape}")
     if dataset.get("transform_invert", False):
-        m4 = np.eye(4, dtype=np.float64)
+        m4 = np.eye(4, dtype=np.floathi)
         m4[:3, :] = m
         m4 = np.linalg.inv(m4)
         m = m4[:3, :]
@@ -87,7 +87,7 @@ def _build_cache_to_volume_zyx(
     down = 1.0 / float(2 ** volume_scale)
 
     # Compose in 4×4 XYZ space
-    m4 = np.eye(4, dtype=np.float64)
+    m4 = np.eye(4, dtype=np.floathi)
     m4[:3, :] = transform_xyz
     # Pre-multiply by scale-up (acts on input): multiply columns 0-2 by up
     m4[:3, :3] *= up
@@ -102,7 +102,7 @@ def _build_cache_to_volume_zyx(
     # Column swap: input is (z, y, x) instead of (x, y, z)
     m4_zyx[:, 0], m4_zyx[:, 2] = m4_zyx[:, 2].copy(), m4_zyx[:, 0].copy()
 
-    return m4_zyx[:3, :].astype(np.float64)
+    return m4_zyx[:3, :].astype(np.floathi)
 
 
 def _apply_affine_zyx(affine_3x4: np.ndarray, zyx: np.ndarray) -> np.ndarray:
@@ -118,8 +118,8 @@ def _apply_affine_zyx(affine_3x4: np.ndarray, zyx: np.ndarray) -> np.ndarray:
     (..., 3) array — transformed points
     """
     shape = zyx.shape
-    pts = zyx.reshape(-1, 3).astype(np.float64)
-    ones = np.ones((pts.shape[0], 1), dtype=np.float64)
+    pts = zyx.reshape(-1, 3).astype(np.floathi)
+    ones = np.ones((pts.shape[0], 1), dtype=np.floathi)
     homo = np.hstack([pts, ones])  # (N, 4)
     out = (affine_3x4 @ homo.T).T  # (N, 3)
     return out.astype(np.float32).reshape(shape)
@@ -1038,13 +1038,13 @@ class TifxyzLasagnaDataset(Dataset):
                 for z in (z0, z1)
                 for y in (y0, y1)
                 for x in (x0, x1)
-            ], dtype=np.float64)
+            ], dtype=np.floathi)
             corners_vol = _apply_affine_zyx(patch.cache_to_volume, corners_zyx)
             aabb_min = corners_vol.min(axis=0)
             aabb_max = corners_vol.max(axis=0)
             aabb_center = (aabb_min + aabb_max) / 2.0
             label_min = np.round(
-                aabb_center - np.array(label_size, dtype=np.float64) / 2.0
+                aabb_center - np.array(label_size, dtype=np.floathi) / 2.0
             ).astype(np.int64)
         else:
             label_min = np.array([z0, y0, x0], dtype=np.int64)
@@ -1452,7 +1452,7 @@ class TifxyzLasagnaDataset(Dataset):
             (bbox[0] + bbox[1]) / 2.0,
             (bbox[2] + bbox[3]) / 2.0,
             (bbox[4] + bbox[5]) / 2.0,
-        ], dtype=np.float64)
+        ], dtype=np.floathi)
 
         sample = {
             "image": vol_crop_t,                        # (1, Z, Y, X)

--- a/lasagna/train_tifxyz.py
+++ b/lasagna/train_tifxyz.py
@@ -104,7 +104,7 @@ def _allreduce_max(value: int, world_size: int, device) -> int:
 def _allreduce_mean(value: float, world_size: int, device) -> float:
     if world_size <= 1:
         return float(value)
-    t = torch.tensor([float(value)], device=device, dtype=torch.float64)
+    t = torch.tensor([float(value)], device=device, dtype=torch.floathi)
     dist.all_reduce(t, op=dist.ReduceOp.SUM)
     return float(t.item() / world_size)
 
@@ -1548,11 +1548,11 @@ def _pick_refine_mode(
     """
     # Weights: [m0, m1, m2, m3, m4, m5, m6]
     #           single-scale   chains        self-refine
-    base_weights = np.array([2, 2, 2, 3, 3, 3, 1], dtype=np.float64)
+    base_weights = np.array([2, 2, 2, 3, 3, 3, 1], dtype=np.floathi)
 
     def _draw():
         # Filter modes to those whose offsets are all available
-        feasible = np.zeros(7, dtype=np.float64)
+        feasible = np.zeros(7, dtype=np.floathi)
         for mi in range(6):
             needed = {off for off, _ in REFINE_MODES_FIXED[mi]}
             if needed.issubset(available_offsets):

--- a/lasagna/train_tifxyz.py
+++ b/lasagna/train_tifxyz.py
@@ -64,6 +64,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from dtypes import torch_float_hi, numpy_float_hi
 import numpy as np
 import torch
 import torch.distributed as dist
@@ -104,7 +105,7 @@ def _allreduce_max(value: int, world_size: int, device) -> int:
 def _allreduce_mean(value: float, world_size: int, device) -> float:
     if world_size <= 1:
         return float(value)
-    t = torch.tensor([float(value)], device=device, dtype=torch.floathi)
+    t = torch.tensor([float(value)], device=device, dtype=torch_float_hi)
     dist.all_reduce(t, op=dist.ReduceOp.SUM)
     return float(t.item() / world_size)
 
@@ -1548,11 +1549,11 @@ def _pick_refine_mode(
     """
     # Weights: [m0, m1, m2, m3, m4, m5, m6]
     #           single-scale   chains        self-refine
-    base_weights = np.array([2, 2, 2, 3, 3, 3, 1], dtype=np.floathi)
+    base_weights = np.array([2, 2, 2, 3, 3, 3, 1], dtype=numpy_float_hi)
 
     def _draw():
         # Filter modes to those whose offsets are all available
-        feasible = np.zeros(7, dtype=np.floathi)
+        feasible = np.zeros(7, dtype=numpy_float_hi)
         for mi in range(6):
             needed = {off for off, _ in REFINE_MODES_FIXED[mi]}
             if needed.issubset(available_offsets):


### PR DESCRIPTION
**In one sentence:** Introduce a floathi tensor type that is float64 on devices that support it and float32 elsewhere. This makes flatten work on macs with the mps backend, which doesn't support float64.

**One real example:** I was able to run `python fit.py configs/flatten_fast_nofilter.json $(pwd)/segment_flatten_input.json --out-dir ../../data/lasagna_flatten_out --device mps` and "flatten" a mesh output by spiral_fit.

**Before:** It failed, complaining about mps not supporting float32.

**After this PR:** It works. Precision will not be the same, but are we sure each of these tensors need to have double precision? The other way to write portable code is to use `torch.set_default_dtype` and not pass an explicit dtype when creating tensors, but that forces you to use the same precision everywhere. This way you can use floathi to ask for a float64 if available, and get a float32 if not.

**Proof:** 
```
...
[optimizer] stage1 'flatten' complete in 2.72s
[optimizer] stage2: params=['map_flatten_ms'] steps=1000 lr=0.0001 min_scaledown=0
[optimizer] stage2: snap_surf_map_weight=0 snap_surf_map_offset=n/a snap_surf_map_offset_mode=n/a
[optimizer] stage2: flatten_edge_step_global_scale=100
[optimizer] stage2: flatten_diagnostics=0
[optimizer] stage2: compile_flatten=1 combined=1
[optimizer] stage2: forward_needs=xyz_lr,data,params+flatten prefetch_grad_channels=[] prefetch_nograd_channels=[]
[optimizer] stage2: flatten_max_update=0.1 (per-scale cap doubles at each coarser level)
[optimizer] stage2: fused_flatten_adam_clamp=1 (Triton CUDA with PyTorch fallback)
[optimizer] progress columns
  col      : meaning                          | col      : meaning                          | col      : meaning
  step     : stage step                       | loss     : total loss                       | it/s     : optimizer it/s
  f_sdir   : flatten_sdir                     | f_sdirW  : weighted flatten_sdir            | f_estep  : physical edge step loss
  f_estpW  : weighted physical edge step loss | f_avg    : flatten_avg_offset               | f_avgW   : weighted flatten_avg_offset
  f_orient : flatten_orient                   | f_oriW   : weighted flatten_orient          | f_step   : flatten current avg grid step
              step     loss  it/s f_sdir f_sdirW f_estep f_estpW  f_avg f_avgW f_orient f_oriW f_step
     stage2 0/1000   0.1344       0.0776  0.0776  0.0567  0.0567 0.0000 0.0000   0.0000 0.0000 20.009
     stage2 1/1000   0.1344 175.8 0.0776  0.0776  0.0567  0.0567 0.0000 0.0000   0.0000 0.0000 20.009
   stage2 100/1000   0.1340 374.4 0.0776  0.0776  0.0564  0.0564 0.0000 0.0000   0.0000 0.0000 20.009
   stage2 200/1000   0.1339 376.1 0.0776  0.0776  0.0563  0.0563 0.0000 0.0000   0.0000 0.0000 20.009
   stage2 300/1000   0.1339 377.8 0.0776  0.0776  0.0563  0.0563 0.0000 0.0000   0.0000 0.0000 20.009
   stage2 400/1000   0.1339 375.8 0.0776  0.0776  0.0563  0.0563 0.0000 0.0000   0.0000 0.0000 20.009
   stage2 500/1000   0.1340 376.2 0.0776  0.0776  0.0564  0.0564 0.0000 0.0000   0.0000 0.0000 20.009
   stage2 600/1000   0.1339 371.1 0.0776  0.0776  0.0563  0.0563 0.0000 0.0000   0.0000 0.0000 20.009
   stage2 700/1000   0.1339 377.2 0.0776  0.0776  0.0563  0.0563 0.0000 0.0000   0.0000 0.0000 20.009
   stage2 800/1000   0.1339 376.2 0.0776  0.0776  0.0563  0.0563 0.0000 0.0000   0.0000 0.0000 20.009
   stage2 900/1000   0.1339 377.9 0.0776  0.0776  0.0563  0.0563 0.0000 0.0000   0.0000 0.0000 20.009
  stage2 1000/1000   0.1340 375.6 0.0776  0.0776  0.0564  0.0564 0.0000 0.0000   0.0000 0.0000 20.009
[optimizer] stage2 'flatten' complete in 2.73s
[optimizer] total optimize time: 18.86s
[fit2tifxyz] area_vx2=1856000
```

**Why / where this is useful:** So people can run lasagna on a mac laptop.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

I searched and replaced `torch.float64` -> `torch.floathi` and `np.float64` -> `np.floathi` in the lasagna directory. Maybe not all uses of np.float64 would have caused failures. I also have no way of knowing how intentional all these uses of torch.float64 are: in some cases, just removing the dtype= parameter would also fix it for mps, by using the default dtype on every device.

I understand if your position is that only cuda or cpu are supported as backends and it isn't worth the trouble to do this and write code this way. Maybe you don't like the monkey patching. But if you want to support mps, this is an option, and all it takes is writing `.floathi` instead of `.float64`.
