### PR TITLE
VC3D: make fetched Open Data segments editable from agent bridge

### DIFF
--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -702,6 +702,25 @@ bool isAvailableOpenDataSegmentsEntry(const VolumePkg& pkg,
         path.string()).empty();
 }
 
+bool isSelectedEditableOpenDataSegmentsEntry(
+    const VolumePkg& pkg,
+    const vc::project::Entry& entry)
+{
+    if (!vc::project::hasEntryTag(entry, "open-data-editable") ||
+        vc::project::isLocationRemote(entry.location)) {
+        return false;
+    }
+    const auto selectedPath = pkg.outputSegmentsPath();
+    if (selectedPath.empty()) {
+        return false;
+    }
+    const auto entryPath = vc::project::resolveLocalPath(
+        entry.location, pkg.path().parent_path());
+    std::error_code error;
+    return std::filesystem::equivalent(selectedPath, entryPath, error) &&
+           !error;
+}
+
 std::vector<QString> openDataCatalogVolumeIdCandidates(const VolumePkg& pkg,
                                                        const std::string& loadedVolumeId)
 {
@@ -736,6 +755,7 @@ const vc::project::Entry* findOpenDataSegmentsEntryForVolume(const VolumePkg& pk
 
     const std::string targetTag = "vc-open-data-target-volume-id:" + catalogVolumeId.toStdString();
     const std::string sourceTag = "vc-open-data-source-volume-id:" + catalogVolumeId.toStdString();
+    const vc::project::Entry* targetMatch = nullptr;
     const vc::project::Entry* sourceMatch = nullptr;
 
     for (const auto& entry : pkg.segmentEntries()) {
@@ -743,15 +763,24 @@ const vc::project::Entry* findOpenDataSegmentsEntryForVolume(const VolumePkg& pk
             continue;
         }
         if (std::find(entry.tags.begin(), entry.tags.end(), targetTag) != entry.tags.end()) {
-            return &entry;
+            if (isSelectedEditableOpenDataSegmentsEntry(pkg, entry)) {
+                return &entry;
+            }
+            if (!targetMatch) {
+                targetMatch = &entry;
+            }
+            continue;
         }
-        if (!sourceMatch &&
-            std::find(entry.tags.begin(), entry.tags.end(), sourceTag) != entry.tags.end()) {
-            sourceMatch = &entry;
+        if (std::find(entry.tags.begin(), entry.tags.end(), sourceTag) !=
+            entry.tags.end()) {
+            if (!sourceMatch ||
+                isSelectedEditableOpenDataSegmentsEntry(pkg, entry)) {
+                sourceMatch = &entry;
+            }
         }
     }
 
-    return sourceMatch;
+    return targetMatch ? targetMatch : sourceMatch;
 }
 
 const vc::project::Entry* findOpenDataSegmentsEntryForLoadedVolume(const VolumePkg& pkg,
@@ -763,16 +792,26 @@ const vc::project::Entry* findOpenDataSegmentsEntryForLoadedVolume(const VolumeP
     if (!coordinateSpace.empty()) {
         const std::string coordinateTag =
             "vc-open-data-coordinate-space:" + coordinateSpace;
+        const vc::project::Entry* coordinateMatch = nullptr;
         for (const auto& entry : pkg.segmentEntries()) {
             if (isAvailableOpenDataSegmentsEntry(pkg, entry) &&
                 std::find(entry.tags.begin(), entry.tags.end(), coordinateTag) !=
                     entry.tags.end()) {
-                if (matchedCatalogVolumeId) {
-                    *matchedCatalogVolumeId =
-                        openDataCatalogVolumeIdForLoadedVolume(pkg, loadedVolumeId);
+                if (isSelectedEditableOpenDataSegmentsEntry(pkg, entry)) {
+                    coordinateMatch = &entry;
+                    break;
                 }
-                return &entry;
+                if (!coordinateMatch) {
+                    coordinateMatch = &entry;
+                }
             }
+        }
+        if (coordinateMatch && matchedCatalogVolumeId) {
+            *matchedCatalogVolumeId =
+                openDataCatalogVolumeIdForLoadedVolume(pkg, loadedVolumeId);
+        }
+        if (coordinateMatch) {
+            return coordinateMatch;
         }
         // Explicitly identified assets must never fall back to lineage-only
         // association, because native and virtual views share that lineage.

--- a/volume-cartographer/apps/VC3D/OpenDataSegmentCache.cpp
+++ b/volume-cartographer/apps/VC3D/OpenDataSegmentCache.cpp
@@ -2052,6 +2052,95 @@ std::vector<OpenDataInkDetectionEntry> cachedInkDetectionsForSegmentDirectory(
     return out;
 }
 
+namespace {
+
+struct RegisteredCatalogEntry {
+    const vc::project::Entry* entry = nullptr;
+    std::filesystem::path path;
+    std::size_t depth = 0;
+};
+
+bool pathContains(const std::filesystem::path& root,
+                  const std::filesystem::path& candidate)
+{
+    auto candidatePart = candidate.begin();
+    for (auto rootPart = root.begin(); rootPart != root.end();
+         ++rootPart, ++candidatePart) {
+        if (candidatePart == candidate.end() || *candidatePart != *rootPart) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::optional<RegisteredCatalogEntry> findRegisteredOpenDataCatalogEntry(
+    const VolumePkg& pkg,
+    const std::filesystem::path& catalogSegmentDir,
+    bool preferDeepest)
+{
+    std::error_code canonicalError;
+    const auto canonicalSegment =
+        std::filesystem::weakly_canonical(catalogSegmentDir, canonicalError);
+    if (canonicalError) {
+        return std::nullopt;
+    }
+
+    std::optional<RegisteredCatalogEntry> match;
+    for (const auto& entry : pkg.segmentEntries()) {
+        if (vc::project::isLocationRemote(entry.location) ||
+            !vc::project::hasEntryTag(entry, "open-data") ||
+            !vc::project::hasEntryTag(entry, "immutable")) {
+            continue;
+        }
+        std::error_code error;
+        const auto entryPath = std::filesystem::weakly_canonical(
+            vc::project::resolveLocalPath(
+                entry.location, pkg.path().parent_path()),
+            error);
+        if (error || !pathContains(entryPath, canonicalSegment)) {
+            continue;
+        }
+        const auto depth = static_cast<std::size_t>(
+            std::distance(entryPath.begin(), entryPath.end()));
+        if (!match || (preferDeepest ? depth > match->depth
+                                    : depth < match->depth)) {
+            match = RegisteredCatalogEntry{&entry, entryPath, depth};
+        }
+    }
+    return match;
+}
+
+std::filesystem::path canonicalPathOrThrow(
+    const std::filesystem::path& path,
+    const char* label)
+{
+    std::error_code error;
+    const auto absolute = std::filesystem::absolute(path, error);
+    if (error) {
+        throw std::runtime_error(
+            std::string("could not resolve ") + label + ": " +
+            error.message());
+    }
+    const auto canonical = std::filesystem::weakly_canonical(absolute, error);
+    if (error) {
+        throw std::runtime_error(
+            std::string("could not resolve ") + label + ": " +
+            error.message());
+    }
+    return canonical;
+}
+
+} // namespace
+
+std::filesystem::path registeredOpenDataCatalogRootForSegment(
+    const VolumePkg& pkg,
+    const std::filesystem::path& catalogSegmentDir)
+{
+    const auto match = findRegisteredOpenDataCatalogEntry(
+        pkg, catalogSegmentDir, false);
+    return match ? match->path : std::filesystem::path{};
+}
+
 std::filesystem::path defaultEditableCopyPathForCatalogSegment(
     const std::filesystem::path& catalogSegmentDir,
     const std::filesystem::path& activeSegmentsRoot)
@@ -2074,6 +2163,7 @@ std::filesystem::path defaultEditableCopyPathForCatalogSegment(
 }
 
 void copyCatalogSegmentToEditableDirectory(
+    const VolumePkg& pkg,
     const std::filesystem::path& catalogSegmentDir,
     const std::filesystem::path& editableSegmentDir)
 {
@@ -2081,6 +2171,39 @@ void copyCatalogSegmentToEditableDirectory(
         !requiredFilesPresent(catalogSegmentDir)) {
         throw std::runtime_error("catalog segment is not a complete open-data tifxyz directory");
     }
+    const auto canonicalSource = canonicalPathOrThrow(
+        catalogSegmentDir, "catalog segment path");
+    const auto canonicalDestination = canonicalPathOrThrow(
+        editableSegmentDir, "editable segment path");
+    const auto pathsOverlap = [&](const std::filesystem::path& protectedPath) {
+        return pathContains(protectedPath, canonicalDestination) ||
+               pathContains(canonicalDestination, protectedPath);
+    };
+    if (pathsOverlap(canonicalSource)) {
+        throw std::runtime_error(
+            "editable destination must not overlap the immutable catalog segment");
+    }
+    if (isOpenDataCatalogSegmentDirectory(editableSegmentDir)) {
+        throw std::runtime_error(
+            "editable destination is an immutable catalog segment");
+    }
+    for (const auto& entry : pkg.segmentEntries()) {
+        if (vc::project::isLocationRemote(entry.location) ||
+            !vc::project::hasEntryTag(entry, "open-data") ||
+            !vc::project::hasEntryTag(entry, "immutable")) {
+            continue;
+        }
+        std::error_code rootError;
+        const auto catalogRoot = std::filesystem::weakly_canonical(
+            vc::project::resolveLocalPath(
+                entry.location, pkg.path().parent_path()),
+            rootError);
+        if (!rootError && pathsOverlap(catalogRoot)) {
+            throw std::runtime_error(
+                "editable destination must be outside the immutable catalog root");
+        }
+    }
+
     std::error_code ec;
     if (std::filesystem::exists(editableSegmentDir, ec)) {
         if (!std::filesystem::is_directory(editableSegmentDir, ec)) {
@@ -2111,6 +2234,60 @@ void copyCatalogSegmentToEditableDirectory(
     if (!requiredFilesPresent(editableSegmentDir)) {
         throw std::runtime_error("editable destination is missing required tifxyz files");
     }
+}
+
+void attachEditableOpenDataSegmentRoot(
+    VolumePkg& pkg,
+    const std::filesystem::path& catalogSegmentDir,
+    const std::filesystem::path& editableSegmentsRoot,
+    bool select)
+{
+    std::vector<std::string> tags{"open-data-editable"};
+    const auto sourceMatch = findRegisteredOpenDataCatalogEntry(
+        pkg, catalogSegmentDir, true);
+    const vc::project::Entry* sourceEntry =
+        sourceMatch ? sourceMatch->entry : nullptr;
+    bool copiedRoutingTag = false;
+    if (sourceEntry) {
+        for (const auto& tag : sourceEntry->tags) {
+            const bool routingTag =
+                tag.rfind("vc-open-data-coordinate-space:", 0) == 0 ||
+                tag.rfind("vc-open-data-source-coordinate-level:", 0) == 0 ||
+                tag.rfind("vc-open-data-source-volume-id:", 0) == 0 ||
+                tag.rfind("vc-open-data-target-volume-id:", 0) == 0;
+            if (routingTag &&
+                std::find(tags.begin(), tags.end(), tag) == tags.end()) {
+                tags.push_back(tag);
+                copiedRoutingTag = true;
+            }
+        }
+    }
+
+    pkg.attachSegmentsEntry(editableSegmentsRoot.string(), tags, select);
+    std::string persistedLocation = editableSegmentsRoot.string();
+    for (const auto& entry : pkg.segmentEntries()) {
+        if (vc::project::isLocationRemote(entry.location)) {
+            continue;
+        }
+        const auto entryPath = vc::project::resolveLocalPath(
+            entry.location, pkg.path().parent_path());
+        std::error_code error;
+        if (std::filesystem::equivalent(
+                editableSegmentsRoot, entryPath, error) && !error) {
+            persistedLocation = entry.location;
+            break;
+        }
+    }
+    pkg.reconcileSegmentsEntryTags(
+        persistedLocation,
+        tags,
+        copiedRoutingTag
+            ? std::vector<std::string>{
+                  "vc-open-data-coordinate-space:",
+                  "vc-open-data-source-coordinate-level:",
+                  "vc-open-data-source-volume-id:",
+                  "vc-open-data-target-volume-id:"}
+            : std::vector<std::string>{});
 }
 
 OpenDataSegmentCacheReconcileResult reconcileOpenDataSampleSegments(

--- a/volume-cartographer/apps/VC3D/OpenDataSegmentCache.hpp
+++ b/volume-cartographer/apps/VC3D/OpenDataSegmentCache.hpp
@@ -173,13 +173,29 @@ materializeOpenDataSegmentFolder(
 [[nodiscard]] std::vector<OpenDataInkDetectionEntry> cachedInkDetectionsForSegmentDirectory(
     const std::filesystem::path& segmentDir);
 
+// Return the outermost registered immutable Open Data root that contains the
+// segment. Using the outermost root keeps editable copies outside every
+// protected catalog entry, including legacy nested representation entries.
+[[nodiscard]] std::filesystem::path registeredOpenDataCatalogRootForSegment(
+    const VolumePkg& pkg,
+    const std::filesystem::path& catalogSegmentDir);
+
 [[nodiscard]] std::filesystem::path defaultEditableCopyPathForCatalogSegment(
     const std::filesystem::path& catalogSegmentDir,
     const std::filesystem::path& activeSegmentsRoot);
 
 void copyCatalogSegmentToEditableDirectory(
+    const VolumePkg& pkg,
     const std::filesystem::path& catalogSegmentDir,
     const std::filesystem::path& editableSegmentDir);
+
+// Attach an editable root while preserving only the catalog entry metadata
+// needed to keep it associated with the correct Open Data volume.
+void attachEditableOpenDataSegmentRoot(
+    VolumePkg& pkg,
+    const std::filesystem::path& catalogSegmentDir,
+    const std::filesystem::path& editableSegmentsRoot,
+    bool select = true);
 
 OpenDataSegmentCacheReconcileResult reconcileOpenDataSampleSegments(
     VolumePkg& pkg,

--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -5654,7 +5654,13 @@ void SegmentationCommandHandler::onRenameSurface(const QString& segmentId)
     }
     if (err == QLatin1String("name unchanged"))
         return;
-    if (err == QLatin1String("invalid name")) {
+    if (err == QLatin1String("immutable catalog segment")) {
+        QMessageBox::warning(
+            _parentWidget,
+            tr("Open Data Segment"),
+            tr("This catalog segment is immutable. Create an editable copy "
+               "before renaming it."));
+    } else if (err == QLatin1String("invalid name")) {
         QMessageBox::warning(_parentWidget, tr("Invalid Name"),
             tr("Surface name can only contain letters, numbers, underscores, and hyphens."));
     } else if (err == QLatin1String("name exists")) {
@@ -5689,6 +5695,9 @@ bool SegmentationCommandHandler::renameSurfaceHeadless(const QString& segmentIdQ
     auto seg = _state->vpkg()->segmentation(oldId);
     if (!seg)
         return fail(QStringLiteral("segment not found"));
+
+    if (vc3d::opendata::isOpenDataCatalogSegmentDirectory(seg->path()))
+        return fail(QStringLiteral("immutable catalog segment"));
 
     const std::string newId = newName.toStdString();
 

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_editing.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_editing.cpp
@@ -341,6 +341,29 @@ QJsonObject AgentBridgeServer::handleSegmentationEnableEditing(const QJsonValue&
         throw AgentBridgeError{-32007, "No active segmentation surface", data};
     }
 
+    if (enabled) {
+        auto surface = std::dynamic_pointer_cast<QuadSurface>(
+            state->surface("segmentation"));
+        if (!surface) {
+            surface = state->activeSurface().lock();
+        }
+        if (surface && !surface->path.empty() &&
+            vc3d::opendata::isOpenDataCatalogSegmentDirectory(surface->path)) {
+            QJsonObject data;
+            data["kind"] = "segment";
+            data["id"] = QString::fromStdString(state->activeSurfaceId());
+            data["path"] = QString::fromStdString(surface->path.string());
+            data["action"] = "segments.create_editable_copy";
+            data["detail"] =
+                "catalog segments are immutable; create and activate an "
+                "editable copy first";
+            throw AgentBridgeError{
+                -32009,
+                "Cannot edit an immutable Open Data catalog segment",
+                data};
+        }
+    }
+
     widget->setEditingEnabled(enabled);
 
     // widget->setEditingEnabled() is silent (never emits editingModeChanged), so

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
@@ -22,6 +22,8 @@
 #include "CWindow.hpp"
 #include "AxisAlignedSliceController.hpp"
 #include "CState.hpp"
+#include "OpenDataCoordinateIdentity.hpp"
+#include "OpenDataSegmentCache.hpp"
 #include "SegmentationCommandHandler.hpp"
 #include "SurfacePanelController.hpp"
 #include "ViewerManager.hpp"
@@ -35,6 +37,7 @@
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/Logging.hpp"
+#include "vc/core/util/QuadSurface.hpp"
 #include "vc/ui/VCCollection.hpp"
 
 QJsonObject AgentBridgeServer::handlePing(const QJsonValue&)
@@ -514,6 +517,153 @@ QJsonObject AgentBridgeServer::handleSegmentsActivate(const QJsonValue& params)
     result["previousSegmentId"] = previousSegmentId;
     result["alreadyActive"] = alreadyActive;
     return result;
+}
+
+
+QJsonObject AgentBridgeServer::handleSegmentsCreateEditableCopy(const QJsonValue& params)
+{
+    CState* state = _window ? _window->_state : nullptr;
+    std::shared_ptr<VolumePkg> vpkg = state ? state->vpkg() : nullptr;
+    if (!state || !state->hasVpkg() || !vpkg)
+        throw AgentBridgeError{-32000, "No volume package loaded", {}};
+
+    if (_window->_segmentationWidget &&
+        _window->_segmentationWidget->isEditingEnabled()) {
+        throw AgentBridgeError{
+            -32004,
+            "Cannot create an editable copy while editing",
+            QJsonObject{{"detail", "disable segmentation editing first"}},
+        };
+    }
+
+    const QJsonObject p = params.toObject();
+    const QString segmentIdQ = p.value("segmentId").toString();
+    if (segmentIdQ.isEmpty()) {
+        throw AgentBridgeError{
+            -32602,
+            "segmentId is required",
+            QJsonObject{{"param", "segmentId"}},
+        };
+    }
+    const std::string segmentId = segmentIdQ.toStdString();
+
+    std::shared_ptr<Segmentation> source;
+    try {
+        source = vpkg->segmentation(segmentId);
+    } catch (...) {
+    }
+    if (!source) {
+        throw AgentBridgeError{
+            -32007,
+            QStringLiteral("Unknown segment id: %1").arg(segmentIdQ),
+            QJsonObject{{"kind", "segment"}, {"id", segmentIdQ}},
+        };
+    }
+
+    const std::filesystem::path sourcePath = source->path();
+    if (!vc3d::opendata::isOpenDataCatalogSegmentDirectory(sourcePath)) {
+        throw AgentBridgeError{
+            -32009,
+            "Segment is not an immutable Open Data catalog segment",
+            QJsonObject{
+                {"kind", "segment"},
+                {"id", segmentIdQ},
+                {"path", QString::fromStdString(sourcePath.string())},
+            },
+        };
+    }
+    if (vc3d::opendata::isOpenDataSegmentPlaceholder(sourcePath)) {
+        throw AgentBridgeError{
+            -32009,
+            "Catalog segment must be fetched before it can be copied",
+            QJsonObject{
+                {"kind", "segment"},
+                {"id", segmentIdQ},
+                {"action", "segments.fetch"},
+            },
+        };
+    }
+
+    const std::filesystem::path editablePath =
+        vc3d::opendata::defaultEditableCopyPathForCatalogSegment(
+            sourcePath, vpkg->outputSegmentsPath());
+    const std::filesystem::path editableRoot = editablePath.parent_path();
+    std::error_code existsError;
+    const bool alreadyExisted = std::filesystem::exists(editablePath, existsError);
+    if (existsError) {
+        throw AgentBridgeError{
+            -32005,
+            "Could not inspect editable segment destination",
+            QJsonObject{{"detail", QString::fromStdString(existsError.message())}},
+        };
+    }
+
+    try {
+        vc3d::opendata::copyCatalogSegmentToEditableDirectory(
+            sourcePath, editablePath);
+        vpkg->attachSegmentsEntry(
+            editableRoot.string(), {"open-data-editable"}, true);
+
+        auto editableSurface = vpkg->loadSurface(segmentId);
+        if (!editableSurface) {
+            editableSurface = std::make_shared<QuadSurface>(editablePath);
+        }
+        vc3d::opendata::copyVolumeCoordinateIdentityToSurface(
+            *editableSurface, *vpkg, state->currentVolumeId());
+        editableSurface->save_meta();
+    } catch (const std::exception& error) {
+        throw AgentBridgeError{
+            -32005,
+            "Could not create editable segment copy",
+            QJsonObject{{"detail", QString::fromUtf8(error.what())}},
+        };
+    }
+
+    try {
+        _window->refreshCurrentVolumePackageUi(QString(), true);
+    } catch (const std::exception& error) {
+        Logger()->warn(
+            "Editable segment copy was committed, but the VC3D UI could not "
+            "refresh: {}",
+            error.what());
+    } catch (...) {
+        Logger()->warn(
+            "Editable segment copy was committed, but the VC3D UI could not "
+            "refresh");
+    }
+
+    SurfacePanelController* panel =
+        _window ? _window->_surfacePanel.get() : nullptr;
+    if (!panel) {
+        throw AgentBridgeError{
+            -32010,
+            "Surface panel unavailable",
+            QJsonObject{
+                {"detail", "editable copy was created but could not be activated"},
+                {"path", QString::fromStdString(editablePath.string())},
+            },
+        };
+    }
+    QString activationError;
+    if (!panel->activateSurfaceById(segmentId, &activationError)) {
+        throw AgentBridgeError{
+            -32005,
+            "Editable segment copy was created but could not be activated",
+            QJsonObject{
+                {"detail", activationError},
+                {"path", QString::fromStdString(editablePath.string())},
+            },
+        };
+    }
+
+    return QJsonObject{
+        {"created", !alreadyExisted},
+        {"alreadyExisted", alreadyExisted},
+        {"segmentId", segmentIdQ},
+        {"sourcePath", QString::fromStdString(sourcePath.string())},
+        {"path", QString::fromStdString(editablePath.string())},
+        {"activated", true},
+    };
 }
 
 
@@ -1168,6 +1318,16 @@ QJsonObject AgentBridgeServer::handleSegmentsRename(const QJsonValue& params)
             QJsonObject data;
             data["param"] = "newName";
             throw AgentBridgeError{-32602, "newName is unchanged", data};
+        }
+        if (err == QLatin1String("immutable catalog segment")) {
+            QJsonObject data;
+            data["kind"] = "segment";
+            data["id"] = segmentIdQ;
+            data["action"] = "segments.create_editable_copy";
+            throw AgentBridgeError{
+                -32009,
+                "Cannot rename an immutable Open Data catalog segment",
+                data};
         }
         if (err == QLatin1String("editing in progress")) {
             QJsonObject data;

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeHandlers_session.cpp
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <unordered_set>
 #include <vector>
@@ -560,7 +561,60 @@ QJsonObject AgentBridgeServer::handleSegmentsCreateEditableCopy(const QJsonValue
         };
     }
 
-    const std::filesystem::path sourcePath = source->path();
+    const std::filesystem::path selectedPath = source->path();
+    std::filesystem::path sourcePath = selectedPath;
+    std::filesystem::path editablePath;
+
+    if (!vc3d::opendata::isOpenDataCatalogSegmentDirectory(sourcePath)) {
+        // A successful first call selects the editable source, so an immediate
+        // retry resolves segmentId there instead of in the catalog source.
+        // A default copy root is named after the selected catalog root with an
+        // `_editable` suffix. Recover that root and search it because aggregate
+        // catalog entries can keep the actual segment in a nested representation.
+        constexpr std::string_view suffix = "_editable";
+        const auto selectedRoot = selectedPath.parent_path();
+        const auto selectedRootName = selectedRoot.filename().string();
+        if (selectedRootName.ends_with(suffix)) {
+            const auto catalogRoot = selectedRoot.parent_path() /
+                selectedRootName.substr(0, selectedRootName.size() - suffix.size());
+            std::filesystem::path candidate =
+                catalogRoot / selectedPath.filename();
+            if (!vc3d::opendata::isOpenDataCatalogSegmentDirectory(candidate)) {
+                candidate.clear();
+                std::error_code scanError;
+                std::filesystem::recursive_directory_iterator it(
+                    catalogRoot,
+                    std::filesystem::directory_options::skip_permission_denied,
+                    scanError);
+                const std::filesystem::recursive_directory_iterator end;
+                for (; it != end && !scanError; it.increment(scanError)) {
+                    std::error_code entryError;
+                    if (!it->is_directory(entryError) || entryError ||
+                        it->path().filename() != selectedPath.filename()) {
+                        continue;
+                    }
+                    if (vc3d::opendata::isOpenDataCatalogSegmentDirectory(
+                            it->path())) {
+                        candidate = it->path();
+                        break;
+                    }
+                }
+            }
+            const auto candidateEditablePath = candidate.empty()
+                ? std::filesystem::path{}
+                : vc3d::opendata::defaultEditableCopyPathForCatalogSegment(
+                      candidate, catalogRoot);
+            std::error_code equivalentError;
+            if (!candidate.empty() &&
+                std::filesystem::equivalent(
+                    selectedPath, candidateEditablePath, equivalentError) &&
+                !equivalentError) {
+                sourcePath = candidate;
+                editablePath = candidateEditablePath;
+            }
+        }
+    }
+
     if (!vc3d::opendata::isOpenDataCatalogSegmentDirectory(sourcePath)) {
         throw AgentBridgeError{
             -32009,
@@ -584,9 +638,17 @@ QJsonObject AgentBridgeServer::handleSegmentsCreateEditableCopy(const QJsonValue
         };
     }
 
-    const std::filesystem::path editablePath =
-        vc3d::opendata::defaultEditableCopyPathForCatalogSegment(
-            sourcePath, vpkg->outputSegmentsPath());
+    if (editablePath.empty()) {
+        const auto registeredCatalogRoot =
+            vc3d::opendata::registeredOpenDataCatalogRootForSegment(
+                *vpkg, sourcePath);
+        const auto copySourceRoot = registeredCatalogRoot.empty()
+            ? vpkg->outputSegmentsPath()
+            : registeredCatalogRoot;
+        editablePath =
+            vc3d::opendata::defaultEditableCopyPathForCatalogSegment(
+                sourcePath, copySourceRoot);
+    }
     const std::filesystem::path editableRoot = editablePath.parent_path();
     std::error_code existsError;
     const bool alreadyExisted = std::filesystem::exists(editablePath, existsError);
@@ -600,9 +662,9 @@ QJsonObject AgentBridgeServer::handleSegmentsCreateEditableCopy(const QJsonValue
 
     try {
         vc3d::opendata::copyCatalogSegmentToEditableDirectory(
-            sourcePath, editablePath);
-        vpkg->attachSegmentsEntry(
-            editableRoot.string(), {"open-data-editable"}, true);
+            *vpkg, sourcePath, editablePath);
+        vc3d::opendata::attachEditableOpenDataSegmentRoot(
+            *vpkg, sourcePath, editableRoot, true);
 
         auto editableSurface = vpkg->loadSurface(segmentId);
         if (!editableSurface) {
@@ -652,6 +714,46 @@ QJsonObject AgentBridgeServer::handleSegmentsCreateEditableCopy(const QJsonValue
             QJsonObject{
                 {"detail", activationError},
                 {"path", QString::fromStdString(editablePath.string())},
+            },
+        };
+    }
+
+    auto equivalentPath = [](const std::filesystem::path& lhs,
+                             const std::filesystem::path& rhs) {
+        std::error_code error;
+        return std::filesystem::equivalent(lhs, rhs, error) && !error;
+    };
+    std::filesystem::path resolvedPath;
+    try {
+        if (auto resolved = vpkg->segmentation(segmentId)) {
+            resolvedPath = resolved->path();
+        }
+    } catch (...) {
+    }
+    const auto activeSurface =
+        std::dynamic_pointer_cast<QuadSurface>(state->surface("segmentation"));
+    const auto activeWeakSurface =
+        std::dynamic_pointer_cast<QuadSurface>(state->activeSurface().lock());
+    const std::filesystem::path activePath =
+        activeSurface ? activeSurface->path : std::filesystem::path{};
+    const std::filesystem::path activeWeakPath =
+        activeWeakSurface ? activeWeakSurface->path : std::filesystem::path{};
+    if (state->activeSurfaceId() != segmentId ||
+        !equivalentPath(vpkg->outputSegmentsPath(), editableRoot) ||
+        !equivalentPath(resolvedPath, editablePath) ||
+        !equivalentPath(activePath, editablePath) ||
+        !equivalentPath(activeWeakPath, editablePath)) {
+        throw AgentBridgeError{
+            -32005,
+            "Editable segment copy was created but did not remain active",
+            QJsonObject{
+                {"path", QString::fromStdString(editablePath.string())},
+                {"selectedRoot", QString::fromStdString(
+                                     vpkg->outputSegmentsPath().string())},
+                {"resolvedPath", QString::fromStdString(resolvedPath.string())},
+                {"activePath", QString::fromStdString(activePath.string())},
+                {"activeSurfacePath", QString::fromStdString(
+                                          activeWeakPath.string())},
             },
         };
     }

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_session.cpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeMethods_session.cpp
@@ -129,6 +129,19 @@ void AgentBridgeServer::registerSessionHandlers()
 
     registerMethod(
         {
+            .name = QStringLiteral("segments.create_editable_copy"),
+            .params = {
+                Params::requiredString(QStringLiteral("segmentId")),
+            },
+            .errors = {-32602, -32000, -32004, -32005, -32007, -32009, -32010},
+            .mcp = mcp(QStringLiteral("vc3d_create_editable_segment_copy"), true),
+        },
+        [this](const QJsonValue& p) {
+            return handleSegmentsCreateEditableCopy(p);
+        });
+
+    registerMethod(
+        {
             .name = QStringLiteral("segments.delete"),
             .params = {
                 Params::requiredString(QStringLiteral("segmentId")),

--- a/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeServer.hpp
+++ b/volume-cartographer/apps/VC3D/agent_bridge/AgentBridgeServer.hpp
@@ -135,6 +135,7 @@ private:
     QJsonObject handleSegmentsList(const QJsonValue& params);
     QJsonObject handleSegmentsActivate(const QJsonValue& params);
     QJsonObject handleSegmentsFetch(const QJsonValue& params);
+    QJsonObject handleSegmentsCreateEditableCopy(const QJsonValue& params);
     // Destructive on-disk operations use the same dialog-free cores as the UI.
     QJsonObject handleSegmentsDelete(const QJsonValue& params);
     QJsonObject handleSegmentsRename(const QJsonValue& params);

--- a/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
+++ b/volume-cartographer/apps/VC3D/agent_bridge/SPEC.md
@@ -432,6 +432,7 @@ is the sole bridge method without an MCP tool.
 | `vc3d_commit_points` | `points.commit` | Add annotation points (volume space) to a named collection, optionally with a winding annotation. |
 | `vc3d_commit_wrap_annotation` | `wrap_annotation.commit` | Commit the seeded same-wrap annotation preview into the point collection (the tutorial's shift+E). Requires the mode enabled. |
 | `vc3d_corrections_set_point_mode` | `segmentation.corrections.set_point_mode` |
+| `vc3d_create_editable_segment_copy` | `segments.create_editable_copy` | Copy a fetched immutable Open Data catalog segment into the project's editable storage, attach it, and activate it. Idempotently reuses an existing copy. |
 | `vc3d_create_project` | `project.create` | Create a `.volpkg.json` that references one local zarr volume or remote `.zarr` URL without opening it. |
 | `vc3d_crop_segment_bounds` | `segment.crop_bounds` | Crop a segment's surface grid to its tightest valid bounds. Synchronous. |
 | `vc3d_delete_segment` | `segments.delete` | Delete a segment from disk. **Irreversible** — requires `confirm=true`. Fails while segmentation editing is enabled; deleting the active segment is allowed. |

--- a/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
+++ b/volume-cartographer/apps/VC3D/agent_bridge/rpc_description.json
@@ -2968,6 +2968,34 @@
         "type": "object"
       }
     },
+    "segments.create_editable_copy": {
+      "errors": [
+        -32602,
+        -32000,
+        -32004,
+        -32005,
+        -32007,
+        -32009,
+        -32010
+      ],
+      "mcp": {
+        "paramRenames": {
+          "segmentId": "segment_id"
+        },
+        "tool": "vc3d_create_editable_segment_copy"
+      },
+      "params": {
+        "properties": {
+          "segmentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "segmentId"
+        ],
+        "type": "object"
+      }
+    },
     "segments.delete": {
       "errors": [
         -32602,

--- a/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
+++ b/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
@@ -1141,22 +1141,32 @@ def check_open_data_editable_copy(
     volpkg: Path,
 ) -> None:
     catalog_root = root / "catalog-segments"
+    catalog_folder = catalog_root / "published-L0"
     segment_id = "20241113090990"
-    catalog_segment = catalog_root / segment_id
+    catalog_segment = catalog_folder / segment_id
     shutil.copytree(
         REPO_ROOT / "core" / "test" / "data" / "segments" / segment_id,
         catalog_segment,
     )
     (catalog_segment / "catalog-origin.json").write_text("{}")
-    renamed_path = catalog_root / "must-not-rename"
+    renamed_path = catalog_folder / "must-not-rename"
 
     try:
+        project = json.loads(volpkg.read_text())
+        project.setdefault("segments", []).append({
+            "location": str(catalog_root),
+            "tags": [
+                "open-data",
+                "immutable",
+                "vc-open-data-segment-aggregate",
+                "vc-open-data-target-volume-id:vol1",
+            ],
+        })
+        project["output_segments"] = str(catalog_root)
+        volpkg.write_text(json.dumps(project))
         client.call(
-            "segments.attach",
-            {
-                "location": str(catalog_root),
-                "tags": ["open-data", "immutable"],
-            },
+            "volume.open",
+            {"path": str(volpkg)},
             timeout=RPC_TIMEOUT,
         )
         client.call(
@@ -1224,6 +1234,11 @@ def check_open_data_editable_copy(
         ]
         state, _ = client.call("state.get", {}, timeout=RPC_TIMEOUT)
         active = state.get("activeSurface") or {}
+        listed, _ = client.call("segments.list", {}, timeout=RPC_TIMEOUT)
+        listed_active = next(
+            (segment for segment in listed.get("segments", []) if segment.get("active")),
+            {},
+        )
         results.record(
             "catalog_segment_create_editable_copy",
             copied.get("created") is True
@@ -1237,10 +1252,56 @@ def check_open_data_editable_copy(
             and (editable_segment / "z.tif").is_file()
             and editable_entries == [{
                 "location": str(editable_root),
-                "tags": ["open-data-editable"],
+                "tags": [
+                    "open-data-editable",
+                    "vc-open-data-target-volume-id:vol1",
+                ],
             }]
-            and active.get("id") == segment_id,
-            f"result={copied} active={active} entries={editable_entries}",
+            and project.get("output_segments") == str(editable_root)
+            and active.get("id") == segment_id
+            and listed_active.get("id") == segment_id
+            and listed_active.get("path") == str(editable_segment),
+            f"result={copied} active={active} listed_active={listed_active} "
+            f"output_segments={project.get('output_segments')} "
+            f"entries={editable_entries}",
+        )
+
+        retried, _ = client.call(
+            "segments.create_editable_copy",
+            {"segmentId": segment_id},
+            timeout=RPC_TIMEOUT,
+        )
+        project_after_retry = json.loads(volpkg.read_text())
+        editable_entries_after_retry = [
+            entry
+            for entry in project_after_retry.get("segments", [])
+            if isinstance(entry, dict) and entry.get("location") == str(editable_root)
+        ]
+        listed_after_retry, _ = client.call(
+            "segments.list", {}, timeout=RPC_TIMEOUT
+        )
+        listed_active_after_retry = next(
+            (
+                segment
+                for segment in listed_after_retry.get("segments", [])
+                if segment.get("active")
+            ),
+            {},
+        )
+        results.record(
+            "catalog_segment_create_editable_copy_retry",
+            retried.get("created") is False
+            and retried.get("alreadyExisted") is True
+            and retried.get("activated") is True
+            and retried.get("sourcePath") == str(catalog_segment)
+            and retried.get("path") == str(editable_segment)
+            and editable_entries_after_retry == editable_entries
+            and project_after_retry.get("output_segments") == str(editable_root)
+            and listed_active_after_retry.get("id") == segment_id
+            and listed_active_after_retry.get("path") == str(editable_segment),
+            f"result={retried} listed_active={listed_active_after_retry} "
+            f"output_segments={project_after_retry.get('output_segments')} "
+            f"entries={editable_entries_after_retry}",
         )
 
         enabled, _ = client.call(
@@ -1252,6 +1313,47 @@ def check_open_data_editable_copy(
             "editable_copy_can_enable_editing",
             enabled.get("enabled") is True,
             f"result={enabled}",
+        )
+        client.call(
+            "segmentation.enable_editing",
+            {"enabled": False},
+            timeout=RPC_TIMEOUT,
+        )
+
+        reopened, _ = client.call(
+            "volume.open", {"path": str(volpkg)}, timeout=RPC_TIMEOUT
+        )
+        listed_after_reopen, _ = client.call(
+            "segments.list", {}, timeout=RPC_TIMEOUT
+        )
+        reopened_segment = next(
+            (
+                segment
+                for segment in listed_after_reopen.get("segments", [])
+                if segment.get("id") == segment_id
+            ),
+            {},
+        )
+        client.call(
+            "segments.activate",
+            {"segmentId": segment_id},
+            timeout=RPC_TIMEOUT,
+        )
+        enabled_after_reopen, _ = client.call(
+            "segmentation.enable_editing",
+            {"enabled": True},
+            timeout=RPC_TIMEOUT,
+        )
+        project_after_reopen = json.loads(volpkg.read_text())
+        results.record(
+            "editable_copy_survives_reopen",
+            reopened.get("opened") is True
+            and reopened_segment.get("path") == str(editable_segment)
+            and project_after_reopen.get("output_segments") == str(editable_root)
+            and enabled_after_reopen.get("enabled") is True,
+            f"reopened={reopened} segment={reopened_segment} "
+            f"output_segments={project_after_reopen.get('output_segments')} "
+            f"editing={enabled_after_reopen}",
         )
         client.call(
             "segmentation.enable_editing",

--- a/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
+++ b/volume-cartographer/apps/VC3D/agent_bridge/test/smoke_offscreen.py
@@ -295,10 +295,10 @@ def check_rpc_describe(
         coverage = description.get("coverage", {})
         complete = (
             description.get("undocumented") == []
-            and coverage.get("described") == 119
-            and coverage.get("registered") == 119
+            and coverage.get("described") == 120
+            and coverage.get("registered") == 120
             and coverage.get("complete") is True
-            and len(snapshot["methods"]) == 119
+            and len(snapshot["methods"]) == 120
         )
         rendered = json.dumps(snapshot, indent=2, sort_keys=True) + "\n"
         if update_snapshot:
@@ -1134,6 +1134,138 @@ def check_segments_attach(
         )
 
 
+def check_open_data_editable_copy(
+    client: BridgeClient,
+    results: Results,
+    root: Path,
+    volpkg: Path,
+) -> None:
+    catalog_root = root / "catalog-segments"
+    segment_id = "20241113090990"
+    catalog_segment = catalog_root / segment_id
+    shutil.copytree(
+        REPO_ROOT / "core" / "test" / "data" / "segments" / segment_id,
+        catalog_segment,
+    )
+    (catalog_segment / "catalog-origin.json").write_text("{}")
+    renamed_path = catalog_root / "must-not-rename"
+
+    try:
+        client.call(
+            "segments.attach",
+            {
+                "location": str(catalog_root),
+                "tags": ["open-data", "immutable"],
+            },
+            timeout=RPC_TIMEOUT,
+        )
+        client.call(
+            "segments.activate",
+            {"segmentId": segment_id},
+            timeout=RPC_TIMEOUT,
+        )
+
+        try:
+            client.call(
+                "segments.rename",
+                {"segmentId": segment_id, "newName": renamed_path.name},
+                timeout=RPC_TIMEOUT,
+            )
+            results.record(
+                "catalog_segment_rename_guard",
+                False,
+                "expected an immutable-cache error, got a result",
+            )
+        except BridgeError as error:
+            results.record(
+                "catalog_segment_rename_guard",
+                error.code == -32009
+                and error.data.get("action") == "segments.create_editable_copy"
+                and catalog_segment.is_dir()
+                and not renamed_path.exists(),
+                f"returned code={error.code} action={error.data.get('action')}",
+            )
+
+        started = time.monotonic()
+        try:
+            client.call(
+                "segmentation.enable_editing",
+                {"enabled": True},
+                timeout=RPC_TIMEOUT,
+            )
+            results.record(
+                "catalog_segment_editing_fails_fast",
+                False,
+                "expected an immutable-cache error, got a result",
+            )
+        except BridgeError as error:
+            elapsed = time.monotonic() - started
+            results.record(
+                "catalog_segment_editing_fails_fast",
+                error.code == -32009
+                and error.data.get("action") == "segments.create_editable_copy"
+                and elapsed < RPC_TIMEOUT,
+                f"returned code={error.code} action={error.data.get('action')} "
+                f"elapsed={elapsed:.3f}s",
+            )
+
+        copied, _ = client.call(
+            "segments.create_editable_copy",
+            {"segmentId": segment_id},
+            timeout=RPC_TIMEOUT,
+        )
+        editable_segment = Path(copied.get("path", ""))
+        editable_root = editable_segment.parent
+        project = json.loads(volpkg.read_text())
+        editable_entries = [
+            entry
+            for entry in project.get("segments", [])
+            if isinstance(entry, dict) and entry.get("location") == str(editable_root)
+        ]
+        state, _ = client.call("state.get", {}, timeout=RPC_TIMEOUT)
+        active = state.get("activeSurface") or {}
+        results.record(
+            "catalog_segment_create_editable_copy",
+            copied.get("created") is True
+            and copied.get("alreadyExisted") is False
+            and copied.get("activated") is True
+            and copied.get("sourcePath") == str(catalog_segment)
+            and editable_segment.is_dir()
+            and not (editable_segment / "catalog-origin.json").exists()
+            and (editable_segment / "x.tif").is_file()
+            and (editable_segment / "y.tif").is_file()
+            and (editable_segment / "z.tif").is_file()
+            and editable_entries == [{
+                "location": str(editable_root),
+                "tags": ["open-data-editable"],
+            }]
+            and active.get("id") == segment_id,
+            f"result={copied} active={active} entries={editable_entries}",
+        )
+
+        enabled, _ = client.call(
+            "segmentation.enable_editing",
+            {"enabled": True},
+            timeout=RPC_TIMEOUT,
+        )
+        results.record(
+            "editable_copy_can_enable_editing",
+            enabled.get("enabled") is True,
+            f"result={enabled}",
+        )
+        client.call(
+            "segmentation.enable_editing",
+            {"enabled": False},
+            timeout=RPC_TIMEOUT,
+        )
+    except Exception as error:  # noqa: BLE001
+        results.record(
+            "catalog_segment_editable_copy_workflow",
+            False,
+            f"unexpected {type(error).__name__}: {error}",
+        )
+
+
 def check_c4(client: BridgeClient, results: Results, volpkg: str,
              broken_fiber_volpkg: str) -> None:
     # Liveness / dispatch sanity.
@@ -1527,6 +1659,7 @@ def main() -> int:
 
             check_volume_attach(client, results, tmp_path, volpkg)
             check_segments_attach(client, results, tmp_path, volpkg)
+            check_open_data_editable_copy(client, results, tmp_path, volpkg)
             check_c4(client, results, str(volpkg), str(broken_volpkg))
             check_project_create(client, results, tmp_path)
             check_c2_oversized(sock_path, results)

--- a/volume-cartographer/apps/VC3D/segmentation/SegmentationModule.cpp
+++ b/volume-cartographer/apps/VC3D/segmentation/SegmentationModule.cpp
@@ -126,9 +126,15 @@ bool ensureEditableOpenDataSegmentTarget(CState* state,
     }
 
     const std::filesystem::path activeSegmentsRoot = state->vpkg()->outputSegmentsPath();
+    const auto registeredCatalogRoot =
+        vc3d::opendata::registeredOpenDataCatalogRootForSegment(
+            *state->vpkg(), surface->path);
+    const auto copySourceRoot = registeredCatalogRoot.empty()
+        ? activeSegmentsRoot
+        : registeredCatalogRoot;
     const std::filesystem::path defaultPath =
         vc3d::opendata::defaultEditableCopyPathForCatalogSegment(
-            surface->path, activeSegmentsRoot);
+            surface->path, copySourceRoot);
 
     QMessageBox prompt(QApplication::activeWindow());
     prompt.setWindowTitle(QObject::tr("Open Data Segment"));
@@ -163,11 +169,12 @@ bool ensureEditableOpenDataSegmentTarget(CState* state,
     }
 
     try {
-        vc3d::opendata::copyCatalogSegmentToEditableDirectory(surface->path, editablePath);
+        vc3d::opendata::copyCatalogSegmentToEditableDirectory(
+            *state->vpkg(), surface->path, editablePath);
         const std::filesystem::path editableRoot = editablePath.parent_path();
         auto pkg = state->vpkg();
-        pkg->addSegmentsEntry(editableRoot.string(), {"open-data-editable"});
-        pkg->setOutputSegments(editableRoot.string());
+        vc3d::opendata::attachEditableOpenDataSegmentRoot(
+            *pkg, surface->path, editableRoot, true);
 
         const std::string segmentId = surface->id.empty()
             ? editablePath.filename().string()

--- a/volume-cartographer/core/test/test_open_data_manifest.cpp
+++ b/volume-cartographer/core/test/test_open_data_manifest.cpp
@@ -1591,7 +1591,7 @@ TEST_CASE("OpenDataSegmentCache names editable copies after the current segments
           editableSegmentsFolder / "segment-100");
 }
 
-TEST_CASE("OpenDataSegmentCache editable copy is selectable from its new folder")
+TEST_CASE("OpenDataSegmentCache editable copy inherits routing from an aggregate root")
 {
     const auto testRoot = std::filesystem::temp_directory_path() /
                           ("vc_open_data_editable_selection_test_" +
@@ -1599,7 +1599,8 @@ TEST_CASE("OpenDataSegmentCache editable copy is selectable from its new folder"
     std::filesystem::remove_all(testRoot);
 
     const auto sourceRoot = testRoot / "catalog-segments";
-    const auto sourceSegment = sourceRoot / "20241113070770";
+    const auto sourceFolder = sourceRoot / "published-L0";
+    const auto sourceSegment = sourceFolder / "20241113070770";
     const auto fixtureSegment = std::filesystem::path(VC_TEST_FIXTURES_DIR) /
                                 "segments" / "20241113070770";
     copyFixtureFile(fixtureSegment / "meta.json", sourceSegment / "meta.json");
@@ -1607,20 +1608,78 @@ TEST_CASE("OpenDataSegmentCache editable copy is selectable from its new folder"
     copyFixtureFile(fixtureSegment / "y.tif", sourceSegment / "y.tif");
     copyFixtureFile(fixtureSegment / "z.tif", sourceSegment / "z.tif");
     writeFile(sourceSegment / "catalog-origin.json", "{}");
-
-    const auto editableSegment =
-        defaultEditableCopyPathForCatalogSegment(sourceSegment, sourceRoot);
-    const auto editableRoot = editableSegment.parent_path();
-    copyCatalogSegmentToEditableDirectory(sourceSegment, editableSegment);
+    const auto otherCatalogRoot = testRoot / "other-catalog-segments";
+    const auto otherCatalogSegment =
+        otherCatalogRoot / "published-L0" / "other-segment";
+    copyFixtureFile(fixtureSegment / "meta.json", otherCatalogSegment / "meta.json");
+    copyFixtureFile(fixtureSegment / "x.tif", otherCatalogSegment / "x.tif");
+    copyFixtureFile(fixtureSegment / "y.tif", otherCatalogSegment / "y.tif");
+    copyFixtureFile(fixtureSegment / "z.tif", otherCatalogSegment / "z.tif");
+    writeFile(otherCatalogSegment / "catalog-origin.json", "{}");
 
     const auto previousAutosaveRoot = VolumePkg::autosaveRoot();
     VolumePkg::setAutosaveRoot(testRoot / "autosave");
     auto pkg = VolumePkg::newEmpty();
-    REQUIRE(pkg->addSegmentsEntry(sourceRoot.string(), {"open-data", "immutable"}));
-    REQUIRE(pkg->addSegmentsEntry(editableRoot.string(), {"open-data-editable"}));
-    pkg->setOutputSegments(editableRoot.string());
+    REQUIRE(pkg->addSegmentsEntry(
+        sourceRoot.string(),
+        {"open-data", "immutable", "vc-open-data-target-volume-id:vol1",
+         "vc-open-data-coordinate-space:sample/vol1@L0",
+         "vc-open-data-source-coordinate-level:0"}));
+    REQUIRE(pkg->addSegmentsEntry(sourceFolder.string(), {"manual"}));
+    REQUIRE(pkg->addSegmentsEntry(
+        otherCatalogRoot.string(),
+        {"open-data", "immutable", "vc-open-data-target-volume-id:vol2"}));
+
+    const auto registeredCatalogRoot =
+        registeredOpenDataCatalogRootForSegment(*pkg, sourceSegment);
+    REQUIRE(registeredCatalogRoot == sourceRoot);
+    const auto editableSegment =
+        defaultEditableCopyPathForCatalogSegment(
+            sourceSegment, registeredCatalogRoot);
+    const auto editableRoot = editableSegment.parent_path();
+    CHECK_THROWS_WITH_AS(
+        copyCatalogSegmentToEditableDirectory(
+            *pkg, sourceSegment, sourceSegment),
+        doctest::Contains("immutable catalog"),
+        std::runtime_error);
+    CHECK_THROWS_WITH_AS(
+        copyCatalogSegmentToEditableDirectory(
+            *pkg, sourceSegment, sourceRoot / "unsafe-copy"),
+        doctest::Contains("immutable catalog"),
+        std::runtime_error);
+    CHECK_THROWS_WITH_AS(
+        copyCatalogSegmentToEditableDirectory(
+            *pkg, sourceSegment, otherCatalogSegment),
+        doctest::Contains("immutable catalog"),
+        std::runtime_error);
+    const auto sourceAlias = testRoot / "catalog-segment-alias";
+    std::error_code symlinkError;
+    std::filesystem::create_directory_symlink(
+        sourceSegment, sourceAlias, symlinkError);
+    if (!symlinkError) {
+        CHECK_THROWS_WITH_AS(
+            copyCatalogSegmentToEditableDirectory(
+                *pkg, sourceSegment, sourceAlias),
+            doctest::Contains("immutable catalog"),
+            std::runtime_error);
+    }
+    copyCatalogSegmentToEditableDirectory(
+        *pkg, sourceSegment, editableSegment);
+
+    attachEditableOpenDataSegmentRoot(
+        *pkg, sourceSegment, editableRoot, true);
 
     CHECK(pkg->outputSegmentsPath() == editableRoot);
+    const auto editableEntry = std::find_if(
+        pkg->segmentEntries().begin(), pkg->segmentEntries().end(),
+        [&](const auto& entry) { return entry.location == editableRoot.string(); });
+    REQUIRE(editableEntry != pkg->segmentEntries().end());
+    CHECK(editableEntry->tags == std::vector<std::string>{
+        "open-data-editable",
+        "vc-open-data-target-volume-id:vol1",
+        "vc-open-data-coordinate-space:sample/vol1@L0",
+        "vc-open-data-source-coordinate-level:0",
+    });
     CHECK_FALSE(std::filesystem::exists(editableSegment / "catalog-origin.json"));
     const auto surface = pkg->loadSurface("20241113070770");
     REQUIRE(surface);

--- a/volume-cartographer/tools/vc3d-mcp/tests/support/agent_bridge.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/support/agent_bridge.py
@@ -453,6 +453,20 @@ class FakeAgentBridgeServer:
             await self._reply(
                 writer, req_id, result={"oldId": seg, "newId": new_name},
             )
+        elif method == "segments.create_editable_copy":
+            seg = params.get("segmentId")
+            await self._reply(
+                writer,
+                req_id,
+                result={
+                    "created": True,
+                    "alreadyExisted": False,
+                    "segmentId": seg,
+                    "sourcePath": f"/catalog/{seg}",
+                    "path": f"/project/paths/{seg}",
+                    "activated": True,
+                },
+            )
         elif method == "viewer.get_render_settings":
             await self._reply(writer, req_id, result=dict(self._render_settings))
         elif method == "viewer.set_render_settings":

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_bridge.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_bridge.py
@@ -51,6 +51,7 @@ from vc3d_mcp.tools.session import (
 from vc3d_mcp.tools.segmentation import (
     vc3d_activate_segment,
     vc3d_attach_segments,
+    vc3d_create_editable_segment_copy,
     vc3d_delete_segment,
     vc3d_fetch_segment,
     vc3d_grow_segment,
@@ -471,6 +472,13 @@ class ToolLayerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["deleted"], ["seg-ready"])
         sent = self.fake_server.received_requests[-1]["params"]
         self.assertEqual(sent, {"segmentId": "seg-ready", "confirm": True})
+
+    async def test_vc3d_create_editable_segment_copy_forwards_segment_id(self) -> None:
+        result = await vc3d_create_editable_segment_copy("seg-catalog")
+        self.assertEqual(result["segmentId"], "seg-catalog")
+        self.assertTrue(result["activated"])
+        sent = self.fake_server.received_requests[-1]["params"]
+        self.assertEqual(sent, {"segmentId": "seg-catalog"})
 
     async def test_vc3d_delete_segment_default_confirm_false_is_forwarded_and_refused(self) -> None:
         # confirm defaults to False and IS forwarded (the bridge enforces the

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_contract.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_contract.py
@@ -12,7 +12,7 @@ from vc3d_mcp import tools as _tools  # noqa: F401 - registers the MCP tools
 VC_ROOT = Path(__file__).resolve().parents[3]
 SPEC_PATH = VC_ROOT / "apps/VC3D/agent_bridge/SPEC.md"
 DESCRIPTION_PATH = VC_ROOT / "apps/VC3D/agent_bridge/rpc_description.json"
-EXPECTED_RPC_METHODS = 119
+EXPECTED_RPC_METHODS = 120
 MCP_ONLY_TOOLS = {"vc3d_wait_job"}
 
 

--- a/volume-cartographer/tools/vc3d-mcp/tests/test_progress.py
+++ b/volume-cartographer/tools/vc3d-mcp/tests/test_progress.py
@@ -403,7 +403,7 @@ class ToolSchemaTest(unittest.IsolatedAsyncioTestCase):
     """Official-SDK schema assertions over the whole registered tool surface."""
 
     # Assert the exact registered count so schema drift (added/removed tools) is caught.
-    EXPECTED_TOOL_COUNT = 119
+    EXPECTED_TOOL_COUNT = 120
 
     async def test_tool_surface_and_schemas(self) -> None:
         tools = await core.mcp.list_tools()

--- a/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/segmentation.py
+++ b/volume-cartographer/tools/vc3d-mcp/vc3d_mcp/tools/segmentation.py
@@ -126,6 +126,27 @@ async def vc3d_activate_segment(
 
 
 @mcp.tool()
+async def vc3d_create_editable_segment_copy(segment_id: str) -> dict[str, Any]:
+    """Copy a fetched, immutable Open Data catalog segment into the project's
+    editable segment directory, attach it to the project, and activate it.
+
+    Open Data catalog files are shared cache objects and cannot safely be
+    edited or renamed in place. Call this after vc3d_fetch_segment when
+    vc3d_enable_editing or vc3d_rename_segment reports error -32009 with
+    action="segments.create_editable_copy". Retrying is idempotent: an existing
+    editable copy is reused and activated instead of copied again.
+
+    segment_id: a fetched catalog segment id returned by vc3d_list_segments.
+
+    Returns the source and editable paths plus created/alreadyExisted and
+    activated flags. Errors: -32004 (editing is enabled), -32007 (unknown
+    segment), -32009 (not a fetched catalog segment), -32005/-32010 (copy,
+    persistence, or activation failure).
+    """
+    return await _call("segments.create_editable_copy", {"segmentId": segment_id})
+
+
+@mcp.tool()
 async def vc3d_delete_segment(segment_id: str, confirm: bool = False) -> dict[str, Any]:
     """Permanently delete a segment from the open volume package, removing it
     from the surface panel AND deleting its files on disk.


### PR DESCRIPTION
**In one sentence:** An agent can now turn a fetched, immutable Open Data segment into an active editable copy without hanging on an invisible modal or accidentally renaming the catalog cache.

**One real example:** In the PHercParis4 workflow documented in #1465, `segmentation.enable_editing` on segment `20230702185753-published-20260411134726-L0-96a63b37f78c8136` still had no response after 45 seconds because VC3D opened a modal dialog. With this change, that request fails immediately with a structured `-32009` response naming `segments.create_editable_copy`; the new method copies, persists, selects, and activates the editable segment, after which editing succeeds.

**Before:** The bridge entered `QMessageBox::exec()` while handling `segmentation.enable_editing`, so the original RPC never completed and no bridge method could perform the dialog's editable-copy action. Independently, `segments.rename` could physically rename the immutable cache directory, strand derived work, and force a full re-download (#1464).

**After this PR:** Catalog editing fails fast with an actionable error. The `vc3d_create_editable_segment_copy` MCP tool (backed by `segments.create_editable_copy {"segmentId":"..."}`) uses the existing Open Data copy implementation, strips catalog provenance, copies coordinate identity, persists and selects the editable segment root, refreshes the UI, and activates the copy. That selection survives an immediate retry and a project reopen. The shared rename core rejects catalog segments in both the bridge and GUI paths, while canonical-path guards prevent the GUI folder picker from treating the original cache, a symlink alias, or another registered catalog root as an editable destination.

**Proof:** The offscreen bridge regression uses a shipped TIFXYZ segment fixture and verifies all of the following in one workflow:

```text
[PASS] catalog_segment_rename_guard: code=-32009 action=segments.create_editable_copy
[PASS] catalog_segment_editing_fails_fast: code=-32009 action=segments.create_editable_copy elapsed=0.000s
[PASS] catalog_segment_create_editable_copy: created=True activated=True; exact editable path selected
[PASS] catalog_segment_create_editable_copy_retry: created=False alreadyExisted=True; no duplicate entry
[PASS] editable_copy_can_enable_editing: enabled=True
[PASS] editable_copy_survives_reopen: editable path retained; editing enabled again
[PASS] described_invalid_inputs: 464 probes passed
[PASS] process_alive: running=True
```

I also replayed the final binary against the public PHercParis4 catalog and its
materialized segment
`20230702185753-published-20260411134726-L0-96a63b37f78c8136`:

```text
catalog.list_samples: 45 samples, PHercParis4 present
catalog edit: -32009 + segments.create_editable_copy in 0.002 s
editable copy: exact _editable path selected; editing enabled in 1.162 s
immediate retry: created=False, alreadyExisted=True
project reopen: editable path retained; editing enabled again
catalog x/y/z SHA-256 before == after; catalog-origin.json retained only at source
```

The native regression also rejects the source itself, a symlink alias, a path
inside the catalog root, and a different registered catalog segment as copy
destinations.

Focused native tests also pass:

```text
test_open_data_manifest .......... Passed
agent_bridge_contract ............ Passed
100% tests passed, 0 failed
```

The public MCP contract and wrapper regression suite passes 55/55 tests,
including schema parity, protocol documentation, and the editable-copy request.
The fresh CI matrix for `6fa5f8ace` is green across Linux VC3D/smoke, Linux
base and GUI tests, rendering, MCP, Windows, macOS, and all CodeQL shards. The
only red status is Vercel preview authorization for an external contributor;
this PR does not change the web application.

**Why / where this is useful:** Published Open Data segments are the natural starting point for review and refinement. This closes the last headless gap between fetching one and editing a safe working copy, while protecting the cache identity that makes later catalog opens and downloads reliable.

- [x] I personally verified that the example and proof above were produced by this PR on the stated repository fixture.

## Details

Tested commit: `6fa5f8ace`

Commands:

```bash
cmake --build build/remote-timeout-ci --target VC3D test_agent_bridge_contract test_open_data_manifest -j2
ctest --test-dir build/remote-timeout-ci --output-on-failure -R '^(agent_bridge_contract|test_open_data_manifest)$'
QT_QPA_PLATFORM=offscreen python3 apps/VC3D/agent_bridge/test/smoke_offscreen.py --vc3d build/remote-timeout-ci/bin/VC3D
cd tools/vc3d-mcp && python -m unittest -v tests.test_contract tests.test_bridge tests.test_progress.ToolSchemaTest
```

Fixes #1464.
Fixes #1465.

AI disclosure: investigation, implementation, and test drafting were assisted by OpenAI Codex; the contributor reviewed the diff and the reported results come from commands run against this commit.
