### PR TITLE
Spiral hyperparams from recent sweeps

### DIFF
--- a/spiral-fitting/README.md
+++ b/spiral-fitting/README.md
@@ -524,3 +524,28 @@ For a headless fit, pass the dataset root with `--dataset` and select inference
 mode (plus any independently disabled losses) through
 `FIT_SPIRAL_CONFIG_OVERRIDES`. The dataset's `spiral-scroll.json` and the
 declarative input catalog determine which conventional inputs are resolved.
+
+## Fiber direction samples
+
+The optional fiber-direction loss consumes one packed artifact extracted from a
+remote Lasagna fiber prediction. Extraction downloads only chunks intersecting
+the requested z ROI and keeps the highest-presence voxel in each fixed
+prediction-space cell:
+
+```bash
+./.venv/bin/python fiber_direction_samples.py \
+  https://example/fibers.lasagna.json \
+  /path/to/dataset/fiber_directions.npz \
+  --z-roi 10000,11000 --output-scale 4 \
+  --presence-threshold 160 --cell-size 2
+```
+
+The z ROI is half-open and expressed in the output/fitter coordinate system;
+`--output-scale 4` means one fitter `/2` coordinate is four base `/0` voxels. The
+extractor always covers the fiber volume's complete XY extent.
+
+Set `loss_weight_fiber_directions` above zero to enable the loss. The fitter
+loads the conventional `fiber_directions.npz` artifact and samples
+`sample_count_fiber_direction_points` observations per step. Positions and
+directions constrain only local fitted-sheet orientation; they do not attach a
+sample to a particular winding.

--- a/spiral-fitting/README.md
+++ b/spiral-fitting/README.md
@@ -544,8 +544,9 @@ The z ROI is half-open and expressed in the output/fitter coordinate system;
 `--output-scale 4` means one fitter `/2` coordinate is four base `/0` voxels. The
 extractor always covers the fiber volume's complete XY extent.
 
-Set `loss_weight_fiber_directions` above zero to enable the loss. The fitter
-loads the conventional `fiber_directions.npz` artifact and samples
-`sample_count_fiber_direction_points` observations per step. Positions and
-directions constrain only local fitted-sheet orientation; they do not attach a
-sample to a particular winding.
+Both `input_use_fiber_directions` and `loss_weight_fiber_directions` default
+to off/zero; set the toggle true and the weight above zero to enable the
+loss. The fitter then loads the conventional `fiber_directions.npz` artifact
+and samples `sample_count_fiber_direction_points` observations per step.
+Positions and directions constrain only local fitted-sheet orientation; they
+do not attach a sample to a particular winding.

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -37,6 +37,7 @@ _PREPARED_INPUT_FIELDS = {
     "track_crossing_mode",
     "track_exclusion_radius",
     "dense_spacing_mode",
+    "loss_weight_fiber_directions",
     "output_first_winding",
     "output_winding_margin",
     "output_step_size",
@@ -60,6 +61,7 @@ _SCALE_WITH_Z_FIELDS = {
     "sample_count_unattached_pcls_per_step",
     "sample_count_tracks_per_step",
     "sample_count_dense_normal_points",
+    "sample_count_fiber_direction_points",
     "sample_count_regularisation_points",
     "sample_count_dense_spacing_pairs",
     "sample_count_dense_spacing_density_extra_pairs",
@@ -102,6 +104,8 @@ _INPUT_TOGGLE_DESCRIPTIONS = {
         "Load tracks and allow track sampling and losses.",
     "input_use_fibers":
         "Load fiber annotations into the point-collection supervision pools.",
+    "input_use_fiber_directions":
+        "Load packed fiber-direction samples and allow their orientation loss.",
     "input_use_pcl_absolute":
         "Load absolute-winding point-collection inputs.",
     "input_use_pcl_relative":
@@ -357,6 +361,7 @@ class Config:
         self.sample_count_tracks_per_step = 48000
         self.sample_count_track_points_per_step = 96
         self.sample_count_dense_normal_points = 60000
+        self.sample_count_fiber_direction_points = 60000
         self.sample_count_regularisation_points = 4500
         self.sample_count_dense_spacing_pairs = 12000
         self.sample_count_dense_spacing_count_extra_pairs = 0
@@ -385,6 +390,7 @@ class Config:
         self.input_use_unverified_patches = True
         self.input_use_tracks = True
         self.input_use_fibers = True
+        self.input_use_fiber_directions = True
         self.input_use_pcl_absolute = True
         self.input_use_pcl_relative = True
         self.input_use_pcl_same_winding = True
@@ -500,6 +506,7 @@ class Config:
         self.loss_weight_track_dt = 10.0
         self.loss_weight_sym_dirichlet = 10.0
         self.loss_weight_dense_normals = 100.0
+        self.loss_weight_fiber_directions = 0.0
         self.loss_weight_dense_spacing = 12.0
         self.loss_weight_umbilicus = 1.25
         self.loss_weight_shell_outer = 1.0
@@ -512,6 +519,7 @@ class Config:
         self.dense_attachment_warmup_steps = 3000
         self.dense_attachment_ramp_steps = 3000
         self.dense_normals_finite_difference_epsilon = 8.0
+        self.fiber_directions_finite_difference_epsilon = 8.0
         self.model_sym_dirichlet_finite_difference_epsilon = 4.0
         self.optimizer_weight_decay_gap_expander = 0.01
         self.optimizer_weight_decay_flow_field = 0.0

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -390,7 +390,7 @@ class Config:
         self.input_use_unverified_patches = True
         self.input_use_tracks = True
         self.input_use_fibers = True
-        self.input_use_fiber_directions = True
+        self.input_use_fiber_directions = False
         self.input_use_pcl_absolute = True
         self.input_use_pcl_relative = True
         self.input_use_pcl_same_winding = True

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -524,7 +524,7 @@ class Config:
         self.optimizer_weight_decay_gap_expander = 0.01
         self.optimizer_weight_decay_flow_field = 0.0
         self.loss_start_patch_dt = 25000
-        self.loss_start_track_dt = 10000
+        self.loss_start_track_dt = 25000
         self.loss_start_unverified_patch_dt = None
         self.dt_progressive_windings = False
         self.dt_progressive_inner_winding = 20

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -388,7 +388,7 @@ class Config:
         # re-enabling a source restores its previous tuning.
         self.input_use_verified_patches = True
         self.input_use_unverified_patches = True
-        self.input_use_tracks = True
+        self.input_use_tracks = False
         self.input_use_fibers = True
         self.input_use_fiber_directions = False
         self.input_use_pcl_absolute = True

--- a/spiral-fitting/fiber_direction_samples.py
+++ b/spiral-fitting/fiber_direction_samples.py
@@ -54,7 +54,7 @@ def _read_chunk(session, array_url, metadata, index):
     begin = np.asarray(index, dtype=np.int64) * chunks
     chunk_shape = tuple(np.minimum(chunks, shape - begin))
     if response.status_code == 404:
-        return np.full(chunk_shape, metadata.get("fill_value", 0),
+        return np.full(chunk_shape, metadata.get("fill_value") or 0,
                        dtype=np.dtype(metadata["dtype"]))
     response.raise_for_status()
     compressor = metadata.get("compressor")
@@ -147,7 +147,7 @@ def _cell_argmax(presence, global_begin, cell_size, threshold, valid_begin, vali
     coords = global_zyx[valid]
     cells = coords // cell_size
     # Presence descending, then flat index ascending gives deterministic ties.
-    order = np.lexsort((flat_indices, -values[valid],
+    order = np.lexsort((flat_indices, -values[valid].astype(np.int64),
                         cells[:, 2], cells[:, 1], cells[:, 0]))
     ordered_cells = cells[order]
     first = np.ones(len(order), dtype=bool)

--- a/spiral-fitting/fiber_direction_samples.py
+++ b/spiral-fitting/fiber_direction_samples.py
@@ -1,0 +1,341 @@
+"""Extract and load sparse, confidence-weighted fiber direction samples.
+
+The extractor reads only Zarr chunks intersecting a requested z range, across
+the full XY extent. Within each fixed prediction-space cell it retains the
+highest-presence voxel, avoiding a full-volume download and most duplicate
+samples across a fiber's thickness.
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import json
+from pathlib import Path
+import time
+from urllib.parse import unquote, urljoin, urlparse
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+
+FORMAT_VERSION = 2
+
+
+def _get_json(session, url):
+    response = session.get(url, timeout=60)
+    response.raise_for_status()
+    return response.json()
+
+
+def _chunk_url(array_url, index, metadata):
+    separator = metadata.get("dimension_separator", ".")
+    return f"{array_url.rstrip('/')}/{separator.join(map(str, index))}"
+
+
+def _read_chunk(session, array_url, metadata, index):
+    import numcodecs
+    import requests
+
+    url = _chunk_url(array_url, index, metadata)
+    for attempt in range(6):
+        try:
+            response = session.get(url, timeout=60)
+            if response.status_code < 500:
+                break
+        except (requests.ConnectionError, requests.Timeout):
+            if attempt == 5:
+                raise
+        if attempt == 5:
+            response.raise_for_status()
+        time.sleep(min(2 ** attempt, 8))
+    shape = np.asarray(metadata["shape"], dtype=np.int64)
+    chunks = np.asarray(metadata["chunks"], dtype=np.int64)
+    begin = np.asarray(index, dtype=np.int64) * chunks
+    chunk_shape = tuple(np.minimum(chunks, shape - begin))
+    if response.status_code == 404:
+        return np.full(chunk_shape, metadata.get("fill_value", 0),
+                       dtype=np.dtype(metadata["dtype"]))
+    response.raise_for_status()
+    compressor = metadata.get("compressor")
+    decoded = (numcodecs.get_codec(compressor).decode(response.content)
+               if compressor is not None else response.content)
+    dtype = np.dtype(metadata["dtype"])
+    values = np.frombuffer(decoded, dtype=dtype)
+    edge_size = int(np.prod(chunk_shape))
+    full_size = int(np.prod(chunks))
+    order = metadata.get("order", "C")
+    if values.size == edge_size:
+        return values.reshape(chunk_shape, order=order)
+    if values.size == full_size:
+        # Some Zarr v2 writers store boundary chunks at the nominal full
+        # chunk shape. Crop that representation to the logical array edge.
+        full = values.reshape(tuple(chunks), order=order)
+        return full[tuple(slice(0, size) for size in chunk_shape)]
+    raise ValueError(
+        f"decoded chunk {index} has {values.size} values; expected "
+        f"{edge_size} (logical edge) or {full_size} (full stored chunk)")
+
+
+def _list_s3_chunk_indices(session, array_url, metadata, first_chunk, last_chunk):
+    """Return existing chunk indices for an anonymous virtual-hosted S3 URL."""
+    parsed = urlparse(array_url)
+    if not parsed.hostname or ".s3." not in parsed.hostname:
+        return None
+    separator = metadata.get("dimension_separator", ".")
+    array_key = unquote(parsed.path.lstrip("/").rstrip("/"))
+    result = set()
+    for cz in range(int(first_chunk[0]), int(last_chunk[0]) + 1):
+        prefix = f"{array_key}/{cz}{separator}"
+        continuation = None
+        while True:
+            params = {"list-type": "2", "prefix": prefix}
+            if continuation:
+                params["continuation-token"] = continuation
+            response = session.get(
+                f"{parsed.scheme}://{parsed.netloc}/", params=params, timeout=60)
+            if response.status_code in (401, 403):
+                return None
+            response.raise_for_status()
+            root = ET.fromstring(response.content)
+            keys = [node.text for node in root.iter()
+                    if node.tag.rsplit("}", 1)[-1] == "Key"]
+            for key in keys:
+                suffix = key[len(array_key) + 1:]
+                try:
+                    index = tuple(int(value) for value in suffix.split(separator))
+                except (TypeError, ValueError):
+                    continue
+                if (len(index) == 3
+                        and all(first_chunk[axis] <= index[axis] <= last_chunk[axis]
+                                for axis in range(3))):
+                    result.add(index)
+            truncated = next((node.text == "true" for node in root.iter()
+                              if node.tag.rsplit("}", 1)[-1] == "IsTruncated"), False)
+            if not truncated:
+                break
+            continuation = next((node.text for node in root.iter()
+                                 if node.tag.rsplit("}", 1)[-1]
+                                 == "NextContinuationToken"), None)
+            if not continuation:
+                raise ValueError("truncated S3 listing omitted continuation token")
+    return result
+
+
+def _parse_z_roi(value):
+    try:
+        result = tuple(int(item) for item in value.split(","))
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "z ROI must be BEGIN,END integers") from error
+    if len(result) != 2 or result[0] < 0 or result[1] <= result[0]:
+        raise argparse.ArgumentTypeError(
+            "z ROI must be BEGIN,END with 0 <= BEGIN < END")
+    return result
+
+
+def _cell_argmax(presence, global_begin, cell_size, threshold, valid_begin, valid_end):
+    local = np.indices(presence.shape, dtype=np.int64).reshape(3, -1).T
+    global_zyx = local + global_begin
+    values = presence.reshape(-1)
+    valid = ((values >= threshold)
+             & (global_zyx >= valid_begin).all(axis=1)
+             & (global_zyx < valid_end).all(axis=1))
+    if not valid.any():
+        return np.empty(0, dtype=np.int64), global_zyx[:0]
+    flat_indices = np.flatnonzero(valid)
+    coords = global_zyx[valid]
+    cells = coords // cell_size
+    # Presence descending, then flat index ascending gives deterministic ties.
+    order = np.lexsort((flat_indices, -values[valid],
+                        cells[:, 2], cells[:, 1], cells[:, 0]))
+    ordered_cells = cells[order]
+    first = np.ones(len(order), dtype=bool)
+    first[1:] = np.any(ordered_cells[1:] != ordered_cells[:-1], axis=1)
+    selected = order[first]
+    return flat_indices[selected], coords[selected]
+
+
+def extract(manifest_url, z_roi, output, *, output_scale=1.0,
+            threshold=160, cell_size=2, overwrite=False, workers=1):
+    import requests
+
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists() and not overwrite:
+        raise FileExistsError(f"output already exists: {output} (use --overwrite)")
+    with requests.Session() as session:
+        manifest = _get_json(session, manifest_url)
+        groups = manifest["groups"]
+        urls = {name: urljoin(manifest_url, groups[name]["zarr"])
+                for name in ("presence", "nx", "ny")}
+        metadata = {name: _get_json(session, f"{url.rstrip('/')}/.zarray")
+                    for name, url in urls.items()}
+        reference = metadata["presence"]
+        for name in ("nx", "ny"):
+            if (metadata[name]["shape"] != reference["shape"]
+                    or metadata[name]["chunks"] != reference["chunks"]):
+                raise ValueError("presence/nx/ny Zarr shapes or chunks differ")
+        chunks = np.asarray(reference["chunks"], dtype=np.int64)
+        if np.any(chunks % cell_size):
+            raise ValueError(
+                f"cell size {cell_size} must divide source chunk shape {tuple(chunks)}")
+
+        scales = []
+        for name in ("presence", "nx", "ny"):
+            scales.append(float(manifest["source_to_base"])
+                          * 2.0 ** int(groups[name]["scaledown"]))
+        if not np.allclose(scales, scales[0]):
+            raise ValueError(f"presence/nx/ny scales differ: {scales}")
+        prediction_to_base_scale = scales[0]
+        prediction_to_output_scale = prediction_to_base_scale / output_scale
+        shape = np.asarray(reference["shape"], dtype=np.int64)
+        z_begin, z_end = z_roi
+        begin = np.asarray((
+            np.floor(z_begin / prediction_to_output_scale), 0, 0),
+            dtype=np.int64)
+        end = np.asarray((
+            np.ceil(z_end / prediction_to_output_scale), shape[1], shape[2]),
+            dtype=np.int64)
+        begin = np.maximum(begin, 0)
+        end = np.minimum(end, shape)
+        if end[0] <= begin[0]:
+            raise ValueError(
+                f"z ROI {z_roi} does not intersect prediction z extent "
+                f"[0, {shape[0] * prediction_to_output_scale:g})")
+        extraction_identity = {
+            "artifact_type": "fiber_direction_samples",
+            "format_version": FORMAT_VERSION,
+            "manifest_url": manifest_url,
+            "z_roi": list(z_roi),
+            "output_scale_base_voxels": float(output_scale),
+            "prediction_to_output_scale": prediction_to_output_scale,
+            "presence_threshold": int(threshold),
+            "dedup_cell_size_prediction_voxels": int(cell_size),
+        }
+        first_chunk = begin // chunks
+        last_chunk = (end - 1) // chunks
+        available = _list_s3_chunk_indices(
+            session, urls["presence"], reference, first_chunk, last_chunk)
+        if available is not None:
+            print(f"S3 listing found {len(available):,} stored presence chunks "
+                  f"in the requested z ROI", flush=True)
+        work = []
+        for cz in range(first_chunk[0], last_chunk[0] + 1):
+            for cy in range(first_chunk[1], last_chunk[1] + 1):
+                for cx in range(first_chunk[2], last_chunk[2] + 1):
+                    index = (int(cz), int(cy), int(cx))
+                    if available is not None and index not in available:
+                        continue
+                    work.append(index)
+
+        def process(index):
+            # requests.Session is not documented as thread-safe. Each worker
+            # invocation therefore owns its short-lived connection context.
+            with requests.Session() as worker_session:
+                presence = _read_chunk(
+                    worker_session, urls["presence"], metadata["presence"], index)
+                chunk_begin = np.asarray(index, dtype=np.int64) * chunks
+                selected, prediction_zyx = _cell_argmax(
+                    presence, chunk_begin, cell_size, threshold, begin, end)
+                position_zyx = (prediction_zyx.astype(np.float32)
+                                * np.float32(prediction_to_output_scale))
+                if len(selected):
+                    nx = _read_chunk(worker_session, urls["nx"], metadata["nx"], index)
+                    ny = _read_chunk(worker_session, urls["ny"], metadata["ny"], index)
+                    nx_selected = nx.reshape(-1)[selected].astype(np.uint8)
+                    ny_selected = ny.reshape(-1)[selected].astype(np.uint8)
+                else:
+                    nx_selected = ny_selected = np.empty(0, dtype=np.uint8)
+                return (position_zyx, nx_selected, ny_selected,
+                        presence.reshape(-1)[selected].astype(np.uint8))
+
+        positions, nxs, nys, presences = [], [], [], []
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            for completed, arrays in enumerate(executor.map(process, work), 1):
+                position, nx, ny, presence = arrays
+                positions.append(position)
+                nxs.append(nx)
+                nys.append(ny)
+                presences.append(presence)
+                if completed % 100 == 0 or completed == len(work):
+                    print(f"downloaded {completed:,}/{len(work):,} chunks", flush=True)
+
+    metadata_out = {
+        **extraction_identity,
+        "sample_count": int(sum(map(len, positions))),
+    }
+    arrays = {
+        "position_zyx": np.concatenate(positions),
+        "nx": np.concatenate(nxs),
+        "ny": np.concatenate(nys),
+        "presence": np.concatenate(presences),
+        "metadata_json": np.asarray(json.dumps(metadata_out)),
+    }
+    temporary = output.with_name(f".{output.name}.tmp.npz")
+    np.savez_compressed(temporary, **arrays)
+    temporary.replace(output)
+    print(f"wrote {metadata_out['sample_count']:,} samples from "
+          f"{len(work):,} chunks to {output}")
+
+
+def load_fiber_direction_samples(path, z_begin, z_end):
+    """Load one packed artifact, filtering in the fitter's coordinate frame."""
+    if not path:
+        return None
+    artifact = Path(path)
+    with np.load(artifact) as packed:
+        metadata = json.loads(str(packed["metadata_json"]))
+        if (metadata.get("artifact_type") != "fiber_direction_samples"
+                or metadata.get("format_version") != FORMAT_VERSION):
+            raise ValueError(f"unsupported fiber-direction artifact in {artifact}")
+        position = packed["position_zyx"]
+        keep = (position[:, 0] >= z_begin) & (position[:, 0] < z_end)
+        if not keep.any():
+            return None
+        whole = bool(keep.all())
+        select = slice(None) if whole else keep
+        result = {
+            "position_zyx": position[select].astype(np.float32, copy=False),
+            "nx": packed["nx"][select].astype(np.uint8, copy=False),
+            "ny": packed["ny"][select].astype(np.uint8, copy=False),
+            "presence": packed["presence"][select].astype(np.uint8, copy=False),
+            "metadata": metadata,
+        }
+    if not len(result["position_zyx"]):
+        return None
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", help="HTTP(S) Lasagna fiber manifest")
+    parser.add_argument("output", type=Path, help="output packed .npz artifact")
+    parser.add_argument("--z-roi", required=True, type=_parse_z_roi,
+                        help="output-coordinate half-open z range BEGIN,END")
+    parser.add_argument(
+        "--output-scale", type=float, default=1.0,
+        help="base /0 voxels per output/fitter voxel (use 4 for pyramid /2)")
+    parser.add_argument("--presence-threshold", type=int, default=160)
+    parser.add_argument("--cell-size", type=int, default=2,
+                        help="deduplication cell edge in prediction voxels")
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--workers", type=int, default=1,
+                        help="parallel chunk downloads (default: 1)")
+    args = parser.parse_args()
+    if not 0 <= args.presence_threshold <= 255:
+        parser.error("--presence-threshold must be in [0, 255]")
+    if args.cell_size <= 0:
+        parser.error("--cell-size must be positive")
+    if args.output_scale <= 0:
+        parser.error("--output-scale must be positive")
+    if args.workers <= 0:
+        parser.error("--workers must be positive")
+    extract(args.manifest, args.z_roi, args.output,
+            output_scale=args.output_scale,
+            threshold=args.presence_threshold, cell_size=args.cell_size,
+            overwrite=args.overwrite, workers=args.workers)
+
+
+if __name__ == "__main__":
+    main()

--- a/spiral-fitting/fit_session.py
+++ b/spiral-fitting/fit_session.py
@@ -155,6 +155,7 @@ _INPUT_TOGGLE_KEYS = {
     "unverified_patches": "input_use_unverified_patches",
     "tracks_dbm": "input_use_tracks",
     "fibers": "input_use_fibers",
+    "fiber_directions": "input_use_fiber_directions",
     "normals": "input_use_normals",
     "surf_sdt": "input_use_surf_sdt",
     "gradient_magnitude": "input_use_gradient_magnitude",
@@ -280,6 +281,11 @@ def _normals_required(config: Mapping[str, Any]) -> bool:
     )
 
 
+def _fiber_directions_enabled(config: Mapping[str, Any]) -> bool:
+    return (input_source_enabled(config, "fiber_directions")
+            and float(config.get("loss_weight_fiber_directions", 0.0)) > 0)
+
+
 def _grad_mag_required(config: Mapping[str, Any]) -> bool:
     return (input_source_enabled(config, "gradient_magnitude")
             and _dense_spacing_mode(config) == "grad_mag"
@@ -349,6 +355,10 @@ FIT_INPUT_CATALOG: tuple[FitInputSpec, ...] = (
                  enabled=_unverified_patches_enabled),
     FitInputSpec("fibers", "directory", conventional_relative="fibers",
                  enabled=_fibers_enabled),
+    FitInputSpec("fiber_directions", "file",
+                 conventional_relative="fiber_directions.npz",
+                 enabled=_fiber_directions_enabled,
+                 required=_fiber_directions_enabled),
     FitInputSpec("outer_shell", "directory",
                  conventional_relative="outer_shell",
                  enabled=lambda config: input_source_enabled(config, "outer_shell"),
@@ -426,6 +436,7 @@ class SpiralInputPaths:
     umbilicus: str = ""
     pcls: tuple[PclInputSpec, ...] = ()
     fibers: str = ""
+    fiber_directions: str = ""
     tracks_dbm: str = ""
     verified_patches: str = ""
     unverified_patches: str = ""
@@ -746,6 +757,7 @@ def conventional_input_paths(
         umbilicus=resolve("umbilicus"),
         pcls=pcls,
         fibers=resolve("fibers"),
+        fiber_directions=resolve("fiber_directions"),
         tracks_dbm=resolve("tracks_dbm"),
         verified_patches=resolve("verified_patches"),
         unverified_patches=spec.path_override("unverified_patches"),

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -69,6 +69,7 @@ def _startup_resource_suffix(started_at=None):
 from lasagna_data import (ensure_fit_sparse_stores, prepare_lasagna_volume,
                           prepare_surf_sdt_volume)
 from checkpoint_io import load_checkpoint_cpu
+from fiber_direction_samples import load_fiber_direction_samples
 from influence import make_influence_state, subsample_rows
 from spiral_sampling import load_spiral_sampling
 from tifxyz import load_tifxyz, patch_from_payload
@@ -104,6 +105,7 @@ from sample_spiral import (
 )
 from losses import (
     build_pcl_sampling_strata,
+    get_fiber_direction_loss,
     iter_lasagna_losses,
     get_patch_abs_winding_loss,
     get_patch_and_umbilicus_losses,
@@ -1194,6 +1196,9 @@ class FitContext:
         self.fibers_path = (
             (paths.fibers or None)
             if input_source_enabled(config, 'fibers') else None)
+        self.fiber_directions_path = (
+            (paths.fiber_directions or None)
+            if input_source_enabled(config, 'fiber_directions') else None)
         self.verified_patches_path = (
             (paths.verified_patches or None)
             if input_source_enabled(config, 'verified_patches') else None)
@@ -1520,6 +1525,24 @@ class FitContext:
             scroll_zarr = zarr.open(self.scroll_zarr_path, mode='r')
         else:
             scroll_zarr = None
+
+        progress.begin('loading', 'Loading fiber direction samples')
+        fiber_direction_samples = None
+        if (self.fiber_directions_path
+                and os.path.isfile(self.fiber_directions_path)):
+            fiber_direction_samples = load_fiber_direction_samples(
+                self.fiber_directions_path, self.z_begin, self.z_end)
+        elif self.config['loss_weight_fiber_directions'] > 0:
+            raise RuntimeError(
+                'fiber-direction loss is enabled, but its sample directory '
+                f'is missing: {self.fiber_directions_path!r}')
+        if fiber_direction_samples is not None:
+            print(f'fiber directions: {len(fiber_direction_samples["position_zyx"]):,} '
+                  f'samples in z ROI')
+        elif self.config['loss_weight_fiber_directions'] > 0:
+            raise RuntimeError(
+                f'fiber-direction sample directory contains no points in '
+                f'z ROI [{self.z_begin}, {self.z_end})')
 
         # ==========================================================================
         # Patch loading and ROI filtering
@@ -2095,6 +2118,7 @@ class FitContext:
         # pcl_sampling_strata were assigned above, before the strata build.
         self.umbilicus = umbilicus
         self.scroll_zarr = scroll_zarr
+        self.fiber_direction_samples = fiber_direction_samples
         self.filter_tracks_by_shell = filter_tracks_by_shell
         self.shell_patch = shell_patch
         self.shell_envelope = shell_envelope
@@ -4360,6 +4384,20 @@ class FitContext:
                     for name, value in self.lasagna_volume['store'].last_timings.items()
                 })
 
+        if (self.config['loss_weight_fiber_directions'] > 0
+                and self.fiber_direction_samples is not None):
+            fiber_direction_loss = get_fiber_direction_loss(
+                self.slice_to_spiral_transform,
+                self.fiber_direction_samples,
+                self.config['sample_count_fiber_direction_points'],
+                self.config['fiber_directions_finite_difference_epsilon'],
+                self.dr_per_winding.device,
+            )
+            backward_family({
+                'fiber_directions': fiber_direction_loss
+                * self.config['loss_weight_fiber_directions']
+            })
+
         self._warn_if_sdt_loss_inactive()
         self._warn_if_dense_losses_structurally_disabled()
         if self._winding_model_mode_active():
@@ -4887,6 +4925,7 @@ if __name__ == '__main__':
             'sample_count_unattached_pcls_per_step',
             'sample_count_tracks_per_step',
             'sample_count_dense_normal_points',
+            'sample_count_fiber_direction_points',
             'sample_count_dense_spacing_pairs',
             'sample_count_dense_spacing_density_extra_pairs',
             'sample_count_winding_model_relative_pairs',

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -1533,15 +1533,19 @@ class FitContext:
             fiber_direction_samples = load_fiber_direction_samples(
                 self.fiber_directions_path, self.z_begin, self.z_end)
         elif self.config['loss_weight_fiber_directions'] > 0:
+            if not self.config['input_use_fiber_directions']:
+                raise RuntimeError(
+                    'fiber-direction loss is enabled, but its input source is '
+                    'off; set input_use_fiber_directions')
             raise RuntimeError(
-                'fiber-direction loss is enabled, but its sample directory '
+                'fiber-direction loss is enabled, but its sample file '
                 f'is missing: {self.fiber_directions_path!r}')
         if fiber_direction_samples is not None:
             print(f'fiber directions: {len(fiber_direction_samples["position_zyx"]):,} '
                   f'samples in z ROI')
         elif self.config['loss_weight_fiber_directions'] > 0:
             raise RuntimeError(
-                f'fiber-direction sample directory contains no points in '
+                f'fiber-direction sample file contains no points in '
                 f'z ROI [{self.z_begin}, {self.z_end})')
 
         # ==========================================================================

--- a/spiral-fitting/losses.py
+++ b/spiral-fitting/losses.py
@@ -1060,6 +1060,33 @@ def get_radial_normal_in_scroll_space(slice_to_spiral_transform, scroll_zyx, spi
 
 
 
+def get_fiber_direction_loss(transform, samples, num_points, epsilon, device):
+    """Penalize fiber axes that leave the fitted winding tangent plane."""
+    if samples is None or num_points <= 0:
+        return torch.zeros([], device=device)
+    count = len(samples["position_zyx"])
+    # Sampling with replacement avoids constructing a permutation of a
+    # potentially multi-million-point host pool every optimizer step.
+    indices = np.random.randint(0, count, size=num_points)
+    position = torch.as_tensor(samples["position_zyx"][indices], device=device)
+    nx = (torch.as_tensor(samples["nx"][indices], device=device).float() - 128.0) / 127.0
+    ny = (torch.as_tensor(samples["ny"][indices], device=device).float() - 128.0) / 127.0
+    nz = torch.sqrt(torch.clamp(1.0 - nx.square() - ny.square(), min=0.0))
+    direction = torch.stack((nz, ny, nx), dim=-1)
+    direction = direction / direction.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+    confidence = torch.as_tensor(
+        samples["presence"][indices], device=device).float() / 255.0
+    normal = get_radial_normal_in_scroll_space(
+        transform, position, epsilon=epsilon)
+    residual = (normal * direction).sum(dim=-1).square()
+    if diagnostics_enabled():
+        with torch.no_grad():
+            spiral = transform(position)
+        record_loss_samples('fiber_directions', spiral, residual)
+    return (residual * confidence).sum() / confidence.sum().clamp(min=1e-8)
+
+
+
 def sample_spiral_surface_frame(dr_per_winding, outer_winding_idx, num_points, z_begin, z_end):
     # Sample points from discrete spiral windings embedded in spiral yx (over the z-ROI) and return
     # each point's orthonormal in-surface frame in spiral space: e1 = z-axis, e2 = the winding tangent.

--- a/spiral-fitting/losses.py
+++ b/spiral-fitting/losses.py
@@ -1024,6 +1024,16 @@ def _decode_uint8_normal_component(value):
     return (value - 128.0) / 127.0
 
 
+def _decode_uint8_normal(nx_u8, ny_u8):
+    # Decode the uint8 nx/ny normal encoding to a unit zyx direction, plus a mask
+    # marking samples that carry a direction at all (both components unset = no data).
+    valid = ((nx_u8 != 0) | (ny_u8 != 0)).float()
+    nx = _decode_uint8_normal_component(nx_u8.float())
+    ny = _decode_uint8_normal_component(ny_u8.float())
+    nz = torch.sqrt((1. - nx * nx - ny * ny).clamp(min=0.))
+    return F.normalize(torch.stack([nz, ny, nx], dim=-1), dim=-1), valid
+
+
 
 def get_radial_normal_in_scroll_space(slice_to_spiral_transform, scroll_zyx, spiral_zyx=None, epsilon=6.0):
     # At each scroll-space point, pull the spiral-space cylinder normal (the outward radial
@@ -1069,12 +1079,10 @@ def get_fiber_direction_loss(transform, samples, num_points, epsilon, device):
     # potentially multi-million-point host pool every optimizer step.
     indices = np.random.randint(0, count, size=num_points)
     position = torch.as_tensor(samples["position_zyx"][indices], device=device)
-    nx = (torch.as_tensor(samples["nx"][indices], device=device).float() - 128.0) / 127.0
-    ny = (torch.as_tensor(samples["ny"][indices], device=device).float() - 128.0) / 127.0
-    nz = torch.sqrt(torch.clamp(1.0 - nx.square() - ny.square(), min=0.0))
-    direction = torch.stack((nz, ny, nx), dim=-1)
-    direction = direction / direction.norm(dim=-1, keepdim=True).clamp(min=1e-8)
-    confidence = torch.as_tensor(
+    direction, valid = _decode_uint8_normal(
+        torch.as_tensor(samples["nx"][indices], device=device),
+        torch.as_tensor(samples["ny"][indices], device=device))
+    confidence = valid * torch.as_tensor(
         samples["presence"][indices], device=device).float() / 255.0
     normal = get_radial_normal_in_scroll_space(
         transform, position, epsilon=epsilon)
@@ -1220,12 +1228,8 @@ def iter_lasagna_losses(slice_to_spiral_transform, dr_per_winding, lasagna_volum
     else:
         raise ValueError(f'unsupported lasagna backend {backend!r}')
     if compute_normals:
-        normal_weight = (((nx_u8 != 0) | (ny_u8 != 0)) & in_bounds).float()
-        nx = _decode_uint8_normal_component(nx_u8.float())
-        ny = _decode_uint8_normal_component(ny_u8.float())
-        nz = torch.sqrt((1. - nx * nx - ny * ny).clamp(min=0.))
-        target_normal = F.normalize(
-            torch.stack([nz, ny, nx], dim=-1), dim=-1)  # zyx
+        target_normal, valid_normal = _decode_uint8_normal(nx_u8, ny_u8)  # zyx
+        normal_weight = valid_normal * in_bounds.float()
 
     if compute_spacing:
         # grad_mag encodes a winding density (windings per base-volume voxel); the decode factor below

--- a/spiral-fitting/tests/test_config.py
+++ b/spiral-fitting/tests/test_config.py
@@ -51,7 +51,8 @@ def test_input_participation_toggles_are_rebuild_scoped_booleans():
     catalog = Config.catalog()
     expected = {
         "input_use_verified_patches", "input_use_unverified_patches",
-        "input_use_tracks", "input_use_fibers", "input_use_pcl_absolute",
+        "input_use_tracks", "input_use_fibers",
+        "input_use_fiber_directions", "input_use_pcl_absolute",
         "input_use_pcl_relative", "input_use_pcl_same_winding",
         "input_use_pcl_drawn_control_points", "input_use_normals",
         "input_use_surf_sdt", "input_use_gradient_magnitude",

--- a/spiral-fitting/tests/test_config.py
+++ b/spiral-fitting/tests/test_config.py
@@ -59,7 +59,10 @@ def test_input_participation_toggles_are_rebuild_scoped_booleans():
     }
     assert {key for key in catalog["defaults"]
             if key.startswith("input_use_")} == expected
-    default_off = {"input_use_surf_sdt", "input_use_fiber_directions"}
+    default_off = {
+        "input_use_surf_sdt", "input_use_fiber_directions",
+        "input_use_tracks",
+    }
     for key in expected:
         assert catalog["defaults"][key] is (key not in default_off)
         assert catalog["schema"]["fields"][key]["type"] == "boolean"

--- a/spiral-fitting/tests/test_config.py
+++ b/spiral-fitting/tests/test_config.py
@@ -59,7 +59,7 @@ def test_input_participation_toggles_are_rebuild_scoped_booleans():
     }
     assert {key for key in catalog["defaults"]
             if key.startswith("input_use_")} == expected
-    default_off = {"input_use_surf_sdt"}
+    default_off = {"input_use_surf_sdt", "input_use_fiber_directions"}
     for key in expected:
         assert catalog["defaults"][key] is (key not in default_off)
         assert catalog["schema"]["fields"][key]["type"] == "boolean"

--- a/spiral-fitting/tests/test_fiber_direction_samples.py
+++ b/spiral-fitting/tests/test_fiber_direction_samples.py
@@ -1,0 +1,106 @@
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+SPIRAL_DIR = Path(__file__).resolve().parents[1]
+if str(SPIRAL_DIR) not in sys.path:
+    sys.path.insert(0, str(SPIRAL_DIR))
+
+from fiber_direction_samples import (FORMAT_VERSION, _cell_argmax, _parse_z_roi,
+                                     load_fiber_direction_samples)
+from losses import get_fiber_direction_loss
+
+
+def test_parse_z_roi():
+    assert _parse_z_roi("10000,11000") == (10000, 11000)
+
+
+def test_read_chunk_crops_full_sized_boundary_chunk():
+    import fiber_direction_samples as module
+
+    stored = np.arange(4 * 4 * 4, dtype=np.uint8).reshape(4, 4, 4)
+
+    class Response:
+        status_code = 200
+        content = stored.tobytes()
+
+        @staticmethod
+        def raise_for_status():
+            return None
+
+    class Session:
+        @staticmethod
+        def get(*args, **kwargs):
+            return Response()
+
+    metadata = {
+        "shape": [5, 4, 4],
+        "chunks": [4, 4, 4],
+        "dtype": "|u1",
+        "compressor": None,
+        "order": "C",
+    }
+    result = module._read_chunk(Session(), "https://example.invalid/a", metadata,
+                                (1, 0, 0))
+    assert result.shape == (1, 4, 4)
+    np.testing.assert_array_equal(result, stored[:1])
+
+
+def test_cell_argmax_keeps_one_highest_presence_voxel_per_cell():
+    presence = np.zeros((4, 4, 4), dtype=np.uint8)
+    presence[0, 0, 0] = 180
+    presence[1, 1, 1] = 220
+    presence[2, 0, 0] = 200
+    selected, coordinates = _cell_argmax(
+        presence, np.zeros(3, dtype=np.int64), 2, 160,
+        np.zeros(3, dtype=np.int64), np.full(3, 4, dtype=np.int64))
+    assert selected.tolist() == [21, 32]
+    assert coordinates.tolist() == [[1, 1, 1], [2, 0, 0]]
+
+
+def test_load_filters_z_and_decodes_axis(tmp_path):
+    np.savez_compressed(
+        tmp_path / "fiber_directions.npz",
+        position_zyx=np.asarray([[5, 2, 3], [15, 2, 3]], dtype=np.float32),
+        nx=np.asarray([128, 255], dtype=np.uint8),
+        ny=np.asarray([128, 128], dtype=np.uint8),
+        presence=np.asarray([200, 255], dtype=np.uint8),
+        metadata_json=np.asarray(json.dumps({
+            "artifact_type": "fiber_direction_samples",
+            "format_version": FORMAT_VERSION,
+        })),
+    )
+    samples = load_fiber_direction_samples(tmp_path / "fiber_directions.npz", 0, 10)
+    assert samples["position_zyx"].tolist() == [[5, 2, 3]]
+    assert samples["nx"].tolist() == [128]
+    assert samples["ny"].tolist() == [128]
+    assert samples["presence"].tolist() == [200]
+
+
+class _IdentityTransform(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.scale = torch.nn.Parameter(torch.tensor(1.0))
+
+    def forward(self, points):
+        return points * self.scale
+
+
+def test_direction_loss_is_zero_for_sheet_tangent_and_one_for_normal():
+    transform = _IdentityTransform()
+    base = {"position_zyx": np.asarray([[0, 0, 10]], dtype=np.float32),
+            "presence": np.asarray([255], dtype=np.uint8)}
+    tangent = {**base, "nx": np.asarray([128], dtype=np.uint8),
+               "ny": np.asarray([128], dtype=np.uint8)}
+    normal = {**base, "nx": np.asarray([255], dtype=np.uint8),
+              "ny": np.asarray([128], dtype=np.uint8)}
+    assert torch.isclose(get_fiber_direction_loss(transform, tangent, 1, 1,
+                                                  torch.device("cpu")),
+                         torch.tensor(0.0), atol=1e-6)
+    assert torch.isclose(get_fiber_direction_loss(transform, normal, 1, 1,
+                                                  torch.device("cpu")),
+                         torch.tensor(1.0), atol=1e-6)


### PR DESCRIPTION
- adds fiber direction loss based on fiber volumes, as an alternative to lasagna normals (both perform comparably for Paris 4)
- disable track losses since these are no longer useful