### PR TITLE
patch cache: notice when a label asset changed under it

### DIFF
--- a/ink-detection/koine_machines/common/common.py
+++ b/ink-detection/koine_machines/common/common.py
@@ -98,6 +98,9 @@ def save_flat_patch_cache(path, patches):
                         "" if getattr(patch.segment, "validation_mask", None) is None
                         else str(patch.segment.validation_mask)
                     ),
+                    "label_fingerprint": str(
+                        getattr(patch.segment, "label_fingerprint", "")
+                    ),
                     "active_supervision_mask_path": (
                         "" if patch.supervision_mask is None else str(patch.supervision_mask)
                     ),

--- a/ink-detection/koine_machines/data/ink_dataset.py
+++ b/ink-detection/koine_machines/data/ink_dataset.py
@@ -1301,6 +1301,7 @@ class InkDataset(Dataset):
                         str(record.get('inklabels_path', '')),
                         str(record.get('supervision_mask_path', '')),
                         str(record.get('validation_mask_path', '')),
+                        str(record.get('label_fingerprint', '')),
                     )
                     segment = segments_by_key.get(cache_key)
                     if segment is None:

--- a/ink-detection/koine_machines/data/segment.py
+++ b/ink-detection/koine_machines/data/segment.py
@@ -1,3 +1,5 @@
+import hashlib
+import os
 from pathlib import Path
 
 _LABEL_SUFFIXES = (
@@ -30,6 +32,52 @@ def _parse_label_asset_path(name):
                 "extension": extension,
             }
     return None
+
+
+def label_asset_fingerprint(paths):
+    """Return a short digest of the label assets' on-disk layout.
+
+    The patch cache identifies a segment's labels by *path*, which catches pointing at a
+    different tree and misses regenerating a mask in place -- the split is then silently
+    reused against labels it no longer describes. Hashing each asset's relative file names
+    and sizes catches that: rewriting a zarr changes chunk sizes, and dropping annotation
+    deletes chunks outright when the store does not write empty ones.
+
+    It reads no chunk contents, so it costs one directory walk (8 ms for a 6,429-file
+    label array here, via ``os.scandir``, which carries the size on Windows and Linux
+    alike) and it does not distinguish two different labels that compress to identical
+    sizes under identical names. A copied tree fingerprints the same as its source, which
+    is the wanted behaviour.
+    """
+    digest = hashlib.sha256()
+    for path in sorted(str(p) for p in paths if p):
+        root = Path(path)
+        digest.update(root.name.encode())
+        if not root.exists():
+            digest.update(b"\0missing")
+            continue
+        stack = [("", str(root))]
+        entries = []
+        while stack:
+            relative, current = stack.pop()
+            try:
+                children = sorted(os.scandir(current), key=lambda entry: entry.name)
+            except OSError:
+                continue
+            for child in children:
+                name = f"{relative}/{child.name}" if relative else child.name
+                if child.is_dir(follow_symlinks=False):
+                    stack.append((name, child.path))
+                else:
+                    try:
+                        size = child.stat().st_size
+                    except OSError:
+                        size = -1
+                    entries.append((name, size))
+        for name, size in sorted(entries):
+            digest.update(name.encode())
+            digest.update(str(size).encode())
+    return digest.hexdigest()[:16]
 
 class Segment:
     def __init__(
@@ -147,6 +195,17 @@ class Segment:
         )
 
     @property
+    def label_fingerprint(self):
+        """Digest of the label assets as they are on disk right now (computed once)."""
+        cached = getattr(self, "_label_fingerprint", None)
+        if cached is None:
+            cached = label_asset_fingerprint(
+                (self.inklabels, self.supervision_mask, self.validation_mask)
+            )
+            object.__setattr__(self, "_label_fingerprint", cached)
+        return cached
+
+    @property
     def cache_key(self):
         return (
             int(self.dataset_idx),
@@ -155,6 +214,7 @@ class Segment:
             "" if self.inklabels is None else str(self.inklabels),
             "" if self.supervision_mask is None else str(self.supervision_mask),
             "" if self.validation_mask is None else str(self.validation_mask),
+            self.label_fingerprint,
         )
     
     def discover_labels(self, *, label_version=None, extension=".zarr", required=True):


### PR DESCRIPTION

**In one sentence:** A run that reuses an `out_dir` after regenerating a mask no longer trains on the previous split without saying so.

**One real example:** Building held-out splits for a label-efficiency study, I regenerated `_supervision_mask.zarr` for a segment and reran training in the same `out_dir`. The run started immediately, found no patches to search for, and trained on the split from before the regeneration.

**Before:** the flat patch cache identifies a segment's labels by *path*. Pointing at a different label tree is caught — the cached paths no longer match any current segment, and the cache is rejected. Regenerating a mask in place is not caught: the paths still match, `flat_patch_finding_cache_token` is built from config knobs only, and the previous split is reused against labels it no longer describes.

**After this PR:** the segment cache key and the cached records carry a digest of the label assets as they are on disk, so an in-place change rejects the cache and the patches are found again.

**Proof:** on a real segment (`phercparis4-w00`, the 21-slice aligned tree), one condition changed at a time:

| step | before this PR | after this PR |
|---|---|---|
| 1. discover patches | 1,266 | 1,266 |
| 2. halve `_supervision_mask.zarr` **in place** | token unchanged | token unchanged |
| 3. rerun, same `out_dir` | **1,266 — byte-identical bounding boxes to step 1** | **1,162** |
| 4. rerun, fresh `out_dir` (the truth) | 1,162 | 1,162 |

So before the change, 104 patches keep training on supervision that no longer exists, and the run looks normal. After it, step 3 returns exactly what step 4 returns, bounding boxes included.

The cache still does its job:

| | first discovery | second, unchanged |
|---|---|---|
| same tree | 3.03 s | **0.02 s** |
| a byte-identical copy of the tree | 3.09 s | **0.02 s** |

61 tests pass across `koine_machines/data`, `common` and `inference`.

**Why / where this is useful:** anyone iterating on held-out splits or on label versions in one `out_dir` — which is what you do when you are measuring what a change to the labels buys. The failure is silent and it points the wrong way: the arm you just changed is scored on the split from the arm before it.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

`Segment.label_fingerprint` hashes, for each of `inklabels` / `supervision_mask` / `validation_mask`, the relative file names and sizes under the asset, and is computed once per segment. It goes into `Segment.cache_key`, into the record written by `save_flat_patch_cache`, and into the tuple `InkDataset` rebuilds when it validates a cache — so the existing "this record matches no current segment → reject the cache" path does the work, and no new invalidation logic is introduced.

Why names and sizes rather than contents: rewriting a zarr changes chunk sizes, and dropping annotation deletes chunks outright when the store does not write empty ones, so the digest moves for the changes that matter. It reads no chunk data, which is what keeps it at 8 ms for a 6,429-file label array — `os.scandir` carries the size on both Windows and Linux, and using `Path.stat()` instead costs 320 ms for the same array.

Two limits I would rather state than have found:

- two different labels that compress to identical sizes under identical names are not distinguished. I could not construct such a case by editing a mask, but it is not impossible, and reading contents would cost the fast path more than the bug costs.
- a tree whose files are rewritten with identical content and identical sizes still fingerprints the same, which is the wanted behaviour: a copied corpus hits the cache, as the table above shows.

**Why this matters to me:** I was trying to see how much F1 changes with the way the held-out regions are split inside a single segment, so I rebuilt the mask several times as I went. The arm I ran with the new mask came out exactly the same as the previous one, and because there was no error and no warning, for a while I took that as the result rather than as something wrong with my setup.