### PR TITLE
prepare_9um_isotropic_input: publish the staged zarr in a way Windows…

### DIFF
--- a/ink-detection/scripts/prepare_9um_isotropic_input.py
+++ b/ink-detection/scripts/prepare_9um_isotropic_input.py
@@ -13,6 +13,7 @@ import argparse
 from concurrent.futures import ThreadPoolExecutor
 import math
 from pathlib import Path
+import time
 
 import numpy as np
 from numcodecs import Blosc
@@ -40,6 +41,39 @@ def open_source_array(path: str, level: str) -> zarr.Array:
         available = sorted(node.array_keys())
         raise KeyError(f"Pyramid level '{level}' not found in {path}; available: {available}")
     return node[level]
+
+
+
+def publish_partial(staged: Path, output: Path, *, attempts: int = 6, delay: float = 0.5) -> None:
+    """Rename a finished staging directory onto the output path.
+
+    POSIX renames a directory whose files are open. Windows refuses with
+    WinError 5 while any file inside is still open, and one handle is enough --
+    measured on this failure: renaming succeeds with nothing held, and fails with
+    exactly WinError 5 with a single file inside opened for read. After writing a
+    multi-gigabyte zarr, something holding a handle for a moment (an indexer, a
+    scanner) is ordinary, so retry briefly before giving up.
+
+    If it still fails, say what is true: every tile was written, so nothing needs
+    recomputing, and a manual rename finishes the job. The bare traceback this
+    replaces looked like a lost conversion.
+    """
+    for attempt in range(attempts):
+        try:
+            staged.replace(output)
+            return
+        except PermissionError as exc:
+            if attempt + 1 == attempts:
+                raise SystemExit(
+                    f"The conversion finished -- every tile was written -- but the result "
+                    f"could not be published:\n"
+                    f"  {staged}\n"
+                    f"  -> {output}\n"
+                    f"  {exc}\n"
+                    f"On Windows a directory cannot be renamed while any file inside it is "
+                    f"open. Nothing needs recomputing: rename the staging directory by hand."
+                ) from None
+            time.sleep(delay * (2 ** attempt))
 
 
 def main() -> int:
@@ -104,8 +138,10 @@ def main() -> int:
             completed += count
             if completed % 50 == 0 or completed == len(tiles):
                 print(f"tiles={completed}/{len(tiles)}", flush=True)
-    partial.replace(args.output_zarr)
-    print(f"wrote {args.output_zarr} shape={tuple(target.shape)}")
+    output_shape = tuple(target.shape)
+    del target, group  # release the store's handles before renaming its directory
+    publish_partial(partial, args.output_zarr)
+    print(f"wrote {args.output_zarr} shape={output_shape}")
     return 0
 
 


### PR DESCRIPTION

**In one sentence:** A finished 9 µm conversion is no longer thrown away by the last line of the script on Windows.

**One real example:** Preparing the aligned inputs for the `ink_9um` corpus, `prepare_9um_isotropic_input.py` wrote all 416 tiles of `phercparis4-w00` and then died renaming the staging directory onto the output path:

```
tiles=416/416
Traceback (most recent call last):
  File "...\scripts\prepare_9um_isotropic_input.py", line 107, in main
    partial.replace(args.output_zarr)
  File "...\Lib\pathlib.py", line 1376, in replace
    os.replace(self, target)
PermissionError: [WinError 5] Access is denied:
  'D:\...\aligned9\phercparis4-w00.zarr.partial' -> 'D:\...\aligned9\phercparis4-w00.zarr'
```

**Before:** the data was complete and on disk, but the script exited non-zero with a traceback that points at `pathlib`. The obvious reading is that the conversion has to be repeated; the actual remedy is a manual rename. Across 24 inputs this happened often enough that I wrote a driver to finish the renames.

**After this PR:** the store's handles are released before the rename, the rename is retried with backoff, and if it still cannot publish the script says so in the terms that matter:

```
The conversion finished -- every tile was written -- but the result could not be published:
  ...\phercparis4-w00.zarr.partial
  -> ...\phercparis4-w00.zarr
  [WinError 5] Access is denied
On Windows a directory cannot be renamed while any file inside it is open.
Nothing needs recomputing: rename the staging directory by hand.
```

**Proof:** the cause first — a directory rename on Windows, one condition changed at a time:

| what is held during the rename | result |
|---|---|
| nothing | renamed |
| one file inside, open for read | **PermissionError WinError 5** |
| one file inside, open for write | **PermissionError WinError 5** |
| an unfinished `os.scandir` on the directory | renamed |
| the process cwd inside the directory | PermissionError WinError 32 |

So WinError 5 here means a file inside is still open — which is what an indexer or scanner does for a moment after a large write, and why a short retry is the right shape of fix rather than a louder failure.

Then the function, on Windows:

| case | result |
|---|---|
| nothing held | published in 0.001 s |
| a handle released after 0.8 s | retried, published at 1.5 s |
| a handle never released | `SystemExit` with the message above; staging directory left intact |

And end to end, on a synthetic 84×300×260 uint8 volume (84 = 21 × `POOL_Z`): exit 0, output shape `(21, 300, 260)`, and the bytes are identical to the expected rounded mean pooling. No staging directory left behind.

**Why / where this is useful:** anyone preparing aligned inputs on Windows, which is the first step of the ink recipe. The cost of the bug is not the rename — it is that a completed multi-gigabyte conversion looks lost.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Three changes in one file:

1. `output_shape` is captured and `target`/`group` deleted before the rename, so the store is not holding the directory it is about to move. (The final `print` used `target.shape` *after* the rename; it now uses the captured value.)
2. `publish_partial()` retries `Path.replace` six times with exponential backoff from 0.5 s.
3. On exhaustion it raises `SystemExit` with both paths, the OS error, the reason, and the fact that nothing needs recomputing.

POSIX renames a directory whose files are open, so this is invisible on Linux and macOS; nothing changes there beyond one `del` and a loop that succeeds on its first attempt.

Scope: `main` factors this into `ink_detection/preprocessing/staged_write.py:publish_staged_output`, shared by `clean_labels`, `composite_from_zarr` and `merge_predictions`. The same exposure applies wherever a *directory* is published rather than a file. I have kept this PR to the script whose failure I actually hit; happy to follow up there if you want the helper hardened too.

**Why this matters to me:** I was preparing 24 alignment inputs at 9.6 µm, and phercparis4-w00 made it all the way through tile 416/416 before failing on the final rename with a PermissionError. Since the only output was a pathlib traceback, I initially thought the whole multi-hour conversion had been lost. It turned out all of the data was already on disk and only the rename step had failed, so I ended up writing a small script just to finish that rename separately.