### PR TITLE
volume: report ink-label placeholder substitution, and its real cause

### DIFF
--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -805,9 +805,14 @@ class Volume:
                 print(f"Successfully loaded ink label with shape: {self.inklabel.shape}, dtype: {self.inklabel.dtype}")
 
         except Exception as e:
-            if self.verbose:
-                print(f"Warning: Could not load ink label from {inklabel_url}: {e}")
-            
+            # fsspec reports network and TLS failures as FileNotFoundError carrying only the
+            # URL, so `e` on its own reads as "the file is not published" even when the file
+            # is there and the connection failed. Surface the underlying cause too.
+            detail = f"{type(e).__name__}: {e}"
+            cause = e.__cause__ or e.__context__
+            if cause is not None:
+                detail += f" (caused by {type(cause).__name__}: {cause})"
+
             # Create an empty/dummy ink label array based on data shape if possible
             if hasattr(self, 'data') and self.data:
                 try:
@@ -815,14 +820,20 @@ class Volume:
                     # Assume inklabel matches YX dimensions of the 3D volume
                     if len(base_shape) >= 3:
                         self.inklabel = np.zeros(base_shape[-2:], dtype=np.uint8)  # (Y, X)
-                        if self.verbose:
-                            print(f"Created empty placeholder ink label with shape: {self.inklabel.shape}")
                     else:
                         self.inklabel = np.zeros((1, 1), dtype=np.uint8)  # Fallback
                 except Exception:
                     self.inklabel = np.zeros((1, 1), dtype=np.uint8)  # Final fallback
             else:
                 self.inklabel = np.zeros((1, 1), dtype=np.uint8)  # Fallback if data not loaded
+
+            # Substituting a placeholder for real data is never silent: this warning is not
+            # gated on self.verbose, which defaults to False.
+            print(
+                f"Warning: could not load ink label from {inklabel_url}. "
+                f"self.inklabel has been set to a blank {self.inklabel.shape} placeholder "
+                f"and does NOT contain real data. {detail}"
+            )
 
     def _read_with_retry(self, store, coord_idx):
         """Read a slice from a store, retrying transient remote failures.

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -813,6 +813,15 @@ class Volume:
             if cause is not None:
                 detail += f" (caused by {type(cause).__name__}: {cause})"
 
+            # A genuine 404 does NOT arrive without a chained cause: aiohttp raises
+            # ClientResponseError with status 404 and fsspec re-raises it as
+            # FileNotFoundError. So whether a cause exists does not separate
+            # "not published" from "the request failed" - the HTTP status does.
+            # Anything that is not a 404 (connection reset, TLS, 403, 5xx) means the
+            # label may well exist and we simply could not reach it.
+            status = getattr(cause, "status", None)
+            absent = cause is None or status == 404
+
             # Create an empty/dummy ink label array based on data shape if possible
             if hasattr(self, 'data') and self.data:
                 try:
@@ -834,7 +843,7 @@ class Volume:
             # normal case and is reported as information. A chained cause means the request
             # itself failed (connection, TLS, permissions) and the label may well exist, so
             # that is reported as a warning. fsspec raises FileNotFoundError for both.
-            if cause is None:
+            if absent:
                 print(
                     f"Note: no ink label is published at {inklabel_url}. "
                     f"self.inklabel is a blank {self.inklabel.shape} placeholder, "

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -827,13 +827,25 @@ class Volume:
             else:
                 self.inklabel = np.zeros((1, 1), dtype=np.uint8)  # Fallback if data not loaded
 
-            # Substituting a placeholder for real data is never silent: this warning is not
-            # gated on self.verbose, which defaults to False.
-            print(
-                f"Warning: could not load ink label from {inklabel_url}. "
-                f"self.inklabel has been set to a blank {self.inklabel.shape} placeholder "
-                f"and does NOT contain real data. {detail}"
-            )
+            # Substituting a placeholder for real data is never silent: these messages are
+            # not gated on self.verbose, which defaults to False.
+            #
+            # Most published segments have no ink label at all, so "not published" is the
+            # normal case and is reported as information. A chained cause means the request
+            # itself failed (connection, TLS, permissions) and the label may well exist, so
+            # that is reported as a warning. fsspec raises FileNotFoundError for both.
+            if cause is None:
+                print(
+                    f"Note: no ink label is published at {inklabel_url}. "
+                    f"self.inklabel is a blank {self.inklabel.shape} placeholder, "
+                    f"not real data. ({detail})"
+                )
+            else:
+                print(
+                    f"Warning: could not fetch the ink label at {inklabel_url} - the request "
+                    f"failed, so the label may exist. self.inklabel has been set to a blank "
+                    f"{self.inklabel.shape} placeholder and does NOT contain real data. {detail}"
+                )
 
     def _read_with_retry(self, store, coord_idx):
         """Read a slice from a store, retrying transient remote failures.

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -819,8 +819,11 @@ class Volume:
             # "not published" from "the request failed" - the HTTP status does.
             # Anything that is not a 404 (connection reset, TLS, 403, 5xx) means the
             # label may well exist and we simply could not reach it.
+            # Only a missing file is "not published". A decode error or any other
+            # failure means the label is there and we could not use it, so it must not
+            # be announced as absent.
             status = getattr(cause, "status", None)
-            absent = cause is None or status == 404
+            absent = isinstance(e, FileNotFoundError) and (cause is None or status == 404)
 
             # Create an empty/dummy ink label array based on data shape if possible
             if hasattr(self, 'data') and self.data:
@@ -839,10 +842,9 @@ class Volume:
             # Substituting a placeholder for real data is never silent: these messages are
             # not gated on self.verbose, which defaults to False.
             #
-            # Most published segments have no ink label at all, so "not published" is the
-            # normal case and is reported as information. A chained cause means the request
-            # itself failed (connection, TLS, permissions) and the label may well exist, so
-            # that is reported as a warning. fsspec raises FileNotFoundError for both.
+            # Most published segments have no ink label at all, so a 404 is the normal case
+            # and is reported as information. Anything else means the label may well exist
+            # and we could not reach it, so that is reported as a warning.
             if absent:
                 print(
                     f"Note: no ink label is published at {inklabel_url}. "

--- a/vesuvius/tests/data/test_volume_inklabel.py
+++ b/vesuvius/tests/data/test_volume_inklabel.py
@@ -8,7 +8,6 @@ from the file genuinely not being published.
 """
 
 import numpy as np
-import pytest
 
 from vesuvius.data import volume as volume_module
 from vesuvius.data.volume import Volume
@@ -33,6 +32,20 @@ def _fail_with(monkeypatch, exc):
     monkeypatch.setattr(volume_module.fsspec, "open", boom)
 
 
+class _ClientResponseErrorLike(Exception):
+    """Mirrors the attribute aiohttp.ClientResponseError exposes: .status.
+
+    A stand-in rather than the real class, because aiohttp's constructor requires a
+    request_info and history that carry no meaning here. The only attribute the code
+    under test reads is .status.
+    """
+
+    def __init__(self, status, message):
+        super().__init__(f"{status}, message={message!r}")
+        self.status = status
+        self.message = message
+
+
 def _absent_404():
     """What fsspec ACTUALLY raises for a label that is not published.
 
@@ -45,15 +58,6 @@ def _absent_404():
     err = FileNotFoundError(LABEL_URL)
     err.__cause__ = cause
     return err
-
-
-class _ClientResponseErrorLike(Exception):
-    """Mirrors the attribute aiohttp.ClientResponseError exposes: .status."""
-
-    def __init__(self, status, message):
-        super().__init__(f"{status}, message={message!r}")
-        self.status = status
-        self.message = message
 
 
 def _tls_failure():
@@ -116,6 +120,20 @@ class TestMissingIsDistinguishedFromFailed:
         assert "no ink label is published" in out
         assert "not real data" in out
         assert "Warning" not in out, "an absent label is not a failure"
+
+    def test_a_decode_failure_is_not_reported_as_absent(self, monkeypatch, capsys):
+        """A published-but-unreadable label is not the same as no label.
+
+        Only a missing file is "not published". If the download succeeds and Image.open
+        raises, there is no chained cause, so a naive `cause is None` check would announce
+        the label as absent when it is in fact there.
+        """
+        _fail_with(monkeypatch, ValueError("cannot identify image file"))
+        v = _bare_segment(verbose=False)
+        v.download_inklabel()
+        out = capsys.readouterr().out
+        assert "no ink label is published" not in out
+        assert "Warning" in out
 
     def test_failed_request_is_reported_as_a_warning(self, monkeypatch, capsys):
         v = _bare_segment(verbose=False)

--- a/vesuvius/tests/data/test_volume_inklabel.py
+++ b/vesuvius/tests/data/test_volume_inklabel.py
@@ -33,6 +33,29 @@ def _fail_with(monkeypatch, exc):
     monkeypatch.setattr(volume_module.fsspec, "open", boom)
 
 
+def _absent_404():
+    """What fsspec ACTUALLY raises for a label that is not published.
+
+    Verified live against dl.ash2txt.org on 2026-08-31: a real 404 surfaces as
+    FileNotFoundError chained from aiohttp's ClientResponseError with status 404.
+    An earlier version of this test used a bare FileNotFoundError with no cause,
+    which no real 404 ever produces, so it could not catch a wrong split.
+    """
+    cause = _ClientResponseErrorLike(404, "Not Found")
+    err = FileNotFoundError(LABEL_URL)
+    err.__cause__ = cause
+    return err
+
+
+class _ClientResponseErrorLike(Exception):
+    """Mirrors the attribute aiohttp.ClientResponseError exposes: .status."""
+
+    def __init__(self, status, message):
+        super().__init__(f"{status}, message={message!r}")
+        self.status = status
+        self.message = message
+
+
 def _tls_failure():
     """What fsspec actually raises for a certificate problem: the URL, cause buried."""
     cause = OSError("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed")
@@ -87,7 +110,7 @@ class TestMissingIsDistinguishedFromFailed:
 
     def test_absent_label_is_reported_as_a_note(self, monkeypatch, capsys):
         v = _bare_segment(verbose=False)
-        _fail_with(monkeypatch, FileNotFoundError(LABEL_URL))  # no chained cause = a real 404
+        _fail_with(monkeypatch, _absent_404())  # a real 404: cause present, status 404
         v.download_inklabel()
         out = capsys.readouterr().out
         assert "no ink label is published" in out

--- a/vesuvius/tests/data/test_volume_inklabel.py
+++ b/vesuvius/tests/data/test_volume_inklabel.py
@@ -48,7 +48,7 @@ class TestInkLabelPlaceholderIsReported:
         _fail_with(monkeypatch, _tls_failure())
         v.download_inklabel()
         out = capsys.readouterr().out
-        assert "could not load ink label" in out.lower()
+        assert "could not fetch the ink label" in out.lower()
         assert "does NOT contain real data" in out
 
     def test_reports_the_underlying_cause_not_just_the_url(self, monkeypatch, capsys):
@@ -79,3 +79,26 @@ class TestInkLabelPlaceholderIsReported:
         v.url = None
         v.download_inklabel()
         assert "URL is not set" in capsys.readouterr().out
+
+
+class TestMissingIsDistinguishedFromFailed:
+    """Most segments publish no ink label at all. That is normal and must not be
+    reported in the same words as a request that failed."""
+
+    def test_absent_label_is_reported_as_a_note(self, monkeypatch, capsys):
+        v = _bare_segment(verbose=False)
+        _fail_with(monkeypatch, FileNotFoundError(LABEL_URL))  # no chained cause = a real 404
+        v.download_inklabel()
+        out = capsys.readouterr().out
+        assert "no ink label is published" in out
+        assert "not real data" in out
+        assert "Warning" not in out, "an absent label is not a failure"
+
+    def test_failed_request_is_reported_as_a_warning(self, monkeypatch, capsys):
+        v = _bare_segment(verbose=False)
+        _fail_with(monkeypatch, _tls_failure())  # chained cause = the request failed
+        v.download_inklabel()
+        out = capsys.readouterr().out
+        assert "Warning" in out
+        assert "the label may exist" in out
+        assert "CERTIFICATE_VERIFY_FAILED" in out

--- a/vesuvius/tests/data/test_volume_inklabel.py
+++ b/vesuvius/tests/data/test_volume_inklabel.py
@@ -1,0 +1,81 @@
+"""Tests for Volume.download_inklabel placeholder reporting.
+
+Regression coverage: when the ink label cannot be loaded, Volume substitutes a
+blank array for real data. That substitution was only reported when verbose=True
+(the default is False), and the reported reason was the fsspec FileNotFoundError,
+which carries only the URL - so a TLS or network failure was indistinguishable
+from the file genuinely not being published.
+"""
+
+import numpy as np
+import pytest
+
+from vesuvius.data import volume as volume_module
+from vesuvius.data.volume import Volume
+
+URL = "https://example.invalid/scrolls/1/segments/54keV_7.91um/20230827161847.zarr/"
+LABEL_URL = "https://example.invalid/scrolls/1/segments/54keV_7.91um/20230827161847_inklabels.png"
+
+
+def _bare_segment(verbose=False):
+    """A Volume with just the attributes download_inklabel touches - no network."""
+    v = Volume.__new__(Volume)
+    v.type = "segment"
+    v.url = URL
+    v.verbose = verbose
+    v.inklabel = None
+    return v
+
+
+def _fail_with(monkeypatch, exc):
+    def boom(*args, **kwargs):
+        raise exc
+    monkeypatch.setattr(volume_module.fsspec, "open", boom)
+
+
+def _tls_failure():
+    """What fsspec actually raises for a certificate problem: the URL, cause buried."""
+    cause = OSError("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed")
+    err = FileNotFoundError(LABEL_URL)
+    err.__cause__ = cause
+    return err
+
+
+class TestInkLabelPlaceholderIsReported:
+    def test_warns_even_though_verbose_is_false(self, monkeypatch, capsys):
+        """The default path must not silently hand back fabricated data."""
+        v = _bare_segment(verbose=False)
+        _fail_with(monkeypatch, _tls_failure())
+        v.download_inklabel()
+        out = capsys.readouterr().out
+        assert "could not load ink label" in out.lower()
+        assert "does NOT contain real data" in out
+
+    def test_reports_the_underlying_cause_not_just_the_url(self, monkeypatch, capsys):
+        """A TLS failure must not read as 'the file is not published'."""
+        v = _bare_segment(verbose=False)
+        _fail_with(monkeypatch, _tls_failure())
+        v.download_inklabel()
+        out = capsys.readouterr().out
+        assert "CERTIFICATE_VERIFY_FAILED" in out, "the real cause was swallowed"
+
+    def test_placeholder_shape_is_stated(self, monkeypatch, capsys):
+        v = _bare_segment(verbose=False)
+        _fail_with(monkeypatch, _tls_failure())
+        v.download_inklabel()
+        out = capsys.readouterr().out
+        assert "(1, 1)" in out
+
+    def test_still_returns_an_array_so_callers_do_not_break(self, monkeypatch):
+        """Deliberately unchanged: the fallback still yields an array, not None."""
+        v = _bare_segment(verbose=False)
+        _fail_with(monkeypatch, _tls_failure())
+        v.download_inklabel()
+        assert isinstance(v.inklabel, np.ndarray)
+        assert int(np.sum(v.inklabel)) == 0
+
+    def test_missing_url_still_reported(self, capsys):
+        v = _bare_segment()
+        v.url = None
+        v.download_inklabel()
+        assert "URL is not set" in capsys.readouterr().out


### PR DESCRIPTION
**In one sentence:** when an ink label cannot be downloaded, `Volume` now says so instead of handing
back a blank image in silence, and it says whether the label is genuinely absent or the request failed.

**One real example:** macOS arm64, Python 3.14, villa @ `e2442b7`. Starting with Scroll 1 segment
`20230827161847`, the only segment the shipped `scrolls.yaml` resolves, I called
`Volume(type="segment", ..., download_only=True)` and asked for its `inklabel`. It came back shape
`(1, 1)` with `sum() == 0`, and the library printed nothing at all. I read that as the segment having
no label published, and moved on. It has one. `curl` on the label URL returns `200`, and changing only
`SSL_CERT_FILE` and rerunning the identical call returns `(9216, 5120)` with `3,762,237` ink pixels.
What actually failed was `SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate
verify failed: unable to get local issuer certificate`, and none of it reached me.

**Before:** `Volume(type="segment", ...)` substitutes a blank array when the ink label cannot be
loaded (`data/volume.py:807-825`). That substitution was only mentioned when `verbose=True`, and
`verbose` defaults to `False`, so the default path hands back fabricated data in silence. The
reported reason was misleading too: `fsspec` raises `FileNotFoundError` carrying only the URL for
network, TLS and permission failures, so a connection problem was indistinguishable from the label
genuinely not being published.

On a macOS python.org interpreter that has not run `Install Certificates.command` (a common
default), loading the one segment shipped in `install/configs/scrolls.yaml`:

```
$ curl -o /dev/null -w '%{http_code}' \
    https://dl.ash2txt.org/other/dev/scrolls/1/segments/54keV_7.91um/20230827161847_inklabels.png
200

>>> v = Volume(type="segment", scroll_id=1, energy=54, resolution=7.91,
...            segment_id=20230827161847, download_only=True)
>>> v.inklabel.shape
(1, 1)
>>> v.inklabel.sum()
0
```

No output of any kind. The label is published and served at HTTP 200, and the caller is handed one
blank pixel.

**After this PR:** the same call prints a warning naming the underlying certificate error, so the
caller knows the array they were handed is a placeholder and why.

**Proof:** changing nothing but `SSL_CERT_FILE`, on the same call:

```
broken certs ->  shape (1, 1)        0 ink pixels        no output
working certs -> shape (9216, 5120)  3,762,237 ink pixels
```

The label was published, reachable and correct the whole time. The failure was a local certificate
problem that takes one line to fix, and the library reported none of it.

**Why / where this is useful:** anyone evaluating which segments carry ink labels gets a truthful
answer instead of a silent blank. The current behaviour makes a transient or local failure look
identical to "this segment has no label", which is a conclusion about the data rather than about the
connection.

## Details

- `data/volume.py::download_inklabel`: the placeholder substitution is now always reported, and the
  message separates the two cases by the **HTTP status on the chained cause**:
  - **a 404** (the label is genuinely not published): reported as a note rather than a warning,
    because having no ink label is the normal case. Listing `scrolls/1/segments/54keV_7.91um/`
    today gives 250 published segments of which 33 have an `_inklabels.png` and 217 do not, so
    warning on that path would be noise on 87% of segments;
  - **anything else** (connection reset, TLS, 403, 5xx, or a file that downloads but will not
    decode): reported as a warning, since the label may well exist and we were simply unable to use
    it, with the underlying exception included. The check requires a `FileNotFoundError` as well as
    the 404, so a decode failure is never announced as "not published".

  Worth stating explicitly, because the obvious rule is wrong: a genuine 404 does **not** arrive
  without a chained cause. `aiohttp` raises `ClientResponseError` with `status=404` and `fsspec`
  re-raises it as `FileNotFoundError`, so splitting on "is there a cause at all" would have sent
  every absent label down the "the request failed" branch. Checked live against `dl.ash2txt.org`:

  ```
  segment 20230504093154 (no label)  -> FileNotFoundError caused by ClientResponseError, status 404
  segment 20230827161847 (has one)   -> opens, (9216, 5120)
  broken certificates                -> FileNotFoundError caused by ClientConnectorCertificateError
  ```

- **Deliberately NOT changed.** The fallback still yields an array rather than `None` or an exception,
  so existing callers are unaffected. Making this fail closed would be a behaviour change worth doing
  separately, and is not needed to stop the silence.
- **Precedent in this repo.** `image_proc/run/zarr_tasks/tasks/recompress.py` already treats
  substituted data this way: it announces itself before starting, warns per level, and prints a final
  summary of every affected chunk. This PR brings `download_inklabel` in line with that.
- **No overlap.** No open PR touches `download_inklabel`. #1543 edits `data/volume.py` but only
  `__init__`, `_init_from_zarr_path`, `load_ome_metadata` and `load_data`; it has not been updated
  since 20 Aug. Re-checked 2026-08-31.

Verification:

```
$ python -m pytest tests/data/test_volume_inklabel.py -q
8 passed
```

Negative control, run by restoring `main`'s `data/volume.py` under this PR's test file. Six of the
eight fail, and they are the six that target the defect:

```
6 failed, 2 passed
FAILED ...TestInkLabelPlaceholderIsReported::test_warns_even_though_verbose_is_false
FAILED ...TestInkLabelPlaceholderIsReported::test_reports_the_underlying_cause_not_just_the_url
FAILED ...TestInkLabelPlaceholderIsReported::test_placeholder_shape_is_stated
FAILED ...TestMissingIsDistinguishedFromFailed::test_absent_label_is_reported_as_a_note
FAILED ...TestMissingIsDistinguishedFromFailed::test_a_decode_failure_is_not_reported_as_absent
FAILED ...TestMissingIsDistinguishedFromFailed::test_failed_request_is_reported_as_a_warning
```

The other two pass on `main` as well, and that is deliberate rather than an oversight. Neither is a
regression test for this change:

- `test_still_returns_an_array_so_callers_do_not_break` asserts the behaviour this PR explicitly does
  NOT change, that the fallback still yields an array rather than `None`. It has to pass both ways or
  the PR has broken its own stated contract.
- `test_missing_url_still_reported` covers the `url is None` branch, which already reported itself on
  `main`. It is there so a future change cannot silence that branch while fixing the others.

Flagging this rather than quoting a bare pass count, since a test that passes before and after proves
nothing on its own.

Whole `tests/data` suite, same machine:

```
before:  60 passed, 1 skipped
after:   68 passed, 1 skipped      (the 8 new tests)
```

Under your CI command (`.github/workflows/test-vesuvius.yml`), same machine, run against `main` and
against this branch:

```
$ python -m pytest tests -m "not slow and not network"
main        15 failed, 276 passed, 6 skipped, 36 errors
this branch 15 failed, 284 passed, 6 skipped, 36 errors
```

Identical failure and error counts: this branch adds 8 passing tests and introduces no new failures.
The 15 failures and 36 collection errors are pre-existing on `main` and come from optional ML
dependencies absent in my local environment; CI installs them with `uv sync --extra all`. The new
tests need no network (their only URLs are `example.invalid` string constants, never fetched) and
exercise no zarr API directly, so they are unaffected by the 2.18.7 / 3.2.1 matrix.

Branched from villa `e2442b7`; every number above was measured on this branch at `f3a7620`, Python
3.14, macOS arm64. Data: Scroll 1 segment 20230827161847 from dl.ash2txt.org.

Two things I am happy to change if you would rather:

- **Silence the absent case entirely** and report only genuine failures. I chose to announce it
  because a caller who does not know the label is absent can read a blank array as "no ink here",
  which is a conclusion about the papyrus rather than about the catalogue. But it does mean one line
  on the 217 segments that have no label, and if you would prefer nothing there, it is a one-line
  change.
- **Make it fail closed** instead of warning, if you would rather callers never receive a placeholder
  at all.

---

The patch was written with Claude Code under my direction. I hit the bug myself while loading a
segment on my own machine, produced the before/after and the control run myself, and wrote the
example above myself.
