### PR TITLE
fiber sync: fix the v3 crash that made every linked-fiber conflict unresolvable

### DIFF
--- a/volume-cartographer/scripts/fiber_merge.py
+++ b/volume-cartographer/scripts/fiber_merge.py
@@ -327,7 +327,9 @@ def line_tangent_at(line, index):
 
 def endpoint_tangent(line, point):
     """Port of endpointTangentFromLinePoints: tangent of the line segment
-    nearest to `point`, or None when the line has fewer than 2 points."""
+    nearest to `point`, or None when the line has fewer than 2 points.
+    Accepts a bare [x, y, z] point or a version-3 control point dict."""
+    point = _cp_position(point)
     if len(line) < 2 or not _finite_point(point):
         return None
     return line_tangent_at(line, nearest_line_point_index(line, point))
@@ -1243,8 +1245,11 @@ def refresh_pair_links(a_doc, b_doc, a_name, b_name, base_doc=None):
                 f"link {a_name} -> {b_name}: anchor control point not found in "
                 f"{a_name if local_index is None else b_name}")
             continue
-        pa = a_cps[local_index]
-        pb = b_cps[far_index]
+        # Version-3 control points are {'position': ...} dicts; everything
+        # below (tangents, the reciprocal's float literals) needs the bare
+        # point.
+        pa = _cp_position(a_cps[local_index])
+        pb = _cp_position(b_cps[far_index])
         da = endpoint_tangent(a_line, pa)
         db = endpoint_tangent(b_line, pb)
 

--- a/volume-cartographer/scripts/tests/test_fiber_merge.py
+++ b/volume-cartographer/scripts/tests/test_fiber_merge.py
@@ -1304,3 +1304,162 @@ def test_reviewed_dropped_when_only_one_side_of_a_splice_was_reviewed():
 
     assert result['ok'], result['conflicts']
     assert fiber_merge.REVIEWED_TAG not in result['merged']['tags']
+
+
+# --- version 3 documents through refresh_pair_links ------------------------
+# v3 control points are {'position': ..., 'segment_to_next': ...} dicts;
+# every refresh test above drives the consistency pass with v1 bare-list
+# points, which is how a dict-vs-list crash shipped (any conflicting linked
+# v3 fiber demoted to a manual conflict). These pin the v3 paths.
+
+
+def make_v3_pair(a_name, b_name, a_cps, b_cps, a_index, b_index,
+                 pending=True):
+    """A consistent linked version-3 fiber pair, as VC3D would write it."""
+    a = make_v3_fiber(a_cps, filename=a_name)
+    b = make_v3_fiber(b_cps, filename=b_name)
+    pa, pb = a_cps[a_index], b_cps[b_index]
+    da = fiber_merge.endpoint_tangent(a['line_points'], pa)
+    db = fiber_merge.endpoint_tangent(b['line_points'], pb)
+    a['branches'] = [{
+        'control_point_index': a_index, 'branch_fiber_id': 2,
+        'branch_control_point_index': b_index, 'branch_file': b_name,
+        'control_point_direction': da, 'branch_control_point_direction': db,
+        'control_point_position': list(pa),
+        'branch_control_point_position': list(pb), 'pending': pending,
+    }]
+    b['branches'] = [{
+        'control_point_index': b_index, 'branch_fiber_id': 1,
+        'branch_control_point_index': a_index, 'branch_file': a_name,
+        'control_point_direction': db, 'branch_control_point_direction': da,
+        'control_point_position': list(pb),
+        'branch_control_point_position': list(pa), 'pending': pending,
+    }]
+    return a, b
+
+
+# Deliberately NOT parallel to BASE_CPS (which runs along x): a z-direction
+# peer gives the pair distinct endpoint tangents, so a swapped or miswired
+# direction field fails the loader checks instead of hiding behind
+# coincidentally equal tangents.
+B_CPS_V3 = [[100.0, 200.0, 350.0 + 10.0 * i] for i in range(4)]
+
+
+def test_refresh_v3_consistent_pair_is_noop():
+    a, b = make_v3_pair('a.json', 'b.json', BASE_CPS, B_CPS_V3, 2, 1)
+    out = refresh_pair_links(a, b, 'a.json', 'b.json')
+    assert out['ok']
+    assert not out['a_changed'] and not out['b_changed']
+    assert out['a_doc'] == a and out['b_doc'] == b
+    assert loader_issues({'a.json': out['a_doc'], 'b.json': out['b_doc']}) == []
+
+
+@pytest.mark.parametrize('with_base', [False, True])
+def test_refresh_v3_restores_missing_reciprocal(with_base):
+    a, b = make_v3_pair('a.json', 'b.json', BASE_CPS, B_CPS_V3, 2, 1)
+    base_a = copy.deepcopy(a) if with_base else None
+    b['branches'] = []
+    out = refresh_pair_links(a, b, 'a.json', 'b.json', base_doc=base_a)
+    assert out['ok'] and out['b_changed'] and not out['a_changed']
+    restored = out['b_doc']['branches'][0]
+    assert restored['branch_file'] == 'a.json'
+    assert restored['control_point_index'] == 1
+    assert restored['branch_control_point_index'] == 2
+    # Positions must be bare float triples (the loader's wire format), not
+    # v3 control-point dicts.
+    assert restored['control_point_position'] == B_CPS_V3[1]
+    assert restored['branch_control_point_position'] == BASE_CPS[2]
+    assert restored['pending'] is True
+    assert out['b_doc']['generation'] == 2
+    assert loader_issues({'a.json': out['a_doc'], 'b.json': out['b_doc']}) == []
+
+
+def test_v3_generation_only_conflict_merges_and_refreshes_cleanly():
+    """The field incident: two users merely OPEN the same linked v3 fiber
+    (VC3D re-saves with a generation bump on open), so both sides differ
+    from the base only in 'generation'. The merge takes the v3 span-merge
+    branch with every span owner 'none'; the consistency pass must then
+    rewrite nothing."""
+    base_a, b = make_v3_pair('a.json', 'b.json', BASE_CPS, B_CPS_V3, 2, 1)
+    local = copy.deepcopy(base_a)
+    local['generation'] = 2
+    remote = copy.deepcopy(base_a)
+    remote['generation'] = 3
+
+    result = merge_fibers(base_a, local, remote)
+    assert result['ok'], result['conflicts']
+    assert result['peer_files'] == ['b.json']
+
+    out = refresh_pair_links(result['merged'], b, 'a.json', 'b.json',
+                             base_doc=base_a)
+    assert out['ok']
+    assert not out['a_changed'] and not out['b_changed']
+    assert out['a_doc'] == result['merged'] and out['b_doc'] == b
+    assert loader_issues({'a.json': out['a_doc'], 'b.json': out['b_doc']}) == []
+
+
+@pytest.mark.parametrize('changed_side', ['local', 'remote'])
+def test_v3_short_circuit_merge_then_refresh(changed_side):
+    """One side untouched since the base: merge_fibers returns through its
+    short-circuit branches, which still report peer_files — the consistency
+    pass runs on those results in production too."""
+    base_a, b = make_v3_pair('a.json', 'b.json', BASE_CPS, B_CPS_V3, 2, 1)
+    changed = copy.deepcopy(base_a)
+    changed['generation'] = 2
+    local = changed if changed_side == 'local' else copy.deepcopy(base_a)
+    remote = changed if changed_side == 'remote' else copy.deepcopy(base_a)
+
+    result = merge_fibers(base_a, local, remote)
+    assert result['ok'], result['conflicts']
+    assert result['peer_files'] == ['b.json']
+    assert result['merged'] == changed
+
+    out = refresh_pair_links(result['merged'], b, 'a.json', 'b.json',
+                             base_doc=base_a)
+    assert out['ok']
+    assert not out['a_changed'] and not out['b_changed']
+    assert loader_issues({'a.json': out['a_doc'], 'b.json': out['b_doc']}) == []
+
+
+def test_v3_one_sided_span_edit_merges_and_refreshes():
+    """A real edit on one side of a linked v3 fiber (span re-run away from
+    the link anchor) while the other side just opened it: the span result
+    must be carried atomically and the pair must clear every loader check."""
+    base_a, b = make_v3_pair('a.json', 'b.json', BASE_CPS, B_CPS_V3, 2, 1)
+    local = copy.deepcopy(base_a)
+    set_v3_span(local, 5, goal='cspline', bend=1.5)
+    local['generation'] = 2
+    remote = copy.deepcopy(base_a)
+    remote['generation'] = 3
+
+    result = merge_fibers(base_a, local, remote)
+    assert result['ok'], result['conflicts']
+    merged = result['merged']
+    assert merged['control_points'][5]['segment_to_next']['interp_goal'] == 'cspline'
+    assert merged['line_points'][21:24] == local['line_points'][21:24]
+    assert result['peer_files'] == ['b.json']
+
+    out = refresh_pair_links(merged, b, 'a.json', 'b.json', base_doc=base_a)
+    assert out['ok']
+    assert loader_issues({'a.json': out['a_doc'], 'b.json': out['b_doc']}) == []
+
+
+def test_refresh_v3_fiber_with_v1_peer_is_noop():
+    """Mid-migration reality: a v3 fiber linked to a not-yet-migrated v1
+    peer. The pass must handle both control-point shapes in one call."""
+    a, _ = make_v3_pair('a.json', 'b.json', BASE_CPS, B_CPS_V3, 2, 1)
+    _, b = make_pair('a.json', 'b.json', BASE_CPS, B_CPS_V3, 2, 1)
+    out = refresh_pair_links(a, b, 'a.json', 'b.json')
+    assert out['ok']
+    assert not out['a_changed'] and not out['b_changed']
+    assert out['a_doc'] == a and out['b_doc'] == b
+    assert loader_issues({'a.json': out['a_doc'], 'b.json': out['b_doc']}) == []
+
+
+def test_endpoint_tangent_accepts_v3_control_point():
+    doc = make_v3_fiber(BASE_CPS)
+    tangent = fiber_merge.endpoint_tangent(doc['line_points'],
+                                           doc['control_points'][2])
+    assert tangent == fiber_merge.endpoint_tangent(doc['line_points'],
+                                                   BASE_CPS[2])
+    assert tangent is not None

--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -789,8 +789,9 @@ class TestLinkConsistency:
     def test_refresh_crash_demotes_with_location(self, manager, monkeypatch,
                                                  capsys):
         """A merge-machinery bug must read as a bug, not as undiagnosable
-        data: the demotion reason names the innermost frame, and
-        VC_SYNC_DEBUG=1 prints the full traceback."""
+        data: the demotion reason names the innermost frame. The full
+        traceback prints ONLY under VC_SYNC_DEBUG=1 — unconditional stacks
+        would bury the merge preview and the conflict prompt."""
         a = self.fiber('a.json', self.CPS_A,
                        branches=[self.entry('b.json', self.CPS_A, 1,
                                             self.CPS_B, 0)])
@@ -801,15 +802,22 @@ class TestLinkConsistency:
             raise TypeError('synthetic refresh crash')
 
         monkeypatch.setattr(vc_sync.fiber_merge, 'refresh_pair_links', boom)
-        monkeypatch.setenv('VC_SYNC_DEBUG', '1')
         plan = self.make_plan(manager, 'fibers/a.json', a,
                               self.fiber('a.json', self.CPS_A), ['b.json'])
+
+        monkeypatch.delenv('VC_SYNC_DEBUG', raising=False)
         peer_fixes, demoted = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert peer_fixes == {} and len(demoted) == 1
         reason = demoted[0][1]
         assert 'synthetic refresh crash' in reason
         assert 'test_vc_sync_helpers.py' in reason and 'boom' in reason
+        assert 'Traceback' not in capsys.readouterr().out
+
+        monkeypatch.setenv('VC_SYNC_DEBUG', '1')
+        peer_fixes, demoted = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], set())
+        assert len(demoted) == 1
         assert 'Traceback' in capsys.readouterr().out
 
 

--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -3,6 +3,7 @@
 Pure-local: a temp directory stands in for the sync dir and tracked rows are
 written straight into the SQLite DB. No S3 or network access.
 """
+import copy
 import json
 import os
 import sqlite3
@@ -13,6 +14,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import fiber_merge
+import test_fiber_merge
 import vc_sync
 from vc_sync import S3SyncManager, SyncAction
 
@@ -768,6 +770,66 @@ class TestLinkConsistency:
         # Based on the remote doc (gen 5), bumped by the rewrite
         assert fixed['generation'] == 6
         assert fixed['branches'][0]['branch_file'] == 'a.json'
+
+    def test_v3_consistent_pair_needs_no_fix(self, manager):
+        """v3 control points are {'position': ...} dicts; the consistency
+        pass must unwrap them (regression: a TypeError here demoted every
+        conflicting linked v3 fiber to a manual conflict)."""
+        a, b = test_fiber_merge.make_v3_pair(
+            'a.json', 'b.json', test_fiber_merge.BASE_CPS,
+            test_fiber_merge.B_CPS_V3, 2, 1)
+        write_local(manager, 'fibers/b.json', json.dumps(b))
+        plan = self.make_plan(manager, 'fibers/a.json', a,
+                              copy.deepcopy(a), ['b.json'])
+        peer_fixes, demoted = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], set())
+        assert demoted == []
+        assert peer_fixes == {}
+
+    def test_refresh_crash_demotes_with_location(self, manager, monkeypatch,
+                                                 capsys):
+        """A merge-machinery bug must read as a bug, not as undiagnosable
+        data: the demotion reason names the innermost frame, and
+        VC_SYNC_DEBUG=1 prints the full traceback."""
+        a = self.fiber('a.json', self.CPS_A,
+                       branches=[self.entry('b.json', self.CPS_A, 1,
+                                            self.CPS_B, 0)])
+        b = self.fiber('b.json', self.CPS_B)
+        write_local(manager, 'fibers/b.json', json.dumps(b))
+
+        def boom(*args, **kwargs):
+            raise TypeError('synthetic refresh crash')
+
+        monkeypatch.setattr(vc_sync.fiber_merge, 'refresh_pair_links', boom)
+        monkeypatch.setenv('VC_SYNC_DEBUG', '1')
+        plan = self.make_plan(manager, 'fibers/a.json', a,
+                              self.fiber('a.json', self.CPS_A), ['b.json'])
+        peer_fixes, demoted = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], set())
+        assert peer_fixes == {} and len(demoted) == 1
+        reason = demoted[0][1]
+        assert 'synthetic refresh crash' in reason
+        assert 'test_vc_sync_helpers.py' in reason and 'boom' in reason
+        assert 'Traceback' in capsys.readouterr().out
+
+
+class TestExceptionLocation:
+    """_exception_location: the compact frame reference appended to
+    demotion reasons."""
+
+    def test_names_innermost_frame(self):
+        def inner():
+            raise ValueError('x')
+
+        try:
+            inner()
+        except ValueError as ex:
+            location = vc_sync._exception_location(ex)
+        assert location.startswith(' at test_vc_sync_helpers.py:')
+        assert location.endswith(' in inner')
+
+    def test_exception_without_traceback_is_empty(self):
+        assert vc_sync._exception_location(ValueError('x')) == ''
 
 
 class TestAnalyzeDeleteActions:

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -107,10 +107,10 @@ def _exception_location(ex):
     Demotion reasons carry this so a merge-machinery bug reads as a bug
     (with a place to look) instead of as undiagnosable annotation data —
     a bare str(ex) once hid a crash behind weeks of manual conflicts."""
-    tb = getattr(ex, '__traceback__', None)
-    if tb is None:
+    frames = traceback.extract_tb(getattr(ex, '__traceback__', None))
+    if not frames:
         return ''
-    frame = traceback.extract_tb(tb)[-1]
+    frame = frames[-1]
     return (f" at {os.path.basename(frame.filename)}:{frame.lineno} "
             f"in {frame.name}")
 

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -61,6 +61,7 @@ import sqlite3
 import hashlib
 import argparse
 import tempfile
+import traceback
 import subprocess
 from datetime import datetime, timezone
 from enum import Enum
@@ -98,6 +99,29 @@ CONFLICT_DIR_NAME = '.s3sync-conflicts'  # versions preserved before overwrite
 # Tag the merge puts on fibers whose line it could not re-fit; mirrored here
 # so hfsync still recognizes them when fiber_merge is unavailable.
 REOPTIMIZE_TAG = getattr(fiber_merge, 'REOPTIMIZE_TAG', 'needs_reoptimization')
+
+
+def _exception_location(ex):
+    """' at file.py:123 in func' for the innermost frame of `ex`, or ''.
+
+    Demotion reasons carry this so a merge-machinery bug reads as a bug
+    (with a place to look) instead of as undiagnosable annotation data —
+    a bare str(ex) once hid a crash behind weeks of manual conflicts."""
+    tb = getattr(ex, '__traceback__', None)
+    if tb is None:
+        return ''
+    frame = traceback.extract_tb(tb)[-1]
+    return (f" at {os.path.basename(frame.filename)}:{frame.lineno} "
+            f"in {frame.name}")
+
+
+def _print_debug_traceback():
+    """Full traceback for the exception being handled, only when the user
+    opted in (VC_SYNC_DEBUG=1): unconditional stacks would bury the merge
+    preview and the interactive conflict prompt."""
+    if os.environ.get('VC_SYNC_DEBUG'):
+        for line in traceback.format_exc().rstrip().splitlines():
+            print(f"      {line}")
 
 class SyncAction(Enum):
     UPLOAD = "upload"
@@ -688,7 +712,9 @@ class S3SyncManager:
             try:
                 result = fiber_merge.merge_fibers(base_doc, local_doc, remote_doc)
             except Exception as ex:
-                print(f"  ⚠️  merge failed for {path} ({ex}); manual resolution")
+                print(f"  ⚠️  merge failed for {path} "
+                      f"({ex}{_exception_location(ex)}); manual resolution")
+                _print_debug_traceback()
                 return None
             summary = fiber_merge.summarize(result)
             if dry_run:
@@ -888,7 +914,9 @@ class S3SyncManager:
                         if refreshed['b_changed']:
                             json.dumps(refreshed['b_doc'], allow_nan=False)
                 except Exception as ex:
-                    failure = f"refresh against {peer_name} failed ({ex})"
+                    failure = (f"refresh against {peer_name} failed "
+                               f"({ex}{_exception_location(ex)})")
+                    _print_debug_traceback()
                     break
                 if not refreshed['ok']:
                     failure = '; '.join(refreshed['conflicts'])


### PR DESCRIPTION
# fiber sync: fix the v3 crash that made every linked-fiber conflict unresolvable

## Problem

Since the v3 fiber format landed (model-interpolation work, #1294/#1324), vc_sync's
auto-merge effectively stopped working for linked fibers: any conflict on a fiber with
links demoted to a manual conflict, and the demotion cascade then demoted every other
pending merge linked to it. Because VC3D re-saves a fiber with a generation bump when a
user merely opens it, another user just opening a fiber was enough to manufacture a
conflict — which then couldn't be resolved.

Verified on production data: a stashed conflict triple from Aug 7 whose remote side
differs from the base **only** in `generation: 189 -> 190` merges cleanly, then crashes
in the link-consistency pass. 330 of the 666 live PHercParis4 fibers carry links, i.e.
half the dataset was affected.

## Root cause

v3 changed control points from bare `[x, y, z]` arrays to
`{'position': [...], 'segment_to_next': {...}}` dicts. `merge_fibers` unwraps them
everywhere via `_cp_position`; `refresh_pair_links` did not:

- `endpoint_tangent(a_line, pa)` with `pa` a dict returns `None` (its `_finite_point`
  guard), and `_snapped_direction(stored, None)` raises
  `TypeError: 'NoneType' object is not iterable`.
- Creating a missing reciprocal, `[float(x) for x in pb]` iterates the dict's keys and
  raises `ValueError: could not convert string to float: 'position'`.

vc_sync catches the exception in `_plan_link_consistency` and demotes the merge with a
bare `str(ex)` reason — which is also why this read as a data problem for weeks.

## Changes

**Commit 1 — `fiber_merge.py` fix + regression tests**
- `refresh_pair_links`: take `pa`/`pb` through `_cp_position` (identity for v1 bare
  points, so v1 behavior is byte-identical and consistent pairs still see zero
  rewrites/re-uploads).
- `endpoint_tangent`: defensive `_cp_position` unwrap at entry, so no future call site
  handing a control point can regress the same way. `_finite_point` deliberately stays
  strict — loosening it would weaken `is_fiber_doc` validation.
- 11 new tests in `test_fiber_merge.py` (a `make_v3_pair` fixture, mirroring the v1
  `make_pair`): consistent-pair no-op with deep equality, reciprocal restoration with
  and without `base_doc`, the generation-only field incident, both merge short-circuit
  paths, a one-sided v3 span edit, a mixed v3/v1 pair, and an `endpoint_tangent` v3
  unit test. All run through the file's `loader_issues` checker; all fail with the
  original TypeError/ValueError before the fix.

**Commit 2 — `vc_sync.py` diagnosability + integration test**
- Demotion reasons now name the innermost frame
  (`... failed ('NoneType' ... at fiber_merge.py:357 in _snapped_direction)`).
- `VC_SYNC_DEBUG=1` prints the full traceback (indented); default output is unchanged
  so stacks can't bury the merge preview or the interactive conflict prompt. Demotion
  semantics are untouched.
- vc_sync-level regression in `TestLinkConsistency`: a consistent linked v3 pair
  through `_plan_link_consistency` plans zero fixes and zero demotions (previously it
  demoted with the TypeError); plus a crash-injection test pinning the location suffix
  and the debug traceback, and unit tests for `_exception_location`.

## How verified

- `pytest scripts/tests/ -q`: **163 passed** (150 existing + 13 new). The 13 new tests
  were run before the fix and all fail with the original errors.
- 4x independent Codex review of the PR (diff-only, full-context, mutation audit,
  behavior-risk): mutation audit confirmed every fix is independently pinned; its two
  escaped mutations (unconditional debug tracebacks; swapped reciprocal directions) are
  now caught after hardening the debug-gate test and giving the v3 pair fixture
  non-parallel geometry; behavior-risk review's empty-frames guard in
  _exception_location applied.
- Read-only live replay (scratch harness, this machine): the Aug 7 stashed triple now
  merges and refreshes cleanly against every on-disk peer; a sweep of **all 330 linked
  live fibers** with simulated open-only (generation-bump) conflicts: 0 failures,
  0 spurious rewrites.

## Out of scope

VC3D's generation-bump-on-open (`LineAnnotationController.cpp:13653`) is the conflict
*generator* and deserves its own C++ PR; this PR makes those conflicts auto-resolve
again. Merge semantics, the demotion cascade, and the upload flow are unchanged.

## Risks / limitations

- Once deployed, previously-demoted conflicts re-classify and auto-merge on the next
  sync (tracking never advanced), which will produce a burst of legitimate merged
  uploads.
- The stashed `.s3sync-conflicts/` copies stay as-is (they are audit copies by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
