### PR TITLE
vesuvius: use the platform temp dir instead of hardcoded /tmp

### DIFF
--- a/vesuvius/src/vesuvius/models/run/inference.py
+++ b/vesuvius/src/vesuvius/models/run/inference.py
@@ -11,6 +11,7 @@ except ImportError:  # pragma: no cover - Windows has no fcntl
 import hashlib
 import multiprocessing
 import subprocess
+import tempfile
 import threading
 import fsspec
 import numcodecs
@@ -240,7 +241,10 @@ class _InferenceDeepSupervisionWrapper(torch.nn.Module):
         return self._collapse(self.network(*args, **kwargs))
 
 
-DEFAULT_MODEL_CACHE_DIR = os.environ.get('VESUVIUS_MODEL_CACHE_DIR', '/tmp/vesuvius-models')
+DEFAULT_MODEL_CACHE_DIR = os.environ.get(
+    'VESUVIUS_MODEL_CACHE_DIR',
+    os.path.join(tempfile.gettempdir(), 'vesuvius-models'),
+)
 
 
 def _lock_file_exclusive(fh):

--- a/vesuvius/src/vesuvius/neural_tracing/fiber_trace_3d/train.py
+++ b/vesuvius/src/vesuvius/neural_tracing/fiber_trace_3d/train.py
@@ -9,6 +9,7 @@ import os
 import re
 import signal
 import socket
+import tempfile
 import time
 from contextlib import nullcontext
 from dataclasses import dataclass, replace
@@ -4401,7 +4402,10 @@ def run_prefetch(
     summaries: dict[str, Any] = {"train": summary}
     if raw_config.get("test_datasets") and (prefetch_steps == 0 or prefetch_steps is None):
         test_raw = _make_test_loader_raw_config(raw_config, training)
-        tmp_path = Path("/tmp") / f"fiber_trace_3d_prefetch_test_{int(time.time() * 1000)}.json"
+        tmp_path = (
+            Path(tempfile.gettempdir())
+            / f"fiber_trace_3d_prefetch_test_{int(time.time() * 1000)}.json"
+        )
         tmp_path.write_text(json.dumps(_json_safe(test_raw)), encoding="utf-8")
         try:
             test_loader = FiberTrace3DLoader(load_config(tmp_path))

--- a/vesuvius/src/vesuvius/neural_tracing/inference/infer_rowcol_triplet_wraps.py
+++ b/vesuvius/src/vesuvius/neural_tracing/inference/infer_rowcol_triplet_wraps.py
@@ -743,7 +743,11 @@ def parse_args(argv=None):
     parser.add_argument("--checkpoint-path", type=str, required=True)
     parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--volume-scale", type=int, default=0)
-    parser.add_argument("--volume-cache-dir", type=str, default="/tmp/vesuvius-volume-cache")
+    parser.add_argument(
+        "--volume-cache-dir",
+        type=str,
+        default=str(Path(tempfile.gettempdir()) / "vesuvius-volume-cache"),
+    )
     parser.add_argument("--volume-cache-retry-seconds", type=float, default=60.0)
     parser.add_argument("--volume-chunk-cache-gb", type=float, default=_DEFAULT_VOLUME_CHUNK_CACHE_GB)
     parser.add_argument("--compile", dest="compile_model", action="store_true", default=True)

--- a/vesuvius/src/vesuvius/neural_tracing/inference/infer_streamline.py
+++ b/vesuvius/src/vesuvius/neural_tracing/inference/infer_streamline.py
@@ -2773,7 +2773,10 @@ def _parse_args(argv=None):
         default=None,
         help="Volume pyramid scale. Defaults to the matched checkpoint dataset scale when --volume-path=auto.",
     )
-    parser.add_argument("--volume-cache-dir", default="/tmp/vesuvius-volume-cache")
+    parser.add_argument(
+        "--volume-cache-dir",
+        default=str(Path(tempfile.gettempdir()) / "vesuvius-volume-cache"),
+    )
     parser.add_argument("--volume-cache-retry-seconds", type=float, default=60.0)
     parser.add_argument("--output-dir", required=True, help="Run output directory.")
     parser.add_argument("--grow-direction", default="left", choices=sorted(_DIRECTION_SPECS))

--- a/vesuvius/src/vesuvius/neural_tracing/nets/models.py
+++ b/vesuvius/src/vesuvius/neural_tracing/nets/models.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import torch
 import torch.nn as nn
 from types import SimpleNamespace
@@ -22,7 +24,7 @@ _CHECKPOINT_SENTINELS = {
         "checkpoint_filename": "copy_displacement_latest.pth",
     },
 }
-_HF_CHECKPOINT_CACHE_ROOT = Path("/tmp/vesuvius_hf_models")
+_HF_CHECKPOINT_CACHE_ROOT = Path(tempfile.gettempdir()) / "vesuvius_hf_models"
 
 
 class SlotConditionedHead(nn.Module):

--- a/vesuvius/tests/test_portable_temp_paths.py
+++ b/vesuvius/tests/test_portable_temp_paths.py
@@ -1,0 +1,69 @@
+"""Guard against POSIX-only temporary paths baked into the package.
+
+A literal like ``/tmp/vesuvius-models`` is not portable. On Windows it is a
+*drive-relative* path, so ``os.path.abspath`` resolves it against whichever
+drive happens to be current:
+
+    cwd D:\\villa            ->  D:\\tmp\\vesuvius-models
+    cwd C:\\Users\\someone   ->  C:\\tmp\\vesuvius-models
+
+For a model or volume cache that means the cache silently moves when the
+working drive changes -- multi-gigabyte checkpoints are re-downloaded, and
+stray caches accumulate at the root of every drive the tool is ever run from.
+Neither location is the platform temporary directory.
+
+``tempfile.gettempdir()`` honours TMPDIR/TEMP/TMP and is correct on every
+platform, so use it instead of a hardcoded literal.
+
+This is a source-level check on purpose: the modules that held these literals
+pull in torch and other heavy optional extras, so importing them here would
+make the check unrunnable in a lightweight environment. Parsing keeps it cheap
+and, unlike an import-time assertion, it fails on Linux too -- where ``/tmp``
+happens to equal ``gettempdir()`` and a value-based assertion would pass while
+the bug was still present.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+from pathlib import Path
+
+# POSIX temp roots that are wrong on Windows. Anchored so that unrelated paths
+# such as "/tmpl" or "/tmp_data" are not flagged.
+_POSIX_TEMP_ROOTS = ("/tmp", "/var/tmp")
+
+_PACKAGE_ROOT = Path(__file__).parents[1] / "src" / "vesuvius"
+
+
+def _is_posix_temp_literal(value: str) -> bool:
+    return any(
+        value == root or value.startswith(root + "/") for root in _POSIX_TEMP_ROOTS
+    )
+
+
+def _string_constants(tree: ast.AST) -> Iterator[tuple[int, str]]:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node.lineno, node.value
+
+
+def test_no_hardcoded_posix_temp_paths_in_package():
+    offenders: list[str] = []
+
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+
+        for lineno, value in _string_constants(tree):
+            if _is_posix_temp_literal(value):
+                rel = path.relative_to(_PACKAGE_ROOT.parents[1])
+                offenders.append(f"{rel}:{lineno}: {value!r}")
+
+    assert not offenders, (
+        "Hardcoded POSIX temporary paths are not portable; on Windows they are "
+        "drive-relative and the location silently follows the current drive. "
+        "Use tempfile.gettempdir() instead.\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
Five call sites bake in a POSIX `/tmp` literal for cache and scratch locations. On Windows those are **drive-relative**, not absolute, so they resolve against whichever drive happens to be current:

```
cwd D:\villa           ->  D:\tmp\vesuvius-models
cwd C:\Users\someone   ->  C:\tmp\vesuvius-models
```

For the model and volume caches that means the cache silently moves when the working drive changes, so multi-gigabyte checkpoints are downloaded again, and stray caches accumulate at the root of every drive the tools are run from. Neither location is the platform temp directory.

Measured on Windows 11 / Python 3.14.3, before this change:

| run from | `DEFAULT_MODEL_CACHE_DIR` resolves to |
|---|---|
| `D:\villa` | `D:\tmp\vesuvius-models` |
| `C:\Users\<user>` | `C:\tmp\vesuvius-models` |
| `tempfile.gettempdir()` | `C:\Users\<user>\AppData\Local\Temp` |

### Affected

| file | site |
|---|---|
| `models/run/inference.py` | `DEFAULT_MODEL_CACHE_DIR` |
| `neural_tracing/nets/models.py` | `_HF_CHECKPOINT_CACHE_ROOT` |
| `neural_tracing/inference/infer_streamline.py` | `--volume-cache-dir` default |
| `neural_tracing/inference/infer_rowcol_triplet_wraps.py` | `--volume-cache-dir` default |
| `neural_tracing/fiber_trace_3d/train.py` | prefetch scratch file |

All five now derive from `tempfile.gettempdir()`, which honours `TMPDIR`/`TEMP`/`TMP` and is correct on every platform. The two inference modules already imported `tempfile`. `VESUVIUS_MODEL_CACHE_DIR` still wins where it was already honoured, so existing overrides are unaffected.

Worth noting `inference.py` already implements Windows file locking via `msvcrt` a few lines below the bug, so the file was deliberately made Windows-safe and this was simply missed.

### Test

Adds `tests/test_portable_temp_paths.py`, an AST scan of the package for POSIX temp literals.

It is a source-level check on purpose: the modules involved pull in torch and other heavy extras, so an import-time assertion could not run in a light environment — and on Linux, where `gettempdir()` is itself `/tmp`, a value-based assertion would pass while the bug was still present. Parsing fails on every platform instead.

Verified the test passes with this change and **fails against the unfixed tree**, naming all five sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSXLLXQw3jKzYmAEPYEPqe