### PR TITLE
vesuvius: make in-place recompression free chunks, and never destroy the only copy

### DIFF
--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
@@ -256,10 +256,18 @@ class RecompressTask(ZarrTask):
                         f"  Warning: {len(level_corrupted)} corrupted chunks filled with zeros"
                     )
             except Exception as e:
-                # Clean up temp on failure
-                if Path(temp_path).exists():
-                    shutil.rmtree(temp_path)
-                raise RuntimeError(f"Recompression failed for {level_path}: {e}") from e
+                # Deliberately do NOT delete temp_path here. Each worker removes
+                # a source chunk as soon as it has copied it (delete_source_path
+                # in _recompress_worker), so once the pool has started, the
+                # original is already incomplete and temp_path holds the only
+                # copy of everything processed so far. Removing it would turn a
+                # recoverable failure into permanent data loss.
+                raise RuntimeError(
+                    f"Recompression failed for {level_path}: {e}. "
+                    f"Partially recompressed data has been left at {temp_path}. "
+                    f"The chunks it contains were already deleted from the "
+                    f"original, so recover from it before removing anything."
+                ) from e
 
     def _run_to_output(self) -> None:
         """Run recompression to a new output location."""

--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/utils.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/utils.py
@@ -262,25 +262,56 @@ def inverse_permutation(perm: List[int]) -> List[int]:
     return inv
 
 
+def _candidate_chunk_paths(zarr_path: str, chunk_indices: Tuple[int, ...]):
+    """Yield the on-disk locations a chunk may occupy, most likely first.
+
+    The key layout depends on the zarr format and its separator, and this
+    package supports zarr>=2.18.7,<4:
+
+        zarr v3, default chunk_key_encoding   ->  c/0/0/0
+        zarr v2, dimension_separator "/"      ->  0/0/0
+        zarr v2, dimension_separator "." (v2
+        default)                              ->  0.0.0
+
+    Probing is cheaper and more robust than parsing zarr.json/.zarray on every
+    call, and the three layouts are mutually exclusive in practice.
+    """
+    root = Path(zarr_path)
+    parts = [str(i) for i in chunk_indices]
+    yield root.joinpath("c", *parts)
+    yield root.joinpath(*parts)
+    yield root / ".".join(parts)
+
+
 def delete_chunk_file(
     zarr_path: str,
     chunk_coords: Tuple[Tuple[int, int], ...],
     chunks: Tuple[int, ...],
-) -> None:
-    """Delete the chunk file for given coordinates (nested directory structure).
+) -> bool:
+    """Delete the chunk file for given coordinates.
+
+    Handles every chunk key layout this package can produce. The previous
+    implementation assumed zarr v2 nested storage ("0/0/0") and therefore did
+    nothing at all for zarr v3 ("c/0/0/0") or for v2's own default separator
+    ("0.0.0"), silently skipping the deletion.
 
     Args:
         zarr_path: Path to zarr array
         chunk_coords: Chunk coordinates as (start, stop) pairs
         chunks: Chunk sizes
+
+    Returns:
+        True if a chunk file was removed, False if none was found.
     """
     chunk_indices = tuple(
         start // chunk_size
         for (start, _), chunk_size in zip(chunk_coords, chunks)
     )
-    chunk_path = Path(zarr_path) / "/".join(str(i) for i in chunk_indices)
-    if chunk_path.exists():
-        chunk_path.unlink()
+    for chunk_path in _candidate_chunk_paths(zarr_path, chunk_indices):
+        if chunk_path.is_file():
+            chunk_path.unlink()
+            return True
+    return False
 
 
 def update_compressor_metadata(zarr_path: str, compressor) -> None:

--- a/vesuvius/tests/image_proc/test_zarr_recompress_inplace.py
+++ b/vesuvius/tests/image_proc/test_zarr_recompress_inplace.py
@@ -1,0 +1,181 @@
+"""In-place recompression: source chunks must actually be freed, and a failure
+must never destroy the only remaining copy of the data.
+
+Both behaviours below were broken in ways that are invisible at runtime:
+
+* ``delete_chunk_file`` assumed zarr v2 *nested* storage (``0/0/0``). For zarr
+  v3 (``c/0/0/0``) and for v2's own default separator (``0.0.0``) it matched
+  nothing and returned silently, so in-place recompression never freed the
+  source. The whole point of deleting as it goes is to avoid needing twice the
+  disk for the array; without it a large in-place recompress can run out of
+  space on exactly the volumes the tool exists for.
+
+* Once deletion does work, the original is incomplete from the first finished
+  work item onward, which makes the temp tree the only full copy. The failure
+  handler used to delete it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+
+from vesuvius.image_proc.run.zarr_tasks import utils as zarr_utils
+from vesuvius.image_proc.run.zarr_tasks.tasks import recompress as recompress_mod
+from vesuvius.image_proc.run.zarr_tasks.tasks.recompress import (
+    RecompressConfig,
+    RecompressTask,
+)
+
+SHAPE = (4, 4, 4)
+CHUNKS = (2, 2, 2)
+TOTAL_CHUNKS = 8  # (4/2)**3
+FIRST_CHUNK_COORDS = ((0, 2), (0, 2), (0, 2))
+
+
+# --------------------------------------------------------------------------
+# chunk key layouts
+# --------------------------------------------------------------------------
+
+# The layouts this package can encounter, given zarr>=2.18.7,<4.
+_LAYOUTS = {
+    "zarr_v3_default": "c/0/0/0",
+    "zarr_v2_nested_separator": "0/0/0",
+    "zarr_v2_dot_separator": "0.0.0",
+}
+
+
+@pytest.mark.parametrize(
+    "relative_key", _LAYOUTS.values(), ids=list(_LAYOUTS)
+)
+def test_delete_chunk_file_removes_the_chunk_in_every_layout(
+    tmp_path: Path, relative_key: str
+) -> None:
+    # Written by hand rather than through zarr so the case is pinned to the key
+    # layout itself and does not depend on which zarr major version is
+    # installed in the environment running the tests.
+    chunk = tmp_path / relative_key
+    chunk.parent.mkdir(parents=True, exist_ok=True)
+    chunk.write_bytes(b"chunk-payload")
+
+    removed = zarr_utils.delete_chunk_file(str(tmp_path), FIRST_CHUNK_COORDS, CHUNKS)
+
+    # The behaviour that regressed. Only the nested layout worked before; the
+    # v3 and dot-separator cases matched nothing and returned silently.
+    assert not chunk.exists()
+    # The reported outcome, so a silent miss cannot masquerade as a deletion.
+    assert removed is True
+
+
+def test_delete_chunk_file_reports_when_nothing_matched(tmp_path: Path) -> None:
+    assert (
+        zarr_utils.delete_chunk_file(str(tmp_path), FIRST_CHUNK_COORDS, CHUNKS) is False
+    )
+
+
+# --------------------------------------------------------------------------
+# failure handling
+# --------------------------------------------------------------------------
+
+
+class _PoolFailingMidway:
+    """Runs work items in-process and then raises, as a dying worker would.
+
+    The items that do run perform real copies and real source deletions, which
+    is precisely the half-destroyed state the failure handler must cope with.
+    """
+
+    def __init__(self, processes: int | None = None) -> None:
+        self.processes = processes
+
+    def __enter__(self) -> "_PoolFailingMidway":
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+    def imap_unordered(self, func, items):
+        for index, item in enumerate(items):
+            if index >= 1:
+                raise RuntimeError("worker died")
+            yield func(item)
+
+
+_ZARR_V3 = int(zarr.__version__.split(".", 1)[0]) >= 3
+
+
+def _chunk_files(root: Path) -> list[Path]:
+    """Every file under `root` that is a chunk rather than metadata.
+
+    Metadata is ``.zarray``/``.zattrs`` on v2 and ``zarr.json`` on v3; chunk
+    names are pure index strings, so filtering on a leading dot plus the v3
+    metadata filename is sufficient and does not depend on the separator.
+    """
+    return [
+        p
+        for p in root.rglob("*")
+        if p.is_file() and not p.name.startswith(".") and p.name != "zarr.json"
+    ]
+
+
+def _make_source(path: Path) -> None:
+    kwargs: dict = {"shape": SHAPE, "chunks": CHUNKS, "dtype": "uint8"}
+    if _ZARR_V3:
+        kwargs["zarr_format"] = 2
+    array = zarr.open(str(path), mode="w", **kwargs)
+    # Non-zero: zarr elides chunks that equal the fill value, and writing zeros
+    # would leave no chunk files on disk to delete.
+    array[:] = np.arange(int(np.prod(SHAPE)), dtype="uint8").reshape(SHAPE) + 1
+
+
+@pytest.mark.skipif(
+    _ZARR_V3,
+    reason=(
+        "RecompressTask cannot run under zarr 3.x at all: it builds its temp "
+        "array with zarr.open(..., compressor=<numcodecs Blosc>), and zarr 3 "
+        "creates new arrays as v3 by default, which rejects `compressor` "
+        "outright ('compressor cannot be used for arrays with zarr_format 3'). "
+        "That happens for every input, v2 sources included, so the task is "
+        "usable only on zarr 2.x today. Tracked separately; this test covers "
+        "the failure-handling contract on the versions where the task runs."
+    ),
+)
+def test_inplace_failure_keeps_the_partially_recompressed_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "volume.zarr"
+    temp_tree = tmp_path / "volume.zarr_tmp"
+    _make_source(source)
+
+    monkeypatch.setattr(recompress_mod, "Pool", _PoolFailingMidway)
+
+    task = RecompressTask(
+        RecompressConfig(
+            input_zarr=str(source),
+            output_zarr=None,
+            num_workers=1,
+            inplace=True,
+        )
+    )
+    task.prepare()
+
+    with pytest.raises(RuntimeError) as failure:
+        task._run_inplace()
+
+    # The run got far enough to start destroying the original ...
+    surviving = _chunk_files(source)
+    assert len(surviving) < TOTAL_CHUNKS, (
+        "expected the worker to have deleted at least one source chunk before "
+        "the failure; otherwise this test is not exercising the dangerous state"
+    )
+
+    # ... so the recompressed copy is the only complete one and must survive.
+    assert temp_tree.exists(), (
+        "the temp tree was deleted on failure, destroying the only copy of the "
+        "chunks already removed from the original"
+    )
+    assert _chunk_files(temp_tree), "temp tree survived but holds no chunks"
+    assert str(temp_tree) in str(failure.value)


### PR DESCRIPTION
Two independent problems in the in-place recompress path. They interact, which is why they ship together.

### 1. `delete_chunk_file` only matched zarr v2 *nested* keys

It built `<array>/0/0/0`, so it matched nothing for zarr v3 (`c/0/0/0`) or for v2's own default separator (`0.0.0`), and returned silently. `pyproject.toml` allows `zarr>=2.18.7,<4`, so the common case did nothing at all.

Measured with zarr 3.3.0, writing one chunk per layout by hand:

| layout | chunk key | removed? |
|---|---|---|
| zarr v3 (default today) | `c/0/0/0` | **no** |
| zarr v2, separator `.` | `0.0.0` | **no** |
| zarr v2, nested separator | `0/0/0` | yes |

Deleting the source chunk as soon as it has been copied is what keeps an in-place recompress from needing twice the disk of the array. When that delete silently no-ops the guarantee is gone, and a large in-place run can exhaust the disk on exactly the volumes this tool exists for.

It now probes the layouts in turn and returns whether anything was removed, so a miss can no longer pass for a deletion.

### 2. The failure handler deleted the partially recompressed copy

`_recompress_worker` removes each source chunk right after copying it, so from the first completed work item the original is incomplete and the temp tree holds the only copy of everything processed so far. The handler ran `shutil.rmtree(temp_path)`, which turned any mid-run failure — a corrupt chunk with `--skip-corrupt` off, a worker dying, an `rmtree` or rename refused on Windows because a handle was still open — into unrecoverable data loss.

Nothing in the `try` block is reachable before deletion may have begun, so the temp tree is now always left in place and the error says where it is.

Fixing (1) is what makes the deletion actually happen on modern zarr, which is precisely when (2) starts to bite.

### Tests

`tests/image_proc/test_zarr_recompress_inplace.py`. The layout cases write chunk files directly rather than through zarr, so they pin the key layout itself and hold on either zarr major.

Verified against the unfixed tree: the v3 and dot-separator cases fail there, and the failure-handling test fails there too.

| environment | result |
|---|---|
| zarr 2.18.7 | 5 passed |
| zarr 3.3.0 | 4 passed, 1 skipped |

### Note on the skip

It is deliberate and unrelated to this change: `RecompressTask` cannot run under zarr 3.x at all, because it creates its temp array with `zarr.open(..., compressor=<numcodecs Blosc>)` while zarr 3 makes new arrays v3 by default and rejects `compressor`. That happens for v2 sources too, so the task is currently usable only on zarr 2.x. I'll file that separately rather than fix it here, since which formats recompress should emit looks like a design call rather than a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSXLLXQw3jKzYmAEPYEPqe