### PR TITLE
Name the missing dependency instead of failing with 'NoneType' object is not callable

### DIFF
--- a/vesuvius/src/vesuvius/__init__.py
+++ b/vesuvius/src/vesuvius/__init__.py
@@ -23,19 +23,59 @@ try:
 except Exception:
     tifxyz = None  # type: ignore
 
-# Attempt to import utils.  utils requires aiohttp and nest_asyncio; if they aren't
-# installed (e.g. when you install with [volume-only] or without extras), we silently
-# fall back to None.  Users who need catalog utilities should install the appropriate
-# optional extra.
+# Optional dependencies of ``vesuvius.utils``. They are not core dependencies, so
+# the plain ``uv sync`` that CONTRIBUTING.md tells contributors to run leaves them
+# out, and the catalog helpers below cannot be imported.
+_CATALOG_REQUIREMENTS = ("aiohttp", "nest_asyncio")
+
+# Package name on PyPI, where it differs from the import name.
+_CATALOG_DISTRIBUTIONS = {"aiohttp": "aiohttp", "nest_asyncio": "nest-asyncio"}
+
+
+def _needs_catalog_extra(name, missing, cause):
+    """Build a stand-in for a catalog helper whose dependencies are missing.
+
+    Binding the helpers to ``None`` made the failure surface at the call site as
+    ``TypeError: 'NoneType' object is not callable``, which says nothing about the
+    real cause.  Keeping them callable lets the failure name the missing package
+    and a command that actually installs it.
+    """
+
+    distribution = _CATALOG_DISTRIBUTIONS.get(missing, missing)
+
+    def _stub(*_args, **_kwargs):
+        raise ImportError(
+            f"vesuvius.{name}() needs the optional dependency {missing!r}, "
+            f"which is not installed. Install it with "
+            f"`uv pip install {distribution}` (or `pip install {distribution}`). "
+            f"Original import error: {cause}"
+        ) from cause
+
+    _stub.__name__ = name
+    _stub.__qualname__ = name
+    _stub.__doc__ = (
+        f"Unavailable: vesuvius.{name}() requires the optional dependency "
+        f"{missing!r}. Calling it raises ImportError."
+    )
+    return _stub
+
+
+# ``utils`` pulls in the packages above.  When one of them is genuinely absent the
+# catalog helpers become stubs that name it.  Any other import failure - a syntax
+# error, a version clash, a bug inside utils - is re-raised untouched, so real
+# breakage is never reported as a missing dependency.
 try:
     from . import utils  # type: ignore
     from .utils import is_aws_ec2_instance, list_cubes, list_files, update_list  # type: ignore
-except Exception:
+except ModuleNotFoundError as _catalog_import_error:
+    _missing = _catalog_import_error.name
+    if _missing not in _CATALOG_REQUIREMENTS:
+        raise
     utils = None  # type: ignore
-    is_aws_ec2_instance = None  # type: ignore
-    list_cubes = None  # type: ignore
-    list_files = None  # type: ignore
-    update_list = None  # type: ignore
+    is_aws_ec2_instance = _needs_catalog_extra("is_aws_ec2_instance", _missing, _catalog_import_error)  # type: ignore
+    list_cubes = _needs_catalog_extra("list_cubes", _missing, _catalog_import_error)  # type: ignore
+    list_files = _needs_catalog_extra("list_files", _missing, _catalog_import_error)  # type: ignore
+    update_list = _needs_catalog_extra("update_list", _missing, _catalog_import_error)  # type: ignore
 
 __all__ = [
     "Volume",

--- a/vesuvius/tests/test_imports.py
+++ b/vesuvius/tests/test_imports.py
@@ -67,3 +67,69 @@ def test_cli_entrypoints_show_help(module: str) -> None:
     assert (  # noqa: PT017
         result.returncode == 0
     ), f"{module} -h failed: {result.stderr}\n{result.stdout}"
+
+
+def _reimport_without(monkeypatch: pytest.MonkeyPatch, blocked: str, error=None):
+    """Reimport vesuvius with one module import failing."""
+
+    import builtins
+    import importlib
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        hit = name == blocked if "." in blocked else name.partition(".")[0] == blocked
+        if hit:
+            raise error or ModuleNotFoundError(f"No module named {blocked!r}", name=blocked)
+        return real_import(name, *args, **kwargs)
+
+    for module in [m for m in list(sys.modules) if m.startswith("vesuvius")]:
+        monkeypatch.delitem(sys.modules, module, raising=False)
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    return importlib.import_module("vesuvius")
+
+
+CATALOG_HELPERS = ("list_files", "list_cubes", "update_list", "is_aws_ec2_instance")
+
+
+@pytest.mark.parametrize(
+    ("blocked", "distribution"),
+    [("aiohttp", "aiohttp"), ("nest_asyncio", "nest-asyncio")],
+)
+def test_catalog_helpers_name_the_missing_package(
+    monkeypatch: pytest.MonkeyPatch, blocked: str, distribution: str
+) -> None:
+    """Without a catalog dependency the helpers must name that exact package.
+
+    test_public_api_exports already asserts vesuvius.list_files is callable. Before
+    this change that held only when the optional dependencies happened to be
+    installed: without them the helpers were bound to None, so the assertion failed
+    and the first call raised ``TypeError: 'NoneType' object is not callable``,
+    naming nothing.
+    """
+
+    reloaded = _reimport_without(monkeypatch, blocked)
+
+    for name in CATALOG_HELPERS:
+        helper = getattr(reloaded, name)
+        assert callable(helper), f"{name} must stay callable so the error can name the cause"
+        with pytest.raises(ImportError) as excinfo:
+            helper()
+        message = str(excinfo.value)
+        assert blocked in message, f"the error should name {blocked}"
+        assert distribution in message, "the error should give an installable package name"
+        assert excinfo.value.__cause__ is not None, "the original ImportError should be chained"
+
+
+def test_unrelated_missing_module_is_not_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing module that is not a catalog dependency must propagate untouched.
+
+    ``vesuvius.utils.catalog`` also imports ``requests``. If that one is absent the
+    package must not pretend the catalog extras are the problem - the real
+    ModuleNotFoundError has to reach the caller, or genuine breakage inside utils
+    would be reported as a missing optional dependency.
+    """
+
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        _reimport_without(monkeypatch, "requests")
+    assert excinfo.value.name == "requests"


### PR DESCRIPTION
## What breaks

`vesuvius.list_files()` is the first call in the README. After the install
CONTRIBUTING.md prescribes (`uv sync`), it fails like this:

```
>>> import vesuvius
>>> vesuvius.list_files()
TypeError: 'NoneType' object is not callable
```

The message names nothing, so the natural reading is "the function is broken".

## Why it happens

`vesuvius.utils.catalog` imports `aiohttp` and `nest_asyncio`. Neither is a core
dependency, so a plain `uv sync` leaves them out. `__init__.py` caught the
ImportError and bound `list_files`, `list_cubes`, `update_list` and
`is_aws_ec2_instance` to `None`, while still exporting all four in `__all__`.
The package imports fine and the failure is deferred to the call site, stripped
of its cause.

## The repo already assumes this cannot happen

`tests/test_imports.py::test_public_api_exports` asserts:

```python
assert callable(vesuvius.list_files)
```

That holds today only when the optional dependencies happen to be installed. On
a default install it fails. This PR makes the code honour the contract the test
already states.

## The change

The `None` bindings become stubs that name the package that is actually missing:

```
ImportError: vesuvius.list_files() needs the optional dependency 'aiohttp',
which is not installed. Install it with `uv pip install aiohttp`
(or `pip install aiohttp`). Original import error: No module named 'aiohttp'
```

Three details worth flagging, because each was a way to get this wrong:

- **Only the two catalog dependencies downgrade to a stub.** The `except` is
  narrowed to `ModuleNotFoundError` and checks `exc.name`. A syntax error, a
  version clash or a genuine bug inside `utils` is re-raised untouched — real
  breakage must never be reported as a missing optional dependency.
- **The message names the package that is missing**, not both, and gives the
  installable distribution name (`nest-asyncio`, not `nest_asyncio`).
- **The install hint avoids `vesuvius[all]`.** That extra pulls in
  `volume-cartographer`, which `pyproject.toml` itself marks as monorepo-only
  and absent from PyPI, so the command would fail for anyone installing from
  PyPI. There is no extra dedicated to these helpers — `aiohttp` and
  `nest_asyncio` only arrive via `models` (which pulls torch), `label-transfer`
  or `all` — so the message names the package directly. If you would rather
  have a small `catalog` extra, I am happy to add it.

Behaviour is unchanged when the dependencies are present: the real functions are
imported and bound as before. The helpers stay callable either way, so
`callable(vesuvius.list_files)` is now true unconditionally.

## This has already cost time on both sides

- #1329 (open since 4 Aug) reports the same `TypeError` from the `volume-only`
  extra, with the same diagnosis.
- In bf57b86 (18 Aug, part of #1527, which was about something else entirely)
  the `blending` extra gained
  `"nest-asyncio>=1.6.0", # Required by vesuvius.utils.catalog (imported via __init__)`.
  That comment is an accurate diagnosis of this bug, written while fixing an
  unrelated problem — and it patches one extra.

The remaining install paths still carry the hole, including the plain `uv sync`
CONTRIBUTING.md prescribes. Fixing the shared failure mode means that pin does
not have to be repeated in every extra that happens to import the catalog.

## Scope, versus #1329

#1329 reports this for the `volume-only` extra. The same breakage happens on the
**default** install, which is the path CONTRIBUTING.md sends every new
contributor down. The `blending` extra already carries a
`"Required by vesuvius.utils.catalog (imported via __init__)"` pin — that
patches one extra rather than the shared failure mode.

## Tests

Three cases, in `tests/test_imports.py`:

- each helper stays callable and names the missing package (parametrised over
  `aiohttp` and `nest_asyncio`, checking the distribution name and that the
  original error is chained);
- a missing module that is *not* a catalog dependency — `requests`, also
  imported by `catalog.py` — still propagates as `ModuleNotFoundError`.

```
$ python -m pytest tests/test_imports.py -k "not cli_entrypoints"
6 passed, 5 deselected
```

Separately: `test_cli_entrypoints_show_help[vesuvius.models.training.train]`
fails on a clean `uv sync` because `tqdm` is not installed either. Out of scope
here, but the same class of problem — happy to open a separate issue.

## Environment

Ubuntu 25.04, Python 3.14.7, `uv sync` per CONTRIBUTING.md, package installed
from this checkout. Verified against Scroll1 over the streaming catalog.
