### PR TITLE
VC3D: add optional focus bounds for fiber annotation

### DIFF
--- a/volume-cartographer/apps/VC3D/CState.cpp
+++ b/volume-cartographer/apps/VC3D/CState.cpp
@@ -201,6 +201,9 @@ std::shared_ptr<VolumePkg> CState::vpkg() const { return _vpkg; }
 
 void CState::setVpkg(std::shared_ptr<VolumePkg> pkg)
 {
+    if (_vpkg != pkg) {
+        clearFocusBounds();
+    }
     _vpkg = std::move(pkg);
     emit vpkgChanged(_vpkg);
 }
@@ -235,6 +238,57 @@ void CState::setCurrentVolume(std::shared_ptr<Volume> vol)
                       *_vpkg, _currentVolumeId))
             : utils::Json::object());
     emit volumeChanged(_currentVolume, _currentVolumeId);
+}
+
+std::optional<Rect3D> CState::focusBounds() const { return _focusBounds; }
+
+std::optional<Rect3D> CState::activeFocusBounds() const
+{
+    return _focusBoundsEnabled ? _focusBounds : std::nullopt;
+}
+
+bool CState::focusBoundsEnabled() const { return _focusBoundsEnabled; }
+
+uint64_t CState::focusBoundsRevision() const { return _focusBoundsRevision; }
+
+void CState::setFocusBounds(const Rect3D& bounds)
+{
+    Rect3D normalized;
+    for (int axis = 0; axis < 3; ++axis) {
+        if (!std::isfinite(bounds.low[axis]) || !std::isfinite(bounds.high[axis])) {
+            return;
+        }
+        normalized.low[axis] = std::min(bounds.low[axis], bounds.high[axis]);
+        normalized.high[axis] = std::max(bounds.low[axis], bounds.high[axis]);
+    }
+    if (_focusBounds && _focusBounds->low == normalized.low &&
+        _focusBounds->high == normalized.high) {
+        return;
+    }
+    _focusBounds = normalized;
+    ++_focusBoundsRevision;
+    emit focusBoundsChanged();
+}
+
+void CState::setFocusBoundsEnabled(bool enabled)
+{
+    if (_focusBoundsEnabled == enabled) {
+        return;
+    }
+    _focusBoundsEnabled = enabled;
+    ++_focusBoundsRevision;
+    emit focusBoundsChanged();
+}
+
+void CState::clearFocusBounds()
+{
+    if (!_focusBounds && !_focusBoundsEnabled) {
+        return;
+    }
+    _focusBounds.reset();
+    _focusBoundsEnabled = false;
+    ++_focusBoundsRevision;
+    emit focusBoundsChanged();
 }
 
 std::string CState::segmentationGrowthVolumeId() const { return _segmentationGrowthVolumeId; }

--- a/volume-cartographer/apps/VC3D/CState.hpp
+++ b/volume-cartographer/apps/VC3D/CState.hpp
@@ -12,6 +12,8 @@
 
 #include <opencv2/core/mat.hpp>
 
+#include "vc/core/util/Rect3D.hpp"
+
 class VolumePkg;
 class Volume;
 class QuadSurface;
@@ -47,6 +49,15 @@ public:
     std::shared_ptr<Volume> currentVolume() const;
     std::string currentVolumeId() const;
     void setCurrentVolume(std::shared_ptr<Volume> vol);
+
+    // --- Session focus bounds (base-volume XYZ) ---
+    std::optional<Rect3D> focusBounds() const;
+    std::optional<Rect3D> activeFocusBounds() const;
+    bool focusBoundsEnabled() const;
+    uint64_t focusBoundsRevision() const;
+    void setFocusBounds(const Rect3D& bounds);
+    void setFocusBoundsEnabled(bool enabled);
+    void clearFocusBounds();
 
     // --- Growth Volume ---
     std::string segmentationGrowthVolumeId() const;
@@ -101,6 +112,7 @@ signals:
     void vpkgChanged(std::shared_ptr<VolumePkg> vpkg);
     void umbilicusChanged();
     void volumeChanged(std::shared_ptr<Volume> volume, const std::string& volumeId);
+    void focusBoundsChanged();
     void surfacesLoaded();
     void volumeClosing();
 
@@ -115,6 +127,9 @@ private:
     std::shared_ptr<VolumePkg> _vpkg;
     std::shared_ptr<Volume> _currentVolume;
     std::string _currentVolumeId;
+    std::optional<Rect3D> _focusBounds;
+    bool _focusBoundsEnabled = false;
+    uint64_t _focusBoundsRevision = 0;
     std::string _segmentationGrowthVolumeId;
     std::weak_ptr<QuadSurface> _activeSurface;
     std::string _activeSurfaceId;

--- a/volume-cartographer/apps/VC3D/CWindow.cpp
+++ b/volume-cartographer/apps/VC3D/CWindow.cpp
@@ -8236,6 +8236,26 @@ void CWindow::CreateWidgets(void)
     QPushButton* btnCopyCoords = ui.btnCopyCoords;
     connect(btnCopyCoords, &QPushButton::clicked, this, &CWindow::onCopyCoordinates);
 
+    const QRegularExpression coordinateTriple(
+        "^\\s*\\d+\\s*,\\s*\\d+\\s*,\\s*\\d+\\s*$");
+    ui.focusBBoxMin->setValidator(
+        new QRegularExpressionValidator(coordinateTriple, ui.focusBBoxMin));
+    ui.focusBBoxMax->setValidator(
+        new QRegularExpressionValidator(coordinateTriple, ui.focusBBoxMax));
+    connect(ui.focusBBoxMin, &QLineEdit::editingFinished,
+            this, &CWindow::onFocusBoundsEdited);
+    connect(ui.focusBBoxMax, &QLineEdit::editingFinished,
+            this, &CWindow::onFocusBoundsEdited);
+    connect(ui.chkFocusBBox, &QCheckBox::toggled,
+            this, &CWindow::onFocusBoundsToggled);
+    connect(_state, &CState::focusBoundsChanged,
+            this, &CWindow::refreshFocusBoundsUi);
+    connect(_state, &CState::volumeChanged, this,
+            [this](std::shared_ptr<Volume>, const std::string&) {
+                refreshFocusBoundsUi();
+            });
+    refreshFocusBoundsUi();
+
     if (auto* chkAxisOverlays = ui.chkAxisOverlays) {
         bool showOverlays = settings.value(vc3d::settings::viewer::SHOW_AXIS_OVERLAYS,
                                            vc3d::settings::viewer::SHOW_AXIS_OVERLAYS_DEFAULT).toBool();
@@ -10220,6 +10240,104 @@ void CWindow::onManualLocationChanged()
     if (_surfacePanel) {
         _surfacePanel->refreshFiltersOnly();
     }
+}
+
+void CWindow::refreshFocusBoundsUi()
+{
+    if (!ui.chkFocusBBox || !ui.focusBBoxMin || !ui.focusBBoxMax) {
+        return;
+    }
+
+    std::optional<Rect3D> bounds = _state ? _state->focusBounds() : std::nullopt;
+    if (!bounds && _state && _state->currentVolume()) {
+        const auto [width, height, depth] = _state->currentVolume()->shapeXyz();
+        bounds = Rect3D{{0.0f, 0.0f, 0.0f},
+                        {static_cast<float>(std::max(0, width - 1)),
+                         static_cast<float>(std::max(0, height - 1)),
+                         static_cast<float>(std::max(0, depth - 1))}};
+    }
+
+    const QSignalBlocker checkBlocker(ui.chkFocusBBox);
+    const QSignalBlocker minBlocker(ui.focusBBoxMin);
+    const QSignalBlocker maxBlocker(ui.focusBBoxMax);
+    ui.chkFocusBBox->setChecked(_state && _state->focusBoundsEnabled());
+    const bool haveVolume = _state && _state->currentVolume();
+    ui.chkFocusBBox->setEnabled(haveVolume);
+    ui.focusBBoxMin->setEnabled(haveVolume);
+    ui.focusBBoxMax->setEnabled(haveVolume);
+    if (!bounds) {
+        ui.focusBBoxMin->clear();
+        ui.focusBBoxMax->clear();
+        return;
+    }
+    const auto formatPoint = [](const cv::Vec3f& point) {
+        return QStringLiteral("%1, %2, %3")
+            .arg(static_cast<int>(std::lround(point[0])))
+            .arg(static_cast<int>(std::lround(point[1])))
+            .arg(static_cast<int>(std::lround(point[2])));
+    };
+    ui.focusBBoxMin->setText(formatPoint(bounds->low));
+    ui.focusBBoxMax->setText(formatPoint(bounds->high));
+}
+
+void CWindow::onFocusBoundsEdited()
+{
+    if (!_state || !_state->currentVolume()) {
+        refreshFocusBoundsUi();
+        return;
+    }
+
+    const auto parsePoint = [](const QString& text) -> std::optional<cv::Vec3f> {
+        const QStringList parts = text.trimmed().split(',');
+        if (parts.size() != 3) {
+            return std::nullopt;
+        }
+        cv::Vec3f point;
+        for (int axis = 0; axis < 3; ++axis) {
+            bool ok = false;
+            const int value = parts[axis].trimmed().toInt(&ok);
+            if (!ok) {
+                return std::nullopt;
+            }
+            point[axis] = static_cast<float>(value);
+        }
+        return point;
+    };
+
+    auto low = parsePoint(ui.focusBBoxMin->text());
+    auto high = parsePoint(ui.focusBBoxMax->text());
+    if (!low || !high) {
+        refreshFocusBoundsUi();
+        return;
+    }
+
+    const auto [width, height, depth] = _state->currentVolume()->shapeXyz();
+    const cv::Vec3f volumeHigh{
+        static_cast<float>(std::max(0, width - 1)),
+        static_cast<float>(std::max(0, height - 1)),
+        static_cast<float>(std::max(0, depth - 1))};
+    for (int axis = 0; axis < 3; ++axis) {
+        (*low)[axis] = std::clamp((*low)[axis], 0.0f, volumeHigh[axis]);
+        (*high)[axis] = std::clamp((*high)[axis], 0.0f, volumeHigh[axis]);
+    }
+    _state->setFocusBounds(Rect3D{*low, *high});
+    refreshFocusBoundsUi();
+}
+
+void CWindow::onFocusBoundsToggled(bool enabled)
+{
+    if (!_state || !_state->currentVolume()) {
+        refreshFocusBoundsUi();
+        return;
+    }
+    if (enabled && !_state->focusBounds()) {
+        onFocusBoundsEdited();
+        if (!_state->focusBounds()) {
+            refreshFocusBoundsUi();
+            return;
+        }
+    }
+    _state->setFocusBoundsEnabled(enabled);
 }
 
 void CWindow::onZoomIn()

--- a/volume-cartographer/apps/VC3D/CWindow.hpp
+++ b/volume-cartographer/apps/VC3D/CWindow.hpp
@@ -319,6 +319,8 @@ private slots:
     void onEditMaskPressed(const QString& segmentId);
     void onAppendMaskPressed(const QString& segmentId);
     void onManualLocationChanged();
+    void onFocusBoundsEdited();
+    void onFocusBoundsToggled(bool enabled);
     void onZoomIn();
     void onZoomOut();
     void onCopyCoordinates();
@@ -331,6 +333,7 @@ private slots:
     void onSegmentationEditingModeChanged(bool enabled);
     void onSegmentationStopToolsRequested();
     void configureChunkedViewerConnections(CChunkedVolumeViewer* viewer);
+    void refreshFocusBoundsUi();
 
     CChunkedVolumeViewer* segmentationViewer() const;
     VolumeViewerBase* segmentationBaseViewer() const;

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -2856,10 +2856,6 @@ void LineAnnotationController::openFiberWithControlPoint(uint64_t fiberId,
 
     if (seedOnlyPoint) {
         const cv::Vec3d seedPoint = *seedOnlyPoint;
-        if (!placementAllowedByFocusBounds(
-                seedPoint, session->suppressErrorDialogs)) {
-            return;
-        }
         session->seedPoint = seedPoint;
         session->focusedLinePosition = 0.0;
         session->focusedControlPoint = seedPoint;
@@ -2886,7 +2882,10 @@ void LineAnnotationController::openFiberWithControlPoint(uint64_t fiberId,
                            true)) {
             return;
         }
-        handleLineSeed(surfaceName, toVec3f(seedPoint), InitialDirectionMode::ZInOut);
+        handleLineSeed(surfaceName,
+                       toVec3f(seedPoint),
+                       InitialDirectionMode::ZInOut,
+                       SeedOrigin::StoredFiber);
         return;
     }
 
@@ -7184,7 +7183,8 @@ bool LineAnnotationController::placementAllowedByFocusBounds(
 
 void LineAnnotationController::handleLineSeed(const std::string& surfaceName,
                                               cv::Vec3f volumePoint,
-                                              InitialDirectionMode directionMode)
+                                              InitialDirectionMode directionMode,
+                                              SeedOrigin seedOrigin)
 {
     auto* pane = paneForSurface(surfaceName);
     if (!pane || !pane->session) {
@@ -7198,7 +7198,8 @@ void LineAnnotationController::handleLineSeed(const std::string& surfaceName,
         return;
     }
 
-    if (!placementAllowedByFocusBounds(
+    if (seedOrigin == SeedOrigin::NewPlacement &&
+        !placementAllowedByFocusBounds(
             toVec3d(volumePoint), session.suppressErrorDialogs)) {
         return;
     }

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -1973,6 +1973,22 @@ LineAnnotationController::OptimizationTaskResult optimizeLineWithSampler(
     return task;
 }
 
+void applyFocusBoundsToOptimizationTask(
+    LineAnnotationController::OptimizationTaskResult& task)
+{
+    if (!task.ok || !task.focusBoundsBase || task.focusBoundsApplied) {
+        return;
+    }
+    try {
+        vc3d::line_annotation::constrainLineOpenTailsToBounds(
+            task.result.line, task.controlPoints, *task.focusBoundsBase);
+        task.focusBoundsApplied = true;
+    } catch (const std::exception& ex) {
+        task.ok = false;
+        task.error = std::string("Could not apply focus bounding box: ") + ex.what();
+    }
+}
+
 } // namespace
 
 LineAnnotationController::LineAnnotationController(CState* state,
@@ -2225,6 +2241,9 @@ void LineAnnotationController::launchFromViewerAtPoint(CChunkedVolumeViewer* vie
 
     const auto sample = viewer->sampleSceneVolume(scenePoint);
     if (!sample) {
+        return;
+    }
+    if (!placementAllowedByFocusBounds(toVec3d(sample->position), false)) {
         return;
     }
     cv::Vec3f normal = sample->normal;
@@ -2837,6 +2856,10 @@ void LineAnnotationController::openFiberWithControlPoint(uint64_t fiberId,
 
     if (seedOnlyPoint) {
         const cv::Vec3d seedPoint = *seedOnlyPoint;
+        if (!placementAllowedByFocusBounds(
+                seedPoint, session->suppressErrorDialogs)) {
+            return;
+        }
         session->seedPoint = seedPoint;
         session->focusedLinePosition = 0.0;
         session->focusedControlPoint = seedPoint;
@@ -7146,6 +7169,19 @@ void LineAnnotationController::onVolumePackageChanged(std::shared_ptr<VolumePkg>
     loadFibersForCurrentPackage();
 }
 
+bool LineAnnotationController::placementAllowedByFocusBounds(
+    const cv::Vec3d& point,
+    bool suppressErrorDialogs) const
+{
+    const auto bounds = _state ? _state->activeFocusBounds() : std::nullopt;
+    if (!bounds || contains_point(*bounds, point)) {
+        return true;
+    }
+    showError(tr("The point is outside the active focus bounding box."),
+              suppressErrorDialogs);
+    return false;
+}
+
 void LineAnnotationController::handleLineSeed(const std::string& surfaceName,
                                               cv::Vec3f volumePoint,
                                               InitialDirectionMode directionMode)
@@ -7159,6 +7195,11 @@ void LineAnnotationController::handleLineSeed(const std::string& surfaceName,
     if (session.taskState == LineAnnotationSession::TaskState::Running) {
         showError(tr("Line optimization is already running."),
                   session.suppressErrorDialogs);
+        return;
+    }
+
+    if (!placementAllowedByFocusBounds(
+            toVec3d(volumePoint), session.suppressErrorDialogs)) {
         return;
     }
 
@@ -7219,6 +7260,10 @@ void LineAnnotationController::handleGeneratedControlPoint(const std::string& su
     // coalesced dirty spans follows. Only a seed solve still excludes edits,
     // via the empty-line check below.
     if (session.optimizedLine.points.empty() || session.controlPoints.empty()) {
+        return;
+    }
+    if (!placementAllowedByFocusBounds(
+            toVec3d(volumePoint), session.suppressErrorDialogs)) {
         return;
     }
     // A debounced autosave still holds the LAST landing's geometry; once
@@ -7333,6 +7378,11 @@ void LineAnnotationController::handleGeneratedControlPoint(const std::string& su
                   prepared.replacedStart,
                   prepared.replacedCount)
             : session.optimizedLine;
+        if (const auto focusBounds = _state ? _state->activeFocusBounds()
+                                            : std::nullopt) {
+            vc3d::line_annotation::constrainLineOpenTailsToBounds(
+                preparedLine, prepared.controlPoints, *focusBounds);
+        }
     } catch (const std::exception& ex) {
         showError(tr("Could not update line control point: %1")
                       .arg(QString::fromStdString(ex.what())),
@@ -7523,12 +7573,22 @@ void LineAnnotationController::handleGeneratedControlPointBranch(const std::stri
                   parentSession.suppressErrorDialogs);
         return;
     }
-    // Cross-fiber operation: make sure no participating fiber's newest
-    // geometry is still session-only behind a debounced autosave.
-    flushAllPendingSessionAutoSaves();
     if (controlPointIndex >= parentSession.controlPoints.size()) {
         return;
     }
+    const cv::Vec3d linkedPoint = toVec3d(linkedControlPoint);
+    if (!finitePoint(linkedPoint)) {
+        showError(tr("Could not determine a finite linked-fiber point from the clicked location."),
+                  parentSession.suppressErrorDialogs);
+        return;
+    }
+    if (!placementAllowedByFocusBounds(
+            linkedPoint, parentSession.suppressErrorDialogs)) {
+        return;
+    }
+    // Cross-fiber operation: make sure no participating fiber's newest
+    // geometry is still session-only behind a debounced autosave.
+    flushAllPendingSessionAutoSaves();
     if (controlPointHasBranchLink(parentSession.branches, controlPointIndex)) {
         showError(tr("This control point is already linked; unlink it first."));
         return;
@@ -7545,12 +7605,6 @@ void LineAnnotationController::handleGeneratedControlPointBranch(const std::stri
     const std::string parentFileName = parentSession.fiberFileName;
     const cv::Vec3d branchPoint = parentSession.controlPoints[controlPointIndex].volumePoint;
     if (!finitePoint(branchPoint)) {
-        return;
-    }
-    const cv::Vec3d linkedPoint = toVec3d(linkedControlPoint);
-    if (!finitePoint(linkedPoint)) {
-        showError(tr("Could not determine a finite linked-fiber point from the clicked location."),
-                  parentSession.suppressErrorDialogs);
         return;
     }
     cv::Vec3d linkDirection = toVec3d(requestedLinkDirection);
@@ -9725,6 +9779,7 @@ bool LineAnnotationController::applyOptimizationTaskResult(LineAnnotationSession
                                                            bool fireSuccessCallback,
                                                            bool allowFiberSave)
 {
+    applyFocusBoundsToOptimizationTask(task);
     if (!task.ok) {
         session.taskState = LineAnnotationSession::TaskState::Failed;
         session.error = task.error;
@@ -9947,6 +10002,8 @@ bool LineAnnotationController::finalizeSessionOptimizationSynchronously(
                   session.suppressErrorDialogs);
         return false;
     }
+    const auto focusBoundsBase = _state ? _state->activeFocusBounds()
+                                        : std::nullopt;
 
     if (session.controlPoints.size() >= 2) {
         const bool needsTrace = session.fiberOptimizationMode ==
@@ -9965,6 +10022,7 @@ bool LineAnnotationController::finalizeSessionOptimizationSynchronously(
         OptimizationTaskResult task;
         task.manifestPath = session.selectedManifestPath;
         task.eventName = "segment_interpolation_final_full_line_opt";
+        task.focusBoundsBase = focusBoundsBase;
         try {
             auto optimized =
                 vc3d::line_annotation::optimizeFiberWithNativeFallback(
@@ -10024,6 +10082,7 @@ bool LineAnnotationController::finalizeSessionOptimizationSynchronously(
                                                           -1,
                                                           -1,
                                                           *session.normalSampler);
+    task.focusBoundsBase = focusBoundsBase;
     const bool applied = applyOptimizationTaskResult(session,
                                                      std::move(task),
                                                      false,
@@ -10171,6 +10230,8 @@ void LineAnnotationController::startOptimization(LineAnnotationSession& session,
     auto dataset = session.dataset;
     auto normalSampler = session.normalSampler;
     auto cancelFlag = session.runningSolveCancel;
+    const auto focusBoundsBase = _state ? _state->activeFocusBounds()
+                                        : std::nullopt;
     watcher->setFuture(QtConcurrent::run(&_lineSolvePool,
                                           [factory,
                                            manifestPath,
@@ -10185,9 +10246,11 @@ void LineAnnotationController::startOptimization(LineAnnotationSession& session,
                                            workingToBaseScale,
                                            dataset,
                                            normalSampler,
-                                           cancelFlag]() mutable {
+                                           cancelFlag,
+                                           focusBoundsBase]() mutable {
+        OptimizationTaskResult task;
         if (factory) {
-            return factory(manifestPath,
+            task = factory(manifestPath,
                            std::move(controlPoints),
                            std::move(initialLinePoints),
                            sourceSliceNormal,
@@ -10196,10 +10259,9 @@ void LineAnnotationController::startOptimization(LineAnnotationSession& session,
                            forceFullOptimization,
                            activeStart,
                            activeEnd);
-        }
-        if (normalSampler) {
+        } else if (normalSampler) {
             (void)dataset;
-            return optimizeLineWithSampler(manifestPath,
+            task = optimizeLineWithSampler(manifestPath,
                                            std::move(controlPoints),
                                            std::move(initialLinePoints),
                                            sourceSliceNormal,
@@ -10210,18 +10272,21 @@ void LineAnnotationController::startOptimization(LineAnnotationSession& session,
                                            activeEnd,
                                            *normalSampler,
                                            cancelFlag.get());
+        } else {
+            task = optimizeLineFromManifest(manifestPath,
+                                            workingToBaseScale,
+                                            std::move(controlPoints),
+                                            std::move(initialLinePoints),
+                                            sourceSliceNormal,
+                                            directionMode,
+                                            initialCenterlineLengthVx,
+                                            forceFullOptimization,
+                                            activeStart,
+                                            activeEnd,
+                                            cancelFlag.get());
         }
-        return optimizeLineFromManifest(manifestPath,
-                                        workingToBaseScale,
-                                        std::move(controlPoints),
-                                        std::move(initialLinePoints),
-                                        sourceSliceNormal,
-                                        directionMode,
-                                        initialCenterlineLengthVx,
-                                        forceFullOptimization,
-                                        activeStart,
-                                        activeEnd,
-                                        cancelFlag.get());
+        task.focusBoundsBase = focusBoundsBase;
+        return task;
     }));
 }
 
@@ -10491,6 +10556,8 @@ void LineAnnotationController::startFiberModeOptimization(
     auto predictionField = session.fiberPredictionField;
     auto normalSampler = session.normalSampler;
     auto traceNormalSampler = session.traceNormalSampler;
+    const auto focusBoundsBase = _state ? _state->activeFocusBounds()
+                                        : std::nullopt;
     // cancelToken keeps the flag the request points at alive for the whole
     // solve, even after the session replaces runningSolveCancel for a
     // successor solve.
@@ -10501,10 +10568,12 @@ void LineAnnotationController::startFiberModeOptimization(
          predictionField,
          normalSampler,
          traceNormalSampler,
+         focusBoundsBase,
          cancelToken = session.runningSolveCancel]() mutable {
             OptimizationTaskResult task;
             task.manifestPath = manifestPath;
             task.eventName = "native_fiber_trace3d_fiber_mode";
+            task.focusBoundsBase = focusBoundsBase;
             try {
                 (void)predictionField;
                 (void)normalSampler;
@@ -10548,6 +10617,7 @@ void LineAnnotationController::finishOptimization(const std::string& surfaceName
     OptimizationTaskResult task = watcher->result();
     session.watcher = nullptr;
     session.runningSolveCancel.reset();
+    applyFocusBoundsToOptimizationTask(task);
 
     if (!session.solveQueue.mayPublish(session.runningSolveEpoch)) {
         // The session was mutated (or began shutdown) while this solve ran:

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -67,6 +67,8 @@ public:
         cv::Vec3d sourceSliceNormal{0.0, 0.0, 1.0};
         InitialDirectionMode initialDirectionMode = InitialDirectionMode::Sideways;
         vc::lasagna::LineOptimizationResult result;
+        std::optional<Rect3D> focusBoundsBase;
+        bool focusBoundsApplied = false;
         std::string error;
         std::string eventName;
     };
@@ -685,6 +687,8 @@ private:
     void setSessionOptimizationState(LineAnnotationSession& session,
                                      SessionOptimizationState state);
     void refreshSessionOptimizationStatus(const LineAnnotationSession& session);
+    bool placementAllowedByFocusBounds(const cv::Vec3d& point,
+                                       bool suppressErrorDialogs) const;
     bool applyOptimizationTaskResult(LineAnnotationSession& session,
                                      OptimizationTaskResult task,
                                      bool updateGeneratedViews,

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -441,6 +441,11 @@ private:
         Optimized,
     };
 
+    enum class SeedOrigin {
+        NewPlacement,
+        StoredFiber,
+    };
+
     // Intentionally opaque outside LineAnnotationController.cpp. Keeping session
     // state private prevents external code from mutating controlPoints/branches
     // without the branch metadata synchronization hook.
@@ -585,7 +590,8 @@ private:
                                    std::optional<std::pair<int, int>> spanControlIndices = std::nullopt);
     void handleLineSeed(const std::string& surfaceName,
                         cv::Vec3f volumePoint,
-                        InitialDirectionMode directionMode);
+                        InitialDirectionMode directionMode,
+                        SeedOrigin seedOrigin = SeedOrigin::NewPlacement);
     void handleGeneratedControlPoint(const std::string& surfaceName,
                                      cv::Vec3f volumePoint,
                                      double linePosition);

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
@@ -1526,7 +1526,44 @@ bool constrainLineOpenTailsToBounds(
     size_t keepBegin = firstControl;
     size_t keepEnd = lastControl;
 
-    if (contains_point(focusBounds, line.points[firstControl].position)) {
+    const bool singleOutsideControl = firstControl == lastControl &&
+        !contains_point(focusBounds, line.points[firstControl].position);
+    if (singleOutsideControl) {
+        bool enteredBounds = false;
+        for (size_t i = firstControl; i > 0;) {
+            --i;
+            const bool inside = contains_point(focusBounds, line.points[i].position);
+            if (!enteredBounds) {
+                if (!inside) {
+                    continue;
+                }
+                enteredBounds = true;
+                keepBegin = i;
+                continue;
+            }
+            keepBegin = i;
+            if (!inside) {
+                break;
+            }
+        }
+
+        enteredBounds = false;
+        for (size_t i = lastControl + 1; i < line.points.size(); ++i) {
+            const bool inside = contains_point(focusBounds, line.points[i].position);
+            if (!enteredBounds) {
+                if (!inside) {
+                    continue;
+                }
+                enteredBounds = true;
+                keepEnd = i;
+                continue;
+            }
+            keepEnd = i;
+            if (!inside) {
+                break;
+            }
+        }
+    } else if (contains_point(focusBounds, line.points[firstControl].position)) {
         while (keepBegin > 0) {
             --keepBegin;
             if (!contains_point(focusBounds, line.points[keepBegin].position)) {
@@ -1534,7 +1571,8 @@ bool constrainLineOpenTailsToBounds(
             }
         }
     }
-    if (contains_point(focusBounds, line.points[lastControl].position)) {
+    if (!singleOutsideControl &&
+        contains_point(focusBounds, line.points[lastControl].position)) {
         while (keepEnd + 1 < line.points.size()) {
             ++keepEnd;
             if (!contains_point(focusBounds, line.points[keepEnd].position)) {

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
@@ -1494,6 +1494,104 @@ std::optional<std::vector<size_t>> orderedControlPointLineIndices(
     return lineIndices;
 }
 
+bool constrainLineOpenTailsToBounds(
+    vc::lasagna::LineModel& line,
+    std::vector<LineControlPoint>& controls,
+    const Rect3D& focusBounds)
+{
+    if (controls.empty() || line.points.size() < 2) {
+        throw std::invalid_argument(
+            "focus-bounds constraint requires a control and at least two line points");
+    }
+
+    std::vector<cv::Vec3d> controlPositions;
+    controlPositions.reserve(controls.size());
+    for (const auto& control : controls) {
+        controlPositions.push_back(control.volumePoint);
+    }
+    std::vector<cv::Vec3d> linePositions;
+    linePositions.reserve(line.points.size());
+    for (const auto& point : line.points) {
+        linePositions.push_back(point.position);
+    }
+    const auto indices = orderedControlPointLineIndices(
+        controlPositions, linePositions);
+    if (!indices) {
+        throw std::runtime_error(
+            "focus-bounds constraint could not resolve controls on the line");
+    }
+
+    const size_t firstControl = indices->front();
+    const size_t lastControl = indices->back();
+    size_t keepBegin = firstControl;
+    size_t keepEnd = lastControl;
+
+    if (contains_point(focusBounds, line.points[firstControl].position)) {
+        while (keepBegin > 0) {
+            --keepBegin;
+            if (!contains_point(focusBounds, line.points[keepBegin].position)) {
+                break;
+            }
+        }
+    }
+    if (contains_point(focusBounds, line.points[lastControl].position)) {
+        while (keepEnd + 1 < line.points.size()) {
+            ++keepEnd;
+            if (!contains_point(focusBounds, line.points[keepEnd].position)) {
+                break;
+            }
+        }
+    }
+
+    // A one-control solve still needs a direction-bearing line. Prefer an
+    // adjacent in-bounds sample, then retain whichever neighbor exists.
+    if (keepBegin == keepEnd) {
+        const bool leftInside = keepBegin > 0 &&
+            contains_point(focusBounds, line.points[keepBegin - 1].position);
+        const bool rightInside = keepEnd + 1 < line.points.size() &&
+            contains_point(focusBounds, line.points[keepEnd + 1].position);
+        if (leftInside || (!rightInside && keepBegin > 0)) {
+            --keepBegin;
+        } else if (keepEnd + 1 < line.points.size()) {
+            ++keepEnd;
+        }
+    }
+
+    const bool changed = keepBegin != 0 || keepEnd + 1 != line.points.size();
+    if (!changed) {
+        for (size_t i = 0; i < controls.size(); ++i) {
+            controls[i].optimizedIndex = static_cast<int>((*indices)[i]);
+            controls[i].linePosition = static_cast<double>((*indices)[i]);
+        }
+        return false;
+    }
+
+    if (line.segmentSamples.size() + 1 == line.points.size()) {
+        line.segmentSamples = std::vector<vc::lasagna::LineSegmentSamples>(
+            line.segmentSamples.begin() + static_cast<std::ptrdiff_t>(keepBegin),
+            line.segmentSamples.begin() + static_cast<std::ptrdiff_t>(keepEnd));
+    } else {
+        line.segmentSamples.clear();
+    }
+    line.points = std::vector<vc::lasagna::LinePoint>(
+        line.points.begin() + static_cast<std::ptrdiff_t>(keepBegin),
+        line.points.begin() + static_cast<std::ptrdiff_t>(keepEnd + 1));
+
+    if (line.displayFrameAnchorIndex >= 0) {
+        const int clampedAnchor = std::clamp(
+            line.displayFrameAnchorIndex,
+            static_cast<int>(keepBegin),
+            static_cast<int>(keepEnd));
+        line.displayFrameAnchorIndex = clampedAnchor - static_cast<int>(keepBegin);
+    }
+    for (size_t i = 0; i < controls.size(); ++i) {
+        const size_t rebased = (*indices)[i] - keepBegin;
+        controls[i].optimizedIndex = static_cast<int>(rebased);
+        controls[i].linePosition = static_cast<double>(rebased);
+    }
+    return true;
+}
+
 vc::lasagna::LineModel spliceLineModelWithInterpolatedNormals(
     const vc::lasagna::LineModel& previous,
     const std::vector<cv::Vec3d>& points,

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.hpp
@@ -14,6 +14,7 @@
 
 #include "vc/fiber_tracer/FiberTrace.hpp"
 #include "vc/lasagna/LineOptimizer.hpp"
+#include "vc/core/util/Rect3D.hpp"
 
 namespace vc3d::line_annotation
 {
@@ -270,6 +271,15 @@ void validateStoredControlPoints(const std::vector<StoredControlPoint>& controls
 [[nodiscard]] std::optional<std::vector<size_t>> orderedControlPointLineIndices(
     const std::vector<cv::Vec3d>& controlPoints,
     const std::vector<cv::Vec3d>& linePoints);
+
+// Keep the complete path between the outer controls, but shorten open tails
+// near focusBounds. One outside sample per tail is retained as bounded
+// overshoot. Control indices and the display anchor are rebased in place.
+// Throws when controls are not an exact ordered subset of line.points.
+bool constrainLineOpenTailsToBounds(
+    vc::lasagna::LineModel& line,
+    std::vector<LineControlPoint>& controls,
+    const Rect3D& focusBounds);
 
 // Publish a superseded solve by span merge (render-job model: edits no
 // longer cancel the in-flight solve, and its landing must not be discarded

--- a/volume-cartographer/apps/VC3D/VCMain.ui
+++ b/volume-cartographer/apps/VC3D/VCMain.ui
@@ -945,6 +945,36 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="chkFocusBBox">
+         <property name="text">
+          <string>BBox</string>
+         </property>
+         <property name="toolTip">
+          <string>Limit new fiber work and dim views outside these base-volume coordinates</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1" colspan="2">
+        <widget class="QLineEdit" name="focusBBoxMin">
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="placeholderText">
+          <string>min x, y, z</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3" colspan="2">
+        <widget class="QLineEdit" name="focusBBoxMax">
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="placeholderText">
+          <string>max x, y, z</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item row="2" column="0">

--- a/volume-cartographer/apps/VC3D/ViewerManager.cpp
+++ b/volume-cartographer/apps/VC3D/ViewerManager.cpp
@@ -359,6 +359,10 @@ VolumeViewerBase* ViewerManager::initializeChunkedViewer(CChunkedVolumeViewer* c
         connect(_state, &CState::poiChanged, chunkedViewer, &CChunkedVolumeViewer::onPOIChanged);
         connect(_state, &CState::volumeChanged, chunkedViewer, &CChunkedVolumeViewer::OnVolumeChanged);
         connect(_state, &CState::volumeClosing, chunkedViewer, &CChunkedVolumeViewer::onVolumeClosing);
+        connect(_state, &CState::focusBoundsChanged, chunkedViewer,
+                [chunkedViewer]() {
+                    chunkedViewer->requestRender("focus bounds changed");
+                });
     }
 
     // Restore persisted viewer preferences

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -2157,6 +2157,10 @@ CChunkedVolumeViewer::RenderResult CChunkedVolumeViewer::renderFrame(RenderConte
     cv::Mat_<uint8_t> overlayValues;
     cv::Mat_<uint8_t> overlayCoverage;
     cv::Mat_<uint8_t> overlayTargetCoverage;
+    cv::Mat_<uint8_t> focusBoundsInside;
+    if (ctx.renderJob.focusBoundsBase) {
+        focusBoundsInside = cv::Mat_<uint8_t>(ctx.fbH, ctx.fbW, uint8_t(0));
+    }
     const bool continuingSameGeometry =
         ctx.prevResult && !ctx.genCacheDirty &&
         renderJobsSameGeometry(ctx.renderJob, ctx.prevResult->renderJob);
@@ -2939,6 +2943,17 @@ CChunkedVolumeViewer::RenderResult CChunkedVolumeViewer::renderFrame(RenderConte
                                + n * ctx.zOff;
         const cv::Vec3f vxStep = vx / ctx.scale;
         const cv::Vec3f vyStep = vy / ctx.scale;
+        if (!focusBoundsInside.empty()) {
+            for (int y = 0; y < ctx.fbH; ++y) {
+                auto* inside = focusBoundsInside.ptr<uint8_t>(y);
+                const cv::Vec3f rowOrigin = origin + vyStep * static_cast<float>(y);
+                for (int x = 0; x < ctx.fbW; ++x) {
+                    inside[x] = contains_point(
+                        *ctx.renderJob.focusBoundsBase,
+                        rowOrigin + vxStep * static_cast<float>(x));
+                }
+            }
+        }
         if (profilePhases) phaseTimer.restart();
         samplePlane(origin, vxStep, vyStep, n, values, coverage, *ctx.chunkArray);
         if (profilePhases) phaseSampleMs += phaseTimer.elapsed();
@@ -3011,9 +3026,21 @@ CChunkedVolumeViewer::RenderResult CChunkedVolumeViewer::renderFrame(RenderConte
         // With both channels cached and an in-band w there is no gen() and no 3D
         // volume sampling in the frame at all. GeneratedSurfaceCache is still
         // needed whenever either channel falls back.
-        const bool needGen = !baseCacheUsable || (overlayActive && !overlayCacheUsable);
+        const bool needGen = !baseCacheUsable ||
+            (overlayActive && !overlayCacheUsable) ||
+            ctx.renderJob.focusBoundsBase.has_value();
         if (needGen)
             std::tie(coords, normals) = generatedSurfaceCoords(needSurfaceNormals);
+        if (!focusBoundsInside.empty() && !coords.empty()) {
+            for (int y = 0; y < ctx.fbH; ++y) {
+                auto* inside = focusBoundsInside.ptr<uint8_t>(y);
+                const auto* coord = coords.ptr<cv::Vec3f>(y);
+                for (int x = 0; x < ctx.fbW; ++x) {
+                    inside[x] = contains_point(
+                        *ctx.renderJob.focusBoundsBase, coord[x]);
+                }
+            }
+        }
         if (baseCacheUsable) {
             if (profilePhases) phaseTimer.restart();
             if (flattenedVolumetricActive) {
@@ -3206,6 +3233,9 @@ CChunkedVolumeViewer::RenderResult CChunkedVolumeViewer::renderFrame(RenderConte
         const auto* colorSrc = hasColorValues ? colorValues.ptr<cv::Vec3b>(y) : nullptr;
         const auto* overlaySrc = hasOverlay ? overlayValues.ptr<uint8_t>(y) : nullptr;
         const auto* overlayCov = hasOverlay ? overlayCoverage.ptr<uint8_t>(y) : nullptr;
+        const auto* focusInside = !focusBoundsInside.empty()
+            ? focusBoundsInside.ptr<uint8_t>(y)
+            : nullptr;
         for (int x = 0; x < ctx.fbW; ++x) {
             uint32_t pixel = !cov[x] ? uncoveredPixel
                 : hasColorValues
@@ -3215,6 +3245,10 @@ CChunkedVolumeViewer::RenderResult CChunkedVolumeViewer::renderFrame(RenderConte
             if (hasOverlay && overlayCov[x] &&
                 overlaySrc[x] >= ctx.overlayWindowLow && overlaySrc[x] <= ctx.overlayWindowHigh) {
                 pixel = alphaBlendArgb(pixel, overlayLut[overlaySrc[x]], ctx.overlayOpacity);
+            }
+            if (focusInside && !focusInside[x]) {
+                pixel = (pixel & 0xFF000000u) |
+                        ((pixel & 0x00FEFEFEu) >> 1);
             }
             row[x] = pixel;
         }
@@ -3280,6 +3314,12 @@ std::optional<CChunkedVolumeViewer::PendingRenderJob> CChunkedVolumeViewer::capt
     job.surfaceCache = _surfaceCache;
     job.overlaySurfaceCache = _overlaySurfaceCache;
     job.surfaceCacheEpoch = _surfaceCacheEpoch;
+    const bool focusBoundsSupported =
+        dynamic_cast<PlaneSurface*>(surf.get()) != nullptr ||
+        property("vc_viewer_role").toString() == QStringLiteral("annotation");
+    if (focusBoundsSupported && _state) {
+        job.focusBoundsBase = _state->activeFocusBounds();
+    }
     job.genCache = _genSurfaceCache;
     job.genCacheDirty = _genCacheDirty;
     job.profileReason = reason ? reason : "";
@@ -3294,9 +3334,17 @@ std::optional<CChunkedVolumeViewer::PendingRenderJob> CChunkedVolumeViewer::capt
 bool CChunkedVolumeViewer::renderJobsEquivalentForDisplay(const PendingRenderJob& a,
                                                           const PendingRenderJob& b)
 {
+    const auto boundsEqual = [](const std::optional<Rect3D>& lhs,
+                                const std::optional<Rect3D>& rhs) {
+        if (lhs.has_value() != rhs.has_value()) {
+            return false;
+        }
+        return !lhs || (lhs->low == rhs->low && lhs->high == rhs->high);
+    };
     return renderJobsSameGeometry(a, b) &&
            a.chunkContentEpoch == b.chunkContentEpoch &&
-           a.genCacheDirty == b.genCacheDirty;
+           a.genCacheDirty == b.genCacheDirty &&
+           boundsEqual(a.focusBoundsBase, b.focusBoundsBase);
 }
 
 bool CChunkedVolumeViewer::renderJobsSameGeometry(const PendingRenderJob& a,

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -34,6 +34,7 @@
 #include "vc/core/render/IChunkedArray.hpp"
 #include "vc/core/types/Sampling.hpp"
 #include "vc/core/util/Compositing.hpp"
+#include "vc/core/util/Rect3D.hpp"
 #include "vc/core/util/SurfacePatchIndex.hpp"
 
 class CState;
@@ -409,6 +410,9 @@ private:
         std::shared_ptr<vc::render::SurfaceCache> surfaceCache;
         std::shared_ptr<vc::render::SurfaceCache> overlaySurfaceCache;
         std::uint64_t surfaceCacheEpoch = 0;
+        // Effective launch-time bounds. Null for disabled bounds and for view
+        // types outside the supported plane/annotation scope.
+        std::optional<Rect3D> focusBoundsBase;
         std::shared_ptr<GeneratedSurfaceCache> genCache;
         bool genCacheDirty = false;
         std::string profileReason;

--- a/volume-cartographer/core/include/vc/core/util/Rect3D.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Rect3D.hpp
@@ -8,6 +8,15 @@ struct Rect3D {
     cv::Vec3f high = {0,0,0};
 };
 
+template <typename T>
+[[nodiscard]] inline bool contains_point(
+    const Rect3D& bounds, const cv::Vec<T, 3>& point) noexcept
+{
+    return point[0] >= bounds.low[0] && point[0] <= bounds.high[0] &&
+           point[1] >= bounds.low[1] && point[1] <= bounds.high[1] &&
+           point[2] >= bounds.low[2] && point[2] <= bounds.high[2];
+}
+
 bool intersect(const Rect3D &a, const Rect3D &b);
 Rect3D expand_rect(const Rect3D &a, const cv::Vec3f &p);
 

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -330,6 +330,97 @@ TEST_CASE("line annotation generated runtime surfaces register and clean up")
     }
 }
 
+TEST_CASE("focus bounds state distinguishes configured and active bounds")
+{
+    CState state;
+    int changes = 0;
+    QObject::connect(&state, &CState::focusBoundsChanged, [&changes]() {
+        ++changes;
+    });
+
+    const Rect3D reversed{{20.0f, 30.0f, 40.0f}, {10.0f, 15.0f, 25.0f}};
+    state.setFocusBounds(reversed);
+    REQUIRE(state.focusBounds());
+    CHECK(state.focusBounds()->low == cv::Vec3f(10.0f, 15.0f, 25.0f));
+    CHECK(state.focusBounds()->high == cv::Vec3f(20.0f, 30.0f, 40.0f));
+    CHECK_FALSE(state.activeFocusBounds());
+    CHECK(changes == 1);
+
+    state.setFocusBounds(reversed);
+    CHECK(changes == 1);
+    state.setFocusBoundsEnabled(true);
+    REQUIRE(state.activeFocusBounds());
+    CHECK(changes == 2);
+    const uint64_t activeRevision = state.focusBoundsRevision();
+    state.setFocusBoundsEnabled(true);
+    CHECK(state.focusBoundsRevision() == activeRevision);
+    CHECK(changes == 2);
+
+    state.clearFocusBounds();
+    CHECK_FALSE(state.focusBounds());
+    CHECK_FALSE(state.activeFocusBounds());
+    CHECK_FALSE(state.focusBoundsEnabled());
+    CHECK(changes == 3);
+    state.clearFocusBounds();
+    CHECK(changes == 3);
+}
+
+TEST_CASE("focus bounds trim only open line tails and rebase indices")
+{
+    vc::lasagna::LineModel line;
+    for (int x = -20; x <= 40; x += 10) {
+        vc::lasagna::LinePoint point;
+        point.position = cv::Vec3d{x == 10 ? 10.0 : static_cast<double>(x),
+                                   x == 10 ? 100.0 : 0.0,
+                                   0.0};
+        line.points.push_back(point);
+    }
+    line.displayFrameAnchorIndex = 4;
+    line.segmentSamples.resize(line.points.size() - 1);
+    std::vector<vc3d::line_annotation::LineControlPoint> controls{
+        {2.0, {0.0, 0.0, 0.0}, true, 2},
+        {4.0, {20.0, 0.0, 0.0}, false, 4},
+    };
+    const Rect3D bounds{{-5.0f, -5.0f, -5.0f}, {25.0f, 5.0f, 5.0f}};
+
+    CHECK(vc3d::line_annotation::constrainLineOpenTailsToBounds(
+        line, controls, bounds));
+    REQUIRE(line.points.size() == 5);
+    CHECK(line.points.front().position == cv::Vec3d(-10.0, 0.0, 0.0));
+    CHECK(line.points[2].position == cv::Vec3d(10.0, 100.0, 0.0));
+    CHECK(line.points.back().position == cv::Vec3d(30.0, 0.0, 0.0));
+    CHECK(line.segmentSamples.size() == 4);
+    CHECK(line.displayFrameAnchorIndex == 3);
+    CHECK(controls[0].optimizedIndex == 1);
+    CHECK(controls[0].linePosition == doctest::Approx(1.0));
+    CHECK(controls[1].optimizedIndex == 3);
+    CHECK(controls[1].linePosition == doctest::Approx(3.0));
+}
+
+TEST_CASE("focus bounds keep a two-point line for one outside control")
+{
+    vc::lasagna::LineModel line;
+    for (int x : {0, 10, 20}) {
+        vc::lasagna::LinePoint point;
+        point.position = cv::Vec3d{static_cast<double>(x), 0.0, 0.0};
+        line.points.push_back(point);
+    }
+    line.displayFrameAnchorIndex = 1;
+    std::vector<vc3d::line_annotation::LineControlPoint> controls{
+        {1.0, {10.0, 0.0, 0.0}, true, 1},
+    };
+    const Rect3D bounds{{100.0f, -1.0f, -1.0f}, {200.0f, 1.0f, 1.0f}};
+
+    CHECK(vc3d::line_annotation::constrainLineOpenTailsToBounds(
+        line, controls, bounds));
+    REQUIRE(line.points.size() == 2);
+    CHECK(line.points[0].position == cv::Vec3d(0.0, 0.0, 0.0));
+    CHECK(line.points[1].position == cv::Vec3d(10.0, 0.0, 0.0));
+    CHECK(controls[0].optimizedIndex == 1);
+    CHECK(controls[0].linePosition == doctest::Approx(1.0));
+    CHECK(line.displayFrameAnchorIndex == 1);
+}
+
 TEST_CASE("line annotation shift scroll uses viewer slice step size")
 {
     CHECK(vc3d::line_annotation::shiftScrollLineStepSize(0) == 1);

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -421,6 +421,32 @@ TEST_CASE("focus bounds keep a two-point line for one outside control")
     CHECK(line.displayFrameAnchorIndex == 1);
 }
 
+TEST_CASE("focus bounds keep paths from one outside control into the box")
+{
+    vc::lasagna::LineModel line;
+    for (int x : {240, 210, 170, 140, 110, 80, 50, 20,
+                  50, 80, 110, 140, 170, 210, 240}) {
+        vc::lasagna::LinePoint point;
+        point.position = cv::Vec3d{static_cast<double>(x), 0.0, 0.0};
+        line.points.push_back(point);
+    }
+    line.displayFrameAnchorIndex = 7;
+    std::vector<vc3d::line_annotation::LineControlPoint> controls{
+        {7.0, {20.0, 0.0, 0.0}, true, 7},
+    };
+    const Rect3D bounds{{100.0f, -1.0f, -1.0f}, {200.0f, 1.0f, 1.0f}};
+
+    CHECK(vc3d::line_annotation::constrainLineOpenTailsToBounds(
+        line, controls, bounds));
+    REQUIRE(line.points.size() == 13);
+    CHECK(line.points.front().position == cv::Vec3d(210.0, 0.0, 0.0));
+    CHECK(line.points[6].position == cv::Vec3d(20.0, 0.0, 0.0));
+    CHECK(line.points.back().position == cv::Vec3d(210.0, 0.0, 0.0));
+    CHECK(controls[0].optimizedIndex == 6);
+    CHECK(controls[0].linePosition == doctest::Approx(6.0));
+    CHECK(line.displayFrameAnchorIndex == 6);
+}
+
 TEST_CASE("line annotation shift scroll uses viewer slice step size")
 {
     CHECK(vc3d::line_annotation::shiftScrollLineStepSize(0) == 1);

--- a/volume-cartographer/core/test/test_quadsurface_basics.cpp
+++ b/volume-cartographer/core/test/test_quadsurface_basics.cpp
@@ -41,6 +41,16 @@ TEST_CASE("Rect3D default-construction is zero box")
     CHECK(r.high == cv::Vec3f(0, 0, 0));
 }
 
+TEST_CASE("Rect3D containment is inclusive in base XYZ")
+{
+    const Rect3D bounds{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}};
+    CHECK(contains_point(bounds, cv::Vec3f(1.0f, 2.0f, 3.0f)));
+    CHECK(contains_point(bounds, cv::Vec3d(4.0, 5.0, 6.0)));
+    CHECK(contains_point(bounds, cv::Vec3d(2.5, 3.5, 4.5)));
+    CHECK_FALSE(contains_point(bounds, cv::Vec3f(0.99f, 3.0f, 4.0f)));
+    CHECK_FALSE(contains_point(bounds, cv::Vec3d(2.0, 5.01, 4.0)));
+}
+
 TEST_CASE("expand_rect grows box to include a new point")
 {
     Rect3D a;

--- a/volume-cartographer/docs/line_annotation_fibers.md
+++ b/volume-cartographer/docs/line_annotation_fibers.md
@@ -62,13 +62,16 @@ and attached-volume composition and does not dim control markers. The main
 segmentation surface view is not covered by this version of the feature.
 
 New seeds, linked branch seeds, and control points must be inside the active
-box. A trace or reoptimization captures the box when it starts; later box
-changes do not cancel that work or alter untouched fibers. After a solve, the
-path between the outer control points is preserved even if it briefly leaves
-the box. Only open tails are shortened: they retain the first sample outside
-the box as a small overshoot. A lone control also retains one neighboring line
-sample so the resulting fiber remains valid. Manual/no-reoptimization edits use
-the same open-tail rule.
+box. Existing controls remain valid outside it, so a saved seed-only fiber can
+still be reopened after the box is enabled or moved. A trace or reoptimization
+captures the box when it starts; later box changes do not cancel that work or
+alter untouched fibers. After a solve, the path between the outer control
+points is preserved even if it briefly leaves the box. Only open tails are
+shortened: they retain the first sample outside the box as a small overshoot. A
+lone outside control retains any connector that reaches the box and its in-box
+run; if neither tail reaches the box, one neighboring line sample is kept so
+the fiber remains valid. Manual/no-reoptimization edits use the same open-tail
+rule.
 
 The rendered strips are derived views, not stored line geometry. Their columns
 retain every annotation control point and both line endpoints. The optimized

--- a/volume-cartographer/docs/line_annotation_fibers.md
+++ b/volume-cartographer/docs/line_annotation_fibers.md
@@ -49,6 +49,27 @@ the current cut from mouse position, accept control-point interactions, and
 show the per-span status labels described below. Cameras and splitter sizes
 survive generated-view updates.
 
+The main window's **BBox** checkbox beneath **Focus** enables an annotation
+focus region. The adjacent minimum and maximum fields use inclusive absolute
+base-volume `x, y, z` coordinates. An unset box starts at the current volume
+extent; edited coordinates are normalized and clamped to that extent. The box
+is session-only, survives volume/channel changes in the current package, and is
+cleared when the project is replaced or closed.
+
+When enabled, ordinary plane views and all line-annotation cut/strip views show
+the area outside the box at half brightness. The dimming is applied after base
+and attached-volume composition and does not dim control markers. The main
+segmentation surface view is not covered by this version of the feature.
+
+New seeds, linked branch seeds, and control points must be inside the active
+box. A trace or reoptimization captures the box when it starts; later box
+changes do not cancel that work or alter untouched fibers. After a solve, the
+path between the outer control points is preserved even if it briefly leaves
+the box. Only open tails are shortened: they retain the first sample outside
+the box as a small overshoot. A lone control also retains one neighboring line
+sample so the resulting fiber remains valid. Manual/no-reoptimization edits use
+the same open-tail rule.
+
 The rendered strips are derived views, not stored line geometry. Their columns
 retain every annotation control point and both line endpoints. The optimized
 line points between adjacent controls define the polyline path but are not

--- a/volume-cartographer/planning/changelog.md
+++ b/volume-cartographer/planning/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-31
+
+- Added optional base-XYZ focus bounds that dim plane and annotation-strip views and roughly constrain new or reoptimized fiber geometry.
+
 ## 2026-08-27
 
 - Added anonymous-first S3 access for public remote Lasagna manifests and Zarr objects, with authenticated fallback for private data.

--- a/volume-cartographer/planning/spec.md
+++ b/volume-cartographer/planning/spec.md
@@ -246,6 +246,34 @@
   render probes the shared `SurfaceGeometryTileCache`; subsequent tile fills
   reuse those geometry tiles and do not allocate a second full-frame matrix.
 
+## Annotation focus bounds
+
+- VC3D may hold one optional session focus bounding box in inclusive
+  base-volume XYZ coordinates. It is preserved across volume/channel switches
+  within one package, cleared when the package is replaced or closed, and is
+  not serialized into project data.
+- While enabled, ordinary plane views and annotation-role strip/cut views draw
+  the final composed framebuffer outside the box at half RGB brightness without
+  a boundary line. Base and attached-volume pixels are dimmed together; Qt
+  control markers and other scene items remain full brightness.
+- Standard segmentation QuadSurface/SurfaceCache views are outside the current
+  display scope. Focus-bounds rendering uses coordinates already generated for
+  sampling and must not add volume reads, surface intersections, or render
+  resubmission loops. Editing configured bounds while disabled must not start a
+  different render job.
+- New line seeds, branch-fiber seeds, and control-point placements are accepted
+  only inside an active box. Validation occurs before pane creation, dataset
+  access, autosave flushing, or persistence.
+- Every trace or reoptimization uses the box state captured when that work was
+  launched. Changing the box does not cancel, restart, or retroactively mutate
+  existing or in-flight annotation geometry.
+- For work launched with an active box, the entire optimized path between the
+  outer controls is retained, including temporary excursions outside the box.
+  Open tails stop after their first outside sample. An already-outside outer
+  control keeps no farther tail, except that a one-control line retains one
+  adjacent sample to remain valid. Manual provisional edits follow the same
+  tail rule.
+
 ## Download label
 
 The main window uses one permanent status label for cache diagnostics and

--- a/volume-cartographer/planning/spec.md
+++ b/volume-cartographer/planning/spec.md
@@ -263,16 +263,19 @@
   different render job.
 - New line seeds, branch-fiber seeds, and control-point placements are accepted
   only inside an active box. Validation occurs before pane creation, dataset
-  access, autosave flushing, or persistence.
+  access, autosave flushing, or persistence. Existing controls remain valid
+  outside the box; in particular, an already-saved seed-only fiber can be
+  reopened and resumed after the box is enabled or moved.
 - Every trace or reoptimization uses the box state captured when that work was
   launched. Changing the box does not cancel, restart, or retroactively mutate
   existing or in-flight annotation geometry.
 - For work launched with an active box, the entire optimized path between the
   outer controls is retained, including temporary excursions outside the box.
-  Open tails stop after their first outside sample. An already-outside outer
-  control keeps no farther tail, except that a one-control line retains one
-  adjacent sample to remain valid. Manual provisional edits follow the same
-  tail rule.
+  Open tails stop after their first outside sample. A lone outside control
+  retains each contiguous connector that reaches the box, the in-box run, and
+  its first sample after exiting. If neither tail reaches the box, it retains
+  one adjacent sample to remain valid. Manual provisional edits follow the
+  same tail rule.
 
 ## Download label
 


### PR DESCRIPTION
**In one sentence:** Let VC3D annotators focus on a base-coordinate bbox that dims outside context and constrains newly changed fiber geometry.

**One real example:** Starting with an open fiber crossing a selected annotation region, enabling the focus bbox dims the surrounding plane and strip pixels while trimming newly optimized tails near the bounds without removing controlled interior geometry.

**Before:** VC3D had no shared annotation-region bound, so views gave no indication of the working region and tracing or reoptimization could continue far beyond it.

**After this PR:** The Focus controls can enable an inclusive base-XYZ bbox. Plane and annotation-strip views render outside pixels at half brightness, outside control placements are rejected, and new or reoptimized open tails are softly trimmed.

**Proof:** At commit `c456a5d2f`, VC3D and the focused test targets build successfully. All focused tests pass. The focus-bbox display and annotation behavior were also manually tested in VC3D.

**Why / where this is useful:** Fiber annotators can keep work and generated annotation data roughly limited to a selected volume region without requiring exact geometric clipping.

## Details

- Bounds are session-local and clear when the project or package changes.
- Each solve captures the active bbox when it starts; toggling it does not restart an in-flight solve.
- Existing control points and geometry between the first and last controls are preserved.
- Persisted seed-only fibers remain reopenable outside a later or moved bbox, and a retrace preserves their path into the bbox.
- Standard SurfaceCache-backed segmentation views are intentionally not dimmed.

Verification:

`cmake --build volume-cartographer/build -j 32 --target VC3D test_line_annotation_generated_views test_quadsurface_basics test_fiber_trace_review`

`ctest --test-dir volume-cartographer/build -R '^(test_fiber_trace_review|test_line_annotation_generated_views|test_quadsurface_basics)$' --output-on-failure`
