### PR TITLE
vc_sync ash: pin the sftp shell type so batched hashing works

### DIFF
--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -1277,6 +1277,29 @@ class TestSftpManagerState:
         assert env['RCLONE_SFTP_KNOWN_HOSTS_FILE'] == os.path.expanduser(
             '~/.ssh/known_hosts')
 
+    def test_shell_type_and_hash_commands_are_pinned(self, sftp_manager):
+        """Detection must not run at all: rclone's lazy per-connection
+        shell/hash probe cannot be persisted for an on-the-fly :sftp:
+        backend, and racing it across --checkers connections makes a
+        batched md5sum report "hash unsupported" for most files —
+        silently degrading change detection to size+mtime."""
+        env = sftp_manager._rclone_env()
+        assert env['RCLONE_SFTP_SHELL_TYPE'] == 'unix'
+        assert env['RCLONE_SFTP_MD5SUM_COMMAND'] == 'md5sum'
+        assert env['RCLONE_SFTP_SHA1SUM_COMMAND'] == 'sha1sum'
+
+    def test_pins_override_a_polluted_caller_environment(self, sftp_manager,
+                                                         monkeypatch):
+        """Like host/user/pass, the pins are enforced, not defaults: a
+        stray RCLONE_SFTP_* in the caller's shell must not reintroduce
+        the probe race. (Deliberate overrides go through
+        VC_SYNC_RCLONE_FLAGS — rclone flags beat its env vars.)"""
+        monkeypatch.setenv('RCLONE_SFTP_SHELL_TYPE', 'powershell')
+        monkeypatch.setenv('RCLONE_SFTP_MD5SUM_COMMAND', 'certutil')
+        env = sftp_manager._rclone_env()
+        assert env['RCLONE_SFTP_SHELL_TYPE'] == 'unix'
+        assert env['RCLONE_SFTP_MD5SUM_COMMAND'] == 'md5sum'
+
     def test_display_url(self, sftp_manager):
         assert sftp_manager._get_s3_url('a/b.json') == (
             'sftp://user1@ash.example.org:2022/srv/backup/a/b.json')
@@ -1429,16 +1452,19 @@ class TestSftpScanAndHashes:
         assert sftp_manager._remote_hashing_works is True
 
     def test_md5sums_unsupported_server_disables_hashing(self, sftp_manager,
-                                                         monkeypatch):
+                                                         monkeypatch, capsys):
         ran = []
         monkeypatch.setattr(
             sftp_manager, '_run_rclone_capture',
             lambda args, timeout=None: ran.append(args) or completed(stdout=''))
         assert sftp_manager._remote_md5sums(['a.json']) == {}
         assert sftp_manager._remote_hashing_works is False
+        # The user is told why hashing degraded — once, on first detection
+        assert 'hashing unavailable' in capsys.readouterr().out
         # Later calls short-circuit instead of re-probing the server
         assert sftp_manager._remote_md5sums(['b.json']) == {}
         assert len(ran) == 1
+        assert 'hashing unavailable' not in capsys.readouterr().out
 
 
 class TestSftpAnalyzeIntegration:

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -48,7 +48,10 @@ SFTP sync (the ash-* commands):
     server. SFTP has no ETags or object versioning, so remote change
     detection uses one batched server-side `rclone md5sum` for
     annotation-sized JSON files (mtime+size for everything else), and merge
-    bases come only from the local .ashsync-base shadow copies.
+    bases come only from the local .ashsync-base shadow copies. The remote
+    shell type is pinned to unix with GNU md5sum/sha1sum (the ash server is
+    a Linux box); on a server without those commands, change detection
+    falls back to size+mtime with a one-time warning.
 
     Credentials live in a JSON file OUTSIDE the sync tree (default
     ~/.vc_ash_sftp.json, override at ash-init time with --creds). Keep it
@@ -2518,6 +2521,19 @@ class SftpSyncManager(S3SyncManager):
         env['RCLONE_SFTP_USER'] = self._creds['user']
         env['RCLONE_SFTP_PORT'] = str(self._creds['port'])
         env['RCLONE_SFTP_PASS'] = self._sftp_pass_obscured
+        # Pin the server shell type and hash commands instead of letting
+        # rclone probe for them. The probe is lazy and per-connection, and
+        # an on-the-fly :sftp: backend has no config section to persist its
+        # result into (rclone's "Can't save config" notices) — so a batched
+        # `rclone md5sum` over N --checkers connections races the probe and
+        # most files come back "hash unsupported" (seen live: 1/70 hashed),
+        # degrading change detection to size+mtime. On a server without
+        # md5sum the pinned command fails cleanly per file and the
+        # server-side-hashing-unavailable fallback in _remote_md5sums
+        # still applies.
+        env['RCLONE_SFTP_SHELL_TYPE'] = 'unix'
+        env['RCLONE_SFTP_MD5SUM_COMMAND'] = 'md5sum'
+        env['RCLONE_SFTP_SHA1SUM_COMMAND'] = 'sha1sum'
         # Only set when a real path is configured (host-key pinning).
         # The "none" default must leave the variable UNSET: older rclone
         # treats any value as a literal path and fails to open "none";


### PR DESCRIPTION
## Problem

ash-sync's change detection runs one batched server-side `rclone md5sum` and stores the results as content MD5s. In practice almost none of them arrive: live runs against the ash server hashed **1/70** files (`⚠️ rclone md5sum reported errors; got hashes for 1/70 file(s)`), the rest erroring `hash unsupported: hash type not supported`, so change detection silently degraded to size+mtime — the weaker mode the md5 batching was added to avoid (an overwrite preserving size and mtime is invisible).

## Root cause

rclone's sftp backend discovers the server shell type and hash commands with a lazy, per-connection probe. The ash sync uses an on-the-fly `:sftp:` backend (credentials via env only), which has no config section to persist the probe result into — that's rclone's `Can't save config "shell_type"/"md5sum_command"/"sha1sum_command"` notice on every run. A batched md5sum over `--checkers 8` connections therefore races the probe: only connections that finish detection produce hashes. Single-file hashing works, which is why this looked like a server quirk rather than a client race.

## Change

Pin the detection results in `_rclone_env` so there is nothing to probe:

```python
env['RCLONE_SFTP_SHELL_TYPE'] = 'unix'
env['RCLONE_SFTP_MD5SUM_COMMAND'] = 'md5sum'
env['RCLONE_SFTP_SHA1SUM_COMMAND'] = 'sha1sum'
```

Verified live against dl.ash2txt.org: **76/76 hashed, exit 0**, and the three notices disappear. The ash CLI docstring documents the pin.

Non-Linux servers: `shell_type` only affects SSH-exec operations (hashing) — listings and transfers use the SFTP protocol itself — so on a server without GNU `md5sum` the batched run returns no hashes and the existing `_remote_hashing_works` latch falls back to size+mtime with its one-time warning, which is no worse than the racing status quo and deterministic. Deliberate overrides remain possible via `VC_SYNC_RCLONE_FLAGS` (rclone flags beat its env vars); a creds-file `shell_type` key is the obvious extension if ash-* ever targets a non-Linux server.

## Tests

- `test_shell_type_and_hash_commands_are_pinned` — each pin line is independently load-bearing (mutation-checked).
- `test_pins_override_a_polluted_caller_environment` — a stray `RCLONE_SFTP_*` in the caller's shell cannot reintroduce the race.
- `test_md5sums_unsupported_server_disables_hashing` extended: the hashing-unavailable warning prints exactly once.
- Full suite: 199 passed.

## Review

4x independent Codex review (diff-only, full-context, server-compatibility, test-mutation audit): approved; the docstring note, env-pollution test, and warning-print assertion came out of that round. The server-compat review confirmed no worse-than-status-quo case on BSD/macOS/Windows/exec-restricted servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)