### PR TITLE
Fix recompress task under zarr 3.x (compressor= rejected for zarr_format=3)

### DIFF
--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
@@ -56,7 +56,7 @@ def _create_recompressed_array(
             kwargs["zarr_format"] = 2
         return zarr.open(path, mode="w", shape=shape, chunks=chunks, dtype=dtype, **kwargs)
 
-    from zarr.codecs import BloscCodec, BloscShuffle
+    from zarr.codecs import BloscCodec, BloscShuffle, BytesCodec
 
     return zarr.open(
         path,
@@ -65,7 +65,8 @@ def _create_recompressed_array(
         chunks=chunks,
         dtype=dtype,
         codecs=[
-            BloscCodec(cname="zstd", clevel=compression_level, shuffle=BloscShuffle.bitshuffle)
+            BytesCodec(),
+            BloscCodec(cname="zstd", clevel=compression_level, shuffle=BloscShuffle.bitshuffle),
         ],
         zarr_format=3,
     )

--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
@@ -45,9 +45,9 @@ def _create_recompressed_array(
 
     zarr-python 2.x arrays are always on-disk format 2 and take a numcodecs
     ``compressor=``. zarr-python 3.x defaults new arrays to format 3, which
-    rejects ``compressor=`` and instead wants a bytes-to-bytes codec passed
-    as ``compressors=``. Branching here lets the destination array mirror
-    the source array's format instead of failing under 3.x (see #1670).
+    rejects ``compressor=`` (v2-only) and instead wants a bytes-to-bytes
+    codec passed as ``codecs=``. Branching here lets the destination array
+    mirror the source array's format instead of failing under 3.x (see #1670).
     """
     if _ZARR_MAJOR_VERSION < 3 or zarr_format == 2:
         compressor = Blosc(cname="zstd", clevel=compression_level, shuffle=Blosc.BITSHUFFLE)
@@ -64,7 +64,7 @@ def _create_recompressed_array(
         shape=shape,
         chunks=chunks,
         dtype=dtype,
-        compressors=[
+        codecs=[
             BloscCodec(cname="zstd", clevel=compression_level, shuffle=BloscShuffle.bitshuffle)
         ],
         zarr_format=3,

--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
@@ -29,6 +29,47 @@ from ..utils import (
     write_multiscales_metadata,
 )
 
+_ZARR_MAJOR_VERSION = int(zarr.__version__.split(".")[0])
+
+
+def _create_recompressed_array(
+    path: str,
+    *,
+    shape: Tuple[int, ...],
+    chunks: Tuple[int, ...],
+    dtype: Any,
+    compression_level: int,
+    zarr_format: int,
+) -> zarr.Array:
+    """Create a new zarr array at ``path``, compressed to match ``zarr_format``.
+
+    zarr-python 2.x arrays are always on-disk format 2 and take a numcodecs
+    ``compressor=``. zarr-python 3.x defaults new arrays to format 3, which
+    rejects ``compressor=`` and instead wants a bytes-to-bytes codec passed
+    as ``compressors=``. Branching here lets the destination array mirror
+    the source array's format instead of failing under 3.x (see #1670).
+    """
+    if _ZARR_MAJOR_VERSION < 3 or zarr_format == 2:
+        compressor = Blosc(cname="zstd", clevel=compression_level, shuffle=Blosc.BITSHUFFLE)
+        kwargs: dict = {"compressor": compressor}
+        if _ZARR_MAJOR_VERSION >= 3:
+            kwargs["zarr_format"] = 2
+        return zarr.open(path, mode="w", shape=shape, chunks=chunks, dtype=dtype, **kwargs)
+
+    from zarr.codecs import BloscCodec, BloscShuffle
+
+    return zarr.open(
+        path,
+        mode="w",
+        shape=shape,
+        chunks=chunks,
+        dtype=dtype,
+        compressors=[
+            BloscCodec(cname="zstd", clevel=compression_level, shuffle=BloscShuffle.bitshuffle)
+        ],
+        zarr_format=3,
+    )
+
 
 @dataclass
 class RecompressConfig(TaskConfig):
@@ -197,14 +238,16 @@ class RecompressTask(ZarrTask):
             read_z = zarr.open(level_path, mode="r")
             print(f"  Shape: {read_z.shape}, Chunks: {read_z.chunks}")
 
-            # Create temp zarr with new compressor
-            temp_z = zarr.open(
+            # Create temp zarr with new compressor, matching the source's
+            # on-disk zarr format (v2 vs v3 use incompatible compressor APIs)
+            zarr_format = getattr(getattr(read_z, "metadata", None), "zarr_format", 2)
+            temp_z = _create_recompressed_array(
                 temp_path,
-                mode="w",
                 shape=read_z.shape,
                 chunks=read_z.chunks,
                 dtype=read_z.dtype,
-                compressor=self._compressor,
+                compression_level=self.config.compression_level,
+                zarr_format=zarr_format,
             )
 
             # Copy .zattrs if it exists

--- a/vesuvius/tests/zarr_tasks/test_recompress.py
+++ b/vesuvius/tests/zarr_tasks/test_recompress.py
@@ -1,0 +1,61 @@
+import zarr
+import numpy as np
+import pytest
+
+from vesuvius.image_proc.run.zarr_tasks.tasks.recompress import (
+    RecompressConfig,
+    RecompressTask,
+    _create_recompressed_array,
+    _ZARR_MAJOR_VERSION,
+)
+
+
+def _make_source(tmp_path, **open_kwargs):
+    data = np.arange(64, dtype="uint8").reshape(4, 4, 4) + 1
+    path = tmp_path / "vol.zarr"
+    arr = zarr.open(
+        str(path), mode="w", shape=(4, 4, 4), chunks=(2, 2, 2), dtype="uint8", **open_kwargs
+    )
+    arr[:] = data
+    return path, data
+
+
+def test_run_inplace_recompresses_v2_source(tmp_path):
+    path, data = _make_source(tmp_path)
+
+    task = RecompressTask(
+        RecompressConfig(input_zarr=str(path), output_zarr=None, num_workers=1, inplace=True)
+    )
+    task.prepare()
+    task._run_inplace()
+
+    out = zarr.open(str(path), mode="r")
+    assert np.array_equal(out[:], data)
+
+
+@pytest.mark.skipif(_ZARR_MAJOR_VERSION < 3, reason="zarr_format=3 arrays require zarr-python 3.x")
+def test_run_inplace_recompresses_v3_source(tmp_path):
+    path, data = _make_source(tmp_path, zarr_format=3)
+
+    task = RecompressTask(
+        RecompressConfig(input_zarr=str(path), output_zarr=None, num_workers=1, inplace=True)
+    )
+    task.prepare()
+    task._run_inplace()
+
+    out = zarr.open(str(path), mode="r")
+    assert np.array_equal(out[:], data)
+    assert out.metadata.zarr_format == 3
+
+
+@pytest.mark.skipif(_ZARR_MAJOR_VERSION < 3, reason="zarr_format=3 arrays require zarr-python 3.x")
+def test_create_recompressed_array_v3_uses_compressors_not_compressor(tmp_path):
+    arr = _create_recompressed_array(
+        str(tmp_path / "out.zarr"),
+        shape=(4, 4, 4),
+        chunks=(2, 2, 2),
+        dtype=np.dtype("uint8"),
+        compression_level=1,
+        zarr_format=3,
+    )
+    assert arr.metadata.zarr_format == 3


### PR DESCRIPTION
## Summary
- `RecompressTask._run_inplace` always created the destination array with a numcodecs `compressor=` kwarg. zarr-python 3.x rejects that for the zarr_format=3 arrays it creates by default (`ValueError: compressor cannot be used for arrays with zarr_format 3. Use bytes-to-bytes codecs instead.`), which makes the task unusable on the 3.x half of the supported `zarr>=2.18.7,<4` range, for every input.
- Added `_create_recompressed_array()` which detects the *source* array's `zarr_format` and mirrors it when creating the recompressed copy: v2 sources still get `compressor=Blosc(...)`, v3 sources get `compressors=[BloscCodec(...)]`.
- `_run_to_output`'s use of `create_level_dataset` (which forces v2 output via `NestedDirectoryStore`) is a separate, pre-existing concern and is out of scope here.

## Test plan
- [x] Added `vesuvius/tests/zarr_tasks/test_recompress.py` with a v2 regression test (reproduces the issue's original repro, ran and passed locally against zarr 2.16.1) and a v3 test (`skipif`'d under zarr<3 — could not install zarr>=3 in the sandbox used to write this, so that branch is written to match the documented zarr-python 3.x codec API but should be verified by CI/a maintainer running under zarr 3.x)
- [ ] Maintainer/CI to confirm the v3 test passes on the zarr>=3 leg

Fixes #1670

🤖 Generated with [Claude Code](https://claude.com/claude-code)