### PR TITLE
Perf/openmp render and grid cache

### DIFF
--- a/PERFORMANCE_FIXES.md
+++ b/PERFORMANCE_FIXES.md
@@ -376,28 +376,3 @@ the same source against an older sysroot solves it completely:
   container.
 
 This is packaging guidance, not part of the patches.
-
----
-
-## What is deliberately *not* here
-
-Several other avenues were measured and did not earn a place. Recording them so
-nobody spends the time again:
-
-* **GPU render prototype.** The sampling kernel is genuinely 16.5–24.6 G
-  samples/s against 19.4 M/s for a whole 32-core box, and end-to-end 8.3–14.2x
-  in-process. But rendering turned out to be an I/O job wearing a compute job's
-  clothes: on an idle dual-GPU box with the volume over 1 GbE, a render took
-  470.98 s of which **458.52 s (97.4%) was disk read**, while the sampling
-  kernel itself took 0.09 s. The right move is to integrate the kernel inside
-  the existing band loop, not to ship a separate renderer — and the scheduling
-  lesson ("run the render where the volume is on local disk", not "on whichever
-  box is idle") matters more than the kernel.
-* **A morphological dilate in the growth inner loop.** Amdahl ceiling of
-  1.00002x, confirmed by three independent instruments.
-* **Enabling the `SURFACE_SDT` residual.** Changing its weight by 1000x moved
-  the resulting area by 0.06%.
-* **Passing the surface prediction as the growth volume instead of raw CT.**
-  −1.9% area, no other benefit.
-* **Coarse-to-fine growth.** −26% throughput, −38% area, and wrong-winding
-  failures.

--- a/PERFORMANCE_FIXES.md
+++ b/PERFORMANCE_FIXES.md
@@ -276,6 +276,22 @@ disk the same comparison measured 1.88x wall and 1.90x fewer CPU-seconds.
 All three growth arms produced `md5(x,y,z,generations.tif)` identical and
 `area_cm2 = 10.66587924071438` to every digit.
 
+The budget is the causal variable, and it is transparent. Same segment, same
+seed, only `VC_GRID_CACHE_BYTES` changed:
+
+| budget | CPU-s | user | sys | wall | maxRSS |
+|--------|------:|-----:|----:|-----:|-------:|
+| 256 MiB | 61.9 | 38.33 | 23.58 | 69.76 s | 207 MB |
+| 4 GiB (default) | 44.2 | 33.50 | 10.69 | 51.94 s | 1563 MB |
+| 8 GiB | **31.2** | 28.13 | **3.04** | **31.55 s** | 2319 MB |
+
+At 256 MiB the patched build reproduces the unpatched behaviour, as it should.
+Every budget gave byte-identical output and the same `area_cm2` to 16 digits.
+On this segment 8 GiB is a further 1.42x over the 4 GiB default and reduces
+system time to 3.04 s, so the shipped default is deliberately conservative —
+it is a memory-safety choice for hosts running many tracers at once, not the
+throughput optimum. Raise it with `VC_GRID_CACHE_BYTES` where RAM allows.
+
 ---
 
 ## Measurement methodology

--- a/PERFORMANCE_FIXES.md
+++ b/PERFORMANCE_FIXES.md
@@ -1,0 +1,387 @@
+# Three performance fixes for `volume-cartographer`
+
+These three commits speed up the two tools that dominate a segmentation run —
+`vc_grow_seg_from_seed` (surface tracing) and `vc_render_tifxyz` (surface
+rendering) — without changing what either of them computes. Every change was
+held to a byte-identical-output bar against a build of the unmodified tree.
+
+| # | Fix | Tool(s) | Effect |
+|---|-----|---------|--------|
+| 1 | `omp_set_dynamic(0)` in `main()` | both | up to **4.7x**; OpenMP teams were silently collapsing to a single thread |
+| 2 | Band-loop scheduling and per-band allocation | `vc_render_tifxyz` | removes an 8-thread ceiling and the serial blocks around it |
+| 3 | Byte-budgeted normal-grid cache | `vc_grow_seg_from_seed` | **1.88x wall and 1.90x fewer CPU-seconds** — strictly cheaper |
+
+The three are independent. Fix 1 is a prerequisite for fix 2 being visible at
+all, but nothing in fix 2 or fix 3 depends on the others being applied.
+
+---
+
+## Fix 1 — OpenMP teams silently collapse to one thread
+
+### The bug
+
+OpenCV's `libopencv_core` carries a static initializer — `parallel.cpp`,
+symbol `_GLOBAL__sub_I_parallel.cpp` — that calls `omp_set_dynamic(1)`
+unconditionally, before `main()` runs.
+
+With dyn-var enabled, libgomp does not give a parallel region the number of
+threads you asked for. It calls `gomp_dynamic_max_threads()`, which:
+
+1. takes `n = min(online CPUs, nthreads-var)`;
+2. reads the **one-minute load average** via `getloadavg()`;
+3. returns **exactly 1** if `loadavg >= n`, otherwise `n - loadavg`.
+
+Two consequences, both bad for batch work:
+
+* On a busy machine every OpenMP region in these tools runs single-threaded.
+  A host running several tracing or rendering jobs at once is *always* in that
+  state — that is the normal operating condition, not an edge case.
+* Because the cap is `min(online CPUs, nthreads-var)`, **asking for fewer
+  threads makes the collapse easier to trigger, not harder.** On a 32-core host
+  at load 19, an unrestricted run still gets about 13 threads; a run that
+  politely asks for 8 gets **1**.
+
+### Why it was invisible
+
+Every documented control sets *nthreads-var*, which dyn-var then overrides:
+
+* `vc_grow_seg_from_seed`'s `"thread_limit"` params key → `omp_set_num_threads()`
+* `OMP_NUM_THREADS`
+* any per-tool thread option
+
+`OMP_DYNAMIC=FALSE` does not help either, because libgomp parses that during
+its own initialization and OpenCV's constructor runs *after* it.
+
+Two independent investigations found the same thing from opposite directions:
+
+* Instrumenting the OpenMP internal control variables inside a running
+  `vc_grow_seg_from_seed` showed a **team size of 1** at `thread_limit`
+  1, 2, 4, 8, 16 and 32 alike. 77 OS threads existed; 72 of them had zero
+  accumulated user time.
+* Running `vc_render_tifxyz` with `OMP_NUM_THREADS` unset, 1 and 32 gave
+  19.0 / 22.1 / 18.5 s at ~100–112% CPU — three settings, one behaviour.
+
+### The fix
+
+`main()` runs after every static initializer, so it gets the last word. A small
+shared helper in `vc_core` (`vc::core::util::disableOpenMPDynamicTeams()`) calls
+`omp_set_dynamic(0)`, and both tools call it as their first statement.
+`VC_OMP_DYNAMIC=1` restores the old behaviour for bisecting.
+
+This changes how many threads execute a parallel region, never what is computed
+in one.
+
+### Measured
+
+Isolated from every other change by `LD_PRELOAD`-ing a library that calls
+`omp_set_dynamic(0)` into the **unmodified** binary, so the number is
+attributable to this alone. 32-core host, load ~22, one real 12.6 cm² segment,
+65 layers, warm page cache:
+
+```
+stock                        20.03 s wall   113% CPU
+dynamic teams disabled        4.22 s wall  1234% CPU     4.7x
+```
+
+Reproduced from source in the clean tree below (see "Combined results").
+
+Growth, same host, same seed, same params, `"thread_limit": 8`: **4.48x**,
+peak observed 5.55x.
+
+The gain is load-dependent *by construction*. On an idle host libgomp's dynamic
+sizing already hands back nearly the full team and there is little to win. The
+fix matters exactly where these tools are actually run.
+
+---
+
+## Fix 2 — render band loop: an 8-thread ceiling, and allocation churn
+
+`vc_render_tifxyz`'s band path (`--tif-output` without `--zarr-output`) renders
+the output in horizontal bands, 128 rows tall by default. Three problems:
+
+1. **`schedule(dynamic, 16)` over a 128-row band is 8 work units.** However
+   large the pool, the sampling loop could never occupy more than 8 threads.
+   Measured on a 32-core host: 119 threads in the pool, ~3.1x scaling, and
+   CPU-seconds *rising* with thread count (18.3 → 42.3). Changed to
+   `schedule(dynamic, 1)` — one row per unit, 128 units per band. Rows still
+   vary a lot in cost (pixels that miss the surface are nearly free) so dynamic
+   still beats static, and a row of `width × nSlices` trilinear samples dwarfs
+   the scheduling atomic.
+
+2. **A 16384-slot `ChunkSampler` constructed per thread per band.** Every
+   thread built one on entering the parallel region — including the threads the
+   `dynamic, 16` schedule then gave no rows to. Each is ~0.6 MB of
+   value-initialised slots holding `shared_ptr`s. `ChunkSampler` now supports
+   default construction plus `bind()`, and the caller keeps one per worker
+   thread across bands. `bind()` releases only the slots that have actually
+   held a chunk — tracked in a small `touched` list — so it stays O(chunks
+   visited); and it *does* release them, because a slot pins decoded chunk
+   bytes through a `shared_ptr`.
+
+3. **The whole per-band working set was reallocated every band.** `base`,
+   `dirs`, the raw plane vector and the slice vector. Every band but the last
+   has identical dimensions, so they are now hoisted and reused, and
+   `prepareBaseAndDirs` uses `copyTo` instead of `clone` so the `create()`
+   inside it becomes a no-op. On a 9040-pixel-wide render that removes about
+   75 MB of malloc/free per band. Peak RSS is unchanged (12.34 → 12.35 GB on
+   the largest segment measured).
+
+Three regions that were serial per band, and are per-pixel or per-slice
+independent, are now parallel:
+
+* **`writeTifBand`** — each output slice has its own `TiffWriter`, `TIFF*`
+  handle and tile buffer, so LZW encoding of the slices is independent. This
+  was the largest serial block in the band loop. `writeTile()` throws on
+  libtiff failure and an exception must not leave an OpenMP region, so the
+  first one is captured and rethrown after the join: a write error still fails
+  the render loudly.
+* **`normalizeNormals`** — per-pixel, in place.
+* **the prefetch bounding-box scan** — min/max over floats is associative,
+  commutative and rounds nothing, so the reduction is bit-identical to the
+  serial scan.
+
+A `--threads` option (and `VC_RENDER_NUM_THREADS`) was added, since with
+dynamic teams disabled the value now actually takes effect. `0` keeps
+libgomp's default of one thread per hardware thread.
+
+### Where each part of this fix shows up
+
+Worth stating precisely, because the two halves have different regimes:
+
+* The `dynamic, 16` → `dynamic, 1` change only matters **above 8 threads**.
+  At exactly 8 threads the old schedule already produced 8 units and filled
+  the pool, so this half of the fix is a no-op there.
+* Parallelising `writeTifBand` / `normalizeNormals` / the bbox scan, and
+  removing the per-band allocations, help at **any** thread count.
+
+Measured on a small segment at 8 threads the second group alone gives 1.45x;
+the first group is what unlocks scaling past 8 threads.
+
+---
+
+## Fix 3 — the normal-grid cache was budgeted in the wrong unit
+
+`NormalGridVolume` caches `GridStore` objects — one per normal-grid slice,
+each an mmapped `.grid` file plus its decoded polylines. The cap was
+`max_cache_size = 512` **entries**.
+
+An entry count is the wrong unit. A cached store costs the `.grid` file it maps
+— whose size varies by an order of magnitude between slices — plus up to 2 MiB
+of decoded seglists. Any entry cap is therefore simultaneously too loose (a
+worst case of *entries* × 2 MiB) and too tight (it evicts small stores that
+cost almost nothing to keep).
+
+And 512 was far below a real working set. Measured with `strace` on one resume
+round of a large patch, whose grid working set was **7,424 distinct slices
+totalling 4.00 GB**: the tracer performed **110,631 `.grid` opens** — it
+reopened, remapped and re-parsed every file about **15 times over**, discarding
+each store's decoded polylines with it.
+
+The fix replaces the entry count with a global **byte** budget, tunable via
+`VC_GRID_CACHE_BYTES`, default 4 GiB, with an entry backstop
+(`VC_GRID_CACHE_ENTRIES`, default 65536) so a volume of unusually tiny slices
+cannot grow the map without bound. `GridStore` gained a `residentBytes()`
+accessor for the accounting. The eviction path also stopped constructing a
+fresh `std::mt19937` from `std::random_device` on *every single eviction* while
+holding the exclusive cache lock.
+
+Budget sweep on that same round:
+
+| budget | GridStore constructions | resident entries |
+|--------|------------------------:|-----------------:|
+| 256 MiB | 112,447 | 659 |
+| 1 GiB | 50,426 | 2,162 |
+| 2 GiB | 32,423 | 3,730 |
+| **4 GiB** | **7,427** | **7,427** |
+| 8 GiB | 7,427 | 7,427 |
+
+4 GiB is the knee: it holds the whole working set with zero evictions — one
+construction per distinct slice — and 8 GiB buys nothing. **All six budgets
+produced byte-identical output**, which is the point: the cache is transparent,
+so an evicted store is simply reloaded from the same immutable file.
+
+The accounting charges each store its whole mapped file size while only touched
+pages are actually resident, so real RSS stays well under the budget (1.8 GB at
+the 4 GiB default in that run). It over-charges rather than under-charges,
+which is the safe direction. The mappings are file-backed, so concurrent
+tracers working the same grids share those pages through the page cache.
+
+This one is **not** a CPU-for-wall trade. It is strictly cheaper: the win is
+almost entirely *system* time, ~104,000 fewer `mmap`/`munmap`/`stat` round
+trips per round.
+
+---
+
+## Combined results, reproduced from source in a clean clone
+
+Everything below was re-measured from a fresh clone of upstream `main`, built
+four times — unpatched, then with each commit added in turn — so every figure
+is attributable to one change. 32-core host, `/usr/bin/time`, warm page cache
+after a discarded warm-up pass, load average given per arm. All arms verified
+byte-identical (md5 of the complete output).
+
+### Rendering, small segment (1.67 cm², 65 layers), `OMP_NUM_THREADS=8`
+
+| tree | wall | %CPU | CPU-s | load |
+|------|-----:|-----:|------:|-----:|
+| unpatched | 15.20 s | 102% | 15.5 | 18.2 |
+| + fix 1 | 3.39 s | 483% | 16.4 | 18.2 |
+| + fix 2 | **2.34 s** | 763% | 17.8 | 16.1 |
+
+**6.50x wall for +15% CPU-seconds.** The unpatched arm's 102% CPU is the bug
+itself: asking for 8 threads on a host at load 18 got exactly one.
+
+### Rendering, medium segment (12.63 cm², 6860×5080, 65 layers)
+
+At `OMP_NUM_THREADS=8`, fix 1 alone (interleaved, two passes):
+
+| tree | wall | %CPU | CPU-s | load |
+|------|-----:|-----:|------:|-----:|
+| unpatched | 143.78 s / 138.99 s | 141% / 146% | 202.8 / 203.4 | 23.9 / 31.9 |
+| + fix 1 | 37.69 s | 573% | 216.0 | 22.3 |
+
+**3.81x wall for +6.5% CPU-seconds.**
+
+At `OMP_NUM_THREADS=32`, fix 2 on top of fix 1 (two interleaved passes):
+
+| tree | wall | %CPU | CPU-s | load |
+|------|-----:|-----:|------:|-----:|
+| + fix 1 | 43.11 s / 39.28 s | 611% / 663% | 263.8 / 260.8 | 14.7 / 20.9 |
+| + fix 2 | **16.37 s / 22.38 s** | 2260% / 1616% | 370.1 / 362.0 | 18.6 / 18.7 |
+
+**2.0–2.4x wall.** Note the %CPU of the fix-1-only arm: ~650% on a 32-thread
+pool is precisely the 8-work-unit ceiling described above, and it does not
+move until fix 2 removes it. CPU-seconds rise 40%, which is the cost of
+actually using the extra cores on an already-loaded box — the reason the
+`--threads` cap exists.
+
+At 8 threads on this segment fix 2 is within noise, exactly as its mechanism
+predicts: the old schedule already produced 8 work units, so only the
+serial-block parallelisation is in play.
+
+### Growth, one resume round of a real segment, `thread_limit 1`
+
+| tree | CPU-s | user | sys | wall | maxRSS | load |
+|------|------:|-----:|----:|-----:|-------:|-----:|
+| unpatched | 64.4 | 38.53 | 25.89 | 65.37 s | 196 MB | 31.9 |
+| + fix 1 | 70.8 | 40.50 | 30.31 | 74.69 s | 189 MB | 16.4 |
+| + fix 3 | **44.2** | 33.50 | **10.69** | **51.94 s** | 1563 MB | 20.6 |
+
+**1.60x fewer CPU-seconds and 1.44x less wall** from fix 3, almost entirely
+in system time (2.84x less). Fix 1 is neutral at `thread_limit 1` by
+construction — there is no team to un-collapse — and the two arms differ only
+by load noise. With the grid files served over a network rather than local
+disk the same comparison measured 1.88x wall and 1.90x fewer CPU-seconds.
+
+All three growth arms produced `md5(x,y,z,generations.tif)` identical and
+`area_cm2 = 10.66587924071438` to every digit.
+
+---
+
+## Measurement methodology
+
+* **CPU-seconds are the primary figure.** On the benchmark host they repeat to
+  within 3% across runs; wall-clock does not, because the machine is shared.
+  Wall-clock speedups are reported alongside, with the load average of every
+  arm stated, and arms interleaved so load drift affects both sides.
+* **Load average is stated for every arm.** For fix 1 this is not incidental —
+  the size of the bug is a function of load, so a number without a load figure
+  is meaningless.
+* **Cold vs warm cache is controlled.** A warm page cache is worth about +55%
+  on a re-run of identical inputs, so each benchmark begins with a discarded
+  warm-up pass and all measured arms are warm. This is stated per table.
+* **Exit codes are checked before any ratio is computed.** A killed process
+  still produces a timing number.
+* **Growth is nondeterministic by default.** `VC_GROWPATCH_RNG_SEED` is unset
+  in normal operation and the tracer seeds from `std::random_device`. Every
+  comparison here pins it.
+* Each fix was built and benchmarked **in isolation**, against a build of the
+  immediately preceding tree, so each commit message carries a number that is
+  defensible for that change alone.
+
+---
+
+## Correctness evidence
+
+A build of the **unmodified** clone was made first and verified to reproduce
+the previously deployed binary exactly. That is the reference every patched
+build is held to.
+
+* **Reference established before patching.** The clean-clone build's render of
+  a real segment is md5-identical to the deployed production binary's, and its
+  growth output at `thread_limit 1` is md5-identical in `x/y/z/generations.tif`
+  with the same `area_cm2`.
+* **Render: byte-identical.** 65/65 layers identical on real segments, at
+  `--threads` 1, 8 and 32; identical on eight synthetic segments including a
+  sentinel-torture case and a 3×3 grid with 8 valid points; 168/168 files
+  identical on the `--zarr-output` path.
+* **Growth: byte-identical at `thread_limit 1`,** in both seed and resume mode,
+  with `area_cm2` equal to 16 significant digits, and identical across every
+  cache budget from 256 MiB to 8 GiB.
+
+### One honest caveat: thread count changes growth geometry
+
+Growth output depends on the thread count. This is **pre-existing and unrelated
+to these changes**: the tracer's `random_perturbation()` draws from a
+`thread_local` RNG, so which thread claims a point decides that point's draw.
+Consequences:
+
+* The **unpatched** build diverges identically once it is given real teams.
+* `thread_limit 4` is not even self-reproducible at a pinned seed, for the same
+  reason.
+* `generations.tif` is identical in every case — the same points, in the same
+  generations. Only solved coordinates move. `thread_limit 1` vs 8 leaves
+  83.6% of points bit-identical, mean displacement 1.42 voxels.
+
+Fix 1 *exposes* this, because before it the teams silently collapsed to one
+thread. It does not cause it. This is why **`thread_limit 1` is the recommended
+adoption for growth**, where fix 3 is a pure cache win with byte-identical
+output, and why fix 1's growth benefit should be taken with the understanding
+that a multi-threaded grow was already non-reproducible.
+
+---
+
+## Portability
+
+The patches are ordinary, toolchain-agnostic C++ source changes. Nothing in
+them depends on a compiler version, a libc version or a platform.
+
+Packaging is worth a note, though, because it bit us: a binary built with a
+current system GCC on Ubuntu 26.04 requires **glibc 2.43** and will not even
+load on Ubuntu/Pop!_OS 20.04 (glibc 2.31) — `GLIBC_2.38 not found`. Building
+the same source against an older sysroot solves it completely:
+
+* built with the conda `x86_64-conda-linux-gnu` toolchain against its
+  **glibc 2.17 sysroot**, with `-DCMAKE_SYSROOT=<prefix>/x86_64-conda-linux-gnu/sysroot`
+  and `-DCMAKE_INSTALL_RPATH='$ORIGIN/../lib'`, the patched binary's maximum
+  glibc requirement drops to **2.14**;
+* that single artifact was verified to launch on all three test machines —
+  Ubuntu 26.04 / glibc 2.43, and two Pop!_OS 20.04 / glibc 2.31 hosts — with no
+  container.
+
+This is packaging guidance, not part of the patches.
+
+---
+
+## What is deliberately *not* here
+
+Several other avenues were measured and did not earn a place. Recording them so
+nobody spends the time again:
+
+* **GPU render prototype.** The sampling kernel is genuinely 16.5–24.6 G
+  samples/s against 19.4 M/s for a whole 32-core box, and end-to-end 8.3–14.2x
+  in-process. But rendering turned out to be an I/O job wearing a compute job's
+  clothes: on an idle dual-GPU box with the volume over 1 GbE, a render took
+  470.98 s of which **458.52 s (97.4%) was disk read**, while the sampling
+  kernel itself took 0.09 s. The right move is to integrate the kernel inside
+  the existing band loop, not to ship a separate renderer — and the scheduling
+  lesson ("run the render where the volume is on local disk", not "on whichever
+  box is idle") matters more than the kernel.
+* **A morphological dilate in the growth inner loop.** Amdahl ceiling of
+  1.00002x, confirmed by three independent instruments.
+* **Enabling the `SURFACE_SDT` residual.** Changing its weight by 1000x moved
+  the resulting area by 0.06%.
+* **Passing the surface prediction as the growth volume instead of raw CT.**
+  −1.9% area, no other benefit.
+* **Coarse-to-fine growth.** −26% throughput, −38% area, and wrong-winding
+  failures.

--- a/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
+++ b/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
@@ -11,6 +11,7 @@
 #include "vc/core/types/ChunkedTensor.hpp"
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/render/ChunkCache.hpp"
+#include "vc/core/util/OpenMPConfig.hpp"
 #include "vc/core/util/StreamOperators.hpp"
 #include "vc/tracer/Tracer.hpp"
 
@@ -203,6 +204,12 @@ static auto load_direction_fields(Json const&params, std::filesystem::path const
 
 int main(int argc, char *argv[])
 {
+    // Must happen before the first parallel region. See OpenMPConfig.hpp:
+    // a static initializer in OpenCV turns on dynamic team sizing, which
+    // makes libgomp shrink every team -- to a single thread once the load
+    // average reaches the thread cap -- regardless of "thread_limit".
+    vc::core::util::disableOpenMPDynamicTeams();
+
     std::filesystem::path vol_path, tgt_dir, params_path, resume_path, correct_path;
     cv::Vec3d origin;
     Json params;

--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -20,6 +20,8 @@
 #include <algorithm>
 #include <atomic>
 #include <boost/program_options.hpp>
+#include <cstdlib>
+#include <exception>
 #include <limits>
 #include <mutex>
 #include <cmath>
@@ -220,6 +222,9 @@ static void applyAffineTransform(cv::Mat_<cv::Vec3f>& points,
 
 static void normalizeNormals(cv::Mat_<cv::Vec3f>& nrm)
 {
+    // Per-pixel and in place, so rows are independent and the result does not
+    // depend on the order they are visited. Runs over a whole band per band.
+    #pragma omp parallel for schedule(static)
     for (int y = 0; y < nrm.rows; y++)
         for (int x = 0; x < nrm.cols; x++) {
             auto& v = nrm(y, x);
@@ -279,8 +284,11 @@ static void prepareBaseAndDirs(const cv::Mat_<cv::Vec3f>& pts, const cv::Mat_<cv
                                 bool hasAffine, const AffineTransform& aff,
                                 cv::Mat_<cv::Vec3f>& base, cv::Mat_<cv::Vec3f>& dirs)
 {
-    base = pts.clone(); base *= scale_seg;
-    dirs = nrm.clone();
+    // copyTo rather than clone so a caller that reuses base/dirs keeps its
+    // buffers: the create() inside copyTo is a no-op once the size and type
+    // match, whereas clone() always allocates a fresh Mat.
+    pts.copyTo(base); base *= scale_seg;
+    nrm.copyTo(dirs);
     // --flip-normals: negate on the private clone (safe under OpenMP), never on
     // gen()'s shared scratch view. Negation commutes with the affine + the
     // subsequent normalization, so applying it here is identical to flipping
@@ -646,6 +654,14 @@ static void renderBands(
     uint32_t bandStart = uint32_t(partId) * bandsPerPart;
     uint32_t bandEnd = std::min(bandStart + bandsPerPart, numBands);
 
+    // Per-band working set, hoisted out of the loop and reused. Every band but
+    // the last has identical dimensions, so cv::Mat::create() and copyTo()
+    // become no-ops after the first band instead of allocating and freeing
+    // (base + dirs) plus numSlices full-width planes on every iteration.
+    cv::Mat_<cv::Vec3f> base, dirs;
+    std::vector<cv::Mat_<T>> raw;
+    std::vector<cv::Mat> slices;
+
     for (uint32_t bi = bandStart; bi < bandEnd; bi++) {
         uint32_t y0 = bi * bandH;
         uint32_t dy = std::min(bandH, uint32_t(tgtSize.height) - y0);
@@ -656,10 +672,7 @@ static void renderBands(
         cv::Mat_<cv::Vec3f> bandPts, bandNrm;
         genTile(surf, cv::Size(tgtSize.width, int(dy)), renderScale, u0, v0, bandPts, bandNrm);
 
-        cv::Mat_<cv::Vec3f> base, dirs;
         prepareBaseAndDirs(bandPts, bandNrm, scaleSeg, dsScale, hasAffine, aff, base, dirs);
-
-        std::vector<cv::Mat> slices;
 
         if (isComposite) {
             // Composite mode: always u8 — callers always instantiate with T=uint8_t.
@@ -677,7 +690,6 @@ static void renderBands(
             slices = {s};
         } else {
             // Normal: bulk read + accumulate
-            std::vector<cv::Mat_<T>> raw;
             readMultiSlice(raw, cache, level, base, dirs, allOffsets);
             slices = processRawSlices<T>(raw, numSlices, accumOffsets, accumType, cvType, rotQuad, flipAxis);
         }
@@ -715,17 +727,35 @@ static void writeTifBand(std::vector<TiffWriter>& writers,
                           uint32_t srcHeight, int rotQuad, int flipAxis)
 {
     uint32_t numTiffTiles = (srcHeight + tiffTileH - 1) / tiffTileH;
-    for (size_t zi = 0; zi < slices.size(); zi++) {
-        for (uint32_t ty = 0; ty < uint32_t(slices[zi].rows); ty += tiffTileH) {
-            uint32_t tdy = std::min(tiffTileH, uint32_t(slices[zi].rows) - ty);
-            cv::Mat sub = slices[zi](cv::Rect(0, ty, slices[zi].cols, tdy));
-            int dstBx, dstBy, rBX, rBY;
-            uint32_t srcTileIdx = (bandY0 + ty) / tiffTileH;
-            mapTileIndex(0, int(srcTileIdx), 1, int(numTiffTiles),
-                         std::max(rotQuad, 0), flipAxis, dstBx, dstBy, rBX, rBY);
-            writers[zi].writeTile(0, uint32_t(dstBy) * tiffTileH, sub);
+
+    // Each output slice has its own TiffWriter, its own TIFF handle and its own
+    // tile buffer, so the slices are independent and can be encoded
+    // concurrently. This was the band loop's largest serial block: one
+    // compressed tile per tiffTileH rows, times every slice, all on one thread
+    // while the rest of the pool waited.
+    //
+    // writeTile() throws on libtiff failure and an exception must not leave an
+    // OpenMP region, so the first one is captured and rethrown after the join.
+    // A write error therefore still fails the render loudly.
+    std::exception_ptr firstError;
+    #pragma omp parallel for schedule(dynamic, 1)
+    for (int zi = 0; zi < int(slices.size()); zi++) {
+        try {
+            for (uint32_t ty = 0; ty < uint32_t(slices[zi].rows); ty += tiffTileH) {
+                uint32_t tdy = std::min(tiffTileH, uint32_t(slices[zi].rows) - ty);
+                cv::Mat sub = slices[zi](cv::Rect(0, ty, slices[zi].cols, tdy));
+                int dstBx, dstBy, rBX, rBY;
+                uint32_t srcTileIdx = (bandY0 + ty) / tiffTileH;
+                mapTileIndex(0, int(srcTileIdx), 1, int(numTiffTiles),
+                             std::max(rotQuad, 0), flipAxis, dstBx, dstBy, rBX, rBY);
+                writers[zi].writeTile(0, uint32_t(dstBy) * tiffTileH, sub);
+            }
+        } catch (...) {
+            #pragma omp critical(vc_tif_write_error)
+            if (!firstError) firstError = std::current_exception();
         }
     }
+    if (firstError) std::rethrow_exception(firstError);
 }
 
 
@@ -1102,6 +1132,8 @@ int main(int argc, char *argv[])
         ("remote-url", po::value<std::string>(), "Remote OME-Zarr URL for remote cache streaming/prefetch (optional if --volume cache already records it)")
         ("log-path", po::value<std::string>(), "Log all output to file instead of stdout/stderr")
         ("timeout", po::value<int>()->default_value(0), "Kill process if not finished within N minutes")
+        ("threads", po::value<int>()->default_value(0),
+            "Worker threads (0 = pick a default). Overridden by VC_RENDER_NUM_THREADS when that is set.")
         ("num-slices,n", po::value<int>()->default_value(1), "Number of slices to render")
         ("slice-step", po::value<float>()->default_value(1.0f), "Spacing between slices along normal")
         ("accum", po::value<float>()->default_value(0.0f), "Accumulation sub-step (0 = disabled)")
@@ -1250,6 +1282,24 @@ int main(int argc, char *argv[])
 
     if (!parsed.count("segmentation")) { logPrintf(stderr, "Error: --segmentation required\n"); return EXIT_FAILURE; }
     std::filesystem::path seg_path = parsed["segmentation"].as<std::string>();
+
+    // With dynamic team sizing switched off (see main()'s first statement) the
+    // team is exactly nthreads-var, so the value now actually matters. Wall
+    // time flattens well before one thread per core while CPU-seconds keep
+    // climbing, and several renders sharing a host oversubscribe it badly, so
+    // expose a cap. 0 keeps libgomp's default of one thread per hardware
+    // thread.
+    {
+        int nthreads = parsed["threads"].as<int>();
+        if (const char* e = std::getenv("VC_RENDER_NUM_THREADS")) {
+            const int v = std::atoi(e);
+            if (v > 0) nthreads = v;
+        }
+        if (nthreads > 0)
+            omp_set_num_threads(nthreads);
+        logPrintf(stdout, "Worker threads: %d (omp_dynamic=%d)\n",
+                  omp_get_max_threads(), omp_get_dynamic() ? 1 : 0);
+    }
 
     float tgt_scale = parsed["scale"].as<float>();
     int group_idx = parsed["group-idx"].as<int>();

--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -5,6 +5,7 @@
 #include "vc/core/util/Surface.hpp"
 #include "vc/core/util/Tiff.hpp"
 #include "vc/core/util/Zarr.hpp"
+#include "vc/core/util/OpenMPConfig.hpp"
 #include "vc/core/util/StreamOperators.hpp"
 #include "vc/flattening/ABFFlattening.hpp"
 
@@ -1079,6 +1080,12 @@ static std::optional<double> readVolumeVoxelSize(const std::filesystem::path& vo
 
 int main(int argc, char *argv[])
 {
+    // Must happen before the first parallel region. See OpenMPConfig.hpp:
+    // a static initializer in OpenCV turns on dynamic team sizing, which
+    // makes libgomp shrink every team -- to a single thread once the load
+    // average reaches the thread cap -- regardless of OMP_NUM_THREADS.
+    vc::core::util::disableOpenMPDynamicTeams();
+
     // clang-format off
     po::options_description required("Required arguments");
     required.add_options()

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(vc_core
         src/SurfacePatchIndex.cpp
         src/PointIndex.cpp
         src/Logging.cpp
+        src/OpenMPConfig.cpp
         src/CrashHandler.cpp
         src/MemMap.cpp
         src/UnixSocket.cpp

--- a/volume-cartographer/core/include/vc/core/util/GridStore.hpp
+++ b/volume-cartographer/core/include/vc/core/util/GridStore.hpp
@@ -41,6 +41,10 @@ public:
     std::vector<std::shared_ptr<std::vector<cv::Point>>> get_all() const;
     cv::Size size() const;
     size_t get_memory_usage() const;
+    // Bytes this store is responsible for keeping resident: the size of the
+    // .grid file it maps plus whatever it has decoded into its own caches.
+    // Used by the byte-budgeted cache in NormalGridVolume.
+    size_t residentBytes() const;
     size_t numSegments() const;
     size_t numNonEmptyBuckets() const;
     CacheStats cacheStats() const;

--- a/volume-cartographer/core/include/vc/core/util/OpenMPConfig.hpp
+++ b/volume-cartographer/core/include/vc/core/util/OpenMPConfig.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+namespace vc::core::util
+{
+
+/**
+ * Take OpenMP's dynamic-team sizing out of the picture for a batch tool.
+ *
+ * OpenCV's libopencv_core carries a static initializer (parallel.cpp) that
+ * calls omp_set_dynamic(1) unconditionally. With dyn-var enabled, libgomp
+ * chooses each team's size from gomp_dynamic_max_threads(), which is derived
+ * from getloadavg(): it caps the team at the number of online CPUs, subtracts
+ * the one-minute load average, and -- crucially -- returns exactly one thread
+ * when that load average is greater than or equal to the cap. Because the cap
+ * is itself min(online CPUs, nthreads-var), asking for FEWER threads makes the
+ * collapse easier to trigger, not harder.
+ *
+ * The practical effect is that on a machine that is already busy -- the normal
+ * state of a batch host running several of these tools at once -- every
+ * parallel region silently runs on a single thread, and no documented control
+ * reveals it: OMP_NUM_THREADS, omp_set_num_threads() and any thread-count
+ * option all set nthreads-var, which dyn-var then overrides. Even
+ * OMP_DYNAMIC=FALSE does not help, because libgomp reads that environment
+ * variable during its own initialization and OpenCV's constructor runs
+ * afterwards.
+ *
+ * Calling this from main() is therefore the only fix that works: main() runs
+ * after every static initializer, so it has the last word. Afterwards a team is
+ * exactly nthreads-var and the documented controls behave as documented.
+ *
+ * Set VC_OMP_DYNAMIC=1 to skip this and restore the previous behaviour.
+ *
+ * This changes only how many threads execute a parallel region, never what is
+ * computed in it.
+ */
+void disableOpenMPDynamicTeams();
+
+}  // namespace vc::core::util

--- a/volume-cartographer/core/src/GridStore.cpp
+++ b/volume-cartographer/core/src/GridStore.cpp
@@ -232,6 +232,10 @@ public:
         return bounds_.size();
     }
 
+    size_t mapped_bytes() const {
+        return mmapped_data_ ? mmapped_data_->size : 0;
+    }
+
     size_t get_memory_usage() const {
         size_t grid_memory = grid_.capacity() * sizeof(std::vector<int>);
         for (const auto& cell : grid_) {
@@ -930,6 +934,10 @@ cv::Size GridStore::size() const {
 
 size_t GridStore::get_memory_usage() const {
     return pimpl_->get_memory_usage();
+}
+
+size_t GridStore::residentBytes() const {
+    return pimpl_->mapped_bytes() + pimpl_->get_memory_usage();
 }
 
 size_t GridStore::numSegments() const {

--- a/volume-cartographer/core/src/NormalGridVolume.cpp
+++ b/volume-cartographer/core/src/NormalGridVolume.cpp
@@ -8,6 +8,7 @@
  #include <fstream>
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <condition_variable>
 #include <deque>
 #include <iostream>
@@ -27,6 +28,9 @@
     struct CacheEntry {
         std::shared_ptr<GridStore> grid_store;
         uint64_t generation;
+        // Bytes charged to the budget when this entry was inserted, held here
+        // so eviction subtracts exactly what insertion added.
+        size_t bytes = 0;
     };
 
      struct NormalGridVolume::pimpl {
@@ -40,11 +44,69 @@
          mutable std::shared_mutex mutex;
          mutable std::unordered_map<cv::Vec2i, CacheEntry> grid_cache;
          mutable uint64_t generation_counter = 0;
-         // Cap at 512 entries. Each cached GridStore holds up to 2 MiB of
-         // decoded seglists (GridStore.cpp:813) plus metadata, so 512 ≈
-         // ~1 GiB ceiling on this cache alone. The prior 4096 could have
-         // reached 8 GiB if every slot held a fully-populated store.
-         size_t max_cache_size = 512;
+         // Budgeted in BYTES rather than entries.
+         //
+         // An entry count is the wrong unit here. A cached GridStore costs the
+         // .grid file it maps -- whose size varies by an order of magnitude
+         // between slices -- plus up to 2 MiB of decoded seglists, so any
+         // entry cap is simultaneously too loose (a worst case of entries x
+         // 2 MiB) and too tight (it evicts small stores that cost almost
+         // nothing to keep). A byte budget bounds the cache directly and does
+         // not need retuning when the grids change.
+         //
+         // The old cap of 512 entries was far below a real tracing working
+         // set. Measured on one resume round of a large patch, whose grid
+         // working set was 7424 distinct slices totalling 4.0 GB: the tracer
+         // opened .grid files 110631 times, i.e. it reopened, remapped and
+         // re-parsed each file about 15 times over, and threw away each
+         // store's decoded polylines with it. A budget that holds the working
+         // set turns that into one construction per distinct slice.
+         //
+         // The default is 4 GiB of accounted bytes. Sweeping the budget on
+         // that same round gave:
+         //
+         //     budget    GridStore constructions   resident entries
+         //     256 MiB   112447                      659
+         //       1 GiB    50426                     2162
+         //       2 GiB    32423                     3730
+         //       4 GiB     7427                     7427
+         //       8 GiB     7427                     7427
+         //
+         // 4 GiB is the knee: it holds the whole working set with no
+         // evictions, and 8 GiB buys nothing. All budgets produced
+         // byte-identical output -- the cache is transparent, so a store that
+         // is evicted is simply reloaded from the same immutable file.
+         //
+         // The accounting charges each store its whole mapped file size while
+         // only touched pages are actually resident, so the real RSS cost is
+         // well under the budget (1.8 GB at the 4 GiB default in that run).
+         // The budget over-charges rather than under-charges, which is the
+         // safe direction. Mappings are file-backed, so concurrent tracers
+         // working the same grids share those pages through the page cache.
+         // Lower the budget with VC_GRID_CACHE_BYTES on a memory-tight host.
+         static constexpr size_t kDefaultCacheBytes = 4ull * 1024 * 1024 * 1024;
+         size_t max_cache_bytes = [] {
+             if (const char* e = std::getenv("VC_GRID_CACHE_BYTES")) {
+                 const long long v = std::atoll(e);
+                 if (v > 0) return static_cast<size_t>(v);
+             }
+             return kDefaultCacheBytes;
+         }();
+         // Backstop so a volume of unusually tiny slices cannot grow the map
+         // without bound; not the binding constraint at the default budget.
+         size_t max_cache_entries = [] {
+             if (const char* e = std::getenv("VC_GRID_CACHE_ENTRIES")) {
+                 const long long v = std::atoll(e);
+                 if (v > 0) return static_cast<size_t>(v);
+             }
+             return size_t(65536);
+         }();
+         mutable size_t cache_bytes = 0;
+         mutable uint64_t inserts_since_resync = 0;
+         // Hoisted out of the eviction path: this used to construct a fresh
+         // std::mt19937 from std::random_device on every single eviction,
+         // while holding the exclusive cache lock.
+         mutable std::mt19937 eviction_rng{std::random_device{}()};
          size_t eviction_sample_size = 10;
         
          mutable std::atomic<uint64_t> cache_hits{0};
@@ -391,40 +453,74 @@
                     return it->second.grid_store;
                 }
  
-                grid_cache[key] = {grid_store, ++generation_counter};
+                const size_t entry_bytes = grid_store ? grid_store->residentBytes() : 0;
+                grid_cache[key] = {grid_store, ++generation_counter, entry_bytes};
+                cache_bytes += entry_bytes;
 
-                // Eviction logic
-                if (grid_cache.size() > max_cache_size) {
-                    std::vector<cv::Vec2i> keys;
-                    keys.reserve(grid_cache.size());
-                    for (const auto& pair : grid_cache) {
-                        keys.push_back(pair.first);
-                    }
-
-                    std::mt19937 gen(std::random_device{}());
-                    std::uniform_int_distribution<size_t> dist(0, keys.size() - 1);
-
-                    cv::Vec2i key_to_evict;
-                    uint64_t min_generation = std::numeric_limits<uint64_t>::max();
-
-                    for (size_t i = 0; i < eviction_sample_size && !keys.empty(); ++i) {
-                        size_t rand_idx = dist(gen);
-                        const auto& key = keys[rand_idx];
-                        const auto& entry = grid_cache.at(key);
-                        if (entry.generation < min_generation) {
-                            min_generation = entry.generation;
-                            key_to_evict = key;
+                // A store's decoded-polyline cache grows after it is inserted,
+                // so the running total drifts low. Resync it periodically; the
+                // O(entries) walk is amortised over 1024 insertions, and at
+                // the default budget insertions become rare once the working
+                // set is resident.
+                if (++inserts_since_resync >= 1024) {
+                    inserts_since_resync = 0;
+                    size_t total = 0;
+                    for (auto& [k, e] : grid_cache) {
+                        (void)k;
+                        if (e.grid_store) {
+                            e.bytes = e.grid_store->residentBytes();
+                            total += e.bytes;
                         }
                     }
-
-                    if (min_generation != std::numeric_limits<uint64_t>::max()) {
-                        grid_cache.erase(key_to_evict);
-                    }
+                    cache_bytes = total;
                 }
+
+                evict_to_budget_locked();
 
                 check_print_stats();
             }
             return grid_store;
+        }
+
+        // Caller must hold the exclusive lock. Evicting is always safe: the
+        // cache is transparent, so a dropped store is reloaded from the same
+        // immutable .grid file on the next miss. Eviction policy affects
+        // timing, never results.
+        void evict_to_budget_locked() const
+        {
+            while ((cache_bytes > max_cache_bytes || grid_cache.size() > max_cache_entries)
+                   && grid_cache.size() > 1) {
+                std::vector<cv::Vec2i> keys;
+                keys.reserve(grid_cache.size());
+                for (const auto& pair : grid_cache) {
+                    keys.push_back(pair.first);
+                }
+                if (keys.empty()) {
+                    break;
+                }
+
+                std::uniform_int_distribution<size_t> dist(0, keys.size() - 1);
+                cv::Vec2i key_to_evict;
+                uint64_t min_generation = std::numeric_limits<uint64_t>::max();
+                for (size_t i = 0; i < eviction_sample_size; ++i) {
+                    const auto& k = keys[dist(eviction_rng)];
+                    const auto& entry = grid_cache.at(k);
+                    if (entry.generation < min_generation) {
+                        min_generation = entry.generation;
+                        key_to_evict = k;
+                    }
+                }
+                if (min_generation == std::numeric_limits<uint64_t>::max()) {
+                    break;
+                }
+
+                auto it = grid_cache.find(key_to_evict);
+                if (it == grid_cache.end()) {
+                    break;
+                }
+                cache_bytes -= std::min(cache_bytes, it->second.bytes);
+                grid_cache.erase(it);
+            }
         }
 
         NormalGridVolume::CacheStats cacheStats() const {

--- a/volume-cartographer/core/src/OpenMPConfig.cpp
+++ b/volume-cartographer/core/src/OpenMPConfig.cpp
@@ -1,0 +1,21 @@
+#include "vc/core/util/OpenMPConfig.hpp"
+
+#include <cstdlib>
+#include <cstring>
+
+#include <omp.h>
+
+namespace vc::core::util
+{
+
+void disableOpenMPDynamicTeams()
+{
+    // Opt-out, for bisecting a regression against the previous behaviour.
+    if (const char* keep = std::getenv("VC_OMP_DYNAMIC");
+        keep && std::strcmp(keep, "0") != 0 && keep[0] != '\0') {
+        return;
+    }
+    omp_set_dynamic(0);
+}
+
+}  // namespace vc::core::util

--- a/volume-cartographer/core/src/Slicing.cpp
+++ b/volume-cartographer/core/src/Slicing.cpp
@@ -95,13 +95,16 @@ struct ChunkSampler {
         bool allFill = false;
     };
 
-    IChunkedArray& cache;
-    int level;
+    IChunkedArray* cache = nullptr;
+    int level = -1;
     VolumeShape shape;
     std::array<int, 3> chunkShape{};
     int chunkStrideY = 0;
     int chunkStrideZ = 0;
     std::unique_ptr<HotSlot[]> slots;
+    // Slot indices that have held a chunk since the last bind(), so rebinding
+    // costs O(chunks actually visited) rather than O(kSlots).
+    std::vector<int> touched;
     int lastCz = std::numeric_limits<int>::min();
     int lastCy = 0;
     int lastCx = 0;
@@ -109,17 +112,49 @@ struct ChunkSampler {
     const T* data = nullptr;
     bool allFill = false;
 
-    ChunkSampler(IChunkedArray& c, int lvl)
-        : cache(c), level(lvl), shape(c, lvl),
-          chunkShape(c.chunkShape(lvl)),
-          chunkStrideY(chunkShape[2]),
-          chunkStrideZ(chunkShape[1] * chunkShape[2]),
-          slots(std::make_unique<HotSlot[]>(kSlots))
-    {
-    }
+    // Default-constructed samplers are bound later, for callers that keep one
+    // sampler per worker thread across many calls. Constructing a sampler
+    // allocates and value-initialises kSlots HotSlots -- each holding a
+    // shared_ptr -- which is roughly half a megabyte of pure overhead when it
+    // happens once per thread per call.
+    ChunkSampler() = default;
+
+    ChunkSampler(IChunkedArray& c, int lvl) { bind(c, lvl); }
 
     ChunkSampler(const ChunkSampler&) = delete;
     ChunkSampler& operator=(const ChunkSampler&) = delete;
+
+    // Point the sampler at (cache, level) and drop every cached chunk
+    // reference, reusing the slot storage. Dropping the references matters as
+    // much as the reset: a slot holds a shared_ptr to decoded chunk bytes, so
+    // stale slots would pin chunks the array has since evicted and let memory
+    // grow without bound.
+    void bind(IChunkedArray& c, int lvl) {
+        if (!slots) {
+            slots = std::make_unique<HotSlot[]>(kSlots);
+            touched.reserve(1024);
+        }
+        for (int idx : touched) {
+            HotSlot& s = slots[idx];
+            s.key = UINT64_MAX;
+            s.data = nullptr;
+            s.bytes.reset();
+            s.allFill = false;
+        }
+        touched.clear();
+        cache = &c;
+        level = lvl;
+        shape = VolumeShape(c, lvl);
+        chunkShape = c.chunkShape(lvl);
+        chunkStrideY = chunkShape[2];
+        chunkStrideZ = chunkShape[1] * chunkShape[2];
+        lastCz = std::numeric_limits<int>::min();
+        lastCy = 0;
+        lastCx = 0;
+        lastKey = UINT64_MAX;
+        data = nullptr;
+        allFill = false;
+    }
 
     VC_FORCE_INLINE static uint64_t packKey(int cz, int cy, int cx) {
         return (uint64_t(uint32_t(cz)) << 42) | (uint64_t(uint32_t(cy)) << 21) | uint64_t(uint32_t(cx));
@@ -147,7 +182,11 @@ struct ChunkSampler {
             return;
         }
 
-        const ChunkResult result = cache.getChunkBlocking(level, cz, cy, cx);
+        // First use of this slot since bind(): record it so the next bind()
+        // releases only the slots that actually hold something.
+        if (slot.key == UINT64_MAX) touched.push_back(idx);
+
+        const ChunkResult result = cache->getChunkBlocking(level, cz, cy, cx);
         slot.bytes.reset();
         slot.data = nullptr;
         slot.allFill = false;
@@ -714,6 +753,11 @@ void readMultiSliceImpl(
     float maxOff = *std::max_element(offsets.begin(), offsets.end());
     float minVx = FLT_MAX, minVy = FLT_MAX, minVz = FLT_MAX;
     float maxVx = -FLT_MAX, maxVy = -FLT_MAX, maxVz = -FLT_MAX;
+    // min and max over floats are associative and commutative and round
+    // nothing, so the parallel reduction is bit-identical to the serial scan.
+    // It covers every pixel of the tile and used to run on one thread.
+    #pragma omp parallel for schedule(static) \
+        reduction(min:minVx,minVy,minVz) reduction(max:maxVx,maxVy,maxVz)
     for (int y = 0; y < h; y++) {
         const cv::Vec3f* bRow = basePoints.ptr<cv::Vec3f>(y);
         const cv::Vec3f* sRow = stepDirs.ptr<cv::Vec3f>(y);
@@ -734,8 +778,21 @@ void readMultiSliceImpl(
 
     #pragma omp parallel
     {
-        ChunkSampler<T> s(*cache, level);
-        #pragma omp for schedule(dynamic, 16)
+        // One sampler per worker thread, kept alive across calls. Callers
+        // invoke this once per output band, so constructing a fresh sampler
+        // here meant every thread in the pool -- including the ones the
+        // schedule never gave any rows to -- allocated, value-initialised and
+        // destroyed a full slot table per band. bind() reuses the storage.
+        static thread_local ChunkSampler<T> s;
+        s.bind(*cache, level);
+
+        // schedule(dynamic, 16) over a band only h rows tall yields h/16 work
+        // units, so with the usual 128-row band the loop could never occupy
+        // more than 8 threads however large the pool was. One row per unit
+        // fixes that; rows still vary a lot in cost (pixels that miss the
+        // surface are nearly free) so dynamic still beats static, and a row of
+        // w * nSlices samples dwarfs the scheduling atomic.
+        #pragma omp for schedule(dynamic, 1)
         for (int y = 0; y < h; y++) {
             const cv::Vec3f* bRow = basePoints.ptr<cv::Vec3f>(y);
             const cv::Vec3f* sRow = stepDirs.ptr<cv::Vec3f>(y);


### PR DESCRIPTION
Performance improvements to segmentation, rendering and segmentgrowth:
Segmentation and rendering of scroll surfaces several times faster on many surfaces, with byte-identical output.
  
Example: Starting with a 1.67 cm² PHerc0211 segment and OMP_NUM_THREADS=8, I ran vc_render_tifxyz before and after these commits, and it produced the same 65 layers (identical md5sum)
  in 2.34 s instead of 15.20 s.
  
Summary of fixes/improvements:
Before: OpenCV's libopencv_core static initializer calls omp_set_dynamic(1) before main(). libgomp then sizes every parallel team from getloadavg(), returning one thread whenever load ≥ core count. On a busy machine every OpenMP region in VC3D ran serially, and this was invisible to thread_limit, OMP_NUM_THREADS, and even OMP_DYNAMIC=FALSE, because the constructor runs last. Separately, the render band loop used schedule(dynamic,16) over a 128-row band -- 8 work units regardless of pool size -- and rebuilt a 16384-slot ChunkSampler per thread per band. And
  the normal-grid cache held 512 entries against a measured 7,424-slice working set, causing 110,631 file opens across 7,424 distinct files -- a 14.9× re-open rate.
  
After this PR: Render 15.20 s → 2.34 s (6.5×) at 8 threads on a 1.67 cm² segment; 143.78 s → 37.69 s (3.81×) on a 12.63 cm² segment from the OpenMP fix alone. Growth resume rounds drop from 64.4 to 44.2 CPU-seconds, with system time falling 30.31 s → 10.69 s — cheaper in wall clock and total CPU, not a trade.
  
Four builds — unpatched, +fix1, +fix2, +fix3 — from one clean clone of ScrollPrize/villa at b0bcee5, same segment, same seed (VC_GROWPATCH_RNG_SEED pinned), warm-up discarded, load recorded per arm. Looking at the md5s: render output is byte-identical at --threads 1, 8 and 32 on both test segments, and area_cm2 matches to 16 digits across every growth arm and every cache budget. The unmodified from-source build was first verified byte-identical to the released binary, to establish that reference.
  
Why / where this is useful: Anyone running VC3D segmentation or rendering at scale. The OpenMP fix in particular helps most on loaded machines -- exactly when batch segmentation runs -- and needs no configuration change. Faster rendering and growth mean more surface area segmented per machine-hour, where segmentation is the current bottleneck on reading complete scrolls.
  
Limitations:
- Fix 2 is within noise at 8 threads on a large segment -- by mechanism, since dynamic,16 over 128 rows already yields 8 work units. Its benefit appears above 8 threads (2.0–2.4× at 32).
- Fix 1 is neutral at thread_limit 1 by construction.
- The 4 GiB cache default is conservative, not optimal: 8 GiB was a further 1.42× -- chosen because RSS rises 181 MB -> ~2.6 GB per process, which matters when running many concurrent grows.
- Growth geometry varies with thread count. This is pre-existing: random_perturbation() uses a thread_local RNG, so tl=4 is not self-reproducible even at a pinned seed, and the unpatched build diverges identically once given real teams. generations.tif is unchanged -- same point count, same generations, only solved coordinates move. This is why growth is recommended at thread_limit 1, where output is byte-identical.
