### PR TITLE
vc_obj2tifxyz: write meta.json scale as grid cells per voxel measured from the emitted grid (#1319)

### DIFF
--- a/lasagna/tifxyz_format.md
+++ b/lasagna/tifxyz_format.md
@@ -30,7 +30,7 @@ Any other `*.tif` files are interpreted as additional channels (by filename stem
 	- `Y = y.tif[row, col]`
 	- `Z = z.tif[row, col]`
 
-The grid is a *regular* 2D lattice in index space; physical spacing of the grid in “surface units” is given by `meta.json.scale`.
+The grid is a *regular* 2D lattice in index space; `meta.json.scale` gives its sampling density in grid cells per voxel (see §5.1).
 
 ## 3. Data types (TIFF)
 
@@ -108,15 +108,12 @@ Common fields produced by tools:
 
 ### 5.1 `scale` meaning
 
-`scale = [sx, sy]` describes the grid spacing in surface-parameter space.
-
-- Many tools interpret the parametric coordinate of a vertex `(row, col)` as `(u = col * sx, v = row * sy)`.
-- Some operations may also use `1/sx` and `1/sy` as a “pixels-per-unit” scaling.
+`scale = [sx, sy]` is the sampling density of the grid: grid cells per voxel along each axis. It is a density, not a spacing: adjacent grid vertices are `1/sx` (resp. `1/sy`) voxels apart, and a grid of `cols x rows` cells spans `cols/sx x rows/sy` voxels (`QuadSurface::size()`). The tracer writes `0.05` for its 20-voxel step.
 
 To stay compatible:
 
 - Preserve `scale` when copying/transforming surfaces.
-- If you resample the grid resolution, update `scale` consistently.
+- If you resample the grid resolution, update `scale` consistently: doubling the cell spacing halves `scale`.
 
 ## 6. Writing rules (recommended)
 

--- a/volume-cartographer/apps/src/vc_obj2tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_obj2tifxyz.cpp
@@ -188,7 +188,7 @@ public:
         const int gw_raw = std::max(2, static_cast<int>(std::ceil(uv_range[0] * stretch_factor)) + 1);
         const int gh_raw = std::max(2, static_cast<int>(std::ceil(uv_range[1] * stretch_factor)) + 1);
 
-        // Apply uniform decimation / capping to the resolution (NOT to the scale)
+        // Apply uniform decimation / capping to the resolution
         const auto apply_decimation = [](int n, double d) {
             if (d <= 1.0) return n;
             // keep endpoints: 1 + floor((n-1)/d)
@@ -224,29 +224,23 @@ public:
             int gw_src = std::max(2, static_cast<int>(std::lround(uv_range[0] * src_scale[0])) + 1);
             int gh_src = std::max(2, static_cast<int>(std::lround(uv_range[1] * src_scale[1])) + 1);
             // Honor any further user decimation / pixel cap on top of source density.
-            gw_src = apply_decimation(gw_src, decim);
-            gh_src = apply_decimation(gh_src, decim);
-            grid_size[0] = gw_src;
-            grid_size[1] = gh_src;
-            scale[0] = src_scale[0];
-            scale[1] = src_scale[1];
+            const int gw_src_dec = apply_decimation(gw_src, decim);
+            const int gh_src_dec = apply_decimation(gh_src, decim);
+            grid_size[0] = gw_src_dec;
+            grid_size[1] = gh_src_dec;
+            // Adopt the source scale verbatim when undecimated; otherwise reduce
+            // it by the decimation actually applied so it describes this grid.
+            scale[0] = static_cast<float>(src_scale[0] * (gw_src_dec - 1) / double(gw_src - 1));
+            scale[1] = static_cast<float>(src_scale[1] * (gh_src_dec - 1) / double(gh_src - 1));
             std::cout << "Source-scale mode: grid " << grid_size[0] << " x " << grid_size[1]
                       << "  scale: " << scale[0] << ", " << scale[1]
                       << "  (matched to input tifxyz)" << std::endl;
         } else if (uv_is_metric) {
-            // --- Preserve physical pixel size (scale) from the RAW grid ---
-            // du_raw/dv_raw are UV units per pixel *before* decimation.
-            const float du_raw = (gw_raw > 1) ? uv_range[0] / float(gw_raw - 1) : 0.f;
-            const float dv_raw = (gh_raw > 1) ? uv_range[1] / float(gh_raw - 1) : 0.f;
-            scale[0] = du_raw * uv_to_obj; // OBJ units per pixel (unchanged by decimation)
-            scale[1] = dv_raw * uv_to_obj;
-
-            std::cout << "UV-metric mode: grid " << grid_size[0] << " x " << grid_size[1]
-                      << "  scale(OBJ units): " << scale[0] << ", " << scale[1] << std::endl;
+            // `scale` is measured from the emitted grid in createQuadSurface().
+            std::cout << "UV-metric mode: grid " << grid_size[0] << " x " << grid_size[1] << std::endl;
             if (decim > 1.0) {
                 std::cout << "  (applied UV decimation ~" << decim << "x per axis; "
-                          << "effective decim [" << eff_decim_x << ", " << eff_decim_y << "]; "
-                          << "preserved per-pixel physical scale)\n";
+                          << "effective decim [" << eff_decim_x << ", " << eff_decim_y << "])\n";
             }
         } else {
             // --- Legacy non-metric: measure from 3D on decimated grid, then compensate ---
@@ -286,7 +280,7 @@ public:
         }
     }
     
-    QuadSurface* createQuadSurface(float mesh_units = 1.0f) {
+    QuadSurface* createQuadSurface() {
         // Create points matrix initialized with invalid values
         cv::Mat_<cv::Vec3f>* points = new cv::Mat_<cv::Vec3f>(grid_size[1], grid_size[0], cv::Vec3f(-1, -1, -1));
 
@@ -313,7 +307,6 @@ public:
         std::cout << "Valid grid points: " << valid_count << " / " << (grid_size[0] * grid_size[1]) 
                   << " (" << (100.0f * valid_count / (grid_size[0] * grid_size[1])) << "%)" << std::endl;
         
-        // Scale is currently in OBJ units. Convert to micrometers now.
         if (valid_count == 0) {
             std::cerr << "Warning: no valid grid points were rasterized." << std::endl;
         }
@@ -321,19 +314,34 @@ public:
         if (src_scale_mode) {
             // Scale was adopted verbatim from the source tifxyz; do not rescale.
             std::cout << "Scale (from source tifxyz): " << scale[0] << ", " << scale[1] << std::endl;
-        } else if (uv_is_metric) {
-            scale[0] *= mesh_units;
-            scale[1] *= mesh_units;
-            std::cout << "Scale from UV (micrometers): " << scale[0] << ", " << scale[1] << std::endl;
         } else {
-            // Measure from 3D to preserve anisotropy and noise-robustness (already compensated in determineGridDimensions)
-            calculateScaleFromGrid(*points, mesh_units);
+            // tifxyz `scale` is grid cells per voxel: QuadSurface::size() is
+            // cols / scale and the tracer writes 0.05 for its 20-voxel step. So
+            // it has to describe the grid actually emitted, whatever stretch,
+            // --uv-downsample or --grid-cap produced it and whether the UVs
+            // were metric or normalized: measure that grid's mean 3D spacing
+            // per axis and invert it. The OBJ coordinates are voxel
+            // coordinates, so the mesh_units argument does not enter.
+            scale = cv::Vec2f(0.f, 0.f);
+            calculateScaleFromGrid(*points);
+            if (!(scale[0] > 0.f) || !(scale[1] > 0.f)) {
+                std::cerr << "Error: could not measure the grid spacing of the emitted surface; "
+                             "not writing a tifxyz with an invalid scale." << std::endl;
+                delete points;
+                return nullptr;
+            }
+            scale[0] = 1.f / scale[0];
+            scale[1] = 1.f / scale[1];
+            std::cout << "Scale (grid cells per voxel, measured from the emitted grid): "
+                      << scale[0] << ", " << scale[1] << std::endl;
         }
         
         return new QuadSurface(points, scale);
     }
     
-    void calculateScaleFromGrid(const cv::Mat_<cv::Vec3f>& points, float mesh_units = 1.0f) {
+    // Fills `scale` with the mean 3D distance between adjacent grid points
+    // along each axis (OBJ units), or leaves it untouched if none was measurable.
+    void calculateScaleFromGrid(const cv::Mat_<cv::Vec3f>& points) {
         // Based on vc_segmentation_scales from Slicing.cpp
         double sum_x = 0;
         double sum_y = 0;
@@ -380,16 +388,14 @@ public:
         }
         
         if (count > 0 && sum_x > 0 && sum_y > 0) {
-            // Scale is the average distance between points, adjusted by mesh units
-            scale[0] = static_cast<float>((sum_x / count) * mesh_units);
-            scale[1] = static_cast<float>((sum_y / count) * mesh_units);
+            // Mean distance between adjacent points
+            scale[0] = static_cast<float>(sum_x / count);
+            scale[1] = static_cast<float>(sum_y / count);
         } else {
-            // Fallback to UV-based scale if we couldn't calculate from grid
-            std::cerr << "Warning: Could not calculate scale from grid, using UV-based fallback" << std::endl;
-            // scale already set in determineGridDimensions
+            std::cerr << "Warning: Could not calculate scale from grid" << std::endl;
         }
-        
-        std::cout << "Calculated scale factors from grid: " << scale[0] << ", " << scale[1] << " micrometers" << std::endl;
+
+        std::cout << "Mean grid spacing (OBJ units): " << scale[0] << ", " << scale[1] << std::endl;
     }
     
 private:
@@ -524,10 +530,10 @@ int main(int argc, char *argv[])
         std::cout << std::endl;
         std::cout << "Parameters:" << std::endl;
         std::cout << "  stretch_factor: UV scaling factor (default: 1.0)" << std::endl;
-        std::cout << "  mesh_units    : micrometers per OBJ unit (default: 1.0)" << std::endl;
+        std::cout << "  mesh_units    : micrometers per OBJ unit (default: 1.0; accepted for compatibility, not used)" << std::endl;
         std::cout << "Flags:" << std::endl;
         std::cout << "  --uv-metric         : UVs are metric (default; UV units == OBJ units unless --uv-to-obj is set)" << std::endl;
-        std::cout << "  --uv-non-metric     : Revert to legacy behavior (measure scale from 3D mesh)" << std::endl;
+        std::cout << "  --uv-non-metric     : Legacy grid sizing from the mesh's measured 3D spacing" << std::endl;
         std::cout << "  --uv-to-obj=<ratio> : OBJ units per 1 UV unit (default: 1.0). Only used with --uv-metric." << std::endl;
         std::cout << "  --uv-downsample=<f> : Uniform UV decimation factor (>=1.0). Reduces grid by ~f^2." << std::endl;
         std::cout << "  --grid-cap=<pixels> : Upper bound on total grid pixels. Implies extra decimation if needed." << std::endl;
@@ -537,7 +543,7 @@ int main(int argc, char *argv[])
         std::cout << "                        scale). If <dir>/approval.tif exists, it is resampled onto the new" << std::endl;
         std::cout << "                        grid via the <input.obj>.griduv sidecar. Absent: legacy metric sizing." << std::endl;
         std::cout << std::endl;
-        std::cout << "Note: Scale factors are automatically calculated from the mesh grid structure." << std::endl;
+        std::cout << "Note: meta.json scale (grid cells per voxel) is measured from the emitted grid." << std::endl;
         std::cout << "Examples:" << std::endl;
         std::cout << "  " << argv[0] << " mesh.obj outdir                       (legacy behavior)" << std::endl;
         std::cout << "  " << argv[0] << " mesh.obj outdir 800 1.0 --uv-metric  (UV is metric, OBJ units == UV units)" << std::endl;
@@ -703,7 +709,7 @@ int main(int argc, char *argv[])
     converter.determineGridDimensions(stretch_factor);
     
     // Create quad surface
-    QuadSurface* surf = converter.createQuadSurface(mesh_units);
+    QuadSurface* surf = converter.createQuadSurface();
     if (!surf) {
         std::cerr << "Failed to create quad surface" << std::endl;
         return EXIT_FAILURE;

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -865,6 +865,13 @@ if(TARGET vc_tifxyz_selfcross)
     add_dependencies(test_tifxyz_selfcross_cli vc_tifxyz_selfcross)
 endif()
 
+if(TARGET vc_obj2tifxyz)
+    vc_add_test(NAME test_obj2tifxyz_cli
+        LIBS doctest::doctest vc_core opencv_core opencv_imgcodecs
+        DEFS VC_OBJ2TIFXYZ_BIN="$<TARGET_FILE:vc_obj2tifxyz>")
+    add_dependencies(test_obj2tifxyz_cli vc_obj2tifxyz)
+endif()
+
 vc_add_test(NAME test_fiber_intersections LIBS doctest::doctest vc_atlas)
 
 vc_add_test(NAME test_remote_url)

--- a/volume-cartographer/core/test/test_obj2tifxyz_cli.cpp
+++ b/volume-cartographer/core/test/test_obj2tifxyz_cli.cpp
@@ -1,0 +1,204 @@
+// End-to-end tests for the vc_obj2tifxyz command line: the tifxyz `scale`
+// it writes must describe the grid it actually emitted (#1319). QuadSurface
+// reads scale as grid cells per voxel (size() == cols / scale), so the 3D
+// spacing of adjacent points in the written x/y/z.tif must equal 1 / scale
+// and the nominal size must stay the mesh's extent whatever stretch,
+// decimation or cap produced the grid, and whether the UVs were metric or
+// normalized. Before the fix, scale was the UV spacing of the undecimated
+// grid (a length, inverted, and blind to --uv-downsample / --grid-cap), so a
+// 20x-decimated surface rendered 20x too small and a stretched one 4x too
+// large.
+//
+// The binary path arrives from CMake as VC_OBJ2TIFXYZ_BIN. The fixture is a
+// flat mesh written into a fresh temp directory in the layout vc_tifxyz2obj
+// emits (v/vt/vn, f v/vt/vn), with UVs equal to the in-plane OBJ coordinates
+// or, for the normalized case, divided by the extent.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "vc_test.hpp"
+
+#include "vc/core/util/QuadSurface.hpp"
+
+#include <opencv2/core/mat.hpp>
+#include <opencv2/imgcodecs.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+TEST_CASE("cli tests are POSIX-only") {}
+#else
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Mesh vertex spacing and vertex counts: a 40 x 30 quad grid of 20-unit
+// cells, i.e. UV extent 800 x 600 OBJ units (the geometry of a tracer
+// segment written through vc_tifxyz2obj).
+constexpr float kSpacing = 20.f;
+constexpr int kCols = 41;
+constexpr int kRows = 31;
+constexpr float kExtentU = kSpacing * (kCols - 1);
+constexpr float kExtentV = kSpacing * (kRows - 1);
+
+void write_obj(const fs::path& path, bool normalized_uv = false)
+{
+    std::ofstream obj(path);
+    for (int r = 0; r < kRows; ++r)
+        for (int c = 0; c < kCols; ++c) {
+            const float x = kSpacing * c, y = kSpacing * r;
+            const float u = normalized_uv ? x / kExtentU : x;
+            const float v = normalized_uv ? y / kExtentV : y;
+            obj << "v " << x << " " << y << " 100\n"
+                << "vt " << u << " " << v << "\n"
+                << "vn 0 0 1\n";
+        }
+    for (int r = 0; r + 1 < kRows; ++r)
+        for (int c = 0; c + 1 < kCols; ++c) {
+            const int a = r * kCols + c + 1, b = a + 1;
+            const int d = a + kCols, e = d + 1;
+            obj << "f " << a << "/" << a << "/" << a << " " << b << "/" << b << "/" << b
+                << " " << e << "/" << e << "/" << e << "\n";
+            obj << "f " << a << "/" << a << "/" << a << " " << e << "/" << e << "/" << e
+                << " " << d << "/" << d << "/" << d << "\n";
+        }
+    REQUIRE(obj.good());
+}
+
+// A tifxyz with the same geometry at the tracer's 1 cell / 20 units, for
+// --tifxyz-source mode.
+void write_source_tifxyz(const fs::path& dir)
+{
+    cv::Mat x(kRows, kCols, CV_32F), y(kRows, kCols, CV_32F), z(kRows, kCols, CV_32F, cv::Scalar(100.f));
+    for (int r = 0; r < kRows; ++r)
+        for (int c = 0; c < kCols; ++c) {
+            x.at<float>(r, c) = kSpacing * c;
+            y.at<float>(r, c) = kSpacing * r;
+        }
+    fs::create_directories(dir);
+    REQUIRE(cv::imwrite((dir / "x.tif").string(), x));
+    REQUIRE(cv::imwrite((dir / "y.tif").string(), y));
+    REQUIRE(cv::imwrite((dir / "z.tif").string(), z));
+    std::ofstream meta(dir / "meta.json");
+    meta << "{\"scale\": [0.05, 0.05], \"uuid\": \"cli-source\"}\n";
+    REQUIRE(meta.good());
+}
+
+// Single-quote every argument so paths containing spaces or shell
+// metacharacters cannot break the command or execute as syntax.
+std::string sh(const std::string& s)
+{
+    std::string q = "'";
+    for (char c : s)
+        if (c == '\'') q += "'\\''"; else q += c;
+    return q + "'";
+}
+
+int run_cli(const std::vector<std::string>& args)
+{
+    std::string cmd = sh(VC_OBJ2TIFXYZ_BIN);
+    for (const auto& a : args) cmd += " " + sh(a);
+    cmd += " >/dev/null 2>&1";
+    int rc = std::system(cmd.c_str());
+    REQUIRE(rc != -1);
+    return WIFEXITED(rc) ? WEXITSTATUS(rc) : -2;
+}
+
+struct TempDir {
+    fs::path path;
+    TempDir()
+    {
+        path = fs::temp_directory_path()
+             / ("vc_obj2tifxyz_cli_" + std::to_string(::getpid()));
+        fs::create_directories(path);
+    }
+    ~TempDir() { std::error_code ec; fs::remove_all(path, ec); }
+};
+
+// Convert with `extra` flags and check the written surface: the grid has the
+// expected column count, scale is cells per voxel of that grid (so the
+// nominal size stays the mesh extent), and the 3D spacing of adjacent grid
+// points read back from x/y/z.tif equals 1 / scale.
+void check_conversion(const TempDir& tmp, const std::string& name,
+                      const std::vector<std::string>& extra, int expect_cols)
+{
+    const fs::path obj = tmp.path / "mesh.obj";
+    const fs::path out = tmp.path / name;  // must not pre-exist
+    std::vector<std::string> args{obj.string(), out.string()};
+    args.insert(args.end(), extra.begin(), extra.end());
+    REQUIRE(run_cli(args) == 0);
+
+    auto surf = load_quad_from_tifxyz(out);
+    REQUIRE(surf);
+    const cv::Mat_<cv::Vec3f> pts = surf->rawPoints();
+    const cv::Vec2f scale = surf->scale();
+    INFO(name << ": grid " << pts.cols << "x" << pts.rows
+              << " scale " << scale[0] << "," << scale[1]);
+    CHECK(pts.cols == expect_cols);
+    CHECK(scale[0] == doctest::Approx((pts.cols - 1) / kExtentU).epsilon(1e-4));
+    CHECK(scale[1] == doctest::Approx((pts.rows - 1) / kExtentV).epsilon(1e-4));
+    // size() is cols / scale, so it counts cells rather than intervals and
+    // may exceed the UV extent by one cell; before the fix it was off by
+    // the whole decimation factor.
+    const cv::Size nominal = surf->size();
+    CHECK(std::abs(nominal.width - kExtentU) <= 1.0 / scale[0] + 0.5);
+    CHECK(std::abs(nominal.height - kExtentV) <= 1.0 / scale[1] + 0.5);
+
+    const int r = pts.rows / 2, c = pts.cols / 2;
+    const double du = cv::norm(pts(r, c + 1) - pts(r, c));
+    const double dv = cv::norm(pts(r + 1, c) - pts(r, c));
+    CHECK(du == doctest::Approx(1.0 / scale[0]).epsilon(1e-3));
+    CHECK(dv == doctest::Approx(1.0 / scale[1]).epsilon(1e-3));
+}
+
+}  // namespace
+
+TEST_CASE("metric mode: scale follows the emitted grid under decimation, "
+          "cap and stretch")
+{
+    TempDir tmp;
+    write_obj(tmp.path / "mesh.obj");
+
+    // 1 cell / OBJ unit: 801 columns, scale 1 (unchanged behaviour).
+    check_conversion(tmp, "plain", {}, 801);
+    // --uv-downsample=20 keeps the endpoints: 1 + 800/20 columns, scale 0.05.
+    check_conversion(tmp, "ds20", {"--uv-downsample=20"}, 41);
+    // --grid-cap forces ceil(sqrt(801*601/50000)) = 4x decimation.
+    check_conversion(tmp, "cap", {"--grid-cap=50000"}, 201);
+    // stretch_factor 2: 2 cells / OBJ unit, scale 2.
+    check_conversion(tmp, "stretch2", {"2"}, 1601);
+}
+
+TEST_CASE("normalized UVs: scale comes from the emitted grid's 3D spacing")
+{
+    TempDir tmp;
+    write_obj(tmp.path / "mesh.obj", /*normalized_uv=*/true);
+    // stretch 40 on a unit UV square: a 41x41 grid over 800x600 voxels, so
+    // an anisotropic scale of 0.05 x 0.0667 (#1319 wrote 1 / stretch).
+    check_conversion(tmp, "norm40", {"40"}, 41);
+}
+
+TEST_CASE("source-scale mode: scale is the source's, reduced by any extra "
+          "decimation")
+{
+    TempDir tmp;
+    write_obj(tmp.path / "mesh.obj");
+    const fs::path src = tmp.path / "source.tifxyz";
+    write_source_tifxyz(src);
+
+    // Sized to the source density: 41 columns at the source's 0.05.
+    check_conversion(tmp, "src", {"--tifxyz-source=" + src.string()}, 41);
+    // A further 4x decimation: 11 columns, scale 0.05 * 10/40.
+    check_conversion(tmp, "src_ds4",
+                     {"--tifxyz-source=" + src.string(), "--uv-downsample=4"}, 11);
+}
+
+#endif  // _WIN32


### PR DESCRIPTION
**In one sentence:** `vc_obj2tifxyz` now writes a `meta.json` `scale` that matches the grid it actually emitted, so a converted mesh renders, flattens and measures at the right size whatever stretch factor, `--uv-downsample`, `--grid-cap` or UV normalization was used.

**One real example:** Starting with PHerc1447 segment `auto_grown_20250703034159599` (tracer output, scale 0.05, 272×185 grid), I ran `vc_tifxyz2obj` on it, converted the OBJ back with `vc_obj2tifxyz seg.obj out --uv-downsample=20`, and rendered the result with `vc_render_tifxyz -g 3 --scale 1`. Before, the render was 34×23 px; after, 680×464 px — the size of rendering the original segment (682×462 px). With normalized UVs and stretch 2000 (the #1319 case), the same render command previously targeted a ~498,000×500,000 px image (killed after 3 minutes, ETA 131 min); after, 678×462 px.

**Before:** `scale` was the UV spacing of the *undecimated* grid — a length, not a density: `--uv-downsample=20` and `--grid-cap` left it at 1.0 while the grid was 20× or 5× sparser, `stretch_factor 2` wrote 0.5 for a grid that has 2 cells per voxel, and normalized UVs got `1/stretch` (#1319 reports 0.0005 instead of ≈0.0865 and `vc_flatten` collapsing to 6×4). `--tifxyz-source` mode copied the source scale but ignored any additional `--uv-downsample`. Everything downstream (`QuadSurface::size()`, `vc_render_tifxyz`, `vc_flatten`, `vc_tifxyz2obj`, the Python `tifxyz` reader) reads `scale` as grid cells per voxel, so those surfaces came out 20× too small, 4× too large, or unusably large.

**After this PR:** `scale` is measured from the emitted grid itself (mean 3D distance between adjacent grid points along each axis, inverted), for metric, normalized and legacy `--uv-non-metric` UVs alike; in `--tifxyz-source` mode the adopted source scale is reduced by the decimation actually applied. `x/y/z.tif` are byte-identical to before — only `meta.json` changes.

**Proof:** same segment, same volume, same renderer settings for every panel (`vc_render_tifxyz -v <level-3 mirror of the PHerc1447 volume> -s <surface> --scale 1 -g 3 -n 1`); look at the render size against the top-left reference.

![vc_obj2tifxyz scale before/after](https://raw.githubusercontent.com/Bullo27/villa/50b77c51b6d6f25f0c6a41924267d9f12425af1a/evidence/obj2tifxyz-scale/evidence_obj2tifxyz_scale.png)

| `vc_obj2tifxyz` arguments | grid | scale before | render before | scale after | render after |
|---|---|---|---|---|---|
| (reference: original tracer segment) | 272×185 | 0.05 | 682×462 | — | — |
| `--uv-downsample=20` | 272×185 | 1.0, 1.0 | 34×23 | 0.04998, 0.04983 | 680×464 |
| `--grid-cap=1000000` | 1085×737 | 1.0, 1.0 | 136×92 | 0.19985, 0.19922 | 679×462 |
| `2` (stretch factor) | 10841×7361 | 0.5, 0.5 | 2710×1840 | 1.9987, 1.9922 | 678×462 |
| normalized UVs (`vc_tifxyz2obj --normalize-uv`), `2000 1.0` as in #1319 | 1994×2001 | 0.0005, 0.0005 | ~498k×500k targeted, killed | 0.3676, 0.5414 | 678×462 |
| (none) | 5421×3681 | 1.0, 1.0 | 678×460 | 0.9993, 0.9961 | 678×462 |
| `--tifxyz-source=<segment>` | 272×185 | 0.05 | 680×462 | 0.05 (unchanged) | 680×462 |
| `--tifxyz-source=<segment> --uv-downsample=20` | 14×10 | 0.05 | 35×25 | 0.00240, 0.00245 | 730×511 |

The last row is one 417-voxel grid cell larger than the reference because `QuadSurface::size()` counts cells, not intervals — pre-existing and negligible at normal densities. All conversions and renders exit 0; `cmp` of `x.tif`/`y.tif`/`z.tif` between the pre-fix and post-fix Release binaries reports no difference (plain and `--uv-downsample=20` conversions checked).

**Why / where this is useful:** anyone who round-trips a segment through OBJ (`vc_tifxyz2obj` → external editing or flattening → `vc_obj2tifxyz`) with a downsample, cap or stretch, or converts a mesh with normalized UVs (#1319), gets a tifxyz that renders and flattens at the right scale instead of one that is silently 20× smaller or too large to render. VC3D's SLIM flatten, the vc3d-mcp flatten tool and `spiral-fitting/render_ink.py` call the tool with `--tifxyz-source` and no extra decimation, so their outputs are unchanged.

- [x] Verified by running the example and proof above on my machine on the stated data (AI-assisted; see disclosure).

## Details

Fixes #1319 (report and the "write the scale measured from the grid actually produced" suggestion: @Aleredfer). Same approach as #1391 by @olgaiv39, which was auto-closed for inactivity on 2026-08-28 after @pmh47's review points were addressed and @hendrikschilling asked for regression coverage of `--uv-downsample`, `--tifxyz-source` scale preservation, varying `stretch_factor` and a direct check against the emitted TIFF grid. This PR supplies exactly that coverage in one 200-line test and keeps the code change small.

**What changed** (`vc_obj2tifxyz.cpp`: +45/−39 lines):
- `createQuadSurface()`: for every non-source mode, measure the emitted grid's mean 3D spacing per axis (the existing `calculateScaleFromGrid`) and write `1 / spacing`; fail with a clear error instead of writing an invalid scale if nothing was measurable. The old metric-mode formula (`uv_range / (gw_raw - 1) * uv_to_obj`, then `* mesh_units`) is gone.
- `--tifxyz-source` mode: `scale = src_scale * (decimated_cols - 1) / (source_cols - 1)` — verbatim when undecimated.
- `mesh_units` is still accepted but no longer affects `scale` (OBJ coordinates are voxel coordinates; the argument was multiplying a density by µm-per-unit). Usage text updated.
- `lasagna/tifxyz_format.md` §2/§5.1: `scale` is grid cells per voxel, adjacent vertices are `1/scale` voxels apart, doubling the cell spacing halves `scale` (the text described it as a spacing).
- New `core/test/test_obj2tifxyz_cli.cpp` (label `vc-core`, registered like `test_tifxyz_selfcross_cli`): a flat 41×31 mesh with 20-voxel cells, 7 conversions (plain, `--uv-downsample=20`, `--grid-cap`, stretch 2, normalized UVs with stretch 40, `--tifxyz-source` with and without `--uv-downsample=4`), each checked for column count, `scale == (cols-1)/extent`, `size()` within one cell of the extent, and adjacent-point 3D distance `== 1/scale` read back from the written tifxyz. On the unpatched binary 30 checks fail in exactly the 5 affected conversions; plain and pure-source pass before and after.

**Tested:** commit d7d099d, Ubuntu 24.04.4, gcc 13.3.0, ASan+UBSan Debug build: the full `vc-core` label — 143/143 tests including the new one — passes; `test_quadsurface_fixtures` is unaffected because the committed fixture keeps its pre-fix baked scale (0.0078125) and the test reads the file. Real-data runs above used a Release build.

**Not changed:** the legacy `--uv-non-metric` grid *sizing* (only its final `scale` now goes through the same measurement); `QuadSurface::resample`'s handling of `_scale` (separate); #1630's degenerate-output handling (adjacent hunks of the same file, no overlap).

**From the author:** I contribute to VC through an AI-assisted workflow (Claude, directed by me), and this fix came out of running the command-line tools end to end on a PHerc1447 segment rather than from searching the code for bugs: the tifxyz written by `vc_obj2tifxyz` looked fine but rendered at the wrong size whenever a downsample, cap or stretch was used. Checking for duplicates showed that #1319 had already reported it and that #1391 had a fix the maintainers were ready to consider merging before it went stale, so this PR picks that up and adds the regression coverage that was asked for. I care about this path because the OBJ round-trip is how externally flattened or edited meshes get back into VC3D, and a wrong `scale` silently breaks everything downstream while the surface data itself looks correct. I reviewed the investigation, the issue history and the evidence; every number in this PR was produced by running the stated commands on my machine.

**AI disclosure:** investigation, patch, test and this write-up were produced with Claude (Anthropic) under my direction; every number above comes from running the stated commands on the stated data on my machine.