### PR TITLE
VC3D line annotation: fixes from annotation sessions (click placement, side cut, node spacing, pan units)

### DIFF
--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -2495,8 +2495,11 @@ bool LineAnnotationController::launchSession(LineAnnotationController::SourceKin
     connect(dialog,
             &LineAnnotationDialog::generatedControlPointRequested,
             this,
-            [this](const std::string& name, cv::Vec3f volumePoint, double linePosition) {
-                handleGeneratedControlPoint(name, volumePoint, linePosition);
+            [this](const std::string& name,
+                   cv::Vec3f volumePoint,
+                   double linePosition,
+                   cv::Vec3f lineAnchor) {
+                handleGeneratedControlPoint(name, volumePoint, linePosition, lineAnchor);
             });
     connect(dialog,
             &LineAnnotationDialog::generatedControlPointDeleteRequested,
@@ -7247,7 +7250,8 @@ void LineAnnotationController::handleLineSeed(const std::string& surfaceName,
 
 void LineAnnotationController::handleGeneratedControlPoint(const std::string& surfaceName,
                                                           cv::Vec3f volumePoint,
-                                                          double linePosition)
+                                                          double linePosition,
+                                                          std::optional<cv::Vec3f> lineAnchor)
 {
     auto* pane = paneForSurface(surfaceName);
     if (!pane || !pane->session) {
@@ -7285,17 +7289,23 @@ void LineAnnotationController::handleGeneratedControlPoint(const std::string& su
     for (const auto& point : session.optimizedLine.points) {
         currentLinePoints.push_back(point.position);
     }
-    {
+    if (lineAnchor && std::isfinite((*lineAnchor)[0]) && std::isfinite((*lineAnchor)[1]) &&
+        std::isfinite((*lineAnchor)[2])) {
         // A rapid second click arrives while the previous edit's geometric
         // splice is still waiting for its landing: its line position was
         // measured on the previously DISPLAYED line, and the splice may have
-        // renumbered since. The 3D click point is frame-independent, so when
-        // the two disagree materially, trust the point.
-        const size_t nearestIndex = vc3d::fiber_slice::nearestLinePointIndex(
-            currentLinePoints, toVec3d(volumePoint));
-        if (std::abs(static_cast<double>(nearestIndex) - linePosition) > 2.0) {
-            linePosition = static_cast<double>(nearestIndex);
-        }
+        // renumbered since. Resolve it on the session line through the
+        // position's own 3D line point (index-continuous nearest match, the
+        // same remap the landing applies to the pane position). Where the
+        // frames agree the anchor sits exactly on the line and the position
+        // is unchanged. The CLICKED point must not drive this: a click is
+        // deliberately off the line, and where another pass of the same fiber
+        // runs through the cut plane the click can be nearer to that pass,
+        // which sent the control point thousands of vertices away -- or
+        // collapsed it into that pass's control point -- with nothing
+        // visible happening at the cut the user was looking at.
+        linePosition = vc3d::line_annotation::remappedGeneratedLinePositionFromAnchor(
+            currentLinePoints, toVec3d(*lineAnchor), linePosition);
     }
     const auto cumulativeArclengths =
         vc3d::fiber_slice::cumulativePolylineArclengths(currentLinePoints);

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -11879,6 +11879,39 @@ bool LineAnnotationController::materializeGeneratedViews(LineAnnotationSession& 
     generatedViews.lineUpVectors = views.lineUpVectors;
     generatedViews.stripPositionMap = views.stripPositionMap;
     generatedViews.lineNormals = std::move(orientedNormals);
+    {
+        // Winding angles for the side cut's half-wrap window (see the side
+        // overlay in LineAnnotationDialog). Same center reference chain as
+        // orientedLineNormalsForSession, which already loaded the umbilicus:
+        // umbilicus, else the volume center; with neither the angles stay NaN
+        // and the side cut shows the whole line as before.
+        constexpr float kNanF = std::numeric_limits<float>::quiet_NaN();
+        cv::Vec2f volumeCenterXY{kNanF, kNanF};
+        try {
+            if (const auto volume = _state->currentVolume()) {
+                volumeCenterXY = {static_cast<float>(volume->sliceWidth()) * 0.5f,
+                                  static_cast<float>(volume->sliceHeight()) * 0.5f};
+            }
+        } catch (...) {
+        }
+        generatedViews.lineWindingAngles =
+            vc3d::line_annotation::unwrappedGeneratedWindingAngles(
+                generatedViews.linePoints,
+                [this, volumeCenterXY](const cv::Vec3f& point) -> cv::Vec3f {
+                    if (_scrollUmbilicus) {
+                        try {
+                            return _scrollUmbilicus->vector_to_umbilicus(point);
+                        } catch (...) {
+                        }
+                    }
+                    if (std::isfinite(volumeCenterXY[0])) {
+                        return {volumeCenterXY[0] - point[0],
+                                volumeCenterXY[1] - point[1],
+                                0.0f};
+                    }
+                    return {kNanF, kNanF, kNanF};
+                });
+    }
     generatedViews.branchLinePoints = generatedBranchLinePointsForSession(session);
     generatedViews.branchLinks = generatedBranchLinkMarkers(session.branches);
     generatedViews.seedPoint = seedPoint;

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -330,8 +330,12 @@ struct LineAnnotationController::IntersectionInspectionSession {
 
 namespace {
 
+// Arclength radius within which a placement click replaces the existing
+// control(s) instead of adding one. Tied to the strip's along-line sampling
+// so no control span can be created shorter than one strip column (#1484:
+// such a span would be drawn stretched to a full column).
 constexpr double kMinimumControlPointSpacingBaseVoxels =
-    vc::lasagna::kLineViewSamplingDistanceBaseVoxels;
+    vc::lasagna::kLineViewAlongSamplingDistanceBaseVoxels;
 
 std::optional<vc3d::opendata::CoordinateIdentity> coordinateIdentityForState(
     const CState* state)

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -592,9 +592,13 @@ private:
                         cv::Vec3f volumePoint,
                         InitialDirectionMode directionMode,
                         SeedOrigin seedOrigin = SeedOrigin::NewPlacement);
+    // lineAnchor: linePosition's 3D point on the line the caller measured it
+    // on (see LineAnnotationDialog::generatedControlPointRequested). Absent,
+    // the position is used as given.
     void handleGeneratedControlPoint(const std::string& surfaceName,
                                      cv::Vec3f volumePoint,
-                                     double linePosition);
+                                     double linePosition,
+                                     std::optional<cv::Vec3f> lineAnchor = std::nullopt);
     void handleGeneratedControlPointDelete(const std::string& surfaceName,
                                            double linePosition,
                                            cv::Vec3f volumePoint);

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -3952,6 +3952,42 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
                                                      _sideCutViewer,
                                                      sideViews.sideCutSurface.get());
         sideOverlay.linePoints = sideViews.linePoints;
+        // Only the stretch within half a wrap of the current position. The
+        // side cut's plane contains the sheet normal, so for a fiber annotated
+        // across several wraps EVERY wrap of this stretch lies (nearly) in the
+        // plane, and projecting the whole line drew them all on top of each
+        // other. Out-of-window points are blanked rather than erased so the
+        // point indices the tail detection keys on stay meaningful, and the
+        // tail range is taken from the plane-near controls BEFORE the window
+        // trims them, so interior spans do not turn into tails.
+        {
+            const auto window = vc3d::line_annotation::generatedLineIndexRangeWithinWinding(
+                sideViews.lineWindingAngles,
+                sideViews.linePoints.size(),
+                sidePosition,
+                vc3d::line_annotation::kGeneratedSideCutHalfWrapAngle);
+            const size_t pointCount = sideOverlay.linePoints.size();
+            if (pointCount > 0 && (window.first > 0 || window.second + 1 < pointCount)) {
+                constexpr float kNanF = std::numeric_limits<float>::quiet_NaN();
+                const cv::Vec3f blank{kNanF, kNanF, kNanF};
+                for (size_t i = 0; i < window.first; ++i) {
+                    sideOverlay.linePoints[i] = blank;
+                }
+                for (size_t i = window.second + 1; i < pointCount; ++i) {
+                    sideOverlay.linePoints[i] = blank;
+                }
+                sideOverlay.lineTailControlRange =
+                    vc3d::line_annotation::generatedControlLinePositionRange(
+                        sideOverlay.controlPoints);
+                const double lowPosition = static_cast<double>(window.first) - 0.5;
+                const double highPosition = static_cast<double>(window.second) + 0.5;
+                std::erase_if(sideOverlay.controlPoints, [&](const auto& control) {
+                    return std::isfinite(control.linePosition) &&
+                           (control.linePosition < lowPosition ||
+                            control.linePosition > highPosition);
+                });
+            }
+        }
         // Highlight the live cursor position on the line. The cross-slice overlay's emphasized
         // marker otherwise sits at the static focus/seed point; override it to the current
         // position so the highlight tracks the cursor as it moves along the line. Use the

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -825,8 +825,8 @@ LineAnnotationDialog::LineAnnotationDialog(ViewerManager* viewerManager,
     {
         QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
         const double savedArrowPanSpeed =
-            settings.value(vc3d::settings::line_annotation::ARROW_PAN_SPEED,
-                           vc3d::settings::line_annotation::ARROW_PAN_SPEED_DEFAULT)
+            settings.value(vc3d::settings::line_annotation::ARROW_PAN_SPEED_VX,
+                           vc3d::settings::line_annotation::ARROW_PAN_SPEED_VX_DEFAULT)
                 .toDouble();
         _arrowPanCruiseSpeed =
             (std::isfinite(savedArrowPanSpeed) && savedArrowPanSpeed > 0.0)
@@ -2618,11 +2618,13 @@ bool LineAnnotationDialog::shiftCurrentLinePositionByScrollSteps(int steps)
     const int sliceStepSize = _viewerManager
         ? std::max(1, static_cast<int>(std::lround(_viewerManager->zScrollSensitivity())))
         : 1;
-    const double position = vc3d::line_annotation::shiftedLinePosition(
+    // Arclength units: one notch is one strip column of base voxels wherever
+    // the dense line's vertex spacing happens to be (see LineAnnotationShiftScroll.hpp).
+    const double position = vc3d::line_annotation::shiftedLinePositionByArclength(
         _currentLinePosition,
         steps,
         sliceStepSize,
-        static_cast<int>(_generatedViews.linePoints.size()));
+        currentLineArclengths());
     _currentCutNormalOffsetVx = 0.0;
     if (_currentCutViewer) {
         _currentCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
@@ -2834,28 +2836,63 @@ void LineAnnotationDialog::tickArrowPan()
     }
     const double acceleration =
         _arrowPanCruiseSpeed / vc3d::line_annotation::kGeneratedArrowPanRampSeconds;
-    const auto step = vc3d::line_annotation::generatedArrowPanStep(_currentLinePosition,
-                                                                   _arrowPanVelocity,
-                                                                   _arrowPanDirection,
-                                                                   _arrowPanCruiseSpeed,
-                                                                   acceleration,
-                                                                   dtSeconds,
-                                                                   _arrowPanStopTarget);
-    _arrowPanVelocity = step.velocity;
-    const double maxPosition = static_cast<double>(_generatedViews.linePoints.size() - 1);
-    const double position = std::clamp(step.position, 0.0, maxPosition);
-    const bool hitLineEnd = (position != step.position);
-    if (step.landed) {
-        finishArrowPan(position);
+    // The integrator runs in base-voxel arclength (speed is vx/s); positions
+    // and the stop target are converted through the current position map each
+    // tick, so an edit that renumbered the line between ticks cannot desync
+    // them. Without a usable map the line positions stand in for arclength.
+    const auto& arclengths = currentLineArclengths();
+    const bool arclengthUnits = !arclengths.empty();
+    // The map only changes with the line geometry, whose in-place update
+    // cancels the pan, so the unit cannot flip mid-gesture; if it ever did the
+    // velocity would be in the wrong unit, so stop rather than lurch.
+    if (_arrowPanArclengthUnits.has_value() && *_arrowPanArclengthUnits != arclengthUnits) {
+        cancelArrowPan();
         return;
     }
+    _arrowPanArclengthUnits = arclengthUnits;
+    const double maxPosition = static_cast<double>(_generatedViews.linePoints.size() - 1);
+    const double maxCoordinate = arclengthUnits ? arclengths.back() : maxPosition;
+    const auto toCoordinate = [&](double linePosition) {
+        return arclengthUnits
+            ? vc3d::fiber_slice::arclengthAtLinePosition(arclengths, linePosition)
+            : linePosition;
+    };
+    const auto toLinePosition = [&](double coordinate) {
+        return arclengthUnits
+            ? vc3d::fiber_slice::linePositionAtArclength(arclengths, coordinate)
+            : coordinate;
+    };
+    std::optional<double> stopTargetCoordinate;
+    if (_arrowPanStopTarget) {
+        stopTargetCoordinate = toCoordinate(*_arrowPanStopTarget);
+    }
+    const auto step = vc3d::line_annotation::generatedArrowPanStep(
+        toCoordinate(_currentLinePosition),
+        _arrowPanVelocity,
+        _arrowPanDirection,
+        _arrowPanCruiseSpeed,
+        acceleration,
+        dtSeconds,
+        stopTargetCoordinate);
+    _arrowPanVelocity = step.velocity;
+    const double coordinate = std::clamp(step.position, 0.0, maxCoordinate);
+    const bool hitLineEnd = (coordinate != step.position);
+    if (step.landed) {
+        // Land on the target's own line position: the round trip through
+        // arclength would otherwise leave a rounding residue on the control.
+        finishArrowPan(_arrowPanStopTarget
+                           ? std::clamp(*_arrowPanStopTarget, 0.0, maxPosition)
+                           : std::clamp(toLinePosition(coordinate), 0.0, maxPosition));
+        return;
+    }
+    const double position = std::clamp(toLinePosition(coordinate), 0.0, maxPosition);
     if (hitLineEnd) {
         // Only stop at the line end while the travel still points out of it. A
         // reversal pressed near the end is still shedding outward velocity, so
         // pin the position to the edge and keep integrating until the velocity
         // crosses zero and carries it back inside.
         const bool reversingBackInside =
-            (step.position > maxPosition && _arrowPanDirection < 0) ||
+            (step.position > maxCoordinate && _arrowPanDirection < 0) ||
             (step.position < 0.0 && _arrowPanDirection > 0);
         if (!reversingBackInside) {
             finishArrowPan(position);
@@ -2900,6 +2937,7 @@ void LineAnnotationDialog::cancelArrowPan()
     _arrowPanVelocity = 0.0;
     _arrowPanStopTarget.reset();
     _arrowPanMinimumTarget = std::numeric_limits<double>::quiet_NaN();
+    _arrowPanArclengthUnits.reset();
     _arrowPanEndedByLanding = false;
 }
 
@@ -2914,7 +2952,7 @@ void LineAnnotationDialog::adjustArrowPanCruiseSpeed(double factor)
     if (updated != _arrowPanCruiseSpeed) {
         _arrowPanCruiseSpeed = updated;
         QSettings settings(vc3d::settingsFilePath(), QSettings::IniFormat);
-        settings.setValue(vc3d::settings::line_annotation::ARROW_PAN_SPEED, updated);
+        settings.setValue(vc3d::settings::line_annotation::ARROW_PAN_SPEED_VX, updated);
     }
     // Flash the badge even when the value clamped, so the key press is answered.
     updateArrowPanSpeedIndicator();
@@ -2956,7 +2994,7 @@ void LineAnnotationDialog::updateArrowPanSpeedIndicator()
         _arrowPanSpeedLabel = label;
     }
     _arrowPanSpeedLabel->setText(
-        tr("pan speed %1 /s").arg(QString::number(_arrowPanCruiseSpeed, 'g', 3)));
+        tr("pan speed %1 vx/s").arg(QString::number(_arrowPanCruiseSpeed, 'g', 3)));
     _arrowPanSpeedLabel->adjustSize();
     // Top-center of the top strip; the pause badge sits on the bottom strip.
     _arrowPanSpeedLabel->move(
@@ -3567,7 +3605,19 @@ double LineAnnotationDialog::snappedControlPointPosition(double position) const
     for (const auto& control : _generatedViews.controlPoints) {
         controlLinePositions.push_back(control.linePosition);
     }
-    return vc3d::line_annotation::snappedControlPointLinePosition(position, controlLinePositions);
+    return vc3d::line_annotation::snappedControlPointLinePositionByArclength(
+        position, controlLinePositions, currentLineArclengths());
+}
+
+const std::vector<double>& LineAnnotationDialog::currentLineArclengths() const
+{
+    // The position map's cumulative arclengths, one per displayed line point;
+    // empty (callers fall back to index units) while no usable map exists.
+    static const std::vector<double> kNone;
+    const auto& arclengths = _generatedViews.stripPositionMap.originalArclengths;
+    return vc3d::line_annotation::lineArclengthsUsable(arclengths, _generatedViews.linePoints.size())
+        ? arclengths
+        : kNone;
 }
 
 LineAnnotationDialog::GeneratedOverlay LineAnnotationDialog::staticStripOverlay() const
@@ -4698,6 +4748,7 @@ bool LineAnnotationDialog::placeControlPointAtCurrentLinePosition()
     // paused -- so, like the shift-click snap, it has to stop the pan itself:
     // the placement renumbers the line positions the pan is steering by.
     cancelArrowPan();
+    // The key places ON the line, so its point is also the position's anchor.
     emit generatedControlPointRequested(_generatedViews.currentCutName,
                                         volumePoint,
                                         _currentLinePosition,

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -2085,7 +2085,8 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                     setCurrentCutFollowsStripMouse(true);
                     emit generatedControlPointRequested(_generatedViews.currentCutName,
                                                         volumePoint,
-                                                        _currentLinePosition);
+                                                        _currentLinePosition,
+                                                        interpolatedLinePoint(_currentLinePosition));
                 }
             });
     topSplitter->addWidget(currentViewer);
@@ -2144,7 +2145,8 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                     setCurrentCutFollowsStripMouse(true);
                     emit generatedControlPointRequested(_generatedViews.sideCutName,
                                                         volumePoint,
-                                                        _currentLinePosition);
+                                                        _currentLinePosition,
+                                                        interpolatedLinePoint(_currentLinePosition));
                 }
             });
     topSplitter->addWidget(sideViewer);
@@ -2259,7 +2261,10 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                             if (!controlPointPlacementAllowedAt(position)) {
                                 return;
                             }
-                            emit generatedControlPointRequested(surfaceName, volumePoint, position);
+                            emit generatedControlPointRequested(surfaceName,
+                                                                volumePoint,
+                                                                position,
+                                                                interpolatedLinePoint(position));
                         }
                     }
                 });
@@ -4659,7 +4664,8 @@ bool LineAnnotationDialog::placeControlPointAtCurrentLinePosition()
     cancelArrowPan();
     emit generatedControlPointRequested(_generatedViews.currentCutName,
                                         volumePoint,
-                                        _currentLinePosition);
+                                        _currentLinePosition,
+                                        volumePoint);
     return true;
 }
 

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -9,6 +9,7 @@
 #include "LineAnnotationShiftScroll.hpp"
 #include "VCSettings.hpp"
 #include "ViewerManager.hpp"
+#include "vc/core/util/Logging.hpp"
 #include "vc/core/util/PlaneSurface.hpp"
 #include "vc/core/util/QuadSurface.hpp"
 
@@ -1528,13 +1529,14 @@ void LineAnnotationDialog::connectGeneratedOverlayRefresh(CChunkedVolumeViewer* 
                     return;
                 }
                 if (_arrowPanDirection != 0) {
-                    // During a keyboard pan every tick already rebuilds the
-                    // dynamic overlays (via setCurrentLinePosition), so only
-                    // the static strip overlays need to track the scrolling
-                    // camera here. The side-strip intersection request (which
-                    // clones geometry and snapshots+hashes every fiber per
-                    // call) waits for the landing's full refresh.
-                    rebuildGeneratedStaticStripOverlays();
+                    // During a keyboard pan every tick rebuilds the dynamic
+                    // overlays and shifts the static strip overlays with the
+                    // camera right after the camera move (tickArrowPan), so a
+                    // rebuild here would only re-place the control-point dots
+                    // at an arbitrary phase relative to the ticks. The
+                    // side-strip intersection request (which clones geometry
+                    // and snapshots+hashes every fiber per call) waits for the
+                    // landing's full refresh.
                     return;
                 }
                 rebuildGeneratedOverlays();
@@ -2503,14 +2505,14 @@ void LineAnnotationDialog::applyGeneratedOverlay(const std::string& surfaceName,
     vc3d::line_annotation::applyGeneratedOverlay(viewer, surfaceName, overlay);
 }
 
-void LineAnnotationDialog::applyOverlayForViewer(const std::string& surfaceName,
-                                                 CChunkedVolumeViewer* viewer,
-                                                 const GeneratedOverlay& overlay)
+std::string LineAnnotationDialog::applyOverlayForViewer(const std::string& surfaceName,
+                                                        CChunkedVolumeViewer* viewer,
+                                                        const GeneratedOverlay& overlay)
 {
     if (!kGeneratedLineAnnotationOverlaysEnabled) {
-        return;
+        return {};
     }
-    vc3d::line_annotation::applyGeneratedOverlay(viewer, surfaceName, overlay);
+    return vc3d::line_annotation::applyGeneratedOverlay(viewer, surfaceName, overlay);
 }
 
 void LineAnnotationDialog::clearControlPointContextPreview(const std::string& surfaceName,
@@ -2906,6 +2908,13 @@ void LineAnnotationDialog::tickArrowPan()
     // centered right after - a ~60 Hz flicker that reads as two green lines.
     centerStripsOnLinePosition(position, false);
     setCurrentLinePosition(position, false);
+    // The static strip overlays (control-point dots) bake the camera in too.
+    // Left to the coalesced post-render refresh they trail the camera by up to
+    // one tick and then snap - a jiggle that grows with the pan speed. Their
+    // scene placement is affine in the camera pointer at a fixed zoom, so the
+    // tick shifts the existing items by the camera delta (no item churn) and
+    // rebuilds only when the zoom changed; the landing does the full rebuild.
+    updateStaticStripOverlaysForPan();
 }
 
 void LineAnnotationDialog::finishArrowPan(double position)
@@ -2938,6 +2947,7 @@ void LineAnnotationDialog::cancelArrowPan()
     _arrowPanStopTarget.reset();
     _arrowPanMinimumTarget = std::numeric_limits<double>::quiet_NaN();
     _arrowPanArclengthUnits.reset();
+    _staticStripOverlayPanFallbackWarned = false;
     _arrowPanEndedByLanding = false;
 }
 
@@ -3651,6 +3661,7 @@ void LineAnnotationDialog::rebuildGeneratedStaticStripOverlays()
         return;
     }
 
+    _staticStripOverlayPlacements.assign(_stripViewers.size(), StaticStripOverlayPlacement{});
     for (size_t i = 0; i < _stripViewers.size(); ++i) {
         auto* viewer = _stripViewers[i].data();
         if (!viewer) {
@@ -3671,15 +3682,68 @@ void LineAnnotationDialog::rebuildGeneratedStaticStripOverlays()
         if (sideStrip) {
             strip.fiberIntersections = stripViews.fiberIntersections;
         }
-        applyOverlayForViewer(staticStripOverlayKey(key), viewer, strip);
+        auto& placement = _staticStripOverlayPlacements[i];
+        placement.groupKey = applyOverlayForViewer(staticStripOverlayKey(key), viewer, strip);
+        // The camera these items were placed against; a pan tick shifts them
+        // from here instead of rebuilding (updateStaticStripOverlaysForPan).
+        placement.camera.referenceScene = viewer->surfaceCoordsToScene(0.0f, 0.0f);
+        placement.camera.scale = static_cast<double>(viewer->cameraState().scale);
     }
 
+}
+
+void LineAnnotationDialog::updateStaticStripOverlaysForPan()
+{
+    if (!kGeneratedLineAnnotationOverlaysEnabled) {
+        return;
+    }
+    if (_closing || !_hasGeneratedViews) {
+        return;
+    }
+    if (_staticStripOverlayPlacements.size() != _stripViewers.size()) {
+        rebuildGeneratedStaticStripOverlays();
+        return;
+    }
+    for (size_t i = 0; i < _stripViewers.size(); ++i) {
+        auto* viewer = _stripViewers[i].data();
+        if (!viewer) {
+            continue;
+        }
+        auto& placement = _staticStripOverlayPlacements[i];
+        const QPointF reference = viewer->surfaceCoordsToScene(0.0f, 0.0f);
+        const auto delta = vc3d::line_annotation::generatedOverlayPanTranslation(
+            placement.camera, reference, static_cast<double>(viewer->cameraState().scale));
+        if (!delta) {
+            // The zoom changed under the pan: one ordinary rebuild re-records
+            // every placement.
+            rebuildGeneratedStaticStripOverlays();
+            return;
+        }
+        if (placement.groupKey.empty() ||
+            !viewer->translateOverlayGroup(placement.groupKey, *delta)) {
+            // No group under the key registration returned. Legitimate only
+            // when the viewer dropped its groups (surface swap); anything else
+            // is a bookkeeping bug that would otherwise hide behind this
+            // rebuild, so say so once per pan.
+            if (!_staticStripOverlayPanFallbackWarned) {
+                _staticStripOverlayPanFallbackWarned = true;
+                Logger()->warn(
+                    "Line annotation: static strip overlay group '{}' missing during arrow pan; "
+                    "rebuilding instead of translating",
+                    placement.groupKey);
+            }
+            rebuildGeneratedStaticStripOverlays();
+            return;
+        }
+        placement.camera.referenceScene = reference;
+    }
 }
 
 void LineAnnotationDialog::clearFastGeneratedOverlayItemRefs()
 {
     _fastStripOverlayItems.clear();
     _fastCurrentCutOverlayItems = {};
+    _staticStripOverlayPlacements.clear();
 }
 
 void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrentCutOverlay,

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -370,6 +370,9 @@ private:
     // arrow pan, Space snap) is measured in these units.
     const std::vector<double>& currentLineArclengths() const;
     void rebuildGeneratedStaticStripOverlays();
+    // Arrow-pan tick: shift the static strip overlays with the camera (exact
+    // while the zoom is unchanged), rebuilding only when it is not.
+    void updateStaticStripOverlaysForPan();
     void rebuildGeneratedDynamicOverlays(bool updateCurrentCutOverlay = true,
                                          bool updateSpanLabels = true);
     void updateGeneratedDynamicOverlaysFast(bool updateCurrentCutOverlay,
@@ -384,7 +387,8 @@ private:
     cv::Vec3f currentCutViewerCenterVolumePoint() const;
     void captureInitialGeneratedViewState();
     void restoreInitialGeneratedViewerCameras();
-    void applyOverlayForViewer(const std::string& overlayKey,
+    // Returns the viewer overlay-group key the items were registered under.
+    std::string applyOverlayForViewer(const std::string& overlayKey,
                                CChunkedVolumeViewer* viewer,
                                const GeneratedOverlay& overlay);
     void clearControlPointContextPreview(const std::string& surfaceName,
@@ -504,6 +508,18 @@ private:
     std::vector<float> _savedStripZooms;
     std::vector<QMetaObject::Connection> _generatedOverlayRefreshConnections;
     std::vector<FastStripOverlayItems> _fastStripOverlayItems;
+    // Per strip viewer: the viewer group the current static overlay was
+    // registered under (the key registration returned, used verbatim for the
+    // pan-time translation) and the camera it was built for.
+    struct StaticStripOverlayPlacement {
+        std::string groupKey;
+        vc3d::line_annotation::GeneratedOverlayCameraBaseline camera;
+    };
+    std::vector<StaticStripOverlayPlacement> _staticStripOverlayPlacements;
+    // A missing group during a pan means a registration/lookup mismatch, not a
+    // legitimate rebuild reason; warn once per pan so it cannot hide behind
+    // the rebuild fallback.
+    bool _staticStripOverlayPanFallbackWarned = false;
     FastCurrentCutOverlayItems _fastCurrentCutOverlayItems;
     QPointer<CChunkedVolumeViewer> _currentCutViewer;
     QPointer<CChunkedVolumeViewer> _sideCutViewer;

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -365,6 +365,10 @@ private:
     bool controlPointPlacementAllowedAt(double linePosition) const;
     vc3d::line_annotation::GeneratedCurrentLineMarkerState currentLineMarkerState() const;
     double snappedControlPointPosition(double position) const;
+    // Cumulative base-voxel arclengths of the displayed line (one per point),
+    // or an empty vector when no usable map exists; along-line motion (wheel,
+    // arrow pan, Space snap) is measured in these units.
+    const std::vector<double>& currentLineArclengths() const;
     void rebuildGeneratedStaticStripOverlays();
     void rebuildGeneratedDynamicOverlays(bool updateCurrentCutOverlay = true,
                                          bool updateSpanLabels = true);
@@ -573,6 +577,9 @@ private:
     // (space, edits): only a landed pan may hand back to a still-held key.
     bool _arrowPanEndedByLanding = false;
     double _arrowPanVelocity = 0.0;
+    // Unit the running pan's velocity is in (true: base-voxel arclength,
+    // false: line positions); a change mid-gesture cancels the pan.
+    std::optional<bool> _arrowPanArclengthUnits;
     std::optional<double> _arrowPanStopTarget;
     double _arrowPanMinimumTarget = std::numeric_limits<double>::quiet_NaN();
     double _arrowPanCruiseSpeed =

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -199,9 +199,13 @@ public:
 signals:
     void paneClosed(const std::string& surfaceName);
     void lineSeedRequested(const std::string& surfaceName, cv::Vec3f volumePoint, QPointF scenePoint);
+    // lineAnchor: the 3D point of linePosition on the DISPLAYED line, so the
+    // controller can resolve the position on its own (possibly renumbered)
+    // line without consulting the clicked point.
     void generatedControlPointRequested(const std::string& surfaceName,
                                         cv::Vec3f volumePoint,
-                                        double linePosition);
+                                        double linePosition,
+                                        cv::Vec3f lineAnchor);
     void generatedControlPointDeleteRequested(const std::string& surfaceName,
                                               double linePosition,
                                               cv::Vec3f volumePoint);

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
@@ -205,26 +205,57 @@ char segmentInterpolationModeMarker(SegmentInterpolationMode mode) noexcept
     return '?';
 }
 
+SegmentInterpolationCutoffs segmentInterpolationCutoffs(
+    const vc::fiber_tracer::FiberTraceConfig& traceConfig,
+    const vc::lasagna::LineOptimizationConfig& lasagnaConfig,
+    double traceToBaseScale)
+{
+    SegmentInterpolationCutoffs cutoffs;
+    cutoffs.traceMinimumSpanBaseVoxels = static_cast<double>(kMinimumTraceSteps) *
+        traceConfig.stepVoxels * traceToBaseScale;
+    cutoffs.lasagnaMinimumSpanBaseVoxels =
+        static_cast<double>(kMinimumLasagnaSegments) * lasagnaConfig.segmentLength;
+    if (!std::isfinite(cutoffs.traceMinimumSpanBaseVoxels) ||
+        cutoffs.traceMinimumSpanBaseVoxels <= 0.0) {
+        throw std::invalid_argument(
+            "trace minimum span must be finite and positive (check stepVoxels and traceToBaseScale)");
+    }
+    if (!std::isfinite(cutoffs.lasagnaMinimumSpanBaseVoxels) ||
+        cutoffs.lasagnaMinimumSpanBaseVoxels <= 0.0) {
+        throw std::invalid_argument(
+            "lasagna minimum span must be finite and positive (check segmentLength)");
+    }
+    return cutoffs;
+}
+
 SegmentInterpolationMode resolveSegmentInterpolationMode(
     SegmentInterpolationGoal goal,
     FiberOptimizationMode globalMode,
-    double endpointDistanceBaseVoxels)
+    double endpointDistanceBaseVoxels,
+    const SegmentInterpolationCutoffs& cutoffs)
 {
     if (!std::isfinite(endpointDistanceBaseVoxels) ||
         endpointDistanceBaseVoxels < 0.0) {
         throw std::invalid_argument("segment endpoint distance must be finite and non-negative");
     }
-    if (goal == SegmentInterpolationGoal::Cspline ||
-        (goal == SegmentInterpolationGoal::Global &&
-         endpointDistanceBaseVoxels < 100.0)) {
+    if (goal == SegmentInterpolationGoal::Cspline) {
         return SegmentInterpolationMode::Cspline;
     }
-    if (goal == SegmentInterpolationGoal::Lasagna ||
-        (goal == SegmentInterpolationGoal::Global &&
-         globalMode == FiberOptimizationMode::Lasagna)) {
+    if (goal == SegmentInterpolationGoal::Lasagna) {
         return SegmentInterpolationMode::Lasagna;
     }
-    return SegmentInterpolationMode::Trace;
+    if (goal == SegmentInterpolationGoal::Trace) {
+        return SegmentInterpolationMode::Trace;
+    }
+    // Global goal: the mode's own regime decides the minimum span.
+    if (globalMode == FiberOptimizationMode::Lasagna) {
+        return endpointDistanceBaseVoxels < cutoffs.lasagnaMinimumSpanBaseVoxels
+            ? SegmentInterpolationMode::Cspline
+            : SegmentInterpolationMode::Lasagna;
+    }
+    return endpointDistanceBaseVoxels < cutoffs.traceMinimumSpanBaseVoxels
+        ? SegmentInterpolationMode::Cspline
+        : SegmentInterpolationMode::Trace;
 }
 
 bool isAcceptedNativeTrace(const FiberTraceSegmentMetadata& metadata) noexcept
@@ -357,6 +388,7 @@ void appendFiberModeReport(FiberModeOptimizationResult& output)
     message << output.optimization.report.message
             << "\nfiber_mode native_segments=" << output.nativeSegments
             << " lasagna_fallback_segments=" << output.lasagnaFallbackSegments
+            << " cspline_fallback_segments=" << output.csplineFallbackSegments
             << " native_extrapolations=" << output.nativeExtrapolations
             << " lasagna_fallback_extrapolations="
             << output.lasagnaFallbackExtrapolations;
@@ -661,6 +693,8 @@ FiberModeOptimizationResult optimizeFiberWithNativeFallback(
                 attempt[index] = true;
         }
     }
+    const SegmentInterpolationCutoffs cutoffs = segmentInterpolationCutoffs(
+        request.traceConfig, request.lasagnaConfig, request.traceToBaseScale);
     std::vector<bool> fixedSpan(spans.size(), false);
     for (size_t spanIndex = 0; spanIndex < spans.size(); ++spanIndex) {
         throwIfCancelled();
@@ -675,11 +709,13 @@ FiberModeOptimizationResult optimizeFiberWithNativeFallback(
             fixedSpan[spanIndex] = true;
             continue;
         }
+        const double endpointDistanceBaseVoxels = pointDistance(
+            owner.volumePoint, request.controlPoints[spanIndex + 1].volumePoint);
         const SegmentInterpolationMode requestedMode = resolveSegmentInterpolationMode(
             goal,
             request.globalMode,
-            pointDistance(owner.volumePoint,
-                          request.controlPoints[spanIndex + 1].volumePoint));
+            endpointDistanceBaseVoxels,
+            cutoffs);
         if (requestedMode == SegmentInterpolationMode::Cspline) {
             modes[spanIndex] = SegmentInterpolationMode::Cspline;
             metadata.interpMode = SegmentInterpolationMode::Cspline;
@@ -755,6 +791,22 @@ FiberModeOptimizationResult optimizeFiberWithNativeFallback(
                       request.traceConfig,
                       std::move(traceException));
             owner.segmentToNext->interpGoal = goal;
+            if (goal == SegmentInterpolationGoal::Global &&
+                endpointDistanceBaseVoxels < cutoffs.lasagnaMinimumSpanBaseVoxels) {
+                // Too short for the Lasagna fallback's discretization (it would
+                // be a spline with solver cost and its own failure mode): go
+                // straight to cspline. The trace failure metadata stays on the
+                // span so the diagnostics show what was attempted.
+                auto& metadata = *owner.segmentToNext;
+                modes[spanIndex] = SegmentInterpolationMode::Cspline;
+                metadata.interpMode = SegmentInterpolationMode::Cspline;
+                metadata.metric.reset();
+                if (!metadata.message.empty())
+                    metadata.message += " -> ";
+                metadata.message += "short span, trace -> cspline";
+                ++output.csplineFallbackSegments;
+                continue;
+            }
             modes[spanIndex] = SegmentInterpolationMode::Lasagna;
             ++output.lasagnaFallbackSegments;
             continue;

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.hpp
@@ -50,10 +50,39 @@ enum class SegmentInterpolationMode {
 [[nodiscard]] std::string segmentInterpolationModeToString(SegmentInterpolationMode mode);
 [[nodiscard]] SegmentInterpolationMode segmentInterpolationModeFromString(const std::string& value);
 [[nodiscard]] char segmentInterpolationModeMarker(SegmentInterpolationMode mode) noexcept;
+// Shortest control-point span (straight endpoint distance, base voxels) each
+// fiber-model regime is attempted on under the Global goal; shorter spans are
+// cubic splines. Native trace: kMinimumTraceSteps tracer steps (48 vx with the
+// default 4 vx step), enough room for the beam to correct while the
+// span-bounded endpoint acceptance still has to be earned. Lasagna:
+// kMinimumLasagnaSegments Ceres segments of the line discretization (~63 vx
+// with the default ~31.6 vx segment); below that Lasagna is a spline with
+// solver cost. The two regimes are independent; no ordering is required.
+inline constexpr int kMinimumTraceSteps = 12;
+inline constexpr int kMinimumLasagnaSegments = 2;
+
+struct SegmentInterpolationCutoffs {
+    double traceMinimumSpanBaseVoxels = 0.0;
+    double lasagnaMinimumSpanBaseVoxels = 0.0;
+};
+
+// Derives both cutoffs from the request's tracer and Lasagna configs; throws
+// std::invalid_argument when either is not finite and positive. Precondition:
+// lasagnaConfig.segmentLength > 0 (LineOptimizationConfig defaults to 16 and
+// the controller's request builder sets it from initialLineDiscretization) and
+// traceConfig.stepVoxels > 0 (validated by the tracer as well).
+[[nodiscard]] SegmentInterpolationCutoffs segmentInterpolationCutoffs(
+    const vc::fiber_tracer::FiberTraceConfig& traceConfig,
+    const vc::lasagna::LineOptimizationConfig& lasagnaConfig,
+    double traceToBaseScale);
+
+// Global goal: the global mode's regime when the span reaches that regime's
+// cutoff, else Cspline. Explicit goals are returned as-is regardless of span.
 [[nodiscard]] SegmentInterpolationMode resolveSegmentInterpolationMode(
     SegmentInterpolationGoal goal,
     FiberOptimizationMode globalMode,
-    double endpointDistanceBaseVoxels);
+    double endpointDistanceBaseVoxels,
+    const SegmentInterpolationCutoffs& cutoffs);
 
 [[nodiscard]] std::string fiberOptimizationModeToString(FiberOptimizationMode mode);
 [[nodiscard]] FiberOptimizationMode fiberOptimizationModeFromString(const std::string& value);
@@ -249,6 +278,9 @@ struct FiberModeOptimizationResult {
     vc::lasagna::LineOptimizationResult optimization;
     int nativeSegments = 0;
     int lasagnaFallbackSegments = 0;
+    // Global-goal spans whose trace was attempted and not accepted, and that
+    // are too short for the Lasagna fallback: they went straight to cspline.
+    int csplineFallbackSegments = 0;
     int nativeExtrapolations = 0;
     int lasagnaFallbackExtrapolations = 0;
 };

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
@@ -236,15 +236,15 @@ GeneratedOverlay makeGeneratedCrossSliceControlOverlayForPlane(
     return overlay;
 }
 
-void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
-                           const std::string& surfaceName,
-                           const GeneratedOverlay& overlay)
+std::string applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
+                                  const std::string& surfaceName,
+                                  const GeneratedOverlay& overlay)
 {
     if (!viewer) {
-        return;
+        return {};
     }
 
-    const auto key = "line_annotation_overlay_" + surfaceName;
+    const std::string key = generatedOverlayGroupKey(surfaceName);
     std::vector<ViewerOverlayControllerBase::OverlayPrimitive> primitives;
     size_t branchPointCount = 0;
     for (const auto& branch : overlay.branchLinePoints) {
@@ -712,6 +712,7 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
     }
 
     ViewerOverlayControllerBase::applyPrimitives(viewer, key, std::move(primitives));
+    return key;
 }
 
 void clearGeneratedControlPointContextPreview(CChunkedVolumeViewer* viewer,

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
@@ -647,7 +647,9 @@ void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
     }
 
     if (!overlay.useSurfaceCenterLine && sceneLine.size() >= 2) {
-        const auto controlRange = generatedControlLinePositionRange(overlay.controlPoints);
+        const auto controlRange = overlay.lineTailControlRange.has_value()
+            ? overlay.lineTailControlRange
+            : generatedControlLinePositionRange(overlay.controlPoints);
         // Consecutive non-tail segments accumulate into one polyline
         // primitive per run (same pattern as the branch lines above): a
         // primitive per segment meant one QGraphicsPathItem per segment,

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
@@ -1105,20 +1105,29 @@ inline std::optional<GeneratedParallaxGhost> generatedParallaxGhost(
 // ramp. Everything below is pure arithmetic so it can be exercised without Qt.
 // ---------------------------------------------------------------------------
 
+// The integrator is unit-agnostic; the dialog runs it in base-voxel arclength
+// along the optimized polyline (LineStripPositionMap::originalArclengths) so
+// the pan covers the same physical distance per second in 4 vx trace spans and
+// ~32 vx cspline spans alike, and converts the result back to a line position.
+
 // Seconds spent ramping from rest to the cruise speed (acceleration = cruise / this).
 inline constexpr double kGeneratedArrowPanRampSeconds = 0.25;
-// Cruise-speed bounds and default, in line positions per second (1 unit ~ 30 voxels).
-inline constexpr double kGeneratedArrowPanMinimumSpeed = 1.0;
-inline constexpr double kGeneratedArrowPanMaximumSpeed = 500.0;
-inline constexpr double kGeneratedArrowPanDefaultSpeed = 12.0;
+// Cruise-speed bounds and default, in base voxels of arclength per second. The
+// default matches the previous 12 positions/s at one strip column (8 vx) per
+// position.
+inline constexpr double kGeneratedArrowPanMinimumSpeed = 8.0;
+inline constexpr double kGeneratedArrowPanMaximumSpeed = 4000.0;
+inline constexpr double kGeneratedArrowPanDefaultSpeed = 96.0;
 // Multiplicative step applied by the Up/Down arrows.
 inline constexpr double kGeneratedArrowPanSpeedStep = 1.25;
-// Distance below which a stop target counts as reached.
-inline constexpr double kGeneratedArrowPanLandingEpsilon = 1.0e-9;
+// Distance below which a stop target counts as reached, in the integrator's
+// unit (base voxels in the dialog): far below anything visible, well above
+// double rounding on arclengths of ~1e4.
+inline constexpr double kGeneratedArrowPanLandingEpsilon = 1.0e-3;
 
 struct GeneratedArrowPanState {
     double position = 0.0;
-    // Signed, in line positions per second.
+    // Signed, in the integrator's unit per second.
     double velocity = 0.0;
     // True once the step consumed the stop target exactly.
     bool landed = false;

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
@@ -117,6 +117,11 @@ struct GeneratedOverlay {
 
     std::vector<cv::Vec3f> linePoints;
     std::vector<std::vector<cv::Vec3f>> branchLinePoints;
+    // Line-position range outside which linePoints segments are tails (not
+    // drawn). Defaults to the span of controlPoints; a caller that shows only
+    // a subset of the controls sets the full fiber's range here so interior
+    // spans are not mistaken for tails.
+    std::optional<std::pair<double, double>> lineTailControlRange;
     cv::Vec3f seedPoint{std::numeric_limits<float>::quiet_NaN(),
                         std::numeric_limits<float>::quiet_NaN(),
                         std::numeric_limits<float>::quiet_NaN()};
@@ -187,6 +192,10 @@ struct GeneratedViews {
     // scroll center (NaN where the sample is invalid). Empty when
     // unavailable.
     std::vector<cv::Vec3f> lineNormals;
+    // Unwrapped winding angle (radians) of each line point about the scroll
+    // center, or empty when no center reference exists. See
+    // unwrappedGeneratedWindingAngles.
+    std::vector<double> lineWindingAngles;
     std::vector<std::vector<cv::Vec3f>> branchLinePoints;
     cv::Vec3f seedPoint{std::numeric_limits<float>::quiet_NaN(),
                         std::numeric_limits<float>::quiet_NaN(),
@@ -458,6 +467,101 @@ inline cv::Vec3f interpolatedGeneratedLinePoint(const std::vector<cv::Vec3f>& li
     const float t = static_cast<float>(linePosition - static_cast<double>(lower));
     return linePoints[static_cast<size_t>(lower)] * (1.0f - t) +
            linePoints[static_cast<size_t>(upper)] * t;
+}
+
+// The side cut shows the stretch of the fiber within this winding distance of
+// the current position, on either side: half a wrap.
+inline constexpr double kGeneratedSideCutHalfWrapAngle = 3.14159265358979323846;
+
+// Unwrapped winding angle (radians) of each line point about the scroll
+// center, accumulated along the line so adjacent wraps differ by ~2*pi instead
+// of aliasing onto the same value. towardCenter(point) returns the vector from
+// the point to the center at that point's z (non-finite when unknown). A point
+// without a usable direction gets NaN and does not break the chain: the next
+// finite angle continues from the last finite one. No towardCenter: all NaN.
+inline std::vector<double> unwrappedGeneratedWindingAngles(
+    const std::vector<cv::Vec3f>& linePoints,
+    const std::function<cv::Vec3f(const cv::Vec3f&)>& towardCenter)
+{
+    constexpr double kTwoPi = 2.0 * kGeneratedSideCutHalfWrapAngle;
+    std::vector<double> angles(linePoints.size(), std::numeric_limits<double>::quiet_NaN());
+    if (!towardCenter) {
+        return angles;
+    }
+    std::optional<double> previous;
+    for (size_t i = 0; i < linePoints.size(); ++i) {
+        const cv::Vec3f& point = linePoints[i];
+        if (!std::isfinite(point[0]) || !std::isfinite(point[1]) || !std::isfinite(point[2])) {
+            continue;
+        }
+        const cv::Vec3f toCenter = towardCenter(point);
+        if (!std::isfinite(toCenter[0]) || !std::isfinite(toCenter[1])) {
+            continue;
+        }
+        // Radial direction, center -> point, in the slice plane (z is the axis).
+        const double dx = -static_cast<double>(toCenter[0]);
+        const double dy = -static_cast<double>(toCenter[1]);
+        if (dx * dx + dy * dy <= 1.0e-12) {
+            continue;
+        }
+        double angle = std::atan2(dy, dx);
+        if (previous) {
+            // Nearest equivalent to the previous angle: remainder lands in [-pi, pi].
+            angle = *previous + std::remainder(angle - *previous, kTwoPi);
+        }
+        angles[i] = angle;
+        previous = angle;
+    }
+    return angles;
+}
+
+// Inclusive index range [first, last] of the contiguous stretch of the line
+// around linePosition whose winding angle stays within maxAngleDelta of the
+// angle at linePosition. Without usable angles (empty, size mismatch, or no
+// finite angle at the position) the whole line qualifies. NaN angles inside
+// the stretch are kept so isolated unknown points do not split the run.
+inline std::pair<size_t, size_t> generatedLineIndexRangeWithinWinding(
+    const std::vector<double>& angles,
+    size_t pointCount,
+    double linePosition,
+    double maxAngleDelta)
+{
+    if (pointCount == 0) {
+        return {0, 0};
+    }
+    const std::pair<size_t, size_t> full{0, pointCount - 1};
+    if (angles.size() != pointCount || !std::isfinite(linePosition) ||
+        !(maxAngleDelta >= 0.0)) {
+        return full;
+    }
+    const double clamped = std::clamp(linePosition, 0.0, static_cast<double>(pointCount - 1));
+    const size_t lower = static_cast<size_t>(std::floor(clamped));
+    const size_t upper = std::min(lower + 1, pointCount - 1);
+    double reference = std::numeric_limits<double>::quiet_NaN();
+    if (std::isfinite(angles[lower]) && std::isfinite(angles[upper])) {
+        const double t = clamped - static_cast<double>(lower);
+        reference = angles[lower] * (1.0 - t) + angles[upper] * t;
+    } else if (std::isfinite(angles[lower])) {
+        reference = angles[lower];
+    } else if (std::isfinite(angles[upper])) {
+        reference = angles[upper];
+    }
+    if (!std::isfinite(reference)) {
+        return full;
+    }
+    const auto within = [&](size_t index) {
+        return !std::isfinite(angles[index]) ||
+               std::abs(angles[index] - reference) <= maxAngleDelta;
+    };
+    size_t first = lower;
+    while (first > 0 && within(first - 1)) {
+        --first;
+    }
+    size_t last = upper;
+    while (last + 1 < pointCount && within(last + 1)) {
+        ++last;
+    }
+    return {first, last};
 }
 
 // Content-anchored remap of a fractional line position across a line-geometry

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
@@ -471,10 +471,23 @@ inline cv::Vec3f interpolatedGeneratedLinePoint(const std::vector<cv::Vec3f>& li
 // geometry by a comparable amount, plain nearest-point could jump the anchor
 // onto the other wrap. Falls back to the clamped input position when either
 // polyline is unusable.
-inline double remappedGeneratedLinePosition(const std::vector<cv::Vec3f>& oldLinePoints,
-                                            const std::vector<cv::Vec3f>& newLinePoints,
-                                            double oldPosition)
+//
+// remappedGeneratedLinePositionFromAnchor is the anchor-based core, shared with
+// the controller: a pane reports control-point edits at a line position it
+// measured on the DISPLAYED line, and the controller resolves that position on
+// the session line through the position's own 3D line point. Deliberately not
+// through the clicked point: a click is meant to be off the line, and where
+// another pass of the same fiber runs through the cut plane the clicked point
+// can be nearer to that pass than to the local one.
+template <typename Point>
+inline double remappedGeneratedLinePositionFromAnchor(const std::vector<Point>& newLinePoints,
+                                                      const Point& anchor,
+                                                      double oldPosition)
 {
+    using Scalar = typename Point::value_type;
+    const auto finite = [](const Point& p) {
+        return std::isfinite(p[0]) && std::isfinite(p[1]) && std::isfinite(p[2]);
+    };
     if (newLinePoints.empty()) {
         return 0.0;
     }
@@ -483,18 +496,17 @@ inline double remappedGeneratedLinePosition(const std::vector<cv::Vec3f>& oldLin
         return 0.0;
     }
     const double fallback = std::clamp(oldPosition, 0.0, maxNewPosition);
-    const cv::Vec3f anchor = interpolatedGeneratedLinePoint(oldLinePoints, oldPosition);
-    if (!std::isfinite(anchor[0]) || !std::isfinite(anchor[1]) || !std::isfinite(anchor[2])) {
+    if (!finite(anchor)) {
         return fallback;
     }
     std::optional<size_t> nearestIndex;
     double nearestDistanceSq = std::numeric_limits<double>::max();
     for (size_t i = 0; i < newLinePoints.size(); ++i) {
-        const cv::Vec3f& point = newLinePoints[i];
-        if (!std::isfinite(point[0]) || !std::isfinite(point[1]) || !std::isfinite(point[2])) {
+        const Point& point = newLinePoints[i];
+        if (!finite(point)) {
             continue;
         }
-        const cv::Vec3f delta = point - anchor;
+        const Point delta = point - anchor;
         const double distanceSq = static_cast<double>(delta.dot(delta));
         if (distanceSq < nearestDistanceSq) {
             nearestDistanceSq = distanceSq;
@@ -515,12 +527,11 @@ inline double remappedGeneratedLinePosition(const std::vector<cv::Vec3f>& oldLin
         double chosenIndexDelta = std::abs(
             static_cast<double>(*nearestIndex) - oldPosition);
         for (size_t i = 0; i < newLinePoints.size(); ++i) {
-            const cv::Vec3f& point = newLinePoints[i];
-            if (!std::isfinite(point[0]) || !std::isfinite(point[1]) ||
-                !std::isfinite(point[2])) {
+            const Point& point = newLinePoints[i];
+            if (!finite(point)) {
                 continue;
             }
-            const cv::Vec3f delta = point - anchor;
+            const Point delta = point - anchor;
             const double distanceSq = static_cast<double>(delta.dot(delta));
             if (distanceSq > tieThresholdSq) {
                 continue;
@@ -544,21 +555,20 @@ inline double remappedGeneratedLinePosition(const std::vector<cv::Vec3f>& oldLin
         if (segmentStart + 1 >= newLinePoints.size()) {
             continue;
         }
-        const cv::Vec3f& a = newLinePoints[segmentStart];
-        const cv::Vec3f& b = newLinePoints[segmentStart + 1];
-        if (!std::isfinite(a[0]) || !std::isfinite(a[1]) || !std::isfinite(a[2]) ||
-            !std::isfinite(b[0]) || !std::isfinite(b[1]) || !std::isfinite(b[2])) {
+        const Point& a = newLinePoints[segmentStart];
+        const Point& b = newLinePoints[segmentStart + 1];
+        if (!finite(a) || !finite(b)) {
             continue;
         }
-        const cv::Vec3f segment = b - a;
+        const Point segment = b - a;
         const double lengthSq = static_cast<double>(segment.dot(segment));
         if (!(lengthSq > 0.0)) {
             continue;
         }
         const double t = std::clamp(
             static_cast<double>((anchor - a).dot(segment)) / lengthSq, 0.0, 1.0);
-        const cv::Vec3f projected = a + segment * static_cast<float>(t);
-        const cv::Vec3f delta = projected - anchor;
+        const Point projected = a + segment * static_cast<Scalar>(t);
+        const Point delta = projected - anchor;
         const double distanceSq = static_cast<double>(delta.dot(delta));
         if (distanceSq < bestDistanceSq) {
             bestDistanceSq = distanceSq;
@@ -566,6 +576,17 @@ inline double remappedGeneratedLinePosition(const std::vector<cv::Vec3f>& oldLin
         }
     }
     return std::clamp(bestPosition, 0.0, maxNewPosition);
+}
+
+inline double remappedGeneratedLinePosition(const std::vector<cv::Vec3f>& oldLinePoints,
+                                            const std::vector<cv::Vec3f>& newLinePoints,
+                                            double oldPosition)
+{
+    if (newLinePoints.empty() || !std::isfinite(oldPosition)) {
+        return 0.0;
+    }
+    const cv::Vec3f anchor = interpolatedGeneratedLinePoint(oldLinePoints, oldPosition);
+    return remappedGeneratedLinePositionFromAnchor(newLinePoints, anchor, oldPosition);
 }
 
 // One sign (+1/-1) per fiber for the DISPLAYED tangent used to pose the

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
@@ -1125,6 +1125,39 @@ inline constexpr double kGeneratedArrowPanSpeedStep = 1.25;
 // double rounding on arclengths of ~1e4.
 inline constexpr double kGeneratedArrowPanLandingEpsilon = 1.0e-3;
 
+// Camera baseline an overlay group was built against: the scene position of
+// a fixed reference surface point and the camera scale. A strip viewer maps
+// surface to scene as (surface - cameraPointer) * scale + viewportCenter, so
+// while the scale is unchanged every camera move (pan, linked-camera echo,
+// viewport recenter) shifts all overlay items by one common scene delta.
+struct GeneratedOverlayCameraBaseline {
+    QPointF referenceScene{std::numeric_limits<double>::quiet_NaN(),
+                           std::numeric_limits<double>::quiet_NaN()};
+    double scale = std::numeric_limits<double>::quiet_NaN();
+};
+
+// The scene delta that moves an overlay built at `baseline` to the camera
+// whose reference point now sits at `referenceScene`, or nullopt when the
+// items must be rebuilt instead: the scale changed (a zoom), or either state
+// is unknown.
+inline std::optional<QPointF> generatedOverlayPanTranslation(
+    const GeneratedOverlayCameraBaseline& baseline,
+    const QPointF& referenceScene,
+    double scale)
+{
+    const auto finitePoint = [](const QPointF& point) {
+        return std::isfinite(point.x()) && std::isfinite(point.y());
+    };
+    if (!finitePoint(baseline.referenceScene) || !std::isfinite(baseline.scale) ||
+        !finitePoint(referenceScene) || !std::isfinite(scale)) {
+        return std::nullopt;
+    }
+    if (scale != baseline.scale) {
+        return std::nullopt;
+    }
+    return referenceScene - baseline.referenceScene;
+}
+
 struct GeneratedArrowPanState {
     double position = 0.0;
     // Signed, in the integrator's unit per second.
@@ -1443,9 +1476,18 @@ GeneratedOverlay makeGeneratedCrossSliceControlOverlayForPlane(const GeneratedVi
                                                                CChunkedVolumeViewer* viewer,
                                                                PlaneSurface* plane,
                                                                const GeneratedControlPointLinePositionIndex* controlIndex = nullptr);
-void applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
-                           const std::string& surfaceName,
-                           const GeneratedOverlay& overlay);
+// The viewer overlay-group key applyGeneratedOverlay registers an overlay
+// under. Single source for registration and for anything that later addresses
+// the group (translateOverlayGroup during a pan).
+inline std::string generatedOverlayGroupKey(const std::string& surfaceName)
+{
+    return "line_annotation_overlay_" + surfaceName;
+}
+// Registers the overlay's items on the viewer and returns the group key they
+// were registered under (empty when nothing was registered).
+std::string applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
+                                  const std::string& surfaceName,
+                                  const GeneratedOverlay& overlay);
 void clearGeneratedControlPointContextPreview(CChunkedVolumeViewer* viewer,
                                               const std::string& surfaceName);
 GeneratedControlPointContextResult showGeneratedControlPointContextMenu(

--- a/volume-cartographer/apps/VC3D/LineAnnotationShiftScroll.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationShiftScroll.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
+#include "FiberSliceGeometry.hpp"
+#include "vc/lasagna/LineViewBuilder.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <vector>
 
 #include <opencv2/core.hpp>
 
@@ -11,7 +15,35 @@ namespace vc3d::line_annotation {
 constexpr double kDefaultBottomCrossSliceLineStep = 10.0;
 constexpr double kMinBottomCrossSliceLineStep = 0.25;
 constexpr double kBottomCrossSliceLineStepFactor = 1.5;
+// Legacy snap threshold in line positions (vertex indices); the current cut
+// uses the arclength threshold below, this one remains for callers without an
+// arclength map (intersection inspection follow slices).
 constexpr double kControlPointSnapLinePositionThreshold = 0.25;
+
+// Along-line motion in the current cut is measured in base-voxel arclength,
+// not vertex indices: the dense line is 4 vx per vertex in trace spans and
+// ~32 vx in cspline/Lasagna spans, so index steps moved 8x faster in one than
+// the other. One shift+wheel notch (at slice step size 1) moves one strip
+// column; Space snaps onto a control within a quarter of a column.
+constexpr double kShiftScrollLineStepBaseVoxels =
+    vc::lasagna::kLineViewAlongSamplingDistanceBaseVoxels;
+constexpr double kControlPointSnapArclengthBaseVoxels =
+    vc::lasagna::kLineViewAlongSamplingDistanceBaseVoxels * 0.25;
+
+// True when `cumulativeArclengths` can map positions of a line with
+// `linePointCount` points (one entry per vertex, at least two).
+inline bool lineArclengthsUsable(const std::vector<double>& cumulativeArclengths,
+                                 size_t linePointCount)
+{
+    return cumulativeArclengths.size() == linePointCount && linePointCount >= 2 &&
+           std::isfinite(cumulativeArclengths.back()) && cumulativeArclengths.back() > 0.0;
+}
+
+// The map on its own: at least two finite, increasing-to-positive entries.
+inline bool lineArclengthsUsable(const std::vector<double>& cumulativeArclengths)
+{
+    return lineArclengthsUsable(cumulativeArclengths, cumulativeArclengths.size());
+}
 
 inline int shiftScrollLineStepSize(int viewerSliceStepSize)
 {
@@ -30,6 +62,31 @@ inline double shiftedLinePosition(double currentPosition,
     const double delta = static_cast<double>(scrollSteps) *
                          static_cast<double>(shiftScrollLineStepSize(viewerSliceStepSize));
     return std::clamp(currentPosition + delta, 0.0, maxLinePosition);
+}
+
+// Arclength-based sibling of shiftedLinePosition: each notch moves
+// kShiftScrollLineStepBaseVoxels * step size along the optimized polyline.
+// Without a usable arclength map it falls back to the index-based step.
+inline double shiftedLinePositionByArclength(double currentPosition,
+                                             int scrollSteps,
+                                             int viewerSliceStepSize,
+                                             const std::vector<double>& cumulativeArclengths)
+{
+    const int linePointCount = static_cast<int>(cumulativeArclengths.size());
+    if (!lineArclengthsUsable(cumulativeArclengths)) {
+        return shiftedLinePosition(currentPosition, scrollSteps, viewerSliceStepSize, linePointCount);
+    }
+    const double maxLinePosition = static_cast<double>(linePointCount - 1);
+    const double deltaBaseVoxels = static_cast<double>(scrollSteps) *
+                                   static_cast<double>(shiftScrollLineStepSize(viewerSliceStepSize)) *
+                                   kShiftScrollLineStepBaseVoxels;
+    const double currentArclength = vc3d::fiber_slice::arclengthAtLinePosition(
+        cumulativeArclengths, std::clamp(currentPosition, 0.0, maxLinePosition));
+    const double targetArclength = std::clamp(
+        currentArclength + deltaBaseVoxels, 0.0, cumulativeArclengths.back());
+    return std::clamp(vc3d::fiber_slice::linePositionAtArclength(cumulativeArclengths, targetArclength),
+                      0.0,
+                      maxLinePosition);
 }
 
 inline cv::Vec3f shiftedPlaneOriginAlongNormal(const cv::Vec3f& currentOrigin,
@@ -98,6 +155,39 @@ inline double snappedControlPointLinePosition(double position,
         }
     }
     return bestDistance <= threshold ? bestPosition : position;
+}
+
+// Arclength-based sibling of snappedControlPointLinePosition: snaps when the
+// nearest control is within `thresholdBaseVoxels` along the optimized
+// polyline. Without a usable arclength map it falls back to the index-based
+// quarter-position threshold.
+template <typename LinePositionRange>
+inline double snappedControlPointLinePositionByArclength(
+    double position,
+    const LinePositionRange& controlLinePositions,
+    const std::vector<double>& cumulativeArclengths,
+    double thresholdBaseVoxels = kControlPointSnapArclengthBaseVoxels)
+{
+    if (!lineArclengthsUsable(cumulativeArclengths) || !std::isfinite(position)) {
+        return snappedControlPointLinePosition(position, controlLinePositions);
+    }
+    const double targetArclength =
+        vc3d::fiber_slice::arclengthAtLinePosition(cumulativeArclengths, position);
+    double bestPosition = position;
+    double bestDistance = std::numeric_limits<double>::infinity();
+    for (const double controlLinePosition : controlLinePositions) {
+        if (!std::isfinite(controlLinePosition)) {
+            continue;
+        }
+        const double distance = std::abs(
+            vc3d::fiber_slice::arclengthAtLinePosition(cumulativeArclengths, controlLinePosition) -
+            targetArclength);
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            bestPosition = controlLinePosition;
+        }
+    }
+    return bestDistance <= thresholdBaseVoxels ? bestPosition : position;
 }
 
 } // namespace vc3d::line_annotation

--- a/volume-cartographer/apps/VC3D/VCSettings.hpp
+++ b/volume-cartographer/apps/VC3D/VCSettings.hpp
@@ -329,10 +329,12 @@ namespace line_annotation {
     // Keep the existing persisted key for settings compatibility.
     constexpr auto MAX_CONTROL_POINT_DISTANCE_VX = "lineAnnotation/max_control_point_distance_vx";
     constexpr int MAX_CONTROL_POINT_DISTANCE_VX_DEFAULT = 0;
-    // Cruise speed of the Left/Right arrow pan between control points, in line
-    // positions per second (1 unit ~ 30 voxels of arc length). Up/Down adjust it.
-    constexpr auto ARROW_PAN_SPEED = "lineAnnotation/arrow_pan_speed";
-    constexpr double ARROW_PAN_SPEED_DEFAULT = 12.0;
+    // Cruise speed of the Left/Right arrow pan between control points, in base
+    // voxels of optimized-polyline arclength per second. Up/Down adjust it.
+    // "_vx" retires the line-positions-per-second key: its values would be 4x
+    // to 32x off in the new unit, so they are neither read nor migrated.
+    constexpr auto ARROW_PAN_SPEED_VX = "lineAnnotation/arrow_pan_speed_vx";
+    constexpr double ARROW_PAN_SPEED_VX_DEFAULT = 96.0;
     // "_v2" retires ratios saved before the fixed top strip / smaller bottom
     // strip layout; old values would override the new default proportions.
     constexpr auto OUTER_SPLITTER_SIZES = "lineAnnotation/outer_splitter_sizes_v2";

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -1399,8 +1399,10 @@ void CChunkedVolumeViewer::onSurfaceChangedImpl(const std::string& name, const s
         dropSurfaceCaches();
         clearIntersectionItems();
         _measurement = {};
-        _scene->clear();
+        // Forget the overlay groups before the scene deletes their items, so
+        // no group ever names a freed item (translateOverlayGroup walks them).
         _overlayGroups.clear();
+        _scene->clear();
         _cursorCrosshair = nullptr;
         _lineAnnotationPlacementMarker = nullptr;
         _focusMarker = nullptr;
@@ -5298,23 +5300,42 @@ void CChunkedVolumeViewer::setOverlayGroup(const std::string& key, const std::ve
     }
 }
 
+bool CChunkedVolumeViewer::translateOverlayGroup(const std::string& key, const QPointF& delta)
+{
+    const auto it = _overlayGroups.find(key);
+    if (it == _overlayGroups.end())
+        return false;
+    if (delta.isNull())
+        return true;
+    for (auto* item : it->second) {
+        if (item)
+            item->moveBy(delta.x(), delta.y());
+    }
+    return true;
+}
+
 void CChunkedVolumeViewer::clearOverlayGroup(const std::string& key)
 {
     auto it = _overlayGroups.find(key);
     if (it == _overlayGroups.end())
         return;
-    for (auto* item : it->second)
-        delete item;
+    // Detach before deleting: the map must never name a freed item
+    // (translateOverlayGroup walks the registered items).
+    const std::vector<QGraphicsItem*> items = std::move(it->second);
     _overlayGroups.erase(it);
+    for (auto* item : items)
+        delete item;
 }
 
 void CChunkedVolumeViewer::clearAllOverlayGroups()
 {
-    for (auto& [_, items] : _overlayGroups) {
+    // Detach before deleting, as in clearOverlayGroup.
+    const auto groups = std::move(_overlayGroups);
+    _overlayGroups.clear();
+    for (const auto& [_, items] : groups) {
         for (auto* item : items)
             delete item;
     }
-    _overlayGroups.clear();
 }
 
 std::vector<std::pair<QRectF, QColor>> CChunkedVolumeViewer::selections() const

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -171,6 +171,11 @@ public:
     const std::vector<ViewerOverlayControllerBase::PathPrimitive>& drawingPaths() const override;
 
     void setOverlayGroup(const std::string& key, const std::vector<QGraphicsItem*>& items) override;
+    // Moves every item registered under `key` by `delta` scene units; false
+    // when no group is registered under that key. Overlay scene coordinates
+    // are affine in the camera pointer at a fixed zoom, so a pan can shift a
+    // group in place instead of rebuilding it.
+    bool translateOverlayGroup(const std::string& key, const QPointF& delta);
     void clearOverlayGroup(const std::string& key) override;
     void clearAllOverlayGroups() override;
 

--- a/volume-cartographer/core/include/vc/fiber_tracer/FiberTrace.hpp
+++ b/volume-cartographer/core/include/vc/fiber_tracer/FiberTrace.hpp
@@ -538,6 +538,22 @@ struct CandidateScoreDebug {
     const vc::lasagna::NormalSampler* normalSampler = nullptr,
     const FiberTraceProgressCallback& progress = {});
 
+// Fraction of a segment's start-to-target distance that bounds the endpoint
+// acceptance threshold for that segment. The fixed threshold
+// (endpointAcceptThresholdBaseVoxels, 20 vx by default) is right for long
+// spans; on a span only a few times that long it would accept an endpoint that
+// never really reached the target. Not a config field: the persisted config
+// keys are matched exactly on load, so the fraction is a compile-time constant
+// and the effective threshold is reproducible from the persisted config plus
+// the span geometry.
+inline constexpr double kEndpointAcceptSpanFraction = 0.25;
+
+// min(config.endpointAcceptThresholdBaseVoxels, kEndpointAcceptSpanFraction * span).
+// A non-finite or negative span leaves the configured threshold unchanged.
+[[nodiscard]] double effectiveEndpointAcceptThresholdBaseVoxels(
+    const FiberTraceConfig& config,
+    double spanLengthBaseVoxels);
+
 [[nodiscard]] FiberTraceSegmentResult traceFiberSegment(
     const FiberPredictionSource& predictions,
     const FiberTraceSegmentRequest& request,

--- a/volume-cartographer/core/include/vc/lasagna/LineViewBuilder.hpp
+++ b/volume-cartographer/core/include/vc/lasagna/LineViewBuilder.hpp
@@ -11,7 +11,15 @@ class QuadSurface;
 
 namespace vc::lasagna {
 
-inline constexpr double kLineViewSamplingDistanceBaseVoxels = 32.0;
+// Along-strip resampling target and declared along-line grid density. Also the
+// control-point collapse radius in VC3D (LineAnnotationController), which keeps
+// every control span at least this long so no span is ever shorter than one
+// strip column (the #1484 strip model: a span shorter than the target is drawn
+// as one full column and would be stretched).
+inline constexpr double kLineViewAlongSamplingDistanceBaseVoxels = 8.0;
+// Cross-row spacing of the fixed seven-row ribbons (192 base voxels first to
+// last row). Independent of the along-strip target; along <= cross.
+inline constexpr double kLineViewCrossRowSpacingBaseVoxels = 32.0;
 inline constexpr int kLineViewCrossSampleCount = 7;
 
 struct LineViewConfig {
@@ -19,7 +27,7 @@ struct LineViewConfig {
     // optimized polyline between adjacent controls as closely as possible to
     // this spacing. The declared along-strip scale always uses this target, so
     // a shorter control-point span occupies one full display interval.
-    double targetSpacingBaseVoxels = kLineViewSamplingDistanceBaseVoxels;
+    double targetSpacingBaseVoxels = kLineViewAlongSamplingDistanceBaseVoxels;
     // Fractional indices into LineModel::points. Line endpoints are always
     // retained as additional supports. Empty retains every line point for
     // callers that do not have separate annotation-control metadata.

--- a/volume-cartographer/core/src/fiber_tracer/FiberTrace.cpp
+++ b/volume-cartographer/core/src/fiber_tracer/FiberTrace.cpp
@@ -4691,6 +4691,10 @@ FiberTraceOneWayResult traceFiberExtrapolation(
     request.targetPoint = startPoint + direction * distanceVoxels;
     request.initialDirection = direction;
     request.budgetSpanVoxels = distanceVoxels;
+    // No target planes and no endpoint acceptance here: an open-tail
+    // extrapolation has a synthetic target at the requested distance, nothing
+    // to "reach", so the span-bounded endpoint threshold of traceFiberSegment
+    // deliberately does not apply.
     request.config = config;
     return traceOneWayCore(
         predictions,
@@ -4699,6 +4703,16 @@ FiberTraceOneWayResult traceFiberExtrapolation(
         progress,
         "extrapolation",
         distanceVoxels);
+}
+
+double effectiveEndpointAcceptThresholdBaseVoxels(const FiberTraceConfig& config,
+                                                  double spanLengthBaseVoxels)
+{
+    if (!std::isfinite(spanLengthBaseVoxels) || spanLengthBaseVoxels < 0.0) {
+        return config.endpointAcceptThresholdBaseVoxels;
+    }
+    return std::min(config.endpointAcceptThresholdBaseVoxels,
+                    kEndpointAcceptSpanFraction * spanLengthBaseVoxels);
 }
 
 FiberTraceSegmentResult traceFiberSegment(
@@ -4721,7 +4735,17 @@ FiberTraceSegmentResult traceFiberSegment(
     FiberTraceSegmentResult result;
     const cv::Vec3d start = request.referenceLine[request.startIndex];
     const cv::Vec3d target = request.referenceLine[request.targetIndex];
+    // The reference line, start, target and span are in trace voxels; the
+    // acceptance threshold is configured in base voxels.
     const double span = length(target - start);
+    // One effective config for this segment: the endpoint acceptance is
+    // bounded by the span (see effectiveEndpointAcceptThresholdBaseVoxels), and
+    // the same value drives both one-way target-plane acceptances (through
+    // targetPlaneAcceptThresholdVoxels; traceOneWayCore does not read the
+    // config threshold itself) and the meeting fusion below.
+    FiberTraceConfig config = request.config;
+    config.endpointAcceptThresholdBaseVoxels = effectiveEndpointAcceptThresholdBaseVoxels(
+        request.config, span * request.config.traceToBaseScale);
     FiberTraceOneWayRequest forwardOneWay;
     forwardOneWay.startPoint = start;
     forwardOneWay.targetPoint = target;
@@ -4734,11 +4758,10 @@ FiberTraceSegmentResult traceFiberSegment(
         request.startIndex,
         target);
     forwardOneWay.targetPlaneAcceptThresholdVoxels =
-        request.config.endpointAcceptThresholdBaseVoxels /
-        request.config.traceToBaseScale;
+        config.endpointAcceptThresholdBaseVoxels / config.traceToBaseScale;
     forwardOneWay.snapTraceToSelectedCrossing = false;
     forwardOneWay.budgetSpanVoxels = span;
-    forwardOneWay.config = request.config;
+    forwardOneWay.config = config;
     FiberTraceOneWayRequest reverseOneWay;
     reverseOneWay.startPoint = target;
     reverseOneWay.targetPoint = start;
@@ -4751,11 +4774,10 @@ FiberTraceSegmentResult traceFiberSegment(
         request.targetIndex,
         start);
     reverseOneWay.targetPlaneAcceptThresholdVoxels =
-        request.config.endpointAcceptThresholdBaseVoxels /
-        request.config.traceToBaseScale;
+        config.endpointAcceptThresholdBaseVoxels / config.traceToBaseScale;
     reverseOneWay.snapTraceToSelectedCrossing = false;
     reverseOneWay.budgetSpanVoxels = span;
-    reverseOneWay.config = request.config;
+    reverseOneWay.config = config;
 
     result.forward = traceOneWayCore(
         predictions, forwardOneWay, normalSampler, progress, "forward");
@@ -4763,7 +4785,7 @@ FiberTraceSegmentResult traceFiberSegment(
         predictions, reverseOneWay, normalSampler, progress, "reverse");
 
     const TraceMeetingFusion fusion =
-        fuseTraceMeetings(result.forward, result.reverse, request.config);
+        fuseTraceMeetings(result.forward, result.reverse, config);
     result.fusedLine = fusion.fusedLine;
     if (!result.fusedLine.empty()) {
         result.fusedLine.front() = request.referenceLine[request.startIndex];

--- a/volume-cartographer/core/src/lasagna/LineViewBuilder.cpp
+++ b/volume-cartographer/core/src/lasagna/LineViewBuilder.cpp
@@ -82,7 +82,7 @@ std::vector<double> crossOffsets()
     const int center = kLineViewCrossSampleCount / 2;
     for (int i = 0; i < kLineViewCrossSampleCount; ++i) {
         offsets.push_back(
-            static_cast<double>(i - center) * kLineViewSamplingDistanceBaseVoxels);
+            static_cast<double>(i - center) * kLineViewCrossRowSpacingBaseVoxels);
     }
     return offsets;
 }
@@ -915,13 +915,13 @@ LineViewSurfaces buildLineViewSurfaces(const LineModel& line, const LineViewConf
                                        fixedCrossOffsets,
                                        ribbonFrames,
                                        positionMap.stripGridSpacingBaseVoxels,
-                                       kLineViewSamplingDistanceBaseVoxels,
+                                       kLineViewCrossRowSpacingBaseVoxels,
                                        true);
     surfaces.lineSideSlice = buildRibbon(ribbonSamples,
                                          fixedCrossOffsets,
                                          ribbonFrames,
                                          positionMap.stripGridSpacingBaseVoxels,
-                                         kLineViewSamplingDistanceBaseVoxels,
+                                         kLineViewCrossRowSpacingBaseVoxels,
                                          false);
     surfaces.stripPositionMap = positionMap;
 

--- a/volume-cartographer/core/test/test_fiber_trace3d.cpp
+++ b/volume-cartographer/core/test/test_fiber_trace3d.cpp
@@ -288,6 +288,24 @@ TEST_CASE("native fiber tracer defaults match regular Trace2CP command")
     CHECK_FALSE(config.baseVoxelSizeUm.has_value());
 }
 
+TEST_CASE("native fiber tracer bounds endpoint acceptance by a quarter of the span")
+{
+    using vc::fiber_tracer::effectiveEndpointAcceptThresholdBaseVoxels;
+    using vc::fiber_tracer::kEndpointAcceptSpanFraction;
+    const vc::fiber_tracer::FiberTraceConfig config;  // 20 vx threshold
+    CHECK(kEndpointAcceptSpanFraction == doctest::Approx(0.25));
+    // Long span: the configured threshold stands.
+    CHECK(effectiveEndpointAcceptThresholdBaseVoxels(config, 200.0) == doctest::Approx(20.0));
+    CHECK(effectiveEndpointAcceptThresholdBaseVoxels(config, 80.0) == doctest::Approx(20.0));
+    // Short span: a 40 vx span accepts at most a 10 vx endpoint miss.
+    CHECK(effectiveEndpointAcceptThresholdBaseVoxels(config, 40.0) == doctest::Approx(10.0));
+    CHECK(effectiveEndpointAcceptThresholdBaseVoxels(config, 0.0) == doctest::Approx(0.0));
+    // Unknown span: unchanged.
+    CHECK(effectiveEndpointAcceptThresholdBaseVoxels(
+              config, std::numeric_limits<double>::quiet_NaN()) == doctest::Approx(20.0));
+    CHECK(effectiveEndpointAcceptThresholdBaseVoxels(config, -5.0) == doctest::Approx(20.0));
+}
+
 TEST_CASE("fiber prediction trace scales derive from existing manifest fields")
 {
     vc::lasagna::LasagnaDatasetManifest manifest;

--- a/volume-cartographer/core/test/test_lasagna_line_view_surfaces.cpp
+++ b/volume-cartographer/core/test/test_lasagna_line_view_surfaces.cpp
@@ -118,9 +118,10 @@ TEST_CASE("LineViewBuilder uses a fixed seven-row cross strip")
     checkVec(sideSlicePoints(3, 0), {0.0, 0.0, 0.0});
     checkVec(sideSlicePoints(4, 0), {0.0, 0.0, 32.0});
     checkVec(sideSlicePoints(6, 0), {0.0, 0.0, 96.0});
-    CHECK(views.lineSurface->scale()[0] == doctest::Approx(1.0 / 32.0));
+    // Along-line density follows the 8 vx sampling target; cross rows stay 32 vx.
+    CHECK(views.lineSurface->scale()[0] == doctest::Approx(1.0 / 8.0));
     CHECK(views.lineSurface->scale()[1] == doctest::Approx(1.0 / 32.0));
-    CHECK(views.lineSideSlice->scale()[0] == doctest::Approx(1.0 / 32.0));
+    CHECK(views.lineSideSlice->scale()[0] == doctest::Approx(1.0 / 8.0));
     CHECK(views.lineSideSlice->scale()[1] == doctest::Approx(1.0 / 32.0));
     CHECK(views.lineSurface->strictQuadRenderValidity());
     CHECK(views.lineSideSlice->strictQuadRenderValidity());
@@ -450,6 +451,7 @@ TEST_CASE("LineViewBuilder resamples by arc length only between annotation contr
     }
 
     vc::lasagna::LineViewConfig config;
+    config.targetSpacingBaseVoxels = 32.0;
     config.controlPointLinePositions = {0.0, 1.0, 3.0};
     const auto views = vc::lasagna::buildLineViewSurfaces(line, config);
     const auto points = views.lineSurface->rawPoints();
@@ -475,6 +477,36 @@ TEST_CASE("LineViewBuilder resamples by arc length only between annotation contr
     }
 }
 
+TEST_CASE("LineViewBuilder default along target is 8 vx while cross rows stay 32 vx")
+{
+    // A 16 vx control span is two columns at the default target (it was one
+    // column at the previous 32 vx target); the 4 vx span stays one column.
+    vc::lasagna::LineModel line;
+    for (const double x : {0.0, 4.0, 20.0}) {
+        line.points.push_back({{x, 0.0, 0.0}, normal({0.0, 0.0, 1.0}), true});
+    }
+    vc::lasagna::LineViewConfig config;
+    config.controlPointLinePositions = {0.0, 1.0, 2.0};
+    const auto views = vc::lasagna::buildLineViewSurfaces(line, config);
+    const auto points = views.lineSurface->rawPoints();
+    REQUIRE(points.rows == 7);
+    REQUIRE(points.cols == 4);
+    CHECK(vc::lasagna::kLineViewAlongSamplingDistanceBaseVoxels == doctest::Approx(8.0));
+    CHECK(views.stripPositionMap.stripGridSpacingBaseVoxels == doctest::Approx(8.0));
+    CHECK(views.lineSurface->scale()[0] == doctest::Approx(1.0 / 8.0));
+    CHECK(views.lineSurface->scale()[1] == doctest::Approx(1.0 / 32.0));
+    checkVec(points(points.rows / 2, 0), {0.0, 0.0, 0.0});
+    checkVec(points(points.rows / 2, 1), {4.0, 0.0, 0.0});
+    checkVec(points(points.rows / 2, 2), {12.0, 0.0, 0.0});
+    checkVec(points(points.rows / 2, 3), {20.0, 0.0, 0.0});
+    checkVec(points(0, 0), {0.0, -96.0, 0.0});
+    checkVec(points(6, 0), {0.0, 96.0, 0.0});
+    CHECK(views.stripPositionMap.originalPositionToStripGridColumn(1.0) ==
+          doctest::Approx(1.0));
+    CHECK(views.stripPositionMap.originalPositionToStripGridColumn(2.0) ==
+          doctest::Approx(3.0));
+}
+
 TEST_CASE("LineViewBuilder follows optimized bends between control supports")
 {
     vc::lasagna::LineModel line;
@@ -487,6 +519,7 @@ TEST_CASE("LineViewBuilder follows optimized bends between control supports")
     }
 
     vc::lasagna::LineViewConfig config;
+    config.targetSpacingBaseVoxels = 32.0;
     config.controlPointLinePositions = {0.0, 2.0, 3.0};
     const auto views = vc::lasagna::buildLineViewSurfaces(line, config);
     const auto points = views.lineSurface->rawPoints();
@@ -510,6 +543,7 @@ TEST_CASE("LineViewBuilder keeps fractional control positions as exact supports"
     }
 
     vc::lasagna::LineViewConfig config;
+    config.targetSpacingBaseVoxels = 32.0;
     config.controlPointLinePositions = {0.5, 2.0};
     const auto views = vc::lasagna::buildLineViewSurfaces(line, config);
     const auto points = views.lineSurface->rawPoints();

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -988,6 +988,66 @@ TEST_CASE("line annotation remapped line position follows the same fiber spot")
     }
 }
 
+TEST_CASE("line annotation anchor remap keeps a pane position on its own fiber pass")
+{
+    using vc3d::line_annotation::remappedGeneratedLinePositionFromAnchor;
+
+    // Two passes of the same fiber through one cut plane: an outbound pass
+    // along y=0 (indices 0..10) and a return pass along y=6 (indices 11..21).
+    // The pane reports position 5 on the outbound pass; the click that
+    // requests the control point lands 5.5 units off that pass, i.e. within
+    // half a unit of the return pass.
+    std::vector<cv::Vec3d> line;
+    for (int i = 0; i <= 10; ++i) {
+        line.push_back({static_cast<double>(i), 0.0, 0.0});
+    }
+    for (int i = 0; i <= 10; ++i) {
+        line.push_back({static_cast<double>(10 - i), 6.0, 0.0});
+    }
+    const cv::Vec3d click(5.0, 5.5, 0.0);
+    const cv::Vec3d anchor(5.0, 0.0, 0.0);
+
+    SUBCASE("the clicked point is nearer to the other pass")
+    {
+        // The regression this guards: resolving the position through the
+        // click picked the return pass, thousands of vertices away on a real
+        // fiber, so the edit collapsed into that pass's control point.
+        CHECK(vc3d::fiber_slice::nearestLinePointIndex(line, click) == 16);
+    }
+
+    SUBCASE("the anchor keeps the position on the outbound pass")
+    {
+        CHECK(remappedGeneratedLinePositionFromAnchor(line, anchor, 5.0) ==
+              doctest::Approx(5.0));
+    }
+
+    SUBCASE("a renumbered line still resolves through the anchor")
+    {
+        // The session line resampled the outbound pass at half spacing while
+        // the pane still measured position 4.25 on the old line: the anchor
+        // (4.25, 0, 0) lives at index 8.5 now.
+        std::vector<cv::Vec3d> renumbered;
+        for (int i = 0; i <= 20; ++i) {
+            renumbered.push_back({static_cast<double>(i) * 0.5, 0.0, 0.0});
+        }
+        for (int i = 0; i <= 10; ++i) {
+            renumbered.push_back({static_cast<double>(10 - i), 6.0, 0.0});
+        }
+        CHECK(remappedGeneratedLinePositionFromAnchor(
+                  renumbered, cv::Vec3d(4.25, 0.0, 0.0), 4.25) ==
+              doctest::Approx(8.5));
+    }
+
+    SUBCASE("a non-finite anchor falls back to the clamped position")
+    {
+        const double nan = std::numeric_limits<double>::quiet_NaN();
+        CHECK(remappedGeneratedLinePositionFromAnchor(
+                  line, cv::Vec3d(nan, 0.0, 0.0), 5.0) == doctest::Approx(5.0));
+        CHECK(remappedGeneratedLinePositionFromAnchor(
+                  line, cv::Vec3d(nan, 0.0, 0.0), 99.0) == doctest::Approx(21.0));
+    }
+}
+
 TEST_CASE("line annotation fixed current slice snaps only within quarter line position")
 {
     const std::vector<double> controlPositions{12.0, 20.0, 40.0};

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -456,6 +456,73 @@ TEST_CASE("line annotation shift scroll uses viewer slice step size")
     CHECK(vc3d::line_annotation::shiftedLinePosition(2.0, -2, 5, 101) == 0.0);
 }
 
+TEST_CASE("line annotation shift scroll by arclength moves one strip column per notch")
+{
+    using vc3d::line_annotation::kShiftScrollLineStepBaseVoxels;
+    using vc3d::line_annotation::shiftedLinePositionByArclength;
+    CHECK(kShiftScrollLineStepBaseVoxels == doctest::Approx(8.0));
+
+    // Mixed density: 4 vx vertices for positions 0..10 (arclength 0..40),
+    // then 32 vx vertices for positions 11..15 (arclength 72..200).
+    std::vector<double> arclengths;
+    for (int i = 0; i <= 10; ++i) {
+        arclengths.push_back(4.0 * i);
+    }
+    for (int i = 1; i <= 5; ++i) {
+        arclengths.push_back(40.0 + 32.0 * i);
+    }
+    REQUIRE(arclengths.size() == 16);
+
+    // One notch = 8 vx: two vertices in the dense region, a quarter vertex in
+    // the sparse one.
+    CHECK(shiftedLinePositionByArclength(2.0, 1, 1, arclengths) == doctest::Approx(4.0));
+    CHECK(shiftedLinePositionByArclength(12.0, 1, 1, arclengths) == doctest::Approx(12.25));
+    CHECK(shiftedLinePositionByArclength(12.0, -1, 1, arclengths) == doctest::Approx(11.75));
+    // Step size scales the notch; crossing the density boundary stays exact.
+    CHECK(shiftedLinePositionByArclength(8.0, 1, 5, arclengths) == doctest::Approx(11.0));
+    // Clamped at both ends.
+    CHECK(shiftedLinePositionByArclength(15.0, 3, 1, arclengths) == doctest::Approx(15.0));
+    CHECK(shiftedLinePositionByArclength(0.5, -1, 1, arclengths) == doctest::Approx(0.0));
+    // Without a usable map the index step applies.
+    const std::vector<double> none;
+    CHECK(shiftedLinePositionByArclength(3.0, 2, 1, none) == doctest::Approx(3.0));
+}
+
+TEST_CASE("line annotation arclength snap uses a quarter strip column")
+{
+    using vc3d::line_annotation::kControlPointSnapArclengthBaseVoxels;
+    using vc3d::line_annotation::snappedControlPointLinePositionByArclength;
+    CHECK(kControlPointSnapArclengthBaseVoxels == doctest::Approx(2.0));
+
+    const std::vector<double> controlPositions{12.0, 20.0, 40.0};
+    std::vector<double> dense;  // 4 vx per position: 2 vx = half a position
+    for (int i = 0; i <= 50; ++i) {
+        dense.push_back(4.0 * i);
+    }
+    CHECK(snappedControlPointLinePositionByArclength(19.5, controlPositions, dense) ==
+          doctest::Approx(20.0));
+    CHECK(snappedControlPointLinePositionByArclength(20.5, controlPositions, dense) ==
+          doctest::Approx(20.0));
+    CHECK(snappedControlPointLinePositionByArclength(19.49, controlPositions, dense) ==
+          doctest::Approx(19.49));
+
+    std::vector<double> sparse;  // 32 vx per position: 2 vx = 1/16 position
+    for (int i = 0; i <= 50; ++i) {
+        sparse.push_back(32.0 * i);
+    }
+    CHECK(snappedControlPointLinePositionByArclength(20.0625, controlPositions, sparse) ==
+          doctest::Approx(20.0));
+    CHECK(snappedControlPointLinePositionByArclength(20.07, controlPositions, sparse) ==
+          doctest::Approx(20.07));
+
+    // Without a usable map the quarter-position rule applies.
+    const std::vector<double> none;
+    CHECK(snappedControlPointLinePositionByArclength(19.75, controlPositions, none) ==
+          doctest::Approx(20.0));
+    CHECK(snappedControlPointLinePositionByArclength(19.7, controlPositions, none) ==
+          doctest::Approx(19.7));
+}
+
 TEST_CASE("line annotation straight shift scroll moves cut origin along plane normal")
 {
     const cv::Vec3f origin{1.0f, 2.0f, 3.0f};

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -1128,6 +1128,77 @@ TEST_CASE("line annotation winding angles unwrap along the line and window half 
     }
 }
 
+TEST_CASE("segment interpolation mode uses regime-specific minimum spans")
+{
+    using vc3d::line_annotation::FiberOptimizationMode;
+    using vc3d::line_annotation::SegmentInterpolationGoal;
+    using vc3d::line_annotation::SegmentInterpolationMode;
+    using vc3d::line_annotation::resolveSegmentInterpolationMode;
+    using vc3d::line_annotation::segmentInterpolationCutoffs;
+
+    vc::fiber_tracer::FiberTraceConfig traceConfig;  // stepVoxels 4
+    vc::lasagna::LineOptimizationConfig lasagnaConfig;
+    lasagnaConfig.segmentLength = 31.5;
+    const auto cutoffs = segmentInterpolationCutoffs(traceConfig, lasagnaConfig, 1.0);
+    CHECK(cutoffs.traceMinimumSpanBaseVoxels == doctest::Approx(48.0));
+    CHECK(cutoffs.lasagnaMinimumSpanBaseVoxels == doctest::Approx(63.0));
+
+    SUBCASE("trace-to-base scale converts the tracer step into base voxels")
+    {
+        const auto scaled = segmentInterpolationCutoffs(traceConfig, lasagnaConfig, 2.0);
+        CHECK(scaled.traceMinimumSpanBaseVoxels == doctest::Approx(96.0));
+        CHECK(scaled.lasagnaMinimumSpanBaseVoxels == doctest::Approx(63.0));
+    }
+
+    SUBCASE("global goal in trace mode uses the trace minimum")
+    {
+        const auto mode = FiberOptimizationMode::NativeFiberTrace3d;
+        CHECK(resolveSegmentInterpolationMode(SegmentInterpolationGoal::Global, mode, 47.9, cutoffs) ==
+              SegmentInterpolationMode::Cspline);
+        CHECK(resolveSegmentInterpolationMode(SegmentInterpolationGoal::Global, mode, 48.0, cutoffs) ==
+              SegmentInterpolationMode::Trace);
+        CHECK(resolveSegmentInterpolationMode(SegmentInterpolationGoal::Global, mode, 100.0, cutoffs) ==
+              SegmentInterpolationMode::Trace);
+    }
+
+    SUBCASE("global goal in lasagna mode uses the lasagna minimum")
+    {
+        const auto mode = FiberOptimizationMode::Lasagna;
+        CHECK(resolveSegmentInterpolationMode(SegmentInterpolationGoal::Global, mode, 62.9, cutoffs) ==
+              SegmentInterpolationMode::Cspline);
+        CHECK(resolveSegmentInterpolationMode(SegmentInterpolationGoal::Global, mode, 63.0, cutoffs) ==
+              SegmentInterpolationMode::Lasagna);
+    }
+
+    SUBCASE("explicit goals ignore the cutoffs")
+    {
+        const auto mode = FiberOptimizationMode::NativeFiberTrace3d;
+        CHECK(resolveSegmentInterpolationMode(SegmentInterpolationGoal::Trace, mode, 10.0, cutoffs) ==
+              SegmentInterpolationMode::Trace);
+        CHECK(resolveSegmentInterpolationMode(SegmentInterpolationGoal::Lasagna, mode, 10.0, cutoffs) ==
+              SegmentInterpolationMode::Lasagna);
+        CHECK(resolveSegmentInterpolationMode(SegmentInterpolationGoal::Cspline, mode, 1000.0, cutoffs) ==
+              SegmentInterpolationMode::Cspline);
+    }
+
+    SUBCASE("degenerate configs are rejected")
+    {
+        vc::fiber_tracer::FiberTraceConfig zeroStep = traceConfig;
+        zeroStep.stepVoxels = 0.0;
+        CHECK_THROWS_AS(segmentInterpolationCutoffs(zeroStep, lasagnaConfig, 1.0),
+                        std::invalid_argument);
+        vc::lasagna::LineOptimizationConfig zeroSegment = lasagnaConfig;
+        zeroSegment.segmentLength = 0.0;
+        CHECK_THROWS_AS(segmentInterpolationCutoffs(traceConfig, zeroSegment, 1.0),
+                        std::invalid_argument);
+        CHECK_THROWS_AS(resolveSegmentInterpolationMode(SegmentInterpolationGoal::Global,
+                                                        FiberOptimizationMode::NativeFiberTrace3d,
+                                                        -1.0,
+                                                        cutoffs),
+                        std::invalid_argument);
+    }
+}
+
 TEST_CASE("line annotation fixed current slice snaps only within quarter line position")
 {
     const std::vector<double> controlPositions{12.0, 20.0, 40.0};
@@ -3068,25 +3139,73 @@ TEST_CASE("native seed tracing requires native mode and configured inference")
     CHECK_FALSE(shouldRunNativeSeedTrace(FiberOptimizationMode::Lasagna, true, 1));
 }
 
-TEST_CASE("segment interpolation resolution applies short fallback only to global goals")
+TEST_CASE("fiber mode sends a failed short global-goal trace straight to cspline")
 {
-    using namespace vc3d::line_annotation;
-    CHECK(resolveSegmentInterpolationMode(
-              SegmentInterpolationGoal::Global,
-              FiberOptimizationMode::NativeFiberTrace3d,
-              99.999) == SegmentInterpolationMode::Cspline);
-    CHECK(resolveSegmentInterpolationMode(
-              SegmentInterpolationGoal::Global,
-              FiberOptimizationMode::NativeFiberTrace3d,
-              100.0) == SegmentInterpolationMode::Trace);
-    CHECK(resolveSegmentInterpolationMode(
-              SegmentInterpolationGoal::Trace,
-              FiberOptimizationMode::Lasagna,
-              1.0) == SegmentInterpolationMode::Trace);
-    CHECK(resolveSegmentInterpolationMode(
-              SegmentInterpolationGoal::Lasagna,
-              FiberOptimizationMode::NativeFiberTrace3d,
-              1.0) == SegmentInterpolationMode::Lasagna);
+    // Trace minimum 12 * 4 = 48 vx, Lasagna minimum 2 * 40 = 80 vx. Two
+    // 64 vx Global-goal spans: both long enough to trace; the second one's
+    // trace throws (invalid prediction at x = 96) and, being shorter than the
+    // Lasagna minimum, goes to cspline instead of the Lasagna fallback.
+    FiberModeNormalSampler normals;
+    FiberModePrediction predictions(96.0);
+    vc3d::line_annotation::FiberModeOptimizationRequest request;
+    request.controlPoints = {
+        {2.0, {0.0, 0.0, 0.0}, true, 2},
+        {18.0, {64.0, 0.0, 0.0}, false, 18},
+        {34.0, {128.0, 0.0, 0.0}, false, 34},
+    };
+    request.controlPoints[0].segmentToNext.emplace();
+    request.controlPoints[0].segmentToNext->interpGoal =
+        vc3d::line_annotation::SegmentInterpolationGoal::Global;
+    request.controlPoints[1].segmentToNext.emplace();
+    request.controlPoints[1].segmentToNext->interpGoal =
+        vc3d::line_annotation::SegmentInterpolationGoal::Global;
+    for (int x = -8; x <= 136; x += 4) {
+        request.linePointsBase.push_back(
+            {static_cast<double>(x), 0.0, 0.0});
+    }
+    request.predictions = &predictions;
+    request.baseNormalSampler = &normals;
+    request.traceNormalSampler = &normals;
+    request.normalManifestLocation = "normal.lasagna.json";
+    request.fiberManifestLocation = "fiber.lasagna.json";
+    request.extrapolationDistanceBaseVoxels = 8.0;
+    request.retraceAll = true;
+    request.globalMode = vc3d::line_annotation::FiberOptimizationMode::NativeFiberTrace3d;
+    request.traceConfig.stepVoxels = 4.0;
+    request.traceConfig.coneAngleDegrees = 0.0;
+    request.traceConfig.beamWidth = 1;
+    request.traceConfig.maxStepFactor = 2.0;
+    request.traceConfig.smoothnessWeight = 0.0;
+    request.traceConfig.smoothnessNormalWeight = 0.0;
+    request.traceConfig.smoothnessTangentWeight = 0.0;
+    request.traceConfig.cumulativeSmoothnessTangentWeight = 0.0;
+    request.lasagnaConfig.segmentsPerSide = 2;
+    request.lasagnaConfig.segmentLength = 40.0;
+    request.lasagnaConfig.maxIterations = 20;
+    request.lasagnaConfig.printSolverProgress = false;
+
+    const auto result =
+        vc3d::line_annotation::optimizeFiberWithNativeFallback(
+            std::move(request));
+
+    REQUIRE(result.controlPoints.size() == 3);
+    CHECK(result.nativeSegments == 1);
+    CHECK(result.lasagnaFallbackSegments == 0);
+    CHECK(result.csplineFallbackSegments == 1);
+    REQUIRE(result.controlPoints[0].segmentToNext.has_value());
+    CHECK(vc3d::line_annotation::isAcceptedNativeTrace(
+        result.controlPoints[0].segmentToNext));
+    REQUIRE(result.controlPoints[1].segmentToNext.has_value());
+    const auto& gated = *result.controlPoints[1].segmentToNext;
+    CHECK(gated.interpMode == vc3d::line_annotation::SegmentInterpolationMode::Cspline);
+    CHECK(gated.interpGoal == vc3d::line_annotation::SegmentInterpolationGoal::Global);
+    // The trace failure stays on the span; the message records the gate.
+    CHECK_FALSE(vc3d::line_annotation::isAcceptedNativeTrace(
+        result.controlPoints[1].segmentToNext));
+    CHECK_FALSE(gated.failureCode.empty());
+    CHECK(gated.message.find("short span, trace -> cspline") != std::string::npos);
+    CHECK(result.optimization.report.message.find("cspline_fallback_segments=1") !=
+          std::string::npos);
 }
 
 TEST_CASE("fiber mode falls back only the failed native span")

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -523,6 +523,53 @@ TEST_CASE("line annotation arclength snap uses a quarter strip column")
           doctest::Approx(19.7));
 }
 
+TEST_CASE("line annotation overlay group key is the registration key")
+{
+    // Registration (applyGeneratedOverlay) and the pan-time translation must
+    // address the viewer group by the same string; both go through this helper.
+    CHECK(vc3d::line_annotation::generatedOverlayGroupKey("line_surface_x") ==
+          "line_annotation_overlay_line_surface_x");
+}
+
+TEST_CASE("line annotation static overlay pan translation shifts at fixed zoom only")
+{
+    using vc3d::line_annotation::GeneratedOverlayCameraBaseline;
+    using vc3d::line_annotation::generatedOverlayPanTranslation;
+
+    GeneratedOverlayCameraBaseline baseline;
+    baseline.referenceScene = QPointF(100.0, 50.0);
+    baseline.scale = 2.0;
+
+    SUBCASE("a camera pan is a common scene delta")
+    {
+        const auto delta = generatedOverlayPanTranslation(baseline, QPointF(90.0, 50.0), 2.0);
+        REQUIRE(delta.has_value());
+        CHECK(delta->x() == doctest::Approx(-10.0));
+        CHECK(delta->y() == doctest::Approx(0.0));
+    }
+
+    SUBCASE("an unchanged camera yields a zero delta")
+    {
+        const auto delta = generatedOverlayPanTranslation(baseline, QPointF(100.0, 50.0), 2.0);
+        REQUIRE(delta.has_value());
+        CHECK(delta->isNull());
+    }
+
+    SUBCASE("a zoom change requires a rebuild")
+    {
+        CHECK_FALSE(generatedOverlayPanTranslation(baseline, QPointF(90.0, 50.0), 2.5).has_value());
+    }
+
+    SUBCASE("an unknown baseline requires a rebuild")
+    {
+        const GeneratedOverlayCameraBaseline unknown;
+        CHECK_FALSE(generatedOverlayPanTranslation(unknown, QPointF(90.0, 50.0), 2.0).has_value());
+        CHECK_FALSE(generatedOverlayPanTranslation(
+                        baseline, QPointF(std::numeric_limits<double>::quiet_NaN(), 0.0), 2.0)
+                        .has_value());
+    }
+}
+
 TEST_CASE("line annotation straight shift scroll moves cut origin along plane normal")
 {
     const cv::Vec3f origin{1.0f, 2.0f, 3.0f};

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -1048,6 +1048,86 @@ TEST_CASE("line annotation anchor remap keeps a pane position on its own fiber p
     }
 }
 
+TEST_CASE("line annotation winding angles unwrap along the line and window half a wrap")
+{
+    using vc3d::line_annotation::generatedLineIndexRangeWithinWinding;
+    using vc3d::line_annotation::kGeneratedSideCutHalfWrapAngle;
+    using vc3d::line_annotation::unwrappedGeneratedWindingAngles;
+    constexpr double kPi = kGeneratedSideCutHalfWrapAngle;
+
+    // A spiral of 1.5 wraps about the origin, one point every quarter turn
+    // (13 points, angles 0 .. 3*pi), radius growing slowly.
+    std::vector<cv::Vec3f> spiral;
+    for (int i = 0; i <= 12; ++i) {
+        const double angle = static_cast<double>(i) * kPi / 4.0;
+        const double radius = 100.0 + static_cast<double>(i);
+        spiral.push_back({static_cast<float>(radius * std::cos(angle)),
+                          static_cast<float>(radius * std::sin(angle)),
+                          static_cast<float>(i)});
+    }
+    const auto towardOrigin = [](const cv::Vec3f& point) {
+        return cv::Vec3f{-point[0], -point[1], 0.0f};
+    };
+
+    SUBCASE("angles accumulate past pi instead of wrapping")
+    {
+        const auto angles = unwrappedGeneratedWindingAngles(spiral, towardOrigin);
+        REQUIRE(angles.size() == spiral.size());
+        for (int i = 0; i <= 12; ++i) {
+            CHECK(angles[static_cast<size_t>(i)] ==
+                  doctest::Approx(static_cast<double>(i) * kPi / 4.0).epsilon(1e-6));
+        }
+    }
+
+    SUBCASE("a point without a center direction is NaN and does not break the chain")
+    {
+        std::vector<cv::Vec3f> withHole = spiral;
+        withHole[6] = {std::numeric_limits<float>::quiet_NaN(), 0.0f, 0.0f};
+        const auto angles = unwrappedGeneratedWindingAngles(withHole, towardOrigin);
+        CHECK(std::isnan(angles[6]));
+        CHECK(angles[7] == doctest::Approx(7.0 * kPi / 4.0).epsilon(1e-6));
+        CHECK(angles[12] == doctest::Approx(3.0 * kPi).epsilon(1e-6));
+    }
+
+    SUBCASE("the half-wrap window keeps only the stretch within pi of the position")
+    {
+        const auto angles = unwrappedGeneratedWindingAngles(spiral, towardOrigin);
+        // At index 4 (angle pi) the window is [0, 2*pi] -> indices 0..8.
+        auto range = generatedLineIndexRangeWithinWinding(angles, spiral.size(), 4.0,
+                                                          kGeneratedSideCutHalfWrapAngle);
+        CHECK(range.first == 0);
+        CHECK(range.second == 8);
+        // At index 6 (1.5*pi) the window is [0.5*pi, 2.5*pi] -> indices 2..10.
+        range = generatedLineIndexRangeWithinWinding(angles, spiral.size(), 6.0,
+                                                     kGeneratedSideCutHalfWrapAngle);
+        CHECK(range.first == 2);
+        CHECK(range.second == 10);
+        // A fractional position interpolates its reference angle.
+        range = generatedLineIndexRangeWithinWinding(angles, spiral.size(), 6.5,
+                                                     kGeneratedSideCutHalfWrapAngle);
+        CHECK(range.first == 3);
+        CHECK(range.second == 10);
+    }
+
+    SUBCASE("without usable angles the whole line qualifies")
+    {
+        const std::vector<double> empty;
+        auto range = generatedLineIndexRangeWithinWinding(empty, spiral.size(), 4.0,
+                                                          kGeneratedSideCutHalfWrapAngle);
+        CHECK(range.first == 0);
+        CHECK(range.second == 12);
+        const auto allNan = unwrappedGeneratedWindingAngles(spiral, nullptr);
+        range = generatedLineIndexRangeWithinWinding(allNan, spiral.size(), 4.0,
+                                                     kGeneratedSideCutHalfWrapAngle);
+        CHECK(range.first == 0);
+        CHECK(range.second == 12);
+        range = generatedLineIndexRangeWithinWinding(allNan, 0, 4.0,
+                                                     kGeneratedSideCutHalfWrapAngle);
+        CHECK(range.first == 0);
+        CHECK(range.second == 0);
+    }
+}
+
 TEST_CASE("line annotation fixed current slice snaps only within quarter line position")
 {
     const std::vector<double> controlPositions{12.0, 20.0, 40.0};

--- a/volume-cartographer/docs/line_annotation_fibers.md
+++ b/volume-cartographer/docs/line_annotation_fibers.md
@@ -23,9 +23,22 @@ finished fiber. If no inference dataset is selected or uniquely attached,
 seed creation remains Lasagna and does not open a dataset picker.
 
 The fallback order is `trace -> lasagna -> cspline` or `lasagna -> cspline`.
-For global Lasagna/trace goals only, endpoint distance below 100 base voxels
-selects `cspline` immediately; exactly 100 voxels still attempts the global
-mode. Explicit goals never use this shortcut. Adjacent cubic-spline spans are
+For the Global goal only, a span shorter than the global mode's own minimum
+selects `cspline` immediately: in trace mode 12 tracer steps
+(`kMinimumTraceSteps * stepVoxels * traceToBaseScale`, 48 base voxels with the
+default 4 vx step), in Lasagna mode two Lasagna segments
+(`kMinimumLasagnaSegments * segmentLength`, about 63 base voxels with the
+default discretization). A span exactly at the minimum still attempts the
+mode (48.0 vx is traced, 47.9 vx is a spline). In trace mode a Global-goal
+span whose trace is not accepted falls back
+to Lasagna only when it is at least the Lasagna minimum long; a shorter one
+goes straight to `cspline` (message `short span, trace -> cspline`, counted as
+`cspline_fallback_segments`, the trace failure metadata kept on the span).
+Explicit goals never use these shortcuts. The tracer's endpoint acceptance is
+bounded per span to a quarter of the start-to-target distance
+(`kEndpointAcceptSpanFraction`; a 50 vx span accepts an endpoint miss of at
+most 12.5 vx, spans of 80 vx and more keep the configured 20 vx), so a short
+accepted trace must actually reach its target. Adjacent cubic-spline spans are
 interpolated jointly with exact CPs, shared internal tangents, and hard boundary
 directions from neighboring stored geometry. The spline helper uses no normal
 or prediction data.

--- a/volume-cartographer/docs/line_annotation_fibers.md
+++ b/volume-cartographer/docs/line_annotation_fibers.md
@@ -157,7 +157,10 @@ more hop, to the Max extrap CP distance allowance or the end of the extrapolated
 line, whichever is shorter. The boundary is converted from base-voxel
 arclength back into optimized-line position. Pressing the opposite arrow
 mid-pan decelerates through zero and reverses. Up and Down scale the cruising
-speed (default 12 line positions per second, roughly 360 voxels per second),
+speed (default 96 base voxels of optimized-polyline arclength per second, the same
+physical speed in 4 vx trace spans and ~32 vx cspline spans; shift+wheel in the
+current cut and the Space snap use the same arclength unit, one strip column
+(8 vx) per notch and a quarter column for the snap),
 which is shown in a transient badge and remembered between sessions. A Left or
 Right press pauses the mouse hover-follow exactly as the space bar does, so the
 ❚❚ badge appears; space (or a click in a strip or cut view) resumes hover-follow

--- a/volume-cartographer/docs/line_annotation_fibers.md
+++ b/volume-cartographer/docs/line_annotation_fibers.md
@@ -78,22 +78,25 @@ retain every annotation control point and both line endpoints. The optimized
 line points between adjacent controls define the polyline path but are not
 mandatory columns. Each control-point span is resampled by polyline arclength
 using the interval count whose physical spacing is closest to the
-32-base-voxel target; a short span remains one interval with both controls
-unchanged. Explicit
+8-base-voxel along-line target; a short span remains one interval with both
+controls unchanged. Explicit
 support arclengths provide a bidirectional mapping that keeps control points,
 span labels, hover positions, cut planes, and saved line positions in the
 original fractional point-index coordinate. The strip grid always declares an
-along-line scale of `1/32`, so a short physical control-point span expands to
+along-line scale of `1/8`, so a short physical control-point span expands to
 one nominal display interval instead of changing the scale of the rest of the
 strip. Both ribbons have a fixed seven-row cross grid at 32 voxels per row,
 giving a 192-base-voxel first-to-last-row extent close to the previous typical
-width without depending on optimized-line spacing.
+width without depending on optimized-line spacing. The along-line target and
+the cross-row spacing are independent constants
+(`kLineViewAlongSamplingDistanceBaseVoxels`, `kLineViewCrossRowSpacingBaseVoxels`).
 
 Clicking to place a control point uses optimized-polyline arclength in base
-voxels. Every existing control within an inclusive 32-voxel radius is collapsed
-into one control at the clicked location. This keeps adjacent control spans from
-becoming shorter than the generated strip's nominal sampling distance. Seed,
-surviving span policy, and branch links follow the collapsed control.
+voxels. Every existing control within an inclusive 8-voxel radius (the strip's
+along-line sampling distance) is collapsed into one control at the clicked
+location. This keeps adjacent control spans from becoming shorter than the
+generated strip's nominal sampling distance. Seed, surviving span policy, and
+branch links follow the collapsed control.
 
 With automatic reoptimization, VC3D prepares the edit before changing the live
 session. The same local update is used for insertion, one-control replacement,

--- a/volume-cartographer/planning/spec.md
+++ b/volume-cartographer/planning/spec.md
@@ -138,17 +138,19 @@
   supports. Optimized line points between adjacent controls define the path but
   are not mandatory columns. Each control-point span is independently
   resampled by optimized-polyline arclength using the interval count whose
-  physical spacing is closest to the 32-base-voxel target; a shorter span
-  remains one interval.
-  The along-strip grid density is always declared as `1/32` samples per base
+  physical spacing is closest to the 8-base-voxel along-line target; a shorter
+  span remains one interval.
+  The along-strip grid density is always declared as `1/8` samples per base
   voxel, so a short physical control-point span expands to one nominal display
   interval. Explicit support arclengths provide the bidirectional mapping
   between original fractional point positions and nonuniform ribbon columns.
   Both generated ribbons have seven cross rows at `1/32` samples per base voxel,
   giving a fixed 192-base-voxel first-to-last-row extent close to the previous
-  typical width without depending on optimized-line spacing.
-  Generated-view clicks collapse all controls within an inclusive 32-base-voxel
-  optimized-polyline arclength radius into one control at the clicked point.
+  typical width without depending on optimized-line spacing; the along and
+  cross spacings are independent constants.
+  Generated-view clicks collapse all controls within an inclusive 8-base-voxel
+  optimized-polyline arclength radius (equal to the along-line sampling
+  distance) into one control at the clicked point.
   Before automatic full optimization, every insertion, replacement, or
   multi-control collapse first reconstructs the replacement's surviving
   adjacent spans from its authoritative line position. A multi-control collapse


### PR DESCRIPTION
Branch `line-annotation-cp-anchor-remap`, 6 commits on main 908aa7f06. Assignee: @hendrikschilling.

## Show us what you made

**In one sentence:** A batch of fixes for problems hit while annotating fibers in VC3D: a left click in the cut pane now places the control point where you are looking, the side cut shows only the local wrap, control points can sit closer together with the fiber model still running on short spans, and along-line navigation moves at one speed regardless of how the span was interpolated.

**One real example:** On a PHercParis4 fiber that passes near itself (7316 dense points, 135 controls), a left click in the Current Line Cut pane at line position 573 was resolved to position 2544 on the other pass and replaced control #37 there. "Optimizing..." ran and nothing appeared at the cut; the "/" key at the same spot worked. With this branch the same click adds a control at 573.

**Before:** Clicks near another pass of the same fiber silently moved or added controls thousands of vertices away. The side cut drew every wrap that crossed its plane on top of each other. Controls within 32 vx of each other were merged, and Global-goal spans under 100 vx never ran the fiber model. Shift+wheel and arrow panning were 8x faster in spline spans (32 vx vertices) than in trace spans (4 vx vertices), and the control-point dots jiggled on the strips while panning.

**After this PR:** The click position is resolved through the pane's own line point. The side cut is windowed to half a turn of winding either side of the current position. Strip sampling and the collapse radius are 8 vx. Trace mode traces Global-goal spans from 48 vx and requires a short trace to actually reach its target; Lasagna mode solves from ~63 vx; a failed trace on a span too short for Lasagna goes straight to cspline. Wheel, arrow pan and Space snap move in base-voxel arclength, and the strip dots stay put while panning.

**Proof:** Reproduction log of the click bug (nearest dense vertex to the click was index 2544 at 3.9 vx, the local vertex at 53.9 vx; the edit landed as `control_edit_span_update`). Unit tests: test_line_annotation_generated_views 97, test_lasagna_line_view_surfaces 25, test_fiber_slice_geometry 11, test_fiber_trace3d 47, all passing. Test-driven in the GUI on PHercParis4: click placement at a self-approaching section, half-wrap side cut, dense placement, wheel and arrow pan across trace and spline stretches, dot jiggle gone.

**Why / where this is useful:** Everyone annotating fibers in VC3D, in particular on fibers that pass near themselves and on stretches that need dense manual guidance.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

### Relative to #1484 and #1502

Kept as is: the strip model from #1484 (annotation controls and endpoints are the grid supports, spans are resampled by arclength to a target, a span shorter than the target is one column), its invariant that a placement click cannot create a span shorter than one strip column (collapse radius = sampling distance), the fixed seven rows at 32 vx, and #1502's collapse semantics (edits reconstruct spans from the control's authoritative line position, never by nearest 3D distance).

Changed: the along-line sampling target and the collapse radius go from 32 to 8 vx together. The single constant is split into `kLineViewAlongSamplingDistanceBaseVoxels` (8, resampling target, declared along scale, collapse radius) and `kLineViewCrossRowSpacingBaseVoxels` (32, cross rows), so the cross extent is unchanged. The declared grid scale only feeds the surface-UV to grid mapping; the volume level comes from the camera zoom, so the strips do not sample a finer level, and saved strip zooms are unaffected. Not done: no adaptive per-fiber target (the densest-segment approach from the closed #1444); the target is a fixed constant as in #1484.

The click fix is in the spirit of #1502: the controller had started re-deriving a click's line position from the clicked 3D point (#1622), which is the nearest-3D lookup #1502 avoids for collapses.

### Commits
1. **Click position through the pane's line point.** Since #1622 `handleGeneratedControlPoint` replaced the pane's line position with the dense vertex nearest the clicked point whenever they disagreed by more than two vertices (8 vx in trace spans). A click is deliberately off the line, and where another pass of the fiber crosses the cut plane it is nearer to that pass. The placement signal now carries the position's 3D point on the displayed line, and the controller resolves it with `remappedGeneratedLinePositionFromAnchor` (the landing remap's index-continuous nearest match, extracted into a shared helper). A rapid second click on an unlanded splice still follows the renumbering; the clicked point no longer influences the position. Side-pane clicks therefore place at the pane position and pull the line toward the click, as before #1622.
2. **Side cut half-wrap window.** Each line point gets an unwrapped winding angle about the umbilicus (else the volume center; with neither the pane shows the whole line as before). The side overlay blanks points more than half a turn from the current position and drops their control markers. Points are blanked, not erased, and the tail range is captured before the markers are trimmed, so the index-keyed tail detection keeps drawing interior spans.
3. **Strip 8 vx along, collapse radius 8 vx.** See above. Tests that exercise subdivision behavior set the 32 vx target explicitly; a new case pins the default (a 16 vx span is two columns, cross rows stay 32 vx).
4. **Regime-specific short-span cutoffs, span-bounded trace acceptance.** The fixed 100 vx Global-goal cutoff becomes the mode's own minimum: 12 tracer steps in trace mode (`kMinimumTraceSteps * stepVoxels * traceToBaseScale`, 48 vx with defaults), two Lasagna segments in Lasagna mode (`kMinimumLasagnaSegments * segmentLength`, ~63 vx). In trace mode a Global-goal span whose trace is not accepted falls back to Lasagna only if it is at least the Lasagna minimum; shorter ones go straight to cspline (`short span, trace -> cspline`, counted as `cspline_fallback_segments`, trace failure metadata kept). Explicit goals are unchanged and the Lasagna global mode remains selectable. The tracer's endpoint acceptance is bounded per segment to a quarter of the start-to-target distance (`kEndpointAcceptSpanFraction`, a constant rather than a persisted config key because saved fibers are matched on exact config keys), for both one-way target-plane acceptances and the meeting fusion. Behavior change to review: Global spans between 48 and 100 vx are now traced in trace mode (previously spline); those between 48 and 63 vx whose trace fails go to cspline instead of Lasagna; short traces must reach their target.
5. **Arclength units for wheel, arrow pan and Space snap.** One shift+wheel notch moves one strip column (8 vx) times the slice step size; the pan integrator runs in arclength with the position and stop target converted through the position map each tick and lands exactly on the target's line position; Space snaps within a quarter column. Pan speed and its setting are voxels per second (default 96, the previous 12 positions/s at one column per position; new key `lineAnnotation/arrow_pan_speed_vx`, so a saved speed resets once). Still in line positions, out of scope here: the bottom strip's cross-slice spacing, the overview bar, the intersection-inspection follow-slice snap.
6. **Static strip overlays shift with the camera during pans.** The control-point dots were refreshed by the coalesced post-render callback while the camera moved every tick, so they trailed by a tick and snapped. The strip maps surface to scene as (surface - cameraPointer) * scale + viewportCenter, so at a fixed zoom every camera move shifts all overlay items by one common scene delta: the pan tick now moves the existing items in place (`CChunkedVolumeViewer::translateOverlayGroup`) by the delta of a reference surface point recorded when the overlay was last built, and rebuilds only when the zoom changed or the viewer dropped the group. No items are created or destroyed per tick; the landing keeps the full rebuild. The viewer group is addressed by the key registration returned: `applyGeneratedOverlay` derives it through `generatedOverlayGroupKey` (single source of the `line_annotation_overlay_` prefix) and returns it, the dialog stores it per strip and passes it verbatim to the translation, and a missing group during a pan is logged once per pan rather than silently rebuilding. The viewer's overlay-group clearing detaches a group from its map before deleting the items, so the map never names a freed item.

### How to build and test
```
cmake -S volume-cartographer -B volume-cartographer/build -DVC_TESTING=ON
cmake --build volume-cartographer/build --target VC3D test_line_annotation_generated_views test_lasagna_line_view_surfaces test_fiber_slice_geometry test_fiber_trace3d
for t in test_line_annotation_generated_views test_lasagna_line_view_surfaces test_fiber_slice_geometry test_fiber_trace3d; do volume-cartographer/build/bin/$t; done
```

### Risks and limitations
- Strips have 4x the columns. Memory is trivial; rebuild time scales with columns and is small next to the solve.
- Trace acceptance is stricter on short spans; expect more `short span, trace -> cspline` on noisy predictions between 48 and 63 vx.
- Saved arrow-pan speed resets to the default once.
- Docs (`docs/line_annotation_fibers.md`) and `planning/spec.md` updated for the new numbers and the fallback rule; the planning task logs were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfUf5Y68iFTXqQFQKJy1FV
