### PR TITLE
utils::ThreadPool: request stop under the queue mutex (refs #1686)

### DIFF
--- a/volume-cartographer/core/test/test_chunked_plane_sampler_fallback.cpp
+++ b/volume-cartographer/core/test/test_chunked_plane_sampler_fallback.cpp
@@ -187,6 +187,23 @@ TEST_CASE("ThreadPool indexed batch propagates worker exceptions")
         std::runtime_error);
 }
 
+TEST_CASE("ThreadPool destruction right after a batch does not lose the stop wakeup")
+{
+    // ~ThreadPool() used to request stop and notify without holding the queue
+    // mutex, so a worker between its wait predicate and cv_.wait() missed the
+    // wakeup and the jthread join never returned. Workers are in exactly that
+    // window while leaving run_indexed_batch(); with the old destructor this
+    // loop hung within a few hundred rounds.
+    std::atomic<size_t> sum{0};
+    for (int round = 0; round < 3000; ++round) {
+        utils::ThreadPool pool(4);
+        pool.run_indexed_batch(17, [&](size_t index) {
+            sum.fetch_add(index, std::memory_order_relaxed);
+        });
+    }
+    CHECK(sum.load(std::memory_order_relaxed) == 3000u * 136u);
+}
+
 TEST_CASE("ChunkedPlaneSampler fine-to-coarse fills missing high-res from coarse level")
 {
     PyramidChunkedArray array(vc::render::ChunkStatus::Missing, 0,

--- a/volume-cartographer/utils/include/utils/thread_pool.hpp
+++ b/volume-cartographer/utils/include/utils/thread_pool.hpp
@@ -43,9 +43,15 @@ public:
     }
 
     ~ThreadPool() {
-        // Request stop on all jthreads (auto-joined on destruction).
-        for (auto& w : workers_)
-            w.request_stop();
+        {
+            // Serialize the stop transition with the worker wait predicate.
+            // Otherwise notify_all() can land after a worker's predicate check
+            // but before it has entered the condition-variable wait, and the
+            // jthread join below never returns.
+            std::lock_guard lk(mu_);
+            for (auto& w : workers_)
+                w.request_stop();
+        }
         cv_.notify_all();
         // jthread destructors join here.
     }
@@ -229,8 +235,12 @@ public:
     }
 
     ~PriorityThreadPool() {
-        for (auto& w : workers_)
-            w.request_stop();
+        {
+            // Same lost-wakeup guard as ThreadPool::~ThreadPool().
+            std::lock_guard lk(mu_);
+            for (auto& w : workers_)
+                w.request_stop();
+        }
         cv_.notify_all();
     }
 


### PR DESCRIPTION
**In one sentence:** `utils::ThreadPool` and `utils::PriorityThreadPool` now request stop on their workers while holding the queue mutex, so destroying a pool can no longer hang on a worker that missed the stop wakeup. This is why `test_chunked_plane_sampler_fallback` and `test_thread_pool_dispatch_lifecycle` hang intermittently (#1686), on Linux as well as on Windows.

**One real example:** On current main (9daa477e0), the unmodified ASan build of `test_chunked_plane_sampler_fallback` run 300 times in a row on Linux (Ubuntu 24.04, gcc 13.3.0, `timeout 90`, normal runtime ~3 s) hung in runs 34 and 214, i.e. 2 of 300. A stand-alone loop doing what its two pool `TEST_CASE`s do (`utils::ThreadPool pool(4); pool.run_indexed_batch(17, …);` then destruction) hangs in 5 of 5 runs after 12–1067 rounds; gdb at the hang shows the main thread in `~ThreadPool → ~vector<jthread> → pthread_join` and the worker it is joining parked in `cv_.wait` inside `worker_loop`. After this PR the same test binary passed 300 consecutive runs with no hang, and the stand-alone loop ran 300 000 rounds (4 workers × 17 tasks), 100 000 rounds pinned to two CPUs and 30 000 rounds with 64 workers × 200 tasks without hanging.

**Before:** `~ThreadPool()` did `for (auto& w : workers_) w.request_stop(); cv_.notify_all();` without taking `mu_`. A worker waits with `cv_.wait(lk, [&]{ return stop.stop_requested() || !queue_.empty(); })`, i.e. it evaluates the predicate under `mu_` and only then blocks. Because the destructor never takes `mu_`, the stop request and the notification can land after the worker has evaluated the predicate (nothing to do yet) and before it is actually waiting: the notification goes to nobody, the worker then blocks in `cv_.wait` for a wakeup that never comes (`std::condition_variable` does not observe `stop_token`s), and the `jthread` destructor joins it forever. A worker is in that window while a `run_indexed_batch()` call is returning: it has just finished the last task and is re-checking the predicate while the caller, released by the latch, goes straight into the destructor. That is the shape of the two `TEST_CASE`s in `test_chunked_plane_sampler_fallback.cpp` and of `bench_thread_pool_dispatch --mode lifecycle`, which is what `test_thread_pool_dispatch_lifecycle` runs.

**After this PR:** both destructors hold `mu_` around the `request_stop()` loop and notify after releasing it. The worker's predicate is evaluated under the same mutex and `wait()` releases it atomically when blocking, so a worker either sees the stop request in its predicate or is already waiting when the notification arrives. This is the same guard `ChunkRequestScheduler::Impl::~Impl` already uses ("Serialize the stop transition with the worker wait predicate", `ChunkRequestScheduler.cpp`). A regression `TEST_CASE` that hangs with the old destructor and passes with the new one is added next to the existing pool tests.

**Proof:** all on the same machine and commit, Linux, gcc 13.3.0. "before" = main @ 9daa477e0, "after" = this branch.

| what | before | after this PR |
|---|---|---|
| in-tree `test_chunked_plane_sampler_fallback` (ASan Debug), 300 consecutive runs, `timeout 90` | hung in runs 34 and 214 (2/300) | 0/300; every run finished within the 90 s timeout (20/20 cases each, including the new one) |
| in-tree `bench_thread_pool_dispatch --mode lifecycle --workers 4 --tasks 1 --work-iterations 0 --rounds 32` (= `test_thread_pool_dispatch_lifecycle`), 300 consecutive runs | not measured on Linux (each run is only 64 pool lifecycles; the stand-alone loop below covers this shape) — on Windows this row is deterministic: 25/25 hangs before, 0/225 after, measured independently by @Aleredfer (see the update at the bottom) | 0/300 hangs, all runs exit 0 |
| new regression case (3000 × `ThreadPool(4)` + `run_indexed_batch(17)` + destroy) built against each header | hung 10/10 (10 runs, 60 s timeout) | passes: 300/300 runs of the test file, about 2.4 s each (ASan) |
| stand-alone batch loop (`pool(4)`, `run_indexed_batch(17)`, destroy; 20 s watchdog), 5 runs | hung 5/5, after 12, …, 1067 rounds; gdb: main in `pthread_join` from `~jthread`, worker in `cv_.wait` at `worker_loop` | 300 000 rounds in 39 s; 100 000 rounds pinned to CPUs 0–1 in 17 s; 30 000 rounds × 64 workers × 200 tasks in 77 s; no hang |
| stand-alone construct/destroy loop (200 000 × `ThreadPool(4)`, no tasks; 30 s watchdog) | idle machine: 200 000 rounds × 4 workers in 23.0 s and 20 000 rounds × 64 workers in 52 s, no hang; machine loaded by other test loops: hung 3/3 at rounds 7470, 16823, 18117 | same loaded machine: completed 3/3 in 18–19 s |

The last row is also the cost check: the lock is taken once per destructor, and 200 000 construct/destroy cycles are not slower after the change (18–19 s vs 23.0 s).

**Why / where this is useful:** #1686 reports both pool tests hanging with no output on Windows; on Linux the same binary hung in 2 of 300 runs, so a CI job can hang on it anywhere. Today the only code in the tree that destroys a `utils::ThreadPool` is these tests (every production pool is a process-lifetime, leaked or static singleton), so app behaviour does not change. The pool is a general utility, though, and any future short-lived use would have hit the same hang.

- [x] Verified by running the example and proof above on my machine (AI-assisted; see disclosure).

## Details

Refs #1686 (report: @Aleredfer). This is part A of my comment there. The other eight tests listed in that issue are, as far as I can tell, a different mechanism (the process-wide `ChunkCacheService` being torn down from vc_core's static destructors at DLL unload, after its worker threads are gone), which I cannot verify without a Windows machine, so this PR does not touch them. If the two pool tests still hang on Windows after this change, the new `TEST_CASE` is the smallest thing that reproduces it and a stack of that process would say why.

**What changed** (2 files, +32/−5):
- `utils/include/utils/thread_pool.hpp`: `~ThreadPool()` and `~PriorityThreadPool()` take `std::lock_guard lk(mu_)` around the `request_stop()` loop; `cv_.notify_all()` stays outside the lock, as before. `PriorityThreadPool` has no in-tree users; it has the same worker loop and gets the same guard.
- `core/test/test_chunked_plane_sampler_fallback.cpp`: `TEST_CASE("ThreadPool destruction right after a batch does not lose the stop wakeup")`: 3000 rounds of `ThreadPool(4)`, `run_indexed_batch(17, …)`, destroy, then checks the summed indices. Registered through the existing `test_chunked_plane_sampler_fallback` target (label `vc-core`). With the old destructor it hangs (10/10 runs, 60 s timeout); with the fix it passes.

**Not changed:** `wait_idle()` has the same lost-wakeup shape on `idle_cv_` (the worker notifies without holding `mu_`), but it has no callers in the tree and guarding it would cost a lock per task on the hot path, so it is left alone. The `_WIN32` "leak instead of joining from a static destructor" branches on the static pools from #1554 are unrelated and untouched.

**Tested:** commit 79e85c7 (on main 9daa477e0), Ubuntu 24.04.4, gcc 13.3.0, ASan+UBSan Debug build: `test_chunked_plane_sampler_fallback` 20/20 cases; full `vc-core` label 142/142 (183 s). All loop counts above are from the same build.

**From the author:** I contribute to VC through an AI-assisted workflow (Claude, directed by me). By looking into #1686, we observed the following: of the ten tests that hang on Windows, the two that use utils::ThreadPool directly turned out to hang on Linux, as well. The pool destructor requests stop and notifies without holding the queue mutex, and the in-tree test hung in 2 of 300 runs on current main. The fix is the same lock that ChunkRequestScheduler's destructor already takes, plus a regression test that hangs with the old destructor and passes with the new one. I reviewed the investigation and the evidence; every number in this PR was produced by running the stated commands on my machine. The other eight tests in #1686 are a different problem (a static torn down at DLL unload on Windows) that I can't verify without a Windows machine, so this PR is not about them.

**AI disclosure:** investigation, patch, test and this write-up were produced with Claude (Anthropic) under my direction; every number above comes from running the stated commands on my machine.

**Update 2026-09-03, after opening:** independent Windows verification by @Aleredfer, [comment below](https://github.com/ScrollPrize/villa/pull/1688#issuecomment-5525901640): same base (9daa477) and same diff, Windows 11, MSYS2 UCRT64, gcc 16.1.0, Release, 25 s watchdog. `test_chunked_plane_sampler_fallback`: 4 hangs / 65 runs before, 0 / 225 after. `bench_thread_pool_dispatch --mode lifecycle …`: 25 / 25 hangs before, 0 / 225 after. Those numbers are theirs, not mine.