### PR TITLE
vc_render_tifxyz: do not treat torn per-slice TIFFs as finished output (refs #1404)

### DIFF
--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -1680,15 +1680,26 @@ int main(int argc, char *argv[])
                 return p;
             };
 
-            // Skip if all exist
+            // Skip if all exist and open as TIFFs. A render killed mid-way
+            // (OOM, --timeout) leaves every slice with a header but no
+            // directory -- TiffWriter writes the IFD in close() -- and a bare
+            // exists() check would treat those torn files as done and skip
+            // them on every rerun (#1404).
             bool tifSkip = false;
             if (numParts <= 1) {
-                bool all = true;
-                for (int z = 0; z < tifSlices; z++) if (!std::filesystem::exists(makePartPath(z))) { all = false; break; }
-                if (all) {
+                int missing = 0, torn = 0;
+                for (int z = 0; z < tifSlices; z++) {
+                    const auto p = makePartPath(z);
+                    if (!std::filesystem::exists(p)) missing++;
+                    else if (!isReadableTiff(p)) torn++;
+                }
+                if (missing == 0 && torn == 0) {
                     if (!wantZarr) { logPrintf(stdout, "[tif] all slices exist, skipping.\n"); return true; }
                     logPrintf(stdout, "[tif] all slices exist, skipping tif output.\n");
                     tifSkip = true;
+                } else if (torn > 0) {
+                    logPrintf(stdout, "[tif] %d of %d existing slices are not readable TIFFs (interrupted render?), re-rendering all slices.\n",
+                              torn, tifSlices - missing);
                 }
             }
             if (!tifSkip) {

--- a/volume-cartographer/core/include/vc/core/util/Tiff.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Tiff.hpp
@@ -90,6 +90,14 @@ private:
     std::filesystem::path _path;     // For error messages
 };
 
+// True if `path` opens as a TIFF with a readable first directory.
+// TiffWriter (like libtiff in general) writes the directory in close(), so
+// a file left behind by a writer that was killed mid-way has a header and
+// tile data but no directory: exists() says "done", this says "torn".
+// libtiff diagnostics are suppressed while probing; the caller decides
+// what to report.
+bool isReadableTiff(const std::filesystem::path& path);
+
 // Merge partial .partN.tif files into final TIFFs.
 // Scans outputPath (or its parent directory) for .partN.tif files,
 // merges them tile-by-tile, and removes the part files.

--- a/volume-cartographer/core/src/Tiff.cpp
+++ b/volume-cartographer/core/src/Tiff.cpp
@@ -312,6 +312,26 @@ void TiffWriter::close() {
 }
 
 // ============================================================================
+// isReadableTiff
+// ============================================================================
+
+bool isReadableTiff(const std::filesystem::path& path)
+{
+    // TIFFOpen("r") reads the first directory and fails without one; a
+    // torn file makes libtiff complain through its global handlers, so
+    // mute them for the probe and hand back a plain yes/no.
+    TIFFErrorHandler prevError = TIFFSetErrorHandler(nullptr);
+    TIFFErrorHandler prevWarning = TIFFSetWarningHandler(nullptr);
+    TIFF* tf = TIFFOpen(path.string().c_str(), "r");
+    TIFFSetErrorHandler(prevError);
+    TIFFSetWarningHandler(prevWarning);
+    if (!tf)
+        return false;
+    TIFFClose(tf);
+    return true;
+}
+
+// ============================================================================
 // mergeTiffParts implementation
 // ============================================================================
 

--- a/volume-cartographer/core/test/test_tiff.cpp
+++ b/volume-cartographer/core/test/test_tiff.cpp
@@ -1,6 +1,7 @@
 // Coverage for core/src/Tiff.cpp. atomicImwriteMulti has its own test elsewhere;
 // here we exercise voxelSizeToDpi, writeTiff (typed & untiled), TiffWriter
-// tiled writes, type-conversion paths, and mergeTiffParts no-input.
+// tiled writes, type-conversion paths, isReadableTiff, and mergeTiffParts
+// no-input.
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
@@ -11,6 +12,7 @@
 #include <opencv2/imgcodecs.hpp>
 
 #include <filesystem>
+#include <fstream>
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -199,6 +201,31 @@ TEST_CASE("TiffWriter: move construction transfers file handle")
     w2.writeTile(0, 0, tile);
     w2.close();
     CHECK(fs::exists(p));
+    fs::remove_all(d);
+}
+
+TEST_CASE("isReadableTiff: finished vs torn, empty and absent files")
+{
+    auto d = tmpDir("readable");
+    auto p = d / "out.tif";
+    auto torn = d / "torn.tif";
+    {
+        TiffWriter w(p, 32, 32, CV_8UC1, 16, 16);
+        cv::Mat tile = ramp(16, 16, CV_8UC1);
+        w.writeTile(0, 0, tile);
+        w.writeTile(16, 0, tile);
+        // What a writer killed at this point leaves on disk: header and
+        // tiles, no directory (that is written by close()).
+        fs::copy_file(p, torn);
+        w.writeTile(0, 16, tile);
+        w.writeTile(16, 16, tile);
+    }
+    CHECK(isReadableTiff(p));
+    CHECK(fs::file_size(torn) > 0);
+    CHECK_FALSE(isReadableTiff(torn));
+    { std::ofstream empty(d / "empty.tif"); }
+    CHECK_FALSE(isReadableTiff(d / "empty.tif"));
+    CHECK_FALSE(isReadableTiff(d / "absent.tif"));
     fs::remove_all(d);
 }
 


### PR DESCRIPTION
**In one sentence:** `vc_render_tifxyz` no longer treats the unreadable per-slice TIFFs left behind by a killed render as finished output, so rerunning the same command after an OOM kill or `--timeout` repairs the output directory instead of printing `[tif] all slices exist, skipping.` forever.

**One real example:** Rendering PHerc1447 segment `auto_grown_20250703034159599` against the level-3 volume with `vc_render_tifxyz -v <volume> -s <segment> --scale 16 -g 3 -n 8 --tif-output out` (8 slices of 10920×7400 uint8, 12.9 s uninterrupted), I killed the process with SIGKILL at 6.0 s (band 25/58, 43%) as a stand-in for the Docker OOM kill in #1404. That left `out/00.tif … 07.tif` at 4.0–4.4 MB each: a TIFF header whose first-IFD offset is 0, plus the tiles written before the kill. `tifffile` reports "contains no pages", `cv2.imread` returns `None`, `tiffinfo` prints nothing. Rerunning the identical command with `--resume` printed `[tif] all slices exist, skipping.` and exited 0 after 0.1 s. (This was first measured on an older `main` where the skip fired with or without `--resume`; #1528 has since gated it behind `--resume`, so the rebased fix now sits inside that `if (resumeFlag && numParts <= 1)` guard and the case it fixes engages on `--resume`.) After this PR the same rerun prints `[tif] 8 of 8 existing slices are not complete, readable TIFFs (interrupted render or damaged file?), re-rendering all slices.`, renders 58/58 bands and exits 0 after 13.0 s; `cmp` against the uninterrupted render reports all 8 slices byte-identical.

**Before:** the "skip if all slices exist" check in the `--tif-output` path tested `std::filesystem::exists()` only. `TiffWriter` opens the file (header written) in its constructor, writes tiles as they are produced, and writes the directory only in `close()`, so a process killed mid-render leaves every slice existing but without a directory. Every later run skipped them, so the only way out was deleting the files by hand — exactly as #1404 describes.

**After this PR:** each existing slice must also open as a TIFF and every tile of it must decode to its full size (`isReadableTiff()`: `TIFFOpen` for read, then `TIFFReadEncodedTile` over all tiles, with libtiff's error/warning handlers muted for the probe). If any slice is missing, torn or damaged, all slices are rendered again — the same all-or-nothing behaviour the check already had for a missing slice — and the bad slices are reported. Finished output is still skipped with the files untouched; because the probe now reads the whole file, that skip costs 2.2 s instead of 0.1 s for the 8 slices above (73 MB of LZW TIFF). A fresh render is unchanged.

**Proof:** terminal transcripts before/after on the same torn directory, the mixed case (5 finished + 3 torn slices → `3 of 8 …`), the finished case, and the recovered slice:

![vc_render_tifxyz torn-slice resume before/after](https://raw.githubusercontent.com/Bullo27/villa/13d9067598a05475233b6d4d10f008b902d76993/evidence/render-tifxyz-torn-resume/evidence_render_tifxyz_torn_resume.png)

| output directory state | before (main @ 908aa7f06) | after this PR |
|---|---|---|
| 8 slices torn by SIGKILL at 43% | `[tif] all slices exist, skipping.` — exit 0, 0.1 s, files stay unreadable | `8 of 8 existing slices are not complete, readable TIFFs …, re-rendering all slices.` — exit 0, 13.0 s, 8/8 slices `cmp`-identical to the uninterrupted render |
| 5 finished slices + 3 torn copies | `[tif] all slices exist, skipping.` | `3 of 8 …` — 12.9 s, 8/8 identical |
| 8 finished slices | `[tif] all slices exist, skipping.` — 0.1 s | same message, 2.2 s (every tile decoded), files untouched |
| 8 finished slices, 4 KiB of one slice's tile data overwritten with 0xFF (directory intact, `TIFFOpen` succeeds) | `[tif] all slices exist, skipping.` — 0.1 s, the damaged slice stays | `1 of 8 …` — 14.7 s, 8/8 identical |
| kill at 43% with the patched binary, then rerun | — | `8 of 8 …` — 13.5 s, 8/8 identical |

**Why / where this is useful:** a render is interrupted precisely in the situations where people rely on rerunning it — container OOM kills (the #1404 case), `--timeout`, a lost SSH session. Without this, the rerun looks successful (exit 0, "all slices exist") while the directory holds files no reader can open, and the failure only surfaces later, when something tries to read the layers.

- [x] Verified by running the example and proof above on my machine on the stated data (AI-assisted; see disclosure).

## Details

Refs #1404 (report: @DarthCeltic). This addresses the second half of that issue — "checking that each existing slice actually opens would make resume safe after a crash". #1415 by @NicolasHuberty took the same approach for this half (together with a cache clamp) and was auto-closed for inactivity on 2026-08-27 with only bot comments; this PR is limited to the resume check, is verified on real scroll data, comes with a test, and leaves the `--cache-gb` default alone. In my reproduction the torn files are 4 MB (header plus the tiles written before the kill) rather than the zero-byte files reported in the issue; the check treats both the same, and the tests cover an empty file, a torn file, a finished one and a finished one whose tile data was damaged after the directory was written.

**What changed** (4 files, +192/−5):
- `core/util/Tiff.hpp` / `Tiff.cpp`: new `bool isReadableTiff(const std::filesystem::path&)` next to `TiffWriter` — `TIFFOpen(path, "r")` succeeds only if the first directory is readable, then every tile (or strip, for untiled files) is decoded with `TIFFReadEncodedTile`/`Strip` and must come back at its full size, so a truncated, missing or undecodable payload behind an intact directory is rejected too; libtiff's global error/warning handlers are set to null around the probe and restored, so a bad file does not spam stderr (the caller decides what to report). The header comment states what is and is not checked: structure and decodability, not pixel values.
- `apps/src/vc_render_tifxyz.cpp`: the single-part `--tif-output` skip check counts missing and torn slices instead of testing existence only; skips only when both are zero; logs `N of M existing slices are not complete, readable TIFFs (interrupted render or damaged file?), re-rendering all slices.` when such slices are found. The multi-part `.partN.tif` path (`numParts > 1`) and zarr output are untouched.
- `core/test/test_tiff.cpp`: new `TEST_CASE("isReadableTiff: finished vs torn, empty and absent files")` — writes a 32×32 tiled TIFF with `TiffWriter`, copies the file after two of four tiles and before `close()` (what a killed writer leaves on disk), and checks finished → true, torn → false, empty file → false, absent → false. Registered through the existing `test_tiff` target (label `vc-core`, CI core shard). With the probe reduced to `exists()` the two torn/empty checks fail and nothing else does. Second `TEST_CASE("isReadableTiff: intact directory over corrupt tile data")` — writes a 128×128 file of random bytes as four 64×64 LZW tiles, overwrites one tile's payload with 0xFF (offsets and byte counts taken from libtiff itself), and checks that the file still opens with `TIFFOpen` but is rejected by `isReadableTiff`.

**Tested:** first round, commit 0e1e0ef, Ubuntu 24.04.4, gcc 13.3.0. ASan+UBSan Debug build: `test_tiff` 14/14, full `vc-core` label 142/142. Real-data runs above used a Release build of the same commit. The skip path on 8 finished slices takes the same 0.1 s as before. Rebased on 2026-09-20 onto main `23c3d759e` as `4373ab9b9` (`git range-diff`: patch unchanged; main has not touched these files since `757f70c01`); on that Release build the torn-directory rerun with `--resume` again prints `8 of 8 …`, exits 0 after 13.9 s with all 8 slices `cmp`-identical to the uninterrupted render, and the finished directory is skipped in 0.15 s with the files untouched.

Review round (2026-09-21, commit `8742eb0d7` on top, Release build of this branch): `test_tiff` 15/15. Same data and command as above: torn directory → `8 of 8 …`, exit 0, 13.0 s, 8/8 `cmp`-identical; finished directory → `all slices exist, skipping.`, 2.2 s, files untouched; finished directory with 4 KiB of `03.tif`'s tile data overwritten → `1 of 8 …`, exit 0, 14.7 s, 8/8 identical (the previous head skipped that directory in 0.14 s and left the damaged slice in place).

**Not changed:** the `--cache-gb` default and the silent stall at the container memory limit (first half of #1404 — a separate decision about defaults/warnings); per-slice partial resume (a torn directory is re-rendered in full, as a directory with a missing slice already was); zarr chunk resume.

**From the author:** I contribute to VC through an AI-assisted workflow (Claude, directed by me). Going through older open issues, and looking for reports that could be reproduced and fixed with a small, tested change, we found the following. #1404 was still open, the earlier fix (#1415) had gone stale without a review, and the failure is easy to reproduce on real data: kill a render midway, rerun it, and the tool declares the output complete. We picked it because a resume path that keeps unreadable output does not work in the one situation it exists for, namely renders interrupted by memory limits or timeouts, which is the case reported in #1404 (a Docker OOM kill). The PR only touches the resume check and leaves the cache-size default alone. I reviewed the investigation, the issue history and the evidence; every number in this PR was produced by running the stated commands on my machine.

**AI disclosure:** investigation, patch, test and this write-up were produced with Claude (Anthropic) under my direction; every number above comes from running the stated commands on the stated data on my machine.