### PR TITLE
spiral: make the spiral tutorial work on native Windows

### DIFF
--- a/lasagna/fit_service.py
+++ b/lasagna/fit_service.py
@@ -66,6 +66,20 @@ _VC3D_SOURCE_HEADER = "X-VC3D-Source"
 os.environ.setdefault("LASAGNA_CHECK_SPARSE_CACHE", "1")
 
 
+def _gpu_pause_or_null():
+    """Return the GPU-pause context, or a no-op where pausing is disabled.
+
+    gpu_pause is imported here rather than at module scope because it is
+    built on fcntl and unix sockets. A host started with --no-gpu-pause has
+    nothing to coordinate with and may not have either.
+    """
+    if not _gpu_pause_enabled:
+        from contextlib import nullcontext
+        return nullcontext()
+    from gpu_pause import gpu_pause_context
+    return gpu_pause_context()
+
+
 def _mib(n_bytes: int) -> float:
     return float(n_bytes) / (1024.0 * 1024.0)
 
@@ -1901,11 +1915,8 @@ def _run_optimization(job: _JobState, body: dict[str, Any]) -> None:
             kwargs["cancel_fn"] = _check_cancel
             return _orig_optimize(**kwargs)
 
-        from contextlib import nullcontext
-        from gpu_pause import gpu_pause_context
-
         opt_mod.optimize = _patched_optimize
-        with (gpu_pause_context() if _gpu_pause_enabled else nullcontext()):
+        with _gpu_pause_or_null():
             try:
                 import fit as fit_mod
                 job.set_running("loading", 0, 0, 0.0)
@@ -2348,9 +2359,7 @@ class _Handler(BaseHTTPRequestHandler):
                         data_input = str(candidate)
 
             import lasagna_analyze
-            from contextlib import nullcontext
-            from gpu_pause import gpu_pause_context
-            with (gpu_pause_context() if _gpu_pause_enabled else nullcontext()):
+            with _gpu_pause_or_null():
                 lasagna_analyze.export_vis_obj(
                     model_path=str(model_input),
                     data_path=str(data_input),

--- a/lasagna/tests/test_fit_service_gpu_pause.py
+++ b/lasagna/tests/test_fit_service_gpu_pause.py
@@ -1,0 +1,75 @@
+"""A service started with --no-gpu-pause must not import gpu_pause.
+
+gpu_pause coordinates GPU handover between processes through an advisory
+file lock and a unix socket, so importing it pulls in fcntl and AF_UNIX.
+Both call sites used to import it unconditionally and only then decide
+whether to use it, which made the module a hard requirement even for a
+service that was told there is nothing to coordinate with -- a private
+service that owns its GPU for the run, or simply a host without fcntl.
+
+These tests pin that the flag decides the import, in both directions.
+"""
+import sys
+import unittest
+
+import fit_service
+
+
+class UnimportableGpuPause:
+    """Make ``import gpu_pause`` fail, the way a host without fcntl would."""
+
+    def __enter__(self):
+        self._saved = sys.modules.get("gpu_pause", "absent")
+        # A None entry in sys.modules is the documented way to make an
+        # import raise ImportError without touching the import path.
+        sys.modules["gpu_pause"] = None
+        return self
+
+    def __exit__(self, *exception):
+        if self._saved == "absent":
+            sys.modules.pop("gpu_pause", None)
+        else:
+            sys.modules["gpu_pause"] = self._saved
+        return False
+
+
+class GpuPauseOrNullTest(unittest.TestCase):
+    def setUp(self):
+        self._enabled = fit_service._gpu_pause_enabled
+        self.addCleanup(
+            setattr, fit_service, "_gpu_pause_enabled", self._enabled)
+
+    def test_disabled_yields_a_no_op_without_importing_gpu_pause(self):
+        fit_service._gpu_pause_enabled = False
+        with UnimportableGpuPause():
+            with fit_service._gpu_pause_or_null() as entered:
+                self.assertIsNone(entered)
+
+    def test_enabled_still_imports_gpu_pause(self):
+        fit_service._gpu_pause_enabled = True
+        with UnimportableGpuPause():
+            with self.assertRaises(ImportError):
+                fit_service._gpu_pause_or_null()
+
+    def test_enabled_returns_the_real_context(self):
+        sentinel = object()
+
+        class StubModule:
+            @staticmethod
+            def gpu_pause_context():
+                return sentinel
+
+        saved = sys.modules.get("gpu_pause", "absent")
+        sys.modules["gpu_pause"] = StubModule
+        try:
+            fit_service._gpu_pause_enabled = True
+            self.assertIs(fit_service._gpu_pause_or_null(), sentinel)
+        finally:
+            if saved == "absent":
+                sys.modules.pop("gpu_pause", None)
+            else:
+                sys.modules["gpu_pause"] = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scrollprize.org/docs/38_tutorial_spiral.md
+++ b/scrollprize.org/docs/38_tutorial_spiral.md
@@ -104,6 +104,11 @@ uv pip install -e ../volume-cartographer   # volume-cartographer python bindings
 
 The spiral scripts declare their dependencies in their own [`pyproject.toml`](https://github.com/ScrollPrize/villa/blob/main/spiral-fitting/pyproject.toml) — only `torch` is left for you to install, so you can pick the right build for your CUDA version. The last line builds the volume-cartographer Python bindings, which the fit uses to link point annotations to patches; it compiles C++, so you'll need cmake and VC's build dependencies (see the [segmentation tutorial](segmentation#installation-instructions) if it fails).
 
+Two notes for Windows, where the fit runs natively:
+
+- PyPI marks PyTorch's CUDA runtime packages `platform_system == "Linux"`, so the line above installs a CPU-only build there. Take it from the CUDA index instead, e.g. `uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128`.
+- PyTorch also publishes no `triton` wheel for Windows, and the fit's fused RK4 and gap kernels quietly fall back to the eager path without it. Installing the community `triton-windows` build that matches the `triton` version your torch pins puts the fused path back; on one machine that was 3.8 vs 1.7 it/s, with the first run paying a one-off kernel compile.
+
 #### Get the dataset
 
 Ready-made inputs are published in the [`spiral-input` dataset](data_datasets#spiral-input-2026-07), which lives on the dl.ash2txt.org data server : [Spiral Datasets](https://dl.ash2txt.org/datasets/spiral_datasets/PHercParis4/) (~90 GB):

--- a/spiral-fitting/flatten_spiral_checkpoint.py
+++ b/spiral-fitting/flatten_spiral_checkpoint.py
@@ -281,7 +281,13 @@ def _store_surface(surface: Path, object_store: Path) -> dict:
         object_store / ref["type"] / manifest_hash
         / quote(ref["name"], safe=""))
     destination.mkdir(parents=True)
-    (destination / "segment").symlink_to(surface, target_is_directory=True)
+    try:
+        (destination / "segment").symlink_to(surface, target_is_directory=True)
+    except OSError:
+        # Symlinks need a privilege or developer mode on Windows and do not
+        # exist on exFAT at all. This store is private to the run and is only
+        # ever read, so a copy serves the same reads.
+        shutil.copytree(surface, destination / "segment")
     (destination / "object.json").write_text(
         json.dumps(ref, indent=2) + "\n", encoding="utf-8")
     return ref
@@ -359,6 +365,10 @@ def _flatten(
                 "--port", "0",
                 "--allow-no-data-dir",
                 "--object-store-dir", str(object_store),
+                # gpu_pause coordination is built on fcntl and unix sockets.
+                # This service is private to the flatten and owns its GPU for
+                # the run, so there is nothing to coordinate with.
+                *(["--no-gpu-pause"] if os.name != "posix" else []),
             ],
             cwd=str(service_path.parent),
             stdout=subprocess.PIPE,

--- a/spiral-fitting/flow_triton.py
+++ b/spiral-fitting/flow_triton.py
@@ -30,8 +30,28 @@ except ImportError:  # pragma: no cover - triton is present on CUDA installs
     _HAS_TRITON = False
 
 
+_warned_missing_triton = False
+
+
+def _warn_missing_triton():
+    # PyTorch publishes no triton wheel for Windows, so this fallback is the
+    # default there rather than the exception the import guard reads like. Say
+    # so once, the way tracks.py does when the native crossing consolidator is
+    # missing; silently running a much slower path with slightly different
+    # results is worse than a line of output.
+    global _warned_missing_triton
+    if not _warned_missing_triton:
+        _warned_missing_triton = True
+        print(
+            'WARNING: triton is unavailable; the fused RK4 flow kernels fall back '
+            'to the much slower eager path, whose results differ slightly')
+
+
 def rk4_triton_available(*tensors):
-    if not _HAS_TRITON or os.environ.get('FIT_SPIRAL_TRITON', '1') == '0':
+    if not _HAS_TRITON:
+        _warn_missing_triton()
+        return False
+    if os.environ.get('FIT_SPIRAL_TRITON', '1') == '0':
         return False
     return all(
         t.is_cuda and t.dtype == torch.float32 for t in tensors if t is not None

--- a/spiral-fitting/gap_triton.py
+++ b/spiral-fitting/gap_triton.py
@@ -35,8 +35,28 @@ except ImportError:  # pragma: no cover - triton is present on CUDA installs
 _TWO_PI = 2 * math.pi
 
 
+_warned_missing_triton = False
+
+
+def _warn_missing_triton():
+    # PyTorch publishes no triton wheel for Windows, so this fallback is the
+    # default there rather than the exception the import guard reads like. Say
+    # so once, the way tracks.py does when the native crossing consolidator is
+    # missing; silently running a much slower path with slightly different
+    # results is worse than a line of output.
+    global _warned_missing_triton
+    if not _warned_missing_triton:
+        _warned_missing_triton = True
+        print(
+            'WARNING: triton is unavailable; the fused gap-expander kernels fall back '
+            'to the much slower eager path, whose results differ slightly')
+
+
 def gap_triton_available(*tensors):
-    if not _HAS_TRITON or os.environ.get('FIT_SPIRAL_TRITON', '1') == '0':
+    if not _HAS_TRITON:
+        _warn_missing_triton()
+        return False
+    if os.environ.get('FIT_SPIRAL_TRITON', '1') == '0':
         return False
     return all(
         t.is_cuda and t.dtype == torch.float32 for t in tensors if t is not None

--- a/spiral-fitting/pyproject.toml
+++ b/spiral-fitting/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "imageio>=2.37.3",
     "kimimaro[all]>=5.8.1",
     "kornia>=0.8.3",
-    "libigl>=2.6.1",
+    # 2.6.2 shipped no Windows wheel; 2.6.3 restored it.
+    "libigl>=2.6.3",
     "matplotlib>=3.11.0",
     "networkx>=3.6.1",
     "numpy>=2.5.0",

--- a/spiral-fitting/tests/test_flatten_spiral_checkpoint.py
+++ b/spiral-fitting/tests/test_flatten_spiral_checkpoint.py
@@ -8,6 +8,7 @@ from flatten_spiral_checkpoint import (
     _checkpoint_config,
     _resolve_lasagna,
     _resolve_umbilicus,
+    _store_surface,
 )
 
 
@@ -54,3 +55,55 @@ def test_resolve_lasagna_requires_service_and_config(tmp_path):
 def test_checkpoint_config_reports_missing_fields():
     with pytest.raises(ValueError, match="missing model configuration"):
         _checkpoint_config({"cfg": {}})
+
+
+def _surface(root: Path) -> Path:
+    """A minimal tifxyz segment: a couple of files in a directory."""
+    surface = root / "segment-0001"
+    (surface / "nested").mkdir(parents=True)
+    (surface / "meta.json").write_text('{"width": 4}', encoding="utf-8")
+    (surface / "nested" / "x.tif").write_bytes(bytes([0, 1, 2]))
+    return surface
+
+
+def test_store_surface_falls_back_to_copying_where_symlinks_are_refused(
+        tmp_path, monkeypatch):
+    """Symlinks need a privilege on Windows and do not exist on exFAT.
+
+    The object store is private to the run and is only ever read, so a copy
+    has to serve where the symlink is refused.
+    """
+    attempted = []
+
+    def refuse(self, target, target_is_directory=False):
+        attempted.append(Path(self))
+        raise OSError(1314, "A required privilege is not held by the client")
+
+    monkeypatch.setattr(Path, "symlink_to", refuse)
+
+    surface = _surface(tmp_path)
+    store = tmp_path / "objects"
+    ref = _store_surface(surface, store)
+
+    segment = store / ref["type"] / ref["hash"].removeprefix("md5:") / "segment-0001" / "segment"
+    assert attempted, "the symlink has to be tried before copying"
+    assert segment.is_dir() and not segment.is_symlink()
+    assert (segment / "meta.json").read_text(encoding="utf-8") == '{"width": 4}'
+    assert (segment / "nested" / "x.tif").read_bytes() == bytes([0, 1, 2])
+    assert json.loads(
+        (segment.parent / "object.json").read_text(encoding="utf-8")) == ref
+
+
+def test_store_surface_hash_does_not_depend_on_how_the_segment_is_stored(
+        tmp_path, monkeypatch):
+    """The manifest hash is over the segment's bytes, not over the store."""
+    linked = _store_surface(_surface(tmp_path / "a"), tmp_path / "a" / "objects")
+
+    def refuse(self, target, target_is_directory=False):
+        raise OSError(1314, "A required privilege is not held by the client")
+
+    monkeypatch.setattr(Path, "symlink_to", refuse)
+    copied = _store_surface(_surface(tmp_path / "b"), tmp_path / "b" / "objects")
+
+    assert linked == copied
+

--- a/spiral-fitting/tests/test_triton_fallback_notice.py
+++ b/spiral-fitting/tests/test_triton_fallback_notice.py
@@ -1,0 +1,44 @@
+"""The fused-kernel fallback says so once, and only when triton is missing."""
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.mark.parametrize(
+    'module_name, gate_name',
+    [('flow_triton', 'rk4_triton_available'),
+     ('gap_triton', 'gap_triton_available')],
+)
+def test_missing_triton_warns_once(module_name, gate_name, monkeypatch, capsys):
+    module = importlib.import_module(module_name)
+    monkeypatch.setattr(module, '_HAS_TRITON', False)
+    monkeypatch.setattr(module, '_warned_missing_triton', False)
+    monkeypatch.delenv('FIT_SPIRAL_TRITON', raising=False)
+    gate = getattr(module, gate_name)
+
+    assert gate() is False
+    assert gate() is False
+
+    out = capsys.readouterr().out
+    assert out.count('triton is unavailable') == 1
+    assert 'slower' in out
+
+
+@pytest.mark.parametrize(
+    'module_name, gate_name',
+    [('flow_triton', 'rk4_triton_available'),
+     ('gap_triton', 'gap_triton_available')],
+)
+def test_opting_out_is_silent(module_name, gate_name, monkeypatch, capsys):
+    # Turning the kernels off by hand is a choice, not a surprise; say nothing.
+    module = importlib.import_module(module_name)
+    monkeypatch.setattr(module, '_HAS_TRITON', True)
+    monkeypatch.setattr(module, '_warned_missing_triton', False)
+    monkeypatch.setenv('FIT_SPIRAL_TRITON', '0')
+
+    assert getattr(module, gate_name)() is False
+    assert capsys.readouterr().out == ''

--- a/spiral-fitting/uv.lock
+++ b/spiral-fitting/uv.lock
@@ -354,7 +354,7 @@ name = "cuda-bindings"
 version = "12.9.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/e4/075052d42872cf8162da53f14447a4b8abc004c3750e4b724ee502428da0/cuda_bindings-12.9.7-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:775960ac9e530717f3b48e165cc6f68684fa9a4141764fd923e4c1a9820acc73", size = 7060090, upload-time = "2026-05-27T18:44:30.281Z" },
@@ -381,37 +381,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12" },
 ]
 cufft = [
-    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12" },
 ]
 cufile = [
-    { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12" },
 ]
 curand = [
-    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12" },
 ]
 
 [[package]]
@@ -820,16 +820,19 @@ wheels = [
 
 [[package]]
 name = "libigl"
-version = "2.6.2"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2d/595f3ba33701b2354723821e38745674ae9b21ec79d18d7757dbe2e893c3/libigl-2.6.2.tar.gz", hash = "sha256:5da0c5d889a66e3e90eefe6b7f0e7239ade6ac94353585f1b5b086bb1372599e", size = 41219283, upload-time = "2026-03-05T17:28:03.963Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/41/8b04eb112af0579790af6a04f7d0ffc9be6827ce44e99495d30c6820e1fc/libigl-2.6.3.tar.gz", hash = "sha256:e2a3ff17b88cae728cb60ea63850131315bb661045a8642db73aea98c91486ab", size = 41273089, upload-time = "2026-09-01T02:47:31.393Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/99/99422c55a722afea4cd25c8d6c2fd5f432be564a12cfa18a2aae7160abff/libigl-2.6.2-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:9b477b584277def1fbf99c05a9ca59c96ad09f6e6572ac58b88ac73c7f3f7ac9", size = 11257225, upload-time = "2026-03-05T17:27:50.124Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/9f/3c6994d112759d25b00007384651157dabf955c61a62050de4fadea794f2/libigl-2.6.2-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e92dac380ec1f81d87a6f5423b2de228e106f90edb9c14033984210c23b32854", size = 12820764, upload-time = "2026-03-05T17:27:52.08Z" },
+    { url = "https://files.pythonhosted.org/packages/28/83/29c5a7a76d1f231ea75dc55369289393f96fd0dd30748bc2109c2454b403/libigl-2.6.3-cp312-abi3-macosx_10_15_x86_64.whl", hash = "sha256:913ae71a57e164ed79237c8c320677923b61fd762fdbaa1d3b2a974a198ba3a9", size = 13481939, upload-time = "2026-09-01T02:46:00.082Z" },
+    { url = "https://files.pythonhosted.org/packages/50/5a/687c38287c1ae298fc1221d8422f6fd63de9b9461dc8b0368e54953cc5ca/libigl-2.6.3-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:da3c62c50103be9b192bc76bbcb9e5031d80a2cf209b3ef0a0cf0060750088d9", size = 12215411, upload-time = "2026-09-01T02:46:11.991Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/88/d964fc9e6ee297793b8c65937f1bbe1365f3faaa29fc22054aa51a1e05a1/libigl-2.6.3-cp312-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98952af1bc41e363a642c880465e91f951164a6ee23ca62e8e8449d00a31e2d0", size = 13158545, upload-time = "2026-09-01T02:46:25.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c2/8641402402fbfa553c51615825434802de9c3b60b2580acdaad5312af396/libigl-2.6.3-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a1d28aebfeb8b232a58943b1af318ec61a1fff7650a9d25a1396ba8fa1ef6d6", size = 13889363, upload-time = "2026-09-01T02:46:41.414Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/13/6893321d8fc1a742a276a5de796e1818cae33a0589b46f487a6cba2547c5/libigl-2.6.3-cp312-abi3-win_amd64.whl", hash = "sha256:1d91745ed0e78c56a04539e3231ce6faff49ae0dbe123caa2034e1886fcb2e7d", size = 20239839, upload-time = "2026-09-01T02:47:07.712Z" },
 ]
 
 [[package]]
@@ -1141,7 +1144,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
@@ -1153,7 +1156,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -1183,9 +1186,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -1197,7 +1200,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -1873,7 +1876,7 @@ requires-dist = [
     { name = "imageio", specifier = ">=2.37.3" },
     { name = "kimimaro", extras = ["all"], specifier = ">=5.8.1" },
     { name = "kornia", specifier = ">=0.8.3" },
-    { name = "libigl", specifier = ">=2.6.1" },
+    { name = "libigl", specifier = ">=2.6.3" },
     { name = "matplotlib", specifier = ">=3.11.0" },
     { name = "networkx", specifier = ">=3.6.1" },
     { name = "numpy", specifier = ">=2.5.0" },
@@ -1959,13 +1962,13 @@ resolution-markers = [
     "sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "setuptools", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
@@ -1981,20 +1984,20 @@ resolution-markers = [
     "sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "networkx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "cuda-bindings", marker = "sys_platform != 'win32'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparselt-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvshmem-cu12", marker = "sys_platform != 'win32'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform != 'win32'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:baa52f7b8a53cab16587b10f1c27d1000ca033f97236878b685b75d5a1b92408", upload-time = "2026-04-27T17:54:24Z" },


### PR DESCRIPTION
**In one sentence:** You can skip WSL and run the whole spiral pipeline natively on Windows: `uv sync`, `fit_spiral.py`, `flatten_spiral_checkpoint.py`, and rendering with the released VC3D binaries.

**Motivation:** I wanted this work to run on native Windows. WSL is too much hassle for me. I went through the tutorial on Windows and hit a few things that make the native path unusable. Today it only really works under WSL. This PR fixes them. The same workflow now runs directly on Windows.

**One real example:** On a laptop with an RTX 4080, starting from the published `spiral-input` PHercParis4 dataset, I followed the four commands in the [spiral fitting tutorial](https://scrollprize.org/tutorial_spiral). `uv sync` failed while building libigl. After working around that by hand, flatten failed twice: once on `symlink_to`, once on `gpu_pause` importing `fcntl`. With these four commits the same commands run through to a flattened surface, and rendering it with the released `vc_render_tifxyz.exe` needs no changes at all.

**Before:**

- `uv sync` exits 1. The lockfile pins `libigl==2.6.2`, the one release with no `win_amd64` wheel, so every Windows install is pushed into a CGAL/Boost source build.
- `flatten_spiral_checkpoint.py` raises `OSError [WinError 1]` from `symlink_to`, and cannot work on exFAT at all. `lasagna/fit_service.py` imports `gpu_pause` before checking the flag, so `--no-gpu-pause` does not stop it reaching a bare `import fcntl`.
- The fit runs, but PyPI marks torch's `triton` dependency `sys_platform == 'linux'`, so `_HAS_TRITON` is False and the fused RK4 and gap kernels fall back to the eager path. Nothing is printed, so the run looks the same while using different kernels from the ones Linux uses.

**After this PR:**

- The lockfile takes `libigl==2.6.3`, released 2026-09-01, which ships the Windows wheels 2.6.2 dropped. Nothing is gated off; SLIM reparameterisation still works.
- flatten copies where it cannot symlink, and the `gpu_pause` import follows the flag.
- The fallback prints one line: the fused kernels are unavailable, the eager path is slower, and its results differ slightly.

**Proof:**

1. The lockfile pins libigl 2.6.2. On the same machine, `--no-build` shows that 2.6.2 has no usable wheel, and that 2.6.3 installs and imports.

![libigl before and after](https://raw.githubusercontent.com/7jycwjmbfn-eng/villa/pr-assets/shots_2026-09-04/shot1_libigl.png)

2. I ran flatten on a checkpoint from my own fit (PHercParis4, z 5000-5400). Clean main stops with `No module named 'fcntl'`. This branch writes `flattened.tifxyz`, 163.5 MB, and exits 0.

![flatten before and after](https://raw.githubusercontent.com/7jycwjmbfn-eng/villa/pr-assets/shots_2026-09-04/shot3_flatten.png)

3. I ran two 20-step fits on real data with triton not installed. On clean main, nothing in the output mentions triton. This branch prints the two warnings and reaches the same `satisfied_area`.

![fused kernel fallback before and after](https://raw.githubusercontent.com/7jycwjmbfn-eng/villa/pr-assets/shots_2026-09-04/shot4_triton.png)

Tests: 4 for the fallback, 11 around flatten and `gpu_pause`. Reverting the source changes and keeping the tests fails them.

Speed, for context: with the community `triton-windows` build installed so the fused path is available, the same window and step count runs at 3.8 it/s against 1.7 it/s. The first fused run pays a one-off kernel compile, and `satisfied_area` moves between the two arms by more than the run-to-run spread, so this is not only a speed difference.

**Why / where this is useful:** For people who want to work on native Windows, and for people who would rather not use WSL or are not familiar with it. With this in, they can just run the workflow.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Four commits, each self-contained:

1. `spiral: take the libigl release that ships a Windows wheel` — a floor in `pyproject.toml` plus `uv lock --upgrade-package libigl`. No other package moves in the lockfile.
2. `spiral: flatten a checkpoint where symlinks and gpu_pause are unavailable` — the object store is private to the run and only ever read, so a copy serves the same reads; the manifest hash is over the segment's bytes and does not move.
3. `spiral: say when the fused kernels fall back to the eager path` — warn-once, only when triton is missing. `FIT_SPIRAL_TRITON=0` stays silent, since that is the user's own choice. Two places in this repo already do this: `spiral-fitting/tracks.py:1450` and `vesuvius/src/vesuvius/ink_detection/inference/inference_runtime.py:158-171`.
4. `docs(spiral): what the install line does on Windows` — the CUDA index, and that `triton-windows` is what puts the fused path back.

The screenshots were taken at `1ee7f94d3`; the branch is rebased onto `23adee047`, which only changes a default in `spiral-fitting/config.py`.

Tested on Windows 11, Python 3.14.7, torch 2.11.0+cu128, RTX 4080 Laptop.
