### PR TITLE
Fix VC3D downloading legacy level_N files on cold start with no ~/.VC…

### DIFF
--- a/volume-cartographer/core/src/render/ChunkCache.cpp
+++ b/volume-cartographer/core/src/render/ChunkCache.cpp
@@ -562,6 +562,11 @@ bool hasLegacyCacheFootprint(const std::filesystem::path& root)
     return false;
 }
 
+bool isLegacyPersistentLayout(PersistentCacheLayout layout)
+{
+    return layout == PersistentCacheLayout::Legacy;
+}
+
 bool hasNativeZarrMetadata(const std::filesystem::path& root)
 {
     std::error_code ec;
@@ -3919,6 +3924,10 @@ void ChunkCache::dispatchStorageObjectResult(
             persistenceSucceeded = writeMirrorEmpty(*state, object);
         }
     }
+    // The exact source object (or .empty marker) is the Zarr-mirror payload.
+    // Decoded-store and missing-store paths must not also write legacy
+    // level_N/z/y/x.{bin,empty} files beside it.
+    fetch.persistentWriteHandled = true;
 
     StorageObjectTransfer transfer;
     {
@@ -4023,6 +4032,7 @@ void ChunkCache::queueStorageObjectDecode(
                     decoded.status = ChunkFetchStatus::DecodeError;
                     decoded.message = error.what();
                 }
+                decoded.persistentWriteHandled = true;
                 FetchContext context{
                     consumer.generation, consumer.fetcherGeneration,
                     consumer.fetchSerial, consumer.schedulerEpoch,
@@ -4485,6 +4495,8 @@ bool ChunkCache::queuePersistentWrite(const std::shared_ptr<State>& state,
 {
     if (!state || !state->options_.persistentCachePath || !bytes)
         return false;
+    if (!isLegacyPersistentLayout(state->persistentLayout_))
+        return false;
     if (persistentEntryIsRaw(*state, key) &&
         bytes->size() != expectedChunkBytes(*state, key))
         return false;
@@ -4768,6 +4780,8 @@ bool ChunkCache::queuePersistentEmptyWrite(const std::shared_ptr<State>& state,
 {
     if (!state || !state->options_.persistentCachePath)
         return false;
+    if (state->persistentLayout_ == PersistentCacheLayout::ZarrMirror)
+        return false;
 
     state->persistentWritesInFlight_.fetch_add(1, std::memory_order_acq_rel);
     persistentCacheWriterPool().enqueue([state, key] {
@@ -4807,6 +4821,8 @@ bool ChunkCache::queuePersistentSourceWrite(
     std::shared_ptr<PersistenceOperation> operation)
 {
     if (!state || !state->options_.persistentCachePath || !bytes || !operation)
+        return false;
+    if (!isLegacyPersistentLayout(state->persistentLayout_))
         return false;
     operation->writeQueued.store(true, std::memory_order_release);
     const std::size_t retainedBytes = bytes->size();
@@ -4905,6 +4921,8 @@ bool ChunkCache::queuePersistentSourceEmptyWrite(
 bool ChunkCache::writePersistent(State& state, const ChunkKey& key, const std::vector<std::byte>& bytes)
 {
     if (!state.options_.persistentCachePath)
+        return false;
+    if (!isLegacyPersistentLayout(state.persistentLayout_))
         return false;
     const bool rawEntry = persistentEntryIsRaw(state, key);
     if (rawEntry && bytes.size() != expectedChunkBytes(state, key))
@@ -5065,6 +5083,8 @@ bool ChunkCache::writePersistentSource(
 {
     if (!state.options_.persistentCachePath)
         return false;
+    if (!isLegacyPersistentLayout(state.persistentLayout_))
+        return false;
 
     const auto path = persistentSourcePath(state, key);
     std::vector<std::filesystem::path> replacements{
@@ -5136,6 +5156,8 @@ bool ChunkCache::writePersistentSource(
 bool ChunkCache::writePersistentEmpty(State& state, const ChunkKey& key)
 {
     if (!state.options_.persistentCachePath)
+        return false;
+    if (state.persistentLayout_ == PersistentCacheLayout::ZarrMirror)
         return false;
 
     const auto path = state.persistentLayout_ == PersistentCacheLayout::Delta3d

--- a/volume-cartographer/core/test/test_chunk_cache_persist.cpp
+++ b/volume-cartographer/core/test/test_chunk_cache_persist.cpp
@@ -1046,6 +1046,7 @@ TEST_CASE("persistent cache format transitions are leased and volume-local")
     REQUIRE(waitForResolved(*mirror, 0, 0, 0, 0).status == ChunkStatus::Data);
     mirror->waitForPersistentWrites();
     REQUIRE(fs::is_regular_file(persist / "scale0" / "0.0.0"));
+    CHECK_FALSE(fs::exists(persist / "level_0"));
     REQUIRE(budget->stats().managedBytes > 0);
     writeSizedFile(bookkeeping, 3);
 
@@ -1103,4 +1104,23 @@ TEST_CASE("persistent cache format transitions are leased and volume-local")
     CHECK(fs::is_regular_file(sibling));
     restored.reset();
     fs::remove_all(parent);
+}
+
+TEST_CASE("Zarr mirror does not write legacy level_N payloads")
+{
+    auto persist = tmpDir("mirror_no_legacy");
+    ChunkFetchResult fetched;
+    fetched.status = ChunkFetchStatus::Found;
+    fetched.bytes = variedBytes(64);
+    auto fetcher = std::make_shared<MirrorFetcher>();
+    fetcher->setCanned({0, 0, 0, 0}, fetched);
+    auto cache = makeMirrorCache(fetcher, persist);
+    REQUIRE(cache->persistentCacheLayout() ==
+            vc::render::PersistentCacheLayout::ZarrMirror);
+    REQUIRE(waitForResolved(*cache, 0, 0, 0, 0).status == ChunkStatus::Data);
+    cache->waitForPersistentWrites();
+    REQUIRE(fs::is_regular_file(persist / "scale0" / "0.0.0"));
+    CHECK_FALSE(fs::exists(persist / "level_0"));
+    cache.reset();
+    fs::remove_all(persist);
 }

--- a/volume-cartographer/core/test/test_zarr_chunk_fetcher.cpp
+++ b/volume-cartographer/core/test/test_zarr_chunk_fetcher.cpp
@@ -436,6 +436,8 @@ TEST_CASE("native mirror stores a complete shard and serves sibling inner chunks
     CHECK(readBytes(mirror / "0" / "zarr.json") ==
           readBytes(source / "0" / "zarr.json"));
     CHECK(cache->storageObjectRepresentatives(0).size() == 1);
+    cache->waitForPersistentWrites();
+    CHECK_FALSE(fs::exists(mirror / "level_0"));
 
     fs::remove(sourceShard);
     const auto sibling = cache->getChunkBlocking(0, 0, 0, 1);
@@ -680,8 +682,10 @@ TEST_CASE("missing whole shard creates one physical empty marker")
           vc::render::ChunkStatus::Missing);
     CHECK(cache->getChunkBlocking(0, 0, 0, 1).status ==
           vc::render::ChunkStatus::Missing);
+    cache->waitForPersistentWrites();
     CHECK_FALSE(fs::exists(mirror / object.key));
     CHECK(fs::is_regular_file((mirror / object.key).string() + ".empty"));
+    CHECK_FALSE(fs::exists(mirror / "level_0"));
 
     cache.reset();
     vc::render::processChunkCacheService()->invalidateSource(identity);
@@ -785,7 +789,9 @@ TEST_CASE("native mirror stores exact unsharded bytes and reopens without source
     REQUIRE(cache);
     const auto first = cache->getChunkBlocking(0, 0, 0, 0);
     REQUIRE(first.status == vc::render::ChunkStatus::Data);
+    cache->waitForPersistentWrites();
     CHECK(readBytes(mirror / object.key) == readBytes(sourceObject));
+    CHECK_FALSE(fs::exists(mirror / "level_0"));
 
     fs::remove(sourceObject);
     cache.reset();


### PR DESCRIPTION
**In one sentence:** [see discord](https://discord.com/channels/1079907749569237093/1243576621722767412/1545371691813703730)

**One real example:** Move ~/.VC3D out of the way and run VC3D. It no longer creates deprecated level_N files.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

### However

I hope this doesn't break the read path. How should it work? It reads from either, but only writes new chunks to N (not level_N) ? 

Please review if this is the right thing, didn't take the time to look at it in depth, sorry.
