### PR TITLE
ink_detection: retry transient remote reads in flat inference and bbox reader (fixes #1666)

### DIFF
--- a/vesuvius/src/vesuvius/data/_transient_reads.py
+++ b/vesuvius/src/vesuvius/data/_transient_reads.py
@@ -1,0 +1,93 @@
+"""Classification and bounded retry for transient remote reads.
+
+zarr and fsspec wrap the underlying transport (aiohttp, botocore, urllib3,
+ssl) differently across versions and backends, so transient failures are
+classified by message substring rather than by exception type.  Retrying
+happens only for failures that look like a network hiccup; deterministic
+errors (missing array, bad coordinates, auth) re-raise immediately.
+
+This module is a leaf: it imports nothing from vesuvius, so both
+``data.volume`` and ``ink_detection.volume_io`` can import it without any
+circular-import risk.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Optional
+
+
+_TRANSIENT_READ_MARKERS = (
+    'payload is not completed',
+    'not enough data to satisfy content length',
+    'contentlengtherror',
+    'connection reset',
+    'connection aborted',
+    'connection closed',
+    'server disconnected',
+    'record layer failure',
+    'ssl',
+    'timed out',
+    'timeout',
+    'temporarily unavailable',
+    'slowdown',
+    'throttl',
+    'too many requests',
+    'internal error',
+    'service unavailable',
+    'bad gateway',
+    'gateway timeout',
+    ' 429',
+    ' 500',
+    ' 502',
+    ' 503',
+    ' 504',
+)
+
+
+def _is_transient_read_error(exc: BaseException) -> bool:
+    """True when a read failure looks like a network hiccup rather than a bug."""
+    seen = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        text = f"{type(exc).__name__}: {exc}".lower()
+        if any(marker in text for marker in _TRANSIENT_READ_MARKERS):
+            return True
+        exc = exc.__cause__ or exc.__context__
+    return False
+
+
+def _read_array_with_retry(
+    volume: Any,
+    selection: tuple[Any, ...],
+    *,
+    retries: int = 4,
+    base_delay: float = 0.5,
+    max_delay: float = 8.0,
+    warn: Optional[Callable[[str], None]] = None,
+) -> Any:
+    """Read ``volume[selection]``, retrying transient remote failures.
+
+    Remote object stores drop connections routinely — truncated payloads,
+    SSL record errors, 5xx, throttling.  A caller streaming a whole volume
+    issues one read per patch, so without this a single hiccup propagates
+    out and aborts the job, discarding everything computed so far.
+
+    Deterministic failures (bad coordinates, missing array, auth) are not
+    retried; they re-raise on the first attempt.
+    """
+    retries = max(1, int(retries))
+    delay = base_delay
+    for attempt in range(retries):
+        try:
+            return volume[selection]
+        except Exception as e:
+            if attempt == retries - 1 or not _is_transient_read_error(e):
+                raise
+            if warn is not None:
+                warn(
+                    f"transient remote read error ({type(e).__name__}), retry "
+                    f"{attempt + 1}/{retries - 1} in {delay:.1f}s: {e}"
+                )
+            time.sleep(delay)
+            delay = min(delay * 2, max_delay)

--- a/vesuvius/src/vesuvius/data/_transient_reads.py
+++ b/vesuvius/src/vesuvius/data/_transient_reads.py
@@ -13,6 +13,7 @@ circular-import risk.
 
 from __future__ import annotations
 
+import re
 import time
 from typing import Any, Callable, Optional
 
@@ -37,22 +38,53 @@ _TRANSIENT_READ_MARKERS = (
     'service unavailable',
     'bad gateway',
     'gateway timeout',
-    ' 429',
-    ' 500',
-    ' 502',
-    ' 503',
-    ' 504',
+)
+
+# HTTP statuses worth retrying, but only when the number appears as a status:
+# "ClientResponseError: 503, message=...", "An error occurred (503) when
+# calling GetObject", "HTTP 429", "status: 502". A bare " 504" also matched
+# "index out of bounds for dimension with length 504" and "size 5040", which
+# turned a coding error into four attempts and 3.5 s of backoff.
+_TRANSIENT_HTTP_STATUS = re.compile(
+    r'(?:(?:error|status|http|response|code)\W{0,4}|\(\s*)(?:429|500|502|503|504)(?!\d)'
+)
+
+# Exceptions that describe a bug or a bad request rather than a network
+# hiccup. Their messages are not scanned for markers (zarr's BoundsCheckError
+# is an IndexError whose text names the dimension length), but the cause
+# chain is still walked in case one wraps a genuine transport error.
+_DETERMINISTIC_ERROR_TYPES = (
+    IndexError,
+    KeyError,
+    TypeError,
+    ValueError,
+    AttributeError,
+    NotImplementedError,
 )
 
 
+_NON_TRANSIENT_TYPES = _DETERMINISTIC_ERROR_TYPES
+
+
 def _is_transient_read_error(exc: BaseException) -> bool:
-    """True when a read failure looks like a network hiccup rather than a bug."""
+    """True when a read failure looks like a network hiccup rather than a bug.
+
+    Coding errors are never transient, regardless of their message: zarr's
+    ``BoundsCheckError`` subclasses ``IndexError`` and its message contains a
+    dimension length (e.g. ``... length 504``) that a bare numeric marker
+    (``' 503'``, ``' 504'``) would otherwise match.  Skip the marker scan for
+    those types, but keep walking the cause chain so a genuine transport
+    error wrapped behind a deterministic wrapper is still detected.
+    """
     seen = set()
     while exc is not None and id(exc) not in seen:
         seen.add(id(exc))
-        text = f"{type(exc).__name__}: {exc}".lower()
-        if any(marker in text for marker in _TRANSIENT_READ_MARKERS):
-            return True
+        if not isinstance(exc, _NON_TRANSIENT_TYPES):
+            text = f"{type(exc).__name__}: {exc}".lower()
+            if any(marker in text for marker in _TRANSIENT_READ_MARKERS):
+                return True
+            if _TRANSIENT_HTTP_STATUS.search(text):
+                return True
         exc = exc.__cause__ or exc.__context__
     return False
 

--- a/vesuvius/src/vesuvius/data/_transient_reads.py
+++ b/vesuvius/src/vesuvius/data/_transient_reads.py
@@ -42,17 +42,23 @@ _TRANSIENT_READ_MARKERS = (
 
 # HTTP statuses worth retrying, but only when the number appears as a status:
 # "ClientResponseError: 503, message=...", "An error occurred (503) when
-# calling GetObject", "HTTP 429", "status: 502". A bare " 504" also matched
-# "index out of bounds for dimension with length 504" and "size 5040", which
-# turned a coding error into four attempts and 3.5 s of backoff.
+# calling GetObject", "HTTP 429", "status: 502", urllib3's "too many 503
+# error responses". A bare " 504" also matched "index out of bounds for
+# dimension with length 504" and "size 5040", which turned a coding error
+# into four attempts and 3.5 s of backoff.
 _TRANSIENT_HTTP_STATUS = re.compile(
-    r'(?:(?:error|status|http|response|code)\W{0,4}|\(\s*)(?:429|500|502|503|504)(?!\d)'
+    r'(?:(?:error|status|http|response|code|returned|got|many)\W{0,4}|\(\s*)'
+    r'(?:429|500|502|503|504)(?!\d)'
 )
 
 # Exceptions that describe a bug or a bad request rather than a network
 # hiccup. Their messages are not scanned for markers (zarr's BoundsCheckError
 # is an IndexError whose text names the dimension length), but the cause
 # chain is still walked in case one wraps a genuine transport error.
+# Note ssl.SSLCertVerificationError (and aiohttp's
+# ClientConnectorCertificateError) inherit ValueError, so a certificate
+# failure now fails fast instead of being retried; that is deliberate, a bad
+# certificate does not fix itself on the next attempt.
 _DETERMINISTIC_ERROR_TYPES = (
     IndexError,
     KeyError,

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -15,47 +15,13 @@ from pathlib import Path
 from vesuvius.install.accept_terms import get_installation_path
 import zarr
 
-# Substrings that mark a read as worth retrying. Matching on the message keeps
-# this independent of which stack (aiohttp, botocore, urllib3, ssl) raised:
-# zarr and fsspec wrap those differently across versions and backends.
-_TRANSIENT_READ_MARKERS = (
-    'payload is not completed',
-    'not enough data to satisfy content length',
-    'contentlengtherror',
-    'connection reset',
-    'connection aborted',
-    'connection closed',
-    'server disconnected',
-    'record layer failure',
-    'ssl',
-    'timed out',
-    'timeout',
-    'temporarily unavailable',
-    'slowdown',
-    'throttl',
-    'too many requests',
-    'internal error',
-    'service unavailable',
-    'bad gateway',
-    'gateway timeout',
-    ' 429',
-    ' 500',
-    ' 502',
-    ' 503',
-    ' 504',
+# Transient-remote-read classification and retry live in a shared leaf module
+# so both the prediction path here and ink_detection.volume_io use the same
+# marker list without drifting.  Re-exported here for backward compatibility.
+from ._transient_reads import (
+    _TRANSIENT_READ_MARKERS,
+    _is_transient_read_error,
 )
-
-
-def _is_transient_read_error(exc: BaseException) -> bool:
-    """True when a read failure looks like a network hiccup rather than a bug."""
-    seen = set()
-    while exc is not None and id(exc) not in seen:
-        seen.add(id(exc))
-        text = f"{type(exc).__name__}: {exc}".lower()
-        if any(marker in text for marker in _TRANSIENT_READ_MARKERS):
-            return True
-        exc = exc.__cause__ or exc.__context__
-    return False
 
 
 # Define the functions needed here to avoid circular imports

--- a/vesuvius/src/vesuvius/ink_detection/inference/infer.py
+++ b/vesuvius/src/vesuvius/ink_detection/inference/infer.py
@@ -42,6 +42,7 @@ from vesuvius.ink_detection.volume_io import (
     open_volume_root,
     select_volume_level,
 )
+from vesuvius.data._transient_reads import _read_array_with_retry
 from vesuvius.utils.cli import HyphenUnderscoreParser
 
 
@@ -345,7 +346,9 @@ def compute_nonempty_mask_from_lowres_array(array: Any) -> np.ndarray:
     """Collapse a 2D/3D low-resolution array to a 2D occupancy mask."""
 
     shape = tuple(int(value) for value in array.shape)
-    values = np.asarray(array[:])
+    values = np.asarray(
+        _read_array_with_retry(array, (slice(None),), warn=LOGGER.warning)
+    )
     if len(shape) == 2:
         return values != 0
     if len(shape) != 3:
@@ -439,20 +442,32 @@ class FlatPatchReader:
 
     def _read_raw(self, y0: int, y1: int, x0: int, x1: int) -> np.ndarray:
         array = self._ensure_array()
+
+        def read(selection):
+            return _read_array_with_retry(
+                array, selection, warn=LOGGER.warning
+            )
+
         if self.depth_axis_first:
             if self._read_mode == "ascending":
-                block = array[self._z_start : self._z_stop, y0:y1, x0:x1]
+                block = read(
+                    (slice(self._z_start, self._z_stop), slice(y0, y1), slice(x0, x1))
+                )
             elif self._read_mode == "descending":
-                block = array[self._z_start : self._z_stop, y0:y1, x0:x1][::-1]
+                block = read(
+                    (slice(self._z_start, self._z_stop), slice(y0, y1), slice(x0, x1))
+                )[::-1]
             else:
-                block = array[self.layer_indices, y0:y1, x0:x1]
+                block = read((self.layer_indices, slice(y0, y1), slice(x0, x1)))
             return np.transpose(np.asarray(block), (1, 2, 0))
         if self._read_mode == "ascending":
-            block = array[y0:y1, x0:x1, self._z_start : self._z_stop]
+            block = read((slice(y0, y1), slice(x0, x1), slice(self._z_start, self._z_stop)))
         elif self._read_mode == "descending":
-            block = array[y0:y1, x0:x1, self._z_start : self._z_stop][..., ::-1]
+            block = read(
+                (slice(y0, y1), slice(x0, x1), slice(self._z_start, self._z_stop))
+            )[..., ::-1]
         else:
-            block = array[y0:y1, x0:x1, self.layer_indices]
+            block = read((slice(y0, y1), slice(x0, x1), self.layer_indices))
         return np.asarray(block)
 
     def read(self, y0: int, x0: int, out_h: int, out_w: int) -> np.ndarray:

--- a/vesuvius/src/vesuvius/ink_detection/volume_io.py
+++ b/vesuvius/src/vesuvius/ink_detection/volume_io.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -13,8 +14,10 @@ import numpy as np
 import zarr
 
 from vesuvius.data.utils import open_zarr as open_vesuvius_zarr
+from vesuvius.data._transient_reads import _read_array_with_retry
 
 
+_LOGGER = logging.getLogger(__name__)
 _PUBLIC_S3_VOLUME_SUBSTRING = "vesuvius-challenge-open-data"
 ZARR_V3 = int(zarr.__version__.split(".", 1)[0]) >= 3
 
@@ -231,11 +234,15 @@ def read_bbox_with_padding(
     if any(stop <= start for start, stop in zip(starts, stops)):
         return output, None
     crop = np.asarray(
-        volume[
-            starts[0] : stops[0],
-            starts[1] : stops[1],
-            starts[2] : stops[2],
-        ]
+        _read_array_with_retry(
+            volume,
+            (
+                slice(starts[0], stops[0]),
+                slice(starts[1], stops[1]),
+                slice(starts[2], stops[2]),
+            ),
+            warn=_LOGGER.warning,
+        )
     )
     destination_starts = starts[0] - z0, starts[1] - y0, starts[2] - x0
     destination = tuple(

--- a/vesuvius/tests/ink_detection/test_volume_io_retry.py
+++ b/vesuvius/tests/ink_detection/test_volume_io_retry.py
@@ -1,0 +1,155 @@
+"""Transient remote read failures must not abort ink-detection runs.
+
+The flat inference path (``vesuvius.ink_detection.inference.infer``, issue
+#1666) and the shared bbox reader both stream remote zarr volumes chunk by
+chunk.  A single truncated download used to propagate out and kill the whole
+multi-minute run.  These tests drive the real entry points — the bbox reader
+and ``FlatPatchReader._read_raw`` — against a store that fails the way an
+object store does, rather than testing the retry helper in isolation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vesuvius.data._transient_reads import (
+    _is_transient_read_error,
+    _read_array_with_retry,
+)
+from vesuvius.ink_detection.inference.infer import FlatPatchReader
+from vesuvius.ink_detection.volume_io import read_bbox_with_padding
+
+
+class _FlakyVolume:
+    """Array-like volume that raises a given sequence of errors before serving."""
+
+    def __init__(self, errors: list[BaseException]) -> None:
+        self._errors = list(errors)
+        self.shape = (3, 4, 4)
+        self.dtype = np.dtype("uint8")
+        self.reads = 0
+
+    def __getitem__(self, idx):
+        self.reads += 1
+        if self._errors:
+            raise self._errors.pop(0)
+        return np.full((3, 4, 4), 7, dtype=np.uint8)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(
+        "vesuvius.data._transient_reads.time.sleep", lambda _s: None
+    )
+
+
+def _bbox():
+    return (0, 0, 0, 3, 4, 4)
+
+
+def test_bbox_read_retries_transient_error_then_succeeds() -> None:
+    volume = _FlakyVolume([
+        OSError("Response payload is not completed: ContentLengthError"),
+        OSError("[SSL: RECORD_LAYER_FAILURE] record layer failure"),
+    ])
+    crop, valid = read_bbox_with_padding(volume, _bbox())
+    assert volume.reads == 3
+    np.testing.assert_array_equal(crop, 7)
+
+
+def test_bbox_read_recovers_from_wrapped_cause() -> None:
+    def make():
+        outer = RuntimeError("Failed to get item")
+        outer.__cause__ = OSError("Connection reset by peer")
+        return outer
+
+    volume = _FlakyVolume([make(), make()])
+    crop, _ = read_bbox_with_padding(volume, _bbox())
+    assert volume.reads == 3
+    np.testing.assert_array_equal(crop, 7)
+
+
+def test_bbox_read_exhausts_attempts_and_raises() -> None:
+    volume = _FlakyVolume([OSError("Connection reset by peer")] * 5)
+    with pytest.raises(OSError):
+        read_bbox_with_padding(volume, _bbox())
+    assert volume.reads == 4, "must stop at the retry cap"
+
+
+def test_bbox_read_deterministic_error_fails_fast() -> None:
+    volume = _FlakyVolume([KeyError("no such array: 0")])
+    with pytest.raises(KeyError):
+        read_bbox_with_padding(volume, _bbox())
+    assert volume.reads == 1, "a coding error must fail fast, not be retried"
+
+
+def test_flat_reader_raw_retries_transient_error_then_succeeds() -> None:
+    # This is the path reported in issue #1666: FlatPatchReader reads the
+    # surface volume through _read_raw during flat inference.
+    volume = _FlakyVolume([OSError("Response payload is not completed")])
+    reader = FlatPatchReader(
+        input_path="ignored.zarr",
+        resolution="0",
+        depth_axis_first=True,
+        height=4,
+        width=4,
+        layer_indices=np.arange(3),
+        output_depth=3,
+        preprocessing="divide_255",
+    )
+    reader._array = volume
+    patch = reader.read(0, 0, 4, 4)
+    assert volume.reads == 2
+    np.testing.assert_array_equal(patch, 7)
+
+
+def test_flat_reader_raw_deterministic_error_fails_fast() -> None:
+    volume = _FlakyVolume([IndexError("index 99 is out of bounds")])
+    reader = FlatPatchReader(
+        input_path="ignored.zarr",
+        resolution="0",
+        depth_axis_first=True,
+        height=4,
+        width=4,
+        layer_indices=np.arange(3),
+        output_depth=3,
+        preprocessing="divide_255",
+    )
+    reader._array = volume
+    with pytest.raises(IndexError):
+        reader.read(0, 0, 4, 4)
+    assert volume.reads == 1
+
+
+def test_retries_disabled_with_one_attempt() -> None:
+    volume = _FlakyVolume([OSError("Connection reset by peer")] * 3)
+    with pytest.raises(OSError):
+        _read_array_with_retry(volume, (slice(None),), retries=1)
+    assert volume.reads == 1
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Response payload is not completed: ContentLengthError: 400, message='Not enough data to satisfy content length header (received 173631 of 507920 bytes).'",
+        "[SSL: RECORD_LAYER_FAILURE] record layer failure (_ssl.c:2713)",
+        "Connection reset by peer",
+        "read operation timed out",
+        "An error occurred (503) when calling GetObject: SlowDown",
+    ],
+)
+def test_transient_messages_detected(message: str) -> None:
+    assert _is_transient_read_error(OSError(message))
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        IndexError("index 99 is out of bounds"),
+        KeyError("no such array: 0"),
+        ValueError("patch_size must be a tuple of 3 integers"),
+    ],
+)
+def test_deterministic_errors_not_flagged(exc: BaseException) -> None:
+    assert not _is_transient_read_error(exc)

--- a/vesuvius/tests/ink_detection/test_volume_io_retry.py
+++ b/vesuvius/tests/ink_detection/test_volume_io_retry.py
@@ -137,6 +137,11 @@ def test_retries_disabled_with_one_attempt() -> None:
         "Connection reset by peer",
         "read operation timed out",
         "An error occurred (503) when calling GetObject: SlowDown",
+        "ClientResponseError: 503, message='Service Unavailable'",
+        "ClientResponseError: 429, message='Too Many Requests'",
+        "An error occurred (500) when calling the GetObject operation (InternalError)",
+        "HTTP 502",
+        "status: 504",
     ],
 )
 def test_transient_messages_detected(message: str) -> None:
@@ -149,7 +154,34 @@ def test_transient_messages_detected(message: str) -> None:
         IndexError("index 99 is out of bounds"),
         KeyError("no such array: 0"),
         ValueError("patch_size must be a tuple of 3 integers"),
+        IndexError("index out of bounds for dimension with length 504"),
+        IndexError("index out of bounds for dimension with length 5000"),
+        IndexError("index 500 is out of bounds for axis 0 with size 429"),
+        ValueError("cannot reshape array of size 5030 into shape (3,4)"),
+        KeyError("0/503/12"),
+        TypeError("unsupported operand type(s) for +: 'int' and 'str' (code 502)"),
+        OSError("read 5040 bytes"),
     ],
 )
 def test_deterministic_errors_not_flagged(exc: BaseException) -> None:
     assert not _is_transient_read_error(exc)
+
+
+def test_deterministic_error_with_status_like_length_fails_fast() -> None:
+    """The exact repro from PR #1698 review: a 504-long axis and a bad index."""
+
+    class BoundsCheckError(IndexError):
+        pass
+
+    volume = _FlakyVolume(
+        [BoundsCheckError("index out of bounds for dimension with length 504")]
+    )
+    with pytest.raises(BoundsCheckError):
+        read_bbox_with_padding(volume, _bbox())
+    assert volume.reads == 1
+
+
+def test_transient_cause_behind_deterministic_wrapper_is_still_detected() -> None:
+    outer = ValueError("failed decoding chunk")
+    outer.__cause__ = OSError("Connection reset by peer")
+    assert _is_transient_read_error(outer)

--- a/vesuvius/tests/ink_detection/test_volume_io_retry.py
+++ b/vesuvius/tests/ink_detection/test_volume_io_retry.py
@@ -142,10 +142,27 @@ def test_retries_disabled_with_one_attempt() -> None:
         "An error occurred (500) when calling the GetObject operation (InternalError)",
         "HTTP 502",
         "status: 504",
+        "Max retries exceeded with url: /x (Caused by ResponseError('too many 503 error responses'))",
+        "too many 429 error responses",
+        "server returned 502",
     ],
 )
 def test_transient_messages_detected(message: str) -> None:
     assert _is_transient_read_error(OSError(message))
+
+
+def test_certificate_failures_fail_fast() -> None:
+    """ssl.SSLCertVerificationError inherits ValueError; a bad certificate is
+    deterministic and must not burn the retry budget."""
+    import ssl
+
+    exc = ssl.SSLCertVerificationError(
+        1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate"
+    )
+    assert isinstance(exc, ValueError)
+    assert not _is_transient_read_error(exc)
+    # but a record-layer failure (plain SSLError, an OSError) is still transient
+    assert _is_transient_read_error(ssl.SSLError(1, "[SSL: RECORD_LAYER_FAILURE] record layer failure"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**In one sentence:** Flat ink-detection inference (`vesuvius.ink_detection.inference.infer`) now retries transient remote chunk reads instead of aborting the whole run when a single network hiccup truncates one chunk download (issue #1666).

**One real example:** Reading the published First Letters surface volume `PHerc1447/segments/20250703025628-auto_grown_20250703025628283/surface-volumes/8.64um-1.2m-116keV-volume-20250521151220.zarr` (level 0, 31×4100×4260 uint8) via `FlatPatchReader` — the exact workflow from #1666 — a single truncated chunk response previously aborted the read with `ClientPayloadError` and no output. With this PR the same read retries and completes.

**Before:**
```
READ FAILED: ClientPayloadError: Response payload is not completed: <ContentLengthError: 400,
message='Not enough data to satisfy content length header (received 232 of 423 bytes).'>
...
RESULT: ABORT
```

**After this PR:**
```
transient remote read error (ClientPayloadError), retry 1/3 in 0.5s: Response payload is not
completed: <ContentLengthError: 400, message='Not enough data to satisfy content length header
(received 232 of 423 bytes).'>
READ OK: patch shape=(128, 128, 31), dtype=uint8
RESULT: SUCCESS
```

**Proof:** Same real volume, same real code path (`FlatPatchReader._read_raw` → zarr → fsspec → aiohttp), same one-shot truncation of chunk `0/0.0.0`, same error type/message as #1666. Pre-fix aborts (exit 1, no output — the reported symptom); post-fix logs one warning line and completes. The truncation is transient, not data corruption: the retried attempt reads the same chunk successfully from the real store.

- `tests/ink_detection/test_volume_io_retry.py` — 15 passed (bbox + flat-reader retry, cap exhaustion, deterministic fail-fast, verbatim #1666 message classification)
- `tests/data/test_volume_retry.py` — 14 passed (refactor is behavior-identical)
- `tests/ink_detection/test_volume_io.py` — 12 passed (no regression)

**Why / where this is useful:** The 18 Aug First Letters tutorial command hits this verbatim (per #1666). One truncated chunk currently discards everything a multi-minute/overnight streaming run already computed. The fix also protects native 3D inference (`infer_full3d_tifxyz`) and the training patch loaders, which read through the same shared `read_bbox_with_padding`.

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

**Root cause:** `ink_detection/volume_io.py` and `inference/infer.py` read remote zarr chunks directly (`array[selection]`) with no retry. The prediction path already got this treatment in #1244 (`data/volume.py`), but ink-detection uses a separate reader that never received it.

**Fix:**
1. Extracted the #1244 transient-error classifier into a shared leaf module `vesuvius/data/_transient_reads.py` (`_TRANSIENT_READ_MARKERS`, `_is_transient_read_error`) plus a new `_read_array_with_retry(volume, selection, ...)`: 4 attempts, 0.5 s doubling to 8 s, `max(1, retries)` guard; deterministic errors (bad coords, missing node, auth) re-raise on the first attempt.
2. `data/volume.py` now imports the helpers from the shared module — no behavior change (14/14 existing retry tests still pass).
3. `inference/infer.py`: the flat-read path `FlatPatchReader._read_raw` (the #1666 path) and the startup occupancy scan `compute_nonempty_mask_from_lowres_array` read through the retry wrapper; one warning line logged per retry.
4. `volume_io.py`: `read_bbox_with_padding` — used by full_3d inference and all training patch loaders — reads through the retry wrapper.

**How the error was reproduced:** a local proxy (`proxy_truncate.py`) forwards every request to the real public S3 object and serves the real bytes, but for exactly one chunk — `0/0.0.0`, 423 bytes — sends the full `Content-Length` header, writes only 232 bytes (~55%), then drops the connection. The client therefore sees the identical `ClientPayloadError` that #1666 reports. This is a deterministic reproduction of a real transient network truncation on the actual published volume; the volume is untouched and re-reads cleanly on the retry.

**Verified:** Python 3.12 / zarr 3.3.0 / CPU torch on a Linux VM, against the real public PHerc1447 surface volume. Test-matrix note: this demo ran on zarr 3; repo CI covers zarr 2.18.7 and 3.2.1. The retry helper is transport-agnostic (classifies on message text across the whole `__cause__`/`__context__` chain), so it does not depend on the zarr/fsspec version.

**Determinism:** retries only trigger on exceptions matching the transient markers; the happy path performs exactly one read. Retry re-reads the whole bbox selection (coarser than #1244's per-read retry) — acceptable at inference patch granularity.

**Reproduction (reviewer can rerun):**
```
python proxy_truncate.py 8899
# open http://localhost:8899/PHerc1447/segments/20250703025628-auto_grown_20250703025628283/
#     surface-volumes/8.64um-1.2m-116keV-volume-20250521151220.zarr
# then read one patch via FlatPatchReader.read(0, 0, 128, 128):
#   pre-fix code -> ClientPayloadError ... RESULT: ABORT
#   this PR      -> retry 1/3 in 0.5s ... READ OK: (128,128,31) ... RESULT: SUCCESS
```
(Proxy + demo scripts and raw before/after logs available on request.)

---

*Written with AI assistance as a coding assistant; directed, reviewed, and verified by a human (community norm — see #1244/#1667).*