### PR TITLE
tifxyz: compute the full-resolution canvas the way QuadSurface::size() does (fixes #1694)

### DIFF
--- a/vesuvius/src/vesuvius/tifxyz/types.py
+++ b/vesuvius/src/vesuvius/tifxyz/types.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,29 +17,13 @@ import cv2
 import numpy as np
 from numpy.typing import NDArray
 
+from vesuvius.tifxyz_canvas import full_resolution_extent
+
 InterpolationMethod = Literal["linear", "bspline", "catmull_rom"]
 
 
-def _full_resolution_extent(stored: int, scale: float) -> int:
-    """Stored grid extent -> full-resolution canvas extent, as vc_render_tifxyz sizes it.
-
-    The renderer (``vc_render_tifxyz.cpp``, "Compute render scale") does::
-
-        double sx = render_scale / surf->_scale[0];      // _scale is cv::Vec2f
-        full_size.width = std::max(1, int(std::lround(full_size.width * sx)));
-
-    i.e. the stored scale is a float32, the reciprocal is taken in double,
-    the product is rounded half away from zero, and the result is at least 1.
-    Tracer meshes store ``scale`` as float32 0.05 (``0.05000000074505806``);
-    ``stored / scale`` in float64 then lands just below the integer
-    (``152 / 0.05000000074505806 == 3039.99995...``), so truncating it is one
-    pixel short of the canvas the renderer and the published surface volumes
-    use. Plain ``round()`` is not equivalent either: Python rounds half to
-    even, ``std::lround`` half away from zero, and exact halves occur with
-    integer scales (7 x 5 at scale 2.0 renders as 4 x 3).
-    """
-    quotient = float(stored) * (1.0 / float(np.float32(scale)))
-    return max(1, int(math.floor(quotient + 0.5)))
+# Shared with tifxyz_label_transfer so the package has one canvas definition.
+_full_resolution_extent = full_resolution_extent
 
 
 @dataclass

--- a/vesuvius/src/vesuvius/tifxyz/types.py
+++ b/vesuvius/src/vesuvius/tifxyz/types.py
@@ -20,6 +20,24 @@ from numpy.typing import NDArray
 InterpolationMethod = Literal["linear", "bspline", "catmull_rom"]
 
 
+def _full_resolution_extent(stored: int, scale: float) -> int:
+    """Stored grid extent -> full-resolution canvas extent, as VC3D computes it.
+
+    ``QuadSurface::size()`` in volume-cartographer evaluates
+    ``static_cast<int>(_points->cols / _scale[0])`` with ``_scale`` held as
+    ``cv::Vec2f``, i.e. a *float32* division followed by truncation. Tracer
+    meshes store ``scale`` as the float32 value 0.05 (``0.05000000074505806``),
+    and ``stored / scale`` in float64 then lands just below the integer
+    (``152 / 0.05000000074505806 == 3039.99995...``), so ``int()`` on the
+    float64 quotient is one pixel short of the canvas ``vc_render_tifxyz``
+    and the published surface volumes use. Doing the division in float32
+    reproduces the C++ result exactly rather than approximating it with
+    ``round``.
+    """
+    quotient = np.float32(stored) / np.float32(scale)
+    return int(quotient)
+
+
 @dataclass
 class Tifxyz:
     """A 3D surface represented as a 2D grid of (x, y, z) coordinates.
@@ -177,11 +195,7 @@ class Tifxyz:
         if self.resolution == "stored":
             return self._x.shape  # type: ignore[return-value]
         # Full resolution
-        h, w = self._x.shape
-        scale_y, scale_x = self._scale
-        if scale_y == 0 or scale_x == 0:
-            return (h, w)
-        return (int(h / scale_y), int(w / scale_x))
+        return self.full_resolution_shape
 
     @property
     def full_resolution_shape(self) -> Tuple[int, int]:
@@ -194,7 +208,10 @@ class Tifxyz:
         scale_y, scale_x = self._scale
         if scale_y == 0 or scale_x == 0:
             return (h, w)
-        return (int(h / scale_y), int(w / scale_x))
+        return (
+            _full_resolution_extent(h, scale_y),
+            _full_resolution_extent(w, scale_x),
+        )
 
     @property
     def _stored_shape(self) -> Tuple[int, int]:

--- a/vesuvius/src/vesuvius/tifxyz/types.py
+++ b/vesuvius/src/vesuvius/tifxyz/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -21,21 +22,25 @@ InterpolationMethod = Literal["linear", "bspline", "catmull_rom"]
 
 
 def _full_resolution_extent(stored: int, scale: float) -> int:
-    """Stored grid extent -> full-resolution canvas extent, as VC3D computes it.
+    """Stored grid extent -> full-resolution canvas extent, as vc_render_tifxyz sizes it.
 
-    ``QuadSurface::size()`` in volume-cartographer evaluates
-    ``static_cast<int>(_points->cols / _scale[0])`` with ``_scale`` held as
-    ``cv::Vec2f``, i.e. a *float32* division followed by truncation. Tracer
-    meshes store ``scale`` as the float32 value 0.05 (``0.05000000074505806``),
-    and ``stored / scale`` in float64 then lands just below the integer
-    (``152 / 0.05000000074505806 == 3039.99995...``), so ``int()`` on the
-    float64 quotient is one pixel short of the canvas ``vc_render_tifxyz``
-    and the published surface volumes use. Doing the division in float32
-    reproduces the C++ result exactly rather than approximating it with
-    ``round``.
+    The renderer (``vc_render_tifxyz.cpp``, "Compute render scale") does::
+
+        double sx = render_scale / surf->_scale[0];      // _scale is cv::Vec2f
+        full_size.width = std::max(1, int(std::lround(full_size.width * sx)));
+
+    i.e. the stored scale is a float32, the reciprocal is taken in double,
+    the product is rounded half away from zero, and the result is at least 1.
+    Tracer meshes store ``scale`` as float32 0.05 (``0.05000000074505806``);
+    ``stored / scale`` in float64 then lands just below the integer
+    (``152 / 0.05000000074505806 == 3039.99995...``), so truncating it is one
+    pixel short of the canvas the renderer and the published surface volumes
+    use. Plain ``round()`` is not equivalent either: Python rounds half to
+    even, ``std::lround`` half away from zero, and exact halves occur with
+    integer scales (7 x 5 at scale 2.0 renders as 4 x 3).
     """
-    quotient = np.float32(stored) / np.float32(scale)
-    return int(quotient)
+    quotient = float(stored) * (1.0 / float(np.float32(scale)))
+    return max(1, int(math.floor(quotient + 0.5)))
 
 
 @dataclass

--- a/vesuvius/src/vesuvius/tifxyz_canvas.py
+++ b/vesuvius/src/vesuvius/tifxyz_canvas.py
@@ -1,0 +1,41 @@
+"""Full-resolution canvas extent of a tifxyz grid, as vc_render_tifxyz sizes it.
+
+Dependency-free on purpose: ``vesuvius.tifxyz`` (OpenCV) and
+``vesuvius.tifxyz_label_transfer`` (SciPy) both need this and neither should
+import the other for it.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+
+def full_resolution_extent(stored: int, scale: float) -> int:
+    """Stored grid extent -> full-resolution canvas extent.
+
+    ``vc_render_tifxyz.cpp`` ("Compute render scale") does::
+
+        double sx = render_scale / surf->_scale[0];      // _scale is cv::Vec2f
+        full_size.width = std::max(1, int(std::lround(full_size.width * sx)));
+
+    i.e. the stored scale is a float32, the reciprocal is taken in double, the
+    product is rounded half away from zero, and the result is at least 1.
+    Tracer meshes store ``scale`` as float32 0.05 (``0.05000000074505806``);
+    ``stored / scale`` in float64 then lands just below the integer
+    (``152 / 0.05000000074505806 == 3039.99995...``), so truncating it is one
+    pixel short of the canvas the renderer and the published surface volumes
+    use. Plain ``round()`` is not equivalent either: Python rounds half to even,
+    ``std::lround`` half away from zero, and exact halves occur with integer
+    scales (7 x 5 at scale 2.0 renders as 4 x 3).
+
+    A scale that is not a positive finite float32 (including one that
+    underflows float32 to 0) falls back to the stored extent.
+    """
+    stored = int(stored)
+    scale32 = float(np.float32(scale))
+    if not math.isfinite(scale32) or scale32 <= 0.0:
+        return max(1, stored)
+    quotient = float(stored) * (1.0 / scale32)
+    return max(1, int(math.floor(quotient + 0.5)))

--- a/vesuvius/src/vesuvius/tifxyz_label_transfer/core.py
+++ b/vesuvius/src/vesuvius/tifxyz_label_transfer/core.py
@@ -32,6 +32,8 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.spatial import cKDTree
 
+from vesuvius.tifxyz_canvas import full_resolution_extent
+
 
 FloatArray = NDArray[np.floating]
 BoolArray = NDArray[np.bool_]
@@ -158,9 +160,11 @@ class Surface:
     def full_resolution_shape(self) -> Tuple[int, int]:
         height, width = self.shape
         scale_y, scale_x = self.scale_yx
+        # Same definition as vesuvius.tifxyz.Tifxyz.full_resolution_shape:
+        # the canvas vc_render_tifxyz renders (float32 scale, lround).
         return (
-            max(1, _positive_lround(height / scale_y)),
-            max(1, _positive_lround(width / scale_x)),
+            full_resolution_extent(height, scale_y),
+            full_resolution_extent(width, scale_x),
         )
 
 
@@ -459,8 +463,8 @@ def infer_output_shape(
     # spurious ~0.1% scale forces every downstream consumer to resample.
     native_candidates = (
         (
-            max(1, _positive_lround(target_height / target_scale_y)),
-            max(1, _positive_lround(target_width / target_scale_x)),
+            full_resolution_extent(target_height, target_scale_y),
+            full_resolution_extent(target_width, target_scale_x),
         ),
         (target_height, target_width),
     )

--- a/vesuvius/tests/tifxyz/test_full_resolution_shape.py
+++ b/vesuvius/tests/tifxyz/test_full_resolution_shape.py
@@ -87,6 +87,25 @@ def test_extent_is_at_least_one() -> None:
     assert _full_resolution_extent(1, 4.0) == 1
 
 
+@pytest.mark.parametrize("scale", [1e-46, 0.0, -0.05, float("inf"), float("nan")])
+def test_unusable_scale_falls_back_to_stored_extent(scale: float) -> None:
+    # 1e-46 underflows float32 to 0; none of these can size a canvas
+    assert _full_resolution_extent(152, scale) == 152
+
+
+def test_label_transfer_surface_agrees_with_tifxyz() -> None:
+    """Both packages must report one canvas; they used to differ near .5 quotients."""
+    from vesuvius.tifxyz_label_transfer.core import Surface
+
+    stored_h, stored_w, scale = 3681, 2001, 0.3313977  # 3681 / scale = 11107.4999...
+    zeros = np.zeros((stored_h, stored_w), dtype=np.float32)
+    ones = np.ones((stored_h, stored_w), dtype=np.float32)
+    lt_surface = Surface(x=ones, y=ones, z=ones, scale_yx=(scale, scale))
+    tifxyz_surface = _surface(stored_h, stored_w, scale)
+    assert lt_surface.full_resolution_shape == tifxyz_surface.full_resolution_shape
+    assert lt_surface.full_resolution_shape == (11107, 6038)
+
+
 def test_shape_properties_agree() -> None:
     surface = _surface(202, 215, FLOAT32_SCALE)
     assert surface.full_resolution_shape == (4040, 4300)

--- a/vesuvius/tests/tifxyz/test_full_resolution_shape.py
+++ b/vesuvius/tests/tifxyz/test_full_resolution_shape.py
@@ -1,10 +1,13 @@
-"""Tifxyz.full_resolution_shape must match the canvas VC3D renders.
+"""Tifxyz.full_resolution_shape must match the canvas vc_render_tifxyz renders.
 
 Tracer meshes (vc_grow_seg_from_seed, published w-series segments) store
 ``scale`` as the float32 value 0.05, which serialises as 0.05000000074505806.
-volume-cartographer's ``QuadSurface::size()`` divides in float32 and truncates,
-which yields the rounded canvas (152 / 0.05f -> 3040). The float64 quotient is
-3039.99995..., so truncating it is one pixel short.
+The float64 quotient 152 / 0.05000000074505806 is 3039.99995..., so truncating
+it is one pixel short of the 3040 the renderer uses. vc_render_tifxyz sizes
+the canvas as ``lround(stored * (render_scale / float32(scale)))`` in double,
+which is what ``_full_resolution_extent`` reproduces, including for the
+non-round scales vc_obj2tifxyz writes and for exact halves (std::lround rounds
+half away from zero, Python's round() half to even).
 """
 
 from __future__ import annotations
@@ -17,13 +20,13 @@ from vesuvius.tifxyz.types import Tifxyz, _full_resolution_extent
 FLOAT32_SCALE = float(np.float32(0.05))  # 0.05000000074505806
 
 
-def _surface(stored_h: int, stored_w: int, scale: float) -> Tifxyz:
+def _surface(stored_h: int, stored_w: int, scale_y: float, scale_x: float | None = None) -> Tifxyz:
     zeros = np.zeros((stored_h, stored_w), dtype=np.float32)
     return Tifxyz(
         _x=zeros,
         _y=zeros.copy(),
         _z=zeros.copy(),
-        _scale=(scale, scale),
+        _scale=(scale_y, scale_y if scale_x is None else scale_x),
         path=None,
     )
 
@@ -41,9 +44,37 @@ def _surface(stored_h: int, stored_w: int, scale: float) -> Tifxyz:
         (215, 4300),
     ],
 )
-def test_float32_rounded_scale_matches_cpp_canvas(stored: int, expected: int) -> None:
+def test_float32_rounded_scale_matches_rendered_canvas(stored: int, expected: int) -> None:
     assert int(stored / FLOAT32_SCALE) == expected - 1, "float64 truncation is short"
     assert _full_resolution_extent(stored, FLOAT32_SCALE) == expected
+
+
+@pytest.mark.parametrize(
+    ("stored_wh", "scale_xy", "rendered_wh"),
+    [
+        # vc_obj2tifxyz outputs measured against `vc_render_tifxyz --scale 1 -g 0`
+        # ("rendering WxH" line) by @Bullo27 on PR #1699; all W x H.
+        ((272, 185), (0.0499802, 0.0498272), (5442, 3713)),
+        ((14, 10), (0.0023985, 0.0024457), (5837, 4089)),
+        ((1085, 737), (0.1998486, 0.1992154), (5429, 3700)),
+        ((10841, 7361), (1.9987041, 1.9921989), (5424, 3695)),
+        ((5421, 3681), (0.9992994, 0.9960730), (5425, 3696)),
+        ((1994, 2001), (0.3675560, 0.5414373), (5425, 3696)),
+        ((272, 185), (FLOAT32_SCALE, FLOAT32_SCALE), (5440, 3700)),
+    ],
+)
+def test_non_round_obj2tifxyz_scales_match_vc_render_tifxyz(stored_wh, scale_xy, rendered_wh) -> None:
+    (w, h), (sx, sy), (rw, rh) = stored_wh, scale_xy, rendered_wh
+    assert (_full_resolution_extent(w, sx), _full_resolution_extent(h, sy)) == (rw, rh)
+    surface = _surface(h, w, sy, sx)
+    assert surface.full_resolution_shape == (rh, rw)
+
+
+def test_exact_half_rounds_away_from_zero_like_lround() -> None:
+    # 7 x 5 grid at scale 2.0: 3.5 -> 4 and 2.5 -> 3 (round() would give 4 and 2)
+    assert _full_resolution_extent(7, 2.0) == 4
+    assert _full_resolution_extent(5, 2.0) == 3
+    assert round(2.5) == 2  # documents why round() is not used
 
 
 def test_exact_scale_is_unchanged() -> None:
@@ -52,7 +83,11 @@ def test_exact_scale_is_unchanged() -> None:
     assert _full_resolution_extent(84300, 1.0) == 84300
 
 
-def test_shape_properties_agree_and_use_float32_division() -> None:
+def test_extent_is_at_least_one() -> None:
+    assert _full_resolution_extent(1, 4.0) == 1
+
+
+def test_shape_properties_agree() -> None:
     surface = _surface(202, 215, FLOAT32_SCALE)
     assert surface.full_resolution_shape == (4040, 4300)
     assert surface.shape == (202, 215)

--- a/vesuvius/tests/tifxyz/test_full_resolution_shape.py
+++ b/vesuvius/tests/tifxyz/test_full_resolution_shape.py
@@ -1,0 +1,65 @@
+"""Tifxyz.full_resolution_shape must match the canvas VC3D renders.
+
+Tracer meshes (vc_grow_seg_from_seed, published w-series segments) store
+``scale`` as the float32 value 0.05, which serialises as 0.05000000074505806.
+volume-cartographer's ``QuadSurface::size()`` divides in float32 and truncates,
+which yields the rounded canvas (152 / 0.05f -> 3040). The float64 quotient is
+3039.99995..., so truncating it is one pixel short.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vesuvius.tifxyz.types import Tifxyz, _full_resolution_extent
+
+FLOAT32_SCALE = float(np.float32(0.05))  # 0.05000000074505806
+
+
+def _surface(stored_h: int, stored_w: int, scale: float) -> Tifxyz:
+    zeros = np.zeros((stored_h, stored_w), dtype=np.float32)
+    return Tifxyz(
+        _x=zeros,
+        _y=zeros.copy(),
+        _z=zeros.copy(),
+        _scale=(scale, scale),
+        path=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        # vc_grow_seg_from_seed patches on PHerc0358/0813/0826 (issue #1694)
+        (152, 3040),
+        # published PHerc0139 w035: 5820x5240 surface volume
+        (291, 5820),
+        (262, 5240),
+        # PHerc1447 20250703025628 mesh/intermediate/tifxyz_original (202x215)
+        (202, 4040),
+        (215, 4300),
+    ],
+)
+def test_float32_rounded_scale_matches_cpp_canvas(stored: int, expected: int) -> None:
+    assert int(stored / FLOAT32_SCALE) == expected - 1, "float64 truncation is short"
+    assert _full_resolution_extent(stored, FLOAT32_SCALE) == expected
+
+
+def test_exact_scale_is_unchanged() -> None:
+    assert _full_resolution_extent(205, 0.05) == 4100
+    assert _full_resolution_extent(213, 0.05) == 4260
+    assert _full_resolution_extent(84300, 1.0) == 84300
+
+
+def test_shape_properties_agree_and_use_float32_division() -> None:
+    surface = _surface(202, 215, FLOAT32_SCALE)
+    assert surface.full_resolution_shape == (4040, 4300)
+    assert surface.shape == (202, 215)
+    assert surface.use_full_resolution().shape == (4040, 4300)
+    assert surface.full_resolution_shape == surface.shape
+
+
+def test_zero_scale_falls_back_to_stored_shape() -> None:
+    surface = _surface(10, 12, 0.0)
+    assert surface.full_resolution_shape == (10, 12)

--- a/vesuvius/tests/tifxyz/test_full_resolution_shape.py
+++ b/vesuvius/tests/tifxyz/test_full_resolution_shape.py
@@ -70,6 +70,24 @@ def test_non_round_obj2tifxyz_scales_match_vc_render_tifxyz(stored_wh, scale_xy,
     assert surface.full_resolution_shape == (rh, rw)
 
 
+@pytest.mark.parametrize(
+    ("stored", "scale", "rendered"),
+    [
+        # crafted near-.5 quotients measured against `vc_render_tifxyz --scale 1 -g 0`
+        # by @Bullo27 on PR #1699; the float64 lround core.py used before was off
+        # by one on every one of them.
+        (4, 1.6, 2),
+        (6, 0.9230769, 6),
+        (10, 0.2247191, 44),
+        (12, 0.5106383, 24),
+        (16, 0.256, 62),
+        (17, 2.2666667, 8),
+    ],
+)
+def test_near_half_quotients_match_vc_render_tifxyz(stored: int, scale: float, rendered: int) -> None:
+    assert _full_resolution_extent(stored, scale) == rendered
+
+
 def test_exact_half_rounds_away_from_zero_like_lround() -> None:
     # 7 x 5 grid at scale 2.0: 3.5 -> 4 and 2.5 -> 3 (round() would give 4 and 2)
     assert _full_resolution_extent(7, 2.0) == 4


### PR DESCRIPTION
**In one sentence:** `vesuvius.tifxyz` now reports the same full-resolution canvas that `vc_render_tifxyz` renders — for tracer meshes whose `meta.json` stores the scale as float32-rounded 0.05 and for the non-round scales `vc_obj2tifxyz` writes — so Python renderers and label producers stop coming out one pixel short.

**One real example:** Starting with the published PHerc1447 segment `20250703025628-auto_grown_20250703025628283` (`mesh/intermediate/tifxyz_original`, 202×215 stored grid, `"scale": [0.05000000074505806, 0.05000000074505806]`), I read it with `read_tifxyz(...).use_full_resolution().shape`, and it produced `(4039, 4299)` before and `(4040, 4300)` after — the latter is the canvas `vc_render_tifxyz` renders for that grid.

**Before:** `Tifxyz.shape` / `full_resolution_shape` did `int(h / scale)` in float64. `202 / 0.05000000074505806 = 4039.99994…`, truncated to 4039. Every mesh written by `vc_grow_seg_from_seed` (and the published w-series meshes with the same float32 scale, e.g. PHerc0139 w035: 5819×5239 vs the published 5820×5240 surface volume) rendered a canvas one pixel smaller than the C++ pipeline; maps/masks/labels produced through the two paths then fail exact-shape checks, and nothing warns (#1694).

**After this PR:** the extent is computed the way the renderer sizes its canvas (`vc_render_tifxyz.cpp`, "Compute render scale": `double sx = render_scale / surf->_scale[0]; lround(full_size.width * sx)` with `_scale` a `cv::Vec2f`), i.e. `max(1, lround(stored * (1.0 / float32(scale))))` in double, rounding half away from zero. Meshes with an exact 0.05 scale are unchanged (`205×213 → 4100×4260`, matching the published `canvas_size` of the same segment's surface volume), and the seven `vc_obj2tifxyz` meshes with non-round scales that @Bullo27 measured against the binary (see the review below) now match on all seven.

**Proof:**

```
$ uv run python check_shape.py   # reads the two tifxyz dirs of the segment above

# main (23adee0):
mesh/tifxyz                         scale= 0.05                stored= (205, 213) full= (4100, 4260)
mesh/intermediate/tifxyz_original   scale= 0.05000000074505806 stored= (202, 215) full= (4039, 4299)   <-- short by 1

# this PR:
mesh/tifxyz                         scale= 0.05                stored= (205, 213) full= (4100, 4260)
mesh/intermediate/tifxyz_original   scale= 0.05000000074505806 stored= (202, 215) full= (4040, 4300)
```

(`check_shape.py` is `read_tifxyz(dir, load_mask=False, validate=False).use_full_resolution().shape` for each directory, printed next to `meta.json["scale"]`.) The surface volume published next to that mesh declares `"canvas_size": [4260, 4100]` in its `.zattrs`, which the exact-scale case reproduces unchanged.

Tests: `tests/tifxyz/test_full_resolution_shape.py` (the 152→3040 patch from the issue, the w035 291/262→5820/5240 canvas, the PHerc1447 grid above, the seven measured `vc_render_tifxyz` cases from the review, the exact-half case 7×5 @ 2.0 → 4×3, exact-scale unchanged, minimum extent 1, unusable/underflowing scales fall back, and `tifxyz_label_transfer.core.Surface` agreeing with `Tifxyz`). `tests/tifxyz` + `tests/tifxyz_label_transfer` + `tests/test_surface_preflight.py`: 168 passed, 5 skipped; `tests/test_surface_preflight.py`, `tests/ink_detection/test_native_full3d_inference.py`, `tests/ink_detection/test_data_foundation.py` also pass.

**Why / where this is useful:** anything that builds a canvas from a tifxyz in Python — the flat renderer path in `ink_detection`, `tifxyz_label_transfer`, custom renderers comparing against published surface volumes — now agrees pixel-for-pixel with `vc_render_tifxyz` output, so shape assertions between the two pipelines pass instead of failing at the far edge.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Fixes #1694. Tested at `23adee0` on macOS / Python 3.14 / zarr 3.2.1.

Behaviour notes (all consistent with the renderer, but broader than the float32 case): any quotient with fraction ≥ .5 now rounds up instead of truncating (152 at scale 20.0: 7 → 8), a negative or non-finite scale no longer yields a negative/zero extent, the result is at least 1, and a scale that underflows float32 to 0 (e.g. 1e-46) falls back to the stored extent instead of raising. `QuadSurface::size()` in VC3D still truncates in float32; its only in-tree consumer is `surface_metrics.cpp`'s sampling bounds, so the renderer, not `size()`, is treated as the canvas of record here.

One shared definition: the helper lives in a dependency-free module, `vesuvius/tifxyz_canvas.py`, and `tifxyz_label_transfer/core.py`'s `Surface.full_resolution_shape` (and the native-canvas candidate in `infer_output_shape`) now call it too. `core.py` previously rounded the float64 quotient, which differs from the renderer whenever `stored / scale` sits within ~1e-4 of .5 (3681 at scale 0.3313977: 11108 vs the rendered 11107), so the two packages could report canvases one pixel apart on the same mesh; a test pins their agreement. `neural_tracing/datasets/common.py` (`int(round(h_s / scale))`) and `tifxyz/upsampling.py` size their own resampling grids with yet another rounding; I left those alone since they are not the canvas the renderer writes, but they are the next candidates for the shared helper.

Revision history: the first version mirrored `QuadSurface::size()` (`static_cast<int>(cols / _scale[0])`, float32 truncation). @Bullo27 measured `vc_render_tifxyz` on seven `vc_obj2tifxyz` meshes and showed the renderer is what defines the canvas people compare against, and it rounds in double; `446dfaf` switches to that formula and adds the seven cases as tests. It also agrees with `tifxyz_label_transfer/core.py`'s `_positive_lround`-based `full_resolution_shape`, so the package carries one canvas definition. Why not plain `round()`: Python rounds half to even, `std::lround` half away from zero, and exact halves occur with integer scales. Whether `QuadSurface::size()` in VC3D should adopt the renderer's rounding is a separate question for the maintainers.

Written with Claude Code as a coding assistant, directed and reviewed by me; the runs above are from my machine on the published data.
