### PR TITLE
structure_tensor: write zarr through helpers that exist under zarr 2 and 3 (fixes #1448)

### DIFF
--- a/vesuvius/src/vesuvius/data/utils.py
+++ b/vesuvius/src/vesuvius/data/utils.py
@@ -78,7 +78,9 @@ def create_zarr_array(group, name: str, *, shape=None, data=None, chunks=None, d
     zarr 3 removed ``Group.create_dataset``/``require_dataset`` and moved
     ``write_empty_chunks`` into ``config`` and ``dimension_separator`` into
     ``chunk_key_encoding``. This wraps both APIs so callers keep one code path
-    and the array is written exactly as before (v2 metadata, same chunk keys).
+    and the array is written as zarr 2 wrote it (v2 metadata, same chunk keys,
+    and empty chunks materialised unless ``write_empty_chunks=False`` is
+    passed, which is zarr 2's default but not zarr 3's).
     """
     if data is not None:
         data = np.asarray(data)
@@ -95,8 +97,11 @@ def create_zarr_array(group, name: str, *, shape=None, data=None, chunks=None, d
         create_kwargs['compressors'] = _v3_compressor(group, compressor)
         if dimension_separator is not None:
             create_kwargs['chunk_key_encoding'] = {'name': 'v2', 'separator': dimension_separator}
-        if write_empty_chunks is not None:
-            create_kwargs['config'] = {'write_empty_chunks': bool(write_empty_chunks)}
+        # zarr 2 defaults write_empty_chunks=True, zarr 3 defaults False; pin
+        # zarr 2's behaviour so the chunk files on disk match across majors.
+        create_kwargs['config'] = {
+            'write_empty_chunks': True if write_empty_chunks is None else bool(write_empty_chunks)
+        }
         array = group.create_array(name, **create_kwargs)
         if data is not None:
             array[...] = data
@@ -117,19 +122,27 @@ def create_zarr_array(group, name: str, *, shape=None, data=None, chunks=None, d
 def require_zarr_array(group, name: str, *, shape, **kwargs) -> zarr.Array:
     """``Group.require_dataset`` for both zarr majors.
 
-    Returns the existing array when one of that name and shape is present,
-    otherwise creates it through :func:`create_zarr_array`. ``overwrite=True``
-    always (re)creates, matching zarr 2's ``require_dataset(..., overwrite=True)``.
+    Same contract as zarr 2's ``require_dataset``: an existing array of that
+    name is returned after a shape check and a dtype cast check (its chunks
+    and compressor are left as they are, and ``overwrite`` is not consulted);
+    otherwise the array is created through :func:`create_zarr_array`. A
+    resumed ``compute_vf`` run therefore keeps the chunks it already wrote.
     """
-    overwrite = bool(kwargs.pop('overwrite', False))
-    if not overwrite and name in group:
+    if name in group:
         existing = group[name]
-        if tuple(existing.shape) != tuple(shape):
+        if not hasattr(existing, 'shape'):
+            raise TypeError(f"{name!r} exists in {group.path!r} but is a group, not an array")
+        if tuple(int(v) for v in existing.shape) != tuple(int(v) for v in shape):
             raise TypeError(
                 f"array {name!r} exists with shape {tuple(existing.shape)}, requested {tuple(shape)}"
             )
+        dtype = kwargs.get('dtype')
+        if dtype is not None and not np.can_cast(existing.dtype, np.dtype(dtype), casting='safe'):
+            raise TypeError(
+                f"array {name!r} exists with dtype {existing.dtype}, requested {np.dtype(dtype)}"
+            )
         return existing
-    return create_zarr_array(group, name, shape=shape, overwrite=overwrite, **kwargs)
+    return create_zarr_array(group, name, shape=shape, **kwargs)
 
 # Function to get the maximum value of a dtype
 def get_max_value(dtype: np.dtype) -> Union[float, int]:

--- a/vesuvius/src/vesuvius/data/utils.py
+++ b/vesuvius/src/vesuvius/data/utils.py
@@ -16,11 +16,24 @@ def open_zarr_group(path, mode: str = 'r', storage_options: Optional[Dict[str, A
     different on-disk layout (``zarr.json`` instead of ``.zgroup``/``.zarray``).
     Every writer in this package predates zarr 3 and its consumers (VC3D,
     ``vesuvius.data.utils.open_zarr``, the eigenanalysis readers) expect v2,
-    so ask for ``zarr_format=2`` whenever the group may be created. zarr 2 has
-    no ``zarr_format`` argument, and an existing store keeps its own format.
+    so ask for ``zarr_format=2`` whenever the group is created. Append modes
+    (``'a'``, ``'r+'``) keep the format of an existing store and only fall
+    back to v2 when nothing is there yet. zarr 2 has no ``zarr_format``
+    argument.
     """
-    if _ZARR_V3 and mode in ('w', 'w-', 'a', 'r+') and 'zarr_format' not in kwargs:
-        kwargs['zarr_format'] = 2
+    if _ZARR_V3 and 'zarr_format' not in kwargs:
+        if mode in ('w', 'w-'):
+            kwargs['zarr_format'] = 2
+        elif mode in ('a', 'r+'):
+            # Appending: keep whatever format the store already has. Forcing
+            # v2 here would write a second .zgroup next to an existing
+            # zarr.json and leave a store that reads as v3 and empty.
+            try:
+                kwargs['zarr_format'] = zarr.open_group(
+                    path, mode='r', storage_options=storage_options
+                ).metadata.zarr_format
+            except FileNotFoundError:  # GroupNotFoundError: nothing there yet
+                kwargs['zarr_format'] = 2
     if storage_options is not None:
         kwargs['storage_options'] = storage_options
     return zarr.open_group(path, mode=mode, **kwargs)

--- a/vesuvius/src/vesuvius/data/utils.py
+++ b/vesuvius/src/vesuvius/data/utils.py
@@ -25,15 +25,24 @@ def open_zarr_group(path, mode: str = 'r', storage_options: Optional[Dict[str, A
         if mode in ('w', 'w-'):
             kwargs['zarr_format'] = 2
         elif mode in ('a', 'r+'):
-            # Appending: keep whatever format the store already has. Forcing
-            # v2 here would write a second .zgroup next to an existing
-            # zarr.json and leave a store that reads as v3 and empty.
+            # Appending: keep the format of a store that already holds data.
+            # Forcing v2 would write a second .zgroup next to an existing
+            # zarr.json and leave a store that reads as v3 and empty. An
+            # *empty* v3 group, though, is what a failed run on zarr 3 leaves
+            # behind (zarr.json only); there is nothing to keep, so recreate
+            # it as v2 rather than write a v3 store no consumer reads.
             try:
-                kwargs['zarr_format'] = zarr.open_group(
+                existing = zarr.open_group(
                     path, mode='r', storage_options=storage_options
-                ).metadata.zarr_format
+                )
             except FileNotFoundError:  # GroupNotFoundError: nothing there yet
                 kwargs['zarr_format'] = 2
+            else:
+                fmt = int(existing.metadata.zarr_format)
+                if fmt != 2 and len(existing) == 0:
+                    mode, kwargs['zarr_format'] = 'w', 2
+                else:
+                    kwargs['zarr_format'] = fmt
     if storage_options is not None:
         kwargs['storage_options'] = storage_options
     return zarr.open_group(path, mode=mode, **kwargs)

--- a/vesuvius/src/vesuvius/data/utils.py
+++ b/vesuvius/src/vesuvius/data/utils.py
@@ -6,6 +6,109 @@ from typing import Union, Dict, Any, Optional, Tuple
 
 _ZARR_V3 = int(zarr.__version__.split('.', 1)[0]) >= 3
 
+
+def open_zarr_group(path, mode: str = 'r', storage_options: Optional[Dict[str, Any]] = None,
+                    **kwargs) -> "zarr.Group":
+    """``zarr.open_group`` that yields a Zarr v2 group under both zarr majors.
+
+    zarr 3 creates *v3* groups by default, and arrays created inside a v3
+    group reject the numcodecs compressors this package uses and produce a
+    different on-disk layout (``zarr.json`` instead of ``.zgroup``/``.zarray``).
+    Every writer in this package predates zarr 3 and its consumers (VC3D,
+    ``vesuvius.data.utils.open_zarr``, the eigenanalysis readers) expect v2,
+    so ask for ``zarr_format=2`` whenever the group may be created. zarr 2 has
+    no ``zarr_format`` argument, and an existing store keeps its own format.
+    """
+    if _ZARR_V3 and mode in ('w', 'w-', 'a', 'r+') and 'zarr_format' not in kwargs:
+        kwargs['zarr_format'] = 2
+    if storage_options is not None:
+        kwargs['storage_options'] = storage_options
+    return zarr.open_group(path, mode=mode, **kwargs)
+
+
+def _v3_compressor(group, compressor):
+    """Translate a numcodecs compressor for ``Group.create_array`` under zarr 3."""
+    if compressor is None:
+        return None
+    if int(getattr(group.metadata, 'zarr_format', 2)) == 2:
+        # v2 arrays still take numcodecs codecs as-is.
+        return compressor
+    # A v3-format group (only reachable when appending to a store somebody
+    # else created as v3): numcodecs.Blosc has a direct v3 equivalent.
+    from zarr.codecs import BloscCodec
+    name = type(compressor).__name__.lower()
+    if name == 'blosc':
+        shuffle = {0: 'noshuffle', 1: 'shuffle', 2: 'bitshuffle'}.get(int(compressor.shuffle), 'shuffle')
+        return BloscCodec(cname=compressor.cname, clevel=int(compressor.clevel), shuffle=shuffle,
+                          blocksize=int(getattr(compressor, 'blocksize', 0)))
+    raise TypeError(
+        f"cannot use numcodecs compressor {compressor!r} in a Zarr v3 group; "
+        "open the group with open_zarr_group() so it is created as v2"
+    )
+
+
+def create_zarr_array(group, name: str, *, shape=None, data=None, chunks=None, dtype=None,
+                      compressor=None, fill_value=None, write_empty_chunks=None,
+                      overwrite: bool = False, dimension_separator: Optional[str] = None,
+                      **kwargs) -> zarr.Array:
+    """``Group.create_dataset`` for zarr 2 *and* zarr 3, same on-disk result.
+
+    zarr 3 removed ``Group.create_dataset``/``require_dataset`` and moved
+    ``write_empty_chunks`` into ``config`` and ``dimension_separator`` into
+    ``chunk_key_encoding``. This wraps both APIs so callers keep one code path
+    and the array is written exactly as before (v2 metadata, same chunk keys).
+    """
+    if data is not None:
+        data = np.asarray(data)
+        if shape is None:
+            shape = data.shape
+        if dtype is None:
+            dtype = data.dtype
+    if _ZARR_V3:
+        create_kwargs: Dict[str, Any] = dict(shape=shape, dtype=dtype, overwrite=overwrite, **kwargs)
+        if chunks is not None:
+            create_kwargs['chunks'] = chunks
+        if fill_value is not None:
+            create_kwargs['fill_value'] = fill_value
+        create_kwargs['compressors'] = _v3_compressor(group, compressor)
+        if dimension_separator is not None:
+            create_kwargs['chunk_key_encoding'] = {'name': 'v2', 'separator': dimension_separator}
+        if write_empty_chunks is not None:
+            create_kwargs['config'] = {'write_empty_chunks': bool(write_empty_chunks)}
+        array = group.create_array(name, **create_kwargs)
+        if data is not None:
+            array[...] = data
+        return array
+    create_kwargs = dict(shape=shape, chunks=chunks, dtype=dtype, compressor=compressor,
+                         overwrite=overwrite, **kwargs)
+    if data is not None:
+        create_kwargs['data'] = data
+    if fill_value is not None:
+        create_kwargs['fill_value'] = fill_value
+    if dimension_separator is not None:
+        create_kwargs['dimension_separator'] = dimension_separator
+    if write_empty_chunks is not None:
+        create_kwargs['write_empty_chunks'] = write_empty_chunks
+    return group.create_dataset(name, **create_kwargs)
+
+
+def require_zarr_array(group, name: str, *, shape, **kwargs) -> zarr.Array:
+    """``Group.require_dataset`` for both zarr majors.
+
+    Returns the existing array when one of that name and shape is present,
+    otherwise creates it through :func:`create_zarr_array`. ``overwrite=True``
+    always (re)creates, matching zarr 2's ``require_dataset(..., overwrite=True)``.
+    """
+    overwrite = bool(kwargs.pop('overwrite', False))
+    if not overwrite and name in group:
+        existing = group[name]
+        if tuple(existing.shape) != tuple(shape):
+            raise TypeError(
+                f"array {name!r} exists with shape {tuple(existing.shape)}, requested {tuple(shape)}"
+            )
+        return existing
+    return create_zarr_array(group, name, shape=shape, overwrite=overwrite, **kwargs)
+
 # Function to get the maximum value of a dtype
 def get_max_value(dtype: np.dtype) -> Union[float, int]:
     """

--- a/vesuvius/src/vesuvius/image_proc/run/generate_mutex_graph.py
+++ b/vesuvius/src/vesuvius/image_proc/run/generate_mutex_graph.py
@@ -14,6 +14,7 @@ import numpy as np
 import tifffile
 import zarr
 from numcodecs import Blosc
+from vesuvius.data.utils import open_zarr_group, create_zarr_array
 from scipy import ndimage
 from tqdm import tqdm
 
@@ -252,7 +253,7 @@ def process_volume(
         else:
             output_path.unlink()
 
-    root = zarr.open_group(str(output_path), mode="w")
+    root = open_zarr_group(str(output_path), mode="w")
 
     # Determine minimal lossless dtypes
     attr_dtype = _select_min_lossless_dtype(attractive)
@@ -262,25 +263,29 @@ def process_volume(
     mask_rep_dtype = np.uint8 if _is_binary_array(repulsive_mask) else _select_min_lossless_dtype(repulsive_mask)
 
     # Cast on write to avoid holding two copies if possible
-    root.create_dataset(
+    create_zarr_array(
+        root,
         "affinities/attractive",
         data=attractive.astype(attr_dtype, copy=False),
         compressor=compressor,
         chunks=chunk_shape,
     )
-    root.create_dataset(
+    create_zarr_array(
+        root,
         "affinities/repulsive",
         data=repulsive.astype(rep_dtype, copy=False),
         compressor=compressor,
         chunks=chunk_shape,
     )
-    root.create_dataset(
+    create_zarr_array(
+        root,
         "mask/attractive",
         data=attractive_mask.astype(mask_attr_dtype, copy=False),
         compressor=compressor,
         chunks=chunk_shape,
     )
-    root.create_dataset(
+    create_zarr_array(
+        root,
         "mask/repulsive",
         data=repulsive_mask.astype(mask_rep_dtype, copy=False),
         compressor=compressor,
@@ -290,7 +295,8 @@ def process_volume(
     if cfg.store_labels:
         max_label = int(labels.max(initial=0)) if labels.size else 0
         label_dtype = _min_uint_dtype(max_label)
-        root.create_dataset(
+        create_zarr_array(
+            root,
             "labels",
             data=labels.astype(label_dtype, copy=False),
             compressor=compressor,

--- a/vesuvius/src/vesuvius/image_proc/run/voxelize_objs.py
+++ b/vesuvius/src/vesuvius/image_proc/run/voxelize_objs.py
@@ -8,6 +8,7 @@ import logging
 from glob import glob
 from itertools import repeat, product
 from numcodecs import Blosc
+from vesuvius.data.utils import open_zarr_group, create_zarr_array
 from concurrent.futures import ProcessPoolExecutor
 import multiprocessing
 from numba import jit, set_num_threads
@@ -1533,8 +1534,7 @@ def main():
     label_datasets = []
     label_dataset_name = None
     if args.format == "zarr":
-        label_store = zarr.DirectoryStore(out_path)
-        label_root = zarr.group(store=label_store, overwrite=True)
+        label_root = open_zarr_group(out_path, mode='w')
         label_base_shape = (z_dim, h, w)
         label_axes = [
             {"name": "z", "type": "space", "unit": "index"},
@@ -1548,7 +1548,8 @@ def main():
             level_shape = compute_level_shape(label_base_shape, level, (0, 1, 2))
             level_chunks = compute_chunks(level_shape, args.chunk_size, level)
             dataset_name = f"{level}"
-            ds = label_root.create_dataset(
+            ds = create_zarr_array(
+                label_root,
                 dataset_name,
                 shape=level_shape,
                 chunks=level_chunks,
@@ -1585,8 +1586,7 @@ def main():
 
     normals_datasets = []
     if args.output_normals:
-        normals_store = zarr.DirectoryStore(normals_out_path)
-        normals_root = zarr.group(store=normals_store, overwrite=True)
+        normals_root = open_zarr_group(normals_out_path, mode='w')
         normals_base_shape = (z_dim, h, w, 3)
         normals_axes = [
             {"name": "z", "type": "space", "unit": "index"},
@@ -1601,7 +1601,8 @@ def main():
             level_shape = compute_level_shape(normals_base_shape, level, (0, 1, 2))
             level_chunks = compute_chunks(level_shape, args.chunk_size, level)
             dataset_name = f"{level}"
-            ds = normals_root.create_dataset(
+            ds = create_zarr_array(
+                normals_root,
                 dataset_name,
                 shape=level_shape,
                 chunks=level_chunks,
@@ -1636,8 +1637,7 @@ def main():
     surface_frame_dataset_name = None
 
     if args.output_surface_frame:
-        surface_frame_store = zarr.DirectoryStore(surface_frame_out_path)
-        surface_frame_root = zarr.group(store=surface_frame_store, overwrite=True)
+        surface_frame_root = open_zarr_group(surface_frame_out_path, mode='w')
         surface_frame_base_shape = (z_dim, h, w, 3, 3)
         surface_frame_axes = [
             {"name": "z", "type": "space", "unit": "index"},
@@ -1653,7 +1653,8 @@ def main():
             level_shape = compute_level_shape(surface_frame_base_shape, level, (0, 1, 2))
             level_chunks = compute_chunks(level_shape, args.chunk_size, level)
             dataset_name = f"{level}"
-            ds = surface_frame_root.create_dataset(
+            ds = create_zarr_array(
+                surface_frame_root,
                 dataset_name,
                 shape=level_shape,
                 chunks=level_chunks,

--- a/vesuvius/src/vesuvius/image_proc/run/voxelize_objs.py
+++ b/vesuvius/src/vesuvius/image_proc/run/voxelize_objs.py
@@ -3,7 +3,9 @@ import math
 import numpy as np
 import os
 import trimesh
+import shutil
 import zarr
+from pathlib import Path
 import logging
 from glob import glob
 from itertools import repeat, product
@@ -378,13 +380,26 @@ def _rechunk_with_dask(zarr_array, chunk_size, desc, num_workers):
     if tmp_component in parent_group:
         del parent_group[tmp_component]
 
-    delayed = da.to_zarr(
-        dask_array,
-        zarr_array.store,
-        component=tmp_component_full,
+    # Create the temporary target ourselves (Zarr v2 under either major) and
+    # hand dask the array object: letting dask create it by path writes a
+    # Zarr v3 array plus a root zarr.json under zarr 3, after which the
+    # existing v2 level arrays are no longer visible in the store.
+    compressors = getattr(zarr_array, 'compressors', None)  # zarr 3
+    if compressors is not None:
+        compressor = compressors[0] if compressors else None
+    else:
+        compressor = zarr_array.compressor  # zarr 2
+    tmp_array = create_zarr_array(
+        parent_group,
+        tmp_component,
+        shape=zarr_array.shape,
+        chunks=target_chunks,
+        dtype=zarr_array.dtype,
+        compressor=compressor,
+        fill_value=zarr_array.fill_value,
         overwrite=True,
-        compute=False,
     )
+    delayed = da.to_zarr(dask_array, tmp_array, compute=False)
 
     with ProgressBar():
         delayed.compute(scheduler="threads", num_workers=max(1, num_workers))
@@ -396,10 +411,32 @@ def _rechunk_with_dask(zarr_array, chunk_size, desc, num_workers):
     dataset_name = zarr_array.path.rpartition("/")[2] or zarr_array.path
     if dataset_name in parent_group:
         del parent_group[dataset_name]
-    parent_group.move(tmp_component, dataset_name)
+    _rename_child(parent_group, tmp_component, dataset_name)
 
     refreshed = parent_group[dataset_name]
     return refreshed
+
+
+def _rename_child(group, old_name, new_name):
+    """Rename a child array of ``group`` under either zarr major.
+
+    zarr 3's ``Group.move`` raises NotImplementedError; a Zarr v2 array in a
+    local store is a directory, so rename it on disk and let the group
+    re-read it. Remote stores fall back to ``move`` where it is implemented.
+    """
+    store = group.store
+    root = getattr(store, "root", None) or getattr(store, "path", None)
+    if root is not None:
+        base = Path(str(root))
+        if group.path:
+            base = base / group.path
+        source, destination = base / old_name, base / new_name
+        if source.is_dir():
+            if destination.exists():
+                shutil.rmtree(destination)
+            os.rename(source, destination)
+            return
+    group.move(old_name, new_name)
 
 
 def _build_tmp_component_name(path):

--- a/vesuvius/src/vesuvius/structure_tensor/create_st.py
+++ b/vesuvius/src/vesuvius/structure_tensor/create_st.py
@@ -13,7 +13,7 @@ import zarr
 import numcodecs
 
 from vesuvius.models.run.inference import Inferer
-from vesuvius.data.utils import open_zarr
+from vesuvius.data.utils import open_zarr, open_zarr_group, create_zarr_array
 from vesuvius.image_proc.geometry.structure_tensor import (
     StructureTensorComputer,
     _get_gaussian_kernel_3d,
@@ -196,14 +196,15 @@ class StructureTensorInferer(Inferer, nn.Module):
             print(f"Chunk shape: {output_chunks}")
             
             # Create the root group
-            root_store = zarr.open_group(
+            root_store = open_zarr_group(
                 main_store_path,
                 mode='w',
                 storage_options={'anon': False} if main_store_path.startswith('s3://') else None
             )
             
             # Create the structure_tensor array within the group
-            self.output_store = root_store.create_dataset(
+            self.output_store = create_zarr_array(
+                root_store,
                 'structure_tensor',
                 shape=output_shape,
                 chunks=output_chunks,
@@ -592,8 +593,8 @@ def _finalize_structure_tensor_torch(
         for axg in (gz, gy, gx):
             if ome_scale in axg:
                 del axg[ome_scale]
-            axg.create_dataset(
-                ome_scale, shape=(Zds, Yds, Xds), chunks=out_chunks_ds,
+            create_zarr_array(
+                axg, ome_scale, shape=(Zds, Yds, Xds), chunks=out_chunks_ds,
                 dtype=np.uint8, compressor=compressor, write_empty_chunks=False
             )
         return gz[ome_scale], gy[ome_scale], gx[ome_scale]
@@ -606,15 +607,16 @@ def _finalize_structure_tensor_torch(
         conf_group = root_store.require_group("confidence")
         if ome_scale in conf_group:
             del conf_group[ome_scale]
-        conf_ds = conf_group.create_dataset(
-            ome_scale, shape=(Zds, Yds, Xds), chunks=out_chunks_ds,
+        conf_ds = create_zarr_array(
+            conf_group, ome_scale, shape=(Zds, Yds, Xds), chunks=out_chunks_ds,
             dtype=np.uint8, compressor=compressor, write_empty_chunks=False
         )
 
     # ---- Optional: keep full-precision eigen* arrays (float32) ----
     if keep_eigen:
         out_chunks = (1, cz, cy, cx)
-        eigenvectors_arr = root_store.create_dataset(
+        eigenvectors_arr = create_zarr_array(
+            root_store,
             'eigenvectors',
             shape=(9, Z, Y, X),
             chunks=out_chunks,
@@ -623,7 +625,8 @@ def _finalize_structure_tensor_torch(
             write_empty_chunks=False,
             overwrite=True
         )
-        eigenvalues_arr = root_store.create_dataset(
+        eigenvalues_arr = create_zarr_array(
+            root_store,
             'eigenvalues',
             shape=(3, Z, Y, X),
             chunks=out_chunks,
@@ -975,6 +978,12 @@ def main():
             else:
                 logits_path = result
             
+            if not logits_path:
+                # infer() already printed the traceback; do not let the
+                # runner report "Completed Successfully" on an empty store.
+                print(f"\n--- Structure Tensor Computation Failed ---")
+                return 1
+
             if logits_path:
                 print(f"\n--- Structure Tensor Computation Finished ---")
                 print(f"Structure tensor saved to: {logits_path}/structure_tensor")

--- a/vesuvius/src/vesuvius/structure_tensor/create_st.py
+++ b/vesuvius/src/vesuvius/structure_tensor/create_st.py
@@ -984,30 +984,29 @@ def main():
                 print(f"\n--- Structure Tensor Computation Failed ---")
                 return 1
 
-            if logits_path:
-                print(f"\n--- Structure Tensor Computation Finished ---")
-                print(f"Structure tensor saved to: {logits_path}/structure_tensor")
+            print(f"\n--- Structure Tensor Computation Finished ---")
+            print(f"Structure tensor saved to: {logits_path}/structure_tensor")
                 
-                # Run eigenanalysis automatically unless --structure-tensor-only is specified
-                if not args.structure_tensor_only:
-                    print("\n--- Running Eigenanalysis ---")
-                    _finalize_structure_tensor_torch(
-                        zarr_path=logits_path,
-                        chunk_size=chunk_size,
-                        num_workers=args.num_workers,
-                        compressor=compressor,
-                        verbose=args.verbose,
-                        swap_eigenvectors=args.swap_eigenvectors,
-                        device=args.device
-                    )
-                    print("\n--- All computations completed successfully ---")
-                    print(f"Final output contains:")
-                    print(f"  - Structure tensor: {logits_path}/structure_tensor")
-                    if args.ome_out:
-                        print(f"  - first_component/, second_component/, normal/, confidence/ (scale '{args.ome_scale}', ds={args.ome_downsample})")
-                    if args.keep_eigen:
-                        print(f"  - Eigenvectors: {logits_path}/eigenvectors")
-                        print(f"  - Eigenvalues: {logits_path}/eigenvalues")
+            # Run eigenanalysis automatically unless --structure-tensor-only is specified
+            if not args.structure_tensor_only:
+                print("\n--- Running Eigenanalysis ---")
+                _finalize_structure_tensor_torch(
+                    zarr_path=logits_path,
+                    chunk_size=chunk_size,
+                    num_workers=args.num_workers,
+                    compressor=compressor,
+                    verbose=args.verbose,
+                    swap_eigenvectors=args.swap_eigenvectors,
+                    device=args.device
+                )
+                print("\n--- All computations completed successfully ---")
+                print(f"Final output contains:")
+                print(f"  - Structure tensor: {logits_path}/structure_tensor")
+                if args.ome_out:
+                    print(f"  - first_component/, second_component/, normal/, confidence/ (scale '{args.ome_scale}', ds={args.ome_downsample})")
+                if args.keep_eigen:
+                    print(f"  - Eigenvectors: {logits_path}/eigenvectors")
+                    print(f"  - Eigenvalues: {logits_path}/eigenvalues")
                 
         except Exception as e:
             print(f"\n--- Structure Tensor Computation Failed ---")

--- a/vesuvius/src/vesuvius/structure_tensor/create_vf.py
+++ b/vesuvius/src/vesuvius/structure_tensor/create_vf.py
@@ -2,7 +2,7 @@
 import torch
 import zarr
 import numpy as np
-from vesuvius.data.utils import open_zarr
+from vesuvius.data.utils import open_zarr, open_zarr_group, require_zarr_array
 from typing import Dict, Tuple, Optional
 from tqdm.auto import tqdm
 
@@ -53,14 +53,14 @@ class VectorFieldComputer:
         cz, cy, cx = chunk_size
 
         # prepare outputs
-        root = zarr.open_group(output_zarr, mode='a')
+        root = open_zarr_group(output_zarr, mode='a')
         if not ome_only:
-            U_ds = root.require_dataset('U', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
-                                        dtype=np.float32, compressor=compressor, overwrite=True)
-            V_ds = root.require_dataset('V', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
-                                        dtype=np.float32, compressor=compressor, overwrite=True)
-            N_ds = root.require_dataset('N', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
-                                        dtype=np.float32, compressor=compressor, overwrite=True)
+            U_ds = require_zarr_array(root, 'U', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
+                                      dtype=np.float32, compressor=compressor, overwrite=True)
+            V_ds = require_zarr_array(root, 'V', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
+                                      dtype=np.float32, compressor=compressor, overwrite=True)
+            N_ds = require_zarr_array(root, 'N', shape=(3,Z,Y,X), chunks=(3,cz,cy,cx),
+                                      dtype=np.float32, compressor=compressor, overwrite=True)
         # OME-ish uint8 writer (writes component groups z/y/x at scale)
         writer = None
         if ome_u8:

--- a/vesuvius/src/vesuvius/structure_tensor/run_create_st.py
+++ b/vesuvius/src/vesuvius/structure_tensor/run_create_st.py
@@ -16,7 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 import zarr
 import numpy as np
 
-from vesuvius.data.utils import open_zarr
+from vesuvius.data.utils import open_zarr, open_zarr_group, create_zarr_array
 from numcodecs import Blosc
 
 def get_available_gpus():
@@ -95,14 +95,15 @@ def create_shared_output_store(args, input_shape, patch_size):
     print(f"Chunk shape: {output_chunks}")
     
     # Create the root group
-    root_store = zarr.open_group(
+    root_store = open_zarr_group(
         main_store_path,
         mode='w',
         storage_options={'anon': False} if main_store_path.startswith('s3://') else None
     )
     
     # Create the structure_tensor array within the group
-    structure_tensor_arr = root_store.create_dataset(
+    structure_tensor_arr = create_zarr_array(
+        root_store,
         'structure_tensor',
         shape=output_shape,
         chunks=output_chunks,

--- a/vesuvius/src/vesuvius/structure_tensor/vf_format.py
+++ b/vesuvius/src/vesuvius/structure_tensor/vf_format.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import zarr
 from numcodecs import Blosc
+from vesuvius.data.utils import open_zarr_group, create_zarr_array
 from typing import Optional, Tuple
 
 def _default_compressor() -> Blosc:
@@ -63,7 +64,7 @@ class OMEU8VectorWriter:
         Xds = (X + self.ds - 1) // self.ds
         self.shape_ds = (Zds, Yds, Xds)
 
-        root = zarr.open_group(output_path, mode="a")
+        root = open_zarr_group(output_path, mode="a")
         grp = root.require_group(group_name)
         self.ds_z = self._require_scale(grp.require_group("z"), chunks_zyx, compressor)
         self.ds_y = self._require_scale(grp.require_group("y"), chunks_zyx, compressor)
@@ -83,7 +84,8 @@ class OMEU8VectorWriter:
                     f"expected {self.shape_ds}"
                 )
             return ds
-        return g.create_dataset(
+        return create_zarr_array(
+            g,
             self.scale_name,
             shape=self.shape_ds,
             chunks=chunks,

--- a/vesuvius/tests/structure_tensor/test_zarr3_compat.py
+++ b/vesuvius/tests/structure_tensor/test_zarr3_compat.py
@@ -67,6 +67,23 @@ def test_open_zarr_group_append_keeps_existing_v3_store(tmp_path):
     np.testing.assert_array_equal(reopened["new"][:], 1.0)
 
 
+@pytest.mark.skipif(not _ZARR_V3, reason="zarr 3 stores only exist under zarr 3")
+def test_open_zarr_group_append_recreates_empty_v3_leftover_as_v2(tmp_path):
+    """A failed run on zarr 3 leaves an empty zarr.json-only group; re-running
+    on the same --output must produce the v2 store the consumers read."""
+    path = str(tmp_path / "leftover.zarr")
+    zarr.open_group(path, mode="w", zarr_format=3)
+    assert os.path.exists(tmp_path / "leftover.zarr" / "zarr.json")
+
+    root = open_zarr_group(path, mode="a")
+    assert root.metadata.zarr_format == 2
+    create_zarr_array(root, "U", shape=(2, 2), chunks=(2, 2), dtype=np.float32, compressor=Blosc())
+    assert not os.path.exists(tmp_path / "leftover.zarr" / "zarr.json")
+    assert os.path.exists(tmp_path / "leftover.zarr" / ".zgroup")
+    assert _is_v2_array_dir(str(tmp_path / "leftover.zarr" / "U"))
+    assert list(zarr.open_group(path, mode="r").keys()) == ["U"]
+
+
 def test_create_zarr_array_matches_create_dataset_layout(tmp_path):
     root = open_zarr_group(str(tmp_path / "g.zarr"), mode="w")
     arr = create_zarr_array(

--- a/vesuvius/tests/structure_tensor/test_zarr3_compat.py
+++ b/vesuvius/tests/structure_tensor/test_zarr3_compat.py
@@ -125,16 +125,56 @@ def test_create_zarr_array_with_data_and_nested_separator(tmp_path):
     np.testing.assert_array_equal(zarr.open_group(str(tmp_path / "g.zarr"), mode="r")["labels"][:], data)
 
 
-def test_require_zarr_array_returns_existing_or_creates(tmp_path):
+def test_require_zarr_array_reuses_existing_like_require_dataset(tmp_path):
+    """zarr 2's require_dataset returns an existing array (shape + dtype-cast
+    checked) and never consults overwrite; a resumed compute_vf run keeps its
+    chunks. The helper must do the same under either major."""
     root = open_zarr_group(str(tmp_path / "g.zarr"), mode="a")
     first = require_zarr_array(root, "U", shape=(3, 2, 2, 2), chunks=(3, 2, 2, 2), dtype=np.float32, compressor=None)
     first[...] = 7.0
-    again = require_zarr_array(root, "U", shape=(3, 2, 2, 2), chunks=(3, 2, 2, 2), dtype=np.float32, compressor=None)
+    again = require_zarr_array(
+        root, "U", shape=(3, 2, 2, 2), chunks=(3, 1, 1, 1), dtype=np.float32, compressor=Blosc(), overwrite=True
+    )
     np.testing.assert_array_equal(again[...], 7.0)
-    with pytest.raises(TypeError):
+    assert tuple(again.chunks) == (3, 2, 2, 2)  # existing layout kept
+    with pytest.raises(TypeError, match="shape"):
         require_zarr_array(root, "U", shape=(3, 1, 1, 1), dtype=np.float32)
-    fresh = require_zarr_array(root, "U", shape=(3, 2, 2, 2), chunks=(3, 2, 2, 2), dtype=np.float32, compressor=None, overwrite=True)
-    assert float(fresh[0, 0, 0, 0]) == 0.0
+    with pytest.raises(TypeError, match="dtype"):
+        require_zarr_array(root, "U", shape=(3, 2, 2, 2), dtype=np.uint8)
+    root.require_group("sub")
+    with pytest.raises(TypeError, match="group, not an array"):
+        require_zarr_array(root, "sub", shape=(1,), dtype=np.uint8)
+
+
+def test_create_zarr_array_writes_empty_chunks_like_zarr2_by_default(tmp_path):
+    root = open_zarr_group(str(tmp_path / "g.zarr"), mode="w")
+    arr = create_zarr_array(root, "z", shape=(4, 4), chunks=(2, 2), dtype=np.uint8, compressor=None)
+    arr[...] = 0
+    chunk_files = sorted(f for f in os.listdir(tmp_path / "g.zarr" / "z") if not f.startswith("."))
+    assert chunk_files == ["0.0", "0.1", "1.0", "1.1"]
+
+
+def test_voxelize_rechunk_keeps_store_v2(tmp_path):
+    """--chunk_size N routes level 0 through a dask rechunk; that must not leave
+    a v3 array or a root zarr.json in the v2 label store (issue #1448 follow-up)."""
+    from vesuvius.image_proc.run.voxelize_objs import _rechunk_with_dask
+
+    path = str(tmp_path / "labels.zarr")
+    root = open_zarr_group(path, mode="w")
+    level0 = create_zarr_array(root, "0", shape=(8, 8, 8), chunks=(8, 8, 8), dtype=np.uint16, compressor=Blosc())
+    expected = np.arange(8 * 8 * 8, dtype=np.uint16).reshape(8, 8, 8)
+    level0[...] = expected
+    level0.attrs["note"] = "kept"
+
+    rechunked = _rechunk_with_dask(level0, 4, "labels", num_workers=1)
+    assert tuple(rechunked.chunks) == (4, 4, 4)
+    assert not os.path.exists(tmp_path / "labels.zarr" / "zarr.json")
+    assert _is_v2_array_dir(str(tmp_path / "labels.zarr" / "0"))
+    reopened = zarr.open_group(path, mode="r")
+    assert list(reopened.keys()) == ["0"]
+    np.testing.assert_array_equal(reopened["0"][:], expected)
+    np.testing.assert_array_equal(rechunked[:], expected)
+    assert reopened["0"].attrs["note"] == "kept"
 
 
 def test_eigenanalysis_writes_ome_and_eigen_arrays(tmp_path):

--- a/vesuvius/tests/structure_tensor/test_zarr3_compat.py
+++ b/vesuvius/tests/structure_tensor/test_zarr3_compat.py
@@ -38,6 +38,35 @@ def test_open_zarr_group_creates_v2_layout(tmp_path):
         assert root.metadata.zarr_format == 2
 
 
+def test_open_zarr_group_append_creates_v2_when_missing(tmp_path):
+    root = open_zarr_group(str(tmp_path / "new.zarr"), mode="a")
+    assert os.path.exists(tmp_path / "new.zarr" / ".zgroup")
+    assert not os.path.exists(tmp_path / "new.zarr" / "zarr.json")
+    create_zarr_array(root, "U", shape=(2, 2), chunks=(2, 2), dtype=np.float32, compressor=Blosc())
+    assert _is_v2_array_dir(str(tmp_path / "new.zarr" / "U"))
+
+
+@pytest.mark.skipif(not _ZARR_V3, reason="zarr 3 stores only exist under zarr 3")
+def test_open_zarr_group_append_keeps_existing_v3_store(tmp_path):
+    """Appending must not write a second .zgroup beside an existing zarr.json."""
+    path = str(tmp_path / "v3.zarr")
+    v3 = zarr.open_group(path, mode="w", zarr_format=3)
+    v3.create_array("existing", shape=(2, 2), chunks=(2, 2), dtype=np.uint8)
+
+    root = open_zarr_group(path, mode="a")
+    assert root.metadata.zarr_format == 3
+    assert not os.path.exists(tmp_path / "v3.zarr" / ".zgroup")
+    # numcodecs Blosc is translated to the v3 BloscCodec on this branch
+    arr = create_zarr_array(
+        root, "new", shape=(2, 2), chunks=(2, 2), dtype=np.float32,
+        compressor=Blosc(cname="zstd", clevel=3, shuffle=Blosc.SHUFFLE),
+    )
+    arr[...] = 1.0
+    reopened = zarr.open_group(path, mode="r")
+    assert sorted(reopened.keys()) == ["existing", "new"]
+    np.testing.assert_array_equal(reopened["new"][:], 1.0)
+
+
 def test_create_zarr_array_matches_create_dataset_layout(tmp_path):
     root = open_zarr_group(str(tmp_path / "g.zarr"), mode="w")
     arr = create_zarr_array(

--- a/vesuvius/tests/structure_tensor/test_zarr3_compat.py
+++ b/vesuvius/tests/structure_tensor/test_zarr3_compat.py
@@ -1,0 +1,157 @@
+"""The structure-tensor writers must work on a zarr 3 install (issue #1448).
+
+``pyproject.toml`` allows ``zarr>=2.18.7,<4``; on the 3.x half of that range
+``Group.create_dataset`` / ``require_dataset`` / ``zarr.DirectoryStore`` no
+longer exist, so ``vesuvius.compute_st`` died before writing a voxel. These
+tests drive the real writers (eigenanalysis, OME vector writer, vector-field
+creator) through the shared compatibility helpers and check the on-disk
+result is still Zarr v2 with the same chunk layout under either zarr major.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import numpy as np
+import pytest
+import zarr
+from numcodecs import Blosc
+
+from vesuvius.data.utils import (
+    _ZARR_V3,
+    create_zarr_array,
+    open_zarr_group,
+    require_zarr_array,
+)
+
+
+def _is_v2_array_dir(path: str) -> bool:
+    return os.path.exists(os.path.join(path, ".zarray"))
+
+
+def test_open_zarr_group_creates_v2_layout(tmp_path):
+    root = open_zarr_group(str(tmp_path / "g.zarr"), mode="w")
+    assert os.path.exists(tmp_path / "g.zarr" / ".zgroup")
+    assert not os.path.exists(tmp_path / "g.zarr" / "zarr.json")
+    if _ZARR_V3:
+        assert root.metadata.zarr_format == 2
+
+
+def test_create_zarr_array_matches_create_dataset_layout(tmp_path):
+    root = open_zarr_group(str(tmp_path / "g.zarr"), mode="w")
+    arr = create_zarr_array(
+        root,
+        "structure_tensor",
+        shape=(6, 4, 8, 8),
+        chunks=(6, 4, 4, 4),
+        dtype=np.float32,
+        compressor=Blosc(cname="zstd", clevel=3, shuffle=Blosc.SHUFFLE),
+        write_empty_chunks=False,
+    )
+    arr[:, :, :4, :4] = 1.0
+    array_dir = str(tmp_path / "g.zarr" / "structure_tensor")
+    assert _is_v2_array_dir(array_dir)
+    meta = json.load(open(os.path.join(array_dir, ".zarray")))
+    assert meta["chunks"] == [6, 4, 4, 4]
+    assert meta["compressor"]["id"] == "blosc"
+    assert meta["compressor"]["cname"] == "zstd"
+    # write_empty_chunks=False: only the written chunk is on disk
+    chunk_files = [f for f in os.listdir(array_dir) if not f.startswith(".")]
+    assert chunk_files == ["0.0.0.0"]
+    reopened = zarr.open_group(str(tmp_path / "g.zarr"), mode="r")
+    np.testing.assert_array_equal(reopened["structure_tensor"][0, 0, :4, :4], 1.0)
+
+
+def test_create_zarr_array_with_data_and_nested_separator(tmp_path):
+    root = open_zarr_group(str(tmp_path / "g.zarr"), mode="w")
+    data = np.arange(2 * 4 * 4, dtype=np.uint16).reshape(2, 4, 4)
+    create_zarr_array(
+        root,
+        "labels",
+        data=data,
+        chunks=(1, 4, 4),
+        compressor=Blosc(),
+        dimension_separator="/",
+    )
+    array_dir = tmp_path / "g.zarr" / "labels"
+    assert (array_dir / "0" / "0" / "0").exists()
+    np.testing.assert_array_equal(zarr.open_group(str(tmp_path / "g.zarr"), mode="r")["labels"][:], data)
+
+
+def test_require_zarr_array_returns_existing_or_creates(tmp_path):
+    root = open_zarr_group(str(tmp_path / "g.zarr"), mode="a")
+    first = require_zarr_array(root, "U", shape=(3, 2, 2, 2), chunks=(3, 2, 2, 2), dtype=np.float32, compressor=None)
+    first[...] = 7.0
+    again = require_zarr_array(root, "U", shape=(3, 2, 2, 2), chunks=(3, 2, 2, 2), dtype=np.float32, compressor=None)
+    np.testing.assert_array_equal(again[...], 7.0)
+    with pytest.raises(TypeError):
+        require_zarr_array(root, "U", shape=(3, 1, 1, 1), dtype=np.float32)
+    fresh = require_zarr_array(root, "U", shape=(3, 2, 2, 2), chunks=(3, 2, 2, 2), dtype=np.float32, compressor=None, overwrite=True)
+    assert float(fresh[0, 0, 0, 0]) == 0.0
+
+
+def test_eigenanalysis_writes_ome_and_eigen_arrays(tmp_path):
+    """_finalize_structure_tensor_torch creates 3 OME vector groups, confidence and eigen* arrays."""
+    from vesuvius.structure_tensor.create_st import _finalize_structure_tensor_torch
+
+    Z, Y, X = 2, 4, 4
+    st = np.zeros((6, Z, Y, X), dtype=np.float32)
+    st[0] = 3.0  # Jzz
+    st[3] = 2.0  # Jyy
+    st[5] = 1.0  # Jxx
+    zarr_path = str(tmp_path / "st.zarr")
+    root = open_zarr_group(zarr_path, mode="w")
+    create_zarr_array(root, "structure_tensor", data=st, chunks=(6, Z, Y, X), dtype="f4")
+
+    _finalize_structure_tensor_torch(
+        zarr_path=zarr_path,
+        chunk_size=None,
+        num_workers=0,
+        compressor=Blosc(cname="zstd", clevel=1),
+        verbose=False,
+        swap_eigenvectors=False,
+        device="cpu",
+        ome_out=True,
+        ome_downsample=1,
+        ome_scale="0",
+        confidence_metric="fa",
+        keep_eigen=True,
+    )
+
+    out = zarr.open_group(zarr_path, mode="r")
+    for name in ("first_component", "second_component", "normal"):
+        for axis in ("z", "y", "x"):
+            assert tuple(out[f"{name}/{axis}/0"].shape) == (Z, Y, X)
+            assert _is_v2_array_dir(os.path.join(zarr_path, name, axis, "0"))
+    assert tuple(out["confidence/0"].shape) == (Z, Y, X)
+    assert tuple(out["eigenvectors"].shape) == (9, Z, Y, X)
+    assert tuple(out["eigenvalues"].shape) == (3, Z, Y, X)
+    assert tuple(out["eigenvectors"].chunks) == (1, Z, Y, X)
+    ev = np.asarray(out["eigenvalues"][:])
+    assert np.isfinite(ev).all()
+
+
+def test_ome_u8_vector_writer_creates_scale_arrays(tmp_path):
+    from vesuvius.structure_tensor.vf_format import OMEU8VectorWriter
+
+    writer = OMEU8VectorWriter(
+        output_path=str(tmp_path / "vf.zarr"),
+        group_name="normal",
+        vol_shape_zyx=(4, 8, 8),
+        chunks_zyx=(4, 4, 4),
+        downsample=2,
+        make_confidence=True,
+    )
+    assert tuple(writer.ds_z.shape) == (2, 4, 4)
+    assert tuple(writer.ds_conf.shape) == (2, 4, 4)
+    assert _is_v2_array_dir(str(tmp_path / "vf.zarr" / "normal" / "z" / "0"))
+    # Re-opening must reuse the existing arrays rather than fail
+    OMEU8VectorWriter(
+        output_path=str(tmp_path / "vf.zarr"),
+        group_name="normal",
+        vol_shape_zyx=(4, 8, 8),
+        chunks_zyx=(4, 4, 4),
+        downsample=2,
+        make_confidence=True,
+    )


### PR DESCRIPTION
**In one sentence:** `vesuvius.compute_st` (structure tensor → eigenanalysis → OME `first_component/second_component/normal/confidence` outputs) runs again on a zarr 3 install, and it no longer reports "Completed Successfully" after the child process failed to create its output store.

**One real example:** Starting with a 31×512×512 crop of the published PHerc1447 surface volume `segments/20250703025628-auto_grown_20250703025628283/surface-volumes/8.64um-1.2m-116keV-volume-20250521151220.zarr` (level 0), I ran `vesuvius.compute_st --input_dir crop.zarr --output_dir st --patch_size 31,128,128 --num-workers 0 --keep-eigen` on a `uv sync --extra models` environment (zarr 3.2.1), and it produced the full `structure_tensor / eigenvectors / eigenvalues / first_component / second_component / normal / confidence` store in 19 s on CPU.

**Before:** the child died at store creation with

```
  File ".../vesuvius/structure_tensor/create_st.py", line 206, in _create_output_stores
    self.output_store = root_store.create_dataset(
AttributeError: 'Group' object has no attribute 'create_dataset'
An error occurred during inference: 'Group' object has no attribute 'create_dataset'
...
--- Structure Tensor Processing Completed Successfully ---      <-- wrong: the store holds only a v3 zarr.json
Output saved to: .../st_before2.zarr

--- Running Eigenanalysis ---
FileNotFoundError: structure_tensor
```

(full log: [compute_st_before.log](https://raw.githubusercontent.com/ge-al/villa/proof-assets/compute_st_before.log)). With `--structure-tensor-only` the runner exits **0** on that empty store, so a batch script has no way to notice. The same removed APIs sit behind the eigenanalysis writers, `create_vf.py`, `vf_format.py`, `vesuvius.voxelize_obj` and `generate_mutex_graph.py` (#1448 lists every line).

**After this PR:**

```
--- Structure Tensor Computation Finished ---
Structure tensor saved to: .../st_after.zarr/structure_tensor
--- Structure Tensor Processing Completed Successfully ---
--- Running Eigenanalysis ---
[Eigen] Chunks: 100%|██████████| 16/16 [00:07<00:00,  2.17it/s]
Eigenanalysis completed successfully
--- All computations completed successfully ---
  - Structure tensor: .../st_after.zarr/structure_tensor
  - first_component/, second_component/, normal/, confidence/ (scale '0', ds=1)
  - Eigenvectors: .../st_after.zarr/eigenvectors
  - Eigenvalues:  .../st_after.zarr/eigenvalues
EXIT: 0
```

On disk it is the same Zarr v2 layout the C++ tools and every existing reader expect:

```
group format: 2
structure_tensor       shape=(6, 31, 512, 512) chunks=(6, 31, 128, 128) dtype=float32 .zarray=True
eigenvectors           shape=(9, 31, 512, 512) chunks=(1, 31, 128, 128) dtype=float32 .zarray=True
eigenvalues            shape=(3, 31, 512, 512) chunks=(1, 31, 128, 128) dtype=float32 .zarray=True
normal/z/0             shape=(31, 512, 512)    chunks=(31, 128, 128)    dtype=uint8   .zarray=True
first_component/x/0    shape=(31, 512, 512)    chunks=(31, 128, 128)    dtype=uint8   .zarray=True
confidence/0           shape=(31, 512, 512)    chunks=(31, 128, 128)    dtype=uint8   .zarray=True
compressor: {'id': 'blosc', 'cname': 'zstd', 'clevel': 3, 'shuffle': 1, 'blocksize': 0}
```

**Proof:** layer 15 of the input crop, the leading eigenvalue, and the written `confidence/0` (the masked holes in the surface volume come out as zero confidence, papyrus as high):

![compute_st output on the PHerc1447 crop](https://raw.githubusercontent.com/ge-al/villa/proof-assets/compute_st_after_panel.png)

Tests: new `tests/structure_tensor/test_zarr3_compat.py` (11 tests) drives the real writers — `_finalize_structure_tensor_torch` with `ome_out` + `keep_eigen`, `OMEU8VectorWriter` create-then-reopen, and the helpers' v2 layout / nested separator / `write_empty_chunks` / `require` semantics — and runs under whichever zarr major is installed. `tests/structure_tensor` + `tests/data/test_utils.py` + `tests/data/test_open_zarr_format.py`: 39 passed.

**Why / where this is useful:** structure-tensor / fiber-direction volumes feed the fiber tools and VC3D's normal grids; anyone who installs with the lockfile (zarr 3) currently cannot produce them. The fix is three small helpers in `vesuvius.data.utils` (`open_zarr_group`, `create_zarr_array`, `require_zarr_array`) so the same pattern can be applied to the remaining `create_dataset` sites elsewhere.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Fixes #1448. Tested at `23adee0` on macOS (CPU), Python 3.14, zarr 3.2.1, numcodecs 0.16; @Bullo27 ran the test file under zarr 2.18.7, 3.2.1 and 3.3.0 (see thread).

- The helpers always create groups as **Zarr v2** (`zarr_format=2` under zarr 3, no-op under zarr 2): a v3 group rejects the numcodecs `Blosc` compressor these writers pass and would write `zarr.json` instead of `.zgroup`/`.zarray`. `create_zarr_array` maps `write_empty_chunks` → `config={...}` and `dimension_separator` → `chunk_key_encoding` under zarr 3, and uses the non-deprecated `compressors=` keyword. If a caller appends to a store somebody created as v3, a `Blosc` compressor is translated to `zarr.codecs.BloscCodec`; anything else raises a clear error instead of zarr's internal `TypeError`.
- `require_zarr_array` keeps zarr 2's `require_dataset` contract: an existing array is returned after a shape check and a safe dtype-cast check, with its chunks and compressor untouched (`overwrite` is not consulted), so a resumed `compute_vf` run keeps what it already wrote. `create_zarr_array` pins `write_empty_chunks=True` under zarr 3 unless the caller passes `False`, matching zarr 2's default so chunk files on disk agree across majors.
- `open_zarr_group` in append modes (`'a'`/`'r+'`) keeps the format of a store that already holds arrays, recreates an *empty* leftover v3 group (what a failed run on zarr 3 leaves behind) as v2, and creates v2 when nothing is there; `'w'`/`'w-'` always create v2.
- `vesuvius.voxelize_obj --chunk_size N` ran its dask rechunk through `da.to_zarr(store, component=…)`, which under zarr 3 writes a v3 array and a root `zarr.json` into the v2 label store and hides the level arrays. The temporary array is now created through the v2 helper and handed to dask as an object, and the final rename no longer relies on `Group.move` (unimplemented in zarr 3).
- `create_st.main` now returns 1 when `infer()` returns `None` (it swallows the exception and prints the traceback itself), so `run_create_st` no longer announces success on an empty store.
- Sites changed: `run_create_st.py`, `create_st.py` (store creation, eigenanalysis OME/eigen arrays), `create_vf.py` (`require_dataset`), `vf_format.py`, `image_proc/run/voxelize_objs.py` (`zarr.DirectoryStore` + `create_dataset`), `image_proc/run/generate_mutex_graph.py`. `stack_composite_tifs.py` also uses `DirectoryStore`, but it imports a module that does not exist on `main` (noted in #1448), so it is left alone.
- `tests/structure_tensor/test_structure_tensor.py` still has three commented-out tests that use `root.create_dataset`; the new test file covers the same eigenanalysis path through the helpers.

Written with Claude Code as a coding assistant, directed and reviewed by me; the runs above are from my machine on the published data.
