### PR TITLE
vesuvius.train: stop argparse schedule defaults from overriding tr_config (fixes #1489)

### DIFF
--- a/vesuvius/src/vesuvius/models/training/cli.py
+++ b/vesuvius/src/vesuvius/models/training/cli.py
@@ -24,13 +24,14 @@ def _maybe_set_spawn_start_method(argv):
             pass
 
 
-def main(argv=None):
-    """Main entry point for the training script."""
-    if argv is None:
-        argv = sys.argv[1:]
+def build_parser() -> argparse.ArgumentParser:
+    """Build the vesuvius.train argument parser.
 
-    _maybe_set_spawn_start_method(argv)
-
+    Schedule flags (--max-epoch, --max-steps-per-epoch, --max-val-steps-per-epoch,
+    --val-every-n) default to None so a value set in the YAML ``tr_config`` is
+    kept unless the flag is passed explicitly; see update_config_from_args for
+    the fallback used when neither sets it.
+    """
     parser = argparse.ArgumentParser(
         description="Train Vesuvius neural networks for ink detection and segmentation",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -104,20 +105,26 @@ def main(argv=None):
                            help="Type of pooling in encoder ('conv' = strided conv)")
 
     # Training Control
-    grp_train.add_argument("--max-epoch", type=int, default=1000,
-                           help="Maximum number of epochs")
-    grp_train.add_argument("--max-steps-per-epoch", type=int, default=250,
-                           help="Max training steps per epoch (use all data if unset)")
-    grp_train.add_argument("--max-val-steps-per-epoch", type=int, default=50,
-                           help="Max validation steps per epoch (use all data if unset)")
+    grp_train.add_argument("--max-epoch", type=int, default=None,
+                           help="Maximum number of epochs (overrides tr_config.max_epoch; "
+                                "1000 if neither is set)")
+    grp_train.add_argument("--max-steps-per-epoch", type=int, default=None,
+                           help="Max training steps per epoch (overrides tr_config.max_steps_per_epoch; "
+                                "250 if neither is set)")
+    grp_train.add_argument("--max-val-steps-per-epoch", type=int, default=None,
+                           help="Max validation steps per epoch (overrides tr_config.max_val_steps_per_epoch; "
+                                "50 if neither is set)")
     grp_train.add_argument("--full-epoch", action="store_true",
                            help="Iterate over entire train/val set per epoch (overrides max-steps)")
-    grp_train.add_argument("--early-stopping-patience", type=int, default=0,
-                           help="Epochs to wait for val loss improvement (0 disables)")
+    grp_train.add_argument("--early-stopping-patience", type=int, default=None,
+                           help="Epochs to wait for val loss improvement (overrides "
+                                "tr_config.early_stopping_patience; 0 disables, and is the "
+                                "default if neither is set)")
     grp_train.add_argument("--ddp", action="store_true",
                            help="Enable DistributedDataParallel (use with torchrun)")
-    grp_train.add_argument("--val-every-n", dest="val_every_n", type=int, default=1,
-                           help="Perform validation every N epochs (1=every epoch)")
+    grp_train.add_argument("--val-every-n", dest="val_every_n", type=int, default=None,
+                           help="Perform validation every N epochs (overrides tr_config.val_every_n; "
+                                "1=every epoch if neither is set)")
     grp_train.add_argument("--gpus", type=str, default=None,
                            help="Comma-separated GPU device IDs to use, e.g. '0,1,3'. With DDP, length must equal WORLD_SIZE")
     grp_train.add_argument("--nproc-per-node", type=int, default=None,
@@ -176,6 +183,17 @@ def main(argv=None):
     grp_logging.add_argument("--verbose", action="store_true",
                              help="Enable verbose debug output")
 
+    return parser
+
+
+def main(argv=None):
+    """Main entry point for the training script."""
+    if argv is None:
+        argv = sys.argv[1:]
+
+    _maybe_set_spawn_start_method(argv)
+
+    parser = build_parser()
     args = parser.parse_args(argv)
 
     mgr = ConfigManager(verbose=args.verbose)
@@ -211,15 +229,6 @@ def main(argv=None):
     Path(args.output).mkdir(parents=True, exist_ok=True)
 
     update_config_from_args(mgr, args)
-
-    # Validation frequency
-    if hasattr(args, 'val_every_n') and args.val_every_n is not None:
-        if int(args.val_every_n) < 1:
-            raise ValueError(f"--val-every-n must be >= 1, got {args.val_every_n}")
-        setattr(mgr, 'val_every_n', int(args.val_every_n))
-        mgr.tr_configs["val_every_n"] = int(args.val_every_n)
-        if args.verbose:
-            print(f"Validate every {args.val_every_n} epoch(s)")
 
     # Enable DDP if requested or if torchrun sets WORLD_SIZE>1
     if getattr(args, 'ddp', False) or int(os.environ.get('WORLD_SIZE', '1')) > 1:

--- a/vesuvius/src/vesuvius/models/training/cli.py
+++ b/vesuvius/src/vesuvius/models/training/cli.py
@@ -28,7 +28,7 @@ def build_parser() -> argparse.ArgumentParser:
     """Build the vesuvius.train argument parser.
 
     Schedule flags (--max-epoch, --max-steps-per-epoch, --max-val-steps-per-epoch,
-    --val-every-n) default to None so a value set in the YAML ``tr_config`` is
+    --val-every-n, --early-stopping-patience) default to None so a value set in the YAML ``tr_config`` is
     kept unless the flag is passed explicitly; see update_config_from_args for
     the fallback used when neither sets it.
     """

--- a/vesuvius/src/vesuvius/models/utilities/cli_utils.py
+++ b/vesuvius/src/vesuvius/models/utilities/cli_utils.py
@@ -1,6 +1,16 @@
 from pathlib import Path
 from vesuvius.models.utilities.data_format_utils import detect_data_format
 
+# Effective defaults for the training schedule when neither the CLI flag nor
+# the YAML tr_config sets a value. These are the values the CLI flags used to
+# carry as argparse defaults; they are applied here so that they no longer
+# override a value the user put in the config.
+CLI_SCHEDULE_DEFAULTS = {
+    "max_epoch": 1000,
+    "max_steps_per_epoch": 250,
+    "max_val_steps_per_epoch": 50,
+}
+
 
 def update_config_from_args(mgr, args):
     if args.input is not None:
@@ -81,17 +91,28 @@ def update_config_from_args(mgr, args):
         if mgr.verbose:
             print(f"Set random seed for train/val split: {mgr.seed}")
 
-    if args.max_epoch is not None:
-        mgr.max_epoch = args.max_epoch
-        mgr.tr_configs["max_epoch"] = args.max_epoch
+    # Training schedule: an explicit CLI flag wins, otherwise the YAML tr_config
+    # value is kept, otherwise the historical CLI default applies.
+    for key, fallback in CLI_SCHEDULE_DEFAULTS.items():
+        cli_value = getattr(args, key, None)
+        if cli_value is not None:
+            value = int(cli_value)
+        elif key in mgr.tr_configs and mgr.tr_configs[key] is not None:
+            value = int(mgr.tr_configs[key])
+        else:
+            value = fallback
+        setattr(mgr, key, value)
+        mgr.tr_configs[key] = value
 
-    if args.max_steps_per_epoch is not None:
-        mgr.max_steps_per_epoch = args.max_steps_per_epoch
-        mgr.tr_configs["max_steps_per_epoch"] = args.max_steps_per_epoch
-
-    if args.max_val_steps_per_epoch is not None:
-        mgr.max_val_steps_per_epoch = args.max_val_steps_per_epoch
-        mgr.tr_configs["max_val_steps_per_epoch"] = args.max_val_steps_per_epoch
+    # Validation frequency
+    val_every_n = getattr(args, 'val_every_n', None)
+    if val_every_n is not None:
+        if int(val_every_n) < 1:
+            raise ValueError(f"--val-every-n must be >= 1, got {val_every_n}")
+        mgr.val_every_n = int(val_every_n)
+        mgr.tr_configs["val_every_n"] = int(val_every_n)
+        if mgr.verbose:
+            print(f"Validate every {val_every_n} epoch(s)")
 
     if getattr(args, 'profile_augmentations', False):
         mgr.profile_augmentations = True

--- a/vesuvius/src/vesuvius/models/utilities/cli_utils.py
+++ b/vesuvius/src/vesuvius/models/utilities/cli_utils.py
@@ -104,15 +104,18 @@ def update_config_from_args(mgr, args):
         setattr(mgr, key, value)
         mgr.tr_configs[key] = value
 
-    # Validation frequency
+    # Validation frequency: flag wins, otherwise the YAML value ConfigManager
+    # already loaded. Validate whichever source it came from, since the YAML
+    # value is now live too.
     val_every_n = getattr(args, 'val_every_n', None)
     if val_every_n is not None:
-        if int(val_every_n) < 1:
-            raise ValueError(f"--val-every-n must be >= 1, got {val_every_n}")
         mgr.val_every_n = int(val_every_n)
         mgr.tr_configs["val_every_n"] = int(val_every_n)
         if mgr.verbose:
             print(f"Validate every {val_every_n} epoch(s)")
+    if int(getattr(mgr, 'val_every_n', 1)) < 1:
+        source = "--val-every-n" if val_every_n is not None else "tr_config.val_every_n"
+        raise ValueError(f"{source} must be >= 1, got {mgr.val_every_n}")
 
     if getattr(args, 'profile_augmentations', False):
         mgr.profile_augmentations = True

--- a/vesuvius/tests/models/training/test_cli_schedule_defaults.py
+++ b/vesuvius/tests/models/training/test_cli_schedule_defaults.py
@@ -101,3 +101,6 @@ def test_full_epoch_still_clears_step_limits(tmp_path):
 def test_val_every_n_below_one_is_rejected(tmp_path):
     with pytest.raises(ValueError, match="--val-every-n must be >= 1"):
         _resolve(tmp_path, {}, ["--val-every-n", "0"])
+    # the YAML value is live now, so it gets the same check
+    with pytest.raises(ValueError, match="tr_config.val_every_n must be >= 1"):
+        _resolve(tmp_path, {"val_every_n": 0}, [])

--- a/vesuvius/tests/models/training/test_cli_schedule_defaults.py
+++ b/vesuvius/tests/models/training/test_cli_schedule_defaults.py
@@ -1,0 +1,103 @@
+"""vesuvius.train must not let argparse defaults override tr_config (issue #1489).
+
+``--max-epoch`` etc. carried non-None argparse defaults (1000 / 250 / 50 / 1),
+and ``update_config_from_args`` could not tell "user passed 1000" from
+"default 1000", so ``tr_config: {max_epoch: 50, max_steps_per_epoch: 150}``
+still trained for ``Epoch 1/1000`` with 250 steps. ``--batch-size`` and
+``--patch-size`` already used ``default=None``; the schedule flags now do too,
+and the old defaults apply only when neither the flag nor the YAML sets a value.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from vesuvius.models.configuration.config_manager import ConfigManager
+from vesuvius.models.training.cli import build_parser
+from vesuvius.models.utilities.cli_utils import CLI_SCHEDULE_DEFAULTS, update_config_from_args
+
+BASE_CONFIG = {
+    "tr_setup": {"model_name": "schedule_test"},
+    "tr_config": {"patch_size": [64, 64, 64], "enable_deep_supervision": False},
+    "model_config": {"architecture_type": "mednext_v1", "mednext_model_id": "B"},
+    "dataset_config": {
+        "normalization_scheme": "zscore",
+        "skip_patch_validation": True,
+        "targets": {"surface": {"activation": "none", "losses": [{"name": "SoftDiceLoss", "weight": 1.0}]}},
+    },
+}
+
+
+def _resolve(tmp_path: Path, tr_config_extra: dict, argv_extra: list[str]) -> ConfigManager:
+    config = yaml.safe_load(yaml.safe_dump(BASE_CONFIG))
+    config["tr_config"].update(tr_config_extra)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config))
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+    args = build_parser().parse_args(
+        ["--config", str(config_path), "--input", str(data_dir), "--format", "zarr",
+         "--output", str(tmp_path / "out"), *argv_extra]
+    )
+    mgr = ConfigManager(verbose=False)
+    mgr.load_config(str(config_path))
+    update_config_from_args(mgr, args)
+    return mgr
+
+
+def test_schedule_flags_default_to_none():
+    args = build_parser().parse_args(["--config", "x.yaml"])
+    assert args.max_epoch is None
+    assert args.max_steps_per_epoch is None
+    assert args.max_val_steps_per_epoch is None
+    assert args.val_every_n is None
+    assert args.early_stopping_patience is None
+
+
+def test_yaml_schedule_survives_without_flags(tmp_path):
+    mgr = _resolve(
+        tmp_path,
+        {"max_epoch": 50, "max_steps_per_epoch": 150, "max_val_steps_per_epoch": 12, "val_every_n": 3},
+        [],
+    )
+    assert (mgr.max_epoch, mgr.max_steps_per_epoch, mgr.max_val_steps_per_epoch, mgr.val_every_n) == (50, 150, 12, 3)
+    assert mgr.tr_configs["max_epoch"] == 50
+    assert mgr.tr_configs["max_steps_per_epoch"] == 150
+
+
+def test_explicit_flags_override_yaml(tmp_path):
+    mgr = _resolve(
+        tmp_path,
+        {"max_epoch": 50, "max_steps_per_epoch": 150, "max_val_steps_per_epoch": 12, "val_every_n": 3},
+        ["--max-epoch", "7", "--max-steps-per-epoch", "9", "--max-val-steps-per-epoch", "4", "--val-every-n", "2"],
+    )
+    assert (mgr.max_epoch, mgr.max_steps_per_epoch, mgr.max_val_steps_per_epoch, mgr.val_every_n) == (7, 9, 4, 2)
+
+
+def test_historical_defaults_apply_when_neither_is_set(tmp_path):
+    mgr = _resolve(tmp_path, {}, [])
+    assert mgr.max_epoch == CLI_SCHEDULE_DEFAULTS["max_epoch"] == 1000
+    assert mgr.max_steps_per_epoch == CLI_SCHEDULE_DEFAULTS["max_steps_per_epoch"] == 250
+    assert mgr.max_val_steps_per_epoch == CLI_SCHEDULE_DEFAULTS["max_val_steps_per_epoch"] == 50
+    assert mgr.val_every_n == 1
+
+
+def test_yaml_early_stopping_patience_survives(tmp_path):
+    mgr = _resolve(tmp_path, {"early_stopping_patience": 15}, [])
+    assert mgr.early_stopping_patience == 15
+    mgr = _resolve(tmp_path, {"early_stopping_patience": 15}, ["--early-stopping-patience", "0"])
+    assert mgr.early_stopping_patience == 0
+
+
+def test_full_epoch_still_clears_step_limits(tmp_path):
+    mgr = _resolve(tmp_path, {"max_steps_per_epoch": 150}, ["--full-epoch"])
+    assert mgr.max_steps_per_epoch is None
+    assert mgr.max_val_steps_per_epoch is None
+
+
+def test_val_every_n_below_one_is_rejected(tmp_path):
+    with pytest.raises(ValueError, match="--val-every-n must be >= 1"):
+        _resolve(tmp_path, {}, ["--val-every-n", "0"])


### PR DESCRIPTION
**In one sentence:** A training schedule written in the YAML `tr_config` (`max_epoch`, `max_steps_per_epoch`, `max_val_steps_per_epoch`, `val_every_n`, `early_stopping_patience`) is now what `vesuvius.train` actually runs, instead of being silently replaced by the CLI's argparse defaults.

**One real example:** Starting with the shipped `single_task/ps256_mednext_v1_medial.yaml` plus the schedule from #1489 (`max_epoch: 50, max_steps_per_epoch: 150, max_val_steps_per_epoch: 10, val_every_n: 2, early_stopping_patience: 15`), I resolved the config the way `vesuvius.train --config … --input … --format zarr` does (`build_parser().parse_args` → `ConfigManager.load_config` → `update_config_from_args`), and the trainer's schedule came out as the YAML values (`Epoch 1/50`, 150 steps) instead of `Epoch 1/1000`, 250 steps.

**Before:** `--max-epoch` (1000), `--max-steps-per-epoch` (250), `--max-val-steps-per-epoch` (50), `--val-every-n` (1) and `--early-stopping-patience` (0) had non-None argparse defaults, and the merge in `update_config_from_args` is `if args.max_epoch is not None: mgr.max_epoch = args.max_epoch`, so the default always won. The reporter lost an overnight run to a 20× schedule inflation on Dataset059 before noticing.

```
=== BEFORE (main 23adee0) ===
YAML tr_config     : {'max_epoch': 50, 'max_steps_per_epoch': 150, 'max_val_steps_per_epoch': 10, 'val_every_n': 2, 'early_stopping_patience': 15}
trainer will use   : {'max_epoch': 1000, 'max_steps_per_epoch': 250, 'max_val_steps_per_epoch': 50, 'val_every_n': 1, 'early_stopping_patience': 0}
progress bar would read: Epoch 1/1000  0/250 steps
```

**After this PR:**

```
=== AFTER ===
YAML tr_config     : {'max_epoch': 50, 'max_steps_per_epoch': 150, 'max_val_steps_per_epoch': 10, 'val_every_n': 2, 'early_stopping_patience': 15}
trainer will use   : {'max_epoch': 50, 'max_steps_per_epoch': 150, 'max_val_steps_per_epoch': 10, 'val_every_n': 2, 'early_stopping_patience': 15}
progress bar would read: Epoch 1/50  0/150 steps
```

An explicit flag still wins (`--max-epoch 7` → 7), and a config that sets no schedule at all still gets the previous CLI defaults (1000 / 250 / 50 / 1 / 0), so nobody's existing runs change length. `--help` now says which value applies when neither is set.

**Proof:** the two blocks above are the output of the same script run on `main` and on this branch (script in the Details). Tests: `tests/models/training/test_cli_schedule_defaults.py` (7 tests: flags default to None, YAML survives, flags override YAML, historical fallbacks, early-stopping, `--full-epoch` still clears the step limits, `--val-every-n 0` rejected). `tests/models/training` + `tests/models/configuration`: 114 passed, 1 skipped.

**Why / where this is useful:** anyone who keeps the training schedule in the config (which is where the shipped configs and the ink/surface recipes put everything else) gets the run they asked for. Short sweeps stop turning into 1000-epoch jobs.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Fixes #1489. Tested at `23adee0`, Python 3.14.

- `models/training/cli.py`: the five schedule flags get `default=None`; the parser construction is moved verbatim into `build_parser()` (main() calls it) so the merge can be exercised end to end in a test; the `val_every_n` block that lived in `main()` after `update_config_from_args` moves into `update_config_from_args` next to the other schedule keys.
- `models/utilities/cli_utils.py`: `CLI_SCHEDULE_DEFAULTS = {max_epoch: 1000, max_steps_per_epoch: 250, max_val_steps_per_epoch: 50}` — explicit flag → YAML value → this fallback. `val_every_n` and `early_stopping_patience` need no fallback because `ConfigManager` already defaults them to 1 and 0 when absent from the YAML.
- The resolution script used above builds the YAML from the shipped config, then runs `build_parser().parse_args([...])` / `ConfigManager.load_config` / `update_config_from_args` and prints `mgr.max_epoch` etc. — the same objects `BaseTrainer` reads to size its epoch loop and progress bar. I did not re-run the Dataset059 training job itself; the reported `Epoch 1/1000` line is `mgr.max_epoch`, which is what the script prints.

Written with Claude Code as a coding assistant, directed and reviewed by me.
