### PR TITLE
vesuvius: install the ink-detection stack on Windows

### DIFF
--- a/vesuvius/pyproject.toml
+++ b/vesuvius/pyproject.toml
@@ -265,3 +265,19 @@ volume-cartographer = { path = "../volume-cartographer", editable = true }
 cucim-cu13 = { index = "nvidia" }
 batchgeneratorsv2 = { path = "../segmentation/models/batchgeneratorsv2" }
 nnunetv2 = { path = "../segmentation/models/arch/nnunet" }
+# PyPI serves a CPU-only torch wheel on Windows, so `uv sync --extra models`
+# there ends with torch.cuda.is_available() False and the tutorial's own check
+# printing "cuda: False". Route torch to a CUDA index on Windows, the way
+# spiral-fitting/pyproject.toml already does for its own torch.
+#
+# Not cu128, which spiral-fitting uses: that index stops at torch 2.11 for
+# cp314/win_amd64, and this package requires >=2.12. cu126 and cu130 both
+# carry 2.12; cu130 matches the CUDA 13 line.
+torch = [
+    { index = "pytorch-cu130", marker = "sys_platform == 'win32'" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true

--- a/vesuvius/pyproject.toml
+++ b/vesuvius/pyproject.toml
@@ -57,10 +57,6 @@ models = [
     "timm>=1.0.20",
     "dynamic-network-architectures>=0.3.1",
     "nnunetv2",
-    # Monorepo-only C++ package (resolved via [tool.uv.sources]); provides the vc /
-    # vc3d bindings imported by vesuvius.neural_tracing. Not on PyPI, so it must stay
-    # out of the base dependencies to keep `pip install vesuvius[volume-only]` working.
-    "volume-cartographer",
     "numba>=0.60.0",
     "batchgenerators>=0.25.1",
     "batchgeneratorsv2",
@@ -92,6 +88,16 @@ models = [
     "cucim-cu13>=26.6; sys_platform == 'linux'",
 ]
 # Rendering and geometry utilities
+# The volume-cartographer Python bindings (vc / vc3d). Monorepo-only, resolved
+# via [tool.uv.sources]; there is no PyPI wheel, so installing this extra builds
+# a large C++ project and needs its full toolchain (CMake, Ceres, Boost, OpenCV).
+# Only vesuvius.neural_tracing imports it -- ink_detection and the rest of the
+# ML stack do not -- so it stays out of `models`, which is otherwise wheels only.
+# Same reasoning as #1442, one level further in.
+neural-tracing = [
+    "volume-cartographer",
+]
+
 render = [
     "trimesh>=4.8.2",
     "opencv-python-headless>=4.11.0.86",
@@ -151,7 +157,7 @@ all = [
     "numba>=0.60.0",
     "dynamic-network-architectures>=0.3.1",
     "nnunetv2",
-    "volume-cartographer",  # monorepo-only, see the note in [project.optional-dependencies.models]
+    "volume-cartographer",  # monorepo-only, see the note in [project.optional-dependencies.neural-tracing]
     "batchgenerators>=0.25.1",
     "batchgeneratorsv2",
     "einops>=0.8.1",

--- a/vesuvius/src/vesuvius/neural_tracing/inference/infer_rowcol_triplet_wraps.py
+++ b/vesuvius/src/vesuvius/neural_tracing/inference/infer_rowcol_triplet_wraps.py
@@ -11,7 +11,17 @@ from scipy import ndimage
 import torch
 import torch.nn.functional as F
 from tqdm import tqdm
-import vc
+try:
+    import vc
+except ImportError:  # pragma: no cover - optional dependency at runtime
+    vc = None
+
+_VC_MISSING = (
+    "this module reads volumes through the volume-cartographer bindings (vc), "
+    "which are not installed. They come with the `neural-tracing` extra, which "
+    "builds volume-cartographer from the monorepo and needs its C++ toolchain; "
+    "`models` alone does not pull them in."
+)
 
 try:
     import trimesh
@@ -129,6 +139,8 @@ class _VcVolumeLevel:
 
 
 def _open_vc_volume_level(volume_path, volume_scale, cache_dir, chunk_cache_gb):
+    if vc is None:
+        raise ImportError(_VC_MISSING)
     path = str(volume_path)
     cache_bytes = int(round(float(chunk_cache_gb) * (1024 ** 3)))
     vc.set_chunk_cache_budget(cache_bytes)

--- a/vesuvius/src/vesuvius/neural_tracing/winding_models/volume_slab_extractor.py
+++ b/vesuvius/src/vesuvius/neural_tracing/winding_models/volume_slab_extractor.py
@@ -7,7 +7,17 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-import vc
+try:
+    import vc
+except ImportError:  # pragma: no cover - optional dependency at runtime
+    vc = None
+
+_VC_MISSING = (
+    "this module reads volumes through the volume-cartographer bindings (vc), "
+    "which are not installed. They come with the `neural-tracing` extra, which "
+    "builds volume-cartographer from the monorepo and needs its C++ toolchain; "
+    "`models` alone does not pull them in."
+)
 
 
 @dataclass(frozen=True)
@@ -135,6 +145,8 @@ class VolumeSlabExtractor:
         return transform
 
     def _volume(self, volume_idx: int) -> vc.Volume:
+        if vc is None:
+            raise ImportError(_VC_MISSING)
         # DataLoader workers must not inherit another process's cache and I/O
         # thread pool, so handles are deliberately opened lazily per process.
         key = (os.getpid(), volume_idx)

--- a/vesuvius/src/vesuvius/neural_tracing/winding_models/winding_model_dataset.py
+++ b/vesuvius/src/vesuvius/neural_tracing/winding_models/winding_model_dataset.py
@@ -16,7 +16,11 @@ import numpy as np
 import scipy.ndimage
 import torch
 from skimage.restoration import unwrap_phase
-from vc.grid_raycast import GridRaycaster
+
+try:
+    from vc.grid_raycast import GridRaycaster
+except ImportError:  # pragma: no cover - optional dependency at runtime
+    GridRaycaster = None
 
 import vesuvius.tifxyz as tifxyz
 from vesuvius.neural_tracing.winding_models.volume_slab_extractor import (
@@ -26,6 +30,20 @@ from vesuvius.neural_tracing.winding_models.volume_slab_extractor import (
 from vesuvius.neural_tracing.winding_models.winding_targets import (
     render_column_targets_batched,
 )
+
+_VC_MISSING = (
+    "seeding a winding model casts rays through the volume-cartographer "
+    "bindings (vc), which are not installed. They come with the "
+    "`neural-tracing` extra, which builds volume-cartographer from the monorepo "
+    "and needs its C++ toolchain; `models` alone does not pull them in."
+)
+
+
+def _grid_raycaster(xyz, quads):
+    if GridRaycaster is None:
+        raise ImportError(_VC_MISSING)
+    return GridRaycaster(xyz, quads)
+
 
 _WINDING_NAME = re.compile(r"(?:^|-)w(?P<index>\d+)(?:_|$)")
 
@@ -494,7 +512,7 @@ class WindingModelDataset(torch.utils.data.Dataset):
         return Segment(
             winding_idx=winding_idx,
             xyz=xyz,
-            raycaster=GridRaycaster(xyz, valid_quads) if build_raycaster else None,
+            raycaster=_grid_raycaster(xyz, valid_quads) if build_raycaster else None,
             valid_quads=valid_quads,
             sample_cells=np.argwhere(valid_quads),
             vertex_turns=vertex_turns,
@@ -545,7 +563,7 @@ class WindingModelDataset(torch.utils.data.Dataset):
                 segment,
                 xyz=xyz,
                 valid_quads=quads,
-                raycaster=GridRaycaster(xyz, quads),
+                raycaster=_grid_raycaster(xyz, quads),
                 sample_cells=np.argwhere(quads),
             )
         return segment


### PR DESCRIPTION
**In one sentence:** You can skip WSL and run ink detection natively on Windows, end to end: `uv sync --extra models`, then `vesuvius.ink_detection.inference.infer` over a published surface volume, on a machine with no C++ toolchain.

**Motivation:** I wanted to use ink detection on native Windows, because WSL is awkward to use, especially when everything else in my workflow is already done natively on Windows. Following the pretrained ink workflow there, the install stopped before I could run anything. So I fixed this problem.

**One real example:** On a laptop with an RTX 4080, starting from a published PHerc0139 w043 surface volume, I followed the install line in the [pretrained ink workflow](https://scrollprize.org/tutorial5). `uv sync --extra models` stopped at `Could not find Ceres`, and uv named the cause itself: `volume-cartographer was included because vesuvius[models] depends on volume-cartographer`. With this PR the sync finishes, torch comes from the CUDA index, and inference runs over that volume to completion.

**Before:**

- `uv sync --extra models` exits 1 building volume-cartographer, which needs the C++ toolchain. `ink_detection` never imports `vc`; three `neural_tracing` modules do.
- Past that, torch installs as a CPU build, because PyPI marks its CUDA runtime packages `platform_system == "Linux"`. The verification command in the tutorial prints `cuda: False`.
- Those three modules import `vc` at module level (`inference/infer_rowcol_triplet_wraps.py`, `winding_models/volume_slab_extractor.py`, and `winding_models/winding_model_dataset.py`, the last as `from vc.grid_raycast import GridRaycaster`), so without the bindings they fail with `No module named 'vc'`, which does not tell the reader what to install.

**After this PR:**

- The volume-cartographer bindings move into their own `neural-tracing` extra, so `models` no longer pulls a C++ build in for people who only want to run a model. Anyone who does need the bindings adds `--extra neural-tracing`; the workflows in the docs that install `--extra models` do not touch them.
- On Windows torch comes from the CUDA index, the same way `spiral-fitting` already does it (#1584).
- All three modules import cleanly, and name the extra when the bindings are missing.

**Proof:**

1. I ran the install, then inference. Clean main stops on Ceres, and uv points at `vesuvius[models]`. This branch installs 160 packages, gets `torch 2.14.0+cu130` with CUDA, and runs inference over the w043 surface volume `[28, 6120, 8120]`: 11006 patches, exit 0, 25.4 MB written.

![install and inference before and after](https://raw.githubusercontent.com/7jycwjmbfn-eng/villa/pr-assets/shots_2026-09-04/shot5_ink.png)

2. I imported the three modules on a machine without the bindings. Clean main raises `No module named 'vc'` for all three. This branch imports all of them.

![vc imports before and after](https://raw.githubusercontent.com/7jycwjmbfn-eng/villa/pr-assets/shots_2026-09-04/shot2_guards.png)


**Why / where this is useful:** Anyone who wants to run a published ink model over their own segments on Windows can now do it without building a C++ toolchain first. It also finishes what #1442 started: that PR moved volume-cartographer out of the base dependencies for the same reason given in #1328, and this moves it out of `models`, which is where the ink workflow actually meets it.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

- The inference run above passes `--no-compile`. With the default, `torch.compile` reaches for triton, which PyTorch does not publish for Windows, and the run dies on the first forward. That is a separate problem in this repo and I have filed it on its own.
- The image that run produced has no legible letters in it. It used the default direction and depth window, so it shows the pipeline running, not a claim about ink on w043.
- No lockfile in this PR. Regenerating `vesuvius/uv.lock` on Windows rewrites a batch of CUDA package markers from `sys_platform == 'linux'` to unconditional, which is a multi-environment resolution artifact I cannot verify, so the relock should happen on Linux. Related: the committed lockfile is already stale against `pyproject.toml`, which is why #1442 never reached uv users; filed separately.

Tested on Windows 11, Python 3.14, RTX 4080 Laptop.

The screenshots were taken at `1ee7f94d3`; the branch is rebased onto `23adee047`, which only changes a default in `spiral-fitting/config.py`.
