### PR TITLE
ink-detection: optional geometry surface consistency post-processing for native OME-Zarr predictions

### DIFF
--- a/vesuvius/docs/ink_detection.md
+++ b/vesuvius/docs/ink_detection.md
@@ -520,6 +520,43 @@ volume because those determine the plan. Level 0 is a sparse uint8 Zarr-v2
 array in scroll Z/Y/X coordinates. Five rounded-mean levels are derived from
 it, producing a six-level OME-Zarr pyramid with ceil-halved shapes.
 
+### Post-processing: geometry surface consistency
+
+`vesuvius.ink_detection.postprocessing.surface_consistency` is an optional,
+label-free step for the native OME-Zarr prediction. For every voxel it keeps
+the maximum, over the three axis-aligned planes through it, of the local mean
+probability on a `(2r+1) x (2r+1)` window in that plane, so probability mass
+that is coherent within the papyrus sheet is preserved while isolated,
+off-sheet responses are attenuated. It processes only the chunks present in
+the source (with an `r` voxel halo), rebuilds the five coarser levels by the
+same rounded mean pooling, and writes the same six-level uint8 OME-Zarr
+layout, so the result opens wherever the original prediction does and the
+output support equals the input support.
+
+```bash
+uv run --extra models python -m vesuvius.ink_detection.postprocessing.surface_consistency \
+  /data/predictions/w035.ome.zarr \
+  /data/predictions/w035-gsc.ome.zarr \
+  --radius 2
+```
+
+| Argument | Meaning |
+|---|---|
+| `input_zarr output_zarr` | Native prediction pyramid in, same-layout pyramid out. |
+| `--radius` | Plane window half-size, default `2` (5x5 windows). |
+| `--levels` | Pyramid levels to write, default the input's. |
+| `--overwrite` | Replace an existing output; otherwise existing output is refused. |
+| `--receipt` | Optional JSON run receipt (paths, radius, chunk counts, seconds). |
+
+On public Scroll 1 data with the official `ckpt_78k_fullsup` native-3D
+checkpoint, eight sealed 256^3 windows of segment `w00_20231016151002` moved
+from mean cube AUC 0.703 to 0.788 (a rolled, misaligned control gives 0.639)
+and eight windows of `w01_20230702185753_r15` from 0.714 to 0.769; the receipts,
+before/after panels and the standalone tool live at
+https://github.com/danilolapegna/vesuvius-geometry-surface-consistency. The
+transform raises the ranking quality of the soft volume; thresholds downstream
+still need their own calibration.
+
 ## Labeling loop
 
 1. Train from Zarr labels and a surface volume.

--- a/vesuvius/src/vesuvius/ink_detection/README.md
+++ b/vesuvius/src/vesuvius/ink_detection/README.md
@@ -163,6 +163,19 @@ six-level uint8 OME-Zarr pyramid in scroll coordinates. Label conversion writes
 preparer writes one `(21,Y,X)` array tagged `level2-zmean4-21slice-v1` and
 refuses to overwrite either a destination or its `.partial` path.
 
+Optional post-processing for native predictions:
+
+```bash
+uv run --extra models python -m vesuvius.ink_detection.postprocessing.surface_consistency \
+  /data/predictions/w035.ome.zarr \
+  /data/predictions/w035-gsc.ome.zarr
+```
+
+This keeps, per voxel, the strongest of the three axis-aligned local plane
+means, which preserves in-sheet probability mass and attenuates isolated
+off-sheet responses; it reads and writes the same sparse six-level OME-Zarr
+layout. See `docs/ink_detection.md` for the evidence and arguments.
+
 ## Labeling loop
 
 Train, infer, inspect the probability TIFF, extend the segment's ink and

--- a/vesuvius/src/vesuvius/ink_detection/postprocessing/__init__.py
+++ b/vesuvius/src/vesuvius/ink_detection/postprocessing/__init__.py
@@ -1,0 +1,1 @@
+"""Post-processing steps applied to ink-detection probability volumes."""

--- a/vesuvius/src/vesuvius/ink_detection/postprocessing/surface_consistency.py
+++ b/vesuvius/src/vesuvius/ink_detection/postprocessing/surface_consistency.py
@@ -1,0 +1,236 @@
+"""Geometry surface consistency: label-free sheet-coherence post-processing for 3D ink
+probability volumes.
+
+For every voxel the output is the maximum, over the three axis-aligned planes through it, of the
+mean probability on a ``(2r+1) x (2r+1)`` window in that plane. Ink lives on a thin papyrus
+sheet, so probability mass that is coherent within a plane is preserved while isolated,
+off-sheet responses are attenuated. The transform is deterministic, needs no labels or
+retraining, and is orientation-robust across the three voxel axes.
+
+The CLI consumes the sparse six-level uint8 OME-Zarr written by
+``vesuvius.ink_detection.inference.infer_full3d_tifxyz`` and writes a pyramid with the same
+shape, chunking, dtype and multiscale metadata. Only chunks present in the source are processed
+(with a ``radius`` halo read from their neighbours, missing neighbours are zero) and coarser
+levels are rebuilt by the same 2x mean pooling, so a whole-segment prediction never has to fit
+in memory and the output support equals the input support.
+
+Blind evidence on public Scroll 1 data (official ``ckpt_78k_fullsup`` native-3D checkpoint, eight
+sealed 256^3 windows of segment w00_20231016151002): mean cube AUC 0.703 -> 0.788 with a
+rolled-volume control at 0.639; second segment w01_20230702185753_r15: 0.714 -> 0.769.
+See https://github.com/danilolapegna/vesuvius-geometry-surface-consistency (MIT).
+
+Usage::
+
+    python -m vesuvius.ink_detection.postprocessing.surface_consistency \\
+        /data/predictions/w035.ome.zarr /data/predictions/w035-gsc.ome.zarr --radius 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import re
+import time
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from numcodecs import Blosc
+from scipy.ndimage import uniform_filter
+import zarr
+
+from vesuvius.label_zarr import ARRAY_DIMENSIONS, create_v2_array, open_v2_group
+
+_CHUNK_KEY = re.compile(r"^(\d+)[./](\d+)[./](\d+)$")
+_COMPRESSOR = Blosc(cname="zstd", clevel=3, shuffle=Blosc.BITSHUFFLE)
+
+
+def enhance(probability: np.ndarray, radius: int = 2) -> np.ndarray:
+    """Return, per voxel, the maximum of the local plane means (XY, XZ, YZ) around it.
+
+    ``probability`` must be a finite 3D array in Z-Y-X order with values in ``[0, 1]``;
+    ``radius`` >= 1 sets the window half-size. The output is float32 with the same shape.
+    """
+
+    value = np.asarray(probability, dtype=np.float32)
+    if value.ndim != 3:
+        raise ValueError("probability must be a 3D array (Z, Y, X)")
+    if radius < 1:
+        raise ValueError("radius must be >= 1")
+    if not np.isfinite(value).all():
+        raise ValueError("probability contains non-finite values")
+    width = 2 * radius + 1
+    xy = uniform_filter(value, size=(1, width, width), mode="nearest")
+    xz = uniform_filter(value, size=(width, 1, width), mode="nearest")
+    yz = uniform_filter(value, size=(width, width, 1), mode="nearest")
+    return np.maximum(np.maximum(xy, xz), yz)
+
+
+def to_unit(array: np.ndarray) -> np.ndarray:
+    """Return ``array`` as float32 in ``[0, 1]``; integer dtypes are divided by their maximum."""
+
+    array = np.asarray(array)
+    if np.issubdtype(array.dtype, np.integer):
+        return array.astype(np.float32) / float(np.iinfo(array.dtype).max)
+    return array.astype(np.float32, copy=False)
+
+
+def encode_uint8(array: np.ndarray) -> np.ndarray:
+    """Encode ``[0, 1]`` probabilities the way the native writer does (round to 0..255)."""
+
+    return np.rint(np.clip(array, 0.0, 1.0) * 255.0).astype(np.uint8)
+
+
+def downsample_mean_3d(block: np.ndarray) -> np.ndarray:
+    """Mean-pool a ZYX block by two (ceil shapes) and round back to the block dtype."""
+
+    block = np.asarray(block)
+    output_shape = tuple((value + 1) // 2 for value in block.shape)
+    total = np.zeros(output_shape, dtype=np.float64)
+    count = np.zeros(output_shape, dtype=np.float64)
+    for offsets in itertools.product((0, 1), repeat=3):
+        sample = block[offsets[0] :: 2, offsets[1] :: 2, offsets[2] :: 2]
+        if sample.size:
+            slices = tuple(slice(0, value) for value in sample.shape)
+            total[slices] += sample
+            count[slices] += 1.0
+    pooled = total / np.maximum(count, 1.0)
+    if np.issubdtype(block.dtype, np.integer):
+        return np.ascontiguousarray(np.rint(pooled).astype(block.dtype))
+    return np.ascontiguousarray(pooled.astype(block.dtype))
+
+
+def multiscale_paths(group) -> list[str]:
+    """Dataset paths of the first multiscale in resolution order (finest first)."""
+
+    attrs = dict(group.attrs)
+    if "multiscales" not in attrs:
+        raise ValueError("input group carries no OME-NGFF multiscales metadata")
+    return [str(entry["path"]) for entry in attrs["multiscales"][0]["datasets"]]
+
+
+def occupied_chunks(array, array_dir: Path | None) -> list[tuple[int, int, int]]:
+    """Chunk indices that hold data: from the on-disk store listing when available, otherwise
+    by testing every chunk for a non-zero voxel."""
+
+    grid = tuple(-(-int(s) // int(c)) for s, c in zip(array.shape, array.chunks))
+    if array_dir is not None and array_dir.is_dir():
+        found = set()
+        for entry in array_dir.rglob("*"):
+            if not entry.is_file():
+                continue
+            match = _CHUNK_KEY.match(entry.relative_to(array_dir).as_posix())
+            if match:
+                index = tuple(int(match.group(i)) for i in (1, 2, 3))
+                if all(index[axis] < grid[axis] for axis in range(3)):
+                    found.add(index)
+        return sorted(found)
+    result = []
+    for index in itertools.product(*(range(g) for g in grid)):
+        bounds = tuple(
+            slice(index[axis] * int(array.chunks[axis]), min(int(array.shape[axis]), (index[axis] + 1) * int(array.chunks[axis])))
+            for axis in range(3)
+        )
+        if np.any(np.asarray(array[bounds])):
+            result.append(index)
+    return result
+
+
+def create_pyramid(output_path: Path, shape_zyx, chunks_zyx, levels: int):
+    """Create a Zarr-v2 OME pyramid with the native writer's layout and return its arrays."""
+
+    from vesuvius.ink_detection.inference.infer_full3d_tifxyz import multiscales_metadata, pyramid_shapes
+
+    group = open_v2_group(output_path)
+    group.attrs.update(multiscales_metadata(output_path.stem, levels))
+    arrays = []
+    for level, shape in enumerate(pyramid_shapes(tuple(int(v) for v in shape_zyx), levels)):
+        chunks = tuple(min(int(chunks_zyx[axis]), shape[axis]) for axis in range(3))
+        array = create_v2_array(
+            group, str(level), shape=shape, chunks=chunks, dtype=np.uint8, compressor=_COMPRESSOR, fill_value=0
+        )
+        array.attrs["_ARRAY_DIMENSIONS"] = ARRAY_DIMENSIONS
+        arrays.append(array)
+    return arrays
+
+
+def enhance_pyramid(input_path: Path, output_path: Path, *, radius: int = 2, levels: int | None = None) -> dict:
+    """Sparse, chunk-wise enhancement of a native prediction pyramid into a new pyramid."""
+
+    source = zarr.open(str(input_path), mode="r")
+    paths = multiscale_paths(source)
+    finest = source[paths[0]]
+    level_count = int(levels or len(paths))
+    chunks = tuple(int(c) for c in finest.chunks)
+    shape = tuple(int(s) for s in finest.shape)
+    arrays = create_pyramid(Path(output_path), shape, chunks, level_count)
+    occupied = occupied_chunks(finest, Path(input_path) / paths[0])
+    for index in occupied:
+        starts = [index[axis] * chunks[axis] for axis in range(3)]
+        stops = [min(shape[axis], starts[axis] + chunks[axis]) for axis in range(3)]
+        lo = [max(0, starts[axis] - radius) for axis in range(3)]
+        hi = [min(shape[axis], stops[axis] + radius) for axis in range(3)]
+        block = to_unit(np.asarray(finest[lo[0] : hi[0], lo[1] : hi[1], lo[2] : hi[2]]))
+        enhanced = enhance(block, radius)
+        core = enhanced[
+            starts[0] - lo[0] : starts[0] - lo[0] + (stops[0] - starts[0]),
+            starts[1] - lo[1] : starts[1] - lo[1] + (stops[1] - starts[1]),
+            starts[2] - lo[2] : starts[2] - lo[2] + (stops[2] - starts[2]),
+        ]
+        arrays[0][starts[0] : stops[0], starts[1] : stops[1], starts[2] : stops[2]] = encode_uint8(core)
+    touched: Iterable[tuple[int, int, int]] = set(occupied)
+    for level in range(1, level_count):
+        previous, current = arrays[level - 1], arrays[level]
+        previous_chunks = tuple(int(c) for c in previous.chunks)
+        next_touched = set()
+        for index in sorted(touched):
+            starts = [index[axis] * previous_chunks[axis] for axis in range(3)]
+            stops = [min(int(previous.shape[axis]), starts[axis] + previous_chunks[axis]) for axis in range(3)]
+            if any(stops[axis] <= starts[axis] for axis in range(3)):
+                continue
+            pooled = downsample_mean_3d(np.asarray(previous[starts[0] : stops[0], starts[1] : stops[1], starts[2] : stops[2]]))
+            target = [starts[axis] // 2 for axis in range(3)]
+            current[
+                target[0] : target[0] + pooled.shape[0],
+                target[1] : target[1] + pooled.shape[1],
+                target[2] : target[2] + pooled.shape[2],
+            ] = pooled
+            next_touched.add(tuple(target[axis] // int(current.chunks[axis]) for axis in range(3)))
+        touched = next_touched
+    return {"levels": level_count, "occupied_chunks": len(occupied), "chunks": list(chunks), "shape": list(shape)}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("input_zarr", type=Path, help="native prediction OME-Zarr written by infer_full3d_tifxyz")
+    parser.add_argument("output_zarr", type=Path, help="destination OME-Zarr (same layout)")
+    parser.add_argument("--radius", type=int, default=2, help="plane window half-size (default 2 -> 5x5)")
+    parser.add_argument("--levels", type=int, default=None, help="pyramid levels to write (default: as input)")
+    parser.add_argument("--overwrite", action="store_true", help="replace an existing output")
+    parser.add_argument("--receipt", type=Path, default=None, help="optional JSON run receipt")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.output_zarr.exists() and not args.overwrite:
+        raise FileExistsError(f"Output already exists: {args.output_zarr}")
+    started = time.time()
+    info = enhance_pyramid(args.input_zarr, args.output_zarr, radius=args.radius, levels=args.levels)
+    receipt = {
+        "input": str(args.input_zarr),
+        "output": str(args.output_zarr),
+        "radius": args.radius,
+        "seconds": round(time.time() - started, 3),
+        **info,
+    }
+    if args.receipt is not None:
+        args.receipt.parent.mkdir(parents=True, exist_ok=True)
+        args.receipt.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vesuvius/tests/ink_detection/test_surface_consistency.py
+++ b/vesuvius/tests/ink_detection/test_surface_consistency.py
@@ -1,0 +1,102 @@
+"""Geometry surface consistency post-processing: transform properties and sparse pyramid parity."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import zarr
+
+from vesuvius.ink_detection.postprocessing import surface_consistency as gsc
+
+
+def test_sheet_is_kept_and_isolated_voxel_is_attenuated():
+    volume = np.zeros((16, 16, 16), dtype=np.float32)
+    volume[8, :, :] = 1.0
+    volume[2, 2, 2] = 1.0
+    out = gsc.enhance(volume, radius=2)
+    assert out.shape == volume.shape and out.dtype == np.float32
+    assert np.isclose(out[8, 8, 8], 1.0)
+    assert out[2, 2, 2] < 0.3
+
+
+def test_orientation_robust_across_axes():
+    base = np.zeros((16, 16, 16), dtype=np.float32)
+    base[8, :, :] = 1.0
+    for axes in ((0, 1, 2), (1, 0, 2), (2, 1, 0)):
+        volume = np.transpose(base, axes)
+        out = gsc.enhance(volume, radius=2)
+        assert np.isclose(out.max(), 1.0) and np.isclose(out[volume == 1.0].min(), 1.0)
+
+
+def test_rejects_bad_input():
+    with pytest.raises(ValueError):
+        gsc.enhance(np.zeros((4, 4), dtype=np.float32))
+    with pytest.raises(ValueError):
+        gsc.enhance(np.zeros((4, 4, 4), dtype=np.float32), radius=0)
+    bad = np.zeros((4, 4, 4), dtype=np.float32)
+    bad[0, 0, 0] = np.nan
+    with pytest.raises(ValueError):
+        gsc.enhance(bad)
+
+
+def test_uint8_round_trip_matches_native_encoding():
+    assert np.isclose(gsc.to_unit(np.array([[[255]]], dtype=np.uint8))[0, 0, 0], 1.0)
+    assert gsc.encode_uint8(np.array([[[0.5]]], dtype=np.float32))[0, 0, 0] == 128
+
+
+def _native_style_pyramid(tmp_path, shape=(20, 30, 40), chunks=(8, 16, 16), levels=3):
+    rng = np.random.default_rng(7)
+    dense = np.zeros(shape, dtype=np.float32)
+    dense[2:12, 4:20, 3:30] = rng.random((10, 16, 27), dtype=np.float32)
+    dense[15, 20:28, 30:38] = 1.0
+    encoded = gsc.encode_uint8(dense)
+    path = tmp_path / "prediction.ome.zarr"
+    arrays = gsc.create_pyramid(path, shape, chunks, levels)
+    arrays[0][:] = encoded
+    level = encoded
+    for index in range(1, levels):
+        level = gsc.downsample_mean_3d(level)
+        arrays[index][:] = level
+    return path, encoded
+
+
+def test_sparse_pyramid_matches_dense_transform_and_keeps_support(tmp_path):
+    path, encoded = _native_style_pyramid(tmp_path)
+    out = tmp_path / "enhanced.ome.zarr"
+    info = gsc.enhance_pyramid(path, out, radius=2)
+    source = zarr.open(str(path), mode="r")
+    result = zarr.open(str(out), mode="r")
+    assert gsc.multiscale_paths(result) == ["0", "1", "2"]
+    assert tuple(result["0"].chunks) == tuple(source["0"].chunks)
+    assert result["0"].dtype == np.uint8
+
+    got = np.asarray(result["0"])
+    expected = gsc.encode_uint8(gsc.enhance(encoded.astype(np.float32) / 255.0, 2))
+    chunks = tuple(int(c) for c in source["0"].chunks)
+    mask = np.zeros(encoded.shape, dtype=bool)
+    occupied = gsc.occupied_chunks(source["0"], path / "0")
+    assert info["occupied_chunks"] == len(occupied) > 0
+    for index in occupied:
+        mask[tuple(slice(index[a] * chunks[a], (index[a] + 1) * chunks[a]) for a in range(3))] = True
+    assert np.array_equal(got[mask], expected[mask])
+    assert not got[~mask].any()
+    assert np.array_equal(np.asarray(result["1"]), gsc.downsample_mean_3d(got))
+    assert np.array_equal(np.asarray(result["2"]), gsc.downsample_mean_3d(gsc.downsample_mean_3d(got)))
+
+
+def test_occupied_chunks_listing_matches_brute_force(tmp_path):
+    path, _ = _native_style_pyramid(tmp_path)
+    array = zarr.open(str(path), mode="r")["0"]
+    listed = gsc.occupied_chunks(array, path / "0")
+    assert listed == gsc.occupied_chunks(array, None) and listed
+
+
+def test_cli_writes_receipt_and_refuses_overwrite(tmp_path):
+    path, _ = _native_style_pyramid(tmp_path)
+    out = tmp_path / "cli.ome.zarr"
+    receipt = tmp_path / "receipt.json"
+    assert gsc.main([str(path), str(out), "--receipt", str(receipt)]) == 0
+    assert receipt.exists()
+    with pytest.raises(FileExistsError):
+        gsc.main([str(path), str(out)])
+    assert gsc.main([str(path), str(out), "--overwrite"]) == 0


### PR DESCRIPTION
**In one sentence:** After the native 3D ink model has written its OME-Zarr prediction, one command makes the probability map coherent along the papyrus sheet, and the result opens in VC3D exactly like the original.

**One real example:** Starting with the official `ckpt_78k_fullsup` native-3D checkpoint's prediction for a 256^3 window of public Scroll 1 segment `w02_20231031143852` (window origin z=38716, y=12328, x=19597; prediction written into the standard six-level uint8 OME-Zarr layout with this repo's `create_output_zarr` and `downsample_mean_3d`), I ran

```
python -m vesuvius.ink_detection.postprocessing.surface_consistency w02-pred.ome.zarr w02-gsc.ome.zarr --radius 2 --receipt gsc.json
```

and it processed the 27 occupied chunks in 1.3 s on CPU, wrote the same six-level layout, and moved the AUC against the public ink labels at the 144 labelled surface points of that window from 0.705 to 0.793.

**Before:** The raw probability volume carries isolated off-sheet responses (speckle) next to the real in-sheet signal, and there is no step in the pipeline between the native prediction and thresholding or rendering.

**After this PR:** An optional, label-free, deterministic step keeps for every voxel the strongest of the three axis-aligned local 5x5 plane means, so in-sheet probability mass is preserved and off-sheet speckle is attenuated. It reads the sparse six-level uint8 OME-Zarr that `infer_full3d_tifxyz` writes, processes only the chunks present in the source (with a halo), rebuilds the coarser levels with the same rounded mean pooling and writes the same layout. Nothing is written outside chunks the model already wrote.

**Proof:** The example above (receipt with the exact command, chunk counts, per-point scores) plus the standalone evaluation of the same transform: eight sealed 256^3 windows of `w00_20231016151002`, mean cube AUC 0.703 -> 0.788 with a rolled-volume control at 0.639 (so the gain is geometric, not smoothing); eight windows of `w01_20230702185753_r15`, 0.714 -> 0.769; before/after XY/XZ/YZ panels for all eight blind windows. Receipts and panels: https://github.com/danilolapegna/vesuvius-geometry-surface-consistency (MIT). Look at the panels: the sheet becomes a continuous band while the speckle around it fades.

**Why / where this is useful:** Anyone producing native-3D predictions for reading, rendering or label transfer gets a cleaner soft volume in seconds on CPU without retraining; thresholds downstream still need their own calibration.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

- Module: `vesuvius/src/vesuvius/ink_detection/postprocessing/surface_consistency.py` (CLI via `python -m ...`); docs in `vesuvius/docs/ink_detection.md` and the package README; tests in `vesuvius/tests/ink_detection/test_surface_consistency.py` (transform properties, uint8 round trip, sparse pyramid parity with the dense transform inside occupied chunks, support preservation, chunk listing, CLI receipt/overwrite). `pytest tests/ink_detection/test_surface_consistency.py`: 7 passed.
- Branch based on `origin/main` 739eefd; the standalone tool (v1.1.0, commit 854cf91) carries the same `enhance` function.
- The real example was produced on this machine (Apple Silicon, CPU) by the commands in the receipt; on macOS the `infer_full3d_tifxyz` DataLoader workers wrote an empty store for me, so the prediction for the example window was produced with `predict_batch` from this repo and stored with this repo's writer.
- Limitations: the three axis-aligned planes approximate the local sheet normal, so a strongly tilted sheet benefits less than an axis-aligned one; a normal-aware variant using the surface mesh is the natural next step. Evidence is on Scroll 1 (PHerc. Paris 4) only.
- About how this was made: this comes out of my lab's work on ink detection; the code was written with AI assistance under my direction, the evaluation protocol (sealed windows, separated oracle, negative control) is ours, and every number above is read from the raw receipt files, not from a summary. Happy to turn this into a flag inside `infer_full3d_tifxyz` instead of a separate step if you prefer.
