### PR TITLE
vesuvius: make every scroll in scrolls.yaml reachable by its canonical scan (#1652)

### DIFF
--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -1126,7 +1126,7 @@ class Volume:
 
         resolution_mapping = {
             "1": 7.91, "1b": 7.91, "2": 7.91, "2b": 7.91, "2c": 7.91,
-            "3": 3.24, "4": 3.24, "5": 7.91
+            "3": 7.91, "4": 3.24, "5": 7.91
         }
         return resolution_mapping.get(scroll_id_key)
 

--- a/vesuvius/src/vesuvius/install/configs/scrolls.yaml
+++ b/vesuvius/src/vesuvius/install/configs/scrolls.yaml
@@ -13,6 +13,12 @@
       segments:
         "20230827161847": "https://dl.ash2txt.org/other/dev/scrolls/1/segments/54keV_7.91um/20230827161847.zarr/"
 
+# Scroll 1B
+"1b":
+  "54":
+    "7.91":
+      volume: "https://dl.ash2txt.org/full-scrolls/Scroll1/PHercParis4.volpkg/volumes_zarr_standardized/54keV_7.91um_Scroll1B.zarr/"
+
 # Scroll 2 - tested 03/24/25
 "2":
   "54":
@@ -30,6 +36,9 @@
   "53":
     "7.91":
       volume: "https://dl.ash2txt.org/full-scrolls/Scroll4/PHerc1667.volpkg/volumes_zarr/20231117161658.zarr/"
+  "88":
+    "3.24":
+      volume: "https://dl.ash2txt.org/full-scrolls/Scroll4/PHerc1667.volpkg/volumes_zarr/20231107190228.zarr/"
 
 # Scroll 5 - tested 03/24/25
 "5":

--- a/vesuvius/tests/data/test_scroll_config.py
+++ b/vesuvius/tests/data/test_scroll_config.py
@@ -1,0 +1,28 @@
+"""The canonical energy/resolution defaults must key into the shipped scrolls.yaml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from vesuvius.data import volume as volume_module
+from vesuvius.data.volume import Volume
+
+CONFIG = Path(volume_module.__file__).resolve().parents[1] / "install" / "configs" / "scrolls.yaml"
+SCROLLS = yaml.safe_load(CONFIG.read_text())
+
+
+@pytest.mark.parametrize("scroll_id", sorted(SCROLLS))
+def test_canonical_defaults_resolve_to_a_volume(scroll_id: str) -> None:
+    """Volume(type="scroll", scroll_id=X) leaves energy/resolution to the canonical
+    maps, so every scroll the config lists must be reachable through them."""
+    vol = Volume.__new__(Volume)
+    vol.scroll_id = scroll_id
+    energy = vol.grab_canonical_energy()
+    resolution = vol.grab_canonical_resolution()
+    assert energy is not None and resolution is not None, f"no canonical scan for scroll {scroll_id}"
+
+    url = SCROLLS[scroll_id].get(str(energy), {}).get(str(resolution), {}).get("volume")
+    assert url, f"scroll {scroll_id}: canonical {energy} keV / {resolution} um is not in scrolls.yaml"


### PR DESCRIPTION
Closes #1652.

**In one sentence:** `Volume(type="scroll1b")`, `Volume(type="scroll", scroll_id=3)` and `Volume(type="scroll", scroll_id=4)` raise instead of opening a volume; this makes them open.

**One real example:** I was walking the published scroll volumes with the `Volume` loader, opening each one by scroll id so I could compare intensity statistics across scans without hard-coding URLs. Three of those calls never reached the data.

**Before** (commit 739eefd, `dl.ash2txt.org`, no credentials):

```
$ cat check_scrolls.py
import numpy as np
from vesuvius.data.volume import Volume

for label, kw in [
    ('Volume(type="scroll1b")', dict(type="scroll1b")),
    ('Volume(type="scroll", scroll_id=3)', dict(type="scroll", scroll_id=3)),
    ('Volume(type="scroll", scroll_id=4)', dict(type="scroll", scroll_id=4)),
    ('Volume(type="scroll", scroll_id=4, energy=88, resolution=3.24)',
     dict(type="scroll", scroll_id=4, energy=88, resolution=3.24)),
]:
    print("\n>>>", label)
    v = Volume(**kw)
    z, y, x = (s // 2 for s in v.shape(0))
    p = np.asarray(v[z, y:y + 64, x:x + 64])
    print(f"    {v.url}")
    print(f"    shape {tuple(v.shape(0))} dtype {v.dtype}")
    print(f"    patch {p.shape} {p.dtype} min={p.min()} max={p.max()} mean={p.mean():.1f}")

$ python check_scrolls.py

>>> Volume(type="scroll1b")
Error reading or parsing config file /private/tmp/villa/main/vesuvius/install/configs/scrolls.yaml: URL not found in config for scroll=1b, energy=54, resolution=7.91
ERROR initializing Volume: URL not found in config for scroll=1b, energy=54, resolution=7.91
Common issues:
- Ensure Zarr path is correct and accessible if using direct path.
- Ensure config file exists and contains entries for the requested scroll/segment/energy/resolution.
- Check network connection if accessing remote data.

Example Usage:
  volume = Volume(type="scroll", scroll_id=1)
  segment = Volume(type="segment", segment_id=20230827161847)
  zarr_vol = Volume(type="zarr", path="/path/to/my/data.zarr")
Traceback (most recent call last):
  File "/private/tmp/villa/check_scrolls.py", line 12, in <module>
    v = Volume(**kw)
  File "/private/tmp/villa/main/vesuvius/data/volume.py", line 341, in __init__
    self.url = self.get_url_from_yaml()  # This sets self.url based on type, scroll, energy, res
               ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/private/tmp/villa/main/vesuvius/data/volume.py", line 572, in get_url_from_yaml
    raise ValueError(
        f"URL not found in config for scroll={self.scroll_id}, energy={self.energy}, resolution={self.resolution}")
ValueError: URL not found in config for scroll=1b, energy=54, resolution=7.91
```

It stops on the first one, so here are all four, catching the error to keep going:

```
{'type': 'scroll1b'}                                           ValueError: URL not found in config for scroll=1b, energy=54, resolution=7.91
{'type': 'scroll', 'scroll_id': 3}                             ValueError: URL not found in config for scroll=3, energy=53, resolution=3.24
{'type': 'scroll', 'scroll_id': 4}                             ValueError: URL not found in config for scroll=4, energy=88, resolution=3.24
{'type': 'scroll', 'scroll_id': 4, 'energy': 88, 'resolution': 3.24} ValueError: URL not found in config for scroll=4, energy=88, resolution=3.24
```

The cause is a disagreement between two files. `data/volume.py` holds the per-scroll defaults used when the caller gives no energy or resolution:

```python
energy_mapping     = {"1": 54, "1b": 54, "2": 54, "2b": 54, "2c": 88, "3": 53, "4": 88, "5": 53}
resolution_mapping = {"1": 7.91, "1b": 7.91, "2": 7.91, "2b": 7.91, "2c": 7.91, "3": 3.24, "4": 3.24, "5": 7.91}
```

`scrolls.yaml` has no `"1b"` key, nothing at `88`/`3.24` under `"4"`, and nothing at `3.24` under `"3"`. The defaults name keys the shipped config does not contain.

**After this PR** — same script, same volumes, each call reading a 64x64 patch from the middle of level 0:

```
$ python check_scrolls.py

>>> Volume(type="scroll1b")
    https://dl.ash2txt.org/full-scrolls/Scroll1/PHercParis4.volpkg/volumes_zarr_standardized/54keV_7.91um_Scroll1B.zarr/
    shape (10532, 7812, 8316) dtype uint8
    patch (64, 64) uint8 min=0 max=216 mean=84.0

>>> Volume(type="scroll", scroll_id=3)
    https://dl.ash2txt.org/full-scrolls/Scroll3/PHerc332.volpkg/volumes_zarr_standardized/53keV_7.91um_Scroll3.zarr/
    shape (9778, 3550, 3400) dtype uint8
    patch (64, 64) uint8 min=0 max=248 mean=61.7

>>> Volume(type="scroll", scroll_id=4)
    https://dl.ash2txt.org/full-scrolls/Scroll4/PHerc1667.volpkg/volumes_zarr/20231107190228.zarr/
    shape (26391, 7960, 8120) dtype uint16
    patch (64, 64) uint16 min=3046 max=55021 mean=22361.4

>>> Volume(type="scroll", scroll_id=4, energy=88, resolution=3.24)
    https://dl.ash2txt.org/full-scrolls/Scroll4/PHerc1667.volpkg/volumes_zarr/20231107190228.zarr/
    shape (26391, 7960, 8120) dtype uint16
    patch (64, 64) uint16 min=3046 max=55021 mean=22361.4
```

**Proof:** each `patch` line is 4096 voxels actually fetched from level 0, not metadata. `scroll1b` gives `(10532, 7812, 8316)`, the shape of `54keV_7.91um_Scroll1B.zarr`, and not of the `Scroll1A` already in the config, `(14376, 7888, 8096)`. Nothing that worked before changed, on the same commit pair:

```
{'type': 'scroll', 'scroll_id': 1, 'energy': 54, 'resolution': 7.91} OK  (14376, 7888, 8096)
{'type': 'scroll', 'scroll_id': 2, 'energy': 54, 'resolution': 7.91} OK  (14428, 10112, 11984)
{'type': 'scroll', 'scroll_id': 3, 'energy': 53, 'resolution': 7.91} OK  (9778, 3550, 3400)
{'type': 'scroll', 'scroll_id': 4, 'energy': 53, 'resolution': 7.91} OK  (11174, 3340, 3440)
{'type': 'scroll', 'scroll_id': 5, 'energy': 53, 'resolution': 7.91} OK  (21000, 6700, 9100)
{'type': '20230827161847'}                                           OK  (65, 9163, 5048)
```

The last line matters because `find_segment_details()` walks every top-level key of `scrolls.yaml`; the new `"1b"` key does not disturb it.

**Why / where this is useful:** anyone picking volumes by scroll instead of by URL. `Volume(type="scroll", scroll_id=3)` and `scroll_id=4` are the form the docs use and both raise today, and Scroll 1B has no name in the package at all even though `volume.py`'s own comment gives `"scroll1b"` as an example input.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

### Motivation

Comparing intensity statistics across the published scans, opening each scroll by identity rather than by URL. Two scrolls would not open with their default scan and the second Scroll 1 volume could not be named. That is #1652 plus the scroll 3 default, which is the same disagreement between the canonical maps and the config.

### What changed

`install/configs/scrolls.yaml`

- New `"1b"` -> `54` -> `7.91` for `54keV_7.91um_Scroll1B.zarr`. `volume.py` already parses non-numeric scroll ids; only the config entry was missing.
- New `88` -> `3.24` under `"4"` for `20231107190228.zarr`. Its `meta.json` reads `"PHerc1667, 88 keV, 3.24 um, merged volume"` with `voxelsize: 3.24`, so the keys match what the volume declares. The existing `53`/`7.91` entry is untouched.

`data/volume.py`

- One value, `resolution_mapping["3"]`, from `3.24` to `7.91`. `PHerc332.volpkg/volumes_zarr_standardized/` contains exactly one entry, `53keV_7.91um_Scroll3.zarr`, and there is no `volumes_zarr/` beside it; the 3.24 um scans of that scroll exist only as TIFF under `volumes/`. So `3.24` cannot resolve for scroll 3, and this makes the default agree with the only volume there is.

`tests/data/test_scroll_config.py` (new, offline)

- Asserts every scroll in `scrolls.yaml` is reachable through its canonical energy and resolution. Fails on `main` for scroll 3 and scroll 4, passes here. Same invariant that broke in #1581.

```
$ python -m pytest tests/data -q --ignore=tests/data/test_vc_dataset_bbox.py
54 passed, 1 skipped, 8 warnings in 1.09s
```

(`test_vc_dataset_bbox.py` needs `torch`, which is not in the volume-only venv I used, and it does not touch this code.)

### What I did not change

- **`2b` and `2c`.** Both are in the canonical maps and neither is in the config, so `Volume(type="scroll2b")` still raises. `PHercParis3.volpkg/volumes_zarr_standardized/` publishes only `54keV_7.91um_Scroll2A.zarr`, so there is no URL to add and guessing one would be worse than the current error.
- **Which scan is canonical for scroll 4.** The default now resolves to the 88 keV / 3.24 um volume, because that is what `energy_mapping` and `resolution_mapping` already said. I did not touch those two entries. If you would rather the default stay at `20231117161658`, say so and I will change the maps instead.

### Environment

macOS 26.5.2 arm64, Python 3.14.6, `uv` venv from `vesuvius/pyproject.toml` (base dependencies), branched from `739eefd`. All reads are anonymous HTTPS against `dl.ash2txt.org`.

### Disclosure

I used Claude Code for the investigation and the patch, under my direction, and I read the diff and re-ran everything above myself. Why I think it is worth your review: the loader's own defaults point at entries the shipped config does not have, so the simplest documented call fails for two scrolls and a published volume has no name in the package. The fix is three config lines and one number.
