### PR TITLE
zarr_tasks: recompress in place under zarr 3 (fixes #1670)

### DIFF
--- a/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
+++ b/vesuvius/src/vesuvius/image_proc/run/zarr_tasks/tasks/recompress.py
@@ -19,6 +19,7 @@ from numcodecs import Blosc
 from tqdm import tqdm
 from multiprocessing import Pool
 
+from vesuvius.data.utils import open_zarr
 from ..base import TaskConfig, ZarrTask, make_task_config
 from ..registry import register_task
 from ..utils import (
@@ -198,7 +199,7 @@ class RecompressTask(ZarrTask):
             print(f"  Shape: {read_z.shape}, Chunks: {read_z.chunks}")
 
             # Create temp zarr with new compressor
-            temp_z = zarr.open(
+            temp_z = open_zarr(
                 temp_path,
                 mode="w",
                 shape=read_z.shape,

--- a/vesuvius/tests/zarr_tasks/test_recompress.py
+++ b/vesuvius/tests/zarr_tasks/test_recompress.py
@@ -1,0 +1,34 @@
+"""In-place recompression must work on both supported zarr versions.
+
+The published scroll volumes are zarr_format 2 and the task builds a numcodecs
+compressor, which zarr 3 rejects on the v3 array it creates by default.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import zarr
+
+from vesuvius.data.utils import open_zarr
+from vesuvius.image_proc.run.zarr_tasks.tasks.recompress import (
+    RecompressConfig,
+    RecompressTask,
+)
+
+
+def test_inplace_recompression_preserves_values(tmp_path: Path) -> None:
+    path = tmp_path / "vol.zarr"
+    data = np.arange(64, dtype="u1").reshape(4, 4, 4) + 1
+    open_zarr(path=str(path), mode="w", shape=(4, 4, 4), chunks=(2, 2, 2),
+              dtype="u1")[:] = data
+
+    RecompressTask(RecompressConfig(input_zarr=str(path), output_zarr=None,
+                                    num_workers=1, inplace=True)).run()
+
+    meta = json.loads((path / ".zarray").read_text())
+    assert meta["zarr_format"] == 2
+    assert meta["compressor"]["cname"] == "zstd"
+    assert np.array_equal(zarr.open(str(path), mode="r")[:], data)


### PR DESCRIPTION
**In one sentence:** `vesuvius.zarr_tasks --task recompress --inplace` runs again on a machine with zarr 3 installed, which is what `uv sync` gives you today (`uv.lock` pins zarr 3.2.1).

**One real example:** I pulled level 5 of the published PHerc0332 volume `20251211183505-2.399um-0.2m-78keV-masked.zarr` out of the open-data bucket to recompress it before copying it around — the published volumes are stored uncompressed (`"compressor": null`), so a local working copy costs a lot more disk than it needs to. `recompress --inplace` refused to start. With this PR the same command turns 178 MB into 53 MB and the voxels come back identical.

**Before:** every invocation raised before a single chunk was read, for any input.

```
$ python -m vesuvius.image_proc.run.zarr_tasks ome.zarr --task recompress --inplace --num-workers 8
Using 8 worker processes
Detected OME-Zarr with 1 resolution levels: ['5']
Input array shape: (1050, 493, 493)
Input array chunks: (128, 128, 128)
Input array dtype: uint8
Task: recompress | zstd level 1

Processing level 5...
  Shape: (1050, 493, 493), Chunks: (128, 128, 128)
Traceback (most recent call last):
  ...
  File ".../vesuvius/image_proc/run/zarr_tasks/__main__.py", line 106, in main
    task.run()
  File ".../zarr_tasks/tasks/recompress.py", line 179, in run
    self._run_inplace()
  File ".../zarr_tasks/tasks/recompress.py", line 201, in _run_inplace
    temp_z = zarr.open(
             ^^^^^^^^^^
  ...
  File ".../zarr/core/array.py", line 476, in _create
    raise ValueError(
ValueError: compressor cannot be used for arrays with zarr_format 3. Use bytes-to-bytes codecs instead.
```

(zarr internals trimmed from the middle of the traceback; nothing else removed.)

**After this PR:** same command, same data.

```
$ du -sh ome.zarr
178M	ome.zarr
$ python -m vesuvius.image_proc.run.zarr_tasks ome.zarr --task recompress --inplace --num-workers 8
Using 8 worker processes
Detected OME-Zarr with 1 resolution levels: ['5']
Input array shape: (1050, 493, 493)
Input array chunks: (128, 128, 128)
Input array dtype: uint8
Task: recompress | zstd level 1

Processing level 5...
  Shape: (1050, 493, 493), Chunks: (128, 128, 128)
  Total chunks to process: 144
Recompressing level 5: 100%|██████████| 144/144 [00:00<00:00, 257.55it/s]
In-place recompression complete: ome.zarr
$ du -sh ome.zarr
53M	ome.zarr
```

**Proof:** the recompressed array decodes to the same 255 MB of voxels, bit for bit.

```
$ python -c "
import hashlib, numpy as np, zarr
a = np.asarray(zarr.open('ome_pristine.zarr/5', mode='r')[:])
b = np.asarray(zarr.open('ome.zarr/5', mode='r')[:])
print('shape', a.shape, 'nonzero', int((a != 0).sum()))
print('before', hashlib.sha256(a.tobytes()).hexdigest())
print('after ', hashlib.sha256(b.tobytes()).hexdigest())
print('equal ', np.array_equal(a, b))"
shape (1050, 493, 493) nonzero 57718132
before c283b5d269e0ce706719f77160d4328259007dad414bae0d618826191c93339c
after  c283b5d269e0ce706719f77160d4328259007dad414bae0d618826191c93339c
equal  True
```

And the output on zarr 3 is the same output zarr 2 was already producing. Running the task on a dense 256³ block of level 0 (chunks `131..132 / 61..62 / 61..62`, downloaded straight from the bucket), then hashing every file it wrote:

| file | zarr 2.18.7, `main` | zarr 2.18.7, this PR | zarr 3.3.0, this PR |
|---|---|---|---|
| `0.0.0` … `1.1.1` (8 chunks) | identical | identical | identical |
| `.zarray` | — | byte-identical to `main` | same values, plus zarr 3's explicit `"dimension_separator": "."` |
| `.zattrs` | not written | not written | empty `{}` written by zarr 3 |

`.zarray` on zarr 3 differs only by that one key, which is the v2 default zarr 2 leaves implicit; `zarr_format`, `compressor`, `chunks`, `dtype`, `fill_value`, `order`, `filters` all match. So this changes nothing for anyone already on zarr 2.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

**Why / where this is useful:** every published volume in the open-data bucket is uncompressed zarr v2. `recompress` is the tool for making a local copy that fits on a laptop, and right now it does not start for anyone who installed the package fresh. Fixes #1670.

## Details

- **The change is two lines.** `_run_inplace` created the destination with `zarr.open(..., mode="w", compressor=self._compressor)`. Under zarr 3 that creates a zarr_format 3 array, and v3 has no `compressor` argument. The package already has the helper for this — `vesuvius.data.utils.open_zarr` asks zarr 3 for `zarr_format=2` and forwards the argument untouched on zarr 2 — and its docstring calls out this exact failure. Swapping the call in is the whole patch.

- **Verified on:** branched from `b218ace`. zarr 2.18.7, zarr 3.2.1 (what `uv.lock` pins) and zarr 3.3.0, macOS arm64, Python 3.12. The real-data run above is 3.3.0; 3.2.1 produces the same sha256 and the same 53 MB.

- **Test.** `vesuvius/tests/zarr_tasks/test_recompress.py`, one test: recompress a small array in place and check the values survive and the store is still v2. I watched it fail on `main` under 3.3.0 with the `ValueError` above, pass on `main` under 2.18.7, and pass on all three with the fix.

  ```
  $ pytest tests/zarr_tasks tests/data -q --ignore=tests/data/test_vc_dataset_bbox.py
  zarr 2.18.7  ->  45 passed, 5 skipped
  zarr 3.2.1   ->  49 passed, 1 skipped
  zarr 3.3.0   ->  49 passed, 1 skipped
  ```

  (`test_vc_dataset_bbox.py` needs torch, which is not in the minimal env I used; it is untouched by this change.)

- **Data.** `s3://vesuvius-challenge-open-data/PHerc0332/volumes/20251211183505-2.399um-0.2m-78keV-masked.zarr`, level 5 (1050×493×493, 89 of 144 chunks present) for the in-place run. The byte-comparison table uses chunks `131..132/61..62/61..62` of level 0, kept exactly as served (2,097,152 bytes each, `compressor: null`, `dimension_separator: "/"`) and reindexed into a 256³ array. Both fetched anonymously over HTTPS.

### What I deliberately did not change

- **`--output` mode.** It fails earlier and for a different reason (`zarr.NestedDirectoryStore` is gone in zarr 3), inside the shared `create_level_dataset`. #1682 fixes that helper; I left it alone rather than collide with it. The two together cover both halves of #1670.
- **A zarr_format 3 input stays converted to v2**, same as `create_level_dataset` does for the `--output` path. `_run_inplace` reads the rest of the store by hand, and both of those readers are v2-only: it copies `.zattrs`, which a v3 store does not have, and `delete_chunk_file` unlinks `<z>/<y>/<x>`, where v3 writes `c/<z>/<y>/<x>`. So mirroring a v3 source would give you an array whose source chunks are silently never freed — worse than converting. Every published volume is v2 anyway.
- **`write_empty_chunks`.** zarr 3 defaults it to `False`, so on the sparse level-5 array it wrote the 89 chunks that hold data and left the 55 all-zero ones absent, where zarr 2 materialised all 144. Same decoded values, same 53 MB, and it preserves the sparse layout the bucket already uses. That is zarr 3's default, not something this PR sets, and `create_level_dataset` in this same module already passes `write_empty_chunks=False` explicitly.

### Credit

The diagnosis is @acejayl's in #1670. @Bullo27 measured, in review on #1680, that `zarr.open` cannot take `compressors=` at all — which is why the mirror-the-source-format approach needs `zarr.create_array`, and part of why forcing v2 through the existing helper is the smaller change here. @kadenpool's #1682 is the other half.

### AI disclosure

Claude Code wrote the patch under my direction. I hit the error myself running `recompress` on the volume above, chose the fix after reading how the rest of the package already handles this, and ran every command and comparison in this description myself on that data.

