### PR TITLE
fix(ink_detection): retry transient remote chunk reads instead of aborting the run (#1666)

### DIFF
--- a/vesuvius/src/vesuvius/ink_detection/volume_io.py
+++ b/vesuvius/src/vesuvius/ink_detection/volume_io.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -13,10 +15,49 @@ import numpy as np
 import zarr
 
 from vesuvius.data.utils import open_zarr as open_vesuvius_zarr
+from vesuvius.data.volume import _is_transient_read_error
 
+
+LOGGER = logging.getLogger(__name__)
 
 _PUBLIC_S3_VOLUME_SUBSTRING = "vesuvius-challenge-open-data"
 ZARR_V3 = int(zarr.__version__.split(".", 1)[0]) >= 3
+READ_ATTEMPTS = 4
+
+
+if ZARR_V3:
+
+    class RetryingFsspecStore(zarr.storage.FsspecStore):
+        """Retry transient remote reads instead of losing the whole run.
+
+        Object stores drop connections routinely: truncated payloads, SSL
+        record errors, 5xx. An absent chunk is not one of those, because the
+        base store already returns None for it, so an error raised here is
+        worth another attempt rather than discarding a job that has been
+        streaming for minutes.
+        """
+
+        async def get(self, key, prototype, byte_range=None):
+            delay = 0.5
+            for attempt in range(READ_ATTEMPTS):
+                try:
+                    return await super().get(key, prototype, byte_range)
+                except Exception as error:
+                    if attempt == READ_ATTEMPTS - 1 or not _is_transient_read_error(
+                        error
+                    ):
+                        raise
+                    LOGGER.warning(
+                        "Transient read error on %s (%s), retry %d/%d in %.1fs: %s",
+                        key,
+                        type(error).__name__,
+                        attempt + 1,
+                        READ_ATTEMPTS - 1,
+                        delay,
+                        error,
+                    )
+                    await asyncio.sleep(delay)
+                    delay *= 2
 
 
 def _cache_snapshot(cache_dir: Path) -> list[tuple[int, int, Path]]:
@@ -128,7 +169,7 @@ def open_volume_root(
         if is_remote:
             remote_options = dict(storage_options)
             remote_options["skip_instance_cache"] = True
-            source_store = zarr.storage.FsspecStore.from_url(
+            source_store = RetryingFsspecStore.from_url(
                 path_text,
                 storage_options=remote_options,
                 read_only=True,
@@ -144,7 +185,7 @@ def open_volume_root(
 
     if is_remote and ZARR_V3:
         storage_options["skip_instance_cache"] = True
-        store = zarr.storage.FsspecStore.from_url(
+        store = RetryingFsspecStore.from_url(
             path_text,
             storage_options=storage_options,
             read_only=True,

--- a/vesuvius/tests/ink_detection/test_volume_io.py
+++ b/vesuvius/tests/ink_detection/test_volume_io.py
@@ -316,6 +316,66 @@ def test_public_substring_http_uses_real_backend_without_s3_options(tmp_path):
 
 
 @pytest.mark.skipif(not _ZARR_V3, reason="direct FsspecStore is a Zarr-3 path")
+def test_truncated_chunk_is_retried_and_absent_chunk_is_not(tmp_path):
+    requests: dict[str, int] = {}
+
+    class TruncateOnceHandler(SimpleHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format, *args):
+            del format, args
+
+        def do_GET(self):
+            requests[self.path] = requests.get(self.path, 0) + 1
+            target = tmp_path / self.path.lstrip("/")
+            if not target.is_file():
+                self.send_error(404)
+                return
+            body = target.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if self.path.endswith("/0.0.0") and requests[self.path] == 1:
+                self.wfile.write(body[: len(body) // 3])
+                self.close_connection = True
+                return
+            self.wfile.write(body)
+
+    expected = np.arange(24, dtype=np.uint16).reshape(2, 3, 4)
+    source_path = tmp_path / "volume.zarr"
+    zarr.open_array(
+        source_path,
+        mode="w",
+        shape=(4, 3, 4),
+        chunks=expected.shape,
+        dtype=expected.dtype,
+        zarr_format=2,
+    )[:2] = expected
+    server = ThreadingHTTPServer(("127.0.0.1", 0), TruncateOnceHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    opened = None
+    try:
+        opened = open_volume_root(
+            f"http://127.0.0.1:{server.server_port}/volume.zarr"
+        )
+        read = np.asarray(opened[:])
+    finally:
+        if opened is not None:
+            filesystem = opened.store.fs
+            opened.store.close()
+            filesystem.close_session(filesystem.loop, filesystem._session)
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=10)
+
+    np.testing.assert_array_equal(read[:2], expected)
+    np.testing.assert_array_equal(read[2:], np.zeros_like(expected))
+    assert requests["/volume.zarr/0.0.0"] == 2
+    assert requests["/volume.zarr/1.0.0"] == 1
+
+
+@pytest.mark.skipif(not _ZARR_V3, reason="direct FsspecStore is a Zarr-3 path")
 def test_private_https_basic_auth_is_unchanged(tmp_path, monkeypatch):
     captured = {}
 


### PR DESCRIPTION
**In one sentence:** Streaming ink inference over a published surface volume no longer loses the whole run when the object store truncates one chunk response.

**One real example:** Starting with `PHerc1447/segments/20250703025628-auto_grown_20250703025628283/surface-volumes/8.64um-1.2m-116keV-volume-20250521151220.zarr` on `vesuvius-challenge-open-data`, I ran `vesuvius.ink_detection.inference.infer` with `scrollprize/ink_9um` `hybrid_3d2d-seed42/step-075000.pth` over a 1024x1024 window, and it produced a full ink probability TIFF instead of dying on one short read.

**Before:** one truncated chunk response killed the run. Exit 1, no output file, all prior work discarded.

**After this PR:** the read is retried, the run finishes, and the TIFF is byte-identical to a run with no truncation.

**Proof:** same command, same segment, same checkpoint, same mask. `$URL` is a localhost mirror of the bucket that truncates one chunk response; see "How the failure was induced" below.

```
$ URL=http://127.0.0.1:8761/PHerc1447/segments/20250703025628-auto_grown_20250703025628283/surface-volumes/8.64um-1.2m-116keV-volume-20250521151220.zarr
```


Failing run (`main`):

```
$ python -m vesuvius.ink_detection.inference.infer "$URL" step-075000.pth out.tif \
    --mask-path mask.tif --num-workers 4 --no-compile
[2026-09-07 01:23:12,350] INFO Loaded model weights from step-075000.pth (missing_keys=0 unexpected_keys=0)
[2026-09-07 01:23:12,362] INFO Selected source layer indices=[7, 8, 9, ..., 23]
[2026-09-07 01:23:12,363] INFO Input level=0 shape=(depth=31, height=4100, width=4260) chunks=(128, 128) patch=128 stride=64 requested_overlap=0.500 blend_mode=hann tta_mirror=False
[2026-09-07 01:23:12,376] INFO Loaded mask mask.tif with foreground coverage 6.004%
[2026-09-07 01:23:12,411] INFO Using occupancy scan level=3 shape=(513, 533) scale=(8, 8) nonempty_coverage=5.463%
[2026-09-07 01:23:12,414] INFO Selected 283 patches for inference
Traceback (most recent call last):
  ...
aiohttp.client_exceptions.ClientPayloadError: Caught ClientPayloadError in DataLoader worker process 2.
Original Traceback (most recent call last):
  ...
  File ".../zarr/storage/_fsspec.py", line 298, in get
    value = prototype.buffer.from_bytes(await self.fs._cat_file(path))
  File ".../fsspec/implementations/http.py", line 249, in _cat_file
    out = await r.read()
  File ".../aiohttp/streams.py", line 365, in _wait
    await waiter
aiohttp.client_exceptions.ClientPayloadError: Response payload is not completed: <ContentLengthError: 400, message='Not enough data to satisfy content length header (received 172570 of 507559 bytes).'>

$ echo $?
1
$ ls out.tif
ls: out.tif: No such file or directory
```

Passing run (this branch), one chunk truncated the same way:

```
$ python -m vesuvius.ink_detection.inference.infer "$URL" step-075000.pth out.tif \
    --mask-path mask.tif --num-workers 4 --no-compile
[2026-09-07 01:23:39,216] INFO Loaded model weights from step-075000.pth (missing_keys=0 unexpected_keys=0)
[2026-09-07 01:23:39,230] INFO Selected source layer indices=[7, 8, 9, ..., 23]
[2026-09-07 01:23:39,230] INFO Input level=0 shape=(depth=31, height=4100, width=4260) chunks=(128, 128) patch=128 stride=64 requested_overlap=0.500 blend_mode=hann tta_mirror=False
[2026-09-07 01:23:39,247] INFO Loaded mask mask.tif with foreground coverage 6.004%
[2026-09-07 01:23:39,282] INFO Using occupancy scan level=3 shape=(513, 533) scale=(8, 8) nonempty_coverage=5.463%
[2026-09-07 01:23:39,286] INFO Selected 283 patches for inference
Transient read error on 0/0.14.13 (ClientPayloadError), retry 1/3 in 0.5s: Response payload is not completed: <ContentLengthError: 400, message='Not enough data to satisfy content length header (received 124128 of 365084 bytes).'>

$ echo $?
0
$ ls -l out.tif
-rw-r--r--  1 user  wheel  733619 Sep  7 01:24 out.tif
```

The retried run produces exactly the reference output. `out_after` is the retried run above; `out_clean` is this branch with nothing truncated; `out_baseline` is `main` with nothing truncated; `out_warm` is this branch reading every byte live from the bucket; `out_s3` is this branch run straight against `s3://vesuvius-challenge-open-data/...` with nothing in the path at all. All five agree.

```
$ python -m vesuvius.ink_detection.inference.infer \
    s3://vesuvius-challenge-open-data/PHerc1447/segments/20250703025628-auto_grown_20250703025628283/surface-volumes/8.64um-1.2m-116keV-volume-20250521151220.zarr \
    step-075000.pth out_s3.tif --mask-path mask.tif --num-workers 0 --no-compile
$ echo $?
0
$ shasum -a256 out_after.tif out_clean.tif out_baseline.tif out_warm.tif out_s3.tif
20bcc140909ba5223f74061de11b302a137543a683470399ce2ba098d603016a  out_after.tif
20bcc140909ba5223f74061de11b302a137543a683470399ce2ba098d603016a  out_clean.tif
20bcc140909ba5223f74061de11b302a137543a683470399ce2ba098d603016a  out_baseline.tif
20bcc140909ba5223f74061de11b302a137543a683470399ce2ba098d603016a  out_warm.tif
20bcc140909ba5223f74061de11b302a137543a683470399ce2ba098d603016a  out_s3.tif
```

Tests, `vesuvius/`, zarr 3.3.0, Python 3.14:

```
$ python -m pytest tests/ink_detection -q          # main
270 passed, 2 skipped, 1 warning in 21.73s
$ python -m pytest tests/ink_detection -q          # this branch
271 passed, 2 skipped, 1 warning in 19.28s
$ python -m pytest tests/data -q
60 passed, 1 skipped, 8 warnings in 1.65s
```

The new test fails on `main` with the same `ContentLengthError`, so it is a real regression guard, not a tautology.

**Why / where this is useful:** anyone running the [18 August First Letters workflow](https://scrollprize.substack.com/p/from-ct-scan-to-ancient-text-a-first) straight off the published surface volumes instead of mirroring them first. Unattended overnight runs stop being a coin flip.

## Details

Fixes the read path in #1666. The diagnosis there is @TAUIL-Abd-Elilah's; I reproduced it and wrote the wrapper. Same treatment as #1244, which fixed `Volume.__getitem__` for the nnU-Net prediction path; `ink_detection` opens its own store through `volume_io.open_volume_root` and never went through `Volume`, so it was still exposed.

**Motivation.** I was working the First Letters workflow on `PHerc1447` off the published Zarr, following up #1666, and wanted to know whether the reported abort was a data problem or a transport problem before proposing anything. It is a transport problem: the object is fine, the connection is not.

**What changed.** `RetryingFsspecStore` subclasses `zarr.storage.FsspecStore` and overrides `get` with four bounded attempts and 0.5/1/2 s backoff. `open_volume_root` builds that store instead of the base one, on both remote branches (plain and `CacheStore`-wrapped). Everything in `ink_detection` that reads a remote volume goes through `open_volume_root`, so `infer`, `infer_full3d_tifxyz`, the training datasets, and `download_required_zarr_chunks` all get it from the one change.

Retrying at the store, not at the caller, means one bad chunk is re-fetched rather than the whole patch, and a `CacheStore` hit never re-fetches at all.

**Absence is not a failure.** `FsspecStore.get` already returns `None` for a missing key, and zarr fills those with `fill_value`. Sparse storage therefore never reaches the retry loop. What reaches it is an exception, which for a read-only remote store means a transport failure. The predicate is the existing `_is_transient_read_error` from `vesuvius/data/volume.py`, added in #1244, so `IndexError`, `PermissionError` and friends still raise on the first attempt with no delay. The test asserts both halves: the truncated chunk is fetched twice, the absent chunk exactly once.

**What I did not change.** No CLI flag. #1244 added `--read-retries` because it had one entry point to thread it through; `open_volume_root` feeds fourteen call sites across inference, training and preprocessing, and plumbing a knob through all of them is a much larger diff than the fix. Four attempts is the same default #1244 settled on. No change to the reader, the dataset, the loader, or `read_bbox_with_padding`. Nothing under zarr 2: `RetryingFsspecStore` is defined only when `ZARR_V3`, and both call sites are already inside `ZARR_V3` branches, so the 2.18.7 CI leg is untouched and the new test skips there.

**How the failure was induced.** S3 will not truncate on demand, so I mirrored the real bucket behind a localhost endpoint that serves the real bytes and cuts one chunk response short while still sending the full `Content-Length`. The URL, the bytes, the store, the reader and the model are all real; only the packet drop is scheduled instead of random. It lands on the same code path with the same exception the issue reports, on the same object size the reporter saw:

```
$ python probe.py "$URL"
aiohttp.client_exceptions.ClientPayloadError: Response payload is not completed: <ContentLengthError: 400, message='Not enough data to satisfy content length header (received 172692 of 507920 bytes).'>
```

507,920 bytes is the same chunk the issue quotes at "received 173631 of 507920 bytes".

**Limitation.** This does not help a request that hangs without ever returning; that behaviour is unchanged. It covers dropped and truncated responses, which is what the issue describes and what I could reproduce.

Environment: macOS arm64 (Darwin 25.5.0, M4 Max), Python 3.14.6, zarr 3.3.0, fsspec 2026.7.0, torch 2.14.0, CPU. Branched from `739eefd`.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

<sub>Written with AI assistance, directed and reviewed by me; every command and transcript above is from my own machine.</sub>
