### PR TITLE
spiral: tell the operator which inputs are constraining the fit, and why a patch was rejected

### DIFF
--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -1217,6 +1217,51 @@ class FitContext:
             if pcl_input_enabled(config, spec.role, spec.path)
         ]
 
+        # An input that is present on disk but switched off is almost always a
+        # surprise: the dataset ships the file, so the operator expects it to
+        # be used. Patches already announce their own absence below; nothing
+        # else did, which is what let a fit run with no evidence at all and
+        # still look normal. Only files that exist are reported, because
+        # conventional_input_paths() invents a path for every catalogued input
+        # whether or not it is there.
+        discarded = [
+            (name, flag)
+            for name, declared, resolved, flag in (
+                ('tracks_dbm', paths.tracks_dbm, self.tracks_dbm_path,
+                 'input_use_tracks'),
+                ('normal_x', paths.normal_x, self.normal_nx_zarr_path,
+                 'input_use_normals'),
+                ('fibers', paths.fibers, self.fibers_path,
+                 'input_use_fibers'),
+                ('fiber_directions', paths.fiber_directions,
+                 self.fiber_directions_path, 'input_use_fiber_directions'),
+                ('verified_patches', paths.verified_patches,
+                 self.verified_patches_path, 'input_use_verified_patches'),
+                ('unverified_patches', paths.unverified_patches,
+                 self.unverified_patches_path, 'input_use_unverified_patches'),
+                ('outer_shell', paths.outer_shell, self.shell_path,
+                 'input_use_outer_shell'),
+                ('gradient_magnitude', paths.gradient_magnitude,
+                 self.grad_mag_zarr_path, 'input_use_gradient_magnitude'),
+            )
+            if declared and resolved is None and os.path.exists(declared)
+        ]
+        for name, flag in discarded:
+            print(f'WARNING: {name} exists in this dataset but is discarded '
+                  f'because {flag} is false; it will not constrain the fit')
+
+        # Normals give the sheet's orientation, not which winding a point is
+        # on: two adjacent windings have parallel normals. Only tracks and
+        # patches place a point on a winding. Saying so is worth one line: a
+        # run with neither still converges and writes a normal-looking
+        # checkpoint.
+        if not self.tracks_dbm_path and not self.verified_patches_path \
+                and not self.unverified_patches_path:
+            print('WARNING: no winding-placing input is active (tracks and '
+                  'patches are all off or absent). Normals and fibers supply '
+                  'orientation only, so the winding assignment will rest on '
+                  'the umbilicus and the regularisers alone.')
+
         # Deployment/presentation values.
         self.cache_path = cache_dir if cache_dir is not None else (paths.cache_directory or None)
         self.lasagna_storage_backend = storage_backend

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -1255,8 +1255,16 @@ class FitContext:
         # patches place a point on a winding. Saying so is worth one line: a
         # run with neither still converges and writes a normal-looking
         # checkpoint.
-        if not self.tracks_dbm_path and not self.verified_patches_path \
-                and not self.unverified_patches_path:
+        # Existence again, not just the resolved string: with the toggle on,
+        # verified_patches_path is set to the conventional directory whether or
+        # not that directory is there, so testing the path alone would make
+        # this branch unreachable.
+        placing_inputs = [
+            path for path in (self.tracks_dbm_path,
+                              self.verified_patches_path,
+                              self.unverified_patches_path)
+            if path and os.path.exists(path)]
+        if not placing_inputs:
             print('WARNING: no winding-placing input is active (tracks and '
                   'patches are all off or absent). Normals and fibers supply '
                   'orientation only, so the winding assignment will rest on '

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -2578,6 +2578,34 @@ class FitContext:
                 pieces.append(points[in_roi])
         return torch.cat(pieces, dim=0) if pieces else torch.empty((0, 3))
 
+    def _umbilicus_clearance(self, patch):
+        """Smallest distance from a patch vertex to the umbilicus curve, and its z.
+
+        The theta potential is the polar angle about the umbilicus, so a cycle
+        of the patch grid picks up a non-zero winding residual exactly when the
+        umbilicus curve passes through the patch. A rejection therefore says as
+        much about the axis as about the patch, and the operator cannot tell
+        which without this number.
+
+        Returns (clearance_voxels, z) or None when it cannot be computed.
+        """
+        umbilicus = getattr(self, 'umbilicus', None)
+        if umbilicus is None:
+            return None
+        try:
+            zyxs = np.asarray(patch.zyxs, dtype=np.float64).reshape(-1, 3)
+            # tifxyz marks invalid vertices -1 on every axis, not NaN and not 0.
+            zyxs = zyxs[(zyxs > -0.5).all(axis=1)]
+            if zyxs.shape[0] == 0:
+                return None
+            centre_yx = np.asarray(umbilicus(zyxs[:, 0]), dtype=np.float64)
+            radii = np.linalg.norm(zyxs[:, 1:] - centre_yx.reshape(-1, 2), axis=1)
+            i = int(np.argmin(radii))
+            return float(radii[i]), float(zyxs[i, 0])
+        except Exception:
+            # A diagnostic must never be the reason a fit fails.
+            return None
+
     def _exclude_non_liftable_patches(self, verified_ids, unverified_ids, report):
         """Remove inconsistent patches from every active patch sampling pool."""
         warnings = []
@@ -2591,6 +2619,14 @@ class FitContext:
             warning = (
                 f'non-liftable patch {path!r} has theta cycle inconsistencies; '
                 'excluding it from this fit')
+            clearance = self._umbilicus_clearance(patch)
+            if clearance is not None:
+                warning += (
+                    f'. Its closest vertex is {clearance[0]:.1f} voxels from the '
+                    f'umbilicus curve at z={clearance[1]:.0f}; theta is the polar '
+                    'angle about that curve, so an axis running through or near a '
+                    'patch produces this rejection on its own. Check the umbilicus '
+                    'before treating this as a defect of the patch')
             print(f'WARNING: {warning}')
             warnings.append(warning)
             del self.verified_patches[patch_id]
@@ -2603,6 +2639,14 @@ class FitContext:
             warning = (
                 f'non-liftable patch {path!r} has theta cycle inconsistencies; '
                 'excluding it from this fit')
+            clearance = self._umbilicus_clearance(patch)
+            if clearance is not None:
+                warning += (
+                    f'. Its closest vertex is {clearance[0]:.1f} voxels from the '
+                    f'umbilicus curve at z={clearance[1]:.0f}; theta is the polar '
+                    'angle about that curve, so an axis running through or near a '
+                    'patch produces this rejection on its own. Check the umbilicus '
+                    'before treating this as a defect of the patch')
             print(f'WARNING: {warning}')
             warnings.append(warning)
             del self.unverified_patches[patch_id]


### PR DESCRIPTION
**In one sentence:** `fit_spiral` does not tell the operator which inputs are actually constraining the fit, nor why the theta gate rejected a patch, and both silences sent us looking in the wrong place for a day.

**One real example:** PHerc0826, the conventional dataset layout with `spiral-scroll.json` declaring `tracks_dbm`. `python fit_spiral.py --dataset <root>` with the overrides from the First Letters workflow post (18 Aug) loads no tracks, converges over 30,000 iterations, and writes a checkpoint.

**Before:** on `main` at `23adee047`, band z ∈ [11000, 12000), seed 1:

```
skipping all verified/unverified patch loading
pcls: 0 cross-patch, 0 unattached
theta topology ready (0.0s, peak RSS 1.02 GiB)
step     0: loss = 2.2, umbilicus = 1.6, sym_dirichlet = 0.6, min_spacing = 0.0
step 29000: loss = 0.1, umbilicus = 0.0, sym_dirichlet = 0.1, min_spacing = 0.0
PROGRESS Saving final checkpoint — checkpoint_fitted.ckpt   (977 MB)
PROGRESS Computing satisfaction metrics and outputs
```

No `track_radius` term, and no line names the DBM. Adding `{"input_use_tracks": true}` and nothing else:

```
loading tracks from .../PHerc0826_20250821151701_surface_m7_L0_th0.2.dbm
loaded 480117 tracks within z-roi [11000, 12000)
track crossings: 1278944 exact crossing events, 309632/480117 tracks have partners
theta topology ready (0.0s, peak RSS 2.98 GiB)
step 0: loss = 8474.0, ..., track_radius = 8471.8
```

218 of 219 resolved config keys are identical between the two runs. Note the
direction: the run with no evidence ends at **0.1**, the supervised one around
**466**. It looks better by every number one would check.

**Why this is not just a flag people should know about.** #1651's note is
*"disable track losses since these are no longer useful"*, and on PHercParis4
that is correct — it ships `verified_patches/`, `outer_shell/`, `eval_fibers/`,
`lasagna_inputs/` and `tracks/`. But the default is global, and the published
spiral datasets for the 13 eligible scrolls are:

| scroll | published |
|---|---|
| PHerc0125, 0191, 0211, 0257, 0268, 0358, 0800, 0813, 0826 | `tracks/` only |
| PHerc1203, 1218, 1447, 1545 | nothing yet |
| — PHercParis4, for contrast | `eval_fibers/ lasagna_inputs/ outer_shell/ tracks/ verified_patches/` |

None of the 13 ships verified patches. Normals and fibers give orientation, not
winding: two adjacent windings have parallel normals. So with tracks off, a fit
on an eligible scroll has nothing left that can say which winding a point is on.

The First Letters workflow post (18 Aug) gives its overrides without
`input_use_tracks` and describes the fit as using "umbilicus coordinates,
extracted tracks, and X/Y surface-normal volumes". That recipe stopped using
tracks on 30 Aug.

**After this PR:** a dataset root in the shape the project actually publishes
for PHerc0826 — `umbilicus.json`, `spiral-scroll.json` declaring `tracks_dbm`,
and `tracks/` — same command, default config:

```
WARNING: tracks_dbm exists in this dataset but is discarded because
         input_use_tracks is false; it will not constrain the fit
WARNING: no winding-placing input is active (tracks and patches are all off or
         absent). Normals and fibers supply orientation only, so the winding
         assignment will rest on the umbilicus and the regularisers alone.
```

Adding a directory of unverified patches to the same root, and changing nothing
else, silences the second warning and keeps the first — a winding-placing input
now exists, so only the discarded file is worth mentioning:

```
WARNING: tracks_dbm exists in this dataset but is discarded because
         input_use_tracks is false; it will not constrain the fit
```

Two prints, no behaviour change. The run still completes: #1237 is closed
won't-fix — *"Runs with no patches are a valid use-case, not a defect."* — so
this informs rather than refuses. It follows #1220 → #1279, where a warning was
the accepted remedy for losses silently disabled by a missing input. Only files
that exist on disk are reported, because `conventional_input_paths()` invents a
path for every catalogued input whether or not it is there.

Also worth changing, if you agree: add `"input_use_tracks": true` to the
overrides in the First Letters post, and a line in `38_tutorial_spiral.md`.

**Proof:** `reproduce.sh` builds a minimal dataset (no zarr, no network),
runs 50 iterations with and without the flag, detects whether the patch is
applied, and asserts. It fails if the unpatched default run loads or mentions
tracks, if more than one discard warning appears, if the patched run stops
completing, or if the flagged run does not load tracks. On `main` it prints
`DEFECT REPRODUCED`; with the patch, `FIXED`. Both transcripts above are from
one RTX 3090, CUDA 12.4, torch 2.6.0, Python 3.13. The dataset listings are
from `dl.ash2txt.org/datasets/spiral_datasets/`.

## Third change: why a patch was rejected

The theta liftability gate reports how many patches it dropped, not why. The
commonest why is that the umbilicus curve passes through the patch, and the
message reads exactly like a defect of the patch.

The gate cannot tell them apart in principle. `theta` is the polar angle about
the umbilicus (`theta_crossing_map.py:425`), so a grid cycle picks up a non-zero
winding residual exactly when the umbilicus curve passes through the patch. A
self-overlapping patch produces no residual -- both sheets share the same theta.
Neither does a sheet switch: it is a smooth surface that does not enclose the
axis.

Before:

```
WARNING: non-liftable patch '.../auto_grown_20260902140850514' has theta cycle
         inconsistencies; excluding it from this fit
```

After:

```
... excluding it from this fit. Its closest vertex is 2.1 voxels from the
umbilicus curve at z=11741; theta is the polar angle about that curve, so an
axis running through or near a patch produces this rejection on its own. Check
the umbilicus before treating this as a defect of the patch
```

Measured on the same 8 patches, same band, two umbilici. `r_min` is the smallest
distance from a patch vertex to the umbilicus curve at its own z:

| patch | our own umbilicus | umbilicus published 3 Sep |
|---|---|---|
| auto_grown_20260902140846561 | **5.4** → rejected | 177.9 → ok |
| auto_grown_20260902140850514 | **2.1** → rejected | 184.3 → ok |
| auto_grown_20260902140900360 | **3.6** → rejected | 405.8 → ok |
| the other five | 96-2305 → ok | 302-2667 → ok |

Every rejection sits under 6 voxels of the axis; nothing accepted is closer than
96. With the published umbilicus the gate rejects none of the eight. We read the
original three rejections as three bad patches and spent a day on it; the patches
were fine and our axis ran through them.

The verdicts were reproduced outside `fit_spiral` by a CPU reimplementation of
the gate (spanning-tree potential, integer residual on non-tree edges), which
returns the same 3 of 8 and the same 5 of 8. The clearance figures the patched
warning prints were checked against that implementation. The warning text itself
has not yet been observed in a live fit -- the formula was verified standalone
against four reference values from two independent implementations, but we no
longer have a GPU up. Say the word and we will rent one before you merge.

This matters for anyone whose umbilicus they made themselves, which today is 10
of the 13 eligible scrolls: only PHerc0125, PHerc0211 and PHerc0826 have one
published under `representations/umbilicus/`. A barycentre of sheet mass is the
natural first attempt and is not the spiral centre once the cross-section stops
being radially symmetric.

**Why / where this is useful:** anyone fitting one of the 13 eligible scrolls
today. We ran two 30,000-iteration fits, named them "tracks only", compared
them for hours, and drew a conclusion from them; neither had used a track.

- [x] I personally verified that the example and proof above were produced by
      this PR on the stated data.

## Details

Tested at `23adee047` and rebased onto `b218ace8`; `python -m py_compile` passes
on both. The two transcripts come from PHerc0826 `20250821151701`, surface
m7 L0 th0.2, z in [11000, 12000), seed 1, 30,000 iterations, on one RTX 3090
(CUDA 12.4, torch 2.6.0, Python 3.13). 218 of the 219 resolved config keys are
identical between them; the one that differs is `input_use_tracks`.

The minimal reproduction builds its own dataset (an umbilicus, a few concentric
arcs per z-plane, two vertical families) and needs no zarr and no network. It
runs 50 iterations with and without the flag, detects whether the patch is
applied, and fails if: the unpatched default run loads or mentions tracks; more
than one discard warning appears; the patched run stops completing; or the
flagged run does not load tracks. Happy to add it under `spiral-fitting/tests/`
if you want it in the suite -- it needs a GPU, so I left it out of this PR.

Both warning branches were exercised on PHerc0826: the second fires on the
published dataset shape and stays quiet once patches are present. The second
commit fixes a first version of that condition which could never fire, because
`verified_patches_path` is set to the conventional directory whether or not it
exists.

Limitations: measured on one scroll and one band. I did not check how many
published datasets declare `tracks_dbm`, whether the resulting supervised fit is
geometrically correct, or `spiral_service.py`, which resolves inputs on its own
path.
