### PR TITLE
Keep excluded ink labels out of native targets and patch discovery

### DIFF
--- a/vesuvius/src/vesuvius/ink_detection/README.md
+++ b/vesuvius/src/vesuvius/ink_detection/README.md
@@ -157,6 +157,24 @@ and train/validation TIFF previews below `out_dir`. Online `val_loss` is the
 smoothed objective. Use `val_bce_unsmoothed` from the JSONL file for
 calibration-comparable BCE.
 
+Native target construction excludes validation ink from training and excludes
+ink outside the selected supervision scope from validation. Ordinary training
+still treats positive ink outside the generic supervision mask as supervised,
+unless that ink is explicitly held out. For a fixed patch, physical geometry
+and the single-wrap surface channel do not depend on annotation values.
+Full-3D validation merges an intersecting segment only through that segment's
+validation mask; a segment without one contributes no validation annotations.
+This is a label-value
+isolation rule; projection thickness and dilation do not establish a spatial
+gap between training and validation regions.
+
+Default and subtiling patch discovery apply the same training exclusion before
+measuring label coverage. Subtiling validation eligibility uses the validation
+mask, including negative-only tiles, so its cohort can differ from older runs.
+Patch cache v7 invalidates older discovery results; empty caches are recomputed.
+Subtiling cache identity includes the minimum labeled coverage threshold.
+Rebuild caches and establish a new validation baseline when adopting this fix.
+
 Flat inference writes a tiled LZW uint8 TIFF. Native inference writes a sparse
 six-level uint8 OME-Zarr pyramid in scroll coordinates. Label conversion writes
 65-plane, six-level OME-Zarr labels with the flat label at Z=32. The 9 µm

--- a/vesuvius/src/vesuvius/ink_detection/data/dataset.py
+++ b/vesuvius/src/vesuvius/ink_detection/data/dataset.py
@@ -389,6 +389,23 @@ class InkDataset(Dataset):
             x0=support_x0,
             x1=support_x1,
         )
+        # Positive ink normally implies supervision. Restrict that contract
+        # only for explicit exclusions, leaving physical surface support intact.
+        # Cached ordinary training patches repeat the generic mask as an
+        # override; that is not a distinct restriction.
+        scoped_override = (
+            patch.supervision_mask_override is not None
+            and str(patch.supervision_mask_override)
+            != str(patch.segment.supervision_mask)
+        )
+        if patch.is_validation or scoped_override:
+            support_labels = np.where(
+                np.asarray(support_supervision) > 0, support_labels, 0
+            )
+        elif validation_volume is not None:
+            support_labels = exclude_validation_voxels(
+                support_labels, support_validation
+            )
         (
             support_bbox,
             support_positions,
@@ -468,6 +485,9 @@ class InkDataset(Dataset):
             if segment.segment_relpath == patch.segment.segment_relpath:
                 continue
             if segment.inklabels is None or segment.supervision_mask is None:
+                continue
+            if patch.is_validation and segment.validation_mask is None:
+                # A training-only segment contributes no held-out annotations.
                 continue
             patch_tifxyz = self._tifxyz(segment)
             coarse_positions, coarse_valid = self._coarse_positions(

--- a/vesuvius/src/vesuvius/ink_detection/data/patch_cache.py
+++ b/vesuvius/src/vesuvius/ink_detection/data/patch_cache.py
@@ -10,11 +10,11 @@ from vesuvius.ink_detection.config import InkDataConfig
 from vesuvius.ink_detection.types import Patch, Segment
 
 
-_CACHE_VERSION = "v6"
+_CACHE_VERSION = "v7"
 
 
 def patch_finding_cache_token(config: InkDataConfig) -> str:
-    """Return the v6 token including every patch-semantic input."""
+    """Return the v7 token including split-isolated discovery semantics."""
     finding = config.patch_finding
     patch_y = config.patch_size[1]
     default_stride = int(patch_y * finding.overlap)
@@ -24,6 +24,7 @@ def patch_finding_cache_token(config: InkDataConfig) -> str:
         return (
             f"{config.discovery_mode}-subtiling-{_CACHE_VERSION}"
             f"-ts-{tile_size}_st-{stride}_fe-{int(finding.filter_empty_tile)}"
+            f"-mlc-{finding.min_labeled_coverage}"
         )
     scan_scale = "" if finding.scan_scale is None else finding.scan_scale
     if config.discovery_mode == "unlabeled":
@@ -99,6 +100,9 @@ def load_patch_cache(
         records = json.load(stream)
     if not isinstance(records, list):
         raise ValueError(f"patch cache {path} must contain a JSON array")
+    if not records:
+        # Empty legacy lists have no record carrying the semantic version.
+        return None
     segments_by_key = {segment.cache_key: segment for segment in segments}
     expected_token = patch_finding_cache_token(config)
     patches: list[Patch] = []

--- a/vesuvius/src/vesuvius/ink_detection/data/patch_finding_default.py
+++ b/vesuvius/src/vesuvius/ink_detection/data/patch_finding_default.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 import numpy as np
 
 from vesuvius.ink_detection.types import Patch, Segment
+from vesuvius.ink_detection.data.normalization import exclude_validation_voxels
 
 
 def surface_patch_bbox(
@@ -113,6 +114,7 @@ def find_segment_patches(
         ]
         has_training = bool(supervision_patch.size and np.any(supervision_patch))
         has_validation = False
+        validation_patch = None
         if validation is not None:
             validation_patch = validation[
                 validation_surface,
@@ -122,7 +124,7 @@ def find_segment_patches(
             has_validation = bool(validation_patch.size and np.any(validation_patch))
             if has_training and has_validation:
                 has_training = bool(
-                    np.any(np.asarray(supervision_patch) & ~np.asarray(validation_patch))
+                    np.any((np.asarray(supervision_patch) > 0) & ~(np.asarray(validation_patch) > 0))
                 )
         y0 = int(round(y_scan * scale_y))
         x0 = int(round(x_scan * scale_x))
@@ -139,6 +141,7 @@ def find_segment_patches(
         label_patch = inklabels[
             mask_surface, y_scan : y_scan + scan_h, x_scan : x_scan + scan_w
         ]
+        label_patch = exclude_validation_voxels(label_patch, validation_patch)
         if has_training and labeled_patch_coverage(label_patch) >= (
             segment.data_config.patch_finding.min_labeled_coverage
         ):

--- a/vesuvius/src/vesuvius/ink_detection/data/patch_finding_subtiling.py
+++ b/vesuvius/src/vesuvius/ink_detection/data/patch_finding_subtiling.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 
 import numpy as np
 
+from vesuvius.ink_detection.data.normalization import exclude_validation_voxels
+from vesuvius.ink_detection.data.patch_finding_default import labeled_patch_coverage
 from vesuvius.ink_detection.types import Patch, Segment
 
 
@@ -118,67 +120,52 @@ def find_segment_patches(
     tile_size = size if finding.tile_size is None else finding.tile_size
     default_stride = int(size * finding.overlap)
     stride = default_stride if finding.stride is None else finding.stride
-    _, xyxys, _ = build_patch_index(
-        inklabels[surface],
-        supervision[surface],
-        size=size,
-        tile_size=tile_size,
-        stride=stride,
-        filter_empty_tile=finding.filter_empty_tile,
+    supervision_slice = np.asarray(supervision[surface])
+    validation_slice = (
+        None if validation is None
+        else np.asarray(validation[int(validation.shape[0] // 2)]) > 0
+    )
+    training_labels = exclude_validation_voxels(
+        np.asarray(inklabels[surface]), validation_slice
+    )
+    training_support = exclude_validation_voxels(
+        supervision_slice > 0, validation_slice
     )
     training: list[Patch] = []
     held_out: list[Patch] = []
-    for x1, y1, _, _ in xyxys.tolist():
-        z0 = surface - patch_size[0] // 2
-        bbox = (
-            z0,
-            int(y1),
-            int(x1),
-            z0 + patch_size[0],
-            int(y1) + patch_size[1],
-            int(x1) + patch_size[2],
+    # Each split has its own deterministic parent-tile sequence. A union
+    # ordered by one split could let its labels reorder the other split.
+    # Validation eligibility uses its mask so annotated negatives are retained.
+    for is_validation, tile_labels, active_support in (
+        (False, training_labels, training_support),
+        (True, validation_slice, validation_slice),
+    ):
+        if tile_labels is None:
+            continue
+        _, xyxys, _ = build_patch_index(
+            tile_labels,
+            supervision_slice,
+            size=size,
+            tile_size=tile_size,
+            stride=stride,
+            filter_empty_tile=finding.filter_empty_tile,
         )
-        supervision_patch = supervision[
-            surface,
-            int(y1) : int(y1) + patch_size[1],
-            int(x1) : int(x1) + patch_size[2],
-        ]
-        has_training = bool(supervision_patch.size and np.any(supervision_patch))
-        has_validation = False
-        if validation is not None:
-            validation_patch = validation[
-                surface,
-                int(y1) : int(y1) + patch_size[1],
-                int(x1) : int(x1) + patch_size[2],
-            ]
-            has_validation = bool(validation_patch.size and np.any(validation_patch))
-            if has_training and has_validation:
-                has_training = bool(
-                    np.any(np.asarray(supervision_patch) & ~np.asarray(validation_patch))
-                )
-        if has_validation:
-            held_out.append(
-                Patch(
+        for x1, y1, _, _ in xyxys.tolist():
+            x1, y1 = int(x1), int(y1)
+            window = (slice(y1, y1 + size), slice(x1, x1 + size))
+            if not np.any(active_support[window]):
+                continue
+            z0 = surface - patch_size[0] // 2
+            bbox = (z0, y1, x1, z0 + patch_size[0], y1 + size, x1 + size)
+            if is_validation:
+                held_out.append(Patch(
                     segment=segment,
                     bbox=bbox,
                     is_validation=True,
                     supervision_mask_override=segment.validation_mask,
-                )
-            )
-        label_patch = inklabels[
-            surface,
-            int(y1) : int(y1) + patch_size[1],
-            int(x1) : int(x1) + patch_size[2],
-        ]
-        labeled_y, labeled_x = np.nonzero(label_patch)
-        coverage = 0.0
-        if labeled_y.size:
-            coverage = float(
-                (int(labeled_y.max()) - int(labeled_y.min()) + 1)
-                * (int(labeled_x.max()) - int(labeled_x.min()) + 1)
-            ) / float(label_patch.size)
-        if has_training and coverage >= finding.min_labeled_coverage:
-            training.append(Patch(segment=segment, bbox=bbox))
+                ))
+            elif labeled_patch_coverage(training_labels[window]) >= finding.min_labeled_coverage:
+                training.append(Patch(segment=segment, bbox=bbox))
     if not training and not held_out:
         raise ValueError(f"{segment.inklabels} produced no valid patches")
     return training, held_out

--- a/vesuvius/tests/ink_detection/test_data_foundation.py
+++ b/vesuvius/tests/ink_detection/test_data_foundation.py
@@ -353,7 +353,7 @@ def test_default_labeled_and_unlabeled_patch_origins(tmp_path):
     assert held_out == []
 
 
-def test_v6_patch_cache_round_trip_and_stale_rejection(tmp_path):
+def test_v7_patch_cache_round_trip_and_stale_rejection(tmp_path):
     config = _config(tmp_path)
     segment = replace(
         _segment(config, tmp_path),
@@ -376,7 +376,7 @@ def test_v6_patch_cache_round_trip_and_stale_rejection(tmp_path):
     assert loaded[0].is_validation
     assert loaded[0].supervision_mask == str(segment.validation_mask)
     assert replace(patch, supervision_mask_override="").supervision_mask == ""
-    assert "v6" in patch_finding_cache_token(config)
+    assert "v7" in patch_finding_cache_token(config)
 
     changed = _config(tmp_path, patch_overlap=0.25)
     assert load_patch_cache(path, config=changed, segments=[segment]) is None
@@ -391,7 +391,7 @@ def test_unlabeled_coverage_key_is_rejected_and_cache_token_stays_compatible(tmp
         ],
     )
     assert patch_finding_cache_token(unlabeled) == (
-        "unlabeled-default-v6-po-0.5-mdc-0.15-pfs-"
+        "unlabeled-default-v7-po-0.5-mdc-0.15-pfs-"
     )
 
     with pytest.raises(

--- a/vesuvius/tests/ink_detection/test_partition_isolation.py
+++ b/vesuvius/tests/ink_detection/test_partition_isolation.py
@@ -1,0 +1,334 @@
+"""Excluded annotation values must not affect native targets or discovery."""
+
+from dataclasses import replace
+import random
+
+import numpy as np
+import pytest
+import torch
+
+from vesuvius.ink_detection.config import InkConfig, TrainingConfig, resolve_training_mapping
+from vesuvius.ink_detection.data.dataset import InkDataset
+from vesuvius.ink_detection.data.patch_cache import load_patch_cache, patch_cache_path, save_patch_cache
+from vesuvius.ink_detection.data.patch_finding_default import find_segment_patches as find_default
+from vesuvius.ink_detection.data.patch_finding_subtiling import find_segment_patches as find_subtiling
+from vesuvius.ink_detection.training.deep_supervision import (
+    DeepSupervisionWrapper,
+    concatenate_deep_supervision_ignore,
+    deep_supervision_weights,
+)
+from vesuvius.ink_detection.training.dilation import apply_label_dilation
+from vesuvius.ink_detection.training.losses import create_loss
+from vesuvius.ink_detection.training.train import prepare_loss_inputs, prepare_model_input
+from vesuvius.ink_detection.types import Patch, Segment
+
+from .test_data_foundation import _FakeTifxyz
+from .test_model_foundation import _config_mapping
+
+
+def _native_fixture(tmp_path, mode, is_validation, *, augment=False):
+    mapping = _config_mapping(depth=5, side=4)
+    mapping.update(mode=mode, datasets=[{"segments_path": str(tmp_path), "volume_scale": 0}])
+    config = InkConfig.from_mapping(mapping)
+    arrays = {
+        "image": np.arange(10**3, dtype=np.uint16).reshape(10, 10, 10),
+        "labels": np.zeros((5, 4, 4), dtype=np.uint8),
+        "supervision": np.full((5, 4, 4), 255, dtype=np.uint8),
+        "validation": np.zeros((5, 4, 4), dtype=np.uint8),
+    }
+    arrays["labels"][:, :, 1:] = 255
+    arrays["supervision"][:, :, 3] = 0
+    arrays["validation"][:, :, 2] = 255
+    segment = Segment(config.data, config.data.datasets[0], 0, "primary", tmp_path,
+                      "primary", "image", "labels", "supervision", "validation")
+    patch = Patch(segment=segment, bbox=(0, 0, 0, 5, 4, 4), is_validation=is_validation,
+                  supervision_mask_override="validation" if is_validation else None)
+    dataset = InkDataset(config.data, do_augmentations=augment, patches=[patch], segments=[segment])
+    dataset._open = lambda path, resolution: arrays[str(path)]
+    yy, xx = np.indices((4, 4), dtype=np.float32)
+    positions = np.stack([np.full_like(yy, 4), yy + 2, xx + 2], axis=-1)
+    dataset._tifxyz_cache[str(tmp_path)] = _FakeTifxyz(positions)
+    return config, dataset, arrays
+
+
+def _load_and_loss(config, dataset):
+    random.seed(431)
+    np.random.seed(431)
+    torch.manual_seed(431)
+    sample = dataset[0]
+    batch = {name: value.unsqueeze(0) for name, value in sample.items() if isinstance(value, torch.Tensor)}
+    batch = apply_label_dilation(batch, 0.0, 0.0)
+    logits = torch.linspace(-1.3, 1.7, sample["inklabels"].numel()).reshape_as(batch["inklabels"])
+    logits.requires_grad_()
+    prediction, targets, ignore = prepare_loss_inputs(logits, batch, mode=config.data.mode)
+    packed = concatenate_deep_supervision_ignore(targets, ignore, prediction)
+    loss = create_loss(config)(prediction, packed)
+    loss.backward()
+    return sample, loss.detach(), logits.grad
+
+
+@pytest.mark.parametrize("mode", ["full_3d", "full_3d_single_wrap"])
+@pytest.mark.parametrize("is_validation", [False, True])
+@pytest.mark.parametrize("augment", [False, True])
+def test_excluded_values_do_not_change_native_sample_loss_or_gradient(tmp_path, mode, is_validation, augment):
+    config, dataset, arrays = _native_fixture(tmp_path, mode, is_validation, augment=augment)
+    excluded = arrays["validation"] == 0 if is_validation else arrays["validation"] > 0
+    original_labels = arrays["labels"].copy()
+    original, loss, gradient = _load_and_loss(config, dataset)
+    for value in (0, 255):
+        arrays["labels"] = original_labels.copy()
+        arrays["labels"][excluded] = value
+        mutated, other_loss, other_gradient = _load_and_loss(config, dataset)
+        for name in original:
+            if isinstance(original[name], torch.Tensor):
+                torch.testing.assert_close(mutated[name], original[name], rtol=0, atol=0)
+            else:
+                assert mutated[name] == original[name]
+        torch.testing.assert_close(other_loss, loss, rtol=0, atol=0)
+        torch.testing.assert_close(other_gradient, gradient, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("mode", ["full_3d", "full_3d_single_wrap"])
+def test_permitted_positive_outside_supervision_is_preserved(tmp_path, mode):
+    config, dataset, arrays = _native_fixture(tmp_path, mode, False)
+    original, _, _ = _load_and_loss(config, dataset)
+    # Column 3 is outside ordinary supervision but is not validation. Native
+    # projection deliberately treats these positive labels as supervised.
+    arrays["labels"][:, :, 3] = 0
+    changed, _, _ = _load_and_loss(config, dataset)
+    assert original["inklabels"].sum() > changed["inklabels"].sum()
+    assert original["supervision_mask"].sum() > changed["supervision_mask"].sum()
+    if mode == "full_3d_single_wrap":
+        torch.testing.assert_close(original["surface_mask"], changed["surface_mask"], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("finder", [find_default, find_subtiling])
+@pytest.mark.parametrize("role", ["train", "validation"])
+@pytest.mark.parametrize("mask_value", [1, 255])
+def test_discovery_membership_ignores_excluded_ink(tmp_path, finder, role, mask_value):
+    mapping = _config_mapping(depth=3, side=4)
+    mapping.update(patch_overlap=0.5, patch_min_labeled_coverage=0.1,
+                   datasets=[{"segments_path": str(tmp_path), "volume_scale": 0}])
+    if finder is find_subtiling:
+        mapping.update(patch_finding_type="subtiling", patch_finding_filter_empty_tile=True)
+    config = InkConfig.from_mapping(mapping)
+    segment = Segment(config.data, config.data.datasets[0], 0, "discovery", tmp_path,
+                      "discovery", "image", "labels", "supervision", "validation")
+    arrays = {"image": np.ones((3, 8, 8), dtype=np.uint8),
+              "supervision": np.full((3, 8, 8), mask_value, dtype=np.uint8),
+              "validation": np.zeros((3, 8, 8), dtype=np.uint8),
+              "labels": np.zeros((3, 8, 8), dtype=np.uint8)}
+    arrays["validation"][:, :, 4:] = mask_value
+    arrays["labels"][:, 1:3, 1:3] = 255
+    arrays["labels"][:, 1:3, 5:7] = 255
+    excluded = arrays["validation"] > 0 if role == "train" else arrays["validation"] == 0
+    original_labels = arrays["labels"].copy()
+    def discover():
+        training, validation = finder(segment, lambda path, resolution: arrays[str(path)])
+        return [p.bbox for p in (training if role == "train" else validation)]
+    original = discover()
+    assert original
+    for value in (0, 255):
+        arrays["labels"] = original_labels.copy()
+        arrays["labels"][excluded] = value
+        assert discover() == original
+
+
+def test_intersecting_segment_already_excludes_heldout_values(tmp_path):
+    config, dataset, arrays = _native_fixture(tmp_path, "full_3d", False)
+    primary = dataset.segments[0]
+    other = replace(primary, segment_relpath="other", segment_dir=tmp_path / "other",
+                    inklabels="other_labels", supervision_mask="other_supervision",
+                    validation_mask="other_validation")
+    for kind in ("labels", "supervision", "validation"):
+        arrays[f"other_{kind}"] = arrays[kind].copy()
+    arrays["labels"].fill(0)
+    dataset._tifxyz_cache[str(other.segment_dir)] = dataset._tifxyz_cache[str(tmp_path)]
+    key = (primary.dataset_idx, str(primary.image_volume), primary.scale)
+    dataset._segments_by_volume[key] = [primary, other]
+    original, loss, gradient = _load_and_loss(config, dataset)
+    arrays["other_labels"][arrays["other_validation"] > 0] = 0
+    mutated, other_loss, other_gradient = _load_and_loss(config, dataset)
+    for name in original:
+        torch.testing.assert_close(mutated[name], original[name], rtol=0, atol=0)
+    torch.testing.assert_close(other_loss, loss, rtol=0, atol=0)
+    torch.testing.assert_close(other_gradient, gradient, rtol=0, atol=0)
+    arrays["other_labels"][:, :, 1] = 0
+    permitted_change, _, permitted_gradient = _load_and_loss(config, dataset)
+    assert not torch.equal(permitted_change["inklabels"], original["inklabels"])
+    assert not torch.equal(permitted_gradient, gradient)
+
+
+@pytest.mark.parametrize("mode", ["full_3d", "full_3d_single_wrap"])
+def test_warm_cache_preserves_ordinary_training_scope(tmp_path, mode):
+    config, dataset, arrays = _native_fixture(tmp_path, mode, False)
+    cold, loss, gradient = _load_and_loss(config, dataset)
+    path = tmp_path / "patches.json"
+    save_patch_cache(path, dataset.patches)
+    restored = load_patch_cache(path, config=config.data, segments=dataset.segments)
+    assert restored is not None
+    assert str(restored[0].supervision_mask_override) == str(restored[0].segment.supervision_mask)
+    dataset.patches = restored
+    warm, other_loss, other_gradient = _load_and_loss(config, dataset)
+    for name in cold:
+        torch.testing.assert_close(warm[name], cold[name], rtol=0, atol=0)
+    torch.testing.assert_close(other_loss, loss, rtol=0, atol=0)
+    torch.testing.assert_close(other_gradient, gradient, rtol=0, atol=0)
+    arrays["labels"][:, :, 3] = 0
+    changed, _, changed_gradient = _load_and_loss(config, dataset)
+    assert changed["inklabels"].sum() < warm["inklabels"].sum()
+    assert not torch.equal(changed_gradient, other_gradient)
+
+
+def test_distinct_training_override_is_a_restrictive_scope(tmp_path):
+    config, dataset, arrays = _native_fixture(tmp_path, "full_3d", False)
+    arrays["scope"] = arrays["supervision"].copy()
+    dataset.patches = [replace(dataset.patches[0], supervision_mask_override="scope")]
+    original, loss, gradient = _load_and_loss(config, dataset)
+    arrays["labels"][arrays["scope"] == 0] = 0
+    changed, other_loss, other_gradient = _load_and_loss(config, dataset)
+    for name in original:
+        torch.testing.assert_close(changed[name], original[name], rtol=0, atol=0)
+    torch.testing.assert_close(other_loss, loss, rtol=0, atol=0)
+    torch.testing.assert_close(other_gradient, gradient, rtol=0, atol=0)
+
+
+def test_empty_cache_is_recomputed(tmp_path):
+    config, dataset, _ = _native_fixture(tmp_path, "full_3d", False)
+    path = tmp_path / "empty.json"
+    path.write_text("[]")
+    assert load_patch_cache(path, config=config.data, segments=dataset.segments) is None
+
+
+@pytest.mark.parametrize("is_validation", [False, True])
+def test_intersecting_segment_without_validation_has_only_training_scope(tmp_path, is_validation):
+    config, dataset, arrays = _native_fixture(tmp_path, "full_3d", is_validation)
+    primary = dataset.segments[0]
+    other = replace(primary, segment_relpath="other", segment_dir=tmp_path / "other",
+                    inklabels="other_labels", supervision_mask="other_supervision",
+                    validation_mask=None)
+    arrays["labels"].fill(0)
+    arrays["other_labels"] = np.zeros_like(arrays["labels"])
+    arrays["other_labels"][:, :, 1] = 255
+    arrays["other_supervision"] = arrays["supervision"].copy()
+    arrays["other_validation"] = np.zeros_like(arrays["validation"])
+    dataset._tifxyz_cache[str(other.segment_dir)] = dataset._tifxyz_cache[str(tmp_path)]
+    key = (primary.dataset_idx, str(primary.image_volume), primary.scale)
+    dataset._segments_by_volume[key] = [primary, other]
+    original, loss, gradient = _load_and_loss(config, dataset)
+    arrays["other_labels"].fill(0)
+    erased, erased_loss, erased_gradient = _load_and_loss(config, dataset)
+    if not is_validation:
+        # Ordinary training must still receive this training-only segment.
+        assert original["inklabels"].sum() > erased["inklabels"].sum()
+        assert not torch.equal(gradient, erased_gradient)
+        return
+    for name in original:
+        torch.testing.assert_close(erased[name], original[name], rtol=0, atol=0)
+    torch.testing.assert_close(erased_loss, loss, rtol=0, atol=0)
+    torch.testing.assert_close(erased_gradient, gradient, rtol=0, atol=0)
+
+    arrays["other_labels"][:, :, 1] = 255
+    other = replace(other, validation_mask="other_validation")
+    dataset._segments_by_volume[key] = [primary, other]
+    empty_validation, _, _ = _load_and_loss(config, dataset)
+    for name in original:
+        torch.testing.assert_close(empty_validation[name], original[name], rtol=0, atol=0)
+    # A real held-out positive is retained once the other segment assigns it V.
+    arrays["other_validation"][:, :, 1] = 255
+    allowed, _, allowed_gradient = _load_and_loss(config, dataset)
+    assert allowed["inklabels"].sum() > original["inklabels"].sum()
+    assert not torch.equal(allowed_gradient, gradient)
+    assert torch.any((allowed["inklabels"] == 0) & (allowed["supervision_mask"] > 0))
+
+
+def test_subtiling_cache_rejects_a_changed_coverage_threshold(tmp_path):
+    mapping = _config_mapping(depth=3, side=2)
+    mapping.update(patch_finding_type="subtiling", patch_finding_filter_empty_tile=True,
+                   patch_finding_tile_size=4, patch_finding_stride=4,
+                   datasets=[{"segments_path": str(tmp_path), "volume_scale": 0}])
+    config = InkConfig.from_mapping(mapping)
+    segment = Segment(config.data, config.data.datasets[0], 0, "cache", tmp_path,
+                      "cache", "image", "labels", "supervision", None)
+    arrays = {"image": np.ones((3, 4, 4), dtype=np.uint8),
+              "supervision": np.full((3, 4, 4), 255, dtype=np.uint8),
+              "labels": np.zeros((3, 4, 4), dtype=np.uint8)}
+    arrays["labels"][:, 0, 0] = 255
+    opener = lambda path, resolution: arrays[str(path)]
+    patches, _ = find_subtiling(segment, opener)
+    assert len(patches) == 4
+    path = tmp_path / "subtiling.json"
+    save_patch_cache(path, patches)
+    warm = load_patch_cache(path, config=config.data, segments=[segment])
+    assert warm is not None
+    assert [p.bbox for p in warm] == [p.bbox for p in patches]
+
+    mapping["patch_min_labeled_coverage"] = 0.1
+    changed_config = InkConfig.from_mapping(mapping)
+    changed_segment = replace(segment, data_config=changed_config.data,
+                              source=changed_config.data.datasets[0])
+    changed, _ = find_subtiling(changed_segment, opener)
+    assert len(changed) == 1
+    assert patch_cache_path(config.data) != patch_cache_path(changed_config.data)
+    assert load_patch_cache(path, config=changed_config.data, segments=[changed_segment]) is None
+
+
+@pytest.mark.parametrize("finder", [find_default, find_subtiling])
+def test_positive_mask_encodings_do_not_create_fully_heldout_training_patches(tmp_path, finder):
+    mapping = _config_mapping(depth=3, side=4)
+    mapping.update(patch_overlap=0.5, patch_min_labeled_coverage=0.0,
+                   datasets=[{"segments_path": str(tmp_path), "volume_scale": 0}])
+    if finder is find_subtiling:
+        mapping.update(patch_finding_type="subtiling", patch_finding_filter_empty_tile=True)
+    config = InkConfig.from_mapping(mapping)
+    segment = Segment(config.data, config.data.datasets[0], 0, "masks", tmp_path,
+                      "masks", "image", "labels", "supervision", "validation")
+    arrays = {"image": np.ones((3, 8, 8), dtype=np.uint8),
+              "supervision": np.full((3, 8, 8), 255, dtype=np.uint8),
+              "validation": np.ones((3, 8, 8), dtype=np.uint8),
+              "labels": np.full((3, 8, 8), 255, dtype=np.uint8)}
+    training, validation = finder(segment, lambda path, resolution: arrays[str(path)])
+    assert not training
+    assert validation
+
+
+@pytest.mark.parametrize("mode", ["full_3d", "full_3d_single_wrap"])
+@pytest.mark.parametrize("is_validation", [False, True])
+def test_excluded_values_do_not_change_model_input_or_deep_supervision(tmp_path, mode, is_validation):
+    config, dataset, arrays = _native_fixture(tmp_path, mode, is_validation)
+    authored = config.to_mapping()
+    authored.update(num_iterations=3, seed=431, out_dir=str(tmp_path),
+                    in_channels=2 if mode == "full_3d_single_wrap" else 1)
+    training = TrainingConfig.from_mapping(resolve_training_mapping(authored))
+
+    def objective():
+        sample = dataset[0]
+        batch = {name: value.unsqueeze(0) for name, value in sample.items()}
+        model_input = prepare_model_input(batch, training)
+        heads = [
+            torch.linspace(-1.3 + index * 0.2, 1.7, int(np.prod(shape)))
+            .reshape(1, 1, *shape).requires_grad_()
+            for index, shape in enumerate(((5, 4, 4), (3, 2, 2), (2, 1, 1)))
+        ]
+        predictions, targets, ignore = prepare_loss_inputs(heads, batch, mode=mode)
+        packed = concatenate_deep_supervision_ignore(targets, ignore, predictions)
+        loss = DeepSupervisionWrapper(create_loss(config), deep_supervision_weights(3))(
+            predictions, packed
+        )
+        loss.backward()
+        gradients = [None if head.grad is None else head.grad.clone() for head in heads]
+        assert all(torch.count_nonzero(gradient) for gradient in gradients[:2])
+        assert gradients[2] is None  # Production gives the last decoder zero weight.
+        return model_input, loss.detach(), gradients
+
+    original_input, original_loss, original_gradients = objective()
+    original_labels = arrays["labels"].copy()
+    excluded = arrays["validation"] == 0 if is_validation else arrays["validation"] > 0
+    for value in (0, 255):
+        arrays["labels"] = original_labels.copy()
+        arrays["labels"][excluded] = value
+        model_input, loss, gradients = objective()
+        torch.testing.assert_close(model_input, original_input, rtol=0, atol=0)
+        torch.testing.assert_close(loss, original_loss, rtol=0, atol=0)
+        for gradient, original_gradient in zip(gradients[:2], original_gradients[:2], strict=True):
+            torch.testing.assert_close(gradient, original_gradient, rtol=0, atol=0)


### PR DESCRIPTION
**In one sentence:** Native ink training and validation now respect explicit annotation exclusions when choosing patches and constructing targets.

**One real example:** On the original PHerc0139 `w016_2025010815` v2 annotations, erasing only held-out ink changed 428 native training-target voxels and 4,795 logit-gradient entries in a real 128³ crop. After this patch, neither changes. CT input, geometry, masks, and random seeds stay fixed.

**Before:** Native projection could restore excluded positive annotations as supervised targets. Those annotations also influenced coverage filtering and subtiling patch selection.

**After this PR:** The tested native samples, objectives, and ordered patch membership are independent of excluded annotation values. Permitted positives outside generic supervision remain supported, and physical model inputs are preserved.

**Proof:** Existing held-out ink affected 22 of 61 mixed training crops across PHerc0139 and PHerc1667 before the fix and zero afterward. A fresh source copy with this exact patch passes the portable real-CT replay on all 28 tested mode/role/crop cases.

![Native targets before and after, using the same scan and crop](https://raw.githubusercontent.com/Mickey123123/vesuvius-native-supervision-isolation/main/figures/native_targets_before_after.png)

[Report and provenance](https://github.com/Mickey123123/vesuvius-native-supervision-isolation/blob/main/REPORT.md) · [Original console output](https://github.com/Mickey123123/vesuvius-native-supervision-isolation/blob/main/evidence/portable-before-full.log) · [Patched console output](https://github.com/Mickey123123/vesuvius-native-supervision-isolation/blob/main/evidence/portable-after-full.log) · [Complete reproduction bundle](https://github.com/Mickey123123/vesuvius-native-supervision-isolation/releases/tag/v1.0.0)

**Why / where this is useful:** I used an AI-assisted workflow to explore improvements to native ink detection. That led to a problem with how excluded annotations were being used in training. We reproduced it on real data from two scrolls, verified the fix, and packaged the tests and before/after evidence so others can check it. The value is straightforward: more reliable experiments before researchers spend time and compute training models.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

- Baseline: `b218ace879d3239a63047e1e2039f327929d283e`. Full ink suite: **302 passed**, two optional teacher-checkpoint tests skipped. The 32 new regression cases produce 24 failures and 8 passing controls on the original source; all pass after the fix.
- Training clears explicitly held-out ink before projection. Validation restricts annotations to its selected scope and skips intersecting segments with no validation mask. Ordinary permitted positives and training-only intersections remain supported.
- Default and subtiling discovery respect the same exclusions. Cache v7 invalidates old semantics; subtiling cache identity includes minimum coverage. Validation now includes eligible negative-only tiles, so rebuild caches and establish a new validation baseline. The separate same-path label-asset invalidation in #1701 is complementary.
- The real-data objective uses fixed, nonconstant CT-derived logits with the production Dice/BCE loss and backward. This demonstrates annotation-value isolation; it does not measure improved reading accuracy or implicate any released checkpoint. Positive CUDA/cuCIM dilation and teacher-label modes were not evaluated.
- Scientific replay and tests ran on Linux aarch64, Python 3.12, Torch 2.14, CPU. The declared Python 3.14 environment was not fully validated. [Exact commands and environment](https://github.com/Mickey123123/vesuvius-native-supervision-isolation/blob/main/REPRODUCE.md).

AI assistance was used for implementation, experiments, review, and drafting. Miika Kestilä personally reviewed the contribution and authorized submission. His review confirmation was: “i have reviewed it myself it looks good.”
