### PR TITLE
docs(spiral tutorial): note that input_use_tracks defaults to false

### DIFF
--- a/scrollprize.org/docs/38_tutorial_spiral.md
+++ b/scrollprize.org/docs/38_tutorial_spiral.md
@@ -121,6 +121,14 @@ re-running rclone resumes interrupted downloads. The dataset contains verified a
 Configuration is straightforward: the input paths and fitting region are plain variables at the top of `fit_spiral.py`. Edit them to point at your download:
 
 - `dataset_path` — the root of the dataset; the per-input paths below it (`verified_patches_path`, `unverified_patches_path`, `pcl_json_paths`, `fibers_path`, `shell_path`, `tracks_dbm_path`, the normals/grad-mag zarr paths, …) default to locations inside it. Set any of them to `None` to fit without that input.
+- **`input_use_*` — whether an input that is present is actually used.** Each optional input has a toggle in `default_config`, independent of whether its file is there. `input_use_tracks` has defaulted to `false` since [#1651](https://github.com/ScrollPrize/villa/pull/1651), so a dataset that ships a tracks DBM will not use it unless you say so:
+
+  ```
+  FIT_SPIRAL_CONFIG_OVERRIDES='{"input_use_tracks": true, ...}'
+  ```
+
+  This matters most on scrolls whose only published supervision is tracks, which is the case for most of the Grand-Prize-eligible ones: with tracks off and no verified patches, nothing left in the fit places a point on a winding — normals give orientation, and two adjacent windings have parallel normals. The fit still converges and writes a normal-looking checkpoint. See [#1716](https://github.com/ScrollPrize/villa/issues/1716).
+
 - `z_begin, z_end` — the slice range (in full-resolution voxels) to fit. **Consider starting with a small range**: the whole written region of Scroll 1 is roughly z 4,000–17,000, and fitting all of it needs a lot of GPU memory (around 60 GB). A ~1,000-slice range is a good first run on a smaller GPU. Per-step sample counts are scaled automatically to the size of the z-range, so hyperparameters don't need retuning when you change it.
 
 Everything else — loss weights, resolutions, step counts — lives in the `default_config` dict just below, with one entry per knob. You can override any of them without editing the file via a JSON environment variable, and a few other environment variables control the run:


### PR DESCRIPTION
**In one sentence:** the tutorial's Configure section lists the per-input paths but not the `input_use_*` toggles, so a reader who has a tracks DBM and points the fitter at it has no way to learn that `input_use_tracks` has defaulted to `false` since #1651.

**One real example:** following the First Letters workflow post on PHerc0826 — published tracks, published umbilicus, the post's overrides verbatim — the tracks are never loaded and never mentioned, and the fit runs its 30,000 iterations anyway. The tutorial is where a reader would go to find out why, and it does not say.

**Before:** the section says the per-input paths "default to locations inside it. Set any of them to `None` to fit without that input." Nothing about the toggles that decide whether a path that *is* set gets used.

**After this PR:** one bullet, before the `z_begin, z_end` one, naming the toggles, giving the override, and saying why it matters on scrolls whose only published supervision is tracks:

> `input_use_tracks` has defaulted to `false` since #1651, so a dataset that ships a tracks DBM will not use it unless you say so […] with tracks off and no verified patches, nothing left in the fit places a point on a winding — normals give orientation, and two adjacent windings have parallel normals. The fit still converges and writes a normal-looking checkpoint.

**Proof:** measured on PHerc0826, volume `20250821151701`, z ∈ [11000, 12000), 30,000 iterations, seed 1, the umbilicus published on 3 September, one config key apart:

| | recipe as published | + `"input_use_tracks": true` |
|---|---:|---:|
| tracks loaded | 0 | 480,117 |
| `dr_per_winding` | 16.8663 vx | 14.8851 vx |
| satisfied track points | 20.9% | 41.6% |

Full write-up and logs in #1716. #1713 makes `fit_spiral` say this at runtime; this PR is the documentation half, and is the cheaper of the two fixes that issue proposes.

**Why / where this is useful:** anyone reading the tutorial to set up a fit on one of the 13 eligible scrolls, nine of which publish tracks and nothing else, and none of which publishes verified patches.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.
