### PR TITLE
spiral-fitting: document the two metrics get_ink_metrics.py already writes

### DIFF
--- a/spiral-fitting/autoresearch.md
+++ b/spiral-fitting/autoresearch.md
@@ -91,13 +91,15 @@ and writes the same numbers as JSON to `.../ink_metric/metrics.json`:
     "num_strips": 42,
     "total_fg_pixels": 1234567,
     "total_pixels": 9876543,
-    "overall_fg_fraction": 0.125
+    "overall_fg_fraction": 0.125,
+    "overall_line_score": 0.403,
+    "overall_column_score": 0.191
   },
   "strips": [ ... ]
 }
 ```
 
-**Read the metric from `metrics.json`** (robust to log formatting) — the primary field is `summary.total_fg_pixels`, the guard is `summary.overall_fg_fraction`. If `metrics.json` is missing, the run did not finish cleanly; check the three per-step logs (`.fit.log`, `.ink.log`, `.coverage.log`) for the failure. (Absolute numbers depend on the machine; only relative comparisons against the baseline on the same machine matter.)
+**Read the metric from `metrics.json`** (robust to log formatting) — the primary field is `summary.total_fg_pixels`, the guard is `summary.overall_fg_fraction`. The scorer also computes and persists `summary.overall_line_score` and `summary.overall_column_score`, text-layout scores over the ensemble ink probabilities; they are recorded here for completeness and are neither the objective nor a prescribed guard. If `metrics.json` is missing, the run did not finish cleanly; check the three per-step logs (`.fit.log`, `.ink.log`, `.coverage.log`) for the failure. (Absolute numbers depend on the machine; only relative comparisons against the baseline on the same machine matter.)
 
 ## Logging results
 


### PR DESCRIPTION
Closes the second half of #1658 (the first half was #1721).

`get_ink_metrics.py` computes and persists two further summary fields, and prints both:

```
630:        'overall_line_score': row['line_score'],
631:        'overall_column_score': row['col_score'],
```

`autoresearch.md` mentions neither, and its `metrics.json` example omits them, so a reader following the doc does not know they are there.

This adds both to the example and notes that they exist.

**Deliberately not promoted to a guard or an objective.** The doc is explicit that ink coverage is the metric and that the satisfaction metrics are a cross-check rather than a target; whether these layout scores should play either role is a judgement for you, not something a docs PR should decide. For what it is worth, we measured them on a duplicate-coverage arm and they moved as much for the honest arm as for the duplicated one, so we would not suggest them as an anti-gaming guard.

Documentation only, no behaviour change.