### PR TITLE
spiral-fitting: note which resident-pool sidecars the defaults load

### DIFF
--- a/spiral-fitting/README.md
+++ b/spiral-fitting/README.md
@@ -135,6 +135,15 @@ python pack_resident_pools.py /path/to/lasagna_inputs \
     --ct /path/to/<scroll>_ds2.zarr --ct-group 2 --verify 2000
 ```
 
+**Which sidecars the defaults actually load.** `dense_spacing_mode` defaults to
+`winding_model`, so `_grad_mag_required()` is false and the gradient-magnitude
+sidecar is never read; `input_use_surf_sdt` defaults to false, so
+`_phase_bundle_enabled()` is false and the surf-SDT sidecar is never read
+either. A default fit therefore needs only the normals sidecar. On the published
+`spiral_datasets/PHercParis4` that is 11 GB of a 47.5 GB `lasagna_inputs/`
+directory — the 33 GB `surf_sdt` and 4.8 GB `grad_mag` pools are only needed if
+you switch `dense_spacing_mode` to `phase` or `grad_mag`.
+
 `--ct` zeroes every voxel whose CT voxel reads 0 (the mask region around the
 scroll) so those bricks drop out of the pool and sample as no-data. The
 fitter loads the sidecars restricted to the configured z-ROI in one


### PR DESCRIPTION
From #1655, narrowed to the one part of that issue still not covered by the docs.

`lasagna_inputs/` on the published `spiral_datasets/PHercParis4` is 47.5 GB, but a default fit reads only the normals sidecar (11 GB):

- `dense_spacing_mode` defaults to `winding_model` (`config.py`), so `_grad_mag_required()` is false and the 4.8 GB gradient-magnitude pool is never read.
- `input_use_surf_sdt` defaults to false, so `_phase_bundle_enabled()` is false and the 33 GB surf-SDT pool is never read.

Someone starting from the published data has no way to know that from the README, and downloading all 47.5 GB is the natural default. I did.

**Correction to #1655, which I should have caught before filing it.** That issue listed four obstacles as undocumented. Three of them are documented and I missed it:

- `spiral-scroll.json` and its required keys — documented in this README since #1628 (2026-08-28), two days *before* I filed.
- The `paths.winding_inference` override — documented in the same file.
- The `input_use_*` switches — documented, and the README example uses the same three I needed.

Only the sidecar point above was actually missing, so that is all this PR changes. Apologies for the noise on #1655; I have changed my own process to check current upstream docs before filing rather than after.

Documentation only, no behaviour change.