### PR TITLE
tifxyz_label_transfer: close memory maps so temp dirs can be removed on Windows

### DIFF
--- a/vesuvius/src/vesuvius/tifxyz_label_transfer/io.py
+++ b/vesuvius/src/vesuvius/tifxyz_label_transfer/io.py
@@ -19,11 +19,30 @@ import tifffile
 from .core import Surface
 
 
+def close_memmap(array: object) -> None:
+    """Release the file mapping behind ``array``, if it has one.
+
+    POSIX lets a mapped file be unlinked or replaced while the mapping is
+    live; Windows refuses with a sharing violation. Any mapping this module
+    opens therefore needs an explicit end of life rather than relying on the
+    owner happening to hold the last reference to the array.
+    """
+    mapping = getattr(array, "_mmap", None)
+    if mapping is not None and not mapping.closed:
+        mapping.close()
+
+
 def _read_tiff(path: Path) -> NDArray:
-    try:
-        return tifffile.memmap(path, mode="r")
-    except ValueError:
-        return tifffile.imread(path)
+    """Read a TIFF into an array this process owns.
+
+    This used to memory-map the file, which handed every caller of
+    :func:`load_surface`, :func:`read_image` and :func:`load_tifxyz_mask` an
+    array that pinned its backing file for as long as they kept it, with no
+    close path. The mapped branch only ever applied to uncompressed files --
+    this module writes its own TIFFs zlib-compressed, so those already took
+    the eager fallback -- and every caller materialises the result anyway.
+    """
+    return tifffile.imread(path)
 
 
 def load_tifxyz_mask(
@@ -234,7 +253,12 @@ class TemporaryRaster:
         self.array[:] = fill_value
 
     def close(self) -> None:
+        # Callers are handed ``self.array`` (core.py's optional output arrays),
+        # so dropping this one reference is not enough to release the mapping;
+        # on Windows the unlink below then fails. Every read of the raster
+        # happens before its owner closes, so ending the mapping here is safe.
         self.array.flush()
+        close_memmap(self.array)
         del self.array
         self.path.unlink(missing_ok=True)
 

--- a/vesuvius/src/vesuvius/tifxyz_label_transfer/io.py
+++ b/vesuvius/src/vesuvius/tifxyz_label_transfer/io.py
@@ -26,7 +26,13 @@ def close_memmap(array: object) -> None:
     live; Windows refuses with a sharing violation. Any mapping this module
     opens therefore needs an explicit end of life rather than relying on the
     owner happening to hold the last reference to the array.
+
+    Pass the array that owns the mapping. NumPy propagates ``_mmap`` to
+    views, so closing through a view would close the parent out from under
+    everyone else holding it; a view is rejected rather than honoured.
     """
+    if isinstance(getattr(array, "base", None), np.memmap):
+        raise ValueError("close_memmap needs the owning array, not a view of it")
     mapping = getattr(array, "_mmap", None)
     if mapping is not None and not mapping.closed:
         mapping.close()
@@ -38,9 +44,14 @@ def _read_tiff(path: Path) -> NDArray:
     This used to memory-map the file, which handed every caller of
     :func:`load_surface`, :func:`read_image` and :func:`load_tifxyz_mask` an
     array that pinned its backing file for as long as they kept it, with no
-    close path. The mapped branch only ever applied to uncompressed files --
-    this module writes its own TIFFs zlib-compressed, so those already took
-    the eager fallback -- and every caller materialises the result anyway.
+    close path -- issue #1671's list of locked files starts with ``x.tif``.
+    The mapped branch applied to exactly the files that matter here: the
+    uncompressed ``x/y/z.tif`` grids that VC's C++ QuadSurface writes. Nothing
+    reads them lazily, though -- ``core``'s neighbour arithmetic differences
+    the whole grid against itself -- so the mapping only ever deferred a read
+    that always happened. The trade is evictable page cache for resident RAM
+    of the same size: three float32 grids per surface, and ``register_render``
+    loads two surfaces at once.
     """
     return tifffile.imread(path)
 

--- a/vesuvius/src/vesuvius/tifxyz_label_transfer/view_alignment_napari.py
+++ b/vesuvius/src/vesuvius/tifxyz_label_transfer/view_alignment_napari.py
@@ -34,7 +34,7 @@ from vesuvius.utils.cli import HyphenUnderscoreParser
 
 from .core import transfer_array as transfer_surface_array
 from .estimate_canvas_offset import measure_render_shift
-from .io import load_surface as load_full_surface
+from .io import close_memmap, load_surface as load_full_surface
 from .prepare_canvas_offset_evidence import (
     DEFAULT_INK_ROOT,
     DEFAULT_OPEN_DATA_ROOT,
@@ -591,7 +591,12 @@ def preview_cache_name(name: str, factor: int) -> str:
 
 
 def read_render_tiff(path: Path) -> np.ndarray:
-    """Open a cached render without copying the complete raster into RAM."""
+    """Open a cached render without copying the complete raster into RAM.
+
+    The result may be a live mapping of ``path``, which pins the file until it
+    is released; pass it to :func:`close_memmap` when done, or call
+    :func:`read_render_array` instead to get an array that owns its memory.
+    """
 
     try:
         return tifffile.memmap(path, mode="r")
@@ -599,6 +604,25 @@ def read_render_tiff(path: Path) -> np.ndarray:
         # Externally supplied evidence may be tiled or compressed and therefore
         # cannot be memory-mapped.  Keep compatibility with those files.
         return tifffile.imread(path)
+
+
+def read_render_array(path: Path) -> np.ndarray:
+    """Read a cached render into an array this process owns.
+
+    Every render handed back to a caller goes through here. Returning the
+    mapping itself leaves ``path`` open for as long as the caller keeps the
+    array: POSIX still allows the file to be unlinked or replaced, Windows
+    refuses with a sharing violation, so a mapping that escapes this module
+    has no end of life anyone can reach.
+    """
+
+    render = read_render_tiff(path)
+    if not isinstance(render, np.memmap):
+        return render
+    try:
+        return np.array(render)
+    finally:
+        close_memmap(render)
 
 
 def read_tiff_nearest(path: Path, shape: tuple[int, int]) -> np.ndarray:
@@ -735,7 +759,7 @@ def load_middle_three_max(
         raise ValueError("plane_count must be a positive odd integer")
     if cache_path.is_file():
         print(f"Using cached middle-{plane_count} max: {cache_path}")
-        return read_render_tiff(cache_path)
+        return read_render_array(cache_path)
     if "://" not in root_url:
         info = inspect_rclone_zarr(root_url, preferred_level)
         middle = info.shape[0] // 2
@@ -755,7 +779,7 @@ def load_middle_three_max(
         print(
             f"Using rclone-backed middle-{plane_count} max: {cache_path}"
         )
-        return read_render_tiff(cache_path)
+        return read_render_array(cache_path)
 
     raise ValueError(
         "HTTP/URL zarr access is disabled; data must be read with "
@@ -807,7 +831,7 @@ def evidence_comparison_render(
             return None
         path = copied_path
     print(f"Using prepared {comparison_name} render: {path}")
-    return read_render_tiff(path)
+    return read_render_array(path)
 
 
 def evidence_center_render(case: Case, key: str) -> np.ndarray | None:
@@ -871,7 +895,7 @@ def _load_registered_render_cache(
         cache_report = json.loads(cache_report_path.read_text(encoding="utf-8"))
         comparable = {key: cache_report.get(key) for key in expected}
         if comparable == expected:
-            return read_render_tiff(cache)
+            return read_render_array(cache)
     except (OSError, ValueError, TypeError):
         pass
     return None
@@ -948,7 +972,7 @@ def register_render(
         encoding="utf-8",
     )
     print(f"Cached TIFXYZ-registered surface render -> {cache}")
-    return read_render_tiff(cache)
+    return read_render_array(cache)
 
 
 def report_affine_matrix(
@@ -1075,8 +1099,8 @@ def load_diagnostic_renders(
                 source_path = Path(self_report[source_key])
                 target_path = Path(self_report[target_key])
                 if source_path.is_file() and target_path.is_file():
-                    source_image = read_render_tiff(source_path)
-                    target_image = read_render_tiff(target_path)
+                    source_image = read_render_array(source_path)
+                    target_image = read_render_array(target_path)
                     plan_path = self_report_path.with_name("plan.json")
                     plan = json.loads(plan_path.read_text(encoding="utf-8"))
                     bounds = [
@@ -1282,7 +1306,7 @@ def prepare_case(
         source_render = matched_source_render
         if source_render is None:
             if source_cache.is_file():
-                source_render = read_render_tiff(source_cache)
+                source_render = read_render_array(source_cache)
                 source_render_kind = "middle3-max"
             else:
                 source_render = evidence_center_render(

--- a/vesuvius/src/vesuvius/tifxyz_label_transfer/view_alignment_napari.py
+++ b/vesuvius/src/vesuvius/tifxyz_label_transfer/view_alignment_napari.py
@@ -614,6 +614,10 @@ def read_render_array(path: Path) -> np.ndarray:
     array: POSIX still allows the file to be unlinked or replaced, Windows
     refuses with a sharing violation, so a mapping that escapes this module
     has no end of life anyone can reach.
+
+    The cost is that an uncompressed cache is now resident rather than paged:
+    one render per call, the largest being ``load_middle_three_max``'s level-2
+    composites (>200 MiB, see ``prepare_canvas_offset_evidence``).
     """
 
     render = read_render_tiff(path)

--- a/vesuvius/tests/tifxyz_label_transfer/test_io.py
+++ b/vesuvius/tests/tifxyz_label_transfer/test_io.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import shutil
 import tempfile
 import unittest
 from unittest import mock
@@ -10,6 +11,7 @@ import numpy as np
 import tifffile
 
 from vesuvius.tifxyz_label_transfer.io import (
+    close_memmap,
     load_surface,
     read_image,
     read_image_shape,
@@ -167,6 +169,7 @@ class SurfaceIoTests(unittest.TestCase):
             return False
 
         temporary = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temporary, ignore_errors=True)
         surface_path = temporary / "surface.tifxyz"
         surface_path.mkdir()
         grid = np.zeros((2, 3), dtype=np.float32)
@@ -203,6 +206,24 @@ class SurfaceIoTests(unittest.TestCase):
         surface_path.rmdir()
         temporary.rmdir()
         self.assertFalse(temporary.exists())
+
+    def test_close_memmap_refuses_a_view_of_the_mapping(self) -> None:
+        """Closing through a view would close the parent for everyone.
+
+        NumPy copies ``_mmap`` onto every view, so the naive call succeeds and
+        leaves the owner reading freed pages -- a segfault, not an exception.
+        """
+        temporary = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temporary, ignore_errors=True)
+        raster = TemporaryRaster(
+            temporary, (2, 3), np.dtype(np.uint8), 0, ".probe-"
+        )
+        self.addCleanup(raster.close)
+
+        with self.assertRaises(ValueError):
+            close_memmap(raster.array[:1])
+
+        self.assertFalse(raster.array._mmap.closed)
 
 
 if __name__ == "__main__":

--- a/vesuvius/tests/tifxyz_label_transfer/test_io.py
+++ b/vesuvius/tests/tifxyz_label_transfer/test_io.py
@@ -14,6 +14,7 @@ from vesuvius.tifxyz_label_transfer.io import (
     read_image,
     read_image_shape,
     StreamingTiffOutputs,
+    TemporaryRaster,
 )
 from tests.zarr_utils import create_v2_group_array
 
@@ -148,6 +149,60 @@ class SurfaceIoTests(unittest.TestCase):
         expected = np.ones((2, 3), dtype=bool)
         expected[1, 2] = False
         np.testing.assert_array_equal(surface.valid, expected)
+
+    def test_readers_and_temporary_rasters_leave_no_file_mapped(self) -> None:
+        """Nothing this module hands back may keep its file mapped.
+
+        A mapping that outlives the call pins the file: on POSIX it merely
+        survives unlink, but on Windows the file cannot be removed at all,
+        which is what made every temporary directory in this suite fail to
+        clean up. Both platforms can see it in the returned arrays.
+        """
+
+        def maps_a_file(array: object) -> bool:
+            while array is not None:
+                if isinstance(array, np.memmap):
+                    return True
+                array = getattr(array, "base", None)
+            return False
+
+        temporary = Path(tempfile.mkdtemp())
+        surface_path = temporary / "surface.tifxyz"
+        surface_path.mkdir()
+        grid = np.zeros((2, 3), dtype=np.float32)
+        for axis in ("x", "y", "z"):
+            tifffile.imwrite(surface_path / f"{axis}.tif", grid, metadata=None)
+        (surface_path / "meta.json").write_text(
+            json.dumps({"scale": [1.0, 1.0]}), encoding="utf-8"
+        )
+        label_path = temporary / "label.tif"
+        tifffile.imwrite(
+            label_path, np.zeros((2, 3), dtype=np.uint8), metadata=None
+        )
+
+        surface = load_surface(surface_path, use_mask=False)
+        label = read_image(label_path)
+
+        for array in (surface.x, surface.y, surface.z, label):
+            self.assertFalse(maps_a_file(array))
+
+        # A caller holding one of the raster's own views must not stop its
+        # owner from releasing the backing file.
+        raster = TemporaryRaster(
+            temporary, (2, 3), np.dtype(np.uint8), 0, ".probe-"
+        )
+        raster_path = raster.path
+        escaped_view = raster.array[:1]
+        raster.close()
+        del escaped_view
+        self.assertFalse(raster_path.exists())
+
+        # Removable immediately, with the loaded arrays still referenced.
+        for item in (label_path, *surface_path.iterdir()):
+            item.unlink()
+        surface_path.rmdir()
+        temporary.rmdir()
+        self.assertFalse(temporary.exists())
 
 
 if __name__ == "__main__":

--- a/vesuvius/tests/tifxyz_label_transfer/test_view_alignment_napari.py
+++ b/vesuvius/tests/tifxyz_label_transfer/test_view_alignment_napari.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import shutil
 import tempfile
 import unittest
 from unittest import mock
@@ -377,6 +378,7 @@ class SurfaceVolumeCompositeTests(unittest.TestCase):
         and on Windows the cache can then be neither replaced nor deleted.
         """
         temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, ignore_errors=True)
         path = temp_dir / "render.tif"
         expected = np.arange(12, dtype=np.uint8).reshape(3, 4)
         tifffile.imwrite(path, expected, metadata=None)

--- a/vesuvius/tests/tifxyz_label_transfer/test_view_alignment_napari.py
+++ b/vesuvius/tests/tifxyz_label_transfer/test_view_alignment_napari.py
@@ -365,6 +365,31 @@ class SurfaceVolumeCompositeTests(unittest.TestCase):
             self.assertIsInstance(actual, np.memmap)
             np.testing.assert_array_equal(actual, expected)
 
+            # read_render_tiff hands back a live mapping, so this test owns it
+            # and has to release it before temp_dir is removed.
+            viewer.close_memmap(actual)
+
+    def test_render_array_reader_leaves_the_cache_file_unmapped(self) -> None:
+        """Renders handed to a caller must not keep their cache file mapped.
+
+        read_render_tiff maps deliberately, but a mapping that escapes has no
+        end of life the caller can reach: on POSIX it silently pins the file,
+        and on Windows the cache can then be neither replaced nor deleted.
+        """
+        temp_dir = Path(tempfile.mkdtemp())
+        path = temp_dir / "render.tif"
+        expected = np.arange(12, dtype=np.uint8).reshape(3, 4)
+        tifffile.imwrite(path, expected, metadata=None)
+
+        actual = viewer.read_render_array(path)
+
+        self.assertNotIsInstance(actual, np.memmap)
+        self.assertNotIsInstance(actual.base, np.memmap)
+        # Removable straight away, with the render still referenced.
+        path.unlink()
+        temp_dir.rmdir()
+        np.testing.assert_array_equal(actual, expected)
+
     def test_centered_thirteen_plane_max_selects_six_each_side(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             cache = Path(temp_dir) / "middle13.tif"


### PR DESCRIPTION
**Motivation (written by me, not the assistant):** I am running this codebase on Windows to work on ink detection, and tifxyz_label_transfer fails there in a way it does not on Linux, because the memory maps are never closed. It cost me time working out that the failures were the tool's and not my environment's.

**In one sentence:** `load_surface`, `read_image`, `load_tifxyz_mask` and the new `read_render_array` no longer leave files memory-mapped, and `TemporaryRaster.close` releases its own mapping, so on Windows a directory a reader touched can be deleted afterwards and the module's test suite passes; `read_render_tiff` keeps its documented mapping contract.

**One real example:** Starting with the published segment `PHercParis4/segments/20231106155351/mesh/20231106155351-on-20260411134726-2.4um.tifxyz` (52.7 MB, anonymous S3 read), I ran `load_surface` + `read_image` on a fresh `TemporaryDirectory` copy and deleted that copy while the returned arrays were still live: on `main` (23adee0) the delete fails with `WinError 32` in 10 of 10 runs; on this branch (aa38d7a) it succeeds in 10 of 10, for +16.7 MiB resident and +4 ms at the median.

**Before:** `python -m pytest tests/tifxyz_label_transfer -q` on Windows: 8 failed / 121 passed / 5 skipped, every failure a `PermissionError: [WinError 32]` raised by temp-dir cleanup, not by a test body.

**After this PR:** 132 passed / 5 skipped. Readers hand out owned arrays (`read_render_array`) or close their mapping (`TemporaryRaster.close`, `io.close_memmap`); `read_render_tiff` keeps its documented mapping contract and its test.

**Proof:** `python -m pytest tests/tifxyz_label_transfer -q` on Windows 11, run today against
current `main` (b218ace) and against this branch (aa38d7a) from the same installed checkout:

![before: 8 failed on main](https://gist.githubusercontent.com/hunghy93-pixel/c7c08ffda4b6a592660976f65884a5a9/raw/before_1671.png)

![after: 132 passed on this branch](https://gist.githubusercontent.com/hunghy93-pixel/c7c08ffda4b6a592660976f65884a5a9/raw/after_1671.png)

Raw output for both runs is in the same gist ([before](https://gist.githubusercontent.com/hunghy93-pixel/c7c08ffda4b6a592660976f65884a5a9/raw/before_1671.txt), [after](https://gist.githubusercontent.com/hunghy93-pixel/c7c08ffda4b6a592660976f65884a5a9/raw/after_1671.txt)); each of the eight failures on `main` carries `WinError 32`.

**Why / where this is useful:** anyone running `tifxyz_label_transfer` or its tests on Windows (CI is `ubuntu-latest` only, so it never showed there), and Windows callers can release temporary files after these reads.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

On Windows, `tests/tifxyz_label_transfer/` fails 8 tests with `PermissionError:
[WinError 32]` from `tempfile.TemporaryDirectory` cleanup, not from any test body.

**Root cause.** The module hands callers live memory mappings with no way to release
them. `io._read_tiff` returned `tifffile.memmap(...)`, so `load_surface`, `read_image`
and `load_tifxyz_mask` returned arrays whose `.base` chain still mapped `x.tif`, and
`view_alignment_napari.read_render_tiff` did the same for every cached render.
`io.TemporaryRaster.close()` released its mapping only via `del self.array`, which is
not enough when a caller holds the array it was given — and `core.py` documents that
callers may. POSIX allows unlinking a mapped file, so none of this shows on Linux, and
CI is `ubuntu-latest` only.

**Fix.** `io.close_memmap()` is the explicit end of life these mappings lacked.
`TemporaryRaster.close()` closes its mapping before unlinking (the issue's option 1: it
owns the file, and every read happens before its `ExitStack` unwinds). `_read_tiff` and
the eight `read_render_tiff` call sites that hand a render to a caller return owned
arrays instead, the latter through a new `read_render_array()` (option 2);
`read_render_tiff` keeps its documented mapping contract and its test. `close_memmap`
refuses a view, because NumPy copies `_mmap` onto every view and closing through one
frees the parent's pages under everyone else — a segfault here, not an exception
(CPython 3.14.7, NumPy 2.5.2), which is why the reader paths cannot simply close.

**Memory trade-off.** `read_render_array` returns an in-RAM copy where the
uncompressed-TIFF branch returned a mapping — one render per call. The largest call
site is `load_middle_three_max`, whose level-2 composites exceed 200 MiB (documented at
`prepare_canvas_offset_evidence.py:420-422`), and `prepare_case` can hold four renders
live at `--preview-factor 1`. Measured on **synthetic** data (8000x8000 uint8
uncompressed TIFF, 61 MiB; Windows 11, Python 3.14.7, RSS via psutil; reproduce with
`bench_render_read.py`, in the gist https://gist.github.com/hunghy93-pixel/c7c08ffda4b6a592660976f65884a5a9):

```
read_render_tiff, untouched    0.006 s   +0 MiB RSS   temp dir NOT removable (WinError 32)
read_render_tiff, then .sum()  0.060 s  +61 MiB RSS   temp dir NOT removable (WinError 32)
read_render_array              0.055 s  +61 MiB RSS   temp dir removable immediately
```

In this synthetic benchmark the fully touched mapping and the copy both added about 61 MiB RSS,
but the copy changes what that memory is: evictable page cache on `main`, anonymous RAM on this branch — the
same trade `_read_tiff` now makes (see its docstring). In the napari viewer that is up to four
level-2 composites (>200 MiB each, `prepare_canvas_offset_evidence.py:420-422`) at
`--preview-factor 1`, not measured here on a real composite. If you would rather keep the viewer
mapped, the alternative is `close_memmap` at case release instead of `read_render_array` at read
time; I took the copy because no call site reads a render lazily, and switching is a small
follow-up. The subpackage's three other `tifffile.memmap` sites (`prepare_canvas_offset_evidence.py:423`,
`:637`, `self_render_tifxyz.py:959-969`) are function-local or unlink before mapping and
are untouched; `vesuvius/tifxyz/reader.py:353` is outside this subpackage and out of scope.

**Real-data receipt.** Repeated on a published segment rather than a synthetic raster:
`PHercParis4/segments/20231106155351/mesh/20231106155351-on-20260411134726-2.4um.tifxyz`
from `https://vesuvius-challenge-open-data.s3.us-east-1.amazonaws.com/` (anonymous read,
no account) — `x/y/z.tif` 17,575,454 B each plus `meta.json`, 52,726,772 B in all, float32
1715x2562 grids. Each reader runs against a fresh `TemporaryDirectory` copy, and that copy
is deleted while the returned arrays are still live; **ten runs per revision**,
`receipt_1671.py --repeat 10 --src <villa>/vesuvius/src/vesuvius/tifxyz_label_transfer --segment <downloaded segment dir>`, same gist (median / p95 over the ten):

```
                         main (23adee0)                 this branch (aa38d7a)
load_surface+read_image  NOT removable, WinError 32     removable
                         +54.5 MiB RSS                  +71.2 MiB RSS
                         0.072 s med / 0.116 s p95      0.076 s med / 0.092 s p95
read_render_tiff         NOT removable, WinError 32     NOT removable, WinError 32
                         +0.0 MiB RSS                   +0.0 MiB RSS
                         0.008 s med / 0.012 s p95      0.008 s med / 0.009 s p95
read_render_array        (does not exist)               removable
                                                        +16.8 MiB RSS
                                                        0.022 s med / 0.026 s p95
```

So on a real surface the branch costs one extra resident grid — +16.7 MiB, the `read_image`
copy that no longer aliases the already-mapped `x.tif` — for +4 ms at the median on that read
path (0.072 s → 0.076 s). The branch p95 was lower (0.092 s vs 0.116 s on `main`); ten runs do not establish a timing
regression either way. In exchange, the directory the reader touched becomes deletable.
`read_render_tiff` still maps, by contract.

```
python -m pytest tests/tifxyz_label_transfer -q
before: 8 failed, 121 passed, 5 skipped
after:  132 passed, 5 skipped
```

Windows 11, Python 3.14.7, tifffile 2026.6.1, test counts on NumPy 2.5.2 (2026-09-05), the real-data receipt on NumPy 2.4.6 (2026-09-06); `tests/test_surface_preflight.py`
(the only other importer) is unaffected: 16 passed. Of the three added tests only
`test_readers_and_temporary_rasters_leave_no_file_mapped` is a regression test — it walks
the `.base` chain rather than the platform's unlink behaviour, Linux regression behaviour has not been tested; the other two are unit tests of the new API and cannot run against `main`.

Measured against `main` at 23adee0 (2026-09-05). `main` has moved on since, to b218ace, but only
through website commits: nothing under `vesuvius/src/` changed, and this branch still merges
cleanly, so the comparison above stands as written.

Fixes #1671
