### PR TITLE
vesuvius: make the documented segment call work without scroll_id

### DIFF
--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -335,6 +335,13 @@ class Volume:
             # energy/resolution are keyed by scroll, so without this the lookup
             # fails on scroll_id=None.
             if self.type == "segment" and self.scroll_id is None:
+                if not self.configs or not os.path.exists(self.configs):
+                    # Distinguish "no config to look in" from "segment not listed",
+                    # and keep the error type the same as get_url_from_yaml's.
+                    raise FileNotFoundError(
+                        f"Configuration file not found at {self.configs}. It is needed to "
+                        f"determine which scroll segment {self.segment_id} belongs to. "
+                        f"Pass scroll_id explicitly to skip this lookup.")
                 inferred = self._infer_scroll_from_segment()
                 if inferred is None:
                     raise ValueError(
@@ -563,15 +570,15 @@ class Volume:
         """Find which scroll a segment belongs to by scanning the config.
 
         Returns (scroll_id, energy, resolution) for the first entry whose
-        ``segments`` map contains ``self.segment_id``, or None if absent.
+        ``segments`` map contains ``self.segment_id``. Returns None if the
+        config does not exist, or if it exists but does not list the segment.
+        A config that exists but cannot be read or parsed raises, rather than
+        being reported later as a missing segment.
         """
         if not self.configs or not os.path.exists(self.configs):
             return None
-        try:
-            with open(self.configs, 'r') as file:
-                config_data: Dict = yaml.safe_load(file) or {}
-        except Exception:
-            return None
+        with open(self.configs, 'r') as file:
+            config_data: Dict = yaml.safe_load(file) or {}
 
         target = str(self.segment_id)
         for scroll_id, energies in config_data.items():

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -340,8 +340,9 @@ class Volume:
                     # and keep the error type the same as get_url_from_yaml's.
                     raise FileNotFoundError(
                         f"Configuration file not found at {self.configs}. It is needed to "
-                        f"determine which scroll segment {self.segment_id} belongs to. "
-                        f"Pass scroll_id explicitly to skip this lookup.")
+                        f"determine which scroll segment {self.segment_id} belongs to, and "
+                        f"again to resolve the segment's URL. Restore scrolls.yaml, or open "
+                        f"the data directly with Volume(type='zarr', path=...).")
                 inferred = self._infer_scroll_from_segment()
                 if inferred is None:
                     raise ValueError(

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -330,6 +330,24 @@ class Volume:
                     f"Warning: Could not find config file at expected locations: {possible_paths}. Will try default: {self.configs}")
                 # Error will be raised in get_url_from_yaml if file truly doesn't exist
 
+            # --- Infer the scroll for a segment given without one ---
+            # Volume(type="segment", segment_id=...) is the documented form, but
+            # energy/resolution are keyed by scroll, so without this the lookup
+            # fails on scroll_id=None.
+            if self.type == "segment" and self.scroll_id is None:
+                inferred = self._infer_scroll_from_segment()
+                if inferred is None:
+                    raise ValueError(
+                        f"Segment {self.segment_id} was not found in {self.configs}. "
+                        f"Pass scroll_id explicitly if it lives elsewhere.")
+                self.scroll_id, inferred_energy, inferred_resolution = inferred
+                if energy is None:
+                    energy = inferred_energy
+                if resolution is None:
+                    resolution = inferred_resolution
+                if self.verbose:
+                    print(f"Inferred scroll_id={self.scroll_id} for segment {self.segment_id}")
+
             # --- Energy & Resolution ---
             self.energy = energy if energy is not None else self.grab_canonical_energy()
             self.resolution = resolution if resolution is not None else self.grab_canonical_resolution()
@@ -540,6 +558,34 @@ class Volume:
                     stack.append((list(value.items()), path + [key]))
 
         return None, None, None, None
+
+    def _infer_scroll_from_segment(self) -> Optional[Tuple[str, int, float]]:
+        """Find which scroll a segment belongs to by scanning the config.
+
+        Returns (scroll_id, energy, resolution) for the first entry whose
+        ``segments`` map contains ``self.segment_id``, or None if absent.
+        """
+        if not self.configs or not os.path.exists(self.configs):
+            return None
+        try:
+            with open(self.configs, 'r') as file:
+                config_data: Dict = yaml.safe_load(file) or {}
+        except Exception:
+            return None
+
+        target = str(self.segment_id)
+        for scroll_id, energies in config_data.items():
+            if not isinstance(energies, dict):
+                continue
+            for energy, resolutions in energies.items():
+                if not isinstance(resolutions, dict):
+                    continue
+                for resolution, entry in resolutions.items():
+                    if not isinstance(entry, dict):
+                        continue
+                    if target in (entry.get("segments") or {}):
+                        return str(scroll_id), int(energy), float(resolution)
+        return None
 
     def get_url_from_yaml(self) -> str:
         """Retrieves the data URL/path from the YAML config file."""

--- a/vesuvius/src/vesuvius/data/volume.py
+++ b/vesuvius/src/vesuvius/data/volume.py
@@ -579,7 +579,11 @@ class Volume:
         if not self.configs or not os.path.exists(self.configs):
             return None
         with open(self.configs, 'r') as file:
-            config_data: Dict = yaml.safe_load(file) or {}
+            config_data: Dict = yaml.safe_load(file)
+        if not config_data:
+            # Same complaint get_url_from_yaml already makes, raised here so an
+            # empty config is not reported as a missing segment.
+            raise ValueError(f"Config file {self.configs} is empty or invalid YAML.")
 
         target = str(self.segment_id)
         for scroll_id, energies in config_data.items():

--- a/vesuvius/tests/data/test_volume_segment_scroll_inference.py
+++ b/vesuvius/tests/data/test_volume_segment_scroll_inference.py
@@ -62,6 +62,18 @@ def test_returns_none_for_unknown_segment(config_file):
 
 
 @pytest.mark.unit
+def test_malformed_config_raises_rather_than_reporting_a_missing_segment(tmp_path):
+    """A config that exists but will not parse is a config problem, not a
+    missing segment, and must not be flattened into the latter."""
+    import yaml
+
+    path = tmp_path / "scrolls.yaml"
+    path.write_text('"1":\n  "54":\n   bad: [unclosed\n')
+    with pytest.raises(yaml.YAMLError):
+        _probe(20230827161847, path)._infer_scroll_from_segment()
+
+
+@pytest.mark.unit
 def test_returns_none_when_config_missing(tmp_path):
     probe = _probe(20230827161847, tmp_path / "does_not_exist.yaml")
     assert probe._infer_scroll_from_segment() is None

--- a/vesuvius/tests/data/test_volume_segment_scroll_inference.py
+++ b/vesuvius/tests/data/test_volume_segment_scroll_inference.py
@@ -1,0 +1,80 @@
+"""A segment given without a scroll should find its own scroll in the config.
+
+Regression: ``Volume(type="segment", segment_id=...)`` is the form printed in
+the class docstring and in the library's own error message, but energy and
+resolution are keyed by scroll id. With no ``scroll_id`` the lookup ran against
+None and init failed with "Could not determine energy/resolution for scroll
+None", so the documented call could never succeed.
+"""
+
+import textwrap
+
+import pytest
+
+from vesuvius.data.volume import Volume
+
+
+CONFIG = textwrap.dedent(
+    """
+    "1":
+      "54":
+        "7.91":
+          volume: "https://example.invalid/scroll1.zarr/"
+          segments:
+            "20230827161847": "https://example.invalid/seg1.zarr/"
+    "3":
+      "53":
+        "3.24":
+          volume: "https://example.invalid/scroll3.zarr/"
+          segments:
+            "20231111135340": "https://example.invalid/seg3.zarr/"
+    """
+)
+
+
+def _probe(segment_id, config_path):
+    """A Volume shell carrying only what the helper reads."""
+    vol = Volume.__new__(Volume)
+    vol.segment_id = segment_id
+    vol.configs = str(config_path)
+    return vol
+
+
+@pytest.fixture
+def config_file(tmp_path):
+    path = tmp_path / "scrolls.yaml"
+    path.write_text(CONFIG)
+    return path
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "segment_id,expected",
+    [(20230827161847, ("1", 54, 7.91)), (20231111135340, ("3", 53, 3.24))],
+)
+def test_infers_scroll_energy_and_resolution(config_file, segment_id, expected):
+    assert _probe(segment_id, config_file)._infer_scroll_from_segment() == expected
+
+
+@pytest.mark.unit
+def test_returns_none_for_unknown_segment(config_file):
+    assert _probe(99999999999999, config_file)._infer_scroll_from_segment() is None
+
+
+@pytest.mark.unit
+def test_returns_none_when_config_missing(tmp_path):
+    probe = _probe(20230827161847, tmp_path / "does_not_exist.yaml")
+    assert probe._infer_scroll_from_segment() is None
+
+
+@pytest.mark.unit
+def test_shipped_config_covers_the_documented_example():
+    """The segment named in the docstring must resolve from the shipped config."""
+    import os
+    import vesuvius
+
+    base = os.path.dirname(os.path.abspath(vesuvius.data.volume.__file__))
+    shipped = os.path.join(os.path.dirname(base), "install", "configs", "scrolls.yaml")
+    if not os.path.exists(shipped):
+        pytest.skip("shipped scrolls.yaml not present in this install")
+    assert _probe(20230827161847, shipped)._infer_scroll_from_segment() is not None

--- a/vesuvius/tests/data/test_volume_segment_scroll_inference.py
+++ b/vesuvius/tests/data/test_volume_segment_scroll_inference.py
@@ -140,3 +140,13 @@ def test_explicit_scroll_id_is_not_overridden_by_inference(monkeypatch):
                  normalization_scheme="none")
 
     assert vol.scroll_id == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("body", ["", "\n", "null\n"])
+def test_empty_config_is_reported_as_a_config_problem(tmp_path, body):
+    """An empty config is a config problem, not a missing segment."""
+    path = tmp_path / "scrolls.yaml"
+    path.write_text(body)
+    with pytest.raises(ValueError, match="empty or invalid YAML"):
+        _probe(20230827161847, path)._infer_scroll_from_segment()

--- a/vesuvius/tests/data/test_volume_segment_scroll_inference.py
+++ b/vesuvius/tests/data/test_volume_segment_scroll_inference.py
@@ -32,6 +32,21 @@ CONFIG = textwrap.dedent(
 )
 
 
+class _FakeArray:
+    """Minimal stand-in for the zarr array Volume expects from load_data."""
+
+    import numpy as _np
+
+    shape = (65, 16, 16)
+    ndim = 3
+    dtype = _np.dtype("uint8")
+
+    def __getitem__(self, idx):
+        import numpy as np
+
+        return np.zeros((1, 1, 1), dtype="uint8")
+
+
 def _probe(segment_id, config_path):
     """A Volume shell carrying only what the helper reads."""
     vol = Volume.__new__(Volume)
@@ -90,3 +105,38 @@ def test_shipped_config_covers_the_documented_example():
     if not os.path.exists(shipped):
         pytest.skip("shipped scrolls.yaml not present in this install")
     assert _probe(20230827161847, shipped)._infer_scroll_from_segment() is not None
+
+
+@pytest.mark.unit
+def test_documented_segment_call_initializes_without_scroll_id(monkeypatch):
+    """The documented one-argument form must actually construct a Volume.
+
+    The inference runs inside ``Volume.__init__``, so the helper tests above do
+    not on their own show that ``Volume(type="segment", segment_id=...)`` works.
+    Network-dependent steps are stubbed; everything before them is the real
+    code path, including reading the shipped config.
+    """
+    import numpy as np
+
+    monkeypatch.setattr(Volume, "load_ome_metadata", lambda self: {})
+    monkeypatch.setattr(Volume, "load_data", lambda self: _FakeArray())
+    monkeypatch.setattr(Volume, "download_inklabel", lambda self, save_path=None: None)
+
+    vol = Volume(type="segment", segment_id=20230827161847, normalization_scheme="none")
+
+    assert vol.scroll_id == "1"
+    assert vol.energy == 54
+    assert vol.resolution == 7.91
+    assert vol.url.endswith("20230827161847.zarr/")
+
+
+@pytest.mark.unit
+def test_explicit_scroll_id_is_not_overridden_by_inference(monkeypatch):
+    monkeypatch.setattr(Volume, "load_ome_metadata", lambda self: {})
+    monkeypatch.setattr(Volume, "load_data", lambda self: _FakeArray())
+    monkeypatch.setattr(Volume, "download_inklabel", lambda self, save_path=None: None)
+
+    vol = Volume(type="segment", segment_id=20230827161847, scroll_id=1,
+                 normalization_scheme="none")
+
+    assert vol.scroll_id == 1


### PR DESCRIPTION
I thought it would be smart to take a peek at Scroll 1, and specifically the ink on it. I copied the segment example from the `Volume` docstring and it wasn't running on my computer. The error said it couldn't determine the energy or resolution for "scroll None", and that didn't really help me much. I took a look at the init code and figured out that segments need a scroll id, even though the documented call doesn't pass one. The config already knows which scroll a segment belongs to, so I made it look that up. I didn't want everyone else to run into the same thing.

_Written with an AI coding assistant. The commentary above is mine._

---

**In one sentence:** `Volume(type="segment", segment_id=...)` now works without also passing `scroll_id`, which is how it is written in the docstring.

**One real example:** Starting with the segment named in the `Volume` docstring, I ran `Volume(type="segment", segment_id=20230827161847)` to look at ink on Scroll 1, and it failed before reaching the data.

**Before:**
```
>>> Volume(type="segment", segment_id=20230827161847)
ValueError: Could not determine energy/resolution for scroll None.
            Please provide them explicitly.
```
Energy and resolution are looked up by scroll id, but `type="segment"` leaves `scroll_id` as whatever was passed, i.e. `None`. The undocumented requirement was to also pass `scroll_id=1`. The same call appears in the class docstring and in the library's own error message, so the first thing a new user copies does not run.

**After this PR:**
```
>>> seg = Volume(type="segment", segment_id=20230827161847)
>>> seg.scroll_id, seg.energy, seg.resolution
('1', 54, 7.91)
>>> seg.shape(0)
(65, 9163, 5048)
```

**Proof:** the shipped `scrolls.yaml` already records which scroll each segment belongs to, so nothing new is fetched. Explicit values still win:

```
Volume(type="segment", segment_id=20230827161847)                    -> scroll 1, 54, 7.91   (was: ValueError)
Volume(type="segment", segment_id=20230827161847, scroll_id=1)       -> scroll 1             (unchanged)
Volume(type="segment", segment_id=..., energy=54, resolution=7.91)   -> 54, 7.91             (unchanged)
Volume(type="segment", segment_id=99999999999999)                    -> ValueError: Segment 99999999999999 was not
                                                                        found in .../scrolls.yaml. Pass scroll_id
                                                                        explicitly if it lives elsewhere.
```

**Why / where this is useful:** it is the first call in the docs, so it is the first thing that fails for anyone starting with segments. The error it produced named `scroll None`, which does not point at the missing argument.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Tested against `d8c5f48`.

Adds `Volume._infer_scroll_from_segment`, which scans the already-loaded config for the first entry whose `segments` map contains the id and returns `(scroll_id, energy, resolution)`. Called from `__init__` only when `type == "segment"` and `scroll_id is None`, before energy and resolution are resolved. No new dependency and no network access; the config is the same file `get_url_from_yaml` already reads.

Tests in `vesuvius/tests/data/test_volume_segment_scroll_inference.py` cover inference for two scrolls with different energy and resolution, an unknown segment, a missing config file, and a check that the segment named in the docstring resolves from the shipped config. All five fail on main.

`pytest vesuvius/tests/data/` passes (33 passed, 5 skipped) with a `volume-only` install.
