### PR TITLE
render_ink: warn when a rendered strip is entirely black

### DIFF
--- a/spiral-fitting/render_ink.py
+++ b/spiral-fitting/render_ink.py
@@ -548,6 +548,14 @@ def main(meshes_dir, volume, remote_url, vc_render_bin, scale, group_idx, num_sl
                 continue
             strip = comp.astype(np.float32)
             p95 = np.percentile(strip, 95)
+            if p95 <= 0:
+                # An entirely black strip is written and the run still exits 0,
+                # so a mesh that samples nowhere in the volume is indistinguishable
+                # from a fit that recovered no ink. Say so loudly.
+                print(f'[{n + 1}/{len(render_items)}] {name}: WARNING strip is '
+                      'entirely black (p95=0). The mesh may not be in the ink '
+                      "volume's frame; check --scale/--group-idx and the volume's "
+                      'level-0 shape against the mesh coordinates.')
             strip = np.clip(strip / p95, 0, 1) * 255 if p95 > 0 else strip
             strip8 = strip.astype(np.uint8)
             width = strip8.shape[1]


### PR DESCRIPTION
From #1660, taking only the part that is unambiguously a defect.

An all-black strip is written and the run exits 0. The `p95 > 0` guard already skips normalisation in that case but reports nothing, so the only trace is `p95=0.0` in one line:

```
[1/1] wrote /work/meshes/ink/w010-019.jpg (1915px wide, p95=0.0)
Done. Strips in /work/meshes/ink
```

Scored, that is `total_fg_pixels = 0` reported as a successful render — a mesh that samples nowhere in the volume is indistinguishable from a fit that recovered no ink.

This adds a WARNING in the same form as the existing `no tifs produced, skipping` message. **Behaviour is otherwise unchanged**: the strip is still written, the exit status is still 0.

A stronger version is available if you prefer it — raising when *every* strip is blank, alongside the existing `render produced no ink strip images` exception, which has the same spirit. I did not do that here because I cannot rule out a legitimately ink-free ROI, and that is your call rather than mine.

Not addressed here, from the same issue: whether the intended workflow is to supply an ink volume already in the fit's frame. In my case the mesh frame was 4x coarser than the published volume and `vc_render_tifxyz --scale-segmentation 4` fixed the sampling, but `render_ink.py` does not pass that through. That is a design question, not a defect, so it stays in the issue.