### PR TITLE
spiral-fitting: fit with tracks when the dataset has no outer shell

### DIFF
--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -1552,15 +1552,31 @@ class FitContext:
         # Patch loading and ROI filtering
         # ==========================================================================
 
-        filter_tracks_by_shell = bool(self.tracks_dbm_path) and bool(self.shell_path)
+        # The conventional outer-shell path is set whether or not the dataset
+        # has one (the headless CLI does no existence probing), and the
+        # 2025-2026 scroll datasets ship tracks without an outer shell. The
+        # shell is optional unless shell losses or winding-model supervision
+        # need it, so only filter tracks by it when it actually exists.
+        shell_available = bool(self.shell_path) and os.path.isfile(
+            os.path.join(self.shell_path, 'meta.json'))
+        filter_tracks_by_shell = bool(self.tracks_dbm_path) and shell_available
         shell_patch = None
         if self.outer_shell_required() or filter_tracks_by_shell:
             if not self.shell_path:
                 raise RuntimeError(
                     'the outer shell is required by shell losses or winding-model '
                     'supervision, but no outer shell path is set')
+            if not shell_available:
+                raise RuntimeError(
+                    'the outer shell is required by shell losses or winding-model '
+                    f'supervision, but no tifxyz was found at {self.shell_path} '
+                    '(set loss_weight_shell_outer and loss_weight_shell_patch_radius '
+                    'to 0, or input_use_outer_shell to false, to fit without one)')
             progress.begin('loading', 'Loading outer shell')
             shell_patch = load_tifxyz(self.shell_path)
+        elif self.tracks_dbm_path and self.shell_path:
+            print(f'no outer shell at {self.shell_path}; tracks will not be '
+                  'filtered to the outer shell')
 
         use_verified_patches = bool(self.verified_patches_path) and not self.config['input_disable_patches']
         use_unverified_patches = bool(self.unverified_patches_path) and not self.config['input_disable_patches']


### PR DESCRIPTION
**In one sentence:** `fit_spiral.py` can now fit a scroll from its published tracks when the dataset has no `outer_shell/`, instead of crashing on `outer_shell/meta.json`.

**One real example:** Starting with the PHerc0125 spiral dataset from dl.ash2txt.org (umbilicus, lasagna inputs and the `surface_m7_L0_th0.2` tracks, no outer shell), I ran the headless fitter with `input_use_tracks: true`, `input_disable_patches: true` and the shell losses set to 0 on z 9000-10500, and it produced a fitted checkpoint and tifxyz windings.

**Before:** The fit died before the first optimisation step:

```
PROGRESS Loading outer shell — elapsed 0s
  ...
  File "/home/mdevi/villa/spiral-fitting/fit_spiral.py", line 1563, in load_host_inputs
    shell_patch = load_tifxyz(self.shell_path)
  File "/home/mdevi/villa/spiral-fitting/tifxyz.py", line 362, in load_tifxyz
    with open(f'{path}/meta.json', 'r') as meta_json:
FileNotFoundError: [Errno 2] No such file or directory: '/home/mdevi/spiral_data/PHerc0125/outer_shell/meta.json'
```

The headless CLI sets the conventional `outer_shell` path without checking it exists (`conventional_input_paths` does no probing on purpose), and `filter_tracks_by_shell` only checked that the path string was set. So any dataset with tracks and no outer shell hit this, even with `loss_weight_shell_outer` and `loss_weight_shell_patch_radius` at 0, where the input catalog itself says the shell is not required. The only workaround was `input_use_outer_shell: false`, which is not documented anywhere near the tracks switch.

![before](https://raw.githubusercontent.com/gmDevi/vc-windows-tools/master/results/villa_pr1/before.png)

**After this PR:** The same command prints one line and runs to completion:

```
no outer shell at /home/mdevi/spiral_data/PHerc0125/outer_shell; tracks will not be filtered to the outer shell
...
PROGRESS Optimizing — 291/300 iterations (97.0%) — 2.8 it/s
satisfied_track_points = 30773120/79967624 (38.5%)
save_mesh fitted: winding range [10, 130)
```

![after](https://raw.githubusercontent.com/gmDevi/vc-windows-tools/master/results/villa_pr1/after.png)

When the shell *is* required (shell losses on, or winding-model spacing) and missing, the fit now fails with a message that names the path and the two ways to fit without one, instead of a bare `FileNotFoundError` from `tifxyz.py`.

**Proof:** The two terminal captures above, same dataset, same overrides, RTX 3090 under WSL2, tested at fork commit `9b24d36` on top of `d8c5f48`. The 300-step run is a smoke test; the same configuration at 30,000 steps produced the meshes used for the ink sweeps in https://github.com/gmDevi/vc-windows-tools (with the workaround applied by hand).

**Why / where this is useful:** All the 2025-2026 scroll datasets on dl.ash2txt.org ship tracks and no outer shell, so this is the first thing anyone hits when following the tracks route on a new scroll. Behaviour with an outer shell present is unchanged.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Motivation (human written): While fitting spirals on PHerc0125 with the published tracks to render sheets for ink detection, the fit crashed on a missing outer shell that the dataset does not have

Change: `spiral-fitting/fit_spiral.py`, `load_host_inputs`. `filter_tracks_by_shell` now requires `<shell_path>/meta.json` to exist; a missing optional shell prints a notice; a missing required shell raises a `RuntimeError` naming the path. 17 lines added, 1 changed. No config keys or defaults change.

Command used (both runs):

```
FIT_SPIRAL_CONFIG_OVERRIDES='{"z_begin": 9000, "z_end": 10500, "optimizer_num_training_steps": 300, "input_disable_patches": true, "loss_weight_shell_outer": 0, "loss_weight_shell_patch_radius": 0, "dense_spacing_mode": "grad_mag", "loss_weight_dense_spacing": 0, "input_use_tracks": true}' \
uv run --no-sync python fit_spiral.py --dataset ~/spiral_data/PHerc0125 --cache ~/spiral_cache
```

Limitation: the service path (`resolve_dataset_root`) already probes existence, so this only changes the headless CLI.

Written with an AI coding assistant (Claude); the bug, the data and the test runs are mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

