### PR TITLE
spiral-fitting: ignore a truncated track crossing cache instead of crashing

### DIFF
--- a/spiral-fitting/tracks.py
+++ b/spiral-fitting/tracks.py
@@ -11,6 +11,7 @@ import shutil
 import struct
 from pathlib import Path
 import tempfile
+import zipfile
 
 import kornia
 import numpy as np
@@ -1824,7 +1825,11 @@ def load_track_crossing_cache(path, warn=True, expected_z_range=None):
                     'partner_local', 'positions', 'clearances')
             }
         _validate_crossing_partner_csr(csr, require_sorted_source_ids=True)
-    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+    # A truncated or partially downloaded sidecar is not a zip archive at all
+    # (zipfile.BadZipFile / EOFError, neither an OSError nor a ValueError);
+    # treat it like any other invalid cache instead of aborting the fit.
+    except (OSError, EOFError, zipfile.BadZipFile, KeyError, TypeError,
+            ValueError, json.JSONDecodeError) as error:
         if warn:
             print(f'WARNING: ignoring invalid track crossing cache '
                   f'{cache_path}: {error}')


### PR DESCRIPTION
**In one sentence:** A truncated or half-downloaded `*.dbm.crossings.npz` no longer aborts `fit_spiral.py`; it is ignored with the existing "invalid track crossing cache" warning and the crossings are rebuilt.

**One real example:** Starting with the PHerc0125 spiral dataset from dl.ash2txt.org, whose 2.8 GB `PHerc0125_20250821151825_surface_m7_L0_th0.2.dbm.crossings.npz` had been cut short by an interrupted download, I ran the headless fitter with tracks enabled, and it went on to a fitted checkpoint and tifxyz windings.

**Before:** The fit died while loading the tracks:

```
loading tracks from /home/mdevi/spiral_data/PHerc0125/tracks/PHerc0125_20250821151825_surface_m7_L0_th0.2.dbm
Traceback (most recent call last):
  ...
  File "/home/mdevi/villa/spiral-fitting/fit_spiral.py", line 1968, in load_host_inputs
    track_crossing_cache = load_track_crossing_cache(self.tracks_dbm_path)
  File "/home/mdevi/villa/spiral-fitting/tracks.py", line 1807, in load_track_crossing_cache
    with np.load(cache_path, allow_pickle=False) as stored:
  ...
  File ".../python3.14/zipfile/__init__.py", line 1538, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file
```

`load_track_crossing_cache` is documented to "return None on a safe miss" and already catches `OSError`, `KeyError`, `TypeError`, `ValueError` and `JSONDecodeError`, but a file that is not a complete zip archive raises `zipfile.BadZipFile` (a plain `Exception`), so the one failure a download interruption actually produces was the one that escaped.

![before](https://raw.githubusercontent.com/gmDevi/vc-windows-tools/master/results/villa_pr2/pr2_before.png)

**After this PR:** Same dataset, with the sidecar deliberately truncated to its first 1 MB:

```
WARNING: ignoring invalid track crossing cache .../PHerc0125_20250821151825_surface_m7_L0_th0.2.dbm.crossings.npz: File is not a zip file
...
save_mesh fitted: winding range [10, 130)
```

![after](https://raw.githubusercontent.com/gmDevi/vc-windows-tools/master/results/villa_pr2/pr2_after.png)

**Proof:** The two terminal captures above. Before: the original interrupted download. After: a copy of the dataset in which every file is a symlink to the original except the crossings sidecar, which is the first 1,000,000 bytes of the real one (`head -c 1000000`), fitted with the patch at fork commit `91820a4` on top of `d8c5f48`. RTX 3090 under WSL2.

**Why / where this is useful:** The crossings sidecars for the 2025-2026 scrolls are 2 to 3 GB each and are fetched over HTTP; a dropped connection leaves a file that looks present but is not a zip. Without this change the fitter's only message is a `zipfile` traceback that does not say which file to delete. With it, the fit logs the path and carries on exactly as if the cache were absent.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Motivation: I was fitting spirals on PHerc0125 with the published tracks (to render windings for ink detection) after my download of the crossings sidecar had been interrupted; the fit crashed in `zipfile` instead of rebuilding the cache.

Change: `spiral-fitting/tracks.py`, `load_track_crossing_cache`: add `zipfile.BadZipFile` and `EOFError` to the caught invalid-cache errors (plus the `zipfile` import). 6 lines added, 1 changed. No behaviour change for a valid cache.

Command used (both runs):

```
FIT_SPIRAL_CONFIG_OVERRIDES='{"z_begin": 9000, "z_end": 10500, "optimizer_num_training_steps": 300, "input_disable_patches": true, "loss_weight_shell_outer": 0, "loss_weight_shell_patch_radius": 0, "dense_spacing_mode": "grad_mag", "loss_weight_dense_spacing": 0, "input_use_tracks": true, "input_use_outer_shell": false}' \
uv run --no-sync python fit_spiral.py --dataset <dataset> --cache ~/spiral_cache
```

Written with an AI coding assistant (Claude); the bug, the data and the test runs are mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

