### PR TITLE
vc_grow_seg_from_seed: deal more reasonably with voxelsizes

### DIFF
--- a/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
+++ b/volume-cartographer/apps/VC3D/SegmentationCommandHandler.cpp
@@ -1027,9 +1027,10 @@ private:
 
     // Compute area_vx2 from the freshly-written tifxyz at 'dir' and write
     // both area_vx2 and area_cm2 into its meta.json. voxelSize is in micrometers
-    // per voxel (same units as Volume::voxelSize()); area_cm2 = vx2 * vs^2 / 1e8
-    // matches SurfaceAreaCalculator's convention. Returns true on success;
-    // failures are non-fatal — caller may continue without updated area.
+    // per voxel (same units as Volume::voxelSize()); area_cm2 is derived by
+    // vc::surface::areaCm2FromVox2, and omitted when the voxel size is unknown,
+    // the same way SurfaceAreaCalculator and the tracers record it. Returns true
+    // on success; failures are non-fatal — caller may continue without updated area.
     static bool updateAreaInMeta_(const QString& dir, double voxelSize) {
         std::unique_ptr<QuadSurface> qs;
         try {
@@ -1042,10 +1043,7 @@ private:
         const double area_vx2 = vc::surface::computeSurfaceAreaVox2(*qs);
         if (!std::isfinite(area_vx2) || area_vx2 <= 0.0) return false;
 
-        double area_cm2 = std::numeric_limits<double>::quiet_NaN();
-        if (std::isfinite(voxelSize) && voxelSize > 0.0) {
-            area_cm2 = area_vx2 * voxelSize * voxelSize / 1e8;
-        }
+        const auto area_cm2 = vc::surface::areaCm2FromVox2(area_vx2, voxelSize);
 
         const QString metaPath = QDir(dir).filePath(QStringLiteral("meta.json"));
         QJsonObject root;
@@ -1058,8 +1056,14 @@ private:
             }
         }
         root.insert(QStringLiteral("area_vx2"), area_vx2);
-        if (std::isfinite(area_cm2)) {
-            root.insert(QStringLiteral("area_cm2"), area_cm2);
+        if (area_cm2) {
+            root.insert(QStringLiteral("area_cm2"), *area_cm2);
+        } else {
+            // The geometry just changed. Leaving the previous area_cm2 beside
+            // the new area_vx2 would describe neither: consumers that recover
+            // a voxel size from the pair would read it scaled by the ratio of
+            // the two geometries.
+            root.remove(QStringLiteral("area_cm2"));
         }
 
         QFile out(metaPath);
@@ -3299,6 +3303,19 @@ bool SegmentationCommandHandler::startGrowPatchFromSeedImpl(
     double selectedVoxelSize = 0.0;
     if (auto selectedVolume = _state->vpkg()->volume(selectedVolumeId.toStdString())) {
         selectedVoxelSize = selectedVolume->voxelSize();
+    }
+    // vc_grow_seg_from_seed refuses a physical min_area_cm without a voxel
+    // size. Say so here, where the message reaches the user and the fix is
+    // one field away, instead of surfacing only as "exit code 1" along with
+    // a hint naming a params file this dialog has already deleted.
+    if (minAreaCm > 0.0 && !(std::isfinite(selectedVoxelSize) && selectedVoxelSize > 0.0)) {
+        return fail(tr("Volume '%1' reports no voxel size, so the minimum patch area of %2 cm² "
+                       "cannot be evaluated. Set the minimum area to 0 to grow without a "
+                       "size threshold, or add \"voxelsize\" (µm per voxel) to the volume's "
+                       "metadata.")
+                        .arg(selectedVolumeId)
+                        .arg(minAreaCm),
+                    CommandLaunchError::InvalidState);
     }
 
     const QString segmentsEntry = segmentsEntryLocationForPath(outputDirPath, volpkgRoot);

--- a/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
+++ b/volume-cartographer/apps/VC3D/SurfacePanelController.cpp
@@ -205,8 +205,12 @@ void set_surface_tree_item_text(SurfaceTreeWidgetItem* item,
     item->setToolTip(SURFACE_ID_COLUMN, idText);
     item->setText(SURFACE_LONG_ID_COLUMN, longIdText);
     item->setToolTip(SURFACE_LONG_ID_COLUMN, longIdText);
-    item->setText(SURFACE_AREA_COLUMN, QString::number(areaCm2, 'f', 3));
-    item->setText(SURFACE_AVG_COST_COLUMN, QString::number(avgCost, 'f', 3));
+    // Match the update path below: a surface whose voxel size was unknown has
+    // no area_cm2 at all, and "-" is honest where "-1.000" is not.
+    item->setText(SURFACE_AREA_COLUMN,
+                  areaCm2 >= 0.0 ? QString::number(areaCm2, 'f', 3) : QStringLiteral("-"));
+    item->setText(SURFACE_AVG_COST_COLUMN,
+                  avgCost >= 0.0 ? QString::number(avgCost, 'f', 3) : QStringLiteral("-"));
     item->setText(SURFACE_OVERLAPS_COLUMN, QString::number(surf->overlappingIds().size()));
     item->setText(TIMESTAMP_COLUMN, surface_timestamp(surf));
 }

--- a/volume-cartographer/apps/VC3D/segmentation/growth/SegmentationGrowth.cpp
+++ b/volume-cartographer/apps/VC3D/segmentation/growth/SegmentationGrowth.cpp
@@ -623,8 +623,11 @@ void updateSegmentationSurfaceMetadata(QuadSurface* surface,
 
     ensureMetaObject(surface);
 
-    const double previousAreaVx2 = surface->meta.contains("area_vx2") ? surface->meta["area_vx2"].get_double() : -1.0;
-    const double previousAreaCm2 = surface->meta.contains("area_cm2") ? surface->meta["area_cm2"].get_double() : -1.0;
+    // Other writers state an unknown area as null rather than omitting the key
+    // (merge_concat_runs.py, for one), so read leniently: anything that is not
+    // a number means "not established".
+    const double previousAreaVx2 = vc::json::number_or(surface->meta, "area_vx2", -1.0);
+    const double previousAreaCm2 = vc::json::number_or(surface->meta, "area_cm2", -1.0);
 
     const cv::Mat_<cv::Vec3f>* points = surface->rawPointsPtr();
     if (points && !points->empty()) {
@@ -632,10 +635,10 @@ void updateSegmentationSurfaceMetadata(QuadSurface* surface,
         surface->meta["area_vx2"] = areaVx2;
 
         double areaCm2 = std::numeric_limits<double>::quiet_NaN();
-        if (voxelSize > 0.0) {
-            const double areaUm2 = areaVx2 * voxelSize * voxelSize;
-            areaCm2 = areaUm2 * 1e-8;
-        } else if (previousAreaVx2 > std::numeric_limits<double>::epsilon() && previousAreaCm2 >= 0.0) {
+        if (const auto derived = vc::surface::areaCm2FromVox2(areaVx2, voxelSize)) {
+            areaCm2 = *derived;
+        } else if (previousAreaVx2 > std::numeric_limits<double>::epsilon() && previousAreaCm2 > 0.0) {
+            // Rescaling a surface whose physical scale was already established.
             const double cm2PerVx2 = previousAreaCm2 / previousAreaVx2;
             areaCm2 = areaVx2 * cm2PerVx2;
         }
@@ -643,10 +646,13 @@ void updateSegmentationSurfaceMetadata(QuadSurface* surface,
         if (std::isfinite(areaCm2)) {
             surface->meta["area_cm2"] = areaCm2;
         } else {
-            // Fall back to assuming the geometry is in microns and convert directly.
-            const double assumedAreaCm2 = areaVx2 * 1e-8;
-            surface->meta["area_cm2"] = assumedAreaCm2;
-            qCWarning(lcSegGrowth) << "Fallback surface area conversion applied due to missing voxel size metadata";
+            // No voxel size and no established scale to carry forward. Leave
+            // area_cm2 absent: a guessed physical area is worse than none,
+            // because nothing downstream can tell it apart from a real one.
+            if (surface->meta.contains("area_cm2")) {
+                surface->meta.erase("area_cm2");
+            }
+            qCWarning(lcSegGrowth) << "Surface area left in voxels only: volume reports no voxel size";
         }
     }
 

--- a/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
+++ b/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
@@ -395,6 +395,25 @@ int main(int argc, char *argv[])
     std::cout << "voxelsize: " << voxelsize << std::endl;
     std::cout << "tgt_overlap_count: " << tgt_overlap_count << std::endl;
 
+    // min_area_cm is a physical threshold, so it cannot be evaluated without a
+    // voxel size. Refuse here rather than after tracing: with voxelsize 0 every
+    // area_cm2 is 0, so the check below would discard every surface however
+    // large it really is, and the run would still look like a success.
+    // gen_neighbor is exempt: it returns before that check and never consults
+    // min_area_cm, so refusing it here would block a mode the threshold does
+    // not apply to.
+    if (mode != "gen_neighbor" && min_area_cm > 0.0f &&
+        !(std::isfinite(voxelsize) && voxelsize > 0.0f)) {
+        std::cerr << "ERROR: volume reports no usable voxel size (" << voxelsize
+                  << " um/voxel), so min_area_cm " << min_area_cm
+                  << " cannot be evaluated." << std::endl
+                  << "       Set \"voxelsize\" (um per voxel) in "
+                  << params_path.string()
+                  << ", or set \"min_area_cm\" to 0 to grow without an area threshold."
+                  << std::endl;
+        return EXIT_FAILURE;
+    }
+
     auto direction_fields = load_direction_fields(params, cache_root);
 
     std::unordered_map<std::string,QuadSurface*> surfs;
@@ -1447,21 +1466,25 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    double area_cm2 = surf->meta["area_cm2"].get_double();
-    if (area_cm2 < min_area_cm) {
-        std::cout << "discarding generated surface because area_cm2 " << area_cm2
-                  << " is below min_area_cm " << min_area_cm << std::endl;
-        if (std::filesystem::exists(seg_dir)) {
-            std::filesystem::remove_all(seg_dir);
-        }
+    if (min_area_cm > 0.0f) {
+        // area_cm2 is guaranteed present here: the startup check rejects an
+        // unusable voxel size, and storeAreaMeta() omits the key only then.
+        const double area_cm2 = surf->meta["area_cm2"].get_double();
+        if (area_cm2 < min_area_cm) {
+            std::cout << "discarding generated surface because area_cm2 " << area_cm2
+                      << " is below min_area_cm " << min_area_cm << std::endl;
+            if (std::filesystem::exists(seg_dir)) {
+                std::filesystem::remove_all(seg_dir);
+            }
 #if defined(_WIN32)
-        // See end of main(): skip CRT teardown, worker threads deadlock it.
-        std::cout.flush();
-        std::cerr.flush();
-        std::_Exit(EXIT_SUCCESS);
+            // See end of main(): skip CRT teardown, worker threads deadlock it.
+            std::cout.flush();
+            std::cerr.flush();
+            std::_Exit(EXIT_SUCCESS);
 #else
-        return EXIT_SUCCESS;
+            return EXIT_SUCCESS;
 #endif
+        }
     }
 
     std::cout << "saving " << seg_dir.string() << std::endl;

--- a/volume-cartographer/apps/src/vc_grow_seg_from_segments.cpp
+++ b/volume-cartographer/apps/src/vc_grow_seg_from_segments.cpp
@@ -21,6 +21,7 @@
 #include "vc/core/util/Slicing.hpp"
 #include "vc/core/util/Surface.hpp"
 #include "vc/core/util/SurfaceArea.hpp"
+#include "vc/core/util/VoxelSizeMetadata.hpp"
 
 #include <filesystem>
 #include <fstream>
@@ -559,6 +560,15 @@ static cv::Point find_center_seed_point(const cv::Mat_<cv::Vec3f>& points)
     return best;
 }
 
+// Physical area for the metrics, or NaN when the voxel size is unknown. NaN
+// serializes as null in the sweep report and fails every threshold and
+// isfinite() check, so an unknown scale can never make a surface "complete".
+static double area_cm2_or_nan(double area_vx2, double voxelsize)
+{
+    return vc::surface::areaCm2FromVox2(area_vx2, voxelsize)
+        .value_or(std::numeric_limits<double>::quiet_NaN());
+}
+
 static std::unique_ptr<QuadSurface> load_or_create_center_cutout(QuadSurface& target,
                                                                  const std::filesystem::path& target_path,
                                                                  double cutout_cm,
@@ -763,7 +773,7 @@ static SweepMetrics score_surface(QuadSurface& result,
     metrics.valid_points = result.countValidPoints();
     metrics.valid_quads = result.countValidQuads();
     metrics.area_vx2 = vc::surface::computeSurfaceAreaVox2(result);
-    metrics.area_cm2 = metrics.area_vx2 * voxelsize * voxelsize / 1e8;
+    metrics.area_cm2 = area_cm2_or_nan(metrics.area_vx2, voxelsize);
     if (target_area_vx2 > 0.0) {
         metrics.area_ratio = metrics.area_vx2 / target_area_vx2;
         metrics.area_abs_error_ratio = std::abs(metrics.area_vx2 - target_area_vx2) / target_area_vx2;
@@ -805,7 +815,7 @@ static SweepMetrics score_surface_without_target(QuadSurface& result, double vox
     metrics.valid_points = result.countValidPoints();
     metrics.valid_quads = result.countValidQuads();
     metrics.area_vx2 = vc::surface::computeSurfaceAreaVox2(result);
-    metrics.area_cm2 = metrics.area_vx2 * voxelsize * voxelsize / 1e8;
+    metrics.area_cm2 = area_cm2_or_nan(metrics.area_vx2, voxelsize);
     add_completeness_metrics(result, metrics);
     const double hole_penalty = 1.0 - std::clamp(metrics.enclosed_hole_fraction, 0.0, 1.0);
     metrics.mesh_completeness_score =
@@ -1148,7 +1158,14 @@ int main(int argc, char *argv[])
     std::cout << "chunk shape shape " << ds->defaultChunkShape() << std::endl;
     add_internal_volume_shape(params, ds->shape());
 
-    float voxelsize = Json::parse_file(vol_path/"meta.json")["voxelsize"].get_float();
+    // Resolved the same way Volume does, so a store that states its voxel size
+    // only through an acquisition record is not read as 0.
+    // 0 still means unknown, and every cm^2 below is then reported as null.
+    float voxelsize = 0.0f;
+    if (const auto resolved = vc::metadata::resolveLocalStoreVoxelSize(vol_path)) {
+        voxelsize = static_cast<float>(*resolved);
+    }
+    std::cout << "voxelsize: " << voxelsize << std::endl;
 
     std::filesystem::create_directories(tgt_dir);
 
@@ -1156,6 +1173,20 @@ int main(int argc, char *argv[])
         const bool seed_only_sweep = sweep_max_width > 0 || sweep_max_height > 0;
         const int seed_only_max_width = sweep_max_width;
         const int seed_only_max_height = sweep_max_height;
+        // --sweep-min-area is a physical threshold, so it cannot be evaluated
+        // without a voxel size. Refuse now: with voxelsize 0 no run could ever
+        // qualify, and the sweep would still finish "successfully" with
+        // nothing selected.
+        if (seed_only_sweep && sweep_min_area_cm2 > 0.0 &&
+            !(std::isfinite(voxelsize) && voxelsize > 0.0f)) {
+            std::cerr << "ERROR: volume reports no usable voxel size (" << voxelsize
+                      << " um/voxel), so --sweep-min-area " << sweep_min_area_cm2
+                      << " cannot be evaluated." << std::endl
+                      << "       Add \"voxelsize\" (um per voxel) to " << (vol_path / "meta.json").string()
+                      << ", or pass --sweep-min-area 0 to select without an area threshold."
+                      << std::endl;
+            return EXIT_FAILURE;
+        }
         auto target = load_quad_from_tifxyz(sweep_target_path.string());
         if (!target) {
             std::cerr << "Error: failed to load sweep target tifxyz " << sweep_target_path << std::endl;
@@ -1172,7 +1203,7 @@ int main(int argc, char *argv[])
         const int target_valid_quads = target->countValidQuads();
         const cv::Size target_grid_size = target->rawPointsPtr()->size();
         const double target_area_vx2 = vc::surface::computeSurfaceAreaVox2(*target);
-        const double target_area_cm2 = target_area_vx2 * voxelsize * voxelsize / 1e8;
+        const double target_area_cm2 = area_cm2_or_nan(target_area_vx2, voxelsize);
         PointIndex target_index;
         if (!seed_only_sweep) {
             target_index.buildFromMat(*target->rawPointsPtr());

--- a/volume-cartographer/core/CMakeLists.txt
+++ b/volume-cartographer/core/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(vc_core
         src/MemMap.cpp
         src/UnixSocket.cpp
         src/VolpkgConvert.cpp
+        src/VoxelSizeMetadata.cpp
         src/SparseChunkSpool.cpp
         src/Slicing.cpp
         src/Compositing.cpp

--- a/volume-cartographer/core/include/vc/core/util/SurfaceArea.hpp
+++ b/volume-cartographer/core/include/vc/core/util/SurfaceArea.hpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -28,6 +29,30 @@ struct MaskAreaResult
     std::size_t contributing_quads = 0;
     std::size_t inside_pixels = 0;
 };
+
+// Physical area for a voxel-space area, in cm^2. voxelSize is micrometers per
+// voxel, as reported by Volume::voxelSize(). Returns nullopt when the voxel
+// size is unusable: a volume whose metadata carries no resolution reports 0,
+// and 0 cm^2 for a real surface cannot be told apart from a genuinely tiny one.
+inline std::optional<double> areaCm2FromVox2(double area_vx2, double voxelSize)
+{
+    if (!std::isfinite(area_vx2) || !std::isfinite(voxelSize) || voxelSize <= 0.0) {
+        return std::nullopt;
+    }
+    return area_vx2 * voxelSize * voxelSize / 1e8;
+}
+
+// Record a surface's area. area_cm2 is written only when it is derivable, so an
+// unknown voxel size leaves the key absent instead of storing a bogus 0.
+inline void storeAreaMeta(utils::Json& meta, double area_vx2, double voxelSize)
+{
+    meta["area_vx2"] = area_vx2;
+    if (const auto cm2 = areaCm2FromVox2(area_vx2, voxelSize)) {
+        meta["area_cm2"] = *cm2;
+    } else if (meta.contains("area_cm2")) {
+        meta.erase("area_cm2");
+    }
+}
 
 namespace detail
 {
@@ -316,8 +341,8 @@ inline bool computeMaskAreaFromGrid(const cv::Mat_<cv::Vec3f>& coords,
     result.contributing_quads = contributing;
     result.inside_pixels = converted.insidePixelCount;
 
-    if (std::isfinite(voxelSize) && voxelSize > 0.0) {
-        result.area_cm2 = areaVox2 * voxelSize * voxelSize / 1e8;
+    if (const auto cm2 = areaCm2FromVox2(areaVox2, voxelSize)) {
+        result.area_cm2 = *cm2;
     }
 
     return true;

--- a/volume-cartographer/core/include/vc/core/util/VoxelSizeMetadata.hpp
+++ b/volume-cartographer/core/include/vc/core/util/VoxelSizeMetadata.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <optional>
+
+#include "utils/Json.hpp"
+
+namespace vc::metadata
+{
+
+// Voxel size, in micrometers, from a volume store's own sidecar document: the
+// parsed contents of `meta.json` or `metadata.json`, exactly as published and
+// before any key flattening.
+//
+// Each recognized schema is matched by its exact path. These documents also
+// record unrelated scales (a segmentation mask downsample, a crop range), and a
+// search for any key that merely looks like a resolution finds those too.
+//
+// Recognized, in order:
+//   * a top-level `voxelsize` (this codebase's own field, micrometers), or one
+//     of the `voxel_size_um` / `voxelSizeUm` / `pixel_size_um` / `pixelSizeUm`
+//     / `resolution_um` spellings. Only at the top level, where the field
+//     describes this volume: the same names nested under `metadata` on a
+//     derived store belong to its *source* volume, at an unstated pyramid
+//     level.
+//   * `scan.tomo.acquisition.detector.samplePixelSize`  -- ESRF/BM18 scan record
+//   * `tomo.acquisition.detector.samplePixelSize`       -- the same record at the
+//                                                document root, as the fused
+//                                                mosaic exports write it
+//   * the two above under `source.metadata`, for a derived store (surface or
+//     ink prediction), scaled by 2^`source.resolution` because inference runs
+//     on a downscaled level of its source volume. `source.resolution` is
+//     required, not defaulted: without it the factor is unknown, and a voxel
+//     size wrong by an unstated power of two is worse than none.
+// `samplePixelSize` is in millimeters in all of these.
+[[nodiscard]] std::optional<double> voxelSizeFromStoreMetadata(const utils::Json& doc);
+
+} // namespace vc::metadata

--- a/volume-cartographer/core/include/vc/core/util/VoxelSizeMetadata.hpp
+++ b/volume-cartographer/core/include/vc/core/util/VoxelSizeMetadata.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <optional>
 
 #include "utils/Json.hpp"
@@ -33,5 +34,12 @@ namespace vc::metadata
 //     size wrong by an unstated power of two is worse than none.
 // `samplePixelSize` is in millimeters in all of these.
 [[nodiscard]] std::optional<double> voxelSizeFromStoreMetadata(const utils::Json& doc);
+
+// voxelSizeFromStoreMetadata() over a local volume store: its `meta.json`,
+// else its `metadata.json`. For tools that read a store without constructing a
+// Volume, so they agree with Volume::voxelSize() on what the store says. Never
+// throws; a missing or malformed document resolves nothing.
+[[nodiscard]] std::optional<double> resolveLocalStoreVoxelSize(
+    const std::filesystem::path& storeRoot);
 
 } // namespace vc::metadata

--- a/volume-cartographer/core/src/GrowPatch.cpp
+++ b/volume-cartographer/core/src/GrowPatch.cpp
@@ -3721,14 +3721,12 @@ QuadSurface *tracer(Volume& volume, float scale, int level, cv::Vec3f origin, co
         }
 
         const double area_est_vx2 = vc::surface::computeSurfaceAreaVox2(*surf);
-        const double voxel_size_d = static_cast<double>(voxelsize);
-        const double area_est_cm2 = area_est_vx2 * voxel_size_d * voxel_size_d / 1e8;
         surf->meta = utils::Json::parse(meta_params.dump());
         if (resume_surf && !resume_surf->id.empty()) {
             surf->meta["seed_surface_id"] = resume_surf->id;
         }
-        surf->meta["area_vx2"] = area_est_vx2;
-        surf->meta["area_cm2"] = area_est_cm2;
+        vc::surface::storeAreaMeta(surf->meta, area_est_vx2,
+                                   static_cast<double>(voxelsize));
         surf->meta["max_gen"] = stop_gen;
         surf->meta["elapsed_time_s"] = f_timer.seconds();
 
@@ -3832,12 +3830,10 @@ QuadSurface *tracer(Volume& volume, float scale, int level, cv::Vec3f origin, co
         }
 
         const double area_est_vx2 = vc::surface::computeSurfaceAreaVox2(*surf);
-        const double voxel_size_d = static_cast<double>(voxelsize);
-        const double area_est_cm2 = area_est_vx2 * voxel_size_d * voxel_size_d / 1e8;
 
         surf->meta = utils::Json::parse(meta_params.dump());
-        surf->meta["area_vx2"] = area_est_vx2;
-        surf->meta["area_cm2"] = area_est_cm2;
+        vc::surface::storeAreaMeta(surf->meta, area_est_vx2,
+                                   static_cast<double>(voxelsize));
         surf->meta["max_gen"] = generation;
         {
             auto seed_arr = utils::Json::array();
@@ -5000,9 +4996,14 @@ QuadSurface *tracer(Volume& volume, float scale, int level, cv::Vec3f origin, co
     QuadSurface* surf = create_surface_from_state();
 
     const double area_est_vx2 = vc::surface::computeSurfaceAreaVox2(*surf);
-    const double voxel_size_d = static_cast<double>(voxelsize);
-    const double area_est_cm2 = area_est_vx2 * voxel_size_d * voxel_size_d / 1e8;
-    printf("generated surface %f vx^2 (%f cm^2)\n", area_est_vx2, area_est_cm2);
+    const auto area_est_cm2 = vc::surface::areaCm2FromVox2(
+        area_est_vx2, static_cast<double>(voxelsize));
+    if (area_est_cm2) {
+        printf("generated surface %f vx^2 (%f cm^2)\n", area_est_vx2, *area_est_cm2);
+    } else {
+        printf("generated surface %f vx^2 (cm^2 unknown: volume has no voxel size)\n",
+               area_est_vx2);
+    }
 
     return surf;
 }

--- a/volume-cartographer/core/src/GrowSurface.cpp
+++ b/volume-cartographer/core/src/GrowSurface.cpp
@@ -9,6 +9,7 @@
 #include "vc/core/util/Geometry.hpp"
 #include "vc/core/util/PointIndex.hpp"
 #include "vc/core/util/QuadSurface.hpp"
+#include "vc/core/util/SurfaceArea.hpp"
 #include "vc/core/util/SurfacePatchIndex.hpp"
 #include "vc/tracer/SurfaceModeling.hpp"
 #include "vc/core/util/OMPThreadPointCollection.hpp"
@@ -3111,9 +3112,9 @@ static QuadSurface *grow_surf_from_surfs_impl(QuadSurface *seed,
                 dbg_surf->meta["vc_grow_seg_from_segments_params"] = json_to_utils(params);
 
                 float const area_est_vx2 = loc_valid_count*src_step*src_step*step*step;
-                float const area_est_cm2 = area_est_vx2 * voxelsize * voxelsize / 1e8;
-                dbg_surf->meta["area_vx2"] = static_cast<double>(area_est_vx2);
-                dbg_surf->meta["area_cm2"] = static_cast<double>(area_est_cm2);
+                vc::surface::storeAreaMeta(dbg_surf->meta,
+                                           static_cast<double>(area_est_vx2),
+                                           static_cast<double>(voxelsize));
                 dbg_surf->meta["used_approved_segments"] = json_to_utils(nlohmann::json(std::vector<std::string>(used_approved_names.begin(), used_approved_names.end())));
                 const std::filesystem::path legacy_current_path = tgt_dir / (std::string(Z_DBG_GEN_PREFIX)+"current");
                 std::string uuid = std::string(Z_DBG_GEN_PREFIX) + get_surface_time_str();
@@ -3198,9 +3199,9 @@ static QuadSurface *grow_surf_from_surfs_impl(QuadSurface *seed,
 
                 std::string uuid = std::string(Z_DBG_GEN_PREFIX)+"opt";
                 float const area_est_vx2 = loc_valid_count*src_step*src_step*step*step;
-                float const area_est_cm2 = area_est_vx2 * voxelsize * voxelsize / 1e8;
-                dbg_surf->meta["area_vx2"] = static_cast<double>(area_est_vx2);
-                dbg_surf->meta["area_cm2"] = static_cast<double>(area_est_cm2);
+                vc::surface::storeAreaMeta(dbg_surf->meta,
+                                           static_cast<double>(area_est_vx2),
+                                           static_cast<double>(voxelsize));
                 dbg_surf->meta["used_approved_segments"] = json_to_utils(nlohmann::json(std::vector<std::string>(used_approved_names.begin(), used_approved_names.end())));
                 dbg_surf->save(tgt_dir / uuid, uuid, true);
                 delete dbg_surf;
@@ -3208,10 +3209,14 @@ static QuadSurface *grow_surf_from_surfs_impl(QuadSurface *seed,
         }
 
         float const current_area_vx2 = loc_valid_count*src_step*src_step*step*step;
-        float const current_area_cm2 = current_area_vx2 * voxelsize * voxelsize / 1e8;
-        printf("gen %d processing %lu fringe cands (total done %d fringe: %lu) area %.0f vx^2 (%f cm^2) best th: %d\n",
+        const auto current_area_cm2 = vc::surface::areaCm2FromVox2(
+            static_cast<double>(current_area_vx2), static_cast<double>(voxelsize));
+        const std::string current_area_cm2_text = current_area_cm2
+            ? std::to_string(*current_area_cm2) + " cm^2"
+            : std::string("cm^2 unknown");
+        printf("gen %d processing %lu fringe cands (total done %d fringe: %lu) area %.0f vx^2 (%s) best th: %d\n",
                generation, static_cast<unsigned long>(cands.size()), succ, static_cast<unsigned long>(fringe.size()),
-               current_area_vx2, current_area_cm2, best_inliers_gen);
+               current_area_vx2, current_area_cm2_text.c_str(), best_inliers_gen);
 
         if (sweep_prune_distance_active &&
             generation >= sweep_prune_min_generations &&
@@ -3534,8 +3539,14 @@ static QuadSurface *grow_surf_from_surfs_impl(QuadSurface *seed,
     }
 
     float const area_est_vx2 = loc_valid_count*src_step*src_step*step*step;
-    float const area_est_cm2 = area_est_vx2 * voxelsize * voxelsize / 1e8;
-    std::cout << "area est: " << area_est_vx2 << " vx^2 (" << area_est_cm2 << " cm^2)" << std::endl;
+    const auto area_est_cm2 = vc::surface::areaCm2FromVox2(
+        static_cast<double>(area_est_vx2), static_cast<double>(voxelsize));
+    std::cout << "area est: " << area_est_vx2 << " vx^2 (";
+    if (area_est_cm2)
+        std::cout << *area_est_cm2 << " cm^2)";
+    else
+        std::cout << "cm^2 unknown: volume has no voxel size)";
+    std::cout << std::endl;
 
     cv::Mat_<cv::Vec3d> points_hr = surftrack_genpoints_hr(data, state, points, used_area, step, src_step);
     cv::Mat_<uint16_t> generations_hr = surftrack_generations_hr(state, generations, used_area, step);
@@ -3544,8 +3555,9 @@ static QuadSurface *grow_surf_from_surfs_impl(QuadSurface *seed,
     surf->setChannel("generations", generations_hr(used_area_hr));
 
     surf->meta = utils::Json::object();
-    surf->meta["area_vx2"] = static_cast<double>(area_est_vx2);
-    surf->meta["area_cm2"] = static_cast<double>(area_est_cm2);
+    vc::surface::storeAreaMeta(surf->meta,
+                               static_cast<double>(area_est_vx2),
+                               static_cast<double>(voxelsize));
     surf->meta["used_approved_segments"] = json_to_utils(nlohmann::json(std::vector<std::string>(used_approved_names.begin(), used_approved_names.end())));
     if (resume_growth) {
         const int offset_col = grid_margin + expanded_left - used_area.x;

--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -32,6 +32,7 @@
 #include "vc/core/util/RemoteFileCache.hpp"
 #include "vc/core/util/RemoteCacheSettings.hpp"
 #include "vc/core/util/PostProcess.hpp"
+#include "vc/core/util/VoxelSizeMetadata.hpp"
 #include "vc/core/render/IChunkedArray.hpp"
 #include "vc/core/render/ChunkFetch.hpp"
 #include "utils/hash.hpp"
@@ -59,92 +60,44 @@ std::string deriveRemoteVolumeName(const std::string& url)
     return normalized.empty() ? std::string("remote") : normalized;
 }
 
+// Record the voxel size resolved from the store's document. When there is
+// none, say so: a volume without one reports 0, and every physical measurement
+// derived from it -- surface areas, the min_area_cm gate, the scale bar --
+// silently becomes 0 too (#1603).
+void applyResolvedVoxelSize(utils::Json& metadata,
+                            std::optional<double> resolved,
+                            const std::string& description)
+{
+    if (resolved) {
+        metadata["voxelsize"] = *resolved;
+        return;
+    }
+    if (vc::json::number_or(metadata, "voxelsize", 0.0) > 0.0) {
+        return;
+    }
+    Logger()->warn(
+        "volume '{}': no voxel size in its store metadata, so physical measurements "
+        "are unavailable for it",
+        description);
+}
+
 std::optional<utils::Json> loadRemoteVolumeMetadata(const std::string& remoteUrl,
                                                     const vc::HttpAuth& auth)
 {
-    const auto numberFromObject = [](const utils::Json& obj,
-                                     std::initializer_list<const char*> keys) -> std::optional<double> {
-        if (!obj.is_object()) {
-            return std::nullopt;
-        }
-        for (const char* key : keys) {
-            if (!obj.contains(key)) {
-                continue;
-            }
-            const auto& value = obj[key];
-            if (value.is_number()) {
-                return value.get_double();
-            }
-            if (value.is_string()) {
-                try {
-                    return std::stod(value.get_string());
-                } catch (...) {
-                }
-            }
-        }
-        return std::nullopt;
-    };
-
-    const auto voxelSizeFromMetadata = [&](const utils::Json& obj) -> std::optional<double> {
-        const auto keys = {
-            "voxelsize",
-            "voxel_size_um",
-            "voxelSizeUm",
-            "pixel_size_um",
-            "pixelSizeUm",
-            "resolution_um",
-        };
-        if (auto value = numberFromObject(obj, keys)) {
-            return value;
-        }
-        for (const char* key : {"scan", "volume", "properties", "metadata"}) {
-            if (obj.is_object() && obj.contains(key)) {
-                if (auto value = numberFromObject(obj[key], keys)) {
-                    return value;
-                }
-            }
-        }
-        return std::nullopt;
-    };
-
     const auto normalize = [&](utils::Json json, const std::string& url) -> utils::Json {
         if (!json.is_object()) {
             throw std::runtime_error("remote volume metadata is not an object: " + url);
         }
+        // Resolve from the document as published, before `scan` is flattened
+        // into the root.
+        const auto voxelSize = vc::metadata::voxelSizeFromStoreMetadata(json);
         if (json.contains("scan") && json["scan"].is_object()) {
             json.update(json["scan"]);
         }
         if (!json.contains("format")) {
             json["format"] = "zarr";
         }
-
-        bool hasVoxelSize = false;
-        if (json.contains("voxelsize") && json["voxelsize"].is_number()) {
-            hasVoxelSize = json["voxelsize"].get_double() > 0.0;
-        }
-        if (!hasVoxelSize) {
-            if (auto voxelSize = voxelSizeFromMetadata(json); voxelSize && *voxelSize > 0.0) {
-                json["voxelsize"] = *voxelSize;
-                hasVoxelSize = true;
-            }
-        }
-        if (!hasVoxelSize) {
-            const utils::Json* current = &json;
-            for (const char* key : {"scan", "tomo", "acquisition", "detector"}) {
-                if (!current->is_object() || !current->contains(key)) {
-                    current = nullptr;
-                    break;
-                }
-                current = &(*current)[key];
-            }
-            if (current && current->is_object() &&
-                current->contains("samplePixelSize") &&
-                (*current)["samplePixelSize"].is_number()) {
-                const double millimeters = (*current)["samplePixelSize"].get_double();
-                if (std::isfinite(millimeters) && millimeters > 0.0)
-                    json["voxelsize"] = millimeters * 1000.0;
-            }
-        }
+        applyResolvedVoxelSize(json, voxelSize, url);
         return json;
     };
 
@@ -1085,11 +1038,15 @@ void Volume::loadMetadata()
             throw std::runtime_error(
                 "metadata.json missing 'scan' key: " + altPath.string());
         }
+        // Resolve from the document as published, before `scan` is flattened
+        // into the root.
+        const auto voxelSize = vc::metadata::voxelSizeFromStoreMetadata(full);
         metadata_ = full;
         metadata_.update(full["scan"]);
         if (!metadata_.contains("format")) {
             metadata_["format"] = "zarr";
         }
+        applyResolvedVoxelSize(metadata_, voxelSize, altPath.string());
         metaPath = altPath;
     } else {
         metadata_["uuid"] = deriveLocalVolumeId(path_);

--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -1574,7 +1574,11 @@ size_t Volume::chunkCount(int level) const
 std::array<int, 3> Volume::shapeXyz() const noexcept { return {_width, _height, _slices}; }
 double Volume::voxelSize() const
 {
-    return metadata_["voxelsize"].get_double();
+    // 0 means unknown. A document may state the key as null, as text, or not
+    // at all, and a physical measurement must degrade to "unavailable" rather
+    // than throw from deep inside whatever asked for it.
+    const double value = vc::json::number_or(metadata_, "voxelsize", 0.0);
+    return std::isfinite(value) && value > 0.0 ? value : 0.0;
 }
 
 size_t Volume::dtypeSize() const noexcept

--- a/volume-cartographer/core/src/VoxelSizeMetadata.cpp
+++ b/volume-cartographer/core/src/VoxelSizeMetadata.cpp
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
+#include <filesystem>
 #include <initializer_list>
 #include <string>
 #include <string_view>
@@ -158,6 +160,21 @@ std::optional<double> voxelSizeFromStoreMetadata(const utils::Json& doc)
     if (!sourceLevel)
         return std::nullopt;
     return detectorVoxelSize(*sourceMetadata, *sourceLevel);
+}
+
+std::optional<double> resolveLocalStoreVoxelSize(const std::filesystem::path& storeRoot)
+{
+    for (const char* name : {"meta.json", "metadata.json"}) {
+        const auto file = storeRoot / name;
+        if (!std::filesystem::exists(file))
+            continue;
+        try {
+            return voxelSizeFromStoreMetadata(utils::Json::parse_file(file));
+        } catch (const std::exception&) {
+            return std::nullopt;
+        }
+    }
+    return std::nullopt;
 }
 
 } // namespace vc::metadata

--- a/volume-cartographer/core/src/VoxelSizeMetadata.cpp
+++ b/volume-cartographer/core/src/VoxelSizeMetadata.cpp
@@ -1,0 +1,163 @@
+#include "vc/core/util/VoxelSizeMetadata.hpp"
+
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <string>
+#include <string_view>
+
+namespace vc::metadata
+{
+
+namespace
+{
+
+// Follow an exact path of object keys. Returns nullopt as soon as a key is
+// missing or a level is not an object, so a caller never has to pre-check the
+// shape of a foreign document.
+//
+// The result is a copy, deliberately. utils::Json::operator[] hands out
+// references into a bounded thread-local cache that evicts its oldest entries,
+// so a reference held across a loop that itself indexes into the document is
+// eventually left dangling. These documents are small.
+std::optional<utils::Json> walk(const utils::Json& root,
+                                std::initializer_list<std::string_view> keys)
+{
+    const utils::Json* current = &root;
+    for (const std::string_view key : keys) {
+        const std::string name(key);
+        if (!current->is_object() || !current->contains(name))
+            return std::nullopt;
+        current = &(*current)[name];
+    }
+    return *current;
+}
+
+// Accept a number, or a string holding one. Several of these documents store
+// numbers as strings -- `source.resolution` is `"2"`, not `2` -- and rejecting
+// those would lose exactly the field that makes a derived store resolvable.
+// Booleans are excluded: JSON true is not the number 1 here.
+std::optional<double> asNumber(const utils::Json& value)
+{
+    if (value.is_boolean())
+        return std::nullopt;
+    if (value.is_number())
+        return value.get_double();
+    if (!value.is_string())
+        return std::nullopt;
+
+    const std::string text = value.get_string();
+    try {
+        std::size_t consumed = 0;
+        const double parsed = std::stod(text, &consumed);
+        while (consumed < text.size() &&
+               std::isspace(static_cast<unsigned char>(text[consumed])) != 0) {
+            ++consumed;
+        }
+        if (consumed == text.size())
+            return parsed;
+    } catch (...) {
+    }
+    return std::nullopt;
+}
+
+std::optional<double> positiveNumber(const utils::Json& value)
+{
+    const auto number = asNumber(value);
+    if (!number || !std::isfinite(*number) || *number <= 0.0)
+        return std::nullopt;
+    return number;
+}
+
+// A pyramid level must be an exact non-negative integer. The upper bound
+// matches the 0..31 range the zarr opener enforces on dataset paths, and keeps
+// the 2^level factor below from overflowing.
+std::optional<int> asPyramidLevel(const utils::Json& value)
+{
+    const auto number = asNumber(value);
+    if (!number || !std::isfinite(*number) || *number < 0.0 || *number > 31.0)
+        return std::nullopt;
+    const auto level = static_cast<int>(*number);
+    if (static_cast<double>(level) != *number)
+        return std::nullopt;
+    return level;
+}
+
+// The ESRF/BM18 acquisition record, either under a "scan" wrapper or at the
+// root of the document. `samplePixelSize` is in millimeters.
+std::optional<double> detectorVoxelSize(const utils::Json& root, int sourceLevel)
+{
+    for (const bool scanWrapper : {true, false}) {
+        const auto value =
+            scanWrapper
+                ? walk(root, {"scan", "tomo", "acquisition", "detector", "samplePixelSize"})
+                : walk(root, {"tomo", "acquisition", "detector", "samplePixelSize"});
+        if (!value)
+            continue;
+        const auto millimeters = positiveNumber(*value);
+        if (!millimeters)
+            continue;
+
+        const double micrometers =
+            *millimeters * 1000.0 * static_cast<double>(std::uint64_t{1} << sourceLevel);
+        if (!std::isfinite(micrometers) || micrometers <= 0.0)
+            return std::nullopt;
+        return micrometers;
+    }
+    return std::nullopt;
+}
+
+// A voxel size the document states outright, at the top level only.
+std::optional<double> explicitVoxelSize(const utils::Json& doc)
+{
+    if (!doc.is_object())
+        return std::nullopt;
+    for (const char* key : {"voxelsize", "voxel_size_um", "voxelSizeUm", "pixel_size_um",
+                            "pixelSizeUm", "resolution_um"}) {
+        if (!doc.contains(key))
+            continue;
+        if (const auto micrometers = positiveNumber(doc[key]))
+            return micrometers;
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+std::optional<double> voxelSizeFromStoreMetadata(const utils::Json& doc)
+{
+    if (!doc.is_object())
+        return std::nullopt;
+
+    if (auto explicitSize = explicitVoxelSize(doc))
+        return explicitSize;
+
+    // A source volume carries its own scan record.
+    if (auto direct = detectorVoxelSize(doc, 0))
+        return direct;
+
+    // A derived store -- a surface or ink prediction -- records the volume it
+    // ran on under `source`: that volume's scan record, and the pyramid level
+    // of it that the run consumed.
+    const auto source = walk(doc, {"source"});
+    if (!source)
+        return std::nullopt;
+    const auto sourceMetadata = walk(*source, {"metadata"});
+    if (!sourceMetadata)
+        return std::nullopt;
+
+    // The level is what converts the source volume's pixel size into this
+    // store's, so it is not optional. Assuming 0 would report a voxel size too
+    // small by whatever factor the run really used, and nothing downstream
+    // could tell. Every derived store the catalog publishes states it.
+    if (!source->is_object() || !source->contains("resolution"))
+        return std::nullopt;
+    const auto sourceLevel = asPyramidLevel((*source)["resolution"]);
+    if (!sourceLevel)
+        return std::nullopt;
+    return detectorVoxelSize(*sourceMetadata, *sourceLevel);
+}
+
+} // namespace vc::metadata

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -68,6 +68,8 @@ vc_add_test(NAME test_smoke LIBS doctest::doctest)
 
 vc_add_test(NAME test_surface_area_units)
 
+vc_add_test(NAME test_voxel_size_metadata)
+
 vc_add_test(NAME test_tifxyz_identity)
 
 vc_add_test(NAME test_appendmask_render)

--- a/volume-cartographer/core/test/CMakeLists.txt
+++ b/volume-cartographer/core/test/CMakeLists.txt
@@ -66,6 +66,8 @@ endfunction()
 
 vc_add_test(NAME test_smoke LIBS doctest::doctest)
 
+vc_add_test(NAME test_surface_area_units)
+
 vc_add_test(NAME test_tifxyz_identity)
 
 vc_add_test(NAME test_appendmask_render)

--- a/volume-cartographer/core/test/test_surface_area_units.cpp
+++ b/volume-cartographer/core/test/test_surface_area_units.cpp
@@ -1,0 +1,75 @@
+// Coverage for the physical-area helpers in SurfaceArea.hpp. The point of
+// these is that an unknown voxel size must not turn into a 0 cm^2 area: a
+// volume whose metadata carries no resolution reports voxelSize() == 0, and a
+// fabricated 0 is indistinguishable from a genuinely tiny surface. See #1603.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "vc/core/util/SurfaceArea.hpp"
+
+#include <cmath>
+#include <limits>
+
+using vc::surface::areaCm2FromVox2;
+using vc::surface::storeAreaMeta;
+
+TEST_CASE("areaCm2FromVox2: converts with a known voxel size")
+{
+    // Measured on a real PHercParis4 trace at 2.4 um/voxel.
+    const auto cm2 = areaCm2FromVox2(3625.31668921149, 2.4);
+    REQUIRE(cm2.has_value());
+    CHECK(*cm2 == doctest::Approx(0.000208818241).epsilon(1e-9));
+
+    // 1e8 um^2 per cm^2, so a 1 um voxel makes the two numbers differ by 1e8.
+    const auto unit = areaCm2FromVox2(1e8, 1.0);
+    REQUIRE(unit.has_value());
+    CHECK(*unit == doctest::Approx(1.0));
+}
+
+TEST_CASE("areaCm2FromVox2: refuses an unusable voxel size")
+{
+    CHECK_FALSE(areaCm2FromVox2(1000.0, 0.0).has_value());
+    CHECK_FALSE(areaCm2FromVox2(1000.0, -2.4).has_value());
+    CHECK_FALSE(areaCm2FromVox2(1000.0, std::numeric_limits<double>::quiet_NaN()).has_value());
+    CHECK_FALSE(areaCm2FromVox2(1000.0, std::numeric_limits<double>::infinity()).has_value());
+}
+
+TEST_CASE("areaCm2FromVox2: refuses a non-finite area")
+{
+    CHECK_FALSE(areaCm2FromVox2(std::numeric_limits<double>::quiet_NaN(), 2.4).has_value());
+    CHECK_FALSE(areaCm2FromVox2(std::numeric_limits<double>::infinity(), 2.4).has_value());
+}
+
+TEST_CASE("storeAreaMeta: records both areas when the voxel size is known")
+{
+    auto meta = utils::Json::object();
+    storeAreaMeta(meta, 3625.31668921149, 2.4);
+
+    REQUIRE(meta.contains("area_vx2"));
+    REQUIRE(meta.contains("area_cm2"));
+    CHECK(meta["area_vx2"].get_double() == doctest::Approx(3625.31668921149));
+    CHECK(meta["area_cm2"].get_double() == doctest::Approx(0.000208818241).epsilon(1e-9));
+}
+
+TEST_CASE("storeAreaMeta: omits area_cm2 when the voxel size is unknown")
+{
+    auto meta = utils::Json::object();
+    storeAreaMeta(meta, 15627277.310839027, 0.0);
+
+    REQUIRE(meta.contains("area_vx2"));
+    CHECK(meta["area_vx2"].get_double() == doctest::Approx(15627277.310839027));
+    CHECK_FALSE(meta.contains("area_cm2"));
+}
+
+TEST_CASE("storeAreaMeta: clears a stale area_cm2 rather than leaving it")
+{
+    // The tracers seed meta from caller-supplied params, so the key can
+    // already be present when the voxel size turns out to be unusable.
+    auto meta = utils::Json::object();
+    meta["area_cm2"] = 12.5;
+    storeAreaMeta(meta, 4096.0, 0.0);
+
+    CHECK_FALSE(meta.contains("area_cm2"));
+    CHECK(meta["area_vx2"].get_double() == doctest::Approx(4096.0));
+}

--- a/volume-cartographer/core/test/test_volume_local.cpp
+++ b/volume-cartographer/core/test/test_volume_local.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include "vc/core/types/Volume.hpp"
 #include "vc/core/types/Array3D.hpp"
+#include "vc/core/util/LoadJson.hpp"
 
 #include <opencv2/core.hpp>
 
@@ -15,6 +16,7 @@
 #include <cstddef>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <random>
 #include <string>
 #include <vector>
@@ -49,6 +51,13 @@ Volume::ZarrCreateOptions makeOpts(std::array<size_t, 3> shape = {64, 64, 64},
     // test runs regardless of whether libblosc was linked.
     opts.compressor = "none";
     return opts;
+}
+
+void writeTextFile(const fs::path& path, const std::string& text)
+{
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    REQUIRE(out.good());
+    out << text;
 }
 
 } // namespace
@@ -378,5 +387,54 @@ TEST_CASE("Volume: shape() / sliceWidth() / sliceHeight() / numSlices() agree")
     CHECK(sh[0] == v->numSlices());
     CHECK(sh[1] == v->sliceHeight());
     CHECK(sh[2] == v->sliceWidth());
+    fs::remove_all(d);
+}
+
+TEST_CASE("Volume: an unusable voxelsize field reports 0 instead of throwing")
+{
+    // voxelSize() promises 0 for "unknown". A document may state the key as
+    // null, as text, or not at all, and each of those used to make the
+    // accessor throw from deep inside whatever asked for a physical area.
+    auto d = tmpDir("unusable_voxelsize");
+    auto opts = makeOpts({32, 32, 32}, {16, 16, 16}, 1);
+    Volume::New(d, opts);
+    const auto meta = vc::json::load_json_file(d / "meta.json");
+    const auto metaWithVoxelSize = [&](const std::string& voxelsizeJson) {
+        std::string text = R"({"type": "vol", "uuid": ")" + meta["uuid"].get_string() +
+                           R"(", "width": 32, "height": 32, "slices": 32)";
+        if (!voxelsizeJson.empty()) {
+            text += R"(, "voxelsize": )" + voxelsizeJson;
+        }
+        return text + "}";
+    };
+
+    SUBCASE("meta.json without a voxelsize key")
+    {
+        writeTextFile(d / "meta.json", metaWithVoxelSize(""));
+        auto v = Volume::New(d);
+        CHECK(v->voxelSize() == 0.0);
+    }
+
+    SUBCASE("meta.json with a null voxelsize")
+    {
+        writeTextFile(d / "meta.json", metaWithVoxelSize("null"));
+        auto v = Volume::New(d);
+        CHECK(v->voxelSize() == 0.0);
+    }
+
+    SUBCASE("meta.json with a non-positive voxelsize")
+    {
+        writeTextFile(d / "meta.json", metaWithVoxelSize("-1"));
+        auto v = Volume::New(d);
+        CHECK(v->voxelSize() == 0.0);
+    }
+
+    SUBCASE("meta.json with voxelsize as unknown text")
+    {
+        writeTextFile(d / "meta.json", metaWithVoxelSize(R"("unknown")"));
+        auto v = Volume::New(d);
+        CHECK(v->voxelSize() == 0.0);
+    }
+
     fs::remove_all(d);
 }

--- a/volume-cartographer/core/test/test_voxel_size_metadata.cpp
+++ b/volume-cartographer/core/test/test_voxel_size_metadata.cpp
@@ -1,0 +1,165 @@
+// Coverage for voxel-size resolution from volume-store metadata. Every schema
+// case below is a real document shape from the Vesuvius open-data catalog,
+// reduced to the fields that matter. The failure this guards is #1603: a
+// volume whose voxel size cannot be resolved reports 0, and every physical
+// measurement derived from it silently becomes 0 too.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "vc/core/util/VoxelSizeMetadata.hpp"
+
+#include <string>
+
+using utils::Json;
+using vc::metadata::voxelSizeFromStoreMetadata;
+
+namespace
+{
+
+Json parse(const std::string& text) { return Json::parse(text); }
+
+// A scan record without the `scan` wrapper. samplePixelSize is in mm.
+std::string scanRecord(double samplePixelSizeMm)
+{
+    return R"({"tomo":{"acquisition":{"detector":{"samplePixelSize":)" +
+           std::to_string(samplePixelSizeMm) + R"(}}}})";
+}
+
+} // namespace
+
+TEST_CASE("store metadata: source volume with a scan-wrapped acquisition record")
+{
+    const auto resolved = voxelSizeFromStoreMetadata(
+        parse(R"({"scan":{"tomo":{"acquisition":{"detector":{"samplePixelSize":0.00791}}}}})"));
+    REQUIRE(resolved.has_value());
+    CHECK(*resolved == doctest::Approx(7.91));
+}
+
+TEST_CASE("store metadata: fused mosaic export with the record at the document root")
+{
+    // The 1.129 um mosaics publish the same record without the `scan` wrapper,
+    // and alongside two numbers a search for anything resolution-shaped would
+    // find first: a mask downsample factor and a z crop range.
+    const auto resolved = voxelSizeFromStoreMetadata(parse(R"({
+        "masking": {"mask_scale": 8, "dilation_iterations": "1"},
+        "zarr_export": {"z_crop_start": 16, "z_crop_end": 42208},
+        "mosaic": {"tile_count": 7},
+        "tomo": {"acquisition": {"detector": {"samplePixelSize": 0.001129}}}
+    })"));
+    REQUIRE(resolved.has_value());
+    CHECK(*resolved == doctest::Approx(1.129));
+}
+
+TEST_CASE("store metadata: prediction run on level 0 of its source volume")
+{
+    const auto resolved = voxelSizeFromStoreMetadata(parse(R"({
+        "kind": "surface-inference",
+        "source": {"resolution": "0", "metadata": )" + scanRecord(0.00864) + R"(}
+    })"));
+    REQUIRE(resolved.has_value());
+    CHECK(*resolved == doctest::Approx(8.64));
+}
+
+TEST_CASE("store metadata: prediction run on level 2 is four times its source voxel size")
+{
+    // Ignoring the level reports 2.4 um instead of 9.6, which makes every
+    // derived area 16x too small -- small enough to fall under a min_area_cm
+    // gate and be discarded as noise.
+    const auto resolved = voxelSizeFromStoreMetadata(parse(R"({
+        "kind": "surface-inference",
+        "source": {
+            "resolution": "2",
+            "metadata": {"scan": {"tomo": {"acquisition": {"detector": {"samplePixelSize": 0.0024}}}}}
+        }
+    })"));
+    REQUIRE(resolved.has_value());
+    CHECK(*resolved == doctest::Approx(9.6));
+}
+
+TEST_CASE("store metadata: an unreadable source level resolves nothing")
+{
+    // Falling back to level 0 would report a plausible number that is wrong by
+    // an unknown power of two, which is worse than reporting none.
+    for (const char* level : {R"("high")", "-1", "2.5", "null", "true", "99"}) {
+        const auto doc = parse(std::string(R"({"source": {"resolution": )") + level +
+                               R"(, "metadata": )" + scanRecord(0.0024) + "}}");
+        CHECK_FALSE(voxelSizeFromStoreMetadata(doc).has_value());
+    }
+}
+
+TEST_CASE("store metadata: a derived store must state its source level")
+{
+    CHECK_FALSE(voxelSizeFromStoreMetadata(parse(R"({
+        "kind": "surface-inference",
+        "source": {"metadata": {"scan": {"tomo": {"acquisition": {"detector":
+                   {"samplePixelSize": 0.0024}}}}}}
+    })")).has_value());
+}
+
+TEST_CASE("store metadata: an explicit voxelsize wins over an acquisition record")
+{
+    const auto resolved = voxelSizeFromStoreMetadata(parse(R"({
+        "voxelsize": 3.24,
+        "scan": {"tomo": {"acquisition": {"detector": {"samplePixelSize": 0.00791}}}}
+    })"));
+    REQUIRE(resolved.has_value());
+    CHECK(*resolved == doctest::Approx(3.24));
+}
+
+TEST_CASE("store metadata: the alternative spellings of an explicit voxel size")
+{
+    for (const char* key : {"voxelsize", "voxel_size_um", "voxelSizeUm", "pixel_size_um",
+                            "pixelSizeUm", "resolution_um"}) {
+        const auto resolved = voxelSizeFromStoreMetadata(
+            parse(std::string(R"({")") + key + R"(": 2.4})"));
+        REQUIRE(resolved.has_value());
+        CHECK(*resolved == doctest::Approx(2.4));
+    }
+}
+
+TEST_CASE("store metadata: a nested pixel size is not read as this volume's")
+{
+    // On a derived store `metadata` holds the source volume's record. A pixel
+    // size found there is the source's, at whatever pyramid level the run
+    // consumed. Only `source.metadata` plus `source.resolution` together carry
+    // enough to answer, and that path is tested above.
+    CHECK_FALSE(voxelSizeFromStoreMetadata(parse(R"({
+        "metadata": {"pixel_size_um": 2.4},
+        "properties": {"voxel_size_um": 2.4},
+        "volume": {"resolution_um": 2.4}
+    })")).has_value());
+}
+
+TEST_CASE("store metadata: a document with no acquisition record resolves nothing")
+{
+    // One published volume really is in this state: its metadata.json holds
+    // only export and masking parameters.
+    CHECK_FALSE(voxelSizeFromStoreMetadata(parse(R"({
+        "zarr_export": {"z_crop_start": 0, "z_crop_end": 20819, "window_u16_max": 65535},
+        "masking": {"method": "SAM2", "mask_scale": 8}
+    })")).has_value());
+
+    CHECK_FALSE(voxelSizeFromStoreMetadata(parse("{}")).has_value());
+    CHECK_FALSE(voxelSizeFromStoreMetadata(parse("[]")).has_value());
+    CHECK_FALSE(voxelSizeFromStoreMetadata(parse("null")).has_value());
+}
+
+TEST_CASE("store metadata: numbers written as strings are accepted")
+{
+    // source.resolution is a string in every published prediction, so string
+    // numbers have to be read rather than rejected.
+    const auto resolved = voxelSizeFromStoreMetadata(
+        parse(R"({"scan":{"tomo":{"acquisition":{"detector":{"samplePixelSize":"0.00791"}}}}})"));
+    REQUIRE(resolved.has_value());
+    CHECK(*resolved == doctest::Approx(7.91));
+}
+
+TEST_CASE("store metadata: a non-positive or unparseable pixel size resolves nothing")
+{
+    for (const char* value : {"0", "-0.00791", R"("")", R"("7.91 um")", "true", "null", "{}"}) {
+        const auto doc = parse(std::string(
+            R"({"scan":{"tomo":{"acquisition":{"detector":{"samplePixelSize":)") + value + "}}}}}");
+        CHECK_FALSE(voxelSizeFromStoreMetadata(doc).has_value());
+    }
+}

--- a/volume-cartographer/core/test/test_voxel_size_metadata.cpp
+++ b/volume-cartographer/core/test/test_voxel_size_metadata.cpp
@@ -9,15 +9,35 @@
 
 #include "vc/core/util/VoxelSizeMetadata.hpp"
 
+#include <filesystem>
+#include <fstream>
+#include <random>
 #include <string>
 
 using utils::Json;
+using vc::metadata::resolveLocalStoreVoxelSize;
 using vc::metadata::voxelSizeFromStoreMetadata;
 
 namespace
 {
 
 Json parse(const std::string& text) { return Json::parse(text); }
+
+std::filesystem::path tmpDir(const std::string& tag)
+{
+    std::mt19937_64 rng(std::random_device{}());
+    auto p = std::filesystem::temp_directory_path() /
+             ("vc_voxel_size_" + tag + "_" + std::to_string(rng()));
+    std::filesystem::create_directories(p);
+    return p;
+}
+
+void writeTextFile(const std::filesystem::path& path, const std::string& text)
+{
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    REQUIRE(out.good());
+    out << text;
+}
 
 // A scan record without the `scan` wrapper. samplePixelSize is in mm.
 std::string scanRecord(double samplePixelSizeMm)
@@ -162,4 +182,42 @@ TEST_CASE("store metadata: a non-positive or unparseable pixel size resolves not
             R"({"scan":{"tomo":{"acquisition":{"detector":{"samplePixelSize":)") + value + "}}}}}");
         CHECK_FALSE(voxelSizeFromStoreMetadata(doc).has_value());
     }
+}
+
+TEST_CASE("resolveLocalStoreVoxelSize: a local store resolves like a Volume would")
+{
+    const auto d = tmpDir("local_store");
+
+    SUBCASE("nothing on disk resolves nothing, without throwing")
+    {
+        CHECK_FALSE(resolveLocalStoreVoxelSize(d).has_value());
+        CHECK_FALSE(resolveLocalStoreVoxelSize(d / "does_not_exist").has_value());
+    }
+
+    SUBCASE("meta.json is authoritative over metadata.json")
+    {
+        writeTextFile(d / "meta.json", R"({"type": "vol", "voxelsize": 7.91})");
+        writeTextFile(d / "metadata.json",
+                      R"({"scan": {"tomo": {"acquisition": {"detector": {"samplePixelSize": 0.0024}}}}})");
+        const auto resolved = resolveLocalStoreVoxelSize(d);
+        REQUIRE(resolved.has_value());
+        CHECK(*resolved == doctest::Approx(7.91));
+    }
+
+    SUBCASE("a published metadata.json is read when there is no meta.json")
+    {
+        writeTextFile(d / "metadata.json",
+                      R"({"scan": {"tomo": {"acquisition": {"detector": {"samplePixelSize": 0.0024}}}}})");
+        const auto resolved = resolveLocalStoreVoxelSize(d);
+        REQUIRE(resolved.has_value());
+        CHECK(*resolved == doctest::Approx(2.4));
+    }
+
+    SUBCASE("a malformed document counts as absent")
+    {
+        writeTextFile(d / "meta.json", "{not json");
+        CHECK_FALSE(resolveLocalStoreVoxelSize(d).has_value());
+    }
+
+    std::filesystem::remove_all(d);
 }


### PR DESCRIPTION
1. Fail early if voxelsize cannot be determined. Before, if no voxelsize for the surface volume could be found, the process discarded results late.
2. Take more metadata into account when figuring out metadata. Most importantly, for some surface predictions, we specify on which level the prediction of the base volume has been run. We can use that value to determine the actual voxelsize. If available we can also determine voxelsize both from zarr and ome-zarr metadata directly if available.
3. some detail changes in the use of the areaCm2

Fixes #1603.

Superseded #1541 