### PR TITLE
vc_sync: resolve linked-fiber conflicts in one run (decide before link planning; dropped links to deleted peers)

### DIFF
--- a/volume-cartographer/docs/line_annotation_fibers.md
+++ b/volume-cartographer/docs/line_annotation_fibers.md
@@ -294,7 +294,15 @@ equal changes converge, and different two-sided changes conflict.
 
 An ambiguous merge does not modify the fiber. The sync tool stores local,
 remote, and base copies under `.s3sync-conflicts/` and asks whether to keep the
-complete local version, keep the complete remote version, or skip. Existing
+complete local version, keep the complete remote version, or skip. Those
+questions are asked before the link-consistency planning of the other
+conflicts: a decided file ([l]ocal or [r]emote) is a known source the planner
+can plan its linked neighbours against, so their auto-merges land in the same
+run; only a skipped file blocks the neighbours that depend on it, which are
+then asked about in turn. A merge that dropped its link to a peer deleted on
+both sides (or pending local deletion) needs no reciprocal fix and is not
+treated as a dangling link. `--dry-run` reports content-merge eligibility only;
+link consistency is assessed in a real run. Existing
 base-aware tag, branch-link, reciprocal-peer, and manual-HV-tag handling runs
 only after geometry merges cleanly. Version-1 fibers retain the older merge
 behavior, including the CP-polyline `needs_reoptimization`

--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -701,7 +701,7 @@ class TestLinkConsistency:
         plan = self.make_plan(manager, 'fibers/a.json', a,
                               self.fiber('a.json', self.CPS_A), ['b.json'])
 
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert demoted == []
         assert list(peer_fixes) == ['fibers/b.json']
@@ -726,7 +726,7 @@ class TestLinkConsistency:
         write_local(manager, 'fibers/b.json', json.dumps(b))
         plan = self.make_plan(manager, 'fibers/a.json', a,
                               self.fiber('a.json', self.CPS_A), ['b.json'])
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert demoted == []
         assert peer_fixes == {}
@@ -737,11 +737,112 @@ class TestLinkConsistency:
                                             self.CPS_B, 0)])
         plan = self.make_plan(manager, 'fibers/a.json', a,
                               self.fiber('a.json', self.CPS_A), ['b.json'])
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert peer_fixes == {}
         assert demoted and demoted[0][0] == 'fibers/a.json'
         assert 'missing' in demoted[0][1]
+
+    def _dropped_link_plan(self, manager, peers):
+        """a's merged doc links b only; base linked c too (dropped link)."""
+        a = self.fiber('a.json', self.CPS_A,
+                       branches=[self.entry('b.json', self.CPS_A, 1,
+                                            self.CPS_B, 0)])
+        base = self.fiber('a.json', self.CPS_A,
+                          branches=[self.entry('b.json', self.CPS_A, 1,
+                                               self.CPS_B, 0),
+                                    self.entry('c.json', self.CPS_A, 0,
+                                               self.CPS_B, 1)])
+        b = self.fiber('b.json', self.CPS_B,
+                       branches=[self.entry('a.json', self.CPS_B, 0,
+                                            self.CPS_A, 1)])
+        write_local(manager, 'fibers/b.json', json.dumps(b))
+        return self.make_plan(manager, 'fibers/a.json', a, base, peers)
+
+    def test_dropped_link_to_vanished_peer_does_not_demote(self, manager):
+        """The incident: c was deleted on both sides, the merged doc has no
+        branch to it, but peer_files still lists it (base peers are kept so
+        a surviving peer's stale reciprocal can be stripped). Nothing to
+        reciprocate -> skip, not "missing"."""
+        plan = self._dropped_link_plan(manager, ['b.json', 'c.json'])
+        peer_fixes, demoted, notes = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], set(), remote_paths=set())
+        assert demoted == []
+        assert peer_fixes == {}
+        assert notes == [('fibers/a.json', 'c.json')]
+        assert 'fibers/c.json' not in manager._peer_doc_cache
+
+    def test_absent_peer_without_remote_inventory_still_demotes(self, manager):
+        """Legacy 2-arg call: absence cannot be established -> as before."""
+        plan = self._dropped_link_plan(manager, ['b.json', 'c.json'])
+        peer_fixes, demoted, notes = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], set())
+        assert demoted and 'missing' in demoted[0][1]
+        assert notes == []
+
+    def test_absent_peer_still_present_remotely_demotes(self, manager):
+        """Pending DELETE_REMOTE: the delete has not happened; do not
+        assume it will."""
+        plan = self._dropped_link_plan(manager, ['b.json', 'c.json'])
+        peer_fixes, demoted, notes = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], set(), remote_paths={'fibers/c.json'})
+        assert demoted and 'still present on S3' in demoted[0][1]
+        assert notes == []
+
+    def test_dropped_link_to_unreadable_peer_still_demotes(self, manager):
+        plan = self._dropped_link_plan(manager, ['b.json', 'c.json'])
+        write_local(manager, 'fibers/c.json', 'not-json')
+        peer_fixes, demoted, notes = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], set(), remote_paths=set())
+        assert demoted and 'unreadable' in demoted[0][1]
+
+    def test_dropped_link_to_downloading_peer_strips_stale_reciprocal(
+            self, manager, monkeypatch):
+        plan = self._dropped_link_plan(manager, ['b.json', 'c.json'])
+        remote_c = self.fiber('c.json', self.CPS_B, generation=4,
+                              branches=[self.entry('a.json', self.CPS_B, 1,
+                                                   self.CPS_A, 0)])
+
+        def fake_fetch(path):
+            tmp = manager._merge_tmp_path(path, '.remote')
+            with open(tmp, 'w') as f:
+                json.dump(remote_c, f)
+            return remote_c, tmp
+
+        monkeypatch.setattr(manager, '_fetch_remote_json', fake_fetch)
+        peer_fixes, demoted, notes = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], {'fibers/c.json'}, remote_paths=set())
+        assert demoted == [] and notes == []
+        assert peer_fixes['fibers/c.json']['branches'] == []
+
+    def test_vanishing_peer_is_never_read_or_fixed(self, manager):
+        """c is present locally with a stale reciprocal but pending local
+        deletion: skip without reading it (a fix would be uploaded)."""
+        plan = self._dropped_link_plan(manager, ['b.json', 'c.json'])
+        stale_c = self.fiber('c.json', self.CPS_B,
+                             branches=[self.entry('a.json', self.CPS_B, 1,
+                                                  self.CPS_A, 0)])
+        write_local(manager, 'fibers/c.json', json.dumps(stale_c))
+        peer_fixes, demoted, notes = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], set(),
+            vanishing_paths={'fibers/c.json'}, remote_paths=set())
+        assert demoted == []
+        assert 'fibers/c.json' not in peer_fixes
+        assert 'fibers/c.json' not in manager._peer_doc_cache
+        assert notes == [('fibers/a.json', 'c.json')]
+
+    def test_live_link_to_vanishing_peer_demotes(self, manager):
+        a = self.fiber('a.json', self.CPS_A,
+                       branches=[self.entry('c.json', self.CPS_A, 1,
+                                            self.CPS_B, 0)])
+        write_local(manager, 'fibers/c.json', json.dumps(
+            self.fiber('c.json', self.CPS_B)))
+        plan = self.make_plan(manager, 'fibers/a.json', a,
+                              self.fiber('a.json', self.CPS_A), ['c.json'])
+        peer_fixes, demoted, notes = manager._plan_link_consistency(
+            [('fibers/a.json', plan)], set(),
+            vanishing_paths={'fibers/c.json'}, remote_paths=set())
+        assert demoted and 'pending deletion' in demoted[0][1]
 
     def test_peer_scheduled_for_download_uses_remote_content(self, manager,
                                                              monkeypatch):
@@ -763,7 +864,7 @@ class TestLinkConsistency:
         monkeypatch.setattr(manager, '_fetch_remote_json', fake_fetch)
         plan = self.make_plan(manager, 'fibers/a.json', a,
                               self.fiber('a.json', self.CPS_A), ['b.json'])
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], {'fibers/b.json'})
         assert demoted == []
         fixed = peer_fixes['fibers/b.json']
@@ -781,7 +882,7 @@ class TestLinkConsistency:
         write_local(manager, 'fibers/b.json', json.dumps(b))
         plan = self.make_plan(manager, 'fibers/a.json', a,
                               copy.deepcopy(a), ['b.json'])
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert demoted == []
         assert peer_fixes == {}
@@ -806,7 +907,7 @@ class TestLinkConsistency:
                               self.fiber('a.json', self.CPS_A), ['b.json'])
 
         monkeypatch.delenv('VC_SYNC_DEBUG', raising=False)
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert peer_fixes == {} and len(demoted) == 1
         reason = demoted[0][1]
@@ -815,7 +916,7 @@ class TestLinkConsistency:
         assert 'Traceback' not in capsys.readouterr().out
 
         monkeypatch.setenv('VC_SYNC_DEBUG', '1')
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert len(demoted) == 1
         assert 'Traceback' in capsys.readouterr().out
@@ -913,8 +1014,9 @@ class TestDemotionFixpoint:
 
     CPS = TestLinkConsistency.CPS_A
 
-    def make_plan_for(self, manager, path, peers):
-        doc = TestLinkConsistency.fiber(os.path.basename(path), self.CPS)
+    def make_plan_for(self, manager, path, peers, branches=None):
+        doc = TestLinkConsistency.fiber(os.path.basename(path), self.CPS,
+                                        branches=branches)
         pending = manager._merge_tmp_path(path, '.merged')
         with open(pending, 'w') as f:
             json.dump(doc, f)
@@ -931,8 +1033,12 @@ class TestDemotionFixpoint:
         plans = {
             'fibers/a.json': self.make_plan_for(manager, 'fibers/a.json',
                                                 ['b.json']),
-            'fibers/b.json': self.make_plan_for(manager, 'fibers/b.json',
-                                                ['c.json']),  # c missing
+            # B's merged doc still LINKS the missing c: a dangling link,
+            # not a dropped one, so it must keep demoting.
+            'fibers/b.json': self.make_plan_for(
+                manager, 'fibers/b.json', ['c.json'],
+                branches=[TestLinkConsistency.entry(
+                    'c.json', self.CPS, 1, TestLinkConsistency.CPS_B, 0)]),
         }
         write_local(manager, 'fibers/a.json', json.dumps(plans['fibers/a.json']['merged_doc']))
         write_local(manager, 'fibers/b.json', json.dumps(plans['fibers/b.json']['merged_doc']))
@@ -946,6 +1052,47 @@ class TestDemotionFixpoint:
         assert peer_fixes == {}
         assert sorted(p for p, _ in manual) == ['fibers/a.json',
                                                 'fibers/b.json']
+
+    def test_dropped_link_to_locally_deleted_peer_does_not_block(
+            self, manager, monkeypatch):
+        """A peer pending local deletion blocks stage 1 only while the
+        merged doc still links it. A dropped link needs no reciprocal fix,
+        and the going-away peer must not be read (a fix over it would be
+        uploaded while it is deleted)."""
+        plan = self.make_plan_for(manager, 'fibers/a.json', ['p.json'])
+        write_local(manager, 'fibers/a.json', json.dumps(plan['merged_doc']))
+        stale = TestLinkConsistency.fiber(
+            'p.json', TestLinkConsistency.CPS_B,
+            branches=[TestLinkConsistency.entry(
+                'a.json', TestLinkConsistency.CPS_B, 0, self.CPS, 1)])
+        write_local(manager, 'fibers/p.json', json.dumps(stale))
+        monkeypatch.setattr(manager, '_attempt_auto_merge',
+                            lambda path, li, si: plan)
+        pending, peer_fixes, manual = manager._plan_conflict_resolutions(
+            [('fibers/a.json', 'both changed')], {}, {}, set(),
+            {'fibers/p.json'}, auto_merge=True)
+        assert [p for p, _ in pending] == ['fibers/a.json']
+        assert manual == []
+        assert peer_fixes == {}
+        assert 'fibers/p.json' not in manager._peer_doc_cache
+
+    def test_live_link_to_locally_deleted_peer_blocks(self, manager,
+                                                      monkeypatch):
+        plan = self.make_plan_for(
+            manager, 'fibers/a.json', ['p.json'],
+            branches=[TestLinkConsistency.entry(
+                'p.json', self.CPS, 1, TestLinkConsistency.CPS_B, 0)])
+        write_local(manager, 'fibers/a.json', json.dumps(plan['merged_doc']))
+        write_local(manager, 'fibers/p.json', json.dumps(
+            TestLinkConsistency.fiber('p.json', TestLinkConsistency.CPS_B)))
+        monkeypatch.setattr(manager, '_attempt_auto_merge',
+                            lambda path, li, si: plan)
+        pending, peer_fixes, manual = manager._plan_conflict_resolutions(
+            [('fibers/a.json', 'both changed')], {}, {}, set(),
+            {'fibers/p.json'}, auto_merge=True)
+        assert pending == []
+        assert [p for p, _ in manual] == ['fibers/a.json']
+        assert 'pending deletion' in manual[0][1]
 
     def test_manual_peer_blocks_merge_upfront(self, manager, monkeypatch):
         plans = {'fibers/a.json': self.make_plan_for(manager, 'fibers/a.json',
@@ -986,7 +1133,7 @@ class TestDemotionFixpoint:
                 'base_doc': TestLinkConsistency.fiber(
                     'a.json', TestLinkConsistency.CPS_A),
                 'peer_files': ['b.json', 'c.json']}
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert demoted and demoted[0][0] == 'fibers/a.json'
         assert peer_fixes == {}
@@ -1027,7 +1174,7 @@ class TestPlannerInputHardening:
         plan = {'pending': pending, 'remote_tmp': None, 'summary': 's',
                 'merged_doc': doc, 'base_doc': doc,
                 'peer_files': ['b\x00.json']}
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert peer_fixes == {}
         assert demoted and 'invalid linked fiber name' in demoted[0][1]
@@ -1051,7 +1198,7 @@ class TestPlannerInputHardening:
                 'base_doc': TestLinkConsistency.fiber(
                     'a.json', TestLinkConsistency.CPS_A),
                 'peer_files': ['b.json']}
-        peer_fixes, demoted = manager._plan_link_consistency(
+        peer_fixes, demoted, _notes = manager._plan_link_consistency(
             [('fibers/a.json', plan)], set())
         assert peer_fixes == {}
         assert demoted and 'refresh against' in demoted[0][1]

--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -469,11 +469,21 @@ class TestAutoMerge:
         outcome = manager._attempt_auto_merge(path, info, s3_info(10, 'b' * 32),
                                               dry_run=True)
 
-        assert outcome and outcome.startswith('would auto-merge')
+        assert outcome and 'summary' in outcome and 'reason' not in outcome
         assert open(local_path).read() == before
         stash_root = os.path.join(manager.local_dir, vc_sync.CONFLICT_DIR_NAME)
         stashed = [f for _, _, fs_ in os.walk(stash_root) for f in fs_]
         assert stashed == []  # probing writes nothing
+
+    def test_dry_run_reports_reason_without_base(self, manager):
+        doc = TestLinkConsistency.fiber('n.json', TestLinkConsistency.CPS_A)
+        path = 'fibers/n.json'
+        write_local(manager, path, json.dumps(doc))
+        info = local_info(manager, path)
+        outcome = manager._attempt_auto_merge(path, info, s3_info(10, 'opaque-1'),
+                                              dry_run=True)
+        assert outcome == {'reason': 'no merge base'}
+        assert manager._attempt_auto_merge(path, info, s3_info(10, 'opaque-1')) is None
 
     def test_conflicting_merge_stashes_all_three(self, manager, monkeypatch):
         base = self.fiber([0, 0, 0, 0])
@@ -1485,6 +1495,39 @@ class TestSyncPromptThenPlan:
         after = {p: open(os.path.join(manager.local_dir, p), 'rb').read()
                  for p in ('a.json', 'r.json')}
         assert after == before
+
+
+class TestPlanStats:
+    """PlanResult.stats: demotion classes counted once per merge."""
+
+    def test_incident_stats(self, manager, monkeypatch):
+        tp = TestPromptThenPlan()
+        result, _ = tp.incident(manager, monkeypatch,
+                                {r: SyncAction.DOWNLOAD for r in tp.ROOTS})
+        assert result.stats == {
+            'merged': 8, 'content_conflicts': 3, 'blocked_by_skip': 0,
+            'blocked_by_delete': 0, 'link_state': 0,
+            'decisions': {'l': 0, 'r': 3, 's': 0}}
+        result, _ = tp.incident(manager, monkeypatch, {})
+        assert result.stats['merged'] == 0
+        assert result.stats['blocked_by_skip'] == 8
+        assert result.stats['decisions'] == {'l': 0, 'r': 0, 's': 11}
+
+    def test_skip_wins_over_delete(self, manager, monkeypatch):
+        """A merge blocked by a skipped peer AND a still-linked deleting
+        peer counts once, as blocked_by_skip."""
+        tp = TestPromptThenPlan()
+        plan = tp.plan_for(
+            manager, 'fibers/a.json', ['r.json', 'p.json'],
+            branches=[TestLinkConsistency.entry(
+                'p.json', tp.CPS, 1, TestLinkConsistency.CPS_B, 0)])
+        tp.install(manager, monkeypatch, {'fibers/a.json': plan}, ['fibers/r.json'])
+        result = manager._plan_conflict_resolutions(
+            tp.conflicts('fibers/a.json', 'fibers/r.json'), {}, {}, set(),
+            {'fibers/p.json'}, auto_merge=True)
+        assert result.stats['blocked_by_skip'] == 1
+        assert result.stats['blocked_by_delete'] == 0
+        assert result.stats['link_state'] == 0
 
 
 class TestDeleteLocalSafety:

--- a/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
+++ b/volume-cartographer/scripts/tests/test_vc_sync_helpers.py
@@ -4,6 +4,7 @@ Pure-local: a temp directory stands in for the sync dir and tracked rows are
 written straight into the SQLite DB. No S3 or network access.
 """
 import copy
+import hashlib
 import json
 import os
 import sqlite3
@@ -48,6 +49,12 @@ def track_row(manager, path, local_size, local_mtime, s3_size, s3_etag,
             '(path, local_size, local_mtime, s3_size, s3_mtime, s3_etag, local_md5) '
             'VALUES (?, ?, ?, ?, ?, ?, ?)',
             (path, local_size, local_mtime, s3_size, 0.0, s3_etag, local_md5))
+
+
+def plan3(manager, *args, **kwargs):
+    """Legacy planner call: (pending, peer_fixes, manual) by attribute."""
+    result = manager._plan_conflict_resolutions(*args, **kwargs)
+    return result.pending, result.peer_fixes, result.manual
 
 
 def local_info(manager, relpath):
@@ -1046,7 +1053,7 @@ class TestDemotionFixpoint:
                             lambda path, li, si: plans[path])
         conflicts = [('fibers/a.json', 'both changed'),
                      ('fibers/b.json', 'both changed')]
-        pending, peer_fixes, manual = manager._plan_conflict_resolutions(
+        pending, peer_fixes, manual = plan3(manager,
             conflicts, {}, {}, set(), set(), auto_merge=True)
         assert pending == []
         assert peer_fixes == {}
@@ -1068,7 +1075,7 @@ class TestDemotionFixpoint:
         write_local(manager, 'fibers/p.json', json.dumps(stale))
         monkeypatch.setattr(manager, '_attempt_auto_merge',
                             lambda path, li, si: plan)
-        pending, peer_fixes, manual = manager._plan_conflict_resolutions(
+        pending, peer_fixes, manual = plan3(manager,
             [('fibers/a.json', 'both changed')], {}, {}, set(),
             {'fibers/p.json'}, auto_merge=True)
         assert [p for p, _ in pending] == ['fibers/a.json']
@@ -1087,7 +1094,7 @@ class TestDemotionFixpoint:
             TestLinkConsistency.fiber('p.json', TestLinkConsistency.CPS_B)))
         monkeypatch.setattr(manager, '_attempt_auto_merge',
                             lambda path, li, si: plan)
-        pending, peer_fixes, manual = manager._plan_conflict_resolutions(
+        pending, peer_fixes, manual = plan3(manager,
             [('fibers/a.json', 'both changed')], {}, {}, set(),
             {'fibers/p.json'}, auto_merge=True)
         assert pending == []
@@ -1107,7 +1114,7 @@ class TestDemotionFixpoint:
         monkeypatch.setattr(manager, '_attempt_auto_merge', attempt)
         conflicts = [('fibers/a.json', 'both changed'),
                      ('fibers/b.json', 'both changed')]
-        pending, peer_fixes, manual = manager._plan_conflict_resolutions(
+        pending, peer_fixes, manual = plan3(manager,
             conflicts, {}, {}, set(), set(), auto_merge=True)
         assert pending == [] and peer_fixes == {}
         assert {p for p, _ in manual} == {'fibers/a.json', 'fibers/b.json'}
@@ -1137,6 +1144,347 @@ class TestDemotionFixpoint:
             [('fibers/a.json', plan)], set())
         assert demoted and demoted[0][0] == 'fibers/a.json'
         assert peer_fixes == {}
+
+
+class TestPromptThenPlan:
+    """_plan_conflict_resolutions with a resolve callback: content
+    conflicts are decided BEFORE link planning, so a decided root un-blocks
+    its dependents in the same run; only skipped files cascade."""
+
+    CPS = TestLinkConsistency.CPS_A
+
+    @pytest.fixture(params=['manager', 'sftp_manager'])
+    def mgr(self, request):
+        return request.getfixturevalue(request.param)
+
+    def plan_for(self, mgr, path, peers, branches=None):
+        doc = TestLinkConsistency.fiber(os.path.basename(path), self.CPS,
+                                        branches=branches)
+        pending = mgr._merge_tmp_path(path, '.merged')
+        with open(pending, 'w') as f:
+            json.dump(doc, f)
+        write_local(mgr, path, json.dumps(doc))
+        return {'pending': pending, 'remote_tmp': None, 'summary': 's',
+                'merged_doc': doc,
+                'base_doc': TestLinkConsistency.fiber(os.path.basename(path),
+                                                      self.CPS),
+                'peer_files': peers}
+
+    def install(self, mgr, monkeypatch, plans, roots):
+        """plans: path -> plan (auto-mergeable); roots: content failures.
+        Returns (merge_calls, fetched) recorders."""
+        merge_calls = []
+        fetched = []
+
+        def attempt(path, li, si):
+            merge_calls.append(path)
+            return plans.get(path)
+
+        def fetch(path):
+            fetched.append(path)
+            doc = TestLinkConsistency.fiber(os.path.basename(path), self.CPS)
+            tmp = mgr._merge_tmp_path(path, '.remote')
+            with open(tmp, 'w') as f:
+                json.dump(doc, f)
+            return doc, tmp
+
+        for root in roots:
+            write_local(mgr, root, json.dumps(
+                TestLinkConsistency.fiber(os.path.basename(root), self.CPS)))
+        monkeypatch.setattr(mgr, '_attempt_auto_merge', attempt)
+        monkeypatch.setattr(mgr, '_fetch_remote_json', fetch)
+        return merge_calls, fetched
+
+    @staticmethod
+    def resolver(answers, default=SyncAction.SKIP):
+        prompts = []
+        reasons = {}
+
+        def resolve(path, reason):
+            prompts.append(path)
+            reasons[path] = reason
+            return answers.get(path, default)
+        resolve.prompts = prompts
+        resolve.reasons = reasons
+        return resolve
+
+    @staticmethod
+    def conflicts(*paths):
+        return [(p, 'Both local and S3 modified since last sync') for p in paths]
+
+    def test_resolve_none_is_legacy_fixpoint(self, mgr, monkeypatch):
+        """R manual; A->R, B->A, C->R. Today's eager stage 1 yields manual
+        order R, A, B, C (B sees A demoted within the same pass)."""
+        plans = {'fibers/a.json': self.plan_for(mgr, 'fibers/a.json', ['r.json']),
+                 'fibers/b.json': self.plan_for(mgr, 'fibers/b.json', ['a.json']),
+                 'fibers/c.json': self.plan_for(mgr, 'fibers/c.json', ['r.json'])}
+        self.install(mgr, monkeypatch, plans, ['fibers/r.json'])
+        result = mgr._plan_conflict_resolutions(
+            self.conflicts('fibers/a.json', 'fibers/b.json', 'fibers/c.json',
+                           'fibers/r.json'),
+            {}, {}, set(), set(), auto_merge=True)
+        assert result.pending == [] and result.peer_fixes == {}
+        assert [p for p, _ in result.manual] == [
+            'fibers/r.json', 'fibers/a.json', 'fibers/b.json', 'fibers/c.json']
+        assert 'r.json' in result.manual[1][1]
+        assert 'a.json' in result.manual[2][1]
+        assert result.resolved == []
+
+    def test_download_decision_unblocks_dependents(self, mgr, monkeypatch):
+        plans = {'fibers/a.json': self.plan_for(mgr, 'fibers/a.json', ['r.json'])}
+        _, fetched = self.install(mgr, monkeypatch, plans, ['fibers/r.json'])
+        resolve = self.resolver({'fibers/r.json': SyncAction.DOWNLOAD})
+        result = mgr._plan_conflict_resolutions(
+            self.conflicts('fibers/a.json', 'fibers/r.json'),
+            {}, {}, set(), set(), auto_merge=True, resolve=resolve)
+        assert resolve.prompts == ['fibers/r.json']
+        assert [p for p, _ in result.pending] == ['fibers/a.json']
+        assert result.resolved == [('fibers/r.json', SyncAction.DOWNLOAD)]
+        assert result.manual == []
+        assert fetched == ['fibers/r.json']      # planned against remote R
+
+    def test_upload_decision_unblocks_dependents(self, mgr, monkeypatch):
+        plans = {'fibers/a.json': self.plan_for(mgr, 'fibers/a.json', ['r.json'])}
+        _, fetched = self.install(mgr, monkeypatch, plans, ['fibers/r.json'])
+        resolve = self.resolver({'fibers/r.json': SyncAction.UPLOAD})
+        result = mgr._plan_conflict_resolutions(
+            self.conflicts('fibers/a.json', 'fibers/r.json'),
+            {}, {}, set(), set(), auto_merge=True, resolve=resolve)
+        assert [p for p, _ in result.pending] == ['fibers/a.json']
+        assert result.resolved == [('fibers/r.json', SyncAction.UPLOAD)]
+        assert fetched == []                      # planned against local R
+
+    def test_skip_decision_cascades_and_prompts_dependent_once(
+            self, mgr, monkeypatch):
+        plans = {'fibers/a.json': self.plan_for(mgr, 'fibers/a.json', ['r.json'])}
+        merge_calls, _ = self.install(mgr, monkeypatch, plans, ['fibers/r.json'])
+        resolve = self.resolver({'fibers/a.json': SyncAction.UPLOAD})  # R skipped
+        result = mgr._plan_conflict_resolutions(
+            self.conflicts('fibers/a.json', 'fibers/r.json'),
+            {}, {}, set(), set(), auto_merge=True, resolve=resolve)
+        assert resolve.prompts == ['fibers/r.json', 'fibers/a.json']
+        assert result.pending == []
+        assert result.manual == [('fibers/r.json',
+                                  'Both local and S3 modified since last sync')]
+        assert result.resolved == [('fibers/a.json', SyncAction.UPLOAD)]
+        # the dependent's prompt names the peer that blocked it
+        assert resolve.reasons['fibers/a.json'].endswith(
+            'auto-merge failed: linked fiber(s) with unresolved conflicts '
+            'or pending deletion: r.json')
+        # content merge exactly once per conflict; no path prompted twice
+        assert sorted(merge_calls) == ['fibers/a.json', 'fibers/r.json']
+        assert len(resolve.prompts) == len(set(resolve.prompts))
+
+    def test_awaiting_peer_does_not_block(self, mgr, monkeypatch):
+        """d1 depends on skipped R (demoted, awaiting); d2 depends on d1.
+        d2 must wait for d1's DECISION, not be demoted with it."""
+        plans = {'fibers/d1.json': self.plan_for(mgr, 'fibers/d1.json', ['r.json']),
+                 'fibers/d2.json': self.plan_for(mgr, 'fibers/d2.json', ['d1.json'])}
+        _, fetched = self.install(mgr, monkeypatch, plans, ['fibers/r.json'])
+        resolve = self.resolver({'fibers/d1.json': SyncAction.DOWNLOAD})
+        result = mgr._plan_conflict_resolutions(
+            self.conflicts('fibers/d1.json', 'fibers/d2.json', 'fibers/r.json'),
+            {}, {}, set(), set(), auto_merge=True, resolve=resolve)
+        assert resolve.prompts == ['fibers/r.json', 'fibers/d1.json']
+        assert [p for p, _ in result.pending] == ['fibers/d2.json']
+        assert fetched == ['fibers/d1.json']      # d2 planned against remote d1
+
+    def test_all_skips_terminate_with_each_path_prompted_once(
+            self, mgr, monkeypatch):
+        """Every answer SKIP (what EOF at the prompt resolves to): the loop
+        must still drain every dependent, once each."""
+        plans = {'fibers/a.json': self.plan_for(mgr, 'fibers/a.json', ['r.json']),
+                 'fibers/b.json': self.plan_for(mgr, 'fibers/b.json', ['a.json'])}
+        self.install(mgr, monkeypatch, plans, ['fibers/r.json'])
+        resolve = self.resolver({})
+        result = mgr._plan_conflict_resolutions(
+            self.conflicts('fibers/a.json', 'fibers/b.json', 'fibers/r.json'),
+            {}, {}, set(), set(), auto_merge=True, resolve=resolve)
+        assert resolve.prompts == ['fibers/r.json', 'fibers/a.json',
+                                   'fibers/b.json']
+        assert result.pending == [] and result.resolved == []
+        assert [p for p, _ in result.manual] == resolve.prompts
+
+    # --- the 2026-09-08 incident topology --------------------------------
+    ROOTS = ['fibers/r1.json', 'fibers/r2.json', 'fibers/r3.json']
+    GRAPH = {'fibers/d1.json': ['r1.json'], 'fibers/d2.json': ['r1.json'],
+             'fibers/d3.json': ['d2.json'],
+             'fibers/d4.json': ['d3.json', 'gone.json'],   # base-only peer
+             'fibers/d5.json': ['r2.json'],
+             'fibers/d6.json': ['d5.json'], 'fibers/d7.json': ['d5.json'],
+             'fibers/d8.json': ['r3.json']}
+
+    def incident(self, mgr, monkeypatch, answers, s3_files=None,
+                 resolve_none=False):
+        plans = {p: self.plan_for(mgr, p, peers) for p, peers in self.GRAPH.items()}
+        self.install(mgr, monkeypatch, plans, self.ROOTS)
+        resolve = None if resolve_none else self.resolver(answers)
+        result = mgr._plan_conflict_resolutions(
+            self.conflicts(*sorted(list(self.GRAPH) + self.ROOTS)),
+            {}, s3_files or {}, set(), set(), auto_merge=True, resolve=resolve)
+        return result, resolve
+
+    def test_incident_rrr_one_round(self, mgr, monkeypatch):
+        result, resolve = self.incident(
+            mgr, monkeypatch, {r: SyncAction.DOWNLOAD for r in self.ROOTS})
+        assert resolve.prompts == self.ROOTS
+        assert len(result.pending) == 8 and result.manual == []
+
+    def test_incident_all_skips(self, mgr, monkeypatch):
+        result, resolve = self.incident(mgr, monkeypatch, {})
+        assert len(resolve.prompts) == 11
+        assert len(set(resolve.prompts)) == 11
+        assert result.pending == [] and len(result.manual) == 11
+
+    def test_incident_rsl_dependent_decided_remote(self, mgr, monkeypatch):
+        result, resolve = self.incident(mgr, monkeypatch, {
+            'fibers/r1.json': SyncAction.DOWNLOAD,
+            'fibers/r3.json': SyncAction.UPLOAD,
+            'fibers/d5.json': SyncAction.DOWNLOAD})      # r2 skipped
+        assert resolve.prompts == self.ROOTS + ['fibers/d5.json']
+        assert len(result.pending) == 7
+        assert [p for p, _ in result.manual] == ['fibers/r2.json']
+
+    def test_incident_rsl_dependent_skipped(self, mgr, monkeypatch):
+        result, resolve = self.incident(mgr, monkeypatch, {
+            'fibers/r1.json': SyncAction.DOWNLOAD,
+            'fibers/r3.json': SyncAction.UPLOAD})        # r2, d5 skipped
+        assert resolve.prompts == self.ROOTS + [
+            'fibers/d5.json', 'fibers/d6.json', 'fibers/d7.json']
+        assert len(result.pending) == 5
+
+    def test_incident_legacy_all_manual(self, mgr, monkeypatch):
+        result, _ = self.incident(mgr, monkeypatch, {}, resolve_none=True)
+        assert result.pending == [] and len(result.manual) == 11
+
+    def test_incident_peer_still_on_remote_prompts_without_cascade(
+            self, mgr, monkeypatch):
+        """Run-1 inventory: gone.json still exists remotely (pending
+        DELETE_REMOTE) -> d4 is prompted once instead of auto-merged; its
+        answer does not cascade."""
+        result, resolve = self.incident(
+            mgr, monkeypatch,
+            dict({r: SyncAction.DOWNLOAD for r in self.ROOTS},
+                 **{'fibers/d4.json': SyncAction.UPLOAD}),
+            s3_files={'fibers/gone.json': s3_info(1, 'e')})
+        assert resolve.prompts == self.ROOTS + ['fibers/d4.json']
+        assert len(result.pending) == 7 and result.manual == []
+        assert result.resolved[-1] == ('fibers/d4.json', SyncAction.UPLOAD)
+
+
+class TestSyncPromptThenPlan:
+    """sync() wiring of the decided-root flow: a decided root that receives
+    a reciprocal correction is uploaded once as a peer fix (never also as a
+    resolved transfer), skip counts come from decisions, and cancelling
+    leaves every local file untouched."""
+
+    CPS_A = TestLinkConsistency.CPS_A
+    CPS_B = TestLinkConsistency.CPS_B
+
+    def arrange(self, manager, monkeypatch, answers):
+        """Local a (auto-mergeable, merged doc links r at cp1<->cp0) and r
+        (content failure: no merge base). Both are 'both modified'
+        conflicts. Transfers are recorded, not performed."""
+        fib = TestLinkConsistency.fiber
+        entry = TestLinkConsistency.entry
+        merged_a = fib('a.json', self.CPS_A,
+                       branches=[entry('r.json', self.CPS_A, 1, self.CPS_B, 0)])
+        local_a = fib('a.json', self.CPS_A, generation=2)
+        local_r = fib('r.json', self.CPS_B, generation=2)     # no reciprocal
+        remote_r = fib('r.json', self.CPS_B, generation=3)    # no reciprocal
+        write_local(manager, 'a.json', json.dumps(local_a))
+        write_local(manager, 'r.json', json.dumps(local_r))
+        remote = {'a.json': json.dumps(fib('a.json', self.CPS_A, generation=3)),
+                  'r.json': json.dumps(remote_r)}
+        s3 = {p: {'path': p, 's3_size': len(b), 's3_mtime': 0.0,
+                  's3_etag': hashlib.md5(b.encode()).hexdigest(),
+                  'is_backup': False} for p, b in remote.items()}
+        for p in ('a.json', 'r.json'):
+            track_row(manager, p, 1, 0.0, 1, 'old-etag', local_md5='0' * 32)
+
+        plan = {'pending': manager._merge_tmp_path('a.json', '.merged'),
+                'remote_tmp': None, 'summary': 's', 'merged_doc': merged_a,
+                'base_doc': fib('a.json', self.CPS_A), 'peer_files': ['r.json']}
+        with open(plan['pending'], 'w') as f:
+            json.dump(merged_a, f)
+
+        def fetch_json(path):
+            tmp = manager._merge_tmp_path(path, '.remote')
+            with open(tmp, 'w') as f:
+                f.write(remote[path])
+            return json.loads(remote[path]), tmp
+
+        def fetch_file(path, dst):
+            with open(dst, 'w') as f:
+                f.write(remote[path])
+
+        rec = {'downloads': [], 'uploads': [], 'deletes': []}
+        prompts = []
+
+        def prompt(message, choices):
+            prompts.append(choices)
+            return answers.pop(0) if answers else 's'
+
+        monkeypatch.setattr(manager, 'scan_s3_files', lambda inc=False: s3)
+        monkeypatch.setattr(manager, '_attempt_auto_merge',
+                            lambda path, li, si: plan if path == 'a.json' else None)
+        monkeypatch.setattr(manager, '_fetch_remote_json', fetch_json)
+        monkeypatch.setattr(manager, '_fetch_remote_file', fetch_file)
+        monkeypatch.setattr(manager, '_remote_md5', lambda path: 'f' * 32)
+        monkeypatch.setattr(manager, '_bucket_versioning_enabled', lambda: False)
+        monkeypatch.setattr(manager, 'perform_downloads_batch',
+                            lambda paths, s3f: rec['downloads'].extend(paths) or len(paths))
+        monkeypatch.setattr(manager, 'perform_uploads_batch',
+                            lambda paths, inc=False: rec['uploads'].extend(paths) or len(paths))
+        monkeypatch.setattr(manager, 'perform_deletes_remote_batch',
+                            lambda paths, inc=False: rec['deletes'].extend(paths) or len(paths))
+        monkeypatch.setattr(vc_sync, 'prompt_choice', prompt)
+        manager.use_rclone = True
+        rec['prompts'] = prompts
+        return rec
+
+    def test_remote_decided_root_with_fix_uploaded_once(self, manager,
+                                                        monkeypatch, capsys):
+        rec = self.arrange(manager, monkeypatch, answers=['r'])
+        monkeypatch.setattr(vc_sync, 'confirm', lambda msg: True)
+        manager.sync()
+        out = capsys.readouterr().out
+        assert rec['prompts'] == [('l', 'r', 's')]
+        assert rec['uploads'].count('r.json') == 1
+        assert rec['uploads'].count('a.json') == 1
+        assert rec['downloads'] == []            # fix supersedes the download
+        assert 'Conflictsunresolved:0' in out.replace(' ', '')
+        assert 'your choice (S3) is applied together with a reciprocal link fix' in out
+        # on disk: r carries the reciprocal, based on the REMOTE doc (gen 3 -> 4)
+        r = json.load(open(os.path.join(manager.local_dir, 'r.json')))
+        assert r['generation'] == 4
+        assert r['branches'][0]['branch_file'] == 'a.json'
+
+    def test_local_decided_root_with_fix_uploaded_once(self, manager,
+                                                       monkeypatch, capsys):
+        rec = self.arrange(manager, monkeypatch, answers=['l'])
+        monkeypatch.setattr(vc_sync, 'confirm', lambda msg: True)
+        manager.sync()
+        out = capsys.readouterr().out
+        assert rec['uploads'].count('r.json') == 1   # not also "Resolved conflict"
+        assert 'your choice (local) is applied together with a reciprocal link fix' in out
+        r = json.load(open(os.path.join(manager.local_dir, 'r.json')))
+        assert r['generation'] == 3                  # local (gen 2) + fix
+
+    def test_skip_cascades_and_cancel_touches_nothing(self, manager,
+                                                     monkeypatch, capsys):
+        rec = self.arrange(manager, monkeypatch, answers=['s', 's'])
+        before = {p: open(os.path.join(manager.local_dir, p), 'rb').read()
+                  for p in ('a.json', 'r.json')}
+        monkeypatch.setattr(vc_sync, 'confirm', lambda msg: False)
+        manager.sync()
+        out = capsys.readouterr().out
+        assert len(rec['prompts']) == 2              # r skipped -> a prompted
+        assert 'Conflictsunresolved:2' in out.replace(' ', '')
+        assert rec['uploads'] == [] and rec['downloads'] == []
+        after = {p: open(os.path.join(manager.local_dir, p), 'rb').read()
+                 for p in ('a.json', 'r.json')}
+        assert after == before
 
 
 class TestDeleteLocalSafety:

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -891,7 +891,20 @@ class S3SyncManager:
             f.write('\n')
         plan['merged_doc'] = doc
 
-    def _plan_link_consistency(self, pending_merges, download_paths):
+    def _absent_locally(self, path):
+        """True only when the path provably does not exist in the sync
+        dir. Unreadable/inaccessible ("cannot tell") is NOT absent: the
+        caller then reads it and demotes on failure, as before."""
+        try:
+            os.lstat(os.path.join(self.local_dir, path))
+        except (FileNotFoundError, NotADirectoryError):
+            return True
+        except OSError:
+            return False
+        return False
+
+    def _plan_link_consistency(self, pending_merges, download_paths,
+                               vanishing_paths=frozenset(), remote_paths=None):
         """Mirror each auto-merged fiber's link decisions into its peer
         files (fiber_merge.refresh_pair_links) so VC3D's index-exact
         cross-file reciprocity holds on the post-sync state.
@@ -899,18 +912,32 @@ class S3SyncManager:
         Pure planning over the files' FUTURE content (pending merge
         results, remote content for scheduled downloads, local content
         otherwise); nothing on disk is touched. Returns (peer_fixes,
-        demoted): peer_fixes maps non-merge peer paths to their fixed
-        docs (to write after downloads and upload), demoted lists
-        (path, reason) merges that must fall back to manual resolution.
+        demoted, notes): peer_fixes maps non-merge peer paths to their
+        fixed docs (to write after downloads and upload), demoted lists
+        (path, reason) merges that must fall back to manual resolution,
+        notes lists (path, peer_name) going-away peers that were skipped.
         Pending files of merges whose far-side fields were refreshed are
         rewritten in place (they are plan artifacts, not user files).
+
+        A peer that will not exist after this sync — pending local
+        deletion (`vanishing_paths`), or absent locally AND absent from
+        the remote inventory (`remote_paths`) AND not being downloaded —
+        has nothing to reciprocate, so a merged doc that dropped its link
+        to it is not a dangling link (it used to demote as "missing").
+        Such a peer is never read: reading a file pending deletion would
+        let refresh_pair_links strip its stale reciprocal and schedule an
+        upload of a file being deleted. A merged doc that STILL links a
+        going-away peer is dangling and demotes. Without a remote
+        inventory (`remote_paths=None`) absence cannot be established and
+        a locally missing peer demotes, as before.
         """
         if fiber_merge is None:
-            return {}, []
+            return {}, [], []
         plans = dict(pending_merges)
         future_docs = {path: plan['merged_doc'] for path, plan in pending_merges}
         changed = set()
         demoted = []
+        notes = []
 
         def future_doc(path):
             if path in future_docs:
@@ -969,9 +996,34 @@ class S3SyncManager:
                 # POSIX join: sync paths are '/'-keyed everywhere (scans,
                 # download_paths), regardless of host OS.
                 peer_path = f"{a_dir}/{peer_name}" if a_dir else peer_name
+                if peer_path not in future_docs:
+                    # Going-away peers are decided before any read. A
+                    # pending merge is served from future_docs first: the
+                    # action sets (conflict / delete-local / download) are
+                    # disjoint per path in analyze_changes, so a pending
+                    # peer can never be going away.
+                    remote_absent = (remote_paths is not None and
+                                     peer_path not in remote_paths)
+                    going_away = (peer_path in vanishing_paths or
+                                  (remote_absent and
+                                   peer_path not in download_paths and
+                                   self._absent_locally(peer_path)))
+                    if going_away:
+                        if fiber_merge.links_to(a_doc, peer_name):
+                            failure = (f"linked fiber {peer_name} is pending "
+                                       f"deletion or missing")
+                            break
+                        notes.append((path, peer_name))
+                        continue
                 b_doc = future_doc(peer_path)
                 if b_doc is None or not fiber_merge.is_fiber_doc(b_doc):
                     failure = f"linked fiber {peer_name} is missing or unreadable"
+                    if (remote_paths is not None and peer_path in remote_paths
+                            and peer_path not in download_paths
+                            and self._absent_locally(peer_path)):
+                        failure += (" (peer is absent locally but still present "
+                                    f"on {self.REMOTE_NAME}; resolve this file "
+                                    "manually)")
                     break
                 # A refresh bug on malformed input must demote this merge,
                 # never abort the whole sync mid-planning.
@@ -1009,13 +1061,13 @@ class S3SyncManager:
                 changed.add(path)
 
         if demoted:
-            return {}, demoted
+            return {}, demoted, notes
 
         for path in changed & set(plans):
             self._rewrite_pending(plans[path], future_docs[path])
         peer_fixes = {path: future_docs[path]
                       for path in changed if path not in plans}
-        return peer_fixes, demoted
+        return peer_fixes, demoted, notes
 
     def _apply_peer_fixes(self, peer_fixes):
         """Write link-consistency fixes into peer files, stashing the prior
@@ -1083,7 +1135,22 @@ class S3SyncManager:
                        f"last sync; auto-merge failed: {reason}"))
             manual_paths.add(path)
 
-        manual_paths = {p for p, _ in manual_conflicts} | set(delete_local_paths)
+        manual_paths = {p for p, _ in manual_conflicts}
+        delete_local_paths = set(delete_local_paths)
+        remote_paths = set(s3_files)
+        printed_notes = set()
+
+        def blocks(path, plan, peer_path):
+            # A manual peer always blocks. A peer pending local deletion
+            # blocks only while the merged doc still links it (a dangling
+            # link); a dropped link to a going-away peer needs no
+            # reciprocal fix, and stage 2 skips that peer without reading it.
+            if peer_path in manual_paths:
+                return True
+            return (peer_path in delete_local_paths and
+                    bool(fiber_merge.links_to(plan['merged_doc'],
+                                              os.path.basename(peer_path))))
+
         peer_fixes = {}
         while True:
             # Stage 1: cascade blocked-peer demotions to a fixpoint.
@@ -1094,7 +1161,7 @@ class S3SyncManager:
                 for path, plan in pending_merges:
                     blocked = sorted(os.path.basename(p)
                                      for p in peer_paths(path, plan)
-                                     if p in manual_paths)
+                                     if blocks(path, plan, p))
                     if blocked:
                         demote(path, plan,
                                "linked fiber(s) with unresolved conflicts "
@@ -1108,8 +1175,14 @@ class S3SyncManager:
                 break
             # Stage 2: plan the cross-file link consistency; its demotions
             # feed back into stage 1 on the next iteration.
-            peer_fixes, demoted = self._plan_link_consistency(
-                pending_merges, download_paths)
+            peer_fixes, demoted, notes = self._plan_link_consistency(
+                pending_merges, download_paths,
+                vanishing_paths=delete_local_paths, remote_paths=remote_paths)
+            for note in notes:
+                if note not in printed_notes:
+                    printed_notes.add(note)
+                    print(f"  (peer {note[1]} of {note[0]} is going away and the "
+                          "merge dropped its link; no reciprocal fix needed)")
             if not demoted:
                 break
             demoted_reasons = dict(demoted)

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -26,6 +26,15 @@ prunes entries for files gone from both sides) and never hides a pending
 difference. 'reset' stamps the current state as the synced baseline, which
 discards pending differences — it asks for confirmation.
 
+Conflict resolution: a conflict whose content cannot be merged three-way is
+put to the user first ([l]ocal / [r]emote / [s]kip). Auto-merges of linked
+fibers are then planned against the decided world, so a decided root
+un-blocks its dependents in the same run and only skipped files cascade to
+the files that depend on them. A dropped link to a peer that will not exist
+after the sync (deleted on both sides, or pending local deletion) needs no
+reciprocal fix and no longer forces manual resolution. --dry-run previews
+content-merge eligibility only; link consistency is assessed in a real run.
+
 Usage:
     python s3_sync.py init <directory> <s3_bucket> <s3_prefix> [--profile=<aws_profile>]
     python s3_sync.py status <directory> [--verbose] [--sync-backups]
@@ -178,7 +187,8 @@ class SyncAction(Enum):
     DELETE_REMOTE = "delete_remote"
 
 
-PlanResult = namedtuple('PlanResult', 'pending peer_fixes manual resolved')
+PlanResult = namedtuple('PlanResult',
+                        'pending peer_fixes manual resolved stats')
 
 
 def is_backup_file(filename):
@@ -745,23 +755,28 @@ class S3SyncManager:
         {'pending': ..., 'remote_tmp': ..., 'summary': ...} for the caller
         to apply with _apply_pending_merges() AFTER the user confirms the
         sync (or discard with _discard_pending_merges() on cancellation).
-        Returns a preview string in dry-run mode, or None when the file is
-        not eligible, no base is available, or the merge has genuine
-        conflicts (all three versions are stashed in that case and the
-        caller falls back to the interactive prompt).
+        Returns None when the file is not eligible, no base is available,
+        or the merge has genuine conflicts (all three versions are stashed
+        in that case and the caller falls back to the interactive prompt).
+        In dry-run mode nothing is stashed and the return is a dict:
+        {'summary', 'merged_doc', 'base_doc', 'peer_files'} for a clean
+        content merge (link consistency is NOT assessed), or {'reason'}.
         """
+        def fail(reason):
+            return {'reason': reason} if dry_run else None
+
         if fiber_merge is None or not local_info or not s3_info:
-            return None
+            return fail("merge support unavailable")
         if not self._should_hash(path, local_info.get('local_size')):
-            return None
+            return fail("not an annotation-sized file")
         local_path = os.path.join(self.local_dir, path)
         try:
             with open(local_path) as f:
                 local_doc = json.load(f)
         except (OSError, json.JSONDecodeError):
-            return None
+            return fail("local file unreadable")
         if not fiber_merge.is_fiber_doc(local_doc):
-            return None
+            return fail("not a fiber document")
 
         with self._get_db() as conn:
             row = conn.execute('SELECT * FROM files WHERE path = ?',
@@ -771,7 +786,7 @@ class S3SyncManager:
         if base_doc is None or not fiber_merge.is_fiber_doc(base_doc):
             if not dry_run:
                 print(f"  (no merge base available for {path})")
-            return None
+            return fail("no merge base")
 
         remote_doc, remote_tmp = self._fetch_remote_json(path)
         if remote_doc is None or not fiber_merge.is_fiber_doc(remote_doc):
@@ -780,7 +795,7 @@ class S3SyncManager:
                     os.remove(remote_tmp)
                 except OSError:
                     pass
-            return None
+            return fail("remote copy unreadable")
 
         keep_remote_tmp = False
         try:
@@ -792,10 +807,14 @@ class S3SyncManager:
                 print(f"  ⚠️  merge failed for {path} "
                       f"({ex}{_exception_location(ex)}); manual resolution")
                 _print_debug_traceback()
-                return None
+                return fail("merger error")
             summary = fiber_merge.summarize(result)
             if dry_run:
-                return f"would auto-merge ({summary})" if result['ok'] else None
+                if not result['ok']:
+                    return fail("content conflict: " + '; '.join(result['conflicts']))
+                return {'summary': summary, 'merged_doc': result['merged'],
+                        'base_doc': base_doc,
+                        'peer_files': result.get('peer_files', [])}
 
             if not result['ok']:
                 print(f"  ✗ cannot auto-merge {path}:")
@@ -1127,11 +1146,15 @@ class S3SyncManager:
         acts as a blocker from that moment — today's eager fixpoint, with
         identical membership, order and reasons.
 
-        Returns PlanResult(pending, peer_fixes, manual, resolved):
+        Returns PlanResult(pending, peer_fixes, manual, resolved, stats):
         pending [(path, plan)], peer_fixes {path: doc}, manual
         [(path, reason)] skipped decisions in prompt order (all demotions
         when resolve is None), resolved [(path, UPLOAD|DOWNLOAD)] in prompt
-        order. Every prompted path is in exactly one of manual/resolved.
+        order, stats {merged, content_conflicts, blocked_by_skip,
+        blocked_by_delete, link_state, decisions: {l, r, s}} — demotion
+        classes counted once per merge (skip wins over delete); with
+        resolve=None every manual conflict counts as 's'. Every
+        prompted path is in exactly one of manual/resolved.
         `download_paths` is not modified.
         """
         pending_merges = []
@@ -1144,6 +1167,9 @@ class S3SyncManager:
         delete_local_paths = set(delete_local_paths)
         remote_paths = set(s3_files)
         printed_notes = set()
+        stats = {'merged': 0, 'content_conflicts': 0, 'blocked_by_skip': 0,
+                 'blocked_by_delete': 0, 'link_state': 0,
+                 'decisions': {'l': 0, 'r': 0, 's': 0}}
 
         for path, reason in conflicts:
             plan = None
@@ -1154,6 +1180,7 @@ class S3SyncManager:
                 pending_merges.append((path, plan))
             else:
                 awaiting.append((path, reason))
+        stats['content_conflicts'] = len(awaiting)
 
         def peer_paths(path, plan):
             directory = os.path.dirname(path)
@@ -1194,15 +1221,19 @@ class S3SyncManager:
                 if resolve is None:
                     manual_conflicts.append((path, reason))
                     blockers.add(path)
+                    stats['decisions']['s'] += 1
                     continue
                 action = resolve(path, reason)
                 if action in (SyncAction.UPLOAD, SyncAction.DOWNLOAD):
                     resolved.append((path, action))
                     if action == SyncAction.DOWNLOAD:
                         effective_downloads.add(path)
+                    stats['decisions']['r' if action == SyncAction.DOWNLOAD
+                                       else 'l'] += 1
                 else:
                     manual_conflicts.append((path, reason))
                     blockers.add(path)
+                    stats['decisions']['s'] += 1
 
         peer_fixes = {}
         while pending_merges or awaiting:
@@ -1212,10 +1243,11 @@ class S3SyncManager:
             # awaits a decision, and the loop re-enters stage 1 after it.
             still_pending = []
             for path, plan in pending_merges:
-                blocked = sorted(os.path.basename(p)
-                                 for p in peer_paths(path, plan)
-                                 if blocks(plan, p))
+                blocking = [p for p in peer_paths(path, plan) if blocks(plan, p)]
+                blocked = sorted(os.path.basename(p) for p in blocking)
                 if blocked:
+                    stats['blocked_by_skip' if any(p in blockers for p in blocking)
+                          else 'blocked_by_delete'] += 1
                     demote(path, plan,
                            "linked fiber(s) with unresolved conflicts "
                            "or pending deletion: " + ", ".join(blocked))
@@ -1240,6 +1272,7 @@ class S3SyncManager:
             if not demoted:
                 break
             demoted_reasons = dict(demoted)
+            stats['link_state'] += len(demoted_reasons)
             still_pending = []
             for path, plan in pending_merges:
                 if path in demoted_reasons:
@@ -1248,7 +1281,9 @@ class S3SyncManager:
                     still_pending.append((path, plan))
             pending_merges = still_pending
 
-        return PlanResult(pending_merges, peer_fixes, manual_conflicts, resolved)
+        stats['merged'] = len(pending_merges)
+        return PlanResult(pending_merges, peer_fixes, manual_conflicts, resolved,
+                          stats)
 
     def scan_local_files(self, include_backups=False):
         """Scan local directory for files"""
@@ -2249,14 +2284,23 @@ class S3SyncManager:
                 for path, problem in invalid_uploads:
                     print(f"  {path}: {problem}")
             if conflicts and auto_merge and fiber_merge is not None:
-                print("\nMerge preview for conflicts (fetches remote copies "
-                      "to test-merge; local files are not touched):")
+                print("\nDry-run conflict preview (fetches remote copies to "
+                      "test-merge; local files are not touched; link "
+                      "consistency between fibers is only assessed in a real run):")
+                mergeable = 0
                 for path, reason in conflicts:
                     probe = self._attempt_auto_merge(path,
                                                      local_files.get(path),
                                                      s3_files.get(path),
                                                      dry_run=True)
-                    print(f"  {path}: {probe or 'manual resolution required'}")
+                    if 'summary' in probe:
+                        mergeable += 1
+                        print(f"  {path}: content merge possible ({probe['summary']})")
+                    else:
+                        print(f"  {path}: manual resolution required "
+                              f"({probe['reason']})")
+                print(f"  {mergeable} of {len(conflicts)} conflict(s) are "
+                      "content-merge candidates")
             self._print_sync_summary(uploads, downloads, deletes_local, deletes_remote,
                                      "Conflicts", len(conflicts))
             print("\n--dry-run mode: No changes will be made")
@@ -2274,6 +2318,14 @@ class S3SyncManager:
             resolve=lambda path, reason: self.resolve_conflict(
                 path, reason, local_files.get(path), s3_files.get(path)))
         pending_merges, peer_fixes = plan.pending, plan.peer_fixes
+        if conflicts:
+            st, dec = plan.stats, plan.stats['decisions']
+            print(f"\nConflicts: {st['merged']} auto-merged, "
+                  f"{st['content_conflicts']} needed a decision, "
+                  f"{st['blocked_by_skip']} blocked by skipped peers, "
+                  f"{st['blocked_by_delete']} blocked by pending deletions, "
+                  f"{st['link_state']} with unresolvable link state; "
+                  f"decisions: {dec['l']} local, {dec['r']} remote, {dec['s']} skipped")
 
         # A decided root that received a reciprocal correction is written
         # and uploaded once as a peer fix: the fix doc embodies the chosen

--- a/volume-cartographer/scripts/vc_sync.py
+++ b/volume-cartographer/scripts/vc_sync.py
@@ -101,6 +101,7 @@ import tempfile
 import traceback
 import subprocess
 from datetime import datetime, timezone
+from collections import namedtuple
 from enum import Enum
 from contextlib import contextmanager
 
@@ -175,6 +176,9 @@ class SyncAction(Enum):
     SKIP = "skip"
     DELETE_LOCAL = "delete_local"
     DELETE_REMOTE = "delete_remote"
+
+
+PlanResult = namedtuple('PlanResult', 'pending peer_fixes manual resolved')
 
 
 def is_backup_file(filename):
@@ -1096,29 +1100,60 @@ class S3SyncManager:
 
     def _plan_conflict_resolutions(self, conflicts, local_files, s3_files,
                                    download_paths, delete_local_paths,
-                                   auto_merge):
-        """Split conflicts into planned auto-merges (with their peer fixes)
-        and manual conflicts.
+                                   auto_merge, resolve=None):
+        """Split conflicts into planned auto-merges (with their peer fixes),
+        user decisions, and skipped conflicts.
 
-        ONE fixpoint drives both demotion causes — peers that are manual
-        conflicts or pending local deletion, and peers the link-consistency
-        planner cannot resolve — so a demotion from either stage re-runs
-        the other. This is what guarantees a peer fix is never computed
-        for (or applied over) a file whose fate the user later decides at
-        the interactive prompt.
+        Each conflict is content-merged exactly once. Conflicts that cannot
+        be merged, and merges demoted later by either stage, are put to the
+        user through `resolve(path, reason) -> SyncAction` BEFORE any link
+        planning depends on them, so a peer fix is never computed for (or
+        applied over) a file whose fate is undecided or skipped, while a
+        decided file ([l]ocal / [r]emote) is a known source the planner can
+        plan against. Only skipped files block their dependents; a decided
+        root un-blocks them in the same run (the 2026-09-08 reconciliation
+        needed three runs for what this does in one).
 
-        Returns (pending_merges, peer_fixes, manual_conflicts).
+        Loop: prompt everything awaiting a decision; stage 1 demotes merges
+        whose peers are skipped (or pending local deletion while still
+        linked); if anything new awaits, prompt again; otherwise stage 2
+        plans cross-file link consistency over an all-decided world and
+        its demotions feed back the same way. 2*len(pending)+len(awaiting)
+        strictly decreases on every prompt and every demotion, so this
+        terminates without a round cap. No path is prompted twice.
+
+        With resolve=None (legacy callers, --no-auto-merge paths, tests)
+        every demotion is recorded as a manual conflict immediately and
+        acts as a blocker from that moment — today's eager fixpoint, with
+        identical membership, order and reasons.
+
+        Returns PlanResult(pending, peer_fixes, manual, resolved):
+        pending [(path, plan)], peer_fixes {path: doc}, manual
+        [(path, reason)] skipped decisions in prompt order (all demotions
+        when resolve is None), resolved [(path, UPLOAD|DOWNLOAD)] in prompt
+        order. Every prompted path is in exactly one of manual/resolved.
+        `download_paths` is not modified.
         """
         pending_merges = []
+        awaiting = []            # (path, reason) to put to the user next
         manual_conflicts = []
+        resolved = []
+        blockers = set()         # skipped paths (and, legacy, all demotions)
+        prompted = set()
+        effective_downloads = set(download_paths)
+        delete_local_paths = set(delete_local_paths)
+        remote_paths = set(s3_files)
+        printed_notes = set()
+
         for path, reason in conflicts:
+            plan = None
             if auto_merge:
                 plan = self._attempt_auto_merge(path, local_files.get(path),
                                                 s3_files.get(path))
-                if isinstance(plan, dict):
-                    pending_merges.append((path, plan))
-                    continue
-            manual_conflicts.append((path, reason))
+            if isinstance(plan, dict):
+                pending_merges.append((path, plan))
+            else:
+                awaiting.append((path, reason))
 
         def peer_paths(path, plan):
             directory = os.path.dirname(path)
@@ -1126,57 +1161,76 @@ class S3SyncManager:
                     for name in plan.get('peer_files') or []
                     if name != os.path.basename(path)]
 
-        def demote(path, plan, reason):
-            self._demote_merge(path, plan, reason)
-            # Keep the real reason ("Both ..." prefix preserved for the
-            # prompt's both-modified warning).
-            manual_conflicts.append(
-                (path, f"Both local and {self.REMOTE_NAME} modified since "
-                       f"last sync; auto-merge failed: {reason}"))
-            manual_paths.add(path)
-
-        manual_paths = {p for p, _ in manual_conflicts}
-        delete_local_paths = set(delete_local_paths)
-        remote_paths = set(s3_files)
-        printed_notes = set()
-
-        def blocks(path, plan, peer_path):
-            # A manual peer always blocks. A peer pending local deletion
+        def blocks(plan, peer_path):
+            # A skipped peer always blocks. A peer pending local deletion
             # blocks only while the merged doc still links it (a dangling
             # link); a dropped link to a going-away peer needs no
             # reciprocal fix, and stage 2 skips that peer without reading it.
-            if peer_path in manual_paths:
+            if peer_path in blockers:
                 return True
             return (peer_path in delete_local_paths and
                     bool(fiber_merge.links_to(plan['merged_doc'],
                                               os.path.basename(peer_path))))
 
+        def demote(path, plan, reason):
+            self._demote_merge(path, plan, reason)
+            # Keep the real reason ("Both ..." prefix preserved for the
+            # prompt's both-modified warning).
+            awaiting.append(
+                (path, f"Both local and {self.REMOTE_NAME} modified since "
+                       f"last sync; auto-merge failed: {reason}"))
+            if resolve is None:
+                # Legacy: a demotion is manual at once, so later entries in
+                # the same stage-1 scan already see it (today's ordering).
+                blockers.add(path)
+
+        def drain():
+            nonlocal awaiting
+            batch, awaiting = awaiting, []
+            for path, reason in batch:
+                if path in prompted:
+                    raise RuntimeError(f"BUG: conflict prompted twice: {path}")
+                prompted.add(path)
+                if resolve is None:
+                    manual_conflicts.append((path, reason))
+                    blockers.add(path)
+                    continue
+                action = resolve(path, reason)
+                if action in (SyncAction.UPLOAD, SyncAction.DOWNLOAD):
+                    resolved.append((path, action))
+                    if action == SyncAction.DOWNLOAD:
+                        effective_downloads.add(path)
+                else:
+                    manual_conflicts.append((path, reason))
+                    blockers.add(path)
+
         peer_fixes = {}
-        while True:
-            # Stage 1: cascade blocked-peer demotions to a fixpoint.
-            progressed = True
-            while progressed:
-                progressed = False
-                still_pending = []
-                for path, plan in pending_merges:
-                    blocked = sorted(os.path.basename(p)
-                                     for p in peer_paths(path, plan)
-                                     if blocks(path, plan, p))
-                    if blocked:
-                        demote(path, plan,
-                               "linked fiber(s) with unresolved conflicts "
-                               "or pending deletion: " + ", ".join(blocked))
-                        progressed = True
-                    else:
-                        still_pending.append((path, plan))
-                pending_merges = still_pending
+        while pending_merges or awaiting:
+            drain()
+            # Stage 1: demote merges whose peers are skipped (or pending
+            # deletion while still linked). One pass; anything demoted
+            # awaits a decision, and the loop re-enters stage 1 after it.
+            still_pending = []
+            for path, plan in pending_merges:
+                blocked = sorted(os.path.basename(p)
+                                 for p in peer_paths(path, plan)
+                                 if blocks(plan, p))
+                if blocked:
+                    demote(path, plan,
+                           "linked fiber(s) with unresolved conflicts "
+                           "or pending deletion: " + ", ".join(blocked))
+                else:
+                    still_pending.append((path, plan))
+            pending_merges = still_pending
+            if awaiting:
+                continue        # never run stage 2 with undecided paths
             if not pending_merges:
                 peer_fixes = {}
                 break
-            # Stage 2: plan the cross-file link consistency; its demotions
-            # feed back into stage 1 on the next iteration.
+            # Stage 2: plan the cross-file link consistency over an
+            # all-decided world; its demotions feed back into stage 1.
             peer_fixes, demoted, notes = self._plan_link_consistency(
-                pending_merges, download_paths,
+                pending_merges, effective_downloads,
                 vanishing_paths=delete_local_paths, remote_paths=remote_paths)
             for note in notes:
                 if note not in printed_notes:
@@ -1194,7 +1248,7 @@ class S3SyncManager:
                     still_pending.append((path, plan))
             pending_merges = still_pending
 
-        return pending_merges, peer_fixes, manual_conflicts
+        return PlanResult(pending_merges, peer_fixes, manual_conflicts, resolved)
 
     def scan_local_files(self, include_backups=False):
         """Scan local directory for files"""
@@ -2208,14 +2262,27 @@ class S3SyncManager:
             print("\n--dry-run mode: No changes will be made")
             return
 
-        # Process conflicts first: plan auto-merges (and their cross-file
-        # link-consistency fixes) for what we safely can, prompt for the
-        # rest. Merges are only applied after confirmation.
-        pending_merges, peer_fixes, manual_conflicts = \
-            self._plan_conflict_resolutions(conflicts, local_files, s3_files,
-                                            {p for p, _ in downloads},
-                                            {p for p, _ in deletes_local},
-                                            auto_merge)
+        # Process conflicts first: content conflicts are put to the user,
+        # then auto-merges (and their cross-file link-consistency fixes)
+        # are planned against the decided world; merges whose peers were
+        # skipped are prompted too. Merges are only applied after
+        # confirmation.
+        plan = self._plan_conflict_resolutions(
+            conflicts, local_files, s3_files,
+            {p for p, _ in downloads}, {p for p, _ in deletes_local},
+            auto_merge,
+            resolve=lambda path, reason: self.resolve_conflict(
+                path, reason, local_files.get(path), s3_files.get(path)))
+        pending_merges, peer_fixes = plan.pending, plan.peer_fixes
+
+        # A decided root that received a reciprocal correction is written
+        # and uploaded once as a peer fix: the fix doc embodies the chosen
+        # source (local or remote) plus the correction.
+        decisions = dict(plan.resolved)
+        resolved_actions = [(p, a) for p, a in plan.resolved
+                            if p not in peer_fixes]
+        resolved_download_paths = {p for p, a in resolved_actions
+                                   if a == SyncAction.DOWNLOAD}
 
         for path, _ in pending_merges:
             uploads.append((path, "Auto-merged local + remote changes"))
@@ -2226,16 +2293,12 @@ class S3SyncManager:
             downloads = [(p, r) for p, r in downloads if p not in peer_fixes]
         for path in sorted(peer_fixes):
             if all(existing != path for existing, _ in uploads):
-                uploads.append((path, "Link consistency for merged fiber"))
-
-        resolved_actions = []
-        for path, reason in manual_conflicts:
-            action = self.resolve_conflict(path, reason, local_files.get(path),
-                                           s3_files.get(path))
-            if action != SyncAction.SKIP:
-                resolved_actions.append((path, action))
-        resolved_download_paths = {p for p, a in resolved_actions
-                                   if a == SyncAction.DOWNLOAD}
+                reason = "Link consistency for merged fiber"
+                if path in decisions:
+                    reason += (" (resolved: keep local)"
+                               if decisions[path] == SyncAction.UPLOAD
+                               else " (resolved: take remote)")
+                uploads.append((path, reason))
 
         merged_count = len(pending_merges)
         if merged_count:
@@ -2244,17 +2307,23 @@ class S3SyncManager:
         if peer_fixes:
             print(f"✓ {len(peer_fixes)} linked fiber file(s) will receive "
                   f"reciprocal link fixes and be uploaded")
+            for path in sorted(peer_fixes):
+                if path in decisions:
+                    chosen = ("local" if decisions[path] == SyncAction.UPLOAD
+                              else self.REMOTE_NAME)
+                    print(f"    {path}: your choice ({chosen}) is applied together "
+                          "with a reciprocal link fix and uploaded once")
 
         # Let the user decide what to do with suspect upload candidates
         invalid_uploads += self._validate_upload_candidates(
             [p for p, a in resolved_actions if a == SyncAction.UPLOAD])
 
+        skip_paths = set()
         if invalid_uploads:
             print(f"\n⚠️  {len(invalid_uploads)} upload candidate(s) look invalid:")
             for path, problem in invalid_uploads:
                 print(f"  {path}: {problem}")
 
-            skip_paths = set()
             for path, problem in invalid_uploads:
                 response = prompt_choice(
                     f"\n{path} ({problem}) — [u]pload anyway, [s]kip? ", ('u', 's'))
@@ -2280,9 +2349,17 @@ class S3SyncManager:
 
         # The summary sits right next to the confirmation prompt: with a long
         # file list above, this is what makes the decision readable
+        unresolved = len(plan.manual) + len(skip_paths & set(decisions))
         self._print_sync_summary(uploads, downloads, deletes_local, deletes_remote,
-                                 "Conflicts skipped",
-                                 len(conflicts) - len(resolved_actions) - merged_count)
+                                 "Conflicts unresolved", unresolved)
+
+        # A going-away peer is never read by the planner, so it can never
+        # be scheduled for upload; make that impossible to regress silently.
+        clash = {p for p, _ in uploads} & {p for p, _ in deletes_local}
+        if clash:
+            self._discard_pending_merges(pending_merges)
+            raise RuntimeError("BUG: upload scheduled for a file pending local "
+                               f"deletion: {', '.join(sorted(clash))}")
 
         total_operations = (len(uploads) + len(downloads) +
                             len(deletes_local) + len(deletes_remote))


### PR DESCRIPTION
## What changed

`scripts/vc_sync.py` conflict planner, three commits:

1. **A dropped link to a going-away peer no longer demotes the merge.** The three-way fiber merge lists `peer_files = links(merged) ∪ links(base)` so a surviving peer's stale reciprocal can be stripped; the link-consistency planner then demanded every listed peer be readable, so a merge whose only change toward a peer was to *drop* the link was demoted as "missing or unreadable" whenever that peer had been deleted. Stage 2 now skips a peer that will not exist after the sync — pending local deletion, or absent locally *and* absent from the scan-time remote inventory *and* not being downloaded — when the merged doc has no branch to it, and never reads it (reading a file pending deletion would let `refresh_pair_links` schedule an upload of a file being deleted). A merged doc that still links a going-away peer is dangling and demotes as before. A peer absent locally but still present on the remote (pending `DELETE_REMOTE`) is not assumed gone. Stage 1 blocks on a delete-local peer only while the merged doc still links it. `_plan_link_consistency` gains `vanishing_paths`/`remote_paths` kwargs (2-arg callers unchanged) and returns `(peer_fixes, demoted, notes)`.

2. **Content conflicts are decided before link planning.** Planning used to run the full auto-merge + link-consistency fixpoint first and only then prompt; a merge whose peer was itself a manual conflict was demoted before the user had said anything about that peer, and the cascade followed link networks transitively. `_plan_conflict_resolutions` now takes a `resolve(path, reason)` callback: conflicts whose content merge fails are put to the user first; an `[l]`/`[r]` decision makes that file a known source its dependents are planned against, `[s]kip` blocks them as before, and demotions from either stage are prompted the same way. `2·|pending| + |awaiting|` strictly decreases per prompt and per demotion, so no round cap; a path is never prompted twice. With `resolve=None` (legacy callers, tests) the old eager fixpoint is reproduced exactly — membership, order and reasons. Returns a `PlanResult` namedtuple. In `sync()`, a decided root that receives a reciprocal correction is uploaded once as a peer fix and the user is told so before confirming; "Conflicts unresolved" counts skips directly; a guard enforces upload ∩ delete-local = ∅ before the confirmation prompt.

3. **Diagnostics + docs.** One summary line after planning (auto-merged / needed a decision / blocked by skipped peers / blocked by pending deletions / unresolvable link state; l/r/s tally). `--dry-run`'s merge probe returns a summary or the reason a merge is not possible, and says that link consistency is only assessed in a real run. Module docstring and `docs/line_annotation_fibers.md` updated.

## Why

The 2026-09-08 PHercParis4 reconciliation (19 "both modified" conflicts) needed **three** `sync` runs: 3 genuine content conflicts cascade-demoted 8 merges before any prompt (run 1); `lt_632` was then demoted because its merged doc had dropped its link to `lt_196`, deleted on both sides (run 2); two dependents merged in run 3. Replaying the 11 run-1 conflict triples through the new planner: post-sync inventory → 3 prompts, 8 auto-merged incl. `lt_632`; run-1 inventory (`lt_196` still on S3) → `lt_632` prompted once, no cascade → 4 prompts.

## Guarantee and non-goals

No auto-merge or peer fix is computed over a file whose fate is undecided or skipped, and the planned merged+fixed set is reciprocally consistent against the planned post-sync content of its peers. Unchanged (pre-existing): transfer-phase partial failures after confirmation, the scan→transfer race, the window between local application and network transfer. An `[r]`-decided root is an ordinary download, as today's manual `[r]`.

## How verified

```
cd volume-cartographer/scripts
python -m pytest tests/test_vc_sync_helpers.py tests/test_fiber_merge.py -q   # 238 passed (199 baseline + 39)
```
New tests: going-away peer cases (vanished / no inventory / still on remote / unreadable / downloading / vanishing never read / live link demotes), stage-1 delete-local blocking, the repaired legacy cascade fixture (its B now carries a real branch to the missing peer), legacy-order exactness (R,A,B,C), decide-then-plan (`r`/`l` unblock, `s` cascades and prompts once, awaiting peer does not block, all-skips drain), the incident topology under four decision patterns and both inventories, `PlanResult.stats`, sync-level dedup for `[l]` and `[r]` (fix computed from local gen 2→3 vs remote gen 3→4), cancel touches nothing, dry-run reason dict.

Two independent code reviews (Claude, Codex) with a binding scope rule: no in-scope findings after one round; legacy exactness confirmed by running old and new planners on identical inputs (incl. 100 seeded graphs); interactive loop fuzzed 800 runs against 8 invariants, 0 failures.

## Risks

Prompts now appear before the "will auto-merge" lines rather than after. Pure Python, no platform-specific code; SFTP (`ash-*`) shares the planner and is covered by the parametrized tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVLwgXhb6PsRgxcPVNpMqw
