### PR TITLE
Spiral flow field smoothing / gradient conditioning

### DIFF
--- a/spiral-fitting/README.md
+++ b/spiral-fitting/README.md
@@ -78,6 +78,28 @@ layouts, pass `--umbilicus /path/to/umbilicus.json`. Use `--lasagna-dir` if
 the Lasagna repository is not in its standard sibling or `~/villa` location.
 An existing output path is never overwritten.
 
+## Flow-gradient conditioning
+
+Two optional optimizer settings condition the flow fit without changing the
+loss. Both are read live every step, so they apply at a run boundary (the
+VC3D profile editor shows them as checkboxes in the optimizer group) and
+default to off:
+
+- `optimizer_flow_grad_smoothing` Gaussian-smooths the flow lattices'
+  gradient before the optimizer step, i.e. gradient descent in a Sobolev
+  metric as in diffeomorphic registration. Every update to the flow is then
+  smooth at `optimizer_flow_grad_smoothing_sigma_voxels` (scroll voxels,
+  applied at the same physical width to both lattices of every flow stage).
+  Cylindrical lattices smooth along z and around each ring, not across rings.
+  Runs after the DDP all-reduce and before influence masks, as fused Triton
+  kernels on CUDA (`flow_grad_smoothing.py`; a conv fallback serves CPU and
+  as the reference).
+- `optimizer_flow_lazy_moments` gives the flow groups torch SparseAdam's
+  masked update on their dense gradients (`lazy_moment_adamw.LazyMomentAdamW`):
+  cells no sample touched this step keep their moments and value instead of
+  decaying the second moment toward zero. State stays in AdamW's format, so
+  checkpoints round-trip and the flag can be toggled between runs.
+
 ## Spiral service host setup
 
 VC3D connects to a Spiral service in one of three modes, all speaking the same

--- a/spiral-fitting/README.md
+++ b/spiral-fitting/README.md
@@ -80,25 +80,104 @@ An existing output path is never overwritten.
 
 ## Flow-gradient conditioning
 
-Two optional optimizer settings condition the flow fit without changing the
-loss. Both are read live every step, so they apply at a run boundary (the
-VC3D profile editor shows them as checkboxes in the optimizer group) and
-default to off:
+These optional settings change how the flow lattices are optimized, without
+adding loss terms or changing the model parameterization. The smoothing,
+lazy-moment and shared-second-moment switches default to off; gradient
+clipping defaults to disabled. The `optimizer_flow_*` settings apply at run
+boundaries and are read every step. Older checkpoints backfill these defaults.
 
-- `optimizer_flow_grad_smoothing` Gaussian-smooths the flow lattices'
-  gradient before the optimizer step, i.e. gradient descent in a Sobolev
-  metric as in diffeomorphic registration. Every update to the flow is then
-  smooth at `optimizer_flow_grad_smoothing_sigma_voxels` (scroll voxels,
-  applied at the same physical width to both lattices of every flow stage).
-  Cylindrical lattices smooth along z and around each ring, not across rings.
-  Runs after the DDP all-reduce and before influence masks, as fused Triton
-  kernels on CUDA (`flow_grad_smoothing.py`; a conv fallback serves CPU and
-  as the reference).
-- `optimizer_flow_lazy_moments` gives the flow groups torch SparseAdam's
-  masked update on their dense gradients (`lazy_moment_adamw.LazyMomentAdamW`):
-  cells no sample touched this step keep their moments and value instead of
-  decaying the second moment toward zero. State stays in AdamW's format, so
-  checkpoints round-trip and the flag can be toggled between runs.
+The step order is: DDP gradient averaging, NaN/Inf detection and replacement
+with zero, optional clipping, optional smoothing, influence masks, then the
+optimizer update. Sanitizing before smoothing prevents a single invalid entry
+from contaminating its neighborhood. Influence masks constrain the processed
+gradient after smoothing.
+
+- `optimizer_flow_grad_smoothing` Gaussian-smooths each flow lattice's
+  gradient. `optimizer_flow_grad_smoothing_sigma_voxels` sets the standard
+  deviation in scroll-voxel units of the flow coordinate frame. Cartesian
+  smoothing is isotropic. Cylindrical smoothing runs along z and periodically
+  around each ring, independently for the local z/radial/tangential components.
+  `optimizer_flow_grad_smoothing_across_sigma_voxels` optionally smooths across
+  rings at matching angles; its default of 0 disables this pass. These are
+  lattice directions approximating along/across-sheet directions, not measured
+  sheet tangents or winding boundaries. Kernels are truncated at three sigma
+  and renormalized at nonperiodic borders to preserve constant gradients.
+- `optimizer_flow_grad_smoothing_low_res_sigma_voxels` overrides the coarse
+  lattice's along-sheet width; 0 uses the same width as the fine lattice. With
+  the default fine spacing of 16 voxels and sixfold coarse spacing, a width of
+  32 voxels is 2 fine cells but only about 0.33 coarse cells. Very small widths
+  become identity kernels. The fitter reports effective widths at startup
+  when smoothing is enabled. The across-ring width has no separate coarse
+  override and is ignored for Cartesian fields.
+- `optimizer_flow_lazy_moments` updates moments and applies the gradient step
+  only to entries whose **processed gradient is nonzero**. Smoothing can make
+  an entry active even without a direct sample there. Other entries retain
+  their moments; configured AdamW weight decay still applies everywhere.
+  This preserves gradient-scale history through unsampled steps and suppresses
+  momentum-only movement there, but retains stale history too. It does not
+  prevent large relative steps on a previously untouched smoothing tail.
+- `optimizer_flow_shared_second_moment` uses one denominator across all cells
+  and vector components of each lattice's leading slab, independently for
+  each flow stage and for the coarse/fine lattices. Per-entry Adam scaling can
+  make even a smooth gradient produce nearly sign-sized steps, particularly
+  on first touch. A shared denominator preserves relative magnitudes and
+  direction of the first moment before lazy masking and weight decay; it
+  does not guarantee a smooth final displacement. The shared statistic is the
+  mean of positive stored second moments, capped before averaging at
+  `optimizer_flow_shared_second_moment_clip_quantile` (default 0.99). A value
+  of 1 disables the cap. This limits outliers' effect on the common scale at
+  the cost of local adaptivity. Full per-entry moments remain stored.
+- `optimizer_flow_grad_clip_median_multiple` clips individual gradient
+  components to this multiple of the median nonzero absolute component value,
+  separately for each lattice slab. Zero disables it. Clipping before blur
+  limits how far an extreme gradient can affect neighbors and optimizer
+  moments, but can also suppress legitimate corrections and change vector
+  direction. The median and second-moment cap are estimated from fixed-stride
+  samples; the final averages and clipped fractions use the whole slab.
+  Sampling is deterministic for identical inputs but may miss sparse support.
+- `model_flow_field_low_res_lr_scale` multiplies the scheduled base learning
+  rate for the coarse lattice independently of the fine lattice's existing
+  ramp. It defaults to 1; 0 freezes coarse parameter values, including weight
+  decay, although moments may still update. The fitter reads it every step,
+  but the configuration catalog currently classifies it as a model-rebuild
+  setting, like the other `model_` learning-rate controls.
+
+`flow_grad_smoothing.py` provides Triton CUDA kernels and PyTorch reference/
+fallback paths. `lazy_moment_adamw.LazyMomentAdamW` retains AdamW's state format
+so its flags can be switched between runs without converting moment buffers.
+For custom optimizer updates, diagnostics report the denominator, nonzero
+update fraction, and per-component RMS over nonzero updates in voxel units.
+These describe flow-parameter increments, excluding weight decay, not final
+sheet displacement after integration. After both moment flags are disabled,
+stored optimizer diagnostics can still describe the last custom step rather
+than the current fused AdamW step. Clipping diagnostics report the bound
+and fraction clipped. No full-scroll accuracy or throughput comparison is
+established by the implementation tests.
+
+### Rationale and references
+
+Gaussian update smoothing has precedent in
+[Vercauteren et al., *Diffeomorphic Demons*](https://www-sop.inria.fr/asclepios/Publications/Tom.Vercauteren/DiffeoDemons-NeuroImage08-Vercauteren.pdf).
+Smooth velocity metrics are central to
+[Beg et al., *Computing Large Deformation Metric Mappings*](https://www.cs.jhu.edu/~misha/ReadingSeminar/Papers/Beg05.pdf).
+These motivate the preconditioning here; this discrete blur followed by Adam,
+clipping and masking is not an implementation of classical Sobolev gradient
+descent or LDDMM, and inherits no guarantee of the same fitted solution or
+fold-free numerical integration. Direction-dependent smoothing has a related
+motivation in [Pace et al.'s sliding-organ registration](https://pmc.ncbi.nlm.nih.gov/articles/PMC4112204/),
+although this fitter uses cylindrical coordinates rather than detected sliding
+interfaces.
+
+Lazy moments follow the masked-update idea of
+[PyTorch SparseAdam](https://docs.pytorch.org/docs/main/generated/torch.optim.SparseAdam.html),
+using an explicit nonzero mask on dense gradients, a global per-parameter step
+counter, AdamW's epsilon placement, and optional decoupled weight decay.
+[Adam-mini](https://arxiv.org/abs/2406.16793) provides precedent for sharing
+adaptive scales within parameter blocks; our grouping and winsorization are
+custom choices, and retaining full moments does not provide its state-memory
+saving. [Koloskova et al., *Revisiting Gradient Clipping*](https://proceedings.mlr.press/v202/koloskova23a/koloskova23a.pdf)
+analyze clipping's stabilization and stochastic bias; their results do not
+validate this particular sampled-median rule or its combination with Adam.
 
 ## Spiral service host setup
 

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -171,73 +171,66 @@ _GAP_EXPANDER_DESCRIPTIONS = {
 }
 
 _OPTIMIZER_DESCRIPTIONS = {
+    # See README.md, "Flow-gradient conditioning", for literature precedents
+    # and the limitations of these custom combinations.
     "optimizer_flow_grad_smoothing": (
-        "Gaussian-smooth the flow lattices' gradient before each optimizer "
-        "step (gradient descent in a Sobolev metric, as in diffeomorphic "
-        "registration). The loss is unchanged; every update to the flow is "
-        "smooth at the configured width instead of moving each lattice cell "
-        "on its own noisy gradient. Cylindrical lattices smooth along z and "
-        "around each ring, not across rings."),
+        "Gaussian-smooth flow gradients before the optimizer step. The loss "
+        "is unchanged, but Adam scaling and masks mean the resulting update "
+        "need not retain the kernel profile. Cylindrical smoothing runs "
+        "along z and around rings, with optional separate across-ring smoothing."),
     "optimizer_flow_grad_smoothing_sigma_voxels": (
-        "Width (standard deviation, scroll voxels) of the flow gradient "
-        "smoothing kernel along the sheet: along z and, on a cylindrical "
-        "lattice, around each ring; a Cartesian lattice is smoothed "
-        "isotropically at this width. Applies to both lattices at the same "
-        "physical width; a high-resolution flow cell is "
-        "model_flow_voxel_resolution voxels, so a width well under half a "
-        "cell is an identity (the fitter logs the effective width per "
-        "lattice at startup)."),
+        "Standard deviation in scroll-voxel units of the flow frame: along "
+        "z and around cylindrical rings, or isotropically for Cartesian "
+        "lattices. These lattice directions approximate sheet directions. "
+        "Used for both lattices unless the low-resolution override is set. "
+        "Divide by model_flow_voxel_resolution for fine-cell units; coarse "
+        "cells are six times wider. Very small widths become identity kernels. "
+        "Effective widths are logged at startup when smoothing is enabled."),
     "optimizer_flow_grad_smoothing_across_sigma_voxels": (
-        "Width (standard deviation, scroll voxels) of the flow gradient "
-        "smoothing across rings of a cylindrical lattice, i.e. across "
-        "windings; 0 leaves rings uncoupled. Ignored by a Cartesian lattice, "
-        "whose smoothing is isotropic at the along-sheet width."),
+        "Standard deviation in scroll-voxel units for smoothing across "
+        "cylindrical rings at matching angles. This approximates coupling "
+        "across windings; it does not identify sheet boundaries. 0 disables "
+        "across-ring smoothing. Ignored for Cartesian lattices."),
     "optimizer_flow_grad_smoothing_low_res_sigma_voxels": (
-        "Along-sheet smoothing width (scroll voxels) for the low-resolution "
-        "flow lattice alone; 0 gives it the same physical width as the "
-        "high-resolution lattice. Its cells are six times wider, so the "
-        "shared width leaves it about one cell of smoothing; set this to "
-        "several of its cells (a few hundred voxels) to smooth the coarse "
-        "warp at its own scale. The across-ring width is not affected."),
+        "Along-sheet smoothing width for the coarse lattice alone; 0 uses "
+        "the fine lattice's width in scroll-voxel units. For example, at the "
+        "default 16-voxel fine spacing, 32 voxels is 2 fine cells but about "
+        "0.33 coarse cells. The across-ring width is not affected."),
     "optimizer_flow_shared_second_moment": (
-        "Give the flow lattices' Adam step one second moment per flow stage "
-        "(shared by every cell and vector component of the stage) instead "
-        "of one per cell, so a smoothed gradient's spatial profile and "
-        "direction survive into the update rather than being flattened to a "
-        "per-cell sign. The value is a winsorised mean of the stored "
-        "per-cell second moments over the cells ever touched (see "
-        "optimizer_flow_shared_second_moment_clip_quantile). The stored "
-        "optimizer state is unchanged, so the flag can be switched between "
-        "runs."),
+        "Use one Adam denominator across cells and components of each "
+        "lattice slab, separately for each flow stage and coarse/fine lattice. "
+        "Preserves relative first-moment magnitudes before lazy masking and "
+        "weight decay, rather than normalizing each entry independently. "
+        "The denominator uses a winsorised mean of positive stored second "
+        "moments. Full per-entry state is retained; the flag can change "
+        "between runs."),
     "optimizer_flow_shared_second_moment_clip_quantile": (
-        "Quantile (of the touched cells, read from a fixed-stride subsample) "
-        "at which the per-cell second moments are capped before the shared "
-        "second moment averages them, so a few cells with persistently huge "
-        "gradients cannot shrink every other cell's step. 1 disables the cap "
-        "(plain mean)."),
+        "Quantile of positive second-moment entries, estimated from a "
+        "fixed-stride sample, used to cap values before averaging the full "
+        "slab for the shared denominator. Limits outliers' effect on the "
+        "common scale. 1 disables the cap; an empty positive sample also "
+        "leaves values uncapped."),
     "model_flow_field_low_res_lr_scale": (
-        "Optimizer LR of the low-resolution flow lattice relative to "
-        "optimizer_learning_rate (the high-resolution lattice has its own "
-        "ramped scale). With the shared flow second moment the typical cell "
-        "moves several times less per step than under per-cell Adam; raise "
-        "this until the logged coarse-lattice update rms is back where the "
-        "fit needs it, without touching the gap, linear and pitch groups. "
-        "0 freezes the coarse lattice. Read live every step."),
+        "Coarse flow learning-rate multiplier relative to the scheduled "
+        "base rate, independent of the fine flow multiplier. Shared second "
+        "moments can change update sizes; use the logged increments to assess "
+        "the scale. 0 freezes coarse values, including weight decay, but "
+        "moments may still update. Read every step by the fitter; currently "
+        "classified as a model-rebuild setting by the configuration catalog."),
     "optimizer_flow_grad_clip_median_multiple": (
-        "Clip each flow lattice's gradient, per stage, at this multiple of "
-        "the median nonzero |gradient| of that stage (read from a "
-        "fixed-stride subsample), after the DDP all-reduce and before the "
-        "gradient smoothing and the optimizer moments. Bounds what a cell "
-        "with an unsatisfiable loss can do to its neighbours' smoothed "
-        "gradient and to the shared second moment. 0 disables clipping. "
-        "The threshold and clipped fraction are logged with the losses."),
+        "Clip individual gradient components at this multiple of the median "
+        "nonzero absolute component value, per lattice slab, estimated from "
+        "a fixed-stride sample. Runs after DDP averaging and nonfinite "
+        "sanitization, before smoothing and optimizer moments. Limits spike "
+        "propagation but can suppress valid corrections and change vector "
+        "direction. 0 disables clipping. Logs the bound and clipped fraction."),
     "optimizer_flow_lazy_moments": (
-        "Lazy Adam moments for the flow lattices (torch SparseAdam's masked "
-        "update on the dense gradient): cells no sample touched this step "
-        "keep their moments and value instead of decaying the second moment "
-        "toward zero, which otherwise makes a cell's first update after a "
-        "quiet spell disproportionately large. Weight decay still applies to "
-        "every cell."),
+        "Use SparseAdam-style masked updates on dense flow gradients: "
+        "entries with zero gradient after conditioning and influence masks "
+        "retain their moments and receive no gradient update. Smoothing can "
+        "activate entries without direct samples. Preserves history through "
+        "quiet steps, including stale momentum, and does not correct first "
+        "touch scaling. Configured weight decay still applies everywhere."),
 }
 
 # Configuration keys that shape the model's parameter tensors. A checkpoint

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -150,6 +150,7 @@ BACKFILLABLE_CONFIG_DEFAULTS.update({
     "optimizer_flow_lazy_moments": False,
     "optimizer_flow_grad_smoothing_across_sigma_voxels": 0.0,
     "optimizer_flow_grad_smoothing_low_res_sigma_voxels": 0.0,
+    "model_flow_field_low_res_lr_scale": 1.0,
     "optimizer_flow_shared_second_moment": False,
     "optimizer_flow_shared_second_moment_clip_quantile": 0.99,
     "optimizer_flow_grad_clip_median_multiple": 0.0,
@@ -214,6 +215,14 @@ _OPTIMIZER_DESCRIPTIONS = {
         "second moment averages them, so a few cells with persistently huge "
         "gradients cannot shrink every other cell's step. 1 disables the cap "
         "(plain mean)."),
+    "model_flow_field_low_res_lr_scale": (
+        "Optimizer LR of the low-resolution flow lattice relative to "
+        "optimizer_learning_rate (the high-resolution lattice has its own "
+        "ramped scale). With the shared flow second moment the typical cell "
+        "moves several times less per step than under per-cell Adam; raise "
+        "this until the logged coarse-lattice update rms is back where the "
+        "fit needs it, without touching the gap, linear and pitch groups. "
+        "Read live every step."),
     "optimizer_flow_grad_clip_median_multiple": (
         "Clip each flow lattice's gradient, per stage, at this multiple of "
         "the median nonzero |gradient| of that stage (read from a "
@@ -270,6 +279,7 @@ MODEL_STAGE_KEYS = frozenset({
     "model_flow_bounds_radius",
     "model_flow_voxel_resolution",
     "model_flow_field_type",
+    "model_flow_field_low_res_lr_scale",
     "model_flow_field_high_res_lr_scale_initial",
     "model_flow_field_high_res_lr_scale_final",
     "model_flow_field_high_res_lr_ramp_start_step",
@@ -408,6 +418,9 @@ class Config:
         self.model_flow_field_high_res_lr_scale_final = 0.2
         self.model_flow_field_high_res_lr_ramp_start_step = 0
         self.model_flow_field_high_res_lr_ramp_steps = 1
+        # Both flow lattices' LRs are optimizer_learning_rate times their
+        # scale; the low-resolution one had no scale of its own before.
+        self.model_flow_field_low_res_lr_scale = 1.0
         self.model_flow_field_direct_lr = True
         self.model_gap_expander_logit_resolution = 24
         # The physical winding estimate and the allocated transform capacity

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -148,6 +148,8 @@ BACKFILLABLE_CONFIG_DEFAULTS.update({
     "optimizer_flow_grad_smoothing": False,
     "optimizer_flow_grad_smoothing_sigma_voxels": 32.0,
     "optimizer_flow_lazy_moments": False,
+    "optimizer_flow_grad_smoothing_across_sigma_voxels": 0.0,
+    "optimizer_flow_shared_second_moment": False,
 })
 
 _GAP_EXPANDER_DESCRIPTIONS = {
@@ -174,9 +176,25 @@ _OPTIMIZER_DESCRIPTIONS = {
         "around each ring, not across rings."),
     "optimizer_flow_grad_smoothing_sigma_voxels": (
         "Width (standard deviation, scroll voxels) of the flow gradient "
-        "smoothing kernel. Applies to both lattices at the same physical "
-        "width; a high-resolution flow cell is model_flow_voxel_resolution "
-        "voxels."),
+        "smoothing kernel along the sheet: along z and, on a cylindrical "
+        "lattice, around each ring; a Cartesian lattice is smoothed "
+        "isotropically at this width. Applies to both lattices at the same "
+        "physical width; a high-resolution flow cell is "
+        "model_flow_voxel_resolution voxels, so a width well under half a "
+        "cell is an identity (the fitter logs the effective width per "
+        "lattice at startup)."),
+    "optimizer_flow_grad_smoothing_across_sigma_voxels": (
+        "Width (standard deviation, scroll voxels) of the flow gradient "
+        "smoothing across rings of a cylindrical lattice, i.e. across "
+        "windings; 0 leaves rings uncoupled. Ignored by a Cartesian lattice, "
+        "whose smoothing is isotropic at the along-sheet width."),
+    "optimizer_flow_shared_second_moment": (
+        "Give the flow lattices' Adam step one second moment per flow stage "
+        "and vector component (the mean of the stored per-cell second "
+        "moments over the cells ever touched) instead of one per cell, so a "
+        "smoothed gradient's spatial profile survives into the update rather "
+        "than being flattened to its sign. The stored optimizer state is "
+        "unchanged, so the flag can be switched between runs."),
     "optimizer_flow_lazy_moments": (
         "Lazy Adam moments for the flow lattices (torch SparseAdam's masked "
         "update on the dense gradient): cells no sample touched this step "
@@ -341,11 +359,13 @@ class Config:
         self.optimizer_lr_final_factor = 0.3
         self.optimizer_num_training_steps = 30000
         # Flow-lattice gradient conditioning (see _OPTIMIZER_DESCRIPTIONS).
-        # Both are read live every step, so they apply at a run boundary
+        # All are read live every step, so they apply at a run boundary
         # without a rebuild. Off by default.
         self.optimizer_flow_grad_smoothing = False
         self.optimizer_flow_grad_smoothing_sigma_voxels = 32.0
+        self.optimizer_flow_grad_smoothing_across_sigma_voxels = 0.0
         self.optimizer_flow_lazy_moments = False
+        self.optimizer_flow_shared_second_moment = False
         self.model_num_flow_integration_steps = 3
         self.model_flow_integration_solver = "rk4"
         self.model_num_flow_timesteps = 1

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -149,7 +149,10 @@ BACKFILLABLE_CONFIG_DEFAULTS.update({
     "optimizer_flow_grad_smoothing_sigma_voxels": 32.0,
     "optimizer_flow_lazy_moments": False,
     "optimizer_flow_grad_smoothing_across_sigma_voxels": 0.0,
+    "optimizer_flow_grad_smoothing_low_res_sigma_voxels": 0.0,
     "optimizer_flow_shared_second_moment": False,
+    "optimizer_flow_shared_second_moment_clip_quantile": 0.99,
+    "optimizer_flow_grad_clip_median_multiple": 0.0,
 })
 
 _GAP_EXPANDER_DESCRIPTIONS = {
@@ -188,13 +191,37 @@ _OPTIMIZER_DESCRIPTIONS = {
         "smoothing across rings of a cylindrical lattice, i.e. across "
         "windings; 0 leaves rings uncoupled. Ignored by a Cartesian lattice, "
         "whose smoothing is isotropic at the along-sheet width."),
+    "optimizer_flow_grad_smoothing_low_res_sigma_voxels": (
+        "Along-sheet smoothing width (scroll voxels) for the low-resolution "
+        "flow lattice alone; 0 gives it the same physical width as the "
+        "high-resolution lattice. Its cells are six times wider, so the "
+        "shared width leaves it about one cell of smoothing; set this to "
+        "several of its cells (a few hundred voxels) to smooth the coarse "
+        "warp at its own scale. The across-ring width is not affected."),
     "optimizer_flow_shared_second_moment": (
         "Give the flow lattices' Adam step one second moment per flow stage "
-        "and vector component (the mean of the stored per-cell second "
-        "moments over the cells ever touched) instead of one per cell, so a "
-        "smoothed gradient's spatial profile survives into the update rather "
-        "than being flattened to its sign. The stored optimizer state is "
-        "unchanged, so the flag can be switched between runs."),
+        "(shared by every cell and vector component of the stage) instead "
+        "of one per cell, so a smoothed gradient's spatial profile and "
+        "direction survive into the update rather than being flattened to a "
+        "per-cell sign. The value is a winsorised mean of the stored "
+        "per-cell second moments over the cells ever touched (see "
+        "optimizer_flow_shared_second_moment_clip_quantile). The stored "
+        "optimizer state is unchanged, so the flag can be switched between "
+        "runs."),
+    "optimizer_flow_shared_second_moment_clip_quantile": (
+        "Quantile (of the touched cells, read from a fixed-stride subsample) "
+        "at which the per-cell second moments are capped before the shared "
+        "second moment averages them, so a few cells with persistently huge "
+        "gradients cannot shrink every other cell's step. 1 disables the cap "
+        "(plain mean)."),
+    "optimizer_flow_grad_clip_median_multiple": (
+        "Clip each flow lattice's gradient, per stage, at this multiple of "
+        "the median nonzero |gradient| of that stage (read from a "
+        "fixed-stride subsample), after the DDP all-reduce and before the "
+        "gradient smoothing and the optimizer moments. Bounds what a cell "
+        "with an unsatisfiable loss can do to its neighbours' smoothed "
+        "gradient and to the shared second moment. 0 disables clipping. "
+        "The threshold and clipped fraction are logged with the losses."),
     "optimizer_flow_lazy_moments": (
         "Lazy Adam moments for the flow lattices (torch SparseAdam's masked "
         "update on the dense gradient): cells no sample touched this step "
@@ -364,8 +391,11 @@ class Config:
         self.optimizer_flow_grad_smoothing = False
         self.optimizer_flow_grad_smoothing_sigma_voxels = 32.0
         self.optimizer_flow_grad_smoothing_across_sigma_voxels = 0.0
+        self.optimizer_flow_grad_smoothing_low_res_sigma_voxels = 0.0
         self.optimizer_flow_lazy_moments = False
         self.optimizer_flow_shared_second_moment = False
+        self.optimizer_flow_shared_second_moment_clip_quantile = 0.99
+        self.optimizer_flow_grad_clip_median_multiple = 0.0
         self.model_num_flow_integration_steps = 3
         self.model_flow_integration_solver = "rk4"
         self.model_num_flow_timesteps = 1

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -142,6 +142,13 @@ BACKFILLABLE_CONFIG_DEFAULTS.update({
     "model_gap_expander_min_gap": 1.0,
     "model_gap_expander_softplus_bias": 4.0,
 })
+# The flow-gradient conditioning settings postdate durable checkpoints;
+# missing means off, which is exactly the earlier behaviour.
+BACKFILLABLE_CONFIG_DEFAULTS.update({
+    "optimizer_flow_grad_smoothing": False,
+    "optimizer_flow_grad_smoothing_sigma_voxels": 32.0,
+    "optimizer_flow_lazy_moments": False,
+})
 
 _GAP_EXPANDER_DESCRIPTIONS = {
     "model_gap_expander_num_windings": (
@@ -155,6 +162,28 @@ _GAP_EXPANDER_DESCRIPTIONS = {
         "minimum-spacing loss remains the separate geological preference."),
     "model_gap_expander_softplus_bias": (
         "Bias of the stable lower-bounded softplus gap parameterisation."),
+}
+
+_OPTIMIZER_DESCRIPTIONS = {
+    "optimizer_flow_grad_smoothing": (
+        "Gaussian-smooth the flow lattices' gradient before each optimizer "
+        "step (gradient descent in a Sobolev metric, as in diffeomorphic "
+        "registration). The loss is unchanged; every update to the flow is "
+        "smooth at the configured width instead of moving each lattice cell "
+        "on its own noisy gradient. Cylindrical lattices smooth along z and "
+        "around each ring, not across rings."),
+    "optimizer_flow_grad_smoothing_sigma_voxels": (
+        "Width (standard deviation, scroll voxels) of the flow gradient "
+        "smoothing kernel. Applies to both lattices at the same physical "
+        "width; a high-resolution flow cell is model_flow_voxel_resolution "
+        "voxels."),
+    "optimizer_flow_lazy_moments": (
+        "Lazy Adam moments for the flow lattices (torch SparseAdam's masked "
+        "update on the dense gradient): cells no sample touched this step "
+        "keep their moments and value instead of decaying the second moment "
+        "toward zero, which otherwise makes a cell's first update after a "
+        "quiet spell disproportionately large. Weight decay still applies to "
+        "every cell."),
 }
 
 # Configuration keys that shape the model's parameter tensors. A checkpoint
@@ -293,6 +322,8 @@ def _field_spec(key, default):
         spec["description"] = _INPUT_TOGGLE_DESCRIPTIONS[key]
     elif key in _GAP_EXPANDER_DESCRIPTIONS:
         spec["description"] = _GAP_EXPANDER_DESCRIPTIONS[key]
+    elif key in _OPTIMIZER_DESCRIPTIONS:
+        spec["description"] = _OPTIMIZER_DESCRIPTIONS[key]
     return spec
 
 
@@ -309,6 +340,12 @@ class Config:
         self.optimizer_exp_lr_schedule = True
         self.optimizer_lr_final_factor = 0.3
         self.optimizer_num_training_steps = 30000
+        # Flow-lattice gradient conditioning (see _OPTIMIZER_DESCRIPTIONS).
+        # Both are read live every step, so they apply at a run boundary
+        # without a rebuild. Off by default.
+        self.optimizer_flow_grad_smoothing = False
+        self.optimizer_flow_grad_smoothing_sigma_voxels = 32.0
+        self.optimizer_flow_lazy_moments = False
         self.model_num_flow_integration_steps = 3
         self.model_flow_integration_solver = "rk4"
         self.model_num_flow_timesteps = 1

--- a/spiral-fitting/config.py
+++ b/spiral-fitting/config.py
@@ -222,7 +222,7 @@ _OPTIMIZER_DESCRIPTIONS = {
         "moves several times less per step than under per-cell Adam; raise "
         "this until the logged coarse-lattice update rms is back where the "
         "fit needs it, without touching the gap, linear and pitch groups. "
-        "Read live every step."),
+        "0 freezes the coarse lattice. Read live every step."),
     "optimizer_flow_grad_clip_median_multiple": (
         "Clip each flow lattice's gradient, per stage, at this multiple of "
         "the median nonzero |gradient| of that stage (read from a "

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -48,6 +48,7 @@ from config import (BACKFILLABLE_CONFIG_DEFAULTS, CHECKPOINT_MODEL_SHAPE_KEYS,
                     Config, FitConfig, durable_config)
 from checkpoint_migrations import (expand_gap_checkpoint_capacity,
                                    migrate_legacy_gap_parameterization)
+from lazy_moment_adamw import LazyMomentAdamW
 from fit_session import (fit_input, input_source_enabled, pcl_input_enabled,
                          phase_bundle_enabled, shell_losses_enabled,
                          winding_inference_enabled)
@@ -2260,7 +2261,10 @@ class FitContext:
                       'to enable it (some of these losses also need the '
                       'phase/SDT assets, see any warnings above).')
 
-    def _apply_high_res_lr_scale(self, iteration):
+    def _apply_flow_group_settings(self, iteration):
+        """Per-step optimizer settings of the two flow-lattice groups: the
+        high-resolution LR scale and the lazy-moment flag. Read from the
+        live configuration every step, so both are run-boundary settings."""
         scale = get_flow_field_high_res_lr_scale(self.config, iteration)
         low_res_group = next(
             group for group in self.optimiser.param_groups
@@ -2268,6 +2272,11 @@ class FitContext:
         high_res_group = next(
             group for group in self.optimiser.param_groups
             if any(param is self.high_res_flow_params[0] for param in group['params']))
+        # A loaded checkpoint's groups replace the live hyperparameters, so
+        # the flag is re-applied here rather than kept in the group.
+        lazy_moments = bool(self.config.get('optimizer_flow_lazy_moments', False))
+        low_res_group['lazy_moments'] = lazy_moments
+        high_res_group['lazy_moments'] = lazy_moments
         set_optimizer_group_lr_scale(
             self.optimiser,
             self.lr_scheduler,
@@ -2800,7 +2809,10 @@ class FitContext:
             },
         ]
         progress.begin('loading', 'Creating optimizer')
-        self.optimiser = torch.optim.AdamW(param_groups, lr=self.config['optimizer_learning_rate'], betas=(0.9, 0.999), eps=1.e-8, fused=True)
+        # AdamW for every group; the flow groups may additionally be stepped
+        # with lazy moments (optimizer_flow_lazy_moments, applied per step by
+        # _apply_flow_group_settings), which keeps AdamW's state format.
+        self.optimiser = LazyMomentAdamW(param_groups, lr=self.config['optimizer_learning_rate'], betas=(0.9, 0.999), eps=1.e-8, fused=True)
         # Influence masks are scoped to one interactive Run request. They are
         # created from that run's pending inputs and discarded before its autosave.
         self.influence_state = None
@@ -4153,7 +4165,7 @@ class FitContext:
 
     def step(self, iteration):
         self.step_timer.start('fwd')
-        flow_field_high_res_lr_scale = self._apply_high_res_lr_scale(iteration)
+        flow_field_high_res_lr_scale = self._apply_flow_group_settings(iteration)
 
         # The tiny graph paths shared by every transform evaluation this
         # iteration (dr softplus, scaled linear logits, pinned gap logits) are
@@ -4591,6 +4603,15 @@ class FitContext:
         self.step_timer.start('comm')
         allreduce_grads_(self.dist_grad_params, self.dist.world_size)
         self.step_timer.stop('comm')
+
+        if self.config.get('optimizer_flow_grad_smoothing', False):
+            # After the all-reduce (smoothing is linear, and every rank then
+            # smooths identical gradients) and before the influence masks, so
+            # smoothing cannot leak gradient outside a masked region.
+            self.step_timer.start('smooth')
+            self.spiral_and_transform.smooth_flow_grad_(
+                float(self.config['optimizer_flow_grad_smoothing_sigma_voxels']))
+            self.step_timer.stop('smooth')
 
         step_had_nonfinite = torch.zeros((), dtype=torch.bool, device=self.nonfinite_grad_steps.device)
         for name, p in self.dist_grad_named:

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -2273,10 +2273,13 @@ class FitContext:
             group for group in self.optimiser.param_groups
             if any(param is self.high_res_flow_params[0] for param in group['params']))
         # A loaded checkpoint's groups replace the live hyperparameters, so
-        # the flag is re-applied here rather than kept in the group.
+        # the flags are re-applied here rather than kept in the group.
         lazy_moments = bool(self.config.get('optimizer_flow_lazy_moments', False))
-        low_res_group['lazy_moments'] = lazy_moments
-        high_res_group['lazy_moments'] = lazy_moments
+        shared_second_moment = bool(
+            self.config.get('optimizer_flow_shared_second_moment', False))
+        for group in (low_res_group, high_res_group):
+            group['lazy_moments'] = lazy_moments
+            group['shared_second_moment'] = shared_second_moment
         set_optimizer_group_lr_scale(
             self.optimiser,
             self.lr_scheduler,
@@ -2286,6 +2289,26 @@ class FitContext:
             initial_lr=self.config['optimizer_learning_rate'],
         )
         return scale
+
+    def _report_flow_grad_conditioning(self):
+        """Log the flow gradient smoothing widths in lattice cells.
+
+        The configured widths are scroll voxels, and a width well under half
+        a cell is an identity kernel, so the per-lattice conversion is printed
+        once at build time rather than left implicit.
+        """
+        if not self.dist.is_main_process:
+            return
+        if not self.config.get('optimizer_flow_grad_smoothing', False):
+            return
+        along = float(self.config['optimizer_flow_grad_smoothing_sigma_voxels'])
+        across = float(self.config.get(
+            'optimizer_flow_grad_smoothing_across_sigma_voxels', 0.0) or 0.0)
+        print(self.spiral_and_transform.describe_flow_grad_smoothing(along, across))
+        if not self.config.get('optimizer_flow_lazy_moments', False):
+            print('NOTE: flow gradient smoothing without optimizer_flow_lazy_moments: '
+                  'the smoothed tails reach cells whose Adam second moment has '
+                  'decayed, so their first step is far larger than the tail warrants')
 
     def _realign_lr_schedule(self, completed_steps):
         """Align optimizer/scheduler state to the current absolute horizon."""
@@ -2813,6 +2836,7 @@ class FitContext:
         # with lazy moments (optimizer_flow_lazy_moments, applied per step by
         # _apply_flow_group_settings), which keeps AdamW's state format.
         self.optimiser = LazyMomentAdamW(param_groups, lr=self.config['optimizer_learning_rate'], betas=(0.9, 0.999), eps=1.e-8, fused=True)
+        self._report_flow_grad_conditioning()
         # Influence masks are scoped to one interactive Run request. They are
         # created from that run's pending inputs and discarded before its autosave.
         self.influence_state = None
@@ -4610,7 +4634,9 @@ class FitContext:
             # smoothing cannot leak gradient outside a masked region.
             self.step_timer.start('smooth')
             self.spiral_and_transform.smooth_flow_grad_(
-                float(self.config['optimizer_flow_grad_smoothing_sigma_voxels']))
+                float(self.config['optimizer_flow_grad_smoothing_sigma_voxels']),
+                float(self.config.get(
+                    'optimizer_flow_grad_smoothing_across_sigma_voxels', 0.0) or 0.0))
             self.step_timer.stop('smooth')
 
         step_had_nonfinite = torch.zeros((), dtype=torch.bool, device=self.nonfinite_grad_steps.device)

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -906,6 +906,11 @@ def get_flow_field_high_res_lr_scale(cfg, iteration):
     return min(1., float(initial) + fraction * (float(final) - float(initial)))
 
 
+def get_flow_field_low_res_lr_scale(cfg):
+    """Relative optimizer LR for the low-resolution flow lattice."""
+    return float(cfg.get('model_flow_field_low_res_lr_scale', 1.0) or 1.0)
+
+
 def set_optimizer_group_lr_scale(
         optimiser, lr_scheduler, *, group, reference_group, scale,
         initial_lr):
@@ -2262,10 +2267,15 @@ class FitContext:
                       'phase/SDT assets, see any warnings above).')
 
     def _apply_flow_group_settings(self, iteration):
-        """Per-step optimizer settings of the two flow-lattice groups: the
-        high-resolution LR scale and the lazy-moment flag. Read from the
-        live configuration every step, so both are run-boundary settings."""
-        scale = get_flow_field_high_res_lr_scale(self.config, iteration)
+        """Per-step optimizer settings of the two flow-lattice groups: their
+        LR scales relative to the base group and the moment flags. Read from
+        the live configuration every step, so all are run-boundary settings.
+        Returns (low-res scale, high-res scale)."""
+        high_res_scale = get_flow_field_high_res_lr_scale(self.config, iteration)
+        low_res_scale = get_flow_field_low_res_lr_scale(self.config)
+        # The base group (pitch and shell parameters) carries the scheduled
+        # optimizer_learning_rate unscaled; both flow groups hang off it.
+        base_group = self.optimiser.param_groups[0]
         low_res_group = next(
             group for group in self.optimiser.param_groups
             if any(param is self.low_res_flow_params[0] for param in group['params']))
@@ -2283,15 +2293,16 @@ class FitContext:
             group['lazy_moments'] = lazy_moments
             group['shared_second_moment'] = shared_second_moment
             group['shared_second_moment_clip_quantile'] = clip_quantile
-        set_optimizer_group_lr_scale(
-            self.optimiser,
-            self.lr_scheduler,
-            group=high_res_group,
-            reference_group=low_res_group,
-            scale=scale,
-            initial_lr=self.config['optimizer_learning_rate'],
-        )
-        return scale
+        for group, scale in ((low_res_group, low_res_scale), (high_res_group, high_res_scale)):
+            set_optimizer_group_lr_scale(
+                self.optimiser,
+                self.lr_scheduler,
+                group=group,
+                reference_group=base_group,
+                scale=scale,
+                initial_lr=self.config['optimizer_learning_rate'],
+            )
+        return low_res_scale, high_res_scale
 
     def _report_flow_grad_conditioning(self):
         """Log the flow gradient smoothing widths in lattice cells.
@@ -2909,6 +2920,7 @@ class FitContext:
         grouped_ids = {id(p) for p in flow_field_params + self.gap_expander_params + linear_params}
         other_params = [p for p in self.spiral_and_transform.parameters() if id(p) not in grouped_ids]
         initial_high_res_lr_scale = get_flow_field_high_res_lr_scale(self.config, 0)
+        initial_low_res_lr_scale = get_flow_field_low_res_lr_scale(self.config)
         param_groups = [
             {'params': other_params, 'weight_decay': 0.0},
             {'params': linear_params, 'weight_decay': 0.0},
@@ -2916,7 +2928,8 @@ class FitContext:
             {
                 'params': self.low_res_flow_params,
                 'weight_decay': self.config['optimizer_weight_decay_flow_field'],
-                'lr_scale': 1.,
+                'lr': self.config['optimizer_learning_rate'] * initial_low_res_lr_scale,
+                'lr_scale': initial_low_res_lr_scale,
             },
             {
                 'params': self.high_res_flow_params,
@@ -4287,7 +4300,8 @@ class FitContext:
 
     def step(self, iteration):
         self.step_timer.start('fwd')
-        flow_field_high_res_lr_scale = self._apply_flow_group_settings(iteration)
+        flow_field_low_res_lr_scale, flow_field_high_res_lr_scale = (
+            self._apply_flow_group_settings(iteration))
 
         # The tiny graph paths shared by every transform evaluation this
         # iteration (dr softplus, scaled linear logits, pinned gap logits) are
@@ -4309,6 +4323,7 @@ class FitContext:
 
         losses = {}
         log_metrics = {
+            'flow_field_low_res_lr_scale': flow_field_low_res_lr_scale,
             'flow_field_high_res_lr_scale': flow_field_high_res_lr_scale,
         }
 

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -908,7 +908,11 @@ def get_flow_field_high_res_lr_scale(cfg, iteration):
 
 def get_flow_field_low_res_lr_scale(cfg):
     """Relative optimizer LR for the low-resolution flow lattice."""
-    return float(cfg.get('model_flow_field_low_res_lr_scale', 1.0) or 1.0)
+    value = cfg.get('model_flow_field_low_res_lr_scale')
+    # Only a missing or null setting takes the default: 0 is a valid scale
+    # that freezes the coarse lattice (a zero AdamW LR also disables its
+    # decoupled weight decay).
+    return 1.0 if value is None else float(value)
 
 
 def set_optimizer_group_lr_scale(
@@ -2332,6 +2336,26 @@ class FitContext:
         low_res = float(self.config.get(
             'optimizer_flow_grad_smoothing_low_res_sigma_voxels', 0.0) or 0.0)
         return along, across, low_res
+
+    def _sanitize_nonfinite_grads_(self):
+        """Count and zero nonfinite entries in every distributed gradient.
+
+        Bumps nonfinite_grad_steps once per step with any nonfinite gradient
+        and nonfinite_grad_by_param per affected parameter, then replaces
+        NaN and +/-inf with zero in place.
+        """
+        step_had_nonfinite = torch.zeros((), dtype=torch.bool, device=self.nonfinite_grad_steps.device)
+        for name, p in self.dist_grad_named:
+            if p.grad is not None:
+                # aminmax propagates NaN and surfaces +/-inf through two scalar
+                # reductions, avoiding the gradient-sized boolean temporaries
+                # that (~torch.isfinite(grad)).any() allocates per parameter.
+                grad_min, grad_max = torch.aminmax(p.grad)
+                param_nonfinite = ~(torch.isfinite(grad_min) & torch.isfinite(grad_max))
+                step_had_nonfinite |= param_nonfinite
+                self.nonfinite_grad_by_param[name] += param_nonfinite.to(self.nonfinite_grad_steps.dtype)
+                torch.nan_to_num_(p.grad, nan=0.0, posinf=0.0, neginf=0.0)
+        self.nonfinite_grad_steps += step_had_nonfinite.to(self.nonfinite_grad_steps.dtype)
 
     def _clip_flow_grads(self):
         """Robustly clip every flow stage's lattice gradients (see
@@ -4741,6 +4765,14 @@ class FitContext:
         allreduce_grads_(self.dist_grad_params, self.dist.world_size)
         self.step_timer.stop('comm')
 
+        # Detect and zero nonfinite gradients straight after the all-reduce
+        # (identical on every rank) and before the clipping and smoothing:
+        # clamping would turn an infinity into a finite bound and hide it
+        # from these counters, and smoothing would spread a single NaN over
+        # every cell within its kernel. Clipping and smoothing finite
+        # gradients cannot produce new nonfinite values.
+        self._sanitize_nonfinite_grads_()
+
         # Clip after the all-reduce (identical gradients and statistics on
         # every rank) and before smoothing, so a cell with an unsatisfiable
         # loss is bounded before its spike is spread over its neighbours.
@@ -4755,19 +4787,6 @@ class FitContext:
             self.step_timer.start('smooth')
             self.spiral_and_transform.smooth_flow_grad_(*self._flow_grad_smoothing_widths())
             self.step_timer.stop('smooth')
-
-        step_had_nonfinite = torch.zeros((), dtype=torch.bool, device=self.nonfinite_grad_steps.device)
-        for name, p in self.dist_grad_named:
-            if p.grad is not None:
-                # aminmax propagates NaN and surfaces +/-inf through two scalar
-                # reductions, avoiding the gradient-sized boolean temporaries
-                # that (~torch.isfinite(grad)).any() allocates per parameter.
-                grad_min, grad_max = torch.aminmax(p.grad)
-                param_nonfinite = ~(torch.isfinite(grad_min) & torch.isfinite(grad_max))
-                step_had_nonfinite |= param_nonfinite
-                self.nonfinite_grad_by_param[name] += param_nonfinite.to(self.nonfinite_grad_steps.dtype)
-                torch.nan_to_num_(p.grad, nan=0.0, posinf=0.0, neginf=0.0)
-        self.nonfinite_grad_steps += step_had_nonfinite.to(self.nonfinite_grad_steps.dtype)
 
         if self.influence_state is not None and self.influence_state.active:
             # After the all-reduce and the accumulated-field-grad handoff, so

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -2272,8 +2272,9 @@ class FitContext:
 
     def _apply_flow_group_settings(self, iteration):
         """Per-step optimizer settings of the two flow-lattice groups: their
-        LR scales relative to the base group and the moment flags. Read from
-        the live configuration every step, so all are run-boundary settings.
+        LR scales relative to the base group and the moment flags are read
+        every step. The catalog exposes optimizer flags at run boundaries,
+        but classifies model_ LR controls as requiring a model rebuild.
         Returns (low-res scale, high-res scale)."""
         high_res_scale = get_flow_field_high_res_lr_scale(self.config, iteration)
         low_res_scale = get_flow_field_low_res_lr_scale(self.config)
@@ -2311,9 +2312,9 @@ class FitContext:
     def _report_flow_grad_conditioning(self):
         """Log the flow gradient smoothing widths in lattice cells.
 
-        The configured widths are scroll voxels, and a width well under half
-        a cell is an identity kernel, so the per-lattice conversion is printed
-        once at build time rather than left implicit.
+        Widths use scroll-voxel units of the flow frame. Very small cell-unit
+        widths collapse to identity kernels. Print the conversion at build
+        time; subsequent live changes do not refresh this startup report.
         """
         if not self.dist.is_main_process:
             return
@@ -2382,8 +2383,11 @@ class FitContext:
         flow-box units to scroll voxels per component (a cylindrical
         lattice's components are z, radial, tangential; a Cartesian one's
         z, y, x), so runs with different smoothing widths or denominators
-        are compared on how far they actually move the field per step. Reads
-        device statistics, so call it only when logging.
+        can be compared using nonzero flow-parameter increments. These RMS
+        values exclude weight decay and do not measure final sheet motion
+        after integration and composition. Optimizer statistics describe the
+        last custom step and may be stale after both moment flags are disabled.
+        Reads device statistics, so call it only when logging.
 
         A flow stage is one flow-field module here (low_res_flow_params[i]
         / high_res_flow_params[i]), whose lattice normally carries a single
@@ -4769,8 +4773,8 @@ class FitContext:
         # (identical on every rank) and before the clipping and smoothing:
         # clamping would turn an infinity into a finite bound and hide it
         # from these counters, and smoothing would spread a single NaN over
-        # every cell within its kernel. Clipping and smoothing finite
-        # gradients cannot produce new nonfinite values.
+        # every cell within its kernel. This does not check for overflow in
+        # subsequent arithmetic or repair invalid parameter/moment state.
         self._sanitize_nonfinite_grads_()
 
         # Clip after the all-reduce (identical gradients and statistics on

--- a/spiral-fitting/fit_spiral.py
+++ b/spiral-fitting/fit_spiral.py
@@ -48,7 +48,7 @@ from config import (BACKFILLABLE_CONFIG_DEFAULTS, CHECKPOINT_MODEL_SHAPE_KEYS,
                     Config, FitConfig, durable_config)
 from checkpoint_migrations import (expand_gap_checkpoint_capacity,
                                    migrate_legacy_gap_parameterization)
-from lazy_moment_adamw import LazyMomentAdamW
+from lazy_moment_adamw import LazyMomentAdamW, robust_clip_
 from fit_session import (fit_input, input_source_enabled, pcl_input_enabled,
                          phase_bundle_enabled, shell_losses_enabled,
                          winding_inference_enabled)
@@ -2277,9 +2277,12 @@ class FitContext:
         lazy_moments = bool(self.config.get('optimizer_flow_lazy_moments', False))
         shared_second_moment = bool(
             self.config.get('optimizer_flow_shared_second_moment', False))
+        clip_quantile = self.config.get(
+            'optimizer_flow_shared_second_moment_clip_quantile', 0.99)
         for group in (low_res_group, high_res_group):
             group['lazy_moments'] = lazy_moments
             group['shared_second_moment'] = shared_second_moment
+            group['shared_second_moment_clip_quantile'] = clip_quantile
         set_optimizer_group_lr_scale(
             self.optimiser,
             self.lr_scheduler,
@@ -2301,14 +2304,105 @@ class FitContext:
             return
         if not self.config.get('optimizer_flow_grad_smoothing', False):
             return
+        along, across, low_res = self._flow_grad_smoothing_widths()
+        print(self.spiral_and_transform.describe_flow_grad_smoothing(along, across, low_res))
+        if not (self.config.get('optimizer_flow_lazy_moments', False)
+                or self.config.get('optimizer_flow_shared_second_moment', False)):
+            print('NOTE: flow gradient smoothing with per-cell Adam moments and '
+                  'without optimizer_flow_lazy_moments: the smoothed tails reach '
+                  'cells whose Adam second moment has decayed, so their first '
+                  'step is far larger than the tail warrants')
+
+    def _flow_grad_smoothing_widths(self):
+        """(along-sheet, across-ring, low-res along-sheet) widths in voxels."""
         along = float(self.config['optimizer_flow_grad_smoothing_sigma_voxels'])
         across = float(self.config.get(
             'optimizer_flow_grad_smoothing_across_sigma_voxels', 0.0) or 0.0)
-        print(self.spiral_and_transform.describe_flow_grad_smoothing(along, across))
-        if not self.config.get('optimizer_flow_lazy_moments', False):
-            print('NOTE: flow gradient smoothing without optimizer_flow_lazy_moments: '
-                  'the smoothed tails reach cells whose Adam second moment has '
-                  'decayed, so their first step is far larger than the tail warrants')
+        low_res = float(self.config.get(
+            'optimizer_flow_grad_smoothing_low_res_sigma_voxels', 0.0) or 0.0)
+        return along, across, low_res
+
+    def _clip_flow_grads(self):
+        """Robustly clip every flow stage's lattice gradients (see
+        lazy_moment_adamw.robust_clip_) and keep the thresholds and clipped
+        fractions for the step log. A non-positive multiple leaves the
+        gradients alone and clears the stats."""
+        multiple = float(self.config.get('optimizer_flow_grad_clip_median_multiple', 0.0) or 0.0)
+        self.flow_grad_clip_stats = {}
+        if multiple <= 0.0:
+            return
+        for name, params in (('LR', self.low_res_flow_params),
+                             ('HR', self.high_res_flow_params)):
+            for stage, param in enumerate(params):
+                if param.grad is None:
+                    continue
+                stats = robust_clip_(param.grad, multiple)
+                if stats is not None:
+                    self.flow_grad_clip_stats[(name, stage)] = stats
+
+    def _flow_conditioning_report(self):
+        """Per-lattice, per-stage gradient-conditioning lines and metrics.
+
+        Update root-mean-squares are converted from the lattices' normalised
+        flow-box units to scroll voxels per component (a cylindrical
+        lattice's components are z, radial, tangential; a Cartesian one's
+        z, y, x), so runs with different smoothing widths or denominators
+        are compared on how far they actually move the field per step. Reads
+        device statistics, so call it only when logging.
+
+        A flow stage is one flow-field module here (low_res_flow_params[i]
+        / high_res_flow_params[i]), whose lattice normally carries a single
+        leading slab; a lattice with several slabs reports each one.
+        """
+        stats = getattr(self.optimiser, 'conditioning_stats', {})
+        clip_stats = getattr(self, 'flow_grad_clip_stats', {})
+        lines, payload = [], {}
+        if not stats and not clip_stats:
+            return lines, payload
+        ranges = (self.spiral_and_transform.flow_max_corner_zyx
+                  - self.spiral_and_transform.flow_min_corner_zyx).to(torch.float64).cpu()
+        cylindrical = self.config['model_flow_field_type'] == 'cylindrical'
+        component_names = ('z', 'r', 't') if cylindrical else ('z', 'y', 'x')
+        # Component 0 is z; the in-plane components (radial and tangential,
+        # or y and x) both live in the square yx box.
+        component_voxels = [float(ranges[0]), float(ranges[1]), float(ranges[2])]
+        for name, params in (('LR', self.low_res_flow_params),
+                             ('HR', self.high_res_flow_params)):
+            for stage, param in enumerate(params):
+                entry = stats.get(param)
+                clip = clip_stats.get((name, stage))
+                if entry is None and clip is None:
+                    continue
+                slabs = int(param.shape[0]) if param.dim() >= 3 else 1
+                cells_per_slab = param.numel() / slabs
+                for slab in range(slabs):
+                    label = f'stage{stage}' if slabs == 1 else f'stage{stage}/slab{slab}'
+                    parts = []
+                    prefix = f'flow_cond/{name}/{label}/'
+                    if entry is not None:
+                        rms = entry['update_rms'][slab].cpu()
+                        count = entry['update_count'][slab].cpu()
+                        voxels = [float(rms[c]) * component_voxels[c] for c in range(rms.numel())]
+                        parts.append('update rms vox ' + ' '.join(
+                            f'{component_names[c]}={v:.4f}' for c, v in enumerate(voxels)))
+                        updated = float(count.sum()) / cells_per_slab
+                        parts.append(f'updated {100.0 * updated:.1f}%')
+                        payload[prefix + 'updated_fraction'] = updated
+                        for c, v in enumerate(voxels):
+                            payload[prefix + f'update_rms_vox_{component_names[c]}'] = v
+                        if entry['scale'] is not None:
+                            scale = float(entry['scale'][slab])
+                            parts.append(f'shared scale {scale:.3e}')
+                            payload[prefix + 'shared_scale'] = scale
+                    if clip is not None:
+                        threshold, fraction = clip
+                        threshold = float(threshold[slab])
+                        fraction = float(fraction[slab])
+                        parts.append(f'clip thr {threshold:.3e} clipped {100.0 * fraction:.3f}%')
+                        payload[prefix + 'clip_threshold'] = threshold
+                        payload[prefix + 'clipped_fraction'] = fraction
+                    lines.append(f'  flow cond {name} {label}: ' + ', '.join(parts))
+        return lines, payload
 
     def _realign_lr_schedule(self, completed_steps):
         """Align optimizer/scheduler state to the current absolute horizon."""
@@ -2986,6 +3080,10 @@ class FitContext:
         )
         self.nonfinite_grad_steps = torch.zeros((), device=self.dist_grad_params[0].device)
         self.nonfinite_grad_by_param = {name: torch.zeros((), device=p.device) for name, p in self.dist_grad_named}
+        # Per-lattice, per-stage (threshold, clipped fraction) of the last
+        # step's robust flow-gradient clip, for the step log (see
+        # _clip_flow_grads).
+        self.flow_grad_clip_stats = {}
         self.interactive_dt_resume_iteration = None
 
     # What _build_model_state() constructs, and therefore what
@@ -4628,15 +4726,19 @@ class FitContext:
         allreduce_grads_(self.dist_grad_params, self.dist.world_size)
         self.step_timer.stop('comm')
 
+        # Clip after the all-reduce (identical gradients and statistics on
+        # every rank) and before smoothing, so a cell with an unsatisfiable
+        # loss is bounded before its spike is spread over its neighbours.
+        self.step_timer.start('clip')
+        self._clip_flow_grads()
+        self.step_timer.stop('clip')
+
         if self.config.get('optimizer_flow_grad_smoothing', False):
             # After the all-reduce (smoothing is linear, and every rank then
             # smooths identical gradients) and before the influence masks, so
             # smoothing cannot leak gradient outside a masked region.
             self.step_timer.start('smooth')
-            self.spiral_and_transform.smooth_flow_grad_(
-                float(self.config['optimizer_flow_grad_smoothing_sigma_voxels']),
-                float(self.config.get(
-                    'optimizer_flow_grad_smoothing_across_sigma_voxels', 0.0) or 0.0))
+            self.spiral_and_transform.smooth_flow_grad_(*self._flow_grad_smoothing_widths())
             self.step_timer.stop('smooth')
 
         step_had_nonfinite = torch.zeros((), dtype=torch.bool, device=self.nonfinite_grad_steps.device)
@@ -4730,8 +4832,12 @@ class FitContext:
                     )
                     by_param = ', '.join(f'{name}: {count}' for name, count in per_param)
                     print(f'  ({n_sanitised} non-finite-gradient steps sanitised so far; by param: {by_param})')
+                conditioning_lines, conditioning_payload = self._flow_conditioning_report()
+                for line in conditioning_lines:
+                    print(line)
                 payload = {
                     'total_loss': loss.item(),
+                    **conditioning_payload,
                     'nonfinite_grad_steps': self.nonfinite_grad_steps.item(),
                     **{f'nonfinite_grad_steps/{name}': count.item() for name, count in self.nonfinite_grad_by_param.items()},
                     **{name + '_loss': value for name, value in losses.items()},

--- a/spiral-fitting/flow_fields.py
+++ b/spiral-fitting/flow_fields.py
@@ -263,6 +263,15 @@ class _RK4SparseFlowIntegrate(torch.autograd.Function):
         return grad_y, None, None, None, None, None, None
 
 
+
+def _low_res_width(sigma_hr_cells, low_res_sigma_hr_cells):
+    # The low-resolution lattice's own along-sheet width when one is set,
+    # else the shared physical width.
+    if low_res_sigma_hr_cells is not None and float(low_res_sigma_hr_cells) > 0.0:
+        return float(low_res_sigma_hr_cells)
+    return float(sigma_hr_cells)
+
+
 class CartesianFlowField(nn.Module):
 
     def __init__(self, resolution, spatial_scale_factor=6, num_flow_timesteps=1, direct_lr=False):
@@ -452,12 +461,15 @@ class CartesianFlowField(nn.Module):
         else:
             hr_param.grad.add_(hr_grad)
 
-    def smooth_grad_(self, sigma_hr_cells, across_sigma_hr_cells=0.0):
+    def smooth_grad_(self, sigma_hr_cells, across_sigma_hr_cells=0.0,
+                     low_res_sigma_hr_cells=0.0):
         """Gaussian-smooth both lattices' gradients in place (isotropic).
 
         ``sigma_hr_cells`` is the width in high-resolution cells; the
         low-resolution lattice's cells are ``spatial_scale_factor`` times
-        larger, so it sees the same physical width in its own cells.
+        larger, so it sees the same physical width in its own cells unless
+        ``low_res_sigma_hr_cells`` (also in high-resolution cells, 0 = same
+        as ``sigma_hr_cells``) gives it a width of its own.
         ``across_sigma_hr_cells`` is accepted for signature parity with the
         cylindrical lattice and ignored: a Cartesian lattice has no
         across-winding axis to smooth differently.
@@ -466,7 +478,8 @@ class CartesianFlowField(nn.Module):
             if flow.grad is None:
                 continue
             scale = self.spatial_scale_factor if level == 0 else 1
-            flow_grad_smoothing.smooth_cartesian_(flow.grad, float(sigma_hr_cells) / scale)
+            along = _low_res_width(sigma_hr_cells, low_res_sigma_hr_cells) if level == 0 else sigma_hr_cells
+            flow_grad_smoothing.smooth_cartesian_(flow.grad, float(along) / scale)
 
 
 class CylindricalFlowField(nn.Module):
@@ -737,22 +750,26 @@ class CylindricalFlowField(nn.Module):
                 [leaf.grad for _, leaf in pending if leaf.grad is not None],
             )
 
-    def smooth_grad_(self, sigma_hr_cells, across_sigma_hr_cells=0.0):
+    def smooth_grad_(self, sigma_hr_cells, across_sigma_hr_cells=0.0,
+                     low_res_sigma_hr_cells=0.0):
         """Gaussian-smooth both lattices' gradients in place: ``sigma_hr_cells``
         along the sheet (along z and around each ring) and
         ``across_sigma_hr_cells`` across rings; see
         flow_grad_smoothing.smooth_cylindrical_.
 
-        Both widths are in high-resolution cells (radial spacing, z spacing
+        All widths are in high-resolution cells (radial spacing, z spacing
         and ring arc length all equal one cell); the low-resolution lattice's
         cells are ``spatial_scale_factor`` times larger, so it sees the same
-        physical widths in its own cells.
+        physical widths in its own cells, except that
+        ``low_res_sigma_hr_cells`` (0 = same as ``sigma_hr_cells``) gives it
+        an along-sheet width of its own.
         """
         tables = ((self._lr_num_phi, self._lr_offsets), (self._hr_num_phi, self._hr_offsets))
         for level, (flow, (num_phi, offsets)) in enumerate(zip(self.flows, tables)):
             if flow.grad is None:
                 continue
             scale = self.spatial_scale_factor if level == 0 else 1
+            along = _low_res_width(sigma_hr_cells, low_res_sigma_hr_cells) if level == 0 else sigma_hr_cells
             flow_grad_smoothing.smooth_cylindrical_(
-                flow.grad, num_phi, offsets, float(sigma_hr_cells) / scale,
+                flow.grad, num_phi, offsets, float(along) / scale,
                 float(across_sigma_hr_cells) / scale)

--- a/spiral-fitting/flow_fields.py
+++ b/spiral-fitting/flow_fields.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+import flow_grad_smoothing
 import flow_triton
 
 
@@ -268,6 +269,7 @@ class CartesianFlowField(nn.Module):
         super().__init__()
         self.num_flow_timesteps = num_flow_timesteps
         self.direct_lr = direct_lr
+        self.spatial_scale_factor = int(spatial_scale_factor)
         self.flows = nn.ParameterList([
             nn.Parameter(torch.zeros([num_flow_timesteps, 3, *shape]))
             for shape in [
@@ -450,6 +452,19 @@ class CartesianFlowField(nn.Module):
         else:
             hr_param.grad.add_(hr_grad)
 
+    def smooth_grad_(self, sigma_hr_cells):
+        """Gaussian-smooth both lattices' gradients in place.
+
+        ``sigma_hr_cells`` is the width in high-resolution cells; the
+        low-resolution lattice's cells are ``spatial_scale_factor`` times
+        larger, so it sees the same physical width in its own cells.
+        """
+        for level, flow in enumerate(self.flows):
+            if flow.grad is None:
+                continue
+            scale = self.spatial_scale_factor if level == 0 else 1
+            flow_grad_smoothing.smooth_cartesian_(flow.grad, float(sigma_hr_cells) / scale)
+
 
 class CylindricalFlowField(nn.Module):
 
@@ -477,6 +492,7 @@ class CylindricalFlowField(nn.Module):
         # cylindrical lattice is always sampled directly (never upsampled).
         super().__init__()
         self.num_flow_timesteps = num_flow_timesteps
+        self.spatial_scale_factor = int(spatial_scale_factor)
         Z, Y, X = (int(s) for s in resolution)
 
         nz_hr = Z
@@ -717,3 +733,20 @@ class CylindricalFlowField(nn.Module):
                 outputs,
                 [leaf.grad for _, leaf in pending if leaf.grad is not None],
             )
+
+    def smooth_grad_(self, sigma_hr_cells):
+        """Gaussian-smooth both lattices' gradients in place (along z and
+        around each ring; see flow_grad_smoothing.smooth_cylindrical_).
+
+        ``sigma_hr_cells`` is the width in high-resolution cells (radial
+        spacing, z spacing and ring arc length all equal one cell); the
+        low-resolution lattice's cells are ``spatial_scale_factor`` times
+        larger, so it sees the same physical width in its own cells.
+        """
+        tables = ((self._lr_num_phi, self._lr_offsets), (self._hr_num_phi, self._hr_offsets))
+        for level, (flow, (num_phi, offsets)) in enumerate(zip(self.flows, tables)):
+            if flow.grad is None:
+                continue
+            scale = self.spatial_scale_factor if level == 0 else 1
+            flow_grad_smoothing.smooth_cylindrical_(
+                flow.grad, num_phi, offsets, float(sigma_hr_cells) / scale)

--- a/spiral-fitting/flow_fields.py
+++ b/spiral-fitting/flow_fields.py
@@ -452,12 +452,15 @@ class CartesianFlowField(nn.Module):
         else:
             hr_param.grad.add_(hr_grad)
 
-    def smooth_grad_(self, sigma_hr_cells):
-        """Gaussian-smooth both lattices' gradients in place.
+    def smooth_grad_(self, sigma_hr_cells, across_sigma_hr_cells=0.0):
+        """Gaussian-smooth both lattices' gradients in place (isotropic).
 
         ``sigma_hr_cells`` is the width in high-resolution cells; the
         low-resolution lattice's cells are ``spatial_scale_factor`` times
         larger, so it sees the same physical width in its own cells.
+        ``across_sigma_hr_cells`` is accepted for signature parity with the
+        cylindrical lattice and ignored: a Cartesian lattice has no
+        across-winding axis to smooth differently.
         """
         for level, flow in enumerate(self.flows):
             if flow.grad is None:
@@ -734,14 +737,16 @@ class CylindricalFlowField(nn.Module):
                 [leaf.grad for _, leaf in pending if leaf.grad is not None],
             )
 
-    def smooth_grad_(self, sigma_hr_cells):
-        """Gaussian-smooth both lattices' gradients in place (along z and
-        around each ring; see flow_grad_smoothing.smooth_cylindrical_).
+    def smooth_grad_(self, sigma_hr_cells, across_sigma_hr_cells=0.0):
+        """Gaussian-smooth both lattices' gradients in place: ``sigma_hr_cells``
+        along the sheet (along z and around each ring) and
+        ``across_sigma_hr_cells`` across rings; see
+        flow_grad_smoothing.smooth_cylindrical_.
 
-        ``sigma_hr_cells`` is the width in high-resolution cells (radial
-        spacing, z spacing and ring arc length all equal one cell); the
-        low-resolution lattice's cells are ``spatial_scale_factor`` times
-        larger, so it sees the same physical width in its own cells.
+        Both widths are in high-resolution cells (radial spacing, z spacing
+        and ring arc length all equal one cell); the low-resolution lattice's
+        cells are ``spatial_scale_factor`` times larger, so it sees the same
+        physical widths in its own cells.
         """
         tables = ((self._lr_num_phi, self._lr_offsets), (self._hr_num_phi, self._hr_offsets))
         for level, (flow, (num_phi, offsets)) in enumerate(zip(self.flows, tables)):
@@ -749,4 +754,5 @@ class CylindricalFlowField(nn.Module):
                 continue
             scale = self.spatial_scale_factor if level == 0 else 1
             flow_grad_smoothing.smooth_cylindrical_(
-                flow.grad, num_phi, offsets, float(sigma_hr_cells) / scale)
+                flow.grad, num_phi, offsets, float(sigma_hr_cells) / scale,
+                float(across_sigma_hr_cells) / scale)

--- a/spiral-fitting/flow_fields.py
+++ b/spiral-fitting/flow_fields.py
@@ -465,9 +465,9 @@ class CartesianFlowField(nn.Module):
                      low_res_sigma_hr_cells=0.0):
         """Gaussian-smooth both lattices' gradients in place (isotropic).
 
-        ``sigma_hr_cells`` is the width in high-resolution cells; the
-        low-resolution lattice's cells are ``spatial_scale_factor`` times
-        larger, so it sees the same physical width in its own cells unless
+        ``sigma_hr_cells`` is the width in nominal high-resolution cells;
+        coarse cells are ``spatial_scale_factor`` times larger, so they see
+        the same flow-frame width in their own cell units unless
         ``low_res_sigma_hr_cells`` (also in high-resolution cells, 0 = same
         as ``sigma_hr_cells``) gives it a width of its own.
         ``across_sigma_hr_cells`` is accepted for signature parity with the
@@ -753,14 +753,14 @@ class CylindricalFlowField(nn.Module):
     def smooth_grad_(self, sigma_hr_cells, across_sigma_hr_cells=0.0,
                      low_res_sigma_hr_cells=0.0):
         """Gaussian-smooth both lattices' gradients in place: ``sigma_hr_cells``
-        along the sheet (along z and around each ring) and
-        ``across_sigma_hr_cells`` across rings; see
+        along z and around each ring (approximating along-sheet directions)
+        and ``across_sigma_hr_cells`` across rings; see
         flow_grad_smoothing.smooth_cylindrical_.
 
-        All widths are in high-resolution cells (radial spacing, z spacing
-        and ring arc length all equal one cell); the low-resolution lattice's
-        cells are ``spatial_scale_factor`` times larger, so it sees the same
-        physical widths in its own cells, except that
+        All widths are in nominal high-resolution cells (ring arc spacing
+        is approximate because angular cell counts are rounded). Coarse
+        cells are ``spatial_scale_factor`` times larger, so they see the same
+        flow-frame widths in their own cell units, except that
         ``low_res_sigma_hr_cells`` (0 = same as ``sigma_hr_cells``) gives it
         an along-sheet width of its own.
         """

--- a/spiral-fitting/flow_grad_smoothing.py
+++ b/spiral-fitting/flow_grad_smoothing.py
@@ -1,0 +1,237 @@
+"""Gaussian smoothing of flow-lattice gradients.
+
+Smoothing the velocity gradient before the optimizer step is gradient
+descent in a Sobolev metric, the standard preconditioner of diffeomorphic
+registration: the loss and its minima are unchanged, but every update to the
+flow is smooth at the kernel's scale instead of moving each lattice cell
+independently on its own noisy gradient. Both functions smooth in place,
+treat the lattices' leading slab axis (the flow stages) and the vector
+components independently, and renormalise the kernel at lattice borders so a
+constant gradient stays constant.
+
+Widths are in lattice cells of the lattice being smoothed; the caller
+converts from scroll voxels (see SpiralAndTransform.smooth_flow_grad_).
+"""
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+import flow_triton
+
+# Truncation radius of the Gaussian, in standard deviations.
+KERNEL_TRUNCATE = 3.0
+# Widest kernel the fused kernels unroll (taps = 2 * radius + 1); wider
+# kernels take the conv fallback.
+MAX_FUSED_RADIUS = 48
+
+if flow_triton._HAS_TRITON:
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _blur_axis_kernel(x_ptr, out_ptr, w_ptr, norm_ptr, L, INNER,
+                          RADIUS: tl.constexpr,
+                          BLOCK_L: tl.constexpr, BLOCK_I: tl.constexpr):
+        # One Gaussian pass along an axis of a contiguous [OUTER, L, INNER]
+        # tensor, zero-padded and divided by the per-position border norm.
+        # Tiles are [BLOCK_L positions, BLOCK_I inner elements]; along the
+        # last axis INNER is 1 and the tile runs along L instead.
+        outer = tl.program_id(0).to(tl.int64)
+        l = tl.program_id(1) * BLOCK_L + tl.arange(0, BLOCK_L)
+        i = tl.program_id(2) * BLOCK_I + tl.arange(0, BLOCK_I)
+        ml = l < L
+        mi = i < INNER
+        base = outer * L * INNER
+        acc = tl.zeros([BLOCK_L, BLOCK_I], dtype=tl.float32)
+        for k in tl.static_range(2 * RADIUS + 1):
+            src = l + (k - RADIUS)
+            m = (src >= 0) & (src < L)
+            w = tl.load(w_ptr + k)
+            vals = tl.load(
+                x_ptr + base + src.to(tl.int64)[:, None] * INNER + i[None, :],
+                mask=m[:, None] & mi[None, :], other=0.0)
+            acc += w * vals
+        norm = tl.load(norm_ptr + l, mask=ml, other=1.0)
+        acc = acc / norm[:, None]
+        tl.store(out_ptr + base + l.to(tl.int64)[:, None] * INNER + i[None, :],
+                 acc, mask=ml[:, None] & mi[None, :])
+
+    @triton.jit
+    def _blur_rings_kernel(x_ptr, out_ptr, w_ptr, ring_ptr, num_phi_ptr,
+                           offsets_ptr, ROWS, TOTAL,
+                           RADIUS: tl.constexpr,
+                           BLOCK_R: tl.constexpr, BLOCK_C: tl.constexpr):
+        # Circular Gaussian pass around every ring of a packed [ROWS, TOTAL]
+        # plane at once: each packed cell looks up its ring, and its taps
+        # wrap within that ring's cells.
+        r = tl.program_id(0) * BLOCK_R + tl.arange(0, BLOCK_R)
+        c = tl.program_id(1) * BLOCK_C + tl.arange(0, BLOCK_C)
+        mr = r < ROWS
+        mc = c < TOTAL
+        ring = tl.load(ring_ptr + c, mask=mc, other=0)
+        n = tl.load(num_phi_ptr + ring, mask=mc, other=1)
+        offset = tl.load(offsets_ptr + ring, mask=mc, other=0)
+        local = c - offset
+        rows = r.to(tl.int64)[:, None] * TOTAL
+        acc = tl.zeros([BLOCK_R, BLOCK_C], dtype=tl.float32)
+        for k in tl.static_range(2 * RADIUS + 1):
+            src = (local + (k - RADIUS)) % n
+            src = tl.where(src < 0, src + n, src)
+            w = tl.load(w_ptr + k)
+            vals = tl.load(x_ptr + rows + (offset + src)[None, :],
+                           mask=mr[:, None] & mc[None, :], other=0.0)
+            acc += w * vals
+        tl.store(out_ptr + rows + c[None, :], acc, mask=mr[:, None] & mc[None, :])
+
+
+def _fused(grad, kernel):
+    return (flow_triton.rk4_triton_available(grad)
+            and kernel.numel() // 2 <= MAX_FUSED_RADIUS)
+
+
+def _blur_axis_fused(x, out, axis, kernel, norm):
+    # x, out :: contiguous, same shape; blur along `axis` (negative index).
+    shape = x.shape
+    axis = axis % x.dim()
+    outer = int(math.prod(shape[:axis]))
+    length = int(shape[axis])
+    inner = int(math.prod(shape[axis + 1:]))
+    radius = kernel.numel() // 2
+    if inner == 1:
+        block_l, block_i = 256, 1
+    else:
+        block_l, block_i = 8, 128
+    grid = (outer, triton.cdiv(length, block_l), triton.cdiv(inner, block_i))
+    _blur_axis_kernel[grid](
+        x, out, kernel, norm, length, inner,
+        RADIUS=radius, BLOCK_L=block_l, BLOCK_I=block_i)
+    return out
+
+
+def gaussian_kernel(sigma_cells, device=None, dtype=torch.float32):
+    """Normalised 1-D Gaussian of width ``sigma_cells`` (radius 3 sigma), or
+    None when it would be a delta."""
+    sigma = float(sigma_cells)
+    if not sigma > 0.0:
+        return None
+    radius = int(math.ceil(KERNEL_TRUNCATE * sigma))
+    if radius < 1:
+        return None
+    offsets = torch.arange(-radius, radius + 1, dtype=torch.float64, device=device)
+    kernel = torch.exp(-0.5 * (offsets / sigma) ** 2)
+    kernel = kernel / kernel.sum()
+    if float(kernel[radius]) >= 1.0 - 1e-7:
+        return None
+    return kernel.to(dtype)
+
+
+def _border_norm(length, kernel, device, dtype):
+    # Response of the zero-padded kernel to a constant 1 along one axis: the
+    # per-position normaliser that makes the border behave like a truncated,
+    # renormalised kernel instead of shrinking toward zero.
+    radius = kernel.numel() // 2
+    ones = torch.ones(1, 1, length, device=device, dtype=dtype)
+    return F.conv1d(ones, kernel.view(1, 1, -1), padding=radius).view(length)
+
+
+def smooth_cartesian_(grad, sigma_cells):
+    """Separable Gaussian blur of ``grad`` ([..., Z, Y, X]) in place."""
+    kernel = gaussian_kernel(sigma_cells, grad.device, grad.dtype)
+    if kernel is None:
+        return grad
+    radius = kernel.numel() // 2
+    spatial = grad.shape[-3:]
+    volumes = grad.reshape(-1, 1, *spatial)  # a view: grads are contiguous
+    if _fused(grad, kernel):
+        # Three fused passes per (slab, component) volume, ping-ponging with
+        # one scratch volume so the transient stays one volume, not a lattice.
+        norms = [_border_norm(spatial[axis], kernel, grad.device, grad.dtype)
+                 for axis in range(3)]
+        scratch = torch.empty_like(volumes[0, 0])
+        for index in range(volumes.shape[0]):
+            volume = volumes[index, 0]
+            _blur_axis_fused(volume, scratch, -3, kernel, norms[0])
+            _blur_axis_fused(scratch, volume, -2, kernel, norms[1])
+            _blur_axis_fused(volume, scratch, -1, kernel, norms[2])
+            volume.copy_(scratch)
+        return grad
+    for axis in range(3):
+        weight_shape = [1, 1, 1, 1, 1]
+        weight_shape[2 + axis] = kernel.numel()
+        weight = kernel.view(*weight_shape)
+        padding = [0, 0, 0]
+        padding[axis] = radius
+        norm_shape = [1, 1, 1, 1, 1]
+        norm_shape[2 + axis] = spatial[axis]
+        norm = _border_norm(spatial[axis], kernel, grad.device, grad.dtype).view(*norm_shape)
+        # One (slab, component) volume at a time bounds the transient to a
+        # single volume rather than the whole lattice.
+        for index in range(volumes.shape[0]):
+            volume = volumes[index:index + 1]
+            volume.copy_(F.conv3d(volume, weight, padding=padding).div_(norm))
+    return grad
+
+
+def smooth_cylindrical_(grad, ring_num_phi, ring_offsets, sigma_cells):
+    """Gaussian blur of a packed cylindrical lattice gradient in place.
+
+    ``grad`` is [..., nz, total_phi] with the rings packed end to end along
+    the last axis (``ring_offsets[r]`` .. ``ring_offsets[r + 1]`` holds ring
+    r's ``ring_num_phi[r]`` cells). Smooths along z (border-renormalised) and
+    around each ring (circular). Ring 0 is the pinned axis cell and is left
+    alone. Rings are not mixed: adjacent rings hold different cell counts, so
+    a radial pass would need resampling; the radial coupling is left to the
+    lattices' own trilinear interpolation.
+    """
+    kernel = gaussian_kernel(sigma_cells, grad.device, grad.dtype)
+    if kernel is None:
+        return grad
+    radius = kernel.numel() // 2
+    nz, total = grad.shape[-2], grad.shape[-1]
+    planes = grad.reshape(-1, 1, nz, total)  # a view
+    ring_num_phi = torch.as_tensor(ring_num_phi, dtype=torch.int64)
+    ring_offsets = torch.as_tensor(ring_offsets, dtype=torch.int64)
+
+    if _fused(grad, kernel):
+        device = grad.device
+        num_phi = ring_num_phi.to(device=device, dtype=torch.int32)
+        offsets = ring_offsets.to(device=device, dtype=torch.int32)
+        cell_ring = torch.repeat_interleave(
+            torch.arange(num_phi.numel(), device=device, dtype=torch.int32),
+            num_phi.to(torch.int64))
+        norm = _border_norm(nz, kernel, device, grad.dtype)
+        scratch = torch.empty_like(planes[0, 0])
+        block_r, block_c = 8, 128
+        grid = (triton.cdiv(nz, block_r), triton.cdiv(total, block_c))
+        for index in range(planes.shape[0]):
+            plane = planes[index, 0]
+            _blur_axis_fused(plane, scratch, -2, kernel, norm)
+            _blur_rings_kernel[grid](
+                scratch, plane, kernel, cell_ring, num_phi, offsets, nz, total,
+                RADIUS=radius, BLOCK_R=block_r, BLOCK_C=block_c)
+        return grad
+
+    # z pass.
+    norm = _border_norm(nz, kernel, grad.device, grad.dtype).view(1, 1, nz, 1)
+    weight = kernel.view(1, 1, -1, 1)
+    for index in range(planes.shape[0]):
+        plane = planes[index:index + 1]
+        plane.copy_(F.conv2d(plane, weight, padding=(radius, 0)).div_(norm))
+
+    # phi pass, per ring, circular.
+    num_phi = ring_num_phi.tolist()
+    offsets = ring_offsets.tolist()
+    kernel_1d = kernel.view(1, 1, -1)
+    lead = grad.shape[:-2]
+    for ring in range(1, len(num_phi)):
+        n = num_phi[ring]
+        if n < 2:
+            continue
+        start = offsets[ring]
+        cells = grad[..., start:start + n]  # [..., nz, n], a view
+        wrapped = torch.arange(-radius, n + radius, device=grad.device) % n
+        padded = cells[..., wrapped].reshape(-1, 1, n + 2 * radius)
+        cells.copy_(F.conv1d(padded, kernel_1d).view(*lead, nz, n))
+    return grad

--- a/spiral-fitting/flow_grad_smoothing.py
+++ b/spiral-fitting/flow_grad_smoothing.py
@@ -349,18 +349,23 @@ def _blur_radial_eager_(grad, num_phi, offsets, kernel):
 
 
 def describe_widths(along_voxels, across_voxels, cell_voxels, spatial_scale_factor,
-                    field_type):
+                    field_type, low_res_along_voxels=0.0):
     """One-line report of the effective smoothing widths per lattice.
 
     Converts the configured scroll-voxel widths to cells of the high- and
     low-resolution lattices and says when a kernel collapses to the identity
     (see gaussian_kernel), so a width that is far below the cell size is
-    visible at startup instead of silently doing nothing.
+    visible at startup instead of silently doing nothing. A positive
+    ``low_res_along_voxels`` is the low-resolution lattice's own along-sheet
+    width and is reported in its place.
     """
-    def per_lattice(voxels):
+    def per_lattice(voxels, low_res_voxels=None):
         parts = []
         for name, scale in (('HR', 1), ('LR', spatial_scale_factor)):
-            cells = float(voxels) / (float(cell_voxels) * scale)
+            lattice_voxels = voxels
+            if name == 'LR' and low_res_voxels is not None and float(low_res_voxels) > 0.0:
+                lattice_voxels = low_res_voxels
+            cells = float(lattice_voxels) / (float(cell_voxels) * scale)
             kernel = gaussian_kernel(cells, dtype=torch.float64)
             if kernel is None:
                 parts.append(f'{name} {cells:.2f} cells (identity)')
@@ -369,7 +374,10 @@ def describe_widths(along_voxels, across_voxels, cell_voxels, spatial_scale_fact
         return ', '.join(parts)
 
     report = (f'flow gradient smoothing ({field_type}): along-sheet '
-              f'{float(along_voxels):g} voxels = {per_lattice(along_voxels)}')
+              f'{float(along_voxels):g} voxels')
+    if low_res_along_voxels is not None and float(low_res_along_voxels) > 0.0:
+        report += f' (LR {float(low_res_along_voxels):g} voxels)'
+    report += f' = {per_lattice(along_voxels, low_res_along_voxels)}'
     if field_type == 'cylindrical':
         report += (f'; across rings {float(across_voxels):g} voxels = '
                    f'{per_lattice(across_voxels)}')

--- a/spiral-fitting/flow_grad_smoothing.py
+++ b/spiral-fitting/flow_grad_smoothing.py
@@ -11,6 +11,11 @@ constant gradient stays constant.
 
 Widths are in lattice cells of the lattice being smoothed; the caller
 converts from scroll voxels (see SpiralAndTransform.smooth_flow_grad_).
+
+On a cylindrical lattice the smoothing is anisotropic: one width along the
+sheet (along z and around each ring, which in the flow frame is along the
+model spiral's windings) and a separate, normally much smaller, width across
+rings (across windings). See smooth_cylindrical_.
 """
 
 import math
@@ -84,6 +89,55 @@ if flow_triton._HAS_TRITON:
                            mask=mr[:, None] & mc[None, :], other=0.0)
             acc += w * vals
         tl.store(out_ptr + rows + c[None, :], acc, mask=mr[:, None] & mc[None, :])
+
+    @triton.jit
+    def _blur_radial_kernel(x_ptr, out_ptr, w_ptr, ring_ptr, num_phi_ptr,
+                            offsets_ptr, ROWS, TOTAL, NUM_RINGS,
+                            RADIUS: tl.constexpr,
+                            BLOCK_R: tl.constexpr, BLOCK_C: tl.constexpr):
+        # Gaussian pass across the rings of a packed [ROWS, TOTAL] plane: each
+        # cell's tap k reads ring (r + k) at the cell's own angle, linearly
+        # interpolated between that ring's two nearest cells (rings hold
+        # different cell counts). Taps falling on the pinned axis ring 0 or
+        # beyond the outermost ring are dropped and the weights renormalised,
+        # so a constant stays constant at the borders; ring 0 itself passes
+        # through unchanged.
+        r = tl.program_id(0) * BLOCK_R + tl.arange(0, BLOCK_R)
+        c = tl.program_id(1) * BLOCK_C + tl.arange(0, BLOCK_C)
+        mr = r < ROWS
+        mc = c < TOTAL
+        ring = tl.load(ring_ptr + c, mask=mc, other=0)
+        n = tl.load(num_phi_ptr + ring, mask=mc, other=1)
+        offset = tl.load(offsets_ptr + ring, mask=mc, other=0)
+        local = c - offset  # cell index within its ring; angle = local / n turns
+        rows = r.to(tl.int64)[:, None] * TOTAL
+        acc = tl.zeros([BLOCK_R, BLOCK_C], dtype=tl.float32)
+        wsum = tl.zeros([BLOCK_C], dtype=tl.float32)
+        for k in tl.static_range(2 * RADIUS + 1):
+            src_ring = ring + (k - RADIUS)
+            valid = mc & (src_ring >= 1) & (src_ring < NUM_RINGS)
+            src_ring_safe = tl.where(valid, src_ring, 0)
+            n_src = tl.load(num_phi_ptr + src_ring_safe, mask=valid, other=1)
+            off_src = tl.load(offsets_ptr + src_ring_safe, mask=valid, other=0)
+            # Position local / n * n_src on the source ring, split exactly in
+            # integers (the eager reference does the same), so aligned angles
+            # land on one cell and the two paths agree to rounding.
+            numerator = local * n_src
+            lo = numerator // n
+            frac = (numerator - lo * n).to(tl.float32) / n.to(tl.float32)
+            hi = (lo + 1) % n_src
+            w = tl.load(w_ptr + k)
+            v_lo = tl.load(x_ptr + rows + (off_src + lo)[None, :],
+                           mask=mr[:, None] & valid[None, :], other=0.0)
+            v_hi = tl.load(x_ptr + rows + (off_src + hi)[None, :],
+                           mask=mr[:, None] & valid[None, :], other=0.0)
+            acc += w * (v_lo + (v_hi - v_lo) * frac[None, :])
+            wsum += tl.where(valid, w, 0.0)
+        wsum = tl.where(wsum > 0.0, wsum, 1.0)
+        out = acc / wsum[None, :]
+        own = tl.load(x_ptr + rows + c[None, :], mask=mr[:, None] & mc[None, :], other=0.0)
+        out = tl.where((ring == 0)[None, :], own, out)
+        tl.store(out_ptr + rows + c[None, :], out, mask=mr[:, None] & mc[None, :])
 
 
 def _fused(grad, kernel):
@@ -174,64 +228,152 @@ def smooth_cartesian_(grad, sigma_cells):
     return grad
 
 
-def smooth_cylindrical_(grad, ring_num_phi, ring_offsets, sigma_cells):
-    """Gaussian blur of a packed cylindrical lattice gradient in place.
+def smooth_cylindrical_(grad, ring_num_phi, ring_offsets, sigma_cells,
+                        across_sigma_cells=0.0):
+    """Anisotropic Gaussian blur of a packed cylindrical lattice gradient in place.
 
     ``grad`` is [..., nz, total_phi] with the rings packed end to end along
     the last axis (``ring_offsets[r]`` .. ``ring_offsets[r + 1]`` holds ring
-    r's ``ring_num_phi[r]`` cells). Smooths along z (border-renormalised) and
-    around each ring (circular). Ring 0 is the pinned axis cell and is left
-    alone. Rings are not mixed: adjacent rings hold different cell counts, so
-    a radial pass would need resampling; the radial coupling is left to the
-    lattices' own trilinear interpolation.
+    r's ``ring_num_phi[r]`` cells). ``sigma_cells`` is the width along the
+    sheet: along z (border-renormalised) and around each ring (circular).
+    ``across_sigma_cells`` is the width across rings: each tap reads the
+    neighbouring ring at the cell's own angle, linearly interpolated between
+    that ring's two nearest cells, with the weights renormalised at the
+    innermost and outermost rings. Ring 0 is the pinned axis cell: it is left
+    alone and never read. Both widths are in cells (the radial spacing, the z
+    spacing and the ring arc length are all one cell). The vector components
+    are stored in the local (z, radial, tangential) basis, so blurring around
+    a ring spreads a radial push as radial pushes at neighbouring angles.
     """
     kernel = gaussian_kernel(sigma_cells, grad.device, grad.dtype)
-    if kernel is None:
+    radial_kernel = gaussian_kernel(across_sigma_cells, grad.device, grad.dtype)
+    if kernel is None and radial_kernel is None:
         return grad
-    radius = kernel.numel() // 2
     nz, total = grad.shape[-2], grad.shape[-1]
     planes = grad.reshape(-1, 1, nz, total)  # a view
     ring_num_phi = torch.as_tensor(ring_num_phi, dtype=torch.int64)
     ring_offsets = torch.as_tensor(ring_offsets, dtype=torch.int64)
 
-    if _fused(grad, kernel):
+    if _fused(grad, kernel if kernel is not None else radial_kernel):
         device = grad.device
         num_phi = ring_num_phi.to(device=device, dtype=torch.int32)
         offsets = ring_offsets.to(device=device, dtype=torch.int32)
         cell_ring = torch.repeat_interleave(
             torch.arange(num_phi.numel(), device=device, dtype=torch.int32),
             num_phi.to(torch.int64))
-        norm = _border_norm(nz, kernel, device, grad.dtype)
         scratch = torch.empty_like(planes[0, 0])
         block_r, block_c = 8, 128
         grid = (triton.cdiv(nz, block_r), triton.cdiv(total, block_c))
+        norm = None if kernel is None else _border_norm(nz, kernel, device, grad.dtype)
         for index in range(planes.shape[0]):
             plane = planes[index, 0]
-            _blur_axis_fused(plane, scratch, -2, kernel, norm)
-            _blur_rings_kernel[grid](
-                scratch, plane, kernel, cell_ring, num_phi, offsets, nz, total,
-                RADIUS=radius, BLOCK_R=block_r, BLOCK_C=block_c)
+            # Ping-pong between the plane and one scratch plane; the sequence
+            # ends back in the plane whatever subset of passes is active.
+            src, dst = plane, scratch
+            if kernel is not None:
+                _blur_axis_fused(src, dst, -2, kernel, norm)
+                src, dst = dst, src
+                _blur_rings_kernel[grid](
+                    src, dst, kernel, cell_ring, num_phi, offsets, nz, total,
+                    RADIUS=kernel.numel() // 2, BLOCK_R=block_r, BLOCK_C=block_c)
+                src, dst = dst, src
+            if radial_kernel is not None:
+                _blur_radial_kernel[grid](
+                    src, dst, radial_kernel, cell_ring, num_phi, offsets,
+                    nz, total, num_phi.numel(),
+                    RADIUS=radial_kernel.numel() // 2, BLOCK_R=block_r, BLOCK_C=block_c)
+                src, dst = dst, src
+            if src is not plane:
+                plane.copy_(src)
         return grad
 
-    # z pass.
-    norm = _border_norm(nz, kernel, grad.device, grad.dtype).view(1, 1, nz, 1)
-    weight = kernel.view(1, 1, -1, 1)
-    for index in range(planes.shape[0]):
-        plane = planes[index:index + 1]
-        plane.copy_(F.conv2d(plane, weight, padding=(radius, 0)).div_(norm))
-
-    # phi pass, per ring, circular.
     num_phi = ring_num_phi.tolist()
     offsets = ring_offsets.tolist()
-    kernel_1d = kernel.view(1, 1, -1)
     lead = grad.shape[:-2]
-    for ring in range(1, len(num_phi)):
-        n = num_phi[ring]
-        if n < 2:
-            continue
-        start = offsets[ring]
-        cells = grad[..., start:start + n]  # [..., nz, n], a view
-        wrapped = torch.arange(-radius, n + radius, device=grad.device) % n
-        padded = cells[..., wrapped].reshape(-1, 1, n + 2 * radius)
-        cells.copy_(F.conv1d(padded, kernel_1d).view(*lead, nz, n))
+    if kernel is not None:
+        radius = kernel.numel() // 2
+        # z pass.
+        norm = _border_norm(nz, kernel, grad.device, grad.dtype).view(1, 1, nz, 1)
+        weight = kernel.view(1, 1, -1, 1)
+        for index in range(planes.shape[0]):
+            plane = planes[index:index + 1]
+            plane.copy_(F.conv2d(plane, weight, padding=(radius, 0)).div_(norm))
+
+        # phi pass, per ring, circular.
+        kernel_1d = kernel.view(1, 1, -1)
+        for ring in range(1, len(num_phi)):
+            n = num_phi[ring]
+            if n < 2:
+                continue
+            start = offsets[ring]
+            cells = grad[..., start:start + n]  # [..., nz, n], a view
+            wrapped = torch.arange(-radius, n + radius, device=grad.device) % n
+            padded = cells[..., wrapped].reshape(-1, 1, n + 2 * radius)
+            cells.copy_(F.conv1d(padded, kernel_1d).view(*lead, nz, n))
+
+    if radial_kernel is not None:
+        _blur_radial_eager_(grad, num_phi, offsets, radial_kernel)
     return grad
+
+
+def _blur_radial_eager_(grad, num_phi, offsets, kernel):
+    # Reference radial pass (see _blur_radial_kernel): every ring reads the
+    # source rings from an untouched copy, so the pass is one linear operator
+    # and not a sweep.
+    source = grad.clone()
+    radius = kernel.numel() // 2
+    weights = kernel.tolist()
+    num_rings = len(num_phi)
+    for ring in range(1, num_rings):
+        n = num_phi[ring]
+        start = offsets[ring]
+        local = torch.arange(n, device=grad.device, dtype=torch.int64)
+        acc = torch.zeros_like(source[..., start:start + n])
+        wsum = 0.0
+        for k, w in enumerate(weights):
+            src_ring = ring + k - radius
+            if src_ring < 1 or src_ring >= num_rings:
+                continue
+            n_src = num_phi[src_ring]
+            off_src = offsets[src_ring]
+            numerator = local * n_src
+            lo = numerator // n  # < n_src since local < n
+            frac = (numerator - lo * n).to(grad.dtype) / n
+            hi = (lo + 1) % n_src
+            v_lo = source[..., off_src + lo]
+            v_hi = source[..., off_src + hi]
+            acc += w * (v_lo + (v_hi - v_lo) * frac)
+            wsum += w
+        grad[..., start:start + n] = acc / wsum
+    return grad
+
+
+def describe_widths(along_voxels, across_voxels, cell_voxels, spatial_scale_factor,
+                    field_type):
+    """One-line report of the effective smoothing widths per lattice.
+
+    Converts the configured scroll-voxel widths to cells of the high- and
+    low-resolution lattices and says when a kernel collapses to the identity
+    (see gaussian_kernel), so a width that is far below the cell size is
+    visible at startup instead of silently doing nothing.
+    """
+    def per_lattice(voxels):
+        parts = []
+        for name, scale in (('HR', 1), ('LR', spatial_scale_factor)):
+            cells = float(voxels) / (float(cell_voxels) * scale)
+            kernel = gaussian_kernel(cells, dtype=torch.float64)
+            if kernel is None:
+                parts.append(f'{name} {cells:.2f} cells (identity)')
+            else:
+                parts.append(f'{name} {cells:.2f} cells (radius {kernel.numel() // 2})')
+        return ', '.join(parts)
+
+    report = (f'flow gradient smoothing ({field_type}): along-sheet '
+              f'{float(along_voxels):g} voxels = {per_lattice(along_voxels)}')
+    if field_type == 'cylindrical':
+        report += (f'; across rings {float(across_voxels):g} voxels = '
+                   f'{per_lattice(across_voxels)}')
+    elif float(across_voxels) > 0.0:
+        report += ('; across-ring width ignored: a Cartesian lattice is '
+                   'smoothed isotropically at the along-sheet width')
+    return report

--- a/spiral-fitting/flow_grad_smoothing.py
+++ b/spiral-fitting/flow_grad_smoothing.py
@@ -1,21 +1,22 @@
-"""Gaussian smoothing of flow-lattice gradients.
+"""Gaussian preconditioning of flow-lattice gradients.
 
-Smoothing the velocity gradient before the optimizer step is gradient
-descent in a Sobolev metric, the standard preconditioner of diffeomorphic
-registration: the loss and its minima are unchanged, but every update to the
-flow is smooth at the kernel's scale instead of moving each lattice cell
-independently on its own noisy gradient. Both functions smooth in place,
-treat the lattices' leading slab axis (the flow stages) and the vector
-components independently, and renormalise the kernel at lattice borders so a
-constant gradient stays constant.
+This spreads gradient information over neighboring lattice entries without
+adding a loss term. Gaussian update smoothing has precedent in Vercauteren
+et al., Diffeomorphic Demons (2009); smooth velocity metrics appear in Beg
+et al., LDDMM (2005). See README.md, "Rationale and references", for links.
+The discrete blur followed by Adam, clipping and masks is not classical
+Sobolev gradient descent and does not guarantee smooth parameter updates,
+the same fitted solution, or fold-free numerical integration.
 
-Widths are in lattice cells of the lattice being smoothed; the caller
-converts from scroll voxels (see SpiralAndTransform.smooth_flow_grad_).
+Both functions smooth in place, independently for each leading slab and
+vector component. Nonperiodic borders use truncated, renormalised kernels
+so constant gradients stay constant. Widths are in cells of the lattice
+being smoothed; the caller converts from scroll-voxel units of the flow
+frame (see SpiralAndTransform.smooth_flow_grad_).
 
-On a cylindrical lattice the smoothing is anisotropic: one width along the
-sheet (along z and around each ring, which in the flow frame is along the
-model spiral's windings) and a separate, normally much smaller, width across
-rings (across windings). See smooth_cylindrical_.
+Cylindrical smoothing uses separate widths along z/around rings and across
+rings. These coordinate directions approximate along/across-sheet directions;
+they do not track material tangents or detect winding boundaries.
 """
 
 import math
@@ -239,9 +240,10 @@ def smooth_cylindrical_(grad, ring_num_phi, ring_offsets, sigma_cells,
     ``across_sigma_cells`` is the width across rings: each tap reads the
     neighbouring ring at the cell's own angle, linearly interpolated between
     that ring's two nearest cells, with the weights renormalised at the
-    innermost and outermost rings. Ring 0 is the pinned axis cell: it is left
-    alone and never read. Both widths are in cells (the radial spacing, the z
-    spacing and the ring arc length are all one cell). The vector components
+    innermost and outermost rings. The radial pass leaves pinned axis ring 0
+    unchanged and never reads it; the z pass still includes that ring.
+    Widths use nominal lattice-cell spacing (ring arc spacing is approximate
+    because each ring's angular cell count is rounded). The vector components
     are stored in the local (z, radial, tangential) basis, so blurring around
     a ring spreads a radial push as radial pushes at neighbouring angles.
     """

--- a/spiral-fitting/lazy_moment_adamw.py
+++ b/spiral-fitting/lazy_moment_adamw.py
@@ -1,0 +1,105 @@
+"""AdamW with lazy (SparseAdam-style) moments for selected parameter groups."""
+
+import torch
+
+
+# Elements per chunk of the masked update, bounding its temporaries to a
+# fraction of the lattice (the full-scroll high-resolution flow lattice is
+# ~400M values per slab).
+_CHUNK_ELEMENTS = 1 << 26
+
+
+class LazyMomentAdamW(torch.optim.AdamW):
+    """AdamW whose ``lazy_moments`` groups update only where the gradient is nonzero.
+
+    torch.optim.SparseAdam masks the Adam update to the entries a sparse
+    gradient carries: moments and parameters change only there, and untouched
+    entries keep their moments instead of decaying the second moment toward
+    zero (which otherwise makes an entry's first update after a quiet spell
+    disproportionately large). SparseAdam itself requires sparse-layout
+    gradients and its own optimizer instance; the flow lattices' gradients
+    here are dense accumulators that are mostly zero, so this class applies
+    the same masked update to dense gradients, for the groups flagged
+    ``lazy_moments=True``, and leaves every other group to AdamW's fused step.
+
+    State is kept in AdamW's own format (``step``, ``exp_avg``,
+    ``exp_avg_sq``), so checkpoints round-trip with a plain AdamW and the flag
+    can be switched on or off between runs. Decoupled weight decay still
+    applies to every entry of a lazy group (SparseAdam has none).
+    """
+
+    def step(self, closure=None):
+        lazy = []
+        for group in self.param_groups:
+            if not group.get('lazy_moments'):
+                continue
+            if group.get('amsgrad') or group.get('maximize'):
+                raise ValueError('lazy_moments does not support amsgrad or maximize')
+            for param in group['params']:
+                if param.grad is not None:
+                    lazy.append((group, param, param.grad))
+        # Hide the lazy groups' gradients from the fused step, which skips
+        # parameters without one; every other group is stepped as usual.
+        for _, param, _ in lazy:
+            param.grad = None
+        try:
+            loss = super().step(closure)
+        finally:
+            for _, param, grad in lazy:
+                param.grad = grad
+        with torch.no_grad():
+            for group, param, grad in lazy:
+                self._lazy_step(group, param, grad)
+        return loss
+
+    def _init_lazy_state(self, group, param):
+        # Mirror AdamW's lazy state initialisation so a later fused step (the
+        # flag switched off) finds exactly the state it would have created.
+        state = self.state[param]
+        if group.get('fused') or group.get('capturable'):
+            state['step'] = torch.zeros((), dtype=torch.float32, device=param.device)
+        else:
+            dtype = (torch.float64 if torch.get_default_dtype() == torch.float64
+                     else torch.float32)
+            state['step'] = torch.tensor(0.0, dtype=dtype)
+        state['exp_avg'] = torch.zeros_like(param, memory_format=torch.preserve_format)
+        state['exp_avg_sq'] = torch.zeros_like(param, memory_format=torch.preserve_format)
+        return state
+
+    def _lazy_step(self, group, param, grad):
+        state = self.state[param]
+        if len(state) == 0:
+            state = self._init_lazy_state(group, param)
+        state['step'] += 1
+        step = float(state['step'])
+        beta1, beta2 = group['betas']
+        lr = float(group['lr'])
+        eps = float(group['eps'])
+        weight_decay = float(group['weight_decay'])
+        bias_correction1 = 1.0 - beta1 ** step
+        bias_correction2_sqrt = (1.0 - beta2 ** step) ** 0.5
+        step_size = lr / bias_correction1
+        if weight_decay != 0.0:
+            param.mul_(1.0 - lr * weight_decay)
+
+        flat_param = param.view(-1)
+        flat_grad = grad.reshape(-1)
+        flat_avg = state['exp_avg'].view(-1)
+        flat_sq = state['exp_avg_sq'].view(-1)
+        for start in range(0, flat_param.numel(), _CHUNK_ELEMENTS):
+            stop = min(start + _CHUNK_ELEMENTS, flat_param.numel())
+            g = flat_grad[start:stop]
+            avg = flat_avg[start:stop]
+            sq = flat_sq[start:stop]
+            touched = g != 0
+            # Moments move only where the gradient is nonzero.
+            torch.where(touched, torch.lerp(avg, g, 1.0 - beta1), avg, out=avg)
+            torch.where(touched, torch.lerp(sq, g * g, 1.0 - beta2), sq, out=sq)
+            # AdamW's update form (epsilon added after the bias-corrected root,
+            # so a fused step on the same state continues seamlessly; SparseAdam
+            # adds it before, an epsilon-scale difference), masked to the
+            # touched entries.
+            denom = (sq.sqrt() / bias_correction2_sqrt).add_(eps)
+            update = (avg / denom).mul_(step_size)
+            update.masked_fill_(~touched, 0.0)
+            flat_param[start:stop].sub_(update)

--- a/spiral-fitting/lazy_moment_adamw.py
+++ b/spiral-fitting/lazy_moment_adamw.py
@@ -9,6 +9,15 @@ import torch
 _CHUNK_ELEMENTS = 1 << 26
 
 
+def _plane_view(tensor):
+    """``tensor`` as [planes, cells]: one plane per (leading, second) index of a
+    lattice-shaped tensor ([stages, components, *spatial]), or a single plane
+    for anything with fewer than three dimensions."""
+    if tensor.dim() >= 3:
+        return tensor.view(tensor.shape[0] * tensor.shape[1], -1)
+    return tensor.view(1, -1)
+
+
 class LazyMomentAdamW(torch.optim.AdamW):
     """AdamW whose ``lazy_moments`` groups update only where the gradient is nonzero.
 
@@ -22,34 +31,49 @@ class LazyMomentAdamW(torch.optim.AdamW):
     the same masked update to dense gradients, for the groups flagged
     ``lazy_moments=True``, and leaves every other group to AdamW's fused step.
 
+    Groups flagged ``shared_second_moment=True`` (with or without lazy
+    moments) divide by one second moment per plane of the parameter (per
+    flow stage and vector component of a lattice, see _plane_view) instead of
+    one per cell: the mean of the stored per-cell second moments over the
+    cells that have ever been touched. Adam's per-cell denominator turns a
+    spatially smooth gradient into (nearly) its sign field; the shared
+    denominator keeps the gradient's spatial profile in the update, so the
+    flow gradient smoothing (flow_grad_smoothing) shapes the step and not
+    just its sign. The stored second moment stays per cell, and its EMA is
+    linear, so the shared value is exactly the EMA of the mean squared
+    gradient over those cells.
+
     State is kept in AdamW's own format (``step``, ``exp_avg``,
-    ``exp_avg_sq``), so checkpoints round-trip with a plain AdamW and the flag
-    can be switched on or off between runs. Decoupled weight decay still
-    applies to every entry of a lazy group (SparseAdam has none).
+    ``exp_avg_sq``), so checkpoints round-trip with a plain AdamW and both
+    flags can be switched on or off between runs. Decoupled weight decay
+    still applies to every entry of a lazy group (SparseAdam has none).
     """
 
     def step(self, closure=None):
-        lazy = []
+        custom = []
         for group in self.param_groups:
-            if not group.get('lazy_moments'):
+            masked = bool(group.get('lazy_moments'))
+            shared = bool(group.get('shared_second_moment'))
+            if not (masked or shared):
                 continue
             if group.get('amsgrad') or group.get('maximize'):
-                raise ValueError('lazy_moments does not support amsgrad or maximize')
+                raise ValueError(
+                    'lazy_moments / shared_second_moment do not support amsgrad or maximize')
             for param in group['params']:
                 if param.grad is not None:
-                    lazy.append((group, param, param.grad))
-        # Hide the lazy groups' gradients from the fused step, which skips
+                    custom.append((group, param, param.grad, masked, shared))
+        # Hide the custom groups' gradients from the fused step, which skips
         # parameters without one; every other group is stepped as usual.
-        for _, param, _ in lazy:
+        for _, param, _, _, _ in custom:
             param.grad = None
         try:
             loss = super().step(closure)
         finally:
-            for _, param, grad in lazy:
+            for _, param, grad, _, _ in custom:
                 param.grad = grad
         with torch.no_grad():
-            for group, param, grad in lazy:
-                self._lazy_step(group, param, grad)
+            for group, param, grad, masked, shared in custom:
+                self._custom_step(group, param, grad, masked, shared)
         return loss
 
     def _init_lazy_state(self, group, param):
@@ -67,6 +91,11 @@ class LazyMomentAdamW(torch.optim.AdamW):
         return state
 
     def _lazy_step(self, group, param, grad):
+        # Kept for callers of the original entry point: the masked update
+        # with per-cell denominators.
+        self._custom_step(group, param, grad, masked=True, shared=False)
+
+    def _custom_step(self, group, param, grad, masked, shared):
         state = self.state[param]
         if len(state) == 0:
             state = self._init_lazy_state(group, param)
@@ -86,20 +115,61 @@ class LazyMomentAdamW(torch.optim.AdamW):
         flat_grad = grad.reshape(-1)
         flat_avg = state['exp_avg'].view(-1)
         flat_sq = state['exp_avg_sq'].view(-1)
-        for start in range(0, flat_param.numel(), _CHUNK_ELEMENTS):
-            stop = min(start + _CHUNK_ELEMENTS, flat_param.numel())
+        numel = flat_param.numel()
+
+        # Moments first (chunked to bound the temporaries), so a shared
+        # denominator sees every cell's updated second moment.
+        for start in range(0, numel, _CHUNK_ELEMENTS):
+            stop = min(start + _CHUNK_ELEMENTS, numel)
             g = flat_grad[start:stop]
             avg = flat_avg[start:stop]
             sq = flat_sq[start:stop]
-            touched = g != 0
-            # Moments move only where the gradient is nonzero.
-            torch.where(touched, torch.lerp(avg, g, 1.0 - beta1), avg, out=avg)
-            torch.where(touched, torch.lerp(sq, g * g, 1.0 - beta2), sq, out=sq)
-            # AdamW's update form (epsilon added after the bias-corrected root,
-            # so a fused step on the same state continues seamlessly; SparseAdam
-            # adds it before, an epsilon-scale difference), masked to the
-            # touched entries.
-            denom = (sq.sqrt() / bias_correction2_sqrt).add_(eps)
-            update = (avg / denom).mul_(step_size)
-            update.masked_fill_(~touched, 0.0)
-            flat_param[start:stop].sub_(update)
+            if masked:
+                touched = g != 0
+                # Moments move only where the gradient is nonzero.
+                torch.where(touched, torch.lerp(avg, g, 1.0 - beta1), avg, out=avg)
+                torch.where(touched, torch.lerp(sq, g * g, 1.0 - beta2), sq, out=sq)
+            else:
+                avg.lerp_(g, 1.0 - beta1)
+                sq.mul_(beta2).addcmul_(g, g, value=1.0 - beta2)
+
+        if shared:
+            planes = _plane_view(state['exp_avg_sq'])
+            # Mean over the cells ever touched: an untouched cell's second
+            # moment is exactly zero (lazy) or has decayed from zero (plain),
+            # and either way it says nothing about the gradient scale.
+            touched_count = torch.zeros(planes.shape[0], dtype=torch.float64, device=planes.device)
+            total = torch.zeros_like(touched_count)
+            for index in range(planes.shape[0]):
+                row = planes[index]
+                total[index] = row.sum(dtype=torch.float64)
+                touched_count[index] = (row > 0).sum(dtype=torch.float64)
+            shared_sq = total / touched_count.clamp(min=1.0)
+            shared_denom = (shared_sq.sqrt() / bias_correction2_sqrt + eps).to(param.dtype)
+            plane_cells = planes.shape[1]
+        else:
+            shared_denom = None
+            plane_cells = numel
+
+        for plane_start in range(0, numel, plane_cells):
+            denom_scalar = None
+            if shared_denom is not None:
+                denom_scalar = shared_denom[plane_start // plane_cells]
+            for start in range(plane_start, plane_start + plane_cells, _CHUNK_ELEMENTS):
+                stop = min(start + _CHUNK_ELEMENTS, plane_start + plane_cells)
+                g = flat_grad[start:stop]
+                avg = flat_avg[start:stop]
+                sq = flat_sq[start:stop]
+                if denom_scalar is not None:
+                    update = (avg / denom_scalar).mul_(step_size)
+                else:
+                    # AdamW's update form (epsilon added after the bias-corrected
+                    # root, so a fused step on the same state continues
+                    # seamlessly; SparseAdam adds it before, an epsilon-scale
+                    # difference).
+                    denom = (sq.sqrt() / bias_correction2_sqrt).add_(eps)
+                    update = (avg / denom).mul_(step_size)
+                if masked:
+                    # Masked to the touched entries.
+                    update.masked_fill_(g == 0, 0.0)
+                flat_param[start:stop].sub_(update)

--- a/spiral-fitting/lazy_moment_adamw.py
+++ b/spiral-fitting/lazy_moment_adamw.py
@@ -2,10 +2,12 @@
 moment for selected parameter groups, plus robust gradient clipping for the
 flow lattices.
 
-Every statistic here (median |g| for clipping, the winsorisation cap of the
-shared second moment) is read from a fixed-stride subsample of the plane, so
-it is deterministic, identical on every DDP rank, and costs the same at any
-lattice size.
+The clipping median and winsorisation quantile use fixed-stride subsamples
+of roughly bounded size. Identical input gradients and state give every DDP
+rank the same samples; structured sparse support may be missed. The final
+shared mean, clipping, and update diagnostics still scan the full lattice.
+See README.md, "Rationale and references", for SparseAdam, Adam-mini and
+clipping precedents; the grouping and robust threshold rules here are custom.
 """
 
 import math
@@ -49,13 +51,15 @@ def _nan_to_inf(value):
 
 def robust_clip_(grad, multiple):
     """Clip a lattice gradient in place, per stage, at ``multiple`` times the
-    median nonzero |g| of that stage.
+    median nonzero absolute component value of that stage. This is
+    componentwise clipping, not vector-norm clipping, and can change direction.
 
-    The median is read from a fixed-stride subsample of the stage's cells
+    The median is read from a fixed-stride subsample of the stage's entries
     (see STATS_SUBSAMPLE), without any host synchronisation. Returns
     ``(threshold, clipped_fraction)``, two float64 tensors of length
-    ``stages`` on ``grad.device`` (threshold is +inf for a stage with no
-    nonzero gradient), or ``None`` when ``multiple`` is not positive, in
+    ``stages`` on ``grad.device`` (threshold is +inf when the sample has no
+    nonzero entry, even if unsampled entries are active), or ``None`` when
+    ``multiple`` is not positive, in
     which case ``grad`` is untouched.
     """
     if multiple is None or float(multiple) <= 0.0:
@@ -81,50 +85,52 @@ def robust_clip_(grad, multiple):
 
 
 class LazyMomentAdamW(torch.optim.AdamW):
-    """AdamW whose ``lazy_moments`` groups update only where the gradient is nonzero.
+    """AdamW with optional masked moments and shared second-moment scaling.
 
-    torch.optim.SparseAdam masks the Adam update to the entries a sparse
-    gradient carries: moments and parameters change only there, and untouched
-    entries keep their moments instead of decaying the second moment toward
-    zero (which otherwise makes an entry's first update after a quiet spell
-    disproportionately large). SparseAdam itself requires sparse-layout
-    gradients and its own optimizer instance; the flow lattices' gradients
-    here are dense accumulators that are mostly zero, so this class applies
-    the same masked update to dense gradients, for the groups flagged
-    ``lazy_moments=True``, and leaves every other group to AdamW's fused step.
+    ``lazy_moments=True`` applies an explicit ``grad != 0`` mask to dense
+    gradients: only these entries update moments and receive a gradient step.
+    This follows torch.optim.SparseAdam's masked-update idea, although that
+    implementation uses materialized sparse entries as its mask. The fitter
+    passes gradients after clipping, smoothing and influence masks, so active
+    entries need not have been directly sampled. Inactive entries retain
+    history, including stale momentum. A global per-parameter step counter
+    drives bias correction; there are no per-entry touch counters. Lazy
+    moments do not resolve first-touch amplification of tiny gradients.
 
-    Groups flagged ``shared_second_moment=True`` (with or without lazy
-    moments) divide by one second moment per *stage* of the parameter (the
-    leading axis of a lattice, see _stage_view; every vector component of a
-    stage shares it) instead of one per cell. Adam's per-cell denominator
-    turns a spatially smooth gradient into (nearly) its sign field; the
-    shared denominator keeps the gradient's spatial profile in the update, so
-    the flow gradient smoothing (flow_grad_smoothing) shapes the step and not
-    just its sign. Sharing across components as well keeps the update's
-    direction that of the gradient: nearly all supervision pushes radially,
-    and a per-component scale would inflate the weakly constrained z and
-    tangential components to the same step as the radial one.
+    ``shared_second_moment=True`` uses one denominator per leading slab of
+    each parameter (see _stage_view), across all its spatial entries and
+    vector components. Coarse/fine lattices and separate flow-stage parameters
+    do not share denominators. Per-entry Adam scaling can produce nearly
+    sign-sized first updates despite very different gradient magnitudes.
+    A shared denominator preserves relative magnitudes and direction of the
+    first moment before lazy masking and weight decay, not necessarily of
+    the current gradient or the final integrated displacement. Sharing across
+    components avoids independently normalizing weak components upward.
+    Adam-mini motivates blockwise scaling, but does not validate this grouping
+    or its robust aggregation for flow fitting (references in README.md).
 
-    The shared value is a winsorised mean of the stored per-cell second
-    moments over the cells ever touched: the plane is capped at the
-    ``shared_second_moment_clip_quantile`` quantile (default 0.99, read from a
-    fixed-stride subsample) of those cells before averaging, so a handful of
-    cells with persistently huge gradients cannot shrink every other cell's
-    step. Set the group's quantile to ``None`` (or >= 1) for the plain mean,
-    which is exactly the EMA of the mean squared gradient over the touched
-    cells. The stored second moment stays per cell.
+    The shared statistic is the mean of positive stored second-moment entries
+    after capping them at ``shared_second_moment_clip_quantile`` (default
+    0.99), estimated from a fixed-stride sample of positive entries. An empty
+    positive sample disables the cap. ``None`` or a value outside (0, 1)
+    also disables it. Positivity is a proxy for past activity, not an explicit
+    ever-touched mask: decayed values may underflow to zero. With lazy updates
+    or changing support, the uncapped mean need not equal a global-time EMA
+    of the active gradients' mean square. Full per-entry moments remain
+    stored; sharing the denominator does not reduce optimizer-state memory.
 
-    After each step ``conditioning_stats[param]`` holds, for every custom
-    group's parameter: ``scale`` (the shared bias-corrected denominator per
-    stage, or None), ``update_rms`` (root mean square of the nonzero update
-    per stage and component, in parameter units) and ``update_count``
-    (cells updated per stage and component), all as device tensors so
-    reading them is a caller-chosen synchronisation.
+    After a custom step, ``conditioning_stats[param]`` holds device tensors:
+    ``scale`` (the shared bias-corrected denominator per slab, or None),
+    ``update_rms`` (RMS over nonzero gradient updates per slab/component,
+    excluding weight decay), and ``update_count`` (nonzero scalar update
+    entries). Entries retain the last custom-step statistics if both flags
+    are subsequently disabled; they are not fresh diagnostics of fused steps.
 
-    State is kept in AdamW's own format (``step``, ``exp_avg``,
-    ``exp_avg_sq``), so checkpoints round-trip with a plain AdamW and both
-    flags can be switched on or off between runs. Decoupled weight decay
-    still applies to every entry of a lazy group (SparseAdam has none).
+    State uses AdamW's ``step``, ``exp_avg`` and ``exp_avg_sq`` format so
+    flags can be toggled and checkpoints exchanged with plain AdamW.
+    Non-custom groups use AdamW's fused step. Unlike SparseAdam, this class
+    uses AdamW's epsilon placement and applies configured decoupled weight
+    decay to every entry, including those masked out of the gradient step.
     """
 
     def __init__(self, *args, **kwargs):
@@ -179,7 +185,7 @@ class LazyMomentAdamW(torch.optim.AdamW):
 
     @staticmethod
     def _shared_second_moment(exp_avg_sq, quantile):
-        """Winsorised mean of the second moment over touched cells, per stage."""
+        """Winsorised mean over positive second-moment entries, per slab."""
         planes = _stage_view(exp_avg_sq)
         stride = _subsample_stride(planes.shape[1])
         shared_sq = torch.zeros(planes.shape[0], dtype=torch.float64, device=planes.device)
@@ -195,9 +201,9 @@ class LazyMomentAdamW(torch.optim.AdamW):
             count = torch.zeros_like(total)
             for start in range(0, row.numel(), _CHUNK_ELEMENTS):
                 chunk = row[start:start + _CHUNK_ELEMENTS]
-                # An untouched cell's second moment is exactly zero (lazy) or
-                # has decayed from zero (plain); either way it says nothing
-                # about the gradient scale, so only touched cells count.
+                # Exclude zero moments from the scale estimate. This is a
+                # positivity test, not a stored activity mask; previously
+                # active moments can also become zero through underflow.
                 count += (chunk > 0).sum(dtype=torch.float64)
                 if cap is not None:
                     chunk = torch.minimum(chunk, cap)

--- a/spiral-fitting/lazy_moment_adamw.py
+++ b/spiral-fitting/lazy_moment_adamw.py
@@ -1,4 +1,14 @@
-"""AdamW with lazy (SparseAdam-style) moments for selected parameter groups."""
+"""AdamW with lazy (SparseAdam-style) moments and a shared, robust second
+moment for selected parameter groups, plus robust gradient clipping for the
+flow lattices.
+
+Every statistic here (median |g| for clipping, the winsorisation cap of the
+shared second moment) is read from a fixed-stride subsample of the plane, so
+it is deterministic, identical on every DDP rank, and costs the same at any
+lattice size.
+"""
+
+import math
 
 import torch
 
@@ -7,15 +17,67 @@ import torch
 # fraction of the lattice (the full-scroll high-resolution flow lattice is
 # ~400M values per slab).
 _CHUNK_ELEMENTS = 1 << 26
+# Target size of the fixed-stride subsample the robust statistics read.
+STATS_SUBSAMPLE = 1 << 20
+# Default winsorisation quantile of the shared second moment (see
+# LazyMomentAdamW); None or >= 1 disables the cap.
+DEFAULT_CLIP_QUANTILE = 0.99
 
 
-def _plane_view(tensor):
-    """``tensor`` as [planes, cells]: one plane per (leading, second) index of a
+def _subsample_stride(numel):
+    return max(1, int(numel) // STATS_SUBSAMPLE)
+
+
+def _stage_view(tensor):
+    """``tensor`` as [stages, cells]: one plane per leading index of a
     lattice-shaped tensor ([stages, components, *spatial]), or a single plane
     for anything with fewer than three dimensions."""
     if tensor.dim() >= 3:
-        return tensor.view(tensor.shape[0] * tensor.shape[1], -1)
+        return tensor.view(tensor.shape[0], -1)
     return tensor.view(1, -1)
+
+
+def _num_components(tensor):
+    return int(tensor.shape[1]) if tensor.dim() >= 3 else 1
+
+
+def _nan_to_inf(value):
+    # A statistic over an empty subsample is NaN; as a clipping bound that
+    # must read "no bound", never propagate into the parameters.
+    return torch.where(torch.isnan(value), torch.full_like(value, math.inf), value)
+
+
+def robust_clip_(grad, multiple):
+    """Clip a lattice gradient in place, per stage, at ``multiple`` times the
+    median nonzero |g| of that stage.
+
+    The median is read from a fixed-stride subsample of the stage's cells
+    (see STATS_SUBSAMPLE), without any host synchronisation. Returns
+    ``(threshold, clipped_fraction)``, two float64 tensors of length
+    ``stages`` on ``grad.device`` (threshold is +inf for a stage with no
+    nonzero gradient), or ``None`` when ``multiple`` is not positive, in
+    which case ``grad`` is untouched.
+    """
+    if multiple is None or float(multiple) <= 0.0:
+        return None
+    planes = _stage_view(grad)
+    stride = _subsample_stride(planes.shape[1])
+    thresholds = torch.empty(planes.shape[0], dtype=torch.float64, device=grad.device)
+    fractions = torch.zeros_like(thresholds)
+    for index in range(planes.shape[0]):
+        plane = planes[index]
+        sub = plane[::stride]
+        magnitude = torch.where(sub != 0, sub.abs(), torch.full_like(sub, math.nan))
+        threshold = _nan_to_inf(torch.nanmedian(magnitude).to(torch.float64) * float(multiple))
+        bound = threshold.to(plane.dtype)
+        clipped = torch.zeros((), dtype=torch.float64, device=grad.device)
+        for start in range(0, plane.numel(), _CHUNK_ELEMENTS):
+            chunk = plane[start:start + _CHUNK_ELEMENTS]
+            clipped += (chunk.abs() > bound).sum(dtype=torch.float64)
+            chunk.clamp_(min=-bound, max=bound)
+        thresholds[index] = threshold
+        fractions[index] = clipped / plane.numel()
+    return thresholds, fractions
 
 
 class LazyMomentAdamW(torch.optim.AdamW):
@@ -32,22 +94,42 @@ class LazyMomentAdamW(torch.optim.AdamW):
     ``lazy_moments=True``, and leaves every other group to AdamW's fused step.
 
     Groups flagged ``shared_second_moment=True`` (with or without lazy
-    moments) divide by one second moment per plane of the parameter (per
-    flow stage and vector component of a lattice, see _plane_view) instead of
-    one per cell: the mean of the stored per-cell second moments over the
-    cells that have ever been touched. Adam's per-cell denominator turns a
-    spatially smooth gradient into (nearly) its sign field; the shared
-    denominator keeps the gradient's spatial profile in the update, so the
-    flow gradient smoothing (flow_grad_smoothing) shapes the step and not
-    just its sign. The stored second moment stays per cell, and its EMA is
-    linear, so the shared value is exactly the EMA of the mean squared
-    gradient over those cells.
+    moments) divide by one second moment per *stage* of the parameter (the
+    leading axis of a lattice, see _stage_view; every vector component of a
+    stage shares it) instead of one per cell. Adam's per-cell denominator
+    turns a spatially smooth gradient into (nearly) its sign field; the
+    shared denominator keeps the gradient's spatial profile in the update, so
+    the flow gradient smoothing (flow_grad_smoothing) shapes the step and not
+    just its sign. Sharing across components as well keeps the update's
+    direction that of the gradient: nearly all supervision pushes radially,
+    and a per-component scale would inflate the weakly constrained z and
+    tangential components to the same step as the radial one.
+
+    The shared value is a winsorised mean of the stored per-cell second
+    moments over the cells ever touched: the plane is capped at the
+    ``shared_second_moment_clip_quantile`` quantile (default 0.99, read from a
+    fixed-stride subsample) of those cells before averaging, so a handful of
+    cells with persistently huge gradients cannot shrink every other cell's
+    step. Set the group's quantile to ``None`` (or >= 1) for the plain mean,
+    which is exactly the EMA of the mean squared gradient over the touched
+    cells. The stored second moment stays per cell.
+
+    After each step ``conditioning_stats[param]`` holds, for every custom
+    group's parameter: ``scale`` (the shared bias-corrected denominator per
+    stage, or None), ``update_rms`` (root mean square of the nonzero update
+    per stage and component, in parameter units) and ``update_count``
+    (cells updated per stage and component), all as device tensors so
+    reading them is a caller-chosen synchronisation.
 
     State is kept in AdamW's own format (``step``, ``exp_avg``,
     ``exp_avg_sq``), so checkpoints round-trip with a plain AdamW and both
     flags can be switched on or off between runs. Decoupled weight decay
     still applies to every entry of a lazy group (SparseAdam has none).
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.conditioning_stats = {}
 
     def step(self, closure=None):
         custom = []
@@ -95,6 +177,34 @@ class LazyMomentAdamW(torch.optim.AdamW):
         # with per-cell denominators.
         self._custom_step(group, param, grad, masked=True, shared=False)
 
+    @staticmethod
+    def _shared_second_moment(exp_avg_sq, quantile):
+        """Winsorised mean of the second moment over touched cells, per stage."""
+        planes = _stage_view(exp_avg_sq)
+        stride = _subsample_stride(planes.shape[1])
+        shared_sq = torch.zeros(planes.shape[0], dtype=torch.float64, device=planes.device)
+        winsorise = quantile is not None and 0.0 < float(quantile) < 1.0
+        for index in range(planes.shape[0]):
+            row = planes[index]
+            cap = None
+            if winsorise:
+                sub = row[::stride].to(torch.float64)
+                touched_sub = torch.where(sub > 0, sub, torch.full_like(sub, math.nan))
+                cap = _nan_to_inf(torch.nanquantile(touched_sub, float(quantile))).to(row.dtype)
+            total = torch.zeros((), dtype=torch.float64, device=planes.device)
+            count = torch.zeros_like(total)
+            for start in range(0, row.numel(), _CHUNK_ELEMENTS):
+                chunk = row[start:start + _CHUNK_ELEMENTS]
+                # An untouched cell's second moment is exactly zero (lazy) or
+                # has decayed from zero (plain); either way it says nothing
+                # about the gradient scale, so only touched cells count.
+                count += (chunk > 0).sum(dtype=torch.float64)
+                if cap is not None:
+                    chunk = torch.minimum(chunk, cap)
+                total += chunk.sum(dtype=torch.float64)
+            shared_sq[index] = total / count.clamp(min=1.0)
+        return shared_sq
+
     def _custom_step(self, group, param, grad, masked, shared):
         state = self.state[param]
         if len(state) == 0:
@@ -133,43 +243,47 @@ class LazyMomentAdamW(torch.optim.AdamW):
                 avg.lerp_(g, 1.0 - beta1)
                 sq.mul_(beta2).addcmul_(g, g, value=1.0 - beta2)
 
-        if shared:
-            planes = _plane_view(state['exp_avg_sq'])
-            # Mean over the cells ever touched: an untouched cell's second
-            # moment is exactly zero (lazy) or has decayed from zero (plain),
-            # and either way it says nothing about the gradient scale.
-            touched_count = torch.zeros(planes.shape[0], dtype=torch.float64, device=planes.device)
-            total = torch.zeros_like(touched_count)
-            for index in range(planes.shape[0]):
-                row = planes[index]
-                total[index] = row.sum(dtype=torch.float64)
-                touched_count[index] = (row > 0).sum(dtype=torch.float64)
-            shared_sq = total / touched_count.clamp(min=1.0)
-            shared_denom = (shared_sq.sqrt() / bias_correction2_sqrt + eps).to(param.dtype)
-            plane_cells = planes.shape[1]
-        else:
-            shared_denom = None
-            plane_cells = numel
+        stages = _stage_view(param).shape[0]
+        components = _num_components(param)
+        cells = numel // (stages * components)
 
-        for plane_start in range(0, numel, plane_cells):
-            denom_scalar = None
-            if shared_denom is not None:
-                denom_scalar = shared_denom[plane_start // plane_cells]
-            for start in range(plane_start, plane_start + plane_cells, _CHUNK_ELEMENTS):
-                stop = min(start + _CHUNK_ELEMENTS, plane_start + plane_cells)
-                g = flat_grad[start:stop]
-                avg = flat_avg[start:stop]
-                sq = flat_sq[start:stop]
-                if denom_scalar is not None:
-                    update = (avg / denom_scalar).mul_(step_size)
-                else:
-                    # AdamW's update form (epsilon added after the bias-corrected
-                    # root, so a fused step on the same state continues
-                    # seamlessly; SparseAdam adds it before, an epsilon-scale
-                    # difference).
-                    denom = (sq.sqrt() / bias_correction2_sqrt).add_(eps)
-                    update = (avg / denom).mul_(step_size)
-                if masked:
-                    # Masked to the touched entries.
-                    update.masked_fill_(g == 0, 0.0)
-                flat_param[start:stop].sub_(update)
+        shared_denom = None
+        if shared:
+            shared_sq = self._shared_second_moment(
+                state['exp_avg_sq'],
+                group.get('shared_second_moment_clip_quantile', DEFAULT_CLIP_QUANTILE))
+            shared_denom = (shared_sq.sqrt() / bias_correction2_sqrt + eps).to(param.dtype)
+
+        update_sumsq = torch.zeros(stages, components, dtype=torch.float64, device=param.device)
+        update_count = torch.zeros_like(update_sumsq)
+        for stage in range(stages):
+            denom_scalar = None if shared_denom is None else shared_denom[stage]
+            for component in range(components):
+                base = (stage * components + component) * cells
+                for start in range(base, base + cells, _CHUNK_ELEMENTS):
+                    stop = min(start + _CHUNK_ELEMENTS, base + cells)
+                    g = flat_grad[start:stop]
+                    avg = flat_avg[start:stop]
+                    sq = flat_sq[start:stop]
+                    if denom_scalar is not None:
+                        update = (avg / denom_scalar).mul_(step_size)
+                    else:
+                        # AdamW's update form (epsilon added after the
+                        # bias-corrected root, so a fused step on the same
+                        # state continues seamlessly; SparseAdam adds it
+                        # before, an epsilon-scale difference).
+                        denom = (sq.sqrt() / bias_correction2_sqrt).add_(eps)
+                        update = (avg / denom).mul_(step_size)
+                    if masked:
+                        # Masked to the touched entries.
+                        update.masked_fill_(g == 0, 0.0)
+                    update_sumsq[stage, component] += torch.linalg.vector_norm(
+                        update, dtype=torch.float64) ** 2
+                    update_count[stage, component] += (update != 0).sum(dtype=torch.float64)
+                    flat_param[start:stop].sub_(update)
+
+        self.conditioning_stats[param] = {
+            'scale': None if shared_denom is None else shared_denom.to(torch.float64),
+            'update_rms': (update_sumsq / update_count.clamp(min=1.0)).sqrt(),
+            'update_count': update_count,
+        }

--- a/spiral-fitting/tests/test_flow_grad_smoothing.py
+++ b/spiral-fitting/tests/test_flow_grad_smoothing.py
@@ -605,6 +605,15 @@ def test_new_optimizer_keys_are_run_boundary_and_off_by_default():
         assert fields[key]['runtime_impact'] == 'run_boundary'
         assert defaults[key] == default
         assert 'description' in fields[key]
+    # The low-res LR scale is a model_ key like the high-res scale it sits
+    # beside, so it shares that key's classification and rebuild stage.
+    low_res_lr = 'model_flow_field_low_res_lr_scale'
+    high_res_lr = 'model_flow_field_high_res_lr_scale_initial'
+    assert fields[low_res_lr]['type'] == 'number'
+    assert defaults[low_res_lr] == 1.0
+    assert 'description' in fields[low_res_lr]
+    assert fields[low_res_lr]['runtime_impact'] == fields[high_res_lr]['runtime_impact']
+    assert fields[low_res_lr].get('rebuild_stage') == fields[high_res_lr].get('rebuild_stage')
     # All postdate durable checkpoints: a checkpoint without them loads as
     # if they were off (the quantile only matters with the shared moment on).
     from config import BACKFILLABLE_CONFIG_DEFAULTS
@@ -613,6 +622,7 @@ def test_new_optimizer_keys_are_run_boundary_and_off_by_default():
     assert BACKFILLABLE_CONFIG_DEFAULTS[low_res] == 0.0
     assert BACKFILLABLE_CONFIG_DEFAULTS[quantile] == 0.99
     assert BACKFILLABLE_CONFIG_DEFAULTS[clip] == 0.0
+    assert BACKFILLABLE_CONFIG_DEFAULTS[low_res_lr] == 1.0
 
 
 cuda = pytest.mark.skipif(

--- a/spiral-fitting/tests/test_flow_grad_smoothing.py
+++ b/spiral-fitting/tests/test_flow_grad_smoothing.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import flow_grad_smoothing
 from config import Config
 from flow_fields import CartesianFlowField, CylindricalFlowField
-from lazy_moment_adamw import LazyMomentAdamW
+from lazy_moment_adamw import LazyMomentAdamW, robust_clip_
 from transforms import SpiralAndTransform
 
 
@@ -136,6 +136,12 @@ def test_field_smooth_grad_scales_width_for_the_low_res_lattice(kind, monkeypatc
     expected = [(0.5,), (2.0,)] if kind == 'cartesian' else [(0.5, 0.25), (2.0, 1.0)]
     assert [widths for _, widths in seen] == expected
     assert seen[0][0] == field.flows[0].shape and seen[1][0] == field.flows[1].shape
+    # A low-res width of its own replaces the shared along-sheet width on the
+    # coarse lattice only; the across-ring width still scales as before.
+    seen.clear()
+    field.smooth_grad_(2.0, 1.0, 8.0)
+    expected = [(2.0,), (2.0,)] if kind == 'cartesian' else [(2.0, 0.25), (2.0, 1.0)]
+    assert [widths for _, widths in seen] == expected
     # Untouched lattices (no gradient) are skipped.
     field.flows[0].grad = None
     seen.clear()
@@ -159,11 +165,12 @@ def test_model_converts_voxels_to_cells():
     seen = []
     # Every flow stage module receives the converted widths.
     for flow_field in model.flow_fields:
-        flow_field.smooth_grad_ = lambda sigma, across: seen.append((sigma, across))
+        flow_field.smooth_grad_ = lambda sigma, across, low_res: seen.append((sigma, across, low_res))
     model.smooth_flow_grad_(40.0)
     model.smooth_flow_grad_(40.0, 8.0)
+    model.smooth_flow_grad_(40.0, 8.0, 160.0)
     assert len(model.flow_fields) == 2
-    assert seen == [(2.5, 0.0)] * 2 + [(2.5, 0.5)] * 2
+    assert seen == [(2.5, 0.0, 0.0)] * 2 + [(2.5, 0.5, 0.0)] * 2 + [(2.5, 0.5, 10.0)] * 2
     # The startup report converts the same way and names identity kernels.
     report = model.describe_flow_grad_smoothing(6.0, 0.0)
     assert report.startswith('flow gradient smoothing (cartesian): along-sheet 6 voxels')
@@ -176,6 +183,14 @@ def test_model_converts_voxels_to_cells():
 def test_describe_widths_reports_both_directions_for_cylindrical_lattices():
     report = flow_grad_smoothing.describe_widths(96.0, 16.0, 16.0, 6, 'cylindrical')
     assert 'along-sheet 96 voxels = HR 6.00 cells (radius 18), LR 1.00 cells (radius 3)' in report
+    assert 'across rings 16 voxels = HR 1.00 cells (radius 3), LR 0.17 cells (identity)' in report
+
+
+def test_describe_widths_reports_the_low_res_lattices_own_width():
+    report = flow_grad_smoothing.describe_widths(
+        96.0, 16.0, 16.0, 6, 'cylindrical', low_res_along_voxels=288.0)
+    assert 'along-sheet 96 voxels (LR 288 voxels) = HR 6.00 cells (radius 18), LR 3.00 cells (radius 9)' in report
+    # The across-ring width is unaffected.
     assert 'across rings 16 voxels = HR 1.00 cells (radius 3), LR 0.17 cells (identity)' in report
 
 
@@ -342,10 +357,11 @@ def test_lazy_step_with_no_state_and_first_touch_matches_sparse_adam():
     assert float(param.detach()[0]) == 0.0
 
 
-def _reference_shared_step(param, grad, state, lr, betas, eps, masked):
+def _reference_shared_step(param, grad, state, lr, betas, eps, masked, quantile=None):
     # Plain-torch reference of the shared-denominator step on a [S, C, ...]
-    # parameter: per-cell EMA moments, one denominator per (S, C) plane from
-    # the mean second moment over cells with a nonzero second moment.
+    # parameter: per-cell EMA moments, one denominator per stage S (shared by
+    # its C components) from the mean second moment over cells with a
+    # nonzero second moment, capped at the given quantile of those cells.
     beta1, beta2 = betas
     state['step'] += 1
     step = state['step']
@@ -353,10 +369,16 @@ def _reference_shared_step(param, grad, state, lr, betas, eps, masked):
     state['exp_avg'] = torch.where(touched, torch.lerp(state['exp_avg'], grad, 1 - beta1), state['exp_avg'])
     state['exp_avg_sq'] = torch.where(touched, torch.lerp(state['exp_avg_sq'], grad * grad, 1 - beta2), state['exp_avg_sq'])
     sq = state['exp_avg_sq']
-    planes = sq.reshape(sq.shape[0] * sq.shape[1], -1)
+    planes = sq.reshape(sq.shape[0], -1)
     ever = planes > 0
-    mean_sq = planes.sum(1) / ever.sum(1).clamp(min=1)
-    denom = (mean_sq.sqrt() / (1 - beta2 ** step) ** 0.5 + eps).view(sq.shape[0], sq.shape[1], *([1] * (sq.dim() - 2)))
+    capped = planes
+    if quantile is not None:
+        caps = torch.stack([
+            torch.quantile(row[row > 0].double(), quantile) if (row > 0).any() else torch.tensor(math.inf, dtype=torch.float64)
+            for row in planes]).to(planes.dtype)
+        capped = torch.minimum(planes, caps[:, None])
+    mean_sq = capped.sum(1) / ever.sum(1).clamp(min=1)
+    denom = (mean_sq.sqrt() / (1 - beta2 ** step) ** 0.5 + eps).view(sq.shape[0], *([1] * (sq.dim() - 1)))
     update = state['exp_avg'] / denom * (lr / (1 - beta1 ** step))
     update = torch.where(touched, update, torch.zeros_like(update))
     return param - update
@@ -372,12 +394,13 @@ def test_shared_second_moment_matches_reference_and_keeps_adamw_state(masked):
     optimiser = LazyMomentAdamW([{
         'params': [param], 'weight_decay': 0.0,
         'lazy_moments': masked, 'shared_second_moment': True,
+        'shared_second_moment_clip_quantile': None,
     }], lr=lr, betas=betas, eps=eps)
     ref_state = {'step': 0, 'exp_avg': torch.zeros_like(ref), 'exp_avg_sq': torch.zeros_like(ref)}
     for _ in range(6):
         grad = _sparse_pattern(param.shape, 0.4, generator)
-        # Plane (1, 2) never receives gradient: its denominator falls back to
-        # epsilon and its (zero) first moment keeps it exactly still.
+        # Component (1, 2) never receives gradient: it shares stage 1's
+        # denominator, but its (zero) first moment keeps it exactly still.
         grad[1, 2] = 0.0
         param.grad = grad.clone()
         optimiser.step()
@@ -400,7 +423,7 @@ def test_shared_second_moment_matches_reference_and_keeps_adamw_state(masked):
 
 
 def test_shared_second_moment_keeps_the_gradient_profile_and_is_per_plane():
-    # A smooth gradient profile on two planes, the second ten times larger.
+    # A smooth gradient profile on two stages, the second ten times larger.
     torch.manual_seed(8)
     profile = torch.exp(-0.5 * ((torch.arange(9.0) - 4.0) / 1.5) ** 2)
     grad = torch.stack([profile, 10.0 * profile])[:, None, :].expand(2, 2, 9).clone()
@@ -428,7 +451,7 @@ def test_shared_second_moment_keeps_the_gradient_profile_and_is_per_plane():
 
 
 def test_shared_second_moment_equals_per_cell_for_uniform_gradients():
-    # Every cell of a plane carrying the same gradient makes the mean second
+    # Every cell of a stage carrying the same gradient makes the mean second
     # moment equal to each cell's own, so the two denominators coincide.
     torch.manual_seed(9)
     generator = torch.Generator().manual_seed(10)
@@ -437,17 +460,111 @@ def test_shared_second_moment_equals_per_cell_for_uniform_gradients():
     a = LazyMomentAdamW([{'params': [shared], 'lazy_moments': True, 'shared_second_moment': True}], lr=1e-2)
     b = LazyMomentAdamW([{'params': [cellwise], 'lazy_moments': True}], lr=1e-2)
     for _ in range(5):
-        per_plane = torch.randn(2, 3, 1, 1, generator=generator)
-        shared.grad = per_plane.expand(2, 3, 4, 4).clone()
+        per_stage = torch.randn(2, 1, 1, 1, generator=generator)
+        shared.grad = per_stage.expand(2, 3, 4, 4).clone()
         cellwise.grad = shared.grad.clone()
         a.step()
         b.step()
         torch.testing.assert_close(shared, cellwise, rtol=1e-6, atol=1e-8)
 
 
+def test_shared_second_moment_is_one_scale_per_stage_across_components():
+    # Components of one stage with gradients of very different size share a
+    # denominator, so the update keeps the gradient's direction instead of
+    # inflating the weak components to the strong one's step.
+    param = torch.nn.Parameter(torch.zeros(1, 3, 4))
+    optimiser = LazyMomentAdamW([{
+        'params': [param], 'shared_second_moment': True,
+        'shared_second_moment_clip_quantile': None}], lr=0.1)
+    param.grad = torch.tensor([[[10.0] * 4, [1.0] * 4, [0.1] * 4]])
+    optimiser.step()
+    update = -param.detach()[0]
+    torch.testing.assert_close(update[0] / update[1], torch.full((4,), 10.0), rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(update[1] / update[2], torch.full((4,), 10.0), rtol=1e-5, atol=1e-6)
+    stats = optimiser.conditioning_stats[param]
+    assert stats['scale'].shape == (1,)
+    assert stats['update_rms'].shape == (1, 3) and stats['update_count'].shape == (1, 3)
+    torch.testing.assert_close(stats['update_rms'][0], update.abs()[:, 0].double(), rtol=1e-6, atol=1e-9)
+    assert stats['update_count'].tolist() == [[4.0, 4.0, 4.0]]
+
+
+def test_shared_second_moment_winsorises_outlier_cells():
+    # One cell with a huge gradient: the plain mean would let it dominate the
+    # shared scale; the winsorised mean caps it at the quantile of the touched
+    # cells, so the other cells' step barely notices it.
+    param = torch.nn.Parameter(torch.zeros(1, 1, 200))
+    grad = torch.ones(1, 1, 200)
+    grad[0, 0, 7] = 1000.0
+    lr, beta2, eps = 0.1, 0.999, 1e-8
+    optimiser = LazyMomentAdamW([{
+        'params': [param], 'shared_second_moment': True,
+        'shared_second_moment_clip_quantile': 0.99}], lr=lr, eps=eps)
+    param.grad = grad.clone()
+    optimiser.step()
+    sq = grad ** 2 * (1 - beta2)
+    cap = torch.quantile(sq.flatten().double(), 0.99).float()
+    mean_sq = torch.minimum(sq, cap).mean()
+    denom = mean_sq.sqrt() / (1 - beta2) ** 0.5 + eps
+    expected = -lr * grad / denom
+    torch.testing.assert_close(param.detach(), expected, rtol=1e-5, atol=1e-7)
+    # Without the cap the outlier's 10^6 squared gradient shrinks every step
+    # by two orders of magnitude.
+    plain = torch.nn.Parameter(torch.zeros(1, 1, 200))
+    reference = LazyMomentAdamW([{
+        'params': [plain], 'shared_second_moment': True,
+        'shared_second_moment_clip_quantile': None}], lr=lr, eps=eps)
+    plain.grad = grad.clone()
+    reference.step()
+    assert float(plain.detach()[0, 0, 0].abs()) < 0.02 * float(param.detach()[0, 0, 0].abs())
+    # Untouched cells do not enter the statistic (or the count).
+    stats = optimiser.conditioning_stats[param]
+    assert stats['update_count'].tolist() == [[200.0]]
+
+
+def test_robust_clip_bounds_spikes_per_stage_and_reports_them():
+    grad = torch.zeros(2, 3, 50)
+    grad[0, 0] = 1.0
+    grad[0, 1, ::2] = -1.0
+    grad[0, 2, 5] = 500.0        # the spike, in a stage whose median |g| is 1
+    grad[1, 0] = 0.01           # a much smaller stage keeps its own median
+    grad[1, 1, 3] = 5.0
+    reference = grad.clone()
+    threshold, fraction = robust_clip_(grad, 10.0)
+    torch.testing.assert_close(threshold, torch.tensor([10.0, 0.1], dtype=torch.float64), rtol=1e-6, atol=0)
+    torch.testing.assert_close(grad[0, 2, 5], torch.tensor(10.0))
+    torch.testing.assert_close(grad[1, 1, 3], torch.tensor(0.1))
+    # Everything else, zeros included, is untouched.
+    mask = torch.ones_like(grad, dtype=torch.bool)
+    mask[0, 2, 5] = False
+    mask[1, 1, 3] = False
+    assert torch.equal(grad[mask], reference[mask])
+    torch.testing.assert_close(fraction, torch.tensor([1 / 150, 1 / 150], dtype=torch.float64))
+    # A stage with no gradient at all gets an infinite threshold and is left
+    # alone; a non-positive multiple is a no-op returning None.
+    empty = torch.zeros(1, 3, 8)
+    threshold, fraction = robust_clip_(empty, 10.0)
+    assert threshold.tolist() == [math.inf] and fraction.tolist() == [0.0]
+    untouched = torch.randn(1, 3, 8)
+    copy = untouched.clone()
+    assert robust_clip_(untouched, 0.0) is None and torch.equal(untouched, copy)
+
+
+def test_robust_clip_reads_a_fixed_stride_subsample():
+    # The median comes from a fixed-stride subsample, so a plane larger than
+    # the subsample target still gets the median of its (uniform) cells.
+    from lazy_moment_adamw import STATS_SUBSAMPLE
+    grad = torch.ones(1, 1, STATS_SUBSAMPLE * 3 + 17)
+    grad[0, 0, 100] = 1e6
+    threshold, _ = robust_clip_(grad, 4.0)
+    assert threshold.tolist() == [4.0]
+    assert float(grad.max()) == 4.0
+
+
 def test_shared_second_moment_on_a_vector_is_one_plane():
     param = torch.nn.Parameter(torch.zeros(6))
-    optimiser = LazyMomentAdamW([{'params': [param], 'shared_second_moment': True}], lr=0.1)
+    optimiser = LazyMomentAdamW([{
+        'params': [param], 'shared_second_moment': True,
+        'shared_second_moment_clip_quantile': None}], lr=0.1)
     param.grad = torch.tensor([1.0, 2.0, 3.0, 0.0, 0.0, 0.0])
     optimiser.step()
     # mean second moment over the three touched cells: (1 + 4 + 9) / 3 * (1 - beta2)
@@ -480,11 +597,22 @@ def test_new_optimizer_keys_are_run_boundary_and_off_by_default():
     assert fields[shared]['runtime_impact'] == 'run_boundary'
     assert defaults[shared] is False
     assert 'description' in fields[across] and 'description' in fields[shared]
-    # Both postdate durable checkpoints: a checkpoint without them loads as
-    # if they were off.
+    low_res = 'optimizer_flow_grad_smoothing_low_res_sigma_voxels'
+    quantile = 'optimizer_flow_shared_second_moment_clip_quantile'
+    clip = 'optimizer_flow_grad_clip_median_multiple'
+    for key, default in ((low_res, 0.0), (quantile, 0.99), (clip, 0.0)):
+        assert fields[key]['type'] == 'number'
+        assert fields[key]['runtime_impact'] == 'run_boundary'
+        assert defaults[key] == default
+        assert 'description' in fields[key]
+    # All postdate durable checkpoints: a checkpoint without them loads as
+    # if they were off (the quantile only matters with the shared moment on).
     from config import BACKFILLABLE_CONFIG_DEFAULTS
     assert BACKFILLABLE_CONFIG_DEFAULTS[across] == 0.0
     assert BACKFILLABLE_CONFIG_DEFAULTS[shared] is False
+    assert BACKFILLABLE_CONFIG_DEFAULTS[low_res] == 0.0
+    assert BACKFILLABLE_CONFIG_DEFAULTS[quantile] == 0.99
+    assert BACKFILLABLE_CONFIG_DEFAULTS[clip] == 0.0
 
 
 cuda = pytest.mark.skipif(

--- a/spiral-fitting/tests/test_flow_grad_smoothing.py
+++ b/spiral-fitting/tests/test_flow_grad_smoothing.py
@@ -2,11 +2,13 @@
 
 Both are optional run-boundary optimizer settings, off by default. Covers:
 the separable Cartesian blur against a dense 3-D reference, border
-renormalisation, slab and component independence, the cylindrical z and
-circular-ring passes, the model-level width conversion; LazyMomentAdamW
-against torch.optim.SparseAdam on sparse gradients and against plain AdamW
-for non-lazy groups, including toggling the flag between steps and
-checkpoint round-trips; and the config classification of the new keys.
+renormalisation, slab and component independence, the cylindrical z,
+circular-ring and across-ring passes (fused against eager), the model-level
+width conversion and the startup width report; LazyMomentAdamW against
+torch.optim.SparseAdam on sparse gradients and against plain AdamW for
+non-lazy groups, including toggling the flag between steps and checkpoint
+round-trips, and its shared (per-plane) second moment; and the config
+classification of the new keys.
 """
 
 import math
@@ -124,12 +126,15 @@ def test_field_smooth_grad_scales_width_for_the_low_res_lattice(kind, monkeypatc
     original = getattr(flow_grad_smoothing, target)
 
     def recording(grad, *args):
-        seen.append((grad.shape, args[-1]))
+        # Cartesian: (sigma,); cylindrical: (num_phi, offsets, sigma, across).
+        widths = args[-1:] if kind == 'cartesian' else args[-2:]
+        seen.append((grad.shape, widths))
         return original(grad, *args)
 
     monkeypatch.setattr(flow_grad_smoothing, target, recording)
-    field.smooth_grad_(2.0)
-    assert [sigma for _, sigma in seen] == [0.5, 2.0]
+    field.smooth_grad_(2.0, 1.0)
+    expected = [(0.5,), (2.0,)] if kind == 'cartesian' else [(0.5, 0.25), (2.0, 1.0)]
+    assert [widths for _, widths in seen] == expected
     assert seen[0][0] == field.flows[0].shape and seen[1][0] == field.flows[1].shape
     # Untouched lattices (no gradient) are skipped.
     field.flows[0].grad = None
@@ -152,12 +157,95 @@ def test_model_converts_voxels_to_cells():
         flow_max_corner_zyx=torch.tensor([48, 48, 48]),
         umbilicus_zyx=torch.zeros(48, 3), config=config)
     seen = []
-    # Every flow stage module receives the converted width.
+    # Every flow stage module receives the converted widths.
     for flow_field in model.flow_fields:
-        flow_field.smooth_grad_ = lambda sigma: seen.append(sigma)
+        flow_field.smooth_grad_ = lambda sigma, across: seen.append((sigma, across))
     model.smooth_flow_grad_(40.0)
+    model.smooth_flow_grad_(40.0, 8.0)
     assert len(model.flow_fields) == 2
-    assert seen == [2.5, 2.5]
+    assert seen == [(2.5, 0.0)] * 2 + [(2.5, 0.5)] * 2
+    # The startup report converts the same way and names identity kernels.
+    report = model.describe_flow_grad_smoothing(6.0, 0.0)
+    assert report.startswith('flow gradient smoothing (cartesian): along-sheet 6 voxels')
+    assert 'HR 0.38 cells (radius 2)' in report
+    assert 'LR 0.06 cells (identity)' in report
+    assert 'across' not in report
+    assert 'ignored' in model.describe_flow_grad_smoothing(6.0, 16.0)
+
+
+def test_describe_widths_reports_both_directions_for_cylindrical_lattices():
+    report = flow_grad_smoothing.describe_widths(96.0, 16.0, 16.0, 6, 'cylindrical')
+    assert 'along-sheet 96 voxels = HR 6.00 cells (radius 18), LR 1.00 cells (radius 3)' in report
+    assert 'across rings 16 voxels = HR 1.00 cells (radius 3), LR 0.17 cells (identity)' in report
+
+
+def test_cylindrical_radial_pass_spreads_across_rings_at_the_same_angle():
+    num_phi, offsets = _cylinder_tables(7)
+    nz = 5
+    grad = torch.zeros(2, 3, nz, offsets[-1])
+    ring, start = 3, offsets[3]
+    grad[1, 1, 2, start] = 1.0  # angle 0 on ring 3
+    grad[..., :1] = 5.0  # ring 0 (the pinned axis cell) must not change
+    # Along-sheet width 0 isolates the radial pass.
+    flow_grad_smoothing.smooth_cylindrical_(grad, num_phi, offsets, 0.0, 1.0)
+    torch.testing.assert_close(grad[..., 0], torch.full_like(grad[..., 0], 5.0))
+    # Other slabs, components and z rows untouched.
+    assert float(grad[0, :, :, 1:].abs().sum()) == 0.0
+    assert float(grad[1, [0, 2], :, 1:].abs().sum()) == 0.0
+    assert float(grad[1, 1, [0, 1, 3, 4], 1:].abs().sum()) == 0.0
+    row = grad[1, 1, 2]
+    kernel = flow_grad_smoothing.gaussian_kernel(1.0).tolist()
+    radius = len(kernel) // 2
+
+    def expected(dst_ring):
+        # Ring dst reads ring 3 with the weight of tap (3 - dst), renormalised
+        # over the taps that land on rings 1..6.
+        valid = [kernel[k + radius] for k in range(-radius, radius + 1)
+                 if 1 <= dst_ring + k < len(num_phi)]
+        return kernel[(3 - dst_ring) + radius] / sum(valid)
+
+    for dst_ring in range(1, 7):
+        n = num_phi[dst_ring]
+        cells = row[offsets[dst_ring]:offsets[dst_ring] + n]
+        # Angle 0 falls exactly on cell 0 of every ring, so cell 0 reads the
+        # delta with its full tap weight.
+        assert float(cells[0]) == pytest.approx(expected(dst_ring), rel=1e-5)
+        for i in range(1, n):
+            # A cell at angle i/n reads ring 3 at position i/n * 19; only
+            # positions within one source cell of 0 (either way round) see
+            # the delta, through the linear interpolation.
+            position = i / n * num_phi[ring]
+            if position < 1.0 or position > num_phi[ring] - 1:
+                assert float(cells[i]) > 0.0
+            else:
+                assert float(cells[i]) == 0.0
+    # Off-cell angles interpolate between a ring's two nearest cells.
+    grad = torch.zeros(1, 1, 1, offsets[-1])
+    grad[0, 0, 0, offsets[2] + 1] = 1.0  # ring 2 (13 cells), angle 1/13 turn
+    flow_grad_smoothing.smooth_cylindrical_(grad, num_phi, offsets, 0.0, 1.0)
+    ring3 = grad[0, 0, 0, offsets[3]:offsets[3] + num_phi[3]]  # 19 cells
+    # Ring 3's cells 1 (1/19) and 2 (2/19) straddle 1/13 of a turn.
+    assert float(ring3[1]) > 0.0 and float(ring3[2]) > 0.0
+    assert float(ring3[[0, 3]].abs().sum()) == 0.0
+    # A constant plane stays constant with both widths active (border
+    # renormalisation and the angular interpolation are both affine-exact).
+    constant = torch.full((1, 3, nz, offsets[-1]), 1.5)
+    flow_grad_smoothing.smooth_cylindrical_(constant, num_phi, offsets, 1.2, 1.5)
+    torch.testing.assert_close(constant, torch.full_like(constant, 1.5))
+
+
+def test_cylindrical_zero_across_width_is_the_ring_and_z_blur_alone():
+    torch.manual_seed(11)
+    num_phi, offsets = _cylinder_tables(6)
+    grad = torch.randn(2, 3, 9, offsets[-1])
+    reference = grad.clone()
+    flow_grad_smoothing.smooth_cylindrical_(reference, num_phi, offsets, 1.3)
+    flow_grad_smoothing.smooth_cylindrical_(grad, num_phi, offsets, 1.3, 0.0)
+    torch.testing.assert_close(grad, reference)
+    # Both widths below the identity threshold: a no-op.
+    before = grad.clone()
+    flow_grad_smoothing.smooth_cylindrical_(grad, num_phi, offsets, 0.01, 0.01)
+    assert torch.equal(grad, before)
 
 
 # ------------------------------------------------------------ lazy moments
@@ -254,6 +342,121 @@ def test_lazy_step_with_no_state_and_first_touch_matches_sparse_adam():
     assert float(param.detach()[0]) == 0.0
 
 
+def _reference_shared_step(param, grad, state, lr, betas, eps, masked):
+    # Plain-torch reference of the shared-denominator step on a [S, C, ...]
+    # parameter: per-cell EMA moments, one denominator per (S, C) plane from
+    # the mean second moment over cells with a nonzero second moment.
+    beta1, beta2 = betas
+    state['step'] += 1
+    step = state['step']
+    touched = grad != 0 if masked else torch.ones_like(grad, dtype=torch.bool)
+    state['exp_avg'] = torch.where(touched, torch.lerp(state['exp_avg'], grad, 1 - beta1), state['exp_avg'])
+    state['exp_avg_sq'] = torch.where(touched, torch.lerp(state['exp_avg_sq'], grad * grad, 1 - beta2), state['exp_avg_sq'])
+    sq = state['exp_avg_sq']
+    planes = sq.reshape(sq.shape[0] * sq.shape[1], -1)
+    ever = planes > 0
+    mean_sq = planes.sum(1) / ever.sum(1).clamp(min=1)
+    denom = (mean_sq.sqrt() / (1 - beta2 ** step) ** 0.5 + eps).view(sq.shape[0], sq.shape[1], *([1] * (sq.dim() - 2)))
+    update = state['exp_avg'] / denom * (lr / (1 - beta1 ** step))
+    update = torch.where(touched, update, torch.zeros_like(update))
+    return param - update
+
+
+@pytest.mark.parametrize('masked', [True, False])
+def test_shared_second_moment_matches_reference_and_keeps_adamw_state(masked):
+    torch.manual_seed(4)
+    generator = torch.Generator().manual_seed(5)
+    param = torch.nn.Parameter(torch.randn(2, 3, 4, 5))
+    ref = param.detach().clone()
+    lr, betas, eps = 1e-2, (0.9, 0.999), 1e-8
+    optimiser = LazyMomentAdamW([{
+        'params': [param], 'weight_decay': 0.0,
+        'lazy_moments': masked, 'shared_second_moment': True,
+    }], lr=lr, betas=betas, eps=eps)
+    ref_state = {'step': 0, 'exp_avg': torch.zeros_like(ref), 'exp_avg_sq': torch.zeros_like(ref)}
+    for _ in range(6):
+        grad = _sparse_pattern(param.shape, 0.4, generator)
+        # Plane (1, 2) never receives gradient: its denominator falls back to
+        # epsilon and its (zero) first moment keeps it exactly still.
+        grad[1, 2] = 0.0
+        param.grad = grad.clone()
+        optimiser.step()
+        ref = _reference_shared_step(ref, grad, ref_state, lr, betas, eps, masked)
+        torch.testing.assert_close(param.detach(), ref, rtol=1e-5, atol=1e-7)
+    assert torch.equal(param.detach()[1, 2], ref[1, 2])
+    state = optimiser.state[param]
+    assert set(state) == {'step', 'exp_avg', 'exp_avg_sq'}
+    torch.testing.assert_close(state['exp_avg_sq'], ref_state['exp_avg_sq'])
+    assert float(state['step']) == 6
+    # The per-cell state is untouched by the flag, so a plain AdamW loads it
+    # and the fused step continues from it.
+    plain = torch.optim.AdamW([torch.nn.Parameter(param.detach().clone())], lr=lr)
+    plain.load_state_dict(optimiser.state_dict())
+    optimiser.param_groups[0]['shared_second_moment'] = False
+    optimiser.param_groups[0]['lazy_moments'] = False
+    param.grad = torch.randn(param.shape, generator=generator)
+    optimiser.step()
+    assert float(state['step']) == 7
+
+
+def test_shared_second_moment_keeps_the_gradient_profile_and_is_per_plane():
+    # A smooth gradient profile on two planes, the second ten times larger.
+    torch.manual_seed(8)
+    profile = torch.exp(-0.5 * ((torch.arange(9.0) - 4.0) / 1.5) ** 2)
+    grad = torch.stack([profile, 10.0 * profile])[:, None, :].expand(2, 2, 9).clone()
+    param = torch.nn.Parameter(torch.zeros(2, 2, 9))
+    optimiser = LazyMomentAdamW([{'params': [param], 'shared_second_moment': True}], lr=1e-2)
+    param.grad = grad.clone()
+    optimiser.step()
+    update = -param.detach()
+    # Within a plane the update is proportional to the gradient (one scale
+    # per plane), not flattened to its sign as per-cell Adam would do.
+    ratio = update / grad
+    for plane in ratio.view(4, 9):
+        assert float(plane.std() / plane.mean()) < 1e-5
+    # Adam's scale invariance holds per plane: the ten-times gradient gets
+    # the same update.
+    torch.testing.assert_close(update[0], update[1])
+    # The per-cell step, for contrast, moves every cell of the profile by
+    # about the learning rate.
+    cellwise = torch.nn.Parameter(torch.zeros(2, 2, 9))
+    LazyMomentAdamW([{'params': [cellwise], 'lazy_moments': True}], lr=1e-2)
+    per_cell = LazyMomentAdamW([{'params': [cellwise], 'lazy_moments': True}], lr=1e-2)
+    cellwise.grad = grad.clone()
+    per_cell.step()
+    torch.testing.assert_close(-cellwise.detach(), torch.full_like(cellwise, 1e-2), rtol=1e-4, atol=1e-6)
+
+
+def test_shared_second_moment_equals_per_cell_for_uniform_gradients():
+    # Every cell of a plane carrying the same gradient makes the mean second
+    # moment equal to each cell's own, so the two denominators coincide.
+    torch.manual_seed(9)
+    generator = torch.Generator().manual_seed(10)
+    shared = torch.nn.Parameter(torch.randn(2, 3, 4, 4))
+    cellwise = torch.nn.Parameter(shared.detach().clone())
+    a = LazyMomentAdamW([{'params': [shared], 'lazy_moments': True, 'shared_second_moment': True}], lr=1e-2)
+    b = LazyMomentAdamW([{'params': [cellwise], 'lazy_moments': True}], lr=1e-2)
+    for _ in range(5):
+        per_plane = torch.randn(2, 3, 1, 1, generator=generator)
+        shared.grad = per_plane.expand(2, 3, 4, 4).clone()
+        cellwise.grad = shared.grad.clone()
+        a.step()
+        b.step()
+        torch.testing.assert_close(shared, cellwise, rtol=1e-6, atol=1e-8)
+
+
+def test_shared_second_moment_on_a_vector_is_one_plane():
+    param = torch.nn.Parameter(torch.zeros(6))
+    optimiser = LazyMomentAdamW([{'params': [param], 'shared_second_moment': True}], lr=0.1)
+    param.grad = torch.tensor([1.0, 2.0, 3.0, 0.0, 0.0, 0.0])
+    optimiser.step()
+    # mean second moment over the three touched cells: (1 + 4 + 9) / 3 * (1 - beta2)
+    mean_sq = (14.0 / 3.0) * 1e-3
+    denom = (mean_sq ** 0.5) / (1e-3 ** 0.5) + 1e-8
+    expected = -0.1 * torch.tensor([1.0, 2.0, 3.0, 0.0, 0.0, 0.0]) / denom
+    torch.testing.assert_close(param.detach(), expected, rtol=1e-5, atol=1e-7)
+
+
 # -------------------------------------------------------------------- config
 
 def test_new_optimizer_keys_are_run_boundary_and_off_by_default():
@@ -268,6 +471,20 @@ def test_new_optimizer_keys_are_run_boundary_and_off_by_default():
     assert fields[sigma]['type'] == 'number'
     assert fields[sigma]['runtime_impact'] == 'run_boundary'
     assert defaults[sigma] == 32.0
+    across = 'optimizer_flow_grad_smoothing_across_sigma_voxels'
+    assert fields[across]['type'] == 'number'
+    assert fields[across]['runtime_impact'] == 'run_boundary'
+    assert defaults[across] == 0.0
+    shared = 'optimizer_flow_shared_second_moment'
+    assert fields[shared]['type'] == 'boolean'
+    assert fields[shared]['runtime_impact'] == 'run_boundary'
+    assert defaults[shared] is False
+    assert 'description' in fields[across] and 'description' in fields[shared]
+    # Both postdate durable checkpoints: a checkpoint without them loads as
+    # if they were off.
+    from config import BACKFILLABLE_CONFIG_DEFAULTS
+    assert BACKFILLABLE_CONFIG_DEFAULTS[across] == 0.0
+    assert BACKFILLABLE_CONFIG_DEFAULTS[shared] is False
 
 
 cuda = pytest.mark.skipif(
@@ -288,16 +505,19 @@ def test_fused_cartesian_blur_matches_conv_reference(sigma, monkeypatch):
 
 
 @cuda
-@pytest.mark.parametrize('sigma', [0.7, 1.6, 3.0])
-def test_fused_cylindrical_blur_matches_conv_reference(sigma, monkeypatch):
+@pytest.mark.parametrize('sigma, across', [
+    (0.7, 0.0), (1.6, 0.0), (3.0, 0.0), (0.0, 0.8), (0.0, 1.5), (1.6, 0.6), (2.5, 1.2)])
+def test_fused_cylindrical_blur_matches_conv_reference(sigma, across, monkeypatch):
     torch.manual_seed(6)
     num_phi, offsets = _cylinder_tables(9)
     grad = torch.randn(2, 3, 11, offsets[-1], device='cuda')
     num_phi_t = torch.tensor(num_phi, device='cuda')
     offsets_t = torch.tensor(offsets, device='cuda')
-    fused = flow_grad_smoothing.smooth_cylindrical_(grad.clone(), num_phi_t, offsets_t, sigma)
+    fused = flow_grad_smoothing.smooth_cylindrical_(
+        grad.clone(), num_phi_t, offsets_t, sigma, across)
     monkeypatch.setenv('FIT_SPIRAL_TRITON', '0')
-    reference = flow_grad_smoothing.smooth_cylindrical_(grad.clone(), num_phi, offsets, sigma)
+    reference = flow_grad_smoothing.smooth_cylindrical_(
+        grad.clone(), num_phi, offsets, sigma, across)
     torch.testing.assert_close(fused, reference, rtol=1e-5, atol=1e-6)
 
 

--- a/spiral-fitting/tests/test_flow_grad_smoothing.py
+++ b/spiral-fitting/tests/test_flow_grad_smoothing.py
@@ -1,0 +1,319 @@
+"""Flow-gradient smoothing and lazy Adam moments.
+
+Both are optional run-boundary optimizer settings, off by default. Covers:
+the separable Cartesian blur against a dense 3-D reference, border
+renormalisation, slab and component independence, the cylindrical z and
+circular-ring passes, the model-level width conversion; LazyMomentAdamW
+against torch.optim.SparseAdam on sparse gradients and against plain AdamW
+for non-lazy groups, including toggling the flag between steps and
+checkpoint round-trips; and the config classification of the new keys.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import flow_grad_smoothing
+from config import Config
+from flow_fields import CartesianFlowField, CylindricalFlowField
+from lazy_moment_adamw import LazyMomentAdamW
+from transforms import SpiralAndTransform
+
+
+def _dense_reference(grad, sigma):
+    # Full 3-D Gaussian with per-position border renormalisation.
+    kernel = flow_grad_smoothing.gaussian_kernel(sigma, dtype=torch.float64)
+    radius = kernel.numel() // 2
+    kernel3 = kernel[:, None, None] * kernel[None, :, None] * kernel[None, None, :]
+    volumes = grad.to(torch.float64).reshape(-1, 1, *grad.shape[-3:])
+    ones = torch.ones_like(volumes[:1])
+    norm = F.conv3d(ones, kernel3[None, None], padding=radius)
+    out = F.conv3d(volumes, kernel3[None, None], padding=radius) / norm
+    return out.view(grad.shape).to(grad.dtype)
+
+
+def test_kernel_is_normalised_and_tiny_widths_are_identity():
+    kernel = flow_grad_smoothing.gaussian_kernel(1.5)
+    assert kernel.numel() == 2 * math.ceil(4.5) + 1
+    assert float(kernel.sum()) == pytest.approx(1.0, abs=1e-6)
+    assert torch.equal(kernel, kernel.flip(0))
+    assert flow_grad_smoothing.gaussian_kernel(0.0) is None
+    assert flow_grad_smoothing.gaussian_kernel(0.01) is None
+    grad = torch.randn(2, 3, 5, 6, 7)
+    before = grad.clone()
+    flow_grad_smoothing.smooth_cartesian_(grad, 0.01)
+    assert torch.equal(grad, before)
+
+
+def test_cartesian_matches_dense_reference_and_keeps_constants():
+    torch.manual_seed(0)
+    grad = torch.randn(2, 3, 7, 9, 11)
+    expected = _dense_reference(grad, 1.2)
+    flow_grad_smoothing.smooth_cartesian_(grad, 1.2)
+    torch.testing.assert_close(grad, expected, rtol=1e-5, atol=1e-6)
+    constant = torch.full((1, 3, 6, 6, 6), 2.5)
+    flow_grad_smoothing.smooth_cartesian_(constant, 2.0)
+    torch.testing.assert_close(constant, torch.full_like(constant, 2.5))
+
+
+def test_cartesian_slabs_and_components_do_not_mix():
+    # The delta's support (radius 3) stays clear of the borders, where the
+    # renormalisation preserves constants rather than mass.
+    grad = torch.zeros(2, 3, 15, 15, 15)
+    grad[1, 2, 7, 7, 7] = 1.0
+    flow_grad_smoothing.smooth_cartesian_(grad, 1.0)
+    assert float(grad[0].abs().sum()) == 0.0
+    assert float(grad[1, :2].abs().sum()) == 0.0
+    assert float(grad[1, 2].sum()) == pytest.approx(1.0, abs=1e-5)
+    assert float(grad[1, 2, 7, 7, 7]) < 1.0
+    assert float(grad[1, 2, 7, 7, 8]) == pytest.approx(float(grad[1, 2, 7, 7, 6]))
+
+
+def _cylinder_tables(nr):
+    num_phi = [1] + [max(1, int(round(2 * math.pi * r))) for r in range(1, nr)]
+    offsets = [0]
+    for n in num_phi:
+        offsets.append(offsets[-1] + n)
+    return num_phi, offsets
+
+
+def test_cylindrical_smooths_z_and_wraps_rings_without_mixing_them():
+    num_phi, offsets = _cylinder_tables(5)
+    nz = 15  # the delta's z support (radius 3) stays clear of the borders
+    grad = torch.zeros(2, 3, nz, offsets[-1])
+    # A delta on ring 3 at phi index 0, middle z, slab 1, component 1.
+    ring, start = 3, offsets[3]
+    grad[1, 1, 7, start] = 1.0
+    grad[..., :1] = 5.0  # ring 0 (the pinned axis cell) must not change
+    flow_grad_smoothing.smooth_cylindrical_(grad, num_phi, offsets, 1.0)
+    torch.testing.assert_close(grad[..., 0], torch.full_like(grad[..., 0], 5.0))
+    assert float(grad[0, :, :, 1:].abs().sum()) == 0.0
+    assert float(grad[1, [0, 2], :, 1:].abs().sum()) == 0.0
+    spread = grad[1, 1, :, start:start + num_phi[ring]]
+    assert float(spread.sum()) == pytest.approx(1.0, abs=1e-5)
+    # Circular: the last cell of the ring is the delta's neighbour.
+    assert float(spread[7, -1]) == pytest.approx(float(spread[7, 1]), rel=1e-5)
+    assert float(spread[7, -1]) > 0.0
+    # Other rings untouched.
+    others = torch.ones(offsets[-1], dtype=torch.bool)
+    others[start:start + num_phi[ring]] = False
+    others[0] = False
+    assert float(grad[1, 1][:, others].abs().sum()) == 0.0
+    # z smoothing renormalises at the border: a constant ring stays constant.
+    constant = torch.full((1, 3, nz, offsets[-1]), 1.5)
+    flow_grad_smoothing.smooth_cylindrical_(constant, num_phi, offsets, 1.5)
+    torch.testing.assert_close(constant, torch.full_like(constant, 1.5))
+
+
+@pytest.mark.parametrize('kind', ['cartesian', 'cylindrical'])
+def test_field_smooth_grad_scales_width_for_the_low_res_lattice(kind, monkeypatch):
+    if kind == 'cartesian':
+        field = CartesianFlowField(torch.tensor([24, 24, 24]), spatial_scale_factor=4)
+    else:
+        field = CylindricalFlowField((24, 24, 24), spatial_scale_factor=4)
+    for flow in field.flows:
+        flow.grad = torch.randn_like(flow)
+    seen = []
+    target = 'smooth_cartesian_' if kind == 'cartesian' else 'smooth_cylindrical_'
+    original = getattr(flow_grad_smoothing, target)
+
+    def recording(grad, *args):
+        seen.append((grad.shape, args[-1]))
+        return original(grad, *args)
+
+    monkeypatch.setattr(flow_grad_smoothing, target, recording)
+    field.smooth_grad_(2.0)
+    assert [sigma for _, sigma in seen] == [0.5, 2.0]
+    assert seen[0][0] == field.flows[0].shape and seen[1][0] == field.flows[1].shape
+    # Untouched lattices (no gradient) are skipped.
+    field.flows[0].grad = None
+    seen.clear()
+    field.smooth_grad_(2.0)
+    assert len(seen) == 1
+
+
+def test_model_converts_voxels_to_cells():
+    config = Config().as_dict()
+    config.update({
+        'model_flow_voxel_resolution': 16,
+        'model_gap_expander_capacity_windings': 8,
+        'model_gap_expander_num_windings': 8,
+        'model_linear_z_resolution': 8,
+    })
+    model = SpiralAndTransform(
+        flow_integration_steps=2, flow_integration_solver='rk4',
+        flow_min_corner_zyx=torch.tensor([0, -48, -48]),
+        flow_max_corner_zyx=torch.tensor([48, 48, 48]),
+        umbilicus_zyx=torch.zeros(48, 3), config=config)
+    seen = []
+    # Every flow stage module receives the converted width.
+    for flow_field in model.flow_fields:
+        flow_field.smooth_grad_ = lambda sigma: seen.append(sigma)
+    model.smooth_flow_grad_(40.0)
+    assert len(model.flow_fields) == 2
+    assert seen == [2.5, 2.5]
+
+
+# ------------------------------------------------------------ lazy moments
+
+def _sparse_pattern(shape, density, generator):
+    mask = torch.rand(shape, generator=generator) < density
+    return torch.randn(shape, generator=generator) * mask
+
+
+def test_lazy_groups_match_sparse_adam_and_others_match_adamw():
+    torch.manual_seed(0)
+    generator = torch.Generator().manual_seed(1)
+    lazy_param = torch.nn.Parameter(torch.randn(2, 3, 5, 5))
+    dense_param = torch.nn.Parameter(torch.randn(7))
+    ref_lazy = torch.nn.Parameter(lazy_param.detach().clone())
+    ref_dense = torch.nn.Parameter(dense_param.detach().clone())
+    lr, betas, eps = 1e-2, (0.9, 0.999), 1e-8
+    optimiser = LazyMomentAdamW([
+        {'params': [dense_param], 'weight_decay': 0.01},
+        {'params': [lazy_param], 'weight_decay': 0.0, 'lazy_moments': True},
+    ], lr=lr, betas=betas, eps=eps)
+    sparse_adam = torch.optim.SparseAdam([ref_lazy], lr=lr, betas=betas, eps=eps)
+    adamw = torch.optim.AdamW([ref_dense], lr=lr, betas=betas, eps=eps, weight_decay=0.01)
+    for _ in range(12):
+        lazy_grad = _sparse_pattern(lazy_param.shape, 0.2, generator)
+        dense_grad = torch.randn(7, generator=generator)
+        lazy_param.grad = lazy_grad.clone()
+        dense_param.grad = dense_grad.clone()
+        ref_lazy.grad = lazy_grad.to_sparse()
+        ref_dense.grad = dense_grad.clone()
+        optimiser.step()
+        sparse_adam.step()
+        adamw.step()
+        # SparseAdam adds epsilon before the bias-corrected root, AdamW after:
+        # an epsilon-scale difference, well inside this tolerance.
+        torch.testing.assert_close(lazy_param, ref_lazy, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(dense_param, ref_dense)
+    state = optimiser.state[lazy_param]
+    ref_state = sparse_adam.state[ref_lazy]
+    torch.testing.assert_close(state['exp_avg'], ref_state['exp_avg'], rtol=1e-5, atol=1e-7)
+    torch.testing.assert_close(state['exp_avg_sq'], ref_state['exp_avg_sq'], rtol=1e-5, atol=1e-7)
+    assert float(state['step']) == 12
+
+
+def test_lazy_flag_can_toggle_between_steps_and_round_trips_state():
+    torch.manual_seed(2)
+    generator = torch.Generator().manual_seed(3)
+    param = torch.nn.Parameter(torch.randn(4, 6))
+    optimiser = LazyMomentAdamW([{'params': [param], 'lazy_moments': False}], lr=1e-2)
+    param.grad = _sparse_pattern(param.shape, 0.5, generator)
+    optimiser.step()  # fused/plain AdamW path initialises the state
+    state = optimiser.state[param]
+    assert set(state) == {'step', 'exp_avg', 'exp_avg_sq'}
+    before_avg = state['exp_avg'].clone()
+    optimiser.param_groups[0]['lazy_moments'] = True
+    grad = _sparse_pattern(param.shape, 0.3, generator)
+    param.grad = grad.clone()
+    optimiser.step()
+    untouched = grad == 0
+    torch.testing.assert_close(state['exp_avg'][untouched], before_avg[untouched])
+    assert not torch.equal(state['exp_avg'][~untouched], before_avg[~untouched])
+    assert float(state['step']) == 2
+    # Back to eager AdamW with the state the lazy step left behind.
+    optimiser.param_groups[0]['lazy_moments'] = False
+    param.grad = torch.randn(param.shape, generator=generator)
+    optimiser.step()
+    assert float(state['step']) == 3
+    # The state dict is a plain AdamW state dict.
+    plain = torch.optim.AdamW([torch.nn.Parameter(param.detach().clone())], lr=1e-2)
+    plain.load_state_dict(optimiser.state_dict())
+    assert float(next(iter(plain.state.values()))['step']) == 3
+
+
+def test_lazy_step_applies_decoupled_weight_decay_everywhere():
+    param = torch.nn.Parameter(torch.ones(10))
+    optimiser = LazyMomentAdamW(
+        [{'params': [param], 'lazy_moments': True, 'weight_decay': 0.5}], lr=0.1)
+    param.grad = torch.zeros(10)
+    optimiser.step()
+    torch.testing.assert_close(param.detach(), torch.full((10,), 0.95))
+
+
+def test_lazy_step_with_no_state_and_first_touch_matches_sparse_adam():
+    param = torch.nn.Parameter(torch.zeros(5))
+    ref = torch.nn.Parameter(torch.zeros(5))
+    optimiser = LazyMomentAdamW([{'params': [param], 'lazy_moments': True}], lr=0.1)
+    sparse_adam = torch.optim.SparseAdam([ref], lr=0.1)
+    grad = torch.tensor([0.0, 2.0, 0.0, -1.0, 0.0])
+    param.grad = grad.clone()
+    ref.grad = grad.to_sparse()
+    optimiser.step()
+    sparse_adam.step()
+    torch.testing.assert_close(param, ref, rtol=1e-5, atol=1e-6)
+    assert float(param.detach()[0]) == 0.0
+
+
+# -------------------------------------------------------------------- config
+
+def test_new_optimizer_keys_are_run_boundary_and_off_by_default():
+    fields = Config.catalog()['schema']['fields']
+    defaults = Config().as_dict()
+    for key in ('optimizer_flow_grad_smoothing', 'optimizer_flow_lazy_moments'):
+        assert fields[key]['type'] == 'boolean'
+        assert fields[key]['runtime_impact'] == 'run_boundary'
+        assert defaults[key] is False
+        assert 'description' in fields[key]
+    sigma = 'optimizer_flow_grad_smoothing_sigma_voxels'
+    assert fields[sigma]['type'] == 'number'
+    assert fields[sigma]['runtime_impact'] == 'run_boundary'
+    assert defaults[sigma] == 32.0
+
+
+cuda = pytest.mark.skipif(
+    not torch.cuda.is_available() or not __import__('flow_triton')._HAS_TRITON,
+    reason='requires CUDA and Triton')
+
+
+@cuda
+@pytest.mark.parametrize('sigma', [0.7, 1.6, 3.0])
+def test_fused_cartesian_blur_matches_conv_reference(sigma, monkeypatch):
+    torch.manual_seed(5)
+    grad = torch.randn(2, 3, 13, 21, 37, device='cuda')
+    fused = flow_grad_smoothing.smooth_cartesian_(grad.clone(), sigma)
+    monkeypatch.setenv('FIT_SPIRAL_TRITON', '0')
+    reference = flow_grad_smoothing.smooth_cartesian_(grad.clone(), sigma)
+    torch.testing.assert_close(fused, reference, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(fused.cpu(), _dense_reference(grad.cpu(), sigma), rtol=1e-5, atol=1e-6)
+
+
+@cuda
+@pytest.mark.parametrize('sigma', [0.7, 1.6, 3.0])
+def test_fused_cylindrical_blur_matches_conv_reference(sigma, monkeypatch):
+    torch.manual_seed(6)
+    num_phi, offsets = _cylinder_tables(9)
+    grad = torch.randn(2, 3, 11, offsets[-1], device='cuda')
+    num_phi_t = torch.tensor(num_phi, device='cuda')
+    offsets_t = torch.tensor(offsets, device='cuda')
+    fused = flow_grad_smoothing.smooth_cylindrical_(grad.clone(), num_phi_t, offsets_t, sigma)
+    monkeypatch.setenv('FIT_SPIRAL_TRITON', '0')
+    reference = flow_grad_smoothing.smooth_cylindrical_(grad.clone(), num_phi, offsets, sigma)
+    torch.testing.assert_close(fused, reference, rtol=1e-5, atol=1e-6)
+
+
+@cuda
+def test_fused_blur_handles_awkward_sizes_and_wide_kernels(monkeypatch):
+    # Axis lengths below the tile, rings shorter than the kernel, and a kernel
+    # wider than the fused unroll (which takes the conv path).
+    grad = torch.randn(1, 3, 3, 5, 300, device='cuda')
+    fused = flow_grad_smoothing.smooth_cartesian_(grad.clone(), 1.0)
+    monkeypatch.setenv('FIT_SPIRAL_TRITON', '0')
+    reference = flow_grad_smoothing.smooth_cartesian_(grad.clone(), 1.0)
+    torch.testing.assert_close(fused, reference, rtol=1e-5, atol=1e-6)
+    monkeypatch.setenv('FIT_SPIRAL_TRITON', '1')
+    wide = torch.randn(1, 3, 4, 4, 200, device='cuda')
+    sigma = (flow_grad_smoothing.MAX_FUSED_RADIUS + 1) / flow_grad_smoothing.KERNEL_TRUNCATE
+    fused_wide = flow_grad_smoothing.smooth_cartesian_(wide.clone(), sigma)
+    monkeypatch.setenv('FIT_SPIRAL_TRITON', '0')
+    torch.testing.assert_close(
+        fused_wide, flow_grad_smoothing.smooth_cartesian_(wide.clone(), sigma))

--- a/spiral-fitting/tests/test_lr_schedule.py
+++ b/spiral-fitting/tests/test_lr_schedule.py
@@ -142,3 +142,31 @@ def test_realign_preserves_parameter_group_lr_scales():
         optimiser.param_groups[0]["lr"] * 0.2,
         rel_tol=1e-12,
     )
+
+
+def test_both_flow_groups_scale_off_the_same_base_group():
+    # The low- and high-resolution flow groups each take their LR relative to
+    # the unscaled base group, so the coarse lattice's scale does not compound
+    # into the fine lattice's.
+    base = torch.nn.Parameter(torch.tensor(0., dtype=torch.float64))
+    low_res = torch.nn.Parameter(torch.tensor(0., dtype=torch.float64))
+    high_res = torch.nn.Parameter(torch.tensor(0., dtype=torch.float64))
+    optimiser = torch.optim.SGD([
+        {"params": [base]},
+        {"params": [low_res], "lr_scale": 1.},
+        {"params": [high_res], "lr_scale": 1.},
+    ], lr=1.e-2)
+    scheduler = torch.optim.lr_scheduler.ExponentialLR(optimiser, gamma=1.)
+    base_group, low_group, high_group = optimiser.param_groups
+    for group, scale in ((low_group, 4.), (high_group, 0.2)):
+        set_optimizer_group_lr_scale(
+            optimiser, scheduler, group=group, reference_group=base_group,
+            scale=scale, initial_lr=1.e-2)
+    for param in (base, low_res, high_res):
+        param.grad = torch.ones_like(param)
+    optimiser.step()
+    assert math.isclose(low_res.item() / base.item(), 4., rel_tol=1e-12)
+    assert math.isclose(high_res.item() / base.item(), 0.2, rel_tol=1e-12)
+    assert scheduler.base_lrs == [1.e-2, 4.e-2, 2.e-3]
+    assert fit_spiral.get_flow_field_low_res_lr_scale({"model_flow_field_low_res_lr_scale": 4.}) == 4.
+    assert fit_spiral.get_flow_field_low_res_lr_scale({}) == 1.

--- a/spiral-fitting/tests/test_lr_schedule.py
+++ b/spiral-fitting/tests/test_lr_schedule.py
@@ -170,3 +170,7 @@ def test_both_flow_groups_scale_off_the_same_base_group():
     assert scheduler.base_lrs == [1.e-2, 4.e-2, 2.e-3]
     assert fit_spiral.get_flow_field_low_res_lr_scale({"model_flow_field_low_res_lr_scale": 4.}) == 4.
     assert fit_spiral.get_flow_field_low_res_lr_scale({}) == 1.
+    # An explicit zero freezes the coarse lattice; only a missing or null
+    # setting falls back to the default.
+    assert fit_spiral.get_flow_field_low_res_lr_scale({"model_flow_field_low_res_lr_scale": 0.}) == 0.
+    assert fit_spiral.get_flow_field_low_res_lr_scale({"model_flow_field_low_res_lr_scale": None}) == 1.

--- a/spiral-fitting/tests/test_vram_reductions.py
+++ b/spiral-fitting/tests/test_vram_reductions.py
@@ -1,3 +1,4 @@
+import inspect
 import types
 import unittest
 from pathlib import Path
@@ -623,6 +624,76 @@ class NonFiniteGradCheckTests(unittest.TestCase):
             self.assertFalse(bool(torch.isfinite(grad_min) & torch.isfinite(grad_max)))
         grad_min, grad_max = torch.aminmax(torch.randn(1024))
         self.assertTrue(bool(torch.isfinite(grad_min) & torch.isfinite(grad_max)))
+
+    @staticmethod
+    def _sanitize(named_params):
+        import fit_spiral
+        context = types.SimpleNamespace(
+            dist_grad_named=named_params,
+            nonfinite_grad_steps=torch.zeros((), dtype=torch.int64),
+            nonfinite_grad_by_param={name: torch.zeros((), dtype=torch.int64)
+                                     for name, _ in named_params},
+        )
+        fit_spiral.FitContext._sanitize_nonfinite_grads_(context)
+        return context
+
+    def test_sanitizer_counts_and_zeroes_only_nonfinite_cells(self):
+        bad = torch.nn.Parameter(torch.ones(1, 3, 5, 5, 5))
+        good = torch.nn.Parameter(torch.ones(4))
+        bad.grad = torch.ones_like(bad)
+        bad.grad[0, 0, 2, 2, 2] = float('nan')
+        bad.grad[0, 1, 0, 0, 0] = float('inf')
+        good.grad = torch.full_like(good, 2.0)
+        context = self._sanitize([('bad', bad), ('good', good)])
+
+        self.assertEqual(int(context.nonfinite_grad_steps), 1)
+        self.assertEqual(int(context.nonfinite_grad_by_param['bad']), 1)
+        self.assertEqual(int(context.nonfinite_grad_by_param['good']), 0)
+        self.assertEqual(bad.grad[0, 0, 2, 2, 2].item(), 0.0)
+        self.assertEqual(bad.grad[0, 1, 0, 0, 0].item(), 0.0)
+        # Exactly the two nonfinite cells were touched.
+        self.assertEqual(int((bad.grad == 0).sum()), 2)
+        self.assertTrue(torch.equal(good.grad, torch.full_like(good, 2.0)))
+
+    def test_sanitizer_runs_before_clipping_and_smoothing(self):
+        # Clipping would clamp an infinity to a finite bound and hide it from
+        # the nonfinite counters; smoothing would spread one NaN over every
+        # cell within its kernel and the later sanitizer would then discard
+        # all of them. Sanitizing first keeps both to the single bad cell.
+        import fit_spiral
+        import flow_grad_smoothing
+        from lazy_moment_adamw import robust_clip_
+
+        step_source = inspect.getsource(fit_spiral.FitContext.step)
+        self.assertLess(step_source.index('self._sanitize_nonfinite_grads_()'),
+                        step_source.index('self._clip_flow_grads()'))
+        self.assertLess(step_source.index('self._clip_flow_grads()'),
+                        step_source.index('smooth_flow_grad_('))
+
+        torch.manual_seed(0)
+        param = torch.nn.Parameter(torch.zeros(1, 3, 7, 7, 7))
+        param.grad = torch.rand_like(param) + 0.5
+        param.grad[0, 0, 3, 3, 3] = float('nan')
+        param.grad[0, 2, 1, 1, 1] = float('inf')
+        reference = param.grad.clone()
+        reference[0, 0, 3, 3, 3] = 0.0
+        reference[0, 2, 1, 1, 1] = 0.0
+
+        context = self._sanitize([('flow', param)])
+        self.assertEqual(int(context.nonfinite_grad_by_param['flow']), 1)
+        self.assertTrue(torch.equal(param.grad, reference))
+
+        thresholds, fractions = robust_clip_(param.grad, 100.0)
+        # Nothing finite exceeds 100x the median, and the (zeroed) infinity is
+        # no longer counted as a clipped cell.
+        self.assertEqual(float(fractions[0]), 0.0)
+        self.assertTrue(torch.equal(param.grad, reference))
+
+        flow_grad_smoothing.smooth_cartesian_(param.grad, 1.0)
+        self.assertTrue(torch.isfinite(param.grad).all())
+        # Smoothing a finite field leaves its neighbours non-zero rather than
+        # discarding them, as the old ordering did.
+        self.assertGreater(int((param.grad != 0).sum()), param.grad.numel() - 2)
 
 
 class CpuTrackStorageTests(unittest.TestCase):

--- a/spiral-fitting/transforms.py
+++ b/spiral-fitting/transforms.py
@@ -9,6 +9,7 @@ import pyro.distributions
 from einops import rearrange
 from torchdiffeq import odeint
 
+import flow_grad_smoothing
 import gap_triton
 import sample_spiral
 from flow_fields import CartesianFlowField, CylindricalFlowField
@@ -611,18 +612,31 @@ class SpiralAndTransform(nn.Module):
         return lower_bounded_dr(
             self.dr_per_winding_logit, self.gap_min_gap)
 
-    def smooth_flow_grad_(self, sigma_voxels):
+    def smooth_flow_grad_(self, sigma_voxels, across_sigma_voxels=0.0):
         """Gaussian-smooth the flow lattices' gradients in place.
 
-        ``sigma_voxels`` is in scroll voxels; a high-resolution flow cell is
-        model_flow_voxel_resolution voxels wide, so the width converts to
-        cells here and each flow field scales it for its coarser lattice.
-        Applies to every flow stage. Call after apply_accumulated_field_grad
-        (and after any all-reduce) and before the optimizer step.
+        ``sigma_voxels`` is the along-sheet width and ``across_sigma_voxels``
+        the across-winding width (cylindrical lattices only; see
+        flow_grad_smoothing), both in scroll voxels. A high-resolution flow
+        cell is model_flow_voxel_resolution voxels wide, so the widths
+        convert to cells here and each flow field scales them for its
+        coarser lattice. Applies to every flow stage. Call after
+        apply_accumulated_field_grad (and after any all-reduce) and before
+        the optimizer step.
         """
         cell_voxels = float(self.cfg['model_flow_voxel_resolution'])
         for flow_field in self.flow_fields:
-            flow_field.smooth_grad_(float(sigma_voxels) / cell_voxels)
+            flow_field.smooth_grad_(
+                float(sigma_voxels) / cell_voxels,
+                float(across_sigma_voxels) / cell_voxels)
+
+    def describe_flow_grad_smoothing(self, sigma_voxels, across_sigma_voxels=0.0):
+        """The effective smoothing widths per lattice, for the startup log."""
+        return flow_grad_smoothing.describe_widths(
+            sigma_voxels, across_sigma_voxels,
+            float(self.cfg['model_flow_voxel_resolution']),
+            self.flow_field.spatial_scale_factor,
+            self.cfg['model_flow_field_type'])
 
     def get_shared_transform_tensors(self):
         """The tiny graph paths every evaluation of one transform instance

--- a/spiral-fitting/transforms.py
+++ b/spiral-fitting/transforms.py
@@ -616,13 +616,15 @@ class SpiralAndTransform(nn.Module):
                           low_res_sigma_voxels=0.0):
         """Gaussian-smooth the flow lattices' gradients in place.
 
-        ``sigma_voxels`` is the along-sheet width, ``across_sigma_voxels``
-        the across-winding width (cylindrical lattices only; see
-        flow_grad_smoothing) and ``low_res_sigma_voxels`` an along-sheet
-        width for the low-resolution lattice alone (0 = same as
-        ``sigma_voxels``), all in scroll voxels. A high-resolution flow cell
-        is model_flow_voxel_resolution voxels wide, so the widths convert to
-        cells here and each flow field scales them for its coarser lattice.
+        ``sigma_voxels`` is the z/around-ring width for cylindrical lattices
+        (isotropic for Cartesian), ``across_sigma_voxels`` the across-ring
+        width (cylindrical only), and ``low_res_sigma_voxels`` a coarse-lattice
+        override for the first width (0 = same as ``sigma_voxels``). Directions
+        approximate along/across-sheet directions; see flow_grad_smoothing.
+        All widths use scroll-voxel units of the flow frame, not distances
+        measured on the deformed sheet. Convert using the nominal fine cell
+        width model_flow_voxel_resolution; each field scales for its coarse
+        lattice.
         Applies to every flow stage. Call after apply_accumulated_field_grad
         (and after any all-reduce) and before the optimizer step.
         """

--- a/spiral-fitting/transforms.py
+++ b/spiral-fitting/transforms.py
@@ -612,31 +612,36 @@ class SpiralAndTransform(nn.Module):
         return lower_bounded_dr(
             self.dr_per_winding_logit, self.gap_min_gap)
 
-    def smooth_flow_grad_(self, sigma_voxels, across_sigma_voxels=0.0):
+    def smooth_flow_grad_(self, sigma_voxels, across_sigma_voxels=0.0,
+                          low_res_sigma_voxels=0.0):
         """Gaussian-smooth the flow lattices' gradients in place.
 
-        ``sigma_voxels`` is the along-sheet width and ``across_sigma_voxels``
+        ``sigma_voxels`` is the along-sheet width, ``across_sigma_voxels``
         the across-winding width (cylindrical lattices only; see
-        flow_grad_smoothing), both in scroll voxels. A high-resolution flow
-        cell is model_flow_voxel_resolution voxels wide, so the widths
-        convert to cells here and each flow field scales them for its
-        coarser lattice. Applies to every flow stage. Call after
-        apply_accumulated_field_grad (and after any all-reduce) and before
-        the optimizer step.
+        flow_grad_smoothing) and ``low_res_sigma_voxels`` an along-sheet
+        width for the low-resolution lattice alone (0 = same as
+        ``sigma_voxels``), all in scroll voxels. A high-resolution flow cell
+        is model_flow_voxel_resolution voxels wide, so the widths convert to
+        cells here and each flow field scales them for its coarser lattice.
+        Applies to every flow stage. Call after apply_accumulated_field_grad
+        (and after any all-reduce) and before the optimizer step.
         """
         cell_voxels = float(self.cfg['model_flow_voxel_resolution'])
         for flow_field in self.flow_fields:
             flow_field.smooth_grad_(
                 float(sigma_voxels) / cell_voxels,
-                float(across_sigma_voxels) / cell_voxels)
+                float(across_sigma_voxels) / cell_voxels,
+                float(low_res_sigma_voxels or 0.0) / cell_voxels)
 
-    def describe_flow_grad_smoothing(self, sigma_voxels, across_sigma_voxels=0.0):
+    def describe_flow_grad_smoothing(self, sigma_voxels, across_sigma_voxels=0.0,
+                                     low_res_sigma_voxels=0.0):
         """The effective smoothing widths per lattice, for the startup log."""
         return flow_grad_smoothing.describe_widths(
             sigma_voxels, across_sigma_voxels,
             float(self.cfg['model_flow_voxel_resolution']),
             self.flow_field.spatial_scale_factor,
-            self.cfg['model_flow_field_type'])
+            self.cfg['model_flow_field_type'],
+            low_res_along_voxels=low_res_sigma_voxels)
 
     def get_shared_transform_tensors(self):
         """The tiny graph paths every evaluation of one transform instance

--- a/spiral-fitting/transforms.py
+++ b/spiral-fitting/transforms.py
@@ -611,6 +611,19 @@ class SpiralAndTransform(nn.Module):
         return lower_bounded_dr(
             self.dr_per_winding_logit, self.gap_min_gap)
 
+    def smooth_flow_grad_(self, sigma_voxels):
+        """Gaussian-smooth the flow lattices' gradients in place.
+
+        ``sigma_voxels`` is in scroll voxels; a high-resolution flow cell is
+        model_flow_voxel_resolution voxels wide, so the width converts to
+        cells here and each flow field scales it for its coarser lattice.
+        Applies to every flow stage. Call after apply_accumulated_field_grad
+        (and after any all-reduce) and before the optimizer step.
+        """
+        cell_voxels = float(self.cfg['model_flow_voxel_resolution'])
+        for flow_field in self.flow_fields:
+            flow_field.smooth_grad_(float(sigma_voxels) / cell_voxels)
+
     def get_shared_transform_tensors(self):
         """The tiny graph paths every evaluation of one transform instance
         shares: the dr-per-winding softplus, the scaled linear logits, and the


### PR DESCRIPTION
optional flow-gradient conditioning: 
- anisotropic Gaussian smoothing (spread gradient along the in-sheet direction, 
- lazy Adam moments, shared second-moment scaling (need to have this for smoothing), more robust grad clipping
- split coarse high res LR  
