### PR TITLE
Use the configured remote cache root for native volumes

### DIFF
--- a/volume-cartographer/apps/VC3D/VolumeAttachmentController.cpp
+++ b/volume-cartographer/apps/VC3D/VolumeAttachmentController.cpp
@@ -81,15 +81,6 @@ bool VolumeAttachmentController::prepare(
                 *failure = VolumeAttachmentPreparationFailure::RemoteConfiguration;
             return false;
         }
-        prepared.remoteCacheRoot = vc3d::remoteCachePathFs();
-        if (prepared.remoteCacheRoot.empty()) {
-            if (errorMessage && errorMessage->isEmpty()) {
-                *errorMessage = QObject::tr("Could not resolve the remote volume cache.");
-            }
-            if (failure)
-                *failure = VolumeAttachmentPreparationFailure::RemoteConfiguration;
-            return false;
-        }
     } else {
         auto localPath = vc::project::resolveLocalPath(input);
         if (localPath.is_relative())
@@ -202,7 +193,6 @@ bool VolumeAttachmentController::start(
                         request.tags.end();
                     result.volume = Volume::NewFromUrl(
                         location,
-                        request.remoteCacheRoot,
                         anonymous ? vc::HttpAuth{} : request.auth,
                         vc::project::volumeMetadataFromEntryTags(request.tags),
                         !anonymous);

--- a/volume-cartographer/apps/VC3D/VolumeAttachmentController.hpp
+++ b/volume-cartographer/apps/VC3D/VolumeAttachmentController.hpp
@@ -29,7 +29,6 @@ struct VolumeAttachmentRequest {
     QString location;
     std::vector<std::string> tags;
     vc::HttpAuth auth;
-    std::filesystem::path remoteCacheRoot;
     VolumeAttachmentSelection selection{VolumeAttachmentSelection::PreserveCurrent};
 };
 

--- a/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
+++ b/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
@@ -332,7 +332,7 @@ int main(int argc, char *argv[])
     if (std::isfinite(requested_voxelsize) && requested_voxelsize > 0.0)
         remote_metadata["voxelsize"] = requested_voxelsize;
     auto volume = remote_volume
-        ? Volume::NewFromUrl(volume_arg, {}, {}, remote_metadata)
+        ? Volume::NewFromUrl(volume_arg, {}, remote_metadata)
         : Volume::New(vol_path);
     if (!volume->hasScaleLevel(0)) {
         // The tracer reads scale group 0 only; on a sparse pyramid those reads

--- a/volume-cartographer/core/include/vc/core/types/Volume.hpp
+++ b/volume-cartographer/core/include/vc/core/types/Volume.hpp
@@ -84,11 +84,10 @@ public:
     // Create a Volume backed by a remote zarr store over HTTP.
     // If auth is provided, it is used as-is. Otherwise credentials are read
     // from the ambient AWS configuration only when discoverAwsCredentials is
-    // true; false forces an anonymous request. When cacheRoot is non-empty,
-    // remote chunks are persisted under a volume-specific subdirectory.
+    // true; false forces an anonymous request. Remote chunks are always
+    // persisted beneath the process-wide remote cache root.
     static std::shared_ptr<Volume> NewFromUrl(
         const std::string& url,
-        const std::filesystem::path& cacheRoot = {},
         const vc::HttpAuth& auth = {},
         const utils::Json& metadata = {},
         bool discoverAwsCredentials = true);

--- a/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
+++ b/volume-cartographer/core/include/vc/core/types/VolumePkg.hpp
@@ -44,13 +44,6 @@ bool isLocationRemote(const std::string& location);
 std::filesystem::path resolveLocalPath(const std::string& location,
                                        const std::filesystem::path& base = {});
 
-// Open-data volume entries carry their sample identity in a tag. Keep their
-// chunk caches grouped with the other catalog data while leaving ordinary
-// remote volumes directly beneath the configured cache root.
-std::filesystem::path remoteVolumeCacheRootForEntry(
-    const std::filesystem::path& configuredRoot,
-    const Entry& entry);
-
 std::string validateLocation(Category category, const std::string& location);
 std::string validateSingleVolumeLocation(const std::string& location);
 utils::Json volumeMetadataFromEntryTags(const std::vector<std::string>& tags);

--- a/volume-cartographer/core/src/Volume.cpp
+++ b/volume-cartographer/core/src/Volume.cpp
@@ -30,6 +30,7 @@
 #include "vc/core/util/HttpFetch.hpp"
 #include "vc/core/util/RemoteUrl.hpp"
 #include "vc/core/util/RemoteFileCache.hpp"
+#include "vc/core/util/RemoteCacheSettings.hpp"
 #include "vc/core/util/PostProcess.hpp"
 #include "vc/core/render/IChunkedArray.hpp"
 #include "vc/core/render/ChunkFetch.hpp"
@@ -1323,7 +1324,6 @@ std::shared_ptr<Volume> Volume::New(std::filesystem::path path,
 
 std::shared_ptr<Volume> Volume::NewFromUrl(
     const std::string& url,
-    const std::filesystem::path& cacheRoot,
     const vc::HttpAuth& authIn,
     const utils::Json& metadata,
     bool discoverAwsCredentials)
@@ -1358,7 +1358,7 @@ std::shared_ptr<Volume> Volume::NewFromUrl(
     vol->remoteLocator_ = spec.portableLocator;
     vol->baseScaleLevel_ = spec.baseScaleLevel;
     vol->remoteAuth_ = auth;
-    vol->remoteCacheRoot_ = cacheRoot;
+    vol->remoteCacheRoot_ = vc::settings::remoteCachePath();
     vol->remoteNumScales_ = opened.shapes.size();
     vol->zarrLevelShapes_ = opened.shapes;
     vol->zarrLevelChunkShapes_ = opened.chunkShapes;

--- a/volume-cartographer/core/src/VolumePkg.cpp
+++ b/volume-cartographer/core/src/VolumePkg.cpp
@@ -34,9 +34,7 @@
 
 #include "vc/core/types/Segmentation.hpp"
 #include "vc/core/types/Volume.hpp"
-#include "vc/core/render/PersistentZarrCacheBudget.hpp"
 #include "vc/core/util/Logging.hpp"
-#include "vc/core/util/RemoteCacheSettings.hpp"
 #include "vc/core/util/RemoteUrl.hpp"
 #include "vc/core/util/NormalGridVolume.hpp"
 #include "vc/core/util/QuadSurface.hpp"
@@ -79,42 +77,6 @@ fs::path resolveLocalPath(const std::string& location, const fs::path& base)
         : fs::path(location);
     if (p.is_absolute() || base.empty()) return p;
     return base / p;
-}
-
-fs::path remoteVolumeCacheRootForEntry(
-    const fs::path& configuredRoot,
-    const Entry& entry)
-{
-    constexpr std::string_view sampleTagPrefix =
-        "vc-open-data-sample-id:";
-    const auto tag = std::find_if(
-        entry.tags.begin(), entry.tags.end(),
-        [sampleTagPrefix](const std::string& value) {
-            return value.rfind(sampleTagPrefix, 0) == 0;
-        });
-    if (configuredRoot.empty() || tag == entry.tags.end())
-        return configuredRoot;
-
-    std::string sample = tag->substr(sampleTagPrefix.size());
-    for (char& c : sample) {
-        const auto uc = static_cast<unsigned char>(c);
-        if (!std::isalnum(uc) && c != '-' && c != '_' && c != '.')
-            c = '_';
-    }
-    while (!sample.empty() &&
-           (sample.front() == '.' || sample.front() == '_')) {
-        sample.erase(sample.begin());
-    }
-    if (sample.empty())
-        sample = "sample";
-
-    const auto root = configuredRoot.lexically_normal();
-    if (root.filename() == sample &&
-        root.parent_path().filename() == "volumes" &&
-        root.parent_path().parent_path().filename() == "open_data") {
-        return root;
-    }
-    return root / "open_data" / "volumes" / sample;
 }
 
 }
@@ -202,63 +164,14 @@ constexpr const char* kDirectRemoteZarrRequired =
 
 std::shared_ptr<Volume> openRemoteVolumeEntry(
     const vc::project::Entry& entry,
-    const fs::path& configuredCacheRoot,
     const vc::HttpAuth& auth = {})
 {
-    const auto volumeCacheRoot =
-        vc::project::remoteVolumeCacheRootForEntry(configuredCacheRoot, entry);
     const bool anonymous = vc::project::usesAnonymousRemoteAuth(entry);
-    auto volume = Volume::NewFromUrl(
-        entry.location, volumeCacheRoot,
+    return Volume::NewFromUrl(
+        entry.location,
         anonymous ? vc::HttpAuth{} : auth,
         vc::project::volumeMetadataFromEntryTags(entry.tags),
         !anonymous);
-
-    const auto legacyRoot = configuredCacheRoot.lexically_normal();
-    if (legacyRoot.empty() || volumeCacheRoot == legacyRoot)
-        return volume;
-
-    const auto legacy = legacyRoot / volume->id();
-    const auto destination = volume->remotePersistentCachePath();
-    std::error_code ec;
-    if (!fs::exists(legacy, ec) || ec)
-        return volume;
-    if (fs::exists(destination, ec)) {
-        if (!ec) {
-            Logger()->info(
-                "Keeping legacy remote volume cache {} because the sample-scoped cache already exists at {}",
-                legacy.string(), destination.string());
-        }
-        return volume;
-    }
-    if (ec)
-        return volume;
-
-    bool moved = false;
-    const auto sourceBudget =
-        vc::render::PersistentZarrCacheBudget::findForPath(legacy);
-    const auto destinationBudget =
-        vc::render::PersistentZarrCacheBudget::findForPath(destination);
-    if (sourceBudget && sourceBudget == destinationBudget) {
-        moved = sourceBudget->moveCacheSubtree(legacy, destination, ec);
-    } else if (!sourceBudget && !destinationBudget) {
-        fs::create_directories(destination.parent_path(), ec);
-        if (!ec) {
-            fs::rename(legacy, destination, ec);
-            moved = !ec;
-        }
-    } else {
-        ec = std::make_error_code(std::errc::cross_device_link);
-    }
-
-    if (moved) {
-        Logger()->info("Migrated remote volume cache {} to {}",
-                       legacy.string(), destination.string());
-    } else {
-        Logger()->warn("Could not migrate remote volume cache {} to {}: {}",
-                       legacy.string(), destination.string(), ec.message());
-    }
-    return volume;
 }
 
 std::string validateRemoteVolumeLocation(
@@ -971,7 +884,6 @@ bool VolumePkg::reconcileVolumeEntryTags(
             try {
                 auto refreshed = openRemoteVolumeEntry(
                     entry,
-                    vc::settings::remoteCachePath(),
                     volume->remoteAuth());
                 const auto oldId = it->first;
                 const auto newId = refreshed->id();
@@ -1025,7 +937,6 @@ bool VolumePkg::mergeVolumeEntryTags(const std::string& location, const std::vec
                     try {
                         auto refreshed = openRemoteVolumeEntry(
                             e,
-                            vc::settings::remoteCachePath(),
                             volume->remoteAuth());
                         const auto refreshedId = refreshed->id();
                         if (refreshedId != id && loadedVolumes_.count(refreshedId) == 0) {
@@ -1980,8 +1891,7 @@ void VolumePkg::resolveAll()
 
     std::vector<RemoteVolumeResult> remoteResults(volumes_.size());
     if (!remoteIndices.empty()) {
-        const auto remoteCacheRoot = vc::settings::remoteCachePath();
-        auto loadRemote = [this, &remoteResults, remoteCacheRoot](std::size_t i) {
+        auto loadRemote = [this, &remoteResults](std::size_t i) {
             const auto& entry = volumes_[i];
             try {
                 if (!isDirectRemoteZarrLocation(entry.location)) {
@@ -1989,7 +1899,7 @@ void VolumePkg::resolveAll()
                     return;
                 }
                 remoteResults[i] = {
-                    openRemoteVolumeEntry(entry, remoteCacheRoot), {}};
+                    openRemoteVolumeEntry(entry), {}};
             } catch (const std::exception& ex) {
                 remoteResults[i] = {nullptr, ex.what()};
             } catch (...) {
@@ -2095,7 +2005,7 @@ void VolumePkg::resolveVolumeEntry(const vc::project::Entry& e)
                                e.location, kDirectRemoteZarrRequired);
                 return;
             }
-            auto v = openRemoteVolumeEntry(e, vc::settings::remoteCachePath());
+            auto v = openRemoteVolumeEntry(e);
             const auto id = v->id();
             if (loadedVolumes_.count(id) > 0) {
                 Logger()->warn("Duplicate remote volume id '{}' from '{}', skipping", id, e.location);

--- a/volume-cartographer/core/src/lasagna/ProjectVolumes.cpp
+++ b/volume-cartographer/core/src/lasagna/ProjectVolumes.cpp
@@ -96,8 +96,7 @@ std::shared_ptr<Volume> openRegularVolumeForGroup(
             ? group.remoteAuth
             : vc::HttpAuth{};
         return Volume::NewFromUrl(
-            location, group.remoteCacheRoot, auth, {},
-            group.discoverAwsCredentials);
+            location, auth, {}, group.discoverAwsCredentials);
     }
     return Volume::New(std::filesystem::path(location));
 }

--- a/volume-cartographer/core/test/test_volume_live_s3.cpp
+++ b/volume-cartographer/core/test/test_volume_live_s3.cpp
@@ -56,7 +56,7 @@ TEST_CASE("Volume::NewFromUrl: invalid credentials fall back to anonymous public
     invalid.region = "us-east-1";
 
     try {
-        const auto volume = Volume::NewFromUrl(kVolumeUrl, {}, invalid);
+        const auto volume = Volume::NewFromUrl(kVolumeUrl, invalid);
         REQUIRE(volume != nullptr);
         CHECK(volume->isRemote());
         CHECK(volume->remoteAuth().empty());

--- a/volume-cartographer/core/test/test_volume_pkg_more.cpp
+++ b/volume-cartographer/core/test/test_volume_pkg_more.cpp
@@ -316,23 +316,6 @@ TEST_CASE("runtime remote cache root is not persisted in projects")
     fs::remove_all(d);
 }
 
-TEST_CASE("open-data remote volume caches are grouped by sample")
-{
-    const fs::path root = "/cache/remote_cache";
-    const vc::project::Entry ordinary{
-        "https://example.test/ordinary.zarr", {}};
-    CHECK(vc::project::remoteVolumeCacheRootForEntry(root, ordinary) == root);
-
-    const vc::project::Entry catalog{
-        "https://example.test/catalog.zarr",
-        {"vc-open-data-sample-id:_Sample With Spaces"}};
-    const auto expected =
-        root / "open_data" / "volumes" / "Sample_With_Spaces";
-    CHECK(vc::project::remoteVolumeCacheRootForEntry(root, catalog) == expected);
-    CHECK(vc::project::remoteVolumeCacheRootForEntry(expected, catalog) ==
-          expected);
-}
-
 TEST_CASE("normalGridPaths + normal3dZarrPaths: empty without entries")
 {
     auto p = VolumePkg::newEmpty();

--- a/volume-cartographer/docs/api/Volume.md
+++ b/volume-cartographer/docs/api/Volume.md
@@ -56,9 +56,11 @@ static std::shared_ptr<Volume> New(std::filesystem::path path,
 // Open a remote HTTP or s3:// zarr volume. s3:// URLs are resolved to HTTPS.
 static std::shared_ptr<Volume> NewFromUrl(
     const std::string& url,
-    const std::filesystem::path& cacheRoot = {},
     const vc::HttpAuth& auth = {});
 ```
+
+Remote volumes always use the process-wide remote cache root configured by
+VC3D.
 
 `New(path, options)` creates a local zarr pyramid when `path` has no existing
 zarr array, or when `options.overwriteExisting` is true. Existing volumes are

--- a/volume-cartographer/python/vc/volume.cpp
+++ b/volume-cartographer/python/vc/volume.cpp
@@ -956,11 +956,10 @@ NB_MODULE(volume, m)
             },
             "path"_a)
         .def_static("open_url",
-            [](const std::string& url, const std::filesystem::path& cacheRoot) {
-                return Volume::NewFromUrl(url, cacheRoot);
+            [](const std::string& url) {
+                return Volume::NewFromUrl(url);
             },
-            "url"_a,
-            "cache_root"_a = std::filesystem::path{})
+            "url"_a)
         .def_prop_ro("is_remote", &Volume::isRemote)
         .def_prop_ro("path", [](const Volume& self) { return self.path().string(); })
         .def_prop_ro("remote_url", [](const Volume& self) { return self.remoteUrl(); })


### PR DESCRIPTION
**In one sentence:** Native remote volumes now always use the remote cache directory configured globally in VC3D.

**One real example:** On a Windows installation, I selected a cache directory on another drive and opened a volume through the Open Data Catalog; native volume access could still omit or override the configured cache root through lower-level APIs.

**Before:** Native remote cache locations could be omitted or independently supplied through C++ and Python Volume APIs, allowing direct callers to bypass the configured VC3D cache directory.

**After this PR:** Native `Volume` access resolves the process-wide cache root internally. Callers of `Volume::NewFromUrl()` and Python `Volume.open_url()` can no longer override or accidentally omit it.

**Why / where this is useful:** VC3D and tools using its native remote-volume implementation consistently store downloaded chunks in the configured cache location.

## Details

- Removes the cache-root argument from C++ `Volume::NewFromUrl()`.
- Changes Python `Volume.open_url()` to accept only the URL.
- Migrates native callers, including project attachment, `vc_grow_seg_from_seed`, and the Lasagna-to-native-Volume bridge.
- Leaves independent Python Zarr and specialized Lasagna cache implementations configurable separately.

Built Python extensions:

- `vc_volume`
- `vc_surface_index`
- `vc_grid_raycast`
- `vc_lasagna_amgx`

Validation:

- `test_lasagna_manifest`
- `test_open_data_manifest`
- `test_volume_pkg_more`
- Python native-volume binding smoke test
