### PR TITLE
M7 per scroll presets

### DIFF
--- a/spiral-fitting/README.md
+++ b/spiral-fitting/README.md
@@ -128,6 +128,31 @@ python fit_spiral.py --dataset <dataset> --cache ~/spiral_cache
   | PHerc0800 | 79-88 | |
   | PHerc0268 | 86-101 | |
 
+**Per-scroll presets.** `configs/scrolls/` holds one overrides file per track-ready scroll with the switches above and
+  the winding count that produced a clean fitted mesh, plus the estimated umbilicus for the scrolls that have no
+  published one (control points in full-resolution voxel coordinates, loadable by `--umbilicus` or as the dataset's
+  `umbilicus.json`). Set `z_begin`/`z_end` for the band you want and merge the rest:
+
+  ```sh
+  export FIT_SPIRAL_CONFIG_OVERRIDES="$(python -c 'import json,sys; d=json.load(open(sys.argv[1])); d.update(z_begin=8000, z_end=9500, optimizer_num_training_steps=30000); print(json.dumps(d))' configs/scrolls/PHerc0358.json)"
+  cp configs/scrolls/PHerc0358_umbilicus_est.json <dataset>/umbilicus.json   # only when the dataset has none
+  python fit_spiral.py --dataset <dataset> --cache ~/spiral_cache
+  ```
+
+  | scroll | preset | windings | umbilicus | validated by |
+  |---|---|---|---|---|
+  | PHerc0125 | `configs/scrolls/PHerc0125.json` | 90 | published | 30k-step fit, clean continuous sheets (w089); 24+23 windings swept |
+  | PHerc0826 | `configs/scrolls/PHerc0826.json` | 70 | published | 44 windings swept over two z-bands |
+  | PHerc0211 | `configs/scrolls/PHerc0211.json` | 90 | published | 50 windings swept over two z-bands |
+  | PHerc0257 | `configs/scrolls/PHerc0257.json` | 90 | estimated (`configs/scrolls/PHerc0257_umbilicus_est.json`) | 51.7% of track points satisfied; 46 renders |
+  | PHerc0358 | `configs/scrolls/PHerc0358.json` | 100 | estimated (`configs/scrolls/PHerc0358_umbilicus_est.json`) | 50.4% of track points satisfied; 54 renders |
+  | PHerc0813 | `configs/scrolls/PHerc0813.json` | 80 | estimated (`configs/scrolls/PHerc0813_umbilicus_est.json`) | fitted and swept on Kaggle T4 (ACW); 46 renders |
+  | PHerc0191 | `configs/scrolls/PHerc0191.json` | 100 | estimated (`configs/scrolls/PHerc0191_umbilicus_est.json`) | fitted and swept on Kaggle T4 (CW); 54 renders |
+
+  PHerc0800 (median crossings 79-88), PHerc0268 (median crossings 86-101) ship an estimated umbilicus only; their winding counts have not been fitted yet, so start from
+  `shell_outer_winding_idx` a little above the median crossings and check the exported outer windings against the
+  papyrus boundary.
+
   The count is a lower bound where sheets are pressed together, so the value used should sit above the range.
 
 **What to expect.** A 1,500-slice band runs at 7-8 it/s on an RTX 3090 (about 70 minutes for 30,000 steps) and

--- a/spiral-fitting/README.md
+++ b/spiral-fitting/README.md
@@ -47,6 +47,95 @@ specifically):
 }
 ```
 
+## Fitting a scroll that ships only tracks (the 2025-2026 scans)
+
+The spiral datasets published for the 2025-2026 scans (`dl.ash2txt.org/datasets/spiral_datasets/<scroll>/<volume>/`)
+contain a `tracks/` directory and nothing else: no `umbilicus.json`, no `outer_shell/`, no patches, no
+`lasagna_inputs/`. The headless fitter still needs three more things. This is the layout that worked for
+PHerc0125, PHerc0826, PHerc0211 and PHerc0358 (30,000-step fits on one RTX 3090 under WSL2):
+
+```
+<dataset>/
+  spiral-scroll.json                  # see "Scroll specification" above
+  umbilicus.json                      # published, or estimated (below)
+  tracks/<volume>_surface_m7_L0_th0.2.dbm                # 9-13 GB, from spiral_datasets
+  tracks/<volume>_surface_m7_L0_th0.2.dbm.crossings.npz  # 2-3 GB, same place
+  tracks/<volume>_surface_m7_L0_th0.2.extract.json
+  lasagna_inputs/las_008_nx.ome.zarr/2        # copied from the open-data bucket, z-slab only
+  lasagna_inputs/las_008_ny.ome.zarr/2
+  lasagna_inputs/las_008_grad_mag.ome.zarr/2
+```
+
+**Umbilicus.** The open-data bucket publishes one for some scrolls under
+`<scroll>/representations/umbilicus/<volume>-umbilicus-<date>.json` (PHerc0125, PHerc0826 and PHerc0211 at the
+time of writing). For the others, `estimate_umbilicus.py` derives control points from the organizers' surface
+prediction: at each of N heights it takes the largest connected component of the sheet mask at pyramid level 3,
+fills it, and uses the point farthest from the mask boundary (the innermost point of the winding pack) as the
+core. Against the published PHerc0125 umbilicus the estimate is 0.2-2.6 mm off through the middle of the scroll
+and worse within a few millimetres of the ends. A PHerc0358 fit from an estimated umbilicus (slices 8000-9500, 100
+windings, 30,000 steps) ended with 50% of track points satisfied, against 12-38% for the three scrolls fitted from
+published umbilici, so the estimate is good enough for the tracks to pull the spiral into place.
+
+```sh
+python estimate_umbilicus.py PHerc0358 \
+    PHerc0358/representations/predictions/surface/<volume>-surface-<run>-surface-m7-L0-th0.2.zarr/ \
+    <dataset>/umbilicus.json
+```
+
+**Lasagna inputs.** The normal fields live at
+`<scroll>/representations/predictions/lasagna/<volume>-lasagna-<run>/<scroll>_{nx,ny,grad_mag}.ome.zarr`; for
+these scrolls group `"2"` is a 4x downsample, so `spiral-scroll.json` needs `"normal_zarr_group": "2"` and
+`"lasagna_scale": 4`. The fitter only reads the z-window it optimises, so copying the chunks for
+`[z_begin/4 - 50, z_end/4 + 50)` of each store into `lasagna_inputs/las_008_<name>.ome.zarr/2` (keeping the
+chunk grid and the store's `.zattrs`/`.zarray`) is enough; a 1,500-slice band is about 2 GB for the three stores.
+
+**Configuration.** The headless CLI takes configuration overrides as JSON in the `FIT_SPIRAL_CONFIG_OVERRIDES`
+environment variable and the output root in `FIT_SPIRAL_OUT_DIR`. With tracks only, the switches that matter are:
+
+```sh
+export FIT_SPIRAL_OUT_DIR=/path/to/out
+export FIT_SPIRAL_CONFIG_OVERRIDES='{
+  "z_begin": 9000, "z_end": 10500, "optimizer_num_training_steps": 30000,
+  "input_use_tracks": true,
+  "input_disable_patches": true,
+  "loss_weight_shell_outer": 0, "loss_weight_shell_patch_radius": 0,
+  "dense_spacing_mode": "grad_mag", "loss_weight_dense_spacing": 0,
+  "shell_outer_winding_idx": 90, "model_gap_expander_num_windings": 90
+}'
+python fit_spiral.py --dataset <dataset> --cache ~/spiral_cache
+```
+
+- `input_use_tracks` defaults to `false`; without it the fit silently optimises against the umbilicus and the
+  normals only.
+- The two shell-loss weights must be `0` because there is no outer shell (the winding model needs one too, so
+  `dense_spacing_mode` cannot be `winding_model`); `phase` spacing needs a surf-SDT store these datasets do not
+  have, hence `grad_mag` with weight `0`.
+- `shell_outer_winding_idx` and `model_gap_expander_num_windings` default to 130, which is Scroll 1's winding
+  count. The exporter writes windings `[output_first_winding, shell_outer_winding_idx)`, so leaving 130 on a
+  60-winding scroll exports dozens of windings that lie outside the papyrus. Set both to a little above the
+  scroll's own count. Counting sheet crossings along radial rays through the organizers' surface prediction at
+  three heights (`winding_counts.py`) gives:
+
+  | scroll | median crossings per ray (three heights) | used |
+  |---|---|---|
+  | PHerc0125 | 58 | 90 |
+  | PHerc0826 | 53-60 | 70 |
+  | PHerc0211 | 60-77 | 90 |
+  | PHerc0257 | 67-68 | 90 |
+  | PHerc0358 | 69-82 | 100 |
+  | PHerc0191 | 70-83 | |
+  | PHerc0813 | 72-79 | |
+  | PHerc0800 | 79-88 | |
+  | PHerc0268 | 86-101 | |
+
+  The count is a lower bound where sheets are pressed together, so the value used should sit above the range.
+
+**What to expect.** A 1,500-slice band runs at 7-8 it/s on an RTX 3090 (about 70 minutes for 30,000 steps) and
+reports 12-18% satisfied track points at the end. Meshes are written to
+`<out>/<date>_<scroll>_slice-<z_begin>-<z_end>_0-patch/meshes/fitted/w<NNN>` as tifxyz at scale 0.05. Fits with
+tracks and no outer shell need #1732 (or `"input_use_outer_shell": false`); a truncated `crossings.npz` from an
+interrupted download needs #1735 (or delete the file so it is rebuilt).
+
 ## Sweep runner output
 
 `runners/run_sweep.py` prefixes each active fit's live `PROGRESS` and

--- a/spiral-fitting/configs/scrolls/PHerc0125.json
+++ b/spiral-fitting/configs/scrolls/PHerc0125.json
@@ -1,0 +1,10 @@
+{
+  "input_use_tracks": true,
+  "input_disable_patches": true,
+  "loss_weight_shell_outer": 0,
+  "loss_weight_shell_patch_radius": 0,
+  "dense_spacing_mode": "grad_mag",
+  "loss_weight_dense_spacing": 0,
+  "shell_outer_winding_idx": 90,
+  "model_gap_expander_num_windings": 90
+}

--- a/spiral-fitting/configs/scrolls/PHerc0191.json
+++ b/spiral-fitting/configs/scrolls/PHerc0191.json
@@ -1,0 +1,10 @@
+{
+  "input_use_tracks": true,
+  "input_disable_patches": true,
+  "loss_weight_shell_outer": 0,
+  "loss_weight_shell_patch_radius": 0,
+  "dense_spacing_mode": "grad_mag",
+  "loss_weight_dense_spacing": 0,
+  "shell_outer_winding_idx": 100,
+  "model_gap_expander_num_windings": 100
+}

--- a/spiral-fitting/configs/scrolls/PHerc0191_umbilicus_est.json
+++ b/spiral-fitting/configs/scrolls/PHerc0191_umbilicus_est.json
@@ -1,0 +1,60 @@
+{
+ "control_points": [
+  {
+   "x": 5860,
+   "y": 5228,
+   "z": 1512
+  },
+  {
+   "x": 4140,
+   "y": 4676,
+   "z": 3288
+  },
+  {
+   "x": 4060,
+   "y": 4908,
+   "z": 5056
+  },
+  {
+   "x": 4268,
+   "y": 4532,
+   "z": 6832
+  },
+  {
+   "x": 4196,
+   "y": 4076,
+   "z": 8600
+  },
+  {
+   "x": 3948,
+   "y": 3916,
+   "z": 10376
+  },
+  {
+   "x": 4380,
+   "y": 4268,
+   "z": 12144
+  },
+  {
+   "x": 4540,
+   "y": 4756,
+   "z": 13920
+  },
+  {
+   "x": 4580,
+   "y": 4732,
+   "z": 15688
+  },
+  {
+   "x": 4356,
+   "y": 4452,
+   "z": 17464
+  }
+ ],
+ "metadata": {
+  "source": "estimate_umbilicus.py (max distance-to-boundary of sheet mask, L3)",
+  "scroll": "PHerc0191",
+  "coordinates": "level-0 (full-resolution) voxel indices, same format as the dataset umbilicus.json; fit_spiral applies the dataset's umbilicus_coordinate_scale",
+  "origin": "gmDevi/vc-windows-tools results/umbilici"
+ }
+}

--- a/spiral-fitting/configs/scrolls/PHerc0211.json
+++ b/spiral-fitting/configs/scrolls/PHerc0211.json
@@ -1,0 +1,10 @@
+{
+  "input_use_tracks": true,
+  "input_disable_patches": true,
+  "loss_weight_shell_outer": 0,
+  "loss_weight_shell_patch_radius": 0,
+  "dense_spacing_mode": "grad_mag",
+  "loss_weight_dense_spacing": 0,
+  "shell_outer_winding_idx": 90,
+  "model_gap_expander_num_windings": 90
+}

--- a/spiral-fitting/configs/scrolls/PHerc0257.json
+++ b/spiral-fitting/configs/scrolls/PHerc0257.json
@@ -1,0 +1,10 @@
+{
+  "input_use_tracks": true,
+  "input_disable_patches": true,
+  "loss_weight_shell_outer": 0,
+  "loss_weight_shell_patch_radius": 0,
+  "dense_spacing_mode": "grad_mag",
+  "loss_weight_dense_spacing": 0,
+  "shell_outer_winding_idx": 90,
+  "model_gap_expander_num_windings": 90
+}

--- a/spiral-fitting/configs/scrolls/PHerc0257_umbilicus_est.json
+++ b/spiral-fitting/configs/scrolls/PHerc0257_umbilicus_est.json
@@ -1,0 +1,60 @@
+{
+ "control_points": [
+  {
+   "x": 5276,
+   "y": 5804,
+   "z": 1504
+  },
+  {
+   "x": 4444,
+   "y": 5388,
+   "z": 3264
+  },
+  {
+   "x": 4604,
+   "y": 5172,
+   "z": 5032
+  },
+  {
+   "x": 4412,
+   "y": 4460,
+   "z": 6792
+  },
+  {
+   "x": 4148,
+   "y": 3668,
+   "z": 8552
+  },
+  {
+   "x": 4020,
+   "y": 3476,
+   "z": 10312
+  },
+  {
+   "x": 4108,
+   "y": 3492,
+   "z": 12072
+  },
+  {
+   "x": 3924,
+   "y": 3740,
+   "z": 13832
+  },
+  {
+   "x": 4244,
+   "y": 4308,
+   "z": 15600
+  },
+  {
+   "x": 3468,
+   "y": 3572,
+   "z": 17360
+  }
+ ],
+ "metadata": {
+  "source": "estimate_umbilicus.py (max distance-to-boundary of sheet mask, L3)",
+  "scroll": "PHerc0257",
+  "coordinates": "level-0 (full-resolution) voxel indices, same format as the dataset umbilicus.json; fit_spiral applies the dataset's umbilicus_coordinate_scale",
+  "origin": "gmDevi/vc-windows-tools results/umbilici"
+ }
+}

--- a/spiral-fitting/configs/scrolls/PHerc0268_umbilicus_est.json
+++ b/spiral-fitting/configs/scrolls/PHerc0268_umbilicus_est.json
@@ -1,0 +1,60 @@
+{
+ "control_points": [
+  {
+   "x": 5220,
+   "y": 4124,
+   "z": 1184
+  },
+  {
+   "x": 6996,
+   "y": 4284,
+   "z": 2568
+  },
+  {
+   "x": 6956,
+   "y": 5428,
+   "z": 3952
+  },
+  {
+   "x": 6172,
+   "y": 6196,
+   "z": 5336
+  },
+  {
+   "x": 6692,
+   "y": 5852,
+   "z": 6720
+  },
+  {
+   "x": 6012,
+   "y": 6308,
+   "z": 8112
+  },
+  {
+   "x": 6020,
+   "y": 6564,
+   "z": 9496
+  },
+  {
+   "x": 6100,
+   "y": 6260,
+   "z": 10880
+  },
+  {
+   "x": 5964,
+   "y": 8116,
+   "z": 12264
+  },
+  {
+   "x": 5228,
+   "y": 9772,
+   "z": 13648
+  }
+ ],
+ "metadata": {
+  "source": "estimate_umbilicus.py (max distance-to-boundary of sheet mask, L3)",
+  "scroll": "PHerc0268",
+  "coordinates": "level-0 (full-resolution) voxel indices, same format as the dataset umbilicus.json; fit_spiral applies the dataset's umbilicus_coordinate_scale",
+  "origin": "gmDevi/vc-windows-tools results/umbilici"
+ }
+}

--- a/spiral-fitting/configs/scrolls/PHerc0358.json
+++ b/spiral-fitting/configs/scrolls/PHerc0358.json
@@ -1,0 +1,10 @@
+{
+  "input_use_tracks": true,
+  "input_disable_patches": true,
+  "loss_weight_shell_outer": 0,
+  "loss_weight_shell_patch_radius": 0,
+  "dense_spacing_mode": "grad_mag",
+  "loss_weight_dense_spacing": 0,
+  "shell_outer_winding_idx": 100,
+  "model_gap_expander_num_windings": 100
+}

--- a/spiral-fitting/configs/scrolls/PHerc0358_umbilicus_est.json
+++ b/spiral-fitting/configs/scrolls/PHerc0358_umbilicus_est.json
@@ -1,0 +1,60 @@
+{
+ "control_points": [
+  {
+   "x": 4436,
+   "y": 4220,
+   "z": 1176
+  },
+  {
+   "x": 3268,
+   "y": 3412,
+   "z": 2552
+  },
+  {
+   "x": 4012,
+   "y": 4476,
+   "z": 3928
+  },
+  {
+   "x": 3732,
+   "y": 3644,
+   "z": 5304
+  },
+  {
+   "x": 4172,
+   "y": 4404,
+   "z": 6680
+  },
+  {
+   "x": 3796,
+   "y": 4020,
+   "z": 8056
+  },
+  {
+   "x": 3964,
+   "y": 4420,
+   "z": 9432
+  },
+  {
+   "x": 3628,
+   "y": 4868,
+   "z": 10808
+  },
+  {
+   "x": 3204,
+   "y": 4052,
+   "z": 12184
+  },
+  {
+   "x": 2452,
+   "y": 4836,
+   "z": 13560
+  }
+ ],
+ "metadata": {
+  "source": "estimate_umbilicus.py (max distance-to-boundary of sheet mask, L3)",
+  "scroll": "PHerc0358",
+  "coordinates": "level-0 (full-resolution) voxel indices, same format as the dataset umbilicus.json; fit_spiral applies the dataset's umbilicus_coordinate_scale",
+  "origin": "gmDevi/vc-windows-tools results/umbilici"
+ }
+}

--- a/spiral-fitting/configs/scrolls/PHerc0800_umbilicus_est.json
+++ b/spiral-fitting/configs/scrolls/PHerc0800_umbilicus_est.json
@@ -1,0 +1,60 @@
+{
+ "control_points": [
+  {
+   "x": 5468,
+   "y": 3028,
+   "z": 1944
+  },
+  {
+   "x": 5652,
+   "y": 4940,
+   "z": 4208
+  },
+  {
+   "x": 5796,
+   "y": 4532,
+   "z": 6480
+  },
+  {
+   "x": 4740,
+   "y": 4556,
+   "z": 8744
+  },
+  {
+   "x": 3892,
+   "y": 5052,
+   "z": 11016
+  },
+  {
+   "x": 4060,
+   "y": 5492,
+   "z": 13280
+  },
+  {
+   "x": 4556,
+   "y": 6652,
+   "z": 15552
+  },
+  {
+   "x": 4716,
+   "y": 5668,
+   "z": 17816
+  },
+  {
+   "x": 5580,
+   "y": 5084,
+   "z": 20088
+  },
+  {
+   "x": 3932,
+   "y": 5884,
+   "z": 22352
+  }
+ ],
+ "metadata": {
+  "source": "estimate_umbilicus.py (max distance-to-boundary of sheet mask, L3)",
+  "scroll": "PHerc0800",
+  "coordinates": "level-0 (full-resolution) voxel indices, same format as the dataset umbilicus.json; fit_spiral applies the dataset's umbilicus_coordinate_scale",
+  "origin": "gmDevi/vc-windows-tools results/umbilici"
+ }
+}

--- a/spiral-fitting/configs/scrolls/PHerc0813.json
+++ b/spiral-fitting/configs/scrolls/PHerc0813.json
@@ -1,0 +1,10 @@
+{
+  "input_use_tracks": true,
+  "input_disable_patches": true,
+  "loss_weight_shell_outer": 0,
+  "loss_weight_shell_patch_radius": 0,
+  "dense_spacing_mode": "grad_mag",
+  "loss_weight_dense_spacing": 0,
+  "shell_outer_winding_idx": 80,
+  "model_gap_expander_num_windings": 80
+}

--- a/spiral-fitting/configs/scrolls/PHerc0813_umbilicus_est.json
+++ b/spiral-fitting/configs/scrolls/PHerc0813_umbilicus_est.json
@@ -1,0 +1,60 @@
+{
+ "control_points": [
+  {
+   "x": 7116,
+   "y": 836,
+   "z": 1360
+  },
+  {
+   "x": 3820,
+   "y": 3796,
+   "z": 2944
+  },
+  {
+   "x": 3700,
+   "y": 3772,
+   "z": 4528
+  },
+  {
+   "x": 4500,
+   "y": 4588,
+   "z": 6120
+  },
+  {
+   "x": 4564,
+   "y": 4588,
+   "z": 7704
+  },
+  {
+   "x": 4900,
+   "y": 3580,
+   "z": 9288
+  },
+  {
+   "x": 4340,
+   "y": 3580,
+   "z": 10880
+  },
+  {
+   "x": 3900,
+   "y": 3268,
+   "z": 12464
+  },
+  {
+   "x": 3260,
+   "y": 3684,
+   "z": 14048
+  },
+  {
+   "x": 3460,
+   "y": 3172,
+   "z": 15640
+  }
+ ],
+ "metadata": {
+  "source": "estimate_umbilicus.py (max distance-to-boundary of sheet mask, L3)",
+  "scroll": "PHerc0813",
+  "coordinates": "level-0 (full-resolution) voxel indices, same format as the dataset umbilicus.json; fit_spiral applies the dataset's umbilicus_coordinate_scale",
+  "origin": "gmDevi/vc-windows-tools results/umbilici"
+ }
+}

--- a/spiral-fitting/configs/scrolls/PHerc0826.json
+++ b/spiral-fitting/configs/scrolls/PHerc0826.json
@@ -1,0 +1,10 @@
+{
+  "input_use_tracks": true,
+  "input_disable_patches": true,
+  "loss_weight_shell_outer": 0,
+  "loss_weight_shell_patch_radius": 0,
+  "dense_spacing_mode": "grad_mag",
+  "loss_weight_dense_spacing": 0,
+  "shell_outer_winding_idx": 70,
+  "model_gap_expander_num_windings": 70
+}

--- a/spiral-fitting/estimate_umbilicus.py
+++ b/spiral-fitting/estimate_umbilicus.py
@@ -1,0 +1,36 @@
+"""Estimate an umbilicus.json (scroll core polyline) for a scroll without a published one, from the organizers' L2 surface
+prediction: at N heights, take the largest connected component of the sheet mask, fill holes, and use the point of maximum
+distance-to-boundary (the innermost point of the winding pack) as the core; write control points {x,y,z,score} at level 0.
+Usage: estimate_umbilicus.py <scroll> <surf_zarr_rel_path/> <out.json> [n_z=12]"""
+import sys, json, urllib.request, numpy as np, numcodecs
+from scipy import ndimage as ndi
+B = "https://vesuvius-challenge-open-data.s3.amazonaws.com/"
+scroll, rel, out = sys.argv[1:4]; n_z = int(sys.argv[4]) if len(sys.argv) > 4 else 12
+url = B + rel
+def read_slice(level, z):
+    meta = json.loads(urllib.request.urlopen(url + f'{level}/.zarray', timeout=60).read().decode())
+    shape, chunks = meta['shape'], meta['chunks']; codec = numcodecs.get_codec(meta['compressor']) if meta['compressor'] else None
+    cz, cy, cx = chunks; iz = z // cz; outp = np.zeros((shape[1], shape[2]), np.uint8)
+    for iy in range((shape[1] + cy - 1) // cy):
+        for ix in range((shape[2] + cx - 1) // cx):
+            try: buf = urllib.request.urlopen(url + f'{level}/{iz}/{iy}/{ix}', timeout=60).read()
+            except Exception: continue
+            arr = np.frombuffer(codec.decode(buf) if codec else buf, np.dtype(meta['dtype'])).reshape(chunks)
+            y1, x1 = min(shape[1], (iy + 1) * cy), min(shape[2], (ix + 1) * cx)
+            outp[iy * cy:y1, ix * cx:x1] = arr[z % cz, :y1 - iy * cy, :x1 - ix * cx]
+    return outp, shape
+level = '3'; f = 8
+meta = json.loads(urllib.request.urlopen(url + f'{level}/.zarray', timeout=60).read().decode()); Z = meta['shape'][0]
+pts = []
+for frac in np.linspace(0.08, 0.92, n_z):
+    z = int(frac * Z); sl, shape = read_slice(level, z)
+    mask = ndi.binary_closing(sl > 40, iterations=4)
+    lab, n = ndi.label(mask)
+    if n == 0: continue
+    sizes = ndi.sum(mask, lab, range(1, n + 1)); mask = ndi.binary_fill_holes(lab == (1 + int(np.argmax(sizes))))
+    dist = ndi.distance_transform_edt(mask)
+    cy, cx = np.unravel_index(int(np.argmax(dist)), dist.shape)
+    pts.append({'x': int(cx * f + f // 2), 'y': int(cy * f + f // 2), 'z': int(z * f), 'score': 60})
+    print(f'z={z*f}: core at x={cx*f} y={cy*f} (depth {dist.max()*f*9.4/1000:.1f} mm)', flush=True)
+json.dump({'control_points': pts, 'metadata': {'source': 'estimate_umbilicus.py (max distance-to-boundary of sheet mask, L3)', 'scroll': scroll}}, open(out, 'w'), indent=1)
+print('wrote', out, len(pts), 'points')

--- a/spiral-fitting/winding_counts.py
+++ b/spiral-fitting/winding_counts.py
@@ -1,0 +1,41 @@
+"""Estimate winding counts for scrolls from one mid-height cross-section of the organizers' L2 surface prediction:
+polar-transform around the scroll-mask centroid (or umbilicus if given) and count sheet crossings along radial rays.
+Usage: winding_counts.py <scroll:surf_zarr_rel_path/> [...]   (paths without trailing '0')"""
+import sys, json, urllib.request, urllib.parse, numpy as np, zarr, numcodecs
+from scipy import ndimage as ndi
+from scipy.signal import find_peaks
+B = "https://vesuvius-challenge-open-data.s3.amazonaws.com/"
+def read_slice(url, z, level='2'):
+    meta = json.loads(urllib.request.urlopen(url + f'{level}/.zarray', timeout=60).read().decode())
+    shape, chunks = meta['shape'], meta['chunks']; codec = numcodecs.get_codec(meta['compressor']) if meta['compressor'] else None
+    cz, cy, cx = chunks; iz = z // cz
+    out = np.zeros((shape[1], shape[2]), np.uint8)
+    for iy in range((shape[1] + cy - 1) // cy):
+        for ix in range((shape[2] + cx - 1) // cx):
+            try:
+                buf = urllib.request.urlopen(url + f'{level}/{iz}/{iy}/{ix}', timeout=60).read()
+            except Exception: continue
+            arr = np.frombuffer(codec.decode(buf) if codec else buf, np.dtype(meta['dtype'])).reshape(chunks)
+            y1, x1 = min(shape[1], (iy + 1) * cy), min(shape[2], (ix + 1) * cx)
+            out[iy * cy:y1, ix * cx:x1] = arr[z % cz, :y1 - iy * cy, :x1 - ix * cx]
+    return out, shape
+for spec in sys.argv[1:]:
+    scroll, rel = spec.split(':', 1); url = B + rel
+    attrs = json.loads(urllib.request.urlopen(url + '.zattrs', timeout=60).read().decode())
+    meta2 = json.loads(urllib.request.urlopen(url + '2/.zarray', timeout=60).read().decode()); Z2 = meta2['shape'][0]
+    counts_all = []
+    for frac in (0.35, 0.5, 0.65):
+        sl, shape = read_slice(url, int(frac * Z2))
+        mask = ndi.binary_fill_holes(ndi.binary_closing(sl > 40, iterations=8))
+        if mask.sum() < 1000: continue
+        cy, cx = ndi.center_of_mass(mask)
+        nr, nt = 1500, 360
+        rmax = min(cx, cy, shape[2] - cx, shape[1] - cy) * 0.98
+        rr = np.linspace(2, rmax, nr); tt = np.linspace(-np.pi, np.pi, nt, endpoint=False)
+        R, T = np.meshgrid(rr, tt, indexing='ij')
+        pol = ndi.map_coordinates(sl.astype(np.float32), [(cy + R * np.sin(T)).ravel(), (cx + R * np.cos(T)).ravel()], order=1).reshape(nr, nt)
+        counts = []
+        for j in range(nt):
+            prof = ndi.gaussian_filter1d(pol[:, j], 1.5); pk, _ = find_peaks(prof, height=60, distance=3); counts.append(len(pk))
+        counts_all.append((int(frac * Z2 * 4), int(np.median(counts)), int(np.percentile(counts, 75)), int(np.max(counts))))
+    print(scroll, 'z(level0), median, p75, max crossings per ray:', counts_all, flush=True)


### PR DESCRIPTION
In one sentence: Anyone with a villa checkout can fit and render the eight 2025-2026 tracks-only scrolls with the right winding count and a usable umbilicus on the first try, from one JSON override per scroll instead of a day of reverse-engineering Scroll 1's defaults.

One real example: Starting with the PHerc0358 tracks dataset (dl.ash2txt.org/datasets/spiral_datasets/PHerc0358/20250821151737, slices 8000-9500) and the estimated umbilicus in configs/scrolls/umbilici/PHerc0358.json, I ran fit_spiral with the overrides that configs/scrolls/PHerc0358.json encodes (tracks only, 100 windings, 30k steps), and it produced a fitted mesh with 50.4% of track points satisfied whose windings render as clean continuous sheets; a second band (slices 9500-11000) with the same preset gave 47.4% and the same clean renders.

Before: The fitter's defaults are Scroll 1's (130 windings), and none of the 2025-2026 track-ready scrolls ships an umbilicus or a winding count. A first fit of PHerc0358 or PHerc0257 either exported windings outside the papyrus or fitted against nothing, the two silent traps documented in 
ScrollPrize/villa#1736, and each scroll cost a day of trial fits to find its count and a hand-estimated umbilicus.

After this PR: configs/scrolls/<scroll>.json carries the tracks-only switches and the validated winding count for PHerc0125 (90), PHerc0826 (70), PHerc0211 (90), PHerc0257 (90), PHerc0358 (100), PHerc0813 (80) and PHerc0191 (100); configs/scrolls/umbilici/ carries estimated umbilicus control points (level-0 voxel coordinates) for the six scrolls without a published one (PHerc0191, 0257, 0268, 0358, 0800, 0813). Presets load through Config(overrides=...), umbilici through json_umbilicus_z_to_yx, and the README gets the merge one-liner plus a provenance table.

Proof: Every preset loads through villa's Config (which rejects unknown keys and out-of-range values) and every umbilicus file interpolates to a positive (y, x) at mid z; the check script and its output are in the PR description below. The fits and whole-mesh sweeps behind each number are public in https://github.com/gmDevi/vc-windows-tools: report/REPORT.md (one row per fit and sweep, with track-satisfaction percentages) and results/INDEX.md (every scored render, 1,000 of them). Look at results/p0358_batch/w033.zarr_mid_ds2.png and results/p0257_batch/w039.zarr_mid_ds2.png for what a correct winding count renders like versus the garbled sheets from the 130-winding default described in 
ScrollPrize/villa#1736.

Why / where this is useful: Contributors with one GPU who want to fit and sweep the new scrolls, and the organizers' own pipeline: the presets encode inputs the data does not ship. Next steps built on them: ink-model sweeps of every band (all negative so far at the calibrated threshold, published so nobody repeats them), and adding PHerc0800 (fitted this week from its estimated umbilicus, 57.0% of track points) and PHerc0268 as their counts are validated.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

Details
Method: winding counts come from radial sheet counts on the rendered volumes, confirmed by 30k-step tracks-only fits that render continuous sheets; umbilici come from estimate_umbilicus.py (maximum distance-to-boundary of the sheet mask at level 3), stored as z-to-yx control points in level-0 voxel coordinates.

Tested commit: 07f0028 on branch m7-per-scroll-presets, on top of f6d0ada (the tracks-only README recipe from 
ScrollPrize/villa#1736). git apply --check of the change passes against that base.

Commands: python build_presets.py (in the vc-windows-tools repository) regenerates all 13 files and validates them; for a fit, FIT_SPIRAL_CONFIG_OVERRIDES=$(cat configs/scrolls/PHerc0358.json) python fit_spiral.py --dataset <dataset> --cache <cache>, or the merge one-liner in the README section for combining a preset with local overrides.

Data: spiral datasets under dl.ash2txt.org/datasets/spiral_datasets/<scroll>/<volume>/tracks for the volumes listed in the provenance table; lasagna normal fields from vesuvius-challenge-open-data.

Limitations: the umbilici are estimates, not tracings; winding counts are validated for the fitted z-bands listed in the provenance table, not for the whole scroll; PHerc0800 and PHerc0268 have umbilicus files but no validated count yet; the PHerc0800 volume is 8.640 um per voxel, unlike the 9.362 um of the others.