### PR TITLE
VC3D line annotation: Ctrl+Shift+wheel slides the current cut straight ahead

### DIFF
--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -1416,6 +1416,7 @@ bool LineAnnotationDialog::setGeneratedRows(
     _currentCutManualRotation = cv::Matx33f::eye();
     _currentCutManualRotationActive = false;
     _currentCutNormalOffsetVx = 0.0;
+    _currentCutStraightAheadActive = false;
     _sideCutNormalOffsetVx = 0.0;
     _generatedControlIndex = {};
     _haveInitialCurrentCutCamera = false;
@@ -1815,6 +1816,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         _sideCutOverlaySwapPending = true;
         _stripOverlaySwapPending.assign(_stripViewers.size(), true);
         _currentCutNormalOffsetVx = 0.0;
+        _currentCutStraightAheadActive = false;
         _sideCutNormalOffsetVx = 0.0;
         _currentCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
         _sideCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
@@ -2004,6 +2006,7 @@ bool LineAnnotationDialog::setGeneratedLineViews(
     _hasGeneratedViews = true;
     _currentCutFollowsStripMouse = views.initialCurrentCutFollowsStripMouse;
     _currentCutNormalOffsetVx = 0.0;
+    _currentCutStraightAheadActive = false;
     _sideCutNormalOffsetVx = 0.0;
     if (!replacingGeneratedViews) {
         _currentCutManualRotation = cv::Matx33f::eye();
@@ -2061,8 +2064,12 @@ bool LineAnnotationDialog::setGeneratedLineViews(
         currentViewer->centerOnVolumePoint(_generatedViews.focusPoint, false);
     }
     currentViewer->setShiftScrollOverride(
-        [this](int steps, QPointF, Qt::KeyboardModifiers) {
-            // Always step along the line; the cut plane never leaves it.
+        [this](int steps, QPointF, Qt::KeyboardModifiers modifiers) {
+            // Ctrl+Shift slides the plane straight ahead (off the model line);
+            // plain Shift steps along the line and the cut plane never leaves it.
+            if (modifiers.testFlag(Qt::ControlModifier)) {
+                return shiftCurrentCutStraightAheadByScrollSteps(steps);
+            }
             return shiftCurrentLinePositionByScrollSteps(steps);
         });
     bindPaneInteractions(views.currentCutName, currentViewer, false);
@@ -2567,13 +2574,18 @@ void LineAnnotationDialog::setCurrentLinePosition(double position,
         return;
     }
     position = std::clamp(position, 0.0, static_cast<double>(_generatedViews.linePoints.size() - 1));
+    // A straight-ahead (Ctrl+Shift+wheel) displacement counts as a change even
+    // at an unchanged position: every along-line navigation snaps the cut plane
+    // back onto the model line.
     const bool currentChanged =
-        forceApply || std::abs(position - _currentLinePosition) >= 1.0e-3;
+        forceApply || std::abs(position - _currentLinePosition) >= 1.0e-3 ||
+        _currentCutStraightAheadActive;
     if (!currentChanged) {
         return;
     }
     if (currentChanged && _generatedViews.currentCutSurface) {
         _currentCutNormalOffsetVx = 0.0;
+        _currentCutStraightAheadActive = false;
         if (_currentCutViewer) {
             _currentCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
         }
@@ -2627,11 +2639,76 @@ bool LineAnnotationDialog::shiftCurrentLinePositionByScrollSteps(int steps)
         steps,
         sliceStepSize,
         currentLineArclengths());
-    _currentCutNormalOffsetVx = 0.0;
-    if (_currentCutViewer) {
-        _currentCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
-    }
+    // setCurrentLinePosition re-poses the plane on the line (and sees a pending
+    // straight-ahead displacement as a change), so no offset reset is needed here.
     setCurrentLinePosition(position);
+    return true;
+}
+
+bool LineAnnotationDialog::shiftCurrentCutStraightAheadByScrollSteps(int steps)
+{
+    PlaneSurface* plane = _generatedViews.currentCutSurface.get();
+    if (!_hasGeneratedViews || _generatedViews.linePoints.empty() || !plane || steps == 0) {
+        return true;
+    }
+    // Like the along-line scroll, the notch supersedes a running keyboard pan
+    // and any coalesced hover-follow flush still in the timer, whether or not
+    // it ends up moving anything: either would otherwise re-pose the plane a
+    // few ms later.
+    cancelArrowPan();
+    _lineUpdatePending = false;
+    if (_lineUpdateTimer) {
+        _lineUpdateTimer->stop();
+    }
+    const int sliceStepSize = _viewerManager
+        ? std::max(1, static_cast<int>(std::lround(_viewerManager->zScrollSensitivity())))
+        : 1;
+    // The geometry is computed and validated before any of it is applied, so a
+    // degenerate plane cannot leave the marker advanced with the plane in place.
+    const auto& arclengths = currentLineArclengths();
+    const double newPosition = vc3d::line_annotation::shiftedLinePositionByArclength(
+        _currentLinePosition,
+        steps,
+        sliceStepSize,
+        arclengths);
+    const double distanceVx = vc3d::line_annotation::straightAheadDistanceForShiftScroll(
+        _currentLinePosition, newPosition, arclengths);
+    if (std::abs(newPosition - _currentLinePosition) < 1.0e-9 ||
+        !std::isfinite(distanceVx) || std::abs(distanceVx) <= 1.0e-6) {
+        // Marker clamped at a line end (or no usable arclength map): stop with
+        // it, as plain Shift+wheel does.
+        return true;
+    }
+    const cv::Vec3f normal = plane->normal({0.0f, 0.0f, 0.0f});
+    // Undo the display sign to get the true "ahead" direction (see
+    // interpolatedLineTangent) and slide the plane along its normal into that
+    // half-space; the sign is fixed for the whole gesture (straightAheadDirection).
+    const cv::Vec3f ahead = interpolatedLineTangent(_currentLinePosition) * _displayTangentSign;
+    if (!finitePoint(normal) || cv::norm(normal) <= 1.0e-6f || !finitePoint(ahead)) {
+        return true;
+    }
+    const double direction = vc3d::line_annotation::straightAheadDirection(
+        normal, ahead, _currentCutStraightAheadActive, _currentCutStraightAheadDirection);
+    const cv::Vec3f shiftedOrigin = vc3d::line_annotation::planeOriginShiftedAlongNormal(
+        plane->origin(), normal, direction * distanceVx);
+    if (!finitePoint(shiftedOrigin)) {
+        return true;
+    }
+
+    // Commit.
+    _currentLinePosition = newPosition;
+    // Pure translation: normal and in-plane basis are kept (decision: fixed
+    // orientation during the gesture). Deliberately no updatePlaneSurface /
+    // updateSidePlaneSurface and no side or strip recentering: only the marker
+    // follows the model line; the side cut catches up on the next snap-back.
+    plane->setFromNormalAndUp(shiftedOrigin, normal, plane->basisY());
+    _currentCutStraightAheadActive = true;
+    _currentCutStraightAheadDirection = direction;
+    if (_currentCutViewer) {
+        _currentCutViewer->markSurfaceGeometryChanged();
+        _currentCutViewer->renderVisible(true, "line annotation current cut straight ahead");
+    }
+    rebuildGeneratedDynamicOverlays();
     return true;
 }
 
@@ -2678,6 +2755,11 @@ void LineAnnotationDialog::startArrowPan(int direction)
         // Nothing that way: a fresh press does nothing, a reversal just stops.
         if (_arrowPanDirection != 0) {
             cancelArrowPan();
+        }
+        if (_currentCutStraightAheadActive) {
+            // Still an along-line navigation: snap a straight-ahead displaced
+            // plane back onto the line even though there is nowhere to go.
+            setCurrentLinePosition(_currentLinePosition, true, true);
         }
         return;
     }
@@ -3194,9 +3276,15 @@ void LineAnnotationDialog::resetGeneratedCutNormalOffsets(bool forceRender)
     }
 
     bool changed = false;
-    const bool currentHadOffset = normalOffsetActive(_currentCutNormalOffsetVx);
-    const bool sideHadOffset = normalOffsetActive(_sideCutNormalOffsetVx);
+    const bool currentHadOffset =
+        normalOffsetActive(_currentCutNormalOffsetVx) || _currentCutStraightAheadActive;
+    // A straight-ahead advance left the side cut frozen at the position where
+    // the gesture began, so it has to catch up with the marker as well.
+    const bool sideHadOffset =
+        normalOffsetActive(_sideCutNormalOffsetVx) || _currentCutStraightAheadActive;
+    const bool recenterSide = _currentCutStraightAheadActive;
     _currentCutNormalOffsetVx = 0.0;
+    _currentCutStraightAheadActive = false;
     _sideCutNormalOffsetVx = 0.0;
     if (_currentCutViewer) {
         _currentCutViewer->setProperty("vc_custom_normal_offset_vx", 0.0);
@@ -3221,6 +3309,12 @@ void LineAnnotationDialog::resetGeneratedCutNormalOffsets(bool forceRender)
             changed = true;
             if (_sideCutViewer) {
                 _sideCutViewer->markSurfaceGeometryChanged();
+                if (recenterSide) {
+                    const cv::Vec3f sidePoint = interpolatedLinePoint(_currentLinePosition);
+                    if (finitePoint(sidePoint)) {
+                        _sideCutViewer->centerOnVolumePoint(sidePoint, false);
+                    }
+                }
                 if (forceRender) {
                     _sideCutViewer->renderVisible(true, "line annotation side cut offset reset");
                 }
@@ -3500,6 +3594,11 @@ bool LineAnnotationDialog::rotateCurrentCut(vc3d::line_annotation::GeneratedCutR
     if (!_hasGeneratedViews || !_generatedViews.currentCutSurface || !_currentCutViewer) {
         return false;
     }
+    if (_currentCutStraightAheadActive) {
+        // The rotation below re-poses the plane on the model line anyway; do it
+        // through the setter so the frozen side cut catches up as well.
+        setCurrentLinePosition(_currentLinePosition, true, true);
+    }
     const cv::Vec3f centerVolumePoint = currentCutViewerCenterVolumePoint();
     _currentCutManualRotation =
         vc3d::line_annotation::accumulatedGeneratedCutRotation(_currentCutManualRotation,
@@ -3571,6 +3670,7 @@ void LineAnnotationDialog::resetGeneratedViews()
     _currentCutManualRotation = cv::Matx33f::eye();
     _currentCutManualRotationActive = false;
     _currentCutNormalOffsetVx = 0.0;
+    _currentCutStraightAheadActive = false;
     _sideCutNormalOffsetVx = 0.0;
     _currentCutFollowsStripMouse = true;
 
@@ -4305,7 +4405,7 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         _currentCutOverlaySwapPending ? _heldLinePosition : _currentLinePosition;
 
     QPointF centerScenePoint;
-    if (normalOffsetActive(_currentCutNormalOffsetVx)) {
+    if (_currentCutStraightAheadActive) {
         centerScenePoint = viewer->volumeToScene(
             vc3d::line_annotation::interpolatedGeneratedLinePoint(
                 cutViews.linePoints, cutPosition));

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -345,6 +345,12 @@ private:
     void jumpToNextControlPoint();
     void previewClosestControlPoint();
     bool shiftCurrentLinePositionByScrollSteps(int steps);
+    // Ctrl+Shift+wheel in the current cut: slide the cut plane straight along
+    // its normal by the arclength the marker advances, WITHOUT re-posing it on
+    // the model line, so a point can be placed where the true fiber is when the
+    // model prediction has diverged. The side cut and strips stay where they
+    // are; any along-line navigation snaps the plane back.
+    bool shiftCurrentCutStraightAheadByScrollSteps(int steps);
     bool shiftSideCutPlaneNormalOffsetByScrollSteps(int steps);
     bool shiftCutPlaneNormalOffsetByScrollSteps(PlaneSurface* plane,
                                                 CChunkedVolumeViewer* viewer,
@@ -354,9 +360,8 @@ private:
     bool applyCutPlaneNormalOffset(PlaneSurface* plane, double offsetVx) const;
     void resetGeneratedCutNormalOffsets(bool forceRender);
     // "B": zero every accumulated normal offset — the side cut plane's and
-    // both strips' surface offsets. The current cut cannot accumulate one
-    // (Shift-scroll steps along the line there) but is reset with the side
-    // cut for symmetry.
+    // both strips' surface offsets — and snap a straight-ahead displaced
+    // current cut (Ctrl+Shift-scroll) back onto the model line.
     void resetGeneratedNormalOffsets();
     void setCurrentCutFollowsStripMouse(bool follows);
     void requestGeneratedSideStripIntersections();
@@ -560,6 +565,12 @@ private:
     cv::Matx33f _currentCutManualRotation = cv::Matx33f::eye();
     bool _currentCutManualRotationActive = false;
     double _currentCutNormalOffsetVx = 0.0;
+    // Set while Ctrl+Shift+wheel has slid the current cut plane off the model
+    // line; cleared wherever the plane is re-posed from the line.
+    bool _currentCutStraightAheadActive = false;
+    // Translation sign along the plane normal, fixed at the gesture's first
+    // notch (see straightAheadDirection).
+    double _currentCutStraightAheadDirection = 1.0;
     double _sideCutNormalOffsetVx = 0.0;
     bool _generatedOverlayRefreshQueued = false;
     // Generation-based deduplication of the coalesced overlay refresh: every

--- a/volume-cartographer/apps/VC3D/LineAnnotationShiftScroll.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationShiftScroll.hpp
@@ -89,10 +89,12 @@ inline double shiftedLinePositionByArclength(double currentPosition,
                       maxLinePosition);
 }
 
-inline cv::Vec3f shiftedPlaneOriginAlongNormal(const cv::Vec3f& currentOrigin,
+// Translates a cut plane origin `distanceVx` voxels along `planeNormal`
+// (any length, sign preserved). Returns the origin unchanged on degenerate
+// input.
+inline cv::Vec3f planeOriginShiftedAlongNormal(const cv::Vec3f& currentOrigin,
                                                const cv::Vec3f& planeNormal,
-                                               int scrollSteps,
-                                               int viewerSliceStepSize)
+                                               double distanceVx)
 {
     const float n = cv::norm(planeNormal);
     if (!std::isfinite(currentOrigin[0]) ||
@@ -101,11 +103,63 @@ inline cv::Vec3f shiftedPlaneOriginAlongNormal(const cv::Vec3f& currentOrigin,
         !std::isfinite(planeNormal[0]) ||
         !std::isfinite(planeNormal[1]) ||
         !std::isfinite(planeNormal[2]) ||
+        !std::isfinite(distanceVx) ||
         n <= 1.0e-6f) {
         return currentOrigin;
     }
-    const float delta = static_cast<float>(scrollSteps * shiftScrollLineStepSize(viewerSliceStepSize));
-    return currentOrigin + planeNormal * (delta / n);
+    return currentOrigin + planeNormal * (static_cast<float>(distanceVx) / n);
+}
+
+// Side-cut Shift+wheel: one notch moves the plane one voxel (times the slice
+// step size) along its normal.
+inline cv::Vec3f shiftedPlaneOriginAlongNormal(const cv::Vec3f& currentOrigin,
+                                               const cv::Vec3f& planeNormal,
+                                               int scrollSteps,
+                                               int viewerSliceStepSize)
+{
+    return planeOriginShiftedAlongNormal(
+        currentOrigin,
+        planeNormal,
+        static_cast<double>(scrollSteps * shiftScrollLineStepSize(viewerSliceStepSize)));
+}
+
+// Sign of the straight-ahead translation along the current cut's plane normal.
+// The normal is the DISPLAY tangent (geometric tangent times the per-fiber
+// display sign) and may be manually rotated, so it can point toward decreasing
+// line position; `ahead` is the raw toward-increasing-position tangent at the
+// marker. Once a gesture is under way (`gestureActive`) the sign chosen at its
+// first notch is kept: the plane slides along a fixed normal while the marker
+// walks a model line that may curve past a quarter turn, and a sign recomputed
+// per wheel event would make the plane's travel depend on how the notches were
+// batched (two +1 events vs one +2) and reverse mid-gesture.
+inline double straightAheadDirection(const cv::Vec3f& planeNormal,
+                                     const cv::Vec3f& ahead,
+                                     bool gestureActive,
+                                     double lockedDirection)
+{
+    if (gestureActive && (lockedDirection == 1.0 || lockedDirection == -1.0)) {
+        return lockedDirection;
+    }
+    return planeNormal.dot(ahead) < 0.0f ? -1.0 : 1.0;
+}
+
+// Current-cut Ctrl+Shift+wheel ("straight ahead"): the plane travels the
+// arclength the current-position marker actually advanced between
+// `fromPosition` and `toPosition` (signed, so a notch clamped at a line end
+// moves the plane only as far as the marker got), which keeps the two
+// coincident on a straight stretch of a correct model. Without a usable
+// arclength map the marker does not move (the dialog passes an empty map and
+// shiftedLinePositionByArclength returns the position unchanged), and neither
+// does the plane: 0.
+inline double straightAheadDistanceForShiftScroll(double fromPosition,
+                                                  double toPosition,
+                                                  const std::vector<double>& cumulativeArclengths)
+{
+    if (!lineArclengthsUsable(cumulativeArclengths)) {
+        return 0.0;
+    }
+    return vc3d::fiber_slice::arclengthAtLinePosition(cumulativeArclengths, toPosition) -
+           vc3d::fiber_slice::arclengthAtLinePosition(cumulativeArclengths, fromPosition);
 }
 
 inline double bottomCrossSliceLinePosition(double centerPosition,

--- a/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.cpp
@@ -354,6 +354,14 @@ void CVolumeViewerView::wheelEvent(QWheelEvent *event)
         delta = angleDelta.x();
     }
 
+    // A partial notch gathered under one modifier set must not complete a
+    // step under another: the line annotation current cut binds Shift and
+    // Ctrl+Shift to different motions, so a remainder carried across the change
+    // would fire the wrong one.
+    if (event->modifiers() != _wheelAccumModifiers) {
+        _wheelAccum = 0;
+        _wheelAccumModifiers = event->modifiers();
+    }
     _wheelAccum += delta;
     constexpr int kStepThreshold = 120;  // one notch = one step
     int steps = _wheelAccum / kStepThreshold;

--- a/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CVolumeViewerView.hpp
@@ -121,6 +121,7 @@ private:
     bool _scrollPanDisabled = false;
     bool _sceneWidgetMouseCapture = false;
     int _wheelAccum = 0;  // fractional wheel delta accumulator
+    Qt::KeyboardModifiers _wheelAccumModifiers = Qt::NoModifier;  // modifiers _wheelAccum was gathered under
     mutable QFont _cachedFont;
     mutable bool _scalebarCacheDirty = true;
     mutable double _cachedBarPx = 0;

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -586,6 +586,101 @@ TEST_CASE("line annotation straight shift scroll moves cut origin along plane no
     CHECK(cv::norm(normal - cv::Vec3f{0.0f, 0.0f, 2.0f}) == doctest::Approx(0.0f));
 }
 
+TEST_CASE("line annotation plane origin shift along normal is signed and normal-length independent")
+{
+    const cv::Vec3f origin{1.0f, 2.0f, 3.0f};
+    const cv::Vec3f normal{0.0f, -4.0f, 0.0f};
+
+    const cv::Vec3f forward =
+        vc3d::line_annotation::planeOriginShiftedAlongNormal(origin, normal, 8.0);
+    CHECK(forward[0] == doctest::Approx(1.0f));
+    CHECK(forward[1] == doctest::Approx(-6.0f));
+    CHECK(forward[2] == doctest::Approx(3.0f));
+
+    const cv::Vec3f backward =
+        vc3d::line_annotation::planeOriginShiftedAlongNormal(origin, normal, -8.0);
+    CHECK(backward[1] == doctest::Approx(10.0f));
+
+    const cv::Vec3f degenerate = vc3d::line_annotation::planeOriginShiftedAlongNormal(
+        origin, cv::Vec3f{0.0f, 0.0f, 0.0f}, 8.0);
+    CHECK(cv::norm(degenerate - origin) == doctest::Approx(0.0f));
+    const cv::Vec3f nanDistance = vc3d::line_annotation::planeOriginShiftedAlongNormal(
+        origin, normal, std::numeric_limits<double>::quiet_NaN());
+    CHECK(cv::norm(nanDistance - origin) == doctest::Approx(0.0f));
+}
+
+TEST_CASE("line annotation straight-ahead direction follows the raw tangent and locks per gesture")
+{
+    using vc3d::line_annotation::straightAheadDirection;
+    const cv::Vec3f ahead{0.0f, 0.0f, 1.0f};
+
+    // Fresh gesture: the sign is whichever half-space of the normal faces
+    // increasing line position, so a display-sign-flipped (or rotated past a
+    // quarter turn) normal translates against itself.
+    CHECK(straightAheadDirection(cv::Vec3f{0.0f, 0.0f, 1.0f}, ahead, false, 1.0) == 1.0);
+    CHECK(straightAheadDirection(cv::Vec3f{0.0f, 0.0f, -1.0f}, ahead, false, 1.0) == -1.0);
+    CHECK(straightAheadDirection(cv::Vec3f{0.1f, 0.0f, -0.05f}, ahead, false, 1.0) == -1.0);
+    // Exactly orthogonal resolves to forward.
+    CHECK(straightAheadDirection(cv::Vec3f{1.0f, 0.0f, 0.0f}, ahead, false, -1.0) == 1.0);
+
+    // Mid-gesture: the tangent at the marker has swung past the plane normal
+    // (the model curving away), yet the plane keeps the sign it started with,
+    // so two +1 notches and one +2 notch travel the same way.
+    CHECK(straightAheadDirection(cv::Vec3f{0.0f, 0.0f, -1.0f}, ahead, true, 1.0) == 1.0);
+    CHECK(straightAheadDirection(cv::Vec3f{0.0f, 0.0f, 1.0f}, ahead, true, -1.0) == -1.0);
+    // A stale lock value that is not a sign is ignored.
+    CHECK(straightAheadDirection(cv::Vec3f{0.0f, 0.0f, -1.0f}, ahead, true, 0.0) == -1.0);
+}
+
+TEST_CASE("line annotation straight-ahead distance follows the marker's actual arclength advance")
+{
+    using vc3d::line_annotation::kShiftScrollLineStepBaseVoxels;
+    using vc3d::line_annotation::shiftedLinePositionByArclength;
+    using vc3d::line_annotation::straightAheadDistanceForShiftScroll;
+
+    // Same mixed-density map as the along-line test: 4 vx vertices for
+    // positions 0..10, 32 vx vertices for positions 11..15 (total 200 vx).
+    std::vector<double> arclengths;
+    for (int i = 0; i <= 10; ++i) {
+        arclengths.push_back(4.0 * i);
+    }
+    for (int i = 1; i <= 5; ++i) {
+        arclengths.push_back(40.0 + 32.0 * i);
+    }
+    REQUIRE(arclengths.size() == 16);
+
+    // One notch inside the line: the plane travels exactly the marker's 8 vx,
+    // in both densities and in both directions.
+    double from = 2.0;
+    double to = shiftedLinePositionByArclength(from, 1, 1, arclengths);
+    CHECK(straightAheadDistanceForShiftScroll(from, to, arclengths) ==
+          doctest::Approx(kShiftScrollLineStepBaseVoxels));
+    from = 12.0;
+    to = shiftedLinePositionByArclength(from, -1, 1, arclengths);
+    CHECK(straightAheadDistanceForShiftScroll(from, to, arclengths) ==
+          doctest::Approx(-kShiftScrollLineStepBaseVoxels));
+    // Slice step size scales the notch.
+    from = 2.0;
+    to = shiftedLinePositionByArclength(from, 1, 3, arclengths);
+    CHECK(straightAheadDistanceForShiftScroll(from, to, arclengths) ==
+          doctest::Approx(3.0 * kShiftScrollLineStepBaseVoxels));
+
+    // A notch that clamps at the line end moves the plane only as far as the
+    // marker got (196 -> 200 is 4 vx, not 8), and a notch AT the end moves nothing.
+    from = vc3d::fiber_slice::linePositionAtArclength(arclengths, 196.0);
+    to = shiftedLinePositionByArclength(from, 1, 1, arclengths);
+    CHECK(to == doctest::Approx(15.0));
+    CHECK(straightAheadDistanceForShiftScroll(from, to, arclengths) == doctest::Approx(4.0));
+    to = shiftedLinePositionByArclength(15.0, 1, 1, arclengths);
+    CHECK(straightAheadDistanceForShiftScroll(15.0, to, arclengths) == doctest::Approx(0.0));
+
+    // Without a usable map (the dialog passes an empty one) the marker does not
+    // move and neither does the plane.
+    const std::vector<double> noMap;
+    CHECK(shiftedLinePositionByArclength(2.0, 2, 1, noMap) == doctest::Approx(2.0));
+    CHECK(straightAheadDistanceForShiftScroll(2.0, 2.0, noMap) == doctest::Approx(0.0));
+}
+
 TEST_CASE("line annotation straight shift scroll clamps invalid step size but not line position")
 {
     const cv::Vec3f origin{10.0f, 0.0f, 0.0f};

--- a/volume-cartographer/docs/line_annotation_fibers.md
+++ b/volume-cartographer/docs/line_annotation_fibers.md
@@ -167,6 +167,22 @@ Right press pauses the mouse hover-follow exactly as the space bar does, so the
 and cancels the pan. While the keyboard is panning, the strips stay centered
 on the current-position line and scroll underneath it.
 
+Ctrl+Shift+wheel (Cmd+Shift+wheel on macOS) in the current cut slides the cut
+plane straight ahead along its own normal instead of following the optimized
+line: the plane travels the same arclength per notch that the green
+current-position marker advances (8 base voxels times the slice step size), so
+with an unrotated cut on a straight stretch of a correct model the two gestures
+coincide, and where the model has curved away from the true fiber the plane
+keeps going straight while the marker keeps counting along the line. The
+direction is fixed at the first notch of the gesture. The side cut and strip
+planes and cameras stay where they are; only the position markers move.
+Release the modifiers and click on the fiber to place a control point at the
+advanced line position with the clicked 3D location, which pulls the
+extrapolation back on track. Any along-line navigation (plain Shift+wheel,
+Left/Right, a strip click, strip hover while hover-follow is on, Space, B, the
+rotation keys) snaps the plane back onto the model line and brings the side
+cut up to the marker.
+
 `/` and `0` both place a control point on the blue current-position dot in the
 current cut, so points can be dropped without leaving the keyboard while
 arrow-panning along the line. The key stops an active pan, because the


### PR DESCRIPTION
**In one sentence:** In the line annotation dialog, Ctrl+Shift+wheel in the top-left cut moves the cut straight ahead to where the true fiber is when the model's extrapolation has wandered off, so a control point can be dropped there and the line re-fits.

**One real example:** While annotating fibers in VC3D, the extrapolated line ahead of the last control point curved away from the fiber; with Shift+wheel the cut followed the wrong prediction and the fiber left the pane, so there was no way to place the next point on it. Ctrl+Shift+wheel forward a few notches kept the cut on the fiber; releasing the modifiers and clicking it placed the point at the advanced line position, and the re-optimization pulled the line back onto the fiber.

**Before:** Shift+wheel in the current cut always re-poses the plane on the optimized line, so once the model diverges the true fiber is gone from the cut and the only recourse is guessing in the strips.

**After this PR:** Ctrl+Shift+wheel translates the plane straight along its own normal while the green position marker keeps advancing along the line one step per notch; the side cut and strips stay put; any along-line navigation snaps the plane back. Plain Shift+wheel is unchanged.

**Proof:** Checked interactively in VC3D on live fibers: forward/backward notches, placement after divergence, snap-back through Shift+wheel, Left/Right, strip click, Space, B. A recording of one divergent fiber before/after will be attached by the author.

**Why / where this is useful:** Anyone tracing fibers with the line annotation tool where the model extrapolation drifts, which is exactly where manual control points are needed most.

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

**Behavior**

- Step: the plane travels the arclength the marker actually advanced per notch (8 base vx × slice step, the same unit as plain Shift+wheel). With an unrotated cut on a straight stretch of a correct model, Ctrl+Shift+wheel and Shift+wheel land in the same place; they differ where the model curves away. At a line end the marker clamps and the plane stops with it. The side cut's Shift+wheel keeps its 1 vx per notch.
- Direction: the current cut's plane normal is the *display* tangent, which is sign-flipped on roughly half of all fibers, so the translation direction is derived from the raw toward-increasing-position tangent, and it is fixed at the first notch of a gesture. A sign recomputed per wheel event would make the travel depend on how notches were batched (two +1 events vs one +2) and could reverse mid-gesture when the model curves past a quarter turn.
- Orientation: pure translation; normal and in-plane basis are kept.
- Side cut and strips: planes and cameras stay where they are during the gesture. The position markers (strip line, overview bar, side cut's on-line marker) follow the model line.
- Snap-back: plain Shift+wheel, Left/Right (including a press with no control point in that direction), strip click, strip hover while hover-follow is on, Space, B, and the rotation keys re-pose the plane on the model line and bring the side cut up to the marker. A notch that cannot move (line end) still cancels a running keyboard pan and a pending hover flush, as plain Shift+wheel does.
- Placement: a click in the cut emits the clicked 3D point plus the advanced line position with its on-line anchor; the controller already remaps through the anchor and stores the clicked point, so no controller change. `/` and `0` still place on the model line point (where the blue dot is drawn during the gesture).
- State: one flag (`_currentCutStraightAheadActive`) plus the locked direction sign, not the accumulated offset, so a forward/back pair clamped at a line end cannot cancel numerically while the geometry is still displaced. The legacy `_currentCutNormalOffsetVx` (left from the StraightNormal mode removed in #1286) stays at zero.
- Wheel accumulation: `CVolumeViewerView::wheelEvent` now discards a partial notch when the modifier set changes, so a remainder gathered under Shift cannot complete a step under Ctrl+Shift (or vice versa). This applies to every viewer; the only visible effect is that a fraction of a notch is dropped when modifiers change mid-scroll. Modifier dispatch in `CChunkedVolumeViewer::onZoom` already tests Shift before Ctrl and forwards the modifiers to the dialog's override, so no other viewer change. Ctrl+wheel without Shift is untouched. On macOS the gesture is Cmd+Shift+wheel.

**Changes**

- `apps/VC3D/LineAnnotationDialog.cpp/.hpp`: the gesture (`shiftCurrentCutStraightAheadByScrollSteps`), Ctrl dispatch in the current-cut Shift-scroll override, the state flag and locked direction with their snap-back sites (`setCurrentLinePosition`, `resetGeneratedCutNormalOffsets` incl. side-cut catch-up and recenter, `rotateCurrentCut`, `startArrowPan` no-target), blue-dot placement, header comment for B.
- `apps/VC3D/LineAnnotationShiftScroll.hpp`: `planeOriginShiftedAlongNormal(origin, normal, distanceVx)` extracted from the side cut's `shiftedPlaneOriginAlongNormal` (arithmetic unchanged), `straightAheadDistanceForShiftScroll(from, to, arclengths)`, `straightAheadDirection(normal, ahead, gestureActive, lockedDirection)`.
- `apps/VC3D/volume_viewers/CVolumeViewerView.cpp/.hpp`: wheel accumulator reset on modifier change.
- `core/test/test_line_annotation_generated_views.cpp`: three doctest cases (signed translation and degenerate inputs; actual-advance distance incl. mixed density, step size, end clamp, no map; direction sign incl. flipped normal and per-gesture lock).
- `docs/line_annotation_fibers.md`: one paragraph.

**Verification**

```
ninja -C volume-cartographer/build VC3D test_line_annotation_generated_views
ctest --test-dir volume-cartographer/build -R '^test_line_annotation_generated_views$'
```

Build clean, test target passes. Plan and implementation were each reviewed by independent Claude and Codex passes (plan review caught the display-sign direction bug and the stale side cut; PR review caught the per-event direction sign and the accumulator carry).

**Known, left alone on purpose**

- On hover-follow snap-back the blue dot can lag one frame (the follow path skips the current-cut overlay; the 16 ms coalesced refresh redraws it).
- While an in-place update's overlay swap is pending after a displaced-cut placement, the blue dot follows the live flag rather than the held state, so it can sit at the pane center for a frame or two before the new frame lands.
- E and T (jump to previous/next control point) do not snap back when there is no control point in that direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aiEsPdPGrYikgw8CRqKWr
