### PR TITLE
VC3D line annotation: linked-to-candidate new fiber, link-state colours, fiber names in menus, CP-range trimming of other fibers

### DIFF
--- a/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.cpp
@@ -2512,18 +2512,12 @@ bool LineAnnotationController::launchSession(LineAnnotationController::SourceKin
                 handleGeneratedControlPointDelete(name, linePosition, volumePoint);
             });
     connect(dialog,
-            &LineAnnotationDialog::generatedControlPointBranchRequested,
+            &LineAnnotationDialog::generatedNewLineAnnotationLinkedToCandidateRequested,
             this,
-            [this](const std::string& name,
-                   size_t controlPointIndex,
-                   cv::Vec3f linkedControlPoint,
-                   bool openAfterCreate,
-                   cv::Vec3f linkDirection) {
-                handleGeneratedControlPointBranch(name,
-                                                  controlPointIndex,
-                                                  linkedControlPoint,
-                                                  openAfterCreate,
-                                                  linkDirection);
+            [this](const std::string& name, cv::Vec3f volumePoint, cv::Vec3f linkDirection) {
+                handleGeneratedNewLineAnnotationLinkedToCandidate(name,
+                                                                  volumePoint,
+                                                                  linkDirection);
             });
     connect(dialog,
             &LineAnnotationDialog::generatedControlPointBranchOpenRequested,
@@ -5623,20 +5617,34 @@ LineAnnotationController::controlMarkersForSession(const LineAnnotationSession& 
     return markers;
 }
 
+bool LineAnnotationController::fibersShareHvDirection(uint64_t localFiberId,
+                                                      uint64_t linkedFiberId) const
+{
+    // Same-orientation links (H-H / V-V) get the orange warning palette; an
+    // unclassified fiber on either side keeps the default H-V colors.
+    const QString localTag = fiberHvDirectionTag(localFiberId);
+    return !localTag.isEmpty() && fiberHvDirectionTag(linkedFiberId) == localTag;
+}
+
 std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker>
 LineAnnotationController::markLinkCandidateFiberIntersections(
     std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker> markers,
-    const std::vector<FiberBranchRef>& branches) const
+    const LineAnnotationSession* session) const
 {
+    static const std::vector<FiberBranchRef> kNoBranches;
+    const std::vector<FiberBranchRef>& branches = session ? session->branches : kNoBranches;
+    const uint64_t localFiberId = session ? session->fiberId : uint64_t{0};
     const uint64_t candidateFiberId =
         _linkCandidate ? _linkCandidate->fiberId : uint64_t{0};
     for (auto& marker : markers) {
         marker.isLinkCandidateFiber =
             candidateFiberId != 0 && marker.fiberId == candidateFiberId;
         marker.pendingBranchLink = false;
+        marker.sameHvBranchLink = false;
         if (!marker.projectedBranchLink || !marker.connectorStart) {
             continue;
         }
+        marker.sameHvBranchLink = fibersShareHvDirection(localFiberId, marker.fiberId);
         for (const auto& branch : branches) {
             // connectorStart carries the local endpoint position through a
             // double->float round trip; match with a coarse tolerance.
@@ -5663,10 +5671,101 @@ LineAnnotationController::linkCandidateMenuState(const LineAnnotationSession& se
         state.label = tr("Link with candidate (same fiber)");
     } else {
         state.enabled = true;
-        state.label = tr("Link with candidate (Fiber %1)")
-                          .arg(static_cast<qulonglong>(_linkCandidate->fiberId));
+        state.label = tr("Link with candidate (%1)").arg(linkCandidateMenuName());
     }
     return state;
+}
+
+vc3d::line_annotation::GeneratedLinkCandidateMenuState
+LineAnnotationController::newLinkedToCandidateMenuState() const
+{
+    vc3d::line_annotation::GeneratedLinkCandidateMenuState state;
+    if (!_linkCandidate || _linkCandidate->fiberId == 0) {
+        return state;
+    }
+    state.enabled = true;
+    state.label = tr("New line annotation - linked to candidate (%1)")
+                      .arg(linkCandidateMenuName());
+    return state;
+}
+
+QString LineAnnotationController::fiberDisplayNameForId(uint64_t fiberId) const
+{
+    // Resolved when a menu opens, so renames are reflected without touching
+    // any cached marker. Live sessions first: an unsaved fiber exists only there.
+    std::string fileName;
+    for (const auto& pane : _panes) {
+        if (pane.session && pane.session->fiberId == fiberId) {
+            fileName = pane.session->fiberFileName;
+            break;
+        }
+    }
+    if (fileName.empty()) {
+        const auto it = std::find_if(_fibers.begin(), _fibers.end(), [fiberId](const StoredFiber& fiber) {
+            return fiber.id == fiberId;
+        });
+        if (it != _fibers.end()) {
+            fileName = it->fileName;
+        }
+    }
+    return fiberDisplayNameFromFileName(fileName);
+}
+
+QString LineAnnotationController::linkCandidateMenuName() const
+{
+    if (!_linkCandidate || _linkCandidate->fiberId == 0) {
+        return {};
+    }
+    const QString name = fiberDisplayNameForId(_linkCandidate->fiberId);
+    const auto resolved = resolvedLinkCandidateControlIndex();
+    if (!resolved) {
+        return name;
+    }
+    // Both substitutions at once: a '%' inside the file stem must not be
+    // re-interpreted by the second .arg().
+    return tr("%1 / CP %2").arg(name, QString::number(resolved->storedControlIndex));
+}
+
+std::optional<LineAnnotationController::ResolvedLinkCandidate>
+LineAnnotationController::resolvedLinkCandidateControlIndex() const
+{
+    if (!_linkCandidate || _linkCandidate->fiberId == 0) {
+        return std::nullopt;
+    }
+    // Prefer a live editing session's geometry so enablement agrees with the
+    // handlers, which bake such a session before acting on the candidate.
+    for (const auto& pane : _panes) {
+        if (!pane.session || pane.session->fiberId != _linkCandidate->fiberId) {
+            continue;
+        }
+        const auto sessionIndex = sessionControlPointIndexByPosition(
+            pane.session->controlPoints, _linkCandidate->position);
+        if (!sessionIndex) {
+            return std::nullopt;
+        }
+        const auto storedIndexMap =
+            storedIndexMapForSessionControls(pane.session->controlPoints);
+        if (static_cast<size_t>(*sessionIndex) >= storedIndexMap.size()) {
+            return std::nullopt;
+        }
+        return ResolvedLinkCandidate{storedIndexMap[*sessionIndex],
+                                     pane.session->controlPoints.size()};
+    }
+    const auto fiberIt = std::find_if(
+        _fibers.begin(), _fibers.end(), [this](const StoredFiber& fiber) {
+            return fiber.id == _linkCandidate->fiberId;
+        });
+    if (fiberIt == _fibers.end()) {
+        return std::nullopt;
+    }
+    const auto candidateIndex = matchingStoredControlPointIndex(
+        fiberIt->controlPoints,
+        _linkCandidate->storedControlPointIndexHint,
+        _linkCandidate->position);
+    if (!candidateIndex) {
+        return std::nullopt;
+    }
+    return ResolvedLinkCandidate{*candidateIndex, fiberIt->controlPoints.size()};
 }
 
 vc3d::line_annotation::GeneratedLinkCandidateMenuState
@@ -5681,55 +5780,19 @@ LineAnnotationController::mergeCandidateMenuState(const LineAnnotationSession& s
         return state;
     }
     // Merging joins fiber endpoints; gate on the candidate side here, the
-    // clicked side is validated in the handler. Prefer a live editing
-    // session's geometry so enablement agrees with the handler, which
-    // bakes such a session before merging.
-    std::optional<int> candidateIndex;
-    size_t controlCount = 0;
-    bool candidateResolved = false;
-    for (const auto& pane : _panes) {
-        if (!pane.session || pane.session->fiberId != _linkCandidate->fiberId) {
-            continue;
-        }
-        const auto sessionIndex = sessionControlPointIndexByPosition(
-            pane.session->controlPoints, _linkCandidate->position);
-        if (sessionIndex) {
-            const auto storedIndexMap =
-                storedIndexMapForSessionControls(pane.session->controlPoints);
-            if (static_cast<size_t>(*sessionIndex) < storedIndexMap.size()) {
-                candidateIndex = storedIndexMap[*sessionIndex];
-            }
-        }
-        controlCount = pane.session->controlPoints.size();
-        candidateResolved = true;
-        break;
-    }
-    if (!candidateResolved) {
-        const auto fiberIt = std::find_if(
-            _fibers.begin(), _fibers.end(), [this](const StoredFiber& fiber) {
-                return fiber.id == _linkCandidate->fiberId;
-            });
-        if (fiberIt == _fibers.end()) {
-            return state;
-        }
-        candidateIndex = matchingStoredControlPointIndex(
-            fiberIt->controlPoints,
-            _linkCandidate->storedControlPointIndexHint,
-            _linkCandidate->position);
-        controlCount = fiberIt->controlPoints.size();
-    }
-    if (!candidateIndex) {
+    // clicked side is validated in the handler.
+    const auto resolved = resolvedLinkCandidateControlIndex();
+    if (!resolved) {
         return state;
     }
-    if (*candidateIndex != 0 &&
-        static_cast<size_t>(*candidateIndex) + 1 != controlCount) {
+    if (resolved->storedControlIndex != 0 &&
+        static_cast<size_t>(resolved->storedControlIndex) + 1 != resolved->controlCount) {
         state.enabled = false;
         state.label = tr("Merge with candidate (not an endpoint)");
         return state;
     }
     state.enabled = true;
-    state.label = tr("Merge with candidate (Fiber %1)")
-                      .arg(static_cast<qulonglong>(_linkCandidate->fiberId));
+    state.label = tr("Merge with candidate (%1)").arg(linkCandidateMenuName());
     return state;
 }
 
@@ -5793,7 +5856,9 @@ bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolu
             linkCandidateMenuState(*pane->session),
             splitCandidateMenuState(*pane->session),
             splitAndLinkCandidateMenuState(*pane->session),
-            mergeCandidateMenuState(*pane->session));
+            mergeCandidateMenuState(*pane->session),
+            newLinkedToCandidateMenuState(),
+            [this](uint64_t fiberId) { return fiberDisplayNameForId(fiberId); });
     } else if (_intersectionInspection) {
         const auto contextIt =
             _intersectionInspection->generatedSurfaceContexts.find(viewer->surfName());
@@ -5850,17 +5915,17 @@ bool LineAnnotationController::showGeneratedControlPointContextMenu(CChunkedVolu
                                               selectedLinePosition,
                                               selectedPoint);
         };
-        options.addBranch = [this, surfaceName = viewer->surfName()](
-                                size_t controlPointIndex,
-                                cv::Vec3f linkedControlPoint,
-                                bool openAfterCreate,
-                                cv::Vec3f linkDirection) {
-            handleGeneratedControlPointBranch(surfaceName,
-                                              controlPointIndex,
-                                              linkedControlPoint,
-                                              openAfterCreate,
-                                              linkDirection);
+        options.newLinkedToCandidateLabel = newLinkedToCandidateMenuState().label;
+        options.fiberDisplayNameForId = [this](uint64_t fiberId) {
+            return fiberDisplayNameForId(fiberId);
         };
+        options.newLineAnnotationLinkedToCandidate =
+            [this, surfaceName = viewer->surfName()](cv::Vec3f volumePoint,
+                                                     cv::Vec3f linkDirection) {
+                handleGeneratedNewLineAnnotationLinkedToCandidate(surfaceName,
+                                                                  volumePoint,
+                                                                  linkDirection);
+            };
         options.designateLinkCandidate = [this, surfaceName = viewer->surfName()](
                                              size_t controlPointIndex,
                                              cv::Vec3f volumePoint) {
@@ -7571,134 +7636,87 @@ void LineAnnotationController::handleGeneratedControlPoint(const std::string& su
     }
 }
 
-void LineAnnotationController::handleGeneratedControlPointBranch(const std::string& surfaceName,
-                                                                size_t controlPointIndex,
-                                                                cv::Vec3f linkedControlPoint,
-                                                                bool openAfterCreate,
-                                                                cv::Vec3f requestedLinkDirection)
+std::optional<uint64_t> LineAnnotationController::createLinkedSeedFiber(
+    const LinkedSeedParent& parent,
+    const cv::Vec3d& seedPoint,
+    const cv::Vec3d& requestedLinkDirection,
+    const LineAnnotationSession& templateSession)
 {
-    auto* pane = paneForSurface(surfaceName);
-    if (!pane || !pane->session) {
-        return;
-    }
-
-    auto& parentSession = *pane->session;
-    if (parentSession.taskState == LineAnnotationSession::TaskState::Running) {
-        showError(tr("Line optimization is already running."),
-                  parentSession.suppressErrorDialogs);
-        return;
-    }
-    if (controlPointIndex >= parentSession.controlPoints.size()) {
-        return;
-    }
-    const cv::Vec3d linkedPoint = toVec3d(linkedControlPoint);
-    if (!finitePoint(linkedPoint)) {
-        showError(tr("Could not determine a finite linked-fiber point from the clicked location."),
-                  parentSession.suppressErrorDialogs);
-        return;
-    }
-    if (!placementAllowedByFocusBounds(
-            linkedPoint, parentSession.suppressErrorDialogs)) {
-        return;
-    }
-    // Cross-fiber operation: make sure no participating fiber's newest
-    // geometry is still session-only behind a debounced autosave.
-    flushAllPendingSessionAutoSaves();
-    if (controlPointHasBranchLink(parentSession.branches, controlPointIndex)) {
-        showError(tr("This control point is already linked; unlink it first."));
-        return;
-    }
-    if (openAfterCreate && !ensureDatasetForSession(parentSession)) {
-        return;
-    }
-
-    ensureSessionFiberIdentity(parentSession);
-    if (parentSession.fiberId == 0) {
-        parentSession.fiberId = nextFiberId();
-    }
-    const uint64_t parentFiberId = parentSession.fiberId;
-    const std::string parentFileName = parentSession.fiberFileName;
-    const cv::Vec3d branchPoint = parentSession.controlPoints[controlPointIndex].volumePoint;
-    if (!finitePoint(branchPoint)) {
-        return;
-    }
-    cv::Vec3d linkDirection = toVec3d(requestedLinkDirection);
-    if (!finiteDirection(linkDirection)) {
-        showError(tr("Could not determine a finite linked-fiber direction from the current view."),
-                  parentSession.suppressErrorDialogs);
-        return;
-    }
-    linkDirection = normalizedOrZero(linkDirection);
-    const std::vector<cv::Vec3d> parentLinePoints =
-        linePointPositions(parentSession.optimizedLine);
+    const cv::Vec3d linkDirection = normalizedOrZero(requestedLinkDirection);
     const cv::Vec3d parentEndpointDirection =
-        endpointTangentFromLinePoints(parentLinePoints, branchPoint, linkDirection);
-    const cv::Vec3d linkedInitialDirection = linkDirection;
+        endpointTangentFromLinePoints(parent.linePoints, parent.point, linkDirection);
 
+    // A one-control fiber at the clicked point; opening it runs the seed
+    // initialization with the link direction as the slice normal.
     auto linkedSeedRecord = std::make_shared<LineAnnotationSession>();
-    linkedSeedRecord->suppressErrorDialogs = parentSession.suppressErrorDialogs;
-    linkedSeedRecord->fiberId = std::max(nextFiberId(), parentFiberId + 1);
-    linkedSeedRecord->sourceSliceNormal = linkedInitialDirection;
+    linkedSeedRecord->suppressErrorDialogs = templateSession.suppressErrorDialogs;
+    linkedSeedRecord->fiberId = std::max(nextFiberId(), parent.fiberId + 1);
+    linkedSeedRecord->sourceSliceNormal = linkDirection;
     linkedSeedRecord->initialDirectionMode = InitialDirectionMode::ZInOut;
-    linkedSeedRecord->selectedDatasetLocation = parentSession.selectedDatasetLocation;
+    linkedSeedRecord->selectedDatasetLocation = templateSession.selectedDatasetLocation;
     linkedSeedRecord->selectedLasagnaManifestIdentity =
-        parentSession.selectedLasagnaManifestIdentity;
-    linkedSeedRecord->selectedManifestPath = parentSession.selectedManifestPath;
-    linkedSeedRecord->workingToBaseScale = parentSession.workingToBaseScale;
-    linkedSeedRecord->dataset = parentSession.dataset;
-    linkedSeedRecord->normalSampler = parentSession.normalSampler;
+        templateSession.selectedLasagnaManifestIdentity;
+    linkedSeedRecord->selectedManifestPath = templateSession.selectedManifestPath;
+    linkedSeedRecord->workingToBaseScale = templateSession.workingToBaseScale;
+    linkedSeedRecord->dataset = templateSession.dataset;
+    linkedSeedRecord->normalSampler = templateSession.normalSampler;
     ensureSessionFiberIdentity(*linkedSeedRecord);
 
     FiberBranchRef parentToLinked;
-    parentToLinked.controlPointIndex = static_cast<int>(controlPointIndex);
+    parentToLinked.controlPointIndex = parent.controlPointIndex;
     parentToLinked.branchFiberId = linkedSeedRecord->fiberId;
     parentToLinked.branchControlPointIndex = 0;
     parentToLinked.branchFileName = linkedSeedRecord->fiberFileName;
     parentToLinked.controlPointDirection = parentEndpointDirection;
-    parentToLinked.branchControlPointDirection = linkedInitialDirection;
-    parentToLinked.controlPointPosition = branchPoint;
-    parentToLinked.branchControlPointPosition = linkedPoint;
+    parentToLinked.branchControlPointDirection = linkDirection;
+    parentToLinked.controlPointPosition = parent.point;
+    parentToLinked.branchControlPointPosition = seedPoint;
     parentToLinked.pending = true;
 
-    const auto duplicateParentLink = std::find_if(
-        parentSession.branches.begin(),
-        parentSession.branches.end(),
-        [&parentToLinked](const FiberBranchRef& branch) {
-            return branch.controlPointIndex == parentToLinked.controlPointIndex &&
-                   branch.branchFiberId == parentToLinked.branchFiberId &&
-                   branch.branchControlPointIndex == parentToLinked.branchControlPointIndex;
-        });
-    if (duplicateParentLink == parentSession.branches.end()) {
-        parentSession.branches.push_back(parentToLinked);
-    }
-
-    FiberBranchRef linkedToParent;
-    linkedToParent.controlPointIndex = 0;
-    linkedToParent.branchFiberId = parentFiberId;
-    linkedToParent.branchControlPointIndex = static_cast<int>(controlPointIndex);
-    linkedToParent.branchFileName = parentFileName;
-    linkedToParent.controlPointDirection = linkedInitialDirection;
-    linkedToParent.branchControlPointDirection = parentEndpointDirection;
-    linkedToParent.controlPointPosition = linkedPoint;
-    linkedToParent.branchControlPointPosition = branchPoint;
-    linkedToParent.pending = true;
-    linkedSeedRecord->branches.push_back(linkedToParent);
-    linkedSeedRecord->showLinkedLineOverlays = false;
-    linkedSeedRecord->surfaceName = "linked_fiber_create_only";
-    linkedSeedRecord->sourceAnnotationSurfaceName = linkedSeedRecord->surfaceName;
-    linkedSeedRecord->seedPoint = linkedPoint;
-    linkedSeedRecord->focusedLinePosition = 0.0;
-    linkedSeedRecord->focusedControlPoint = linkedPoint;
-    linkedSeedRecord->controlPoints = {{0.0, linkedPoint, true, -1}};
-    linkedSeedRecord->optimizedLine = syntheticLineModelFromPoints({linkedPoint});
-    linkedSeedRecord->taskState = LineAnnotationSession::TaskState::Succeeded;
-    linkedSeedRecord->optimizationState = SessionOptimizationState::Optimized;
-
-    uint64_t linkedFiberId = linkedSeedRecord->fiberId;
     try {
-        StoredFiber parentFiber = storedFiberFromSession(parentSession);
+        // Inside the try: with several live copies of the parent a partial
+        // insertion must be rolled back like every later failure.
+        parent.addRef(parentToLinked);
+        const StoredFiber parentFiber = parent.storedFiber();
+        // The reciprocal ref must carry the parent's STORED control index; a
+        // live session's index may differ, so read it back from the snapshot.
+        const auto storedParentBranch = std::find_if(
+            parentFiber.branches.begin(),
+            parentFiber.branches.end(),
+            [&parentToLinked](const FiberBranchRef& branch) {
+                return branch.branchFiberId == parentToLinked.branchFiberId &&
+                       branch.branchControlPointIndex == parentToLinked.branchControlPointIndex &&
+                       pointsApproximatelyEqual(branch.controlPointPosition,
+                                                parentToLinked.controlPointPosition);
+            });
+        if (storedParentBranch == parentFiber.branches.end()) {
+            throw std::runtime_error("link entry missing after serialization");
+        }
+
+        FiberBranchRef linkedToParent;
+        linkedToParent.controlPointIndex = 0;
+        linkedToParent.branchFiberId = parentFiber.id;
+        linkedToParent.branchControlPointIndex = storedParentBranch->controlPointIndex;
+        linkedToParent.branchFileName = parentFiber.fileName;
+        linkedToParent.controlPointDirection = linkDirection;
+        linkedToParent.branchControlPointDirection = parentEndpointDirection;
+        linkedToParent.controlPointPosition = seedPoint;
+        linkedToParent.branchControlPointPosition = parent.point;
+        linkedToParent.pending = true;
+        linkedSeedRecord->branches.push_back(linkedToParent);
+        linkedSeedRecord->showLinkedLineOverlays = false;
+        linkedSeedRecord->surfaceName = "linked_fiber_create_only";
+        linkedSeedRecord->sourceAnnotationSurfaceName = linkedSeedRecord->surfaceName;
+        linkedSeedRecord->seedPoint = seedPoint;
+        linkedSeedRecord->focusedLinePosition = 0.0;
+        linkedSeedRecord->focusedControlPoint = seedPoint;
+        linkedSeedRecord->controlPoints = {{0.0, seedPoint, true, -1}};
+        linkedSeedRecord->optimizedLine = syntheticLineModelFromPoints({seedPoint});
+        linkedSeedRecord->taskState = LineAnnotationSession::TaskState::Succeeded;
+        linkedSeedRecord->optimizationState = SessionOptimizationState::Optimized;
+
         StoredFiber linkedFiber = storedFiberFromSession(*linkedSeedRecord);
-        linkedFiberId = linkedFiber.id;
+        const uint64_t linkedFiberId = linkedFiber.id;
         scheduleFiberPairSave(parentFiber, linkedFiber);
 
         auto upsertFiber = [this](StoredFiber fiber) {
@@ -7715,53 +7733,226 @@ void LineAnnotationController::handleGeneratedControlPointBranch(const std::stri
                 *it = std::move(fiber);
             }
         };
-        upsertFiber(std::move(parentFiber));
+        upsertFiber(parentFiber);
         upsertFiber(std::move(linkedFiber));
+        return linkedFiberId;
     } catch (const std::exception& ex) {
-        parentSession.branches.erase(
-            std::remove_if(parentSession.branches.begin(),
-                           parentSession.branches.end(),
-                           [&parentToLinked](const FiberBranchRef& branch) {
-                               return branch.branchFiberId == parentToLinked.branchFiberId &&
-                                      branch.controlPointIndex ==
-                                          parentToLinked.controlPointIndex &&
-                                      branch.branchControlPointIndex ==
-                                          parentToLinked.branchControlPointIndex;
-                           }),
-            parentSession.branches.end());
-        if (pane->dialog) {
-            pane->dialog->setGeneratedBranchOverlayData(
-                controlMarkersForSession(parentSession),
-                generatedBranchLinePointsForSession(parentSession),
-                generatedBranchLinkMarkers(parentSession.branches),
-                true,
-                generatedSpanAlignmentMetricsForSession(parentSession));
+        parent.rollback(parentToLinked);
+        showError(tr("Could not save linked fiber: %1").arg(QString::fromStdString(ex.what())),
+                  templateSession.suppressErrorDialogs);
+        return std::nullopt;
+    }
+}
+
+void LineAnnotationController::handleGeneratedNewLineAnnotationLinkedToCandidate(
+    const std::string& surfaceName,
+    cv::Vec3f volumePoint,
+    cv::Vec3f requestedLinkDirection)
+{
+    auto* pane = paneForSurface(surfaceName);
+    if (!pane || !pane->session) {
+        return;
+    }
+    auto& session = *pane->session;
+    if (session.taskState == LineAnnotationSession::TaskState::Running) {
+        showError(tr("Line optimization is already running."), session.suppressErrorDialogs);
+        return;
+    }
+    const cv::Vec3d seedPoint = toVec3d(volumePoint);
+    if (!finitePoint(seedPoint)) {
+        showError(tr("Could not determine a finite point for the new line annotation from the "
+                     "clicked location."),
+                  session.suppressErrorDialogs);
+        return;
+    }
+    if (!placementAllowedByFocusBounds(seedPoint, session.suppressErrorDialogs)) {
+        return;
+    }
+    const cv::Vec3d linkDirection = toVec3d(requestedLinkDirection);
+    if (!finiteDirection(linkDirection)) {
+        showError(tr("Could not determine a finite linked-fiber direction from the current view."),
+                  session.suppressErrorDialogs);
+        return;
+    }
+    if (!_linkCandidate || _linkCandidate->fiberId == 0) {
+        showError(tr("No link candidate is designated."), session.suppressErrorDialogs);
+        return;
+    }
+    // Cross-fiber operation: make sure no participating fiber's newest
+    // geometry is still session-only behind a debounced autosave.
+    flushAllPendingSessionAutoSaves();
+    // The new fiber inherits this session's dataset and is opened right away.
+    if (!ensureDatasetForSession(session)) {
+        return;
+    }
+    const LinkCandidate candidate = *_linkCandidate;
+
+    // The candidate's fiber may be live in several panes at once (the clicked
+    // dialog session and a dialog-less inspection session, say) and only one
+    // of them is saved by the open below: every live copy gets the ref.
+    struct LiveParent {
+        LineAnnotationSession* session = nullptr;
+        bool hasDialog = false;
+        int controlIndex = -1;
+    };
+    std::vector<LiveParent> liveParents;
+    for (const auto& record : _panes) {
+        if (record.session && record.session->fiberId == candidate.fiberId) {
+            liveParents.push_back({record.session.get(), record.dialog != nullptr, -1});
         }
-        showError(tr("Could not save linked fiber: %1")
-                      .arg(QString::fromStdString(ex.what())),
-                  parentSession.suppressErrorDialogs);
+    }
+
+    LinkedSeedParent parent;
+    if (!liveParents.empty()) {
+        for (auto& live : liveParents) {
+            if (live.session->taskState == LineAnnotationSession::TaskState::Running) {
+                showError(tr("Line optimization is already running."),
+                          session.suppressErrorDialogs);
+                return;
+            }
+            const auto index = sessionControlPointIndexByPosition(
+                live.session->controlPoints, candidate.position);
+            if (!index) {
+                _linkCandidate.reset();
+                showError(tr("The link candidate control point no longer exists."),
+                          session.suppressErrorDialogs);
+                return;
+            }
+            if (controlPointHasBranchLink(live.session->branches,
+                                          static_cast<size_t>(*index))) {
+                showError(tr("The link candidate is already linked; unlink it first."),
+                          session.suppressErrorDialogs);
+                return;
+            }
+            live.controlIndex = *index;
+        }
+        const auto authoritativeIt = std::find_if(
+            liveParents.begin(), liveParents.end(),
+            [](const LiveParent& live) { return live.hasDialog; });
+        const LiveParent authoritative =
+            authoritativeIt != liveParents.end() ? *authoritativeIt : liveParents.front();
+        parent.fiberId = authoritative.session->fiberId;
+        parent.controlPointIndex = authoritative.controlIndex;
+        parent.point = authoritative.session
+                           ->controlPoints[static_cast<size_t>(authoritative.controlIndex)]
+                           .volumePoint;
+        parent.linePoints = linePointPositions(authoritative.session->optimizedLine);
+        // The candidate CP was verified unlinked in every copy and the new
+        // fiber id is fresh, so the ref cannot already be present.
+        parent.addRef = [liveParents](const FiberBranchRef& ref) {
+            for (const auto& live : liveParents) {
+                FiberBranchRef sessionRef = ref;
+                sessionRef.controlPointIndex = live.controlIndex;
+                live.session->branches.push_back(sessionRef);
+            }
+        };
+        parent.rollback = [liveParents](const FiberBranchRef& ref) {
+            for (const auto& live : liveParents) {
+                auto& branches = live.session->branches;
+                branches.erase(
+                    std::remove_if(branches.begin(), branches.end(),
+                                   [&ref](const FiberBranchRef& branch) {
+                                       return branch.branchFiberId == ref.branchFiberId &&
+                                              branch.branchControlPointIndex ==
+                                                  ref.branchControlPointIndex;
+                                   }),
+                    branches.end());
+            }
+        };
+        parent.storedFiber = [this, authoritativeSession = authoritative.session]() {
+            return storedFiberFromSession(*authoritativeSession);
+        };
+    } else {
+        const auto findParentFiber = [this, fiberId = candidate.fiberId]() {
+            return std::find_if(_fibers.begin(), _fibers.end(),
+                                [fiberId](const StoredFiber& fiber) {
+                                    return fiber.id == fiberId;
+                                });
+        };
+        const auto parentIt = findParentFiber();
+        if (parentIt == _fibers.end()) {
+            _linkCandidate.reset();
+            showError(tr("The link candidate's fiber no longer exists."),
+                      session.suppressErrorDialogs);
+            return;
+        }
+        const auto parentIndex = matchingStoredControlPointIndex(
+            parentIt->controlPoints,
+            candidate.storedControlPointIndexHint,
+            candidate.position);
+        if (!parentIndex) {
+            _linkCandidate.reset();
+            showError(tr("The link candidate control point no longer exists."),
+                      session.suppressErrorDialogs);
+            return;
+        }
+        if (controlPointHasBranchLink(parentIt->branches, static_cast<size_t>(*parentIndex))) {
+            showError(tr("The link candidate is already linked; unlink it first."),
+                      session.suppressErrorDialogs);
+            return;
+        }
+        parent.fiberId = parentIt->id;
+        parent.controlPointIndex = *parentIndex;
+        parent.point = parentIt->controlPoints[static_cast<size_t>(*parentIndex)];
+        parent.linePoints = parentIt->linePoints;
+        // Re-find the entry on every use: _fibers may reallocate in between.
+        parent.addRef = [this, findParentFiber](const FiberBranchRef& ref) {
+            if (auto it = findParentFiber(); it != _fibers.end()) {
+                it->branches.push_back(ref);
+            }
+        };
+        parent.rollback = [this, findParentFiber](const FiberBranchRef& ref) {
+            auto it = findParentFiber();
+            if (it == _fibers.end()) {
+                return;
+            }
+            it->branches.erase(
+                std::remove_if(it->branches.begin(), it->branches.end(),
+                               [&ref](const FiberBranchRef& branch) {
+                                   return branch.branchFiberId == ref.branchFiberId &&
+                                          branch.branchControlPointIndex ==
+                                              ref.branchControlPointIndex;
+                               }),
+                it->branches.end());
+        };
+        parent.storedFiber = [this, findParentFiber]() {
+            const auto it = findParentFiber();
+            if (it == _fibers.end()) {
+                throw std::runtime_error("linked fiber disappeared while saving");
+            }
+            return *it;
+        };
+    }
+    if (!finitePoint(parent.point)) {
+        showError(tr("Could not determine a finite position for the link candidate."),
+                  session.suppressErrorDialogs);
         return;
     }
 
-    parentSession.fiberMetricsMatchStoredFiber = true;
-    invalidateFiberAlignmentMetrics(parentFiberId, true);
-    emitFiberSummaries();
-    if (pane->dialog) {
-        auto controlMarkers = controlMarkersForSession(parentSession);
-        auto branchLinePoints = generatedBranchLinePointsForSession(parentSession);
-        auto branchLinks = generatedBranchLinkMarkers(parentSession.branches);
-        pane->dialog->setGeneratedBranchOverlayData(
-            std::move(controlMarkers),
-            std::move(branchLinePoints),
-            std::move(branchLinks),
-            true,
-            generatedSpanAlignmentMetricsForSession(parentSession));
-    }
-    if (openAfterCreate) {
-        openFiberAtControlPoint(linkedFiberId, 0);
+    const auto newFiberId = createLinkedSeedFiber(parent, seedPoint, linkDirection, session);
+    if (!newFiberId) {
+        refreshBranchLineViews(parent.fiberId);
         return;
     }
-    refreshBranchLineViews(parentFiberId);
+    _linkCandidate.reset();
+    for (const auto& live : liveParents) {
+        live.session->fiberMetricsMatchStoredFiber = true;
+    }
+    invalidateFiberAlignmentMetrics(parent.fiberId, true);
+    emitFiberSummaries();
+    refreshBranchLineViews(parent.fiberId);
+    // Deferred: this runs inside the context-menu callback of the current
+    // dialog, and opening finalizes, saves and closes that dialog. Value
+    // capture only; the controller is the context object. Fiber ids are
+    // reassigned per package load, so a switch that lands in between must
+    // not open an unrelated fiber of the new package.
+    QTimer::singleShot(0, this,
+                       [this, fiberId = *newFiberId, packageGeneration = _packageGeneration]() {
+                           if (_packageGeneration != packageGeneration) {
+                               return;
+                           }
+                           openFiberAtControlPoint(fiberId, 0);
+                       });
 }
 
 void LineAnnotationController::handleGeneratedControlPointLinkCandidate(
@@ -13106,6 +13297,8 @@ LineAnnotationController::generatedBranchLinePointsForSession(
     }
     std::unordered_set<uint64_t> seenFiberIds;
 
+    // Linked fibers are drawn between their outer control points only; the
+    // extrapolated tails stay hidden like their intersection markers.
     auto linePointsForFiber = [this](uint64_t fiberId) -> std::vector<cv::Vec3d> {
         for (const auto& pane : _panes) {
             if (!pane.session || pane.session->fiberId != fiberId ||
@@ -13117,12 +13310,22 @@ LineAnnotationController::generatedBranchLinePointsForSession(
             for (const auto& point : pane.session->optimizedLine.points) {
                 points.push_back(point.position);
             }
-            return points;
+            std::vector<cv::Vec3d> controls;
+            controls.reserve(pane.session->controlPoints.size());
+            for (const auto& control : pane.session->controlPoints) {
+                controls.push_back(control.volumePoint);
+            }
+            return vc3d::line_annotation::linePointsBetweenOuterControlPoints(points, controls);
         }
         auto it = std::find_if(_fibers.begin(), _fibers.end(), [fiberId](const StoredFiber& fiber) {
             return fiber.id == fiberId;
         });
-        return it == _fibers.end() ? std::vector<cv::Vec3d>{} : it->linePoints;
+        if (it == _fibers.end()) {
+            return {};
+        }
+        return vc3d::line_annotation::linePointsBetweenOuterControlPoints(
+            it->linePoints,
+            vc3d::line_annotation::storedControlPointPositions(it->controlPoints));
     };
 
     for (const auto& branch : session.branches) {
@@ -13180,12 +13383,17 @@ LineAnnotationController::fiberSnapshotsForSideStripQuery() const
                                  uint64_t generation,
                                  const std::vector<cv::Vec3d>& linePoints,
                                  std::vector<cv::Vec3d> controlPoints) {
+        // Other fibers take part only between their outer control points:
+        // extrapolated tails must not produce intersection markers.
+        const std::vector<cv::Vec3d> controlledSpan =
+            vc3d::line_annotation::linePointsBetweenOuterControlPoints(linePoints,
+                                                                       controlPoints);
         auto polyline = std::make_shared<vc::atlas::FiberPolyline>();
         polyline->id = id;
         polyline->generation = std::max<uint64_t>(uint64_t{1}, generation);
         polyline->controlPoints = std::move(controlPoints);
-        polyline->points.reserve(linePoints.size());
-        for (const auto& point : linePoints) {
+        polyline->points.reserve(controlledSpan.size());
+        for (const auto& point : controlledSpan) {
             polyline->points.push_back(vc::atlas::FiberPoint{point, std::nullopt});
         }
         SideStripFiberSnapshot snapshot;
@@ -13448,7 +13656,7 @@ void LineAnnotationController::dispatchSideStripIntersectionQuery(
         pane->dialog->setGeneratedSideStripIntersectionBusy(runningHere);
         pane->dialog->setGeneratedFiberIntersectionMarkers(
             markLinkCandidateFiberIntersections(reuseIt->second.markers,
-                                                pane->session->branches));
+                                                pane->session.get()));
         if (!runningHere) {
             // While this surface's own query is still in flight, the busy
             // indicator tells the truth; a completed-count would show 100%
@@ -13535,7 +13743,7 @@ void LineAnnotationController::dispatchSideStripIntersectionQuery(
         pane->dialog->setGeneratedSideStripIntersectionBusy(false);
         pane->dialog->setGeneratedFiberIntersectionMarkers(
             markLinkCandidateFiberIntersections(reuseIt->second.markers,
-                                                pane->session->branches));
+                                                pane->session.get()));
         pane->dialog->setGeneratedSideStripIntersectionResult(
             reuseIt->second.markers.size());
         return;
@@ -13920,8 +14128,7 @@ void LineAnnotationController::applyPartialSideStripIntersectionMarkers(
         pane->dialog->setGeneratedFiberIntersectionMarkers(
             markLinkCandidateFiberIntersections(
                 std::move(markers),
-                pane->session ? pane->session->branches
-                              : std::vector<FiberBranchRef>{}));
+                pane->session.get()));
     }
 }
 
@@ -13960,8 +14167,7 @@ void LineAnnotationController::finishSideStripIntersectionQuery(
                 pane->dialog->setGeneratedFiberIntersectionMarkers(
                     markLinkCandidateFiberIntersections(
                         std::move(result.markers),
-                        pane->session ? pane->session->branches
-                                      : std::vector<FiberBranchRef>{}));
+                        pane->session.get()));
                 if (!samePanePending) {
                     pane->dialog->setGeneratedSideStripIntersectionResult(markerCount);
                 }
@@ -13981,8 +14187,7 @@ void LineAnnotationController::finishSideStripIntersectionQuery(
                     pane->dialog->setGeneratedFiberIntersectionMarkers(
                         markLinkCandidateFiberIntersections(
                             reuseIt->second.markers,
-                            pane->session ? pane->session->branches
-                                          : std::vector<FiberBranchRef>{}));
+                            pane->session.get()));
                 }
                 if (!samePanePending) {
                     pane->dialog->setGeneratedSideStripIntersectionError();

--- a/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationController.hpp
@@ -346,6 +346,9 @@ public:
     [[nodiscard]] uint64_t fiberIdForFileName(const std::string& fileName) const;
     // Display name as shown in the fiber panel (file stem, "unnamed" fallback).
     [[nodiscard]] QString fiberDisplayName(uint64_t fiberId) const;
+    // File stem of a fiber by id (live session first, then stored), or
+    // "unsaved fiber"; resolved at menu time so renames show immediately.
+    [[nodiscard]] QString fiberDisplayNameForId(uint64_t fiberId) const;
     [[nodiscard]] std::vector<std::string> knownFiberTags() const;
     [[nodiscard]] std::vector<vc::atlas::FiberPolyline> fiberSnapshots() const;
     [[nodiscard]] std::vector<vc::atlas::FiberPolyline> fiberSnapshotsFromStorage() const;
@@ -602,11 +605,32 @@ private:
     void handleGeneratedControlPointDelete(const std::string& surfaceName,
                                            double linePosition,
                                            cv::Vec3f volumePoint);
-    void handleGeneratedControlPointBranch(const std::string& surfaceName,
-                                           size_t controlPointIndex,
-                                           cv::Vec3f linkedControlPoint,
-                                           bool openAfterCreate,
-                                           cv::Vec3f requestedLinkDirection);
+    // "New line annotation - linked to candidate": a new fiber seeded at
+    // volumePoint whose seed control point is pending-linked to the designated
+    // link candidate; the new fiber is then opened (deferred out of the menu
+    // callback frame).
+    void handleGeneratedNewLineAnnotationLinkedToCandidate(const std::string& surfaceName,
+                                                           cv::Vec3f volumePoint,
+                                                           cv::Vec3f requestedLinkDirection);
+    // The candidate ("parent") side of a new linked seed fiber: either the
+    // live session(s) of that fiber or its stored record. addRef/rollback
+    // mutate the parent's branch list(s); storedFiber snapshots it for the
+    // pair save after the ref was added.
+    struct LinkedSeedParent {
+        uint64_t fiberId = 0;
+        int controlPointIndex = -1;
+        cv::Vec3d point{0.0, 0.0, 0.0};
+        std::vector<cv::Vec3d> linePoints;
+        std::function<void(const FiberBranchRef&)> addRef;
+        std::function<void(const FiberBranchRef&)> rollback;
+        std::function<StoredFiber()> storedFiber;
+    };
+    // Creates and schedules the save of the one-control linked fiber; returns
+    // its id, or nullopt after showing the error (parent ref rolled back).
+    std::optional<uint64_t> createLinkedSeedFiber(const LinkedSeedParent& parent,
+                                                  const cv::Vec3d& seedPoint,
+                                                  const cv::Vec3d& requestedLinkDirection,
+                                                  const LineAnnotationSession& templateSession);
     void handleGeneratedPredSnapPoint(const std::string& surfaceName,
                                       cv::Vec3f volumePoint);
     // Debouncing entry point (signal-connected): one placement triggers
@@ -681,10 +705,25 @@ private:
         splitAndLinkCandidateMenuState(const LineAnnotationSession& session) const;
     [[nodiscard]] vc3d::line_annotation::GeneratedLinkCandidateMenuState
         mergeCandidateMenuState(const LineAnnotationSession& session) const;
+    [[nodiscard]] vc3d::line_annotation::GeneratedLinkCandidateMenuState
+        newLinkedToCandidateMenuState() const;
+    // "<name> / CP <stored index>" of the link candidate for menu labels
+    // (name only when the control point cannot be resolved).
+    [[nodiscard]] QString linkCandidateMenuName() const;
+    struct ResolvedLinkCandidate {
+        int storedControlIndex = -1;
+        size_t controlCount = 0;
+    };
+    // Live pane session first, then the stored fiber; nullopt when the
+    // candidate control point no longer exists.
+    [[nodiscard]] std::optional<ResolvedLinkCandidate> resolvedLinkCandidateControlIndex() const;
+    // Decorates published side-strip markers for one pane: link-candidate
+    // fiber, pending / same-H/V link state (the session may be null).
     [[nodiscard]] std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker>
         markLinkCandidateFiberIntersections(
             std::vector<vc3d::line_annotation::GeneratedOverlay::FiberIntersectionMarker> markers,
-            const std::vector<FiberBranchRef>& branches) const;
+            const LineAnnotationSession* session) const;
+    [[nodiscard]] bool fibersShareHvDirection(uint64_t localFiberId, uint64_t linkedFiberId) const;
     bool ensureDatasetForSession(LineAnnotationSession& session);
     bool ensureFiberInferenceDatasetForSession(LineAnnotationSession& session);
     void refreshLineAnnotationDatasetMenus() const;

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -75,6 +75,14 @@ namespace {
 constexpr float kCurrentCutRotationStepRadians = 3.14159265358979323846f / 36.0f;
 constexpr bool kGeneratedLineAnnotationOverlaysEnabled = true;
 constexpr char kGeneratedDynamicCurrentCutOverlayKey[] = "line-z-slice-current";
+
+// Index of a link state in the per-state fast overlay item arrays.
+constexpr size_t linkStateIndex(bool pending, bool sameHv)
+{
+    return (pending ? 1u : 0u) | (sameHv ? 2u : 0u);
+}
+constexpr bool linkStatePending(size_t state) { return (state & 1u) != 0; }
+constexpr bool linkStateSameHv(size_t state) { return (state & 2u) != 0; }
 constexpr float kNominalGeneratedRowWidth = 900.0f;
 constexpr float kNominalGeneratedRowHeight = 260.0f;
 constexpr double kSpanMetricHighlightThresholdDegrees = 45.0;
@@ -2333,7 +2341,9 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(
     const vc3d::line_annotation::GeneratedLinkCandidateMenuState& linkCandidateState,
     const vc3d::line_annotation::GeneratedLinkCandidateMenuState& splitCandidateState,
     const vc3d::line_annotation::GeneratedLinkCandidateMenuState& splitAndLinkCandidateState,
-    const vc3d::line_annotation::GeneratedLinkCandidateMenuState& mergeCandidateState)
+    const vc3d::line_annotation::GeneratedLinkCandidateMenuState& mergeCandidateState,
+    const vc3d::line_annotation::GeneratedLinkCandidateMenuState& newLinkedToCandidateState,
+    std::function<QString(uint64_t)> fiberDisplayNameForId)
 {
     if (!viewer || !_hasGeneratedViews || _generatedViews.controlPoints.empty() ||
         _generatedViews.linePoints.empty()) {
@@ -2406,6 +2416,8 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(
     options.splitFromCandidateEnabled = splitCandidateState.enabled;
     options.splitFromCandidateLabel = splitCandidateState.label;
     options.splitFromCandidateAndLinkLabel = splitAndLinkCandidateState.label;
+    options.newLinkedToCandidateLabel = newLinkedToCandidateState.label;
+    options.fiberDisplayNameForId = std::move(fiberDisplayNameForId);
     options.branchLinkDirection = branchLinkDirectionForViewer(viewer, linePosition);
     options.deleteControlPoint = [this, surfaceName](double selectedLinePosition,
                                                      cv::Vec3f selectedPoint) {
@@ -2413,15 +2425,11 @@ LineAnnotationDialog::showGeneratedControlPointContextMenu(
                                                   selectedLinePosition,
                                                   selectedPoint);
     };
-    options.addBranch = [this, surfaceName](size_t controlPointIndex,
-                                            cv::Vec3f linkedControlPoint,
-                                            bool openAfterCreate,
-                                            cv::Vec3f linkDirection) {
-        emit generatedControlPointBranchRequested(surfaceName,
-                                                  controlPointIndex,
-                                                  linkedControlPoint,
-                                                  openAfterCreate,
-                                                  linkDirection);
+    options.newLineAnnotationLinkedToCandidate = [this, surfaceName](cv::Vec3f volumePoint,
+                                                                     cv::Vec3f linkDirection) {
+        emit generatedNewLineAnnotationLinkedToCandidateRequested(surfaceName,
+                                                                  volumePoint,
+                                                                  linkDirection);
     };
     options.openBranch = [this](uint64_t branchFiberId, int branchControlPointIndex) {
         emit generatedControlPointBranchOpenRequested(branchFiberId, branchControlPointIndex);
@@ -4134,9 +4142,12 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         !_fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints ||
         !_fastCurrentCutOverlayItems.fiberIntersections ||
         !_fastCurrentCutOverlayItems.linkCandidateFiberIntersections ||
-        !_fastCurrentCutOverlayItems.branchLinkFiberIntersections ||
-        !_fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections ||
-        !_fastCurrentCutOverlayItems.fiberIntersectionConnectors ||
+        std::any_of(_fastCurrentCutOverlayItems.branchLinkFiberIntersections.begin(),
+                    _fastCurrentCutOverlayItems.branchLinkFiberIntersections.end(),
+                    [](const QGraphicsPathItem* item) { return !item; }) ||
+        std::any_of(_fastCurrentCutOverlayItems.fiberIntersectionConnectors.begin(),
+                    _fastCurrentCutOverlayItems.fiberIntersectionConnectors.end(),
+                    [](const QGraphicsPathItem* item) { return !item; }) ||
         !_fastCurrentCutOverlayItems.ghostControlPointPrev ||
         !_fastCurrentCutOverlayItems.ghostControlPointNext) {
         viewer->clearOverlayGroup(kGeneratedDynamicCurrentCutOverlayKey);
@@ -4234,32 +4245,31 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         _fastCurrentCutOverlayItems.linkCandidateFiberIntersections->setBrush(Qt::NoBrush);
         _fastCurrentCutOverlayItems.linkCandidateFiberIntersections->setZValue(168.5);
 
-        QPen branchLinkFiberIntersectionPen(QColor(210, 95, 255, 245));
-        branchLinkFiberIntersectionPen.setWidthF(1.75);
-        branchLinkFiberIntersectionPen.setCapStyle(Qt::FlatCap);
-        _fastCurrentCutOverlayItems.branchLinkFiberIntersections = new QGraphicsPathItem();
-        _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setPen(
-            branchLinkFiberIntersectionPen);
-        _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setBrush(Qt::NoBrush);
-        _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setZValue(168.25);
+        // Linked-fiber X markers and their connectors, one item per link
+        // state so each wears its control point's colour.
+        for (size_t state = 0; state < FastCurrentCutOverlayItems::kLinkStateCount; ++state) {
+            const bool pending = linkStatePending(state);
+            const bool sameHv = linkStateSameHv(state);
+            QPen branchLinkFiberIntersectionPen(
+                vc3d::line_annotation::generatedLinkStateColor(pending, sameHv, 245));
+            branchLinkFiberIntersectionPen.setWidthF(1.75);
+            branchLinkFiberIntersectionPen.setCapStyle(Qt::FlatCap);
+            auto* xItem = new QGraphicsPathItem();
+            xItem->setPen(branchLinkFiberIntersectionPen);
+            xItem->setBrush(Qt::NoBrush);
+            // Pending glyphs keep drawing over approved ones where they overlap.
+            xItem->setZValue(pending ? 168.3 : 168.25);
+            _fastCurrentCutOverlayItems.branchLinkFiberIntersections[state] = xItem;
 
-        QPen pendingBranchLinkFiberIntersectionPen(QColor(80, 150, 255, 245));
-        pendingBranchLinkFiberIntersectionPen.setWidthF(1.75);
-        pendingBranchLinkFiberIntersectionPen.setCapStyle(Qt::FlatCap);
-        _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections =
-            new QGraphicsPathItem();
-        _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections->setPen(
-            pendingBranchLinkFiberIntersectionPen);
-        _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections->setBrush(Qt::NoBrush);
-        _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections->setZValue(168.3);
-
-        QPen fiberIntersectionConnectorPen(QColor(255, 60, 180, 225));
-        fiberIntersectionConnectorPen.setWidthF(1.4);
-        _fastCurrentCutOverlayItems.fiberIntersectionConnectors = new QGraphicsPathItem();
-        _fastCurrentCutOverlayItems.fiberIntersectionConnectors->setPen(
-            fiberIntersectionConnectorPen);
-        _fastCurrentCutOverlayItems.fiberIntersectionConnectors->setBrush(Qt::NoBrush);
-        _fastCurrentCutOverlayItems.fiberIntersectionConnectors->setZValue(164.0);
+            QPen fiberIntersectionConnectorPen(
+                vc3d::line_annotation::generatedLinkStateColor(pending, sameHv, 225));
+            fiberIntersectionConnectorPen.setWidthF(1.4);
+            auto* connectorItem = new QGraphicsPathItem();
+            connectorItem->setPen(fiberIntersectionConnectorPen);
+            connectorItem->setBrush(Qt::NoBrush);
+            connectorItem->setZValue(164.0);
+            _fastCurrentCutOverlayItems.fiberIntersectionConnectors[state] = connectorItem;
+        }
 
         // Hollow dashed rings, deliberately unlike the solid control markers:
         // they sit at a fictional, parallax-shifted spot until they land.
@@ -4276,23 +4286,27 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
         _fastCurrentCutOverlayItems.ghostControlPointNext->setBrush(Qt::NoBrush);
         _fastCurrentCutOverlayItems.ghostControlPointNext->setZValue(155.0);
 
-        viewer->setOverlayGroup(kGeneratedDynamicCurrentCutOverlayKey,
-                                {_fastCurrentCutOverlayItems.centerPoint,
-                                 _fastCurrentCutOverlayItems.controlPoints,
-                                 _fastCurrentCutOverlayItems.seedPoints,
-                                 _fastCurrentCutOverlayItems.linkCandidatePoints,
-                                 _fastCurrentCutOverlayItems.splitCandidatePoints,
-                                 _fastCurrentCutOverlayItems.branchControlPoints,
-                                 _fastCurrentCutOverlayItems.pendingBranchControlPoints,
-                                 _fastCurrentCutOverlayItems.sameHvBranchControlPoints,
-                                 _fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints,
-                                 _fastCurrentCutOverlayItems.fiberIntersections,
-                                 _fastCurrentCutOverlayItems.linkCandidateFiberIntersections,
-                                 _fastCurrentCutOverlayItems.branchLinkFiberIntersections,
-                                 _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections,
-                                 _fastCurrentCutOverlayItems.fiberIntersectionConnectors,
-                                 _fastCurrentCutOverlayItems.ghostControlPointPrev,
-                                 _fastCurrentCutOverlayItems.ghostControlPointNext});
+        std::vector<QGraphicsItem*> groupItems{
+            _fastCurrentCutOverlayItems.centerPoint,
+            _fastCurrentCutOverlayItems.controlPoints,
+            _fastCurrentCutOverlayItems.seedPoints,
+            _fastCurrentCutOverlayItems.linkCandidatePoints,
+            _fastCurrentCutOverlayItems.splitCandidatePoints,
+            _fastCurrentCutOverlayItems.branchControlPoints,
+            _fastCurrentCutOverlayItems.pendingBranchControlPoints,
+            _fastCurrentCutOverlayItems.sameHvBranchControlPoints,
+            _fastCurrentCutOverlayItems.sameHvPendingBranchControlPoints,
+            _fastCurrentCutOverlayItems.fiberIntersections,
+            _fastCurrentCutOverlayItems.linkCandidateFiberIntersections};
+        for (auto* item : _fastCurrentCutOverlayItems.branchLinkFiberIntersections) {
+            groupItems.push_back(item);
+        }
+        for (auto* item : _fastCurrentCutOverlayItems.fiberIntersectionConnectors) {
+            groupItems.push_back(item);
+        }
+        groupItems.push_back(_fastCurrentCutOverlayItems.ghostControlPointPrev);
+        groupItems.push_back(_fastCurrentCutOverlayItems.ghostControlPointNext);
+        viewer->setOverlayGroup(kGeneratedDynamicCurrentCutOverlayKey, std::move(groupItems));
     }
 
     // During an in-place update, draw from the held pre-update views until this
@@ -4444,9 +4458,8 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
 
     QPainterPath fiberIntersectionPath;
     QPainterPath linkCandidateFiberIntersectionPath;
-    QPainterPath branchLinkFiberIntersectionPath;
-    QPainterPath pendingBranchLinkFiberIntersectionPath;
-    QPainterPath fiberIntersectionConnectorPath;
+    std::array<QPainterPath, FastCurrentCutOverlayItems::kLinkStateCount> branchLinkFiberIntersectionPaths;
+    std::array<QPainterPath, FastCurrentCutOverlayItems::kLinkStateCount> fiberIntersectionConnectorPaths;
     auto* currentCutPlane = cutViews.currentCutSurface.get();
     const std::optional<float> intersectionThreshold =
         (currentCutPlane && !cutViews.fiberIntersections.empty())
@@ -4466,20 +4479,21 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
             if (!std::isfinite(scenePoint.x()) || !std::isfinite(scenePoint.y())) {
                 continue;
             }
+            const size_t linkState = linkStateIndex(intersection.pendingBranchLink,
+                                                    intersection.sameHvBranchLink);
             if (intersection.connectorStart && finitePoint(*intersection.connectorStart)) {
                 const QPointF connectorScene =
                     viewer->volumeToScene(*intersection.connectorStart);
                 if (std::isfinite(connectorScene.x()) && std::isfinite(connectorScene.y())) {
-                    fiberIntersectionConnectorPath.moveTo(connectorScene);
-                    fiberIntersectionConnectorPath.lineTo(scenePoint);
+                    fiberIntersectionConnectorPaths[linkState].moveTo(connectorScene);
+                    fiberIntersectionConnectorPaths[linkState].lineTo(scenePoint);
                 }
             }
+            // The link candidate's green keeps precedence on the X.
             QPainterPath& path = intersection.isLinkCandidateFiber
                 ? linkCandidateFiberIntersectionPath
                 : (intersection.projectedBranchLink
-                       ? (intersection.pendingBranchLink
-                              ? pendingBranchLinkFiberIntersectionPath
-                              : branchLinkFiberIntersectionPath)
+                       ? branchLinkFiberIntersectionPaths[linkState]
                        : fiberIntersectionPath);
             path.moveTo(scenePoint + QPointF(-kIntersectionArm, -kIntersectionArm));
             path.lineTo(scenePoint + QPointF(kIntersectionArm, kIntersectionArm));
@@ -4490,12 +4504,12 @@ void LineAnnotationDialog::updateGeneratedDynamicOverlaysFast(bool updateCurrent
     _fastCurrentCutOverlayItems.fiberIntersections->setPath(fiberIntersectionPath);
     _fastCurrentCutOverlayItems.linkCandidateFiberIntersections->setPath(
         linkCandidateFiberIntersectionPath);
-    _fastCurrentCutOverlayItems.branchLinkFiberIntersections->setPath(
-        branchLinkFiberIntersectionPath);
-    _fastCurrentCutOverlayItems.pendingBranchLinkFiberIntersections->setPath(
-        pendingBranchLinkFiberIntersectionPath);
-    _fastCurrentCutOverlayItems.fiberIntersectionConnectors->setPath(
-        fiberIntersectionConnectorPath);
+    for (size_t state = 0; state < FastCurrentCutOverlayItems::kLinkStateCount; ++state) {
+        _fastCurrentCutOverlayItems.branchLinkFiberIntersections[state]->setPath(
+            branchLinkFiberIntersectionPaths[state]);
+        _fastCurrentCutOverlayItems.fiberIntersectionConnectors[state]->setPath(
+            fiberIntersectionConnectorPaths[state]);
+    }
 }
 
 void LineAnnotationDialog::rebuildGeneratedDynamicOverlays(bool updateCurrentCutOverlay,

--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.hpp
@@ -6,6 +6,7 @@
 #include <QMetaObject>
 #include <QPointer>
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <functional>
@@ -89,9 +90,12 @@ public:
         QGraphicsPathItem* sameHvPendingBranchControlPoints = nullptr;
         QGraphicsPathItem* fiberIntersections = nullptr;
         QGraphicsPathItem* linkCandidateFiberIntersections = nullptr;
-        QGraphicsPathItem* branchLinkFiberIntersections = nullptr;
-        QGraphicsPathItem* pendingBranchLinkFiberIntersections = nullptr;
-        QGraphicsPathItem* fiberIntersectionConnectors = nullptr;
+        // One item per link state (kLinkStateCount, indexed by
+        // linkStateIndex): the projected X of a linked fiber and the
+        // connector from the local control point, both in that state's colour.
+        static constexpr size_t kLinkStateCount = 4;
+        std::array<QGraphicsPathItem*, kLinkStateCount> branchLinkFiberIntersections{};
+        std::array<QGraphicsPathItem*, kLinkStateCount> fiberIntersectionConnectors{};
         QGraphicsPathItem* ghostControlPointPrev = nullptr;
         QGraphicsPathItem* ghostControlPointNext = nullptr;
     };
@@ -138,7 +142,9 @@ public:
         const vc3d::line_annotation::GeneratedLinkCandidateMenuState& linkCandidateState = {},
         const vc3d::line_annotation::GeneratedLinkCandidateMenuState& splitCandidateState = {},
         const vc3d::line_annotation::GeneratedLinkCandidateMenuState& splitAndLinkCandidateState = {},
-        const vc3d::line_annotation::GeneratedLinkCandidateMenuState& mergeCandidateState = {});
+        const vc3d::line_annotation::GeneratedLinkCandidateMenuState& mergeCandidateState = {},
+        const vc3d::line_annotation::GeneratedLinkCandidateMenuState& newLinkedToCandidateState = {},
+        std::function<QString(uint64_t)> fiberDisplayNameForId = {});
     const std::vector<Pane>& panes() const { return _panes; }
     ReoptimizationMode reoptimizationMode() const;
     int initialCenterlineLengthVx() const;
@@ -209,11 +215,11 @@ signals:
     void generatedControlPointDeleteRequested(const std::string& surfaceName,
                                               double linePosition,
                                               cv::Vec3f volumePoint);
-    void generatedControlPointBranchRequested(const std::string& surfaceName,
-                                              size_t controlPointIndex,
-                                              cv::Vec3f linkedControlPoint,
-                                              bool openAfterCreate,
-                                              cv::Vec3f linkDirection);
+    // New fiber seeded at volumePoint, seed control point linked to the
+    // designated link candidate; linkDirection is the clicked view's normal.
+    void generatedNewLineAnnotationLinkedToCandidateRequested(const std::string& surfaceName,
+                                                              cv::Vec3f volumePoint,
+                                                              cv::Vec3f linkDirection);
     void generatedControlPointBranchOpenRequested(uint64_t branchFiberId,
                                                    int branchControlPointIndex);
     void generatedControlPointLinkCandidateRequested(const std::string& surfaceName,

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.cpp
@@ -1546,6 +1546,21 @@ std::optional<std::vector<size_t>> orderedControlPointLineIndices(
     return lineIndices;
 }
 
+std::vector<cv::Vec3d> linePointsBetweenOuterControlPoints(
+    const std::vector<cv::Vec3d>& linePoints,
+    const std::vector<cv::Vec3d>& controlPoints)
+{
+    if (controlPoints.empty()) {
+        return {};
+    }
+    const auto indices = orderedControlPointLineIndices(controlPoints, linePoints);
+    if (!indices || indices->empty()) {
+        return {};
+    }
+    return std::vector<cv::Vec3d>(linePoints.begin() + static_cast<std::ptrdiff_t>(indices->front()),
+                                  linePoints.begin() + static_cast<std::ptrdiff_t>(indices->back()) + 1);
+}
+
 bool constrainLineOpenTailsToBounds(
     vc::lasagna::LineModel& line,
     std::vector<LineControlPoint>& controls,

--- a/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationFiberSegments.hpp
@@ -304,6 +304,15 @@ void validateStoredControlPoints(const std::vector<StoredControlPoint>& controls
     const std::vector<cv::Vec3d>& controlPoints,
     const std::vector<cv::Vec3d>& linePoints);
 
+// The controlled span of a fiber: linePoints from the first control's line
+// index to the last control's (inclusive), mapped with the ordered scan above.
+// Empty when there are no controls or the scan fails (no controlled span), a
+// single point for one control. Used to hide other fibers' extrapolated tails
+// in the line annotation views.
+[[nodiscard]] std::vector<cv::Vec3d> linePointsBetweenOuterControlPoints(
+    const std::vector<cv::Vec3d>& linePoints,
+    const std::vector<cv::Vec3d>& controlPoints);
+
 // Keep the complete path between the outer controls, but shorten open tails
 // near focusBounds. One outside sample per tail is retained as bounded
 // overshoot. Control indices and the display anchor are rebased in place.

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.cpp
@@ -90,6 +90,14 @@ QColor generatedCurrentLineMarkerColor(GeneratedCurrentLineMarkerState state,
 
 } // namespace
 
+QColor generatedLinkStateColor(bool pending, bool sameHv, int alpha)
+{
+    if (sameHv) {
+        return pending ? QColor(255, 190, 120, alpha) : QColor(255, 140, 0, alpha);
+    }
+    return pending ? QColor(80, 150, 255, alpha) : QColor(210, 95, 255, alpha);
+}
+
 QPointF generatedStripLinePositionToScene(CChunkedVolumeViewer* viewer,
                                           QuadSurface* surface,
                                           double linePosition,
@@ -379,11 +387,6 @@ std::string applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
     branchLinkFiberIntersectionStyle.penWidth = 1.75;
     branchLinkFiberIntersectionStyle.z = 168.25;
 
-    ViewerOverlayControllerBase::OverlayStyle pendingBranchLinkFiberIntersectionStyle =
-        branchLinkFiberIntersectionStyle;
-    pendingBranchLinkFiberIntersectionStyle.penColor = QColor(80, 150, 255, 245);
-    pendingBranchLinkFiberIntersectionStyle.z = 168.3;
-
     auto addVolumePointMarker = [&](const cv::Vec3f& point,
                                     qreal radius,
                                     const ViewerOverlayControllerBase::OverlayStyle& style) {
@@ -601,23 +604,35 @@ std::string applyGeneratedOverlay(CChunkedVolumeViewer* viewer,
             continue;
         }
         const QPointF scenePoint = viewer->volumeToScene(intersection.point);
+        // Connector and projected X follow the linked control point's palette
+        // (pending / same-H/V); the link candidate's green keeps precedence
+        // on the X.
+        auto linkXStyle = branchLinkFiberIntersectionStyle;
+        linkXStyle.penColor = generatedLinkStateColor(intersection.pendingBranchLink,
+                                                      intersection.sameHvBranchLink,
+                                                      245);
+        // Pending glyphs keep drawing over approved ones where they overlap.
+        linkXStyle.z = intersection.pendingBranchLink ? 168.3 : 168.25;
         if (intersection.connectorStart &&
             finiteGeneratedPoint(*intersection.connectorStart)) {
             const QPointF connectorScene = viewer->volumeToScene(*intersection.connectorStart);
             if (finiteScenePoint(connectorScene) && finiteScenePoint(scenePoint)) {
+                auto connectorStyle = branchLinkStyle;
+                connectorStyle.penColor = generatedLinkStateColor(
+                    intersection.pendingBranchLink, intersection.sameHvBranchLink, 225);
+                connectorStyle.brushColor = generatedLinkStateColor(
+                    intersection.pendingBranchLink, intersection.sameHvBranchLink, 165);
                 primitives.push_back(ViewerOverlayControllerBase::LineStripPrimitive{
                     {connectorScene, scenePoint},
                     false,
-                    branchLinkStyle});
+                    connectorStyle});
             }
         }
         addFiberIntersectionMarker(scenePoint,
                                    intersection.isLinkCandidateFiber
                                        ? linkCandidateFiberIntersectionStyle
                                        : (intersection.projectedBranchLink
-                                              ? (intersection.pendingBranchLink
-                                                     ? pendingBranchLinkFiberIntersectionStyle
-                                                     : branchLinkFiberIntersectionStyle)
+                                              ? linkXStyle
                                               : fiberIntersectionStyle));
     }
 
@@ -797,6 +812,12 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
         }
     }
 
+    const auto fiberName = [&options](uint64_t fiberId) {
+        return options.fiberDisplayNameForId
+            ? options.fiberDisplayNameForId(fiberId)
+            : QWidget::tr("Fiber %1").arg(static_cast<qulonglong>(fiberId));
+    };
+
     clearGeneratedControlPointContextPreview(options.viewer, options.surfaceName);
     if (finiteScenePoint(options.scenePoint) && finiteScenePoint(targetScene)) {
         ViewerOverlayControllerBase::OverlayStyle previewStyle;
@@ -919,9 +940,8 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
         QMenu* branchMenu = menu.addMenu(QWidget::tr("Go to linked annotation"));
         for (const auto& branch : selectedControl.branchLinks) {
             QAction* action = branchMenu->addAction(
-                QWidget::tr("Fiber %1 / CP %2")
-                    .arg(static_cast<qulonglong>(branch.fiberId))
-                    .arg(branch.controlPointIndex));
+                QWidget::tr("%1 / CP %2")
+                    .arg(fiberName(branch.fiberId), QString::number(branch.controlPointIndex)));
             action->setEnabled(static_cast<bool>(options.openBranch));
             openBranchActions.push_back({action, branch});
         }
@@ -931,17 +951,15 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
         if (selectedControl.branchLinks.size() == 1) {
             const auto& branch = selectedControl.branchLinks.front();
             QAction* action = menu.addAction(
-                QWidget::tr("Unlink from Fiber %1 / CP %2")
-                    .arg(static_cast<qulonglong>(branch.fiberId))
-                    .arg(branch.controlPointIndex));
+                QWidget::tr("Unlink from %1 / CP %2")
+                    .arg(fiberName(branch.fiberId), QString::number(branch.controlPointIndex)));
             unlinkActions.push_back({action, branch});
         } else {
             QMenu* unlinkMenu = menu.addMenu(QWidget::tr("Unlink"));
             for (const auto& branch : selectedControl.branchLinks) {
                 QAction* action = unlinkMenu->addAction(
-                    QWidget::tr("Fiber %1 / CP %2")
-                        .arg(static_cast<qulonglong>(branch.fiberId))
-                        .arg(branch.controlPointIndex));
+                    QWidget::tr("%1 / CP %2")
+                        .arg(fiberName(branch.fiberId), QString::number(branch.controlPointIndex)));
                 unlinkActions.push_back({action, branch});
             }
         }
@@ -950,7 +968,7 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
     std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>> markPendingActions;
     if (options.setBranchLinkPending && !selectedControl.branchLinks.empty()) {
         auto addPendingChangeActions =
-            [&menu](std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>>& actions,
+            [&menu, &fiberName](std::vector<std::pair<QAction*, GeneratedOverlay::ControlPointMarker::BranchLink>>& actions,
                     const std::vector<GeneratedOverlay::ControlPointMarker::BranchLink>& links,
                     const QString& singleFormat,
                     const QString& submenuTitle) {
@@ -960,17 +978,16 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
                 if (links.size() == 1) {
                     const auto& branch = links.front();
                     QAction* action = menu.addAction(
-                        singleFormat
-                            .arg(static_cast<qulonglong>(branch.fiberId))
-                            .arg(branch.controlPointIndex));
+                        singleFormat.arg(fiberName(branch.fiberId),
+                                         QString::number(branch.controlPointIndex)));
                     actions.push_back({action, branch});
                 } else {
                     QMenu* submenu = menu.addMenu(submenuTitle);
                     for (const auto& branch : links) {
                         QAction* action = submenu->addAction(
-                            QWidget::tr("Fiber %1 / CP %2")
-                                .arg(static_cast<qulonglong>(branch.fiberId))
-                                .arg(branch.controlPointIndex));
+                            QWidget::tr("%1 / CP %2")
+                                .arg(fiberName(branch.fiberId),
+                                     QString::number(branch.controlPointIndex)));
                         actions.push_back({action, branch});
                     }
                 }
@@ -982,11 +999,11 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
         }
         addPendingChangeActions(approveActions,
                                 pendingLinks,
-                                QWidget::tr("Approve link to Fiber %1 / CP %2"),
+                                QWidget::tr("Approve link to %1 / CP %2"),
                                 QWidget::tr("Approve link"));
         addPendingChangeActions(markPendingActions,
                                 approvedLinks,
-                                QWidget::tr("Mark link as pending (Fiber %1 / CP %2)"),
+                                QWidget::tr("Mark link as pending (%1 / CP %2)"),
                                 QWidget::tr("Mark link as pending"));
     }
     const bool canSampleClickedVolume =
@@ -994,14 +1011,13 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
     QAction* newLineAnnotationAction =
         menu.addAction(QWidget::tr("New line annotation"));
     newLineAnnotationAction->setEnabled(canSampleClickedVolume);
+    // Only while a link candidate is designated; like "New line annotation"
+    // it acts on the clicked location, not on the selected control point.
     QAction* newLinkedLineAnnotationAction = nullptr;
-    if (options.addBranch) {
-        newLinkedLineAnnotationAction = menu.addAction(
-            QWidget::tr("New linked line annotation from control point"));
-        newLinkedLineAnnotationAction->setEnabled(
-            selectedControlIndex != std::numeric_limits<size_t>::max() &&
-            canSampleClickedVolume &&
-            !selectedControl.hasBranches);
+    if (options.newLineAnnotationLinkedToCandidate &&
+        !options.newLinkedToCandidateLabel.isEmpty()) {
+        newLinkedLineAnnotationAction = menu.addAction(options.newLinkedToCandidateLabel);
+        newLinkedLineAnnotationAction->setEnabled(canSampleClickedVolume);
     }
     QAction* linkWithCandidateAction = nullptr;
     if (options.linkWithCandidate && !options.linkWithCandidateLabel.isEmpty()) {
@@ -1039,8 +1055,8 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
     QAction* openNearbyAnnotationAction = nullptr;
     if (options.openNearbyAnnotation && nearbyIntersection) {
         openNearbyAnnotationAction = menu.addAction(
-            QWidget::tr("Go to nearby annotation (Fiber %1)")
-                .arg(static_cast<qulonglong>(nearbyIntersection->fiberId)));
+            QWidget::tr("Go to nearby annotation (%1)")
+                .arg(fiberName(nearbyIntersection->fiberId)));
     }
     QAction* selected = menu.exec(options.globalPos);
     clearGeneratedControlPointContextPreview(options.viewer, options.surfaceName);
@@ -1094,10 +1110,8 @@ GeneratedControlPointContextResult showGeneratedControlPointContextMenu(
         if (!clickedVolumePoint) {
             return GeneratedControlPointContextResult::Handled;
         }
-        options.addBranch(selectedControlIndex,
-                          clickedVolumePoint->position,
-                          false,
-                          options.branchLinkDirection);
+        options.newLineAnnotationLinkedToCandidate(clickedVolumePoint->position,
+                                                   options.branchLinkDirection);
         return GeneratedControlPointContextResult::Handled;
     }
     if (designateLinkCandidateAction &&

--- a/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationGeneratedViews.hpp
@@ -22,6 +22,7 @@
 
 class CChunkedVolumeViewer;
 class PlaneSurface;
+class QColor;
 class QuadSurface;
 class QWidget;
 
@@ -111,6 +112,9 @@ struct GeneratedOverlay {
         double distance = std::numeric_limits<double>::quiet_NaN();
         bool projectedBranchLink = false;
         bool pendingBranchLink = false;
+        // Set with projectedBranchLink when the local and linked fibers share
+        // an H/V classification (the orange warning palette).
+        bool sameHvBranchLink = false;
         bool isLinkCandidateFiber = false;
         std::optional<cv::Vec3f> connectorStart;
     };
@@ -1419,6 +1423,12 @@ struct GeneratedLinkCandidateMenuState {
     QString label;
 };
 
+// The link-state palette shared by linked control points, their connector
+// lines and the linked fiber's projected X marker: purple approved, blue
+// pending, orange same-H/V approved, light orange same-H/V pending.
+// Defined in the .cpp: this header is also compiled into QtCore-only tests.
+[[nodiscard]] QColor generatedLinkStateColor(bool pending, bool sameHv, int alpha);
+
 struct GeneratedControlPointContextMenuOptions {
     QWidget* parent = nullptr;
     std::string surfaceName;
@@ -1441,8 +1451,14 @@ struct GeneratedControlPointContextMenuOptions {
     cv::Vec3f branchLinkDirection{std::numeric_limits<float>::quiet_NaN(),
                                   std::numeric_limits<float>::quiet_NaN(),
                                   std::numeric_limits<float>::quiet_NaN()};
+    // Shown only while a link candidate is designated (empty label = hidden).
+    QString newLinkedToCandidateLabel;
+    // Fiber file stem for menu labels, resolved when the menu opens.
+    std::function<QString(uint64_t)> fiberDisplayNameForId;
     std::function<void(double, cv::Vec3f)> deleteControlPoint;
-    std::function<void(size_t, cv::Vec3f, bool, cv::Vec3f)> addBranch;
+    // (clicked volume point, link direction): start a new fiber seeded at the
+    // click whose seed control point is linked to the designated candidate.
+    std::function<void(cv::Vec3f, cv::Vec3f)> newLineAnnotationLinkedToCandidate;
     std::function<void(uint64_t, int)> openBranch;
     std::function<void(size_t, uint64_t, int)> unlinkBranch;
     // (controlIndex, linkedFiberId, linkedControlPointIndex, newPendingState)

--- a/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
+++ b/volume-cartographer/core/test/test_line_annotation_generated_views.cpp
@@ -3805,3 +3805,46 @@ TEST_CASE("stale-view refresh: rebuilds exactly the panes built before the chang
     neverRecorded.orientationEpoch = -1;
     CHECK(paneNeedsOrientationRefresh(neverRecorded, kEpoch));
 }
+
+TEST_CASE("controlled span keeps only the line between the outer control points")
+{
+    using vc3d::line_annotation::linePointsBetweenOuterControlPoints;
+    const std::vector<cv::Vec3d> line{
+        {0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}, {4.0, 0.0, 0.0}};
+
+    SUBCASE("interior controls drop both extrapolated tails")
+    {
+        const auto span = linePointsBetweenOuterControlPoints(line, {line[1], line[3]});
+        REQUIRE(span.size() == 3);
+        CHECK(span.front() == line[1]);
+        CHECK(span.back() == line[3]);
+    }
+    SUBCASE("one control is a single point, so nothing of the fiber is drawn")
+    {
+        const auto span = linePointsBetweenOuterControlPoints(line, {line[2]});
+        REQUIRE(span.size() == 1);
+        CHECK(span.front() == line[2]);
+    }
+    SUBCASE("a control off the line has no controlled span")
+    {
+        CHECK(linePointsBetweenOuterControlPoints(line, {line[1], {2.5, 0.0, 0.0}}).empty());
+    }
+    SUBCASE("no controls has no controlled span")
+    {
+        CHECK(linePointsBetweenOuterControlPoints(line, {}).empty());
+    }
+    SUBCASE("a line revisiting a coordinate is mapped in loader order, not by nearest point")
+    {
+        const cv::Vec3d a{0.0, 0.0, 0.0};
+        const cv::Vec3d b{2.0, 0.0, 0.0};
+        const cv::Vec3d c{2.0, 2.0, 0.0};
+        const cv::Vec3d d{0.0, -2.0, 0.0};
+        const std::vector<cv::Vec3d> loop{a, b, c, a, d};
+        const auto span = linePointsBetweenOuterControlPoints(loop, {b, a});
+        // Controls B then A: the second A (index 3), so the span is B, C, A.
+        REQUIRE(span.size() == 3);
+        CHECK(span[0] == b);
+        CHECK(span[1] == c);
+        CHECK(span[2] == a);
+    }
+}


### PR DESCRIPTION
**In one sentence:** In the VC3D Line Annotation GUI you can start a new fiber that is already linked to the designated link candidate, read link states off the connector lines, see which fiber a menu entry refers to by its file name, and no longer get intersection markers from other fibers' extrapolated tails.

**One real example:** Starting with a scroll fiber set open in the Line Annotation GUI, I designated a control point on fiber A as link candidate, Ctrl+right-clicked in a cut view and chose "New line annotation - linked to candidate (<fiber stem> / CP n)", and it opened a new fiber seeded at the click whose seed control point is pending-linked (blue) to the candidate, with the candidate cleared.

**Before:** The option was "New linked line annotation from control point" (linked to the clicked control point, no candidate, did not open the new fiber). Link connector lines were always pink and the linked fiber's X was purple/blue only. Menu entries named fibers by runtime id ("Fiber 12 / CP 3"). Other fibers' extrapolated tails produced intersection X markers and full-length linked polylines.

**After this PR:**
1. "New line annotation - linked to candidate (<fiber stem> / CP n)" appears only while a link candidate is designated (on any fiber), seeds a new fiber at the click, pending-links its seed control point to the candidate, clears the candidate and opens the new fiber. The candidate side is resolved through every live session of that fiber first (dialog and dialog-less inspection sessions), then the stored record; the open is deferred out of the menu callback frame and guarded against a package switch.
2. Connector lines and the linked fiber's projected X use the linked control point's palette (purple approved, blue pending, orange / light orange same-H/V) in both the strip overlays and the fast current-cut path; link-candidate green keeps precedence on the X.
3. Every context-menu entry that names a fiber shows its file stem, resolved when the menu opens (rename-safe): "Go to nearby annotation (<stem>)", "Unlink from <stem> / CP n", "Approve link to <stem> / CP n", "Link/Merge with candidate (<stem> / CP n)". Unsaved fibers show "unsaved fiber".
4. Other fibers take part in the side-strip / cut-view intersection markers and in the linked-fiber polylines only between their outer control points, mapped with the loader's ordered control-point scan.

**Proof:** GUI-tested by the author on the local fiber dataset: linked-to-candidate creation from the candidate's own fiber and from another fiber, connector/X recolouring per link state, menu names, and the disappearance of tail X markers. Unit test `test_line_annotation_generated_views` gains "controlled span keeps only the line between the outer control points" (interior controls, one control, off-line control, no controls, revisiting-coordinate line); all 100 cases pass.

**Why / where this is useful:** Fiber annotators linking fibers across sheets get a one-step "designate candidate, start linked fiber" workflow, can tell approved from pending and same-H/V links at a glance from the connectors, know which file a menu action targets, and stop chasing X markers that only come from the model's extrapolation.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Tested commit: the single commit of this branch on main 40f9c6bac.

Build and tests:
```
cmake --build volume-cartographer/build --target VC3D test_line_annotation_generated_views -j
volume-cartographer/build/bin/test_line_annotation_generated_views
```

Implementation notes:
- `LineAnnotationController::handleGeneratedNewLineAnnotationLinkedToCandidate` + `createLinkedSeedFiber` replace `handleGeneratedControlPointBranch`; the reciprocal ref reads the parent's STORED control index back from the serialized parent snapshot. The parent ref is inserted inside the try so a partial insertion across several live copies is rolled back.
- `generatedLinkStateColor(pending, sameHv, alpha)` is declared behind a `class QColor;` forward declaration and defined in `LineAnnotationGeneratedViews.cpp` because `test_line_annotation_generated_views` links QtCore only. The fast current-cut path uses one `QGraphicsPathItem` per link state for X markers and connectors; pending X keeps z 168.3 over approved 168.25.
- Menu names come from a `std::function<QString(uint64_t)>` resolver in the menu options (live session first, then stored), so no names are cached in markers. Candidate labels share `resolvedLinkCandidateControlIndex()`, extracted from `mergeCandidateMenuState` with identical enablement.
- `linePointsBetweenOuterControlPoints` (LineAnnotationFiberSegments) returns the inclusive span between the outer controls via `orderedControlPointLineIndices`, a singleton for one control, empty when there is no controlled span. Used by `fiberSnapshotsForSideStripQuery` (before the controls are moved into the polyline; the geometry hash therefore follows) and `generatedBranchLinePointsForSession`. No core `vc::atlas` change.
- `GeneratedOverlay::branchLinks` (direct-link renderer) is not populated by any GUI overlay builder and was left untouched.

Limitations / pre-existing: a dialog-less intersection-inspection session of a fiber can coexist with a dialog session of the same fiber; `scheduleBranchMetadataSaves` serializes the first surviving live session, so a stale inspection copy can overwrite a dialog edit when any linked fiber's optimization lands. This exists on main for any link and is not changed here.

Review: three plan rounds and three code rounds with fresh Codex reviewers (full-context maintainer + Qt lifetime/rendering specialist); both round-3 reviewers READY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkfhFpqpfNBtZPhxKZJ8J8
