### PR TITLE
Fix lasagna flush worker error

### DIFF
--- a/lasagna/preprocess_cos_omezarr.py
+++ b/lasagna/preprocess_cos_omezarr.py
@@ -225,6 +225,9 @@ class LasagnaCosPredict3DAdapter:
 	COS_PRODUCT = "cos"
 	NORMAL_PRODUCT = "lasagna_normal"
 	PRED_DT_PRODUCT = "pred_dt"
+	# UNet channels 1:8 — grad_mag plus six 3×2 direction channels — before
+	# finalize_product_slab encodes them to persisted grad_mag/nx/ny.
+	NORMAL_RAW_CHANNEL_COUNT = 7
 
 	def __init__(
 		self,
@@ -242,6 +245,12 @@ class LasagnaCosPredict3DAdapter:
 		self.cos_product = cos_product
 		self.normal_product = normal_product
 		self.pred_dt_product = pred_dt_product
+		if int(self.normal_product.raw_channel_count) != self.NORMAL_RAW_CHANNEL_COUNT:
+			raise ValueError(
+				f"normal product must accumulate {self.NORMAL_RAW_CHANNEL_COUNT} raw "
+				f"channels (grad_mag + 6 direction); got "
+				f"{self.normal_product.raw_channel_count}"
+			)
 		self.norm_type = None
 		self.upsample_mode = None
 		self.output_sigmoid = True
@@ -300,14 +309,15 @@ class LasagnaCosPredict3DAdapter:
 		output = torch.sigmoid(output) if self.output_sigmoid else output.clamp(0.0, 1.0)
 		if output.ndim != 5:
 			raise ValueError("Lasagna predict3d model output must have shape B,C,D,H,W")
-		if int(output.shape[1]) < 8:
+		raw_n = 1 + self.NORMAL_RAW_CHANNEL_COUNT
+		if int(output.shape[1]) < raw_n:
 			raise ValueError(
 				"Lasagna predict3d model output must contain at least 8 channels: "
 				"cos, grad_mag, and six direction channels"
 			)
 		return {
 			self.cos_product.name: output[:, 0:1],
-			self.normal_product.name: output[:, 1:8],
+			self.normal_product.name: output[:, 1:raw_n],
 		}
 
 	def finalize_product_slab(
@@ -323,9 +333,10 @@ class LasagnaCosPredict3DAdapter:
 				"cos": np.clip(slab[0] * 255.0, 0.0, 255.0).astype(np.uint8),
 			}
 		if product.name == self.normal_product.name:
-			if slab.ndim != 4 or int(slab.shape[0]) != 7:
+			if slab.ndim != 4 or int(slab.shape[0]) != self.NORMAL_RAW_CHANNEL_COUNT:
 				raise ValueError(
-					f"normal slab must have shape 7,D,H,W; got {slab.shape}"
+					f"normal slab must have shape {self.NORMAL_RAW_CHANNEL_COUNT},D,H,W; "
+					f"got {slab.shape}"
 				)
 			gm_u8 = np.clip(slab[0] * 1000.0, 0.0, 255.0).astype(np.uint8)
 			nx_u8, ny_u8 = encode_normal_nxny_u8(
@@ -1752,6 +1763,7 @@ def run_preprocess_3d(
 			),
 			chunk_size=oc,
 			pyramid_policy=PYRAMID_POLICY_CUSTOM,
+			accumulator_channel_count=LasagnaCosPredict3DAdapter.NORMAL_RAW_CHANNEL_COUNT,
 			inference_scaledown=other_sd,
 		),
 		pred_dt_product=(

--- a/lasagna/tests/test_preprocess_cos_omezarr.py
+++ b/lasagna/tests/test_preprocess_cos_omezarr.py
@@ -730,6 +730,7 @@ class PreprocessCosOmezarrTests(unittest.TestCase):
 				),
 				chunk_size=32,
 				pyramid_policy=PYRAMID_POLICY_CUSTOM,
+				accumulator_channel_count=LasagnaCosPredict3DAdapter.NORMAL_RAW_CHANNEL_COUNT,
 			),
 			pred_dt_product=OutputProductSpec(
 				name=LasagnaCosPredict3DAdapter.PRED_DT_PRODUCT,
@@ -753,10 +754,82 @@ class PreprocessCosOmezarrTests(unittest.TestCase):
 			adapter.normal_product.channel_names,
 			("grad_mag", "nx", "ny"),
 		)
+		self.assertEqual(adapter.normal_product.channel_count, 3)
+		self.assertEqual(
+			adapter.normal_product.raw_channel_count,
+			LasagnaCosPredict3DAdapter.NORMAL_RAW_CHANNEL_COUNT,
+		)
 		self.assertEqual(
 			[product.name for product in adapter.derived_output_products],
 			[LasagnaCosPredict3DAdapter.PRED_DT_PRODUCT],
 		)
+
+	def test_lasagna_adapter_rejects_three_channel_normal_accumulator(self):
+		cos = OutputProductSpec(
+			name=LasagnaCosPredict3DAdapter.COS_PRODUCT,
+			level=1,
+			scaledown=2,
+			channels=(OutputChannelSpec("cos", relative_path="cos.ome.zarr"),),
+			chunk_size=32,
+		)
+		normal = OutputProductSpec(
+			name=LasagnaCosPredict3DAdapter.NORMAL_PRODUCT,
+			level=2,
+			scaledown=4,
+			channels=(
+				OutputChannelSpec("grad_mag", relative_path="grad_mag.ome.zarr"),
+				OutputChannelSpec("nx", relative_path="nx.ome.zarr"),
+				OutputChannelSpec("ny", relative_path="ny.ome.zarr"),
+			),
+			chunk_size=32,
+		)
+		with self.assertRaisesRegex(ValueError, "accumulate 7 raw channels"):
+			LasagnaCosPredict3DAdapter(
+				checkpoint="model.pt",
+				tile_size=64,
+				device_name="cpu",
+				cos_product=cos,
+				normal_product=normal,
+			)
+
+	def test_lasagna_normal_finalize_uses_seven_raw_channels(self):
+		product = OutputProductSpec(
+			name=LasagnaCosPredict3DAdapter.NORMAL_PRODUCT,
+			level=2,
+			scaledown=4,
+			channels=(
+				OutputChannelSpec("grad_mag", relative_path="grad_mag.ome.zarr"),
+				OutputChannelSpec("nx", relative_path="nx.ome.zarr"),
+				OutputChannelSpec("ny", relative_path="ny.ome.zarr"),
+			),
+			chunk_size=32,
+			accumulator_channel_count=LasagnaCosPredict3DAdapter.NORMAL_RAW_CHANNEL_COUNT,
+		)
+		adapter = LasagnaCosPredict3DAdapter(
+			checkpoint="model.pt",
+			tile_size=64,
+			device_name="cpu",
+			cos_product=OutputProductSpec(
+				name=LasagnaCosPredict3DAdapter.COS_PRODUCT,
+				level=1,
+				scaledown=2,
+				channels=(OutputChannelSpec("cos", relative_path="cos.ome.zarr"),),
+				chunk_size=32,
+			),
+			normal_product=product,
+		)
+		with self.assertRaisesRegex(ValueError, "shape 7,D,H,W"):
+			adapter.finalize_product_slab(product, np.zeros((3, 4, 4, 4), dtype=np.float32))
+		raw = torch.rand(1, 8, 2, 2, 2)
+		tensors = adapter.product_tensors_from_output(raw)
+		self.assertEqual(tuple(tensors[product.name].shape), (1, 7, 2, 2, 2))
+		persisted = adapter.finalize_product_slab(
+			product, tensors[product.name][0].detach().numpy(),
+		)
+		self.assertEqual(set(persisted), {"grad_mag", "nx", "ny"})
+		for name, arr in persisted.items():
+			self.assertEqual(arr.dtype, np.uint8, name)
+			self.assertEqual(arr.shape, (2, 2, 2), name)
 
 	def test_lasagna_output_adapter_requires_complete_normal_bundle(self):
 		with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
**Before:**

`lasagna predict3d` failed at ~11% with the following error:

```
[predict3d] flush sd=4 z=[2688,2752) dirty_chunks=214
Traceback (most recent call last):
  File "/workspace/villa/lasagna/.venv/bin/lasagna-preprocess", line 10, in <module>
    sys.exit(cli_main())
             ~~~~~~~~^^
  File "/workspace/villa/lasagna/preprocess_cos_omezarr.py", line 2985, in cli_main
    return main_predict3d(args[1:])
  File "/workspace/villa/lasagna/preprocess_cos_omezarr.py", line 2915, in main_predict3d
    run_preprocess_3d(
    ~~~~~~~~~~~~~~~~~^
    input_path=str(args.input),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<34 lines>...
    live_cache=live_cache,
    ^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/workspace/villa/lasagna/preprocess_cos_omezarr.py", line 1857, in run_preprocess_3d
    run_tiled_inference_3d(
    ~~~~~~~~~~~~~~~~~~~~~~^
        model,
     ^^^^^^
    ...<38 lines>...
        live_cache=live_cache,
     ^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/workspace/villa/lasagna/tiled_predict3d.py", line 2364, in wrapped
    return function(*args, **kwargs)
  File "/workspace/villa/lasagna/tiled_predict3d.py", line 3257, in run_tiled_inference_3d
    _pump_pending_flush(block=False)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/workspace/villa/lasagna/tiled_predict3d.py", line 2938, in _pump_pending_flush
    _handle_flush_message(message)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/workspace/villa/lasagna/tiled_predict3d.py", line 2907, in _handle_flush_message
    raise RuntimeError(
        f"flush worker {message[3]} failed task {task_id}: {message[4]}: {message[5]}"
    )
RuntimeError: flush worker 13 failed task 16: ValueError: normal slab must have shape 7,D,H,W; got (3, 64, 64, 64)
```

**After this PR:** Got past 11%.

I don't claim to understand exactly what the problem was other than a tensor shape mismatch, but this seems to have fixed it.