### PR TITLE
vc_render_tifxyz: create ome-zarr pyramid downscales isotropically

### DIFF
--- a/volume-cartographer/apps/src/vc_render_tifxyz.cpp
+++ b/volume-cartographer/apps/src/vc_render_tifxyz.cpp
@@ -751,6 +751,7 @@ static void renderTiles(
     size_t tilesXSrc, size_t tilesYSrc,
     // Pyramid datasets L1-L5 (empty = no inline pyramid)
     const std::vector<vc::VcDataset*>& pyramidDs,
+    PyramidMode pyramidMode,
     // TIF output (optional)
     std::vector<TiffWriter>* tifWriters, uint32_t tiffTileH,
     bool quickTif,
@@ -843,7 +844,8 @@ static void renderTiles(
                         size_t offX = (size_t(tx) & 1) * halfCW;
                         auto& pa = pyrAccum[0];
                         if (l1cx < pa.bufs.size()) {
-                            downsampleTileIntoPreserveZ(
+                            downsampleTileIntoMode(
+                                pyramidMode,
                                 existingBuf.data(), chunkZ, chunkY, chunkX,
                                 pa.bufs[l1cx].data(), pa.chZ, pa.chY, pa.chX,
                                 numZ, dy_actual, dx_actual,
@@ -936,7 +938,8 @@ static void renderTiles(
                     size_t offX = (size_t(tx) & 1) * halfCW;
                     auto& pa = pyrAccum[0];
                     if (l1cx < pa.bufs.size()) {
-                        downsampleTileIntoPreserveZ(
+                        downsampleTileIntoMode(
+                            pyramidMode,
                             chunkBuf.data(), chunkZ, chunkY, chunkX,
                             pa.bufs[l1cx].data(), pa.chZ, pa.chY, pa.chX,
                             numZ, dy_actual, dx_actual,
@@ -1011,7 +1014,8 @@ static void renderTiles(
                         size_t offY = (pyrChunkRow & 1) * halfY;
                         size_t offX = (cx & 1) * halfX;
                         if (nextCx < nextPa.bufs.size()) {
-                            downsampleTileIntoPreserveZ(
+                            downsampleTileIntoMode(
+                                pyramidMode,
                                 pa.bufs[cx].data(), pa.chZ, pa.chY, pa.chX,
                                 nextPa.bufs[nextCx].data(), nextPa.chZ, nextPa.chY, nextPa.chX,
                                 pa.chZ, pa.chY, pa.chX,
@@ -1071,6 +1075,18 @@ static std::optional<double> readVolumeVoxelSize(const std::filesystem::path& vo
     if (auto v = tryFile(volPath / "metadata.json", "scan")) return v;
     if (auto v = tryFile(volPath / "metadata.json", nullptr)) return v;
     return std::nullopt;
+}
+
+// Pyramid geometry recorded in an existing store. Stores written before the attribute
+// existed are preserve-z, which is what the renderer used to always produce.
+static std::optional<PyramidMode> readStorePyramidMode(const std::filesystem::path& storePath)
+{
+    const auto attrs = storePath / ".zattrs";
+    if (!std::filesystem::exists(attrs)) return std::nullopt;
+    Json j = Json::parse_file(attrs.string());
+    if (!j.is_object() || !j.contains("pyramid_mode")) return PyramidMode::PreserveZ;
+    return j["pyramid_mode"].get_string() == "isotropic" ? PyramidMode::Isotropic
+                                                         : PyramidMode::PreserveZ;
 }
 
 // ============================================================
@@ -1149,6 +1165,9 @@ int main(int argc, char *argv[])
         ("part-id", po::value<int>()->default_value(0), "Part ID (0-indexed)")
         ("merge-tiff-parts", po::bool_switch()->default_value(false), "Merge partial TIFFs from multi-VM render")
         ("pyramid", po::value<bool>()->default_value(true), "Build pyramid levels L1-L5 (default: true)")
+        ("pyramid-mode", po::value<std::string>()->default_value("isotropic"),
+            "Pyramid downsampling: isotropic (default; 2x2x2, so a cubic level 0 stays cubic at "
+            "every level) or preserve-z (2x2x1, every level keeps the full slice stack)")
         ("resume", po::bool_switch()->default_value(false), "Skip chunks that already exist on disk")
         ("pre", po::bool_switch()->default_value(false), "Create zarr + all level datasets")
         ("voxel-size", po::value<double>(), "Physical voxel size for OME-Zarr scale metadata (reads from volume metadata if omitted)")
@@ -1249,6 +1268,22 @@ int main(int argc, char *argv[])
     int num_slices = parsed["num-slices"].as<int>();
     double slice_step = parsed["slice-step"].as<float>();
     if (!std::isfinite(slice_step) || slice_step <= 0) { logPrintf(stderr, "Error: --slice-step must be positive\n"); return EXIT_FAILURE; }
+
+    const std::string pyramid_mode_str = parsed["pyramid-mode"].as<std::string>();
+    PyramidMode pyramid_mode;
+    if (pyramid_mode_str == "preserve-z")      pyramid_mode = PyramidMode::PreserveZ;
+    else if (pyramid_mode_str == "isotropic")  pyramid_mode = PyramidMode::Isotropic;
+    else { logPrintf(stderr, "Error: --pyramid-mode must be preserve-z or isotropic\n"); return EXIT_FAILURE; }
+    // Halving all three axes preserves whatever aspect level 0 has, and the .zattrs scale is
+    // declared per axis either way, so this is a naming caveat rather than an error: level 0 is
+    // only cubic when the in-plane spacing (1/--scale level-g voxels per pixel) equals the
+    // through-plane spacing (--slice-step).
+    if (pyramid_mode == PyramidMode::Isotropic
+        && std::abs(double(tgt_scale) * slice_step - 1.0) > 1e-6) {
+        logPrintf(stderr, "Warning: level 0 is not cubic (--slice-step %g vs 1/--scale %g), so the "
+                          "isotropic pyramid preserves that aspect rather than making it cubic\n",
+                  slice_step, 1.0 / double(tgt_scale));
+    }
 
     double accum_step = parsed["accum"].as<float>();
     if (!std::isfinite(accum_step) || accum_step < 0) { logPrintf(stderr, "Error: --accum must be non-negative\n"); return EXIT_FAILURE; }
@@ -1621,6 +1656,15 @@ int main(int argc, char *argv[])
             size_t baseY = zarrXY.height, baseX = zarrXY.width;
 
             outFilePath = zarrOutputArg;
+            // Level shapes and chunk contents differ between the two geometries, so writing
+            // into a store built with the other one would silently mix them.
+            if (auto recorded = readStorePyramidMode(outFilePath);
+                recorded && *recorded != pyramid_mode) {
+                logPrintf(stderr, "Error: %s was built with --pyramid-mode %s; delete it or pass "
+                                  "that mode\n", outFilePath.c_str(),
+                          *recorded == PyramidMode::Isotropic ? "isotropic" : "preserve-z");
+                return false;
+            }
             std::vector<size_t> shape0 = {baseZ, baseY, baseX};
             chunks0 = {shape0[0], std::min(CH, shape0[1]), std::min(CW, shape0[2])};
             auto vcDtype = useU16 ? vc::VcDtype::uint16 : vc::VcDtype::uint8;
@@ -1632,13 +1676,14 @@ int main(int argc, char *argv[])
                                       zarrCompressor, zarrSeparator, 0, zarrCompressionLevel);
                 logPrintf(stdout, "[pre] L0 shape: [%zu,%zu,%zu]\n", shape0[0], shape0[1], shape0[2]);
                 if (wantPyramid)
-                    createPyramidDatasets(outFilePath, shape0, CH, CW, useU16,
+                    createPyramidDatasets(outFilePath, shape0, CH, CW, useU16, pyramid_mode,
                                           zarrCompressor, zarrCompressionLevel, zarrSeparator);
 
                 cv::Size attrXY = tgt_size;
                 if (rotQuad >= 0 && (rotQuad % 2) == 1) std::swap(attrXY.width, attrXY.height);
                 writeZarrAttrs(outFilePath, vol_path, group_idx, baseZ, slice_step, accum_step,
                                accum_type_str, accumOffsets.size(), attrXY, baseZ, CH, CW,
+                               pyramid_mode,
                                render_level_voxel_size, voxel_unit, tgt_scale);
                 return true;
             } else if (numParts > 1) {
@@ -1712,7 +1757,7 @@ int main(int argc, char *argv[])
                 cv::Size zarrXY = tgt_size;
                 if (rotQuad >= 0 && (rotQuad % 2) == 1) std::swap(zarrXY.width, zarrXY.height);
                 std::vector<size_t> shape0 = {baseZ, size_t(zarrXY.height), size_t(zarrXY.width)};
-                createPyramidDatasets(outFilePath, shape0, CH, CW, useU16,
+                createPyramidDatasets(outFilePath, shape0, CH, CW, useU16, pyramid_mode,
                                       zarrCompressor, zarrCompressionLevel, zarrSeparator);
             }
             if (inlinePyramid) {
@@ -1772,7 +1817,7 @@ int main(int argc, char *argv[])
                         accumOffsets, accumType, isCompositeMode, compositeStart, compositeEnd,
                         compositeParams, rotQuad, flip_axis, numParts, partId, cvType,
                         dsOut.get(), chunks0, tilesXSrc, tilesYSrc,
-                        pyramidDs,
+                        pyramidDs, pyramid_mode,
                         tifWriters.empty() ? nullptr : &tifWriters, tiffTileH, quickTif,
                         resumeFlag);
                 else
@@ -1782,7 +1827,7 @@ int main(int argc, char *argv[])
                         accumOffsets, accumType, isCompositeMode, compositeStart, compositeEnd,
                         compositeParams, rotQuad, flip_axis, numParts, partId, cvType,
                         dsOut.get(), chunks0, tilesXSrc, tilesYSrc,
-                        pyramidDs,
+                        pyramidDs, pyramid_mode,
                         tifWriters.empty() ? nullptr : &tifWriters, tiffTileH, quickTif,
                         resumeFlag);
             } else {
@@ -1830,8 +1875,8 @@ int main(int argc, char *argv[])
             if (wantPyramid && hasRotFlip) {
                 logPrintf(stdout, "[pyramid] building from L0...\n");
                 for (int level = 1; level <= 5; level++) {
-                    if (useU16) buildPyramidLevel<uint16_t>(outFilePath, level, CH, CW, numParts, partId);
-                    else        buildPyramidLevel<uint8_t>(outFilePath, level, CH, CW, numParts, partId);
+                    if (useU16) buildPyramidLevel<uint16_t>(outFilePath, level, CH, CW, pyramid_mode, numParts, partId);
+                    else        buildPyramidLevel<uint8_t>(outFilePath, level, CH, CW, pyramid_mode, numParts, partId);
                 }
             }
 
@@ -1841,6 +1886,7 @@ int main(int argc, char *argv[])
                 if (rotQuad >= 0 && (rotQuad % 2) == 1) std::swap(attrXY.width, attrXY.height);
                 writeZarrAttrs(outFilePath, vol_path, group_idx, baseZ, slice_step, accum_step,
                                accum_type_str, accumOffsets.size(), attrXY, baseZ, CH, CW,
+                               pyramid_mode,
                                render_level_voxel_size, voxel_unit, tgt_scale);
             }
         }

--- a/volume-cartographer/core/include/vc/core/util/Zarr.hpp
+++ b/volume-cartographer/core/include/vc/core/util/Zarr.hpp
@@ -10,6 +10,12 @@
 
 namespace vc { class VcDataset; }
 
+// Pyramid downsampling geometry. PreserveZ halves only Y/X, so every level keeps the
+// full slice stack and levels above 0 are anisotropic. Isotropic halves Z as well,
+// keeping the voxel cubic at every level - which only holds if level 0 is itself cubic
+// (in-plane baseVoxelSize/pixelsPerVoxel == through-plane baseVoxelSize*sliceStep).
+enum class PyramidMode { PreserveZ, Isotropic };
+
 // Map a tile index through rotation + flip (pure integer tile coordinate transform).
 // Used by both zarr and tif writers.
 inline void mapTileIndex(int tx, int ty, int tilesX, int tilesY,
@@ -67,11 +73,20 @@ void downsampleTileIntoPreserveZ(const T* src, size_t srcZ, size_t srcY, size_t 
                                 size_t srcActualZ, size_t srcActualY, size_t srcActualX,
                                 size_t dstOffY, size_t dstOffX);
 
+// Dispatch to downsampleTileInto (Isotropic) or downsampleTileIntoPreserveZ (PreserveZ);
+// the two kernels share this signature.
+template <typename T>
+void downsampleTileIntoMode(PyramidMode mode,
+                            const T* src, size_t srcZ, size_t srcY, size_t srcX,
+                            T* dst, size_t dstZ, size_t dstY, size_t dstX,
+                            size_t srcActualZ, size_t srcActualY, size_t srcActualX,
+                            size_t dstOffY, size_t dstOffX);
+
 // Build one pyramid level (2x mean downsample) via readChunk/writeChunk + OMP.
 // numParts/partId partition the output tile-rows across VMs (1/0 = no partitioning).
 template <typename T>
 void buildPyramidLevel(const std::filesystem::path& outFile, int level,
-                       size_t CH, size_t CW,
+                       size_t CH, size_t CW, PyramidMode mode,
                        int numParts = 1, int partId = 0);
 
 // Create pyramid level datasets L1-L5 (metadata only, no data).
@@ -80,19 +95,21 @@ void buildPyramidLevel(const std::filesystem::path& outFile, int level,
 // createZarrDataset so the pyramid matches L0.
 void createPyramidDatasets(const std::filesystem::path& outFile,
                            const std::vector<size_t>& shape0,
-                           size_t CH, size_t CW, bool isU16,
+                           size_t CH, size_t CW, bool isU16, PyramidMode mode,
                            const std::string& compressor = "blosc",
                            int compressionLevel = -1,
                            const std::string& dimensionSeparator = ".");
 
-// Write OME-Zarr .zattrs multiscales JSON. The declared scale is per-axis:
+// Write OME-Zarr .zattrs multiscales JSON. The declared level-0 scale is per-axis:
 // Z = baseVoxelSize * sliceStep, Y/X = baseVoxelSize / pixelsPerVoxel
-// (baseVoxelSize describes one source voxel at the rendered level).
+// (baseVoxelSize describes one source voxel at the rendered level). Each pyramid level
+// doubles Y/X, and doubles Z as well when mode is Isotropic.
 void writeZarrAttrs(const std::filesystem::path& outFile,
                     const std::filesystem::path& volPath, int groupIdx,
                     size_t baseZ, double sliceStep, double accumStep,
                     const std::string& accumTypeStr, size_t accumSamples,
                     const cv::Size& canvasSize, size_t CZ, size_t CH, size_t CW,
+                    PyramidMode mode,
                     double baseVoxelSize = 1.0,
                     const std::string& voxelUnit = "",
                     double pixelsPerVoxel = 1.0);

--- a/volume-cartographer/core/src/Zarr.cpp
+++ b/volume-cartographer/core/src/Zarr.cpp
@@ -234,13 +234,33 @@ template void downsampleTileIntoPreserveZ<uint8_t>(const uint8_t*, size_t, size_
 template void downsampleTileIntoPreserveZ<uint16_t>(const uint16_t*, size_t, size_t, size_t,
     uint16_t*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t);
 
+template <typename T>
+void downsampleTileIntoMode(PyramidMode mode,
+                            const T* src, size_t srcZ, size_t srcY, size_t srcX,
+                            T* dst, size_t dstZ, size_t dstY, size_t dstX,
+                            size_t srcActualZ, size_t srcActualY, size_t srcActualX,
+                            size_t dstOffY, size_t dstOffX)
+{
+    if (mode == PyramidMode::Isotropic)
+        downsampleTileInto(src, srcZ, srcY, srcX, dst, dstZ, dstY, dstX,
+                           srcActualZ, srcActualY, srcActualX, dstOffY, dstOffX);
+    else
+        downsampleTileIntoPreserveZ(src, srcZ, srcY, srcX, dst, dstZ, dstY, dstX,
+                                    srcActualZ, srcActualY, srcActualX, dstOffY, dstOffX);
+}
+
+template void downsampleTileIntoMode<uint8_t>(PyramidMode, const uint8_t*, size_t, size_t, size_t,
+    uint8_t*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t);
+template void downsampleTileIntoMode<uint16_t>(PyramidMode, const uint16_t*, size_t, size_t, size_t,
+    uint16_t*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t);
+
 // ============================================================
 // buildPyramidLevel
 // ============================================================
 
 template <typename T>
 void buildPyramidLevel(const std::filesystem::path& outDir, int level,
-                       size_t CH, size_t CW,
+                       size_t CH, size_t CW, PyramidMode mode,
                        int numParts, int partId)
 {
     auto src = std::make_unique<vc::VcDataset>(outDir / std::to_string(level - 1));
@@ -289,7 +309,8 @@ void buildPyramidLevel(const std::filesystem::path& outDir, int level,
                 size_t offY = sy * halfY;
                 size_t offX = sx * halfX;
 
-                downsampleTileIntoPreserveZ(
+                downsampleTileIntoMode(
+                    mode,
                     srcBuf.data(), sc[0], sc[1], sc[2],
                     dstBuf.data(), dc[0], dc[1], dc[2],
                     saZ, saY, saX, offY, offX);
@@ -307,8 +328,8 @@ void buildPyramidLevel(const std::filesystem::path& outDir, int level,
     if (myTiles > 0) std::cout << std::endl;
 }
 
-template void buildPyramidLevel<uint8_t>(const std::filesystem::path&, int, size_t, size_t, int, int);
-template void buildPyramidLevel<uint16_t>(const std::filesystem::path&, int, size_t, size_t, int, int);
+template void buildPyramidLevel<uint8_t>(const std::filesystem::path&, int, size_t, size_t, PyramidMode, int, int);
+template void buildPyramidLevel<uint16_t>(const std::filesystem::path&, int, size_t, size_t, PyramidMode, int, int);
 
 // ============================================================
 // createPyramidDatasets
@@ -316,7 +337,7 @@ template void buildPyramidLevel<uint16_t>(const std::filesystem::path&, int, siz
 
 void createPyramidDatasets(const std::filesystem::path& outDir,
                            const std::vector<size_t>& shape0,
-                           size_t CH, size_t CW, bool isU16,
+                           size_t CH, size_t CW, bool isU16, PyramidMode mode,
                            const std::string& compressor,
                            int compressionLevel,
                            const std::string& dimensionSeparator)
@@ -325,10 +346,11 @@ void createPyramidDatasets(const std::filesystem::path& outDir,
 
     std::vector<size_t> prevShape = shape0;
     for (int level = 1; level <= 5; level++) {
-        // Keep Z fixed and halve only Y/X at each level (anisotropic scaling).
-        std::vector<size_t> shape = {prevShape[0], (prevShape[1]+1)/2, (prevShape[2]+1)/2};
-        size_t chZ = std::min(shape[0], shape0[0]);
-        std::vector<size_t> chunks = {chZ, std::min(CH, shape[1]), std::min(CW, shape[2])};
+        // Y/X halve at every level; Z halves only in Isotropic mode.
+        const size_t z = mode == PyramidMode::Isotropic ? (prevShape[0]+1)/2 : prevShape[0];
+        std::vector<size_t> shape = {z, (prevShape[1]+1)/2, (prevShape[2]+1)/2};
+        // One chunk spans the level's whole Z extent, as at level 0.
+        std::vector<size_t> chunks = {shape[0], std::min(CH, shape[1]), std::min(CW, shape[2])};
         vc::createZarrDataset(outDir, std::to_string(level), shape, chunks, dtype,
                               compressor, dimensionSeparator, 0, compressionLevel);
         prevShape = shape;
@@ -344,6 +366,7 @@ void writeZarrAttrs(const std::filesystem::path& outDir,
                     size_t baseZ, double sliceStep, double accumStep,
                     const std::string& accumTypeStr, size_t accumSamples,
                     const cv::Size& canvasSize, size_t CZ, size_t CH, size_t CW,
+                    PyramidMode mode,
                     double baseVoxelSize, const std::string& voxelUnit,
                     double pixelsPerVoxel)
 {
@@ -366,6 +389,7 @@ void writeZarrAttrs(const std::filesystem::path& outDir,
         attrs["chunk_size"] = std::move(ck);
     }
     attrs["note_axes_order"] = "ZYX (slice, row, col)";
+    attrs["pyramid_mode"] = mode == PyramidMode::Isotropic ? "isotropic" : "preserve-z";
 
     Json ms;
     ms["version"] = "0.4"; ms["name"] = "render";
@@ -382,14 +406,17 @@ void writeZarrAttrs(const std::filesystem::path& outDir,
     ms["datasets"] = Json::array();
     // The two axes scale independently of each other: in-plane, one output
     // pixel spans 1/pixelsPerVoxel base voxels; through-plane, adjacent output
-    // layers sit sliceStep base voxels apart. Pyramid levels halve only YX.
+    // layers sit sliceStep base voxels apart. Pyramid levels halve YX, and Z
+    // as well in Isotropic mode.
     const double px = (std::isfinite(pixelsPerVoxel) && pixelsPerVoxel > 0.0)
         ? pixelsPerVoxel : 1.0;
     const double step = (std::isfinite(sliceStep) && sliceStep > 0.0)
         ? sliceStep : 1.0;
     for (int l = 0; l <= 5; l++) {
-        const double sYX = baseVoxelSize / px * std::pow(2.0, l);
-        const double sZ = baseVoxelSize * step;
+        const double levelFactor = std::pow(2.0, l);
+        const double sYX = baseVoxelSize / px * levelFactor;
+        const double sZ = baseVoxelSize * step
+            * (mode == PyramidMode::Isotropic ? levelFactor : 1.0);
         Json scale_arr = Json::array();
         scale_arr.push_back(sZ); scale_arr.push_back(sYX); scale_arr.push_back(sYX);
         Json trans_arr = Json::array();

--- a/volume-cartographer/core/test/test_zarr.cpp
+++ b/volume-cartographer/core/test/test_zarr.cpp
@@ -106,7 +106,8 @@ TEST_CASE("createPyramidDatasets writes L1..L5 metadata directories")
         /*shape=*/{64, 64, 64}, /*chunks=*/{32, 32, 32},
         vc::VcDtype::uint8, /*compressor=*/"none");
     createPyramidDatasets(d, /*shape0=*/{64, 64, 64},
-                          /*CH=*/32, /*CW=*/32, /*isU16=*/false);
+                          /*CH=*/32, /*CW=*/32, /*isU16=*/false,
+                          PyramidMode::PreserveZ);
     for (int lvl = 1; lvl <= 5; ++lvl) {
         CHECK(fs::exists(d / std::to_string(lvl) / ".zarray"));
     }
@@ -122,6 +123,7 @@ TEST_CASE("writeZarrAttrs writes a parseable .zattrs at the volume path")
                    /*accumTypeStr=*/"mean", /*accumSamples=*/1,
                    /*canvasSize=*/cv::Size(64, 64),
                    /*CZ=*/32, /*CH=*/32, /*CW=*/32,
+                   PyramidMode::PreserveZ,
                    /*baseVoxelSize=*/7.91, /*voxelUnit=*/"um");
     CHECK(fs::exists(d / ".zattrs"));
     auto j = utils::Json::parse_file(d / ".zattrs");
@@ -139,6 +141,7 @@ TEST_CASE("writeZarrAttrs derives per-axis scale from slice step and pixel densi
                    /*accumTypeStr=*/"max", /*accumSamples=*/0,
                    /*canvasSize=*/cv::Size(32, 32),
                    /*CZ=*/8, /*CH=*/16, /*CW=*/16,
+                   PyramidMode::PreserveZ,
                    /*baseVoxelSize=*/8.0, /*voxelUnit=*/"um",
                    /*pixelsPerVoxel=*/2.0);
     auto j = utils::Json::parse_file(d / ".zattrs");
@@ -213,8 +216,8 @@ TEST_CASE("buildPyramidLevel: builds L1 from L0")
     l0->writeChunk(0, 0, 0, payload.data(), payload.size());
 
     // createPyramidDatasets writes L1..L5 metadata.
-    createPyramidDatasets(d, {16, 16, 16}, 8, 8, /*isU16=*/false);
-    buildPyramidLevel<uint8_t>(d, /*level=*/1, /*CH=*/8, /*CW=*/8);
+    createPyramidDatasets(d, {16, 16, 16}, 8, 8, /*isU16=*/false, PyramidMode::PreserveZ);
+    buildPyramidLevel<uint8_t>(d, /*level=*/1, /*CH=*/8, /*CW=*/8, PyramidMode::PreserveZ);
 
     // L1 chunk (0,0,0) should have the downsampled constant.
     vc::VcDataset l1(d / "1");
@@ -224,5 +227,120 @@ TEST_CASE("buildPyramidLevel: builds L1 from L0")
         // L0 was constant 60 — L1 should also be 60 in the downsampled region.
         CHECK(int(out[0]) == 60);
     }
+    fs::remove_all(d);
+}
+
+// The existing downsampleTileInto / ...PreserveZ cases above use constant input, which
+// cannot tell the two kernels apart. This one varies along Z so the results diverge.
+TEST_CASE("downsampleTileIntoMode: isotropic averages across Z, preserve-z does not")
+{
+    // src 2x2x2: z=0 plane all 0, z=1 plane all 100.
+    std::vector<uint8_t> src(2 * 2 * 2, 0);
+    for (size_t i = 4; i < 8; ++i) src[i] = 100;
+
+    std::vector<uint8_t> iso(2 * 1 * 1, 0);
+    downsampleTileIntoMode<uint8_t>(PyramidMode::Isotropic,
+                                    src.data(), 2, 2, 2,
+                                    iso.data(), /*dstZ=*/2, /*dstY=*/1, /*dstX=*/1,
+                                    /*actual=*/2, 2, 2, /*dstOffY=*/0, /*dstOffX=*/0);
+    // One output layer, the mean of all 8 voxels; the second layer is never written.
+    CHECK(int(iso[0]) == 50);
+    CHECK(int(iso[1]) == 0);
+
+    std::vector<uint8_t> pz(2 * 1 * 1, 0);
+    downsampleTileIntoMode<uint8_t>(PyramidMode::PreserveZ,
+                                    src.data(), 2, 2, 2,
+                                    pz.data(), /*dstZ=*/2, /*dstY=*/1, /*dstX=*/1,
+                                    /*actual=*/2, 2, 2, /*dstOffY=*/0, /*dstOffX=*/0);
+    // Both input layers survive, each averaged only in-plane.
+    CHECK(int(pz[0]) == 0);
+    CHECK(int(pz[1]) == 100);
+}
+
+TEST_CASE("createPyramidDatasets: isotropic halves Z per level, preserve-z keeps it")
+{
+    auto d = tmpDir("pyr_iso_shape");
+    vc::createZarrDataset(d, "0", {64, 64, 64}, {64, 32, 32},
+                          vc::VcDtype::uint8, "none");
+    createPyramidDatasets(d, {64, 64, 64}, 32, 32, /*isU16=*/false,
+                          PyramidMode::Isotropic);
+    for (int lvl = 1; lvl <= 5; ++lvl) {
+        const size_t want = size_t(64) >> lvl;
+        vc::VcDataset ds(d / std::to_string(lvl));
+        CHECK(ds.shape()[0] == want);
+        CHECK(ds.shape()[1] == want);
+        CHECK(ds.shape()[2] == want);
+        // One chunk spans the level's whole Z extent, as at level 0.
+        CHECK(ds.defaultChunkShape()[0] == want);
+    }
+    fs::remove_all(d);
+
+    auto e = tmpDir("pyr_pz_shape");
+    vc::createZarrDataset(e, "0", {64, 64, 64}, {64, 32, 32},
+                          vc::VcDtype::uint8, "none");
+    createPyramidDatasets(e, {64, 64, 64}, 32, 32, /*isU16=*/false,
+                          PyramidMode::PreserveZ);
+    for (int lvl = 1; lvl <= 5; ++lvl) {
+        vc::VcDataset ds(e / std::to_string(lvl));
+        CHECK(ds.shape()[0] == 64);
+        CHECK(ds.shape()[1] == size_t(64) >> lvl);
+    }
+    fs::remove_all(e);
+}
+
+TEST_CASE("writeZarrAttrs: isotropic scales Z with the level, keeping voxels cubic")
+{
+    auto d = tmpDir("attrs_iso");
+    // slice step 0.5 x 2 pixels-per-voxel == 1, so level 0 is cubic: 8/2 == 8*0.5 == 4.
+    writeZarrAttrs(/*outDir=*/d, /*volPath=*/d,
+                   /*groupIdx=*/0, /*baseZ=*/8,
+                   /*sliceStep=*/0.5, /*accumStep=*/0.0,
+                   /*accumTypeStr=*/"max", /*accumSamples=*/0,
+                   /*canvasSize=*/cv::Size(32, 32),
+                   /*CZ=*/8, /*CH=*/16, /*CW=*/16,
+                   PyramidMode::Isotropic,
+                   /*baseVoxelSize=*/8.0, /*voxelUnit=*/"um",
+                   /*pixelsPerVoxel=*/2.0);
+    auto j = utils::Json::parse_file(d / ".zattrs");
+    CHECK(j["pyramid_mode"].get_string() == "isotropic");
+    auto scaleAt = [&](size_t level) {
+        return j["multiscales"][size_t(0)]["datasets"][level]
+                ["coordinateTransformations"][size_t(0)]["scale"]
+                .get_double_array();
+    };
+    for (size_t lvl = 0; lvl <= 5; ++lvl) {
+        auto sc = scaleAt(lvl);
+        REQUIRE(sc.size() == 3);
+        const double want = 4.0 * double(size_t(1) << lvl);
+        CHECK(sc[0] == doctest::Approx(want));
+        CHECK(sc[1] == doctest::Approx(want));
+        CHECK(sc[2] == doctest::Approx(want));
+    }
+    fs::remove_all(d);
+}
+
+TEST_CASE("buildPyramidLevel: isotropic L1 halves the Z extent")
+{
+    auto d = tmpDir("buildpyr_iso");
+    // Single chunk in Z, as every render output has.
+    auto l0 = vc::createZarrDataset(d, "0", {8, 16, 16}, {8, 8, 8},
+                                    vc::VcDtype::uint8, "none");
+    REQUIRE(l0);
+    std::vector<uint8_t> payload(8 * 8 * 8, 60);
+    l0->writeChunk(0, 0, 0, payload.data(), payload.size());
+
+    createPyramidDatasets(d, {8, 16, 16}, 8, 8, /*isU16=*/false, PyramidMode::Isotropic);
+    buildPyramidLevel<uint8_t>(d, /*level=*/1, /*CH=*/8, /*CW=*/8, PyramidMode::Isotropic);
+
+    vc::VcDataset l1(d / "1");
+    CHECK(l1.shape()[0] == 4);
+    CHECK(l1.shape()[1] == 8);
+    REQUIRE(l1.chunkExists(0, 0, 0));
+    std::vector<uint8_t> out(l1.defaultChunkSize(), 0);
+    REQUIRE(l1.readChunk(0, 0, 0, out.data()));
+    const size_t cy = l1.defaultChunkShape()[1], cx = l1.defaultChunkShape()[2];
+    // The filled L0 chunk covers the first 4x4x4 of L1; constant in, constant out.
+    CHECK(int(out[0]) == 60);
+    CHECK(int(out[3 * cy * cx]) == 60);
     fs::remove_all(d);
 }


### PR DESCRIPTION
And make it the default.

So far, we rendered all segments with z-anisotropic pyramid creation for the benefit of webknossos users. However, this
now means that users that require isotropic downscales (e.g. to retrieve 4x downscales from 2um segments) need to redo the downscale in z direction leading to extra storage and processing cost.