### PR TITLE
fix(lasagna): use cosine channel spacing for dense loss sampling

### DIFF
--- a/lasagna/opt_loss_data.py
+++ b/lasagna/opt_loss_data.py
@@ -30,7 +30,8 @@ def _sample_cos_diff(res: fit_model.FitResult3D) -> torch.Tensor:
 	# Dense mode: direct kernel call (cos channel only, more efficient)
 	dev = res.xyz_hr.device
 	offset = torch.tensor(res.data.origin_fullres, dtype=torch.float32, device=dev)
-	inv_scale = torch.tensor([1.0 / s for s in res.data.spacing], dtype=torch.float32, device=dev)
+	spacing = res.data._spacing_for("cos")
+	inv_scale = torch.tensor([1.0 / s for s in spacing], dtype=torch.float32, device=dev)
 	vol = res.data.cos.squeeze(0)  # (1, Z, Y, X) uint8
 	sampled_raw = grid_sample_3d_u8_diff(vol, res.xyz_hr, offset, inv_scale)  # (1, D, He, We)
 	return (sampled_raw / 255.0).permute(1, 0, 2, 3)  # (D, 1, He, We)

--- a/lasagna/tests/test_opt_loss_data_spacing.py
+++ b/lasagna/tests/test_opt_loss_data_spacing.py
@@ -1,0 +1,120 @@
+"""Normal-import CPU regressions using the actual dense manifest loader.
+
+No extracted functions, replaced samplers, external data, or optimizer runs.
+Run: python -m unittest discover -s tests -p test_opt_loss_data_spacing.py -v
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+import zarr
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import fit_data
+import opt_loss_data
+from lasagna_volume import ChannelGroup, LasagnaVolume
+
+
+def make_manifest(root, *, cos_level=1, density_level=2, source_to_base=1.0):
+    groups = {}
+    for channel, level in (("cos", cos_level), ("grad_mag", density_level),
+                           ("nx", density_level), ("ny", density_level)):
+        size = 16 // (2 ** level)
+        values = (np.broadcast_to(16 + 2 * np.arange(size), (size, size, size))
+                  if channel == "cos" else np.full((size, size, size), 128))
+        array = zarr.open(str(root / (channel + ".zarr")), mode="w",
+                          shape=values.shape, chunks=values.shape, dtype="uint8",
+                          zarr_format=2)
+        array[:] = values.astype(np.uint8)
+        groups[channel] = ChannelGroup(channel + ".zarr", level, [channel])
+    manifest = LasagnaVolume(path=root / "volume.lasagna.json", groups=groups,
+                            source_to_base=source_to_base,
+                            base_shape_zyx=(16, 16, 16))
+    manifest.save()
+    return manifest.path
+
+
+def load_manifest(path, crop=None, cuda_gridsample=True):
+    with contextlib.redirect_stdout(io.StringIO()):
+        return fit_data.load_3d(path=str(path), device=torch.device("cpu"),
+                               crop=crop, cuda_gridsample=cuda_gridsample)
+
+
+def sample_pair(data, xyz):
+    query = torch.tensor(xyz, dtype=torch.float32).reshape(1, 1, -1, 3)
+    direct_query = query.clone().requires_grad_(True)
+    reference_query = query.clone().requires_grad_(True)
+    direct = opt_loss_data._sample_cos_diff(SimpleNamespace(data=data, xyz_hr=direct_query))
+    reference = data.grid_sample_fullres(reference_query, diff=True, channels={"cos"})
+    reference = reference.cos.squeeze(0).permute(1, 0, 2, 3)
+    direct_grad, = torch.autograd.grad(direct.sum(), direct_query)
+    reference_grad, = torch.autograd.grad(reference.sum(), reference_query)
+    return direct, reference, direct_grad, reference_grad
+
+
+class DenseCosSpacingTests(unittest.TestCase):
+    def check_case(self, *, cos_level=1, density_level=2, source_to_base=1.0,
+                   crop=None, xyz=((8, 8, 8),), cuda_gridsample=True):
+        with tempfile.TemporaryDirectory(prefix="lasagna-cos-spacing-") as td:
+            manifest = make_manifest(Path(td), cos_level=cos_level,
+                                     density_level=density_level,
+                                     source_to_base=source_to_base)
+            data = load_manifest(manifest, crop, cuda_gridsample)
+            self.assertEqual(data._spacing_for("cos"), (2 ** cos_level * source_to_base,) * 3)
+            self.assertEqual(data.spacing, (2 ** density_level * source_to_base,) * 3)
+            pair = sample_pair(data, xyz)
+            torch.testing.assert_close(pair[0], pair[1], rtol=0, atol=2e-7)
+            torch.testing.assert_close(pair[2], pair[3], rtol=0, atol=2e-7)
+            return pair
+
+    def test_mixed_spacing_analytic_value_and_gradient(self):
+        direct, _, grad, _ = self.check_case()
+        self.assertAlmostEqual(float(direct.detach().item()), 24 / 255, delta=2e-7)
+        torch.testing.assert_close(grad.flatten(), torch.tensor([1 / 255, 0, 0]), rtol=0, atol=2e-7)
+
+    def test_equal_spacing_negative_control(self):
+        self.check_case(cos_level=1, density_level=1)
+
+    def test_reverse_spacing_ratio(self):
+        self.check_case(cos_level=2, density_level=1)
+
+    def test_aligned_nonzero_crop_origin(self):
+        self.check_case(crop=(4, 4, 4, 12, 12, 12), xyz=((8, 8, 8), (10, 10, 10)))
+
+    def test_nonunit_source_to_base(self):
+        self.check_case(source_to_base=2.0, xyz=((16, 16, 16), (20, 18, 22)))
+
+    def test_boundary_and_zero_padding(self):
+        self.check_case(xyz=((-2, 4, 4), (0, 4, 4), (14, 4, 4), (16, 4, 4)))
+
+    def test_torch_sampler_parity(self):
+        self.check_case(cuda_gridsample=False, xyz=((7.25, 7.5, 8.75),))
+
+    def test_public_loss_maps_at_same_physical_positions(self):
+        with tempfile.TemporaryDirectory(prefix="lasagna-cos-loss-") as td:
+            data = load_manifest(make_manifest(Path(td)))
+            query = torch.tensor([[[[6., 8., 8.], [8., 8., 8.], [10., 8., 8.]]]],
+                                 requires_grad=True)
+            target = data.grid_sample_fullres(query, diff=True, channels={"cos"})
+            target = target.cos.squeeze(0).permute(1, 0, 2, 3).detach()
+            res = SimpleNamespace(data=data, xyz_hr=query, target_mod=target,
+                                  target_plain=target, mask_hr=torch.ones_like(target))
+            for loss_fn in (opt_loss_data.data_loss, opt_loss_data.data_plain_loss):
+                loss, _, _ = loss_fn(res=res)
+                self.assertAlmostEqual(float(loss.detach()), 0.0, delta=1e-12)
+
+
+if __name__ == "__main__":
+    torch.set_num_threads(1)
+    unittest.main()


### PR DESCRIPTION
**In one sentence:** Make dense cosine-loss sampling use the cosine channel's voxel spacing when a Lasagna manifest contains mixed-resolution channels.

**One real example:** During a Vesuvius scroll-research workflow, the actual dense loader was used with previously captured public PHerc0211 channels (scan `20250821151803`): cosine at 2-native-voxel spacing and grad_mag/normals at 4. At 1,728 fixed physical points in the same aligned 64-voxel crop, the dense loss path was compared with an independently implemented eight-corner interpolation oracle.

**Before:** `_sample_cos_diff()` uses `res.data.spacing`, which the dense loader derives from grad_mag. All 1,728 samples differ from the cosine oracle by more than `1e-5`.

**After this PR:** Use the existing `res.data._spacing_for("cos")` accessor. All 1,728 samples are within that tolerance; position gradients agree with the unified sampler.

**Proof:** Local CPU replay on identical data/queries; values are in normalized cosine units:

| Check | Before | After |
|---|---:|---:|
| Mean absolute sampling error | 0.293885834 | 3.04273e-8 |
| Maximum sampling error | 0.869431670 | 2.66000e-7 |
| Samples exceeding 1e-5 error | 1728/1728 | 0/1728 |
| Maximum gradient error vs independent oracle | 0.300582120 | 8.03568e-8 |
| New regression tests | 7 failures / 8 | 8 passing |

The 15 existing `test_fit_data_manifest_lazy.py` tests also pass. Actual before/after screenshots and a portable public-data replay packet are still pending; the checked-in tests are small synthetic regressions through the real loader, not a substitute for the real-data example.

**Why / where this is useful:** I’m working toward recovering readable text from the Vesuvius Challenge scans. Reliable sampling matters because errors can mislead subsequent analysis. This fix makes Lasagna’s dense cosine-sampling path use the correct channel spacing. It addresses a concrete reliability problem without claiming newly recovered letters or improved reconstruction.

- [ ] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

**AI assistance / draft status:** Code, tests, analysis and this description were AI-assisted. The repository-requested human-written relevance commentary and personal code/evidence verification remain outstanding; the checkbox above is intentionally unchecked. This is a draft, not ready for review, and does not claim that the contribution requirements are complete.

Tested source: `40f9c6bacbacad0e0ae6a34a1923832e68e028f6`; refreshed main `18a2eb10470f06487d8fe2168830c219d19d9cae` has the identical complete Lasagna tree `fe6476e09e3df234b96db52f9c9ff51119cfeb7c`. CPU Python 3.14.6, torch 2.12.1, NumPy 2.4.6, Zarr 3.3.0.

From `lasagna/`, in an existing compatible environment:
```sh
python -m unittest discover -s tests -p test_opt_loss_data_spacing.py -v
python -m unittest discover -s tests -p test_fit_data_manifest_lazy.py -v
```

The tests cover values/gradients, equal and reversed spacing ratios, aligned crop origins, nonunit source-to-base scaling, boundary/zero padding, general Torch sampler parity, and public loss maps.

**Limits:** The standard CLI uses streaming; a production optimizer failure is not demonstrated. GPU/real sparse-backend parity was not run. A separate shared-origin error for crops not aligned to all channel grids is not fixed here; the real-data comparison uses a common-grid-aligned crop. Masks, loss fallback, quadrature and streaming dispatch are unchanged. No ink or anatomical-accuracy claim.
