### PR TITLE
VC3D line annotation: pin the strip views' centre line vertically

### DIFF
--- a/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
+++ b/volume-cartographer/apps/VC3D/LineAnnotationDialog.cpp
@@ -192,6 +192,23 @@ std::optional<cv::Vec2f> generatedStripSurfaceCenter(CChunkedVolumeViewer* viewe
                      static_cast<float>(surfacePoint[1])};
 }
 
+// Surface Y of the strip's centre row (the fiber line runs along it), the
+// value the strip cameras are pinned to. Independent of the along-line
+// position, so it needs no position map.
+std::optional<float> generatedStripCenterlineSurfaceY(const QuadSurface* quad)
+{
+    const auto* points = quad ? quad->rawPointsPtr() : nullptr;
+    if (!points || points->empty()) {
+        return std::nullopt;
+    }
+    const cv::Vec2d surfacePoint =
+        quad->gridToSurface({0.0, static_cast<double>(points->rows / 2)});
+    if (!std::isfinite(surfacePoint[1])) {
+        return std::nullopt;
+    }
+    return static_cast<float>(surfacePoint[1]);
+}
+
 // Inverse of generatedStripSurfaceCenter for a camera: maps a strip camera's
 // surface coordinates back to the fractional line position under the view
 // center, through the given strip quad and position map (which must describe
@@ -1685,6 +1702,13 @@ void LineAnnotationDialog::anchorGeneratedStripSurfacesForUpdate(
         _generatedViews.lineSurface.get(),
         _generatedViews.lineSideSlice.get()};
     const std::array<QuadSurface*, 2> newQuads{newLineSurface, newLineSideSlice};
+    // The new strips' centre row is where each camera stays pinned (the row
+    // layout is normally unchanged, so this is a no-op most of the time).
+    for (size_t i = 0; i < newQuads.size(); ++i) {
+        if (_stripViewers[i] && newQuads[i]) {
+            _stripViewers[i]->setPinnedSurfaceY(generatedStripCenterlineSurfaceY(newQuads[i]));
+        }
+    }
     for (size_t i = 0; i < oldQuads.size(); ++i) {
         auto* stripViewer = _stripViewers[i].data();
         QuadSurface* newQuad = newQuads[i];
@@ -1729,8 +1753,8 @@ void LineAnnotationDialog::anchorGeneratedStripSurfacesForUpdate(
         // per-strip delta would tear the link apart. Both strips are built
         // from the same line at the same along-spacing, so the first usable
         // strip's delta is the right one for both. Y is left alone -- the
-        // cross-strip parameterization is stable and vertical pan is the
-        // user's.
+        // cameras are pinned to the centre row, which the cross-strip
+        // parameterization keeps stable.
         for (QuadSurface* quad : newQuads) {
             if (quad) {
                 quad->shiftSurfaceOrigin({delta, 0.0});
@@ -2242,6 +2266,10 @@ bool LineAnnotationDialog::setGeneratedLineViews(
                 stripCamera.scale = _savedStripZooms[stripIndex];
             }
         }
+        // The fiber line stays on the strip's vertical centre: pans move the
+        // strip along the line only and zooms are anchored on the centre row.
+        viewer->setPinnedSurfaceY(generatedStripCenterlineSurfaceY(
+            dynamic_cast<QuadSurface*>(viewer->currentSurface())));
         viewer->applyCameraState(stripCamera, false);
         bindPaneInteractions(surfaceName, viewer, false);
         connect(viewer,

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.cpp
@@ -870,6 +870,22 @@ void CChunkedVolumeViewer::applyCameraState(const CameraState& state, bool force
     emit overlaysUpdated();
 }
 
+void CChunkedVolumeViewer::setPinnedSurfaceY(std::optional<float> surfaceY)
+{
+    if (surfaceY && !std::isfinite(*surfaceY)) {
+        surfaceY.reset();
+    }
+    _pinnedSurfacePtrY = surfaceY;
+    if (_closing || !_pinnedSurfacePtrY || _surfacePtrY == *_pinnedSurfacePtrY) {
+        return;
+    }
+    _genCacheDirty = true;
+    // submitRender's syncCameraTransform moves the camera onto the pin and
+    // refreshes the measurement overlay.
+    submitRender("camera pinned");
+    emit overlaysUpdated();
+}
+
 void CChunkedVolumeViewer::applyCameraStateForReplayRepaint(const CameraState& state)
 {
     if (_closing) {
@@ -1808,6 +1824,14 @@ void CChunkedVolumeViewer::setSegmentationIntersectionDeferral(bool active)
 
 void CChunkedVolumeViewer::syncCameraTransform()
 {
+    // Every render submission and repaint passes through here before the
+    // camera is captured, so this is the one place the pinned row is
+    // enforced: pans keep only their X component, zooms end up anchored on
+    // the pinned row at the cursor's X, and resets / centering / applied
+    // camera states land back on it.
+    if (_pinnedSurfacePtrY) {
+        _surfacePtrY = *_pinnedSurfacePtrY;
+    }
     _camSurfX = _surfacePtrX;
     _camSurfY = _surfacePtrY;
     _camScale = _scale;

--- a/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
+++ b/volume-cartographer/apps/VC3D/volume_viewers/CChunkedVolumeViewer.hpp
@@ -111,6 +111,11 @@ public:
     float normalOffset() const override { return _zOff; }
     CameraState cameraState() const;
     void applyCameraState(const CameraState& state, bool forceRender = true);
+    // Pins the camera's surface Y: pans move only along X, zooms are anchored
+    // on that row, and resets, centering and applied camera states land back
+    // on it. Enforced in syncCameraTransform(), i.e. before any render is
+    // submitted or repainted, so no frame is ever shown off the pinned row.
+    void setPinnedSurfaceY(std::optional<float> surfaceY);
     void applyCameraStateForReplayRepaint(const CameraState& state);
     // Render-bench helpers: true when no render is running/queued/pending; count of
     // remote chunk fetches still outstanding. Used by replay to settle each frame.
@@ -599,6 +604,7 @@ private:
 
     float _surfacePtrX = 0.0f;
     float _surfacePtrY = 0.0f;
+    std::optional<float> _pinnedSurfacePtrY;
     float _scale = 1.0f;
     float _dsScale = 1.0f;
     int _dsScaleIdx = 0;


### PR DESCRIPTION
**In one sentence:** In the VC3D Line Annotation GUI the two strip views keep the fiber line on their vertical middle, so panning moves a strip only along the line and zooming stays anchored on the centre line.

**One real example:** With a fiber open in the Line Annotation GUI, I dragged a strip view diagonally and wheel-zoomed with the cursor near the strip's top edge; the strip moved only left/right and zoomed about the centre line, with the fiber line staying in the vertical middle of both strips.

**Before:** A drag with a vertical component moved the strip up or down, and a wheel zoom anchored on the cursor shifted the line vertically too, so the fiber line could leave the strip viewport entirely. The viewer's pan clamp only exists for plane surfaces; the strips are quad surfaces, so nothing bounded their vertical pan.

**After this PR:** The strip cameras are pinned to the strip's centre row. Drags keep only their horizontal component, zooms are anchored on the centre line at the cursor's X, and the reset / snap / restore paths (M, overview snap, arrow-key pan, camera restore, the re-optimization strip surface swap) all land back on the centre line. The existing X and zoom link between the two strips is unchanged.

**Proof:** GUI-tested by the author on the local fiber dataset: vertical and diagonal drags, wheel zooms at several cursor heights, M reset, overview snap, arrow-key pan and a re-optimization all keep the fiber line vertically centred in both strips. `test_line_annotation_generated_views` (103 cases) and `test_lasagna_line_view_surfaces` (25 cases) pass unchanged.

**Why / where this is useful:** Fiber annotators pan and zoom the strips constantly while placing control points; the line no longer wanders off the strip vertically, so every pan is an along-line pan and no view needs re-centring.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Tested commit: the single commit of this branch on main f2ddb46fe.

Build and tests:
```
cmake --build volume-cartographer/build --target VC3D test_line_annotation_generated_views -j
volume-cartographer/build/bin/test_line_annotation_generated_views
```

Implementation:
- `CChunkedVolumeViewer::setPinnedSurfaceY(std::optional<float>)`. The pin is enforced in exactly one place, `syncCameraTransform()`, which `submitRender` (hence every render path: pan, zoom, `applyCameraState`, `resetSurfaceOffsets` / `fitSurfaceInView` behind the M shortcut, `centerOnVolumePoint`) and the replay repaint run before the camera is captured into the render job. No frame is ever rendered or presented off the pinned row; a post-hoc correction through `overlaysUpdated` would have let an off-centre frame start first. The pan and zoom arithmetic is otherwise unchanged; the zoom keeps `x' + a/s' = x + a/s` for the cursor offset `a`, i.e. it is anchored on the pinned row at the cursor's X. Unpinned viewers are unaffected (the optional is unset).
- `LineAnnotationDialog`: `generatedStripCenterlineSurfaceY(quad)` (surface Y of the middle row, column independent) pins each strip right before its first `applyCameraState` in `setGeneratedLineViews`, and again for the new quads in the re-optimization strip surface swap (normally a no-op: the strips keep the same row layout). The linked X/scale sync between the strips (`syncLinkedStripCamera`) is untouched.

Review: three rounds with fresh Codex reviewers (maintainer + input/camera-math specialist). Round 1 rejected a dialog-side fix in the `overlaysUpdated` handler (off-centre frame rendered first); round 2 found the M-reset bypass of per-site pins, which led to the single funnel in `syncCameraTransform`; round 3 both READY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkfhFpqpfNBtZPhxKZJ8J8
