### PR TITLE
volume-cartographer README: working on remote volumes from the command line

### DIFF
--- a/volume-cartographer/README.md
+++ b/volume-cartographer/README.md
@@ -180,6 +180,94 @@ Your folder structure should resemble this:
     ├── paths 
     └── config.json - REQUIRED!
 ```
+
+### Working on remote volumes from the command line
+
+`vc_grow_seg_from_seed` accepts the remote locators described above and
+`vc_render_tifxyz` streams through `--remote-url`, so a segment can be grown
+and rendered on a public OME-Zarr volume without downloading it or building a
+volpkg. The tools fetch only the chunks they touch, over anonymous HTTPS or
+S3. The GUI equivalent is `File -> Open Data Catalog…`, covered in the
+[VC3D tutorial](https://scrollprize.org/tutorial_VC3D).
+
+#### Finding a volume URL
+
+The catalog of the Vesuvius Challenge open-data bucket lives at
+`https://vesuvius-challenge-open-data.s3.amazonaws.com/metadata.json` and
+describes the samples with their scans, volumes and segments. It is served
+gzip-encoded, hence `--compressed`. This lists the volumes of one sample with
+their level-0 shape and voxel size in micrometers:
+
+```bash
+curl -s --compressed https://vesuvius-challenge-open-data.s3.amazonaws.com/metadata.json |
+  python3 -c 'import json, sys
+for v in json.load(sys.stdin)["samples"]["PHercParis4"]["volumes"].values():
+    print(v["long_id"], v["properties"]["shape"], v["properties"]["pixel_size_um"])'
+```
+
+A volume sits at `<sample>/volumes/<long_id>` in the bucket and can be
+addressed either way:
+
+```text
+https://vesuvius-challenge-open-data.s3.amazonaws.com/PHercParis4/volumes/20260310173927-45.532um-11.0m-110keV-masked.zarr
+s3://vesuvius-challenge-open-data/PHercParis4/volumes/20260310173927-45.532um-11.0m-110keV-masked.zarr
+```
+
+The examples below use this 45.532 µm PHercParis4 volume: level 0 is
+4066×2264×2264 voxels stored in 128³ chunks, and the pyramid has levels 0 to 5.
+
+#### Growing a segment
+
+```bash
+URL=https://vesuvius-challenge-open-data.s3.amazonaws.com/PHercParis4/volumes/20260310173927-45.532um-11.0m-110keV-masked.zarr
+echo '{"mode": "seed", "cache_size": 2000000000, "generations": 8, "thread_limit": 4}' > params.json
+vc_grow_seg_from_seed -v "$URL" -t out/ -p params.json --seed 1408 1408 1024
+```
+
+The seed is given as `x y z` in level-0 voxel coordinates. `cache_size` caps
+the decoded chunk cache in bytes (default 1e9) and `thread_limit` the number
+of OpenMP threads. The tracer reads the voxel size from the volume's
+`metadata.json` (`voxelsize: 45.532` in the log) and writes the segment to
+`out/auto_grown_<timestamp>/` as `x.tif`, `y.tif`, `z.tif`, `generations.tif`
+and `meta.json`. It also keeps a copy of every chunk it fetches in VC3D's
+remote cache directory, `~/.VC3D/remote_cache/<volume>-<id>/` unless
+`remote_cache_dir` under `[viewer]` in `~/.VC3D/VC3D.ini` points elsewhere,
+and later runs on the same volume read from there. On this volume the eight
+generations take ten to twenty seconds on a 14-core workstation and fetch
+about 2 MiB the first time;
+`--resume out/auto_grown_<timestamp>` continues a segment against the remote
+volume in the same way.
+
+#### Rendering it
+
+```bash
+vc_render_tifxyz -v render_cache --remote-url "$URL" -s out/auto_grown_* \
+  --scale 1 -g 0 --voxel-size 45.532 --voxel-unit micrometer --tif-output render/
+```
+
+This writes `render/00.tif` (360×360 pixels for the segment above, about
+17 MiB fetched). Things to know:
+
+- `-v` is mandatory, but with `--remote-url` it is only consulted for a local
+  `meta.json`: a nonexistent or empty directory works and stays empty. Chunks
+  are cached in RAM only, sized by `--cache-gb` (default 16); the renderer
+  does not use the tracer's on-disk cache. `--prefetch-remote` fills the RAM
+  cache before rendering starts.
+- Remote volumes are not probed for a voxel size. Without `--voxel-size` the
+  log says `Voxel size: 1.0 (no metadata found; override with --voxel-size)`
+  and the TIFF carries no resolution tag. `--voxel-unit` defaults to
+  `nanometer`, so pass both flags; `--voxel-size 45.532` alone yields a TIFF
+  resolution 1000× too large.
+- `-g` selects the pyramid level: `-g 3` renders the same segment at 1/8
+  scale (45×45 pixels, about 4 MiB fetched). A level the remote pyramid does
+  not have fails immediately with
+  `Error: group index 6 not available in remote zarr (present levels: 0 1 2 3 4 5)`.
+- The `#vc-base-scale=N` selector described above applies to the tracer as
+  well: with `#vc-base-scale=2` it reports
+  `zarr dataset size for scale group 0 [1017, 566, 566]` and
+  `voxelsize: 182.128`, the seed is expected in level-2 coordinates, and the
+  segment's `meta.json` keeps the selector in `target_volume`.
+
 ### Opening a volume package and navigating the UI
 First, click `File -> Open volpkg` and select the volpkg you wish to work with (select the folder ending in .volpkg)
 


### PR DESCRIPTION
**In one sentence:** with this README section, anyone can grow and render a segment on a public open-data volume with `vc_grow_seg_from_seed` and `vc_render_tifxyz` straight from the bucket — no download, no volpkg, no credentials — and knows where the volume URLs come from, which flags matter (`--voxel-size`/`--voxel-unit`, `-g`, `#vc-base-scale=N`) and where the tracer keeps the chunks it fetched.

**One real example:** Starting from an empty directory on a machine with no AWS credentials and no local scroll data, I ran the three code blocks of the new section exactly as committed (extracted from the README by a script) with binaries built from main at 777cb16cf: the catalog snippet lists the seven PHercParis4 volumes with level-0 shape and voxel size (3.3 s); `vc_grow_seg_from_seed` on the 45.532 µm PHercParis4 volume grows eight generations from seed `1408 1408 1024` in 12.0 s (`voxelsize: 45.532` picked up from the remote `metadata.json`, 1.41 cm²), receiving 2.3 MB; `vc_render_tifxyz --remote-url … --voxel-size 45.532 --voxel-unit micrometer` renders it to `render/00.tif` (360×360 px, 557.85 dpi = 45.532 µm/px) in 8.2 s, receiving 17.6 MB. Besides the segment and the TIFF, the only thing written to disk was the tracer's copy of the one chunk it fetched, 4.1 MB under the remote cache directory; the renderer wrote nothing else.

**Before:** no page in the repo describes this workflow. The README covers the remote locators for VC3D (`#vc-base-scale=N`, the `vc_open_data_*` tags) and the volpkg layout; the only mention of `--remote-url` in any `.md` file is one bullet inside the 9 µm render recipe of the ink-detection tutorial (`scrollprize.org/docs/07_tutorial5.md`), and the remote cache directory is described as a VC3D setting (`docs/api/Volume.md`, `docs/vc3d_project_files.md`), not in connection with the tracer. Someone who wants to try the command-line tools on open data has to find out from `--help` and the source that `--volume` is mandatory but unused for a remote render, that `--voxel-unit` defaults to nanometer (so `--voxel-size 45.532` alone writes a resolution 1000× too large), that the tracer leaves its fetched chunks in `~/.VC3D/remote_cache/`, and where the volume URLs come from.

**After this PR:** a new subsection "Working on remote volumes from the command line" in `volume-cartographer/README.md`, between the volpkg folder tree and "Opening a volume package": finding a volume URL in the bucket catalog (both `https://` and `s3://` forms), growing a segment, rendering it, and four "things to know" bullets, each backed by a run. 88 added lines, nothing else touched.

**Proof:** every command and every quoted message in the section was run on binaries built from 23adee047 (the branch base) when the text was written, and run again on binaries built from main at 777cb16cf on 2026-09-10 (the branch merges cleanly there); the table shows the 777cb16cf runs. The final check re-ran the three code blocks as committed from a fresh directory with a cold remote cache, pointed at an empty directory through `VC3D_CONFIG_DIR`. The rendered output:

![render of the README example on main 777cb16cf](https://raw.githubusercontent.com/Bullo27/villa/7fabe7dc349f289306c1a63b17535fa6ad419bab/evidence/remote-volumes-cli/evidence_remote_volumes_cli.png)

| command | result |
|---|---|
| catalog snippet | 7 volumes, e.g. `20260310173927-45.532um-11.0m-110keV-masked.zarr [4066, 2264, 2264] 45.532`; 3.3 s |
| `vc_grow_seg_from_seed -v "$URL" -t out/ -p params.json --seed 1408 1408 1024` (https, cold cache) | exit 0, 12.0 s (13.6 s in the harness run), 2.3 MB received, `voxelsize: 45.532`, `out/auto_grown_<ts>/{x,y,z,generations}.tif` + `meta.json`, 1.41 cm² |
| same command a second time on the same volume | exit 0, 10.3 s, 77 KB received, no new file in the remote cache directory (the chunk is read from `level_0/8/11/11.bin`) |
| same with the `s3://` locator | exit 0, 16.4 s, same output layout, 1.41 cm² (run-to-run the area differs in the fourth digit; the tracer is not bit-deterministic), cached under a different `<volume>-<id>` directory than the https run |
| `--resume out/auto_grown_<ts>` with `"generations": 12` | exit 0, 12.3 s, 115 KB received, 1.41 → 3.68 cm², `vc_gsfs_mode: resume` |
| `…masked.zarr#vc-base-scale=2` with `--seed 352 352 256` | `zarr dataset size for scale group 0 [1017, 566, 566]`, `voxelsize: 182.128`; `meta.json` `target_volume` keeps the selector |
| `vc_render_tifxyz -v render_cache --remote-url "$URL" -s out/auto_grown_* --scale 1 -g 0 --voxel-size 45.532 --voxel-unit micrometer --tif-output render/` | exit 0, 8.2 s (9.0 s in the harness run), 17.6 MB received, `render/00.tif` 360×360, XResolution 557.85 dpi (= 25400/45.532), unit inch; `render_cache/` stays empty |
| same with the `s3://` locator | exit 0, 11.7 s |
| without `--voxel-size` | `Voxel size: 1.0 (no metadata found; override with --voxel-size)`; the TIFF has no resolution tags |
| `--voxel-size 45.532` without `--voxel-unit` | log `Voxel size (from CLI): 45.532 nanometer`; TIFF resolution 557849 dpi |
| `-g 3` | `group 3 [509 283 283]`, 45×45 px, 4.5 MB received, 69.73 dpi; 9.3 s on the final segment (right panel of the figure) |
| `-g 6` | exit 1, `Error: group index 6 not available in remote zarr (present levels: 0 1 2 3 4 5)` |
| `-v` omitted | exit 1, `Error: the option '--volume' is required but missing` |
| `-v does_not_exist` | exit 0, the directory is not created |
| `-v` pointing at a directory holding only a `meta.json` with `"voxelsize": 45.532` | `Voxel size (from volume metadata): 45.532 nanometer`, i.e. the local `meta.json` is consulted, but the unit still defaults to nanometer |
| `--cache-gb 1` | exit 0, 7.7 s, `00.tif` has the same size (58168 B) as in the default run |
| `--prefetch-remote` | `Prefetch: 27 chunk(s) across rows 0..2`, still nothing written besides `00.tif` |
| `--zarr-output seg.zarr --num-slices 4` with a nonexistent `-v` | exit 0, 18.0 s, only `seg.zarr` written, `-v` not created |
| `strace -f -e trace=openat,creat,mkdir,mkdirat,rename,renameat,unlink,unlinkat` around the render, prefetch and zarr-output runs | the renderer opens exactly one path for writing (`00.tif`, or the `seg.zarr` tree); the `-v` directory is never opened or created; zero accesses under `~/.VC3D` (this was the behaviour on 777cb16cf, before #1657 — see the 2026-09-16 update below) |
| same strace around the tracer, cold cache | besides its output directory (`.tmp_<id>/auto_grown_<ts>/…`, renamed into place) it reads `~/.VC3D/VC3D.ini`, takes `.<volume>-<id>.vc_cache.lock` in the remote cache directory, writes and removes a `.vc3d-write-probe-*`, then writes `<volume>-<id>/level_0/8/11/11.bin` (2 MiB, the one chunk around the seed) plus a zarr mirror of it (`.zgroup`, `.zattrs`, `0..5/.zarray`, `0/8/11/11`): 4.1 MB in total |
| `VC3D_CONFIG_DIR=$PWD/cfg` with `cfg/VC3D.ini` containing `[viewer]` / `remote_cache_dir=<dir>` (the final run) | exit 0, the same 4.1 MB tree appears under `<dir>`, nothing new under `~/.VC3D` |

"Received" is the host's network RX delta over the run (`/proc/net/dev`), so it is an upper bound that includes any background traffic. Timings are wall clock on a 14-core Xeon E5-2680 v4; the tracer ran with `thread_limit: 4`.

**Update (2026-09-16, re-measured on current `main` 757f70c01):** #1657 has since merged. The renderer now opens `--remote-url` through `Volume::NewFromUrl` and takes VC3D's shared persistent chunk cache, so the chunks it fetches are written to disk under the remote cache directory (`~/.VC3D/remote_cache/<volume>-<id>/`, or `remote_cache_dir` under `[viewer]` in `VC3D.ini`) — the same place the tracer uses — and `--cache-gb` now sizes the process-wide cache budget. I rebuilt the renderer on 757f70c01 and re-ran the render with a cold `remote_cache_dir`: `-v render_cache` still stays empty (0 files), but 33 MB — 8 `level_0/*.bin` chunks plus a zarr mirror — persist under the remote cache, and `strace` shows the renderer taking the cache lock and writing those chunks. The README `-v` bullet has been updated accordingly; the 777cb16cf table above is left as the dated snapshot it was measured on.

**Why / where this is useful:** the open-data catalog now exposes 71 volumes across 45 samples, and the command-line tools can already work on them without a local copy — but nothing tells a newcomer that, or how. This section is the shortest path from "I have the tools built" to "I rendered a piece of a scroll", it puts the two flags that are easy to get wrong (`--voxel-unit`, `-g` on a remote pyramid) next to the commands, and it says where the fetched chunks end up, which matters on machines with small home directories. It sits in the README right after the remote locator description it builds on, so it should stay in sync with the tools.

- [x] Verified by running the example and proof above on my machine on the stated data (AI-assisted; see disclosure).

## Details

**What changed** (1 file, +88 lines): `volume-cartographer/README.md` gains `### Working on remote volumes from the command line` with three sub-headings (finding a volume URL, growing a segment, rendering it) between the volpkg folder-tree block and `### Opening a volume package and navigating the UI`. No code, no other document.

**How the facts were established:** each statement in the section corresponds to a run in the table above (S1–S20 in my harness on 2026-09-10, binaries from main 777cb16cf, Ubuntu 24.04, gcc 13.3.0; the same harness ran on 23adee047 on 2026-09-06 with the same outcomes except the tracer's cache, see below). The renderer bullet comes from `strace` and from reading `vc_render_tifxyz.cpp`: with `--remote-url` the renderer builds `createChunkCache(openHttpZarrPyramid(...), cache_bytes)`, an in-memory cache sized by `--cache-gb`, and `--prefetch-remote` fills that same cache; no persistent cache path is set on the CLI path (true on 777cb16cf; #1657 has since changed this, see the update below). The tracer sentence comes from the same strace and from `Volume::NewFromUrl`, which since #1733/#1744 sets `remoteCacheRoot_ = vc::settings::remoteCachePath()`: `remote_cache_dir` from `VC3D.ini` (`$VC3D_CONFIG_DIR/VC3D.ini`, else `~/.VC3D/VC3D.ini`) if set, otherwise `~/.VC3D/remote_cache`. The code also prefers `/volpkgs/remote_cache` or `/ephemeral/remote_cache` when those roots exist; I could not exercise that on my machine, so the README only names the two cases I ran. The catalog snippet uses `--compressed` because the bucket serves `metadata.json` gzip-encoded, and `.values()` because `samples.<id>.volumes` is a dictionary keyed by volume id.

**Related, deliberately not in this PR:**
- `scrollprize.org/docs/07_tutorial5.md`, last bullet of the render recipe, says `--volume` "names a local directory where fetched chunks are cached, so only the parts of the scroll your segment touches ever get downloaded". The second half is right; the first half does not match main (nothing is written under `--volume`, see the strace row). That file has different code owners, so I left it for a separate one-line change.
- The `--help` texts of `--remote-url` ("optional if --volume cache already records it") and `--prefetch-remote` ("into the existing staged cache") describe a persistent cache the CLI does not currently create; the section documents the behaviour, not the help text.
- #1657 (persistent remote cache for the renderer) has since merged; the README `-v` bullet and this description have been updated to describe the shared persistent cache (see the 2026-09-16 update below). #1753 (isotropic zarr pyramids) would change the `-g 6` message if it lands; I will update the section then.
- The example traces the scan volume itself. The 45.532 µm volume has no surface prediction in the catalog (the 2.4 µm PHercParis4 volume does, under `representations/predictions/surfaces/`), and a remote run on a 2.4 µm surface prediction is a bigger example than the README needs. The section does not claim the segment is a good one, only that the workflow runs.

**From the author:** I contribute to VC through an AI-assisted workflow (Claude, directed by me). Over the summer I kept a small personal guide for using the command-line tools on the open-data bucket without downloading anything, and it went stale within days each time main moved. The README, next to the remote locator description, is the one place where this can stay correct, so I am upstreaming the part that held up. Every command in the section was run on the base commit before the text was written, and the three code blocks were run once more exactly as committed. I reviewed the runs and the text; every number in this PR comes from those runs on my machine.

**AI disclosure:** the measurements, the section and this write-up were produced with Claude (Anthropic) under my direction; every number above comes from running the stated commands on my machine.