### PR TITLE
optimized_inference README: centre the 62-layer window for the 2 um 3D-decoder model

### DIFF
--- a/ink-detection/optimized_inference/README.md
+++ b/ink-detection/optimized_inference/README.md
@@ -41,7 +41,7 @@ GPU-accelerated, containerized inference for ink detection models. The GPU image
 - `TILE_SIZE`: Sets both the tile extraction size and network input size. Larger values = more context but more memory. Should match training size for best results (typically 64)
 - `STRIDE`: Controls overlap between tiles. Smaller stride = more overlap = smoother blending but slower inference
 - `BATCH_SIZE`: Number of tiles to process in parallel. Larger values = faster but more GPU memory. Reduce if you encounter OOM errors
-- `resnet3d-152-3d-decoder`: Best aligned with the tracked 3D-decoder checkpoints when using `TILE_SIZE=256` and a 62-layer window such as `START_LAYER=1`, `END_LAYER=63`
+- `resnet3d-152-3d-decoder`: Best aligned with the tracked 3D-decoder checkpoints when using `TILE_SIZE=256` and a 62-layer window centred on the segment surface, which is the middle slice of the published surface volumes: for a 109-layer volume (e.g. PHerc0139 at 2.4 um) use `START_LAYER=24`, `END_LAYER=86`. `START_LAYER=1`, `END_LAYER=63` is centred only on a 65-layer volume. On PHerc0139 segment 20250108000000-w025 (109 layers), layers 24-85 reproduce the published prediction (pixel correlation 0.875, ink area 85.0% vs 84.8% published) while layers 1-62 do not (0.38, 40.6%)
 
 ### S3 layout (expected)
 
@@ -319,6 +319,7 @@ argo submit wf.yaml \
 
 Tip:
 - `END_LAYER` is exclusive. For layers `00.tif` through `25.tif`, use `START_LAYER=0`, `END_LAYER=26`.
+- Centre the window on the surface. For a volume of `N` layers with the surface in the middle slice and a window of `W` layers, use `START_LAYER` = (N - W) / 2 rounded to a whole number and `END_LAYER` = `START_LAYER` + W.
 
 ## Notes on models
 

--- a/ink-detection/optimized_inference/README.md
+++ b/ink-detection/optimized_inference/README.md
@@ -41,7 +41,7 @@ GPU-accelerated, containerized inference for ink detection models. The GPU image
 - `TILE_SIZE`: Sets both the tile extraction size and network input size. Larger values = more context but more memory. Should match training size for best results (typically 64)
 - `STRIDE`: Controls overlap between tiles. Smaller stride = more overlap = smoother blending but slower inference
 - `BATCH_SIZE`: Number of tiles to process in parallel. Larger values = faster but more GPU memory. Reduce if you encounter OOM errors
-- `resnet3d-152-3d-decoder`: Best aligned with the tracked 3D-decoder checkpoints when using `TILE_SIZE=256` and a 62-layer window centred on the segment surface, which is the middle slice of the published surface volumes: for a 109-layer volume (e.g. PHerc0139 at 2.4 um) use `START_LAYER=24`, `END_LAYER=86`. `START_LAYER=1`, `END_LAYER=63` is centred only on a 65-layer volume. On PHerc0139 segment 20250108000000-w025 (109 layers), layers 24-85 reproduce the published prediction (pixel correlation 0.875, ink area 85.0% vs 84.8% published) while layers 1-62 do not (0.38, 40.6%)
+- `resnet3d-152-3d-decoder`: Best aligned with the tracked 3D-decoder checkpoints when using `TILE_SIZE=256` and a 62-layer window centred on the segment surface, which is the middle slice of the published surface volumes: for a 109-layer volume (e.g. PHerc0139 at 2.4 um) use `START_LAYER=23`, `END_LAYER=85`, the window that reproduces the published predictions. `START_LAYER=1`, `END_LAYER=63` is centred only on a 65-layer volume
 
 ### S3 layout (expected)
 
@@ -319,7 +319,7 @@ argo submit wf.yaml \
 
 Tip:
 - `END_LAYER` is exclusive. For layers `00.tif` through `25.tif`, use `START_LAYER=0`, `END_LAYER=26`.
-- Centre the window on the surface. For a volume of `N` layers with the surface in the middle slice and a window of `W` layers, use `START_LAYER` = (N - W) / 2 rounded to a whole number and `END_LAYER` = `START_LAYER` + W.
+- Centre the window on the surface. For a volume of `N` layers with the surface in the middle slice and a window of `W` layers, use `START_LAYER` = (N - W) / 2 rounded down and `END_LAYER` = `START_LAYER` + W (109 layers: 23 and 85; 65 layers: 1 and 63).
 
 ## Notes on models
 


### PR DESCRIPTION
**In one sentence:** the README's window for `resnet3d-152-3d-decoder` now points at the middle of the published 2 um surface volumes, so following it reproduces the team's published ink maps instead of finding far less of it (40.6% against the published 84.8% on the example window below).

**One real example:** Starting with the published 109-layer surface volume of PHerc0139 segment `20250108000000-w025_2025010863` and its published `new_canon` prediction, I ran the canonical checkpoint with the README's window (layers 1-62) and with a centred one (24-85), and compared both with the published map.

**Before:** on that window, layers 1-62 match the published prediction at r 0.380 and find 40.6% ink where the published map has 84.8%. Over 8 more text windows in segments w025, w026 and w027 the README window matches at 0.23-0.62 (median 0.51) and its ink area is off by 13-62%, or 3.5x too high on one window.

**After this PR:** the README says to centre the window on the surface and gives `START_LAYER=23`, `END_LAYER=85` for the published 109-layer volumes, plus the general rule. That is the window flummoxjr showed reproduces the published prediction exactly (r 0.9999997, [measure-before-you-hunt, bench/w059_c0/RESULTS.md](https://github.com/flummoxjr/measure-before-you-hunt/blob/master/bench/w059_c0/RESULTS.md), 3 Sep). On my 8 text windows it matches at 0.85-0.93 (median 0.905), against 0.874 for the one-layer-later 24/86 I first tried, with ink area within a few points of the published map.

**Proof:** the table (13 windows over 3 segments) and the picture are in #1765; its notebook reproduces the two w025 windows.

**Why / where this is useful:** I wanted to run the challenge's 2 µm ink model on scans myself, so before relying on it I tested it against a map the team had already published. Anyone who follows the README on the published 2 µm volumes ends up with a far weaker ink map than the team's own, and nothing warns them.

## Details

- README only: the `resnet3d-152-3d-decoder` note (the line recommending `START_LAYER=1`, `END_LAYER=63`) and one line in the Tips with the rule `START_LAYER` = (N - 62) / 2 rounded down, `END_LAYER` = `START_LAYER` + 62 (23 and 85 for 109 layers).
- Not changed: any code, defaults, or the developer smoke example (`START_LAYER=1`, `END_LAYER=63`), which only sets the channel count.
- #1813 (AndreasHad04, 16 Sep) makes the same README change, measured on four scrolls; its author wrote there that this PR has priority and that #1813 can be closed in favour of it. **I would not hold #1813 on that.** This one has been a draft since 11 Sep and I did not say so on the PR itself, which was unfair to someone who stood down for it. It is a draft because I keep to three non-draft PRs open at a time, and those places are held by #1676, #1682 and #1847, not because anything here is unfinished. If a maintainer would rather take #1813, which measures the same change on four scrolls, that is the better outcome for the repository and I will close this. Both replace the same line, so only one can merge. Besides #1813, the only other open PR in `ink-detection/optimized_inference` is #1812 (MPS support), which edits the Python files and merges cleanly with this one. The folder is unchanged on `main` since 25 Aug (checked 20 Sep).
- Credit: flummoxjr found the exact window first. I found the README problem independently and measured what the documented window costs (#1765).

Refs #1765.

Found while working with an LLM coding assistant (Claude), which wrote the notebook and ran the comparison under my direction, including the run on my own Kaggle account; I checked the numbers and the picture myself.

---

**Status: draft**, and the reason is above rather than left to the label. *Edited 21 Sep 2026 to say so, after noticing this PR had sat as a silent draft for ten days while another contributor waited on it.*

*Rebuilt 21 Sep 2026 on current `main`, with no merges. The two commits keep their changes and messages, and the README is byte-identical.*
