### PR TITLE
ink_detection: fall back to a CPU edt dilation when cuCIM is unavailable

### DIFF
--- a/vesuvius/docs/ink_detection.md
+++ b/vesuvius/docs/ink_detection.md
@@ -20,9 +20,11 @@ uv run --extra models python -m vesuvius.ink_detection.training.train -h
 ```
 
 The `models` extra includes PyTorch, Accelerate, the model-building stack,
-OpenCV, TIFF/Zarr codecs, and the CUDA cuCIM package used by positive native-3D
-label dilation. The volume-only installation does not include the training
-stack.
+OpenCV, TIFF/Zarr codecs, and, on Linux, the CUDA cuCIM package that accelerates
+positive native-3D label dilation. Where cuCIM is missing (macOS, Windows, a
+CPU-only host, or a Linux install whose `cucim-cu13` wheel did not resolve),
+dilation falls back to the CPU `edt` package with identical output. The
+volume-only installation does not include the training stack.
 
 ## Data layout
 
@@ -554,8 +556,9 @@ uv run --no-sync pytest tests -m "not slow and not network"
 - ResNet3D, TimeSformer/container inference, `normal_pooled_3d`, mean-teacher,
   Betti matching, sweeps, and the embedded sample viewer are not available in
   this package.
-- Positive native label or supervision dilation enters the CUDA/cuCIM path;
-  use zero dilation where that capability is unavailable.
+- Positive native label or supervision dilation uses cuCIM on CUDA when it is
+  installed and otherwise the CPU `edt` fallback, which computes the same labels
+  but adds host round trips per batch; expect slower steps without cuCIM.
 - Flat TIFF and native OME-Zarr encoding intentionally differ: flat output
   truncates scaled probabilities, while native output rounds probabilities and
   derived pyramid means.

--- a/vesuvius/src/vesuvius/ink_detection/README.md
+++ b/vesuvius/src/vesuvius/ink_detection/README.md
@@ -178,5 +178,7 @@ uv run --no-sync pytest tests/ink_detection -q
 
 The supported modes are `flat`, `full_3d`, and `full_3d_single_wrap`.
 ResNet3D/container inference, `normal_pooled_3d`, mean-teacher, and Betti
-matching are outside this package. Positive native dilation requires the
-CUDA/cuCIM capability.
+matching are outside this package. Positive native dilation runs on the GPU
+through cuCIM when the labels are on CUDA and cuCIM imports; otherwise it falls
+back to the CPU `edt` package, which yields the same labels but is slower and
+logs one warning per process.

--- a/vesuvius/src/vesuvius/ink_detection/training/dilation.py
+++ b/vesuvius/src/vesuvius/ink_detection/training/dilation.py
@@ -133,9 +133,11 @@ def dilate_label_batch_with_edt(
     labels_np = (
         labels_BCZYX.detach().to(device="cpu", dtype=host_dtype).numpy().copy()
     )
-    valid_np = valid_B1ZYX.detach().to(device="cpu").numpy()
+    # Threshold before the host copy: the validity mask arrives in the label
+    # dtype, and NumPy has no bfloat16.
+    valid_np = (valid_B1ZYX.detach() > 0).to(device="cpu").numpy()
     for batch_index in range(labels_np.shape[0]):
-        valid_ZYX = valid_np[batch_index, 0] > 0
+        valid_ZYX = valid_np[batch_index, 0]
         for channel_index in range(labels_np.shape[1]):
             label_ZYX = labels_np[batch_index, channel_index]
             source_ZYX = (label_ZYX == 1) & valid_ZYX

--- a/vesuvius/src/vesuvius/ink_detection/training/dilation.py
+++ b/vesuvius/src/vesuvius/ink_detection/training/dilation.py
@@ -1,13 +1,27 @@
-"""Lazy CUDA label dilation and full-3D batch morphology."""
+"""Lazy CUDA label dilation, a CPU fallback, and full-3D batch morphology."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
+import logging
 
+import edt
+import numpy as np
 import torch
 
 from vesuvius.ink_detection.config import TrainingConfig
 from vesuvius.ink_detection.data.geometry import native_volume_downsample_factor
+
+
+logger = logging.getLogger(__name__)
+
+_CUCIM_UNAVAILABLE_MESSAGE = (
+    "positive full_3d dilation requires CUDA with CuPy and cuCIM"
+)
+# Process-wide memo: once a CUDA tensor could not use cuCIM, stop retrying the
+# import on every batch. The warning is logged once per process.
+_cucim_unavailable = False
+_fallback_announced = False
 
 
 def resolve_dilation_distances(
@@ -35,6 +49,10 @@ def resolve_dilation_distances(
     return label_distance / factor, supervision_distance / factor
 
 
+class CucimUnavailableError(RuntimeError):
+    """Raised when the cuCIM dilation path cannot run on this tensor or host."""
+
+
 def dilate_label_batch_with_cucim(
     labels_BCZYX: torch.Tensor,
     valid_B1ZYX: torch.Tensor,
@@ -45,16 +63,12 @@ def dilate_label_batch_with_cucim(
     if distance in (None, 0):
         return labels_BCZYX
     if labels_BCZYX.device.type != "cuda":
-        raise RuntimeError(
-            "positive full_3d dilation requires CUDA with CuPy and cuCIM"
-        )
+        raise CucimUnavailableError(_CUCIM_UNAVAILABLE_MESSAGE)
     try:
         import cupy as cp
         from cucim.core.operations.morphology import distance_transform_edt
     except ImportError as exc:
-        raise RuntimeError(
-            "positive full_3d dilation requires CUDA with CuPy and cuCIM"
-        ) from exc
+        raise CucimUnavailableError(_CUCIM_UNAVAILABLE_MESSAGE) from exc
 
     cp.cuda.Device(labels_BCZYX.device.index).use()
     output_BCZYX = labels_BCZYX.clone()
@@ -90,6 +104,83 @@ def dilate_label_batch_with_cucim(
     return output_BCZYX
 
 
+def dilate_label_batch_with_edt(
+    labels_BCZYX: torch.Tensor,
+    valid_B1ZYX: torch.Tensor,
+    distance: float | None,
+) -> torch.Tensor:
+    """Dilate binary labels within a validity mask via the CPU ``edt`` package.
+
+    Same semantics as :func:`dilate_label_batch_with_cucim`: a voxel with
+    label 0 inside the validity mask becomes 1 when its Euclidean distance to
+    the nearest label-1 voxel that is also inside the mask is at most
+    ``distance``. Tensors on any device are accepted; the work happens in host
+    memory and the result is returned on the input device with the input dtype.
+    """
+
+    if distance in (None, 0):
+        return labels_BCZYX
+
+    if valid_B1ZYX.ndim == labels_BCZYX.ndim - 1:
+        valid_B1ZYX = valid_B1ZYX.unsqueeze(1)
+    threshold = float(distance)
+    source_dtype = labels_BCZYX.dtype
+    host_dtype = (
+        torch.float32
+        if source_dtype in (torch.float16, torch.bfloat16)
+        else source_dtype
+    )
+    labels_np = (
+        labels_BCZYX.detach().to(device="cpu", dtype=host_dtype).numpy().copy()
+    )
+    valid_np = valid_B1ZYX.detach().to(device="cpu").numpy()
+    for batch_index in range(labels_np.shape[0]):
+        valid_ZYX = valid_np[batch_index, 0] > 0
+        for channel_index in range(labels_np.shape[1]):
+            label_ZYX = labels_np[batch_index, channel_index]
+            source_ZYX = (label_ZYX == 1) & valid_ZYX
+            if not source_ZYX.any():
+                continue
+            fill_ZYX = (label_ZYX == 0) & valid_ZYX
+            if not fill_ZYX.any():
+                continue
+            distances_ZYX = edt.edt(
+                np.ascontiguousarray(~source_ZYX), black_border=False
+            )
+            fill_ZYX &= distances_ZYX <= threshold
+            label_ZYX[fill_ZYX] = 1
+    return torch.from_numpy(labels_np).to(
+        device=labels_BCZYX.device, dtype=source_dtype
+    )
+
+
+def dilate_label_batch(
+    labels_BCZYX: torch.Tensor,
+    valid_B1ZYX: torch.Tensor,
+    distance: float | None,
+) -> torch.Tensor:
+    """Dilate with cuCIM when the tensor is on CUDA and cuCIM imports, else with edt."""
+
+    global _cucim_unavailable, _fallback_announced
+    if distance in (None, 0):
+        return labels_BCZYX
+    if labels_BCZYX.device.type == "cuda" and not _cucim_unavailable:
+        try:
+            return dilate_label_batch_with_cucim(
+                labels_BCZYX, valid_B1ZYX, distance
+            )
+        except CucimUnavailableError:
+            _cucim_unavailable = True
+    if not _fallback_announced:
+        _fallback_announced = True
+        logger.warning(
+            "cuCIM is unavailable for full_3d label dilation on %s; using the "
+            "CPU edt fallback, which produces the same labels but is slower",
+            labels_BCZYX.device,
+        )
+    return dilate_label_batch_with_edt(labels_BCZYX, valid_B1ZYX, distance)
+
+
 def apply_label_dilation(
     batch: Mapping[str, torch.Tensor],
     label_distance: float,
@@ -110,14 +201,14 @@ def apply_label_dilation(
         dtype=inklabels_BCZYX.dtype,
     )
     if label_distance > 0.0:
-        inklabels_BCZYX = dilate_label_batch_with_cucim(
+        inklabels_BCZYX = dilate_label_batch(
             inklabels_BCZYX, valid_B1ZYX, label_distance
         )
     if supervision_distance > 0.0:
         background_BCZYX = (
             (supervision_BCZYX > 0) & (inklabels_BCZYX <= 0)
         ).to(dtype=inklabels_BCZYX.dtype)
-        background_BCZYX = dilate_label_batch_with_cucim(
+        background_BCZYX = dilate_label_batch(
             background_BCZYX, valid_B1ZYX, supervision_distance
         )
         background_BCZYX = background_BCZYX * (

--- a/vesuvius/tests/ink_detection/test_dilation_fallback.py
+++ b/vesuvius/tests/ink_detection/test_dilation_fallback.py
@@ -1,0 +1,205 @@
+"""CPU ``edt`` fallback for positive full_3d label dilation."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+from scipy import ndimage
+import torch
+
+import vesuvius.ink_detection.training.dilation as dilation_module
+from vesuvius.ink_detection.training.dilation import (
+    CucimUnavailableError,
+    apply_label_dilation,
+    dilate_label_batch,
+    dilate_label_batch_with_cucim,
+    dilate_label_batch_with_edt,
+)
+
+
+def _reference_dilation(
+    labels_BCZYX: np.ndarray, valid_B1ZYX: np.ndarray, distance: float
+) -> np.ndarray:
+    """Spell out the cuCIM path with SciPy: fill label-0 voxels within reach."""
+
+    output = labels_BCZYX.copy()
+    for batch_index in range(output.shape[0]):
+        valid_ZYX = valid_B1ZYX[batch_index, 0] > 0
+        for channel_index in range(output.shape[1]):
+            label_ZYX = output[batch_index, channel_index]
+            source_ZYX = (label_ZYX == 1) & valid_ZYX
+            distances_ZYX = ndimage.distance_transform_edt(~source_ZYX)
+            fill_ZYX = (label_ZYX == 0) & valid_ZYX & (distances_ZYX <= distance)
+            label_ZYX[fill_ZYX] = 1
+    return output
+
+
+@pytest.fixture(autouse=True)
+def _reset_fallback_memo(monkeypatch):
+    monkeypatch.setattr(dilation_module, "_cucim_unavailable", False)
+    monkeypatch.setattr(dilation_module, "_fallback_announced", False)
+
+
+@pytest.mark.parametrize("distance", [1.0, 1.5, 2.0, 3.7])
+@pytest.mark.parametrize("shape", [(2, 1, 9, 11, 13), (1, 2, 1, 17, 19)])
+def test_edt_fallback_matches_scipy_reference(distance, shape):
+    generator = np.random.default_rng(seed=int(distance * 10) + sum(shape))
+    labels = (generator.random(shape) < 0.04).astype(np.float32)
+    valid = (generator.random((shape[0], 1, *shape[2:])) < 0.85).astype(
+        np.float32
+    )
+
+    expected = _reference_dilation(labels, valid, distance)
+    output = dilate_label_batch_with_edt(
+        torch.from_numpy(labels), torch.from_numpy(valid), distance
+    )
+
+    np.testing.assert_array_equal(output.numpy(), expected)
+    assert output.dtype == torch.float32
+    assert output.shape == labels.shape
+    assert (output.numpy() >= labels).all()
+
+
+def test_edt_fallback_respects_validity_mask_and_leaves_input_untouched():
+    labels = torch.zeros(1, 1, 1, 1, 7)
+    labels[..., 3] = 1
+    valid = torch.ones(1, 1, 1, 1, 7)
+    valid[..., 0] = 0
+    valid[..., 5] = 0
+    original = labels.clone()
+
+    output = dilate_label_batch_with_edt(labels, valid, 2.0)
+
+    torch.testing.assert_close(labels, original)
+    torch.testing.assert_close(
+        output, torch.tensor([[[[[0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0]]]]])
+    )
+
+    # Ink outside the validity mask must not seed growth.
+    labels_outside = torch.zeros(1, 1, 1, 1, 7)
+    labels_outside[..., 0] = 1
+    torch.testing.assert_close(
+        dilate_label_batch_with_edt(labels_outside, valid, 2.0), labels_outside
+    )
+
+
+def test_edt_fallback_handles_empty_and_full_labels_and_valid_rank():
+    empty = torch.zeros(1, 1, 3, 4, 5)
+    full = torch.ones(1, 1, 3, 4, 5)
+    valid_BZYX = torch.ones(1, 3, 4, 5)
+
+    torch.testing.assert_close(dilate_label_batch_with_edt(empty, valid_BZYX, 2.0), empty)
+    torch.testing.assert_close(dilate_label_batch_with_edt(full, valid_BZYX, 2.0), full)
+    assert dilate_label_batch_with_edt(empty, valid_BZYX, 0) is empty
+    assert dilate_label_batch_with_edt(empty, valid_BZYX, None) is empty
+
+
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.bool, torch.bfloat16])
+def test_edt_fallback_preserves_integer_bool_and_half_dtypes(dtype):
+    labels = torch.zeros(1, 1, 1, 3, 3, dtype=dtype)
+    labels[..., 1, 1] = 1
+    valid = torch.ones(1, 1, 1, 3, 3, dtype=torch.uint8)
+
+    output = dilate_label_batch_with_edt(labels, valid, 1.0)
+
+    assert output.dtype == dtype
+    expected = torch.tensor(
+        [[[[[0, 1, 0], [1, 1, 1], [0, 1, 0]]]]], dtype=dtype
+    )
+    assert torch.equal(output, expected)
+
+
+def test_dispatcher_uses_edt_on_cpu_and_warns_once(caplog):
+    labels = torch.zeros(1, 1, 1, 1, 5)
+    labels[..., 2] = 1
+    valid = torch.ones(1, 1, 1, 1, 5)
+
+    with caplog.at_level(logging.WARNING, logger=dilation_module.__name__):
+        first = dilate_label_batch(labels, valid, 1.0)
+        second = dilate_label_batch(labels, valid, 1.0)
+
+    torch.testing.assert_close(first, torch.tensor([[[[[0.0, 1.0, 1.0, 1.0, 0.0]]]]]))
+    torch.testing.assert_close(second, first)
+    fallback_messages = [
+        record for record in caplog.records if "edt fallback" in record.getMessage()
+    ]
+    assert len(fallback_messages) == 1
+    assert dilate_label_batch(labels, valid, 0) is labels
+
+
+def test_dispatcher_falls_back_when_cucim_raises_and_stops_retrying(monkeypatch):
+    calls: list[int] = []
+
+    def _unavailable(labels, valid, distance):
+        calls.append(1)
+        raise CucimUnavailableError("nope")
+
+    monkeypatch.setattr(dilation_module, "dilate_label_batch_with_cucim", _unavailable)
+    monkeypatch.setattr(
+        dilation_module,
+        "dilate_label_batch_with_edt",
+        lambda labels, valid, distance: labels + 1,
+    )
+
+    class _CudaLike(torch.Tensor):
+        pass
+
+    labels = torch.zeros(1, 1, 1, 1, 3)
+    valid = torch.ones_like(labels)
+    fake_cuda = labels.as_subclass(_CudaLike)
+    monkeypatch.setattr(
+        _CudaLike, "device", property(lambda self: torch.device("cuda", 0))
+    )
+
+    torch.testing.assert_close(
+        torch.Tensor(dilate_label_batch(fake_cuda, valid, 1.0)), labels + 1
+    )
+    torch.testing.assert_close(
+        torch.Tensor(dilate_label_batch(fake_cuda, valid, 1.0)), labels + 1
+    )
+    assert len(calls) == 1
+    assert dilation_module._cucim_unavailable is True
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+@pytest.mark.parametrize("distance", [1.0, 2.5, 4.0])
+def test_edt_fallback_matches_cucim_on_cuda(distance):
+    pytest.importorskip("cupy")
+    pytest.importorskip("cucim")
+    generator = torch.Generator().manual_seed(int(distance * 100))
+    labels = (torch.rand(2, 1, 17, 33, 29, generator=generator) < 0.03).float()
+    valid = (torch.rand(2, 1, 17, 33, 29, generator=generator) < 0.9).float()
+
+    with_cucim = dilate_label_batch_with_cucim(labels.cuda(), valid.cuda(), distance)
+    with_edt = dilate_label_batch_with_edt(labels, valid, distance)
+
+    assert torch.equal(with_cucim.cpu(), with_edt)
+
+
+def test_cucim_path_still_refuses_cpu_tensors_with_the_typed_error():
+    labels = torch.zeros(1, 1, 2, 2, 2)
+    valid = torch.ones_like(labels)
+
+    with pytest.raises(CucimUnavailableError, match="CUDA.*CuPy.*cuCIM"):
+        dilate_label_batch_with_cucim(labels, valid, 1)
+
+
+def test_apply_label_dilation_runs_end_to_end_on_cpu():
+    labels = torch.zeros(1, 1, 1, 1, 5)
+    labels[..., 2] = 1
+    supervision = torch.zeros_like(labels)
+    supervision[..., 0] = 1
+
+    output = apply_label_dilation(
+        {"inklabels": labels, "supervision_mask": supervision}, 1.0, 1.0
+    )
+
+    torch.testing.assert_close(
+        output["inklabels"], torch.tensor([[[[[0.0, 1.0, 1.0, 1.0, 0.0]]]]])
+    )
+    torch.testing.assert_close(
+        output["supervision_mask"],
+        torch.tensor([[[[[1.0, 1.0, 1.0, 1.0, 0.0]]]]]),
+    )

--- a/vesuvius/tests/ink_detection/test_dilation_fallback.py
+++ b/vesuvius/tests/ink_detection/test_dilation_fallback.py
@@ -96,11 +96,14 @@ def test_edt_fallback_handles_empty_and_full_labels_and_valid_rank():
     assert dilate_label_batch_with_edt(empty, valid_BZYX, None) is empty
 
 
-@pytest.mark.parametrize("dtype", [torch.uint8, torch.bool, torch.bfloat16])
+@pytest.mark.parametrize(
+    "dtype", [torch.uint8, torch.bool, torch.float16, torch.bfloat16]
+)
 def test_edt_fallback_preserves_integer_bool_and_half_dtypes(dtype):
     labels = torch.zeros(1, 1, 1, 3, 3, dtype=dtype)
     labels[..., 1, 1] = 1
-    valid = torch.ones(1, 1, 1, 3, 3, dtype=torch.uint8)
+    # apply_label_dilation hands over a validity mask in the label dtype.
+    valid = torch.ones(1, 1, 1, 3, 3, dtype=dtype)
 
     output = dilate_label_batch_with_edt(labels, valid, 1.0)
 
@@ -109,6 +112,27 @@ def test_edt_fallback_preserves_integer_bool_and_half_dtypes(dtype):
         [[[[[0, 1, 0], [1, 1, 1], [0, 1, 0]]]]], dtype=dtype
     )
     assert torch.equal(output, expected)
+
+
+def test_apply_label_dilation_accepts_bfloat16_batches_on_cpu():
+    labels = torch.zeros(1, 1, 1, 1, 5, dtype=torch.bfloat16)
+    labels[..., 2] = 1
+    supervision = torch.zeros_like(labels)
+    supervision[..., 0] = 1
+
+    output = apply_label_dilation(
+        {"inklabels": labels, "supervision_mask": supervision}, 1.0, 1.0
+    )
+
+    assert output["inklabels"].dtype == torch.bfloat16
+    assert output["supervision_mask"].dtype == torch.bfloat16
+    assert torch.equal(
+        output["inklabels"].float(), torch.tensor([[[[[0.0, 1.0, 1.0, 1.0, 0.0]]]]])
+    )
+    assert torch.equal(
+        output["supervision_mask"].float(),
+        torch.tensor([[[[[1.0, 1.0, 1.0, 1.0, 0.0]]]]]),
+    )
 
 
 def test_dispatcher_uses_edt_on_cpu_and_warns_once(caplog):
@@ -176,6 +200,28 @@ def test_edt_fallback_matches_cucim_on_cuda(distance):
     with_edt = dilate_label_batch_with_edt(labels, valid, distance)
 
     assert torch.equal(with_cucim.cpu(), with_edt)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test_dispatcher_selects_cucim_for_cuda_tensors(monkeypatch, caplog):
+    pytest.importorskip("cupy")
+    pytest.importorskip("cucim")
+
+    def _must_not_run(labels, valid, distance):
+        raise AssertionError("CUDA tensors with a working cuCIM must not fall back")
+
+    monkeypatch.setattr(dilation_module, "dilate_label_batch_with_edt", _must_not_run)
+    generator = torch.Generator().manual_seed(7)
+    labels = (torch.rand(1, 1, 9, 21, 23, generator=generator) < 0.03).float().cuda()
+    valid = torch.ones_like(labels)
+
+    with caplog.at_level(logging.WARNING, logger=dilation_module.__name__):
+        output = dilate_label_batch(labels, valid, 2.0)
+
+    assert output.device == labels.device
+    assert torch.equal(output, dilate_label_batch_with_cucim(labels, valid, 2.0))
+    assert dilation_module._cucim_unavailable is False
+    assert not [r for r in caplog.records if "edt fallback" in r.getMessage()]
 
 
 def test_cucim_path_still_refuses_cpu_tensors_with_the_typed_error():

--- a/vesuvius/tests/ink_detection/test_training_numerics.py
+++ b/vesuvius/tests/ink_detection/test_training_numerics.py
@@ -257,9 +257,7 @@ def test_dilation_union_excludes_new_ink_from_background(monkeypatch):
     supervision = torch.zeros_like(labels)
     supervision[..., 0] = 1
 
-    monkeypatch.setattr(
-        dilation_module, "dilate_label_batch_with_cucim", _fake_dilator
-    )
+    monkeypatch.setattr(dilation_module, "dilate_label_batch", _fake_dilator)
     output = apply_label_dilation(
         {"inklabels": labels, "supervision_mask": supervision},
         1.0,


### PR DESCRIPTION
**In one sentence:** Native (full_3d) ink training with positive label or supervision dilation now runs on any machine, not only Linux boxes with the cuCIM wheel.

**One real example:** Starting with the PHerc0139 native9 segment w035 ink labels (`w035_inklabels.zarr` and `w035_supervision_mask.zarr` from the `ink_9um` dataset), I ran `apply_label_dilation` (the call `train.py` makes on every batch) on eight 17x128x128 label crops held as CPU tensors, on upstream main 963d6817, and it produced `RuntimeError: positive full_3d dilation requires CUDA with CuPy and cuCIM`. With this PR the same command completes (ink voxels grew by 6485 across the eight crops), and on my 5090 the CPU result is identical to the cuCIM output on every crop.

**Before:** Any host without cuCIM (macOS, Windows, a Linux install where the NVIDIA index wheel did not resolve, or a CPU tensor) cannot use positive full_3d dilation at all; the only workaround the docs offered was setting the distances to zero, which changes the training recipe.

**After this PR:** `apply_label_dilation` dispatches to cuCIM when the labels are on CUDA and cuCIM imports, otherwise to a CPU implementation built on the `edt` package that is already a core dependency. One warning is logged per process. Output is bit-identical.

**Proof:**
- Before screenshot:  (bench command on main, ending in the RuntimeError)
- 
<img width="1836" height="1510" alt="2026-09-10-target-c-before-main-963d6817" src="https://github.com/user-attachments/assets/bed8e850-3497-4e8b-8e2f-5fcbda3c47d0" />

- After screenshot:  (same command on the branch, 5090 visible: `tree has edt fallback: True`, `apply_label_dilation on CPU: OK, ink voxels grew by 6485`, 8 of 8 crops identical, edt p50 19.7 ms vs cuCIM p50 1.0 ms)
<img width="1024" height="823" alt="2026-09-11-target-c-after-branch-c4e11447" src="https://github.com/user-attachments/assets/99a2f37b-e591-496a-aa0d-4e168b25772b" />

- Differential + timing on real label crops from w035, `--crops 8 --crop 128 --depth 17 --distance 4`, 3 timing repeats per crop, RTX 5090, cupy 14.1.1, cucim 26.06.00, torch 2.12.1+cu130:

| backend | crops | mean ms | p50 ms | p95 ms |
|---|---:|---:|---:|---:|
| edt (CPU) | 8 | 21.4 | 21.2 | 24.1 |
| cuCIM (GPU) | 8 | 61.2 | 1.3 | 3.4 |

crops with any differing voxel: 0 of 8. The cuCIM mean is dominated by the first call (kernel compile and CuPy warmup); warmed-up crops take 1 to 2 ms.Command: uv run --no-sync python bench_dilation_real_labels.py /data/ink_9um/labels/native9-scrollprizeorg-21slices/w035 --crops 8 --crop 128 --depth 17 --distance 4 --json dilation_bench.json, bench script (not part of this PR): [gist.github.com/mythorath/8bfb87a15a40c93477fad3805ff192ce](https://gist.github.com/mythorath/8bfb87a15a40c93477fad3805ff192ce). The CPU-only run of the same command gave edt mean 22.8, p50 22.3, p95 27.1 ms.

- In-repo test `test_edt_fallback_matches_cucim_on_cuda` passes on the 5090 (3 distances, random volumes); on CPU-only hosts it skips.

**Why / where this is useful:** Anyone training or fine-tuning the native ink recipe on a consumer or non-Linux machine, and anyone whose `uv sync` silently skipped cuCIM. It also lets the dilation tests run in CI without a GPU.

- [x] I personally verified that the example and proof above were produced by this PR on the stated data.

## Details

Tested commit: a129b4e9 (Bench runs and screenshots were made on an earlier commit of this branch whose only difference from a129b4e is the import placement.). Upstream base: 963d6817.

Method: `dilate_label_batch_with_edt` copies the batch to host memory once, and per (batch, channel) computes `edt.edt(~source)` where `source = (label == 1) & valid`, then fills `label == 0` voxels inside the validity mask whose distance is `<= distance`. That is the same formula as the cuCIM path. `dilate_label_batch` tries cuCIM for CUDA tensors, remembers a failed import so it is not retried on every batch, and logs one warning. `dilate_label_batch_with_cucim` is unchanged except that it raises the typed `CucimUnavailableError` (a `RuntimeError` subclass, so the existing test still matches).

Cost: about 21 ms per 17x128x128 crop on the CPU fallback vs 1 to 2 ms warmed-up cuCIM on the 5090. The fallback is slower per batch and adds a host round trip, so the docs say so; nobody with a working cuCIM sees any change.

Commands:
```
cd vesuvius
uv run --no-sync pytest tests/ink_detection/test_dilation_fallback.py -v -rs
uv run --no-sync pytest tests/ink_detection -q -m "not slow and not network"
```
On the 5090 with cuCIM: 20 passed in 3.1 s for `test_dilation_fallback.py` (including the 3 CUDA equality cases); 302 passed, 2 skipped in 24.9 s for `tests/ink_detection` on this branch alone (a129b4e9). On the CPU-only run earlier the fallback file gave 17 passed, 3 skipped.

Limitations: labels in bfloat16/float16 are converted to float32 on the host and cast back. The fallback is single-threaded per (batch, channel); `edt` supports `parallel` but it was left at the default to k

eep the change minimal.

## Motivation paragraph

I am setting up native 9 um ink training on more than one machine, and only my Linux box with the 5090 has a working cuCIM. On the others the recipe with `label_dilation_distance` above zero dies at the first batch, and the documented answer was to set the distance to zero, which is a different recipe. Label dilation is a small, well defined operation, and `edt` is already a required dependency, so I wanted a CPU path that gives the same labels and lets the same config run everywhere. I checked it against cuCIM on real w035 label crops rather than trusting the formula.

