### PR TITLE
VC3D open data: do not seed a placeholder bbox from a stored bbox carrying the -1 marker (refs #1734, #1618)

### DIFF
--- a/volume-cartographer/apps/VC3D/OpenDataSegmentCache.cpp
+++ b/volume-cartographer/apps/VC3D/OpenDataSegmentCache.cpp
@@ -915,6 +915,27 @@ void publishSegmentDirectory(const std::filesystem::path& tempDir,
     std::filesystem::remove_all(backupDir, ec);
 }
 
+// True if any component of a [[lo], [hi]] bbox is exactly the tifxyz -1
+// missing-point marker. A stored bbox like that was taken over the raw grid,
+// marker included (villa #1618), so it describes the grid, not the surface.
+bool bboxCarriesMissingMarker(const nlohmann::json& bbox)
+{
+    if (!bbox.is_array()) {
+        return false;
+    }
+    for (const auto& corner : bbox) {
+        if (!corner.is_array()) {
+            continue;
+        }
+        for (const auto& value : corner) {
+            if (value.is_number() && value.get<double>() == -1.0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 nlohmann::json placeholderMetadata(
     const OpenDataSample& sample,
     const OpenDataSegment& segment,
@@ -934,7 +955,19 @@ nlohmann::json placeholderMetadata(
             }
         }
     }
-    if (segment.properties.is_object()) {
+    // The catalogue derives every volume_coverage[*].bbox_transformed from the
+    // stored bbox. When that one carries the marker, so does each derived box,
+    // pushed through the downscale or transform (villa #1734): -4 on the
+    // segment's own volume, an arbitrary number on any other. QuadSurface::bbox()
+    // recomputes from the points only when low[0] == -1 exactly, so it would
+    // trust those. Leave the key out instead: with no stored bbox the extent
+    // is computed from the valid points once the surface is loaded, the same
+    // fallback #1731 gave the Python reader.
+    const bool storedBboxCarriesMarker =
+        bboxCarriesMissingMarker(meta.value("bbox", nlohmann::json()));
+    if (storedBboxCarriesMarker) {
+        meta.erase("bbox");
+    } else if (segment.properties.is_object()) {
         const auto coverage = segment.properties.find("volume_coverage");
         if (coverage != segment.properties.end() && coverage->is_object()) {
             const auto target = coverage->find(coordinateVolumeId);

--- a/volume-cartographer/core/test/test_open_data_manifest.cpp
+++ b/volume-cartographer/core/test/test_open_data_manifest.cpp
@@ -736,6 +736,138 @@ TEST_CASE("OpenDataSegmentCache prepares lazy source and generated placeholders"
     std::filesystem::remove_all(cacheRoot);
 }
 
+namespace {
+
+// The fixture sample plus a second volume reachable by transform, so that
+// reconciling writes both a source placeholder (vol1) and a generated one
+// (vol2); each seeds its bbox from volume_coverage[<that volume>].
+OpenDataSample sampleWithGeneratedTarget()
+{
+    auto manifest = parseOpenDataManifest(kFixture);
+    auto sample = *manifest.findSample("PHerc0139");
+    OpenDataVolume targetVolume;
+    targetVolume.id = "vol2";
+    sample.volumes.push_back(targetVolume);
+    sample.properties["properties"]["volume_transforms"] = nlohmann::json::array({
+        {
+            {"from_volume_id", "vol1"},
+            {"transforms", nlohmann::json::array({
+                {
+                    {"to_volume_id", "vol2"},
+                    {"matrix", nlohmann::json::array({
+                        nlohmann::json::array({1.0, 0.0, 0.0, 10.0}),
+                        nlohmann::json::array({0.0, 1.0, 0.0, 20.0}),
+                        nlohmann::json::array({0.0, 0.0, 1.0, 30.0})
+                    })}
+                }
+            })}
+        }
+    });
+    return sample;
+}
+
+nlohmann::json readMetaJson(const std::filesystem::path& segmentDir)
+{
+    std::ifstream metaIn(segmentDir / "meta.json", std::ios::binary);
+    REQUIRE(metaIn.good());
+    return nlohmann::json::parse(metaIn);
+}
+
+} // namespace
+
+TEST_CASE("OpenDataSegmentCache placeholders drop a bbox derived from the -1 marker")
+{
+    // villa #1618: 28 published PHercParis4 surfaces store a bbox taken over
+    // the raw grid, so its lower corner is the tifxyz missing-point marker on
+    // the axes whose true minimum is positive (x and z here; y is genuine).
+    // villa #1734: the catalogue pushes that corner through the segment's
+    // downscale (2 in this fixture) on its own volume, and through the volume
+    // transform elsewhere. Neither result is -1, so QuadSurface::bbox() would
+    // trust it instead of measuring the points.
+    auto sample = sampleWithGeneratedTarget();
+    auto& segment = sample.segments.front();
+    segment.raw["creation"]["metadata"]["bbox"] = nlohmann::json::array({
+        nlohmann::json::array({-1.0, -281.3, -1.0}),
+        nlohmann::json::array({5401.2, 6047.1, 18020.9})});
+    segment.properties["volume_coverage"]["vol1"]["bbox_transformed"] =
+        nlohmann::json::array({
+            nlohmann::json::array({-2.0, -562.6, -2.0}),
+            nlohmann::json::array({10802.4, 12094.2, 36041.8})});
+    segment.properties["volume_coverage"]["vol2"]["bbox_transformed"] =
+        nlohmann::json::array({
+            nlohmann::json::array({8.0, -542.6, 28.0}),
+            nlohmann::json::array({10812.4, 12114.2, 36071.8})});
+
+    const auto cacheRoot = std::filesystem::temp_directory_path() /
+        ("vc_open_data_marker_bbox_test_" + std::to_string(vc::memmap::pid()));
+    std::filesystem::remove_all(cacheRoot);
+    const auto previousAutosaveRoot = VolumePkg::autosaveRoot();
+    VolumePkg::setAutosaveRoot(cacheRoot / "autosave");
+    auto pkg = VolumePkg::newEmpty();
+
+    const auto result = reconcileOpenDataSampleSegments(
+        *pkg, sample, cacheRoot, {}, false);
+    CHECK(result.attachedSegmentEntries == 2);
+    const auto sourceDir = openDataCanonicalSegmentCacheDirectory(
+        cacheRoot, sample, segment);
+    const auto generatedDir = openDataTransformedSegmentCacheDirectory(
+        cacheRoot, sample, segment, "vol2");
+    REQUIRE(isOpenDataSegmentPlaceholder(sourceDir));
+    REQUIRE(isOpenDataSegmentPlaceholder(generatedDir));
+
+    // Was [[-2, -562.6, -2], ...] and [[8, -542.6, 28], ...]: the marker, scaled
+    // and shifted, which QuadSurface::bbox() would not recognise as unset.
+    CHECK_FALSE(readMetaJson(sourceDir).contains("bbox"));
+    CHECK_FALSE(readMetaJson(generatedDir).contains("bbox"));
+
+    pkg.reset();
+    VolumePkg::setAutosaveRoot(previousAutosaveRoot);
+    std::filesystem::remove_all(cacheRoot);
+}
+
+TEST_CASE("OpenDataSegmentCache placeholders keep a bbox derived from an honest one")
+{
+    // Control: a stored bbox with no marker is trusted exactly as before, and
+    // each placeholder is seeded from its own volume's bbox_transformed.
+    auto sample = sampleWithGeneratedTarget();
+    auto& segment = sample.segments.front();
+    segment.raw["creation"]["metadata"]["bbox"] = nlohmann::json::array({
+        nlohmann::json::array({2824.2, 2809.4, 2980.8}),
+        nlohmann::json::array({5401.2, 6047.1, 18020.9})});
+    const auto ownVolumeBox = nlohmann::json::array({
+        nlohmann::json::array({5648.4, 5618.8, 5961.6}),
+        nlohmann::json::array({10802.4, 12094.2, 36041.8})});
+    const auto targetVolumeBox = nlohmann::json::array({
+        nlohmann::json::array({5658.4, 5638.8, 5991.6}),
+        nlohmann::json::array({10812.4, 12114.2, 36071.8})});
+    segment.properties["volume_coverage"]["vol1"]["bbox_transformed"] = ownVolumeBox;
+    segment.properties["volume_coverage"]["vol2"]["bbox_transformed"] = targetVolumeBox;
+
+    const auto cacheRoot = std::filesystem::temp_directory_path() /
+        ("vc_open_data_honest_bbox_test_" + std::to_string(vc::memmap::pid()));
+    std::filesystem::remove_all(cacheRoot);
+    const auto previousAutosaveRoot = VolumePkg::autosaveRoot();
+    VolumePkg::setAutosaveRoot(cacheRoot / "autosave");
+    auto pkg = VolumePkg::newEmpty();
+
+    const auto result = reconcileOpenDataSampleSegments(
+        *pkg, sample, cacheRoot, {}, false);
+    CHECK(result.attachedSegmentEntries == 2);
+    const auto sourceDir = openDataCanonicalSegmentCacheDirectory(
+        cacheRoot, sample, segment);
+    const auto generatedDir = openDataTransformedSegmentCacheDirectory(
+        cacheRoot, sample, segment, "vol2");
+    REQUIRE(isOpenDataSegmentPlaceholder(sourceDir));
+    REQUIRE(isOpenDataSegmentPlaceholder(generatedDir));
+
+    CHECK(readMetaJson(sourceDir).at("bbox") == ownVolumeBox);
+    CHECK(readMetaJson(generatedDir).at("bbox") == targetVolumeBox);
+
+    pkg.reset();
+    VolumePkg::setAutosaveRoot(previousAutosaveRoot);
+    std::filesystem::remove_all(cacheRoot);
+}
+
 TEST_CASE("VolumePkg aggregate open-data folders deduplicate segment lineage")
 {
     const auto root = std::filesystem::temp_directory_path() /


### PR DESCRIPTION
**In one sentence:** a segment fetched through the Open Data catalog whose stored bbox carries the tifxyz `-1` missing-point marker (#1618) no longer gets its cached bounding box seeded from the catalog's derived `bbox_transformed` (#1734); VC3D computes the box from the valid points instead, so a stored `-4` corner can no longer make the surface panel's z filter list a surface for z ranges its points never reach.

**One real example** (the catalog read anonymously on 2026-09-12 with the script from #1734, and the published grids read directly). PHercParis4, segment `20260701183124-w010-027`, on its own volume `20260411134726` (2.4 um):

```
catalog creation.metadata.bbox            [[-1.0, -1.0, -1.0], [5401.19, 6047.11, 18020.88]]
catalog original_volume_downscale         4
catalog volume_coverage[20260411134726].bbox_transformed
                                          [[-4.0, -4.0, -4.0], [21604.77, 24188.46, 72083.52]]
published transformed grid on that volume 28,221,728 valid points of 29,648,000
  lowest  x, y, z over valid points       [11304.9, 11250.3, 11953.3]
  highest x, y, z over valid points       [21584.0, 24169.7, 72051.4]
```

The corner VC3D stores for this segment is `-4`. Its points start at z 11,953.

**Before:** `placeholderMetadata()` in `apps/VC3D/OpenDataSegmentCache.cpp` starts from the catalog's `creation.metadata` and then copies `volume_coverage[<volume>].bbox_transformed` over `meta["bbox"]`. For the 28 segments in #1618 that field is the stored `-1` corner times the segment's `original_volume_downscale` of 4, exactly, 28 of 28 (#1734), and an arbitrary number on any other volume (the same segment's box on volume `20230205180739` starts at `[1189.8, -1609.6, -9076.4]`). All 28 publish a transformed grid on their own volume, so the representation VC3D caches for them is the published transformed one, and that download keeps the placeholder's `meta.json`. `QuadSurface::bbox()` recomputes from the points only when the stored low x is exactly `-1`; it receives `-4` and trusts it. The z filter in `SurfacePanelController` then tests `low[2] <= zUpperBound`, which `-4` passes for every range, and `intersect(a->bbox(), b->bbox())` in `surface_diff` never fast-rejects these surfaces.

**After this PR:** when the stored bbox carries `-1` on any component, the placeholder is written without a `bbox` key and is not seeded from `bbox_transformed`. With no stored bbox, `QuadSurface::bbox()` computes the extent from the valid points on first use, the same fallback #1731 gave the Python reader. A stored bbox without the marker is seeded exactly as before.

**Proof:** two new cases in `core/test/test_open_data_manifest.cpp`, on the existing fixture with a generated target volume. A stored bbox `[[-1, -281.3, -1], ...]` (the #1618 shape: marker on x and z, genuine negative y) with `bbox_transformed` set for the source volume and the generated target produces placeholders with no `bbox` key in both cache directories; on `main` the same placeholders carry `-2` and `8`. An honest stored bbox produces placeholders whose `bbox` equals their volume's `bbox_transformed`, unchanged behaviour. The `vc3d-ci` test shards run this file on the PR.

CI on the current head, rebuilt on `main` on 21 Sep: every build and test job that ran passed.

**Still to add before this leaves draft** (mine to do, on a build of this branch): the screen check on this segment in VC3D. Surface panel z filter `Lower 0 z` / `Upper 1000 z`: listed on `main`, should not be; `Lower 12000 z` / `Upper 13000 z`: listed either way; control segment `20260623170305-w122-123` (honest stored bbox, not one of the 28): unchanged. Plus the `ctest -R test_open_data_manifest` output from that build. Draft until then.

**Why / where this is useful:** the 28 segments are the whole 1 July 2026 batch of PHercParis4's `w` series; the 30 `w` segments from 23 June, including the control above, are not affected. Anyone filtering that sample by z in VC3D gets them back for every range from -4 upward. Fixing the derivation in the catalog generator (#1734) makes every consumer right, but that generator is outside this repo; this is the villa-side half, in the one place VC3D turns the catalog field into a stored bbox.

## Details

- **What it does.** One check in `placeholderMetadata()`: if any component of the stored bbox is exactly `-1`, erase `bbox` and skip the `bbox_transformed` seed. Otherwise identical to before. The check is `== -1` exactly, not "negative": a `tifxyz-transformed` surface can genuinely extend below a volume's origin (the second table row of #1734, where the real extent on volume `20230205180739` starts at z -5330).
- **Why here and not in `QuadSurface`.** `bbox()`'s sentinel is its own "not computed yet" marker, and widening it to "any negative" would be wrong for the real negative extents above. `-4` is only recognisable as the marker by code that has the stored bbox in hand, which `placeholderMetadata()` does.
- **Which representations this reaches.** Placeholders for the canonical source, published transformed targets, and VC3D-generated transforms all go through `placeholderMetadata()`. The derived-native path (`applyOriginalVolumeDownscale`) already rewrote the bbox on materialisation via `save()` (#1285); none of the 28 take that path because each has a published transformed grid on its own volume.
- **What it deliberately does NOT change.** `QuadSurface::bbox()` and its x-only sentinel (every affected published file carries the marker on x, so a local volpkg copy of these files is already recomputed); `rect_from_json`; the CLI tools that read `meta["bbox"]` directly (`vc_project_tifxyz`, `vc_grow_seg_from_seed`, `vc_grow_seg_from_segments`, `vc_seg_add_overlap`): different files, different callers, not exercised here. `overlap_ratio` is not touched; VC3D does not read it.
- **Already-cached segments.** The placeholder `meta.json` is written when the segment is cached, so an existing cache entry keeps its `-4` until it is re-cached (`Cache Selected` on an already-cached segment force-refreshes it) or the `bbox` key is removed by hand. This PR does not migrate existing caches.
- **Duplicate check (2026-09-12).** All villa issues and PRs, open and closed: only #1734 (mine) mentions `bbox_transformed`; #1285 (merged) fixed the writer's stale bbox on save and states it left the app caches alone; #1618 is the per-file report; #1731 is the Python reader. GitHub-wide code search for `bbox_transformed`: only this file in villa. #1801 (a draft opened on 15 Sep) also changes `OpenDataSegmentCache.cpp`; the two merge cleanly, checked with `git merge-tree` on 21 Sep. (#1748 touched `SurfacePanelController.cpp`, which this PR does not, and closed on 12 Sep.)

Verification so far:

```
# 2026-09-12, macOS arm64, clang: syntax-only compile of both changed files with the test build's flags
#   OpenDataSegmentCache.cpp    clean
#   test_open_data_manifest.cpp clean
# The two test cases have not been executed on my machine yet (no linked test build here); CI runs them on this PR,
# and the ctest lines from a build of the branch will be added before this leaves draft.
```

Happy to drop the second test case if one is preferred, or to fold the check into `rect_from_json` instead if you would rather have it in core.

---

The patch and this write-up were prepared with Claude Code under my direction. The catalog numbers above were read from the public bucket with the script from #1734, and the grid numbers from the published grids directly. The VC3D screen check on a build of this branch is still mine to do, and this stays a draft until it is in.

*Rebuilt 21 Sep 2026 on current `main`, with no merges. The commit keeps its change and message, and both files are byte-identical.*
