### PR TITLE
loss: standalone MemoryEfficientSoftDiceLoss must consume probabilities, not raw logits

### DIFF
--- a/vesuvius/src/vesuvius/models/training/loss/losses.py
+++ b/vesuvius/src/vesuvius/models/training/loss/losses.py
@@ -991,6 +991,33 @@ class NormalGatedRepulsionLoss(nn.Module):
 
 #######################################################################################################################
 
+#: nonlinearities a config may name for a loss that needs probabilities
+_NONLINEARITIES = {
+    'sigmoid': torch.sigmoid,
+    'softmax': lambda x: torch.softmax(x, dim=1),
+    'none': None,
+    'null': None,
+}
+
+
+def _resolve_nonlin(value):
+    """Turn a config's ``apply_nonlin`` into a callable.
+
+    Configs are YAML, so this arrives as a string; a callable is accepted too so
+    that Python callers are unaffected.  ``none`` turns the nonlinearity off,
+    which is what a model that already emits probabilities wants.
+    """
+    if value is None or callable(value):
+        return value
+    key = str(value).strip().lower()
+    if key not in _NONLINEARITIES:
+        raise ValueError(
+            f"unknown apply_nonlin {value!r}; expected one of "
+            f"{sorted(k for k in _NONLINEARITIES)}"
+        )
+    return _NONLINEARITIES[key]
+
+
 def _create_loss(name, loss_config, weight, ignore_index, pos_weight, mgr=None):
     # Define losses that don't natively support ignore_index
     losses_without_ignore_support = ['BCEWithLogitsLoss', 'MSELoss', 'SmoothL1Loss', 'L1Loss', 'WeightedSmoothL1Loss']
@@ -1144,9 +1171,22 @@ def _create_loss(name, loss_config, weight, ignore_index, pos_weight, mgr=None):
         )
     
     elif name == 'MemoryEfficientSoftDiceLoss':
-        # Standalone memory efficient dice loss
+        # Standalone memory efficient dice loss.
+        #
+        # Dice needs probabilities.  DC_and_BCE_loss passes
+        # apply_nonlin=torch.sigmoid for exactly this reason, but the standalone
+        # path defaulted to None, so under the documented raw-logits setup
+        # (activation: none alongside BCEWithLogitsLoss) it consumed logits as
+        # if they were probabilities.  Once the mean logit drifts negative the
+        # dice denominator crosses zero and the loss explodes to ~1e13, which
+        # dominates the combined gradient and erases BCE supervision for as long
+        # as the regime lasts.
+        #
+        # A YAML config could not fix it either: the value arrives as a string,
+        # so passing it straight through could only ever yield None or something
+        # that raises when called.
         base_loss = MemoryEfficientSoftDiceLoss(
-            apply_nonlin=loss_config.get('apply_nonlin', None),
+            apply_nonlin=_resolve_nonlin(loss_config.get('apply_nonlin', 'sigmoid')),
             batch_dice=loss_config.get('batch_dice', False),
             do_bg=loss_config.get('do_bg', True),
             smooth=loss_config.get('smooth', 1.),

--- a/vesuvius/tests/models/training/test_dice_standalone_nonlin.py
+++ b/vesuvius/tests/models/training/test_dice_standalone_nonlin.py
@@ -1,0 +1,67 @@
+"""The standalone MemoryEfficientSoftDiceLoss must consume probabilities.
+
+Regression test for the case where it consumed raw logits instead: under the
+documented raw-logits setup (activation: none alongside BCEWithLogitsLoss) the
+dice denominator crosses zero as the mean logit drifts negative, and the loss
+explodes to ~1e13 -- which dominates the combined gradient and erases BCE
+supervision for as long as the regime lasts.
+"""
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from vesuvius.models.training.loss.losses import _create_loss, _resolve_nonlin
+
+
+def _logits(mean, shape=(2, 1, 16, 16, 16), seed=0):
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn(shape, generator=generator) * 0.3 + mean
+
+
+def _target(shape=(2, 1, 16, 16, 16), positive=0.15, seed=1):
+    generator = torch.Generator().manual_seed(seed)
+    return (torch.rand(shape, generator=generator) < positive).float()
+
+
+def _dice(config=None):
+    return _create_loss("MemoryEfficientSoftDiceLoss", config or {}, 1.0, None, None)
+
+
+@pytest.mark.parametrize("mean", [0.1, 0.0, -0.1, -0.15, -0.16, -1.0])
+def test_dice_stays_bounded_across_the_logit_range(mean):
+    """The reported explosion happened between mu=-0.10 and mu=-0.15."""
+    loss = _dice()(_logits(mean), _target())
+    assert torch.isfinite(loss)
+    assert abs(float(loss)) <= 1.0, f"dice out of range at mu={mean}: {float(loss)}"
+
+
+def test_the_default_applies_sigmoid():
+    """Same convention DC_and_BCE_loss already uses when it builds this class."""
+    logits = _logits(-1.0)
+    target = _target()
+    default = _dice()(logits, target)
+    explicit = _dice({"apply_nonlin": "sigmoid"})(logits, target)
+    assert torch.allclose(default, explicit)
+
+
+def test_a_config_can_turn_the_nonlinearity_off():
+    """For a model that already emits probabilities."""
+    probs = torch.sigmoid(_logits(-1.0))
+    target = _target()
+    off = _dice({"apply_nonlin": "none"})(probs, target)
+    assert torch.isfinite(off) and abs(float(off)) <= 1.0
+
+
+def test_a_named_nonlinearity_resolves_to_a_callable():
+    assert _resolve_nonlin("sigmoid") is torch.sigmoid
+    assert _resolve_nonlin(None) is None
+    assert _resolve_nonlin("none") is None
+    assert callable(_resolve_nonlin("softmax"))
+    assert _resolve_nonlin(torch.sigmoid) is torch.sigmoid
+
+
+def test_an_unknown_nonlinearity_is_rejected_rather_than_called():
+    """A string passed straight through used to raise deep inside the forward
+    pass, if it did not silently do nothing first."""
+    with pytest.raises(ValueError, match="unknown apply_nonlin"):
+        _resolve_nonlin("selu")


### PR DESCRIPTION
Fixes #1488.

`_create_loss`'s standalone `MemoryEfficientSoftDiceLoss` branch defaulted
`apply_nonlin` to `None`, so under the documented raw-logits setup
(`activation: none` alongside `BCEWithLogitsLoss`) the dice loss consumed logits
as if they were probabilities. `DC_and_BCE_loss` already passes
`apply_nonlin=torch.sigmoid` when it builds the same class
(`nnunet_losses.py:331`) — the standalone path just did not.

A config could not correct it either. The value arrives from YAML as a string,
so passing it straight through could only ever yield `None` or something that
raises when called; there was no way to ask for sigmoid from a config file.

**Reproduced independently** of the issue, sweeping the mean of
`logits ~ N(mu, 0.3)` against a 15%-positive target, shape `(2, 1, 16³)`:

| mu | before (no nonlinearity) | after (sigmoid) |
|---|---|---|
| +0.10 | −0.1377 | −0.2357 |
| 0.00 | −0.0277 | −0.2332 |
| −0.10 | +0.5399 | −0.2305 |
| −0.15 | **+1.68e+10** | −0.2291 |
| −0.16 | **+1.80e+10** | −0.2288 |
| −1.00 | **+1.22e+11** | −0.1961 |

The denominator crosses zero between −0.10 and −0.15, exactly as reported. The
magnitudes differ from the issue's ~1e13 because of tensor shape and `smooth`,
but the behaviour is the same, and the sign flip at −0.10 is arguably worse than
the explosion: a dice "loss" of +0.54 is a gradient pointing the wrong way.

## What changed

* the standalone branch now defaults to `sigmoid`, matching `DC_and_BCE_loss`;
* `apply_nonlin` accepts a name from YAML — `sigmoid`, `softmax`, or `none` —
  resolved by a small `_resolve_nonlin` helper, with callables passed through
  unchanged so Python callers are unaffected;
* an unknown name raises at construction with the accepted values, rather than
  failing somewhere inside the forward pass.

## Behaviour change, deliberately

A config that relied on the old default now gets sigmoid applied. That is the
fix — but a model that already emits probabilities should set
`apply_nonlin: none` explicitly, which is now expressible where it was not
before.

## Tests

`vesuvius/tests/models/training/test_dice_standalone_nonlin.py` pins the loss
bounded across the whole logit range the issue reports, the default matching an
explicit `sigmoid`, `none` working for pre-activated inputs, name resolution in
both directions, and an unknown name being rejected at construction.

---

Reopened as a new pull request because #1644 was closed by the staleness bot today (14 days, no review), and neither reopening nor pushing to the closed PR was permitted for this account. The branch, the fix and the regression test are unchanged from that PR.