### PR TITLE
ink_detection: native full-3D inference must honour the checkpoint's input_pad_depth_to

### DIFF
--- a/vesuvius/src/vesuvius/ink_detection/inference/infer_full3d_tifxyz.py
+++ b/vesuvius/src/vesuvius/ink_detection/inference/infer_full3d_tifxyz.py
@@ -980,7 +980,14 @@ def _load_native_model(payload, config, args) -> NativeModelBundle:
     )
     base_model = make_model(config)
     load_model_state(base_model, state)
-    model = TargetModel(base_model.eval()).eval()
+    # Training center-pads the model input to model_config.input_pad_depth_to
+    # before every forward pass, and flat inference passes the same value into
+    # this wrapper.  Native inference has to honour the same contract, or a
+    # checkpoint trained at a padded depth is fed an unpadded one here.
+    model = TargetModel(
+        base_model.eval(),
+        input_pad_depth_to=config.model.input_pad_depth_to,
+    ).eval()
     model, device = prepare_model_for_inference(
         model,
         gpu_ids=args.gpu_ids,

--- a/vesuvius/tests/ink_detection/test_native_full3d_inference.py
+++ b/vesuvius/tests/ink_detection/test_native_full3d_inference.py
@@ -566,3 +566,69 @@ def test_injected_command_runtime_writes_then_builds_all_levels(tmp_path, monkey
         np.all(np.asarray(zarr.open_group(output, mode="r")[str(level)]) == 128)
         for level in range(6)
     )
+
+
+class _DepthRecorder(torch.nn.Module):
+    """Records the BCZYX depth each forward pass actually receives."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen: list[tuple[int, ...]] = []
+
+    def forward(self, image_BCZYX):
+        self.seen.append(tuple(image_BCZYX.shape))
+        return {"ink": image_BCZYX.mean(dim=2, keepdim=True)}
+
+
+def test_native_inference_honours_the_checkpoint_input_depth_padding(monkeypatch):
+    """Training center-pads the model input to model_config.input_pad_depth_to
+    and flat inference passes the same value into TargetModel.  Native
+    inference has to as well, or a checkpoint trained at a padded depth is fed
+    an unpadded one."""
+    recorder = _DepthRecorder()
+    monkeypatch.setattr(native, "make_model", lambda config: recorder)
+    monkeypatch.setattr(native, "load_model_state", lambda model, state: None)
+    monkeypatch.setattr(
+        native, "select_native_inference_weights", lambda payload, source=None: ("model", {})
+    )
+    monkeypatch.setattr(native, "resolve_amp_dtype", lambda *a, **k: None)
+
+    config = SimpleNamespace(model=SimpleNamespace(input_pad_depth_to=5))
+    args = SimpleNamespace(
+        checkpoint="memory://checkpoint",
+        gpu_ids=(),
+        compile_model=False,
+        compile_mode="default",
+        amp_dtype="fp32",
+    )
+
+    bundle = native._load_native_model({}, config, args)
+    bundle.model(torch.zeros(1, 1, 3, 4, 4))
+
+    assert recorder.seen == [(1, 1, 5, 4, 4)], (
+        "native inference fed the network depth "
+        f"{recorder.seen[0][2]} where training would have fed 5"
+    )
+
+
+def test_native_inference_leaves_depth_alone_when_no_padding_is_configured(monkeypatch):
+    recorder = _DepthRecorder()
+    monkeypatch.setattr(native, "make_model", lambda config: recorder)
+    monkeypatch.setattr(native, "load_model_state", lambda model, state: None)
+    monkeypatch.setattr(
+        native, "select_native_inference_weights", lambda payload, source=None: ("model", {})
+    )
+    monkeypatch.setattr(native, "resolve_amp_dtype", lambda *a, **k: None)
+
+    config = SimpleNamespace(model=SimpleNamespace(input_pad_depth_to=None))
+    args = SimpleNamespace(
+        checkpoint="memory://checkpoint",
+        gpu_ids=(),
+        compile_model=False,
+        compile_mode="default",
+        amp_dtype="fp32",
+    )
+
+    bundle = native._load_native_model({}, config, args)
+    bundle.model(torch.zeros(1, 1, 3, 4, 4))
+    assert recorder.seen == [(1, 1, 3, 4, 4)]


### PR DESCRIPTION
Fixes #1507.

`_load_native_model` builds `TargetModel` without `input_pad_depth_to`, so a
checkpoint trained at a padded depth is fed an unpadded one at native inference
time. Training pads explicitly (`training/train.py` calls
`center_pad_input_depth(image_BCZYX, config.ink.model.input_pad_depth_to)`) and
flat inference passes the value into the same wrapper
(`inference/infer.py:929`) — only the native path does not.

```diff
-    model = TargetModel(base_model.eval()).eval()
+    model = TargetModel(
+        base_model.eval(),
+        input_pad_depth_to=config.model.input_pad_depth_to,
+    ).eval()
```

## Verified

Two regressions in `tests/ink_detection/test_native_full3d_inference.py`, using a
recording module that stores the BCZYX shape it actually receives — no
checkpoint, no GPU, as the issue suggested.

On unpatched `main` the first one fails with the reported symptom:

```
AssertionError: native inference fed the network depth 3 where training would have fed 5
assert [(1, 1, 3, 4, 4)] == [(1, 1, 5, 4, 4)]
```

and passes on this branch. The second pins the `input_pad_depth_to=None` case,
which is unaffected and passes on both — so the pair distinguishes the fix rather
than just asserting current behaviour.

Suites run on this branch (Python 3.12, torch 2.13):

| suite | result |
|---|---|
| `test_native_full3d_inference.py` | 15 passed |
| `test_flat_inference.py`, `test_model_foundation.py`, `test_inference_boundaries.py` | 47 passed |

## Scope

I have not established that any published native checkpoint carries a non-null
`input_pad_depth_to`, and I am not claiming an ink-accuracy change — this is a
train/inference parity fix that becomes operational whenever such a checkpoint is
used, exactly as the issue frames it.

---

Reopened as a new pull request because #1645 was closed by the staleness bot today (14 days, no review), and neither reopening nor pushing to the closed PR was permitted for this account. The branch, the fix and the regression test are unchanged from that PR.