### PR TITLE
ink_detection: robust flat normalization must exclude the reader's zero padding

### DIFF
--- a/vesuvius/src/vesuvius/ink_detection/inference/infer.py
+++ b/vesuvius/src/vesuvius/ink_detection/inference/infer.py
@@ -455,16 +455,44 @@ class FlatPatchReader:
             block = array[y0:y1, x0:x1, self.layer_indices]
         return np.asarray(block)
 
-    def read(self, y0: int, x0: int, out_h: int, out_w: int) -> np.ndarray:
-        """Read one padded H/W/Z patch with centered short-depth placement."""
+    def source_placement(self, y0: int, x0: int, out_h: int, out_w: int):
+        """Where in an output patch `read` puts source voxels, or None.
 
+        Everything outside this region is padding the reader inserted, and
+        training leaves such padding at zero rather than folding it into
+        normalization statistics.  Both `read` and the flat dataset derive
+        their placement from here so the two cannot drift apart.
+        """
         y1, x1 = y0 + out_h, x0 + out_w
         source_y0, source_x0 = max(0, y0), max(0, x0)
         source_y1, source_x1 = min(self.height, y1), min(self.width, x1)
+        if source_y1 <= source_y0 or source_x1 <= source_x0:
+            return None
+        depth_start = self.output_depth_start
+        return {
+            "source": (source_y0, source_y1, source_x0, source_x1),
+            "rows": slice(source_y0 - y0, source_y1 - y0),
+            "cols": slice(source_x0 - x0, source_x1 - x0),
+            "depth": slice(depth_start, depth_start + self.layer_indices.size),
+        }
+
+    def valid_region_zyx(self, y0: int, x0: int, out_h: int, out_w: int):
+        """`source_placement` as a Z/Y/X slice tuple, or None."""
+
+        placement = self.source_placement(y0, x0, out_h, out_w)
+        if placement is None:
+            return None
+        return (placement["depth"], placement["rows"], placement["cols"])
+
+    def read(self, y0: int, x0: int, out_h: int, out_w: int) -> np.ndarray:
+        """Read one padded H/W/Z patch with centered short-depth placement."""
+
         dtype = np.float32 if self.preprocessing == "tifxyz_robust" else np.uint8
         output = np.zeros((out_h, out_w, self.output_depth), dtype=dtype)
-        if source_y1 <= source_y0 or source_x1 <= source_x0:
+        placement = self.source_placement(y0, x0, out_h, out_w)
+        if placement is None:
             return output
+        source_y0, source_y1, source_x0, source_x1 = placement["source"]
         block = self._read_raw(source_y0, source_y1, source_x0, source_x1)
         if self.preprocessing == "tifxyz_robust":
             block = np.asarray(block, dtype=np.float32)
@@ -478,12 +506,7 @@ class FlatPatchReader:
             block = np.ascontiguousarray(block)
         else:
             raise ValueError(f"Unsupported flat preprocessing {self.preprocessing!r}")
-        depth_start = self.output_depth_start
-        output[
-            source_y0 - y0 : source_y1 - y0,
-            source_x0 - x0 : source_x1 - x0,
-            depth_start : depth_start + self.layer_indices.size,
-        ] = block
+        output[placement["rows"], placement["cols"], placement["depth"]] = block
         return output
 
 
@@ -518,7 +541,21 @@ class FlatBlockDataset(Dataset):
         # maps an all-zero patch to nonzero values.
         nonempty = int(patch_HWZ.any())
         patch_ZYX = np.moveaxis(patch_HWZ, -1, 0)
-        patch_ZYX = normalize_flat_patch(patch_ZYX, self.preprocessing)
+        # Training normalizes only the voxels actually read from the source and
+        # leaves reader padding at zero (data/dataset.py::_tensor_sample).
+        # Robust normalization takes full-array percentiles, median and MAD, so
+        # normalizing the padded patch lets artificial zeros move the statistics
+        # for every real CT voxel.  divide_255 is unaffected: zero stays zero.
+        valid_zyx = self.reader.valid_region_zyx(
+            block.y0, block.x0, self.patch_size, self.patch_size
+        )
+        if self.preprocessing == "tifxyz_robust" and valid_zyx is not None:
+            patch_ZYX = np.ascontiguousarray(patch_ZYX, dtype=np.float32)
+            patch_ZYX[valid_zyx] = normalize_flat_patch(
+                patch_ZYX[valid_zyx], self.preprocessing
+            )
+        else:
+            patch_ZYX = normalize_flat_patch(patch_ZYX, self.preprocessing)
         image_CZYX = torch.from_numpy(patch_ZYX).unsqueeze(0)
         metadata = torch.tensor(
             [block.y0, block.x0, block.valid_h, block.valid_w, nonempty],

--- a/vesuvius/tests/ink_detection/test_flat_inference.py
+++ b/vesuvius/tests/ink_detection/test_flat_inference.py
@@ -495,3 +495,78 @@ def test_flat_inference_ignores_embedded_io_paths_and_keeps_reference_defaults(
     assert "stride=8 requested_overlap=0.500 blend_mode=hann" in caplog.text
     assert np.all(tifffile.imread(output) == 127)
     assert not any(path.name.startswith("ink_flat_infer_") for path in tmp_path.iterdir())
+
+
+def test_flat_robust_normalization_excludes_reader_padding(tmp_path):
+    """Training normalizes only the voxels read from the source and leaves the
+    reader's padding at zero (`data/dataset.py::_tensor_sample`).  Robust
+    normalization takes full-array percentiles, median and MAD, so normalizing
+    the padded patch lets artificial zeros move the statistics for every real
+    CT voxel."""
+    from vesuvius.image_proc.intensity.normalization import normalize_robust
+    from vesuvius.ink_detection.inference.infer import Block, FlatBlockDataset
+
+    source_ZYX = np.arange(100, 100 + 3 * 4 * 4, dtype=np.uint8).reshape(3, 4, 4)
+    path = tmp_path / "short-depth.zarr"
+    array = zarr.open(path, mode="w", shape=source_ZYX.shape,
+                      chunks=source_ZYX.shape, dtype="u1", zarr_format=2)
+    array[:] = source_ZYX
+
+    layers = select_layer_indices(
+        3, layer_start=None, layer_end=None, output_depth=5, direction="forward"
+    )
+    reader = FlatPatchReader(
+        input_path=path,
+        resolution="0",
+        depth_axis_first=True,
+        height=4,
+        width=4,
+        layer_indices=layers,
+        output_depth=5,
+        preprocessing="tifxyz_robust",
+    )
+    dataset = FlatBlockDataset(
+        reader=reader,
+        blocks=[Block(y0=0, x0=0, valid_h=4, valid_w=4)],
+        patch_size=4,
+        preprocessing="tifxyz_robust",
+    )
+    image_CZYX, _ = dataset[0]
+    got = image_CZYX.numpy()[0]
+
+    expected = np.zeros((5, 4, 4), dtype=np.float32)
+    expected[1:4] = normalize_robust(source_ZYX.astype(np.float32))
+
+    # the two planes the reader padded must still be exactly zero
+    np.testing.assert_array_equal(got[0], np.zeros((4, 4), dtype=np.float32))
+    np.testing.assert_array_equal(got[4], np.zeros((4, 4), dtype=np.float32))
+    # and every real voxel must match what training would have produced
+    np.testing.assert_allclose(got, expected, rtol=0, atol=1e-6)
+
+
+def test_flat_divide_255_is_unchanged_by_the_padding_rule(tmp_path):
+    """divide_255 needs no special case: zero divided by 255 is still zero."""
+    from vesuvius.ink_detection.inference.infer import Block, FlatBlockDataset
+
+    source_ZYX = np.arange(100, 100 + 3 * 4 * 4, dtype=np.uint8).reshape(3, 4, 4)
+    path = tmp_path / "divide.zarr"
+    array = zarr.open(path, mode="w", shape=source_ZYX.shape,
+                      chunks=source_ZYX.shape, dtype="u1", zarr_format=2)
+    array[:] = source_ZYX
+
+    layers = select_layer_indices(
+        3, layer_start=None, layer_end=None, output_depth=5, direction="forward"
+    )
+    reader = FlatPatchReader(
+        input_path=path, resolution="0", depth_axis_first=True,
+        height=4, width=4, layer_indices=layers, output_depth=5,
+        preprocessing="divide_255",
+    )
+    dataset = FlatBlockDataset(
+        reader=reader, blocks=[Block(y0=0, x0=0, valid_h=4, valid_w=4)],
+        patch_size=4, preprocessing="divide_255",
+    )
+    got = dataset[0][0].numpy()[0]
+    expected = np.zeros((5, 4, 4), dtype=np.float32)
+    expected[1:4] = source_ZYX.astype(np.float32) / 255.0
+    np.testing.assert_allclose(got, expected, rtol=0, atol=1e-7)


### PR DESCRIPTION
Fixes #1481.

`FlatBlockDataset.__getitem__` normalizes the whole patch after
`FlatPatchReader.read()` has already inserted zero padding, so for
`tifxyz_robust` the artificial zeros enter the percentiles, median and MAD and
shift every real CT voxel. Training does the opposite — it normalizes only the
voxels read from the source and leaves padding at zero:

```python
# data/dataset.py::_tensor_sample
if image_valid_slices is not None:
    image[image_valid_slices] = normalize_image(
        image[image_valid_slices], self.config.normalization
    )
```

## Verified, and it reproduces the issue's number exactly

On unpatched `main`, with a 3×4×4 source centered into a 5×4×4 model input, the
padded planes come out at **−2.2658674716949463** instead of 0 — the issue
predicted "about −2.266":

```
Mismatched elements: 16 / 16 (100%)
 [0, 0]: -2.2658674716949463 (ACTUAL), 0.0 (DESIRED)
Max absolute difference among violations: 2.2658675
```

Two regressions in `tests/ink_detection/test_flat_inference.py`:

* `test_flat_robust_normalization_excludes_reader_padding` — asserts both padded
  planes stay exactly zero and every real voxel matches
  `normalize_robust(source)` placed into a zero tensor. **Fails on `main`,
  passes here.**
* `test_flat_divide_255_is_unchanged_by_the_padding_rule` — the control.
  `divide_255` needs no special case because zero over 255 is still zero, and it
  **passes on both**, so the pair distinguishes the fix rather than asserting
  current behaviour.

Suites on this branch (Python 3.12, torch 2.13): `test_flat_inference.py`,
`test_native_full3d_inference.py`, `test_inference_boundaries.py`,
`test_model_foundation.py`, `test_data_foundation.py` — **84 passed**.

## Implementation note

Rather than recomputing the padding arithmetic in the dataset, I factored it out
of `FlatPatchReader.read()` into `source_placement()` and used it from both
sides, so the placement and the normalization region cannot drift apart. That
also covers the case the issue's sketch does not: when a block starts before the
array, `read()` places source data at `source_y0 - y0`, not at 0, so a
`slice(0, block.valid_h)` would normalize the wrong rows.

`valid_region_zyx()` returns the same placement as a Z/Y/X slice tuple for the
dataset's post-`moveaxis` view, and `None` when a block is entirely outside the
volume — those patches are all zeros and are already dropped downstream by
`keep = metadata[:, 4] > 0`, so their behaviour is deliberately unchanged.

---

Reopened as a new pull request because #1646 was closed by the staleness bot today (14 days, no review), and neither reopening nor pushing to the closed PR was permitted for this account. The branch, the fix and the regression test are unchanged from that PR.