### PR TITLE
vc_grow_seg_from_seed: cap the OpenBLAS thread pool (#1316)

### DIFF
--- a/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
+++ b/volume-cartographer/apps/src/vc_grow_seg_from_seed.cpp
@@ -19,8 +19,13 @@
 
 #include <omp.h>
 
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <fstream>
 #include <limits>
 #include <optional>
@@ -32,6 +37,38 @@ using shape = std::vector<size_t>;
 
 
 using Json = utils::Json;
+
+// The tracer's Ceres solves go through CHOLMOD, whose BLAS calls land in the
+// process-wide OpenBLAS pool. The pthreads build of OpenBLAS sizes that pool
+// from the core count when the library is loaded and the idle workers
+// spin-wait (sched_yield) between jobs; the tracer issues many small
+// factorizations, so on an N-core machine the pool burns N-1 cores for
+// nothing, and neither thread_limit nor omp_set_num_threads() reaches it.
+// Measured on a 14C/28T Xeon, same 1.78 cm2 patch: thread_limit=1 took
+// 189 CPU-s for 16.6 s of wall with the pool and 13 CPU-s / 12.7 s with it
+// capped; 28 threads took 122 CPU-s / 6.6 s versus 33 CPU-s / 3.7 s.
+// Same runtime cap as VC3D's VCAppMain.cpp: runs launched from VC3D get
+// OMP_NUM_THREADS from CommandLineToolRunner (OpenBLAS honours it too),
+// direct CLI runs had nothing. An explicit OPENBLAS_NUM_THREADS /
+// GOTO_NUM_THREADS in the environment wins: OpenBLAS already honoured it.
+static void cap_blas_thread_pool()
+{
+#ifndef _WIN32
+    if (std::getenv("OPENBLAS_NUM_THREADS") || std::getenv("GOTO_NUM_THREADS"))
+        return;
+    const int omp_threads = omp_get_max_threads();
+    if (auto fn = reinterpret_cast<void (*)(int)>(dlsym(RTLD_DEFAULT, "openblas_set_num_threads")))
+        fn(1);
+    // Retire the workers created at load; OpenBLAS re-creates a pool on
+    // demand, now sized to one thread.
+    if (auto fn = reinterpret_cast<void (*)()>(dlsym(RTLD_DEFAULT, "blas_shutdown")))
+        fn();
+    // OpenMP builds of OpenBLAS up to 0.3.0 forwarded the call above to
+    // omp_set_num_threads(); the tracer's own thread count stays as it was.
+    if (omp_get_max_threads() != omp_threads)
+        omp_set_num_threads(omp_threads);
+#endif
+}
 
 static bool is_remote_volume_path(const std::string& path)
 {
@@ -203,6 +240,11 @@ static auto load_direction_fields(Json const&params, std::filesystem::path const
 
 int main(int argc, char *argv[])
 {
+    // First: the workers spin for about 0.1 s after the OpenBLAS constructor
+    // creates them (3 CPU-s for 27 workers), so retire them before the
+    // volume is opened rather than when the thread settings are applied.
+    cap_blas_thread_pool();
+
     std::filesystem::path vol_path, tgt_dir, params_path, resume_path, correct_path;
     cv::Vec3d origin;
     Json params;


### PR DESCRIPTION
**In one sentence:** `vc_grow_seg_from_seed` now caps the OpenBLAS thread pool the way VC3D already does for itself, because that pool (reached through Ceres → CHOLMOD → `dsyrk_`) is where the CPU reported in #1316 goes: on a 14C/28T machine a `thread_limit: 1` run drops from 189 CPU-s to 14 CPU-s and from 16.6 s to 12.7 s of wall, for the same surface (re-verified on current main 4b3c728 on 2026-09-15, see Proof).

**One real example:** PHerc1447 surface prediction `20250521151220-surface-20260413222639-surface-m7-L0-th0.2.zarr` (level 0, mirrored locally around the seed, see Data below), seed `2226 4121 5665`, params `{"thread_limit": 1, "generations": 40, "step_size": 20, "voxelsize": 8.64, "min_area_cm": 0.0, "cache_size": 8e9, "use_cuda": false}`, `VC_GROWPATCH_RNG_SEED=42`:

```
/usr/bin/time -v vc_grow_seg_from_seed -v predvol/vol.zarr -t out -p params.json --seed 2226 4121 5665 --skip-overlap-check
```

Before (main 23adee047): 16.6 s wall, 91.7 s user + 97.2 s system = 189 CPU-s, "Percent of CPU this job got: 1135%", 1.782 cm² surface. After (this branch): 12.7 s wall, 13.0 s user + 0.9 s system = 13.9 CPU-s, same surface. The same trace on main with `OPENBLAS_NUM_THREADS=1` in the environment: 12.7 s / 12.9 CPU-s, and its x/y/z.tif are bit-identical to this branch's.

**Before:** the tracer's Ceres solves (`SPARSE_NORMAL_CHOLESKY`) run through CHOLMOD's supernodal factorization, whose BLAS calls land in the process-wide OpenBLAS pool. The pthreads build of OpenBLAS (Ubuntu's default `libopenblas0-pthread`) sizes that pool from the core count when the library is loaded, and the idle workers spin in `sched_yield` between jobs. The tracer issues many small factorizations, so the N-1 workers spin for the whole run. `thread_limit` / `omp_set_num_threads()` never reach that pool. `OMP_NUM_THREADS` does (OpenBLAS reads it as a fallback), which is why the issue's 16 one-thread *processes* were cheap while `thread_limit` in the JSON was not, and why the issue's sweep (`OMP_NUM_THREADS` per column) found its optimum at 4 threads: every extra OpenMP thread also added a spinning BLAS worker.

Thread dump of a `thread_limit: 1` run on main (`gdb -p <pid> -batch -ex "thread apply all bt 8"`, per-thread CPU from `/proc/<pid>/task/*/stat`): 159 threads. The main thread in `cholmod_factorize → cholmod_super_numeric → dsyrk_ → dsyrk_LN → dgemm_beta_HASWELL`; 27 threads with only `libopenblas.so.0` frames, 26 of them in `sched_yield` at the time of the dump, holding 165 of the 181 CPU-s accumulated by the end of the run (main thread: 16.4); 27 libgomp workers and 104 `ChunkRequestScheduler` workers at 0 CPU.

**After this PR:** `cap_blas_thread_pool()` runs first thing in `main()`: `openblas_set_num_threads(1)` then `blas_shutdown()`, both resolved with `dlsym(RTLD_DEFAULT, …)` so a build without OpenBLAS (or with another BLAS) is untouched. Those are the two calls `VCAppMain.cpp` already makes for VC3D. An explicit `OPENBLAS_NUM_THREADS` / `GOTO_NUM_THREADS` in the environment is respected (the function returns early; OpenBLAS already sized the pool from it). The OpenMP thread count is read before and restored after, because OpenMP builds of OpenBLAS up to 0.3.0 forwarded `openblas_set_num_threads()` to `omp_set_num_threads()` (checked in `driver/others/blas_server_omp.c` at v0.2.20 and v0.3.0; gone by v0.3.26; not run here, the Ubuntu package is the pthreads build). Thread count of the same run: 132 instead of 159 from the first sample at 0.25 s, no thread with measurable system time.

Placement: the workers spin for a fixed time right after the OpenBLAS constructor creates them, so where the call sits matters. A 10-line program that loads OpenBLAS and makes the two calls after a delay: 0 ms → 0.04 CPU-s; 50 ms → 1.4; 100 ms and anything longer → 3.0 CPU-s (1.3 user + 1.7 system, 27 workers). With the call in the thread-settings block after the volume is opened the tracer paid those 3 CPU-s (15.8 CPU-s at `thread_limit: 1`); at the top of `main()` it pays about 1 (13.9), the remainder being the time the dynamic loader and static initializers take before `main()`.

**Proof:** main 23adee047 vs this branch (the file is byte-identical to the one built and measured), Release builds, gcc 13.3, Ubuntu 24.04, `libopenblas0-pthread` 0.3.26, libceres 2.2.0, SuiteSparse 7.6.1, Xeon E5-2680 v4 (14C/28T, 35 MiB L3), every run the same seed/params/generations; wall / CPU-s (user+system); n = number of runs, ranges over them.

| `thread_limit` | main, default environment | main, `OPENBLAS_NUM_THREADS=1` | this branch, default environment |
|---|---|---|---|
| 1 | 16.6–16.7 s / 189 (n=2) | 12.7–13.7 s / 12.9–13.9 (n=4) | 12.7–12.9 s / 13.9–14.1 (n=3) |
| 4 | 6.1 s / 104 (n=1) | 4.1 s / 14.5 (n=1) | 4.1 s / 15.4–15.5 (n=2) |
| 8 | – | 3.0–3.6 s / 15.5–16.6 (n=2) | 3.5–4.5 s / 17.7–19.6 (n=2) |
| 28 | 6.6 s / 122 (n=1) | 3.3–4.4 s / 28.8–32.1 (n=2) | 3.9–6.0 s / 31.9–35.9 (n=2) |
| 0 (default, 28 here) | – | – | 4.0–5.0 s / 32.3–33.8 (n=2) |

Per cm²: 106 CPU-s at `thread_limit: 1` and 68.6 at 28 threads on main (the issue measured 66.4 at 16 threads); 7.8 and 18–20 on this branch; 7.2 with the environment variable.

Override check: `OPENBLAS_NUM_THREADS=4` in the environment with this branch at `thread_limit: 1` → 13.1 s / 25.9 CPU-s with 6.8 s of system time (n=3), i.e. the pool is kept at 4 as asked and its 3 idle workers spin as before.

Output: at `thread_limit: 1` the tracer is repeatable, and this branch's `x/y/z.tif` are bit-identical across three runs, bit-identical to main's with `OPENBLAS_NUM_THREADS=1`, and within 0.001 voxel of main's default run (float32 rounding from the single-thread versus threaded BLAS reduction order). Runs at more than one thread are not repeatable on main either (#1317): two 28-thread runs on main differ by up to 528 voxels at some grid nodes, two of this branch by up to 446. Areas of all 59 runs made for this PR lie in 1.7816–1.7827 cm² (0.06 % spread).

**Re-verified 2026-09-15 on current main (4b3c728).** `apps/src/vc_grow_seg_from_seed.cpp` is byte-identical to the file measured above and this branch merges clean onto 4b3c728. Same volume, seed and params, `thread_limit: 1`, one binary toggled by the environment this PR honours: default (pool capped by this PR) 14.2 s / 16.0 CPU-s at 112 % CPU; `OPENBLAS_NUM_THREADS=28` (the function returns early, pool left uncapped) 17.7 s / 189 CPU-s at ~1060 % CPU; both produce the same 1.782 cm² surface and the two capped runs are byte-identical. The uncapped 189 CPU-s matches the `main, default environment` column exactly; the capped figure is a couple of CPU-s above the branch-base column because the surrounding core libraries moved over the five days between builds. The effect is unchanged.

**Why / where this is useful:** this is the "root cause not identified" part of #1316, and it applies to every direct run of the CLI tool (batch tracing, scripts, the official binaries) on a machine with more cores than the trace can use. Runs launched from VC3D already get `OMP_NUM_THREADS` from `CommandLineToolRunner`, so they were covered by the fallback. The tracer's own OpenMP scaling is left as it is: with the pool capped, wall time improves about 3× from 1 to 8 threads and not at all beyond, so the startup NOTE from #1554 still applies (its quoted 2.2×/3.5× penalties were measured with the pool spinning; on this machine the remaining penalty is CPU per cm², about 1.8× at 28 threads versus 8), and one thread per process is still the cheapest way to fill a machine.

- [x] Verified by running the example and proof above on my machine on the stated data (AI-assisted; see disclosure).

## Details

Refs #1316 (report and measurements: @Aleredfer; the startup NOTE half went in with #1554). Related: #1317 (non-determinism at >1 thread, untouched here).

**What changed** (+42 lines, 1 file): `apps/src/vc_grow_seg_from_seed.cpp`: `#include <dlfcn.h>` (non-Windows) and `<cstdlib>`; static `cap_blas_thread_pool()` as described above; one call at the top of `main()`. Default `thread_limit` and the NOTE text are unchanged. The function is compiled out on Windows (`dlfcn`); not run on Windows or macOS.

**Data:** the trace runs on a local mirror of the level-0 chunks of the PHerc1447 surface prediction within ±800 voxels of the seed (`ListObjectsV2` on the open-data bucket, 723 existing chunks, 281 MB; keys absent on S3 are absent locally too, so inside that box the mirror behaves like the remote store), with a `meta.json` carrying `voxelsize: 8.64` so areas are in cm². `min_area_cm: 0` is a leftover precaution (the surface is above the 0.3 default anyway).

**Tested:** branch based on 23adee047 (its Proof table's base), re-verified 2026-09-15 on current main 4b3c728 as above; Release/Ninja gcc 13.3 build of the tracer target; 59 timed runs in total for this PR (`/usr/bin/time -v`, `OMP_NUM_THREADS` unset unless stated), the 12 of the final build listed above; thread inventory with gdb 15.1 (`perf` is locked down on this machine); all runs exit 0 and write the surface. Not run: the OpenMP build of OpenBLAS (the guard for it is read from the OpenBLAS sources, not measured), other BLAS implementations, Windows, macOS.

**Note on VC3D's `.preinit_array` hook (measured with a 20-line reduction, not in VC3D itself):** I first tried the same `setenv` from `.preinit_array` in the tracer and it changed nothing. On glibc 2.39 `environ` is still null when the executable's preinit array runs; `LD_DEBUG=all` shows `calling preinit: <exe>` → `calling init: libc.so.6` → … → `calling init: libopenblas.so.0`, and libc's initializer sets `environ` from the kernel-provided array, so a value set in preinit is gone before OpenBLAS's constructor reads it (`getenv` in `main()` returns null, 28 threads exist at `main()` entry, and a child `env` does not see the variable either). In VC3D the runtime `openblas_set_num_threads(1)` + `blas_shutdown()` calls right below the hook are the ones that do the work; by the same load order `OMP_WAIT_POLICY` set there does not reach libgomp either (inferred from the order, not measured separately). Left alone in this PR, mentioned in case it matters for the environment VC3D passes to child processes.

<details>
<summary>the reduction</summary>

```cpp
#include <cstdio>
#include <cstdlib>
extern "C" char **environ;
extern "C" int openblas_get_num_threads(void);
static char** environ_in_preinit = (char**)1;
static void early() { environ_in_preinit = environ; setenv("OPENBLAS_NUM_THREADS", "1", 0); }
__attribute__((section(".preinit_array"), used)) static auto preinitFn = &early;
static int threads() { int n = 0; char b[256]; FILE* f = fopen("/proc/self/status", "r");
    while (fgets(b, sizeof b, f)) if (sscanf(b, "Threads: %d", &n) == 1) break; fclose(f); return n; }
int main() {
    printf("environ in preinit: %p\n", (void*)environ_in_preinit);
    printf("getenv in main: %s\n", getenv("OPENBLAS_NUM_THREADS") ? getenv("OPENBLAS_NUM_THREADS") : "(null)");
    printf("threads at main entry: %d, openblas_get_num_threads: %d\n", threads(), openblas_get_num_threads());
    return system("env | grep -c OPENBLAS_NUM_THREADS");
}
// g++ -O1 t.cpp -Wl,--no-as-needed -lopenblas && ./a.out
// environ in preinit: (nil)
// getenv in main: (null)
// threads at main entry: 28, openblas_get_num_threads: 28
// 0
```
</details>

**From the author:** I contribute to VC through an AI-assisted workflow (Claude, directed by me). This picks up the root cause question left open in #1316: most of the CPU that vc_grow_seg_from_seed burns on a many core machine goes to the OpenBLAS pool that CHOLMOD uses underneath Ceres, which spins between the many small factorizations and is out of reach of thread_limit. The fix is the same pair of calls VC3D already makes for itself at startup, applied to the CLI tool, with an explicit OPENBLAS_NUM_THREADS still respected. On my machine a thread_limit 1 run goes from 189 CPU seconds to 14 for the same surface. I reviewed the investigation and the evidence; every number in this PR was produced by running the stated commands on my machine.

**AI disclosure:** investigation, patch and this write-up were produced with Claude (Anthropic) under my direction; every number above comes from running the stated commands on the stated data on my machine.